### PR TITLE
Bound active runner control exchanges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,11 @@ members = [
     "crates/automata-ci-runner-runtime",
     "crates/automata-ci-runner-spool",
     "crates/automata-ci-runner-transport",
+    "crates/automata-ci-sandbox-guest",
+    "crates/automata-ci-sandbox-kubernetes",
     "crates/automata-ci-sandbox-podman",
     "crates/automata-ci-sandbox-windows",
+    "crates/automata-ci-schedule",
     "crates/automata-ci-scm",
     "crates/automata-ci-secret",
     "crates/automata-ci-secret-postgres",
@@ -104,8 +107,11 @@ automata-ci-runner-journal = { path = "crates/automata-ci-runner-journal", versi
 automata-ci-runner-runtime = { path = "crates/automata-ci-runner-runtime", version = "0.1.0" }
 automata-ci-runner-spool = { path = "crates/automata-ci-runner-spool", version = "0.1.0" }
 automata-ci-runner-transport = { path = "crates/automata-ci-runner-transport", version = "0.1.0" }
+automata-ci-sandbox-guest = { path = "crates/automata-ci-sandbox-guest", version = "0.1.0" }
+automata-ci-sandbox-kubernetes = { path = "crates/automata-ci-sandbox-kubernetes", version = "0.1.0" }
 automata-ci-sandbox-podman = { path = "crates/automata-ci-sandbox-podman", version = "0.1.0" }
 automata-ci-sandbox-windows = { path = "crates/automata-ci-sandbox-windows", version = "0.1.0" }
+automata-ci-schedule = { path = "crates/automata-ci-schedule", version = "0.1.0" }
 automata-ci-scm = { path = "crates/automata-ci-scm", version = "0.1.0" }
 automata-ci-secret = { path = "crates/automata-ci-secret", version = "0.1.0" }
 automata-ci-secret-postgres = { path = "crates/automata-ci-secret-postgres", version = "0.1.0" }

--- a/crates/automata-ci-runner-transport/src/client.rs
+++ b/crates/automata-ci-runner-transport/src/client.rs
@@ -327,6 +327,22 @@ impl RunnerControlClient for HyperRunnerControlClient {
         cancellation: CancellationToken,
     ) -> ClientFuture<'a> {
         Box::pin(async move {
+            // Long polls may consume the negotiated request budget, but active lease traffic
+            // must fail early enough for an exact retry before the lease can expire.
+            let request_timeout = match request.message() {
+                RunnerToServer::Hello(_) | RunnerToServer::LeaseRequest(_) => {
+                    self.transport_limits.total_request_timeout()
+                }
+                RunnerToServer::LeaseResponse(_)
+                | RunnerToServer::Heartbeat(_)
+                | RunnerToServer::JobState(_)
+                | RunnerToServer::JobResult(_)
+                | RunnerToServer::LogBatch(_)
+                | RunnerToServer::CommandAck(_) => self
+                    .transport_limits
+                    .total_request_timeout()
+                    .min(self.transport_limits.response_body_timeout()),
+            };
             tokio::select! {
                 biased;
                 () = cancellation.cancelled() => Err(ClientError::new(
@@ -334,7 +350,7 @@ impl RunnerControlClient for HyperRunnerControlClient {
                     RetryClass::Never,
                 )),
                 result = timeout(
-                    self.transport_limits.total_request_timeout(),
+                    request_timeout,
                     self.exchange_bounded(request),
                 ) => result.unwrap_or_else(|_| Err(ClientError::new(
                     ClientErrorKind::Timeout,

--- a/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
+++ b/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
@@ -3,7 +3,7 @@ mod support;
 use std::{
     convert::Infallible,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use automata_ci_core::{OperationId, RunnerSessionId};
@@ -23,8 +23,8 @@ use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 
 use support::{
-    HandlerMode, RecordingVerifier, TestHandler, TestPki, client, hello_request, poll_request,
-    raw_h2_sender, spawn_server,
+    HandlerMode, RecordingVerifier, TestHandler, TestPki, client, heartbeat_request, hello_request,
+    poll_request, raw_h2_sender, spawn_server,
 };
 
 #[derive(Debug, Default)]
@@ -239,6 +239,38 @@ async fn invalid_and_timed_out_responses_record_dispatch_but_not_acceptance() {
         timeout_observer.bytes().as_slice(),
         [(RunnerControlClientByteDirection::Request, _)]
     ));
+    running.stop().await;
+}
+
+#[tokio::test]
+async fn active_sync_timeout_is_shorter_than_the_long_poll_budget() {
+    let pki = TestPki::new();
+    let verifier = RecordingVerifier::accepting();
+    let handler = TestHandler::new(HandlerMode::Delay(Duration::from_millis(200)));
+    let client_limits = TransportLimits::default()
+        .with_client_timeouts(
+            Duration::from_millis(250),
+            Duration::from_millis(250),
+            Duration::from_millis(500),
+            Duration::from_millis(40),
+        )
+        .expect("distinct active and long-poll deadlines");
+    let running = spawn_server(&pki, verifier, handler, &TransportLimits::default()).await;
+    let client = client(&running, &pki, &client_limits);
+
+    let started = Instant::now();
+    let error = client
+        .exchange(&heartbeat_request(), CancellationToken::new())
+        .await
+        .expect_err("active heartbeat must not consume the long-poll budget");
+    assert_eq!(error.kind(), ClientErrorKind::Timeout);
+    assert_eq!(error.retry_class(), RetryClass::RetrySameRequest);
+    assert!(started.elapsed() < Duration::from_millis(150));
+
+    client
+        .exchange(&poll_request(), CancellationToken::new())
+        .await
+        .expect("lease long poll retains the total request budget");
     running.stop().await;
 }
 

--- a/crates/automata-ci-runner-transport/tests/support/mod.rs
+++ b/crates/automata-ci-runner-transport/tests/support/mod.rs
@@ -19,12 +19,13 @@ use automata_ci_auth::{
     time::UnixTimestamp,
 };
 use automata_ci_core::{
-    Architecture, JobIrVersion, JobIrVersionRange, OperatingSystem, OperationId,
-    RunnerCapabilities, RunnerId, RunnerPlatform, RunnerSessionId, UnixMillis,
+    Architecture, AttemptId, FencingToken, JobIrVersion, JobIrVersionRange, JobLifecycle,
+    LeaseGuard, LeaseId, OperatingSystem, OperationId, RunnerCapabilities, RunnerId,
+    RunnerPlatform, RunnerSessionId, UnixMillis,
 };
 use automata_ci_protocol::{
-    CommandCursor, ErrorMessage, LeaseRequest, MessageHeader, NegotiatedSession, NoWork,
-    ProtocolLimits, RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer,
+    CommandCursor, ErrorMessage, LeaseHeartbeat, LeaseRequest, MessageHeader, NegotiatedSession,
+    NoWork, ProtocolLimits, RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer,
     SUPPORTED_PROTOCOL_RANGE, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_transport::{
@@ -509,6 +510,33 @@ pub fn poll_request() -> PreparedRequest {
         &ProtocolLimits::default(),
     )
     .expect("valid poll")
+}
+
+pub fn heartbeat_request() -> PreparedRequest {
+    let session_id = RunnerSessionId::new();
+    let header = MessageHeader::request(
+        SUPPORTED_PROTOCOL_RANGE.max(),
+        session_id,
+        OperationId::new(),
+    );
+    PreparedRequest::for_session(
+        RunnerToServer::Heartbeat(LeaseHeartbeat::new(
+            header,
+            AttemptId::new(),
+            LeaseGuard::new(LeaseId::new(), FencingToken::new(1).expect("fencing token")),
+            JobLifecycle::Running,
+            UnixMillis::new(1_700_000_000_000),
+        )),
+        NegotiatedSession::new(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            JobIrVersion::current(),
+            session_id,
+            SessionDisposition::Opened,
+            CommandCursor::initial(),
+        ),
+        &ProtocolLimits::default(),
+    )
+    .expect("valid heartbeat")
 }
 
 pub struct RunningServer {


### PR DESCRIPTION
Active runner-control messages previously inherited the 75-second long-poll request deadline. A blocked heartbeat could therefore consume an entire 60-second lease before exact retry, causing the production runner to isolate and park the slot.

This change keeps the total request budget for Hello/LeaseRequest while bounding active lease traffic by the shorter response-body deadline. The regression test proves heartbeats time out early with RetrySameRequest while lease polling retains the long-poll budget.

Validated locally:
- focused regression
- full runner-transport test suite (40 tests)
- strict all-target/all-feature Clippy
- strict rustdoc
- rustfmt and diff checks