### PR TITLE
Stabilize PostgreSQL timing fixtures

### DIFF
--- a/crates/automata-ci-store/tests/postgres_github_checks.rs
+++ b/crates/automata-ci-store/tests/postgres_github_checks.rs
@@ -888,6 +888,8 @@ async fn missing_create_retries_only_reconciliation_until_exact_bind() -> TestRe
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
 async fn proven_unissued_release_reopens_prepare_under_the_exact_fence_only() -> TestResult {
     run_with_unmigrated_database(|database| async move {
+        const RETRY_HORIZON_MILLIS: i64 = 1_000;
+
         apply_checks_migrations(&database).await?;
         let fixture = seed_fixture(&database).await?;
         let (receipt, fence, _) = seed_indeterminate_create(
@@ -900,7 +902,7 @@ async fn proven_unissued_release_reopens_prepare_under_the_exact_fence_only() ->
         )
         .await?;
         let released_at = UnixMillis::new(database_now_ms(&database).await?);
-        let retry_at = UnixMillis::new(released_at.get() + 10);
+        let retry_at = UnixMillis::new(released_at.get() + RETRY_HORIZON_MILLIS);
         let release = ReleaseUnissuedGithubCheckRunCreate::new(fence, released_at, retry_at)?;
         assert_eq!(
             database

--- a/crates/automata-ci-store/tests/postgres_logical_job_result.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_job_result.rs
@@ -84,6 +84,8 @@ struct PreparedInstance {
 #[allow(clippy::too_many_lines)]
 async fn logical_result_is_ordered_fenced_replayable_and_terminal() -> TestResult {
     run_with_database(|database| async move {
+        const INSTANCE_RESULT_CLAIM_MILLIS: i64 = 60_000;
+
         let idle_observed_at = database_now_ms(&database).await?;
         let idle_request = ClaimNextLogicalJobResult::new(
             LogicalJobResultSelectionId::from_uuid(Uuid::from_u128(90_590))?,
@@ -248,7 +250,7 @@ async fn logical_result_is_ordered_fenced_replayable_and_terminal() -> TestResul
                             90_500 + u128::try_from(index)?,
                         ))?,
                         UnixMillis::new(claimed_at),
-                        UnixMillis::new(claimed_at + 3_000),
+                        UnixMillis::new(claimed_at + INSTANCE_RESULT_CLAIM_MILLIS),
                     )?)
                     .await?,
             );


### PR DESCRIPTION
## Summary
- give the unissued-create retry-horizon assertion a 1-second observation window while preserving the database-time eligibility wait
- keep instance-result claims alive across the test's deliberate trigger tamper/restore probes
- leave the dedicated 3-second selection expiry and takeover checks unchanged

## Verification
- PostgreSQL 18.4: `postgres_github_checks` 11/11 and `postgres_logical_job_result` 5/5, run concurrently
- exact formerly failing tests pass independently
- `cargo clippy -p automata-ci-store --tests --all-features --offline --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`