### PR TITLE
Fix Podman runtime sysctl ownership verification

### DIFF
--- a/crates/automata-ci-credential-github/src/adapter.rs
+++ b/crates/automata-ci-credential-github/src/adapter.rs
@@ -47,6 +47,8 @@ const MAX_TOKEN_LIFETIME_SECONDS: u64 = 3_600;
 const MAX_PROVIDER_CLOCK_SKEW_SECONDS: u64 = 60;
 const MAX_REPOSITORY_COMPONENT_BYTES: usize = 100;
 const BROKER_POLICY_FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/github-app-broker-policy/v2\0";
+const COMPATIBLE_BROKER_POLICY_FINGERPRINT_DOMAIN_V1: &[u8] =
+    b"automata-ci/github-app-broker-policy/v1\0";
 
 struct ValidatedResponseMetadata {
     provider_expires_at: UnixTimestamp,
@@ -141,8 +143,35 @@ impl GithubAppCredentialBroker {
     /// validation and constructs a fractional-millisecond timeout.
     #[must_use]
     pub fn broker_policy_fingerprint(&self) -> automata_ci_store::Sha256Digest {
+        self.broker_policy_fingerprint_for_domain(BROKER_POLICY_FINGERPRINT_DOMAIN)
+    }
+
+    /// Returns explicitly supported predecessor fingerprints for immutable
+    /// historical server-service authorities.
+    ///
+    /// Version 1 differs only in rejecting GitHub's unavoidable implicit
+    /// `metadata:read` permission in an otherwise exact token response. The
+    /// current broker preserves the same request permissions, origin, API
+    /// version, resource limits, timeouts, transport mode, issuer, and key.
+    /// Product routing may therefore recognize this one predecessor while
+    /// continuing to reject every unknown policy fingerprint.
+    #[must_use]
+    pub fn compatible_historical_broker_policy_fingerprints(
+        &self,
+    ) -> [automata_ci_store::Sha256Digest; 1] {
+        [
+            self.broker_policy_fingerprint_for_domain(
+                COMPATIBLE_BROKER_POLICY_FINGERPRINT_DOMAIN_V1,
+            ),
+        ]
+    }
+
+    fn broker_policy_fingerprint_for_domain(
+        &self,
+        domain: &[u8],
+    ) -> automata_ci_store::Sha256Digest {
         let mut digest = Sha256::new();
-        digest.update(BROKER_POLICY_FINGERPRINT_DOMAIN);
+        digest.update(domain);
         update_fingerprint_part(&mut digest, self.config.api_base.as_str().as_bytes());
         update_fingerprint_part(&mut digest, GITHUB_API_VERSION.as_bytes());
         update_fingerprint_part(&mut digest, self.config.user_agent.as_bytes());

--- a/crates/automata-ci-credential-github/src/adapter.rs
+++ b/crates/automata-ci-credential-github/src/adapter.rs
@@ -46,7 +46,7 @@ const MAX_REQUEST_BODY_BYTES: usize = 16 * 1_024;
 const MAX_TOKEN_LIFETIME_SECONDS: u64 = 3_600;
 const MAX_PROVIDER_CLOCK_SKEW_SECONDS: u64 = 60;
 const MAX_REPOSITORY_COMPONENT_BYTES: usize = 100;
-const BROKER_POLICY_FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/github-app-broker-policy/v1\0";
+const BROKER_POLICY_FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/github-app-broker-policy/v2\0";
 
 struct ValidatedResponseMetadata {
     provider_expires_at: UnixTimestamp,

--- a/crates/automata-ci-credential-github/src/adapter.rs
+++ b/crates/automata-ci-credential-github/src/adapter.rs
@@ -5,8 +5,8 @@ use automata_ci_auth::{
     time::{Clock, SystemClock, UnixTimestamp},
 };
 use automata_ci_credential::{
-    CredentialError, CredentialErrorKind, CredentialProvenance, PermissionSet, ProviderResourceId,
-    RepositoryCredentialRequest,
+    CredentialError, CredentialErrorKind, CredentialProvenance, PermissionLevel, PermissionSet,
+    ProviderResourceId, RepositoryCredentialRequest,
 };
 use automata_ci_scm::ScmProviderId;
 use reqwest::{
@@ -428,7 +428,7 @@ impl GithubAppCredentialBroker {
             )));
         }
         let returned_permissions = response.permissions.into_inner();
-        if &returned_permissions != request.permissions() {
+        if !permissions_match_github_response(request.permissions(), &returned_permissions) {
             return Err(failure(CredentialError::new(
                 CredentialErrorKind::PermissionMismatch,
             )));
@@ -530,6 +530,24 @@ impl GithubAppCredentialBroker {
         }
         Ok(endpoint)
     }
+}
+
+fn permissions_match_github_response(requested: &PermissionSet, returned: &PermissionSet) -> bool {
+    if returned == requested {
+        return true;
+    }
+    if returned.len() != requested.len().saturating_add(1) {
+        return false;
+    }
+
+    returned.iter().all(|(returned_name, returned_level)| {
+        if returned_name.as_str() == "metadata" {
+            return returned_level == PermissionLevel::Read;
+        }
+        requested.iter().any(|(requested_name, requested_level)| {
+            requested_name == returned_name && requested_level == returned_level
+        })
+    })
 }
 
 fn update_fingerprint_part(digest: &mut Sha256, value: &[u8]) {

--- a/crates/automata-ci-credential-github/tests/app_key_fingerprint.rs
+++ b/crates/automata-ci-credential-github/tests/app_key_fingerprint.rs
@@ -8,6 +8,10 @@ use support::{INSTALLATION_ID, ISSUER, pkcs8_private_key, private_key};
 
 const EXPECTED_SPKI_SHA256: &str =
     "efeda9bfead9fd0594f6a5cf6fdf6c163116a3b1fad6d73cea05295b68fd1794";
+const EXPECTED_BROKER_POLICY_V2_SHA256: &str =
+    "ce7b0f55188ada8d003efc3765e87c1bf0860501437ed5a6b3ded9e08b3e6612";
+const EXPECTED_COMPATIBLE_BROKER_POLICY_V1_SHA256: &str =
+    "79035a0f4a3a0d97d3843099ae48f5ec5c85fb2a10b00fa3849660bdbc642f0d";
 
 #[test]
 fn pkcs1_and_pkcs8_derive_the_same_exact_spki_fingerprint() {
@@ -24,6 +28,22 @@ fn pkcs1_and_pkcs8_derive_the_same_exact_spki_fingerprint() {
     assert_eq!(
         pkcs1.broker_policy_fingerprint(),
         pkcs8.broker_policy_fingerprint()
+    );
+    assert_eq!(
+        pkcs1.compatible_historical_broker_policy_fingerprints(),
+        pkcs8.compatible_historical_broker_policy_fingerprints()
+    );
+    assert_ne!(
+        pkcs1.broker_policy_fingerprint(),
+        pkcs1.compatible_historical_broker_policy_fingerprints()[0]
+    );
+    assert_eq!(
+        pkcs1.broker_policy_fingerprint().to_string(),
+        EXPECTED_BROKER_POLICY_V2_SHA256
+    );
+    assert_eq!(
+        pkcs1.compatible_historical_broker_policy_fingerprints()[0].to_string(),
+        EXPECTED_COMPATIBLE_BROKER_POLICY_V1_SHA256
     );
     assert_eq!(
         pkcs1.app_key_spki_sha256().to_string(),

--- a/crates/automata-ci-credential-github/tests/issuance.rs
+++ b/crates/automata-ci-credential-github/tests/issuance.rs
@@ -170,6 +170,54 @@ async fn permission_drift_and_duplicate_keys_are_rejected() {
 }
 
 #[tokio::test]
+async fn accepts_only_github_implicit_metadata_read_permission() {
+    let fixture = FixtureServer::spawn().await;
+    fixture.enqueue(support::token_response(
+        "ghs_implicit_metadata",
+        EXPIRATION,
+        r#"{"contents":"read","metadata":"read","statuses":"write"}"#,
+        REPOSITORY_ID,
+        "automata-ci/automata",
+        "selected",
+    ));
+    for permissions in [
+        r#"{"contents":"read","metadata":"write","statuses":"write"}"#,
+        r#"{"contents":"read","issues":"read","metadata":"read","statuses":"write"}"#,
+    ] {
+        fixture.enqueue(support::token_response(
+            "ghs_excess_permission",
+            EXPIRATION,
+            permissions,
+            REPOSITORY_ID,
+            "automata-ci/automata",
+            "selected",
+        ));
+    }
+
+    let broker = fixture.broker();
+    let accepted = broker.mint_once(&request()).await;
+    let GithubInstallationTokenMintOutcome::Ready(accepted) = accepted else {
+        panic!("expected GitHub implicit metadata permission to be accepted: {accepted:?}");
+    };
+    assert_eq!(accepted.secret().expose_secret(), "ghs_implicit_metadata");
+
+    for _ in 0..2 {
+        let rejected = broker.mint_once(&request()).await;
+        let GithubInstallationTokenMintOutcome::RevokePending(rejected) = rejected else {
+            panic!("expected excess permission to require revocation: {rejected:?}");
+        };
+        assert_eq!(
+            rejected.reason().kind(),
+            CredentialErrorKind::PermissionMismatch
+        );
+        assert_eq!(
+            rejected.candidate().secret().expose_secret(),
+            "ghs_excess_permission"
+        );
+    }
+}
+
+#[tokio::test]
 async fn expiration_and_token_format_fail_closed() {
     let fixture = FixtureServer::spawn().await;
     fixture.enqueue(support::token_response(

--- a/crates/automata-ci-github/src/checks.rs
+++ b/crates/automata-ci-github/src/checks.rs
@@ -20,6 +20,7 @@ use crate::{
 const ACCEPT_API_JSON: &str = "application/vnd.github+json";
 const MAX_CHECK_NAME_BYTES: usize = 255;
 const MAX_EXTERNAL_ID_BYTES: usize = 1_024;
+const CHECK_SUITES_PER_PAGE: usize = 100;
 const CHECK_RUNS_PER_PAGE: usize = 100;
 const MAX_GITHUB_ID: u64 = i64::MAX as u64;
 const MAX_RETRY_AFTER_SECONDS: u64 = 86_400;
@@ -517,6 +518,12 @@ struct SuiteResponse {
     app: AppResponse,
 }
 
+#[derive(Deserialize)]
+struct CheckSuitesPage {
+    total_count: u64,
+    check_suites: Vec<SuiteResponse>,
+}
+
 #[derive(Serialize)]
 struct CreateRunBody<'a> {
     name: &'a str,
@@ -650,7 +657,55 @@ impl GithubHttpEndpoint {
                 GithubCheckSuiteCreateOutcome::Created(suite)
             });
         }
+        if status == StatusCode::UNPROCESSABLE_ENTITY
+            && let Some(suite) = self
+                .resolve_existing_check_suite(repository, head_sha, app_id, server_service_token)
+                .await?
+        {
+            return Ok(GithubCheckSuiteCreateOutcome::Existing(suite));
+        }
         classify_create_failure(&response).map(GithubCheckSuiteCreateOutcome::Indeterminate)
+    }
+
+    async fn resolve_existing_check_suite(
+        &self,
+        repository: &RepositoryId,
+        head_sha: &ExactRevision,
+        app_id: GithubCheckAppId,
+        server_service_token: &SecretString,
+    ) -> Result<Option<GithubCheckSuite>, GithubChecksError> {
+        let app_id_query = app_id.get().to_string();
+        let mut endpoint = self
+            .checks_repository_url(repository, &["commits", head_sha.as_str(), "check-suites"])?;
+        endpoint
+            .query_pairs_mut()
+            .append_pair("app_id", &app_id_query)
+            .append_pair("per_page", &CHECK_SUITES_PER_PAGE.to_string())
+            .append_pair("page", "1");
+        let response =
+            authenticated_checks_request(self.client.get(endpoint), server_service_token)?
+                .send()
+                .await
+                .map_err(|_| GithubChecksError::Unavailable(GithubCheckRetryEvidence::default()))?;
+        if response.status() != StatusCode::OK {
+            return Err(map_error_response(&response));
+        }
+        let response =
+            read_json_response(response, self.trusted.limits().max_response_bytes, false)
+                .await
+                .map_err(map_endpoint_error)?;
+        let page: CheckSuitesPage = decode_json(&response.body).map_err(map_endpoint_error)?;
+        if page.check_suites.len() > 1
+            || page.check_suites.len() > CHECK_SUITES_PER_PAGE
+            || u64::try_from(page.check_suites.len()).ok() != Some(page.total_count)
+        {
+            return Err(GithubChecksError::InvalidResponse);
+        }
+        page.check_suites
+            .into_iter()
+            .next()
+            .map(|suite| validate_suite(suite, head_sha, app_id))
+            .transpose()
     }
 
     /// Creates one queued Check Run with no output, annotations, actions, or images.
@@ -966,20 +1021,7 @@ impl GithubHttpEndpoint {
                 .await
                 .map_err(map_endpoint_error)?;
         let wire: SuiteResponse = decode_json(&response.body).map_err(map_endpoint_error)?;
-        let id =
-            GithubCheckSuiteId::new(wire.id).map_err(|_| GithubChecksError::InvalidResponse)?;
-        let app_id =
-            GithubCheckAppId::new(wire.app.id).map_err(|_| GithubChecksError::InvalidResponse)?;
-        let head_sha =
-            ExactRevision::new(wire.head_sha).map_err(|_| GithubChecksError::InvalidResponse)?;
-        if app_id != expected_app || &head_sha != expected_sha {
-            return Err(GithubChecksError::InvalidResponse);
-        }
-        Ok(GithubCheckSuite {
-            id,
-            app_id,
-            head_sha,
-        })
+        validate_suite(wire, expected_sha, expected_app)
     }
 
     async fn decode_run_response(
@@ -993,6 +1035,26 @@ impl GithubHttpEndpoint {
         let wire: RunResponse = decode_json(&response.body).map_err(map_endpoint_error)?;
         validate_run(wire)
     }
+}
+
+fn validate_suite(
+    wire: SuiteResponse,
+    expected_sha: &ExactRevision,
+    expected_app: GithubCheckAppId,
+) -> Result<GithubCheckSuite, GithubChecksError> {
+    let id = GithubCheckSuiteId::new(wire.id).map_err(|_| GithubChecksError::InvalidResponse)?;
+    let app_id =
+        GithubCheckAppId::new(wire.app.id).map_err(|_| GithubChecksError::InvalidResponse)?;
+    let head_sha =
+        ExactRevision::new(wire.head_sha).map_err(|_| GithubChecksError::InvalidResponse)?;
+    if app_id != expected_app || &head_sha != expected_sha {
+        return Err(GithubChecksError::InvalidResponse);
+    }
+    Ok(GithubCheckSuite {
+        id,
+        app_id,
+        head_sha,
+    })
 }
 
 fn validate_run(wire: RunResponse) -> Result<ValidatedRun, GithubChecksError> {

--- a/crates/automata-ci-github/tests/checks.rs
+++ b/crates/automata-ci-github/tests/checks.rs
@@ -153,6 +153,77 @@ async fn check_suite_creation_preserves_the_exact_200_and_201_distinction() {
 }
 
 #[tokio::test]
+async fn check_suite_creation_resolves_the_exact_auto_created_suite_after_422() {
+    let server = FixtureServer::spawn().await;
+    server.enqueue(ResponseSpec::status(
+        axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+    ));
+    server.enqueue(ResponseSpec::json(
+        axum::http::StatusCode::OK,
+        json!({
+            "total_count": 1,
+            "check_suites": [
+                {"id": 23, "head_sha": SHA, "app": {"id": 17}}
+            ]
+        })
+        .to_string(),
+    ));
+    let endpoint = server.endpoint();
+    let app = GithubCheckAppId::new(17).expect("app id");
+
+    let outcome = endpoint
+        .create_check_suite(&repository(), &revision(), app, &token())
+        .await
+        .expect("existing suite must reconcile");
+    let GithubCheckSuiteCreateOutcome::Existing(suite) = outcome else {
+        panic!("expected an existing suite");
+    };
+    assert_eq!(suite.id().get(), 23);
+    assert_eq!(suite.app_id(), app);
+    assert_eq!(suite.head_sha(), &revision());
+
+    let requests = server.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(requests[0].uri, "/api/repos/acme/widget/check-suites");
+    assert_eq!(requests[1].method, "GET");
+    assert_eq!(
+        requests[1].uri,
+        concat!(
+            "/api/repos/acme/widget/commits/",
+            "0123456789abcdef0123456789abcdef01234567",
+            "/check-suites?app_id=17&per_page=100&page=1"
+        )
+    );
+    assert!(requests[1].body.is_empty());
+}
+
+#[tokio::test]
+async fn check_suite_creation_does_not_hide_a_rejected_request_without_an_exact_suite() {
+    let server = FixtureServer::spawn().await;
+    server.enqueue(ResponseSpec::status(
+        axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+    ));
+    server.enqueue(ResponseSpec::json(
+        axum::http::StatusCode::OK,
+        json!({"total_count": 0, "check_suites": []}).to_string(),
+    ));
+
+    let error = server
+        .endpoint()
+        .create_check_suite(
+            &repository(),
+            &revision(),
+            GithubCheckAppId::new(17).expect("app id"),
+            &token(),
+        )
+        .await
+        .expect_err("an unrelated rejected request must stay rejected");
+    assert_eq!(error, GithubChecksError::Rejected);
+    assert_eq!(server.requests().len(), 2);
+}
+
+#[tokio::test]
 async fn check_run_creation_sends_only_bounded_identity_and_accepts_exact_201() {
     let server = FixtureServer::spawn().await;
     server.enqueue(ResponseSpec::json(

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -56,8 +56,7 @@ const SERVICE_PROXY_CONFIG_FORMAT: &str =
 const CONTAINER_POD_FORMAT: &str = "{{.Pod}}";
 const POD_INFRA_CONTAINER_FORMAT: &str = "{{.InfraContainerID}}";
 const JOB_NETWORK_SYSCTL: &str = "net.ipv4.ip_unprivileged_port_start=0";
-const JOB_NETWORK_SYSCTL_FORMAT: &str =
-    "{{ index .HostConfig.Sysctls \"net.ipv4.ip_unprivileged_port_start\" }}";
+const CREATE_COMMAND_FORMAT: &str = "{{json .CreateCommand}}";
 const ENDPOINT_CAPABILITIES: [SandboxCapability; 6] = [
     SandboxCapability::Exec,
     SandboxCapability::Signal,
@@ -1137,12 +1136,22 @@ impl PodmanInner {
             stage,
             None,
         )?;
-        let expected = format!("{}\nunpublished\nalias\n0", entry.image());
         let actual = std::str::from_utf8(output.stdout())
             .ok()
             .map(str::trim_end)
             .ok_or_else(|| provider_error::invalid_state(stage))?;
-        if actual != expected {
+        let mut lines = actual.split('\n');
+        let image = lines.next();
+        let publication = lines.next();
+        let alias = lines.next();
+        let create_command = lines.next();
+        if lines.next().is_some()
+            || image != Some(entry.image())
+            || publication != Some("unpublished")
+            || alias != Some("alias")
+            || create_command
+                .is_none_or(|value| !creation_command_has_exact_network_sysctl(value.as_bytes()))
+        {
             return Err(provider_error::ownership_mismatch(
                 ProviderStage::VerifyOwnership,
             ));
@@ -2518,9 +2527,9 @@ impl PodmanInner {
     ) -> Result<(), ProviderError> {
         let infra_identifier = self.pod_infra_identifier(names, deadline, cancellation)?;
         let mut arguments = self.base_arguments();
-        arguments.extend(os_args(["container", "inspect", "--format"]));
-        arguments.push(JOB_NETWORK_SYSCTL_FORMAT.into());
-        arguments.push(infra_identifier.clone().into());
+        arguments.extend(os_args(["pod", "inspect", "--format"]));
+        arguments.push(CREATE_COMMAND_FORMAT.into());
+        arguments.push(names.pod().into());
         let output = Self::require_success(
             self.run(
                 arguments,
@@ -2531,7 +2540,7 @@ impl PodmanInner {
             ProviderStage::VerifyOwnership,
             None,
         )?;
-        if output.stdout() != b"0\n" && output.stdout() != b"0" {
+        if !creation_command_has_exact_network_sysctl(output.stdout()) {
             return Err(provider_error::ownership_mismatch(
                 ProviderStage::VerifyOwnership,
             ));
@@ -3607,6 +3616,22 @@ mod command_completion_tests {
             PodmanCommandOutcome::InputIncomplete
         );
     }
+
+    #[test]
+    fn persisted_creation_command_requires_one_exact_network_sysctl() {
+        let exact = br#"["/usr/bin/podman","pod","create","--sysctl","net.ipv4.ip_unprivileged_port_start=0"]"#;
+        assert!(creation_command_has_exact_network_sysctl(exact));
+
+        for rejected in [
+            br#"["/usr/bin/podman","pod","create"]"#.as_slice(),
+            br#"["/usr/bin/podman","pod","create","--sysctl","net.ipv4.ip_unprivileged_port_start=1024"]"#.as_slice(),
+            br#"["/usr/bin/podman","pod","create","--sysctl=net.ipv4.ip_unprivileged_port_start=0"]"#.as_slice(),
+            br#"["/usr/bin/podman","pod","create","--sysctl","net.ipv4.ip_unprivileged_port_start=0","--sysctl","net.ipv4.ip_unprivileged_port_start=0"]"#.as_slice(),
+            b"not-json".as_slice(),
+        ] {
+            assert!(!creation_command_has_exact_network_sysctl(rejected));
+        }
+    }
 }
 
 fn finish_create(
@@ -4199,8 +4224,36 @@ fn service_configuration_format(network: &str, alias: &str) -> String {
          {{{{with index .NetworkSettings.Networks \"{network}\"}}}}\
          {{{{range .Aliases}}}}{{{{if eq . \"{alias}\"}}}}alias{{{{end}}}}{{{{end}}}}\
          {{{{else}}}}missing{{{{end}}}}\n\
-         {JOB_NETWORK_SYSCTL_FORMAT}"
+         {CREATE_COMMAND_FORMAT}"
     )
+}
+
+fn creation_command_has_exact_network_sysctl(bytes: &[u8]) -> bool {
+    let Ok(value) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let value = value.strip_suffix('\n').unwrap_or(value);
+    let Ok(arguments) = serde_json::from_str::<Vec<String>>(value) else {
+        return false;
+    };
+    let mut found = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let argument = &arguments[index];
+        if argument == "--sysctl" {
+            if found || arguments.get(index + 1).map(String::as_str) != Some(JOB_NETWORK_SYSCTL) {
+                return false;
+            }
+            found = true;
+            index += 2;
+            continue;
+        }
+        if argument.starts_with("--sysctl=") {
+            return false;
+        }
+        index += 1;
+    }
+    found
 }
 
 fn parse_service_inspection(bytes: &[u8]) -> Option<InspectedServiceContainer> {

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -639,19 +639,44 @@ fn execute_fake_inspection(state: &FakeState, command: &[String]) -> Option<Comm
             Some(container_resource(state, name).map_or_else(
                 || CommandOutput::failure(1, Vec::new()),
                 |resource| {
+                    let create_command = serde_json::to_string(&[
+                        "/usr/bin/podman",
+                        "create",
+                        "--sysctl",
+                        "net.ipv4.ip_unprivileged_port_start=0",
+                    ])
+                    .expect("fake create-command JSON");
                     CommandOutput::success(
                         format!(
-                            "{}\nunpublished\n{}\n",
+                            "{}\nunpublished\n{}\n{create_command}\n",
                             resource.image_name,
                             if resource.network_address.is_some() {
-                                "alias\n0"
+                                "alias"
                             } else {
-                                "missing\n0"
+                                "missing"
                             }
                         )
                         .into_bytes(),
                     )
                 },
+            ))
+        }
+        [pod, inspect, format, template, name]
+            if pod == "pod"
+                && inspect == "inspect"
+                && format == "--format"
+                && template == "{{json .CreateCommand}}"
+                && resource(state, "pod", name).is_some() =>
+        {
+            Some(CommandOutput::success(
+                serde_json::to_vec(&[
+                    "/usr/bin/podman",
+                    "pod",
+                    "create",
+                    "--sysctl",
+                    "net.ipv4.ip_unprivileged_port_start=0",
+                ])
+                .expect("fake pod create-command JSON"),
             ))
         }
         [pod, inspect, format, template, name]

--- a/crates/automata-ci-store/migrations/0052_github_service_policy_rotation.sql
+++ b/crates/automata-ci-store/migrations/0052_github_service_policy_rotation.sql
@@ -1,0 +1,154 @@
+-- Permit a repository policy revision to advance solely to rotate its
+-- manifest-pinned server-service authorities.  The revision remains strictly
+-- contiguous and every other independent evidence revision remains exact.
+CREATE OR REPLACE FUNCTION automata_github_provider_manifest_current_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $automata$
+DECLARE
+    prior github_provider_manifest_revisions%ROWTYPE;
+    replacement github_provider_manifest_revisions%ROWTYPE;
+    app_evidence_changed BOOLEAN;
+    verifier_evidence_changed BOOLEAN;
+    policy_evidence_changed BOOLEAN;
+    runtime_policy_changed BOOLEAN;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'GitHub provider manifest current pointers cannot be removed'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_provider_manifest_current_removal_forbidden';
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        SELECT * INTO STRICT replacement
+        FROM github_provider_manifest_revisions
+        WHERE tenant_id = NEW.tenant_id
+          AND repository_id = NEW.repository_id
+          AND provider_connection_id = NEW.provider_connection_id
+          AND manifest_revision = NEW.manifest_revision
+          AND manifest_digest = NEW.manifest_digest;
+        IF NEW.manifest_revision <> 1 THEN
+            RAISE EXCEPTION 'initial GitHub provider manifest revision must be one'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'github_provider_manifest_current_initial_revision';
+        ELSIF NEW.activated_at_ms <> replacement.registered_at_ms THEN
+            RAISE EXCEPTION 'GitHub provider manifest activation must equal registration'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'github_provider_manifest_current_time';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+        OR NEW.repository_id IS DISTINCT FROM OLD.repository_id
+        OR NEW.provider_connection_id IS DISTINCT FROM OLD.provider_connection_id
+        OR OLD.manifest_revision = 9223372036854775807
+        OR NEW.manifest_revision <> OLD.manifest_revision + 1
+        OR NEW.manifest_digest IS NOT DISTINCT FROM OLD.manifest_digest
+        OR NEW.activated_at_ms < OLD.activated_at_ms
+    THEN
+        RAISE EXCEPTION 'GitHub provider manifest current transition is invalid'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_provider_manifest_current_transition';
+    END IF;
+
+    SELECT * INTO STRICT prior
+    FROM github_provider_manifest_revisions
+    WHERE tenant_id = OLD.tenant_id
+      AND repository_id = OLD.repository_id
+      AND provider_connection_id = OLD.provider_connection_id
+      AND manifest_revision = OLD.manifest_revision
+      AND manifest_digest = OLD.manifest_digest;
+    SELECT * INTO STRICT replacement
+    FROM github_provider_manifest_revisions
+    WHERE tenant_id = NEW.tenant_id
+      AND repository_id = NEW.repository_id
+      AND provider_connection_id = NEW.provider_connection_id
+      AND manifest_revision = NEW.manifest_revision
+      AND manifest_digest = NEW.manifest_digest;
+
+    IF NEW.activated_at_ms <> replacement.registered_at_ms THEN
+        RAISE EXCEPTION 'GitHub provider manifest activation must equal registration'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_provider_manifest_current_time';
+    END IF;
+    IF replacement.repository_id IS DISTINCT FROM prior.repository_id
+        OR replacement.provider_installation_id IS DISTINCT FROM prior.provider_installation_id
+        OR replacement.github_repository_id IS DISTINCT FROM prior.github_repository_id
+        OR replacement.github_repository_name IS DISTINCT FROM prior.github_repository_name
+        OR replacement.github_app_id IS DISTINCT FROM prior.github_app_id
+        OR replacement.github_app_client_id IS DISTINCT FROM prior.github_app_client_id
+        OR replacement.github_app_jwt_issuer_kind IS DISTINCT FROM prior.github_app_jwt_issuer_kind
+        OR replacement.github_web_origin IS DISTINCT FROM prior.github_web_origin
+        OR replacement.github_api_origin IS DISTINCT FROM prior.github_api_origin
+        OR replacement.github_archive_origin IS DISTINCT FROM prior.github_archive_origin
+    THEN
+        RAISE EXCEPTION 'GitHub provider manifest connection identity changed'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_provider_manifest_connection_immutable';
+    END IF;
+
+    app_evidence_changed = replacement.app_key_spki_sha256
+        IS DISTINCT FROM prior.app_key_spki_sha256;
+    verifier_evidence_changed = replacement.webhook_verifier_fingerprint_sha256
+        IS DISTINCT FROM prior.webhook_verifier_fingerprint_sha256;
+    runtime_policy_changed = replacement.runtime_policy_digest
+        IS DISTINCT FROM prior.runtime_policy_digest;
+    policy_evidence_changed =
+        replacement.policy_revision IS DISTINCT FROM prior.policy_revision
+        OR replacement.repository_visibility IS DISTINCT FROM prior.repository_visibility
+        OR replacement.authority_profile IS DISTINCT FROM prior.authority_profile
+        OR replacement.runner_policy_digest IS DISTINCT FROM prior.runner_policy_digest
+        OR replacement.runner_policy_object_key IS DISTINCT FROM prior.runner_policy_object_key
+        OR replacement.runner_policy_size_bytes IS DISTINCT FROM prior.runner_policy_size_bytes
+        OR replacement.runner_policy_media_type IS DISTINCT FROM prior.runner_policy_media_type
+        OR runtime_policy_changed
+        OR replacement.workflow_path IS DISTINCT FROM prior.workflow_path
+        OR replacement.event_name IS DISTINCT FROM prior.event_name
+        OR replacement.git_ref IS DISTINCT FROM prior.git_ref
+        OR replacement.check_subject_key IS DISTINCT FROM prior.check_subject_key
+        OR replacement.check_name IS DISTINCT FROM prior.check_name
+        OR replacement.github_rest_api_version IS DISTINCT FROM prior.github_rest_api_version
+        OR replacement.github_rest_accept IS DISTINCT FROM prior.github_rest_accept
+        OR replacement.github_archive_accept IS DISTINCT FROM prior.github_archive_accept
+        OR replacement.repository_source_authentication IS DISTINCT FROM prior.repository_source_authentication
+        OR replacement.repository_source_revision IS DISTINCT FROM prior.repository_source_revision
+        OR replacement.repository_archive_format IS DISTINCT FROM prior.repository_archive_format
+        OR replacement.webhook_max_body_bytes IS DISTINCT FROM prior.webhook_max_body_bytes
+        OR replacement.webhook_accept_timeout_ms IS DISTINCT FROM prior.webhook_accept_timeout_ms
+        OR replacement.push_webhook_max_commits IS DISTINCT FROM prior.push_webhook_max_commits
+        OR replacement.path_filter_max_commits IS DISTINCT FROM prior.path_filter_max_commits
+        OR replacement.path_filter_max_changed_files IS DISTINCT FROM prior.path_filter_max_changed_files
+        OR replacement.archive_max_compressed_bytes IS DISTINCT FROM prior.archive_max_compressed_bytes
+        OR replacement.archive_max_decompressed_bytes IS DISTINCT FROM prior.archive_max_decompressed_bytes
+        OR replacement.archive_max_entries IS DISTINCT FROM prior.archive_max_entries
+        OR replacement.archive_max_expanded_bytes IS DISTINCT FROM prior.archive_max_expanded_bytes
+        OR replacement.archive_max_entry_path_bytes IS DISTINCT FROM prior.archive_max_entry_path_bytes
+        OR replacement.archive_max_workflows IS DISTINCT FROM prior.archive_max_workflows
+        OR replacement.workflow_max_bytes IS DISTINCT FROM prior.workflow_max_bytes;
+
+    IF NOT (app_evidence_changed OR verifier_evidence_changed OR policy_evidence_changed)
+        OR (CASE WHEN app_evidence_changed THEN
+            prior.app_configuration_revision = 9223372036854775807
+            OR replacement.app_configuration_revision <> prior.app_configuration_revision + 1
+          ELSE replacement.app_configuration_revision <> prior.app_configuration_revision END)
+        OR (CASE WHEN verifier_evidence_changed THEN
+            prior.webhook_verifier_revision = 9223372036854775807
+            OR replacement.webhook_verifier_revision <> prior.webhook_verifier_revision + 1
+          ELSE replacement.webhook_verifier_revision <> prior.webhook_verifier_revision END)
+        OR (CASE WHEN policy_evidence_changed THEN
+            prior.policy_revision = 9223372036854775807
+            OR replacement.policy_revision <> prior.policy_revision + 1
+          ELSE replacement.policy_revision <> prior.policy_revision END)
+        OR (CASE WHEN runtime_policy_changed THEN
+            prior.runtime_policy_revision = 9223372036854775807
+            OR replacement.runtime_policy_revision <> prior.runtime_policy_revision + 1
+          ELSE replacement.runtime_policy_revision <> prior.runtime_policy_revision END)
+    THEN
+        RAISE EXCEPTION 'GitHub provider manifest policy revision did not advance'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_provider_manifest_revision_transition';
+    END IF;
+    RETURN NEW;
+END;
+$automata$;

--- a/crates/automata-ci-store/src/github_provider_manifest.rs
+++ b/crates/automata-ci-store/src/github_provider_manifest.rs
@@ -700,7 +700,13 @@ impl GithubProviderManifest {
         let app_evidence_changed = self.app_key_spki_sha256 != prior.app_key_spki_sha256;
         let verifier_evidence_changed =
             self.webhook_verifier_fingerprint != prior.webhook_verifier_fingerprint;
-        let policy_evidence_changed = self.repository_visibility != prior.repository_visibility
+        // The repository policy revision also versions the manifest-pinned
+        // server-service authorities.  An authority implementation policy can
+        // therefore rotate without changing another manifest field; the
+        // strictly contiguous revision is the durable evidence for that
+        // otherwise external policy transition.
+        let policy_evidence_changed = self.policy_revision != prior.policy_revision
+            || self.repository_visibility != prior.repository_visibility
             || self.check_name != prior.check_name
             || self.check_subject_key != prior.check_subject_key
             || self.authority_profile != prior.authority_profile

--- a/crates/automata-ci-store/tests/postgres_github_provider_manifest.rs
+++ b/crates/automata-ci-store/tests/postgres_github_provider_manifest.rs
@@ -277,6 +277,62 @@ async fn exact_successor_preserves_historical_revision_and_rejects_skips() -> Te
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn authority_policy_only_rotation_is_a_contiguous_manifest_successor() -> TestResult {
+    run_with_database(|database| async move {
+        let tenant = tenant("manifest-authority-policy-rotation");
+        let connection = connection(0x225);
+        let first = manifest(
+            tenant.clone(),
+            connection,
+            RevisionSet::new(1, 1, 1),
+            [7; 32],
+            "Automata CI",
+        );
+        database
+            .store()
+            .bootstrap_github_provider_repository(request(first.clone(), 100))
+            .await?;
+
+        let rotated = manifest(
+            tenant.clone(),
+            connection,
+            RevisionSet::new(2, 1, 2),
+            [7; 32],
+            "Automata CI",
+        );
+        let receipt = database
+            .store()
+            .bootstrap_github_provider_repository(request(rotated.clone(), 200))
+            .await?;
+        assert!(!receipt.manifest().is_replay());
+        assert_eq!(receipt.manifest().current().manifest(), &rotated);
+
+        let replay = database
+            .store()
+            .bootstrap_github_provider_repository(request(rotated.clone(), 300))
+            .await?;
+        assert!(replay.manifest().is_replay());
+
+        let skipped = manifest(
+            tenant,
+            connection,
+            RevisionSet::new(3, 1, 4),
+            [7; 32],
+            "Automata CI",
+        );
+        assert_drift(
+            database
+                .store()
+                .bootstrap_github_provider_repository(request(skipped, 400))
+                .await,
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn verifier_rotation_and_visibility_transitions_are_independently_revisioned() -> TestResult {
     run_with_database(|database| async move {
         let tenant = tenant("manifest-private-transition");

--- a/crates/automata-ci/src/server/github_provider.rs
+++ b/crates/automata-ci/src/server/github_provider.rs
@@ -452,7 +452,15 @@ impl fmt::Debug for GithubProviderBootstrapReady {
     }
 }
 
-/// Immutable exact-match resolver derived from the converged product registry.
+/// Immutable live-route resolver derived from the converged product registry.
+///
+/// Current identities resolve exactly. Historical revisions remain authorized
+/// only while every provider-facing and repository-facing route field still
+/// matches one current configured authority. Authority IDs and revision fields
+/// are deliberately excluded from that route comparison: they identify the
+/// immutable historical descriptor, while the retained route proves that the
+/// same live App installation, key, issuer, repository, and least-authority
+/// scope are still configured.
 #[derive(Clone)]
 pub struct GithubProviderCredentialRequestResolver {
     authorities:
@@ -460,7 +468,7 @@ pub struct GithubProviderCredentialRequestResolver {
 }
 
 impl GithubProviderCredentialRequestResolver {
-    fn new(
+    pub(super) fn new(
         authorities: &[GithubServerServiceAuthorityIdentity],
     ) -> Result<Self, GithubProviderBootstrapError> {
         let mut by_id = BTreeMap::new();
@@ -508,18 +516,40 @@ impl GithubServerServiceCredentialRequestResolver for GithubProviderCredentialRe
         Option<ResolvedGithubServerServiceCredentialRequest>,
         GithubServerServiceResolutionError,
     > {
-        let Some(configured) = self.authorities.get(&identity.authority_id()) else {
+        let mut routes = self
+            .authorities
+            .values()
+            .filter(|configured| authority_uses_configured_live_route(identity, configured));
+        let Some(_configured) = routes.next() else {
             return Ok(None);
         };
-        if configured != identity {
-            return Ok(None);
+        if routes.next().is_some() {
+            return Err(GithubServerServiceResolutionError::Inconsistent);
         }
-        let request = github_server_service_credential_request(configured)
+        let request = github_server_service_credential_request(identity)
             .map_err(|_| GithubServerServiceResolutionError::Inconsistent)?;
-        ResolvedGithubServerServiceCredentialRequest::new(configured.clone(), request)
+        ResolvedGithubServerServiceCredentialRequest::new(identity.clone(), request)
             .map(Some)
             .map_err(|_| GithubServerServiceResolutionError::Inconsistent)
     }
+}
+
+fn authority_uses_configured_live_route(
+    identity: &GithubServerServiceAuthorityIdentity,
+    configured: &GithubServerServiceAuthorityIdentity,
+) -> bool {
+    identity.tenant() == configured.tenant()
+        && identity.repository_id() == configured.repository_id()
+        && identity.connection_id() == configured.connection_id()
+        && identity.installation_id() == configured.installation_id()
+        && identity.github_app_id() == configured.github_app_id()
+        && identity.github_repository_id() == configured.github_repository_id()
+        && identity.github_repository_name() == configured.github_repository_name()
+        && identity.scope() == configured.scope()
+        && identity.app_client_id() == configured.app_client_id()
+        && identity.jwt_issuer() == configured.jwt_issuer()
+        && identity.app_key_spki_sha256() == configured.app_key_spki_sha256()
+        && identity.configuration_fingerprint() == configured.configuration_fingerprint()
 }
 
 /// Sanitized provider bootstrap failure.

--- a/crates/automata-ci/src/server/github_provider.rs
+++ b/crates/automata-ci/src/server/github_provider.rs
@@ -103,6 +103,7 @@ impl GithubProviderBootstrapPlan {
             broker.app_key_spki_sha256(),
             webhook_fingerprint,
             broker.broker_policy_fingerprint(),
+            &broker.compatible_historical_broker_policy_fingerprints(),
         )
     }
 
@@ -115,6 +116,7 @@ impl GithubProviderBootstrapPlan {
         app_key_spki_sha256: Sha256Digest,
         webhook_fingerprint: GithubProviderWebhookVerifierFingerprint,
         broker_policy_fingerprint: Sha256Digest,
+        compatible_historical_broker_policy_fingerprints: &[Sha256Digest],
     ) -> Result<Self, GithubProviderBootstrapError> {
         let mut manifests = Vec::with_capacity(config.repositories().len());
         let mut runner_policies = Vec::with_capacity(config.repositories().len());
@@ -244,7 +246,10 @@ impl GithubProviderBootstrapPlan {
             manifests.push(manifest);
         }
 
-        let resolver = GithubProviderCredentialRequestResolver::new(&authorities)?;
+        let resolver = GithubProviderCredentialRequestResolver::new(
+            &authorities,
+            compatible_historical_broker_policy_fingerprints,
+        )?;
         Ok(Self {
             manifests: manifests.into(),
             runner_policies: runner_policies.into(),
@@ -465,13 +470,16 @@ impl fmt::Debug for GithubProviderBootstrapReady {
 pub struct GithubProviderCredentialRequestResolver {
     authorities:
         Arc<BTreeMap<GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity>>,
+    compatible_historical_configuration_fingerprints: Arc<BTreeSet<Sha256Digest>>,
 }
 
 impl GithubProviderCredentialRequestResolver {
     pub(super) fn new(
         authorities: &[GithubServerServiceAuthorityIdentity],
+        compatible_historical_broker_policy_fingerprints: &[Sha256Digest],
     ) -> Result<Self, GithubProviderBootstrapError> {
         let mut by_id = BTreeMap::new();
+        let mut scopes = BTreeSet::new();
         for authority in authorities {
             if by_id
                 .insert(authority.authority_id(), authority.clone())
@@ -479,9 +487,22 @@ impl GithubProviderCredentialRequestResolver {
             {
                 return Err(GithubProviderBootstrapError::DuplicateSelector);
             }
+            scopes.insert(authority.scope());
         }
+        let compatible_historical_configuration_fingerprints =
+            compatible_historical_broker_policy_fingerprints
+                .iter()
+                .flat_map(|broker_fingerprint| {
+                    scopes.iter().map(move |scope| {
+                        authority_configuration_fingerprint(*broker_fingerprint, *scope)
+                    })
+                })
+                .collect();
         Ok(Self {
             authorities: Arc::new(by_id),
+            compatible_historical_configuration_fingerprints: Arc::new(
+                compatible_historical_configuration_fingerprints,
+            ),
         })
     }
 
@@ -503,6 +524,10 @@ impl fmt::Debug for GithubProviderCredentialRequestResolver {
         formatter
             .debug_struct("GithubProviderCredentialRequestResolver")
             .field("authority_count", &self.authorities.len())
+            .field(
+                "compatible_historical_configuration_fingerprint_count",
+                &self.compatible_historical_configuration_fingerprints.len(),
+            )
             .finish()
     }
 }
@@ -516,10 +541,13 @@ impl GithubServerServiceCredentialRequestResolver for GithubProviderCredentialRe
         Option<ResolvedGithubServerServiceCredentialRequest>,
         GithubServerServiceResolutionError,
     > {
-        let mut routes = self
-            .authorities
-            .values()
-            .filter(|configured| authority_uses_configured_live_route(identity, configured));
+        let mut routes = self.authorities.values().filter(|configured| {
+            authority_uses_configured_live_route(
+                identity,
+                configured,
+                &self.compatible_historical_configuration_fingerprints,
+            )
+        });
         let Some(_configured) = routes.next() else {
             return Ok(None);
         };
@@ -537,6 +565,7 @@ impl GithubServerServiceCredentialRequestResolver for GithubProviderCredentialRe
 fn authority_uses_configured_live_route(
     identity: &GithubServerServiceAuthorityIdentity,
     configured: &GithubServerServiceAuthorityIdentity,
+    compatible_historical_configuration_fingerprints: &BTreeSet<Sha256Digest>,
 ) -> bool {
     identity.tenant() == configured.tenant()
         && identity.repository_id() == configured.repository_id()
@@ -549,7 +578,9 @@ fn authority_uses_configured_live_route(
         && identity.app_client_id() == configured.app_client_id()
         && identity.jwt_issuer() == configured.jwt_issuer()
         && identity.app_key_spki_sha256() == configured.app_key_spki_sha256()
-        && identity.configuration_fingerprint() == configured.configuration_fingerprint()
+        && (identity.configuration_fingerprint() == configured.configuration_fingerprint()
+            || compatible_historical_configuration_fingerprints
+                .contains(&identity.configuration_fingerprint()))
 }
 
 /// Sanitized provider bootstrap failure.
@@ -643,7 +674,7 @@ fn authority_identity(
     .map_err(|_| GithubProviderBootstrapError::InvalidConfiguration)
 }
 
-fn authority_configuration_fingerprint(
+pub(super) fn authority_configuration_fingerprint(
     broker_policy_fingerprint: Sha256Digest,
     scope: GithubServerServiceScope,
 ) -> Sha256Digest {

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -747,15 +747,13 @@ impl GithubProviderCredentialAdapters {
         authority_repository: Arc<dyn GithubServerServiceAuthorityRepository>,
         releases: Arc<GithubProviderCredentialReleaseSupervisor>,
         authorities: &[GithubServerServiceAuthorityIdentity],
+        routes: GithubProviderCredentialRequestResolver,
     ) -> Result<Self, GithubProviderCredentialAdapterConfigurationError> {
         let handoffs = Arc::new(ExactCredentialHandoffIssuer {
             issuer,
             repository,
             releases,
         });
-        let routes = GithubProviderCredentialRequestResolver::new(authorities).map_err(|_| {
-            GithubProviderCredentialAdapterConfigurationError::InvalidAuthorityRegistry
-        })?;
         let mut adapters = Self::with_handoffs(handoffs, authorities)?;
         adapters.durable_authorities = Some(DurableGithubProviderAuthorityResolver {
             repository: Arc::new(StoreGithubProviderAuthorityLookup {
@@ -807,14 +805,11 @@ impl GithubProviderCredentialAdapters {
         handoffs: Arc<dyn GithubProviderCredentialHandoffIssuer>,
         authorities: &[GithubServerServiceAuthorityIdentity],
         repository: Arc<dyn GithubProviderAuthorityLookup>,
+        routes: GithubProviderCredentialRequestResolver,
     ) -> Result<Self, GithubProviderCredentialAdapterConfigurationError> {
         let mut adapters = Self::with_handoffs(handoffs, authorities)?;
-        adapters.durable_authorities = Some(DurableGithubProviderAuthorityResolver {
-            repository,
-            routes: GithubProviderCredentialRequestResolver::new(authorities).map_err(|_| {
-                GithubProviderCredentialAdapterConfigurationError::InvalidAuthorityRegistry
-            })?,
-        });
+        adapters.durable_authorities =
+            Some(DurableGithubProviderAuthorityResolver { repository, routes });
         Ok(adapters)
     }
 

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -15,8 +15,9 @@ use automata_ci_auth::secret::SecretString;
 use automata_ci_core::UnixMillis;
 use automata_ci_credential_github::{
     GithubServerServiceCoordinatorClock, GithubServerServiceCredentialIssuer,
-    GithubServerServiceCredentialRepository, GithubServerServiceHandoffBinding,
-    GithubServerServiceHandoffError, PendingGithubServerServiceCorruptionCleanup,
+    GithubServerServiceCredentialRepository, GithubServerServiceCredentialRequestResolver,
+    GithubServerServiceHandoffBinding, GithubServerServiceHandoffError,
+    GithubServerServiceResolutionError, PendingGithubServerServiceCorruptionCleanup,
     PendingGithubServerServiceHandoffRelease, github_server_service_credential_request,
 };
 use automata_ci_github_delivery::{
@@ -30,9 +31,10 @@ use automata_ci_github_delivery::{
 use automata_ci_store::{
     AcquireGithubServerServiceHandoff, GithubCheckSubjectIdentity, GithubServerServiceAction,
     GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
-    GithubServerServiceAuthoritySelector, GithubServerServiceConsumerClaim,
+    GithubServerServiceAuthorityRepository, GithubServerServiceAuthoritySelector,
+    GithubServerServiceAuthorityState, GithubServerServiceConsumerClaim,
     GithubServerServiceHandoffId, GithubServerServiceIssuanceKey, GithubServerServiceScope,
-    ProviderDeliveryIdentity, ProviderRepositoryOwnerId,
+    GithubServerServiceStoreError, ProviderDeliveryIdentity, ProviderRepositoryOwnerId,
 };
 use thiserror::Error;
 use tokio::{
@@ -40,6 +42,8 @@ use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore, oneshot},
 };
 use uuid::Uuid;
+
+use super::GithubProviderCredentialRequestResolver;
 
 /// Maximum live or release-pending handoffs supervised by one adapter set.
 pub const MAX_GITHUB_PROVIDER_SUPERVISED_RELEASES: usize = 4_096;
@@ -677,13 +681,61 @@ pub struct GithubProviderCredentialAdapters {
     handoffs: Arc<dyn GithubProviderCredentialHandoffIssuer>,
     authorities:
         Arc<BTreeMap<GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity>>,
+    durable_authorities: Option<DurableGithubProviderAuthorityResolver>,
+}
+
+#[derive(Clone)]
+struct DurableGithubProviderAuthorityResolver {
+    repository: Arc<dyn GithubProviderAuthorityLookup>,
+    routes: GithubProviderCredentialRequestResolver,
+}
+
+#[async_trait]
+trait GithubProviderAuthorityLookup: fmt::Debug + Send + Sync {
+    async fn inspect(
+        &self,
+        selector: &GithubServerServiceAuthoritySelector,
+    ) -> Result<
+        automata_ci_store::GithubServerServiceAuthorityDescriptor,
+        GithubServerServiceStoreError,
+    >;
+}
+
+struct StoreGithubProviderAuthorityLookup {
+    repository: Arc<dyn GithubServerServiceAuthorityRepository>,
+}
+
+#[async_trait]
+impl GithubProviderAuthorityLookup for StoreGithubProviderAuthorityLookup {
+    async fn inspect(
+        &self,
+        selector: &GithubServerServiceAuthoritySelector,
+    ) -> Result<
+        automata_ci_store::GithubServerServiceAuthorityDescriptor,
+        GithubServerServiceStoreError,
+    > {
+        self.repository
+            .inspect_github_server_service_authority(selector.tenant(), selector.authority_id())
+            .await
+    }
+}
+
+impl fmt::Debug for StoreGithubProviderAuthorityLookup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StoreGithubProviderAuthorityLookup")
+            .field("repository", &"[AUTHORITY REPOSITORY]")
+            .finish()
+    }
 }
 
 impl GithubProviderCredentialAdapters {
     /// Constructs product adapters from a bootstrap-projected exact authority set.
     ///
-    /// The repository must be the same durable 0032 implementation used by the
-    /// issuer. It is retained only inside redacted pending-release replay
+    /// Both repository ports must be views of the same durable 0032
+    /// implementation used by the issuer. The authority view revalidates exact
+    /// current and historical descriptors before any handoff attempt; the
+    /// credential view is retained inside redacted pending-release replay
     /// evidence.
     ///
     /// # Errors
@@ -692,6 +744,7 @@ impl GithubProviderCredentialAdapters {
     pub fn new(
         issuer: Arc<GithubServerServiceCredentialIssuer>,
         repository: Arc<dyn GithubServerServiceCredentialRepository>,
+        authority_repository: Arc<dyn GithubServerServiceAuthorityRepository>,
         releases: Arc<GithubProviderCredentialReleaseSupervisor>,
         authorities: &[GithubServerServiceAuthorityIdentity],
     ) -> Result<Self, GithubProviderCredentialAdapterConfigurationError> {
@@ -700,7 +753,17 @@ impl GithubProviderCredentialAdapters {
             repository,
             releases,
         });
-        Self::with_handoffs(handoffs, authorities)
+        let routes = GithubProviderCredentialRequestResolver::new(authorities).map_err(|_| {
+            GithubProviderCredentialAdapterConfigurationError::InvalidAuthorityRegistry
+        })?;
+        let mut adapters = Self::with_handoffs(handoffs, authorities)?;
+        adapters.durable_authorities = Some(DurableGithubProviderAuthorityResolver {
+            repository: Arc::new(StoreGithubProviderAuthorityLookup {
+                repository: authority_repository,
+            }),
+            routes,
+        });
+        Ok(adapters)
     }
 
     fn with_handoffs(
@@ -735,20 +798,60 @@ impl GithubProviderCredentialAdapters {
         Ok(Self {
             handoffs,
             authorities: Arc::new(exact),
+            durable_authorities: None,
         })
     }
 
-    fn authority(
+    #[cfg(test)]
+    fn with_durable_handoffs(
+        handoffs: Arc<dyn GithubProviderCredentialHandoffIssuer>,
+        authorities: &[GithubServerServiceAuthorityIdentity],
+        repository: Arc<dyn GithubProviderAuthorityLookup>,
+    ) -> Result<Self, GithubProviderCredentialAdapterConfigurationError> {
+        let mut adapters = Self::with_handoffs(handoffs, authorities)?;
+        adapters.durable_authorities = Some(DurableGithubProviderAuthorityResolver {
+            repository,
+            routes: GithubProviderCredentialRequestResolver::new(authorities).map_err(|_| {
+                GithubProviderCredentialAdapterConfigurationError::InvalidAuthorityRegistry
+            })?,
+        });
+        Ok(adapters)
+    }
+
+    async fn authority(
         &self,
         selector: &GithubServerServiceAuthoritySelector,
         scope: GithubServerServiceScope,
-    ) -> Result<&GithubServerServiceAuthorityIdentity, GithubProviderCredentialHandoffError> {
-        let identity = self
-            .authorities
-            .get(&selector.authority_id())
-            .ok_or(GithubProviderCredentialHandoffError::Rejected)?;
+    ) -> Result<GithubServerServiceAuthorityIdentity, GithubProviderCredentialHandoffError> {
+        let identity = if let Some(durable) = &self.durable_authorities {
+            let descriptor = durable
+                .repository
+                .inspect(selector)
+                .await
+                .map_err(|error| map_authority_resolution_store_error(&error))?;
+            if descriptor.state() != GithubServerServiceAuthorityState::Active
+                || GithubServerServiceAuthoritySelector::from_identity(descriptor.identity())
+                    != *selector
+            {
+                return Err(GithubProviderCredentialHandoffError::Rejected);
+            }
+            match durable
+                .routes
+                .resolve_github_server_service_credential_request(descriptor.identity())
+                .await
+                .map_err(map_authority_resolution_error)?
+            {
+                Some(resolved) => resolved.identity().clone(),
+                None => return Err(GithubProviderCredentialHandoffError::Rejected),
+            }
+        } else {
+            self.authorities
+                .get(&selector.authority_id())
+                .cloned()
+                .ok_or(GithubProviderCredentialHandoffError::Rejected)?
+        };
         if identity.scope() != scope
-            || GithubServerServiceAuthoritySelector::from_identity(identity) != *selector
+            || GithubServerServiceAuthoritySelector::from_identity(&identity) != *selector
         {
             return Err(GithubProviderCredentialHandoffError::Rejected);
         }
@@ -761,8 +864,9 @@ impl GithubProviderCredentialAdapters {
     ) -> Result<GithubChecksServerServiceCredential, GithubChecksCredentialProviderError> {
         let authority = self
             .authority(&context.selector, GithubServerServiceScope::ChecksWrite)
+            .await
             .map_err(checks_handoff_error)?;
-        if !checks_identity_matches(authority, &context.identity)
+        if !checks_identity_matches(&authority, &context.identity)
             || context.consumer.action().required_scope() != GithubServerServiceScope::ChecksWrite
         {
             return Err(GithubChecksCredentialProviderError::Rejected);
@@ -783,7 +887,7 @@ impl GithubProviderCredentialAdapters {
             release_invalid_handoff(handoff).await;
             return Err(GithubChecksCredentialProviderError::InvariantViolation);
         }
-        let Ok(canonical_request) = github_server_service_credential_request(authority) else {
+        let Ok(canonical_request) = github_server_service_credential_request(&authority) else {
             release_invalid_handoff(handoff).await;
             return Err(GithubChecksCredentialProviderError::InvariantViolation);
         };
@@ -824,8 +928,9 @@ impl GithubProviderCredentialAdapters {
                 &context.selector,
                 GithubServerServiceScope::PrivateRepositorySourceRead,
             )
+            .await
             .map_err(source_handoff_error)?;
-        if !private_identity_matches(authority, &context.identity)
+        if !private_identity_matches(&authority, &context.identity)
             || context.consumer.action() != private_action(context.action)
         {
             return Err(GithubDeliverySourceCredentialProviderError::Rejected);
@@ -846,7 +951,7 @@ impl GithubProviderCredentialAdapters {
             release_invalid_handoff(handoff).await;
             return Err(GithubDeliverySourceCredentialProviderError::InvariantViolation);
         }
-        let Ok(canonical_request) = github_server_service_credential_request(authority) else {
+        let Ok(canonical_request) = github_server_service_credential_request(&authority) else {
             release_invalid_handoff(handoff).await;
             return Err(GithubDeliverySourceCredentialProviderError::InvariantViolation);
         };
@@ -881,12 +986,47 @@ impl GithubProviderCredentialAdapters {
     }
 }
 
+fn map_authority_resolution_store_error(
+    error: &GithubServerServiceStoreError,
+) -> GithubProviderCredentialHandoffError {
+    match error {
+        GithubServerServiceStoreError::Operation(_) => {
+            GithubProviderCredentialHandoffError::Unavailable
+        }
+        GithubServerServiceStoreError::NotFound => GithubProviderCredentialHandoffError::Rejected,
+        GithubServerServiceStoreError::CorruptData
+        | GithubServerServiceStoreError::IdentityConflict
+        | GithubServerServiceStoreError::ClaimRejected
+        | GithubServerServiceStoreError::HandoffRejected
+        | GithubServerServiceStoreError::RefreshAlreadyActive
+        | GithubServerServiceStoreError::FenceExhausted
+        | GithubServerServiceStoreError::RetryLimitReached
+        | GithubServerServiceStoreError::HandoffStillLive => {
+            GithubProviderCredentialHandoffError::Inconsistent
+        }
+    }
+}
+
+fn map_authority_resolution_error(
+    error: GithubServerServiceResolutionError,
+) -> GithubProviderCredentialHandoffError {
+    match error {
+        GithubServerServiceResolutionError::Unavailable => {
+            GithubProviderCredentialHandoffError::Unavailable
+        }
+        GithubServerServiceResolutionError::Inconsistent => {
+            GithubProviderCredentialHandoffError::Inconsistent
+        }
+    }
+}
+
 impl fmt::Debug for GithubProviderCredentialAdapters {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("GithubProviderCredentialAdapters")
             .field("handoffs", &self.handoffs)
             .field("authority_count", &self.authorities.len())
+            .field("durable_authorities", &self.durable_authorities.is_some())
             .finish()
     }
 }

--- a/crates/automata-ci/src/server/github_provider_credentials_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials_tests.rs
@@ -156,6 +156,61 @@ impl GithubProviderCredentialHandoffIssuer for FakeHandoffs {
     }
 }
 
+struct FakeAuthorityLookup {
+    descriptors: Mutex<
+        BTreeMap<
+            GithubServerServiceAuthorityId,
+            automata_ci_store::GithubServerServiceAuthorityDescriptor,
+        >,
+    >,
+    calls: AtomicUsize,
+}
+
+impl FakeAuthorityLookup {
+    fn new(
+        descriptors: impl IntoIterator<Item = automata_ci_store::GithubServerServiceAuthorityDescriptor>,
+    ) -> Self {
+        Self {
+            descriptors: Mutex::new(
+                descriptors
+                    .into_iter()
+                    .map(|descriptor| (descriptor.identity().authority_id(), descriptor))
+                    .collect(),
+            ),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl fmt::Debug for FakeAuthorityLookup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FakeAuthorityLookup")
+            .field("descriptors", &"[AUTHORITY DESCRIPTORS]")
+            .field("calls", &self.calls.load(Ordering::SeqCst))
+            .finish()
+    }
+}
+
+#[async_trait]
+impl GithubProviderAuthorityLookup for FakeAuthorityLookup {
+    async fn inspect(
+        &self,
+        selector: &GithubServerServiceAuthoritySelector,
+    ) -> Result<
+        automata_ci_store::GithubServerServiceAuthorityDescriptor,
+        GithubServerServiceStoreError,
+    > {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.descriptors
+            .lock()
+            .expect("descriptor lock")
+            .get(&selector.authority_id())
+            .cloned()
+            .ok_or(GithubServerServiceStoreError::NotFound)
+    }
+}
+
 #[derive(Debug)]
 struct FakeDeliveryRelease {
     calls: Arc<AtomicUsize>,
@@ -403,6 +458,51 @@ fn authority(scope: GithubServerServiceScope, id: u128) -> GithubServerServiceAu
         Sha256Digest::from_bytes([0x61; 32]),
     )
     .expect("authority")
+}
+
+fn historical_authority(
+    current: &GithubServerServiceAuthorityIdentity,
+    id: u128,
+    app_key_spki_sha256: Sha256Digest,
+) -> GithubServerServiceAuthorityIdentity {
+    GithubServerServiceAuthorityIdentity::new(
+        current.tenant().clone(),
+        authority_id(id),
+        current.repository_id(),
+        current.connection_id(),
+        current.installation_id(),
+        current.github_app_id(),
+        current.github_repository_id(),
+        current.github_repository_name().clone(),
+        current.scope(),
+        current.app_client_id().clone(),
+        current.jwt_issuer(),
+        app_key_spki_sha256,
+        GithubServerServiceRevision::new(2).expect("historical App revision"),
+        GithubServerServiceRevision::new(4).expect("historical policy revision"),
+        current.configuration_fingerprint(),
+    )
+    .expect("historical authority")
+}
+
+fn authority_descriptor(
+    identity: GithubServerServiceAuthorityIdentity,
+    state: GithubServerServiceAuthorityState,
+) -> automata_ci_store::GithubServerServiceAuthorityDescriptor {
+    automata_ci_store::GithubServerServiceAuthorityDescriptor::from_durable_parts(
+        identity,
+        state,
+        None,
+        None,
+        GithubServerServiceGeneration::new(1).expect("next generation"),
+        0,
+        None,
+        None,
+        None,
+        UnixMillis::new(0),
+        UnixMillis::new(0),
+    )
+    .expect("authority descriptor")
 }
 
 fn concrete_release_codec() -> Arc<EnvelopeCodec> {
@@ -659,6 +759,16 @@ fn adapters(
     GithubProviderCredentialAdapters::with_handoffs(handoffs, authorities).expect("adapters")
 }
 
+fn durable_adapters(
+    handoffs: Arc<FakeHandoffs>,
+    authorities: &[GithubServerServiceAuthorityIdentity],
+    lookup: Arc<FakeAuthorityLookup>,
+) -> GithubProviderCredentialAdapters {
+    let lookup: Arc<dyn GithubProviderAuthorityLookup> = lookup;
+    GithubProviderCredentialAdapters::with_durable_handoffs(handoffs, authorities, lookup)
+        .expect("durable adapters")
+}
+
 #[test]
 fn registry_is_bounded_unique_and_implements_both_delivery_ports() {
     fn assert_ports<T: GithubChecksCredentialProvider + GithubDeliverySourceCredentialProvider>() {}
@@ -719,6 +829,64 @@ async fn full_checks_coordinates_are_rejected_before_handoff_io() {
         GithubChecksCredentialProviderError::Rejected
     );
     assert_eq!(fake.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn active_historical_checks_authority_uses_the_exact_current_live_route() {
+    let current = authority(GithubServerServiceScope::ChecksWrite, 0x60);
+    let historical = historical_authority(&current, 0x62, current.app_key_spki_sha256());
+    let lookup = Arc::new(FakeAuthorityLookup::new([authority_descriptor(
+        historical.clone(),
+        GithubServerServiceAuthorityState::Active,
+    )]));
+    let handoffs = Arc::new(FakeHandoffs::new(FakeHandoffMode::Exact));
+    let adapters = durable_adapters(
+        Arc::clone(&handoffs),
+        std::slice::from_ref(&current),
+        Arc::clone(&lookup),
+    );
+
+    let credential = adapters
+        .acquire_checks(checks_context(&historical))
+        .await
+        .expect("historical authority on the current route");
+    assert_eq!(
+        credential.authority_selector(),
+        &GithubServerServiceAuthoritySelector::from_identity(&historical)
+    );
+    drop(credential);
+    assert_eq!(lookup.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(handoffs.calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn retired_unknown_and_route_drifted_authorities_never_enter_handoff_io() {
+    let current = authority(GithubServerServiceScope::ChecksWrite, 0x60);
+    let retired = historical_authority(&current, 0x62, current.app_key_spki_sha256());
+    let drifted = historical_authority(&current, 0x63, Sha256Digest::from_bytes([0x77; 32]));
+    let lookup = Arc::new(FakeAuthorityLookup::new([
+        authority_descriptor(retired.clone(), GithubServerServiceAuthorityState::Retired),
+        authority_descriptor(drifted.clone(), GithubServerServiceAuthorityState::Active),
+    ]));
+    let handoffs = Arc::new(FakeHandoffs::new(FakeHandoffMode::Exact));
+    let adapters = durable_adapters(
+        Arc::clone(&handoffs),
+        std::slice::from_ref(&current),
+        Arc::clone(&lookup),
+    );
+    let unknown = historical_authority(&current, 0x64, current.app_key_spki_sha256());
+
+    for rejected in [&retired, &drifted, &unknown] {
+        assert_eq!(
+            adapters
+                .acquire_checks(checks_context(rejected))
+                .await
+                .expect_err("historical route must fail closed"),
+            GithubChecksCredentialProviderError::Rejected
+        );
+    }
+    assert_eq!(lookup.calls.load(Ordering::SeqCst), 3);
+    assert_eq!(handoffs.calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/crates/automata-ci/src/server/github_provider_credentials_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials_tests.rs
@@ -465,6 +465,20 @@ fn historical_authority(
     id: u128,
     app_key_spki_sha256: Sha256Digest,
 ) -> GithubServerServiceAuthorityIdentity {
+    historical_authority_with_fingerprint(
+        current,
+        id,
+        app_key_spki_sha256,
+        current.configuration_fingerprint(),
+    )
+}
+
+fn historical_authority_with_fingerprint(
+    current: &GithubServerServiceAuthorityIdentity,
+    id: u128,
+    app_key_spki_sha256: Sha256Digest,
+    configuration_fingerprint: Sha256Digest,
+) -> GithubServerServiceAuthorityIdentity {
     GithubServerServiceAuthorityIdentity::new(
         current.tenant().clone(),
         authority_id(id),
@@ -480,7 +494,7 @@ fn historical_authority(
         app_key_spki_sha256,
         GithubServerServiceRevision::new(2).expect("historical App revision"),
         GithubServerServiceRevision::new(4).expect("historical policy revision"),
-        current.configuration_fingerprint(),
+        configuration_fingerprint,
     )
     .expect("historical authority")
 }
@@ -765,7 +779,25 @@ fn durable_adapters(
     lookup: Arc<FakeAuthorityLookup>,
 ) -> GithubProviderCredentialAdapters {
     let lookup: Arc<dyn GithubProviderAuthorityLookup> = lookup;
-    GithubProviderCredentialAdapters::with_durable_handoffs(handoffs, authorities, lookup)
+    let routes = GithubProviderCredentialRequestResolver::new(authorities, &[])
+        .expect("strict durable routes");
+    GithubProviderCredentialAdapters::with_durable_handoffs(handoffs, authorities, lookup, routes)
+        .expect("durable adapters")
+}
+
+fn durable_adapters_with_compatible(
+    handoffs: Arc<FakeHandoffs>,
+    authorities: &[GithubServerServiceAuthorityIdentity],
+    lookup: Arc<FakeAuthorityLookup>,
+    compatible_historical_broker_policy_fingerprints: &[Sha256Digest],
+) -> GithubProviderCredentialAdapters {
+    let lookup: Arc<dyn GithubProviderAuthorityLookup> = lookup;
+    let routes = GithubProviderCredentialRequestResolver::new(
+        authorities,
+        compatible_historical_broker_policy_fingerprints,
+    )
+    .expect("compatible durable routes");
+    GithubProviderCredentialAdapters::with_durable_handoffs(handoffs, authorities, lookup, routes)
         .expect("durable adapters")
 }
 
@@ -834,16 +866,26 @@ async fn full_checks_coordinates_are_rejected_before_handoff_io() {
 #[tokio::test]
 async fn active_historical_checks_authority_uses_the_exact_current_live_route() {
     let current = authority(GithubServerServiceScope::ChecksWrite, 0x60);
-    let historical = historical_authority(&current, 0x62, current.app_key_spki_sha256());
+    let historical_broker_fingerprint = Sha256Digest::from_bytes([0x70; 32]);
+    let historical = historical_authority_with_fingerprint(
+        &current,
+        0x62,
+        current.app_key_spki_sha256(),
+        super::super::github_provider::authority_configuration_fingerprint(
+            historical_broker_fingerprint,
+            current.scope(),
+        ),
+    );
     let lookup = Arc::new(FakeAuthorityLookup::new([authority_descriptor(
         historical.clone(),
         GithubServerServiceAuthorityState::Active,
     )]));
     let handoffs = Arc::new(FakeHandoffs::new(FakeHandoffMode::Exact));
-    let adapters = durable_adapters(
+    let adapters = durable_adapters_with_compatible(
         Arc::clone(&handoffs),
         std::slice::from_ref(&current),
         Arc::clone(&lookup),
+        std::slice::from_ref(&historical_broker_fingerprint),
     );
 
     let credential = adapters
@@ -864,9 +906,19 @@ async fn retired_unknown_and_route_drifted_authorities_never_enter_handoff_io() 
     let current = authority(GithubServerServiceScope::ChecksWrite, 0x60);
     let retired = historical_authority(&current, 0x62, current.app_key_spki_sha256());
     let drifted = historical_authority(&current, 0x63, Sha256Digest::from_bytes([0x77; 32]));
+    let fingerprint_drifted = historical_authority_with_fingerprint(
+        &current,
+        0x65,
+        current.app_key_spki_sha256(),
+        Sha256Digest::from_bytes([0x78; 32]),
+    );
     let lookup = Arc::new(FakeAuthorityLookup::new([
         authority_descriptor(retired.clone(), GithubServerServiceAuthorityState::Retired),
         authority_descriptor(drifted.clone(), GithubServerServiceAuthorityState::Active),
+        authority_descriptor(
+            fingerprint_drifted.clone(),
+            GithubServerServiceAuthorityState::Active,
+        ),
     ]));
     let handoffs = Arc::new(FakeHandoffs::new(FakeHandoffMode::Exact));
     let adapters = durable_adapters(
@@ -876,7 +928,7 @@ async fn retired_unknown_and_route_drifted_authorities_never_enter_handoff_io() 
     );
     let unknown = historical_authority(&current, 0x64, current.app_key_spki_sha256());
 
-    for rejected in [&retired, &drifted, &unknown] {
+    for rejected in [&retired, &drifted, &fingerprint_drifted, &unknown] {
         assert_eq!(
             adapters
                 .acquire_checks(checks_context(rejected))
@@ -885,7 +937,7 @@ async fn retired_unknown_and_route_drifted_authorities_never_enter_handoff_io() 
             GithubChecksCredentialProviderError::Rejected
         );
     }
-    assert_eq!(lookup.calls.load(Ordering::SeqCst), 3);
+    assert_eq!(lookup.calls.load(Ordering::SeqCst), 4);
     assert_eq!(handoffs.calls.load(Ordering::SeqCst), 0);
 }
 

--- a/crates/automata-ci/src/server/github_provider_runtime.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime.rs
@@ -56,9 +56,10 @@ use automata_ci_store::{
     GITHUB_PROVIDER_WEB_ORIGIN, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
     GithubCheckStoreError, GithubJobRuntimeAuthorityRepository, GithubRuntimeAuthorityRepository,
     GithubRuntimeAuthorityWorkerId, GithubServerServiceAppClientId, GithubServerServiceAppId,
-    GithubServerServiceJwtIssuer, GithubServerServiceScope, GithubServerServiceWorkerId,
-    GithubSubjectEvidenceRepository, LogicalWorkflowAdmissionRepository, PostgresStore,
-    ProviderConnectionId, ProviderDeliveryClaimOwnerId, ProviderRepositoryVisibility, TenantScope,
+    GithubServerServiceAuthorityRepository, GithubServerServiceJwtIssuer, GithubServerServiceScope,
+    GithubServerServiceWorkerId, GithubSubjectEvidenceRepository,
+    LogicalWorkflowAdmissionRepository, PostgresStore, ProviderConnectionId,
+    ProviderDeliveryClaimOwnerId, ProviderRepositoryVisibility, TenantScope,
 };
 use automata_ci_workflow_service::{
     GithubWorkflowPlanVerifier, WorkflowAdmissionObserver, WorkflowAdmissionService,
@@ -418,8 +419,9 @@ impl GithubProviderRuntimeBuilder {
         }
 
         let ready = plan.bootstrap(store.as_ref(), applied_at).await?;
+        let credential_request_resolver = ready.credential_request_resolver();
         let resolver: Arc<dyn GithubServerServiceCredentialRequestResolver> =
-            Arc::new(ready.credential_request_resolver());
+            Arc::new(credential_request_resolver.clone());
         let routed_brokers = brokers
             .iter()
             .map(|(installation_id, broker)| {
@@ -433,6 +435,8 @@ impl GithubProviderRuntimeBuilder {
         );
         let broker: Arc<dyn GithubServerServiceCredentialBroker> = router.clone();
         let credential_repository: Arc<dyn GithubServerServiceCredentialRepository> = store.clone();
+        let credential_authority_repository: Arc<dyn GithubServerServiceAuthorityRepository> =
+            store.clone();
         let envelopes = Arc::new(EnvelopeCodec::new(key_encryption_provider));
         let runtime_handle = Handle::try_current()
             .map_err(|_| GithubProviderRuntimeBuildError::RuntimeUnavailable)?;
@@ -586,6 +590,7 @@ impl GithubProviderRuntimeBuilder {
         let adapters = Arc::new(GithubProviderCredentialAdapters::new(
             credential_issuer,
             credential_repository.clone(),
+            credential_authority_repository,
             releases.clone(),
             plan.authorities(),
         )?);

--- a/crates/automata-ci/src/server/github_provider_runtime.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime.rs
@@ -420,6 +420,7 @@ impl GithubProviderRuntimeBuilder {
 
         let ready = plan.bootstrap(store.as_ref(), applied_at).await?;
         let credential_request_resolver = ready.credential_request_resolver();
+        let credential_adapter_routes = credential_request_resolver.clone();
         let resolver: Arc<dyn GithubServerServiceCredentialRequestResolver> =
             Arc::new(credential_request_resolver.clone());
         let routed_brokers = brokers
@@ -593,6 +594,7 @@ impl GithubProviderRuntimeBuilder {
             credential_authority_repository,
             releases.clone(),
             plan.authorities(),
+            credential_adapter_routes,
         )?);
 
         let endpoint = GithubHttpEndpoint::github_dot_com(GITHUB_HTTP_USER_AGENT)

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -149,12 +149,21 @@ fn fixed_evidence_plan(
     config: &GithubProviderConfig,
     broker_policy_byte: u8,
 ) -> GithubProviderBootstrapPlan {
+    fixed_evidence_plan_with_compatible(config, broker_policy_byte, &[])
+}
+
+fn fixed_evidence_plan_with_compatible(
+    config: &GithubProviderConfig,
+    broker_policy_byte: u8,
+    compatible_historical_broker_policy_fingerprints: &[Sha256Digest],
+) -> GithubProviderBootstrapPlan {
     GithubProviderBootstrapPlan::from_derived_evidence(
         config,
         Sha256Digest::from_bytes([0x51; 32]),
         GithubProviderWebhookVerifierFingerprint::from_sha256(Sha256Digest::from_bytes([0x61; 32]))
             .expect("fixture verifier fingerprint"),
         Sha256Digest::from_bytes([broker_policy_byte; 32]),
+        compatible_historical_broker_policy_fingerprints,
     )
     .expect("fixed-evidence plan")
 }
@@ -402,7 +411,12 @@ fn historical_authority(
 #[tokio::test]
 async fn historical_revision_resolves_only_through_the_exact_current_live_route() {
     let config = load_config("historical-route.json", &mixed_document()).expect("mixed config");
-    let plan = fixed_evidence_plan(&config, 0x71);
+    let historical_broker_fingerprint = Sha256Digest::from_bytes([0x70; 32]);
+    let plan = fixed_evidence_plan_with_compatible(
+        &config,
+        0x71,
+        std::slice::from_ref(&historical_broker_fingerprint),
+    );
     let target = MemoryBootstrapTarget::default();
     let ready = plan
         .bootstrap_with_target(&target, UnixMillis::new(2_000))
@@ -416,7 +430,7 @@ async fn historical_revision_resolves_only_through_the_exact_current_live_route(
         current.app_configuration_revision().get() - 1,
         current.policy_revision().get() - 1,
         current.app_key_spki_sha256(),
-        current.configuration_fingerprint(),
+        authority_configuration_fingerprint(historical_broker_fingerprint, current.scope()),
     );
 
     let historical_request = resolver

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -368,6 +368,96 @@ async fn exact_bootstrap_replays_and_only_then_exposes_the_resolver() {
     }
 }
 
+fn historical_authority(
+    current: &GithubServerServiceAuthorityIdentity,
+    authority_id: u128,
+    app_revision: u64,
+    policy_revision: u64,
+    app_key_spki_sha256: Sha256Digest,
+    configuration_fingerprint: Sha256Digest,
+) -> GithubServerServiceAuthorityIdentity {
+    GithubServerServiceAuthorityIdentity::new(
+        current.tenant().clone(),
+        GithubServerServiceAuthorityId::from_uuid(Uuid::from_u128(authority_id))
+            .expect("historical authority ID"),
+        current.repository_id(),
+        current.connection_id(),
+        current.installation_id(),
+        current.github_app_id(),
+        current.github_repository_id(),
+        current.github_repository_name().clone(),
+        current.scope(),
+        current.app_client_id().clone(),
+        current.jwt_issuer(),
+        app_key_spki_sha256,
+        automata_ci_store::GithubServerServiceRevision::new(app_revision)
+            .expect("historical App revision"),
+        automata_ci_store::GithubServerServiceRevision::new(policy_revision)
+            .expect("historical policy revision"),
+        configuration_fingerprint,
+    )
+    .expect("historical authority")
+}
+
+#[tokio::test]
+async fn historical_revision_resolves_only_through_the_exact_current_live_route() {
+    let config = load_config("historical-route.json", &mixed_document()).expect("mixed config");
+    let plan = fixed_evidence_plan(&config, 0x71);
+    let target = MemoryBootstrapTarget::default();
+    let ready = plan
+        .bootstrap_with_target(&target, UnixMillis::new(2_000))
+        .await
+        .expect("bootstrap");
+    let resolver = ready.credential_request_resolver();
+    let current = &plan.authorities()[0];
+    let historical = historical_authority(
+        current,
+        0x7a1,
+        current.app_configuration_revision().get() - 1,
+        current.policy_revision().get() - 1,
+        current.app_key_spki_sha256(),
+        current.configuration_fingerprint(),
+    );
+
+    let historical_request = resolver
+        .resolve_github_server_service_credential_request(&historical)
+        .await
+        .expect("historical resolution")
+        .expect("same live route remains authorized");
+    assert_eq!(historical_request.identity(), &historical);
+    assert_eq!(
+        historical_request.request(),
+        &github_server_service_credential_request(&historical).expect("canonical request")
+    );
+
+    for mismatch in [
+        historical_authority(
+            current,
+            0x7a2,
+            current.app_configuration_revision().get() - 1,
+            current.policy_revision().get() - 1,
+            Sha256Digest::from_bytes([0xa2; 32]),
+            current.configuration_fingerprint(),
+        ),
+        historical_authority(
+            current,
+            0x7a3,
+            current.app_configuration_revision().get() - 1,
+            current.policy_revision().get() - 1,
+            current.app_key_spki_sha256(),
+            Sha256Digest::from_bytes([0xa3; 32]),
+        ),
+    ] {
+        assert!(
+            resolver
+                .resolve_github_server_service_credential_request(&mismatch)
+                .await
+                .expect("closed mismatch")
+                .is_none()
+        );
+    }
+}
+
 #[tokio::test]
 async fn runtime_policy_drift_fails_before_manifest_or_authority_writes() {
     const DRIFTED_POLICY: &[u8] = br#"{

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -772,7 +772,10 @@ where
         provider
             .run_with_fatal_notification(provider_cancellation, fatal_notification)
             .await
-            .map_err(|_| ManagedServiceError::GithubProvider)
+            .map_err(|error| {
+                tracing::error!(%error, "GitHub provider runtime failed");
+                ManagedServiceError::GithubProvider
+            })
     };
     supervise_services_with_metrics_and_provider(
         (


### PR DESCRIPTION
Summary:

- verify the required network sysctl from Podman durable container CreateCommand
- reject missing, malformed, duplicate, or alternate-form sysctl arguments
- cover both pod and service-container ownership verification

Why:

Current Podman container inspection no longer exposes HostConfig.Sysctls, while CreateCommand retains the exact creation arguments. The old verifier therefore rejected valid freshly-created sandboxes in production.

Validation:

- full automata-ci-sandbox-podman all-target test suite
- strict all-target/all-feature Clippy with warnings denied
- rustdoc with warnings denied
- rustfmt and diff checks
- deployed immutable runner artifact is active with zero restarts; admission and exact-store cleanup passed