### PR TITLE
Enable Windows-native preview and passive runner diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,137 @@ jobs:
           cargo deny --locked --workspace --all-features check advisories bans licenses sources
           crates/automata-ci-protocol-protobuf/tools/protobuf-codegen.sh audit
 
+  windows:
+    name: Windows preview and passive diagnostics
+    runs-on: windows-2025
+    timeout-minutes: 45
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Show pinned MSVC toolchain
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:TMPDIR | Out-Null
+          rustc --version --verbose
+          cargo --version --verbose
+          $hostTriple = (
+            rustc --version --verbose |
+              Select-String -Pattern '^host: ' |
+              ForEach-Object { $_.Line.Substring(6) }
+          )
+          if ($hostTriple -ne 'x86_64-pc-windows-msvc') {
+            throw "expected x86_64-pc-windows-msvc, got $hostTriple"
+          }
+
+      - name: Check Windows source binaries
+        run: cargo check --locked --bin automata --bin automata-runner
+
+      - name: Test fail-closed Windows operator commands
+        run: cargo test -p automata-ci --locked --test unsupported_operator
+
+      - name: Test Windows runner diagnostics
+        run: >-
+          cargo test
+          -p automata-ci-runner
+          --locked
+          --test doctor
+          --test doctor_cli
+
+      - name: Smoke test preview and passive diagnostics
+        shell: pwsh
+        run: |
+          cargo build --locked --bin automata --bin automata-runner
+
+          $listener = [System.Net.Sockets.TcpListener]::new(
+            [System.Net.IPAddress]::Loopback,
+            0
+          )
+          $listener.Start()
+          $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+          $listener.Stop()
+
+          $origin = "http://127.0.0.1:$port"
+          $automata = (Resolve-Path 'target/debug/automata.exe').Path
+          $runner = (Resolve-Path 'target/debug/automata-runner.exe').Path
+          $previewStdout = Join-Path $env:TMPDIR 'preview.stdout.log'
+          $previewStderr = Join-Path $env:TMPDIR 'preview.stderr.log'
+          $preview = Start-Process `
+            -FilePath $automata `
+            -ArgumentList @('preview', '--listen', "127.0.0.1:$port") `
+            -RedirectStandardOutput $previewStdout `
+            -RedirectStandardError $previewStderr `
+            -WindowStyle Hidden `
+            -PassThru
+
+          try {
+            $health = $null
+            for ($attempt = 0; $attempt -lt 90; $attempt++) {
+              if ($preview.HasExited) {
+                $detail = Get-Content -Raw $previewStderr -ErrorAction SilentlyContinue
+                throw "preview exited before becoming healthy: $detail"
+              }
+              try {
+                $health = Invoke-RestMethod `
+                  -Uri "$origin/healthz" `
+                  -TimeoutSec 2
+                break
+              } catch {
+                Start-Sleep -Seconds 1
+              }
+            }
+            if ($null -eq $health -or $health.status -ne 'ok') {
+              throw 'preview health endpoint did not become healthy'
+            }
+
+            $readiness = Invoke-WebRequest -Uri "$origin/readyz" -TimeoutSec 5
+            if ($readiness.Content.Trim() -ne 'ready') {
+              throw "unexpected readiness response: $($readiness.Content)"
+            }
+            $repositories = Invoke-WebRequest `
+              -Uri "$origin/repositories" `
+              -TimeoutSec 5
+            if ($repositories.StatusCode -ne 200) {
+              throw "unexpected repositories status: $($repositories.StatusCode)"
+            }
+
+            & $automata --server-url $origin admin status
+            if ($LASTEXITCODE -ne 0) {
+              throw 'admin status failed against the Windows preview'
+            }
+
+            $doctorJson = & $runner doctor --server $origin --json
+            if ($LASTEXITCODE -ne 0) {
+              throw 'passive runner doctor failed against the Windows preview'
+            }
+            $doctor = ($doctorJson -join [Environment]::NewLine) |
+              ConvertFrom-Json
+            if ($doctor.os -ne 'windows') {
+              throw "unexpected doctor operating system: $($doctor.os)"
+            }
+            if ($doctor.capabilities -notcontains 'core.process-exec/v1') {
+              throw 'passive doctor did not prove child process execution'
+            }
+            if ($doctor.capabilities -contains 'linux.podman-network-isolation/v1') {
+              throw 'Windows doctor advertised Linux Podman isolation'
+            }
+            if ($doctor.server.status -ne 'healthy') {
+              throw "doctor could not reach preview health: $($doctor.server.status)"
+            }
+          } finally {
+            if (-not $preview.HasExited) {
+              Stop-Process -Id $preview.Id -Force
+              $preview.WaitForExit()
+            }
+          }
+
   frontend:
     name: React SSR frontend
     runs-on: ubuntu-24.04

