### PR TITLE
Fix OCI candidate directory permissions

### DIFF
--- a/scripts/ci/service-proxy-candidate.py
+++ b/scripts/ci/service-proxy-candidate.py
@@ -240,7 +240,7 @@ def load_oci(archive_bytes: bytes, source: dict, source_sha256: str) -> tuple[st
 def add_tar_directory(archive: tarfile.TarFile, name: str, mtime: int) -> None:
     info = tarfile.TarInfo(name)
     info.type = tarfile.DIRTYPE
-    info.mode = 0o555
+    info.mode = 0o755
     info.uid = info.gid = 0
     info.uname = info.gname = ""
     info.mtime = mtime

--- a/scripts/ci/tests/service-proxy-candidate.test.py
+++ b/scripts/ci/tests/service-proxy-candidate.test.py
@@ -175,6 +175,32 @@ class CandidateContract(unittest.TestCase):
         self.assertRegex(identity["image"]["manifest_digest"], candidate.OCI_DIGEST)
         self.assertEqual(identity["release"], self.release)
 
+    def test_canonical_oci_archive_uses_extractable_directory_modes(self) -> None:
+        output = self.root / "candidate.tar"
+        candidate.create(
+            argparse.Namespace(
+                context=self.context,
+                oci_archive=self.oci,
+                output=output,
+                github_output=None,
+            )
+        )
+        with tarfile.open(output, "r:") as archive:
+            image_archive = archive.extractfile(candidate.IMAGE_ARCHIVE_NAME)
+            self.assertIsNotNone(image_archive)
+            image_bytes = image_archive.read()
+
+        with tarfile.open(fileobj=io.BytesIO(image_bytes), mode="r:") as archive:
+            members = {member.name: member for member in archive.getmembers()}
+
+        for name in ("blobs", "blobs/sha256"):
+            self.assertTrue(members[name].isdir())
+            self.assertEqual(members[name].mode, 0o755)
+        for name, member in members.items():
+            if name not in {"blobs", "blobs/sha256"}:
+                self.assertTrue(member.isfile())
+                self.assertEqual(member.mode, 0o444)
+
     def test_mismatched_image_provenance_fails_before_candidate_output(self) -> None:
         self.write_oci(revision="b" * 40)
         output = self.root / "candidate.tar"


### PR DESCRIPTION
## Summary

- emit canonical OCI archive directories with mode `0755` so sequential extractors can populate `blobs/sha256`
- retain deterministic read-only `0444` modes for regular archive members
- add a focused regression that pins the canonical directory and file modes

## Verification

- `python3 scripts/ci/tests/service-proxy-candidate.test.py` (8/8)
- `python3 -m py_compile scripts/ci/service-proxy-candidate.py scripts/ci/tests/service-proxy-candidate.test.py`
- `git diff --check`

This closes the exact Skopeo publication failure from workflow run 31535617241, where extraction failed creating `blobs/sha256` beneath a canonicalized `0555` parent.