### PR TITLE
Finish stabilizing Store database-time horizons

### DIFF
--- a/crates/automata-ci-store/tests/postgres_github_checks.rs
+++ b/crates/automata-ci-store/tests/postgres_github_checks.rs
@@ -831,7 +831,9 @@ async fn missing_create_retries_only_reconciliation_until_exact_bind() -> TestRe
         let missing = ResolveGithubCheckRunCreate::missing(
             reconcile.claim(),
             observed_at,
-            UnixMillis::new(observed_at.get() + 100),
+            // Preserve enough live database time for exact replay and the
+            // immutable schedule checks before proving retry ineligibility.
+            UnixMillis::new(observed_at.get() + 5_000),
         )?;
         assert_eq!(
             database

--- a/crates/automata-ci-store/tests/postgres_logical_instance_result.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_instance_result.rs
@@ -771,7 +771,9 @@ async fn terminal_projection_is_fenced_replayable_and_secret_safe() -> TestResul
             LogicalInstanceResultSelectionId::from_uuid(Uuid::from_u128(30_690))?,
             LogicalInstanceResultWorkerId::from_uuid(Uuid::from_u128(30_691))?,
             UnixMillis::new(short_idle_observed_at),
-            UnixMillis::new(short_idle_observed_at + 100),
+            // The reserving transactions must finish before the later wait
+            // proves expiry and bounded cleanup under hosted database load.
+            UnixMillis::new(short_idle_observed_at + 5_000),
         )?;
         assert!(matches!(
             database
@@ -793,7 +795,7 @@ async fn terminal_projection_is_fenced_replayable_and_secret_safe() -> TestResul
                     LogicalInstanceResultSelectionId::from_uuid(Uuid::from_u128(30_700))?,
                     LogicalInstanceResultWorkerId::from_uuid(Uuid::from_u128(30_701))?,
                     UnixMillis::new(cleanup_observed_at),
-                    UnixMillis::new(cleanup_observed_at + 1_000),
+                    UnixMillis::new(cleanup_observed_at + 5_000),
                 )?)
                 .await?,
             LogicalInstanceResultClaimNextOutcome::Idle

--- a/crates/automata-ci-store/tests/postgres_logical_job_result.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_job_result.rs
@@ -814,7 +814,9 @@ async fn logical_result_is_ordered_fenced_replayable_and_terminal() -> TestResul
             LogicalJobResultSelectionId::from_uuid(Uuid::from_u128(90_690))?,
             LogicalJobResultWorkerId::from_uuid(Uuid::from_u128(90_691))?,
             UnixMillis::new(short_idle_observed_at),
-            UnixMillis::new(short_idle_observed_at + 100),
+            // The reserving transactions must finish before the later wait
+            // proves expiry and bounded cleanup under hosted database load.
+            UnixMillis::new(short_idle_observed_at + 5_000),
         )?;
         assert!(matches!(
             database
@@ -836,7 +838,7 @@ async fn logical_result_is_ordered_fenced_replayable_and_terminal() -> TestResul
                     LogicalJobResultSelectionId::from_uuid(Uuid::from_u128(90_700))?,
                     LogicalJobResultWorkerId::from_uuid(Uuid::from_u128(90_701))?,
                     UnixMillis::new(cleanup_observed_at),
-                    UnixMillis::new(cleanup_observed_at + 1_000),
+                    UnixMillis::new(cleanup_observed_at + 5_000),
                 )?)
                 .await?,
             LogicalJobResultClaimNextOutcome::Idle


### PR DESCRIPTION
Follow-up to #20. The original main run also exposed a 100ms logical-job Idle receipt expiry; this patch widens that exact fixture and its cloned logical-instance/cleanup hazards, plus the missing-create retry proof, to 5 seconds. Production expiry and database-time logic are unchanged.\n\nLocal PostgreSQL 18.4 evidence after rebasing on #20: affected targets 21/21, exact Store shards 2 and 3 green, repeated exact cases 5/5, strict target Clippy, rustfmt, and diff checks green.