--- a/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
+++ b/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
@@ -1196,6 +1196,10 @@ impl ProbeContext {
         Ok(())
     }
 
+    fn verify_for_use(&self, _expected_payload: &[u8]) -> Result<(), String> {
+        Err("active Podman probing is unsupported on this platform".to_owned())
+    }
+
     fn remove(&mut self) -> Result<(), String> {
         let entries = fs::read_dir(&self.path)
             .map_err(|error| format!("could not scan the owned probe context: {error}"))?

--- a/crates/automata-ci-runner/tests/doctor.rs
+++ b/crates/automata-ci-runner/tests/doctor.rs
@@ -5,8 +5,13 @@ use std::{
     time::Duration,
 };
 
+#[cfg(not(target_os = "linux"))]
+use automata_ci_runner::capability_probe::{
+    PODMAN_NETWORK_ISOLATION, ProbeReasonCode, ProbeStatus,
+};
 use automata_ci_runner::doctor::{
-    ServerHttpPolicy, ServerHttpPolicyError, ServerStatus, inspect, probe_server_with_policy,
+    ServerHttpPolicy, ServerHttpPolicyError, ServerStatus, inspect, inspect_with_options,
+    probe_server_with_policy,
 };
 
 #[test]
@@ -174,6 +179,29 @@ async fn serializes_capability_evidence_separately_from_advertised_capabilities(
             .iter()
             .all(|probe| probe["status"].is_string() && probe["detail"].is_string())
     );
+}
+
+#[cfg(not(target_os = "linux"))]
+#[tokio::test]
+async fn active_doctor_reports_unsupported_platform_without_advertising_isolation() {
+    let report = inspect_with_options(None, true).await;
+    let probe = report
+        .capability_probes()
+        .iter()
+        .find(|probe| probe.capability() == PODMAN_NETWORK_ISOLATION)
+        .expect("active diagnostics must include Podman isolation evidence");
+
+    assert_eq!(probe.status(), ProbeStatus::Unavailable);
+    assert_eq!(
+        probe
+            .reason()
+            .expect("unsupported evidence must include a reason")
+            .code(),
+        ProbeReasonCode::ActiveProbeUnsupportedPlatform
+    );
+    assert!(!probe.is_usable());
+    assert!(!report.capabilities().contains(PODMAN_NETWORK_ISOLATION));
+    assert!(!report.is_healthy());
 }
 
 fn serve_once(status: &'static str) -> (String, JoinHandle<()>) {

--- a/crates/automata-ci-runner/tests/doctor_cli.rs
+++ b/crates/automata-ci-runner/tests/doctor_cli.rs
@@ -31,3 +31,42 @@ fn doctor_json_command_emits_a_machine_readable_report() {
             .any(|capability| capability == PODMAN_NETWORK_ISOLATION)
     );
 }
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn active_doctor_json_reports_unsupported_platform_and_exits_unsuccessfully() {
+    let output = Command::new(env!("CARGO_BIN_EXE_automata-runner"))
+        .args(["doctor", "--active", "--json"])
+        .env_remove("RUST_LOG")
+        .output()
+        .expect("active runner doctor must start");
+
+    assert!(!output.status.success());
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("doctor output must be JSON");
+    assert_eq!(report["active"], true);
+    assert!(
+        !report["capabilities"]
+            .as_array()
+            .expect("capabilities must be an array")
+            .iter()
+            .any(|capability| capability == PODMAN_NETWORK_ISOLATION)
+    );
+    assert!(
+        report["capability_probes"]
+            .as_array()
+            .expect("capability probes must be an array")
+            .iter()
+            .any(|probe| {
+                probe["capability"] == PODMAN_NETWORK_ISOLATION
+                    && probe["status"] == "unavailable"
+                    && probe["reason"]["code"] == "active_probe_unsupported_platform"
+            })
+    );
+    assert_eq!(
+        String::from_utf8(output.stderr)
+            .expect("stderr must be UTF-8")
+            .trim(),
+        "Error: active Podman network isolation probe failed"
+    );
+}

