### PR TITLE
docs: define shard capability contract

### DIFF
--- a/contracts/cloud-core/README.md
+++ b/contracts/cloud-core/README.md
@@ -1,0 +1,19 @@
+# Automata Cloud/Core contracts
+
+This directory contains the public, language-neutral wire contracts between an
+Automata Core deployment and an optional external control plane such as
+Automata Cloud. Core implementations must not depend on private Cloud code.
+
+Contracts are versioned independently from the Automata release. Within a
+version, objects are exact and reject unknown fields; an incompatible change
+requires a new contract version.
+
+The first contract is
+[`v1/shard-capabilities.schema.json`](v1/shard-capabilities.schema.json). It
+describes the response from `GET /internal/v1/capabilities`, allowing a control
+plane to verify a load-balanced Core shard's identity, release, public data-plane
+origin, and supported protocol versions before routing customer traffic.
+
+Consumers may vendor a released schema, but should record its upstream path and
+SHA-256 digest so local generated types and runtime validators cannot drift
+silently.

--- a/contracts/cloud-core/v1/examples/shard-capabilities.json
+++ b/contracts/cloud-core/v1/examples/shard-capabilities.json
@@ -1,0 +1,20 @@
+{
+  "protocol_version": 1,
+  "shard_id": "prod-us-east-1-001",
+  "release": {
+    "version": "0.1.0-alpha.1",
+    "commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "protocols": {
+    "delegated_actor": [1],
+    "core_http": [1],
+    "page_model": [1],
+    "live_log": [1],
+    "usage_event": [1],
+    "entitlement": [1]
+  },
+  "public_endpoints": {
+    "live_logs_origin": "https://logs.us-east-1.automata.example"
+  },
+  "server_time_ms": 1786500060000
+}

--- a/contracts/cloud-core/v1/shard-capabilities.schema.json
+++ b/contracts/cloud-core/v1/shard-capabilities.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:automata:cloud-core:v1:shard-capabilities",
+  "title": "Automata Core shard capabilities v1",
+  "description": "Identity, release, endpoints, and protocol versions advertised by one load-balanced Automata Core shard.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol_version",
+    "shard_id",
+    "release",
+    "protocols",
+    "public_endpoints",
+    "server_time_ms"
+  ],
+  "properties": {
+    "protocol_version": {
+      "const": 1
+    },
+    "shard_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "commit"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[0-9A-Za-z][0-9A-Za-z.+-]*$"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 40,
+          "maxLength": 64,
+          "pattern": "^[0-9a-f]+$"
+        }
+      }
+    },
+    "protocols": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delegated_actor",
+        "core_http",
+        "live_log",
+        "usage_event",
+        "entitlement"
+      ],
+      "properties": {
+        "delegated_actor": { "$ref": "#/$defs/versionSet" },
+        "core_http": { "$ref": "#/$defs/versionSet" },
+        "page_model": { "$ref": "#/$defs/versionSet" },
+        "live_log": { "$ref": "#/$defs/versionSet" },
+        "usage_event": { "$ref": "#/$defs/versionSet" },
+        "entitlement": { "$ref": "#/$defs/versionSet" }
+      }
+    },
+    "public_endpoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["live_logs_origin"],
+      "properties": {
+        "live_logs_origin": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://",
+          "minLength": 9,
+          "maxLength": 2048
+        }
+      }
+    },
+    "server_time_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    }
+  },
+  "$defs": {
+    "versionSet": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 255
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the first public, language-neutral Cloud/Core boundary contract
- define an exact JSON Schema for `GET /internal/v1/capabilities`
- cover shard identity, release metadata, supported protocol versions, public live-log origin, and server time
- include a valid v1 example and vendoring/versioning guidance

This publishes only a wire contract. It does not implement the endpoint or introduce a dependency on private Automata Cloud code.

## Validation

- validated the schema against the JSON Schema 2020-12 metaschema
- validated the example against the schema
- compiled and exercised the byte-identical vendored schema with Ajv in the linked Automata Cloud change
- `git diff --cached --check`
