### PR TITLE
Fix macOS source builds

### DIFF
--- a/crates/automata-ci-runner/src/podman_probe/command.rs
+++ b/crates/automata-ci-runner/src/podman_probe/command.rs
@@ -361,7 +361,7 @@ fn execute_system_command(
     let (termination, wait_error) =
         wait_for_termination(&mut child, request, cancellation, deadline);
 
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     let mut wait_error = wait_error;
 
     #[cfg(target_os = "linux")]

--- a/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
+++ b/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
@@ -814,7 +814,7 @@ impl<'a> ProbeResources<'a> {
 #[cfg(unix)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct FileIdentity {
-    device: u64,
+    device: rustix::fs::Dev,
     inode: u64,
 }
 
@@ -1127,7 +1127,7 @@ fn ensure_private_directory_descriptor(
 fn ensure_owned_directory_descriptor(
     descriptor: &impl std::os::fd::AsFd,
     description: &str,
-    expected_mode: u32,
+    expected_mode: rustix::fs::RawMode,
 ) -> Result<(), String> {
     let metadata =
         fstat(descriptor).map_err(|error| format!("could not inspect {description}: {error}"))?;

--- a/crates/automata-ci-runner/src/product/files.rs
+++ b/crates/automata-ci-runner/src/product/files.rs
@@ -318,7 +318,7 @@ fn read_file(
 #[cfg(unix)]
 const fn file_is_trusted(
     owner: u32,
-    permission_bits: u32,
+    permission_bits: rustix::fs::RawMode,
     trust: FileTrust,
     effective_uid: u32,
 ) -> bool {

--- a/crates/automata-ci/src/server/static_registration.rs
+++ b/crates/automata-ci/src/server/static_registration.rs
@@ -424,7 +424,7 @@ fn read_bounded_nofollow(
         FileType::from_raw_mode(metadata.st_mode) == FileType::RegularFile,
         metadata.st_uid,
         metadata.st_mode,
-        metadata.st_nlink,
+        metadata.st_nlink == 1,
         required_owner,
     ) {
         return Err(StaticRunnerRegistrationError::InsecureFile);
@@ -485,18 +485,18 @@ fn map_path_open_error(error: rustix::io::Errno) -> StaticRunnerRegistrationErro
 const fn privileged_file_attributes(
     is_regular_file: bool,
     owner: u32,
-    mode: u32,
-    link_count: u64,
+    mode: rustix::fs::RawMode,
+    has_single_link: bool,
     required_owner: u32,
 ) -> bool {
-    is_regular_file && owner == required_owner && mode & 0o222 == 0 && link_count == 1
+    is_regular_file && owner == required_owner && mode & 0o222 == 0 && has_single_link
 }
 
 #[cfg(unix)]
 const fn privileged_directory_attributes(
     is_directory: bool,
     owner: u32,
-    mode: u32,
+    mode: rustix::fs::RawMode,
     required_owner: u32,
 ) -> bool {
     is_directory && (owner == 0 || owner == required_owner) && mode & 0o022 == 0
@@ -1154,11 +1154,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn privileged_metadata_requires_root_regular_nonwritable_single_link() {
-        assert!(privileged_file_attributes(true, 0, 0o100_440, 1, 0));
-        assert!(!privileged_file_attributes(true, 1_000, 0o100_440, 1, 0));
-        assert!(!privileged_file_attributes(true, 0, 0o100_640, 1, 0));
-        assert!(!privileged_file_attributes(false, 0, 0o120_440, 1, 0));
-        assert!(!privileged_file_attributes(true, 0, 0o100_440, 2, 0));
+        assert!(privileged_file_attributes(true, 0, 0o100_440, true, 0));
+        assert!(!privileged_file_attributes(true, 1_000, 0o100_440, true, 0));
+        assert!(!privileged_file_attributes(true, 0, 0o100_640, true, 0));
+        assert!(!privileged_file_attributes(false, 0, 0o120_440, true, 0));
+        assert!(!privileged_file_attributes(true, 0, 0o100_440, false, 0));
 
         assert!(privileged_directory_attributes(true, 0, 0o040_755, 0));
         assert!(!privileged_directory_attributes(true, 0, 0o040_775, 0));


### PR DESCRIPTION
## Outcome

Make the documented source-build path compile both `automata` and `automata-runner` on macOS.

Rustix exposes several Unix `stat` fields with platform-native widths. The existing code assumed Linux widths for file modes, device identifiers, and link counts, and only made the process-cleanup error mutable on Linux even though non-Linux Unix cleanup also updates it. Use Rustix's `RawMode` and `Dev` aliases, reduce the link-count input to the exact single-link predicate at the OS boundary, and make cleanup error accumulation mutable on every Unix target.

This restores the local preview plus passive runner-doctor development loop on Apple Silicon. It does not add a macOS job-execution provider.

## Related issue

None.

## Trust and compatibility impact

This touches privileged-file validation and Podman probe process cleanup without weakening their contracts. Owner, regular-file, non-writable-permission, and exact single-link checks remain unchanged. Filesystem identities retain the platform-native device value, and non-Linux Unix process-group termination errors are preserved in the same output path as Linux errors.

There is no credential format, storage schema, protocol, release, or GitHub Actions compatibility change, and no new runner capability is advertised.

## Verification

Run on macOS 26.5.2 arm64 with the repository-pinned Rust 1.97.1 toolchain:

- `cargo fmt --all -- --check` — passed.
- `cargo build --locked` — passed; built both default product binaries.
- `cargo clippy -p automata-ci --all-targets --all-features --locked -- -D warnings` — passed.
- `cargo clippy -p automata-ci-runner --all-targets --all-features --no-deps --locked -- -D warnings` — passed. `--no-deps` avoids three pre-existing macOS-only dead-code warnings in the Linux Podman dependency.
- `cargo test -p automata-ci --lib server::static_registration::tests --locked` — passed, 16 tests.
- `cargo test -p automata-ci-runner --lib product::files::tests --locked` — passed, 2 tests.
- `cargo test -p automata-ci-runner --lib podman_probe::command::tests --locked` — passed, 1 test.
- Started `automata preview`, verified `/healthz`, and ran `automata-runner doctor --server http://127.0.0.1:8080 --json` — preview was healthy and the macOS process-exec capability probe was usable.

The full workspace command was not used as a macOS gate because the workspace deliberately contains the Linux-only `automata-ci-service-proxy` executable. Linux CI remains the complete workspace gate.

## AI assistance

OpenAI Codex materially assisted by inspecting the repository guidance, reproducing and diagnosing the macOS build failures, implementing the portability changes, running verification, and preparing this pull request.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
