### PR TITLE
Add ARM64 macOS runner support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,91 @@ jobs:
           cargo test -p automata-ci-results-github --test postgres_cache --all-features --locked -- --ignored --test-threads=1
           cargo test -p automata-ci --test github_provider_end_to_end_matrix --all-features --locked -- --ignored --test-threads=1
 
+  macos:
+    name: macOS native runner
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Require pinned Apple Silicon toolchain
+        run: |
+          install -d -m 0700 -- "$TMPDIR"
+          rustc --version --verbose
+          cargo --version --verbose
+          host_triple="$(rustc --version --verbose | sed -n 's/^host: //p')"
+          test "$host_triple" = "aarch64-apple-darwin"
+          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 15
+
+      - name: Check shipped macOS binaries
+        run: cargo check --locked --bin automata --bin automata-runner
+
+      - name: Lint macOS provider, executor, and runner
+        run: >-
+          cargo clippy
+          --locked
+          -p automata-ci-metrics
+          -p automata-ci-sandbox-macos
+          -p automata-ci-job-executor-github
+          -p automata-ci-runner
+          --all-targets
+          --no-deps
+          --
+          -D warnings
+
+      - name: Record GitHub-hosted Bash shell reference
+        id: macos_shell_reference
+        shell: bash
+        run: |
+          reference="$RUNNER_TEMP/automata-macos-shell-reference.txt"
+          printf 'differential.bash=ok\n' > "$reference"
+          printf 'AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE=%s\n' "$reference" >> "$GITHUB_ENV"
+          printf 'AUTOMATA_DIFFERENTIAL_ENV=command-file\n' >> "$GITHUB_ENV"
+          printf 'fixture=native-output\n' >> "$GITHUB_OUTPUT"
+
+      - name: Record GitHub-hosted sh shell reference
+        shell: sh
+        env:
+          FROM_OUTPUT: ${{ steps.macos_shell_reference.outputs.fixture }}
+        run: |
+          test "$AUTOMATA_DIFFERENTIAL_ENV" = command-file
+          test "$FROM_OUTPUT" = native-output
+          test "$PWD" = "$GITHUB_WORKSPACE"
+          {
+            printf 'differential.sh=ok\n'
+            printf 'differential.environment=%s\n' "$AUTOMATA_DIFFERENTIAL_ENV"
+            printf 'differential.output=%s\n' "$FROM_OUTPUT"
+            printf 'differential.workspace=true\n'
+            printf 'differential.conclusion=success\n'
+          } >> "$AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE"
+
+      - name: Test macOS execution contracts
+        run: |
+          cargo test --locked -p automata-ci-execution
+          cargo test --locked -p automata-ci-job-executor-github --all-targets
+          cargo test --locked -p automata-ci-sandbox-macos --all-targets
+          cargo test --locked -p automata-ci-runner --lib
+          cargo test --locked -p automata-ci-runner --test product_context
+          cargo test --locked -p automata-ci-runner --test runner_product_config_macos
+          cargo test --locked -p automata-ci-runner --test capabilities_cli --test cli
+
+      - name: Test shipped macOS runner process
+        run: cargo test --locked -p automata-ci-runner --test native_runner_process_e2e -- --nocapture
+
+      - name: Exercise hidden shipped-binary supervisor
+        run: |
+          cargo build --locked --bin automata-runner
+          python3 scripts/ci/tests/macos-supervisor-smoke.py \
+            target/debug/automata-runner
+
   frontend:
     name: React SSR frontend
     runs-on: ubuntu-24.04
@@ -510,6 +595,7 @@ jobs:
           && needs.renderer_tests.result == 'success'
           && needs.postgres_store.result == 'success'
           && needs.postgres_integrations.result == 'success'