--- a/crates/automata-ci-sandbox-podman/Cargo.toml
+++ b/crates/automata-ci-sandbox-podman/Cargo.toml
@@ -16,10 +16,12 @@ workspace = true
 
 [dependencies]
 automata-ci-execution.workspace = true
-rustix = { workspace = true, features = ["event"] }
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["event"] }
 
 [dev-dependencies]
 static_assertions.workspace = true

--- a/crates/automata-ci-sandbox-podman/src/docker.rs
+++ b/crates/automata-ci-sandbox-podman/src/docker.rs
@@ -17,7 +17,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use automata_ci_execution::{ResourceLimits, SandboxHandle};
 use rustix::event::{PollFd, PollFlags, poll};
 use serde_json::{Map, Value, json};
 
@@ -57,33 +56,12 @@ const JOB_LOCAL_LOG_DRIVER: &str = "json-file";
 // review and coverage in the opt-in distribution command-surface test.
 const DISTRIBUTION_BUILD_QUERY_PARAMETERS: [&str; 4] = ["dockerfile", "q", "t", "version"];
 
-pub(crate) const DOCKER_SOCKET_DIRECTORY_TARGET: &str = "/run/automata-engine";
+pub(crate) use crate::docker_contract::DOCKER_SOCKET_DIRECTORY_TARGET;
 
 #[derive(Debug)]
 pub(crate) struct JobDockerListener(UnixListener);
 
-pub(crate) struct JobDockerLaunch<'a> {
-    sandbox: &'a SandboxHandle,
-    outer_process_id: u32,
-    outer_cgroup: String,
-    resources: ResourceLimits,
-}
-
-impl<'a> JobDockerLaunch<'a> {
-    pub(crate) const fn new(
-        sandbox: &'a SandboxHandle,
-        outer_process_id: u32,
-        outer_cgroup: String,
-        resources: ResourceLimits,
-    ) -> Self {
-        Self {
-            sandbox,
-            outer_process_id,
-            outer_cgroup,
-            resources,
-        }
-    }
-}
+pub(crate) use crate::docker_contract::JobDockerLaunch;
 
 #[derive(Debug)]
 pub(crate) struct JobDockerService {

--- a/crates/automata-ci-sandbox-podman/src/docker_contract.rs
+++ b/crates/automata-ci-sandbox-podman/src/docker_contract.rs
@@ -1,0 +1,26 @@
+use automata_ci_execution::{ResourceLimits, SandboxHandle};
+
+pub(crate) const DOCKER_SOCKET_DIRECTORY_TARGET: &str = "/run/automata-engine";
+
+pub(crate) struct JobDockerLaunch<'a> {
+    pub(crate) sandbox: &'a SandboxHandle,
+    pub(crate) outer_process_id: u32,
+    pub(crate) outer_cgroup: String,
+    pub(crate) resources: ResourceLimits,
+}
+
+impl<'a> JobDockerLaunch<'a> {
+    pub(crate) const fn new(
+        sandbox: &'a SandboxHandle,
+        outer_process_id: u32,
+        outer_cgroup: String,
+        resources: ResourceLimits,
+    ) -> Self {
+        Self {
+            sandbox,
+            outer_process_id,
+            outer_cgroup,
+            resources,
+        }
+    }
+}

--- a/crates/automata-ci-sandbox-podman/src/docker_unsupported.rs
+++ b/crates/automata-ci-sandbox-podman/src/docker_unsupported.rs
@@ -1,8 +1,8 @@
-use automata_ci_execution::{ResourceLimits, SandboxHandle};
+use std::sync::Arc;
 
-use crate::{PodmanConfigurationError, PodmanOptions, state::JobEnginePaths};
+pub(crate) use crate::docker_contract::{DOCKER_SOCKET_DIRECTORY_TARGET, JobDockerLaunch};
 
