### PR TITLE
Recover uncertain sandbox creation custody

### DIFF
--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -359,6 +359,21 @@ pub trait SandboxProvider: fmt::Debug + Send + Sync {
     /// Returns the provider's fixed, explicit capability declaration.
     fn capabilities(&self) -> &ProviderCapabilities;
 
+    /// Reconstructs the exact opaque identity reserved by a create operation.
+    ///
+    /// Providers with deterministic create identities should return the same
+    /// handle that an uncertain [`Self::create`] failure carries. The runtime
+    /// uses this only to recover legacy durable intents that predate custody of
+    /// that handle; returning `None` keeps the unresolved operation fenced.
+    #[must_use]
+    fn create_recovery_handle(
+        &self,
+        _operation_id: OperationId,
+        _generation: SandboxGeneration,
+    ) -> Option<SandboxHandle> {
+        None
+    }
+
     /// Creates or exactly replays one sandbox operation.
     ///
     /// Reusing an operation identifier with different request material must

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -12,12 +12,12 @@ use std::{
 use automata_ci_action_github::GithubActionMetadataDecoder;
 use automata_ci_core::{
     ActionReference, AttemptId, JobAuthorityProfile, JobConclusion, JobIrEnvelope, JobLifecycle,
-    JobResult, JobResultOutput, JobResultValidationError, JobRuntimeContext,
+    JobResult, JobResultOutput, JobResultValidationError, JobRuntimeContext, LeaseGuard,
     MAX_JOB_RESULT_ANNOTATIONS, MAX_JOB_RESULT_ATTACHMENT_BYTES, MAX_STEP_ANNOTATION_PROPERTIES,
-    MAX_STEP_ATTACHMENT_TEXT_BYTES, OutputSensitivity, RuntimeBoolean, RuntimePositiveInteger,
-    RuntimeTimeoutTemplate, SecretBinding, SemanticStep, ShellTemplate, StepAnnotation,
-    StepAnnotationLevel, StepAnnotationProperty, StepResult, UnixMillis, ValueSource,
-    ValueTemplate,
+    MAX_STEP_ATTACHMENT_TEXT_BYTES, OperationId, OutputSensitivity, RuntimeBoolean,
+    RuntimePositiveInteger, RuntimeTimeoutTemplate, SecretBinding, SemanticStep, ShellTemplate,
+    StepAnnotation, StepAnnotationLevel, StepAnnotationProperty, StepResult, UnixMillis,
+    ValueSource, ValueTemplate,
 };
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, DestroySandbox, ExecutionArgv, ExecutionCommand,
@@ -4283,6 +4283,23 @@ impl GithubJobExecutor {
         }
     }
 
+    fn retain_create_failure_custody(
+        events: &Arc<dyn ExecutionEvents>,
+        operation_id: OperationId,
+        error: &ProviderError,
+    ) -> Result<(), ExecutorAdapterError> {
+        if error.outcome() == automata_ci_execution::OperationOutcome::Uncertain
+            && let Some(handle) = error.recovery_handle()
+        {
+            let identity = journal_identity(handle)?;
+            return events
+                .sandbox_created(operation_id, identity)
+                .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal));
+        }
+        let _ = events.provider_operation_failed(operation_id, provider_failure_outcome(error));
+        Ok(())
+    }
+
     fn obtain_endpoint(
         &self,
         request: &ExecutionRequest,
@@ -4348,8 +4365,7 @@ impl GithubJobExecutor {
             let record = match self.ports.provider.create(&spec, &cancellation) {
                 Ok(record) => record,
                 Err(error) => {
-                    let _ = events
-                        .provider_operation_failed(operation_id, provider_failure_outcome(&error));
+                    Self::retain_create_failure_custody(events, operation_id, &error)?;
                     return Err(map_provider_error(&error));
                 }
             };
@@ -5188,6 +5204,23 @@ impl fmt::Debug for GithubJobExecutor {
 impl JobExecutor for GithubJobExecutor {
     fn admit(&self, job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
         self.validate_admission(job).map(ExecutionAdmission::new)
+    }
+
+    fn create_recovery_sandbox(
+        &self,
+        operation_id: OperationId,
+        guard: LeaseGuard,
+    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
+        let generation = SandboxGeneration::new(guard.fencing_token().get())
+            .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+        self.ports
+            .provider
+            .create_recovery_handle(operation_id, generation)
+            .map(|handle| {
+                journal_identity(&handle)
+                    .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))
+            })
+            .transpose()
     }
 
     fn execute(

--- a/crates/automata-ci-job-executor-github/tests/provider_saga.rs
+++ b/crates/automata-ci-job-executor-github/tests/provider_saga.rs
@@ -242,27 +242,46 @@ async fn provider_failures_map_to_exact_executor_and_durable_domains() {
                 panic!("one durable create intent for {provider_kind:?} with {outcome:?}");
             };
             assert_eq!(*operation_kind, ProviderOperationKind::CreateSandbox);
-            let expected_failure = match outcome {
-                OperationOutcome::KnownNoEffect => {
-                    ProviderFailureOutcome::KnownNoEffect(failure_kind)
-                }
-                OperationOutcome::Uncertain => ProviderFailureOutcome::Uncertain(failure_kind),
+            let expected_failures = match outcome {
+                OperationOutcome::KnownNoEffect => vec![(
+                    *operation_id,
+                    ProviderFailureOutcome::KnownNoEffect(failure_kind),
+                )],
+                OperationOutcome::Uncertain => Vec::new(),
             };
             assert_eq!(
                 fixture.events.provider_operation_failures(),
-                vec![(*operation_id, expected_failure)],
+                expected_failures,
                 "wrong journal mapping for {provider_kind:?} with {outcome:?}"
             );
             assert_eq!(
                 fixture.events.pending_provider_operation(),
-                (outcome == OperationOutcome::Uncertain)
-                    .then_some((*operation_id, ProviderOperationKind::CreateSandbox)),
+                None,
                 "wrong replay state for {provider_kind:?} with {outcome:?}"
             );
             assert_eq!(fixture.provider.counts(), (1, 0, 0));
-            assert_eq!(fixture.events.sandbox(), None);
+            assert_eq!(
+                fixture.events.sandbox(),
+                (outcome == OperationOutcome::Uncertain).then(journal_identity),
+                "uncertain create retains exact cleanup custody"
+            );
         }
     }
+}
+
+#[test]
+fn deterministic_provider_identity_reconstructs_legacy_create_custody() {
+    let fixture = Fixture::new(Vec::new(), Vec::new());
+    let request = fixture.request(run_job("true\n"));
+    let operation_id = automata_ci_core::OperationId::new();
+
+    let recovered = fixture
+        .executor
+        .create_recovery_sandbox(operation_id, request.lease().guard())
+        .expect("recovery identity construction")
+        .expect("fake provider has deterministic identity");
+
+    assert_eq!(recovered, journal_identity());
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -1634,6 +1634,14 @@ impl SandboxProvider for FakeProvider {
         &self.capabilities
     }
 
+    fn create_recovery_handle(
+        &self,
+        _operation_id: OperationId,
+        _generation: automata_ci_execution::SandboxGeneration,
+    ) -> Option<SandboxHandle> {
+        Some(self.handle.clone())
+    }
+
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-runner-runtime/src/port.rs
+++ b/crates/automata-ci-runner-runtime/src/port.rs
@@ -543,6 +543,25 @@ pub trait JobExecutor: fmt::Debug + Send + Sync {
     /// selected environment cannot be supported exactly.
     fn admit(&self, job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection>;
 
+    /// Reconstructs exact cleanup custody for a legacy uncertain create.
+    ///
+    /// New executions must durably retain the recovery handle returned by the
+    /// provider. This compatibility seam lets a provider with deterministic
+    /// create identities recover an older intent without broad enumeration or
+    /// weakening the journal's unresolved-operation fence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if the durable operation identity cannot be
+    /// mapped to an exact provider-owned sandbox handle.
+    fn create_recovery_sandbox(
+        &self,
+        _operation_id: OperationId,
+        _guard: LeaseGuard,
+    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
+        Ok(None)
+    }
+
     /// Starts or reattaches to one admitted attempt.
     fn execute(
         &self,

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -24,8 +24,9 @@ use automata_ci_protocol_protobuf::{
 use automata_ci_runner_journal::{
     CancellationRecord, CommandDisposition, CommandIgnoredReason, DurableCommand, JobIrContentRef,
     JournalContentRetainSet, JournalInvariantError, LeaseOfferRecord, LeaseOfferStatus,
-    LeasePollCheckpoint, LogSegmentAcknowledgement, RunnerJournal, RuntimeAuthorityContentRef,
-    SessionBinding as JournalSessionBinding, SlotSnapshot, TerminalResultRecord,
+    LeasePollCheckpoint, LogSegmentAcknowledgement, ProviderOperationKind, RunnerJournal,
+    RuntimeAuthorityContentRef, SessionBinding as JournalSessionBinding, SlotSnapshot,
+    TerminalResultRecord,
 };
 use automata_ci_runner_spool::{ContentKind, DurableContentStore};
 use automata_ci_runner_transport::PreparedRequest;
@@ -2454,12 +2455,13 @@ impl RunnerSessionSupervisor {
         durable: &SlotSnapshot,
         cancellation: CancellationToken,
     ) -> Result<(), RunnerRuntimeError> {
+        let durable = self.recover_uncertain_create_custody(session, durable)?;
         if durable
             .terminal_result()
             .is_some_and(TerminalResultRecord::is_acknowledged)
         {
             return self
-                .finish_terminal_slot_delivery(session, durable, cancellation)
+                .finish_terminal_slot_delivery(session, &durable, cancellation)
                 .await;
         }
         let watchdog = Arc::new(LeaseWatchdog::new(self.local_lease_deadline(
@@ -2480,16 +2482,51 @@ impl RunnerSessionSupervisor {
         let result = self
             .finish_terminal_slot_maintained(
                 session,
-                durable,
+                &durable,
                 watchdog,
                 lease_expired,
-                Self::recovered_finalization_lifecycle(durable),
+                Self::recovered_finalization_lifecycle(&durable),
                 cancellation,
             )
             .await;
         watchdog_stop.cancel();
         let _ = watchdog_task.await;
         result
+    }
+
+    fn recover_uncertain_create_custody(
+        &self,
+        session: RuntimeSession,
+        durable: &SlotSnapshot,
+    ) -> Result<SlotSnapshot, RunnerRuntimeError> {
+        let Some(operation) = durable.provider_operations().last().copied() else {
+            return Ok(durable.clone());
+        };
+        if durable.sandbox().is_some()
+            || operation.kind() != ProviderOperationKind::CreateSandbox
+            || !operation.is_pending()
+        {
+            return Ok(durable.clone());
+        }
+        let guard = durable.offer().lease().guard();
+        let sandbox = self
+            .inner
+            .ports
+            .executor
+            .create_recovery_sandbox(operation.operation_id(), guard)
+            .map_err(RunnerRuntimeError::Executor)?
+            .ok_or(RunnerRuntimeError::ExecutorContract)?;
+        let snapshot = self.inner.ports.journal.record_sandbox_created(
+            session.negotiated.session_id(),
+            durable.slot(),
+            guard,
+            operation.operation_id(),
+            sandbox,
+        )?;
+        snapshot
+            .slot(durable.slot())
+            .cloned()
+            .ok_or(RunnerRuntimeError::ExecutorContract)
     }
 
     async fn finish_terminal_slot_maintained(

--- a/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
+++ b/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
@@ -7,15 +7,16 @@ use std::sync::{
 use std::time::Duration;
 
 use automata_ci_core::{
-    JobConclusion, JobLifecycle, JobSecretExposure, LogChannel, RunnerId, RunnerSessionId,
-    UnixMillis,
+    JobConclusion, JobLifecycle, JobSecretExposure, LogChannel, OperationId, RunnerId,
+    RunnerSessionId, UnixMillis,
 };
 use automata_ci_protocol::{
     MessageHeader, NegotiatedSession, OperationAck, RunnerToServer, SUPPORTED_PROTOCOL_RANGE,
     ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_journal::{
-    CommandDisposition, CommandIgnoredReason, RunnerJournal, SessionBinding,
+    CommandDisposition, CommandIgnoredReason, ProviderFailureKind, ProviderFailureOutcome,
+    ProviderOperation, ProviderOperationKind, RunnerJournal, SessionBinding,
 };
 use automata_ci_runner_runtime::{
     ExecutionCancellationReason, MonotonicMillis, RetryPolicy, RunnerRuntimeControlClient,
@@ -1229,6 +1230,90 @@ async fn executor_failure_is_terminalized_per_slot_while_sibling_and_supervisor_
         .expect("runner shutdown")
         .expect("runtime task")
         .expect("clean shutdown after isolated failure");
+}
+
+#[tokio::test]
+async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_release() {
+    let scratch = support::Scratch::new("legacy-uncertain-create-recovery");
+    let runner_id = RunnerId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
+    let guard = fixture.lease.guard();
+    journal
+        .transition_lifecycle(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Preparing,
+        )
+        .expect("begin legacy preparation");
+    let create = OperationId::new();
+    journal
+        .record_provider_intent(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            ProviderOperation::intent(create, ProviderOperationKind::CreateSandbox),
+        )
+        .expect("record legacy create intent");
+    journal
+        .fail_provider_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            create,
+            ProviderFailureOutcome::Uncertain(ProviderFailureKind::Internal),
+        )
+        .expect("retain uncertain legacy create");
+    support::seed_failed_terminal_without_logs(journal.as_ref(), spool.as_ref(), &fixture);
+    let terminal_operation = journal
+        .snapshot()
+        .expect("terminal snapshot")
+        .slot(fixture.slot)
+        .and_then(|slot| slot.terminal_result())
+        .expect("terminal result")
+        .operation_id();
+    journal
+        .acknowledge_terminal_result(fixture.session_id, fixture.slot, guard, terminal_operation)
+        .expect("acknowledge legacy terminal result");
+
+    let shutdown = CancellationToken::new();
+    let client = Arc::new(support::FailureIsolationClient::new(fixture.session_id));
+    let executor = Arc::new(support::LegacyUncertainCreateExecutor::default());
+    let runtime = RunnerSessionSupervisor::new(
+        support::config(runner_id),
+        RunnerRuntimePorts::new(
+            client.clone(),
+            journal.clone(),
+            spool,
+            executor.clone(),
+            Arc::new(support::FixedClock::new(10_000, 50)),
+            Arc::new(support::ImmediateSleeper),
+            Arc::new(SystemRuntimeIds),
+        ),
+    );
+    let task_shutdown = shutdown.clone();
+    let task = tokio::spawn(async move { runtime.run(task_shutdown).await });
+
+    tokio::time::timeout(Duration::from_secs(5), client.wait_for_released_slot_poll())
+        .await
+        .expect("legacy create custody is destroyed and slot released");
+    assert_eq!(executor.recovery_calls(), vec![(create, guard)]);
+    assert_eq!(executor.cleanup_calls(), 1);
+    assert!(
+        journal
+            .snapshot()
+            .expect("released snapshot")
+            .slots()
+            .is_empty()
+    );
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("runner shutdown")
+        .expect("runtime task")
+        .expect("clean shutdown after legacy recovery");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -1486,6 +1486,79 @@ impl JobExecutor for CancellationContentRaceExecutor {
 }
 
 #[derive(Debug, Default)]
+pub struct LegacyUncertainCreateExecutor {
+    recovery_calls: Mutex<Vec<(OperationId, automata_ci_core::LeaseGuard)>>,
+    cleanup_calls: AtomicUsize,
+}
+
+impl LegacyUncertainCreateExecutor {
+    pub fn recovery_calls(&self) -> Vec<(OperationId, automata_ci_core::LeaseGuard)> {
+        self.recovery_calls
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    pub fn cleanup_calls(&self) -> usize {
+        self.cleanup_calls.load(Ordering::SeqCst)
+    }
+
+    fn recovery_identity() -> SandboxIdentity {
+        SandboxIdentity::new(
+            ProviderName::new("legacy-recovery-provider").expect("provider name"),
+            JournalSandboxHandle::new("legacy-uncertain-create").expect("sandbox handle"),
+        )
+    }
+}
+
+impl JobExecutor for LegacyUncertainCreateExecutor {
+    fn admit(&self, _job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
+        Ok(ExecutionAdmission::new(sandbox_environment()))
+    }
+
+    fn create_recovery_sandbox(
+        &self,
+        operation_id: OperationId,
+        guard: automata_ci_core::LeaseGuard,
+    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
+        self.recovery_calls
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push((operation_id, guard));
+        Ok(Some(Self::recovery_identity()))
+    }
+
+    fn execute(
+        &self,
+        _request: ExecutionRequest,
+        _events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> ExecutorFuture<'_> {
+        Box::pin(async { Err(ExecutorError::new(ExecutorErrorKind::Internal)) })
+    }
+
+    fn cleanup(
+        &self,
+        request: CleanupRequest,
+        events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> CleanupFuture<'_> {
+        Box::pin(async move {
+            if request.sandbox() != &Self::recovery_identity() {
+                return Err(ExecutorError::new(ExecutorErrorKind::Internal));
+            }
+            self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+            let destroy = events
+                .begin_provider_operation(ProviderOperationKind::DestroySandbox)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+            events
+                .provider_operation_completed(destroy)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))
+        })
+    }
+}
+
+#[derive(Debug, Default)]
 pub struct FailureIsolationExecutor {
     survivor_started: AtomicBool,
 }

--- a/crates/automata-ci-runner/src/product/managed_secret_delivery.rs
+++ b/crates/automata-ci-runner/src/product/managed_secret_delivery.rs
@@ -4,11 +4,12 @@ use async_trait::async_trait;
 use automata_ci_auth::secret::{SecretString, SecureRandom};
 use std::collections::BTreeMap;
 
-use automata_ci_core::{RunnerId, SecretBinding};
+use automata_ci_core::{LeaseGuard, OperationId, RunnerId, SecretBinding};
 use automata_ci_job_executor_github::{
     EphemeralJobSecret, EphemeralJobSecrets, GithubJobExecutor, SecretCustodyAcknowledger,
 };
 use automata_ci_protocol::ManagedSecretBindingOverlay;
+use automata_ci_runner_journal::SandboxIdentity;
 use automata_ci_runner_runtime::{
     AdmissionRejection, CleanupFuture, CleanupRequest, ExecutionAdmission, ExecutionCancellation,
     ExecutionEvents, ExecutionRequest, ExecutorError, ExecutorErrorKind, ExecutorFuture,
@@ -122,6 +123,14 @@ impl JobExecutor for ManagedSecretJobExecutor {
         job: &automata_ci_core::JobIrEnvelope,
     ) -> Result<ExecutionAdmission, AdmissionRejection> {
         self.base.admit(job)
+    }
+
+    fn create_recovery_sandbox(
+        &self,
+        operation_id: OperationId,
+        guard: LeaseGuard,
+    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
+        self.base.create_recovery_sandbox(operation_id, guard)
     }
 
     fn execute(

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -2210,6 +2210,14 @@ impl SandboxProvider for ObservedSandboxProvider {
         self.inner.capabilities()
     }
 
+    fn create_recovery_handle(
+        &self,
+        operation_id: automata_ci_execution::OperationId,
+        generation: automata_ci_execution::SandboxGeneration,
+    ) -> Option<SandboxHandle> {
+        self.inner.create_recovery_handle(operation_id, generation)
+    }
+
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -229,6 +229,14 @@ impl SandboxProvider for RootlessPodmanProvider {
         &self.inner.capabilities
     }
 
+    fn create_recovery_handle(
+        &self,
+        operation_id: automata_ci_execution::OperationId,
+        generation: automata_ci_execution::SandboxGeneration,
+    ) -> Option<SandboxHandle> {
+        Some(ResourceNames::for_create(operation_id, generation).handle())
+    }
+
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
+++ b/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
@@ -37,6 +37,24 @@ impl PodmanLaunchTrust for ToggleLaunchTrust {
 }
 
 #[test]
+fn deterministic_create_recovery_handle_matches_the_created_sandbox() {
+    let fixture = Fixture::new("create-recovery-handle");
+    let operation_id = OperationId::new();
+    let spec = sample_spec(operation_id);
+    let recovered = fixture
+        .provider
+        .create_recovery_handle(operation_id, spec.generation())
+        .expect("Podman create identities are deterministic");
+
+    let created = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create sandbox");
+
+    assert_eq!(&recovered, created.handle());
+}
+
+#[test]
 fn provider_use_quarantines_before_dynamic_state_or_podman_work() {
     let admitted = Arc::new(AtomicBool::new(true));
     let trust = PodmanLaunchTrustHandle::new(Arc::new(ToggleLaunchTrust(Arc::clone(&admitted))));


### PR DESCRIPTION
## Summary

- retain exact sandbox cleanup custody when provider create returns an uncertain outcome
- reconstruct legacy Podman create identity from the durable operation ID and lease generation
- run the existing fenced destroy/replay path before terminal slot release; unsupported providers remain fail-closed

This supersedes #27, whose stale branch predates the reconstructed runtime merged in #29.

## Validation

- full `automata-ci-runner-runtime` all-target suite
- full `automata-ci-job-executor-github` all-target suite
- full `automata-ci-sandbox-podman` all-target suite (live tests intentionally ignored)
- `cargo check -p automata-ci-runner --lib --locked`
- focused provider saga: 6/6
- strict all-target/all-feature Clippy `-D warnings` for all affected packages
- strict private-item rustdoc `-D warnings`
- workspace rustfmt check and `git diff --check`

All local Rust gates used `CARGO_BUILD_JOBS=1`.