### PR TITLE
Block stale GitHub Checks credential projections

### DIFF
--- a/crates/automata-ci-github-delivery/src/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/src/checks_publisher.rs
@@ -22,19 +22,19 @@ use automata_ci_github::{
 use automata_ci_scm::{ExactRevision, RepositoryId as ScmRepositoryId};
 use automata_ci_store::{
     BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
-    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, CompleteGithubCheckProjection,
-    GithubCheckAppId, GithubCheckConclusion, GithubCheckDesiredProjection,
-    GithubCheckProjectionAction, GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox,
-    GithubCheckProjectionWorkerId, GithubCheckRunBindingFence, GithubCheckRunCreateFence,
-    GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectIdentity, GithubCheckSubjectReceipt,
-    GithubCheckSuiteId, GithubCheckValueError, GithubServerServiceAction,
-    GithubServerServiceAuthoritySelector, GithubServerServiceClaimFence,
-    GithubServerServiceConsumerClaim, GithubServerServiceConsumerId, GithubServerServiceHandoffId,
-    GithubServerServiceRevision, GithubServerServiceWorkerId, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
-    MAX_GITHUB_CHECK_PROJECTION_CLAIM_MILLIS, MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS,
-    ProviderConnectionId, ProviderInstallationId, ProviderRepositoryId,
-    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
-    RetryGithubCheckProjection, TenantScope,
+    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
+    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, GithubCheckAppId,
+    GithubCheckConclusion, GithubCheckDesiredProjection, GithubCheckProjectionAction,
+    GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
+    GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
+    GithubCheckSubjectIdentity, GithubCheckSubjectReceipt, GithubCheckSuiteId,
+    GithubCheckValueError, GithubServerServiceAction, GithubServerServiceAuthoritySelector,
+    GithubServerServiceClaimFence, GithubServerServiceConsumerClaim, GithubServerServiceConsumerId,
+    GithubServerServiceHandoffId, GithubServerServiceRevision, GithubServerServiceWorkerId,
+    MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS, MAX_GITHUB_CHECK_PROJECTION_CLAIM_MILLIS,
+    MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS, ProviderConnectionId, ProviderInstallationId,
+    ProviderRepositoryId, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
+    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, TenantScope,
 };
 use thiserror::Error;
 use tokio::time::{Instant, timeout_at};
@@ -475,7 +475,7 @@ pub enum GithubChecksPublisherOutcome {
     RetryScheduled(GithubCheckSubjectReceipt),
     /// A Check Run create may have succeeded and must be reconciled before another POST.
     ReconciliationRequired(GithubCheckRunCreateFence),
-    /// Multiple exact provider identities were observed and the outbox was blocked.
+    /// Exact durable evidence made this projection permanently unpublishable.
     Blocked(GithubCheckSubjectReceipt),
 }
 
@@ -488,8 +488,8 @@ pub enum GithubChecksPublisherError {
     /// The repository adapter returned a claim inconsistent with the exact request.
     #[error("the GitHub Checks outbox returned an invalid claim")]
     InvalidClaim,
-    /// Current server-service authority rejected the operation.
-    #[error("the GitHub Checks server-service credential was rejected")]
+    /// GitHub rejected a credential after exact local authority handed it off.
+    #[error("GitHub rejected the exact Checks server-service credential")]
     CredentialRejected,
     /// Returned credential binding or lifetime was not exact.
     #[error("the GitHub Checks server-service credential was not exact")]
@@ -579,8 +579,8 @@ impl GithubChecksPublisher {
     ///
     /// # Errors
     ///
-    /// Fails closed on stale durability, credential rejection or mismatch,
-    /// provider identity/state mismatch, and local invariant violations.
+    /// Fails closed on stale durability, handed-off credential rejection or
+    /// mismatch, provider identity/state mismatch, and local invariant violations.
     pub async fn run_once(
         &self,
         connection_id: ProviderConnectionId,
@@ -639,7 +639,7 @@ impl GithubChecksPublisher {
                     .await;
             }
             Ok(Err(GithubChecksCredentialProviderError::Rejected)) => {
-                return Err(GithubChecksPublisherError::CredentialRejected);
+                return self.block_credential_rejection(&claimed, horizon).await;
             }
             Ok(Err(GithubChecksCredentialProviderError::InvariantViolation)) => {
                 return Err(GithubChecksPublisherError::CredentialMismatch);
@@ -682,6 +682,23 @@ impl GithubChecksPublisher {
         };
         release_credential(credential, deadline).await;
         outcome
+    }
+
+    async fn block_credential_rejection(
+        &self,
+        claimed: &ClaimedGithubCheckProjection,
+        horizon: GithubChecksClaimHorizon,
+    ) -> Result<GithubChecksPublisherOutcome, GithubChecksPublisherError> {
+        let request = BlockGithubCheckProjectionForCredentialRejection::new(
+            claimed.claim(),
+            horizon.observed_at()?,
+        )
+        .map_err(invariant)?;
+        let receipt = self
+            .outbox
+            .block_github_check_projection_for_credential_rejection(request)
+            .await?;
+        Ok(GithubChecksPublisherOutcome::Blocked(receipt))
     }
 
     async fn ensure_suite(

--- a/crates/automata-ci-github-delivery/tests/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/tests/checks_publisher.rs
@@ -21,18 +21,18 @@ use automata_ci_github_delivery::{
 use automata_ci_scm::RepositoryId as ScmRepositoryId;
 use automata_ci_store::{
     BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
-    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, CompleteGithubCheckProjection,
-    GithubCheckAppId, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
-    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
-    GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
-    GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
-    GithubCheckSubjectId, GithubCheckSubjectIdentity, GithubCheckSubjectKey,
-    GithubCheckSubjectReceipt, GithubCheckSuiteId, GithubCheckTerminalCause, GithubRepositoryName,
-    GithubServerServiceAction, GithubServerServiceAuthorityId,
-    GithubServerServiceAuthoritySelector, GithubServerServiceClaimFence,
-    GithubServerServiceConsumerClaim, GithubServerServiceConsumerId, GithubServerServiceHandoffId,
-    GithubServerServiceRevision, GithubServerServiceWorkerId, ProviderConnectionId,
-    ProviderDeliveryId, ProviderInstallationId, ProviderRepositoryId,
+    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
+    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, GithubCheckAppId,
+    GithubCheckCreateReconciliation, GithubCheckDesiredProjection, GithubCheckHeadSha,
+    GithubCheckName, GithubCheckProjectionAction, GithubCheckProjectionClaimFence,
+    GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
+    GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectId,
+    GithubCheckSubjectIdentity, GithubCheckSubjectKey, GithubCheckSubjectReceipt,
+    GithubCheckSuiteId, GithubCheckTerminalCause, GithubRepositoryName, GithubServerServiceAction,
+    GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
+    GithubServerServiceClaimFence, GithubServerServiceConsumerClaim, GithubServerServiceConsumerId,
+    GithubServerServiceHandoffId, GithubServerServiceRevision, GithubServerServiceWorkerId,
+    ProviderConnectionId, ProviderDeliveryId, ProviderInstallationId, ProviderRepositoryId,
     ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
     RetryGithubCheckProjection, TenantScope,
 };
@@ -90,6 +90,7 @@ struct FakeOutbox {
     begin_delay_millis: AtomicUsize,
     claim_time_offset: AtomicI64,
     claim_delay_millis: AtomicUsize,
+    credential_rejection_blocks: Mutex<Vec<BlockGithubCheckProjectionForCredentialRejection>>,
     events: Arc<Mutex<Vec<String>>>,
 }
 
@@ -109,6 +110,7 @@ impl FakeOutbox {
             begin_delay_millis: AtomicUsize::new(0),
             claim_time_offset: AtomicI64::new(0),
             claim_delay_millis: AtomicUsize::new(0),
+            credential_rejection_blocks: Mutex::new(Vec::new()),
             events,
         }
     }
@@ -298,6 +300,21 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
         Self::receipt(request.claim().subject_id(), request.observed())
     }
 
+    async fn block_github_check_projection_for_credential_rejection(
+        &self,
+        request: BlockGithubCheckProjectionForCredentialRejection,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
+        self.event("store:block:credential_rejected");
+        self.credential_rejection_blocks
+            .lock()
+            .expect("credential rejection blocks lock")
+            .push(request);
+        Self::receipt(
+            request.claim().subject_id(),
+            GithubCheckDesiredProjection::Queued,
+        )
+    }
+
     async fn retry_github_check_projection(
         &self,
         request: RetryGithubCheckProjection,
@@ -329,6 +346,7 @@ enum CredentialMode {
     FutureAcquisition,
     TooShort,
     Unavailable,
+    Rejected,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -445,6 +463,9 @@ impl GithubChecksCredentialProvider for FakeCredentials {
         }
         if matches!(self.mode, CredentialMode::Unavailable) {
             return Err(GithubChecksCredentialProviderError::Unavailable);
+        }
+        if matches!(self.mode, CredentialMode::Rejected) {
+            return Err(GithubChecksCredentialProviderError::Rejected);
         }
         let identity = request.identity();
         let authority_selector = match self.mode {
@@ -1639,6 +1660,83 @@ async fn rate_and_credential_unavailability_use_bounded_durable_retry() {
     assert!(credential.server.requests().is_empty());
 }
 
+#[tokio::test]
+async fn locally_rejected_credential_blocks_the_exact_claim_without_provider_io() {
+    let harness = Harness::new(
+        [claim(
+            GithubCheckProjectionAction::EnsureSuite,
+            queued(),
+            1,
+            None,
+            None,
+        )],
+        Vec::new(),
+        CredentialMode::Rejected,
+    )
+    .await;
+
+    assert!(matches!(
+        harness.run().await.expect("credential rejection is closed"),
+        GithubChecksPublisherOutcome::Blocked(_)
+    ));
+    assert_eq!(harness.release_calls(), 0);
+    assert!(harness.server.requests().is_empty());
+    let credential_claim = harness
+        .credentials
+        .last_claim
+        .lock()
+        .expect("claim evidence lock")
+        .expect("credential request");
+    let blocks = harness
+        .outbox
+        .credential_rejection_blocks
+        .lock()
+        .expect("credential rejection blocks lock");
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].claim(), credential_claim.claim);
+    assert!(
+        blocks[0].blocked_at() >= credential_claim.claimed_at
+            && blocks[0].blocked_at() < credential_claim.expires_at
+    );
+    assert_eq!(
+        harness.events(),
+        [
+            "store:claim".to_owned(),
+            "credential:acquire".to_owned(),
+            "store:block:credential_rejected".to_owned(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn provider_unauthorized_after_exact_handoff_remains_fatal() {
+    let harness = Harness::new(
+        [claim(
+            GithubCheckProjectionAction::EnsureSuite,
+            queued(),
+            1,
+            None,
+            None,
+        )],
+        vec![ResponseSpec::json(401, "{}")],
+        CredentialMode::Exact,
+    )
+    .await;
+
+    assert!(matches!(
+        harness.run().await,
+        Err(GithubChecksPublisherError::CredentialRejected)
+    ));
+    assert_eq!(harness.release_calls(), 1);
+    assert_eq!(methods(&harness.server.requests()), ["POST"]);
+    assert!(
+        !harness
+            .events()
+            .iter()
+            .any(|event| event == "store:block:credential_rejected")
+    );
+}
+
 fn claim(
     action: GithubCheckProjectionAction,
     desired: GithubCheckDesiredProjection,
@@ -1854,6 +1952,7 @@ async fn read_request(stream: &mut tokio::net::TcpStream) -> RecordedRequest {
 
 async fn write_response(stream: &mut tokio::net::TcpStream, response: ResponseSpec) {
     let reason = match response.status {
+        401 => "Unauthorized",
         200 => "OK",
         201 => "Created",
         429 => "Too Many Requests",

--- a/crates/automata-ci-store/migrations/0053_github_check_credential_rejection.sql
+++ b/crates/automata-ci-store/migrations/0053_github_check_credential_rejection.sql
@@ -1,0 +1,333 @@
+-- A locally unavailable immutable Checks authority is terminal for that exact
+-- projection.  This is distinct from a provider HTTP rejection: no provider
+-- request was made, and the historical delivery evidence remains unchanged.
+ALTER TABLE github_check_projection_outbox
+    DROP CONSTRAINT github_check_projection_outbox_block_shape,
+    ADD CONSTRAINT github_check_projection_outbox_block_shape CHECK (
+        state = 'blocked' AND blocked_reason IN (
+            'ambiguous_create', 'attempt_limit', 'credential_rejected'
+        )
+        OR state <> 'blocked' AND blocked_reason IS NULL
+    );
+
+-- Only an exact live claim may record local credential rejection.  Once
+-- recorded, the block is immutable even if a newer desired revision appears.
+CREATE FUNCTION automata_github_check_credential_rejection_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $automata$
+DECLARE
+    expected github_check_projection_outbox%ROWTYPE;
+BEGIN
+    IF OLD.state = 'blocked' AND OLD.blocked_reason = 'credential_rejected' THEN
+        IF NEW IS DISTINCT FROM OLD THEN
+            RAISE EXCEPTION 'GitHub Check credential-rejection evidence is immutable'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT = 'github_check_projection_credential_rejection_immutable';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.state = 'blocked' AND NEW.blocked_reason = 'credential_rejected' THEN
+        expected := OLD;
+        expected.state := 'blocked';
+        expected.claim_owner_id := NULL;
+        expected.claim_action := NULL;
+        expected.claimed_desired_revision := NULL;
+        expected.claimed_desired_state := NULL;
+        expected.claimed_desired_conclusion := NULL;
+        expected.claimed_at_ms := NULL;
+        expected.claim_expires_at_ms := NULL;
+        expected.next_attempt_at_ms := NULL;
+        expected.last_failure_kind := NULL;
+        expected.blocked_reason := 'credential_rejected';
+        expected.state_updated_at_ms := NEW.state_updated_at_ms;
+
+        IF OLD.state <> 'claimed'
+            OR NEW.state_updated_at_ms < OLD.claimed_at_ms
+            OR NEW.state_updated_at_ms >= OLD.claim_expires_at_ms
+            OR NEW IS DISTINCT FROM expected
+        THEN
+            RAISE EXCEPTION 'GitHub Check credential rejection did not consume its exact live claim'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT = 'github_check_projection_credential_rejection_exact';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$automata$;
+
+CREATE TRIGGER github_check_projection_outbox_00_credential_rejection_guard
+BEFORE UPDATE ON github_check_projection_outbox
+FOR EACH ROW
+EXECUTE FUNCTION automata_github_check_credential_rejection_guard();
+
+-- Policy/App revision rotation may leave historical authorities active while
+-- admitted work drains.  Preserve those rows when their complete operational
+-- broker route is still the current route.  Retire only historical rows whose
+-- route cannot be serviced by the current manifest, including obsolete
+-- Private-source authority after a repository becomes Public.
+LOCK TABLE github_provider_manifest_current, github_provider_manifest_revisions
+    IN SHARE MODE;
+LOCK TABLE github_server_service_authorities,
+           github_server_service_authority_issuances
+    IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE TEMPORARY TABLE automata_migration_0053_retire_authorities (
+    authority_id UUID PRIMARY KEY,
+    transition_at_ms BIGINT NOT NULL
+) ON COMMIT DROP;
+
+-- Product runtime explicitly supports the GitHub broker-policy v1 predecessor:
+-- v1 requested the same least-authority token but rejected GitHub's unavoidable
+-- implicit metadata:read response permission.  These are the exact v1 product
+-- configuration fingerprints for the two closed service scopes.  Preserve no
+-- other historical fingerprint; unknown policy remains an incompatible route.
+CREATE TEMPORARY TABLE automata_migration_0053_compatible_routes (
+    service_scope TEXT PRIMARY KEY,
+    configuration_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(configuration_fingerprint) = 32
+    )
+) ON COMMIT DROP;
+
+INSERT INTO automata_migration_0053_compatible_routes (
+    service_scope, configuration_fingerprint
+) VALUES
+    (
+        'checks_write',
+        decode(
+            '86db54f098adc51219d176555d5f7b5461a4c45ddd0625393846b1b3a5ae6543',
+            'hex'
+        )
+    ),
+    (
+        'private_repository_source_read',
+        decode(
+            '878f4bd01bfe4b04e84d9b9eee32667d31d55feebe78a7b2f59ed715b1145b32',
+            'hex'
+        )
+    );
+
+CREATE TEMPORARY TABLE automata_migration_0053_manifest_scopes
+ON COMMIT DROP
+AS
+WITH current_manifests AS MATERIALIZED (
+    SELECT revision.*
+    FROM github_provider_manifest_current AS current
+    JOIN github_provider_manifest_revisions AS revision
+      ON revision.tenant_id = current.tenant_id
+     AND revision.repository_id = current.repository_id
+     AND revision.provider_connection_id = current.provider_connection_id
+     AND revision.manifest_revision = current.manifest_revision
+     AND revision.manifest_digest = current.manifest_digest
+), manifest_scopes AS MATERIALIZED (
+    SELECT manifest.*, 'checks_write'::TEXT AS service_scope
+    FROM current_manifests AS manifest
+    UNION ALL
+    SELECT manifest.*, 'private_repository_source_read'::TEXT AS service_scope
+    FROM current_manifests AS manifest
+    WHERE manifest.repository_source_authentication =
+          'github_app_installation_token'
+)
+SELECT * FROM manifest_scopes;
+
+CREATE TEMPORARY TABLE automata_migration_0053_current_routes
+ON COMMIT DROP
+AS
+SELECT scope.tenant_id,
+       scope.repository_id,
+       scope.provider_connection_id,
+       scope.repository_source_authentication,
+       authority.id AS authority_id,
+       authority.provider_installation_id,
+       authority.github_app_id,
+       authority.github_app_client_id,
+       authority.github_app_jwt_issuer_kind,
+       authority.github_repository_id,
+       authority.github_repository_name,
+       authority.service_scope,
+       authority.app_key_spki_sha256,
+       authority.configuration_fingerprint
+FROM automata_migration_0053_manifest_scopes AS scope
+JOIN github_server_service_authorities AS authority
+  ON authority.tenant_id = scope.tenant_id
+ AND authority.repository_id = scope.repository_id
+ AND authority.provider_connection_id = scope.provider_connection_id
+ AND authority.provider_installation_id = scope.provider_installation_id
+ AND authority.github_app_id = scope.github_app_id
+ AND authority.github_app_client_id = scope.github_app_client_id
+ AND authority.github_app_jwt_issuer_kind = scope.github_app_jwt_issuer_kind
+ AND authority.github_repository_id = scope.github_repository_id
+ AND authority.github_repository_name = scope.github_repository_name
+ AND authority.service_scope = scope.service_scope
+ AND authority.app_key_spki_sha256 = scope.app_key_spki_sha256
+ AND authority.app_configuration_revision = scope.app_configuration_revision
+ AND authority.policy_revision = scope.policy_revision
+ AND authority.state = 'active';
+
+DO $automata$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM automata_migration_0053_manifest_scopes AS scope
+        LEFT JOIN automata_migration_0053_current_routes AS route
+          ON route.tenant_id = scope.tenant_id
+         AND route.repository_id = scope.repository_id
+         AND route.provider_connection_id = scope.provider_connection_id
+         AND route.service_scope = scope.service_scope
+        GROUP BY scope.tenant_id, scope.repository_id,
+                 scope.provider_connection_id, scope.service_scope
+        HAVING count(route.authority_id) <> 1
+    ) THEN
+        RAISE EXCEPTION 'current GitHub manifest scope lacks one exact active authority route'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_server_service_current_manifest_route_exact';
+    END IF;
+END;
+$automata$;
+
+WITH incompatible AS MATERIALIZED (
+    SELECT historical.id AS authority_id
+    FROM automata_migration_0053_current_routes AS current_route
+    JOIN github_server_service_authorities AS historical
+      ON historical.tenant_id = current_route.tenant_id
+     AND historical.repository_id = current_route.repository_id
+     AND historical.service_scope = current_route.service_scope
+     AND historical.state = 'active'
+    WHERE NOT (
+        ROW(
+            historical.tenant_id,
+            historical.repository_id,
+            historical.provider_connection_id,
+            historical.provider_installation_id,
+            historical.github_app_id,
+            historical.github_app_client_id,
+            historical.github_app_jwt_issuer_kind,
+            historical.github_repository_id,
+            historical.github_repository_name,
+            historical.service_scope,
+            historical.app_key_spki_sha256
+        ) IS NOT DISTINCT FROM ROW(
+            current_route.tenant_id,
+            current_route.repository_id,
+            current_route.provider_connection_id,
+            current_route.provider_installation_id,
+            current_route.github_app_id,
+            current_route.github_app_client_id,
+            current_route.github_app_jwt_issuer_kind,
+            current_route.github_repository_id,
+            current_route.github_repository_name,
+            current_route.service_scope,
+            current_route.app_key_spki_sha256
+        )
+        AND (
+            historical.configuration_fingerprint
+                = current_route.configuration_fingerprint
+            OR EXISTS (
+                SELECT 1
+                FROM automata_migration_0053_compatible_routes AS compatible
+                WHERE compatible.service_scope = historical.service_scope
+                  AND compatible.configuration_fingerprint
+                      = historical.configuration_fingerprint
+            )
+        )
+    )
+
+    UNION
+
+    SELECT historical.id AS authority_id
+    FROM automata_migration_0053_manifest_scopes AS manifest
+    JOIN github_server_service_authorities AS historical
+      ON historical.tenant_id = manifest.tenant_id
+     AND historical.repository_id = manifest.repository_id
+     AND historical.service_scope = 'private_repository_source_read'
+     AND historical.state = 'active'
+    WHERE manifest.service_scope = 'checks_write'
+      AND manifest.repository_source_authentication = 'anonymous_public'
+), database_time AS MATERIALIZED (
+    SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT AS now_ms
+)
+INSERT INTO automata_migration_0053_retire_authorities (
+    authority_id, transition_at_ms
+)
+SELECT incompatible.authority_id, database_time.now_ms
+FROM incompatible
+CROSS JOIN database_time;
+
+-- Migration cannot prove that any nonterminal issuance avoided provider I/O or
+-- safely advance the authority's failure budget.  Every issuance must already
+-- be terminal and custody-free; otherwise the live lifecycle worker must
+-- reconcile it before this migration can proceed.
+DO $automata$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM automata_migration_0053_retire_authorities AS candidate
+        JOIN github_server_service_authorities AS authority
+          ON authority.id = candidate.authority_id
+        LEFT JOIN github_server_service_authority_issuances AS issuance
+          ON issuance.authority_id = authority.id
+        WHERE authority.state_updated_at_ms > candidate.transition_at_ms
+           OR issuance.state_updated_at_ms > candidate.transition_at_ms
+    ) THEN
+        RAISE EXCEPTION 'incompatible historical GitHub authority has future lifecycle evidence'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_server_service_historical_route_retirement_time';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM automata_migration_0053_retire_authorities AS candidate
+        JOIN github_server_service_authority_issuances AS issuance
+          ON issuance.authority_id = candidate.authority_id
+        WHERE issuance.state NOT IN ('rejected', 'revoked')
+           OR issuance.envelope_schema IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'incompatible historical GitHub authority requires live credential reconciliation'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_server_service_historical_route_retirement_safe';
+    END IF;
+END;
+$automata$;
+
+UPDATE github_server_service_authorities AS authority
+SET state = 'retiring',
+    current_issuance_generation = NULL,
+    refresh_issuance_generation = NULL,
+    state_updated_at_ms = candidate.transition_at_ms
+FROM automata_migration_0053_retire_authorities AS candidate
+WHERE authority.id = candidate.authority_id
+  AND authority.state = 'active';
+
+UPDATE github_server_service_authorities AS authority
+SET state = 'retired',
+    retired_at_ms = candidate.transition_at_ms,
+    state_updated_at_ms = candidate.transition_at_ms
+FROM automata_migration_0053_retire_authorities AS candidate
+WHERE authority.id = candidate.authority_id
+  AND authority.state = 'retiring'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM github_server_service_authority_issuances AS issuance
+      WHERE issuance.authority_id = authority.id
+        AND (
+            issuance.state NOT IN ('rejected', 'revoked')
+            OR issuance.envelope_schema IS NOT NULL
+        )
+  );
+
+DO $automata$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM automata_migration_0053_retire_authorities AS candidate
+        JOIN github_server_service_authorities AS authority
+          ON authority.id = candidate.authority_id
+        WHERE authority.state <> 'retired'
+    ) THEN
+        RAISE EXCEPTION 'incompatible historical GitHub authority did not retire atomically'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'github_server_service_historical_route_retirement_complete';
+    END IF;
+END;
+$automata$;

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -1355,6 +1355,40 @@ impl CompleteGithubCheckProjection {
     }
 }
 
+/// Blocks one live projection whose immutable credential authority is unavailable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BlockGithubCheckProjectionForCredentialRejection {
+    claim: GithubCheckProjectionClaimFence,
+    blocked_at: UnixMillis,
+}
+
+impl BlockGithubCheckProjectionForCredentialRejection {
+    /// Constructs a closed credential-authority rejection under an exact claim.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a block time before the Unix epoch.
+    pub fn new(
+        claim: GithubCheckProjectionClaimFence,
+        blocked_at: UnixMillis,
+    ) -> Result<Self, GithubCheckValueError> {
+        validate_timestamp(blocked_at, "GitHub Check credential rejection time")?;
+        Ok(Self { claim, blocked_at })
+    }
+
+    /// Returns the exact live claim being blocked.
+    #[must_use]
+    pub const fn claim(self) -> GithubCheckProjectionClaimFence {
+        self.claim
+    }
+
+    /// Returns the trusted time at which local authority rejected the claim.
+    #[must_use]
+    pub const fn blocked_at(self) -> UnixMillis {
+        self.blocked_at
+    }
+}
+
 /// Releases a live claim for bounded delayed retry without changing external identity.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetryGithubCheckProjection {
@@ -1600,6 +1634,12 @@ pub trait GithubCheckProjectionOutbox: Send + Sync {
     async fn complete_github_check_projection(
         &self,
         request: CompleteGithubCheckProjection,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
+
+    /// Permanently blocks a live claim rejected by its immutable credential authority.
+    async fn block_github_check_projection_for_credential_rejection(
+        &self,
+        request: BlockGithubCheckProjectionForCredentialRejection,
     ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
 
     /// Releases a live claim into bounded retry state without losing uncertainty.

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -80,9 +80,10 @@ pub use error::{
 };
 pub use github_checks::{
     BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
-    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, CompleteGithubCheckProjection,
-    GithubCheckAppId, GithubCheckConclusion, GithubCheckCreateReconciliation,
-    GithubCheckDesiredProjection, GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
+    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
+    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, GithubCheckAppId,
+    GithubCheckConclusion, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
+    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
     GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
     GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
     GithubCheckSubjectId, GithubCheckSubjectIdentity, GithubCheckSubjectKey,

--- a/crates/automata-ci-store/src/postgres/github_checks.rs
+++ b/crates/automata-ci-store/src/postgres/github_checks.rs
@@ -5,20 +5,20 @@ use uuid::Uuid;
 
 use crate::{
     BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
-    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, CompleteGithubCheckProjection,
-    GithubCheckAppId, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
-    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
-    GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
-    GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
-    GithubCheckSubjectIdentity, GithubCheckSubjectKey, GithubCheckSubjectReceipt,
-    GithubCheckSubjectRepository, GithubCheckSubjectTarget, GithubCheckSuiteId,
-    GithubCheckTerminalCause, GithubCheckTerminalizationRepository, GithubRepositoryName,
-    GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
-    GithubServerServiceRevision, LinkGithubCheckWorkflowRun, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
-    ProviderConnectionId, ProviderDeliveryId, ProviderInstallationId, ProviderRepositoryId,
-    RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
-    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, StartGithubCheckProjection,
-    TenantScope, TerminalizeGithubCheck,
+    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
+    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, GithubCheckAppId,
+    GithubCheckCreateReconciliation, GithubCheckDesiredProjection, GithubCheckHeadSha,
+    GithubCheckName, GithubCheckProjectionAction, GithubCheckProjectionClaimFence,
+    GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
+    GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectIdentity,
+    GithubCheckSubjectKey, GithubCheckSubjectReceipt, GithubCheckSubjectRepository,
+    GithubCheckSubjectTarget, GithubCheckSuiteId, GithubCheckTerminalCause,
+    GithubCheckTerminalizationRepository, GithubRepositoryName, GithubServerServiceAuthorityId,
+    GithubServerServiceAuthoritySelector, GithubServerServiceRevision, LinkGithubCheckWorkflowRun,
+    MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS, ProviderConnectionId, ProviderDeliveryId,
+    ProviderInstallationId, ProviderRepositoryId, RegisterGithubCheckSubject,
+    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
+    RetryGithubCheckProjection, StartGithubCheckProjection, TenantScope, TerminalizeGithubCheck,
 };
 
 use super::PostgresStore;
@@ -868,6 +868,46 @@ impl GithubCheckProjectionOutbox for PostgresStore {
             Some(receipt) => Ok(receipt),
             None => Err(GithubCheckStoreError::ProjectionMismatch),
         }
+    }
+
+    async fn block_github_check_projection_for_credential_rejection(
+        &self,
+        request: BlockGithubCheckProjectionForCredentialRejection,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
+        let query = format!(
+            r"
+            UPDATE github_check_projection_outbox AS outbox
+            SET state = 'blocked',
+                next_attempt_at_ms = NULL,
+                last_failure_kind = NULL,
+                blocked_reason = 'credential_rejected',
+                claim_owner_id = NULL, claim_action = NULL,
+                claimed_desired_revision = NULL, claimed_desired_state = NULL,
+                claimed_desired_conclusion = NULL,
+                claimed_at_ms = NULL, claim_expires_at_ms = NULL,
+                state_updated_at_ms = $4
+            FROM github_check_subjects AS subject
+            WHERE outbox.subject_id = $1
+              AND subject.id = outbox.subject_id
+              AND outbox.state = 'claimed'
+              AND outbox.claim_owner_id = $2
+              AND outbox.claim_fence = $3
+              AND outbox.claimed_at_ms <= $4
+              AND outbox.claim_expires_at_ms > $4
+            RETURNING {SUBJECT_COLUMNS}
+            "
+        );
+        let row = sqlx::query(AssertSqlSafe(query))
+            .bind(request.claim().subject_id().as_uuid())
+            .bind(request.claim().owner().as_uuid())
+            .bind(request.claim().fence_i64())
+            .bind(request.blocked_at().get())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(operation_error)?;
+        row.map(|row| decode_subject(&row).map(|subject| subject.receipt))
+            .transpose()?
+            .ok_or(GithubCheckStoreError::ClaimRejected)
     }
 
     async fn retry_github_check_projection(

--- a/crates/automata-ci-store/tests/github_check_credential_rejection_migration.rs
+++ b/crates/automata-ci-store/tests/github_check_credential_rejection_migration.rs
@@ -1,0 +1,94 @@
+const MIGRATION: &str = include_str!("../migrations/0053_github_check_credential_rejection.sql");
+
+#[test]
+fn credential_rejection_is_one_exact_immutable_claim_transition() {
+    for required in [
+        "'ambiguous_create', 'attempt_limit', 'credential_rejected'",
+        "github_check_projection_outbox_00_credential_rejection_guard",
+        "OLD.state = 'blocked' AND OLD.blocked_reason = 'credential_rejected'",
+        "NEW IS DISTINCT FROM OLD",
+        "expected := OLD",
+        "expected.state := 'blocked'",
+        "expected.blocked_reason := 'credential_rejected'",
+        "OLD.state <> 'claimed'",
+        "NEW.state_updated_at_ms < OLD.claimed_at_ms",
+        "NEW.state_updated_at_ms >= OLD.claim_expires_at_ms",
+        "github_check_projection_credential_rejection_exact",
+        "github_check_projection_credential_rejection_immutable",
+    ] {
+        assert!(
+            MIGRATION.contains(required),
+            "missing credential-rejection transition invariant: {required}"
+        );
+    }
+}
+
+#[test]
+fn historical_authority_retirement_preserves_only_the_exact_live_route() {
+    for (scope, fingerprint) in [
+        (
+            "checks_write",
+            "86db54f098adc51219d176555d5f7b5461a4c45ddd0625393846b1b3a5ae6543",
+        ),
+        (
+            "private_repository_source_read",
+            "878f4bd01bfe4b04e84d9b9eee32667d31d55feebe78a7b2f59ed715b1145b32",
+        ),
+    ] {
+        assert!(
+            MIGRATION.contains(&format!(
+                "'{scope}',\n        decode(\n            '{fingerprint}',"
+            )),
+            "compatible fingerprint is not bound to {scope}"
+        );
+    }
+    for required in [
+        "github_provider_manifest_current AS current",
+        "automata_migration_0053_manifest_scopes",
+        "automata_migration_0053_current_routes",
+        "automata_migration_0053_compatible_routes",
+        "86db54f098adc51219d176555d5f7b5461a4c45ddd0625393846b1b3a5ae6543",
+        "878f4bd01bfe4b04e84d9b9eee32667d31d55feebe78a7b2f59ed715b1145b32",
+        "authority.app_configuration_revision =",
+        "scope.app_configuration_revision",
+        "authority.policy_revision = scope.policy_revision",
+        "HAVING count(route.authority_id) <> 1",
+        "github_server_service_current_manifest_route_exact",
+        "historical.configuration_fingerprint",
+        "current_route.configuration_fingerprint",
+        ") IS NOT DISTINCT FROM ROW(",
+        "compatible.service_scope = historical.service_scope",
+        "compatible.configuration_fingerprint",
+        "manifest.repository_source_authentication = 'anonymous_public'",
+        "historical.service_scope = 'private_repository_source_read'",
+        "issuance.state NOT IN ('rejected', 'revoked')",
+        "github_server_service_historical_route_retirement_safe",
+        "state = 'retired'",
+        "github_server_service_historical_route_retirement_complete",
+    ] {
+        assert!(
+            MIGRATION.contains(required),
+            "missing historical-authority retirement invariant: {required}"
+        );
+    }
+}
+
+#[test]
+fn migration_never_rebinds_history_or_forges_provider_reconciliation() {
+    for prohibited in [
+        "UPDATE github_provider_delivery_evidence",
+        "SET checks_authority_id",
+        "SET private_source_authority_id",
+        "DELETE FROM github_server_service",
+        "WHEN state = 'ready' THEN 'revoke_pending'",
+        "WHEN state = 'minting' THEN 'indeterminate'",
+        "authority_retired_before_mint",
+        "UPDATE github_server_service_authority_issuances",
+        "provider_revoked",
+    ] {
+        assert!(
+            !MIGRATION.contains(prohibited),
+            "migration must not rewrite history or fake provider work: {prohibited}"
+        );
+    }
+}

--- a/crates/automata-ci-store/tests/github_checks_api.rs
+++ b/crates/automata-ci-store/tests/github_checks_api.rs
@@ -1,8 +1,9 @@
 use automata_ci_core::{RunId, Sha256Digest, UnixMillis};
 use automata_ci_store::{
-    BeginGithubCheckRunCreate, ClaimGithubCheckProjection, ClaimedGithubCheckProjection,
-    GithubCheckAppId, GithubCheckConclusion, GithubCheckCreateReconciliation,
-    GithubCheckDesiredProjection, GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
+    BeginGithubCheckRunCreate, BlockGithubCheckProjectionForCredentialRejection,
+    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, GithubCheckAppId,
+    GithubCheckConclusion, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
+    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
     GithubCheckProjectionClaimFence, GithubCheckProjectionWorkerId, GithubCheckRunId,
     GithubCheckSubjectId, GithubCheckSubjectIdentity, GithubCheckSubjectKey,
     GithubCheckSubjectReceipt, GithubCheckSubjectTarget, GithubCheckSuiteId,
@@ -144,6 +145,26 @@ fn create_release_and_missing_reconciliation_are_temporally_bounded() {
             .retry_at(),
         None
     );
+}
+
+#[test]
+fn credential_rejection_block_retains_its_exact_claim_and_nonnegative_time() {
+    let subject = GithubCheckSubjectId::from_uuid(Uuid::new_v4()).expect("subject ID");
+    let worker = GithubCheckProjectionWorkerId::from_uuid(Uuid::new_v4()).expect("worker ID");
+    let claim = GithubCheckProjectionClaimFence::from_durable_parts(subject, worker, 7)
+        .expect("claim fence");
+
+    let request =
+        BlockGithubCheckProjectionForCredentialRejection::new(claim, UnixMillis::new(1_234))
+            .expect("credential rejection block");
+    assert_eq!(request.claim(), claim);
+    assert_eq!(request.blocked_at(), UnixMillis::new(1_234));
+    assert!(matches!(
+        BlockGithubCheckProjectionForCredentialRejection::new(claim, UnixMillis::new(-1)),
+        Err(GithubCheckValueError::NegativeTimestamp(
+            "GitHub Check credential rejection time"
+        ))
+    ));
 }
 
 fn prepare_projection(

--- a/crates/automata-ci-store/tests/postgres_github_check_credential_rejection_migration.rs
+++ b/crates/automata-ci-store/tests/postgres_github_check_credential_rejection_migration.rs
@@ -1,0 +1,905 @@
+#[allow(dead_code)]
+mod common;
+mod github_manifest_fixture;
+
+use automata_ci_core::{JobAuthorityProfile, Sha256Digest, UnixMillis};
+use automata_ci_store::{
+    ClaimGithubServerServiceMint, EnsureGithubServerServiceAuthority, GithubCheckName,
+    GithubProviderManifest, GithubProviderManifestLimits, GithubProviderManifestRepository as _,
+    GithubProviderManifestRevision, GithubProviderOrigins,
+    GithubProviderWebhookVerifierFingerprint, GithubRepositoryName, GithubServerServiceAppClientId,
+    GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
+    GithubServerServiceAuthorityRepository as _, GithubServerServiceAuthoritySelector,
+    GithubServerServiceGeneration, GithubServerServiceIssuanceState, GithubServerServiceJwtIssuer,
+    GithubServerServiceRevision, GithubServerServiceScope, GithubServerServiceWorkerId,
+    ProviderConnectionId, ProviderInstallationId, ProviderRepositoryId,
+    ProviderRepositoryVisibility, ReconcileExpiredGithubServerServiceMint, TenantScope,
+};
+use sqlx::{AssertSqlSafe, migrate::Migrate as _};
+use uuid::Uuid;
+
+use common::{TestDatabase, TestResult, run_with_unmigrated_database};
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+const INSTALLATION_ID: u64 = 101;
+const GITHUB_REPOSITORY_ID: u64 = 202;
+const APP_ID: u64 = 303;
+const APP_CONFIGURATION_REVISION: u64 = 1;
+const COMPATIBLE_CHECKS_V1_FINGERPRINT: [u8; 32] = [
+    0x86, 0xdb, 0x54, 0xf0, 0x98, 0xad, 0xc5, 0x12, 0x19, 0xd1, 0x76, 0x55, 0x5d, 0x5f, 0x7b, 0x54,
+    0x61, 0xa4, 0xc4, 0x5d, 0xdd, 0x06, 0x25, 0x39, 0x38, 0x46, 0xb1, 0xb3, 0xa5, 0xae, 0x65, 0x43,
+];
+const COMPATIBLE_PRIVATE_V1_FINGERPRINT: [u8; 32] = [
+    0x87, 0x8f, 0x4b, 0xd0, 0x1b, 0xfe, 0x4b, 0x04, 0xe8, 0x4d, 0x9b, 0x9e, 0xee, 0x32, 0x66, 0x7d,
+    0x31, 0xd5, 0x5f, 0xee, 0xbe, 0x78, 0xa7, 0xb2, 0xf5, 0x9e, 0xd7, 0x15, 0xb1, 0x14, 0x5b, 0x32,
+];
+
+#[derive(Debug)]
+struct ManifestFixture {
+    connection_id: ProviderConnectionId,
+    current: GithubProviderManifest,
+}
+
+#[derive(Debug)]
+struct PrivateRouteFixture {
+    current_checks: GithubServerServiceAuthorityIdentity,
+    current_private: GithubServerServiceAuthorityIdentity,
+    compatible_checks_v1_historical: GithubServerServiceAuthorityIdentity,
+    compatible_private_v1_historical: GithubServerServiceAuthorityIdentity,
+    unknown_checks_historical: GithubServerServiceAuthorityIdentity,
+    swapped_scope_checks_historical: GithubServerServiceAuthorityIdentity,
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn migration_preserves_scope_bound_v1_history_and_retires_safe_unknown_and_swapped_history()
+-> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_through_0052(&database).await?;
+        install_database_test_clock(&database, 100).await?;
+        let manifest = bootstrap_private_manifest_history(&database).await?;
+        let authorities = seed_private_routes(&database, &manifest).await?;
+        reject_one_unissued_generation(&database, &authorities.unknown_checks_historical, 600)
+            .await?;
+        reject_one_unissued_generation(
+            &database,
+            &authorities.swapped_scope_checks_historical,
+            700,
+        )
+        .await?;
+
+        let manifest_before = manifest_snapshot(&database, manifest.connection_id).await?;
+        let current_checks_before =
+            authority_snapshot(&database, &authorities.current_checks).await?;
+        let current_private_before =
+            authority_snapshot(&database, &authorities.current_private).await?;
+        let compatible_checks_before =
+            authority_snapshot(&database, &authorities.compatible_checks_v1_historical).await?;
+        let compatible_private_before =
+            authority_snapshot(&database, &authorities.compatible_private_v1_historical).await?;
+        let unknown_identity_before =
+            authority_identity_snapshot(&database, &authorities.unknown_checks_historical).await?;
+        let unknown_issuance_before =
+            issuance_snapshot(&database, &authorities.unknown_checks_historical).await?;
+        let swapped_identity_before =
+            authority_identity_snapshot(&database, &authorities.swapped_scope_checks_historical)
+                .await?;
+        let swapped_issuance_before =
+            issuance_snapshot(&database, &authorities.swapped_scope_checks_historical).await?;
+
+        set_database_test_clock(&database, 100_000).await?;
+        apply_0053(&database).await?;
+
+        assert_eq!(
+            manifest_snapshot(&database, manifest.connection_id).await?,
+            manifest_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &authorities.current_checks).await?,
+            current_checks_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &authorities.current_private).await?,
+            current_private_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &authorities.compatible_checks_v1_historical).await?,
+            compatible_checks_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &authorities.compatible_private_v1_historical).await?,
+            compatible_private_before
+        );
+        assert_eq!(
+            authority_identity_snapshot(&database, &authorities.unknown_checks_historical).await?,
+            unknown_identity_before
+        );
+        assert_eq!(
+            issuance_snapshot(&database, &authorities.unknown_checks_historical).await?,
+            unknown_issuance_before,
+            "migration must not rewrite unknown-route issuance history"
+        );
+        assert_eq!(
+            authority_identity_snapshot(&database, &authorities.swapped_scope_checks_historical,)
+                .await?,
+            swapped_identity_before
+        );
+        assert_eq!(
+            issuance_snapshot(&database, &authorities.swapped_scope_checks_historical).await?,
+            swapped_issuance_before,
+            "migration must not rewrite swapped-scope issuance history"
+        );
+        assert_authority_state(
+            &database,
+            &authorities.unknown_checks_historical,
+            "retired",
+            Some(100_000),
+        )
+        .await?;
+        assert_authority_state(
+            &database,
+            &authorities.swapped_scope_checks_historical,
+            "retired",
+            Some(100_000),
+        )
+        .await?;
+        assert!(migration_0053_applied(&database).await?);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn migration_retires_obsolete_private_route_after_public_transition() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_through_0052(&database).await?;
+        install_database_test_clock(&database, 100).await?;
+        let manifest = bootstrap_public_successor_of_private(&database).await?;
+        let current_checks = ensure_authority(
+            &database,
+            authority(
+                &manifest.current,
+                GithubServerServiceScope::ChecksWrite,
+                2,
+                [0x51; 32],
+            )?,
+            300,
+        )
+        .await?;
+        let obsolete_private = ensure_authority(
+            &database,
+            authority(
+                &manifest.current,
+                GithubServerServiceScope::PrivateRepositorySourceRead,
+                1,
+                COMPATIBLE_PRIVATE_V1_FINGERPRINT,
+            )?,
+            301,
+        )
+        .await?;
+        assert_eq!(
+            obsolete_private.configuration_fingerprint(),
+            Sha256Digest::from_bytes(COMPATIBLE_PRIVATE_V1_FINGERPRINT)
+        );
+        let manifest_before = manifest_snapshot(&database, manifest.connection_id).await?;
+        let current_before = authority_snapshot(&database, &current_checks).await?;
+        let obsolete_identity_before =
+            authority_identity_snapshot(&database, &obsolete_private).await?;
+
+        set_database_test_clock(&database, 1_000).await?;
+        apply_0053(&database).await?;
+
+        assert_eq!(
+            manifest_snapshot(&database, manifest.connection_id).await?,
+            manifest_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &current_checks).await?,
+            current_before
+        );
+        assert_eq!(
+            authority_identity_snapshot(&database, &obsolete_private).await?,
+            obsolete_identity_before
+        );
+        assert_authority_state(&database, &obsolete_private, "retired", Some(1_000)).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn migration_rejects_a_missing_current_route_without_partial_ddl() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_through_0052(&database).await?;
+        install_database_test_clock(&database, 100).await?;
+        let manifest = bootstrap_public_manifest(&database).await?;
+        let manifest_before = manifest_snapshot(&database, manifest.connection_id).await?;
+
+        set_database_test_clock(&database, 1_000).await?;
+        let error = apply_0053(&database)
+            .await
+            .expect_err("a current manifest without its exact active route must fail");
+        assert_migration_constraint(error, "github_server_service_current_manifest_route_exact");
+        assert_eq!(
+            manifest_snapshot(&database, manifest.connection_id).await?,
+            manifest_before
+        );
+        assert_failed_migration_rolled_back(&database).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn migration_rejects_nonterminal_incompatible_history_atomically() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_through_0052(&database).await?;
+        install_database_test_clock(&database, 100).await?;
+        let manifest = bootstrap_public_manifest(&database).await?;
+        let current = ensure_authority(
+            &database,
+            authority(
+                &manifest.current,
+                GithubServerServiceScope::ChecksWrite,
+                1,
+                [0x71; 32],
+            )?,
+            200,
+        )
+        .await?;
+        let incompatible = ensure_authority(
+            &database,
+            authority(
+                &manifest.current,
+                GithubServerServiceScope::ChecksWrite,
+                2,
+                [0x72; 32],
+            )?,
+            201,
+        )
+        .await?;
+        claim_one_generation(&database, &incompatible, 300).await?;
+        let manifest_before = manifest_snapshot(&database, manifest.connection_id).await?;
+        let current_before = authority_snapshot(&database, &current).await?;
+        let incompatible_before = authority_snapshot(&database, &incompatible).await?;
+        let issuance_before = issuance_snapshot(&database, &incompatible).await?;
+
+        set_database_test_clock(&database, 1_000).await?;
+        let error = apply_0053(&database)
+            .await
+            .expect_err("nonterminal incompatible issuance must block migration");
+        assert_migration_constraint(
+            error,
+            "github_server_service_historical_route_retirement_safe",
+        );
+        assert_eq!(
+            manifest_snapshot(&database, manifest.connection_id).await?,
+            manifest_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &current).await?,
+            current_before
+        );
+        assert_eq!(
+            authority_snapshot(&database, &incompatible).await?,
+            incompatible_before
+        );
+        assert_eq!(
+            issuance_snapshot(&database, &incompatible).await?,
+            issuance_before
+        );
+        assert_failed_migration_rolled_back(&database).await?;
+        Ok(())
+    })
+    .await
+}
+
+async fn apply_through_0052(database: &TestDatabase) -> TestResult {
+    let mut connection = database.pool().acquire().await?;
+    connection
+        .ensure_migrations_table(MIGRATOR.table_name.as_ref())
+        .await?;
+    for migration in MIGRATOR.iter().filter(|migration| migration.version <= 52) {
+        connection
+            .apply(MIGRATOR.table_name.as_ref(), migration)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn apply_0053(database: &TestDatabase) -> Result<(), sqlx::migrate::MigrateError> {
+    let mut connection = database
+        .pool()
+        .acquire()
+        .await
+        .map_err(sqlx::migrate::MigrateError::Execute)?;
+    let migration = MIGRATOR
+        .iter()
+        .find(|migration| migration.version == 53)
+        .expect("credential-rejection migration");
+    connection
+        .apply(MIGRATOR.table_name.as_ref(), migration)
+        .await
+        .map(|_| ())
+}
+
+async fn install_database_test_clock(database: &TestDatabase, now_ms: i64) -> TestResult {
+    let schema: String = sqlx::query_scalar("SELECT current_schema()")
+        .fetch_one(database.pool())
+        .await?;
+    if !schema
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err("test schema contains a non-identifier byte".into());
+    }
+    let schema = format!("\"{schema}\"");
+    sqlx::query(AssertSqlSafe(format!(
+        "CREATE TABLE {schema}.github_check_migration_test_clock (\
+         singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton), \
+         now_ms BIGINT NOT NULL CHECK (now_ms >= 0))"
+    )))
+    .execute(database.pool())
+    .await?;
+    sqlx::query(AssertSqlSafe(format!(
+        "INSERT INTO {schema}.github_check_migration_test_clock (singleton, now_ms) \
+         VALUES (TRUE, $1)"
+    )))
+    .bind(now_ms)
+    .execute(database.pool())
+    .await?;
+    sqlx::query(AssertSqlSafe(format!(
+        "CREATE FUNCTION {schema}.clock_timestamp() RETURNS TIMESTAMPTZ \
+         LANGUAGE SQL VOLATILE AS $clock$ \
+         SELECT TIMESTAMPTZ 'epoch' + now_ms * INTERVAL '1 millisecond' \
+         FROM {schema}.github_check_migration_test_clock WHERE singleton \
+         $clock$"
+    )))
+    .execute(database.pool())
+    .await?;
+    set_database_test_clock(database, now_ms).await
+}
+
+async fn set_database_test_clock(database: &TestDatabase, now_ms: i64) -> TestResult {
+    let updated =
+        sqlx::query("UPDATE github_check_migration_test_clock SET now_ms = $1 WHERE singleton")
+            .bind(now_ms)
+            .execute(database.pool())
+            .await?;
+    assert_eq!(updated.rows_affected(), 1);
+    let observed: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(database.pool())
+            .await?;
+    assert_eq!(observed, now_ms);
+    Ok(())
+}
+
+async fn bootstrap_private_manifest_history(
+    database: &TestDatabase,
+) -> TestResult<ManifestFixture> {
+    let tenant = tenant("private-history")?;
+    let connection_id = ProviderConnectionId::from_uuid(Uuid::new_v4())?;
+    let mut current = manifest(
+        tenant.clone(),
+        connection_id,
+        ProviderRepositoryVisibility::Private,
+        1,
+        1,
+    )?;
+    bootstrap_manifest(database, current.clone(), 100).await?;
+    current = manifest(
+        tenant,
+        connection_id,
+        ProviderRepositoryVisibility::Private,
+        2,
+        2,
+    )?;
+    bootstrap_manifest(database, current.clone(), 200).await?;
+    Ok(ManifestFixture {
+        connection_id,
+        current,
+    })
+}
+
+async fn bootstrap_public_successor_of_private(
+    database: &TestDatabase,
+) -> TestResult<ManifestFixture> {
+    let tenant = tenant("public-successor")?;
+    let connection_id = ProviderConnectionId::from_uuid(Uuid::new_v4())?;
+    let private = manifest(
+        tenant.clone(),
+        connection_id,
+        ProviderRepositoryVisibility::Private,
+        1,
+        1,
+    )?;
+    bootstrap_manifest(database, private, 100).await?;
+    let current = manifest(
+        tenant.clone(),
+        connection_id,
+        ProviderRepositoryVisibility::Public,
+        2,
+        2,
+    )?;
+    bootstrap_manifest(database, current.clone(), 200).await?;
+    Ok(ManifestFixture {
+        connection_id,
+        current,
+    })
+}
+
+async fn bootstrap_public_manifest(database: &TestDatabase) -> TestResult<ManifestFixture> {
+    let tenant = tenant("public-current")?;
+    let connection_id = ProviderConnectionId::from_uuid(Uuid::new_v4())?;
+    let current = manifest(
+        tenant.clone(),
+        connection_id,
+        ProviderRepositoryVisibility::Public,
+        1,
+        1,
+    )?;
+    bootstrap_manifest(database, current.clone(), 100).await?;
+    Ok(ManifestFixture {
+        connection_id,
+        current,
+    })
+}
+
+async fn bootstrap_manifest(
+    database: &TestDatabase,
+    manifest: GithubProviderManifest,
+    applied_at: i64,
+) -> TestResult {
+    set_database_test_clock(database, applied_at).await?;
+    let receipt = database
+        .store()
+        .bootstrap_github_provider_repository(
+            github_manifest_fixture::fixture_github_repository_bootstrap(
+                manifest.clone(),
+                UnixMillis::new(applied_at),
+            ),
+        )
+        .await?;
+    assert_eq!(receipt.manifest().current().manifest(), &manifest);
+    Ok(())
+}
+
+fn manifest(
+    tenant: TenantScope,
+    connection_id: ProviderConnectionId,
+    visibility: ProviderRepositoryVisibility,
+    manifest_revision: u64,
+    policy_revision: u64,
+) -> TestResult<GithubProviderManifest> {
+    let runtime_policy = github_manifest_fixture::fixture_github_runtime_policy(policy_revision);
+    Ok(GithubProviderManifest::new(
+        tenant,
+        connection_id,
+        ProviderInstallationId::new(INSTALLATION_ID)?,
+        ProviderRepositoryId::new(GITHUB_REPOSITORY_ID)?,
+        GithubRepositoryName::new("automata-ci/automata")?,
+        visibility,
+        GithubServerServiceAppId::new(APP_ID)?,
+        GithubServerServiceAppClientId::new("Iv1.8a61f9b3a7aba766")?,
+        GithubServerServiceJwtIssuer::AppClientId,
+        Sha256Digest::from_bytes([0x11; 32]),
+        GithubServerServiceRevision::new(APP_CONFIGURATION_REVISION)?,
+        GithubProviderWebhookVerifierFingerprint::from_sha256(Sha256Digest::from_bytes(
+            [0x21; 32],
+        ))?,
+        GithubServerServiceRevision::new(1)?,
+        GithubServerServiceRevision::new(policy_revision)?,
+        JobAuthorityProfile::Standard,
+        runtime_policy.runner_policy,
+        runtime_policy.revision,
+        runtime_policy.semantic_digest,
+        GithubCheckName::new("Automata CI")?,
+        GithubProviderOrigins::github_dot_com(),
+        GithubProviderManifestLimits::github_dot_com_ci(),
+        GithubProviderManifestRevision::new(manifest_revision)?,
+    ))
+}
+
+fn tenant(suffix: &str) -> TestResult<TenantScope> {
+    Ok(TenantScope::from_authenticated_tenant_id(format!(
+        "check-migration-{suffix}-{}",
+        Uuid::new_v4().simple()
+    ))?)
+}
+
+async fn seed_private_routes(
+    database: &TestDatabase,
+    manifest: &ManifestFixture,
+) -> TestResult<PrivateRouteFixture> {
+    let current_checks = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::ChecksWrite,
+            2,
+            [0x31; 32],
+        )?,
+        300,
+    )
+    .await?;
+    let current_private = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::PrivateRepositorySourceRead,
+            2,
+            [0x41; 32],
+        )?,
+        301,
+    )
+    .await?;
+    let compatible_checks_v1_historical = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::ChecksWrite,
+            1,
+            COMPATIBLE_CHECKS_V1_FINGERPRINT,
+        )?,
+        302,
+    )
+    .await?;
+    let compatible_private_v1_historical = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::PrivateRepositorySourceRead,
+            1,
+            COMPATIBLE_PRIVATE_V1_FINGERPRINT,
+        )?,
+        303,
+    )
+    .await?;
+    let unknown_checks_historical = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::ChecksWrite,
+            3,
+            [0x32; 32],
+        )?,
+        304,
+    )
+    .await?;
+    let swapped_scope_checks_historical = ensure_authority(
+        database,
+        authority(
+            &manifest.current,
+            GithubServerServiceScope::ChecksWrite,
+            4,
+            COMPATIBLE_PRIVATE_V1_FINGERPRINT,
+        )?,
+        305,
+    )
+    .await?;
+    let fixture = PrivateRouteFixture {
+        current_checks,
+        current_private,
+        compatible_checks_v1_historical,
+        compatible_private_v1_historical,
+        unknown_checks_historical,
+        swapped_scope_checks_historical,
+    };
+    assert_private_route_fixture(&fixture);
+    Ok(fixture)
+}
+
+fn assert_private_route_fixture(fixture: &PrivateRouteFixture) {
+    assert_eq!(
+        fixture
+            .compatible_checks_v1_historical
+            .configuration_fingerprint(),
+        Sha256Digest::from_bytes(COMPATIBLE_CHECKS_V1_FINGERPRINT)
+    );
+    assert_eq!(
+        fixture.compatible_checks_v1_historical.scope(),
+        GithubServerServiceScope::ChecksWrite
+    );
+    assert_eq!(
+        fixture
+            .compatible_private_v1_historical
+            .configuration_fingerprint(),
+        Sha256Digest::from_bytes(COMPATIBLE_PRIVATE_V1_FINGERPRINT)
+    );
+    assert_eq!(
+        fixture.compatible_private_v1_historical.scope(),
+        GithubServerServiceScope::PrivateRepositorySourceRead
+    );
+    assert_ne!(
+        fixture.current_checks.configuration_fingerprint(),
+        fixture
+            .compatible_checks_v1_historical
+            .configuration_fingerprint()
+    );
+    assert_ne!(
+        fixture.current_private.configuration_fingerprint(),
+        fixture
+            .compatible_private_v1_historical
+            .configuration_fingerprint()
+    );
+    assert_ne!(
+        fixture
+            .unknown_checks_historical
+            .configuration_fingerprint(),
+        fixture.current_checks.configuration_fingerprint()
+    );
+    assert_ne!(
+        fixture
+            .unknown_checks_historical
+            .configuration_fingerprint(),
+        fixture
+            .compatible_checks_v1_historical
+            .configuration_fingerprint()
+    );
+    assert_ne!(
+        fixture
+            .unknown_checks_historical
+            .configuration_fingerprint(),
+        fixture
+            .compatible_private_v1_historical
+            .configuration_fingerprint()
+    );
+    assert_eq!(
+        fixture.swapped_scope_checks_historical.scope(),
+        GithubServerServiceScope::ChecksWrite
+    );
+    assert_eq!(
+        fixture
+            .swapped_scope_checks_historical
+            .configuration_fingerprint(),
+        fixture
+            .compatible_private_v1_historical
+            .configuration_fingerprint()
+    );
+}
+
+fn authority(
+    manifest: &GithubProviderManifest,
+    scope: GithubServerServiceScope,
+    policy_revision: u64,
+    configuration_fingerprint: [u8; 32],
+) -> TestResult<GithubServerServiceAuthorityIdentity> {
+    Ok(GithubServerServiceAuthorityIdentity::new(
+        manifest.tenant().clone(),
+        GithubServerServiceAuthorityId::from_uuid(Uuid::new_v4())?,
+        manifest.repository_id(),
+        manifest.connection_id(),
+        manifest.installation_id(),
+        manifest.github_app_id(),
+        manifest.github_repository_id(),
+        manifest.github_repository_name().clone(),
+        scope,
+        manifest.app_client_id().clone(),
+        manifest.jwt_issuer(),
+        manifest.app_key_spki_sha256(),
+        manifest.app_configuration_revision(),
+        GithubServerServiceRevision::new(policy_revision)?,
+        Sha256Digest::from_bytes(configuration_fingerprint),
+    )?)
+}
+
+async fn ensure_authority(
+    database: &TestDatabase,
+    identity: GithubServerServiceAuthorityIdentity,
+    created_at: i64,
+) -> TestResult<GithubServerServiceAuthorityIdentity> {
+    set_database_test_clock(database, created_at).await?;
+    database
+        .store()
+        .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
+            identity.clone(),
+            UnixMillis::new(created_at),
+        )?)
+        .await?;
+    Ok(identity)
+}
+
+async fn claim_one_generation(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+    requested_at: i64,
+) -> TestResult<automata_ci_store::GithubServerServiceIssuanceKey> {
+    set_database_test_clock(database, requested_at).await?;
+    let claimed = database
+        .store()
+        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
+            GithubServerServiceAuthoritySelector::from_identity(identity),
+            GithubServerServiceGeneration::new(1)?,
+            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+            UnixMillis::new(requested_at),
+            UnixMillis::new(requested_at + 20),
+            UnixMillis::new(requested_at + 10),
+        )?)
+        .await?;
+    Ok(claimed.claim().key())
+}
+
+async fn reject_one_unissued_generation(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+    requested_at: i64,
+) -> TestResult {
+    let key = claim_one_generation(database, identity, requested_at).await?;
+    set_database_test_clock(database, requested_at + 10).await?;
+    let receipt = database
+        .store()
+        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
+            GithubServerServiceAuthoritySelector::from_identity(identity),
+            key,
+            UnixMillis::new(requested_at + 10),
+        )?)
+        .await?;
+    assert_eq!(receipt.state(), GithubServerServiceIssuanceState::Rejected);
+    let terminal_and_custody_free: bool = sqlx::query_scalar(
+        "SELECT state = 'rejected' AND envelope_schema IS NULL \
+         FROM github_server_service_authority_issuances \
+         WHERE authority_id = $1 AND generation = 1",
+    )
+    .bind(identity.authority_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert!(terminal_and_custody_free);
+    Ok(())
+}
+
+async fn manifest_snapshot(
+    database: &TestDatabase,
+    connection_id: ProviderConnectionId,
+) -> TestResult<String> {
+    Ok(sqlx::query_scalar(
+        r"
+        SELECT jsonb_build_object(
+            'current', (
+                SELECT to_jsonb(current_manifest)
+                FROM github_provider_manifest_current AS current_manifest
+                WHERE current_manifest.provider_connection_id = $1
+            ),
+            'revisions', (
+                SELECT jsonb_agg(to_jsonb(revision) ORDER BY revision.manifest_revision)
+                FROM github_provider_manifest_revisions AS revision
+                WHERE revision.provider_connection_id = $1
+            )
+        )::TEXT
+        ",
+    )
+    .bind(connection_id.as_uuid())
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn authority_snapshot(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+) -> TestResult<String> {
+    Ok(sqlx::query_scalar(
+        "SELECT to_jsonb(authority)::TEXT FROM github_server_service_authorities AS authority \
+         WHERE authority.id = $1",
+    )
+    .bind(identity.authority_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn authority_identity_snapshot(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+) -> TestResult<String> {
+    Ok(sqlx::query_scalar(
+        r"
+        SELECT to_jsonb(immutable_authority)::TEXT
+        FROM (
+            SELECT id, tenant_id, repository_id, provider_connection_id,
+                   provider_installation_id, github_app_id, github_app_client_id,
+                   github_app_jwt_issuer_kind, github_repository_id,
+                   github_repository_name, service_scope, permission_policy,
+                   policy_digest, policy_revision, app_key_spki_sha256,
+                   app_configuration_revision, configuration_fingerprint,
+                   identity_digest, created_at_ms
+            FROM github_server_service_authorities
+            WHERE id = $1
+        ) AS immutable_authority
+        ",
+    )
+    .bind(identity.authority_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn issuance_snapshot(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+) -> TestResult<String> {
+    Ok(sqlx::query_scalar(
+        r"
+        SELECT COALESCE(
+            jsonb_agg(to_jsonb(issuance) ORDER BY issuance.generation),
+            '[]'::JSONB
+        )::TEXT
+        FROM github_server_service_authority_issuances AS issuance
+        WHERE issuance.authority_id = $1
+        ",
+    )
+    .bind(identity.authority_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn assert_authority_state(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+    expected_state: &str,
+    expected_retired_at: Option<i64>,
+) -> TestResult {
+    let state: (String, Option<i64>, i64) = sqlx::query_as(
+        "SELECT state, retired_at_ms, state_updated_at_ms \
+         FROM github_server_service_authorities WHERE id = $1",
+    )
+    .bind(identity.authority_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(state.0, expected_state);
+    assert_eq!(state.1, expected_retired_at);
+    if let Some(retired_at) = expected_retired_at {
+        assert_eq!(state.2, retired_at);
+    }
+    Ok(())
+}
+
+async fn migration_0053_applied(database: &TestDatabase) -> TestResult<bool> {
+    Ok(sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM _sqlx_migrations WHERE version = 53 AND success)",
+    )
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn assert_failed_migration_rolled_back(database: &TestDatabase) -> TestResult {
+    assert!(!migration_0053_applied(database).await?);
+    let function_exists: bool = sqlx::query_scalar(
+        "SELECT to_regprocedure(\
+         'automata_github_check_credential_rejection_guard()') IS NOT NULL",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert!(
+        !function_exists,
+        "failed migration retained its trigger function"
+    );
+    let block_constraint: String = sqlx::query_scalar(
+        r"
+        SELECT pg_get_constraintdef(catalog_constraint.oid)
+        FROM pg_constraint AS catalog_constraint
+        WHERE catalog_constraint.conrelid = 'github_check_projection_outbox'::REGCLASS
+          AND catalog_constraint.conname = 'github_check_projection_outbox_block_shape'
+        ",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert!(!block_constraint.contains("credential_rejected"));
+    Ok(())
+}
+
+fn assert_migration_constraint(error: sqlx::migrate::MigrateError, expected: &str) {
+    let database_error = match error {
+        sqlx::migrate::MigrateError::ExecuteMigration(
+            sqlx::Error::Database(database_error),
+            53,
+        )
+        | sqlx::migrate::MigrateError::Execute(sqlx::Error::Database(database_error)) => {
+            database_error
+        }
+        other => panic!("unexpected migration failure: {other:?}"),
+    };
+    assert_eq!(database_error.code().as_deref(), Some("23514"));
+    assert_eq!(database_error.constraint(), Some(expected));
+}

--- a/crates/automata-ci-store/tests/postgres_github_checks.rs
+++ b/crates/automata-ci-store/tests/postgres_github_checks.rs
@@ -4,19 +4,19 @@ mod common;
 use automata_ci_core::{RunId, Sha256Digest, UnixMillis};
 use automata_ci_store::{
     AcceptProviderDelivery, AdmissionObject, BeginGithubCheckRunCreate, BindGithubCheckRun,
-    BindGithubCheckSuite, ClaimGithubCheckProjection, ClaimedGithubCheckProjection,
-    CompleteGithubCheckProjection, GithubCheckAppId, GithubCheckDesiredProjection,
-    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
-    GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
-    GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectIdentity,
-    GithubCheckSubjectKey, GithubCheckSubjectReceipt, GithubCheckSubjectRepository as _,
-    GithubCheckSubjectTarget, GithubCheckSuiteId, GithubCheckTerminalCause,
-    GithubCheckTerminalizationRepository as _, GithubRepositoryName, LinkGithubCheckWorkflowRun,
-    ObjectKey, ProviderConnectionId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryVisibility, RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckRunCreate,
-    RepositoryId, ResolveGithubCheckRunCreate, StartGithubCheckProjection, TenantScope,
-    TerminalizeGithubCheck,
+    BindGithubCheckSuite, BlockGithubCheckProjectionForCredentialRejection,
+    ClaimGithubCheckProjection, ClaimedGithubCheckProjection, CompleteGithubCheckProjection,
+    GithubCheckAppId, GithubCheckDesiredProjection, GithubCheckHeadSha, GithubCheckName,
+    GithubCheckProjectionAction, GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox as _,
+    GithubCheckProjectionWorkerId, GithubCheckRunBindingFence, GithubCheckRunCreateFence,
+    GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectIdentity, GithubCheckSubjectKey,
+    GithubCheckSubjectReceipt, GithubCheckSubjectRepository as _, GithubCheckSubjectTarget,
+    GithubCheckSuiteId, GithubCheckTerminalCause, GithubCheckTerminalizationRepository as _,
+    GithubRepositoryName, LinkGithubCheckWorkflowRun, ObjectKey, ProviderConnectionId,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryVisibility,
+    RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
+    ResolveGithubCheckRunCreate, StartGithubCheckProjection, TenantScope, TerminalizeGithubCheck,
 };
 use sqlx::migrate::Migrate as _;
 use uuid::Uuid;
@@ -31,6 +31,60 @@ const GITHUB_APP_ID: u64 = 303;
 const HEAD_SHA: [u8; 20] = [9; 20];
 const CLAIM_MILLIS: i64 = 200;
 
+async fn apply_credential_rejection_migration(connection: &mut sqlx::PgConnection) -> TestResult {
+    // Migration 0053 also retires incompatible authorities against the 0035
+    // manifest tables. This 0029-focused fixture has no manifest candidates;
+    // empty connection-local tables let it execute the exact migration while
+    // retirement lifecycle coverage remains in the dedicated 0053 tests.
+    sqlx::query(
+        r"
+        CREATE TEMPORARY TABLE github_provider_manifest_revisions (
+            tenant_id TEXT NOT NULL,
+            repository_id UUID NOT NULL,
+            provider_connection_id UUID NOT NULL,
+            manifest_revision BIGINT NOT NULL,
+            manifest_digest BYTEA NOT NULL,
+            provider_installation_id BIGINT NOT NULL,
+            github_repository_id BIGINT NOT NULL,
+            github_repository_name TEXT NOT NULL,
+            github_app_id BIGINT NOT NULL,
+            github_app_client_id TEXT NOT NULL,
+            github_app_jwt_issuer_kind TEXT NOT NULL,
+            app_key_spki_sha256 BYTEA NOT NULL,
+            app_configuration_revision BIGINT NOT NULL,
+            policy_revision BIGINT NOT NULL,
+            repository_source_authentication TEXT NOT NULL
+        )
+        ",
+    )
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query(
+        r"
+        CREATE TEMPORARY TABLE github_provider_manifest_current (
+            tenant_id TEXT NOT NULL,
+            repository_id UUID NOT NULL,
+            provider_connection_id UUID NOT NULL,
+            manifest_revision BIGINT NOT NULL,
+            manifest_digest BYTEA NOT NULL
+        )
+        ",
+    )
+    .execute(&mut *connection)
+    .await?;
+    let credential_rejection = MIGRATOR
+        .iter()
+        .find(|migration| migration.version == 53)
+        .expect("credential-rejection migration");
+    connection
+        .apply(MIGRATOR.table_name.as_ref(), credential_rejection)
+        .await?;
+    sqlx::query("DROP TABLE github_provider_manifest_current, github_provider_manifest_revisions")
+        .execute(&mut *connection)
+        .await?;
+    Ok(())
+}
+
 async fn apply_checks_migrations(database: &TestDatabase) -> TestResult {
     let mut connection = database.pool().acquire().await?;
     connection
@@ -41,6 +95,7 @@ async fn apply_checks_migrations(database: &TestDatabase) -> TestResult {
             .apply(MIGRATOR.table_name.as_ref(), migration)
             .await?;
     }
+    apply_credential_rejection_migration(&mut connection).await?;
     // These focused 0029 lifecycle tests intentionally stop before the 0035
     // current-only cutover. Model only the later immutable selector projection
     // consumed by the current outbox adapter; full 0037 parity is covered by
@@ -300,6 +355,107 @@ async fn wait_until_database(database: &TestDatabase, target: UnixMillis) -> Tes
     while database_now_ms(database).await? < target.get() {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
     }
+    Ok(())
+}
+
+async fn github_check_outbox_snapshot(
+    database: &TestDatabase,
+    subject_id: automata_ci_store::GithubCheckSubjectId,
+) -> TestResult<String> {
+    Ok(sqlx::query_scalar(
+        r"
+        SELECT row_to_json(outbox)::text
+        FROM github_check_projection_outbox AS outbox
+        WHERE outbox.subject_id = $1
+        ",
+    )
+    .bind(subject_id.as_uuid())
+    .fetch_one(database.pool())
+    .await?)
+}
+
+async fn assert_credential_block_rejected_without_mutation(
+    database: &TestDatabase,
+    subject_id: automata_ci_store::GithubCheckSubjectId,
+    request: BlockGithubCheckProjectionForCredentialRejection,
+    before: &str,
+) -> TestResult {
+    assert!(matches!(
+        database
+            .store()
+            .block_github_check_projection_for_credential_rejection(request)
+            .await,
+        Err(GithubCheckStoreError::ClaimRejected)
+    ));
+    assert_eq!(
+        github_check_outbox_snapshot(database, subject_id).await?,
+        before,
+        "a rejected credential block must not mutate durable state"
+    );
+    Ok(())
+}
+
+async fn assert_credential_rejection_blocked_state(
+    database: &TestDatabase,
+    fixture: &Fixture,
+    receipt: &GithubCheckSubjectReceipt,
+    create_fence: GithubCheckRunCreateFence,
+    suite: GithubCheckSuiteId,
+    blocked_at: UnixMillis,
+) -> TestResult {
+    let row: (String, String, bool, bool, bool, i64) = sqlx::query_as(
+        r"
+        SELECT state, blocked_reason,
+               claim_owner_id IS NULL
+                   AND claim_action IS NULL
+                   AND claimed_desired_revision IS NULL
+                   AND claimed_desired_state IS NULL
+                   AND claimed_desired_conclusion IS NULL
+                   AND claimed_at_ms IS NULL
+                   AND claim_expires_at_ms IS NULL AS claim_cleared,
+               next_attempt_at_ms IS NULL
+                   AND last_failure_kind IS NULL AS retry_cleared,
+               COALESCE(
+                   external_suite_id = $2
+                   AND external_run_id IS NULL
+                   AND external_bound_at_ms IS NULL
+                   AND create_owner_id = $3
+                   AND create_fence = $4
+                   AND create_started_at_ms = $5
+                   AND create_issue_expires_at_ms = $6
+                   AND reconcile_not_before_ms = $7
+                   AND next_reconcile_at_ms = $7,
+                   FALSE
+               ) AS external_and_create_evidence_preserved,
+               state_updated_at_ms
+        FROM github_check_projection_outbox
+        WHERE subject_id = $1
+        ",
+    )
+    .bind(receipt.subject_id().as_uuid())
+    .bind(i64::try_from(suite.get()).expect("suite ID fits BIGINT"))
+    .bind(create_fence.claim().owner().as_uuid())
+    .bind(i64::try_from(create_fence.claim().fence()).expect("create fence fits BIGINT"))
+    .bind(create_fence.started_at().get())
+    .bind(create_fence.issue_expires_at().get())
+    .bind(create_fence.reconcile_not_before().get())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(
+        row,
+        (
+            "blocked".into(),
+            "credential_rejected".into(),
+            true,
+            true,
+            true,
+            blocked_at.get(),
+        )
+    );
+    assert!(
+        claim_projection(database, fixture).await?.is_none(),
+        "a credential-rejected projection must never be reclaimed"
+    );
     Ok(())
 }
 
@@ -802,6 +958,92 @@ async fn assert_missing_create_schedule(
     .expect_err("next reconciliation requires exact missing evidence");
     assert_constraint(&mutate_next, "github_check_projection_next_reconcile_exact");
     Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn credential_rejection_blocks_only_the_exact_live_claim_without_losing_evidence()
+-> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_checks_migrations(&database).await?;
+        let fixture = seed_fixture(&database).await?;
+        let (receipt, create_fence, suite) = seed_indeterminate_create(
+            &database,
+            &fixture,
+            ".github/workflows/credential-rejection.yml",
+            "Automata / Credential Rejection",
+            500,
+            801,
+        )
+        .await?;
+        wait_until_database(&database, create_fence.reconcile_not_before()).await?;
+        let claimed = claim_projection(&database, &fixture)
+            .await?
+            .expect("reconciliation claim");
+        assert_eq!(
+            claimed.action(),
+            GithubCheckProjectionAction::ReconcileRunCreate
+        );
+
+        let before = github_check_outbox_snapshot(&database, receipt.subject_id()).await?;
+        let wrong_owner = GithubCheckProjectionClaimFence::from_durable_parts(
+            receipt.subject_id(),
+            worker(),
+            claimed.claim().fence(),
+        )?;
+        let wrong_fence = GithubCheckProjectionClaimFence::from_durable_parts(
+            receipt.subject_id(),
+            claimed.claim().owner(),
+            claimed.claim().fence() + 1,
+        )?;
+        for request in [
+            BlockGithubCheckProjectionForCredentialRejection::new(
+                wrong_owner,
+                live_observation(&claimed),
+            )?,
+            BlockGithubCheckProjectionForCredentialRejection::new(
+                wrong_fence,
+                live_observation(&claimed),
+            )?,
+            BlockGithubCheckProjectionForCredentialRejection::new(
+                claimed.claim(),
+                claimed.expires_at(),
+            )?,
+        ] {
+            assert_credential_block_rejected_without_mutation(
+                &database,
+                receipt.subject_id(),
+                request,
+                &before,
+            )
+            .await?;
+        }
+
+        let blocked_at = live_observation(&claimed);
+        assert_eq!(
+            database
+                .store()
+                .block_github_check_projection_for_credential_rejection(
+                    BlockGithubCheckProjectionForCredentialRejection::new(
+                        claimed.claim(),
+                        blocked_at,
+                    )?,
+                )
+                .await?,
+            receipt
+        );
+        assert_credential_rejection_blocked_state(
+            &database,
+            &fixture,
+            &receipt,
+            create_fence,
+            suite,
+            blocked_at,
+        )
+        .await?;
+        Ok(())
+    })
+    .await
 }
 
 #[tokio::test]

--- a/crates/automata-ci/src/server/github_provider.rs
+++ b/crates/automata-ci/src/server/github_provider.rs
@@ -470,7 +470,8 @@ impl fmt::Debug for GithubProviderBootstrapReady {
 pub struct GithubProviderCredentialRequestResolver {
     authorities:
         Arc<BTreeMap<GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity>>,
-    compatible_historical_configuration_fingerprints: Arc<BTreeSet<Sha256Digest>>,
+    compatible_historical_configuration_fingerprints:
+        Arc<BTreeSet<(GithubServerServiceScope, Sha256Digest)>>,
 }
 
 impl GithubProviderCredentialRequestResolver {
@@ -494,7 +495,10 @@ impl GithubProviderCredentialRequestResolver {
                 .iter()
                 .flat_map(|broker_fingerprint| {
                     scopes.iter().map(move |scope| {
-                        authority_configuration_fingerprint(*broker_fingerprint, *scope)
+                        (
+                            *scope,
+                            authority_configuration_fingerprint(*broker_fingerprint, *scope),
+                        )
                     })
                 })
                 .collect();
@@ -565,7 +569,10 @@ impl GithubServerServiceCredentialRequestResolver for GithubProviderCredentialRe
 fn authority_uses_configured_live_route(
     identity: &GithubServerServiceAuthorityIdentity,
     configured: &GithubServerServiceAuthorityIdentity,
-    compatible_historical_configuration_fingerprints: &BTreeSet<Sha256Digest>,
+    compatible_historical_configuration_fingerprints: &BTreeSet<(
+        GithubServerServiceScope,
+        Sha256Digest,
+    )>,
 ) -> bool {
     identity.tenant() == configured.tenant()
         && identity.repository_id() == configured.repository_id()
@@ -580,7 +587,7 @@ fn authority_uses_configured_live_route(
         && identity.app_key_spki_sha256() == configured.app_key_spki_sha256()
         && (identity.configuration_fingerprint() == configured.configuration_fingerprint()
             || compatible_historical_configuration_fingerprints
-                .contains(&identity.configuration_fingerprint()))
+                .contains(&(identity.scope(), identity.configuration_fingerprint())))
 }
 
 /// Sanitized provider bootstrap failure.

--- a/crates/automata-ci/src/server/github_provider_credentials_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials_tests.rs
@@ -499,6 +499,23 @@ fn historical_authority_with_fingerprint(
     .expect("historical authority")
 }
 
+fn historical_authority_for_broker_scope(
+    current: &GithubServerServiceAuthorityIdentity,
+    id: u128,
+    broker_fingerprint: Sha256Digest,
+    fingerprint_scope: GithubServerServiceScope,
+) -> GithubServerServiceAuthorityIdentity {
+    historical_authority_with_fingerprint(
+        current,
+        id,
+        current.app_key_spki_sha256(),
+        super::super::github_provider::authority_configuration_fingerprint(
+            broker_fingerprint,
+            fingerprint_scope,
+        ),
+    )
+}
+
 fn authority_descriptor(
     identity: GithubServerServiceAuthorityIdentity,
     state: GithubServerServiceAuthorityState,
@@ -864,26 +881,57 @@ async fn full_checks_coordinates_are_rejected_before_handoff_io() {
 }
 
 #[tokio::test]
-async fn active_historical_checks_authority_uses_the_exact_current_live_route() {
+async fn active_historical_authorities_use_only_their_scope_specific_live_routes() {
     let current = authority(GithubServerServiceScope::ChecksWrite, 0x60);
+    let current_private = authority(GithubServerServiceScope::PrivateRepositorySourceRead, 0x61);
     let historical_broker_fingerprint = Sha256Digest::from_bytes([0x70; 32]);
-    let historical = historical_authority_with_fingerprint(
+    let historical = historical_authority_for_broker_scope(
         &current,
         0x62,
-        current.app_key_spki_sha256(),
-        super::super::github_provider::authority_configuration_fingerprint(
-            historical_broker_fingerprint,
-            current.scope(),
-        ),
+        historical_broker_fingerprint,
+        current.scope(),
     );
-    let lookup = Arc::new(FakeAuthorityLookup::new([authority_descriptor(
-        historical.clone(),
-        GithubServerServiceAuthorityState::Active,
-    )]));
+    let swapped_scope = historical_authority_for_broker_scope(
+        &current,
+        0x63,
+        historical_broker_fingerprint,
+        current_private.scope(),
+    );
+    let historical_private = historical_authority_for_broker_scope(
+        &current_private,
+        0x64,
+        historical_broker_fingerprint,
+        current_private.scope(),
+    );
+    let swapped_private_scope = historical_authority_for_broker_scope(
+        &current_private,
+        0x65,
+        historical_broker_fingerprint,
+        current.scope(),
+    );
+    let lookup = Arc::new(FakeAuthorityLookup::new([
+        authority_descriptor(
+            historical.clone(),
+            GithubServerServiceAuthorityState::Active,
+        ),
+        authority_descriptor(
+            swapped_scope.clone(),
+            GithubServerServiceAuthorityState::Active,
+        ),
+        authority_descriptor(
+            historical_private.clone(),
+            GithubServerServiceAuthorityState::Active,
+        ),
+        authority_descriptor(
+            swapped_private_scope.clone(),
+            GithubServerServiceAuthorityState::Active,
+        ),
+    ]));
     let handoffs = Arc::new(FakeHandoffs::new(FakeHandoffMode::Exact));
+    let current_authorities = [current.clone(), current_private];
     let adapters = durable_adapters_with_compatible(
         Arc::clone(&handoffs),
-        std::slice::from_ref(&current),
+        &current_authorities,
         Arc::clone(&lookup),
         std::slice::from_ref(&historical_broker_fingerprint),
     );
@@ -897,8 +945,36 @@ async fn active_historical_checks_authority_uses_the_exact_current_live_route() 
         &GithubServerServiceAuthoritySelector::from_identity(&historical)
     );
     drop(credential);
-    assert_eq!(lookup.calls.load(Ordering::SeqCst), 1);
-    assert_eq!(handoffs.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        adapters
+            .acquire_checks(checks_context(&swapped_scope))
+            .await
+            .expect_err("a private-source fingerprint cannot authorize Checks"),
+        GithubChecksCredentialProviderError::Rejected
+    );
+    drop(
+        adapters
+            .acquire_private_source(private_context(
+                &historical_private,
+                PrivateIdentityDrift::Exact,
+                GithubDeliveryPrivateRepositoryAction::FetchPrivateRepositoryRevision,
+            ))
+            .await
+            .expect("historical private authority on the current route"),
+    );
+    assert_eq!(
+        adapters
+            .acquire_private_source(private_context(
+                &swapped_private_scope,
+                PrivateIdentityDrift::Exact,
+                GithubDeliveryPrivateRepositoryAction::FetchPrivateRepositoryRevision,
+            ))
+            .await
+            .expect_err("a Checks fingerprint cannot authorize private source"),
+        GithubDeliverySourceCredentialProviderError::Rejected
+    );
+    assert_eq!(lookup.calls.load(Ordering::SeqCst), 4);
+    assert_eq!(handoffs.calls.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]

--- a/crates/automata-ci/src/server/github_provider_runtime_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime_tests.rs
@@ -26,6 +26,7 @@ use automata_ci_store::{
 };
 use serde_json::{Value, json};
 
+use super::super::github_provider::authority_configuration_fingerprint;
 use super::*;
 
 static CONFIG_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
@@ -170,6 +171,40 @@ fn live_test_broker(
         GithubAppCredentialBroker::new(broker_config, &private_key)
             .expect("published RSA fixture constructs a live broker"),
     )
+}
+
+#[test]
+fn production_broker_v1_compatibility_fingerprints_match_migration_0053() {
+    let config = load_config(&document(&[repository(
+        "tenant-compatible-fingerprint",
+        0x201,
+        202,
+        302,
+        402,
+        "octo/compatible-fingerprint",
+        "private",
+        0x801,
+        Some(0x802),
+    )]));
+    let broker = live_test_broker(&config, 202);
+    let [historical_broker_fingerprint] = broker.compatible_historical_broker_policy_fingerprints();
+
+    assert_eq!(
+        authority_configuration_fingerprint(
+            historical_broker_fingerprint,
+            GithubServerServiceScope::ChecksWrite,
+        )
+        .to_string(),
+        "86db54f098adc51219d176555d5f7b5461a4c45ddd0625393846b1b3a5ae6543"
+    );
+    assert_eq!(
+        authority_configuration_fingerprint(
+            historical_broker_fingerprint,
+            GithubServerServiceScope::PrivateRepositorySourceRead,
+        )
+        .to_string(),
+        "878f4bd01bfe4b04e84d9b9eee32667d31d55feebe78a7b2f59ed715b1145b32"
+    );
 }
 
 fn checks_authority(

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -423,52 +423,73 @@ async fn historical_revision_resolves_only_through_the_exact_current_live_route(
         .await
         .expect("bootstrap");
     let resolver = ready.credential_request_resolver();
-    let current = &plan.authorities()[0];
-    let historical = historical_authority(
-        current,
-        0x7a1,
-        current.app_configuration_revision().get() - 1,
-        current.policy_revision().get() - 1,
-        current.app_key_spki_sha256(),
-        authority_configuration_fingerprint(historical_broker_fingerprint, current.scope()),
-    );
-
-    let historical_request = resolver
-        .resolve_github_server_service_credential_request(&historical)
-        .await
-        .expect("historical resolution")
-        .expect("same live route remains authorized");
-    assert_eq!(historical_request.identity(), &historical);
-    assert_eq!(
-        historical_request.request(),
-        &github_server_service_credential_request(&historical).expect("canonical request")
-    );
-
-    for mismatch in [
-        historical_authority(
+    for (index, current) in plan.authorities().iter().enumerate() {
+        let other_scope = match current.scope() {
+            GithubServerServiceScope::ChecksWrite => {
+                GithubServerServiceScope::PrivateRepositorySourceRead
+            }
+            GithubServerServiceScope::PrivateRepositorySourceRead => {
+                GithubServerServiceScope::ChecksWrite
+            }
+        };
+        let authority_id = 0x7a1 + u128::try_from(index).expect("authority index");
+        let historical = historical_authority(
             current,
-            0x7a2,
-            current.app_configuration_revision().get() - 1,
-            current.policy_revision().get() - 1,
-            Sha256Digest::from_bytes([0xa2; 32]),
-            current.configuration_fingerprint(),
-        ),
-        historical_authority(
-            current,
-            0x7a3,
+            authority_id,
             current.app_configuration_revision().get() - 1,
             current.policy_revision().get() - 1,
             current.app_key_spki_sha256(),
-            Sha256Digest::from_bytes([0xa3; 32]),
-        ),
-    ] {
-        assert!(
-            resolver
-                .resolve_github_server_service_credential_request(&mismatch)
-                .await
-                .expect("closed mismatch")
-                .is_none()
+            authority_configuration_fingerprint(historical_broker_fingerprint, current.scope()),
         );
+
+        let historical_request = resolver
+            .resolve_github_server_service_credential_request(&historical)
+            .await
+            .expect("historical resolution")
+            .expect("same live route remains authorized");
+        assert_eq!(historical_request.identity(), &historical);
+        assert_eq!(
+            historical_request.request(),
+            &github_server_service_credential_request(&historical).expect("canonical request")
+        );
+
+        for (offset, mismatch) in [
+            historical_authority(
+                current,
+                authority_id + 0x10,
+                current.app_configuration_revision().get() - 1,
+                current.policy_revision().get() - 1,
+                Sha256Digest::from_bytes([0xa2; 32]),
+                current.configuration_fingerprint(),
+            ),
+            historical_authority(
+                current,
+                authority_id + 0x20,
+                current.app_configuration_revision().get() - 1,
+                current.policy_revision().get() - 1,
+                current.app_key_spki_sha256(),
+                Sha256Digest::from_bytes([0xa3; 32]),
+            ),
+            historical_authority(
+                current,
+                authority_id + 0x30,
+                current.app_configuration_revision().get() - 1,
+                current.policy_revision().get() - 1,
+                current.app_key_spki_sha256(),
+                authority_configuration_fingerprint(historical_broker_fingerprint, other_scope),
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            assert!(
+                resolver
+                    .resolve_github_server_service_credential_request(&mismatch)
+                    .await
+                    .unwrap_or_else(|_| panic!("closed mismatch {index}/{offset}"))
+                    .is_none()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- preserve only the explicitly compatible broker-v1 GitHub service-authority routes, keyed by service scope
- terminally block an exact claimed Checks projection when its immutable local credential authority is rejected, without provider I/O
- keep provider HTTP 401 fatal and retire only incompatible historical authorities whose issuance state is already terminal and custody-free
- add forward-only migration, Store fencing, publisher, runtime, static, and PostgreSQL 18 regression coverage

## Safety properties

- the block transition is subject/owner/fence/time bound and immutable
- delivery, provider, and create evidence is preserved
- Checks and private-source fingerprints cannot authorize each other
- unknown/nonterminal authority history fails or rolls back atomically

## Verification

- focused product resolver/runtime tests
- GitHub Checks publisher: 26/26
- Store API: 8/8
- migration contract: 3/3; inventory: 6/6
- PostgreSQL 18.4 full migration chain: 4/4
- strict all-target/all-feature Clippy for affected packages
- rustfmt and diff checks