-pub(crate) const DOCKER_SOCKET_DIRECTORY_TARGET: &str = "/run/automata-engine";
+use crate::{PodmanConfigurationError, PodmanObserver, PodmanOptions, state::JobEnginePaths};
 
 #[derive(Debug)]
 pub(crate) struct JobDockerListener;
@@ -21,10 +21,8 @@ impl JobDockerService {
         _options: &PodmanOptions,
         _paths: &JobEnginePaths,
         _listener: JobDockerListener,
-        _sandbox: &SandboxHandle,
-        _outer_process_id: u32,
-        _outer_cgroup: String,
-        _resources: ResourceLimits,
+        _launch: JobDockerLaunch<'_>,
+        _observer: Arc<dyn PodmanObserver>,
     ) -> Result<Self, PodmanConfigurationError> {
         Err(PodmanConfigurationError::UnsupportedPlatform)
     }

--- a/crates/automata-ci-sandbox-podman/src/lib.rs
+++ b/crates/automata-ci-sandbox-podman/src/lib.rs
@@ -15,6 +15,7 @@ mod docker;
 #[cfg(not(unix))]
 #[path = "docker_unsupported.rs"]
 mod docker;
+mod docker_contract;
 mod endpoint;
 mod error;
 mod naming;

--- a/crates/automata-ci/Cargo.toml
+++ b/crates/automata-ci/Cargo.toml
@@ -56,7 +56,6 @@ getrandom.workspace = true
 futures.workspace = true
 reqwest.workspace = true
 prometheus-client.workspace = true
-rustix.workspace = true
 rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -73,6 +72,9 @@ url.workspace = true
 uuid.workspace = true
 x509-parser.workspace = true
 zeroize.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+rustix.workspace = true
 
 [build-dependencies]
 automata-ci-build-support.workspace = true

--- a/crates/automata-ci/src/cli/auth_unsupported.rs
+++ b/crates/automata-ci/src/cli/auth_unsupported.rs
@@ -1,0 +1,15 @@
+use anyhow::{Result, bail};
+
+use super::{AuthCommand, OutputFormat};
+
+#[allow(
+    clippy::unused_async,
+    reason = "the platform implementation must preserve the async dispatch contract"
+)]
+pub(crate) async fn execute_auth_command(
+    _server_url: &str,
+    _output: OutputFormat,
+    _command: &AuthCommand,
+) -> Result<()> {
+    bail!("CLI authentication is not supported on this platform")
+}

--- a/crates/automata-ci/src/cli/mod.rs
+++ b/crates/automata-ci/src/cli/mod.rs
@@ -1,10 +1,19 @@
 //! Command-line interface for both control-plane service roles and operators.
 
+#[cfg(unix)]
+mod auth;
+#[cfg(not(unix))]
+#[path = "auth_unsupported.rs"]
 mod auth;
 mod commands;
+#[cfg(unix)]
 mod credential_store;
 mod execution;
 mod output;
+#[cfg(unix)]
+mod secret;
+#[cfg(not(unix))]
+#[path = "secret_unsupported.rs"]
 mod secret;
 mod values;
 

--- a/crates/automata-ci/src/cli/secret_unsupported.rs
+++ b/crates/automata-ci/src/cli/secret_unsupported.rs
@@ -1,0 +1,15 @@
+use anyhow::{Result, bail};
+
+use super::{OutputFormat, SecretCommand};
+
+#[allow(
+    clippy::unused_async,
+    reason = "the platform implementation must preserve the async dispatch contract"
+)]
+pub(crate) async fn execute_secret_command(
+    _server_url: &str,
+    _output: OutputFormat,
+    _command: &SecretCommand,
+) -> Result<()> {
+    bail!("CLI secret management is not supported on this platform")
+}

