### PR TITLE
Fix schema 2 provider manifest digest goldens

### DIFF
--- a/crates/automata-ci-store/tests/github_provider_manifest_api.rs
+++ b/crates/automata-ci-store/tests/github_provider_manifest_api.rs
@@ -317,7 +317,7 @@ fn digest_binds_every_mutable_evidence_and_server_derived_repository() {
     );
     assert_eq!(
         original.digest().to_string(),
-        "56bb579d90d1b06f96ee860ece75f0bd33106285bb454c54ab477f00d23ad644"
+        "92d2d6a43e9e4e24c87003cd1ab13d9f58c5745451722119c402d2ca6e74de41"
     );
     assert_eq!(
         credential_free.authority_profile(),
@@ -342,7 +342,7 @@ fn digest_binds_every_mutable_evidence_and_server_derived_repository() {
 }
 
 #[test]
-fn owner_binding_uses_a_new_domain_without_changing_legacy_goldens() {
+fn owner_binding_uses_an_independent_domain_and_preserves_the_base_digest() {
     let legacy = manifest(1, 1, 1, [7; 32], "Automata CI");
     let owner = legacy
         .clone()
@@ -360,7 +360,7 @@ fn owner_binding_uses_a_new_domain_without_changing_legacy_goldens() {
     assert_ne!(owner.digest(), other_owner.digest());
     assert_eq!(
         legacy.digest().to_string(),
-        "56bb579d90d1b06f96ee860ece75f0bd33106285bb454c54ab477f00d23ad644"
+        "92d2d6a43e9e4e24c87003cd1ab13d9f58c5745451722119c402d2ca6e74de41"
     );
 }
 

--- a/crates/automata-ci-store/tests/postgres_github_provider_manifest.rs
+++ b/crates/automata-ci-store/tests/postgres_github_provider_manifest.rs
@@ -708,7 +708,7 @@ async fn sql_canonical_functions_match_rust_golden_and_reject_direct_forgery() -
         assert_eq!(sql_digest, desired.digest().as_bytes().as_slice());
         assert_eq!(
             desired.digest().to_string(),
-            "56bb579d90d1b06f96ee860ece75f0bd33106285bb454c54ab477f00d23ad644"
+            "92d2d6a43e9e4e24c87003cd1ab13d9f58c5745451722119c402d2ca6e74de41"
         );
 
         let forged_repository = sqlx::query(


### PR DESCRIPTION
## Summary

- update the three provider-manifest golden assertions to the schema-2 digest introduced by permission-policy migration 0071
- rename the owner-binding test to describe the current base-digest invariant without legacy wording

Rust and PostgreSQL already agree on this digest; only the hard-coded test expectations were stale.

## Validation

- `cargo test --locked -p automata-ci-store --test github_provider_manifest_api` (9/9)
- exact ignored PostgreSQL 18 `sql_canonical_functions_match_rust_golden_and_reject_direct_forgery` (1/1)
- strict Clippy for both affected test targets with `-D warnings`
- rustfmt and `git diff --check`