+          && needs.macos.result == 'success'
           && needs.frontend.result == 'success'
           && (needs.renderer.result == 'success'
               || (github.event_name == 'pull_request'
@@ -522,6 +608,7 @@ jobs:
       - renderer_tests
       - postgres_store
       - postgres_integrations
+      - macos
       - frontend
       - renderer
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http-body-util",
+ "processkit",
  "prometheus-client",
  "prost",
  "rustix",
@@ -740,6 +741,7 @@ dependencies = [
  "automata-ci-runner-spool",
  "automata-ci-runner-transport",
  "automata-ci-sandbox-kubernetes",
+ "automata-ci-sandbox-macos",
  "automata-ci-sandbox-podman",
  "automata-ci-sandbox-windows",
  "automata-ci-scm",
@@ -754,6 +756,7 @@ dependencies = [
  "reqwest",
  "rustix",
  "rustls",
+ "security-framework",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -946,6 +949,21 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
+]
+
+[[package]]
+name = "automata-ci-sandbox-macos"
+version = "0.1.0"
+dependencies = [
+ "automata-ci-execution",
+ "processkit",
+ "rustix",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "static_assertions",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,10 @@ members = [
     "crates/automata-ci-runner-runtime",
     "crates/automata-ci-runner-spool",
     "crates/automata-ci-runner-transport",
-    "crates/automata-ci-sandbox-podman",
     "crates/automata-ci-sandbox-guest",
     "crates/automata-ci-sandbox-kubernetes",
+    "crates/automata-ci-sandbox-macos",
+    "crates/automata-ci-sandbox-podman",
     "crates/automata-ci-sandbox-windows",
     "crates/automata-ci-schedule",
     "crates/automata-ci-scm",
@@ -107,9 +108,10 @@ automata-ci-runner-journal = { path = "crates/automata-ci-runner-journal", versi
 automata-ci-runner-runtime = { path = "crates/automata-ci-runner-runtime", version = "0.1.0" }
 automata-ci-runner-spool = { path = "crates/automata-ci-runner-spool", version = "0.1.0" }
 automata-ci-runner-transport = { path = "crates/automata-ci-runner-transport", version = "0.1.0" }
-automata-ci-sandbox-podman = { path = "crates/automata-ci-sandbox-podman", version = "0.1.0" }
 automata-ci-sandbox-guest = { path = "crates/automata-ci-sandbox-guest", version = "0.1.0" }
 automata-ci-sandbox-kubernetes = { path = "crates/automata-ci-sandbox-kubernetes", version = "0.1.0" }
+automata-ci-sandbox-macos = { path = "crates/automata-ci-sandbox-macos", version = "0.1.0" }
+automata-ci-sandbox-podman = { path = "crates/automata-ci-sandbox-podman", version = "0.1.0" }
 automata-ci-sandbox-windows = { path = "crates/automata-ci-sandbox-windows", version = "0.1.0" }
 automata-ci-schedule = { path = "crates/automata-ci-schedule", version = "0.1.0" }
 automata-ci-scm = { path = "crates/automata-ci-scm", version = "0.1.0" }
@@ -142,6 +144,7 @@ reqwest = { version = "0.12.23", default-features = false, features = ["http2", 
 ring = { version = "=0.17.14", default-features = false, features = ["std"] }
 rustls = { version = "=0.23.43", default-features = false, features = ["ring", "std"] }
 rustix = { version = "1.1.4", features = ["fs", "process"] }
+security-framework = "3.7.0"
 saphyr-parser = { version = "0.0.11", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.143", features = ["raw_value"] }

--- a/crates/automata-ci-execution/src/capability.rs
+++ b/crates/automata-ci-execution/src/capability.rs
@@ -50,6 +50,8 @@ pub enum SandboxCapability {
     DeviceLimits,
     /// Enforces the requested process-count limit as a hard limit.
     ProcessLimits,
+    /// Runs trusted work against shared host resources without per-job hard limits.
+    HostResources,
     /// Creates, health-checks, discovers, and destroys services with a sandbox.
     ServiceContainers,
     /// A policy-filtered Docker Engine API is scoped to one sandbox.

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -53,7 +53,7 @@ pub use error::{
 };
 pub use sandbox::{
     DestroyDisposition, DestroySandbox, SandboxInspection, SandboxProvider, SandboxRecord,
-    SandboxSpec, SandboxState,
+    SandboxResourcePolicy, SandboxSpec, SandboxState,
 };
 pub use service::{
     ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs,

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -20,9 +20,29 @@ pub struct SandboxSpec {
     network: NetworkPolicy,
     root_filesystem: RootFilesystemPolicy,
     privilege: SandboxPrivilegePolicy,
-    resources: ResourceLimits,
+    resource_policy: SandboxResourcePolicy,
     resource_allocation: Option<JobResourceAllocation>,
     services: ServiceContainerSpecs,
+}
+
+/// Resource enforcement selected for one whole-job sandbox.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxResourcePolicy {
+    /// CPU, memory, and process ceilings are hard provider-enforced limits.
+    Enforced(ResourceLimits),
+    /// A trusted native job shares host resources without per-job hard limits.
+    HostShared,
+}
+
+impl SandboxResourcePolicy {
+    /// Returns hard limits when this policy requires provider enforcement.
+    #[must_use]
+    pub const fn enforced(self) -> Option<ResourceLimits> {
+        match self {
+            Self::Enforced(resources) => Some(resources),
+            Self::HostShared => None,
+        }
+    }
 }
 
 impl SandboxSpec {
@@ -51,7 +71,35 @@ impl SandboxSpec {
             network,
             root_filesystem,
             privilege: SandboxPrivilegePolicy::Unprivileged,
-            resources,
+            resource_policy: SandboxResourcePolicy::Enforced(resources),
+            resource_allocation: None,
+            services: ServiceContainerSpecs::empty(),
+        }
+    }
+
+    /// Creates a trusted native request that explicitly shares host resources.
+    ///
+    /// This policy is not a resource-isolation boundary. Providers accepting
+    /// it must advertise [`crate::SandboxCapability::HostResources`].
+    #[must_use]
+    pub const fn host_shared(
+        operation_id: OperationId,
+        generation: SandboxGeneration,
+        profile: SandboxEnvironment,
+        workspace: TargetPath,
+        network: NetworkPolicy,
+        root_filesystem: RootFilesystemPolicy,
+    ) -> Self {
+        Self {
+            operation_id,
+            generation,
+            profile,
+            workspace,
+            scratch: None,
+            network,
+            root_filesystem,
+            privilege: SandboxPrivilegePolicy::Unprivileged,
+            resource_policy: SandboxResourcePolicy::HostShared,
             resource_allocation: None,
             services: ServiceContainerSpecs::empty(),
         }
@@ -129,10 +177,16 @@ impl SandboxSpec {
         self.privilege
     }
 
-    /// Returns the hard whole-job resource limits.
+    /// Returns the exact resource-enforcement policy.
     #[must_use]
-    pub const fn resources(&self) -> ResourceLimits {
-        self.resources
+    pub const fn resource_policy(&self) -> SandboxResourcePolicy {
+        self.resource_policy
+    }
+
+    /// Returns hard whole-job resource limits when enforcement was selected.
+    #[must_use]
+    pub const fn resources(&self) -> Option<ResourceLimits> {
+        self.resource_policy.enforced()
     }
 
     /// Attaches the complete placement-request and enforcement-limit contract.
@@ -161,8 +215,11 @@ impl SandboxSpec {
         let Some(allocation) = self.resource_allocation else {
             return true;
         };
-        allocation.limits().cpu_millis() == self.resources.cpu_millis()
-            && allocation.limits().memory_bytes() == self.resources.memory_bytes()
+        let Some(resources) = self.resources() else {
+            return true;
+        };
+        allocation.limits().cpu_millis() == resources.cpu_millis()
+            && allocation.limits().memory_bytes() == resources.memory_bytes()
     }
 
     /// Adds services which the provider must create, make healthy, and own as

--- a/crates/automata-ci-execution/src/value.rs
+++ b/crates/automata-ci-execution/src/value.rs
@@ -439,7 +439,8 @@ pub enum SandboxLaunch {
     /// Launch trusted commands as native host processes.
     ///
     /// Native providers must advertise host network/filesystem semantics and
-    /// enforce process-tree containment plus the requested resource limits.
+    /// process-tree containment. Their sandbox resource policy declares
+    /// whether per-job limits are enforced or explicitly shared with the host.
     Native,
 }
 
@@ -480,7 +481,7 @@ impl SandboxEnvironment {
         })
     }
 
-    /// Binds a trusted native launch to an exact scheduler-selected profile.
+    /// Binds a trusted native Windows launch to an exact scheduler-selected profile.
     ///
     /// # Errors
     ///
@@ -491,6 +492,27 @@ impl SandboxEnvironment {
         default_environment: ExecutionEnvironment,
     ) -> Result<Self, ValueError> {
         if workspace.platform() != TargetPlatform::Windows {
+            return Err(ValueError::InvalidTargetPath);
+        }
+        Ok(Self {
+            attestation,
+            launch: SandboxLaunch::Native,
+            workspace,
+            default_environment,
+        })
+    }
+
+    /// Binds a trusted native POSIX launch to an exact scheduler-selected profile.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a workspace that does not use normalized absolute POSIX syntax.
+    pub fn native_posix(
+        attestation: EnvironmentProfile,
+        workspace: TargetPath,
+        default_environment: ExecutionEnvironment,
+    ) -> Result<Self, ValueError> {
+        if workspace.platform() != TargetPlatform::Posix {
             return Err(ValueError::InvalidTargetPath);
         }
         Ok(Self {

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -7,10 +7,10 @@ use automata_ci_execution::{
     MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES, MAX_EXECUTION_OUTPUT_RECORDS,
     NetworkPolicy, OperationId, ProviderCapabilities, ProviderId, ResourceLimits,
     RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration, SandboxHandle,
-    SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding, ServiceContainerBindings,
-    ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy,
-    ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol, Sha256Digest,
-    TargetPath, ValueError,
+    SandboxPrivilegePolicy, SandboxResourcePolicy, SandboxSpec, ServiceContainerBinding,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
+    ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol,
+    Sha256Digest, TargetPath, ValueError,
 };
 
 const IMAGE: &str = "docker.io/library/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -31,6 +31,21 @@ fn profile() -> SandboxEnvironment {
         ExecutionEnvironment::empty(),
     )
     .expect("profile")
+}
+
+#[test]
+fn host_shared_resources_are_explicit_and_have_no_hard_limits() {
+    let spec = SandboxSpec::host_shared(
+        OperationId::new(),
+        SandboxGeneration::new(9).expect("generation"),
+        profile(),
+        TargetPath::posix("/__w").expect("workspace"),
+        NetworkPolicy::Host,
+        RootFilesystemPolicy::Host,
+    );
+    assert_eq!(spec.resource_policy(), SandboxResourcePolicy::HostShared);
+    assert_eq!(spec.resources(), None);
+    assert!(spec.has_coherent_resource_contract());
 }
 
 #[test]
@@ -79,7 +94,10 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
         spec.profile().image().expect("container image").reference(),
         IMAGE
     );
-    assert_eq!(spec.resources().cpu_millis(), 2_000);
+    assert_eq!(
+        spec.resources().expect("enforced resources").cpu_millis(),
+        2_000
+    );
 }
 
 #[test]

--- a/crates/automata-ci-job-executor-github/src/adapter.rs
+++ b/crates/automata-ci-job-executor-github/src/adapter.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, fmt};
 
 use automata_ci_action_github::JavascriptRuntime;
 use automata_ci_core::EnvironmentProfile;
-use automata_ci_execution::{SandboxEnvironment, TargetPath, TargetPlatform};
+use automata_ci_execution::{ExecutionArgv, SandboxEnvironment, TargetPath, TargetPlatform};
 
 use crate::{GithubToolchain, PortError, SandboxEnvironmentCatalog, error::PortErrorKind};
 
@@ -77,7 +77,7 @@ pub struct StaticGithubToolchain {
     cmd: Option<TargetPath>,
     install: Option<TargetPath>,
     tar: Option<TargetPath>,
-    sha256sum: Option<TargetPath>,
+    sha256: Option<ExecutionArgv>,
     nodes: Vec<(JavascriptRuntime, TargetPath)>,
 }
 
@@ -110,7 +110,10 @@ impl StaticGithubToolchain {
             cmd: None,
             install: Some(install),
             tar: Some(tar),
-            sha256sum: Some(sha256sum),
+            sha256: Some(
+                ExecutionArgv::new(sha256sum, Vec::<String>::new())
+                    .map_err(|_| PortError::new(PortErrorKind::InvalidData))?,
+            ),
             nodes: Vec::new(),
         })
     }
@@ -141,7 +144,43 @@ impl StaticGithubToolchain {
             cmd: Some(cmd),
             install: None,
             tar: None,
-            sha256sum: None,
+            sha256: None,
+            nodes: Vec::new(),
+        })
+    }
+
+    /// Creates the required system tool paths for an ARM64 macOS runner profile.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-POSIX or root executable paths.
+    pub fn macos(
+        bash: TargetPath,
+        sh: TargetPath,
+        install: TargetPath,
+        tar: TargetPath,
+        shasum: TargetPath,
+    ) -> Result<Self, PortError> {
+        if [&bash, &sh, &install, &tar, &shasum]
+            .into_iter()
+            .any(|path| !valid_tool(path, TargetPlatform::Posix))
+        {
+            return Err(PortError::new(PortErrorKind::InvalidData));
+        }
+        Ok(Self {
+            platform: TargetPlatform::Posix,
+            bash: Some(bash),
+            sh: Some(sh),
+            python: None,
+            pwsh: None,
+            powershell: None,
+            cmd: None,
+            install: Some(install),
+            tar: Some(tar),
+            sha256: Some(
+                ExecutionArgv::new(shasum, vec!["-a".to_owned(), "256".to_owned()])
+                    .map_err(|_| PortError::new(PortErrorKind::InvalidData))?,
+            ),
             nodes: Vec::new(),
         })
     }
@@ -232,8 +271,8 @@ impl GithubToolchain for StaticGithubToolchain {
         self.tar.as_ref()
     }
 
-    fn sha256sum(&self) -> Option<&TargetPath> {
-        self.sha256sum.as_ref()
+    fn sha256(&self) -> Option<&ExecutionArgv> {
+        self.sha256.as_ref()
     }
 
     fn node(&self, runtime: JavascriptRuntime) -> Option<&TargetPath> {
@@ -257,7 +296,7 @@ impl fmt::Debug for StaticGithubToolchain {
             .field("cmd", &self.cmd)
             .field("install", &self.install)
             .field("tar", &self.tar)
-            .field("sha256sum", &self.sha256sum)
+            .field("sha256", &self.sha256)
             .field(
                 "node_runtimes",
                 &self

--- a/crates/automata-ci-job-executor-github/src/config.rs
+++ b/crates/automata-ci-job-executor-github/src/config.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use automata_ci_execution::{
     MAX_EXECUTION_OUTPUT_BYTES, NetworkPolicy, ResourceLimits, RootFilesystemPolicy,
-    SandboxPrivilegePolicy, TargetPath, TargetPlatform, ValueError,
+    SandboxPrivilegePolicy, SandboxResourcePolicy, TargetPath, TargetPlatform, ValueError,
 };
 use thiserror::Error;
 
@@ -11,7 +11,7 @@ const MAX_POST_JOB_CLEANUP_TIMEOUT: Duration = Duration::from_mins(5);
 /// Validated policy for one GitHub job executor instance.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubJobExecutorConfig {
-    resources: ResourceLimits,
+    resource_policy: SandboxResourcePolicy,
     network: NetworkPolicy,
     root_filesystem: RootFilesystemPolicy,
     privilege: SandboxPrivilegePolicy,
@@ -29,6 +29,51 @@ impl GithubJobExecutorConfig {
     /// bounds, and root or separator-terminated runner scratch paths.
     pub fn new(
         resources: ResourceLimits,
+        network: NetworkPolicy,
+        root_filesystem: RootFilesystemPolicy,
+        privilege: SandboxPrivilegePolicy,
+        default_step_timeout: Duration,
+        maximum_output_bytes: usize,
+        runner_root: TargetPath,
+    ) -> Result<Self, GithubJobExecutorConfigError> {
+        Self::with_resource_policy(
+            SandboxResourcePolicy::Enforced(resources),
+            network,
+            root_filesystem,
+            privilege,
+            default_step_timeout,
+            maximum_output_bytes,
+            runner_root,
+        )
+    }
+
+    /// Creates trusted-native policy without per-job hard resource limits.
+    ///
+    /// # Errors
+    ///
+    /// Applies the same timeout, output, and runner-root validation as
+    /// [`Self::new`].
+    pub fn host_shared(
+        network: NetworkPolicy,
+        root_filesystem: RootFilesystemPolicy,
+        privilege: SandboxPrivilegePolicy,
+        default_step_timeout: Duration,
+        maximum_output_bytes: usize,
+        runner_root: TargetPath,
+    ) -> Result<Self, GithubJobExecutorConfigError> {
+        Self::with_resource_policy(
+            SandboxResourcePolicy::HostShared,
+            network,
+            root_filesystem,
+            privilege,
+            default_step_timeout,
+            maximum_output_bytes,
+            runner_root,
+        )
+    }
+
+    fn with_resource_policy(
+        resource_policy: SandboxResourcePolicy,
         network: NetworkPolicy,
         root_filesystem: RootFilesystemPolicy,
         privilege: SandboxPrivilegePolicy,
@@ -54,7 +99,7 @@ impl GithubJobExecutorConfig {
             return Err(GithubJobExecutorConfigError::InvalidRunnerRoot);
         }
         Ok(Self {
-            resources,
+            resource_policy,
             network,
             root_filesystem,
             privilege,
@@ -64,10 +109,16 @@ impl GithubJobExecutorConfig {
         })
     }
 
-    /// Returns whole-job hard resource limits.
+    /// Returns the exact resource-enforcement policy.
     #[must_use]
-    pub const fn resources(&self) -> ResourceLimits {
-        self.resources
+    pub const fn resource_policy(&self) -> SandboxResourcePolicy {
+        self.resource_policy
+    }
+
+    /// Returns whole-job hard resource limits when selected.
+    #[must_use]
+    pub const fn resources(&self) -> Option<ResourceLimits> {
+        self.resource_policy.enforced()
     }
 
     /// Returns whole-job network policy.

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -22,11 +22,11 @@ use automata_ci_core::{
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, DestroySandbox, ExecutionArgv, ExecutionCommand,
     ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionTermination,
-    ImmutableImage, NetworkPolicy, ProviderError, ProviderErrorKind, ResourceLimits,
-    RootFilesystemPolicy, SandboxCapability, SandboxGeneration, SandboxHandle, SandboxProvider,
-    SandboxSpec, SandboxState, ServiceContainerBindings, ServiceContainerSpec,
-    ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy, ServicePort,
-    ServiceTransportProtocol, TargetPath, TargetPlatform,
+    ImmutableImage, NetworkPolicy, ProviderCapabilities, ProviderError, ProviderErrorKind,
+    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxGeneration, SandboxHandle,
+    SandboxLaunch, SandboxProvider, SandboxResourcePolicy, SandboxSpec, SandboxState,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
+    ServiceHealthPolicy, ServicePort, ServiceTransportProtocol, TargetPath, TargetPlatform,
 };
 use automata_ci_expression_github::{
     GithubEvaluationContext, GithubExpressionEvaluator, GithubExpressionFunctionProvider,
@@ -80,7 +80,7 @@ const JOB_RUNTIME_CONTEXT_MEDIA_TYPE: &str =
 const TRUNCATED_OUTPUT_DIAGNOSTIC: &str =
     "command output exceeded the configured capture limit; user output was suppressed";
 const LOCAL_ACTION_PROBE_SCRIPT: &str = "# automata-local-action-metadata\nif [ -f \"$1\" ]; then printf yml; elif [ -f \"$2\" ]; then printf yaml; else exit 44; fi";
-const ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\nif [ ! -f \"$1\" ]; then exit 44; fi\nvalue=$(\"$0\" < \"$1\") || exit $?\ndigest=${value%% *}\nprintf '%s' \"$digest\"";
+const ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\npath=$1\nshift\nif [ ! -f \"$path\" ]; then exit 44; fi\nvalue=$(\"$0\" \"$@\" < \"$path\") || exit $?\ndigest=${value%% *}\nprintf '%s' \"$digest\"";
 const WINDOWS_ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\n$ErrorActionPreference = 'Stop'\n$path = $env:AUTOMATA_INTERNAL_ARTIFACT_PATH\nif (-not [System.IO.File]::Exists($path)) { exit 44 }\n$stream = $null\n$hasher = $null\ntry {\n  $stream = [System.IO.File]::OpenRead($path)\n  $hasher = [System.Security.Cryptography.SHA256]::Create()\n  $bytes = $hasher.ComputeHash($stream)\n  $digest = [System.BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant()\n  [Console]::Out.Write($digest)\n} finally {\n  if ($null -ne $stream) { $stream.Dispose() }\n  if ($null -ne $hasher) { $hasher.Dispose() }\n}";
 const WINDOWS_ARTIFACT_PATH_ENVIRONMENT: &str = "AUTOMATA_INTERNAL_ARTIFACT_PATH";
 const ARTIFACT_HASH_OUTPUT_BYTES: usize = 128;
@@ -502,13 +502,12 @@ impl GithubJobExecutor {
             SandboxCapability::CopyTo,
             SandboxCapability::CopyFrom,
             SandboxCapability::EnvironmentInjection,
-            SandboxCapability::ResourceLimits,
-            SandboxCapability::ProcessLimits,
         ] {
             if !capabilities.supports(required) {
                 return Err(AdmissionRejection::CapabilityChanged);
             }
         }
+        validate_resource_admission(job, self.config.resource_policy(), capabilities)?;
         let network = match self.config.network() {
             NetworkPolicy::Disabled => SandboxCapability::NetworkDisabled,
             NetworkPolicy::PrivateEgress => SandboxCapability::PrivateEgress,
@@ -4341,27 +4340,14 @@ impl GithubJobExecutor {
             let operation_id = events
                 .begin_provider_operation(ProviderOperationKind::CreateSandbox)
                 .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-            let allocation = request
-                .job()
-                .job()
-                .requirements()
-                .resource_allocation()
-                .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-            let mut spec = SandboxSpec::new(
+            let spec = self.sandbox_spec(
+                request,
                 operation_id,
                 generation,
-                request.environment().clone(),
-                workspace.clone(),
-                self.config.network(),
-                self.config.root_filesystem(),
-                self.sandbox_resources(request)?,
-            )
-            .with_privilege(self.config.privilege())
-            .with_services(service_specs.clone())
-            .with_resource_allocation(allocation);
-            if workspace.platform() == TargetPlatform::Windows {
-                spec = spec.with_scratch(scratch.clone());
-            }
+                workspace,
+                scratch,
+                service_specs,
+            )?;
             let record = match self.ports.provider.create(&spec, &cancellation) {
                 Ok(record) => record,
                 Err(error) => {
@@ -4401,10 +4387,57 @@ impl GithubJobExecutor {
         Ok(ObtainedSandbox { endpoint, services })
     }
 
-    fn sandbox_resources(
+    fn sandbox_spec(
         &self,
         request: &ExecutionRequest,
-    ) -> Result<ResourceLimits, ExecutorAdapterError> {
+        operation_id: OperationId,
+        generation: SandboxGeneration,
+        workspace: &TargetPath,
+        scratch: &TargetPath,
+        service_specs: &ServiceContainerSpecs,
+    ) -> Result<SandboxSpec, ExecutorAdapterError> {
+        let mut spec = match self.sandbox_resource_policy(request)? {
+            SandboxResourcePolicy::Enforced(resources) => SandboxSpec::new(
+                operation_id,
+                generation,
+                request.environment().clone(),
+                workspace.clone(),
+                self.config.network(),
+                self.config.root_filesystem(),
+                resources,
+            ),
+            SandboxResourcePolicy::HostShared => SandboxSpec::host_shared(
+                operation_id,
+                generation,
+                request.environment().clone(),
+                workspace.clone(),
+                self.config.network(),
+                self.config.root_filesystem(),
+            ),
+        }
+        .with_privilege(self.config.privilege())
+        .with_services(service_specs.clone())
+        .with_resource_allocation(
+            request
+                .job()
+                .job()
+                .requirements()
+                .resource_allocation()
+                .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?,
+        );
+        if matches!(request.environment().launch(), SandboxLaunch::Native) {
+            spec = spec.with_scratch(scratch.clone());
+        }
+        Ok(spec)
+    }
+
+    fn sandbox_resource_policy(
+        &self,
+        request: &ExecutionRequest,
+    ) -> Result<SandboxResourcePolicy, ExecutorAdapterError> {
+        if self.config.resource_policy() == SandboxResourcePolicy::HostShared {
+            return Ok(SandboxResourcePolicy::HostShared);
+        }
         let allocation = request
             .job()
             .job()
@@ -4415,8 +4448,12 @@ impl GithubJobExecutor {
         ResourceLimits::new(
             limits.memory_bytes(),
             limits.cpu_millis(),
-            self.config.resources().pids(),
+            self.config
+                .resources()
+                .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?
+                .pids(),
         )
+        .map(SandboxResourcePolicy::Enforced)
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))
     }
 
@@ -6750,6 +6787,42 @@ fn validate_action_step_admission(
     Ok(())
 }
 
+fn validate_resource_admission(
+    job: &JobIrEnvelope,
+    resource_policy: SandboxResourcePolicy,
+    capabilities: &ProviderCapabilities,
+) -> Result<(), AdmissionRejection> {
+    let allocation = job
+        .job()
+        .requirements()
+        .resource_allocation()
+        .ok_or(AdmissionRejection::InvalidJob)?;
+    match resource_policy {
+        SandboxResourcePolicy::Enforced(_) => {
+            if !capabilities.supports(SandboxCapability::ResourceLimits)
+                || !capabilities.supports(SandboxCapability::ProcessLimits)
+            {
+                return Err(AdmissionRejection::CapabilityChanged);
+            }
+            let limits = allocation.limits();
+            if limits.ephemeral_disk_bytes() > 0
+                && !capabilities.supports(SandboxCapability::EphemeralStorageLimits)
+            {
+                return Err(AdmissionRejection::CapabilityChanged);
+            }
+            if limits.gpu_count() > 0 && !capabilities.supports(SandboxCapability::DeviceLimits) {
+                return Err(AdmissionRejection::CapabilityChanged);
+            }
+        }
+        SandboxResourcePolicy::HostShared => {
+            if !capabilities.supports(SandboxCapability::HostResources) {
+                return Err(AdmissionRejection::CapabilityChanged);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn validate_service_admission(
     job: &JobIrEnvelope,
     capabilities: &automata_ci_execution::ProviderCapabilities,
@@ -6983,7 +7056,7 @@ fn valid_toolchain(toolchain: &dyn GithubToolchain) -> bool {
         toolchain.cmd(),
         toolchain.install(),
         toolchain.tar(),
-        toolchain.sha256sum(),
+        toolchain.sha256().map(ExecutionArgv::program),
     ]
     .into_iter()
     .flatten()
@@ -6995,7 +7068,7 @@ fn valid_toolchain(toolchain: &dyn GithubToolchain) -> bool {
                     && toolchain.sh().is_some()
                     && toolchain.install().is_some()
                     && toolchain.tar().is_some()
-                    && toolchain.sha256sum().is_some()
+                    && toolchain.sha256().is_some()
                     && toolchain.powershell().is_none()
                     && toolchain.cmd().is_none()
             }
@@ -7007,7 +7080,7 @@ fn valid_toolchain(toolchain: &dyn GithubToolchain) -> bool {
                     && toolchain.cmd().is_some()
                     && toolchain.install().is_none()
                     && toolchain.tar().is_none()
-                    && toolchain.sha256sum().is_none()
+                    && toolchain.sha256().is_none()
             }
         }
 }
@@ -7026,17 +7099,18 @@ fn artifact_hash_invocation(
     match platform {
         TargetPlatform::Posix => {
             let sh = required_tool(toolchain.sh())?;
-            let sha256sum = required_tool(toolchain.sha256sum())?;
-            let argv = ExecutionArgv::new(
-                sh,
-                vec![
-                    "-c".to_owned(),
-                    ARTIFACT_HASH_SCRIPT.to_owned(),
-                    sha256sum.as_str().to_owned(),
-                    declared_path.to_owned(),
-                ],
-            )
-            .map_err(|_| invalid_job())?;
+            let sha256 = toolchain
+                .sha256()
+                .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Unsupported))?;
+            let mut arguments = Vec::with_capacity(4 + sha256.arguments().len());
+            arguments.extend([
+                "-c".to_owned(),
+                ARTIFACT_HASH_SCRIPT.to_owned(),
+                sha256.program().as_str().to_owned(),
+                declared_path.to_owned(),
+            ]);
+            arguments.extend(sha256.arguments().iter().cloned());
+            let argv = ExecutionArgv::new(sh, arguments).map_err(|_| invalid_job())?;
             Ok((argv, automata_ci_execution::ExecutionEnvironment::empty()))
         }
         TargetPlatform::Windows => {
@@ -7236,8 +7310,8 @@ fn job_workspace(
     const LOGICAL_WORKSPACE_ROOT: &str = "/__w";
     let logical_workspace = TargetPath::posix(job.execution().workspace())
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-    match environment.workspace().platform() {
-        TargetPlatform::Posix => {
+    match (environment.workspace().platform(), environment.launch()) {
+        (TargetPlatform::Posix, SandboxLaunch::Container { .. }) => {
             let root = environment.workspace().as_str().trim_end_matches('/');
             let prefix = format!("{root}/");
             if logical_workspace.as_str() == root
@@ -7247,7 +7321,7 @@ fn job_workspace(
             }
             Ok(logical_workspace)
         }
-        TargetPlatform::Windows => {
+        (TargetPlatform::Posix | TargetPlatform::Windows, SandboxLaunch::Native) => {
             let relative = logical_workspace
                 .as_str()
                 .strip_prefix(LOGICAL_WORKSPACE_ROOT)
@@ -7255,6 +7329,7 @@ fn job_workspace(
                 .ok_or_else(invalid_job)?;
             child(environment.workspace(), relative)
         }
+        (TargetPlatform::Windows, SandboxLaunch::Container { .. }) => Err(invalid_job()),
     }
 }
 

--- a/crates/automata-ci-job-executor-github/src/port.rs
+++ b/crates/automata-ci-job-executor-github/src/port.rs
@@ -8,7 +8,7 @@ use automata_ci_core::{
     JobIrEnvelope, JobRuntimeContext, Lease, OperationId, UnixMillis,
 };
 use automata_ci_execution::{
-    SandboxEnvironment, ServiceContainerBindings, TargetPath, TargetPlatform,
+    ExecutionArgv, SandboxEnvironment, ServiceContainerBindings, TargetPath, TargetPlatform,
 };
 use automata_ci_expression_github::{GithubEvaluationContext, GithubStatus, GithubValue};
 use automata_ci_github_runtime::JobCommandState;
@@ -557,8 +557,8 @@ pub trait GithubToolchain: fmt::Debug + Send + Sync {
     fn install(&self) -> Option<&TargetPath>;
     /// Returns the exact POSIX archive extraction utility, when available.
     fn tar(&self) -> Option<&TargetPath>;
-    /// Returns the exact POSIX SHA-256 regular-file hashing utility, when available.
-    fn sha256sum(&self) -> Option<&TargetPath>;
+    /// Returns the exact POSIX SHA-256 utility and its fixed arguments, when available.
+    fn sha256(&self) -> Option<&ExecutionArgv>;
     /// Returns the exact executable for a metadata-selected Node runtime.
     fn node(&self, runtime: JavascriptRuntime) -> Option<&TargetPath>;
 }

--- a/crates/automata-ci-metrics/Cargo.toml
+++ b/crates/automata-ci-metrics/Cargo.toml
@@ -20,6 +20,9 @@ rustix = { workspace = true, features = ["param"] }
 thiserror.workspace = true
 tokio.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+processkit = { workspace = true, features = ["process-control"] }
+
 [dev-dependencies]
 http-body-util.workspace = true
 tower.workspace = true

--- a/crates/automata-ci-metrics/src/process.rs
+++ b/crates/automata-ci-metrics/src/process.rs
@@ -457,6 +457,7 @@ fn parse_max_open_files(process_limits: &str) -> Result<u64, SnapshotError> {
     Err(SnapshotError::Invalid)
 }
 
+#[cfg(target_os = "linux")]
 fn process_start_time_seconds() -> Option<f64> {
     linux_process_start_time_seconds()
 }
@@ -472,8 +473,15 @@ fn linux_process_start_time_seconds() -> Option<f64> {
     )
 }
 
-#[cfg(not(target_os = "linux"))]
-fn linux_process_start_time_seconds() -> Option<f64> {
+#[cfg(target_os = "macos")]
+fn process_start_time_seconds() -> Option<f64> {
+    let process = processkit::process_info(std::process::id()).ok()??;
+    let start_time_micros = process.start_time()?;
+    Some(Duration::from_micros(start_time_micros).as_secs_f64())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_start_time_seconds() -> Option<f64> {
     None
 }
 

--- a/crates/automata-ci-runner/Cargo.toml
+++ b/crates/automata-ci-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-runner"
-description = "Automata workflow runner for Linux and trusted native Windows hosts"
+description = "Automata workflow runner for Linux and trusted native Windows/macOS hosts"
 publish.workspace = true
 readme = "README.md"
 keywords = ["ci", "github-actions", "self-hosted", "runner", "automation"]
@@ -41,6 +41,7 @@ automata-ci-runner-spool.workspace = true
 automata-ci-runner-transport.workspace = true
 automata-ci-sandbox-kubernetes.workspace = true
 automata-ci-sandbox-podman.workspace = true
+automata-ci-sandbox-macos.workspace = true
 automata-ci-sandbox-windows.workspace = true
 automata-ci-scm.workspace = true
 automata-ci-workflow-github.workspace = true
@@ -64,6 +65,9 @@ zeroize.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rustix.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework.workspace = true
 
 [build-dependencies]
 automata-ci-build-support.workspace = true

--- a/crates/automata-ci-runner/README.md
+++ b/crates/automata-ci-runner/README.md
@@ -1,19 +1,22 @@
 # `automata-runner`
 
-The `automata-ci-runner` package builds the `automata-runner` command for Linux
-and Windows execution hosts. It validates the host, opens an mTLS session to
+The `automata-ci-runner` package builds the `automata-runner` command for Linux,
+Windows, and macOS execution hosts. It validates the host, opens an mTLS session to
 the control plane, accepts fenced leases, runs jobs through the configured
 sandbox provider, streams logs, and removes interrupted work.
 
 `automata-runner run` selects exactly one host-compatible provider from its
 configuration: rootless Podman or Kubernetes on Linux, or the experimental
-native provider on Windows. The checked-in Linux host examples
+trusted-native provider on Windows or Apple Silicon macOS 15+. The checked-in
+Linux host examples
 ([one](config/runner.local-1.example.json),
 [two](config/runner.local-2.example.json), and
 [three](config/runner.local-3.example.json)) select three independent
 single-slot Podman processes; the
-[Windows](config/runner.windows.example.json) example remains one process and
-one slot. The bootstrap guide documents the Kubernetes configuration shape.
+[Windows](config/runner.windows.example.json) and
+[macOS](config/runner.macos.example.json) examples each remain one process and
+one slot. The [configuration guide](config/README.md) documents Kubernetes
+and the native trust boundaries.
 
 No crates.io package or public runner archive has been published. Install a
 reviewed source build for configuration work and diagnostics:
@@ -91,6 +94,13 @@ Windows runners. The native-provider tests remain in the repository, but they
 are not a release gate; do not deploy this path until its Windows end-to-end CI
 gate is restored.
 
+The macOS profile supports Bash and `sh` `run:` steps, plus optional explicitly
+configured Python and PowerShell Core interpreters. Startup probes every
+configured interpreter through the same shipped-binary supervisor used by job
+execution. The provider is single-slot and host-shared: CPU, memory, and PID
+inventory values guide placement but are not hard per-job limits. It does not
+advertise actions, containers, services, GPUs, or ephemeral-disk capacity.
+
 ## Job boundary
 
 On Linux, workload environment values are sent to Podman through a bounded
@@ -111,9 +121,9 @@ must not access runner state paths. See the
 [Windows source-build boundary](../../docs/getting-started.md#windows-source-build-and-native-runner-boundary)
 before supplying environment-backed credentials.
 
-Rootless Podman is a shared-kernel Linux boundary, and Windows native execution
-is a trusted-host boundary. Neither is hostile multi-tenant isolation. Stronger
-providers remain planned and are listed in the
+Rootless Podman is a shared-kernel Linux boundary, while Windows and macOS
+native execution are trusted-host boundaries. None is hostile multi-tenant
+isolation. Stronger providers remain planned and are listed in the
 [implementation plan](https://github.com/automata-ci/automata/blob/main/docs/implementation-plan.md#provider-scope).
 
 ## Configure a host

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -1,15 +1,17 @@
 # Local runner bootstrap
 
 This directory contains three checked-in Linux Podman instance configurations
-plus one Windows configuration for `automata-runner`.
+plus Windows and macOS native configurations for `automata-runner`.
 [`runner.local-1.example.json`](runner.local-1.example.json),
 [`runner.local-2.example.json`](runner.local-2.example.json), and
 [`runner.local-3.example.json`](runner.local-3.example.json) select the same
 locked Ubuntu 24.04 profile while keeping every host-local identity, state
 path, credential path, runtime mount, and metrics port distinct.
 [`runner.windows.example.json`](runner.windows.example.json) selects the
-trusted native provider on Windows. Exactly one of the `podman`, `kubernetes`,
-and `windows_native` provider objects may be configured.
+trusted native provider on Windows. [`runner.macos.example.json`](runner.macos.example.json)
+selects the trusted native provider on Apple Silicon macOS 15+. Exactly one of
+the `podman`, `kubernetes`, `windows_native`, and `macos_native` provider
+objects may be configured.
 
 The Linux examples' local bootstrap digest is not an official promoted profile;
 follow the
@@ -18,7 +20,9 @@ before trusting a protected-main candidate.
 
 Product schema v2 accepts exactly one sandbox provider. Host runners use the
 top-level `podman` object and require `state.podman`. Kubernetes runners omit
-both fields and use a top-level `kubernetes` object. The runner loads
+`state.podman`, `state.windows_native`, and `state.macos_native` and use a
+top-level `kubernetes` object. Native Windows and macOS runners use their
+matching provider name in both locations. The runner loads
 credentials through Kubernetes' standard in-cluster or ambient kubeconfig
 discovery; the JSON remains secret-free.
 
@@ -122,8 +126,40 @@ host-specific path and follow the
 [Windows source-build boundary](../../../docs/getting-started.md#windows-source-build-and-native-runner-boundary)
 before starting `automata-runner run --config C:\path\to\runner.windows.json`.
 
+## macOS native example
+
+The macOS example is an experimental trusted-workflow path for Apple Silicon
+running macOS 15 or newer. It executes Bash and `sh` scripts through a hidden
+same-binary supervisor which owns a POSIX process group and terminates that
+group on timeout, cancellation, output overflow, or runner disconnect.
+Optional absolute Python and PowerShell Core paths are accepted and probed at
+startup. Every `uses:` action, job or service container, parallel native slot,
+GPU claim, and nonzero ephemeral-disk capacity fails closed.
+
+This provider deliberately uses the dedicated runner account's unchanged host
+identity, filesystem, and network. Its configured CPU, memory, and PID values
+are one-slot scheduling capacity, not hard resource limits. Run only trusted
+workflows under a dedicated non-administrative account. Provision the provider
+root and every existing descendant as that account with mode 0700; the adapter
+opens paths descriptor-relatively, rejects symlink traversal and hard-linked
+copy targets, and keeps a checksummed, exclusively locked lifecycle journal.
+
+The `macos_keychain` secret source selects one exact generic-password item by
+`service` and `account` in the account's default Keychain. Reads are serialized,
+bounded, and performed with authentication UI disabled; missing, duplicate,
+locked, interactive-only, or malformed values stop startup without exposing
+secret bytes. Pre-provision item access for the exact reviewed
+`automata-runner` binary and verify it while logged in as the service account.
+Do not pass secret values on a command line or store them in the JSON.
+
+Copy [`runner.macos.example.json`](runner.macos.example.json) to an ignored
+host-specific path, replace the identity and endpoints, provision its roots and
+Keychain items, then start `automata-runner run --config /absolute/path/to/runner.macos.json`.
+The implementation and remaining VM-isolation work are tracked in the
+[macOS plan](../../../docs/platforms/macos.md).
+
 The remainder of this guide describes the three-process rootless-Podman Linux
-host. Windows remains one process with one slot.
+host. Windows and macOS each remain one process with one slot.
 
 ## What the Linux example assumes
 

--- a/crates/automata-ci-runner/config/runner.macos.example.json
+++ b/crates/automata-ci-runner/config/runner.macos.example.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 2,
+  "runner_id": "75934d27-b027-45df-94c4-97e5a91f4011",
+  "control_endpoint": "https://127.0.0.1:9090/",
+  "state": {
+    "journal": "/Users/automata-runner/Library/Application Support/Automata/state/journal",
+    "spool": "/Users/automata-runner/Library/Application Support/Automata/state/spool",
+    "macos_native": "/Users/automata-runner/Library/Application Support/Automata/native"
+  },
+  "tls": {
+    "server_roots": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "server-roots-pem"
+    },
+    "certificate_chain": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "certificate-chain-pem"
+    },
+    "private_key": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "private-key-pem"
+    }
+  },
+  "spool": {
+    "protection_id": "macos-runner-key-v1",
+    "key_hex": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "spool-key-hex"
+    },
+    "decrypt_only": []
+  },
+  "inventory": {
+    "labels": ["self-hosted", "macos", "arm64", "macos-15"],
+    "groups": ["default"],
+    "max_parallel_jobs": 1,
+    "resources_per_job": {
+      "cpu_millis": 4000,
+      "memory_bytes": 8589934592,
+      "ephemeral_disk_bytes": 0,
+      "pids": 512
+    },
+    "environment_profiles": [
+      {
+        "id": "automata.dev/macos-15-arm64-native-v1",
+        "manifest_sha256": "55177392ec9af57b967ecf016c7f12ab27c8e1e570caaae4cc39b17790e81ba3",
+        "workspace": "/Users/automata-runner/Library/Application Support/Automata/native/workspaces",
+        "default_environment": {}
+      }
+    ]
+  },
+  "macos_native": {},
+  "executor": {
+    "resources": {
+      "cpu_millis": 4000,
+      "memory_bytes": 8589934592,
+      "ephemeral_disk_bytes": 0,
+      "pids": 512
+    },
+    "network": "host",
+    "root_filesystem": "host",
+    "privilege": "host",
+    "default_step_timeout_seconds": 3600,
+    "maximum_output_bytes": 16777216,
+    "runner_root": "/Users/automata-runner/Library/Application Support/Automata/native/runner",
+    "home": "/Users/automata-runner",
+    "path": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    "temp": "/Users/automata-runner/Library/Caches/Automata/tmp",
+    "tool_cache": "/Users/automata-runner/Library/Caches/Automata/tool-cache",
+    "toolchain": {
+      "bash": "/bin/bash",
+      "sh": "/bin/sh",
+      "python": null,
+      "pwsh": null,
+      "powershell": null,
+      "cmd": null,
+      "install": "/usr/bin/install",
+      "tar": "/usr/bin/tar",
+      "sha256sum": "/usr/bin/shasum",
+      "node12": null,
+      "node16": null,
+      "node20": null,
+      "node24": null
+    }
+  },
+  "object_store": {
+    "endpoint": "https://s3.amazonaws.com/",
+    "region": "us-east-1",
+    "bucket": "automata-runner",
+    "prefix": "automata/v1",
+    "loopback_development": false,
+    "operation_timeout_seconds": 30,
+    "access_key_id": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "s3-access-key-id"
+    },
+    "secret_access_key": {
+      "kind": "macos_keychain",
+      "service": "dev.automata.runner",
+      "account": "s3-secret-access-key"
+    }
+  },
+  "github": {
+    "user_agent": "automata-runner/0.1.0",
+    "server_url": "https://github.com/",
+    "api_url": "https://api.github.com/",
+    "graphql_url": "https://api.github.com/graphql"
+  }
+}

--- a/crates/automata-ci-runner/src/cli.rs
+++ b/crates/automata-ci-runner/src/cli.rs
@@ -7,7 +7,7 @@ use clap::{Args, Parser, Subcommand};
     name = "automata-runner",
     version,
     long_version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("AUTOMATA_BUILD_GIT_SHA"), ")"),
-    about = "Automata runner for rootless Linux and trusted native Windows execution hosts"
+    about = "Automata runner for rootless Linux and trusted native Windows/macOS execution hosts"
 )]
 pub(crate) struct Cli {
     #[command(subcommand)]
@@ -25,6 +25,9 @@ pub(crate) enum Command {
     /// Internal one-shot readiness server used by the isolated network probe.
     #[command(name = "__probe-http-ready", hide = true)]
     InternalProbeHttp(InternalProbeHttpArgs),
+    /// Internal same-binary supervisor for one trusted native macOS command.
+    #[command(name = "__macos-job-supervisor", hide = true)]
+    InternalMacosJobSupervisor,
 }
 
 #[derive(Debug, Args)]

--- a/crates/automata-ci-runner/src/lib.rs
+++ b/crates/automata-ci-runner/src/lib.rs
@@ -5,9 +5,10 @@
 //! either requires the configured rootless-Podman network probe and cleanup to
 //! succeed or constructs the authenticated Kubernetes adapter. Trusted Windows
 //! execution uses native processes contained by a Job Object with explicit
-//! host-network and host-filesystem semantics. Every path exercises configured
-//! environments through exact lifecycle admission before supervising fenced
-//! job execution.
+//! host-network and host-filesystem semantics; trusted macOS execution uses
+//! supervised POSIX process groups with the same explicit host semantics.
+//! Every path exercises configured environments through exact lifecycle
+//! admission before supervising fenced job execution.
 //! [`run`] is the `automata-runner` process entry point; diagnostic and product
 //! modules expose the same typed boundaries for embedding and tests.
 
@@ -83,6 +84,9 @@ async fn execute(cli: Cli) -> Result<()> {
             doctor::run(args, &cancellation).await
         }
         Command::InternalProbeHttp(args) => probe_http::serve(args).await,
+        Command::InternalMacosJobSupervisor => {
+            automata_ci_sandbox_macos::run_supervisor().map_err(Into::into)
+        }
     }
 }
 

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -28,11 +28,15 @@ use automata_ci_runner_transport::{
     HyperRunnerControlClient, HyperRunnerEphemeralClient, RunnerControlClient,
     RunnerEphemeralClient, TransportLimits,
 };
+use automata_ci_sandbox_macos::{MacosSandboxProvider, MacosSandboxProviderOptions};
 #[cfg(not(target_os = "linux"))]
 use automata_ci_sandbox_podman::PodmanLaunchTrust;
 use automata_ci_sandbox_podman::{
-    PodmanBinary, PodmanCommandExecutor, PodmanLaunchTrustHandle, PodmanOptions,
-    PodmanProcessEnvironment, PodmanStateRoot, RootlessPodmanProvider, SystemCommandExecutor,
+    PodmanBinary, PodmanLaunchTrustHandle, PodmanOptions, PodmanProcessEnvironment, PodmanStateRoot,
+};
+#[cfg(target_os = "linux")]
+use automata_ci_sandbox_podman::{
+    PodmanCommandExecutor, RootlessPodmanProvider, SystemCommandExecutor,
 };
 use automata_ci_sandbox_windows::{WindowsSandboxProvider, WindowsSandboxProviderOptions};
 use automata_ci_scm::ScmProvider;
@@ -130,6 +134,7 @@ pub async fn run(config_path: &Path, shutdown: RunnerShutdown) -> Result<(), Run
         RunnerProviderConfig::Podman(_) => run_podman(&config, shutdown).await,
         RunnerProviderConfig::Kubernetes(_) => run_kubernetes(&config, shutdown).await,
         RunnerProviderConfig::WindowsNative(_) => run_windows_native(&config, shutdown).await,
+        RunnerProviderConfig::MacosNative(_) => run_macos_native(&config, shutdown).await,
     }
 }
 
@@ -226,6 +231,35 @@ async fn run_windows_native(
     }
     let metrics = build_metrics(config, None)?;
     let provider = build_windows_provider(config, metrics.as_ref())?;
+    let metrics_listener = match config.metrics() {
+        Some(metrics) => Some(bind_metrics_listener(metrics.listen()).await?),
+        None => None,
+    };
+    let composition = compose_with_provider(
+        config,
+        provider,
+        metrics,
+        &shutdown.probe,
+        false,
+        false,
+        || Ok(()),
+    )?
+    .filter(|_| !shutdown.is_requested());
+    let Some(composition) = composition else {
+        return Ok(());
+    };
+    supervise_composition(config, composition, metrics_listener, shutdown).await
+}
+
+async fn run_macos_native(
+    config: &RunnerProductConfig,
+    shutdown: RunnerShutdown,
+) -> Result<(), RunnerProductError> {
+    if shutdown.is_requested() {
+        return Ok(());
+    }
+    let metrics = build_metrics(config, None)?;
+    let provider = build_macos_provider(config, metrics.as_ref())?;
     let metrics_listener = match config.metrics() {
         Some(metrics) => Some(bind_metrics_listener(metrics.listen()).await?),
         None => None,
@@ -387,15 +421,13 @@ fn mark_admitted_composition_ready(config: &RunnerProductConfig, composition: &R
     }
 }
 
+#[cfg(target_os = "linux")]
 fn compose_podman(
     config: &RunnerProductConfig,
     podman_options: &PodmanOptions,
     cancellation: &crate::podman_probe::ProbeCancellation,
     _admission: CapabilityAdmission,
 ) -> Result<Option<RunnerComposition>, RunnerProductError> {
-    #[cfg(not(target_os = "linux"))]
-    return Err(RunnerProductError::UnsupportedPlatform);
-
     let runner_cgroup = config
         .metrics()
         .and_then(|_| PodmanCommandExecutor::delegated_no_swap_cgroup(&SystemCommandExecutor));
@@ -414,6 +446,16 @@ fn compose_podman(
         podman.buildkit_runtime().is_some(),
         || revalidate_podman_launch_trust(podman_options),
     )
+}
+
+#[cfg(not(target_os = "linux"))]
+fn compose_podman(
+    _config: &RunnerProductConfig,
+    _podman_options: &PodmanOptions,
+    _cancellation: &crate::podman_probe::ProbeCancellation,
+    _admission: CapabilityAdmission,
+) -> Result<Option<RunnerComposition>, RunnerProductError> {
+    Err(RunnerProductError::UnsupportedPlatform)
 }
 
 fn build_metrics(
@@ -573,16 +615,25 @@ fn admit_configured_environment_profiles(
     let capacity = config.executor().resource_capacity();
     let allocation = automata_ci_core::JobResourceAllocation::new(capacity, capacity)
         .map_err(|_| RunnerProductError::SandboxProviderInvariant)?;
-    let policy = ProfileAdmissionPolicy::new(
-        config.executor().network(),
-        config.executor().root_filesystem(),
-        config.executor().privilege(),
-        config.executor().resources(),
-        allocation,
-    );
-    let policy = if config.windows_native().is_some() {
-        let toolchain = config.executor().toolchain();
-        policy
+    let policy = if config.macos_native().is_some() {
+        ProfileAdmissionPolicy::host_shared(
+            config.executor().network(),
+            config.executor().root_filesystem(),
+            config.executor().privilege(),
+            allocation,
+        )
+    } else {
+        ProfileAdmissionPolicy::new(
+            config.executor().network(),
+            config.executor().root_filesystem(),
+            config.executor().privilege(),
+            config.executor().resources(),
+            allocation,
+        )
+    };
+    let toolchain = config.executor().toolchain();
+    let policy = match config.provider() {
+        RunnerProviderConfig::WindowsNative(_) => policy
             .with_native_windows_shells(
                 config.executor().runner_root().clone(),
                 toolchain
@@ -599,9 +650,23 @@ fn admit_configured_environment_profiles(
                     .clone(),
                 toolchain.python().cloned(),
             )
-            .map_err(|_| RunnerProductError::ProviderConfiguration)?
-    } else {
-        policy
+            .map_err(|_| RunnerProductError::ProviderConfiguration)?,
+        RunnerProviderConfig::MacosNative(_) => policy
+            .with_native_macos_shells(
+                config.executor().runner_root().clone(),
+                toolchain
+                    .bash()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .sh()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain.python().cloned(),
+                toolchain.pwsh().cloned(),
+            )
+            .map_err(|_| RunnerProductError::ProviderConfiguration)?,
+        RunnerProviderConfig::Podman(_) | RunnerProviderConfig::Kubernetes(_) => policy,
     };
     let result = admit_environment_profiles(provider, config.environments(), policy, cancellation);
     match result {
@@ -780,6 +845,7 @@ async fn verify_configured_capabilities(
     Err(RunnerProductError::CapabilityAdmission)
 }
 
+#[cfg(target_os = "linux")]
 fn build_podman_provider(
     podman_options: PodmanOptions,
     metrics: Option<&RunnerMetrics>,
@@ -817,6 +883,28 @@ fn build_windows_provider(
     }
 }
 
+fn build_macos_provider(
+    config: &RunnerProductConfig,
+    metrics: Option<&RunnerMetrics>,
+) -> Result<Arc<dyn automata_ci_execution::SandboxProvider>, RunnerProductError> {
+    if config.macos_native().is_none() {
+        return Err(RunnerProductError::ProviderConfiguration);
+    }
+    let state_root = config
+        .state()
+        .macos_native()
+        .ok_or(RunnerProductError::ProviderConfiguration)?;
+    let executable =
+        std::env::current_exe().map_err(|_| RunnerProductError::ProviderConfiguration)?;
+    let options = MacosSandboxProviderOptions::new(state_root.to_path_buf(), executable)?;
+    let provider: Arc<dyn automata_ci_execution::SandboxProvider> =
+        Arc::new(MacosSandboxProvider::open(options)?);
+    match metrics {
+        Some(metrics) => Ok(metrics.instrument_sandbox_provider(provider)),
+        None => Ok(provider),
+    }
+}
+
 fn build_executor(
     config: &RunnerProductConfig,
     provider: Arc<dyn automata_ci_execution::SandboxProvider>,
@@ -834,19 +922,31 @@ fn build_executor(
     let toolchain = Arc::new(build_toolchain(config)?);
     let contexts = Arc::new(StandardGithubContext::new(
         config.runner_id(),
+        config.inventory().platform().clone(),
         config.environments(),
         config.executor(),
         config.github().clone(),
     )?);
-    let executor_config = GithubJobExecutorConfig::new(
-        config.executor().resources(),
-        config.executor().network(),
-        config.executor().root_filesystem(),
-        config.executor().privilege(),
-        config.executor().default_step_timeout(),
-        config.executor().maximum_output_bytes(),
-        config.executor().runner_root().clone(),
-    )?;
+    let executor_config = if matches!(config.provider(), RunnerProviderConfig::MacosNative(_)) {
+        GithubJobExecutorConfig::host_shared(
+            config.executor().network(),
+            config.executor().root_filesystem(),
+            config.executor().privilege(),
+            config.executor().default_step_timeout(),
+            config.executor().maximum_output_bytes(),
+            config.executor().runner_root().clone(),
+        )?
+    } else {
+        GithubJobExecutorConfig::new(
+            config.executor().resources(),
+            config.executor().network(),
+            config.executor().root_filesystem(),
+            config.executor().privilege(),
+            config.executor().default_step_timeout(),
+            config.executor().maximum_output_bytes(),
+            config.executor().runner_root().clone(),
+        )?
+    };
     let executor = Arc::new(GithubJobExecutor::new(
         executor_config,
         GithubJobExecutorPorts::new(
@@ -971,13 +1071,37 @@ fn build_toolchain(
                 .ok_or(RunnerProductError::ProviderConfiguration)?
                 .clone(),
         )?,
+        RunnerProviderConfig::MacosNative(_) => StaticGithubToolchain::macos(
+            configured
+                .bash()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+            configured
+                .sh()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+            configured
+                .install()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+            configured
+                .tar()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+            configured
+                .sha256sum()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+        )?,
     };
     if let Some(path) = configured.python() {
         toolchain = toolchain.with_python(path.clone())?;
     }
     if matches!(
         config.provider(),
-        RunnerProviderConfig::Podman(_) | RunnerProviderConfig::Kubernetes(_)
+        RunnerProviderConfig::Podman(_)
+            | RunnerProviderConfig::Kubernetes(_)
+            | RunnerProviderConfig::MacosNative(_)
     ) && let Some(path) = configured.pwsh()
     {
         toolchain = toolchain.with_pwsh(path.clone())?;
@@ -1127,18 +1251,18 @@ pub enum RunnerProductError {
     /// The provider-specific product configuration was internally inconsistent.
     #[error("runner provider configuration is inconsistent")]
     ProviderConfiguration,
-    /// Native Windows provider initialization failed.
-    #[error("runner native Windows provider initialization failed")]
-    WindowsProvider(#[from] automata_ci_execution::ProviderError),
-    /// Product configuration and the selected provider path disagreed.
-    #[error("runner sandbox provider composition invariant failed")]
-    SandboxProviderInvariant,
     /// Ambient Kubernetes client discovery or authentication failed.
     #[error("runner Kubernetes client initialization failed")]
     KubernetesClient(#[source] kube::Error),
     /// Kubernetes sandbox adapter configuration failed.
     #[error("runner Kubernetes provider configuration failed")]
     KubernetesConfiguration(#[from] automata_ci_sandbox_kubernetes::KubernetesConfigurationError),
+    /// Native host provider initialization failed.
+    #[error("runner native host provider initialization failed")]
+    NativeProvider(#[from] automata_ci_execution::ProviderError),
+    /// Product configuration and the selected provider path disagreed.
+    #[error("runner sandbox provider composition invariant failed")]
+    SandboxProviderInvariant,
     /// The configured Podman network admission boundary did not produce usable evidence.
     #[error("runner capability admission failed")]
     CapabilityAdmission,
@@ -1416,10 +1540,14 @@ mod tests {
 
     #[test]
     fn registered_helper_ceiling_is_reduced_to_the_verified_provider() {
-        let config = RunnerProductConfig::from_json(include_bytes!(
-            "../../config/runner.local-1.example.json"
-        ))
-        .expect("checked-in runner configuration");
+        #[cfg(target_os = "linux")]
+        let configuration = include_bytes!("../../config/runner.local-1.example.json").as_slice();
+        #[cfg(target_os = "macos")]
+        let configuration = include_bytes!("../../config/runner.macos.example.json").as_slice();
+        #[cfg(target_os = "windows")]
+        let configuration = include_bytes!("../../config/runner.windows.example.json").as_slice();
+        let config = RunnerProductConfig::from_json(configuration)
+            .expect("checked-in host runner configuration");
         let mut registered_features = config.inventory().containers().features().clone();
         registered_features.extend([
             ContainerFeature::SERVICE_CONTAINERS,

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -106,7 +106,7 @@ impl RunnerProductConfig {
         &self.control_endpoint
     }
 
-    /// Returns the three non-overlapping durable provider-state roots.
+    /// Returns the non-overlapping durable state roots for the selected provider.
     #[must_use]
     pub const fn state(&self) -> &StateRoots {
         &self.state
@@ -150,7 +150,9 @@ impl RunnerProductConfig {
     pub const fn podman(&self) -> Option<&PodmanProductConfig> {
         match &self.provider {
             RunnerProviderConfig::Podman(config) => Some(config),
-            RunnerProviderConfig::Kubernetes(_) | RunnerProviderConfig::WindowsNative(_) => None,
+            RunnerProviderConfig::Kubernetes(_)
+            | RunnerProviderConfig::WindowsNative(_)
+            | RunnerProviderConfig::MacosNative(_) => None,
         }
     }
 
@@ -159,7 +161,9 @@ impl RunnerProductConfig {
     pub const fn kubernetes(&self) -> Option<&KubernetesProductConfig> {
         match &self.provider {
             RunnerProviderConfig::Kubernetes(config) => Some(config),
-            RunnerProviderConfig::Podman(_) | RunnerProviderConfig::WindowsNative(_) => None,
+            RunnerProviderConfig::Podman(_)
+            | RunnerProviderConfig::WindowsNative(_)
+            | RunnerProviderConfig::MacosNative(_) => None,
         }
     }
 
@@ -168,7 +172,20 @@ impl RunnerProductConfig {
     pub const fn windows_native(&self) -> Option<&WindowsNativeProductConfig> {
         match &self.provider {
             RunnerProviderConfig::WindowsNative(config) => Some(config),
-            RunnerProviderConfig::Podman(_) | RunnerProviderConfig::Kubernetes(_) => None,
+            RunnerProviderConfig::Podman(_)
+            | RunnerProviderConfig::Kubernetes(_)
+            | RunnerProviderConfig::MacosNative(_) => None,
+        }
+    }
+
+    /// Returns trusted native-macOS provider policy when selected.
+    #[must_use]
+    pub const fn macos_native(&self) -> Option<&MacosNativeProductConfig> {
+        match &self.provider {
+            RunnerProviderConfig::MacosNative(config) => Some(config),
+            RunnerProviderConfig::Podman(_)
+            | RunnerProviderConfig::Kubernetes(_)
+            | RunnerProviderConfig::WindowsNative(_) => None,
         }
     }
 
@@ -238,6 +255,7 @@ pub struct StateRoots {
     spool: SpoolRoot,
     podman: Option<PathBuf>,
     windows_native: Option<PathBuf>,
+    macos_native: Option<PathBuf>,
 }
 
 impl StateRoots {
@@ -256,7 +274,10 @@ impl StateRoots {
     /// Returns the selected local execution provider's durable state root.
     #[must_use]
     pub fn provider(&self) -> Option<&Path> {
-        self.podman.as_deref().or(self.windows_native.as_deref())
+        self.podman
+            .as_deref()
+            .or(self.windows_native.as_deref())
+            .or(self.macos_native.as_deref())
     }
 
     /// Returns the rootless-Podman durable state root when selected.
@@ -270,6 +291,25 @@ impl StateRoots {
     pub fn windows_native(&self) -> Option<&Path> {
         self.windows_native.as_deref()
     }
+
+    /// Returns the native-macOS durable state root when selected.
+    #[must_use]
+    pub fn macos_native(&self) -> Option<&Path> {
+        self.macos_native.as_deref()
+    }
+}
+
+/// Validated execution-provider selection for one runner process.
+#[derive(Clone, Debug)]
+pub enum RunnerProviderConfig {
+    /// Rootless Podman on a dedicated Linux execution host.
+    Podman(PodmanProductConfig),
+    /// Authenticated Kubernetes Pods on a dedicated Linux execution host.
+    Kubernetes(KubernetesProductConfig),
+    /// Job Object-contained native processes for trusted Windows jobs.
+    WindowsNative(WindowsNativeProductConfig),
+    /// Supervised POSIX process groups for trusted macOS jobs.
+    MacosNative(MacosNativeProductConfig),
 }
 
 /// Validated Kubernetes product configuration and operator attestations.
@@ -286,20 +326,13 @@ impl KubernetesProductConfig {
     }
 }
 
-/// Validated execution-provider selection for one runner process.
-#[derive(Clone, Debug)]
-pub enum RunnerProviderConfig {
-    /// Rootless Podman on a dedicated Linux execution host.
-    Podman(PodmanProductConfig),
-    /// Authenticated Kubernetes Pods on a dedicated Linux execution host.
-    Kubernetes(KubernetesProductConfig),
-    /// Job Object-contained native processes for trusted Windows jobs.
-    WindowsNative(WindowsNativeProductConfig),
-}
-
 /// Trusted native-Windows execution provider configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WindowsNativeProductConfig;
+
+/// Trusted native-macOS execution provider configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MacosNativeProductConfig;
 
 /// Explicit material locations for outbound runner mTLS.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -856,6 +889,7 @@ enum ProviderKind {
     Podman,
     Kubernetes,
     WindowsNative,
+    MacosNative,
 }
 
 #[derive(Deserialize)]
@@ -874,6 +908,8 @@ struct RawRunnerProductConfig {
     kubernetes: Option<RawKubernetesProductConfig>,
     #[serde(default)]
     windows_native: Option<RawWindowsNativeProductConfig>,
+    #[serde(default)]
+    macos_native: Option<RawMacosNativeProductConfig>,
     executor: RawExecutorProductConfig,
     object_store: RawObjectStoreProductConfig,
     github: RawGithubProductConfig,
@@ -887,7 +923,20 @@ impl RawRunnerProductConfig {
         if self.schema_version != RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION {
             return Err(RunnerProductConfigError::UnsupportedSchema);
         }
+        let provider_kind = match (
+            &self.podman,
+            &self.kubernetes,
+            &self.windows_native,
+            &self.macos_native,
+        ) {
+            (Some(_), None, None, None) => ProviderKind::Podman,
+            (None, Some(_), None, None) => ProviderKind::Kubernetes,
+            (None, None, Some(_), None) => ProviderKind::WindowsNative,
+            (None, None, None, Some(_)) => ProviderKind::MacosNative,
+            _ => return Err(RunnerProductConfigError::InvalidProvider),
+        };
         let control_endpoint = validate_control_endpoint(&self.control_endpoint)?;
+        let state = self.state.validate(provider_kind)?;
         let tls = self.tls.validate()?;
         let spool = self.spool.validate()?;
         let github = self.github.validate()?;
@@ -895,25 +944,24 @@ impl RawRunnerProductConfig {
             .metrics
             .map(RawMetricsProductConfig::validate)
             .transpose()?;
-        let provider_kind = match (
-            self.podman.is_some(),
-            self.kubernetes.is_some(),
-            self.windows_native.is_some(),
-        ) {
-            (true, false, false) => ProviderKind::Podman,
-            (false, true, false) => ProviderKind::Kubernetes,
-            (false, false, true) => ProviderKind::WindowsNative,
-            _ => return Err(RunnerProductConfigError::InvalidProvider),
-        };
-        let state = self.state.validate(provider_kind)?;
         let executor = self.executor.validate(provider_kind)?;
-        let provider = match (self.podman, self.kubernetes, self.windows_native) {
-            (Some(raw), None, None) => {
+        let provider = match (
+            self.podman,
+            self.kubernetes,
+            self.windows_native,
+            self.macos_native,
+        ) {
+            (Some(raw), None, None, None) => {
                 RunnerProviderConfig::Podman(raw.validate(github.server_url())?)
             }
-            (None, Some(raw), None) => RunnerProviderConfig::Kubernetes(raw.validate(&executor)?),
-            (None, None, Some(_)) => {
+            (None, Some(raw), None, None) => {
+                RunnerProviderConfig::Kubernetes(raw.validate(&executor)?)
+            }
+            (None, None, Some(_), None) => {
                 RunnerProviderConfig::WindowsNative(RawWindowsNativeProductConfig::validate()?)
+            }
+            (None, None, None, Some(_)) => {
+                RunnerProviderConfig::MacosNative(RawMacosNativeProductConfig::validate()?)
             }
             _ => return Err(RunnerProductConfigError::InvalidProvider),
         };
@@ -934,27 +982,33 @@ impl RawRunnerProductConfig {
                 return Err(RunnerProductConfigError::InvalidStateRoots);
             }
         }
+        let (job_container_engine, service_proxy_configured, buildkit_configured) = match &provider
+        {
+            RunnerProviderConfig::Podman(podman) => (
+                podman.job_container_engine(),
+                podman.service_proxy_image().is_some(),
+                podman.buildkit_runtime().is_some(),
+            ),
+            RunnerProviderConfig::Kubernetes(_)
+            | RunnerProviderConfig::WindowsNative(_)
+            | RunnerProviderConfig::MacosNative(_) => (
+                automata_ci_sandbox_podman::JobContainerEngine::Disabled,
+                false,
+                false,
+            ),
+        };
         let (inventory, environments) = self.inventory.validate(
             self.runner_id,
             &executor,
             provider_kind,
-            match &provider {
-                RunnerProviderConfig::Podman(podman) => podman.job_container_engine(),
-                RunnerProviderConfig::Kubernetes(_) | RunnerProviderConfig::WindowsNative(_) => {
-                    automata_ci_sandbox_podman::JobContainerEngine::Disabled
-                }
-            },
-            matches!(
-                &provider,
-                RunnerProviderConfig::Podman(podman) if podman.service_proxy_image().is_some()
-            ),
-            matches!(
-                &provider,
-                RunnerProviderConfig::Podman(podman) if podman.buildkit_runtime().is_some()
-            ),
+            job_container_engine,
+            service_proxy_configured,
+            buildkit_configured,
         )?;
         match &provider {
-            RunnerProviderConfig::Podman(_) => {
+            RunnerProviderConfig::Podman(_)
+            | RunnerProviderConfig::WindowsNative(_)
+            | RunnerProviderConfig::MacosNative(_) => {
                 if inventory.resources_per_job().ephemeral_disk_bytes() != 0
                     || inventory.resources_per_job().gpu_count() != 0
                 {
@@ -973,11 +1027,16 @@ impl RawRunnerProductConfig {
                     return Err(RunnerProductConfigError::InvalidKubernetes);
                 }
             }
-            RunnerProviderConfig::WindowsNative(_) => {
-                if !valid_windows_provider_topology(&state, &executor, &environments) {
-                    return Err(RunnerProductConfigError::InvalidInventory);
-                }
-            }
+        }
+        if matches!(&provider, RunnerProviderConfig::WindowsNative(_))
+            && !valid_windows_provider_topology(&state, &executor, &environments)
+        {
+            return Err(RunnerProductConfigError::InvalidInventory);
+        }
+        if matches!(&provider, RunnerProviderConfig::MacosNative(_))
+            && !valid_macos_provider_topology(&state, &executor, &environments)
+        {
+            return Err(RunnerProductConfigError::InvalidInventory);
         }
         let object_store = self.object_store.validate()?;
         Ok(RunnerProductConfig {
@@ -1041,6 +1100,31 @@ fn valid_windows_provider_topology(
     })
 }
 
+fn valid_macos_provider_topology(
+    state: &StateRoots,
+    executor: &ExecutorProductConfig,
+    environments: &BTreeMap<EnvironmentProfile, SandboxEnvironment>,
+) -> bool {
+    let Some(provider_root) = state.macos_native() else {
+        return false;
+    };
+    let strict_descendant = |path: &TargetPath| {
+        path.platform() == TargetPlatform::Posix
+            && Path::new(path.as_str()) != provider_root
+            && Path::new(path.as_str()).starts_with(provider_root)
+    };
+    if !strict_descendant(executor.runner_root()) {
+        return false;
+    }
+    let runner_root = Path::new(executor.runner_root().as_str());
+    environments.values().all(|environment| {
+        let workspace = Path::new(environment.workspace().as_str());
+        strict_descendant(environment.workspace())
+            && !workspace.starts_with(runner_root)
+            && !runner_root.starts_with(workspace)
+    })
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawMetricsProductConfig {
@@ -1069,31 +1153,31 @@ struct RawStateRoots {
     podman: Option<PathBuf>,
     #[serde(default)]
     windows_native: Option<PathBuf>,
+    #[serde(default)]
+    macos_native: Option<PathBuf>,
 }
 
 impl RawStateRoots {
     fn validate(self, provider_kind: ProviderKind) -> Result<StateRoots, RunnerProductConfigError> {
-        let valid_selection = matches!(
-            (
-                provider_kind,
-                self.podman.is_some(),
-                self.windows_native.is_some()
-            ),
-            (ProviderKind::Podman, true, false)
-                | (ProviderKind::Kubernetes, false, false)
-                | (ProviderKind::WindowsNative, false, true)
-        );
-        if !valid_selection {
-            return Err(RunnerProductConfigError::InvalidStateRoots);
-        }
+        let provider = match (
+            provider_kind,
+            self.podman.as_ref(),
+            self.windows_native.as_ref(),
+            self.macos_native.as_ref(),
+        ) {
+            (ProviderKind::Podman, Some(provider), None, None)
+            | (ProviderKind::WindowsNative, None, Some(provider), None)
+            | (ProviderKind::MacosNative, None, None, Some(provider)) => Some(provider),
+            (ProviderKind::Kubernetes, None, None, None) => None,
+            _ => return Err(RunnerProductConfigError::InvalidStateRoots),
+        };
         let mut roots = vec![&self.journal, &self.spool];
-        roots.extend(self.podman.iter());
-        roots.extend(self.windows_native.iter());
+        roots.extend(provider);
         let invalid_path = roots
             .iter()
             .any(|path| validate_absolute_path(path).is_err());
         let overlap = match provider_kind {
-            ProviderKind::Podman | ProviderKind::Kubernetes => {
+            ProviderKind::Podman | ProviderKind::Kubernetes | ProviderKind::MacosNative => {
                 roots.iter().enumerate().any(|(left_index, left)| {
                     roots.iter().enumerate().any(|(right_index, right)| {
                         left_index != right_index
@@ -1134,6 +1218,7 @@ impl RawStateRoots {
             spool,
             podman: self.podman,
             windows_native: self.windows_native,
+            macos_native: self.macos_native,
         })
     }
 }
@@ -1255,7 +1340,10 @@ impl RawInventory {
             || self.groups.len() > MAX_SELECTORS
             || self.environment_profiles.is_empty()
             || self.environment_profiles.len() > MAX_ENVIRONMENTS
-            || (provider_kind == ProviderKind::WindowsNative && self.max_parallel_jobs != 1)
+            || (matches!(
+                provider_kind,
+                ProviderKind::WindowsNative | ProviderKind::MacosNative
+            ) && self.max_parallel_jobs != 1)
         {
             return Err(RunnerProductConfigError::InvalidInventory);
         }
@@ -1301,10 +1389,16 @@ impl RawInventory {
                 ProviderKind::Podman | ProviderKind::Kubernetes,
                 OperatingSystem::Linux
             ) | (ProviderKind::WindowsNative, OperatingSystem::Windows)
+                | (ProviderKind::MacosNative, OperatingSystem::Macos)
         ) {
             return Err(RunnerProductConfigError::InvalidProvider);
         }
-        let platform = RunnerPlatform::new(host_operating_system, host_architecture()?);
+        let host_architecture = host_architecture()?;
+        if provider_kind == ProviderKind::MacosNative && host_architecture != Architecture::Aarch64
+        {
+            return Err(RunnerProductConfigError::InvalidProvider);
+        }
+        let platform = RunnerPlatform::new(host_operating_system, host_architecture);
         let (sandbox, container_features, runner_features) = provider_capabilities(
             provider_kind,
             executor,
@@ -1374,7 +1468,7 @@ fn provider_capabilities(
                 ]),
             )
         }
-        ProviderKind::WindowsNative => (
+        ProviderKind::WindowsNative | ProviderKind::MacosNative => (
             SandboxCapabilities::new(IsolationLevel::Process, [SandboxFeature::CLEAN_WORKSPACE]),
             BTreeSet::new(),
             BTreeSet::from([RunnerFeature::SHELL_STEPS, RunnerFeature::COMMAND_FILES]),
@@ -1550,6 +1644,18 @@ impl RawEnvironment {
                 SandboxEnvironment::native(attestation, workspace, default_environment)
                     .map_err(|_| RunnerProductConfigError::InvalidInventory)
             }
+            ProviderKind::MacosNative => {
+                if self.image.is_some()
+                    || self.keepalive_program.is_some()
+                    || !self.keepalive_arguments.is_empty()
+                {
+                    return Err(RunnerProductConfigError::InvalidInventory);
+                }
+                let workspace = TargetPath::posix(self.workspace)
+                    .map_err(|_| RunnerProductConfigError::InvalidInventory)?;
+                SandboxEnvironment::native_posix(attestation, workspace, default_environment)
+                    .map_err(|_| RunnerProductConfigError::InvalidInventory)
+            }
         }
     }
 }
@@ -1584,6 +1690,19 @@ impl RawWindowsNativeProductConfig {
             return Err(RunnerProductConfigError::InvalidProvider);
         }
         Ok(WindowsNativeProductConfig)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMacosNativeProductConfig {}
+
+impl RawMacosNativeProductConfig {
+    fn validate() -> Result<MacosNativeProductConfig, RunnerProductConfigError> {
+        if std::env::consts::OS != "macos" || std::env::consts::ARCH != "aarch64" {
+            return Err(RunnerProductConfigError::InvalidProvider);
+        }
+        Ok(MacosNativeProductConfig)
     }
 }
 
@@ -1882,10 +2001,12 @@ impl RawExecutorProductConfig {
                 _,
                 SandboxPrivilegePolicy::Host
             )
-        ) || (provider_kind == ProviderKind::WindowsNative
-            && (network != NetworkPolicy::Host
-                || root_filesystem != RootFilesystemPolicy::Host
-                || privilege != SandboxPrivilegePolicy::Host))
+        ) || (matches!(
+            provider_kind,
+            ProviderKind::WindowsNative | ProviderKind::MacosNative
+        ) && (network != NetworkPolicy::Host
+            || root_filesystem != RootFilesystemPolicy::Host
+            || privilege != SandboxPrivilegePolicy::Host))
         {
             return Err(RunnerProductConfigError::InvalidExecutor);
         }
@@ -1899,7 +2020,7 @@ impl RawExecutorProductConfig {
         let tool_cache = parse_path(self.tool_cache)?;
         let temp = parse_path(self.temp)?;
         let path_separator = match provider_kind {
-            ProviderKind::Podman | ProviderKind::Kubernetes => ':',
+            ProviderKind::Podman | ProviderKind::Kubernetes | ProviderKind::MacosNative => ':',
             ProviderKind::WindowsNative => ';',
         };
         if target_is_root(&home)
@@ -1914,16 +2035,27 @@ impl RawExecutorProductConfig {
             return Err(RunnerProductConfigError::InvalidExecutor);
         }
         let toolchain = self.toolchain.validate(provider_kind)?;
-        automata_ci_job_executor_github::GithubJobExecutorConfig::new(
-            resources,
-            network,
-            root_filesystem,
-            privilege,
-            default_step_timeout,
-            self.maximum_output_bytes,
-            runner_root.clone(),
-        )
-        .map_err(|_| RunnerProductConfigError::InvalidExecutor)?;
+        let executor_contract = if provider_kind == ProviderKind::MacosNative {
+            automata_ci_job_executor_github::GithubJobExecutorConfig::host_shared(
+                network,
+                root_filesystem,
+                privilege,
+                default_step_timeout,
+                self.maximum_output_bytes,
+                runner_root.clone(),
+            )
+        } else {
+            automata_ci_job_executor_github::GithubJobExecutorConfig::new(
+                resources,
+                network,
+                root_filesystem,
+                privilege,
+                default_step_timeout,
+                self.maximum_output_bytes,
+                runner_root.clone(),
+            )
+        };
+        executor_contract.map_err(|_| RunnerProductConfigError::InvalidExecutor)?;
         Ok(ExecutorProductConfig {
             resources,
             resource_capacity: validated_resources.capacity,
@@ -1951,7 +2083,9 @@ fn provider_target_path(
         return Err(RunnerProductConfigError::InvalidExecutor);
     }
     match provider_kind {
-        ProviderKind::Podman | ProviderKind::Kubernetes => TargetPath::posix(value),
+        ProviderKind::Podman | ProviderKind::Kubernetes | ProviderKind::MacosNative => {
+            TargetPath::posix(value)
+        }
         ProviderKind::WindowsNative => TargetPath::windows(value),
     }
     .map_err(|_| RunnerProductConfigError::InvalidExecutor)
@@ -2036,6 +2170,19 @@ impl RawToolchainConfig {
                     && config.install.is_none()
                     && config.tar.is_none()
                     && config.sha256sum.is_none()
+                    && config.node12.is_none()
+                    && config.node16.is_none()
+                    && config.node20.is_none()
+                    && config.node24.is_none()
+            }
+            ProviderKind::MacosNative => {
+                config.bash.is_some()
+                    && config.sh.is_some()
+                    && config.install.is_some()
+                    && config.tar.is_some()
+                    && config.sha256sum.is_some()
+                    && config.powershell.is_none()
+                    && config.cmd.is_none()
                     && config.node12.is_none()
                     && config.node16.is_none()
                     && config.node20.is_none()
@@ -2200,6 +2347,7 @@ fn host_operating_system() -> Result<OperatingSystem, RunnerProductConfigError> 
     match std::env::consts::OS {
         "linux" => Ok(OperatingSystem::Linux),
         "windows" => Ok(OperatingSystem::Windows),
+        "macos" => Ok(OperatingSystem::Macos),
         _ => Err(RunnerProductConfigError::InvalidInventory),
     }
 }

--- a/crates/automata-ci-runner/src/product/context.rs
+++ b/crates/automata-ci-runner/src/product/context.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use automata_ci_core::{
-    ContextValue, JobAuthorityProfile, JobConclusion, NeedContext, PermissionLevel, RunnerId,
-    SemanticStep, StrategyContext, ValueSource,
+    Architecture, ContextValue, JobAuthorityProfile, JobConclusion, NeedContext, OperatingSystem,
+    PermissionLevel, RunnerId, RunnerPlatform, SemanticStep, StrategyContext, ValueSource,
 };
 use automata_ci_execution::{TargetPath, TargetPlatform};
 use automata_ci_expression_github::{
@@ -35,6 +35,7 @@ pub struct StandardGithubContext {
     runner_id: RunnerId,
     workspaces: BTreeMap<automata_ci_core::EnvironmentProfile, TargetPath>,
     platform: TargetPlatform,
+    runner_platform: RunnerPlatform,
     runner_root: String,
     home: String,
     path: String,
@@ -52,6 +53,7 @@ impl StandardGithubContext {
     /// Rejects an empty environment catalog.
     pub fn new(
         runner_id: RunnerId,
+        runner_platform: RunnerPlatform,
         environments: &BTreeMap<
             automata_ci_core::EnvironmentProfile,
             automata_ci_execution::SandboxEnvironment,
@@ -81,10 +83,19 @@ impl StandardGithubContext {
         {
             return Err(invalid_data());
         }
+        let expected_target_platform = match runner_platform.operating_system() {
+            OperatingSystem::Linux | OperatingSystem::Macos => TargetPlatform::Posix,
+            OperatingSystem::Windows => TargetPlatform::Windows,
+            OperatingSystem::Other(_) => return Err(invalid_data()),
+        };
+        if platform != expected_target_platform {
+            return Err(invalid_data());
+        }
         Ok(Self {
             runner_id,
             workspaces,
             platform,
+            runner_platform,
             runner_root: executor.runner_root().as_str().to_owned(),
             home: executor.home().as_str().to_owned(),
             path: executor.path().to_owned(),
@@ -103,8 +114,8 @@ impl StandardGithubContext {
             .ok_or_else(invalid_data)?;
         let root = self.workspaces.get(profile).ok_or_else(invalid_data)?;
         let workspace = request.job().execution().workspace();
-        match self.platform {
-            TargetPlatform::Posix => {
+        match (self.runner_platform.operating_system(), self.platform) {
+            (OperatingSystem::Linux, TargetPlatform::Posix) => {
                 TargetPath::posix(workspace).map_err(|_| invalid_data())?;
                 let prefix = format!("{}/", root.as_str().trim_end_matches('/'));
                 if workspace == root.as_str() || !workspace.starts_with(&prefix) {
@@ -112,7 +123,14 @@ impl StandardGithubContext {
                 }
                 Ok(workspace.to_owned())
             }
-            TargetPlatform::Windows => {
+            (OperatingSystem::Macos, TargetPlatform::Posix) => {
+                TargetPath::posix(workspace).map_err(|_| invalid_data())?;
+                let suffix = workspace.strip_prefix("/__w/").ok_or_else(invalid_data)?;
+                let mapped = format!("{}/{suffix}", root.as_str().trim_end_matches('/'));
+                TargetPath::posix(mapped.clone()).map_err(|_| invalid_data())?;
+                Ok(mapped)
+            }
+            (OperatingSystem::Windows, TargetPlatform::Windows) => {
                 TargetPath::posix(workspace).map_err(|_| invalid_data())?;
                 let suffix = workspace.strip_prefix("/__w/").ok_or_else(invalid_data)?;
                 let mut mapped = root.as_str().trim_end_matches('\\').to_owned();
@@ -121,6 +139,7 @@ impl StandardGithubContext {
                 TargetPath::windows(mapped.clone()).map_err(|_| invalid_data())?;
                 Ok(mapped)
             }
+            _ => Err(invalid_data()),
         }
     }
 
@@ -216,7 +235,10 @@ impl StandardGithubContext {
         object(vec![
             string_entry("name", self.runner_id.to_string()),
             string_entry("os", self.runner_os()),
-            string_entry("arch", github_architecture()),
+            string_entry(
+                "arch",
+                github_architecture(self.runner_platform.architecture()),
+            ),
             string_entry("environment", "self-hosted"),
             string_entry("temp", &self.temp),
             string_entry("tool_cache", &self.tool_cache),
@@ -260,7 +282,10 @@ impl StandardGithubContext {
             plain("GITHUB_WORKSPACE", workspace),
             plain("HOME", &self.home),
             plain("PATH", &self.path),
-            plain("RUNNER_ARCH", github_architecture()),
+            plain(
+                "RUNNER_ARCH",
+                github_architecture(self.runner_platform.architecture()),
+            ),
             plain("RUNNER_ENVIRONMENT", "self-hosted"),
             plain("RUNNER_NAME", self.runner_id.to_string()),
             plain("RUNNER_OS", self.runner_os()),
@@ -319,9 +344,11 @@ impl StandardGithubContext {
     }
 
     const fn runner_os(&self) -> &'static str {
-        match self.platform {
-            TargetPlatform::Posix => "Linux",
-            TargetPlatform::Windows => "Windows",
+        match self.runner_platform.operating_system() {
+            OperatingSystem::Linux => "Linux",
+            OperatingSystem::Windows => "Windows",
+            OperatingSystem::Macos => "macOS",
+            OperatingSystem::Other(_) => "Unknown",
         }
     }
 }
@@ -371,6 +398,7 @@ impl fmt::Debug for StandardGithubContext {
             .debug_struct("StandardGithubContext")
             .field("runner_id", &self.runner_id)
             .field("environment_count", &self.workspaces.len())
+            .field("runner_platform", &self.runner_platform)
             .field("runner_root", &self.runner_root)
             .field("github", &self.github)
             .field("context_values", &"[REDACTED]")
@@ -693,10 +721,10 @@ const fn conclusion_text(conclusion: JobConclusion) -> &'static str {
     }
 }
 
-fn github_architecture() -> &'static str {
-    match std::env::consts::ARCH {
-        "x86_64" => "X64",
-        "aarch64" => "ARM64",
-        _ => "Unknown",
+const fn github_architecture(architecture: &Architecture) -> &'static str {
+    match architecture {
+        Architecture::X86_64 => "X64",
+        Architecture::Aarch64 => "ARM64",
+        Architecture::Other(_) => "Unknown",
     }
 }

--- a/crates/automata-ci-runner/src/product/files.rs
+++ b/crates/automata-ci-runner/src/product/files.rs
@@ -13,7 +13,14 @@ use zeroize::Zeroizing;
 
 /// Maximum supported path length at the product configuration boundary.
 const MAX_PATH_BYTES: usize = 4_096;
+const MAX_KEYCHAIN_LOCATOR_BYTES: usize = 256;
 const TEMPORARY_COMPONENT: &str = "tmp";
+#[cfg(target_os = "macos")]
+const KEYCHAIN_RESULT_LIMIT: i64 = 2;
+#[cfg(target_os = "macos")]
+const KEYCHAIN_SKIP_AUTHENTICATED_ITEMS: bool = true;
+#[cfg(target_os = "macos")]
+const KEYCHAIN_DISABLE_INTERACTION: bool = true;
 
 /// A secret-bearing input location. Secret bytes are never accepted directly
 /// in process arguments or in the runner configuration document.
@@ -30,6 +37,13 @@ pub enum SecretSource {
         /// Canonical environment-variable name; the value is never formatted.
         name: String,
     },
+    /// Read one generic-password item from the default macOS Keychain.
+    MacosKeychain {
+        /// Exact Keychain service attribute.
+        service: String,
+        /// Exact Keychain account attribute.
+        account: String,
+    },
 }
 
 impl SecretSource {
@@ -37,6 +51,15 @@ impl SecretSource {
         match self {
             Self::File { path } => validate_absolute_path(path),
             Self::Environment { name } => validate_environment_name(name),
+            Self::MacosKeychain { service, account } => {
+                validate_keychain_locator(service)?;
+                validate_keychain_locator(account)?;
+                if cfg!(target_os = "macos") {
+                    Ok(())
+                } else {
+                    Err(SecureInputError::UnsupportedPlatform)
+                }
+            }
         }
     }
 
@@ -61,6 +84,9 @@ impl SecretSource {
                     return Err(SecureInputError::InvalidSize);
                 }
                 Ok(Zeroizing::new(value.into_bytes()))
+            }
+            Self::MacosKeychain { service, account } => {
+                read_macos_keychain(service, account, maximum_bytes)
             }
         }
     }
@@ -88,7 +114,7 @@ impl SecretSource {
             Self::File { .. } => maximum_bytes
                 .checked_add(2)
                 .ok_or(SecureInputError::InvalidLimit)?,
-            Self::Environment { .. } => maximum_bytes,
+            Self::Environment { .. } | Self::MacosKeychain { .. } => maximum_bytes,
         };
         let mut bytes = self.read(input_limit)?;
         if matches!(self, Self::File { .. }) {
@@ -125,6 +151,13 @@ impl fmt::Debug for SecretSource {
                 .field("name", name)
                 .field("value", &"[REDACTED]")
                 .finish(),
+            Self::MacosKeychain { service, account } => formatter
+                .debug_struct("SecretSource")
+                .field("kind", &"macos_keychain")
+                .field("service", service)
+                .field("account", account)
+                .field("value", &"[REDACTED]")
+                .finish(),
         }
     }
 }
@@ -141,6 +174,9 @@ pub enum SecureInputError {
     /// An environment-variable name was not canonical.
     #[error("secure input environment name is invalid")]
     InvalidEnvironmentName,
+    /// A Keychain service or account locator was empty, oversized, or non-canonical.
+    #[error("secure input Keychain locator is invalid")]
+    InvalidKeychainLocator,
     /// The source was absent or inaccessible.
     #[error("secure input is unavailable")]
     Unavailable,
@@ -177,7 +213,9 @@ pub(crate) fn read_public_material(
     maximum_bytes: usize,
 ) -> Result<Zeroizing<Vec<u8>>, SecureInputError> {
     match source {
-        SecretSource::Environment { .. } => source.read(maximum_bytes),
+        SecretSource::Environment { .. } | SecretSource::MacosKeychain { .. } => {
+            source.read(maximum_bytes)
+        }
         SecretSource::File { path } => {
             read_file(path, maximum_bytes, FileTrust::PublicMaterial).map(Zeroizing::new)
         }
@@ -236,6 +274,90 @@ fn validate_environment_name(name: &str) -> Result<(), SecureInputError> {
     valid
         .then_some(())
         .ok_or(SecureInputError::InvalidEnvironmentName)
+}
+
+fn validate_keychain_locator(value: &str) -> Result<(), SecureInputError> {
+    let valid = !value.is_empty()
+        && value.len() <= MAX_KEYCHAIN_LOCATOR_BYTES
+        && value.trim() == value
+        && value
+            .bytes()
+            .all(|byte| byte == b' ' || byte.is_ascii_graphic());
+    valid
+        .then_some(())
+        .ok_or(SecureInputError::InvalidKeychainLocator)
+}
+
+#[cfg(target_os = "macos")]
+fn read_macos_keychain(
+    service: &str,
+    account: &str,
+    maximum_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecureInputError> {
+    use std::sync::Mutex;
+
+    use security_framework::{
+        item::{ItemClass, ItemSearchOptions, Limit},
+        os::macos::keychain::SecKeychain,
+    };
+
+    static KEYCHAIN_INTERACTION: Mutex<()> = Mutex::new(());
+
+    validate_keychain_locator(service)?;
+    validate_keychain_locator(account)?;
+    let _serialized_interaction_policy = KEYCHAIN_INTERACTION
+        .lock()
+        .map_err(|_| SecureInputError::Unavailable)?;
+    let interaction_allowed =
+        SecKeychain::user_interaction_allowed().map_err(|_| SecureInputError::Unavailable)?;
+    let _disabled_interaction = (interaction_allowed && KEYCHAIN_DISABLE_INTERACTION)
+        .then(SecKeychain::disable_user_interaction)
+        .transpose()
+        .map_err(|_| SecureInputError::Unavailable)?;
+    let keychain = SecKeychain::default().map_err(|_| SecureInputError::Unavailable)?;
+    let mut search = ItemSearchOptions::new();
+    let results = search
+        .keychains(std::slice::from_ref(&keychain))
+        .class(ItemClass::generic_password())
+        .service(service)
+        .account(account)
+        .load_data(true)
+        .limit(Limit::Max(KEYCHAIN_RESULT_LIMIT))
+        .skip_authenticated_items(KEYCHAIN_SKIP_AUTHENTICATED_ITEMS)
+        .search()
+        .map_err(|_| SecureInputError::Unavailable)?;
+    select_macos_keychain_password(results, maximum_bytes)
+}
+
+#[cfg(target_os = "macos")]
+fn select_macos_keychain_password(
+    mut results: Vec<security_framework::item::SearchResult>,
+    maximum_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecureInputError> {
+    use security_framework::item::SearchResult;
+
+    if maximum_bytes == 0 {
+        return Err(SecureInputError::InvalidLimit);
+    }
+    if results.len() != 1 {
+        return Err(SecureInputError::Unavailable);
+    }
+    let SearchResult::Data(password) = results.pop().ok_or(SecureInputError::Unavailable)? else {
+        return Err(SecureInputError::Unavailable);
+    };
+    if password.is_empty() || password.len() > maximum_bytes {
+        return Err(SecureInputError::InvalidSize);
+    }
+    Ok(Zeroizing::new(password))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_macos_keychain(
+    _service: &str,
+    _account: &str,
+    _maximum_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecureInputError> {
+    Err(SecureInputError::UnsupportedPlatform)
 }
 
 #[cfg(unix)]
@@ -430,7 +552,15 @@ fn read_file(
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{FileTrust, file_is_trusted};
+    use super::{
+        FileTrust, SecretSource, SecureInputError, file_is_trusted, validate_keychain_locator,
+    };
+
+    #[cfg(target_os = "macos")]
+    use super::{
+        KEYCHAIN_DISABLE_INTERACTION, KEYCHAIN_RESULT_LIMIT, KEYCHAIN_SKIP_AUTHENTICATED_ITEMS,
+        select_macos_keychain_password,
+    };
 
     #[test]
     fn configuration_and_public_files_require_a_trusted_owner() {
@@ -447,6 +577,99 @@ mod tests {
         assert!(file_is_trusted(1_000, 0o600, FileTrust::OwnerOnly, 1_000));
         assert!(!file_is_trusted(0, 0o600, FileTrust::OwnerOnly, 1_000));
         assert!(!file_is_trusted(1_000, 0o640, FileTrust::OwnerOnly, 1_000));
+    }
+
+    #[test]
+    fn keychain_locators_are_bounded_visible_text() {
+        for value in [
+            "automata-ci.runner",
+            "Automata CI Runner",
+            "runner@example.com",
+        ] {
+            assert_eq!(validate_keychain_locator(value), Ok(()));
+        }
+        for value in ["", " leading", "trailing ", "line\nfeed"] {
+            assert_eq!(
+                validate_keychain_locator(value),
+                Err(SecureInputError::InvalidKeychainLocator)
+            );
+        }
+        assert_eq!(
+            validate_keychain_locator(&"a".repeat(257)),
+            Err(SecureInputError::InvalidKeychainLocator)
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn macos_keychain_source_fails_closed_on_other_unix_hosts() {
+        let source = SecretSource::MacosKeychain {
+            service: "automata-ci.runner".to_owned(),
+            account: "runner@example.com".to_owned(),
+        };
+        assert_eq!(
+            source.validate(),
+            Err(SecureInputError::UnsupportedPlatform)
+        );
+        assert_eq!(source.read(64), Err(SecureInputError::UnsupportedPlatform));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn missing_macos_keychain_item_is_sanitized_without_interaction() {
+        let source = SecretSource::MacosKeychain {
+            service: format!(
+                "automata-ci.missing-test.{}.{}",
+                std::process::id(),
+                uuid::Uuid::new_v4()
+            ),
+            account: "missing".to_owned(),
+        };
+        assert_eq!(source.validate(), Ok(()));
+        assert_eq!(source.read(64), Err(SecureInputError::Unavailable));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keychain_selection_rejects_ambiguous_oversized_and_malformed_values() {
+        use security_framework::item::SearchResult;
+
+        assert_eq!(
+            select_macos_keychain_password(
+                vec![
+                    SearchResult::Data(b"first".to_vec()),
+                    SearchResult::Data(b"second".to_vec())
+                ],
+                64,
+            ),
+            Err(SecureInputError::Unavailable)
+        );
+        assert_eq!(
+            select_macos_keychain_password(vec![SearchResult::Data(vec![0x41; 65])], 64),
+            Err(SecureInputError::InvalidSize)
+        );
+        assert_eq!(
+            select_macos_keychain_password(vec![SearchResult::Data(Vec::new())], 64),
+            Err(SecureInputError::InvalidSize)
+        );
+        assert_eq!(
+            select_macos_keychain_password(vec![SearchResult::Other], 64),
+            Err(SecureInputError::Unavailable)
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn interactive_keychain_items_are_excluded_by_the_bounded_search_policy() {
+        const {
+            assert!(KEYCHAIN_DISABLE_INTERACTION);
+            assert!(KEYCHAIN_SKIP_AUTHENTICATED_ITEMS);
+            assert!(KEYCHAIN_RESULT_LIMIT == 2);
+        }
+        assert_eq!(
+            select_macos_keychain_password(Vec::new(), 64),
+            Err(SecureInputError::Unavailable)
+        );
     }
 }
 

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -152,6 +152,7 @@ impl RunnerMetrics {
         Arc::new(self.clone())
     }
 
+    #[cfg(target_os = "linux")]
     pub(super) fn podman_observer(&self) -> Arc<dyn PodmanObserver> {
         Arc::new(self.clone())
     }

--- a/crates/automata-ci-runner/src/product/mod.rs
+++ b/crates/automata-ci-runner/src/product/mod.rs
@@ -17,7 +17,7 @@ pub use composition::{
 };
 pub use config::{
     ClientTlsSources, ExecutorProductConfig, GithubProductConfig, KubernetesProductConfig,
-    MetricsProductConfig, ObjectStoreProductConfig, PodmanProductConfig,
+    MacosNativeProductConfig, MetricsProductConfig, ObjectStoreProductConfig, PodmanProductConfig,
     RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION, RunnerProductConfig, RunnerProductConfigError,
     RunnerProviderConfig, SpoolProtectionConfig, StateRoots, ToolchainConfig,
     WindowsNativeProductConfig,

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -11,7 +11,8 @@ use automata_ci_execution::{
     ExecutionArgv, ExecutionCommand, ExecutionError, ExecutionErrorKind, ExecutionStage,
     ExecutionTermination, NetworkPolicy, OperationId, OperationOutcome, ProviderError,
     ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration,
-    SandboxHandle, SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, SandboxState, TargetPath,
+    SandboxHandle, SandboxPrivilegePolicy, SandboxProvider, SandboxResourcePolicy, SandboxSpec,
+    SandboxState, TargetPath, TargetPlatform,
 };
 use automata_ci_job_executor_github::{WindowsScriptShell, windows_script_arguments};
 use uuid::Uuid;
@@ -27,17 +28,17 @@ const NATIVE_MAX_SHELL_PROBE_COUNT: usize = NATIVE_SHELL_PROBE_COUNT + 1;
 const POWERSHELL_PROBE_SCRIPT: &[u8] = b"$ErrorActionPreference = 'Stop'\r\nexit 0\r\n";
 const CMD_PROBE_SCRIPT: &[u8] = b"@echo off\r\nexit /B 0\r\n";
 const PYTHON_PROBE_SCRIPT: &[u8] = b"raise SystemExit(0)\r\n";
+const POSIX_PROBE_SCRIPT: &[u8] = b"set -eu\nexit 0\n";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ProfileAdmissionPolicy {
     network: NetworkPolicy,
     root_filesystem: RootFilesystemPolicy,
     privilege: SandboxPrivilegePolicy,
-    resources: ResourceLimits,
+    resource_policy: SandboxResourcePolicy,
     resource_allocation: JobResourceAllocation,
     native: Option<NativeProfileAdmissionPolicy>,
 }
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct NativeProfileAdmissionPolicy {
     scratch_root: TargetPath,
@@ -52,6 +53,8 @@ struct NativeShellProbe {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum NativeShellKind {
+    Bash,
+    Sh,
     Pwsh,
     WindowsPowerShell,
     Cmd,
@@ -65,6 +68,8 @@ impl NativeShellProbe {
 
     const fn script_name(&self) -> &'static str {
         match self.kind {
+            NativeShellKind::Bash => "profile admission bash.sh",
+            NativeShellKind::Sh => "profile admission sh.sh",
             NativeShellKind::Pwsh => "profile admission pwsh.ps1",
             NativeShellKind::WindowsPowerShell => "profile admission powershell.ps1",
             NativeShellKind::Cmd => "profile admission cmd.cmd",
@@ -74,6 +79,7 @@ impl NativeShellProbe {
 
     const fn script_content(&self) -> &'static [u8] {
         match self.kind {
+            NativeShellKind::Bash | NativeShellKind::Sh => POSIX_PROBE_SCRIPT,
             NativeShellKind::Pwsh | NativeShellKind::WindowsPowerShell => POWERSHELL_PROBE_SCRIPT,
             NativeShellKind::Cmd => CMD_PROBE_SCRIPT,
             NativeShellKind::Python => PYTHON_PROBE_SCRIPT,
@@ -81,14 +87,38 @@ impl NativeShellProbe {
     }
 
     fn argv(&self, script: &TargetPath) -> Result<ExecutionArgv, ProfileAdmissionError> {
-        let shell = match self.kind {
-            NativeShellKind::Pwsh | NativeShellKind::WindowsPowerShell => {
-                WindowsScriptShell::PowerShell
+        let arguments = match (self.kind, script.platform()) {
+            (NativeShellKind::Bash, TargetPlatform::Posix) => vec![
+                "--noprofile".to_owned(),
+                "--norc".to_owned(),
+                "-e".to_owned(),
+                script.as_str().to_owned(),
+            ],
+            (NativeShellKind::Sh, TargetPlatform::Posix) => {
+                vec!["-e".to_owned(), script.as_str().to_owned()]
             }
-            NativeShellKind::Cmd => WindowsScriptShell::Cmd,
-            NativeShellKind::Python => WindowsScriptShell::Python,
+            (NativeShellKind::Pwsh, TargetPlatform::Posix) => vec![
+                "-command".to_owned(),
+                format!(". '{}'", script.as_str().replace('\'', "''")),
+            ],
+            (NativeShellKind::Python, TargetPlatform::Posix) => {
+                vec![script.as_str().to_owned()]
+            }
+            (
+                NativeShellKind::Pwsh | NativeShellKind::WindowsPowerShell,
+                TargetPlatform::Windows,
+            ) => windows_script_arguments(WindowsScriptShell::PowerShell, script)
+                .ok_or_else(invalid_catalog)?,
+            (NativeShellKind::Cmd, TargetPlatform::Windows) => {
+                windows_script_arguments(WindowsScriptShell::Cmd, script)
+                    .ok_or_else(invalid_catalog)?
+            }
+            (NativeShellKind::Python, TargetPlatform::Windows) => {
+                windows_script_arguments(WindowsScriptShell::Python, script)
+                    .ok_or_else(invalid_catalog)?
+            }
+            _ => return Err(invalid_catalog()),
         };
-        let arguments = windows_script_arguments(shell, script).ok_or_else(invalid_catalog)?;
         ExecutionArgv::new(self.program.clone(), arguments).map_err(|_| invalid_catalog())
     }
 }
@@ -105,7 +135,23 @@ impl ProfileAdmissionPolicy {
             network,
             root_filesystem,
             privilege,
-            resources,
+            resource_policy: SandboxResourcePolicy::Enforced(resources),
+            resource_allocation,
+            native: None,
+        }
+    }
+
+    pub(super) const fn host_shared(
+        network: NetworkPolicy,
+        root_filesystem: RootFilesystemPolicy,
+        privilege: SandboxPrivilegePolicy,
+        resource_allocation: JobResourceAllocation,
+    ) -> Self {
+        Self {
+            network,
+            root_filesystem,
+            privilege,
+            resource_policy: SandboxResourcePolicy::HostShared,
             resource_allocation,
             native: None,
         }
@@ -141,6 +187,44 @@ impl ProfileAdmissionPolicy {
         ];
         if let Some(python) = python {
             shell_probes.push(NativeShellProbe::new(NativeShellKind::Python, python));
+        }
+        self.native = Some(NativeProfileAdmissionPolicy {
+            scratch_root,
+            shell_probes,
+        });
+        Ok(self)
+    }
+
+    pub(super) fn with_native_macos_shells(
+        mut self,
+        scratch_root: TargetPath,
+        bash: TargetPath,
+        sh: TargetPath,
+        python: Option<TargetPath>,
+        pwsh: Option<TargetPath>,
+    ) -> Result<Self, ProfileAdmissionError> {
+        if self.native.is_some()
+            || [scratch_root.platform(), bash.platform(), sh.platform()]
+                .into_iter()
+                .any(|platform| platform != TargetPlatform::Posix)
+            || python
+                .as_ref()
+                .is_some_and(|python| python.platform() != TargetPlatform::Posix)
+            || pwsh
+                .as_ref()
+                .is_some_and(|pwsh| pwsh.platform() != TargetPlatform::Posix)
+        {
+            return Err(invalid_catalog());
+        }
+        let mut shell_probes = vec![
+            NativeShellProbe::new(NativeShellKind::Bash, bash),
+            NativeShellProbe::new(NativeShellKind::Sh, sh),
+        ];
+        if let Some(python) = python {
+            shell_probes.push(NativeShellProbe::new(NativeShellKind::Python, python));
+        }
+        if let Some(pwsh) = pwsh {
+            shell_probes.push(NativeShellProbe::new(NativeShellKind::Pwsh, pwsh));
         }
         self.native = Some(NativeProfileAdmissionPolicy {
             scratch_root,
@@ -351,21 +435,31 @@ impl ProfileAdmissionContext<'_> {
                 native
                     .shell_probes
                     .iter()
-                    .map(|probe| windows_child(scratch, probe.script_name()))
+                    .map(|probe| native_child(scratch, probe.script_name()))
                     .collect::<Result<Vec<_>, _>>()?,
             ),
             (None, None) => None,
             _ => return Err(invalid_catalog()),
         };
-        let mut spec = SandboxSpec::new(
-            operation_ids.create,
-            self.generation,
-            environment.clone(),
-            workspace.clone(),
-            self.policy.network,
-            self.policy.root_filesystem,
-            self.policy.resources,
-        )
+        let mut spec = match self.policy.resource_policy {
+            SandboxResourcePolicy::Enforced(resources) => SandboxSpec::new(
+                operation_ids.create,
+                self.generation,
+                environment.clone(),
+                workspace.clone(),
+                self.policy.network,
+                self.policy.root_filesystem,
+                resources,
+            ),
+            SandboxResourcePolicy::HostShared => SandboxSpec::host_shared(
+                operation_ids.create,
+                self.generation,
+                environment.clone(),
+                workspace.clone(),
+                self.policy.network,
+                self.policy.root_filesystem,
+            ),
+        }
         .with_privilege(self.policy.privilege)
         .with_resource_allocation(self.policy.resource_allocation);
         if let Some(scratch) = &scratch {
@@ -396,16 +490,17 @@ impl ProfileAdmissionContext<'_> {
         let Some(native) = &self.policy.native else {
             return Ok((environment.workspace().clone(), None));
         };
-        if environment.workspace().platform() != automata_ci_execution::TargetPlatform::Windows
-            || native.scratch_root.platform() != automata_ci_execution::TargetPlatform::Windows
-            || environment.workspace().as_str().contains(['%', '"'])
-            || native.scratch_root.as_str().contains(['%', '"'])
+        let platform = native.scratch_root.platform();
+        if environment.workspace().platform() != platform
+            || (platform == TargetPlatform::Windows
+                && (environment.workspace().as_str().contains(['%', '"'])
+                    || native.scratch_root.as_str().contains(['%', '"'])))
         {
             return Err(invalid_catalog());
         }
         let suffix = format!("profile-admission-{create_operation_id}");
-        let workspace = windows_child(environment.workspace(), &suffix)?;
-        let scratch = windows_child(&native.scratch_root, &suffix)?;
+        let workspace = native_child(environment.workspace(), &suffix)?;
+        let scratch = native_child(&native.scratch_root, &suffix)?;
         Ok((workspace, Some(scratch)))
     }
 
@@ -716,12 +811,19 @@ impl ProfileAdmissionContext<'_> {
     }
 }
 
-fn windows_child(root: &TargetPath, child: &str) -> Result<TargetPath, ProfileAdmissionError> {
+fn native_child(root: &TargetPath, child: &str) -> Result<TargetPath, ProfileAdmissionError> {
     if child.is_empty() || child.contains(['/', '\\', ':']) || matches!(child, "." | "..") {
         return Err(invalid_catalog());
     }
-    TargetPath::windows(format!("{}\\{child}", root.as_str().trim_end_matches('\\')))
-        .map_err(|_| invalid_catalog())
+    match root.platform() {
+        TargetPlatform::Posix => {
+            TargetPath::posix(format!("{}/{child}", root.as_str().trim_end_matches('/')))
+        }
+        TargetPlatform::Windows => {
+            TargetPath::windows(format!("{}\\{child}", root.as_str().trim_end_matches('\\')))
+        }
+    }
+    .map_err(|_| invalid_catalog())
 }
 
 fn invalid_catalog() -> ProfileAdmissionError {
@@ -750,10 +852,15 @@ fn validate_provider_policy(
                 SandboxCapability::HostNetwork,
                 SandboxCapability::HostFilesystem,
                 SandboxCapability::HostIdentity,
-                SandboxCapability::ResourceLimits,
             ]
             .into_iter()
-            .all(|capability| provider.capabilities().supports(capability)))
+            .all(|capability| provider.capabilities().supports(capability))
+            || !provider
+                .capabilities()
+                .supports(match policy.resource_policy {
+                    SandboxResourcePolicy::Enforced(_) => SandboxCapability::ResourceLimits,
+                    SandboxResourcePolicy::HostShared => SandboxCapability::HostResources,
+                }))
     {
         return Err(ProfileAdmissionError::evidence(
             ProfileAdmissionErrorKind::InvalidProviderEvidence,
@@ -1463,7 +1570,7 @@ mod tests {
             assert_eq!(spec.network(), NetworkPolicy::Disabled);
             assert_eq!(spec.root_filesystem(), RootFilesystemPolicy::Writable);
             assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Administrator);
-            assert_eq!(spec.resources(), policy().resources);
+            assert_eq!(spec.resources(), policy().resource_policy.enforced());
             assert_eq!(spec.generation().get(), ADMISSION_GENERATION);
             let Call::Inspect(inspected) = &calls[1] else {
                 panic!("profile create must be inspected")
@@ -1590,7 +1697,7 @@ mod tests {
                 };
                 assert_eq!(
                     request.target(),
-                    &windows_child(scratch, name).expect("expected script target")
+                    &native_child(scratch, name).expect("expected script target")
                 );
                 assert_eq!(request.content(), content);
                 assert!(operation_ids.insert(request.operation_id()));

--- a/crates/automata-ci-runner/tests/capabilities_cli.rs
+++ b/crates/automata-ci-runner/tests/capabilities_cli.rs
@@ -9,12 +9,16 @@ use std::{fs, os::unix::fs::PermissionsExt as _, path::PathBuf};
 #[cfg(unix)]
 use automata_ci_core::OperationId;
 
+#[cfg(target_os = "macos")]
+const EXAMPLE_CONFIG: &str = "runner.macos.example.json";
+#[cfg(target_os = "windows")]
+const EXAMPLE_CONFIG: &str = "runner.windows.example.json";
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+const EXAMPLE_CONFIG: &str = "runner.local-1.example.json";
+
 #[test]
 fn capabilities_command_emits_only_the_canonical_validated_inventory() {
-    let config_path = format!(
-        "{}/config/runner.local-1.example.json",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let config_path = format!("{}/config/{EXAMPLE_CONFIG}", env!("CARGO_MANIFEST_DIR"));
     let secret_sentinel = "capabilities-must-not-read-this-secret";
     let output = Command::new(env!("CARGO_BIN_EXE_automata-runner"))
         .args(["capabilities", "--config", &config_path])
@@ -36,9 +40,9 @@ fn capabilities_command_emits_only_the_canonical_validated_inventory() {
         !observed.features().contains(&RunnerFeature::OIDC_TOKENS),
         "the official observed runner inventory must keep OIDC dark"
     );
-    let config =
-        RunnerProductConfig::from_json(include_bytes!("../config/runner.local-1.example.json"))
-            .expect("checked-in product configuration must validate");
+    let config_bytes = std::fs::read(&config_path).expect("read checked-in product configuration");
+    let config = RunnerProductConfig::from_json(&config_bytes)
+        .expect("checked-in product configuration must validate");
     let expected = serde_json::to_value(config.inventory()).expect("inventory must serialize");
     assert_eq!(actual, expected);
 

--- a/crates/automata-ci-runner/tests/cli.rs
+++ b/crates/automata-ci-runner/tests/cli.rs
@@ -9,11 +9,9 @@ fn top_level_help_describes_the_supported_execution_hosts() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("runner help must be UTF-8");
-    assert!(
-        stdout.contains(
-            "Automata runner for rootless Linux and trusted native Windows execution hosts"
-        )
-    );
+    assert!(stdout.contains(
+        "Automata runner for rootless Linux and trusted native Windows/macOS execution hosts"
+    ));
     assert!(stdout.contains("capabilities"));
     assert!(stdout.contains("without loading credentials"));
     assert!(!stdout.contains("cross-platform"));

--- a/crates/automata-ci-runner/tests/native_runner_process_e2e.rs
+++ b/crates/automata-ci-runner/tests/native_runner_process_e2e.rs
@@ -1,4 +1,4 @@
-#![cfg(windows)]
+#![cfg(any(windows, target_os = "macos"))]
 #![deny(warnings)]
 
 use std::{
@@ -22,11 +22,14 @@ use automata_ci_auth::{
 use automata_ci_core::{
     AttemptId, ContextValue, EnvironmentProfile, EnvironmentProfileId, FencingToken,
     JobAuthorityProfile, JobConclusion, JobContentReference, JobExecutionContext, JobId,
-    JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest, JobRuntimeContext, JobSource,
-    Lease, LeaseId, LogAck, OperatingSystem, OperationId, RunId, RunValueTemplates, RunnerId,
-    RunnerRequirements, RunnerSessionId, RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate,
-    StepId, StepIr, StrategyContext, UnixMillis, ValueTemplate, WorkflowId,
+    JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest, JobResourceAllocation,
+    JobRuntimeContext, JobSource, Lease, LeaseId, LogAck, OperatingSystem, OperationId,
+    ResourceCapacity, RunId, RunValueTemplates, RunnerId, RunnerRequirements, RunnerSessionId,
+    RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, StrategyContext,
+    UnixMillis, ValueTemplate, WorkflowId,
 };
+#[cfg(target_os = "macos")]
+use automata_ci_core::{ExpressionProgram, ValueSource};
 use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandSequence, JobResultMessage, JobRuntimeAuthorities,
     LeaseDisposition, LeaseOffer, LeaseRenewal, LeaseRequest, LogAckMessage, LogBatch,
@@ -35,11 +38,14 @@ use automata_ci_protocol::{
     ServerToRunner, SessionDisposition,
 };
 use automata_ci_protocol_protobuf::encode_job_runtime_context;
+#[cfg(windows)]
 use automata_ci_runner::product::RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION;
 use automata_ci_runner_transport::{
     ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, HandlerFuture,
     RunnerControlHandler, RunnerControlServer, ServerTlsConfig, TransportLimits,
 };
+#[cfg(target_os = "macos")]
+use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use rcgen::{
     BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose, IsCa,
@@ -57,24 +63,42 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
+#[cfg(target_os = "macos")]
+use std::os::unix::fs::PermissionsExt as _;
+
 const JOB_RUNTIME_CONTEXT_MEDIA_TYPE: &str =
     "application/vnd.automata.job-runtime-context.protobuf";
+#[cfg(windows)]
 const PROFILE_ID: &str = "automata.test/windows-process-e2e";
+#[cfg(target_os = "macos")]
+const PROFILE_ID: &str = "automata.test/macos-process-e2e";
 const S3_BUCKET: &str = "automata-process-e2e";
 const S3_PREFIX: &str = "process-e2e";
+#[cfg(windows)]
 const SENTINEL: &str = "AUTOMATA_WINDOWS_RUNNER_PROCESS_E2E";
+#[cfg(target_os = "macos")]
+const SENTINEL: &str = "AUTOMATA_MACOS_RUNNER_PROCESS_E2E";
+#[cfg(target_os = "macos")]
+const DIFFERENTIAL_REFERENCE_ENV: &str = "AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE";
+#[cfg(target_os = "macos")]
+const DIFFERENTIAL_REFERENCE: &str = "differential.bash=ok\ndifferential.sh=ok\ndifferential.environment=command-file\ndifferential.output=native-output\ndifferential.workspace=true\ndifferential.conclusion=success\n";
+#[cfg(windows)]
 const REQUIRE_STANDALONE_PWSH_ENV: &str = "AUTOMATA_RUNNER_WINDOWS_E2E_REQUIRE_STANDALONE_PWSH";
 const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[allow(clippy::too_many_lines)]
-async fn shipped_runner_process_executes_a_claimed_windows_shell_job() {
+async fn shipped_runner_process_executes_a_claimed_native_shell_job() {
     let root = TemporaryRoot::new();
     let runner_id = RunnerId::new();
     let session_id = RunnerSessionId::new();
     let pki = TestPki::new();
     let (job, event, runtime_context) = process_job();
-    let expected_s3_paths = [event.fixture_path(), runtime_context.fixture_path()];
+    let expected_s3_paths = [
+        event.fixture_path(),
+        runtime_context.fixture_path(),
+        runtime_context.fixture_path(),
+    ];
     let lease = Lease::new(
         LeaseId::new(),
         AttemptId::new(),
@@ -120,18 +144,30 @@ async fn shipped_runner_process_executes_a_claimed_windows_shell_job() {
         .kill_on_drop(true)
         .spawn()
         .expect("launch shipped automata-runner binary");
-    let stdout_task = tokio::spawn(drain_output(
+    let mut stdout_task = Some(tokio::spawn(drain_output(
         child.stdout.take().expect("runner stdout pipe"),
-    ));
-    let stderr_task = tokio::spawn(drain_output(
+    )));
+    let mut stderr_task = Some(tokio::spawn(drain_output(
         child.stderr.take().expect("runner stderr pipe"),
-    ));
+    )));
 
-    wait_for_terminal_result(&handler, &mut child, Duration::from_secs(90)).await;
+    wait_for_terminal_result(
+        &handler,
+        &mut child,
+        &mut stdout_task,
+        &mut stderr_task,
+        Duration::from_secs(90),
+    )
+    .await;
     tokio::time::timeout(Duration::from_secs(10), handler.wait_for_completed_poll())
         .await
         .expect("runner finalizes the completed job and polls its released slot");
-    let workspace = root.path().join(r"native\workspaces\automata\automata");
+    let workspace = root
+        .path()
+        .join("native")
+        .join("workspaces")
+        .join("automata")
+        .join("automata");
     let scratch = root
         .path()
         .join("native")
@@ -148,8 +184,8 @@ async fn shipped_runner_process_executes_a_claimed_windows_shell_job() {
     );
 
     stop_runner(&mut child).await;
-    let stdout = collect_output(stdout_task, "stdout").await;
-    let stderr = collect_output(stderr_task, "stderr").await;
+    let stdout = collect_output(stdout_task.take().expect("stdout task"), "stdout").await;
+    let stderr = collect_output(stderr_task.take().expect("stderr task"), "stderr").await;
     let s3_requests = s3.requests();
     control.stop().await;
     s3.stop().await;
@@ -158,7 +194,7 @@ async fn shipped_runner_process_executes_a_claimed_windows_shell_job() {
     assert_eq!(observation.hello_runner_id, Some(runner_id));
     assert_eq!(
         observation.hello_operating_system,
-        Some(OperatingSystem::Windows)
+        Some(native_operating_system())
     );
     assert!(
         observation.accepted,
@@ -173,10 +209,12 @@ async fn shipped_runner_process_executes_a_claimed_windows_shell_job() {
     let logs = String::from_utf8_lossy(&observation.logs);
     assert!(
         logs.contains(SENTINEL),
-        "real cmd.exe output did not reach the control plane; logs={logs:?}; stdout={:?}; stderr={:?}",
+        "real native-shell output did not reach the control plane; logs={logs:?}; stdout={:?}; stderr={:?}",
         String::from_utf8_lossy(&stdout),
         String::from_utf8_lossy(&stderr),
     );
+    #[cfg(target_os = "macos")]
+    assert_macos_differential_fixture(&logs);
     assert!(
         observation.completed_poll,
         "runner reported the result but did not finalize the slot and poll again; stdout={:?}; stderr={:?}",
@@ -220,6 +258,8 @@ async fn collect_output(task: JoinHandle<io::Result<Vec<u8>>>, stream: &'static 
 async fn wait_for_terminal_result(
     handler: &ProcessFlowHandler,
     child: &mut tokio::process::Child,
+    stdout_task: &mut Option<JoinHandle<io::Result<Vec<u8>>>>,
+    stderr_task: &mut Option<JoinHandle<io::Result<Vec<u8>>>>,
     limit: Duration,
 ) {
     let deadline = tokio::time::Instant::now() + limit;
@@ -228,7 +268,14 @@ async fn wait_for_terminal_result(
             return;
         }
         if let Some(status) = child.try_wait().expect("query runner process") {
-            panic!("automata-runner exited before reporting a job result: {status}");
+            let stdout = collect_output(stdout_task.take().expect("stdout task"), "stdout").await;
+            let stderr = collect_output(stderr_task.take().expect("stderr task"), "stderr").await;
+            panic!(
+                "automata-runner exited before reporting a job result: {status}; observation={:?}; stdout={:?}; stderr={:?}",
+                handler.observation(),
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr),
+            );
         }
         assert!(
             tokio::time::Instant::now() < deadline,
@@ -263,19 +310,13 @@ fn process_job() -> (JobIrEnvelope, S3Object, S3Object) {
         EnvironmentProfileId::new(PROFILE_ID).expect("profile ID"),
         Sha256Digest::from_bytes([0x08; 32]),
     );
-    let requirements = RunnerRequirements::default().with_environment_profile(profile);
-    let step = StepIr::new(
-        StepId::new("process-e2e").expect("step ID"),
-        ValueTemplate::literal("Run cmd.exe through the shipped runner").expect("step name"),
-        RuntimeBoolean::literal(false),
-        SemanticStep::run(RunValueTemplates::new(
-            ValueTemplate::literal(format!(
-                "@echo {SENTINEL}\r\n@echo process-level-execution>runner-process-e2e.txt"
-            ))
-            .expect("cmd command"),
-            ShellTemplate::named(ValueTemplate::literal("cmd").expect("cmd shell")),
-        )),
-    );
+    let capacity = ResourceCapacity::new(1_000, 1_073_741_824, 0, 0);
+    let allocation =
+        JobResourceAllocation::new(capacity, capacity).expect("native process allocation");
+    let requirements = RunnerRequirements::default()
+        .with_environment_profile(profile)
+        .with_resource_allocation(allocation);
+    let steps = native_steps();
     let job = JobIr::new(
         JobId::new(),
         RunId::new(),
@@ -284,7 +325,7 @@ fn process_job() -> (JobIrEnvelope, S3Object, S3Object) {
         JobInstanceIdentity::new("process-e2e", 0, 1, Sha256Digest::from_bytes([0x44; 32]))
             .expect("job instance"),
         false,
-        vec![step],
+        steps,
     )
     .with_authority_profile(JobAuthorityProfile::CredentialFree)
     .with_permission_request(JobPermissionRequest::Mapping(Vec::new()));
@@ -294,12 +335,12 @@ fn process_job() -> (JobIrEnvelope, S3Object, S3Object) {
             "github",
             "automata-ci/automata",
             "0123456789abcdef0123456789abcdef01234567",
-            ".github/workflows/windows-process-e2e.yml",
+            ".github/workflows/native-process-e2e.yml",
             "workflow_dispatch",
         ),
         JobExecutionContext::new(
             "CI",
-            "refs/heads/windows-process-e2e",
+            "refs/heads/native-process-e2e",
             "/__w/automata/automata",
             event_reference.clone(),
             runtime_reference.clone(),
@@ -311,6 +352,96 @@ fn process_job() -> (JobIrEnvelope, S3Object, S3Object) {
         S3Object::new(&event_reference, event_bytes),
         S3Object::new(&runtime_reference, runtime_bytes),
     )
+}
+
+#[cfg(windows)]
+fn native_steps() -> Vec<StepIr> {
+    vec![StepIr::new(
+        StepId::new("process-e2e").expect("step ID"),
+        ValueTemplate::literal(native_step_name()).expect("step name"),
+        RuntimeBoolean::literal(false),
+        SemanticStep::run(RunValueTemplates::new(
+            ValueTemplate::literal(native_step_script()).expect("native command"),
+            ShellTemplate::named(
+                ValueTemplate::literal(native_shell_name()).expect("native shell"),
+            ),
+        )),
+    )]
+}
+
+#[cfg(target_os = "macos")]
+fn native_steps() -> Vec<StepIr> {
+    let producer = StepIr::new(
+        StepId::new("macos-bash-reference").expect("producer step ID"),
+        ValueTemplate::literal("Run Bash differential fixture").expect("producer step name"),
+        RuntimeBoolean::literal(false),
+        SemanticStep::run(RunValueTemplates::new(
+            ValueTemplate::literal(
+                "set -eu\nprintf 'differential.bash=ok\\n'\nprintf 'AUTOMATA_DIFFERENTIAL_ENV=command-file\\n' >> \"$GITHUB_ENV\"\nprintf 'fixture=native-output\\n' >> \"$GITHUB_OUTPUT\"\nprintf '%s\\n' native-workspace > differential-artifact.txt",
+            )
+            .expect("producer command"),
+            ShellTemplate::named(ValueTemplate::literal("bash").expect("Bash shell")),
+        )),
+    );
+    let consumer = StepIr::new(
+        StepId::new("macos-sh-reference").expect("consumer step ID"),
+        ValueTemplate::literal("Run sh differential fixture").expect("consumer step name"),
+        RuntimeBoolean::literal(false),
+        SemanticStep::run(RunValueTemplates::new(
+            ValueTemplate::literal(format!(
+                "set -eu\ntest \"$AUTOMATA_DIFFERENTIAL_ENV\" = command-file\ntest \"$FROM_OUTPUT\" = native-output\ntest \"$PWD\" = \"$GITHUB_WORKSPACE\"\ntest \"$(cat differential-artifact.txt)\" = native-workspace\nprintf 'differential.sh=ok\\ndifferential.environment=%s\\ndifferential.output=%s\\ndifferential.workspace=true\\ndifferential.conclusion=success\\n%s\\n' \"$AUTOMATA_DIFFERENTIAL_ENV\" \"$FROM_OUTPUT\" '{SENTINEL}'"
+            ))
+            .expect("consumer command"),
+            ShellTemplate::named(ValueTemplate::literal("sh").expect("sh shell")),
+        )),
+    )
+    .with_environment(BTreeMap::from([(
+        "FROM_OUTPUT".to_owned(),
+        ValueSource::Expression(output_expression(
+            "${{ steps.macos-bash-reference.outputs.fixture }}",
+        )),
+    )]));
+    vec![producer, consumer]
+}
+
+#[cfg(target_os = "macos")]
+fn output_expression(source: &str) -> ExpressionProgram {
+    GithubConditionCompiler::default()
+        .compile_value_expression(source, GithubConditionPhase::Step)
+        .expect("valid step-output expression")
+}
+
+#[cfg(target_os = "macos")]
+fn assert_macos_differential_fixture(logs: &str) {
+    let reference = std::env::var_os(DIFFERENTIAL_REFERENCE_ENV).map_or_else(
+        || DIFFERENTIAL_REFERENCE.to_owned(),
+        |path| fs::read_to_string(path).expect("read GitHub-hosted macOS shell reference"),
+    );
+    assert_eq!(
+        reference, DIFFERENTIAL_REFERENCE,
+        "GitHub-hosted Bash/sh reference changed"
+    );
+    for expected in DIFFERENTIAL_REFERENCE.lines() {
+        assert!(
+            logs.lines().any(|line| line == expected),
+            "Automata native shell fixture omitted {expected:?}; logs={logs:?}"
+        );
+    }
+}
+
+#[cfg(windows)]
+const fn native_step_name() -> &'static str {
+    "Run cmd.exe through the shipped runner"
+}
+
+#[cfg(windows)]
+fn native_step_script() -> String {
+    format!("@echo {SENTINEL}\r\n@echo process-level-execution>runner-process-e2e.txt")
+}
+
+#[cfg(windows)]
+const fn native_shell_name() -> &'static str {
+    "cmd"
 }
 
 fn content_reference(key: &str, media_type: &str, bytes: &[u8]) -> JobContentReference {
@@ -470,7 +601,7 @@ async fn serve_s3_request(
     write_all(&stream, &object.bytes).await
 }
 
-fn assert_s3_requests(requests: &[S3RequestObservation], expected_paths: &[String; 2]) {
+fn assert_s3_requests(requests: &[S3RequestObservation], expected_paths: &[String]) {
     let expected = expected_paths
         .iter()
         .cloned()
@@ -486,7 +617,7 @@ fn assert_s3_requests(requests: &[S3RequestObservation], expected_paths: &[Strin
     expected.sort_by(|left, right| left.path.cmp(&right.path));
     assert_eq!(
         observed, expected,
-        "runner must issue exactly one signed GET for each referenced job-content object"
+        "runner signed GETs must match the exact immutable job-content reads"
     );
 }
 
@@ -621,7 +752,7 @@ impl ProcessFlowHandler {
         state.observation.hello_operating_system =
             Some(hello.runner().platform().operating_system().clone());
         if hello.runner().runner_id() != self.runner_id
-            || hello.runner().platform().operating_system() != &OperatingSystem::Windows
+            || hello.runner().platform().operating_system() != &native_operating_system()
         {
             return Err(internal_application_error());
         }
@@ -763,6 +894,16 @@ impl ProcessFlowHandler {
             reply_header(ack.header()),
         )))
     }
+}
+
+#[cfg(windows)]
+const fn native_operating_system() -> OperatingSystem {
+    OperatingSystem::Windows
+}
+
+#[cfg(target_os = "macos")]
+const fn native_operating_system() -> OperatingSystem {
+    OperatingSystem::Macos
 }
 
 impl RunnerControlHandler for ProcessFlowHandler {
@@ -970,6 +1111,7 @@ fn pem(label: &str, der: &[u8]) -> String {
 }
 
 #[allow(clippy::too_many_lines)]
+#[cfg(windows)]
 fn write_runner_config(
     root: &Path,
     runner_id: RunnerId,
@@ -1115,6 +1257,124 @@ fn write_runner_config(
     config_path
 }
 
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_lines)]
+fn write_runner_config(
+    root: &Path,
+    runner_id: RunnerId,
+    control_address: SocketAddr,
+    s3_address: SocketAddr,
+) -> PathBuf {
+    let journal = root.join("journal");
+    let spool = root.join("spool");
+    let native = root.join("native");
+    let workspaces = native.join("workspaces");
+    let runner = native.join("runner");
+    let temp = root.join("temp");
+    let home = root.join("home");
+    let tool_cache = root.join("tool-cache");
+    for path in [&temp, &home, &tool_cache] {
+        fs::create_dir_all(path).expect("create runner support directory");
+    }
+    let config = json!({
+        "schema_version": 2,
+        "runner_id": runner_id.to_string(),
+        "control_endpoint": format!("https://{control_address}/"),
+        "state": {
+            "journal": journal,
+            "spool": spool,
+            "macos_native": native,
+        },
+        "tls": {
+            "server_roots": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_SERVER_ROOTS_PEM"},
+            "certificate_chain": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_CERTIFICATE_CHAIN_PEM"},
+            "private_key": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_PRIVATE_KEY_PEM"},
+        },
+        "spool": {
+            "protection_id": "macos-process-e2e-key-v1",
+            "key_hex": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_SPOOL_KEY_HEX"},
+            "decrypt_only": [],
+        },
+        "inventory": {
+            "labels": ["self-hosted", "macos", "arm64"],
+            "groups": ["default"],
+            "max_parallel_jobs": 1,
+            "resources_per_job": {
+                "cpu_millis": 1000,
+                "memory_bytes": 1_073_741_824_u64,
+                "ephemeral_disk_bytes": 0,
+                "pids": 128,
+            },
+            "environment_profiles": [{
+                "id": PROFILE_ID,
+                "manifest_sha256": "08".repeat(32),
+                "workspace": workspaces,
+                "default_environment": {},
+            }],
+        },
+        "macos_native": {},
+        "executor": {
+            "resources": {
+                "cpu_millis": 1000,
+                "memory_bytes": 1_073_741_824_u64,
+                "ephemeral_disk_bytes": 0,
+                "pids": 128,
+            },
+            "network": "host",
+            "root_filesystem": "host",
+            "privilege": "host",
+            "default_step_timeout_seconds": 60,
+            "maximum_output_bytes": 1_048_576,
+            "runner_root": runner,
+            "home": home,
+            "path": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "temp": temp,
+            "tool_cache": tool_cache,
+            "toolchain": {
+                "bash": "/bin/bash",
+                "sh": "/bin/sh",
+                "python": null,
+                "pwsh": null,
+                "powershell": null,
+                "cmd": null,
+                "install": "/usr/bin/install",
+                "tar": "/usr/bin/tar",
+                "sha256sum": "/usr/bin/shasum",
+                "node12": null,
+                "node16": null,
+                "node20": null,
+                "node24": null,
+            },
+        },
+        "object_store": {
+            "endpoint": format!("http://{s3_address}/"),
+            "region": "us-east-1",
+            "bucket": S3_BUCKET,
+            "prefix": S3_PREFIX,
+            "loopback_development": true,
+            "operation_timeout_seconds": 5,
+            "access_key_id": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_S3_ACCESS_KEY"},
+            "secret_access_key": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_S3_SECRET_KEY"},
+        },
+        "github": {
+            "user_agent": "automata-runner-process-e2e/0.1.0",
+            "server_url": "https://github.com/",
+            "api_url": "https://api.github.com/",
+            "graphql_url": "https://api.github.com/graphql",
+        },
+    });
+    let config_path = root.join("runner.macos.process-e2e.json");
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&config).expect("encode runner config"),
+    )
+    .expect("write runner config");
+    fs::set_permissions(&config_path, fs::Permissions::from_mode(0o600))
+        .expect("restrict runner config");
+    config_path
+}
+
+#[cfg(windows)]
 fn require_standalone_pwsh() -> bool {
     match std::env::var_os(REQUIRE_STANDALONE_PWSH_ENV) {
         None => false,
@@ -1134,7 +1394,10 @@ struct TemporaryRoot {
 
 impl TemporaryRoot {
     fn new() -> Self {
+        #[cfg(windows)]
         let parent = std::env::temp_dir();
+        #[cfg(target_os = "macos")]
+        let parent = fs::canonicalize(std::env::temp_dir()).expect("canonical macOS temp root");
         let path = parent.join(format!(
             "automata-runner-process-e2e-{}",
             RunnerSessionId::new()

--- a/crates/automata-ci-runner/tests/product_context.rs
+++ b/crates/automata-ci-runner/tests/product_context.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", windows))]
+#![cfg(any(target_os = "linux", target_os = "macos", windows))]
 
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -58,6 +58,7 @@ fn admitted_execution_context_is_exposed_without_workspace_or_ref_rederivation()
     );
     assert_eq!(environment["RUNNER_ENVIRONMENT"], "self-hosted");
     assert_eq!(environment["RUNNER_OS"], expected_runner_os());
+    assert_eq!(environment["RUNNER_ARCH"], expected_runner_arch());
     assert_eq!(environment["GITHUB_EVENT_PATH"], expected_event_path());
     assert_eq!(environment["GITHUB_ACTOR"], "local-bootstrap");
     assert_eq!(environment["GITHUB_RUN_ID"], "42");
@@ -107,6 +108,10 @@ fn admitted_execution_context_is_exposed_without_workspace_or_ref_rederivation()
     assert_eq!(
         runner.get("os").and_then(GithubValue::as_str),
         Some(expected_runner_os())
+    );
+    assert_eq!(
+        runner.get("arch").and_then(GithubValue::as_str),
+        Some(expected_runner_arch())
     );
 }
 
@@ -725,6 +730,8 @@ fn fixture_runner_config() -> RunnerProductConfig {
     let config_bytes = include_bytes!("../config/runner.windows.example.json").as_slice();
     #[cfg(target_os = "linux")]
     let config_bytes = include_bytes!("../config/runner.local-1.example.json").as_slice();
+    #[cfg(target_os = "macos")]
+    let config_bytes = include_bytes!("../config/runner.macos.example.json").as_slice();
     let mut document: serde_json::Value =
         serde_json::from_slice(config_bytes).expect("runner config JSON");
     document["github"]["server_url"] = serde_json::json!("https://github.com/");
@@ -793,6 +800,7 @@ impl ContextFixture {
         );
         let context = StandardGithubContext::new(
             config.runner_id(),
+            config.inventory().platform().clone(),
             config.environments(),
             config.executor(),
             config.github().clone(),
@@ -1037,19 +1045,35 @@ fn fixture_event_path() -> TargetPath {
     {
         TargetPath::windows(expected_event_path()).expect("event target")
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         TargetPath::posix(expected_event_path()).expect("event target")
     }
 }
 
 const fn expected_runner_os() -> &'static str {
-    if cfg!(windows) { "Windows" } else { "Linux" }
+    if cfg!(windows) {
+        "Windows"
+    } else if cfg!(target_os = "macos") {
+        "macOS"
+    } else {
+        "Linux"
+    }
+}
+
+const fn expected_runner_arch() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "ARM64"
+    } else {
+        "X64"
+    }
 }
 
 const fn expected_workspace() -> &'static str {
     if cfg!(windows) {
         r"C:\automata\native\workspaces\automata\automata"
+    } else if cfg!(target_os = "macos") {
+        "/Users/automata-runner/Library/Application Support/Automata/native/workspaces/automata/automata"
     } else {
         "/__w/automata/automata"
     }
@@ -1058,6 +1082,8 @@ const fn expected_workspace() -> &'static str {
 const fn expected_event_path() -> &'static str {
     if cfg!(windows) {
         r"C:\automata\native\runner\attempts\fixture\event.json"
+    } else if cfg!(target_os = "macos") {
+        "/Users/automata-runner/Library/Application Support/Automata/native/runner/attempts/fixture/event.json"
     } else {
         "/__automata/attempts/fixture/event.json"
     }

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -1,4 +1,4 @@
-#![cfg(unix)]
+#![cfg(target_os = "linux")]
 
 use automata_ci_core::{
     Architecture, ContainerFeature, OperatingSystem, ResourceCapacity, RunnerFeature,

--- a/crates/automata-ci-runner/tests/runner_product_config_macos.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_macos.rs
@@ -1,0 +1,150 @@
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+use automata_ci_core::{Architecture, IsolationLevel, OperatingSystem, RunnerFeature};
+use automata_ci_execution::{SandboxLaunch, SandboxPrivilegePolicy};
+use automata_ci_runner::product::{RunnerProductConfig, RunnerProductConfigError};
+
+fn baseline() -> serde_json::Value {
+    serde_json::from_slice(include_bytes!("../config/runner.macos.example.json"))
+        .expect("checked-in macOS runner configuration JSON")
+}
+
+fn parse(value: &serde_json::Value) -> Result<RunnerProductConfig, RunnerProductConfigError> {
+    RunnerProductConfig::from_json(
+        &serde_json::to_vec(value).expect("serialize mutated macOS configuration"),
+    )
+}
+
+#[test]
+fn checked_in_macos_configuration_selects_host_shared_arm64_execution() {
+    let config = parse(&baseline()).expect("checked-in macOS runner configuration");
+
+    assert!(config.macos_native().is_some());
+    assert!(config.podman().is_none());
+    assert!(config.kubernetes().is_none());
+    assert!(config.windows_native().is_none());
+    assert_eq!(config.executor().privilege(), SandboxPrivilegePolicy::Host);
+    assert_eq!(
+        config.inventory().platform().operating_system(),
+        &OperatingSystem::Macos
+    );
+    assert_eq!(
+        config.inventory().platform().architecture(),
+        &Architecture::Aarch64
+    );
+    assert_eq!(
+        config.inventory().sandbox().maximum_isolation(),
+        IsolationLevel::Process
+    );
+    assert!(
+        config
+            .inventory()
+            .features()
+            .contains(&RunnerFeature::SHELL_STEPS)
+    );
+    assert!(
+        !config
+            .inventory()
+            .features()
+            .contains(&RunnerFeature::JAVASCRIPT_ACTIONS)
+    );
+    let environment = config
+        .environments()
+        .first_key_value()
+        .expect("native macOS environment")
+        .1;
+    assert!(matches!(environment.launch(), SandboxLaunch::Native));
+    assert_eq!(
+        environment.workspace().as_str(),
+        "/Users/automata-runner/Library/Application Support/Automata/native/workspaces"
+    );
+    assert_eq!(
+        config
+            .executor()
+            .toolchain()
+            .sha256sum()
+            .expect("shasum")
+            .as_str(),
+        "/usr/bin/shasum"
+    );
+}
+
+#[test]
+fn macos_configuration_rejects_unsupported_native_surface() {
+    let mut no_provider = baseline();
+    no_provider
+        .as_object_mut()
+        .expect("configuration object")
+        .remove("macos_native");
+    assert_eq!(
+        parse(&no_provider).expect_err("a provider is required"),
+        RunnerProductConfigError::InvalidProvider
+    );
+
+    for (field, invalid) in [
+        ("network", serde_json::json!("private_egress")),
+        ("root_filesystem", serde_json::json!("writable")),
+        ("privilege", serde_json::json!("unprivileged")),
+        ("privilege", serde_json::json!("administrator")),
+    ] {
+        let mut value = baseline();
+        value["executor"][field] = invalid;
+        assert_eq!(
+            parse(&value).expect_err("macOS host policy must remain explicit"),
+            RunnerProductConfigError::InvalidExecutor
+        );
+    }
+
+    let mut parallel = baseline();
+    parallel["inventory"]["max_parallel_jobs"] = serde_json::json!(2);
+    assert_eq!(
+        parse(&parallel).expect_err("native macOS is one-slot"),
+        RunnerProductConfigError::InvalidInventory
+    );
+
+    let mut javascript = baseline();
+    javascript["executor"]["toolchain"]["node20"] = serde_json::json!("/opt/homebrew/bin/node");
+    assert_eq!(
+        parse(&javascript).expect_err("JavaScript actions are not supported"),
+        RunnerProductConfigError::InvalidExecutor
+    );
+
+    for field in ["ephemeral_disk_bytes", "gpu_count"] {
+        let mut value = baseline();
+        value["executor"]["resources"][field] = serde_json::json!(1);
+        value["inventory"]["resources_per_job"][field] = serde_json::json!(1);
+        assert!(parse(&value).is_err(), "nonzero {field} must fail closed");
+    }
+}
+
+#[test]
+fn macos_provider_roots_are_private_disjoint_descendants() {
+    for (section, invalid) in [
+        ("executor", "/Users/automata-runner/outside/runner"),
+        ("inventory", "/Users/automata-runner/outside/workspaces"),
+        (
+            "inventory",
+            "/Users/automata-runner/Library/Application Support/Automata/native/runner/workspaces",
+        ),
+    ] {
+        let mut value = baseline();
+        if section == "executor" {
+            value["executor"]["runner_root"] = serde_json::json!(invalid);
+        } else {
+            value["inventory"]["environment_profiles"][0]["workspace"] = serde_json::json!(invalid);
+        }
+        assert_eq!(
+            parse(&value).expect_err("provider-owned roots require disjoint descendants"),
+            RunnerProductConfigError::InvalidInventory
+        );
+    }
+
+    let mut overlap = baseline();
+    overlap["state"]["journal"] = serde_json::json!(
+        "/Users/automata-runner/Library/Application Support/Automata/native/journal"
+    );
+    assert_eq!(
+        parse(&overlap).expect_err("durable and native roots cannot overlap"),
+        RunnerProductConfigError::InvalidStateRoots
+    );
+}

--- a/crates/automata-ci-sandbox-kubernetes/src/objects.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/objects.rs
@@ -88,6 +88,9 @@ fn validated_allocation(
     let allocation = spec
         .resource_allocation()
         .ok_or_else(|| invalid_configuration(automata_ci_execution::ProviderStage::Validate))?;
+    let resources = spec
+        .resources()
+        .ok_or_else(|| invalid_configuration(automata_ci_execution::ProviderStage::Validate))?;
     if allocation.limits().gpu_count() > 0 && config.gpu_resource_name().is_none() {
         return Err(invalid_configuration(
             automata_ci_execution::ProviderStage::Validate,
@@ -98,7 +101,7 @@ fn validated_allocation(
             automata_ci_execution::ProviderStage::Validate,
         ));
     }
-    if config.process_limit() != Some(spec.resources().pids()) {
+    if config.process_limit() != Some(resources.pids()) {
         return Err(invalid_configuration(
             automata_ci_execution::ProviderStage::Validate,
         ));
@@ -701,7 +704,7 @@ mod tests {
             original.workspace().clone(),
             original.network(),
             original.root_filesystem(),
-            original.resources(),
+            original.resources().expect("enforced resources"),
         );
         assert!(build_objects("a-test-7", &missing_allocation, &config()).is_err());
 
@@ -734,7 +737,7 @@ mod tests {
             original.workspace().clone(),
             original.network(),
             original.root_filesystem(),
-            original.resources(),
+            original.resources().expect("enforced resources"),
         )
         .with_resource_allocation(incoherent);
         assert!(build_objects("a-test-7", &incoherent, &config()).is_err());

--- a/crates/automata-ci-sandbox-macos/Cargo.toml
+++ b/crates/automata-ci-sandbox-macos/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "automata-ci-sandbox-macos"
+description = "Trusted native macOS whole-job sandbox adapter for Automata"
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+automata-ci-execution.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+processkit.workspace = true
+rustix.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tokio.workspace = true
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+static_assertions.workspace = true
+uuid.workspace = true

--- a/crates/automata-ci-sandbox-macos/LICENSE
+++ b/crates/automata-ci-sandbox-macos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexander Dzhoganov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-sandbox-macos/README.md
+++ b/crates/automata-ci-sandbox-macos/README.md
@@ -1,0 +1,22 @@
+# automata-ci-sandbox-macos
+
+`automata-ci-sandbox-macos` executes trusted ARM64 macOS jobs as native
+processes. Each job receives fresh workspace and scratch directories below one
+dedicated provider root. Commands run under a same-binary supervisor that owns
+their POSIX process group and terminates it on timeout, cancellation, provider
+shutdown, or runner/control-channel loss.
+
+This provider is deliberately not a hostile-workload boundary. It advertises
+the host network, host filesystem, unchanged host identity, and shared host
+resources. Deploy it only under a dedicated non-administrative runner account
+and only for trusted repositories. Per-job CPU, memory, process, filesystem,
+identity, and network isolation require the separate Virtualization.framework
+provider.
+
+Lifecycle mutations are operation-replay safe and generation fenced. The
+provider owns and exclusively locks its state root, persists checksummed
+create/destroy events before filesystem mutation, rejects corrupt history, and
+recovers unfinished sandboxes by terminating their supervisor and removing the
+owned directories.
+
+Automata is pre-1.0 and not production-ready.

--- a/crates/automata-ci-sandbox-macos/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-macos/src/endpoint.rs
@@ -1,0 +1,343 @@
+use std::{collections::HashMap, fmt, sync::Arc};
+
+use automata_ci_execution::{
+    Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
+    ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionStage, SandboxCapability,
+    SandboxHandle, SandboxState, SignalRequest, WaitRequest,
+};
+
+use crate::{
+    filesystem::{read_owned_file, require_directory, require_executable, write_owned_file},
+    provider::{ENDPOINT_CAPABILITIES, ProviderInner, SandboxEntry},
+    supervisor,
+};
+
+#[derive(Default)]
+pub(crate) struct EndpointState {
+    exec: HashMap<automata_ci_execution::OperationId, ExecReplay>,
+    copy_to: HashMap<automata_ci_execution::OperationId, CopyToReplay>,
+    copy_from: HashMap<automata_ci_execution::OperationId, CopyFromReplay>,
+}
+
+struct ExecReplay {
+    request: ExecutionCommand,
+    result: Result<ExecutionOutput, ExecutionError>,
+}
+
+struct CopyToReplay {
+    request: CopyToRequest,
+    result: Result<(), ExecutionError>,
+}
+
+struct CopyFromReplay {
+    request: CopyFromRequest,
+    result: Result<Vec<u8>, ExecutionError>,
+}
+
+#[derive(Clone)]
+pub(crate) struct MacosExecutionEndpoint {
+    provider: Arc<ProviderInner>,
+    entry: Arc<SandboxEntry>,
+}
+
+impl MacosExecutionEndpoint {
+    pub(crate) const fn new(provider: Arc<ProviderInner>, entry: Arc<SandboxEntry>) -> Self {
+        Self { provider, entry }
+    }
+
+    fn require_running(&self, stage: ExecutionStage) -> Result<(), ExecutionError> {
+        match self.entry.state() {
+            Ok(SandboxState::Running) => Ok(()),
+            Ok(SandboxState::Absent) => Err(error(ExecutionErrorKind::NotFound, stage)),
+            Ok(_) => Err(error(ExecutionErrorKind::InvalidState, stage)),
+            Err(()) => Err(error(ExecutionErrorKind::LocalStorage, stage)),
+        }
+    }
+}
+
+impl fmt::Debug for MacosExecutionEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MacosExecutionEndpoint")
+            .field("handle", &self.entry.handle)
+            .field("capabilities", &&ENDPOINT_CAPABILITIES[..])
+            .finish_non_exhaustive()
+    }
+}
+
+impl ExecutionEndpoint for MacosExecutionEndpoint {
+    fn handle(&self) -> &SandboxHandle {
+        &self.entry.handle
+    }
+
+    fn capabilities(&self) -> &[SandboxCapability] {
+        &ENDPOINT_CAPABILITIES
+    }
+
+    fn exec(
+        &self,
+        request: &ExecutionCommand,
+        cancellation: &dyn Cancellation,
+    ) -> Result<ExecutionOutput, ExecutionError> {
+        let _operation = self
+            .entry
+            .operation_lock
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec))?;
+        {
+            let state = self
+                .entry
+                .endpoint_state
+                .lock()
+                .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec))?;
+            if let Some(replay) = state.exec.get(&request.operation_id()) {
+                return if replay.request == *request {
+                    replay.result.clone()
+                } else {
+                    Err(error(
+                        ExecutionErrorKind::BackendRejected,
+                        ExecutionStage::Exec,
+                    ))
+                };
+            }
+        }
+        let result = self.exec_once(request, cancellation);
+        self.entry
+            .endpoint_state
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec))?
+            .exec
+            .insert(
+                request.operation_id(),
+                ExecReplay {
+                    request: request.clone(),
+                    result: result.clone(),
+                },
+            );
+        result
+    }
+
+    fn signal(
+        &self,
+        _request: SignalRequest,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        Err(error(
+            ExecutionErrorKind::UnsupportedCapability,
+            ExecutionStage::Signal,
+        ))
+    }
+
+    fn wait(
+        &self,
+        _request: WaitRequest,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<i32, ExecutionError> {
+        Err(error(
+            ExecutionErrorKind::UnsupportedCapability,
+            ExecutionStage::Wait,
+        ))
+    }
+
+    fn copy_to(
+        &self,
+        request: &CopyToRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        let _operation = self
+            .entry
+            .operation_lock
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyTo))?;
+        {
+            let state = self
+                .entry
+                .endpoint_state
+                .lock()
+                .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyTo))?;
+            if let Some(replay) = state.copy_to.get(&request.operation_id()) {
+                return if replay.request == *request {
+                    replay.result
+                } else {
+                    Err(error(
+                        ExecutionErrorKind::BackendRejected,
+                        ExecutionStage::CopyTo,
+                    ))
+                };
+            }
+        }
+        let result = self.copy_to_once(request, cancellation);
+        self.entry
+            .endpoint_state
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyTo))?
+            .copy_to
+            .insert(
+                request.operation_id(),
+                CopyToReplay {
+                    request: request.clone(),
+                    result,
+                },
+            );
+        result
+    }
+
+    fn copy_from(
+        &self,
+        request: &CopyFromRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let _operation = self
+            .entry
+            .operation_lock
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyFrom))?;
+        {
+            let state =
+                self.entry.endpoint_state.lock().map_err(|_| {
+                    error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyFrom)
+                })?;
+            if let Some(replay) = state.copy_from.get(&request.operation_id()) {
+                return if replay.request == *request {
+                    replay.result.clone()
+                } else {
+                    Err(error(
+                        ExecutionErrorKind::BackendRejected,
+                        ExecutionStage::CopyFrom,
+                    ))
+                };
+            }
+        }
+        let result = self.copy_from_once(request, cancellation);
+        self.entry
+            .endpoint_state
+            .lock()
+            .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::CopyFrom))?
+            .copy_from
+            .insert(
+                request.operation_id(),
+                CopyFromReplay {
+                    request: request.clone(),
+                    result: result.clone(),
+                },
+            );
+        result
+    }
+}
+
+impl MacosExecutionEndpoint {
+    fn exec_once(
+        &self,
+        request: &ExecutionCommand,
+        cancellation: &dyn Cancellation,
+    ) -> Result<ExecutionOutput, ExecutionError> {
+        self.require_running(ExecutionStage::Exec)?;
+        require_executable(request.argv().program())
+            .map_err(|_| error(ExecutionErrorKind::BackendRejected, ExecutionStage::Exec))?;
+        let working_directory = self
+            .provider
+            .root
+            .resolve_owned_target(
+                request.working_directory(),
+                &self.entry.workspace,
+                &self.entry.scratch,
+            )
+            .and_then(|target| require_directory(&target))
+            .map_err(|_| error(ExecutionErrorKind::OwnershipMismatch, ExecutionStage::Exec))?;
+        if working_directory != std::path::Path::new(request.working_directory().as_str()) {
+            return Err(error(
+                ExecutionErrorKind::OwnershipMismatch,
+                ExecutionStage::Exec,
+            ));
+        }
+        supervisor::execute(
+            self.provider.options.supervisor_executable(),
+            request,
+            cancellation,
+        )
+    }
+
+    fn copy_to_once(
+        &self,
+        request: &CopyToRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        self.require_running(ExecutionStage::CopyTo)?;
+        if cancellation.is_cancelled() {
+            return Err(error(ExecutionErrorKind::Cancelled, ExecutionStage::CopyTo));
+        }
+        let target = self
+            .provider
+            .root
+            .resolve_owned_target(request.target(), &self.entry.workspace, &self.entry.scratch)
+            .map_err(|_| {
+                error(
+                    ExecutionErrorKind::OwnershipMismatch,
+                    ExecutionStage::CopyTo,
+                )
+            })?;
+        write_owned_file(&target, request.content()).map_err(|source| {
+            filesystem_error(
+                &source,
+                ExecutionStage::CopyTo,
+                ExecutionErrorKind::LocalStorage,
+            )
+        })
+    }
+
+    fn copy_from_once(
+        &self,
+        request: &CopyFromRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        self.require_running(ExecutionStage::CopyFrom)?;
+        if cancellation.is_cancelled() {
+            return Err(error(
+                ExecutionErrorKind::Cancelled,
+                ExecutionStage::CopyFrom,
+            ));
+        }
+        let target = self
+            .provider
+            .root
+            .resolve_owned_target(request.source(), &self.entry.workspace, &self.entry.scratch)
+            .map_err(|_| {
+                error(
+                    ExecutionErrorKind::OwnershipMismatch,
+                    ExecutionStage::CopyFrom,
+                )
+            })?;
+        let content = read_owned_file(&target, request.byte_limit()).map_err(|source| {
+            filesystem_error(
+                &source,
+                ExecutionStage::CopyFrom,
+                ExecutionErrorKind::LocalStorage,
+            )
+        })?;
+        if cancellation.is_cancelled() {
+            return Err(error(
+                ExecutionErrorKind::Cancelled,
+                ExecutionStage::CopyFrom,
+            ));
+        }
+        Ok(content)
+    }
+}
+
+fn filesystem_error(
+    source: &std::io::Error,
+    stage: ExecutionStage,
+    fallback: ExecutionErrorKind,
+) -> ExecutionError {
+    let kind = match source.kind() {
+        std::io::ErrorKind::NotFound => ExecutionErrorKind::NotFound,
+        std::io::ErrorKind::PermissionDenied => ExecutionErrorKind::OwnershipMismatch,
+        std::io::ErrorKind::FileTooLarge => ExecutionErrorKind::OutputLimitExceeded,
+        _ => fallback,
+    };
+    error(kind, stage)
+}
+
+const fn error(kind: ExecutionErrorKind, stage: ExecutionStage) -> ExecutionError {
+    ExecutionError::new(kind, stage)
+}

--- a/crates/automata-ci-sandbox-macos/src/filesystem.rs
+++ b/crates/automata-ci-sandbox-macos/src/filesystem.rs
@@ -1,0 +1,378 @@
+use std::{
+    ffi::{CStr, OsString},
+    fs::File,
+    io::{self, Read as _, Write as _},
+    os::unix::ffi::OsStrExt as _,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+
+use automata_ci_execution::{TargetPath, TargetPlatform};
+use rustix::{
+    fd::OwnedFd,
+    fs::{
+        self, AtFlags, Dir, FileType, Mode, OFlags, fchmod, fstat, mkdirat, open, openat, unlinkat,
+    },
+    io::Errno,
+};
+
+use crate::path::is_strict_descendant;
+
+const DIRECTORY_MODE: Mode = Mode::from_raw_mode(0o700);
+const FILE_MODE: Mode = Mode::from_raw_mode(0o600);
+const DIRECTORY_FLAGS: OFlags = OFlags::RDONLY
+    .union(OFlags::DIRECTORY)
+    .union(OFlags::CLOEXEC)
+    .union(OFlags::NOFOLLOW);
+
+#[derive(Debug)]
+pub(crate) struct SecureRoot {
+    path: PathBuf,
+    target: TargetPath,
+    descriptor: Arc<OwnedFd>,
+}
+
+impl SecureRoot {
+    pub(crate) fn open_or_create(path: &Path, target: TargetPath) -> io::Result<Self> {
+        let descriptor = open_or_create_absolute_directory(path)?;
+        require_private_owned_directory(&descriptor)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            target,
+            descriptor: Arc::new(descriptor),
+        })
+    }
+
+    pub(crate) fn descriptor(&self) -> &OwnedFd {
+        &self.descriptor
+    }
+
+    pub(crate) fn ensure_owned_directory(&self, target: &TargetPath) -> io::Result<()> {
+        let components = self.relative_components(target)?;
+        let mut current = self.descriptor.try_clone()?;
+        for component in components {
+            current = open_or_create_child_directory(&current, &component)?;
+            require_private_owned_directory(&current)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn require_directory_absent(&self, target: &TargetPath) -> io::Result<()> {
+        let components = self.relative_components(target)?;
+        let (name, parents) = components
+            .split_last()
+            .ok_or_else(|| io::Error::from(io::ErrorKind::PermissionDenied))?;
+        let mut parent = self.descriptor.try_clone()?;
+        for component in parents {
+            parent = match openat(&parent, component, DIRECTORY_FLAGS, Mode::empty()) {
+                Ok(directory) => directory,
+                Err(Errno::NOENT) => return Ok(()),
+                Err(error) => return Err(error.into()),
+            };
+            require_private_owned_directory(&parent)?;
+        }
+        match openat(
+            &parent,
+            name,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+            Mode::empty(),
+        ) {
+            Err(Errno::NOENT) => Ok(()),
+            Ok(_) | Err(Errno::LOOP | Errno::NOTDIR) => {
+                Err(io::Error::from(io::ErrorKind::AlreadyExists))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(crate) fn remove_owned_tree(&self, target: &TargetPath) -> io::Result<()> {
+        let components = self.relative_components(target)?;
+        let (parent, name) = self.open_parent(&components)?;
+        let directory = match openat(&parent, &name, DIRECTORY_FLAGS, Mode::empty()) {
+            Ok(directory) => directory,
+            Err(Errno::NOENT) => return Ok(()),
+            Err(error) => return Err(error.into()),
+        };
+        require_private_owned_directory(&directory)?;
+        remove_directory_contents(&directory)?;
+        unlinkat(&parent, &name, AtFlags::REMOVEDIR).map_err(io::Error::from)?;
+        fs::fsync(&parent).map_err(io::Error::from)
+    }
+
+    pub(crate) fn resolve_owned_target(
+        &self,
+        target: &TargetPath,
+        workspace: &TargetPath,
+        scratch: &TargetPath,
+    ) -> io::Result<OwnedTarget> {
+        let boundary = if target == workspace || is_strict_descendant(target, workspace) {
+            workspace
+        } else if target == scratch || is_strict_descendant(target, scratch) {
+            scratch
+        } else {
+            return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+        };
+        let boundary_components = self.relative_components(boundary)?;
+        let boundary_descriptor = self.open_directory_components(&boundary_components)?;
+        let relative = Path::new(target.as_str())
+            .strip_prefix(Path::new(boundary.as_str()))
+            .map_err(|_| io::Error::from(io::ErrorKind::PermissionDenied))?
+            .components()
+            .map(component_name)
+            .collect::<io::Result<Vec<_>>>()?;
+        Ok(OwnedTarget {
+            host: PathBuf::from(target.as_str()),
+            boundary: Arc::new(boundary_descriptor),
+            relative,
+        })
+    }
+
+    fn relative_components(&self, target: &TargetPath) -> io::Result<Vec<OsString>> {
+        if target.platform() != TargetPlatform::Posix || !is_strict_descendant(target, &self.target)
+        {
+            return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+        }
+        Path::new(target.as_str())
+            .strip_prefix(&self.path)
+            .map_err(|_| io::Error::from(io::ErrorKind::PermissionDenied))?
+            .components()
+            .map(component_name)
+            .collect()
+    }
+
+    fn open_parent(&self, components: &[OsString]) -> io::Result<(OwnedFd, OsString)> {
+        let (name, parents) = components
+            .split_last()
+            .ok_or_else(|| io::Error::from(io::ErrorKind::PermissionDenied))?;
+        Ok((self.open_directory_components(parents)?, name.clone()))
+    }
+
+    fn open_directory_components(&self, components: &[OsString]) -> io::Result<OwnedFd> {
+        let mut current = self.descriptor.try_clone()?;
+        for component in components {
+            current = openat(&current, component, DIRECTORY_FLAGS, Mode::empty())
+                .map_err(io::Error::from)?;
+            require_private_owned_directory(&current)?;
+        }
+        Ok(current)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct OwnedTarget {
+    host: PathBuf,
+    boundary: Arc<OwnedFd>,
+    relative: Vec<OsString>,
+}
+
+impl OwnedTarget {
+    fn open_parent(&self) -> io::Result<(OwnedFd, &OsString)> {
+        let (name, parents) = self
+            .relative
+            .split_last()
+            .ok_or_else(|| io::Error::from(io::ErrorKind::IsADirectory))?;
+        let mut current = self.boundary.try_clone()?;
+        for component in parents {
+            current = openat(&current, component, DIRECTORY_FLAGS, Mode::empty())
+                .map_err(io::Error::from)?;
+            require_owned_directory(&current)?;
+        }
+        Ok((current, name))
+    }
+}
+
+pub(crate) fn require_directory(target: &OwnedTarget) -> io::Result<PathBuf> {
+    let mut current = target.boundary.try_clone()?;
+    for component in &target.relative {
+        current =
+            openat(&current, component, DIRECTORY_FLAGS, Mode::empty()).map_err(io::Error::from)?;
+        require_owned_directory(&current)?;
+    }
+    Ok(target.host.clone())
+}
+
+pub(crate) fn require_executable(target: &TargetPath) -> io::Result<PathBuf> {
+    if target.platform() != TargetPlatform::Posix || target.as_str() == "/" {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    let path = Path::new(target.as_str());
+    let (name, parent) = path
+        .file_name()
+        .zip(path.parent())
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+    let parent = open_absolute_directory(parent)?;
+    let executable = openat(
+        &parent,
+        name,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    let stat = fstat(&executable).map_err(io::Error::from)?;
+    if FileType::from_raw_mode(stat.st_mode) != FileType::RegularFile || stat.st_mode & 0o111 == 0 {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    Ok(path.to_path_buf())
+}
+
+pub(crate) fn write_owned_file(target: &OwnedTarget, content: &[u8]) -> io::Result<()> {
+    let (parent, name) = target.open_parent()?;
+    let descriptor = openat(
+        &parent,
+        name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        FILE_MODE,
+    )
+    .map_err(open_error)?;
+    require_single_link_regular_file(&descriptor)?;
+    fs::ftruncate(&descriptor, 0).map_err(io::Error::from)?;
+    fchmod(&descriptor, FILE_MODE).map_err(io::Error::from)?;
+    let mut file = File::from(descriptor);
+    file.write_all(content)?;
+    file.sync_all()?;
+    fs::fsync(&parent).map_err(io::Error::from)
+}
+
+pub(crate) fn read_owned_file(target: &OwnedTarget, byte_limit: usize) -> io::Result<Vec<u8>> {
+    let (parent, name) = target.open_parent()?;
+    let descriptor = openat(
+        &parent,
+        name,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(open_error)?;
+    require_single_link_regular_file(&descriptor)?;
+    let mut content = Vec::new();
+    File::from(descriptor)
+        .take(
+            u64::try_from(byte_limit)
+                .unwrap_or(u64::MAX)
+                .saturating_add(1),
+        )
+        .read_to_end(&mut content)?;
+    if content.len() > byte_limit {
+        return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+    }
+    Ok(content)
+}
+
+fn open_or_create_absolute_directory(path: &Path) -> io::Result<OwnedFd> {
+    if !path.is_absolute() || path == Path::new("/") {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    let mut current = open("/", DIRECTORY_FLAGS, Mode::empty()).map_err(io::Error::from)?;
+    let components = path
+        .components()
+        .skip(1)
+        .map(component_name)
+        .collect::<io::Result<Vec<_>>>()?;
+    for component in components {
+        current = open_or_create_child_directory(&current, &component)?;
+    }
+    Ok(current)
+}
+
+fn open_absolute_directory(path: &Path) -> io::Result<OwnedFd> {
+    if !path.is_absolute() {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    let mut current = open("/", DIRECTORY_FLAGS, Mode::empty()).map_err(io::Error::from)?;
+    for component in path.components().skip(1) {
+        current = openat(
+            &current,
+            component_name(component)?,
+            DIRECTORY_FLAGS,
+            Mode::empty(),
+        )
+        .map_err(io::Error::from)?;
+    }
+    Ok(current)
+}
+
+fn open_or_create_child_directory(parent: &OwnedFd, name: &OsString) -> io::Result<OwnedFd> {
+    match openat(parent, name, DIRECTORY_FLAGS, Mode::empty()) {
+        Ok(directory) => Ok(directory),
+        Err(Errno::NOENT) => {
+            match mkdirat(parent, name, DIRECTORY_MODE) {
+                Ok(()) | Err(Errno::EXIST) => {}
+                Err(error) => return Err(error.into()),
+            }
+            fs::fsync(parent).map_err(io::Error::from)?;
+            openat(parent, name, DIRECTORY_FLAGS, Mode::empty()).map_err(io::Error::from)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_directory_contents(directory: &OwnedFd) -> io::Result<()> {
+    let entries = Dir::read_from(directory).map_err(io::Error::from)?;
+    for entry in entries {
+        let entry = entry.map_err(io::Error::from)?;
+        let name = entry.file_name();
+        if is_dot(name) {
+            continue;
+        }
+        match openat(directory, name, DIRECTORY_FLAGS, Mode::empty()) {
+            Ok(child) => {
+                require_owned_directory(&child)?;
+                remove_directory_contents(&child)?;
+                unlinkat(directory, name, AtFlags::REMOVEDIR).map_err(io::Error::from)?;
+            }
+            Err(Errno::NOTDIR | Errno::LOOP) => {
+                unlinkat(directory, name, AtFlags::empty()).map_err(io::Error::from)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    fs::fsync(directory).map_err(io::Error::from)
+}
+
+fn require_private_owned_directory(descriptor: &OwnedFd) -> io::Result<()> {
+    require_owned_directory(descriptor)?;
+    let stat = fstat(descriptor).map_err(io::Error::from)?;
+    if stat.st_mode & 0o077 != 0 {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    Ok(())
+}
+
+fn require_owned_directory(descriptor: &OwnedFd) -> io::Result<()> {
+    let stat = fstat(descriptor).map_err(io::Error::from)?;
+    if FileType::from_raw_mode(stat.st_mode) != FileType::Directory
+        || stat.st_uid != rustix::process::geteuid().as_raw()
+    {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    Ok(())
+}
+
+fn require_single_link_regular_file(descriptor: &OwnedFd) -> io::Result<()> {
+    let stat = fstat(descriptor).map_err(io::Error::from)?;
+    if FileType::from_raw_mode(stat.st_mode) != FileType::RegularFile
+        || stat.st_uid != rustix::process::geteuid().as_raw()
+        || stat.st_nlink != 1
+    {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    Ok(())
+}
+
+fn component_name(component: Component<'_>) -> io::Result<OsString> {
+    match component {
+        Component::Normal(value) if !value.as_bytes().is_empty() => Ok(value.to_os_string()),
+        _ => Err(io::Error::from(io::ErrorKind::InvalidInput)),
+    }
+}
+
+fn is_dot(name: &CStr) -> bool {
+    matches!(name.to_bytes(), b"." | b"..")
+}
+
+fn open_error(error: Errno) -> io::Error {
+    if error == Errno::LOOP {
+        io::Error::from(io::ErrorKind::PermissionDenied)
+    } else {
+        error.into()
+    }
+}

--- a/crates/automata-ci-sandbox-macos/src/lib.rs
+++ b/crates/automata-ci-sandbox-macos/src/lib.rs
@@ -1,0 +1,34 @@
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+//! Trusted native macOS whole-job sandbox provider.
+//!
+//! This adapter is a process-lifetime boundary for trusted jobs, not a VM or
+//! hostile-workload sandbox. Commands inherit the dedicated runner account,
+//! host network, host filesystem, and shared host resources. A same-binary
+//! supervisor owns each POSIX process group and observes a private control
+//! channel so runner loss terminates the job process tree.
+
+#[cfg(target_os = "macos")]
+mod endpoint;
+#[cfg(target_os = "macos")]
+mod filesystem;
+#[cfg(target_os = "macos")]
+mod path;
+#[cfg(target_os = "macos")]
+mod persistence;
+#[cfg(target_os = "macos")]
+mod provider;
+#[cfg(target_os = "macos")]
+mod supervisor;
+#[cfg(not(target_os = "macos"))]
+mod unsupported;
+
+#[cfg(target_os = "macos")]
+pub use provider::{MacosSandboxProvider, MacosSandboxProviderOptions};
+#[cfg(target_os = "macos")]
+pub use supervisor::run_supervisor;
+#[cfg(not(target_os = "macos"))]
+pub use unsupported::{MacosSandboxProvider, MacosSandboxProviderOptions, run_supervisor};
+
+/// Hidden command name used for the same-binary command supervisor.
+pub const SUPERVISOR_COMMAND: &str = "__macos-job-supervisor";

--- a/crates/automata-ci-sandbox-macos/src/path.rs
+++ b/crates/automata-ci-sandbox-macos/src/path.rs
@@ -1,0 +1,47 @@
+use std::path::{Component, Path};
+
+use automata_ci_execution::{TargetPath, TargetPlatform};
+
+pub(crate) fn validate_posix_path(path: &TargetPath) -> bool {
+    path.platform() == TargetPlatform::Posix
+        && path.as_str() != "/"
+        && Path::new(path.as_str())
+            .components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+}
+
+pub(crate) fn is_strict_descendant(path: &TargetPath, root: &TargetPath) -> bool {
+    if !validate_posix_path(path) || !validate_posix_path(root) || path == root {
+        return false;
+    }
+    Path::new(path.as_str())
+        .strip_prefix(Path::new(root.as_str()))
+        .is_ok_and(|relative| {
+            relative
+                .components()
+                .all(|component| matches!(component, Component::Normal(_)))
+        })
+}
+
+pub(crate) fn overlaps(left: &TargetPath, right: &TargetPath) -> bool {
+    left == right || is_strict_descendant(left, right) || is_strict_descendant(right, left)
+}
+
+#[cfg(test)]
+mod tests {
+    use automata_ci_execution::TargetPath;
+
+    use super::{is_strict_descendant, overlaps};
+
+    #[test]
+    fn component_boundaries_prevent_prefix_confusion() {
+        let root = TargetPath::posix("/private/runner").expect("root");
+        let child = TargetPath::posix("/private/runner/jobs/a").expect("child");
+        let prefix = TargetPath::posix("/private/runner-evil/a").expect("prefix");
+
+        assert!(is_strict_descendant(&child, &root));
+        assert!(!is_strict_descendant(&prefix, &root));
+        assert!(overlaps(&root, &child));
+        assert!(!overlaps(&root, &prefix));
+    }
+}

--- a/crates/automata-ci-sandbox-macos/src/persistence.rs
+++ b/crates/automata-ci-sandbox-macos/src/persistence.rs
@@ -1,0 +1,425 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{self, BufRead, BufReader, Seek as _, SeekFrom, Write as _},
+};
+
+use automata_ci_execution::{
+    DestroyDisposition, EnvironmentProfile, OperationId, SandboxGeneration,
+};
+use rustix::{
+    fs::{self, FlockOperation, Mode, OFlags, fchmod, flock, fstat, openat},
+    io::Errno,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::filesystem::SecureRoot;
+
+const LOCK_FILE_NAME: &str = ".automata-macos-provider-v1.lock";
+const JOURNAL_FILE_NAME: &str = ".automata-macos-provider-v1.events";
+const DURABLE_SCHEMA: u32 = 1;
+const MAX_EVENT_BYTES: usize = 64 * 1024;
+const MAX_JOURNAL_BYTES: u64 = 16 * 1024 * 1024;
+const FILE_MODE: Mode = Mode::from_raw_mode(0o600);
+
+#[derive(Default)]
+pub(crate) struct DurableSnapshot {
+    pub(crate) creates: HashMap<OperationId, DurableCreate>,
+    pub(crate) pending_destroys: HashMap<OperationId, DurableDestroyRequest>,
+    pub(crate) destroys: HashMap<OperationId, DurableDestroy>,
+    pub(crate) entries: HashMap<String, DurableEntry>,
+    pub(crate) tombstones: HashMap<String, DurableTombstone>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableCreate {
+    pub(crate) operation_id: OperationId,
+    pub(crate) fingerprint: [u8; 32],
+    pub(crate) handle: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableEntry {
+    pub(crate) handle: String,
+    pub(crate) generation: u64,
+    pub(crate) profile: EnvironmentProfile,
+    pub(crate) workspace: String,
+    pub(crate) scratch: String,
+    pub(crate) phase: DurableEntryPhase,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DurableEntryPhase {
+    Intent,
+    Running,
+    Destroying,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableDestroyRequest {
+    pub(crate) operation_id: OperationId,
+    pub(crate) handle: String,
+    pub(crate) generation: u64,
+    pub(crate) profile: EnvironmentProfile,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableDestroy {
+    pub(crate) request: DurableDestroyRequest,
+    pub(crate) disposition: DurableDestroyDisposition,
+    pub(crate) completed_sequence: u64,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DurableDestroyDisposition {
+    Destroyed,
+    AlreadyAbsent,
+}
+
+impl From<DurableDestroyDisposition> for DestroyDisposition {
+    fn from(value: DurableDestroyDisposition) -> Self {
+        match value {
+            DurableDestroyDisposition::Destroyed => Self::Destroyed,
+            DurableDestroyDisposition::AlreadyAbsent => Self::AlreadyAbsent,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableTombstone {
+    pub(crate) handle: String,
+    pub(crate) generation: u64,
+    pub(crate) profile: EnvironmentProfile,
+    pub(crate) completed_sequence: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum DurableEvent {
+    CreateIntent {
+        create: DurableCreate,
+        entry: DurableEntry,
+    },
+    CreateReady {
+        handle: String,
+    },
+    DestroyIntent {
+        request: DurableDestroyRequest,
+    },
+    DestroyComplete {
+        operation_id: OperationId,
+    },
+    DestroyAbsent {
+        request: DurableDestroyRequest,
+    },
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EventRecord {
+    schema: u32,
+    sequence: u64,
+    checksum: [u8; 32],
+    event: DurableEvent,
+}
+
+pub(crate) struct LifecycleJournal {
+    _lock: File,
+    journal: File,
+    next_sequence: u64,
+}
+
+impl LifecycleJournal {
+    pub(crate) fn open(root: &SecureRoot) -> io::Result<(Self, DurableSnapshot)> {
+        let lock = open_private_file(root, LOCK_FILE_NAME, false)?;
+        flock(&lock, FlockOperation::NonBlockingLockExclusive).map_err(|error| {
+            if error == Errno::AGAIN {
+                io::Error::from(io::ErrorKind::WouldBlock)
+            } else {
+                error.into()
+            }
+        })?;
+        let mut journal = File::from(open_private_file(root, JOURNAL_FILE_NAME, false)?);
+        if journal.metadata()?.len() > MAX_JOURNAL_BYTES {
+            return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+        }
+        journal.seek(SeekFrom::Start(0))?;
+
+        let mut snapshot = DurableSnapshot::default();
+        let mut expected_sequence = 1_u64;
+        let mut valid_length = 0_u64;
+        let mut unterminated_tail = false;
+        {
+            let mut reader = BufReader::new(&mut journal);
+            loop {
+                match read_bounded_record(&mut reader)? {
+                    RecordRead::End => break,
+                    RecordRead::Unterminated => {
+                        unterminated_tail = true;
+                        break;
+                    }
+                    RecordRead::Complete(bytes) => {
+                        let record: EventRecord = serde_json::from_slice(&bytes)
+                            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                        if record.schema != DURABLE_SCHEMA
+                            || record.sequence != expected_sequence
+                            || checksum(record.sequence, &record.event)? != record.checksum
+                        {
+                            return Err(io::Error::from(io::ErrorKind::InvalidData));
+                        }
+                        apply_event(&mut snapshot, &record.event, record.sequence)?;
+                        expected_sequence = expected_sequence
+                            .checked_add(1)
+                            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+                        valid_length = valid_length
+                            .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX) + 1)
+                            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+                    }
+                }
+            }
+        }
+        if unterminated_tail {
+            journal.set_len(valid_length)?;
+            journal.sync_all()?;
+        }
+        journal.seek(SeekFrom::End(0))?;
+        Ok((
+            Self {
+                _lock: File::from(lock),
+                journal,
+                next_sequence: expected_sequence,
+            },
+            snapshot,
+        ))
+    }
+
+    pub(crate) fn append(&mut self, event: DurableEvent) -> io::Result<u64> {
+        let sequence = self.next_sequence;
+        let record = EventRecord {
+            schema: DURABLE_SCHEMA,
+            sequence,
+            checksum: checksum(sequence, &event)?,
+            event,
+        };
+        let mut bytes = serde_json::to_vec(&record)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if bytes.is_empty() || bytes.len() > MAX_EVENT_BYTES {
+            return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+        }
+        let future_length = self
+            .journal
+            .metadata()?
+            .len()
+            .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX) + 1)
+            .ok_or_else(|| io::Error::from(io::ErrorKind::FileTooLarge))?;
+        if future_length > MAX_JOURNAL_BYTES {
+            return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+        }
+        bytes.push(b'\n');
+        self.journal.write_all(&bytes)?;
+        self.journal.flush()?;
+        self.journal.sync_all()?;
+        self.next_sequence = sequence
+            .checked_add(1)
+            .ok_or_else(|| io::Error::from(io::ErrorKind::FileTooLarge))?;
+        Ok(sequence)
+    }
+
+    pub(crate) fn append_to_snapshot(
+        &mut self,
+        snapshot: &mut DurableSnapshot,
+        event: &DurableEvent,
+    ) -> io::Result<u64> {
+        let sequence = self.append(event.clone())?;
+        apply_event(snapshot, event, sequence)?;
+        Ok(sequence)
+    }
+}
+
+fn open_private_file(
+    root: &SecureRoot,
+    name: &str,
+    append: bool,
+) -> io::Result<rustix::fd::OwnedFd> {
+    let mut flags = OFlags::RDWR | OFlags::CREATE | OFlags::CLOEXEC | OFlags::NOFOLLOW;
+    if append {
+        flags |= OFlags::APPEND;
+    }
+    let descriptor = openat(root.descriptor(), name, flags, FILE_MODE).map_err(io::Error::from)?;
+    let stat = fstat(&descriptor).map_err(io::Error::from)?;
+    if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::RegularFile
+        || stat.st_uid != rustix::process::geteuid().as_raw()
+        || stat.st_nlink != 1
+    {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    fchmod(&descriptor, FILE_MODE).map_err(io::Error::from)?;
+    fs::fsync(root.descriptor()).map_err(io::Error::from)?;
+    Ok(descriptor)
+}
+
+enum RecordRead {
+    End,
+    Complete(Vec<u8>),
+    Unterminated,
+}
+
+fn read_bounded_record(reader: &mut impl BufRead) -> io::Result<RecordRead> {
+    let mut record = Vec::new();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return if record.is_empty() {
+                Ok(RecordRead::End)
+            } else {
+                Ok(RecordRead::Unterminated)
+            };
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            let length = record
+                .len()
+                .checked_add(newline)
+                .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+            if length == 0 || length > MAX_EVENT_BYTES {
+                return Err(io::Error::from(io::ErrorKind::InvalidData));
+            }
+            record.extend_from_slice(&available[..newline]);
+            reader.consume(newline + 1);
+            return Ok(RecordRead::Complete(record));
+        }
+        if record.len().saturating_add(available.len()) > MAX_EVENT_BYTES {
+            return Err(io::Error::from(io::ErrorKind::InvalidData));
+        }
+        record.extend_from_slice(available);
+        let consumed = available.len();
+        reader.consume(consumed);
+    }
+}
+
+fn checksum(sequence: u64, event: &DurableEvent) -> io::Result<[u8; 32]> {
+    let bytes = serde_json::to_vec(&(DURABLE_SCHEMA, sequence, event))
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    Ok(Sha256::digest(bytes).into())
+}
+
+fn apply_event(
+    snapshot: &mut DurableSnapshot,
+    event: &DurableEvent,
+    sequence: u64,
+) -> io::Result<()> {
+    match event {
+        DurableEvent::CreateIntent { create, entry } => {
+            if create.handle != entry.handle
+                || entry.phase != DurableEntryPhase::Intent
+                || snapshot.creates.contains_key(&create.operation_id)
+                || snapshot.entries.contains_key(&entry.handle)
+                || snapshot.tombstones.contains_key(&entry.handle)
+            {
+                return Err(invalid());
+            }
+            snapshot.creates.insert(create.operation_id, create.clone());
+            snapshot.entries.insert(entry.handle.clone(), entry.clone());
+        }
+        DurableEvent::CreateReady { handle } => {
+            let entry = snapshot.entries.get_mut(handle).ok_or_else(invalid)?;
+            if entry.phase != DurableEntryPhase::Intent {
+                return Err(invalid());
+            }
+            entry.phase = DurableEntryPhase::Running;
+        }
+        DurableEvent::DestroyIntent { request } => {
+            let entry = snapshot
+                .entries
+                .get_mut(&request.handle)
+                .ok_or_else(invalid)?;
+            if entry.generation != request.generation
+                || entry.profile != request.profile
+                || entry.phase == DurableEntryPhase::Destroying
+                || snapshot
+                    .pending_destroys
+                    .contains_key(&request.operation_id)
+                || snapshot.destroys.contains_key(&request.operation_id)
+                || snapshot
+                    .pending_destroys
+                    .values()
+                    .any(|pending| pending.handle == request.handle)
+            {
+                return Err(invalid());
+            }
+            entry.phase = DurableEntryPhase::Destroying;
+            snapshot
+                .pending_destroys
+                .insert(request.operation_id, request.clone());
+        }
+        DurableEvent::DestroyComplete { operation_id } => {
+            let request = snapshot
+                .pending_destroys
+                .remove(operation_id)
+                .ok_or_else(invalid)?;
+            let entry = snapshot
+                .entries
+                .remove(&request.handle)
+                .ok_or_else(invalid)?;
+            if entry.phase != DurableEntryPhase::Destroying
+                || entry.generation != request.generation
+                || entry.profile != request.profile
+            {
+                return Err(invalid());
+            }
+            snapshot.tombstones.insert(
+                request.handle.clone(),
+                DurableTombstone {
+                    handle: request.handle.clone(),
+                    generation: request.generation,
+                    profile: request.profile.clone(),
+                    completed_sequence: sequence,
+                },
+            );
+            snapshot.destroys.insert(
+                *operation_id,
+                DurableDestroy {
+                    request,
+                    disposition: DurableDestroyDisposition::Destroyed,
+                    completed_sequence: sequence,
+                },
+            );
+        }
+        DurableEvent::DestroyAbsent { request } => {
+            let tombstone = snapshot
+                .tombstones
+                .get(&request.handle)
+                .ok_or_else(invalid)?;
+            if tombstone.generation != request.generation
+                || tombstone.profile != request.profile
+                || snapshot.destroys.contains_key(&request.operation_id)
+            {
+                return Err(invalid());
+            }
+            snapshot.destroys.insert(
+                request.operation_id,
+                DurableDestroy {
+                    request: request.clone(),
+                    disposition: DurableDestroyDisposition::AlreadyAbsent,
+                    completed_sequence: sequence,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn recovered_generation(value: u64) -> io::Result<SandboxGeneration> {
+    SandboxGeneration::new(value).map_err(|_| invalid())
+}
+
+fn invalid() -> io::Error {
+    io::Error::from(io::ErrorKind::InvalidData)
+}

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -1,0 +1,1120 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Arc, Mutex, MutexGuard, TryLockError},
+    time::{Duration, Instant},
+};
+
+use automata_ci_execution::{
+    Cancellation, DestroyDisposition, DestroySandbox, EnvironmentProfile, ExecutionEndpoint,
+    NetworkPolicy, OperationId, OperationOutcome, ProviderCapabilities, ProviderError,
+    ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy, SandboxCapability,
+    SandboxGeneration, SandboxHandle, SandboxInspection, SandboxLaunch, SandboxPrivilegePolicy,
+    SandboxProvider, SandboxRecord, SandboxResourcePolicy, SandboxSpec, SandboxState, TargetPath,
+    TargetPlatform,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::{
+    endpoint::MacosExecutionEndpoint,
+    filesystem::{SecureRoot, require_executable},
+    path::{is_strict_descendant, overlaps, validate_posix_path},
+    persistence::{
+        DurableCreate, DurableDestroyRequest, DurableEntry, DurableEntryPhase, DurableEvent,
+        DurableSnapshot, DurableTombstone, LifecycleJournal, recovered_generation,
+    },
+};
+
+const QUIESCE_TIMEOUT: Duration = Duration::from_secs(5);
+const QUIESCE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+const PROVIDER_CAPABILITIES: [SandboxCapability; 11] = [
+    SandboxCapability::WholeJob,
+    SandboxCapability::Attach,
+    SandboxCapability::Inspect,
+    SandboxCapability::Exec,
+    SandboxCapability::CopyTo,
+    SandboxCapability::CopyFrom,
+    SandboxCapability::EnvironmentInjection,
+    SandboxCapability::HostNetwork,
+    SandboxCapability::HostFilesystem,
+    SandboxCapability::HostIdentity,
+    SandboxCapability::HostResources,
+];
+
+pub(crate) const ENDPOINT_CAPABILITIES: [SandboxCapability; 4] = [
+    SandboxCapability::Exec,
+    SandboxCapability::CopyTo,
+    SandboxCapability::CopyFrom,
+    SandboxCapability::EnvironmentInjection,
+];
+
+/// Immutable host roots and same-binary supervisor executable for native macOS.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MacosSandboxProviderOptions {
+    provider_root: PathBuf,
+    provider_target: TargetPath,
+    supervisor_executable: PathBuf,
+}
+
+impl MacosSandboxProviderOptions {
+    /// Creates a provider configuration rooted at one dedicated private path.
+    ///
+    /// Sandbox workspace and scratch directories must be distinct strict
+    /// descendants of this root. `supervisor_executable` must be the absolute
+    /// path of the shipped `automata-runner` binary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-absolute, non-Unicode, root, non-normalized, or mismatched
+    /// POSIX paths.
+    pub fn new(
+        provider_root: impl Into<PathBuf>,
+        supervisor_executable: impl Into<PathBuf>,
+    ) -> Result<Self, ProviderError> {
+        let provider_root = provider_root.into();
+        let supervisor_executable = supervisor_executable.into();
+        let provider = provider_root.to_str().ok_or_else(|| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let provider_target = TargetPath::posix(provider.to_owned()).map_err(|_| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        if !validate_posix_path(&provider_target)
+            || !supervisor_executable.is_absolute()
+            || supervisor_executable.to_str().is_none()
+        {
+            return Err(known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            ));
+        }
+        Ok(Self {
+            provider_root,
+            provider_target,
+            supervisor_executable,
+        })
+    }
+
+    /// Returns the dedicated provider-owned root.
+    #[must_use]
+    pub fn provider_root(&self) -> &Path {
+        &self.provider_root
+    }
+
+    /// Returns the exact same-binary supervisor executable.
+    #[must_use]
+    pub fn supervisor_executable(&self) -> &Path {
+        &self.supervisor_executable
+    }
+
+    pub(crate) const fn provider_target(&self) -> &TargetPath {
+        &self.provider_target
+    }
+}
+
+/// Trusted native macOS provider backed by supervised POSIX process groups.
+///
+/// Clones share the exclusive lifecycle lock and all operation-replay state.
+/// The provider exposes host-shared semantics and must not be used for
+/// untrusted workflows.
+#[derive(Clone)]
+pub struct MacosSandboxProvider {
+    inner: Arc<ProviderInner>,
+}
+
+impl MacosSandboxProvider {
+    /// Opens and exclusively locks the provider root, then reconciles orphaned
+    /// lifecycle entries before accepting work.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unsupported macOS hosts, insecure roots or supervisor paths,
+    /// concurrent opens, corrupt state, and failed recovery cleanup.
+    pub fn open(options: MacosSandboxProviderOptions) -> Result<Self, ProviderError> {
+        require_supported_host()?;
+        let supervisor = options
+            .supervisor_executable()
+            .to_str()
+            .and_then(|path| TargetPath::posix(path.to_owned()).ok())
+            .ok_or_else(|| {
+                known(
+                    ProviderErrorKind::InvalidConfiguration,
+                    ProviderStage::Validate,
+                )
+            })?;
+        require_executable(&supervisor).map_err(|_| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let root =
+            SecureRoot::open_or_create(options.provider_root(), options.provider_target().clone())
+                .map_err(|_| {
+                    known(
+                        ProviderErrorKind::InvalidConfiguration,
+                        ProviderStage::CreateWorkspace,
+                    )
+                })?;
+        let provider_id = ProviderId::new("macos-native").map_err(|_| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let capabilities = ProviderCapabilities::new(PROVIDER_CAPABILITIES).map_err(|_| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let (mut journal, mut snapshot) = LifecycleJournal::open(&root).map_err(|error| {
+            let kind = if error.kind() == std::io::ErrorKind::WouldBlock {
+                ProviderErrorKind::Conflict
+            } else {
+                ProviderErrorKind::LocalStorage
+            };
+            known(kind, ProviderStage::Validate)
+        })?;
+        validate_snapshot_paths(&options, &snapshot)?;
+        reconcile_orphans(&root, &mut journal, &mut snapshot)?;
+        let state = restore_state(&provider_id, journal, snapshot)?;
+        Ok(Self {
+            inner: Arc::new(ProviderInner {
+                provider_id,
+                capabilities,
+                options,
+                root,
+                state: Mutex::new(state),
+            }),
+        })
+    }
+}
+
+impl fmt::Debug for MacosSandboxProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MacosSandboxProvider")
+            .field("provider_id", &self.inner.provider_id)
+            .field("capabilities", &self.inner.capabilities)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SandboxProvider for MacosSandboxProvider {
+    fn provider_id(&self) -> &ProviderId {
+        &self.inner.provider_id
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.inner.capabilities
+    }
+
+    fn create(
+        &self,
+        spec: &SandboxSpec,
+        cancellation: &dyn Cancellation,
+    ) -> Result<SandboxRecord, ProviderError> {
+        self.inner.create(spec, cancellation)
+    }
+
+    fn attach(
+        &self,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ProviderError> {
+        self.inner.attach(handle, cancellation)
+    }
+
+    fn inspect(
+        &self,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+    ) -> Result<SandboxInspection, ProviderError> {
+        self.inner.inspect(handle, cancellation)
+    }
+
+    fn destroy(
+        &self,
+        request: &DestroySandbox,
+        cancellation: &dyn Cancellation,
+    ) -> Result<DestroyDisposition, ProviderError> {
+        self.inner.destroy(request, cancellation)
+    }
+}
+
+pub(crate) struct SandboxEntry {
+    pub(crate) handle: SandboxHandle,
+    pub(crate) generation: SandboxGeneration,
+    pub(crate) profile: EnvironmentProfile,
+    pub(crate) workspace: TargetPath,
+    pub(crate) scratch: TargetPath,
+    pub(crate) operation_lock: Mutex<()>,
+    pub(crate) endpoint_state: Mutex<crate::endpoint::EndpointState>,
+    phase: Mutex<DurableEntryPhase>,
+}
+
+impl SandboxEntry {
+    pub(crate) fn state(&self) -> Result<SandboxState, ()> {
+        self.phase
+            .lock()
+            .map(|phase| match *phase {
+                DurableEntryPhase::Intent => SandboxState::Created,
+                DurableEntryPhase::Running => SandboxState::Running,
+                DurableEntryPhase::Destroying => SandboxState::Stopped,
+            })
+            .map_err(|_| ())
+    }
+
+    fn set_phase(&self, phase: DurableEntryPhase) -> Result<(), ()> {
+        *self.phase.lock().map_err(|_| ())? = phase;
+        Ok(())
+    }
+
+    fn record(&self) -> Result<SandboxRecord, ProviderError> {
+        Ok(SandboxRecord::new(
+            self.handle.clone(),
+            self.generation,
+            self.profile.clone(),
+            self.state().map_err(|()| local(ProviderStage::Inspect))?,
+        ))
+    }
+
+    fn inspection(&self) -> Result<SandboxInspection, ProviderError> {
+        Ok(SandboxInspection::new(
+            self.handle.clone(),
+            self.generation,
+            self.profile.clone(),
+            self.state().map_err(|()| local(ProviderStage::Inspect))?,
+        ))
+    }
+}
+
+pub(crate) struct ProviderInner {
+    provider_id: ProviderId,
+    capabilities: ProviderCapabilities,
+    pub(crate) options: MacosSandboxProviderOptions,
+    pub(crate) root: SecureRoot,
+    state: Mutex<ProviderState>,
+}
+
+impl fmt::Debug for ProviderInner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderInner")
+            .field("provider_id", &self.provider_id)
+            .field("capabilities", &self.capabilities)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProviderInner {
+    fn lock_state(
+        &self,
+        stage: ProviderStage,
+    ) -> Result<MutexGuard<'_, ProviderState>, ProviderError> {
+        self.state.lock().map_err(|_| local(stage))
+    }
+
+    fn create(
+        &self,
+        spec: &SandboxSpec,
+        cancellation: &dyn Cancellation,
+    ) -> Result<SandboxRecord, ProviderError> {
+        validate_spec(&self.options, spec)?;
+        require_not_cancelled(cancellation, ProviderStage::Validate)?;
+        let fingerprint = spec_fingerprint(spec)?;
+        let mut state = self.lock_state(ProviderStage::CreateSandbox)?;
+        if let Some(replay) = state.create_operations.get(&spec.operation_id()) {
+            if replay.fingerprint != fingerprint {
+                return Err(known(ProviderErrorKind::Conflict, ProviderStage::Validate));
+            }
+            if let Some(entry) = state.entries.get(&replay.handle).cloned() {
+                return resume_create(&self.root, &mut state, &entry, cancellation);
+            }
+            if let Some(tombstone) = state.tombstones.get(&replay.handle) {
+                return Ok(SandboxRecord::new(
+                    tombstone.handle.clone(),
+                    tombstone.generation,
+                    tombstone.profile.clone(),
+                    SandboxState::Absent,
+                ));
+            }
+            return Err(known(
+                ProviderErrorKind::InvalidState,
+                ProviderStage::CreateSandbox,
+            ));
+        }
+        if !state.entries.is_empty() {
+            return Err(known(ProviderErrorKind::Conflict, ProviderStage::Validate));
+        }
+        let scratch = spec.scratch().ok_or_else(|| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        self.root
+            .require_directory_absent(spec.workspace())
+            .and_then(|()| self.root.require_directory_absent(scratch))
+            .map_err(|error| preflight_error(&error))?;
+        let handle = SandboxHandle::new(self.provider_id.clone(), OperationId::new().to_string())
+            .map_err(|_| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::CreateSandbox,
+            )
+        })?;
+        let entry = Arc::new(SandboxEntry {
+            handle: handle.clone(),
+            generation: spec.generation(),
+            profile: spec.profile().attestation().clone(),
+            workspace: spec.workspace().clone(),
+            scratch: scratch.clone(),
+            operation_lock: Mutex::new(()),
+            endpoint_state: Mutex::new(crate::endpoint::EndpointState::default()),
+            phase: Mutex::new(DurableEntryPhase::Intent),
+        });
+        let event = DurableEvent::CreateIntent {
+            create: DurableCreate {
+                operation_id: spec.operation_id(),
+                fingerprint,
+                handle: handle.opaque().to_owned(),
+            },
+            entry: durable_entry(&entry, DurableEntryPhase::Intent),
+        };
+        state.journal.append(event).map_err(|_| {
+            uncertain(
+                ProviderErrorKind::LocalStorage,
+                ProviderStage::CreateSandbox,
+                handle.clone(),
+            )
+        })?;
+        state.create_operations.insert(
+            spec.operation_id(),
+            CreateReplay {
+                fingerprint,
+                handle: handle.clone(),
+            },
+        );
+        state.entries.insert(handle, Arc::clone(&entry));
+        resume_create(&self.root, &mut state, &entry, cancellation)
+    }
+
+    fn attach(
+        self: &Arc<Self>,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ProviderError> {
+        require_not_cancelled(cancellation, ProviderStage::Attach)?;
+        self.require_owned_handle(handle, ProviderStage::Attach)?;
+        let state = self.lock_state(ProviderStage::Attach)?;
+        let entry = state
+            .entries
+            .get(handle)
+            .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::Attach))?;
+        if entry.state().map_err(|()| local(ProviderStage::Attach))? != SandboxState::Running {
+            return Err(known(
+                ProviderErrorKind::InvalidState,
+                ProviderStage::Attach,
+            ));
+        }
+        Ok(Box::new(MacosExecutionEndpoint::new(
+            Arc::clone(self),
+            Arc::clone(entry),
+        )))
+    }
+
+    fn inspect(
+        &self,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+    ) -> Result<SandboxInspection, ProviderError> {
+        require_not_cancelled(cancellation, ProviderStage::Inspect)?;
+        self.require_owned_handle(handle, ProviderStage::Inspect)?;
+        let state = self.lock_state(ProviderStage::Inspect)?;
+        if let Some(entry) = state.entries.get(handle) {
+            return entry.inspection();
+        }
+        state
+            .tombstones
+            .get(handle)
+            .map(Tombstone::inspection)
+            .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::Inspect))
+    }
+
+    fn destroy(
+        &self,
+        request: &DestroySandbox,
+        cancellation: &dyn Cancellation,
+    ) -> Result<DestroyDisposition, ProviderError> {
+        require_not_cancelled(cancellation, ProviderStage::DestroySandbox)?;
+        self.require_owned_handle(request.handle(), ProviderStage::VerifyOwnership)?;
+        let mut state = self.lock_state(ProviderStage::DestroySandbox)?;
+        if let Some(replay) = state.destroy_operations.get(&request.operation_id()) {
+            return if replay.request == *request {
+                Ok(replay.disposition)
+            } else {
+                Err(known(
+                    ProviderErrorKind::Conflict,
+                    ProviderStage::VerifyOwnership,
+                ))
+            };
+        }
+        if let Some(pending) = state
+            .pending_destroy_operations
+            .get(&request.operation_id())
+            .cloned()
+        {
+            if pending.request != *request {
+                return Err(known(
+                    ProviderErrorKind::Conflict,
+                    ProviderStage::VerifyOwnership,
+                ));
+            }
+            let entry = state
+                .entries
+                .get(request.handle())
+                .cloned()
+                .ok_or_else(invalid_journal)?;
+            return complete_destroy(&self.root, &mut state, &entry, &pending, cancellation);
+        }
+        if state
+            .pending_destroy_operations
+            .values()
+            .any(|pending| pending.request.handle() == request.handle())
+        {
+            return Err(known(
+                ProviderErrorKind::Conflict,
+                ProviderStage::VerifyOwnership,
+            ));
+        }
+        if let Some(tombstone) = state.tombstones.get(request.handle()) {
+            if tombstone.generation != request.generation() {
+                return Err(known(
+                    ProviderErrorKind::OwnershipMismatch,
+                    ProviderStage::VerifyOwnership,
+                ));
+            }
+            let event = DurableEvent::DestroyAbsent {
+                request: durable_destroy_request(request, &tombstone.profile),
+            };
+            state.journal.append(event).map_err(|_| {
+                uncertain(
+                    ProviderErrorKind::LocalStorage,
+                    ProviderStage::DestroySandbox,
+                    request.handle().clone(),
+                )
+            })?;
+            state.destroy_operations.insert(
+                request.operation_id(),
+                DestroyReplay {
+                    request: request.clone(),
+                    disposition: DestroyDisposition::AlreadyAbsent,
+                },
+            );
+            return Ok(DestroyDisposition::AlreadyAbsent);
+        }
+        let entry = state
+            .entries
+            .get(request.handle())
+            .cloned()
+            .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::VerifyOwnership))?;
+        if entry.generation != request.generation() {
+            return Err(known(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::VerifyOwnership,
+            ));
+        }
+        let durable = durable_destroy_request(request, &entry.profile);
+        state
+            .journal
+            .append(DurableEvent::DestroyIntent { request: durable })
+            .map_err(|_| {
+                uncertain(
+                    ProviderErrorKind::LocalStorage,
+                    ProviderStage::DestroySandbox,
+                    entry.handle.clone(),
+                )
+            })?;
+        let pending = PendingDestroy {
+            request: request.clone(),
+            profile: entry.profile.clone(),
+        };
+        state
+            .pending_destroy_operations
+            .insert(request.operation_id(), pending.clone());
+        entry
+            .set_phase(DurableEntryPhase::Destroying)
+            .map_err(|()| local(ProviderStage::DestroySandbox))?;
+        complete_destroy(&self.root, &mut state, &entry, &pending, cancellation)
+    }
+
+    fn require_owned_handle(
+        &self,
+        handle: &SandboxHandle,
+        stage: ProviderStage,
+    ) -> Result<(), ProviderError> {
+        if handle.provider() == &self.provider_id {
+            Ok(())
+        } else {
+            Err(known(ProviderErrorKind::OwnershipMismatch, stage))
+        }
+    }
+}
+
+fn complete_destroy(
+    root: &SecureRoot,
+    state: &mut ProviderState,
+    entry: &Arc<SandboxEntry>,
+    pending: &PendingDestroy,
+    cancellation: &dyn Cancellation,
+) -> Result<DestroyDisposition, ProviderError> {
+    if pending.request.handle() != &entry.handle
+        || pending.request.generation() != entry.generation
+        || pending.profile != entry.profile
+    {
+        return Err(invalid_journal());
+    }
+    let operation = quiesce(entry, cancellation)?;
+    root.remove_owned_tree(&entry.scratch)
+        .and_then(|()| root.remove_owned_tree(&entry.workspace))
+        .map_err(|_| {
+            uncertain(
+                ProviderErrorKind::LocalStorage,
+                ProviderStage::DestroyWorkspace,
+                entry.handle.clone(),
+            )
+        })?;
+    let operation_id = pending.request.operation_id();
+    state
+        .journal
+        .append(DurableEvent::DestroyComplete { operation_id })
+        .map_err(|_| {
+            uncertain(
+                ProviderErrorKind::LocalStorage,
+                ProviderStage::DestroySandbox,
+                entry.handle.clone(),
+            )
+        })?;
+    state.pending_destroy_operations.remove(&operation_id);
+    state.entries.remove(&entry.handle);
+    state.tombstones.insert(
+        entry.handle.clone(),
+        Tombstone {
+            handle: entry.handle.clone(),
+            generation: entry.generation,
+            profile: entry.profile.clone(),
+        },
+    );
+    state.destroy_operations.insert(
+        operation_id,
+        DestroyReplay {
+            request: pending.request.clone(),
+            disposition: DestroyDisposition::Destroyed,
+        },
+    );
+    drop(operation);
+    Ok(DestroyDisposition::Destroyed)
+}
+
+struct ProviderState {
+    journal: LifecycleJournal,
+    create_operations: HashMap<OperationId, CreateReplay>,
+    pending_destroy_operations: HashMap<OperationId, PendingDestroy>,
+    destroy_operations: HashMap<OperationId, DestroyReplay>,
+    entries: HashMap<SandboxHandle, Arc<SandboxEntry>>,
+    tombstones: HashMap<SandboxHandle, Tombstone>,
+}
+
+struct CreateReplay {
+    fingerprint: [u8; 32],
+    handle: SandboxHandle,
+}
+
+#[derive(Clone)]
+struct PendingDestroy {
+    request: DestroySandbox,
+    profile: EnvironmentProfile,
+}
+
+struct DestroyReplay {
+    request: DestroySandbox,
+    disposition: DestroyDisposition,
+}
+
+struct Tombstone {
+    handle: SandboxHandle,
+    generation: SandboxGeneration,
+    profile: EnvironmentProfile,
+}
+
+impl Tombstone {
+    fn inspection(&self) -> SandboxInspection {
+        SandboxInspection::new(
+            self.handle.clone(),
+            self.generation,
+            self.profile.clone(),
+            SandboxState::Absent,
+        )
+    }
+}
+
+fn resume_create(
+    root: &SecureRoot,
+    state: &mut ProviderState,
+    entry: &Arc<SandboxEntry>,
+    cancellation: &dyn Cancellation,
+) -> Result<SandboxRecord, ProviderError> {
+    if entry
+        .state()
+        .map_err(|()| local(ProviderStage::CreateSandbox))?
+        == SandboxState::Running
+    {
+        return entry.record();
+    }
+    if cancellation.is_cancelled() {
+        return Err(uncertain(
+            ProviderErrorKind::Cancelled,
+            ProviderStage::CreateWorkspace,
+            entry.handle.clone(),
+        ));
+    }
+    root.ensure_owned_directory(&entry.workspace)
+        .and_then(|()| root.ensure_owned_directory(&entry.scratch))
+        .map_err(|_| {
+            uncertain(
+                ProviderErrorKind::LocalStorage,
+                ProviderStage::CreateWorkspace,
+                entry.handle.clone(),
+            )
+        })?;
+    state
+        .journal
+        .append(DurableEvent::CreateReady {
+            handle: entry.handle.opaque().to_owned(),
+        })
+        .map_err(|_| {
+            uncertain(
+                ProviderErrorKind::LocalStorage,
+                ProviderStage::CreateSandbox,
+                entry.handle.clone(),
+            )
+        })?;
+    entry
+        .set_phase(DurableEntryPhase::Running)
+        .map_err(|()| local(ProviderStage::CreateSandbox))?;
+    entry.record()
+}
+
+fn validate_spec(
+    options: &MacosSandboxProviderOptions,
+    spec: &SandboxSpec,
+) -> Result<(), ProviderError> {
+    let scratch = spec.scratch().ok_or_else(|| {
+        known(
+            ProviderErrorKind::InvalidConfiguration,
+            ProviderStage::Validate,
+        )
+    })?;
+    let valid = matches!(spec.profile().launch(), SandboxLaunch::Native)
+        && spec.profile().workspace().platform() == TargetPlatform::Posix
+        && spec.workspace().platform() == TargetPlatform::Posix
+        && scratch.platform() == TargetPlatform::Posix
+        && is_strict_descendant(spec.profile().workspace(), options.provider_target())
+        && is_strict_descendant(spec.workspace(), spec.profile().workspace())
+        && is_strict_descendant(scratch, options.provider_target())
+        && !overlaps(spec.workspace(), scratch)
+        && spec.network() == NetworkPolicy::Host
+        && spec.root_filesystem() == RootFilesystemPolicy::Host
+        && spec.privilege() == SandboxPrivilegePolicy::Host
+        && spec.resource_policy() == SandboxResourcePolicy::HostShared
+        && spec.services().is_empty()
+        && spec.has_coherent_resource_contract()
+        && !spec
+            .profile()
+            .default_environment()
+            .values()
+            .iter()
+            .any(automata_ci_execution::EnvironmentVariable::is_secret);
+    valid.then_some(()).ok_or_else(|| {
+        known(
+            ProviderErrorKind::InvalidConfiguration,
+            ProviderStage::Validate,
+        )
+    })
+}
+
+fn spec_fingerprint(spec: &SandboxSpec) -> Result<[u8; 32], ProviderError> {
+    let mut digest = Sha256::new();
+    fingerprint_field(&mut digest, b"automata-macos-sandbox-spec-v1");
+    fingerprint_field(&mut digest, &spec.generation().get().to_le_bytes());
+    fingerprint_field(
+        &mut digest,
+        &serde_json::to_vec(spec.profile().attestation())
+            .map_err(|_| local(ProviderStage::Validate))?,
+    );
+    fingerprint_field(&mut digest, spec.profile().workspace().as_str().as_bytes());
+    fingerprint_field(&mut digest, spec.workspace().as_str().as_bytes());
+    if let Some(scratch) = spec.scratch() {
+        fingerprint_field(&mut digest, b"scratch-present");
+        fingerprint_field(&mut digest, scratch.as_str().as_bytes());
+    } else {
+        fingerprint_field(&mut digest, b"scratch-absent");
+    }
+    fingerprint_field(
+        &mut digest,
+        &[
+            spec.network() as u8,
+            spec.root_filesystem() as u8,
+            spec.privilege() as u8,
+            match spec.resource_policy() {
+                SandboxResourcePolicy::Enforced(_) => 0,
+                SandboxResourcePolicy::HostShared => 1,
+            },
+        ],
+    );
+    if let Some(allocation) = spec.resource_allocation() {
+        fingerprint_field(
+            &mut digest,
+            &serde_json::to_vec(&allocation).map_err(|_| local(ProviderStage::Validate))?,
+        );
+    }
+    for variable in spec.profile().default_environment().values() {
+        fingerprint_field(&mut digest, variable.name().as_str().as_bytes());
+        fingerprint_field(&mut digest, variable.value().expose().as_bytes());
+        fingerprint_field(&mut digest, &[u8::from(variable.is_secret())]);
+    }
+    Ok(digest.finalize().into())
+}
+
+fn fingerprint_field(digest: &mut Sha256, value: &[u8]) {
+    digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
+    digest.update(value);
+}
+
+fn durable_entry(entry: &SandboxEntry, phase: DurableEntryPhase) -> DurableEntry {
+    DurableEntry {
+        handle: entry.handle.opaque().to_owned(),
+        generation: entry.generation.get(),
+        profile: entry.profile.clone(),
+        workspace: entry.workspace.as_str().to_owned(),
+        scratch: entry.scratch.as_str().to_owned(),
+        phase,
+    }
+}
+
+fn durable_destroy_request(
+    request: &DestroySandbox,
+    profile: &EnvironmentProfile,
+) -> DurableDestroyRequest {
+    DurableDestroyRequest {
+        operation_id: request.operation_id(),
+        handle: request.handle().opaque().to_owned(),
+        generation: request.generation().get(),
+        profile: profile.clone(),
+    }
+}
+
+fn restore_state(
+    provider_id: &ProviderId,
+    journal: LifecycleJournal,
+    snapshot: DurableSnapshot,
+) -> Result<ProviderState, ProviderError> {
+    let mut state = ProviderState {
+        journal,
+        create_operations: HashMap::new(),
+        pending_destroy_operations: HashMap::new(),
+        destroy_operations: HashMap::new(),
+        entries: HashMap::new(),
+        tombstones: HashMap::new(),
+    };
+    for durable in snapshot.entries.into_values() {
+        let handle = recovered_handle(provider_id, &durable.handle)?;
+        let entry = Arc::new(SandboxEntry {
+            handle: handle.clone(),
+            generation: recovered_generation(durable.generation).map_err(|_| invalid_journal())?,
+            profile: durable.profile,
+            workspace: TargetPath::posix(durable.workspace).map_err(|_| invalid_journal())?,
+            scratch: TargetPath::posix(durable.scratch).map_err(|_| invalid_journal())?,
+            operation_lock: Mutex::new(()),
+            endpoint_state: Mutex::new(crate::endpoint::EndpointState::default()),
+            phase: Mutex::new(durable.phase),
+        });
+        if state.entries.insert(handle, entry).is_some() {
+            return Err(invalid_journal());
+        }
+    }
+    for durable in snapshot.tombstones.into_values() {
+        let tombstone = restored_tombstone(provider_id, durable)?;
+        if state
+            .tombstones
+            .insert(tombstone.handle.clone(), tombstone)
+            .is_some()
+        {
+            return Err(invalid_journal());
+        }
+    }
+    for durable in snapshot.creates.into_values() {
+        let handle = recovered_handle(provider_id, &durable.handle)?;
+        if !(state.entries.contains_key(&handle) || state.tombstones.contains_key(&handle))
+            || state
+                .create_operations
+                .insert(
+                    durable.operation_id,
+                    CreateReplay {
+                        fingerprint: durable.fingerprint,
+                        handle,
+                    },
+                )
+                .is_some()
+        {
+            return Err(invalid_journal());
+        }
+    }
+    for durable in snapshot.destroys.into_values() {
+        let handle = recovered_handle(provider_id, &durable.request.handle)?;
+        let request = DestroySandbox::new(
+            durable.request.operation_id,
+            handle,
+            recovered_generation(durable.request.generation).map_err(|_| invalid_journal())?,
+        );
+        if state
+            .destroy_operations
+            .insert(
+                request.operation_id(),
+                DestroyReplay {
+                    request,
+                    disposition: durable.disposition.into(),
+                },
+            )
+            .is_some()
+        {
+            return Err(invalid_journal());
+        }
+    }
+    if !snapshot.pending_destroys.is_empty() {
+        return Err(invalid_journal());
+    }
+    Ok(state)
+}
+
+fn validate_snapshot_paths(
+    options: &MacosSandboxProviderOptions,
+    snapshot: &DurableSnapshot,
+) -> Result<(), ProviderError> {
+    let mut paths: Vec<(TargetPath, TargetPath)> = Vec::new();
+    for entry in snapshot.entries.values() {
+        let workspace =
+            TargetPath::posix(entry.workspace.clone()).map_err(|_| invalid_journal())?;
+        let scratch = TargetPath::posix(entry.scratch.clone()).map_err(|_| invalid_journal())?;
+        if !is_strict_descendant(&workspace, options.provider_target())
+            || !is_strict_descendant(&scratch, options.provider_target())
+            || overlaps(&workspace, &scratch)
+            || paths.iter().any(|(other_workspace, other_scratch)| {
+                overlaps(&workspace, other_workspace)
+                    || overlaps(&workspace, other_scratch)
+                    || overlaps(&scratch, other_workspace)
+                    || overlaps(&scratch, other_scratch)
+            })
+        {
+            return Err(invalid_journal());
+        }
+        paths.push((workspace, scratch));
+    }
+    Ok(())
+}
+
+fn reconcile_orphans(
+    root: &SecureRoot,
+    journal: &mut LifecycleJournal,
+    snapshot: &mut DurableSnapshot,
+) -> Result<(), ProviderError> {
+    let entries: Vec<_> = snapshot.entries.values().cloned().collect();
+    for entry in entries {
+        let pending = snapshot
+            .pending_destroys
+            .values()
+            .find(|request| request.handle == entry.handle)
+            .cloned();
+        let request = if let Some(pending) = pending {
+            pending
+        } else {
+            let request = DurableDestroyRequest {
+                operation_id: OperationId::new(),
+                handle: entry.handle.clone(),
+                generation: entry.generation,
+                profile: entry.profile.clone(),
+            };
+            journal
+                .append_to_snapshot(
+                    snapshot,
+                    &DurableEvent::DestroyIntent {
+                        request: request.clone(),
+                    },
+                )
+                .map_err(|_| local(ProviderStage::DestroySandbox))?;
+            request
+        };
+        let workspace = TargetPath::posix(entry.workspace).map_err(|_| invalid_journal())?;
+        let scratch = TargetPath::posix(entry.scratch).map_err(|_| invalid_journal())?;
+        root.remove_owned_tree(&scratch)
+            .and_then(|()| root.remove_owned_tree(&workspace))
+            .map_err(|_| local(ProviderStage::DestroyWorkspace))?;
+        journal
+            .append_to_snapshot(
+                snapshot,
+                &DurableEvent::DestroyComplete {
+                    operation_id: request.operation_id,
+                },
+            )
+            .map_err(|_| local(ProviderStage::DestroySandbox))?;
+    }
+    Ok(())
+}
+
+fn restored_tombstone(
+    provider_id: &ProviderId,
+    durable: DurableTombstone,
+) -> Result<Tombstone, ProviderError> {
+    if durable.completed_sequence == 0 {
+        return Err(invalid_journal());
+    }
+    Ok(Tombstone {
+        handle: recovered_handle(provider_id, &durable.handle)?,
+        generation: recovered_generation(durable.generation).map_err(|_| invalid_journal())?,
+        profile: durable.profile,
+    })
+}
+
+fn recovered_handle(
+    provider_id: &ProviderId,
+    opaque: &str,
+) -> Result<SandboxHandle, ProviderError> {
+    SandboxHandle::new(provider_id.clone(), opaque.to_owned()).map_err(|_| invalid_journal())
+}
+
+fn quiesce<'a>(
+    entry: &'a SandboxEntry,
+    _cancellation: &dyn Cancellation,
+) -> Result<MutexGuard<'a, ()>, ProviderError> {
+    let deadline = Instant::now() + QUIESCE_TIMEOUT;
+    loop {
+        match entry.operation_lock.try_lock() {
+            Ok(operation) => return Ok(operation),
+            Err(TryLockError::Poisoned(_)) => return Err(local(ProviderStage::DestroySandbox)),
+            Err(TryLockError::WouldBlock) if Instant::now() >= deadline => {
+                return Err(uncertain(
+                    ProviderErrorKind::TimedOut,
+                    ProviderStage::DestroySandbox,
+                    entry.handle.clone(),
+                ));
+            }
+            Err(TryLockError::WouldBlock) => {
+                std::thread::sleep(QUIESCE_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
+fn require_supported_host() -> Result<(), ProviderError> {
+    if !cfg!(target_arch = "aarch64") {
+        return Err(known(
+            ProviderErrorKind::UnsupportedPlatform,
+            ProviderStage::Validate,
+        ));
+    }
+    let output = Command::new("/usr/bin/sw_vers")
+        .args(["-productVersion"])
+        .env_clear()
+        .output()
+        .map_err(|_| {
+            known(
+                ProviderErrorKind::UnsupportedPlatform,
+                ProviderStage::Validate,
+            )
+        })?;
+    if output.status.success() && supported_product_version(&output.stdout) {
+        Ok(())
+    } else {
+        Err(known(
+            ProviderErrorKind::UnsupportedPlatform,
+            ProviderStage::Validate,
+        ))
+    }
+}
+
+fn supported_product_version(output: &[u8]) -> bool {
+    std::str::from_utf8(output)
+        .ok()
+        .and_then(|version| version.trim().split('.').next())
+        .and_then(|major| major.parse::<u32>().ok())
+        .is_some_and(|major| major >= 15)
+}
+
+fn preflight_error(error: &std::io::Error) -> ProviderError {
+    let kind = if error.kind() == std::io::ErrorKind::AlreadyExists {
+        ProviderErrorKind::Conflict
+    } else {
+        ProviderErrorKind::LocalStorage
+    };
+    known(kind, ProviderStage::CreateWorkspace)
+}
+
+fn require_not_cancelled(
+    cancellation: &dyn Cancellation,
+    stage: ProviderStage,
+) -> Result<(), ProviderError> {
+    if cancellation.is_cancelled() {
+        Err(known(ProviderErrorKind::Cancelled, stage))
+    } else {
+        Ok(())
+    }
+}
+
+fn invalid_journal() -> ProviderError {
+    known(
+        ProviderErrorKind::InvalidConfiguration,
+        ProviderStage::Validate,
+    )
+}
+
+const fn known(kind: ProviderErrorKind, stage: ProviderStage) -> ProviderError {
+    ProviderError::new(kind, stage, OperationOutcome::KnownNoEffect, None)
+}
+
+const fn local(stage: ProviderStage) -> ProviderError {
+    known(ProviderErrorKind::LocalStorage, stage)
+}
+
+fn uncertain(
+    kind: ProviderErrorKind,
+    stage: ProviderStage,
+    handle: SandboxHandle,
+) -> ProviderError {
+    ProviderError::new(kind, stage, OperationOutcome::Uncertain, Some(handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supported_product_version;
+
+    #[test]
+    fn native_provider_requires_macos_15_or_newer() {
+        for supported in [b"15.0\n".as_slice(), b"15.7.1", b"26.0"] {
+            assert!(supported_product_version(supported));
+        }
+        for unsupported in [b"14.7.6\n".as_slice(), b"0", b"", b"macOS 15", &[0xff]] {
+            assert!(!supported_product_version(unsupported));
+        }
+    }
+}

--- a/crates/automata-ci-sandbox-macos/src/supervisor.rs
+++ b/crates/automata-ci-sandbox-macos/src/supervisor.rs
@@ -1,0 +1,693 @@
+use std::{
+    io::{self, Read, Write},
+    path::Path,
+    pin::Pin,
+    process::{Child, Command as ProcessCommand, Stdio},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU8, Ordering},
+    },
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use automata_ci_execution::{
+    Cancellation, EnvironmentName, EnvironmentValue, EnvironmentVariable, ExecutionArgv,
+    ExecutionCommand, ExecutionEnvironment, ExecutionError, ExecutionErrorKind, ExecutionOutput,
+    ExecutionOutputRecord, ExecutionOutputStream, ExecutionStage, ExecutionTermination,
+    MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES, MAX_EXECUTION_OUTPUT_RECORDS,
+    OperationId, TargetPath,
+};
+use processkit::{
+    Command, Mechanism, Outcome, OutputBufferPolicy, ProcessGroup, ProcessRunner as _,
+};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWrite;
+
+use crate::SUPERVISOR_COMMAND;
+
+const REQUEST_MAGIC: [u8; 4] = *b"AMSQ";
+const RESPONSE_MAGIC: [u8; 4] = *b"AMSR";
+const MAX_REQUEST_BYTES: usize = 6 * 1024 * 1024;
+const MAX_RESPONSE_BYTES: usize =
+    MAX_EXECUTION_OUTPUT_BYTES + MAX_EXECUTION_OUTPUT_RECORDS * 6 + 32;
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const SUPERVISOR_GRACE: Duration = Duration::from_secs(5);
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SupervisorRequest {
+    program: String,
+    arguments: Vec<String>,
+    working_directory: String,
+    environment: Vec<(String, String)>,
+    timeout_millis: u64,
+    output_limit: usize,
+}
+
+impl SupervisorRequest {
+    fn from_command(command: &ExecutionCommand) -> Self {
+        Self {
+            program: command.argv().program().as_str().to_owned(),
+            arguments: command.argv().arguments().to_vec(),
+            working_directory: command.working_directory().as_str().to_owned(),
+            environment: command
+                .environment()
+                .values()
+                .iter()
+                .map(|variable| {
+                    (
+                        variable.name().as_str().to_owned(),
+                        variable.value().expose().to_owned(),
+                    )
+                })
+                .collect(),
+            timeout_millis: u64::try_from(command.timeout().as_millis()).unwrap_or(u64::MAX),
+            output_limit: command.output_limit(),
+        }
+    }
+
+    fn validate(self) -> io::Result<ExecutionCommand> {
+        let program = TargetPath::posix(self.program).map_err(invalid_data)?;
+        let argv = ExecutionArgv::new(program, self.arguments).map_err(invalid_data)?;
+        let working_directory = TargetPath::posix(self.working_directory).map_err(invalid_data)?;
+        let environment = self
+            .environment
+            .into_iter()
+            .map(|(name, value)| {
+                Ok(EnvironmentVariable::new(
+                    EnvironmentName::new(name).map_err(invalid_data)?,
+                    EnvironmentValue::new(value).map_err(invalid_data)?,
+                ))
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+        let environment = ExecutionEnvironment::new(environment).map_err(invalid_data)?;
+        ExecutionCommand::new(
+            OperationId::new(),
+            argv,
+            working_directory,
+            environment,
+            Duration::from_millis(self.timeout_millis),
+            self.output_limit,
+        )
+        .map_err(invalid_data)
+    }
+}
+
+pub(crate) fn execute(
+    executable: &Path,
+    request: &ExecutionCommand,
+    cancellation: &dyn Cancellation,
+) -> Result<ExecutionOutput, ExecutionError> {
+    let wire = SupervisorRequest::from_command(request);
+    let encoded = serde_json::to_vec(&wire).map_err(|_| local_error())?;
+    if encoded.is_empty() || encoded.len() > MAX_REQUEST_BYTES {
+        return Err(local_error());
+    }
+    let mut child = ProcessCommand::new(executable)
+        .arg(SUPERVISOR_COMMAND)
+        .env_clear()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| backend_error())?;
+    let Some(stdin) = child.stdin.take() else {
+        kill_and_reap(&mut child);
+        return Err(backend_error());
+    };
+    let mut control = Some(stdin);
+    write_request(control.as_mut().ok_or_else(backend_error)?, &encoded).map_err(|_| {
+        kill_and_reap(&mut child);
+        backend_error()
+    })?;
+    let Some(stdout) = child.stdout.take() else {
+        kill_and_reap(&mut child);
+        return Err(backend_error());
+    };
+    let reader = std::thread::Builder::new()
+        .name("automata-macos-supervisor-output".to_owned())
+        .spawn(move || read_bounded(stdout, MAX_RESPONSE_BYTES))
+        .map_err(|_| local_error());
+    let reader = match reader {
+        Ok(reader) => reader,
+        Err(error) => {
+            kill_and_reap(&mut child);
+            return Err(error);
+        }
+    };
+
+    let deadline = Instant::now() + request.timeout() + SUPERVISOR_GRACE;
+    let mut cancellation_sent = false;
+    let status = loop {
+        if cancellation.is_cancelled() && !cancellation_sent {
+            drop(control.take());
+            cancellation_sent = true;
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(POLL_INTERVAL),
+            Ok(None) | Err(_) => {
+                drop(control.take());
+                kill_and_reap(&mut child);
+                return Err(backend_error());
+            }
+        }
+    };
+    drop(control);
+    let response = reader
+        .join()
+        .map_err(|_| backend_error())?
+        .map_err(|_| backend_error())?;
+    if !status.success() {
+        return Err(backend_error());
+    }
+    decode_response(&response)
+}
+
+/// Runs one hidden same-binary supervisor request from standard input.
+///
+/// The caller keeps stdin open as a liveness channel. EOF cancels the child
+/// process group, including when the runner exits abruptly. The bounded result
+/// is emitted on stdout using an internal binary frame.
+///
+/// # Errors
+///
+/// Rejects malformed or oversized requests and reports process/control I/O
+/// failures without including command, environment, or output bytes.
+pub fn run_supervisor() -> io::Result<()> {
+    std::thread::Builder::new()
+        .name("automata-macos-supervisor-runtime".to_owned())
+        .spawn(run_supervisor_inner)?
+        .join()
+        .map_err(|_| io::Error::other("supervisor runtime failed"))?
+}
+
+fn run_supervisor_inner() -> io::Result<()> {
+    let request = read_request(std::io::stdin().lock())?;
+    let request: SupervisorRequest = serde_json::from_slice(&request)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let request = request.validate()?;
+    let disconnected = Arc::new(AtomicBool::new(false));
+    let watcher_state = Arc::clone(&disconnected);
+    std::thread::Builder::new()
+        .name("automata-macos-supervisor-liveness".to_owned())
+        .spawn(move || {
+            let mut byte = [0_u8; 1];
+            let _ = std::io::stdin().read(&mut byte);
+            watcher_state.store(true, Ordering::Release);
+        })?;
+    let output = run_supervised(request, disconnected)?;
+    write_response(std::io::stdout().lock(), &output)
+}
+
+fn run_supervised(
+    request: ExecutionCommand,
+    disconnected: Arc<AtomicBool>,
+) -> io::Result<ExecutionOutput> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(async move {
+        let group = Arc::new(ProcessGroup::new().map_err(process_error)?);
+        if group.mechanism() != Mechanism::ProcessGroup {
+            return Err(io::Error::from(io::ErrorKind::Unsupported));
+        }
+        run_process(group, request, disconnected).await
+    })
+}
+
+async fn run_process(
+    group: Arc<ProcessGroup>,
+    request: ExecutionCommand,
+    disconnected: Arc<AtomicBool>,
+) -> io::Result<ExecutionOutput> {
+    let reason = Arc::new(AtomicU8::new(StopReason::Natural as u8));
+    let capture = Arc::new(Mutex::new(CaptureState::new(request.output_limit())));
+    let stdout = CaptureWriter::new(
+        ExecutionOutputStream::Stdout,
+        Arc::clone(&capture),
+        Arc::clone(&group),
+        Arc::clone(&reason),
+    );
+    let stderr = CaptureWriter::new(
+        ExecutionOutputStream::Stderr,
+        Arc::clone(&capture),
+        Arc::clone(&group),
+        Arc::clone(&reason),
+    );
+    let mut command = Command::new(request.argv().program().as_str())
+        .args(request.argv().arguments())
+        .current_dir(request.working_directory().as_str())
+        .env_clear()
+        .no_timeout()
+        .stdout_raw_tee(stdout)
+        .stderr_raw_tee(stderr)
+        .output_buffer(OutputBufferPolicy::bounded(0).with_max_bytes(request.output_limit()));
+    for variable in request.environment().values() {
+        command = command.env(variable.name().as_str(), variable.value().expose());
+    }
+    let running = group.start(&command).await.map_err(process_error)?;
+    let finished = running.output_string();
+    tokio::pin!(finished);
+    let deadline = tokio::time::sleep(request.timeout());
+    tokio::pin!(deadline);
+    let mut liveness_poll = tokio::time::interval(POLL_INTERVAL);
+    liveness_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let process_result = loop {
+        tokio::select! {
+            biased;
+            _ = liveness_poll.tick() => {
+                if disconnected.load(Ordering::Acquire) {
+                    reason.store(StopReason::Cancelled as u8, Ordering::SeqCst);
+                    group.kill_all().map_err(process_error)?;
+                    break tokio::time::timeout(SUPERVISOR_GRACE, &mut finished).await.ok();
+                }
+            }
+            () = &mut deadline => {
+                reason.store(StopReason::TimedOut as u8, Ordering::SeqCst);
+                group.kill_all().map_err(process_error)?;
+                break tokio::time::timeout(SUPERVISOR_GRACE, &mut finished).await.ok();
+            }
+            result = &mut finished => break Some(result),
+        }
+    };
+    let stop_reason = StopReason::from_u8(reason.load(Ordering::SeqCst));
+    let (termination, complete) = match (stop_reason, process_result) {
+        (StopReason::Cancelled, Some(Ok(_))) => (ExecutionTermination::Cancelled, true),
+        (StopReason::Cancelled, Some(Err(_)) | None) => (ExecutionTermination::Cancelled, false),
+        (StopReason::TimedOut, Some(Ok(_))) => (ExecutionTermination::TimedOut, true),
+        (StopReason::TimedOut, Some(Err(_)) | None) => (ExecutionTermination::TimedOut, false),
+        (StopReason::OutputLimit, Some(Ok(_))) => (ExecutionTermination::Signalled, true),
+        (StopReason::OutputLimit, Some(Err(_)) | None) => (ExecutionTermination::Signalled, false),
+        (StopReason::Natural, Some(Ok(result))) => (map_outcome(result.outcome()), true),
+        (StopReason::Natural, Some(Err(_)) | None) => {
+            return Err(io::Error::other("process failed"));
+        }
+    };
+    capture
+        .lock()
+        .map_err(|_| io::Error::other("capture state poisoned"))?
+        .finish(
+            termination,
+            complete,
+            stop_reason == StopReason::OutputLimit || !complete,
+        )
+}
+
+fn write_request(mut destination: impl Write, bytes: &[u8]) -> io::Result<()> {
+    destination.write_all(&REQUEST_MAGIC)?;
+    destination.write_all(
+        &u32::try_from(bytes.len())
+            .map_err(invalid_data)?
+            .to_le_bytes(),
+    )?;
+    destination.write_all(bytes)?;
+    destination.flush()
+}
+
+fn read_request(mut source: impl Read) -> io::Result<Vec<u8>> {
+    let mut magic = [0_u8; 4];
+    source.read_exact(&mut magic)?;
+    if magic != REQUEST_MAGIC {
+        return Err(io::Error::from(io::ErrorKind::InvalidData));
+    }
+    let length = usize::try_from(read_u32(&mut source)?).map_err(invalid_data)?;
+    if length == 0 || length > MAX_REQUEST_BYTES {
+        return Err(io::Error::from(io::ErrorKind::InvalidData));
+    }
+    let mut bytes = vec![0_u8; length];
+    source.read_exact(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn write_response(mut destination: impl Write, output: &ExecutionOutput) -> io::Result<()> {
+    destination.write_all(&RESPONSE_MAGIC)?;
+    let (termination, code) = match output.termination() {
+        ExecutionTermination::Exited(code) => (0_u8, code),
+        ExecutionTermination::Signalled => (1, 0),
+        ExecutionTermination::TimedOut => (2, 0),
+        ExecutionTermination::Cancelled => (3, 0),
+    };
+    destination.write_all(&[termination, u8::from(output.was_truncated())])?;
+    destination.write_all(&code.to_le_bytes())?;
+    destination.write_all(
+        &u32::try_from(output.records().len())
+            .map_err(invalid_data)?
+            .to_le_bytes(),
+    )?;
+    for record in output.records() {
+        let stream = match record.stream() {
+            ExecutionOutputStream::Stdout => 0_u8,
+            ExecutionOutputStream::Stderr => 1_u8,
+        };
+        destination.write_all(&[stream, u8::from(record.is_end_of_stream())])?;
+        destination.write_all(
+            &u32::try_from(record.bytes().len())
+                .map_err(invalid_data)?
+                .to_le_bytes(),
+        )?;
+        destination.write_all(record.bytes())?;
+    }
+    destination.flush()
+}
+
+fn decode_response(bytes: &[u8]) -> Result<ExecutionOutput, ExecutionError> {
+    let mut source = bytes;
+    let mut magic = [0_u8; 4];
+    source.read_exact(&mut magic).map_err(|_| backend_error())?;
+    if magic != RESPONSE_MAGIC {
+        return Err(backend_error());
+    }
+    let mut flags = [0_u8; 2];
+    source.read_exact(&mut flags).map_err(|_| backend_error())?;
+    let code = read_i32(&mut source).map_err(|_| backend_error())?;
+    let termination = match flags[0] {
+        0 => ExecutionTermination::Exited(code),
+        1 => ExecutionTermination::Signalled,
+        2 => ExecutionTermination::TimedOut,
+        3 => ExecutionTermination::Cancelled,
+        _ => return Err(backend_error()),
+    };
+    let count = usize::try_from(read_u32(&mut source).map_err(|_| backend_error())?)
+        .map_err(|_| backend_error())?;
+    if count > MAX_EXECUTION_OUTPUT_RECORDS {
+        return Err(backend_error());
+    }
+    let mut records = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut flags = [0_u8; 2];
+        source.read_exact(&mut flags).map_err(|_| backend_error())?;
+        let stream = match flags[0] {
+            0 => ExecutionOutputStream::Stdout,
+            1 => ExecutionOutputStream::Stderr,
+            _ => return Err(backend_error()),
+        };
+        let length = usize::try_from(read_u32(&mut source).map_err(|_| backend_error())?)
+            .map_err(|_| backend_error())?;
+        if length > MAX_EXECUTION_OUTPUT_RECORD_BYTES || flags[1] > 1 {
+            return Err(backend_error());
+        }
+        let mut content = vec![0_u8; length];
+        source
+            .read_exact(&mut content)
+            .map_err(|_| backend_error())?;
+        let record = if flags[1] == 1 {
+            if !content.is_empty() {
+                return Err(backend_error());
+            }
+            ExecutionOutputRecord::end_of_stream(stream)
+        } else {
+            ExecutionOutputRecord::data(stream, content).map_err(|_| backend_error())?
+        };
+        records.push(record);
+    }
+    if !source.is_empty() {
+        return Err(backend_error());
+    }
+    ExecutionOutput::new(termination, records, flags[1] != 0).map_err(|_| backend_error())
+}
+
+fn read_bounded(mut source: impl Read, maximum: usize) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    source
+        .by_ref()
+        .take(u64::try_from(maximum).unwrap_or(u64::MAX).saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > maximum {
+        return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+    }
+    Ok(bytes)
+}
+
+fn read_u32(mut source: impl Read) -> io::Result<u32> {
+    let mut bytes = [0_u8; 4];
+    source.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_i32(mut source: impl Read) -> io::Result<i32> {
+    let mut bytes = [0_u8; 4];
+    source.read_exact(&mut bytes)?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+fn kill_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn map_outcome(outcome: Outcome) -> ExecutionTermination {
+    if let Some(code) = outcome.code() {
+        ExecutionTermination::Exited(code)
+    } else if outcome.timed_out() {
+        ExecutionTermination::TimedOut
+    } else {
+        ExecutionTermination::Signalled
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(u8)]
+enum StopReason {
+    Natural = 0,
+    Cancelled = 1,
+    TimedOut = 2,
+    OutputLimit = 3,
+}
+
+impl StopReason {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Cancelled,
+            2 => Self::TimedOut,
+            3 => Self::OutputLimit,
+            _ => Self::Natural,
+        }
+    }
+}
+
+struct CaptureWriter {
+    stream: ExecutionOutputStream,
+    capture: Arc<Mutex<CaptureState>>,
+    group: Arc<ProcessGroup>,
+    reason: Arc<AtomicU8>,
+}
+
+impl CaptureWriter {
+    const fn new(
+        stream: ExecutionOutputStream,
+        capture: Arc<Mutex<CaptureState>>,
+        group: Arc<ProcessGroup>,
+        reason: Arc<AtomicU8>,
+    ) -> Self {
+        Self {
+            stream,
+            capture,
+            group,
+            reason,
+        }
+    }
+}
+
+impl AsyncWrite for CaptureWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        bytes: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if bytes.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let Ok(mut capture) = self.capture.lock() else {
+            return Poll::Ready(Err(io::Error::other("capture state poisoned")));
+        };
+        let remaining = capture.limit.saturating_sub(capture.bytes);
+        let record_capacity = MAX_EXECUTION_OUTPUT_RECORDS
+            .saturating_sub(2)
+            .saturating_sub(capture.records.len());
+        let record_bytes = record_capacity.saturating_mul(MAX_EXECUTION_OUTPUT_RECORD_BYTES);
+        let accepted = remaining.min(record_bytes).min(bytes.len());
+        for chunk in bytes[..accepted].chunks(MAX_EXECUTION_OUTPUT_RECORD_BYTES) {
+            let record = ExecutionOutputRecord::data(self.stream, chunk.to_vec())
+                .map_err(|_| io::Error::other("invalid output record"));
+            match record {
+                Ok(record) => capture.records.push(record),
+                Err(error) => return Poll::Ready(Err(error)),
+            }
+        }
+        capture.bytes += accepted;
+        if accepted != bytes.len() {
+            capture.truncated = true;
+            if self
+                .reason
+                .compare_exchange(
+                    StopReason::Natural as u8,
+                    StopReason::OutputLimit as u8,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
+                .is_ok()
+            {
+                let _ = self.group.kill_all();
+            }
+        }
+        Poll::Ready(Ok(bytes.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct CaptureState {
+    records: Vec<ExecutionOutputRecord>,
+    bytes: usize,
+    limit: usize,
+    truncated: bool,
+}
+
+impl CaptureState {
+    const fn new(limit: usize) -> Self {
+        Self {
+            records: Vec::new(),
+            bytes: 0,
+            limit,
+            truncated: false,
+        }
+    }
+
+    fn finish(
+        &mut self,
+        termination: ExecutionTermination,
+        complete: bool,
+        force_truncated: bool,
+    ) -> io::Result<ExecutionOutput> {
+        if complete {
+            self.records.push(ExecutionOutputRecord::end_of_stream(
+                ExecutionOutputStream::Stdout,
+            ));
+            self.records.push(ExecutionOutputRecord::end_of_stream(
+                ExecutionOutputStream::Stderr,
+            ));
+        }
+        ExecutionOutput::new(
+            termination,
+            std::mem::take(&mut self.records),
+            self.truncated || force_truncated,
+        )
+        .map_err(invalid_data)
+    }
+}
+
+fn process_error(error: impl std::fmt::Display) -> io::Error {
+    let _ = error;
+    io::Error::other("supervised process failed")
+}
+
+fn invalid_data(_error: impl std::fmt::Debug) -> io::Error {
+    io::Error::from(io::ErrorKind::InvalidData)
+}
+
+const fn local_error() -> ExecutionError {
+    ExecutionError::new(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec)
+}
+
+const fn backend_error() -> ExecutionError {
+    ExecutionError::new(ExecutionErrorKind::BackendRejected, ExecutionStage::Exec)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, atomic::AtomicBool},
+        time::Duration,
+    };
+
+    use automata_ci_execution::{
+        ExecutionArgv, ExecutionCommand, ExecutionEnvironment, ExecutionTermination, OperationId,
+        TargetPath,
+    };
+
+    use super::run_supervised;
+
+    #[test]
+    fn supervisor_preserves_bounded_stdout_stderr_and_exit_status() {
+        let output = run_supervised(
+            command(
+                "printf stdout; printf stderr >&2; exit 7",
+                Duration::from_secs(5),
+            ),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("supervise shell command");
+
+        assert_eq!(output.termination(), ExecutionTermination::Exited(7));
+        assert_eq!(output.stdout(), b"stdout");
+        assert_eq!(output.stderr(), b"stderr");
+        assert!(!output.was_truncated());
+    }
+
+    #[test]
+    fn supervisor_enforces_timeout_and_control_disconnect() {
+        let timed_out = run_supervised(
+            command("sleep 5", Duration::from_millis(20)),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("timeout is a command termination");
+        assert_eq!(timed_out.termination(), ExecutionTermination::TimedOut);
+
+        let disconnected = run_supervised(
+            command("sleep 5", Duration::from_secs(5)),
+            Arc::new(AtomicBool::new(true)),
+        )
+        .expect("disconnect is a command termination");
+        assert_eq!(disconnected.termination(), ExecutionTermination::Cancelled);
+    }
+
+    #[test]
+    fn supervisor_kills_the_process_group_at_the_output_bound() {
+        let output = run_supervised(
+            command_with_limit(
+                "printf '%s' 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'",
+                Duration::from_secs(5),
+                32,
+            ),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("output overflow is a bounded command termination");
+
+        assert_eq!(output.termination(), ExecutionTermination::Signalled);
+        assert!(output.was_truncated());
+        assert!(output.stdout().len() <= 32);
+    }
+
+    fn command(script: &str, timeout: Duration) -> ExecutionCommand {
+        command_with_limit(script, timeout, 1024 * 1024)
+    }
+
+    fn command_with_limit(
+        script: &str,
+        timeout: Duration,
+        output_limit: usize,
+    ) -> ExecutionCommand {
+        ExecutionCommand::new(
+            OperationId::new(),
+            ExecutionArgv::new(
+                TargetPath::posix("/bin/sh").expect("shell"),
+                vec!["-c".to_owned(), script.to_owned()],
+            )
+            .expect("argv"),
+            TargetPath::posix("/").expect("working directory"),
+            ExecutionEnvironment::empty(),
+            timeout,
+            output_limit,
+        )
+        .expect("command")
+    }
+}

--- a/crates/automata-ci-sandbox-macos/src/unsupported.rs
+++ b/crates/automata-ci-sandbox-macos/src/unsupported.rs
@@ -1,0 +1,115 @@
+use std::{fmt, path::PathBuf};
+
+use automata_ci_execution::{
+    Cancellation, DestroyDisposition, DestroySandbox, ExecutionEndpoint, OperationOutcome,
+    ProviderCapabilities, ProviderError, ProviderErrorKind, ProviderId, ProviderStage,
+    SandboxInspection, SandboxProvider, SandboxRecord, SandboxSpec,
+};
+
+/// macOS provider configuration placeholder on unsupported hosts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MacosSandboxProviderOptions;
+
+impl MacosSandboxProviderOptions {
+    /// Rejects macOS provider configuration on a non-macOS host.
+    ///
+    /// # Errors
+    ///
+    /// Always returns `UnsupportedPlatform`.
+    pub fn new(
+        _provider_root: impl Into<PathBuf>,
+        _supervisor_executable: impl Into<PathBuf>,
+    ) -> Result<Self, ProviderError> {
+        Err(unsupported(ProviderStage::Validate))
+    }
+}
+
+/// macOS sandbox provider placeholder on unsupported hosts.
+pub struct MacosSandboxProvider {
+    provider_id: ProviderId,
+    capabilities: ProviderCapabilities,
+}
+
+impl MacosSandboxProvider {
+    /// Rejects provider startup on a non-macOS host.
+    ///
+    /// # Errors
+    ///
+    /// Always returns `UnsupportedPlatform`.
+    pub fn open(_options: MacosSandboxProviderOptions) -> Result<Self, ProviderError> {
+        Err(unsupported(ProviderStage::Validate))
+    }
+}
+
+impl fmt::Debug for MacosSandboxProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MacosSandboxProvider")
+            .field("provider_id", &self.provider_id)
+            .field("capabilities", &self.capabilities)
+            .finish()
+    }
+}
+
+impl SandboxProvider for MacosSandboxProvider {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+
+    fn create(
+        &self,
+        _spec: &SandboxSpec,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<SandboxRecord, ProviderError> {
+        Err(unsupported(ProviderStage::CreateSandbox))
+    }
+
+    fn attach(
+        &self,
+        _handle: &automata_ci_execution::SandboxHandle,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ProviderError> {
+        Err(unsupported(ProviderStage::Attach))
+    }
+
+    fn inspect(
+        &self,
+        _handle: &automata_ci_execution::SandboxHandle,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<SandboxInspection, ProviderError> {
+        Err(unsupported(ProviderStage::Inspect))
+    }
+
+    fn destroy(
+        &self,
+        _request: &DestroySandbox,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<DestroyDisposition, ProviderError> {
+        Err(unsupported(ProviderStage::DestroySandbox))
+    }
+}
+
+/// Rejects the hidden supervisor command on a non-macOS host.
+///
+/// # Errors
+///
+/// Always returns an unsupported-platform I/O error.
+pub fn run_supervisor() -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "macOS supervisor is unavailable",
+    ))
+}
+
+const fn unsupported(stage: ProviderStage) -> ProviderError {
+    ProviderError::new(
+        ProviderErrorKind::UnsupportedPlatform,
+        stage,
+        OperationOutcome::KnownNoEffect,
+        None,
+    )
+}

--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -1,0 +1,468 @@
+#![cfg(target_os = "macos")]
+#![forbid(unsafe_code)]
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write as _,
+    os::unix::fs::PermissionsExt as _,
+    path::{Path, PathBuf},
+};
+
+use automata_ci_execution::{
+    Cancellation, CopyFromRequest, CopyToRequest, DestroyDisposition, DestroySandbox,
+    EnvironmentName, EnvironmentProfile, EnvironmentProfileId, EnvironmentValue,
+    EnvironmentVariable, ExecutionEnvironment, ExecutionErrorKind, NetworkPolicy, NeverCancelled,
+    OperationId, ProviderErrorKind, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment,
+    SandboxGeneration, SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, SandboxState,
+    Sha256Digest, TargetPath,
+};
+use automata_ci_sandbox_macos::{MacosSandboxProvider, MacosSandboxProviderOptions};
+use static_assertions::assert_impl_all;
+
+assert_impl_all!(MacosSandboxProvider: Send, Sync, Clone);
+
+struct AlwaysCancelled;
+
+impl Cancellation for AlwaysCancelled {
+    fn is_cancelled(&self) -> bool {
+        true
+    }
+}
+
+#[test]
+fn lifecycle_copy_replay_and_destroy_are_generation_fenced() {
+    let fixture = Fixture::new("lifecycle");
+    let spec = fixture.spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create macOS sandbox");
+    assert_eq!(record.state(), SandboxState::Running);
+    assert_eq!(
+        fixture
+            .provider
+            .create(&spec, &NeverCancelled)
+            .expect("replay exact create"),
+        record
+    );
+    assert!(
+        fixture
+            .provider
+            .capabilities()
+            .supports(SandboxCapability::HostResources)
+    );
+    assert!(
+        !fixture
+            .provider
+            .capabilities()
+            .supports(SandboxCapability::ResourceLimits)
+    );
+
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach macOS sandbox");
+    let payload = fixture.workspace.join("payload.txt");
+    let copy_to = CopyToRequest::new(OperationId::new(), target(&payload), b"payload".to_vec())
+        .expect("copy request");
+    endpoint
+        .copy_to(&copy_to, &NeverCancelled)
+        .expect("copy into sandbox");
+    endpoint
+        .copy_to(&copy_to, &NeverCancelled)
+        .expect("replay copy into sandbox");
+    let copy_from =
+        CopyFromRequest::new(OperationId::new(), target(&payload), 64).expect("copy-from request");
+    assert_eq!(
+        endpoint
+            .copy_from(&copy_from, &NeverCancelled)
+            .expect("copy out of sandbox"),
+        b"payload"
+    );
+    drop(endpoint);
+
+    let destroy = DestroySandbox::new(
+        OperationId::new(),
+        record.handle().clone(),
+        record.generation(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&destroy, &NeverCancelled)
+            .expect("destroy sandbox"),
+        DestroyDisposition::Destroyed
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&destroy, &NeverCancelled)
+            .expect("replay destroy"),
+        DestroyDisposition::Destroyed
+    );
+    assert!(!fixture.workspace.exists());
+    assert!(!fixture.scratch.exists());
+}
+
+#[test]
+fn restart_reconciles_live_sandbox_and_preserves_create_witness() {
+    let root = TestRoot::new("restart");
+    let profile_workspace = root.path.join("workspaces");
+    let workspace = profile_workspace.join("job-a");
+    let scratch = root.path.join("scratch-a");
+    let spec = spec(
+        &profile_workspace,
+        &workspace,
+        &scratch,
+        ExecutionEnvironment::empty(),
+    );
+    let record = {
+        let provider = open(&root.path);
+        provider
+            .create(&spec, &NeverCancelled)
+            .expect("create before restart")
+    };
+    assert!(workspace.is_dir());
+    assert!(scratch.is_dir());
+
+    OpenOptions::new()
+        .append(true)
+        .open(root.path.join(".automata-macos-provider-v1.events"))
+        .and_then(|mut journal| journal.write_all(b"interrupted-tail"))
+        .expect("append crash-truncated journal tail");
+
+    let provider = open(&root.path);
+    assert!(!workspace.exists());
+    assert!(!scratch.exists());
+    assert_eq!(
+        provider
+            .inspect(record.handle(), &NeverCancelled)
+            .expect("inspect recovered handle")
+            .state(),
+        SandboxState::Absent
+    );
+    assert_eq!(
+        provider
+            .create(&spec, &NeverCancelled)
+            .expect("replay recovered create")
+            .state(),
+        SandboxState::Absent
+    );
+}
+
+#[test]
+fn provider_is_single_slot_generation_fenced_and_cancellation_safe() {
+    let fixture = Fixture::new("single-slot");
+    let cancelled = AlwaysCancelled;
+    assert_eq!(
+        fixture
+            .provider
+            .create(&fixture.spec(), &cancelled)
+            .expect_err("cancelled create must stop before mutation")
+            .kind(),
+        ProviderErrorKind::Cancelled
+    );
+    assert!(!fixture.workspace.exists());
+    assert!(!fixture.scratch.exists());
+
+    let record = fixture
+        .provider
+        .create(&fixture.spec(), &NeverCancelled)
+        .expect("create first sandbox");
+    let second_workspace = fixture.profile_workspace.join("job-b");
+    let second_scratch = fixture.root.path.join("scratch-b");
+    let second = spec(
+        &fixture.profile_workspace,
+        &second_workspace,
+        &second_scratch,
+        ExecutionEnvironment::empty(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .create(&second, &NeverCancelled)
+            .expect_err("one provider root must admit one slot")
+            .kind(),
+        ProviderErrorKind::Conflict
+    );
+    let stale = DestroySandbox::new(
+        OperationId::new(),
+        record.handle().clone(),
+        SandboxGeneration::new(record.generation().get() + 1).expect("stale generation"),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&stale, &NeverCancelled)
+            .expect_err("stale generation must not destroy the live sandbox")
+            .kind(),
+        ProviderErrorKind::OwnershipMismatch
+    );
+    assert!(fixture.workspace.is_dir());
+}
+
+#[test]
+fn provider_lock_and_bounded_journal_fail_closed() {
+    let root = TestRoot::new("exclusive-lock");
+    let provider = open(&root.path);
+    let error = MacosSandboxProvider::open(
+        MacosSandboxProviderOptions::new(&root.path, "/bin/sh").expect("provider options"),
+    )
+    .expect_err("a second provider process must not share one root");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    drop(provider);
+
+    let corrupt = TestRoot::new("corrupt-journal");
+    prepare_journal(
+        &corrupt.path,
+        Some(b"{\"schema\":1,\"corrupt\":true}\n"),
+        None,
+    );
+    assert_eq!(
+        MacosSandboxProvider::open(
+            MacosSandboxProviderOptions::new(&corrupt.path, "/bin/sh").expect("provider options"),
+        )
+        .expect_err("corrupt journal must fail closed")
+        .kind(),
+        ProviderErrorKind::LocalStorage
+    );
+
+    let oversized = TestRoot::new("oversized-journal");
+    prepare_journal(&oversized.path, None, Some(16 * 1024 * 1024 + 1));
+    assert_eq!(
+        MacosSandboxProvider::open(
+            MacosSandboxProviderOptions::new(&oversized.path, "/bin/sh").expect("provider options"),
+        )
+        .expect_err("oversized journal must fail closed")
+        .kind(),
+        ProviderErrorKind::LocalStorage
+    );
+}
+
+#[test]
+fn copy_rejects_symlink_escape_without_touching_foreign_file() {
+    let fixture = Fixture::new("symlink");
+    let record = fixture
+        .provider
+        .create(&fixture.spec(), &NeverCancelled)
+        .expect("create sandbox");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach sandbox");
+    let foreign = fixture.root.path.join("foreign.txt");
+    fs::write(&foreign, b"foreign").expect("write foreign sentinel");
+    let link = fixture.workspace.join("escape.txt");
+    std::os::unix::fs::symlink(&foreign, &link).expect("create attack symlink");
+    let error = endpoint
+        .copy_to(
+            &CopyToRequest::new(OperationId::new(), target(&link), b"changed".to_vec())
+                .expect("copy request"),
+            &NeverCancelled,
+        )
+        .expect_err("copy must not follow symlink");
+    assert_eq!(
+        error.kind(),
+        automata_ci_execution::ExecutionErrorKind::OwnershipMismatch
+    );
+    assert_eq!(fs::read(&foreign).expect("read sentinel"), b"foreign");
+}
+
+#[test]
+fn copy_rejects_hard_links_and_bounds_reads() {
+    let fixture = Fixture::new("hard-link");
+    let record = fixture
+        .provider
+        .create(&fixture.spec(), &NeverCancelled)
+        .expect("create sandbox");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach sandbox");
+    let foreign = fixture.root.path.join("foreign.txt");
+    fs::write(&foreign, b"foreign").expect("write foreign sentinel");
+    let link = fixture.workspace.join("linked.txt");
+    fs::hard_link(&foreign, &link).expect("create attack hard link");
+    assert_eq!(
+        endpoint
+            .copy_to(
+                &CopyToRequest::new(OperationId::new(), target(&link), b"changed".to_vec())
+                    .expect("copy request"),
+                &NeverCancelled,
+            )
+            .expect_err("copy must reject a multiply linked target")
+            .kind(),
+        ExecutionErrorKind::OwnershipMismatch
+    );
+    assert_eq!(fs::read(&foreign).expect("read sentinel"), b"foreign");
+
+    let payload = fixture.workspace.join("bounded.txt");
+    fs::write(&payload, b"12345").expect("write bounded payload");
+    assert_eq!(
+        endpoint
+            .copy_from(
+                &CopyFromRequest::new(OperationId::new(), target(&payload), 4)
+                    .expect("copy-from request"),
+                &NeverCancelled,
+            )
+            .expect_err("copy must not return content beyond the caller's bound")
+            .kind(),
+        ExecutionErrorKind::OutputLimitExceeded
+    );
+}
+
+#[test]
+fn host_policy_and_nonsecret_profile_defaults_are_mandatory() {
+    let fixture = Fixture::new("policy");
+    let enforced = SandboxSpec::new(
+        OperationId::new(),
+        SandboxGeneration::new(2).expect("generation"),
+        environment(&fixture.profile_workspace, ExecutionEnvironment::empty()),
+        target(&fixture.workspace),
+        NetworkPolicy::Host,
+        RootFilesystemPolicy::Host,
+        automata_ci_execution::ResourceLimits::new(64 * 1024 * 1024, 1_000, 8).expect("limits"),
+    )
+    .with_privilege(SandboxPrivilegePolicy::Host)
+    .with_scratch(target(&fixture.scratch));
+    assert_eq!(
+        fixture
+            .provider
+            .create(&enforced, &NeverCancelled)
+            .expect_err("hard-limit claim must be rejected")
+            .kind(),
+        ProviderErrorKind::InvalidConfiguration
+    );
+
+    let defaults = ExecutionEnvironment::new(vec![EnvironmentVariable::secret(
+        EnvironmentName::new("PROFILE_SECRET").expect("name"),
+        EnvironmentValue::new("never-persist").expect("value"),
+    )])
+    .expect("secret defaults");
+    let secret = spec(
+        &fixture.profile_workspace,
+        &fixture.workspace,
+        &fixture.scratch,
+        defaults,
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .create(&secret, &NeverCancelled)
+            .expect_err("secret profile default must be rejected")
+            .kind(),
+        ProviderErrorKind::InvalidConfiguration
+    );
+}
+
+struct Fixture {
+    provider: MacosSandboxProvider,
+    profile_workspace: PathBuf,
+    workspace: PathBuf,
+    scratch: PathBuf,
+    root: TestRoot,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let root = TestRoot::new(label);
+        let provider = open(&root.path);
+        let profile_workspace = root.path.join("workspaces");
+        let workspace = profile_workspace.join("job-a");
+        let scratch = root.path.join("scratch-a");
+        Self {
+            provider,
+            profile_workspace,
+            workspace,
+            scratch,
+            root,
+        }
+    }
+
+    fn spec(&self) -> SandboxSpec {
+        spec(
+            &self.profile_workspace,
+            &self.workspace,
+            &self.scratch,
+            ExecutionEnvironment::empty(),
+        )
+    }
+}
+
+fn spec(
+    profile_workspace: &Path,
+    workspace: &Path,
+    scratch: &Path,
+    defaults: ExecutionEnvironment,
+) -> SandboxSpec {
+    SandboxSpec::host_shared(
+        OperationId::new(),
+        SandboxGeneration::new(1).expect("generation"),
+        environment(profile_workspace, defaults),
+        target(workspace),
+        NetworkPolicy::Host,
+        RootFilesystemPolicy::Host,
+    )
+    .with_privilege(SandboxPrivilegePolicy::Host)
+    .with_scratch(target(scratch))
+}
+
+fn environment(workspace: &Path, defaults: ExecutionEnvironment) -> SandboxEnvironment {
+    SandboxEnvironment::native_posix(
+        EnvironmentProfile::new(
+            EnvironmentProfileId::new("automata.dev/macos-native-arm64-v1").expect("profile ID"),
+            Sha256Digest::from_bytes([0x6d; 32]),
+        ),
+        target(workspace),
+        defaults,
+    )
+    .expect("native POSIX environment")
+}
+
+fn open(root: &Path) -> MacosSandboxProvider {
+    MacosSandboxProvider::open(
+        MacosSandboxProviderOptions::new(root, "/bin/sh").expect("provider options"),
+    )
+    .expect("open macOS provider")
+}
+
+fn prepare_journal(root: &Path, bytes: Option<&[u8]>, length: Option<u64>) {
+    fs::create_dir_all(root).expect("create provider root");
+    fs::set_permissions(root, fs::Permissions::from_mode(0o700)).expect("restrict provider root");
+    let path = root.join(".automata-macos-provider-v1.events");
+    match bytes {
+        Some(bytes) => fs::write(&path, bytes).expect("write journal fixture"),
+        None => {
+            File::create(&path)
+                .and_then(|journal| journal.set_len(length.expect("journal fixture length")))
+                .expect("size journal fixture");
+        }
+    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("restrict journal fixture");
+}
+
+fn target(path: &Path) -> TargetPath {
+    TargetPath::posix(path.to_str().expect("Unicode test path")).expect("POSIX target")
+}
+
+struct TestRoot {
+    path: PathBuf,
+}
+
+impl TestRoot {
+    fn new(label: &str) -> Self {
+        let path = std::env::current_dir()
+            .expect("current directory")
+            .join("target/agent-scratch/macos-provider")
+            .join(format!("{label}-{}", uuid::Uuid::new_v4()));
+        Self { path }
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            fs::remove_dir_all(&self.path).expect("remove exact test root");
+        }
+    }
+}

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -573,10 +573,16 @@ impl PodmanInner {
         names: &ResourceNames,
         fingerprint: &str,
     ) -> Result<ServiceManifest, ProviderError> {
+        let resources = spec.resources().ok_or_else(|| {
+            provider_error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
         let manifest = ServiceManifest::from_specs(
             names,
             fingerprint,
-            spec.resources().pids(),
+            resources.pids(),
             spec.services(),
             self.options.service_proxy_image(),
         )
@@ -778,7 +784,12 @@ impl PodmanInner {
                 )
                 .map(|inspection| inspection.identifier);
         }
-        let resources = sandbox.resources();
+        let resources = sandbox.resources().ok_or_else(|| {
+            provider_error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
         let mut arguments = self.base_arguments();
         arguments.extend(os_args(["create"]));
         push_option(&mut arguments, "--name", entry.container());
@@ -2525,7 +2536,12 @@ impl PodmanInner {
             )?;
             return self.verify_pod_network_sysctl(names, deadline, cancellation);
         }
-        let resources = spec.resources();
+        let resources = spec.resources().ok_or_else(|| {
+            provider_error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
         let mut arguments = self.base_arguments();
         arguments.extend(os_args([
             "pod",
@@ -2688,11 +2704,13 @@ impl PodmanInner {
             "--init",
         ]));
         push_job_engine_create_options(&mut arguments, storage.engine)?;
-        push_option(
-            &mut arguments,
-            "--pids-limit",
-            spec.resources().pids().to_string(),
-        );
+        let resources = spec.resources().ok_or_else(|| {
+            provider_error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        push_option(&mut arguments, "--pids-limit", resources.pids().to_string());
         push_option(&mut arguments, "--volume", mount);
         push_option(&mut arguments, "--workdir", spec.workspace().as_str());
         push_option(
@@ -2895,7 +2913,17 @@ impl PodmanInner {
             &self.options,
             paths,
             listener,
-            JobDockerLaunch::new(&names.handle(), process_id, cgroup, spec.resources()),
+            JobDockerLaunch::new(
+                &names.handle(),
+                process_id,
+                cgroup,
+                spec.resources().ok_or_else(|| {
+                    provider_error::known(
+                        ProviderErrorKind::InvalidConfiguration,
+                        ProviderStage::Validate,
+                    )
+                })?,
+            ),
             Arc::clone(&self.observer),
         )
         .map_err(|_| {
@@ -4276,9 +4304,15 @@ fn spec_fingerprint(
     hash_field(&mut hasher, &[spec.network() as u8]);
     hash_field(&mut hasher, &[spec.root_filesystem() as u8]);
     hash_field(&mut hasher, &[spec.privilege() as u8]);
-    hash_field(&mut hasher, &spec.resources().memory_bytes().to_be_bytes());
-    hash_field(&mut hasher, &spec.resources().cpu_millis().to_be_bytes());
-    hash_field(&mut hasher, &spec.resources().pids().to_be_bytes());
+    match spec.resources() {
+        Some(resources) => {
+            hash_field(&mut hasher, &[1]);
+            hash_field(&mut hasher, &resources.memory_bytes().to_be_bytes());
+            hash_field(&mut hasher, &resources.cpu_millis().to_be_bytes());
+            hash_field(&mut hasher, &resources.pids().to_be_bytes());
+        }
+        None => hash_field(&mut hasher, &[0]),
+    }
     match spec.resource_allocation() {
         Some(allocation) => {
             hash_field(&mut hasher, &[1]);

--- a/crates/automata-ci-sandbox-podman/tests/api.rs
+++ b/crates/automata-ci-sandbox-podman/tests/api.rs
@@ -57,6 +57,7 @@ fn docker_api_capability_is_advertised_only_when_explicitly_enabled() {
     );
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn buildkit_capability_requires_the_attempt_api_and_a_successful_local_probe() {
     let scratch = ScratchRoot::new("buildkit-capability-enabled");
@@ -122,6 +123,7 @@ fn buildkit_capability_requires_the_attempt_api_and_a_successful_local_probe() {
     ));
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn buildkit_capability_rejects_missing_mismatched_or_unprobeable_runtimes() {
     fn mismatch_digest(fake: &FakePodman) {

--- a/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
+++ b/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
@@ -527,7 +527,7 @@ fn writable_ephemeral_rootfs_is_explicit_and_retains_isolation_controls() {
         baseline.workspace().clone(),
         NetworkPolicy::PrivateEgress,
         RootFilesystemPolicy::Writable,
-        baseline.resources(),
+        baseline.resources().expect("enforced resources"),
     )
     .with_privilege(SandboxPrivilegePolicy::Administrator);
     let created = fixture

--- a/crates/automata-ci-sandbox-windows/src/provider.rs
+++ b/crates/automata-ci-sandbox-windows/src/provider.rs
@@ -385,7 +385,12 @@ impl ProviderInner {
             )
         })?;
         let group = create_process_group(spec)?;
-        let resources = spec.resources();
+        let resources = spec.resources().ok_or_else(|| {
+            known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
         let entry = Arc::new(SandboxEntry {
             handle: handle.clone(),
             generation: spec.generation(),
@@ -924,7 +929,12 @@ fn preflight_error(error: &std::io::Error) -> ProviderError {
 }
 
 fn create_process_group(spec: &SandboxSpec) -> Result<Arc<ProcessGroup>, ProviderError> {
-    let limits = spec.resources();
+    let limits = spec.resources().ok_or_else(|| {
+        known(
+            ProviderErrorKind::InvalidConfiguration,
+            ProviderStage::Validate,
+        )
+    })?;
     create_process_group_with_limits(limits.memory_bytes(), limits.cpu_millis(), limits.pids())
 }
 
@@ -1397,10 +1407,15 @@ fn spec_fingerprint(spec: &SandboxSpec) -> [u8; 32] {
     } else {
         fingerprint_field(&mut digest, b"scratch-absent");
     }
-    let resources = spec.resources();
-    fingerprint_field(&mut digest, &resources.memory_bytes().to_le_bytes());
-    fingerprint_field(&mut digest, &resources.cpu_millis().to_le_bytes());
-    fingerprint_field(&mut digest, &resources.pids().to_le_bytes());
+    match spec.resources() {
+        Some(resources) => {
+            fingerprint_field(&mut digest, b"enforced-resources");
+            fingerprint_field(&mut digest, &resources.memory_bytes().to_le_bytes());
+            fingerprint_field(&mut digest, &resources.cpu_millis().to_le_bytes());
+            fingerprint_field(&mut digest, &resources.pids().to_le_bytes());
+        }
+        None => fingerprint_field(&mut digest, b"host-shared-resources"),
+    }
     digest.finalize().into()
 }
 

--- a/crates/automata-ci-workflow-github/tests/ci_workflow.rs
+++ b/crates/automata-ci-workflow-github/tests/ci_workflow.rs
@@ -33,7 +33,7 @@ fn repository_ci_produces_an_accepted_source_plan() {
         plan.workflow().name().map(|name| name.value().as_str()),
         Some("CI")
     );
-    assert_eq!(plan.workflow().jobs().len(), 10);
+    assert_eq!(plan.workflow().jobs().len(), 11);
     assert_eq!(
         plan.workflow()
             .jobs()
@@ -47,6 +47,7 @@ fn repository_ci_produces_an_accepted_source_plan() {
             "renderer_tests",
             "postgres_store",
             "postgres_integrations",
+            "macos",
             "frontend",
             "renderer",
             "dist_build",
@@ -101,6 +102,7 @@ fn repository_ci_produces_an_accepted_source_plan() {
     && needs.renderer_tests.result == 'success'
     && needs.postgres_store.result == 'success'
     && needs.postgres_integrations.result == 'success'
+    && needs.macos.result == 'success'
     && needs.frontend.result == 'success'
     && (needs.renderer.result == 'success'
         || (github.event_name == 'pull_request'

--- a/crates/automata-ci-workflow-github/tests/fixtures/repository-ci.yml
+++ b/crates/automata-ci-workflow-github/tests/fixtures/repository-ci.yml
@@ -309,6 +309,91 @@ jobs:
           cargo test -p automata-ci-results-github --test postgres_cache --all-features --locked -- --ignored --test-threads=1
           cargo test -p automata-ci --test github_provider_end_to_end_matrix --all-features --locked -- --ignored --test-threads=1
 
+  macos:
+    name: macOS native runner
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Require pinned Apple Silicon toolchain
+        run: |
+          install -d -m 0700 -- "$TMPDIR"
+          rustc --version --verbose
+          cargo --version --verbose
+          host_triple="$(rustc --version --verbose | sed -n 's/^host: //p')"
+          test "$host_triple" = "aarch64-apple-darwin"
+          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 15
+
+      - name: Check shipped macOS binaries
+        run: cargo check --locked --bin automata --bin automata-runner
+
+      - name: Lint macOS provider, executor, and runner
+        run: >-
+          cargo clippy
+          --locked
+          -p automata-ci-metrics
+          -p automata-ci-sandbox-macos
+          -p automata-ci-job-executor-github
+          -p automata-ci-runner
+          --all-targets
+          --no-deps
+          --
+          -D warnings
+
+      - name: Record GitHub-hosted Bash shell reference
+        id: macos_shell_reference
+        shell: bash
+        run: |
+          reference="$RUNNER_TEMP/automata-macos-shell-reference.txt"
+          printf 'differential.bash=ok\n' > "$reference"
+          printf 'AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE=%s\n' "$reference" >> "$GITHUB_ENV"
+          printf 'AUTOMATA_DIFFERENTIAL_ENV=command-file\n' >> "$GITHUB_ENV"
+          printf 'fixture=native-output\n' >> "$GITHUB_OUTPUT"
+
+      - name: Record GitHub-hosted sh shell reference
+        shell: sh
+        env:
+          FROM_OUTPUT: ${{ steps.macos_shell_reference.outputs.fixture }}
+        run: |
+          test "$AUTOMATA_DIFFERENTIAL_ENV" = command-file
+          test "$FROM_OUTPUT" = native-output
+          test "$PWD" = "$GITHUB_WORKSPACE"
+          {
+            printf 'differential.sh=ok\n'
+            printf 'differential.environment=%s\n' "$AUTOMATA_DIFFERENTIAL_ENV"
+            printf 'differential.output=%s\n' "$FROM_OUTPUT"
+            printf 'differential.workspace=true\n'
+            printf 'differential.conclusion=success\n'
+          } >> "$AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE"
+
+      - name: Test macOS execution contracts
+        run: |
+          cargo test --locked -p automata-ci-execution
+          cargo test --locked -p automata-ci-job-executor-github --all-targets
+          cargo test --locked -p automata-ci-sandbox-macos --all-targets
+          cargo test --locked -p automata-ci-runner --lib
+          cargo test --locked -p automata-ci-runner --test product_context
+          cargo test --locked -p automata-ci-runner --test runner_product_config_macos
+          cargo test --locked -p automata-ci-runner --test capabilities_cli --test cli
+
+      - name: Test shipped macOS runner process
+        run: cargo test --locked -p automata-ci-runner --test native_runner_process_e2e -- --nocapture
+
+      - name: Exercise hidden shipped-binary supervisor
+        run: |
+          cargo build --locked --bin automata-runner
+          python3 scripts/ci/tests/macos-supervisor-smoke.py \
+            target/debug/automata-runner
+
   frontend:
     name: React SSR frontend
     runs-on: ubuntu-24.04
@@ -510,6 +595,7 @@ jobs:
           && needs.renderer_tests.result == 'success'
           && needs.postgres_store.result == 'success'
           && needs.postgres_integrations.result == 'success'
+          && needs.macos.result == 'success'
           && needs.frontend.result == 'success'
           && (needs.renderer.result == 'success'
               || (github.event_name == 'pull_request'
@@ -522,6 +608,7 @@ jobs:
       - renderer_tests
       - postgres_store
       - postgres_integrations
+      - macos
       - frontend
       - renderer
     runs-on: ubuntu-24.04

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -1,8 +1,8 @@
 # macOS runner implementation plan
 
 This page records the accepted implementation order for macOS runner support.
-Support remains planned until the native and virtual-machine acceptance gates
-below pass through the production runner composition.
+The trusted-native slice described in stages 1 and 2 is experimental. The
+Virtualization.framework isolation boundary in stage 3 remains planned.
 
 The first supported host is Apple Silicon running macOS 15 or newer. Workflow
 syntax does not change: the first slice executes GitHub-compatible `run:` steps
@@ -18,11 +18,12 @@ host networking, a writable host filesystem, and the unchanged host identity.
 This is not a hostile-workload boundary.
 
 macOS cannot enforce Automata's whole-job CPU, memory, and process limits for a
-native process tree. The execution contract will therefore distinguish
-enforced limits from an explicit host-shared resource policy. Native macOS
-advertises zero quantitative capacity and accepts only jobs with zero minimum
-resource requirements. Podman and Windows continue to require and enforce
-their existing hard limits.
+native process tree. The execution contract therefore distinguishes enforced
+limits from an explicit host-shared resource policy. Native macOS advertises
+one operator-configured scheduling capacity and one execution slot, but those
+CPU, memory, and PID values are admission metadata rather than hard per-job
+ceilings. Ephemeral-disk and GPU capacity remain zero. Podman and Windows
+continue to require and enforce their existing hard limits.
 
 Each command is owned by a same-binary supervisor over a private bounded
 control channel. The supervisor owns the POSIX process group and terminates it
@@ -86,8 +87,9 @@ scoped self-hosted Apple Silicon runner.
 - Existing Linux and Windows provider, executor, configuration, and workflow
   tests remain unchanged and green.
 - Native configuration rejects the wrong OS/architecture, macOS below 15,
-  nonzero resource claims, parallel slots, overlapping roots, unsupported
-  network/filesystem/privilege policies, and unsupported workflow features.
+  parallel slots, overlapping roots, nonzero ephemeral-disk or GPU capacity,
+  unsupported network/filesystem/privilege policies, and unsupported workflow
+  features. Configured CPU, memory, and PID capacity is explicitly advisory.
 - Native provider tests cover path attacks, bounded copies and output, WAL
   replay and corruption, stale generations, timeout, cancellation, process
   cleanup, supervisor loss, and restart recovery.

--- a/scripts/ci/tests/macos-supervisor-smoke.py
+++ b/scripts/ci/tests/macos-supervisor-smoke.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Exercise the shipped runner's private macOS supervisor protocol."""
+
+import json
+import pathlib
+import struct
+import subprocess
+import sys
+
+REQUEST_MAGIC = b"AMSQ"
+RESPONSE_MAGIC = b"AMSR"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: macos-supervisor-smoke.py <automata-runner>")
+    runner = pathlib.Path(sys.argv[1]).resolve(strict=True)
+    request = json.dumps(
+        {
+            "program": "/bin/sh",
+            "arguments": ["-c", "printf macos-supervisor-smoke"],
+            "working_directory": "/",
+            "environment": [],
+            "timeout_millis": 5000,
+            "output_limit": 4096,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    frame = REQUEST_MAGIC + struct.pack("<I", len(request)) + request
+    process = subprocess.Popen(
+        [str(runner), "__macos-job-supervisor"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdin is not None
+    process.stdin.write(frame)
+    process.stdin.flush()
+    try:
+        response = read_response(process.stdout)
+    finally:
+        process.stdin.close()
+    stderr = process.stderr.read() if process.stderr is not None else b""
+    return_code = process.wait(timeout=15)
+    if return_code != 0:
+        raise RuntimeError("shipped macOS supervisor exited unsuccessfully")
+    if stderr:
+        raise RuntimeError("shipped macOS supervisor emitted diagnostics")
+    verify_response(response)
+    return 0
+
+
+def read_response(stream) -> bytes:
+    header = read_exact(stream, 14)
+    record_count = struct.unpack_from("<I", header, 10)[0]
+    response = bytearray(header)
+    for _ in range(record_count):
+        record_header = read_exact(stream, 6)
+        response.extend(record_header)
+        length = struct.unpack_from("<I", record_header, 2)[0]
+        response.extend(read_exact(stream, length))
+    return bytes(response)
+
+
+def read_exact(stream, length: int) -> bytes:
+    if stream is None:
+        raise RuntimeError("macOS supervisor output pipe is unavailable")
+    result = bytearray()
+    while len(result) < length:
+        chunk = stream.read(length - len(result))
+        if not chunk:
+            raise RuntimeError("truncated macOS supervisor response")
+        result.extend(chunk)
+    return bytes(result)
+
+
+def verify_response(response: bytes) -> None:
+    if len(response) < 14 or response[:4] != RESPONSE_MAGIC:
+        raise RuntimeError("invalid macOS supervisor response header")
+    termination, truncated = response[4:6]
+    exit_code, record_count = struct.unpack_from("<iI", response, 6)
+    if termination != 0 or truncated != 0 or exit_code != 0:
+        raise RuntimeError("unexpected macOS supervisor termination")
+    offset = 14
+    stdout = bytearray()
+    ended = set()
+    for _ in range(record_count):
+        if offset + 6 > len(response):
+            raise RuntimeError("truncated macOS supervisor output record")
+        stream, end = response[offset : offset + 2]
+        length = struct.unpack_from("<I", response, offset + 2)[0]
+        offset += 6
+        if offset + length > len(response):
+            raise RuntimeError("truncated macOS supervisor output bytes")
+        content = response[offset : offset + length]
+        offset += length
+        if end:
+            if content:
+                raise RuntimeError("end-of-stream record carried data")
+            ended.add(stream)
+        elif stream == 0:
+            stdout.extend(content)
+    if offset != len(response) or ended != {0, 1}:
+        raise RuntimeError("invalid macOS supervisor response tail")
+    if bytes(stdout) != b"macos-supervisor-smoke":
+        raise RuntimeError("macOS supervisor did not preserve stdout")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/tests/workflow-safety.test.mjs
+++ b/scripts/ci/tests/workflow-safety.test.mjs
@@ -377,6 +377,26 @@ test("repository CI omits the hosted Windows job and retains fixture parity", ()
   assert.doesNotMatch(ci, /^[ \t]+runs-on: windows-/m);
 });
 
+test("CI runs the native macOS contract on pinned Apple Silicon", () => {
+  const ci = source(".github/workflows/ci.yml");
+  const macos = workflowJob(ci, "macos");
+
+  assert.match(macos, /runs-on: macos-15/);
+  assert.match(macos, /host_triple[^\n]+aarch64-apple-darwin/);
+  assert.match(macos, /sw_vers -productVersion/);
+  assert.match(macos, /-p automata-ci-metrics/);
+  assert.match(macos, /-p automata-ci-sandbox-macos/);
+  assert.match(macos, /--test product_context/);
+  assert.match(macos, /--test runner_product_config_macos/);
+  assert.match(macos, /--test native_runner_process_e2e/);
+  assert.match(macos, /macos-supervisor-smoke\.py/);
+  assert.match(macos, /Record GitHub-hosted Bash shell reference/);
+  assert.match(macos, /Record GitHub-hosted sh shell reference/);
+  assert.match(macos, /AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE/);
+  assert.match(macos, /steps\.macos_shell_reference\.outputs\.fixture/);
+  assert.doesNotMatch(macos, /self-hosted/);
+});
+
 test("Rust CI publishes an ordinary-lane report with a service-aware guard", () => {
   const ci = source(".github/workflows/ci.yml");
   const rustCoverage = section(
@@ -495,7 +515,7 @@ test("distribution build overlaps validation while the final gate retains every 
   );
   assert.match(
     dist,
-    /needs:\n      - dist_build\n      - verify\n      - rust_tests\n      - rust_coverage\n      - renderer_tests\n      - postgres_store\n      - postgres_integrations\n      - frontend\n      - renderer/,
+    /needs:\n      - dist_build\n      - verify\n      - rust_tests\n      - rust_coverage\n      - renderer_tests\n      - postgres_store\n      - postgres_integrations\n      - macos\n      - frontend\n      - renderer/,
   );
   assert.match(dist, /needs\.dist_build\.result == 'success'/);
   assert.match(dist, /needs\.verify\.result == 'success'/);
@@ -504,6 +524,7 @@ test("distribution build overlaps validation while the final gate retains every 
   assert.match(dist, /needs\.renderer_tests\.result == 'success'/);
   assert.match(dist, /needs\.postgres_store\.result == 'success'/);
   assert.match(dist, /needs\.postgres_integrations\.result == 'success'/);
+  assert.match(dist, /needs\.macos\.result == 'success'/);
   assert.match(dist, /needs\.frontend\.result == 'success'/);
   assert.match(
     dist,

--- a/scripts/ci/verify-product-targets.sh
+++ b/scripts/ci/verify-product-targets.sh
@@ -139,10 +139,10 @@ runner_package = next(
     package for package in metadata["packages"] if package["name"] == "automata-ci-runner"
 )
 if runner_package["description"] != (
-    "Automata workflow runner for Linux and trusted native Windows hosts"
+    "Automata workflow runner for Linux and trusted native Windows/macOS hosts"
 ):
     print(
-        "error: runner package description must match its current Linux and trusted Windows support boundary",
+        "error: runner package description must match its Linux and trusted native host support boundary",
         file=sys.stderr,
     )
     raise SystemExit(1)


### PR DESCRIPTION
## Summary

- add trusted native ARM64 macOS 15+ runner execution with one host-shared slot
- supervise POSIX process groups through a hidden same-binary protocol with bounded output, cancellation, timeout, replay, and cleanup
- add exact macOS context/toolchain behavior and noninteractive Keychain-backed runner secrets
- add a pinned `macos-15` CI lane, shipped-runner E2E, Bash/sh differential fixture, provider recovery tests, and supervisor smoke coverage
- keep the Virtualization.framework provider as the documented next isolation stage

## Base

The workflow-runtime repair from #29 has merged. This PR contains one macOS implementation commit, and GitHub validated its merge result against current `main`.

## Validation

- `cargo fmt --all -- --check`
- targeted Clippy for metrics, macOS provider, GitHub executor, and runner with `-D warnings`
- all-target tests for execution, GitHub executor, metrics, macOS provider, runner, and workflow compiler
- shipped `automata-runner` native process E2E with Bash to sh command-file propagation
- hidden supervisor shipped-binary smoke
- workflow safety tests and pinned actionlint 1.7.12

GitHub CI is green, including the pinned macOS 15 lane and final static-distribution gate.