### PR TITLE
fix: make OCI layout archives extractable

### DIFF
--- a/scripts/ci/service-proxy-candidate.py
+++ b/scripts/ci/service-proxy-candidate.py
@@ -240,7 +240,8 @@ def load_oci(archive_bytes: bytes, source: dict, source_sha256: str) -> tuple[st
 def add_tar_directory(archive: tarfile.TarFile, name: str, mtime: int) -> None:
     info = tarfile.TarInfo(name)
     info.type = tarfile.DIRTYPE
-    info.mode = 0o555
+    # OCI transports extract parent entries before creating their children.
+    info.mode = 0o755
     info.uid = info.gid = 0
     info.uname = info.gname = ""
     info.mtime = mtime

--- a/scripts/ci/tests/service-proxy-candidate.test.py
+++ b/scripts/ci/tests/service-proxy-candidate.test.py
@@ -171,6 +171,11 @@ class CandidateContract(unittest.TestCase):
                 ),
             )
             identity = json.load(archive.extractfile(candidate.IDENTITY_NAME))
+            oci_bytes = archive.extractfile(candidate.IMAGE_ARCHIVE_NAME).read()
+        with tarfile.open(fileobj=io.BytesIO(oci_bytes), mode="r:") as archive:
+            members = {member.name: member for member in archive.getmembers()}
+        self.assertEqual(members["blobs"].mode, 0o755)
+        self.assertEqual(members["blobs/sha256"].mode, 0o755)
         self.assertEqual(identity["image"]["name"], candidate.IMAGE_NAME)
         self.assertRegex(identity["image"]["manifest_digest"], candidate.OCI_DIGEST)
         self.assertEqual(identity["release"], self.release)


### PR DESCRIPTION
The service-proxy publisher reached Skopeo for the first time in run 31535617241 and exposed a transport-only permission mismatch: canonical OCI layout parent directories were mode 0555, so Skopeo could not create blobs/sha256 while extracting the archive.

This changes only those canonical transport directories to 0755 and pins both modes in the candidate contract test. Image payload permissions remain unchanged and independently enforced.

Verified:
- service-proxy candidate tests: 7/7
- service-proxy publication tests: 12/12
- all Python CI suites
- real Ubuntu 24.04 Skopeo copy with --all --preserve-digests
- diff/compile checks