--- a/crates/automata-ci/src/preview.rs
+++ b/crates/automata-ci/src/preview.rs
@@ -22,6 +22,10 @@ pub async fn serve(args: &PreviewArgs) -> Result<()> {
     let listener = TcpListener::bind(args.listen)
         .await
         .context("failed to bind preview listener")?;
+    serve_listener(listener).await
+}
+
+async fn serve_listener(listener: TcpListener) -> Result<()> {
     let address = listener
         .local_addr()
         .context("failed to inspect preview listener")?;
@@ -37,4 +41,43 @@ pub async fn serve(args: &PreviewArgs) -> Result<()> {
         .with_graceful_shutdown(shutdown::wait())
         .await
         .context("preview HTTP service failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+
+    use super::*;
+    use crate::cli::{StatusHttpPolicy, fetch_control_plane_status};
+
+    #[tokio::test]
+    async fn preview_listener_serves_status() {
+        let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .expect("preview listener must bind");
+        let address = listener
+            .local_addr()
+            .expect("preview listener address must be available");
+        let task = tokio::spawn(serve_listener(listener));
+
+        let policy =
+            StatusHttpPolicy::new(Duration::from_secs(5), Duration::from_secs(60), 64 * 1024)
+                .expect("preview test status policy must be valid");
+        let status = fetch_control_plane_status(&format!("http://{address}"), policy)
+            .await
+            .expect("preview status must be available");
+
+        assert_eq!(status["health"]["status"], "ok");
+        assert_eq!(status["health"]["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(status["readiness"]["ready"], true);
+
+        task.abort();
+        let error = task
+            .await
+            .expect_err("aborted preview task must not complete");
+        assert!(error.is_cancelled());
+    }
 }

--- a/crates/automata-ci/tests/github_provider_end_to_end_matrix.rs
+++ b/crates/automata-ci/tests/github_provider_end_to_end_matrix.rs
@@ -357,8 +357,7 @@ impl AutonomousWorkflowPhaseExecutor for MatrixExecutorTrace {
         shutdown: CancellationToken,
         deadline: AutonomousWorkflowDeadline,
     ) -> AutonomousWorkflowExecutionFuture<'a> {
-        self.inner
-            .execute_preparation(lease, shutdown, deadline)
+        self.inner.execute_preparation(lease, shutdown, deadline)
     }
 
     fn execute_activation<'a>(

--- a/crates/automata-ci/tests/unsupported_operator.rs
+++ b/crates/automata-ci/tests/unsupported_operator.rs
@@ -1,0 +1,115 @@
+#![cfg(not(unix))]
+
+use std::{io::ErrorKind, net::TcpListener, process::Command};
+
+const SERVER_SENTINEL: &str = "http://127.0.0.1:9";
+const SECRET_SENTINEL: &str = "WINDOWS_SECRET_SENTINEL";
+const PATH_SENTINEL: &str = "WINDOWS_PATH_SENTINEL.txt";
+
+#[test]
+fn authentication_commands_fail_before_using_operator_input() {
+    for operation in ["login", "status", "logout"] {
+        assert_unsupported(
+            &["--server-url", SERVER_SENTINEL, "auth", operation],
+            "CLI authentication is not supported on this platform",
+        );
+    }
+}
+
+#[test]
+fn secret_commands_fail_before_using_operator_input() {
+    for arguments in [
+        vec![
+            "--server-url",
+            SERVER_SENTINEL,
+            "secret",
+            "list",
+            "--scope",
+            "repo:owner/repository",
+        ],
+        vec![
+            "--server-url",
+            SERVER_SENTINEL,
+            "secret",
+            "create",
+            SECRET_SENTINEL,
+            "--scope",
+            "repo:owner/repository",
+            "--from-file",
+            PATH_SENTINEL,
+        ],
+        vec![
+            "--server-url",
+            SERVER_SENTINEL,
+            "secret",
+            "delete",
+            SECRET_SENTINEL,
+            "--scope",
+            "repo:owner/repository",
+            "--yes",
+        ],
+        vec![
+            "--server-url",
+            SERVER_SENTINEL,
+            "secret",
+            "provider",
+            "status",
+        ],
+        vec![
+            "--server-url",
+            SERVER_SENTINEL,
+            "secret",
+            "provider",
+            "activate",
+        ],
+    ] {
+        assert_unsupported(
+            &arguments,
+            "CLI secret management is not supported on this platform",
+        );
+    }
+}
+
+fn assert_unsupported(arguments: &[&str], expected: &str) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("sentinel server must bind");
+    listener
+        .set_nonblocking(true)
+        .expect("sentinel server must become nonblocking");
+    let server = format!(
+        "http://{}",
+        listener
+            .local_addr()
+            .expect("sentinel server address must be available")
+    );
+    let arguments = arguments
+        .iter()
+        .map(|argument| {
+            if *argument == SERVER_SENTINEL {
+                server.clone()
+            } else {
+                (*argument).to_owned()
+            }
+        })
+        .collect::<Vec<_>>();
+    let output = Command::new(env!("CARGO_BIN_EXE_automata"))
+        .args(&arguments)
+        .env_remove("RUST_LOG")
+        .output()
+        .expect("operator command must start");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr must be UTF-8");
+    assert_eq!(stderr.trim(), format!("Error: {expected}"));
+    assert!(!stderr.contains(&server));
+    assert!(!stderr.contains(SECRET_SENTINEL));
+    assert!(!stderr.contains(PATH_SENTINEL));
+    assert_eq!(
+        listener
+            .accept()
+            .expect_err("unsupported commands must not contact the server")
+            .kind(),
+        ErrorKind::WouldBlock
+    );
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,12 @@ Install [Git](https://git-scm.com/),
 repository pins Rust 1.97.1 and its required components in
 `rust-toolchain.toml`.
 
+On Windows, use rustup's 64-bit MSVC host and install the
+[Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/)
+**Desktop development with C++** workload. Run the source-build commands below
+from PowerShell. The same checkout and Cargo commands build native
+`automata.exe` and `automata-runner.exe` binaries.
+
 ```console
 git clone https://github.com/automata-ci/automata.git
 cd automata
@@ -32,6 +38,31 @@ cargo install --path crates/automata-ci-runner --locked
 The first build downloads and compiles Rust dependencies, then embeds the
 checked-in server-side renderer and browser assets, so it may take a few
 minutes.
+
+### Windows source-build boundary
+
+A native Windows source build provides a deliberately limited preview and
+diagnostic surface. It supports:
+
+- `automata preview` on a loopback address;
+- `automata admin status` against that preview; and
+- passive `automata-runner doctor` diagnostics, including an optional preview
+  health check.
+
+It does not make Windows an execution host or a production control-plane
+platform. The following boundaries fail closed on Windows:
+
+- `automata auth` and `automata secret` operator commands;
+- file-backed credential and secret sources;
+- static runner registration files and the full `automata server` deployment
+  composition;
+- `automata-runner doctor --active`, which requires rootless Podman network
+  isolation; and
+- `automata-runner run` and native job execution.
+
+Linux with rootless Podman remains the only supported job-execution host. A
+successful Windows build or passive doctor report is evidence only for the
+preview and diagnostics listed above.
 
 A compiled runner is useful for diagnostics, but it is not proof that the host
 can execute jobs. The initial execution-host path is Linux with rootless Podman,
@@ -53,9 +84,20 @@ guess a version, or assume that a documented registry name has been published.
 
 ## Verify the installation
 
+On Linux:
+
 ```console
 command -v automata
 command -v automata-runner
+automata --version
+automata-runner --version
+```
+
+On Windows PowerShell:
+
+```powershell
+Get-Command automata
+Get-Command automata-runner
 automata --version
 automata-runner --version
 ```
@@ -83,6 +125,15 @@ curl --fail http://127.0.0.1:8080/readyz
 automata admin status
 ```
 
+On Windows PowerShell, use the native HTTP command and the same explicit
+loopback origin:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8080/healthz
+Invoke-RestMethod http://127.0.0.1:8080/readyz
+automata --server-url http://127.0.0.1:8080 admin status
+```
+
 `/healthz` returns process identity and build information as JSON. `/readyz`
 returns `ready` in preview mode. `automata admin status` reads both endpoints
 and reports process health separately from dependency readiness.
@@ -98,7 +149,8 @@ The report separates host capability problems from server reachability. Add
 and remove temporary rootless Podman resources. This ambient doctor check is
 useful preparation, but `automata-runner run` performs its own mandatory probe
 with the configured Podman binary and clean provider environment before it
-opens a control-plane session.
+opens a control-plane session. On Windows, `--active` and `run` return an error
+instead of attempting Linux isolation or job execution.
 
 Stop the preview with `Ctrl-C`.
 


### PR DESCRIPTION
## Outcome

Adds a focused native Windows source-build path for two non-execution developer
operations:

- `automata preview` now builds and runs on `x86_64-pc-windows-msvc`, serving
  the embedded UI plus health and readiness endpoints.
- Passive `automata-runner doctor` now reports build, platform, generic process,
  and optional bounded server-health evidence on Windows.

Unix-only authentication and secret-custody modules are replaced on non-Unix
targets by explicit fail-closed command implementations. The unsupported
commands return fixed errors before using operator URLs, secret names, files,
stdin, credential stores, or the network. The non-Unix Podman adapter now shares
the current launch contract with its Unix implementation while continuing to
reject service startup.

A `windows-2025` CI job builds both source binaries, exercises the fail-closed
operator and active-diagnostic boundaries, and runs a real loopback preview,
admin-status, SSR, and passive-doctor smoke test. The getting-started guide now
documents the exact Windows source-build tier and its exclusions.

The change preserves the Linux-only execution boundary. Windows receives no
runner provider, execution label, environment profile, schedulable capability,
installer, or release artifact. Rootless Linux Podman remains the only current
job-execution implementation.

## Related issue

Closes #11

## Trust and compatibility impact

No credential format, storage schema, protocol, runner-registration, scheduling,
provider, or GitHub Actions compatibility contract changes.

Preview mode still starts no durable control plane or execution service. Passive
doctor creates no Podman, container, network, mount, cgroup, or provider
resources. Its optional server probe retains the existing HTTPS or
literal-loopback-HTTP policy, deadlines, response-size bound, redirect rejection,
and sanitized diagnostics.

On Windows:

- only `core.process-exec/v1` can be advertised by passive doctor;
- no `linux.*` capability is advertised usable;
- `doctor --active` reports `active_probe_unsupported_platform`, creates no
  resources, and exits unsuccessfully;
- `automata auth` and `automata secret` fail before credential, file, stdin, or
  network access; and
- runner production, static registration, file-backed secure inputs, and the
  full server deployment remain unsupported.

This PR does not implement PowerShell/cmd job semantics, Windows workspace/path
semantics, Job Objects, Windows containers, Podman machine integration, Hyper-V,
a Windows service, or Windows packaging. The planned G6 Windows execution work
is unchanged.

The branch also applies the one existing rustfmt correction reported by the
base branch's required formatting check so workspace verification can proceed.
The [base branch's latest CI run](https://github.com/automata-ci/automata/actions/runs/31423206644)
independently reports two frontend visual-test failures; this PR does not change
frontend code or baselines.

## Verification

Windows 11, pinned Rust 1.97.1, `x86_64-pc-windows-msvc`:

- `cargo check --locked --bin automata --bin automata-runner` — passed.
- `cargo test -p automata-ci --locked --test unsupported_operator` — 2 passed;
  every auth/secret variant returned the fixed sanitized error and made no TCP
  connection to the sentinel server.
- `cargo test -p automata-ci-runner --locked --test doctor --test doctor_cli` —
  12 passed, including passive capability and active unsupported-platform
  process behavior.
- Native smoke using the built MSVC binaries — passed: `/healthz` reported
  `ok`, `/readyz` reported `ready`, `/repositories` returned 200,
  `automata admin status` succeeded, and passive doctor reported
  `os: windows`, only `core.process-exec/v1`, and a healthy preview probe.

Additional focused validation:

- `cargo test -p automata-ci --locked --lib preview::tests::preview_listener_serves_status`
  — passed on the native Windows GNU host toolchain; the real listener served
  canonical health and readiness through the bounded public status client.
- Direct `rustfmt --check` over every changed Rust source — passed.
- `git diff --check` — passed.
- `actionlint 1.7.12 .github/workflows/ci.yml` — passed.
- Final PowerShell smoke block parsed successfully with the PowerShell parser.
- Two independent read-only reviews found no blocking code, trust-boundary,
  workflow, PowerShell, or documentation issue.

Not run locally:

- Full Linux workspace Clippy, test, doctest, and rustdoc commands. The Windows
  host has no pinned Linux build environment; the existing Linux CI jobs remain
  the regression authority.
- Full frontend visual tests. The latest base-branch CI run already fails two
  unrelated visual assertions, and this branch changes no frontend source or
  snapshot.

## AI assistance

OpenAI Codex assisted with repository investigation, portability analysis,
implementation, tests, Windows CI and documentation, validation, and review. I
reviewed and understand every submitted change and verified the results reported
above.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
