### PR TITLE
Fix runtime authority lease renewal continuity

### DIFF
--- a/crates/automata-ci-store/migrations/0072_github_runtime_authority_lease_renewals.sql
+++ b/crates/automata-ci-store/migrations/0072_github_runtime_authority_lease_renewals.sql
@@ -1,0 +1,585 @@
+-- Preserve immutable GitHub authority identity while allowing an exact runner
+-- lease to advance through database-authorized renewals. The issuance's
+-- original lease horizon remains part of its encrypted identity; each later
+-- horizon is instead retained as append-only evidence in the same transaction
+-- that mutates the attempt.
+
+CREATE TABLE github_runtime_authority_lease_renewal_receipts (
+    attempt_id UUID NOT NULL,
+    fencing_token BIGINT NOT NULL,
+    lease_id UUID NOT NULL,
+    runner_id UUID NOT NULL,
+    runner_session_id UUID NOT NULL,
+    runner_session_epoch BIGINT NOT NULL,
+    runner_generation BIGINT NOT NULL,
+    previous_lease_expires_at_ms BIGINT NOT NULL,
+    renewed_lease_expires_at_ms BIGINT NOT NULL,
+    authorized_at_ms BIGINT NOT NULL,
+    CONSTRAINT github_runtime_authority_lease_renewal_receipts_pk PRIMARY KEY (
+        attempt_id, fencing_token, renewed_lease_expires_at_ms
+    ),
+    CONSTRAINT github_runtime_authority_lease_renewal_predecessor_unique
+        UNIQUE (attempt_id, fencing_token, previous_lease_expires_at_ms),
+    CONSTRAINT github_runtime_authority_lease_renewal_receipts_authority_fk
+        FOREIGN KEY (attempt_id, fencing_token)
+        REFERENCES github_runtime_authority_issuances(attempt_id, fencing_token)
+        ON DELETE RESTRICT,
+    CONSTRAINT github_runtime_authority_lease_renewal_receipts_interval CHECK (
+        fencing_token > 0
+        AND runner_session_epoch > 0
+        AND runner_generation > 0
+        AND previous_lease_expires_at_ms > authorized_at_ms
+        AND renewed_lease_expires_at_ms > previous_lease_expires_at_ms
+        AND authorized_at_ms >= 0
+        AND renewed_lease_expires_at_ms > authorized_at_ms
+    ),
+    CONSTRAINT github_runtime_authority_lease_renewal_receipts_non_nil CHECK (
+        attempt_id <> '00000000-0000-0000-0000-000000000000'::UUID
+        AND lease_id <> '00000000-0000-0000-0000-000000000000'::UUID
+        AND runner_id <> '00000000-0000-0000-0000-000000000000'::UUID
+        AND runner_session_id <> '00000000-0000-0000-0000-000000000000'::UUID
+    )
+);
+
+-- Quiesce both old heartbeat writers and authority reconciliation before
+-- deciding whether every READY authority still has its immutable root
+-- horizon. There is no safe receipt to fabricate for a preexisting mismatch.
+LOCK TABLE job_attempts IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE github_runtime_authority_issuances IN SHARE ROW EXCLUSIVE MODE;
+
+DO $automata$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM github_runtime_authority_issuances AS authority
+        JOIN job_attempts AS attempt
+          ON attempt.id = authority.attempt_id
+         AND attempt.fencing_token = authority.fencing_token
+        WHERE authority.state = 'ready'
+          AND attempt.lease_expires_at_ms <> authority.lease_expires_at_ms
+    ) THEN
+        RAISE EXCEPTION 'ready GitHub runtime authority has an unevidenced lease horizon'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_legacy_current';
+    END IF;
+END;
+$automata$;
+
+CREATE FUNCTION automata_github_runtime_authority_lease_horizon_is_tail(
+    authority github_runtime_authority_issuances,
+    horizon BIGINT,
+    observed_at BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $automata$
+    SELECT (
+        horizon = authority.lease_expires_at_ms
+        AND NOT EXISTS (
+            SELECT 1
+            FROM github_runtime_authority_lease_renewal_receipts AS any_renewal
+            WHERE any_renewal.attempt_id = authority.attempt_id
+              AND any_renewal.fencing_token = authority.fencing_token
+        )
+    ) OR EXISTS (
+        SELECT 1
+        FROM github_runtime_authority_lease_renewal_receipts AS tail
+        WHERE tail.attempt_id = authority.attempt_id
+          AND tail.fencing_token = authority.fencing_token
+          AND tail.lease_id = authority.lease_id
+          AND tail.runner_id = authority.runner_id
+          AND tail.runner_session_id = authority.runner_session_id
+          AND tail.runner_session_epoch = authority.runner_session_epoch
+          AND tail.runner_generation = authority.runner_generation
+          AND tail.renewed_lease_expires_at_ms = horizon
+          AND tail.authorized_at_ms <= observed_at
+          AND NOT EXISTS (
+              SELECT 1
+              FROM github_runtime_authority_lease_renewal_receipts AS successor
+              WHERE successor.attempt_id = tail.attempt_id
+                AND successor.fencing_token = tail.fencing_token
+                AND successor.previous_lease_expires_at_ms =
+                    tail.renewed_lease_expires_at_ms
+          )
+    )
+$automata$;
+
+CREATE FUNCTION automata_validate_github_runtime_authority_lease_renewal()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $automata$
+BEGIN
+    PERFORM 1
+    FROM github_runtime_authority_issuances AS authority
+    JOIN job_attempts AS attempt
+      ON attempt.id = authority.attempt_id
+     AND attempt.job_id = authority.job_id
+    WHERE authority.attempt_id = NEW.attempt_id
+      AND authority.fencing_token = NEW.fencing_token
+      AND authority.lease_id = NEW.lease_id
+      AND authority.runner_id = NEW.runner_id
+      AND authority.runner_session_id = NEW.runner_session_id
+      AND authority.runner_session_epoch = NEW.runner_session_epoch
+      AND authority.runner_generation = NEW.runner_generation
+      AND authority.state = 'ready'
+      AND authority.ready_at_ms <= NEW.authorized_at_ms
+      AND authority.provider_expires_at_ms IS NOT NULL
+      AND authority.provider_expires_at_ms - 60000
+            >= NEW.renewed_lease_expires_at_ms
+      AND attempt.fencing_token = authority.fencing_token
+      AND attempt.lease_id = authority.lease_id
+      AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
+      AND attempt.lease_expires_at_ms = NEW.previous_lease_expires_at_ms
+      AND attempt.runner_id = authority.runner_id
+      AND attempt.runner_session_id = authority.runner_session_id
+      AND attempt.runner_session_epoch = authority.runner_session_epoch
+      AND attempt.runner_generation = authority.runner_generation
+      AND attempt.changed_at_ms <= NEW.authorized_at_ms
+      AND automata_github_runtime_authority_lease_horizon_is_tail(
+          authority,
+          NEW.previous_lease_expires_at_ms,
+          NEW.authorized_at_ms
+      )
+    FOR SHARE OF authority, attempt;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'GitHub runtime authority lease renewal lacks exact durable authority'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_receipts_authority';
+    END IF;
+    RETURN NEW;
+END;
+$automata$;
+
+CREATE TRIGGER github_runtime_authority_lease_renewal_receipts_validate
+BEFORE INSERT ON github_runtime_authority_lease_renewal_receipts
+FOR EACH ROW
+EXECUTE FUNCTION automata_validate_github_runtime_authority_lease_renewal();
+
+CREATE FUNCTION automata_github_runtime_authority_lease_final_exact(
+    checked_attempt_id UUID,
+    checked_fencing_token BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $automata$
+    SELECT EXISTS (
+        SELECT 1
+        FROM github_runtime_authority_issuances AS authority
+        JOIN job_attempts AS attempt
+          ON attempt.id = authority.attempt_id
+         AND attempt.job_id = authority.job_id
+        JOIN github_runtime_authority_lease_renewal_receipts AS tail
+          ON tail.attempt_id = authority.attempt_id
+         AND tail.fencing_token = authority.fencing_token
+         AND tail.lease_id = authority.lease_id
+         AND tail.runner_id = authority.runner_id
+         AND tail.runner_session_id = authority.runner_session_id
+         AND tail.runner_session_epoch = authority.runner_session_epoch
+         AND tail.runner_generation = authority.runner_generation
+         AND tail.renewed_lease_expires_at_ms = attempt.lease_expires_at_ms
+         AND tail.authorized_at_ms = attempt.changed_at_ms
+        WHERE authority.attempt_id = checked_attempt_id
+          AND authority.fencing_token = checked_fencing_token
+          AND authority.state = 'ready'
+          AND attempt.fencing_token = authority.fencing_token
+          AND attempt.lease_id = authority.lease_id
+          AND attempt.runner_id = authority.runner_id
+          AND attempt.runner_session_id = authority.runner_session_id
+          AND attempt.runner_session_epoch = authority.runner_session_epoch
+          AND attempt.runner_generation = authority.runner_generation
+          AND NOT EXISTS (
+              SELECT 1
+              FROM github_runtime_authority_lease_renewal_receipts AS successor
+              WHERE successor.attempt_id = tail.attempt_id
+                AND successor.fencing_token = tail.fencing_token
+                AND successor.previous_lease_expires_at_ms =
+                    tail.renewed_lease_expires_at_ms
+          )
+    )
+$automata$;
+
+CREATE FUNCTION automata_require_github_runtime_authority_lease_final_exact()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $automata$
+BEGIN
+    IF NOT automata_github_runtime_authority_lease_final_exact(
+        NEW.attempt_id,
+        NEW.fencing_token
+    ) THEN
+        RAISE EXCEPTION 'GitHub runtime authority lease renewal is not reciprocal'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_final_exact';
+    END IF;
+    RETURN NULL;
+END;
+$automata$;
+
+CREATE CONSTRAINT TRIGGER github_runtime_authority_lease_renewal_final_exact
+AFTER INSERT ON github_runtime_authority_lease_renewal_receipts
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE FUNCTION automata_require_github_runtime_authority_lease_final_exact();
+
+CREATE FUNCTION automata_require_github_runtime_authority_attempt_renewal()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $automata$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM github_runtime_authority_issuances AS authority
+        WHERE authority.attempt_id = NEW.id
+          AND authority.fencing_token = NEW.fencing_token
+          AND authority.state = 'ready'
+    ) AND NOT automata_github_runtime_authority_lease_final_exact(
+        NEW.id,
+        NEW.fencing_token
+    ) THEN
+        RAISE EXCEPTION 'ready GitHub runtime authority lease edit lacks evidence'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_attempt_renewal_final_exact';
+    END IF;
+    RETURN NULL;
+END;
+$automata$;
+
+CREATE CONSTRAINT TRIGGER job_attempts_github_runtime_authority_renewal_exact
+AFTER UPDATE ON job_attempts
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+WHEN (OLD.lease_expires_at_ms IS DISTINCT FROM NEW.lease_expires_at_ms)
+EXECUTE FUNCTION automata_require_github_runtime_authority_attempt_renewal();
+
+CREATE FUNCTION automata_reject_github_runtime_authority_lease_renewal_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $automata$
+BEGIN
+    RAISE EXCEPTION 'GitHub runtime authority lease renewal evidence is append-only'
+        USING ERRCODE = 'check_violation',
+              CONSTRAINT =
+                  'github_runtime_authority_lease_renewal_receipts_append_only';
+END;
+$automata$;
+
+CREATE TRIGGER github_runtime_authority_lease_renewal_receipts_reject_mutation
+BEFORE UPDATE OR DELETE ON github_runtime_authority_lease_renewal_receipts
+FOR EACH ROW
+EXECUTE FUNCTION automata_reject_github_runtime_authority_lease_renewal_mutation();
+
+CREATE TRIGGER github_runtime_authority_lease_renewal_receipts_reject_truncate
+BEFORE TRUNCATE ON github_runtime_authority_lease_renewal_receipts
+FOR EACH STATEMENT
+EXECUTE FUNCTION automata_reject_github_runtime_authority_lease_renewal_mutation();
+
+-- Rebind currentness to either the immutable issued horizon or one exact
+-- append-only renewal horizon. All manifest, workflow, runner, fence, and
+-- lifecycle proofs from 0065 remain unchanged.
+
+CREATE OR REPLACE FUNCTION automata_github_runtime_authority_v2_base_is_current(
+    authority github_runtime_authority_issuances,
+    observed_at BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $automata$
+    SELECT EXISTS (
+        SELECT 1
+        FROM job_attempts AS attempt
+        JOIN jobs AS job
+          ON job.id = attempt.job_id
+         AND job.id = authority.job_id
+         AND job.run_id = authority.run_id
+        JOIN workflow_runs AS run
+          ON run.id = job.run_id
+         AND run.id = authority.run_id
+         AND run.repository_id = authority.repository_id
+        JOIN repositories AS repository
+          ON repository.id = run.repository_id
+         AND repository.id = authority.repository_id
+         AND repository.tenant_id = authority.tenant_id
+        JOIN workflow_definitions AS workflow
+          ON workflow.id = run.workflow_id
+         AND workflow.repository_id = run.repository_id
+        JOIN workflow_snapshots AS snapshot
+          ON snapshot.id = run.snapshot_id
+         AND snapshot.workflow_id = run.workflow_id
+        JOIN workflow_plan_v2_runs AS marker
+          ON marker.run_id = run.id
+        JOIN workflow_plan_v2_concrete_jobs AS concrete
+          ON concrete.run_id = run.id
+         AND concrete.job_id = job.id
+        JOIN workflow_plan_v2_invocations AS invocation
+          ON invocation.run_id = run.id
+         AND invocation.id = concrete.invocation_id
+        JOIN workflow_plan_v2_jobs AS logical_job
+          ON logical_job.run_id = run.id
+         AND logical_job.invocation_id = invocation.id
+         AND logical_job.id = concrete.logical_job_id
+        JOIN workflow_plan_v2_activation_preparation_claims AS preparation_claim
+          ON preparation_claim.run_id = logical_job.run_id
+         AND preparation_claim.invocation_id = logical_job.invocation_id
+         AND preparation_claim.logical_job_id = logical_job.id
+        JOIN workflow_plan_v2_activation_preparations AS preparation
+          ON preparation.run_id = preparation_claim.run_id
+         AND preparation.invocation_id = preparation_claim.invocation_id
+         AND preparation.logical_job_id = preparation_claim.logical_job_id
+         AND preparation.descriptor_digest = preparation_claim.descriptor_digest
+        JOIN workflow_plan_v2_activation_publications AS activation_publication
+          ON activation_publication.run_id = logical_job.run_id
+         AND activation_publication.invocation_id = logical_job.invocation_id
+         AND activation_publication.logical_job_id = logical_job.id
+         AND activation_publication.activation_input_digest =
+             preparation.activation_input_digest
+        JOIN workflow_plan_v2_instances AS instance
+          ON instance.run_id = activation_publication.run_id
+         AND instance.invocation_id = activation_publication.invocation_id
+         AND instance.logical_job_id = activation_publication.logical_job_id
+         AND instance.id = concrete.instance_id
+        JOIN workflow_plan_v2_materialization_claims AS materialization
+          ON materialization.instance_id = instance.id
+         AND materialization.run_id = instance.run_id
+         AND materialization.invocation_id = instance.invocation_id
+         AND materialization.logical_job_id = instance.logical_job_id
+        JOIN github_workflow_run_manifest_origins AS origin
+          ON origin.tenant_id = repository.tenant_id
+         AND origin.repository_id = repository.id
+         AND origin.workflow_id = run.workflow_id
+         AND origin.snapshot_id = run.snapshot_id
+         AND origin.run_id = run.id
+         AND origin.root_invocation_id = marker.root_invocation_id
+        JOIN workflow_admission_receipts AS admission_receipt
+          ON admission_receipt.tenant_id = origin.tenant_id
+         AND admission_receipt.idempotency_kind =
+             origin.admission_idempotency_kind
+         AND admission_receipt.idempotency_key =
+             origin.admission_idempotency_key
+         AND admission_receipt.request_digest = origin.logical_admission_digest
+         AND admission_receipt.repository_id = origin.repository_id
+         AND admission_receipt.run_id = origin.run_id
+         AND admission_receipt.committed_at_ms = origin.admitted_at_ms
+         AND admission_receipt.github_subject_evidence_required
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = origin.tenant_id
+         AND manifest.repository_id = origin.repository_id
+         AND manifest.provider_connection_id = origin.provider_connection_id
+         AND manifest.manifest_revision = origin.provider_manifest_revision
+         AND manifest.manifest_digest = origin.provider_manifest_digest
+        JOIN github_server_service_authorities AS checks_authority
+          ON checks_authority.tenant_id = origin.tenant_id
+         AND checks_authority.id = origin.checks_authority_id
+         AND checks_authority.repository_id = origin.repository_id
+         AND checks_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND checks_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND checks_authority.github_repository_id = origin.github_repository_id
+         AND checks_authority.github_repository_name =
+             origin.github_repository_name
+         AND checks_authority.service_scope = 'checks_write'
+         AND checks_authority.identity_digest =
+             origin.checks_authority_identity_digest
+         AND checks_authority.app_configuration_revision =
+             origin.checks_authority_app_configuration_revision
+         AND checks_authority.policy_revision =
+             origin.checks_authority_policy_revision
+        LEFT JOIN github_server_service_authorities AS private_authority
+          ON private_authority.tenant_id = origin.tenant_id
+         AND private_authority.id = origin.private_source_authority_id
+         AND private_authority.repository_id = origin.repository_id
+         AND private_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND private_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND private_authority.github_repository_id = origin.github_repository_id
+         AND private_authority.github_repository_name =
+             origin.github_repository_name
+         AND private_authority.service_scope = 'private_repository_source_read'
+         AND private_authority.identity_digest =
+             origin.private_source_authority_identity_digest
+         AND private_authority.app_configuration_revision =
+             origin.private_source_authority_app_configuration_revision
+         AND private_authority.policy_revision =
+             origin.private_source_authority_policy_revision
+        JOIN runners AS runner
+          ON runner.id = attempt.runner_id
+         AND runner.id = authority.runner_id
+         AND runner.tenant_id = authority.tenant_id
+         AND runner.generation = authority.runner_generation
+         AND runner.session_epoch = authority.runner_session_epoch
+        JOIN runner_sessions AS session
+          ON session.id = attempt.runner_session_id
+         AND session.id = authority.runner_session_id
+         AND session.runner_id = authority.runner_id
+         AND session.session_epoch = authority.runner_session_epoch
+         AND session.runner_generation = authority.runner_generation
+        WHERE attempt.id = authority.attempt_id
+          AND attempt.job_id = authority.job_id
+          AND attempt.fencing_token = authority.fencing_token
+          AND attempt.lease_id = authority.lease_id
+          AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
+          AND automata_github_runtime_authority_lease_horizon_is_tail(
+              authority,
+              attempt.lease_expires_at_ms,
+              observed_at
+          )
+          AND attempt.lease_expires_at_ms > observed_at
+          AND attempt.runner_id = authority.runner_id
+          AND attempt.runner_session_id = authority.runner_session_id
+          AND attempt.runner_session_epoch = authority.runner_session_epoch
+          AND attempt.runner_generation = authority.runner_generation
+          AND attempt.runner_slot = authority.runner_slot
+          AND attempt.lifecycle IN ('leased', 'preparing', 'running')
+          AND attempt.changed_at_ms <= observed_at
+          AND job.admission_epoch = 4
+          AND job.job_ir_schema = 5
+          AND job.job_ir_schema = authority.job_ir_schema
+          AND job.job_ir_size_bytes = authority.job_ir_size_bytes
+          AND job.job_ir_digest = authority.job_ir_digest
+          AND job.job_ir_digest = authority.policy_digest
+          AND concrete.requirements = job.requirements
+          AND concrete.instance_id = materialization.instance_id
+          AND concrete.run_id = materialization.run_id
+          AND concrete.invocation_id = materialization.invocation_id
+          AND concrete.logical_job_id = materialization.logical_job_id
+          AND concrete.descriptor_digest = materialization.descriptor_digest
+          AND concrete.job_id = materialization.expected_job_id
+          AND concrete.initial_attempt_id = materialization.expected_attempt_id
+          AND concrete.claim_owner_id = materialization.owner_id
+          AND concrete.claim_generation = materialization.generation
+          AND concrete.claim_started_at_ms = materialization.claimed_at_ms
+          AND concrete.claim_expires_at_ms = materialization.expires_at_ms
+          AND concrete.committed_at_ms = materialization.updated_at_ms
+          AND run.admission_epoch = 4
+          AND run.plan_schema = 2
+          AND (
+              invocation.id <> marker.root_invocation_id
+              OR run.plan_digest = invocation.plan_digest
+          )
+          AND run.plan_digest = origin.plan_digest
+          AND run.event_digest = origin.event_digest
+          AND run.head_sha = origin.github_check_head_sha
+          AND run.event_name = origin.event_name
+          AND run.git_ref = origin.git_ref
+          AND run.status IN ('queued', 'in_progress')
+          AND workflow.path = origin.workflow_path
+          AND snapshot.source_digest = origin.source_digest
+          AND marker.orchestration_schema = 1
+          AND marker.admission_digest = origin.logical_admission_digest
+          AND marker.admitted_at_ms = origin.admitted_at_ms
+          AND marker.state IN ('pending', 'active')
+          AND automata_workflow_plan_v2_invocation_published(
+              run.id, invocation.id
+          )
+          AND invocation.plan_schema = 2
+          AND (
+              invocation.id <> marker.root_invocation_id
+              OR invocation.plan_digest = origin.plan_digest
+          )
+          AND invocation.state IN ('pending', 'active')
+          AND logical_job.execution_kind = 'steps'
+          AND logical_job.state = 'activated'
+          AND logical_job.activation_input_digest =
+              preparation.activation_input_digest
+          AND preparation_claim.state = 'prepared'
+          AND activation_publication.condition_matched
+          AND activation_publication.job_ir_version = 5
+          AND activation_publication.runtime_context_schema = 2
+          AND instance.job_ir_version = 5
+          AND instance.job_ir_digest = job.job_ir_digest
+          AND instance.job_ir_size_bytes = job.job_ir_size_bytes
+          AND instance.job_ir_object_key = job.job_ir_object_key
+          AND instance.job_ir_media_type =
+              'application/vnd.automata.job-ir.protobuf'
+          AND materialization.state = 'materialized'
+          AND concrete.runtime_context_schema = 2
+          AND manifest.authority_profile = 'standard'
+          AND logical_job.authority_profile = 'standard'
+          AND preparation_claim.authority_profile = 'standard'
+          AND preparation.authority_profile = 'standard'
+          AND activation_publication.authority_profile = 'standard'
+          AND materialization.authority_profile = 'standard'
+          AND concrete.authority_profile = 'standard'
+          AND repository.scm_provider = 'github'
+          AND repository.provider_repository_id =
+              origin.github_repository_id::TEXT
+          AND repository.owner || '/' || repository.name =
+              origin.github_repository_name
+          AND authority.provider_connection_id = origin.provider_connection_id
+          AND authority.provider_connection_id = manifest.provider_connection_id
+          AND authority.provider_installation_id =
+              origin.provider_installation_id
+          AND authority.provider_installation_id =
+              manifest.provider_installation_id
+          AND authority.github_repository_id = origin.github_repository_id
+          AND authority.github_repository_id = manifest.github_repository_id
+          AND authority.github_repository_name = origin.github_repository_name
+          AND authority.github_repository_name = manifest.github_repository_name
+          AND authority.authority_namespace = 'github.repository'
+          AND authority.issuer_fingerprint = manifest.app_key_spki_sha256
+          AND authority.configuration_fingerprint =
+              checks_authority.configuration_fingerprint
+          AND authority.requested_at_ms = attempt.lease_issued_at_ms
+          AND authority.request_deadline_at_ms = LEAST(
+              authority.lease_expires_at_ms,
+              authority.lease_issued_at_ms + 120000
+          )
+          AND manifest.webhook_verifier_fingerprint_sha256 =
+              origin.authenticated_webhook_verifier_fingerprint_sha256
+          AND manifest.webhook_verifier_revision =
+              origin.authenticated_webhook_verifier_revision
+          AND manifest.repository_visibility = origin.repository_visibility
+          AND manifest.github_web_origin = 'https://github.com/'
+          AND manifest.github_api_origin = 'https://api.github.com/'
+          AND manifest.github_rest_api_version = '2026-03-10'
+          AND manifest.github_app_id = checks_authority.github_app_id
+          AND manifest.github_app_client_id = checks_authority.github_app_client_id
+          AND manifest.github_app_jwt_issuer_kind =
+              checks_authority.github_app_jwt_issuer_kind
+          AND manifest.app_key_spki_sha256 = checks_authority.app_key_spki_sha256
+          AND manifest.app_configuration_revision =
+              checks_authority.app_configuration_revision
+          AND manifest.policy_revision = checks_authority.policy_revision
+          AND manifest.registered_at_ms <= observed_at
+          AND checks_authority.state = 'active'
+          AND checks_authority.created_at_ms <= observed_at
+          AND checks_authority.state_updated_at_ms <= observed_at
+          AND origin.origin_kind IN (
+              'provider_delivery', 'scheduled_fire', 'workflow_rerun'
+          )
+          AND (
+              origin.repository_visibility = 'public'
+              AND origin.private_source_authority_id IS NULL
+              AND private_authority.id IS NULL
+              OR origin.repository_visibility = 'private'
+              AND private_authority.id IS NOT NULL
+              AND private_authority.github_app_id = manifest.github_app_id
+              AND private_authority.github_app_client_id =
+                  manifest.github_app_client_id
+              AND private_authority.github_app_jwt_issuer_kind =
+                  manifest.github_app_jwt_issuer_kind
+              AND private_authority.app_key_spki_sha256 =
+                  manifest.app_key_spki_sha256
+              AND private_authority.app_configuration_revision =
+                  manifest.app_configuration_revision
+              AND private_authority.policy_revision = manifest.policy_revision
+              AND private_authority.state = 'active'
+              AND private_authority.created_at_ms <= observed_at
+              AND private_authority.state_updated_at_ms <= observed_at
+          )
+          AND origin.admitted_at_ms <= observed_at
+          AND runner.status = 'online'
+          AND runner.desired_state IN ('active', 'draining')
+          AND session.job_ir_schema = 5
+          AND session.disconnected_at_ms IS NULL
+    )
+$automata$;

--- a/crates/automata-ci-store/migrations/0072_github_runtime_authority_lease_renewals.sql
+++ b/crates/automata-ci-store/migrations/0072_github_runtime_authority_lease_renewals.sql
@@ -110,12 +110,75 @@ CREATE FUNCTION automata_validate_github_runtime_authority_lease_renewal()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $automata$
+DECLARE
+    database_now BIGINT;
 BEGIN
+    -- Match the Store's global runner/session -> attempt -> authority order.
+    -- These separate row-lock phases also make direct SQL writers deterministic
+    -- instead of relying on a multi-relation plan's row-mark order.
+    PERFORM 1
+    FROM runners AS runner
+    JOIN runner_sessions AS session
+      ON session.runner_id = runner.id
+     AND session.id = NEW.runner_session_id
+     AND session.session_epoch = NEW.runner_session_epoch
+     AND session.runner_generation = NEW.runner_generation
+    WHERE runner.id = NEW.runner_id
+      AND runner.generation = NEW.runner_generation
+      AND runner.session_epoch = NEW.runner_session_epoch
+      AND runner.status = 'online'
+      AND runner.desired_state IN ('active', 'draining')
+      AND session.disconnected_at_ms IS NULL
+      AND session.job_ir_schema = 5
+    FOR SHARE OF runner, session;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'GitHub runtime authority lease renewal lacks a live runner session'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_receipts_authority';
+    END IF;
+
+    PERFORM 1
+    FROM job_attempts AS attempt
+    WHERE attempt.id = NEW.attempt_id
+      AND attempt.fencing_token = NEW.fencing_token
+      AND attempt.lease_id = NEW.lease_id
+      AND attempt.lease_expires_at_ms = NEW.previous_lease_expires_at_ms
+      AND attempt.runner_id = NEW.runner_id
+      AND attempt.runner_session_id = NEW.runner_session_id
+      AND attempt.runner_session_epoch = NEW.runner_session_epoch
+      AND attempt.runner_generation = NEW.runner_generation
+      AND attempt.lifecycle IN ('leased', 'preparing', 'running', 'cancelling')
+      AND attempt.changed_at_ms <= NEW.authorized_at_ms
+    FOR UPDATE OF attempt;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'GitHub runtime authority lease renewal lacks the exact current attempt'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_receipts_authority';
+    END IF;
+
+    -- Sample after every preceding row lock. A writer that queued while the
+    -- predecessor was live must not renew it after waiting past its horizon.
+    database_now := floor(
+        extract(epoch FROM clock_timestamp()) * 1000
+    )::BIGINT;
+    IF NEW.authorized_at_ms > database_now
+        OR NEW.previous_lease_expires_at_ms <= database_now
+    THEN
+        RAISE EXCEPTION 'GitHub runtime authority lease renewal uses a stale lease horizon'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT =
+                      'github_runtime_authority_lease_renewal_receipts_authority';
+    END IF;
+
     PERFORM 1
     FROM github_runtime_authority_issuances AS authority
-    JOIN job_attempts AS attempt
-      ON attempt.id = authority.attempt_id
-     AND attempt.job_id = authority.job_id
+    JOIN job_attempts AS exact_attempt
+      ON exact_attempt.id = authority.attempt_id
+     AND exact_attempt.job_id = authority.job_id
     WHERE authority.attempt_id = NEW.attempt_id
       AND authority.fencing_token = NEW.fencing_token
       AND authority.lease_id = NEW.lease_id
@@ -128,21 +191,15 @@ BEGIN
       AND authority.provider_expires_at_ms IS NOT NULL
       AND authority.provider_expires_at_ms - 60000
             >= NEW.renewed_lease_expires_at_ms
-      AND attempt.fencing_token = authority.fencing_token
-      AND attempt.lease_id = authority.lease_id
-      AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
-      AND attempt.lease_expires_at_ms = NEW.previous_lease_expires_at_ms
-      AND attempt.runner_id = authority.runner_id
-      AND attempt.runner_session_id = authority.runner_session_id
-      AND attempt.runner_session_epoch = authority.runner_session_epoch
-      AND attempt.runner_generation = authority.runner_generation
-      AND attempt.changed_at_ms <= NEW.authorized_at_ms
+      AND exact_attempt.fencing_token = authority.fencing_token
+      AND exact_attempt.lease_id = authority.lease_id
+      AND exact_attempt.lease_issued_at_ms = authority.lease_issued_at_ms
       AND automata_github_runtime_authority_lease_horizon_is_tail(
           authority,
           NEW.previous_lease_expires_at_ms,
           NEW.authorized_at_ms
       )
-    FOR SHARE OF authority, attempt;
+    FOR SHARE OF authority;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'GitHub runtime authority lease renewal lacks exact durable authority'
@@ -169,8 +226,13 @@ STABLE
 AS $automata$
     SELECT EXISTS (
         SELECT 1
-        FROM github_runtime_authority_issuances AS authority
+        FROM runners AS runner
+        JOIN runner_sessions AS session
+          ON session.runner_id = runner.id
         JOIN job_attempts AS attempt
+          ON attempt.runner_id = runner.id
+         AND attempt.runner_session_id = session.id
+        JOIN github_runtime_authority_issuances AS authority
           ON attempt.id = authority.attempt_id
          AND attempt.job_id = authority.job_id
         JOIN github_runtime_authority_lease_renewal_receipts AS tail
@@ -188,10 +250,24 @@ AS $automata$
           AND authority.state = 'ready'
           AND attempt.fencing_token = authority.fencing_token
           AND attempt.lease_id = authority.lease_id
+          AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
           AND attempt.runner_id = authority.runner_id
           AND attempt.runner_session_id = authority.runner_session_id
           AND attempt.runner_session_epoch = authority.runner_session_epoch
           AND attempt.runner_generation = authority.runner_generation
+          AND attempt.lifecycle IN ('leased', 'preparing', 'running', 'cancelling')
+          AND attempt.changed_at_ms < attempt.lease_expires_at_ms
+          AND runner.id = authority.runner_id
+          AND runner.tenant_id = authority.tenant_id
+          AND runner.generation = authority.runner_generation
+          AND runner.session_epoch = authority.runner_session_epoch
+          AND runner.status = 'online'
+          AND runner.desired_state IN ('active', 'draining')
+          AND session.id = authority.runner_session_id
+          AND session.session_epoch = authority.runner_session_epoch
+          AND session.runner_generation = authority.runner_generation
+          AND session.disconnected_at_ms IS NULL
+          AND session.job_ir_schema = 5
           AND NOT EXISTS (
               SELECT 1
               FROM github_runtime_authority_lease_renewal_receipts AS successor
@@ -255,7 +331,11 @@ CREATE CONSTRAINT TRIGGER job_attempts_github_runtime_authority_renewal_exact
 AFTER UPDATE ON job_attempts
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
-WHEN (OLD.lease_expires_at_ms IS DISTINCT FROM NEW.lease_expires_at_ms)
+WHEN (
+    NEW.lease_expires_at_ms IS NOT NULL
+    AND OLD.lease_expires_at_ms IS DISTINCT FROM NEW.lease_expires_at_ms
+    AND NEW.lifecycle IN ('leased', 'preparing', 'running', 'cancelling')
+)
 EXECUTE FUNCTION automata_require_github_runtime_authority_attempt_renewal();
 
 CREATE FUNCTION automata_reject_github_runtime_authority_lease_renewal_mutation()

--- a/crates/automata-ci-store/src/postgres.rs
+++ b/crates/automata-ci-store/src/postgres.rs
@@ -1156,10 +1156,13 @@ pub(super) async fn issue_lease_renewal_in_transaction(
     }
     let requested_expires_at = runner_attempt_database_expiry(database_now, requested_duration)?;
     let authority_ceiling = validate_github_runtime_authority_renewal_evidence(
+        transaction,
         authority_evidence,
+        request,
+        current_expiration,
         database_now,
-        request.attempt_id(),
-    )?;
+    )
+    .await?;
     let expires_at = authority_ceiling.map_or(requested_expires_at, |ceiling| {
         requested_expires_at.min(ceiling)
     });
@@ -1209,10 +1212,13 @@ pub(super) async fn commit_database_issued_lease_renewal_in_transaction(
         return Err(AttemptStoreError::LeaseExpired(request.attempt_id));
     }
     let authority_ceiling = validate_github_runtime_authority_renewal_evidence(
+        transaction,
         authority_evidence,
+        request,
+        current_expiration,
         database_now,
-        request.attempt_id(),
-    )?;
+    )
+    .await?;
     if authority_ceiling.is_some_and(|ceiling| request.expires_at() > ceiling) {
         return Err(AttemptStoreError::RuntimeAuthorityCeilingExceeded(
             request.attempt_id(),
@@ -1229,7 +1235,22 @@ pub(super) async fn commit_database_issued_lease_renewal_in_transaction(
     }
 
     if !refreshes_exact_ceiling {
-        update_database_issued_lease_expiration(transaction, request, database_now).await?;
+        if authority_evidence.is_some() {
+            record_github_runtime_authority_lease_renewal(
+                transaction,
+                request,
+                current_expiration,
+                database_now,
+            )
+            .await?;
+        }
+        update_database_issued_lease_expiration(
+            transaction,
+            request,
+            current_expiration,
+            database_now,
+        )
+        .await?;
     }
     let runner_id = snapshot
         .runner_id
@@ -1255,6 +1276,7 @@ pub(super) async fn commit_database_issued_lease_renewal_in_transaction(
 async fn update_database_issued_lease_expiration(
     transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     request: RenewLease,
+    previous_expires_at: UnixMillis,
     database_now: UnixMillis,
 ) -> Result<(), AttemptStoreError> {
     let result = sqlx::query(
@@ -1269,6 +1291,7 @@ async fn update_database_issued_lease_expiration(
           AND runner_session_id = $7
           AND runner_session_epoch = $8
           AND runner_generation = $9
+          AND lease_expires_at_ms = $10
           AND changed_at_ms <= $6
           AND lease_expires_at_ms > $6
         ",
@@ -1284,6 +1307,42 @@ async fn update_database_issued_lease_expiration(
     .bind(g1::runner_generation_to_i64(
         request.session.runner_generation(),
     )?)
+    .bind(previous_expires_at.get())
+    .execute(&mut **transaction)
+    .await
+    .map_err(operation_error)?;
+    require_single_update(result.rows_affected())
+}
+
+async fn record_github_runtime_authority_lease_renewal(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    request: RenewLease,
+    previous_expires_at: UnixMillis,
+    authorized_at: UnixMillis,
+) -> Result<(), AttemptStoreError> {
+    let result = sqlx::query(
+        r"
+        INSERT INTO github_runtime_authority_lease_renewal_receipts (
+            attempt_id, fencing_token, lease_id, runner_id,
+            runner_session_id, runner_session_epoch, runner_generation,
+            previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
+            authorized_at_ms
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ",
+    )
+    .bind(request.attempt_id().as_uuid())
+    .bind(fencing_to_i64(request.guard().fencing_token())?)
+    .bind(request.guard().lease_id().as_uuid())
+    .bind(request.runner_id().as_uuid())
+    .bind(request.session().session_id().as_uuid())
+    .bind(g1::session_epoch_to_i64(request.session().session_epoch())?)
+    .bind(g1::runner_generation_to_i64(
+        request.session().runner_generation(),
+    )?)
+    .bind(previous_expires_at.get())
+    .bind(request.expires_at().get())
+    .bind(authorized_at.get())
     .execute(&mut **transaction)
     .await
     .map_err(operation_error)?;
@@ -1363,10 +1422,12 @@ async fn lock_github_runtime_authority_renewal_evidence(
     }))
 }
 
-fn validate_github_runtime_authority_renewal_evidence(
+async fn validate_github_runtime_authority_renewal_evidence(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     evidence: Option<LockedGithubRuntimeAuthorityRenewalEvidence>,
+    request: RenewLease,
+    current_expiration: UnixMillis,
     database_now: UnixMillis,
-    attempt_id: AttemptId,
 ) -> Result<Option<UnixMillis>, AttemptStoreError> {
     let Some(evidence) = evidence else {
         return Ok(None);
@@ -1384,7 +1445,31 @@ fn validate_github_runtime_authority_renewal_evidence(
             .is_none_or(|ready_at| ready_at > database_now)
         || ceiling.is_none_or(|ceiling| ceiling <= database_now)
     {
-        return Err(AttemptStoreError::RuntimeAuthorityUnavailable(attempt_id));
+        return Err(AttemptStoreError::RuntimeAuthorityUnavailable(
+            request.attempt_id(),
+        ));
+    }
+    let horizon_is_tail: bool = sqlx::query_scalar(
+        r"
+        SELECT automata_github_runtime_authority_lease_horizon_is_tail(
+            authority, $3, $4
+        )
+        FROM github_runtime_authority_issuances AS authority
+        WHERE authority.attempt_id = $1
+          AND authority.fencing_token = $2
+        ",
+    )
+    .bind(request.attempt_id().as_uuid())
+    .bind(fencing_to_i64(request.guard().fencing_token())?)
+    .bind(current_expiration.get())
+    .bind(database_now.get())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operation_error)?;
+    if !horizon_is_tail {
+        return Err(AttemptStoreError::RuntimeAuthorityUnavailable(
+            request.attempt_id(),
+        ));
     }
     Ok(ceiling)
 }

--- a/crates/automata-ci-store/src/postgres/runtime_authority.rs
+++ b/crates/automata-ci-store/src/postgres/runtime_authority.rs
@@ -3175,11 +3175,47 @@ async fn lock_exact_authority_attempt(
     lock_exact_authority_graph(transaction, identity).await
 }
 
-#[allow(clippy::too_many_lines)] // One query locks the complete historical authority graph.
+async fn lock_exact_authority_runner_session(
+    transaction: &mut Transaction<'_, Postgres>,
+    identity: &GithubRuntimeAuthorityIdentity,
+) -> Result<bool, GithubRuntimeAuthorityStoreError> {
+    sqlx::query_scalar(
+        r"
+        SELECT TRUE
+        FROM runners AS runner
+        JOIN runner_sessions AS session
+          ON session.id = $2
+         AND session.runner_id = runner.id
+        WHERE runner.id = $1
+          AND runner.tenant_id = $3
+          AND session.session_epoch = $4
+          AND session.runner_generation = $5
+        FOR SHARE OF runner, session
+        ",
+    )
+    .bind(identity.runner_id().as_uuid())
+    .bind(identity.runner_session_id().as_uuid())
+    .bind(identity.tenant().as_str())
+    .bind(positive_i64(identity.runner_session_epoch().get())?)
+    .bind(positive_i64(identity.runner_generation().get())?)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map(|locked| locked.unwrap_or(false))
+    .map_err(operation_error)
+}
+
+#[allow(clippy::too_many_lines)] // Phase-ordered queries lock the historical authority graph.
 async fn lock_exact_authority_graph(
     transaction: &mut Transaction<'_, Postgres>,
     identity: &GithubRuntimeAuthorityIdentity,
 ) -> Result<bool, GithubRuntimeAuthorityStoreError> {
+    // Lease renewal takes these same two locks before it locks the attempt.
+    // Keep reconciliation and every other authority operation in that order:
+    // runner/session, execution graph, historical graph, then issuance.
+    if !lock_exact_authority_runner_session(transaction, identity).await? {
+        return Ok(false);
+    }
+
     let execution_locked: bool = sqlx::query_scalar(
         r"
         SELECT TRUE
@@ -3200,12 +3236,6 @@ async fn lock_exact_authority_graph(
         JOIN workflow_snapshots AS snapshot
           ON snapshot.id = run.snapshot_id
          AND snapshot.workflow_id = run.workflow_id
-        JOIN runners AS runner
-          ON runner.id = $12
-         AND runner.tenant_id = repository.tenant_id
-        JOIN runner_sessions AS session
-          ON session.id = $13
-         AND session.runner_id = runner.id
         WHERE attempt.id = $1
           AND attempt.job_id = $2
           AND job.job_ir_schema = $6
@@ -3215,9 +3245,7 @@ async fn lock_exact_authority_graph(
           AND repository.scm_provider = 'github'
           AND repository.provider_repository_id = $10::TEXT
           AND repository.owner || '/' || repository.name = $11
-          AND session.session_epoch = $14
-          AND session.runner_generation = $15
-        FOR SHARE OF attempt, job, run, repository, workflow, snapshot, runner, session
+        FOR SHARE OF attempt, job, run, repository, workflow, snapshot
         ",
     )
     .bind(identity.key().attempt_id().as_uuid())
@@ -3231,10 +3259,6 @@ async fn lock_exact_authority_graph(
     .bind(identity.policy_digest().as_bytes().as_slice())
     .bind(identity.github_repository_id().as_i64())
     .bind(identity.github_repository_name().as_str())
-    .bind(identity.runner_id().as_uuid())
-    .bind(identity.runner_session_id().as_uuid())
-    .bind(positive_i64(identity.runner_session_epoch().get())?)
-    .bind(positive_i64(identity.runner_generation().get())?)
     .fetch_optional(&mut **transaction)
     .await
     .map_err(operation_error)?

--- a/crates/automata-ci-store/tests/github_runtime_authority_lease_renewal_migration.rs
+++ b/crates/automata-ci-store/tests/github_runtime_authority_lease_renewal_migration.rs
@@ -1,0 +1,782 @@
+#[allow(dead_code)]
+mod common;
+
+use sqlx::{PgPool, Postgres, Transaction, migrate::Migrate as _};
+use uuid::Uuid;
+
+use common::{
+    TestDatabase, TestResult, run_with_database, run_with_unmigrated_database, seed_control_plane,
+};
+
+const FORWARD_VERSION: i64 = 72;
+const FORWARD_MIGRATION: &str =
+    include_str!("../migrations/0072_github_runtime_authority_lease_renewals.sql");
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+#[test]
+fn renewal_migration_is_contiguous_linear_and_reciprocal() {
+    let migrations = MIGRATOR.iter().collect::<Vec<_>>();
+    let forward = migrations
+        .iter()
+        .position(|migration| migration.version == FORWARD_VERSION)
+        .expect("migration 0072 is embedded");
+    assert_eq!(migrations[forward - 1].version, 71);
+    assert_eq!(
+        migrations[forward].description.as_ref(),
+        "github runtime authority lease renewals"
+    );
+
+    for required in [
+        "github_runtime_authority_lease_renewal_predecessor_unique",
+        "previous_lease_expires_at_ms > authorized_at_ms",
+        "renewed_lease_expires_at_ms > previous_lease_expires_at_ms",
+        "automata_github_runtime_authority_lease_horizon_is_tail",
+        "extract(epoch FROM clock_timestamp())",
+        "NEW.previous_lease_expires_at_ms <= database_now",
+        "FOR SHARE OF runner, session",
+        "FOR UPDATE OF attempt",
+        "FOR SHARE OF authority",
+        "attempt.lifecycle IN ('leased', 'preparing', 'running', 'cancelling')",
+        "NEW.lifecycle IN ('leased', 'preparing', 'running', 'cancelling')",
+        "github_runtime_authority_lease_renewal_legacy_current",
+        "github_runtime_authority_lease_renewal_final_exact",
+        "github_runtime_authority_attempt_renewal_final_exact",
+        "DEFERRABLE INITIALLY DEFERRED",
+        "BEFORE UPDATE OR DELETE ON github_runtime_authority_lease_renewal_receipts",
+        "BEFORE TRUNCATE ON github_runtime_authority_lease_renewal_receipts",
+        "CREATE OR REPLACE FUNCTION automata_github_runtime_authority_v2_base_is_current",
+    ] {
+        assert!(
+            FORWARD_MIGRATION.contains(required),
+            "missing renewal invariant: {required}"
+        );
+    }
+    for prohibited in [
+        "ON CONFLICT DO NOTHING",
+        "UPDATE github_runtime_authority_issuances SET lease_expires_at_ms",
+        "DELETE FROM github_runtime_authority_lease_renewal_receipts",
+    ] {
+        assert!(
+            !FORWARD_MIGRATION.contains(prohibited),
+            "unsafe renewal compatibility path remains: {prohibited}"
+        );
+    }
+    let attempt_lock = FORWARD_MIGRATION
+        .find("FOR UPDATE OF attempt")
+        .expect("attempt lock phase");
+    let post_lock_clock = FORWARD_MIGRATION
+        .find("database_now := floor(")
+        .expect("post-lock database clock sample");
+    assert!(post_lock_clock > attempt_lock);
+    assert!(FORWARD_MIGRATION.contains("NEW.lease_expires_at_ms IS NOT NULL"));
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn schema_71_upgrade_and_fresh_install_have_the_exact_renewal_catalog() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_before(&database, FORWARD_VERSION).await?;
+        assert!(!renewal_table_exists(&database).await?);
+        apply_version(&database, FORWARD_VERSION).await?;
+        assert_renewal_catalog(&database).await
+    })
+    .await?;
+
+    run_with_database(|database| async move { assert_renewal_catalog(&database).await }).await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn schema_71_refuses_unevidenced_ready_horizon_atomically() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        apply_before(&database, FORWARD_VERSION).await?;
+        let fixture = seed_ready_authority(&database).await?;
+        sqlx::query(
+            "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+             WHERE id = $1 AND fencing_token = 7",
+        )
+        .bind(fixture.attempt_id)
+        .bind(fixture.root_horizon + 10_000)
+        .bind(fixture.authorized_at)
+        .execute(database.pool())
+        .await?;
+
+        let error = apply_version(&database, FORWARD_VERSION)
+            .await
+            .expect_err("0072 must not invent renewal evidence for legacy state");
+        let database_error = error
+            .downcast_ref::<sqlx::migrate::MigrateError>()
+            .and_then(|error| match error {
+                sqlx::migrate::MigrateError::ExecuteMigration(error, FORWARD_VERSION) => {
+                    error.as_database_error()
+                }
+                _ => None,
+            })
+            .expect("migration refusal is a PostgreSQL error");
+        assert_eq!(database_error.code().as_deref(), Some("23514"));
+        assert_eq!(
+            database_error.constraint(),
+            Some("github_runtime_authority_lease_renewal_legacy_current")
+        );
+        assert!(!renewal_table_exists(&database).await?);
+        let function_exists: bool = sqlx::query_scalar(
+            "SELECT to_regprocedure(\
+             'automata_github_runtime_authority_lease_horizon_is_tail(\
+             github_runtime_authority_issuances,bigint,bigint)') IS NOT NULL",
+        )
+        .fetch_one(database.pool())
+        .await?;
+        assert!(!function_exists);
+        let migration_recorded: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM _sqlx_migrations \
+             WHERE version = 72 AND success)",
+        )
+        .fetch_one(database.pool())
+        .await?;
+        assert!(!migration_recorded);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn renewal_edges_are_linear_current_reciprocal_and_append_only() -> TestResult {
+    run_with_database(|database| async move {
+        let fixture = seed_ready_authority(&database).await?;
+        assert_expired_horizon_rejected(&database, &fixture).await?;
+        assert_orphan_and_wrong_target_rejected(&database, &fixture).await?;
+        let e1 = fixture.root_horizon + 10_000;
+        insert_valid_edge(&database, &fixture, fixture.root_horizon, e1).await?;
+        assert_predecessor_and_target_uniqueness(&database, &fixture, e1).await?;
+        assert_append_only(&database).await
+    })
+    .await
+}
+
+async fn apply_before(database: &TestDatabase, version: i64) -> TestResult {
+    let mut connection = database.pool().acquire().await?;
+    connection
+        .ensure_migrations_table(MIGRATOR.table_name.as_ref())
+        .await?;
+    for migration in MIGRATOR
+        .iter()
+        .filter(|migration| migration.version < version)
+    {
+        connection
+            .apply(MIGRATOR.table_name.as_ref(), migration)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn apply_version(database: &TestDatabase, version: i64) -> TestResult {
+    let mut connection = database.pool().acquire().await?;
+    connection
+        .apply(MIGRATOR.table_name.as_ref(), migration(version))
+        .await?;
+    Ok(())
+}
+
+fn migration(version: i64) -> &'static sqlx::migrate::Migration {
+    MIGRATOR
+        .iter()
+        .find(|migration| migration.version == version)
+        .expect("migration is embedded")
+}
+
+async fn renewal_table_exists(database: &TestDatabase) -> TestResult<bool> {
+    Ok(sqlx::query_scalar(
+        "SELECT to_regclass('github_runtime_authority_lease_renewal_receipts') IS NOT NULL",
+    )
+    .fetch_one(database.pool())
+    .await?)
+}
+
+#[allow(clippy::too_many_lines)] // One catalog assertion pins every 0072 object and binding.
+async fn assert_renewal_catalog(database: &TestDatabase) -> TestResult {
+    let catalog: (i64, i64, i64, i64, i64) = sqlx::query_as(
+        r"
+        SELECT
+            (SELECT count(*)
+             FROM pg_constraint
+             WHERE conrelid =
+                       'github_runtime_authority_lease_renewal_receipts'::REGCLASS
+               AND conname IN (
+                   'github_runtime_authority_lease_renewal_receipts_pk',
+                   'github_runtime_authority_lease_renewal_predecessor_unique',
+                   'github_runtime_authority_lease_renewal_receipts_authority_fk',
+                   'github_runtime_authority_lease_renewal_receipts_interval',
+                   'github_runtime_authority_lease_renewal_receipts_non_nil'
+               )),
+            (SELECT count(*)
+             FROM pg_trigger
+             WHERE tgrelid =
+                       'github_runtime_authority_lease_renewal_receipts'::REGCLASS
+               AND NOT tgisinternal
+               AND tgname IN (
+                   'github_runtime_authority_lease_renewal_receipts_validate',
+                   'github_runtime_authority_lease_renewal_final_exact',
+                   'github_runtime_authority_lease_renewal_receipts_reject_mutation',
+                   'github_runtime_authority_lease_renewal_receipts_reject_truncate'
+               )),
+            (SELECT count(*)
+             FROM pg_trigger
+             WHERE (
+                   (
+                       tgname = 'github_runtime_authority_lease_renewal_final_exact'
+                       AND tgrelid =
+                           'github_runtime_authority_lease_renewal_receipts'::REGCLASS
+                   ) OR (
+                       tgname = 'job_attempts_github_runtime_authority_renewal_exact'
+                       AND tgrelid = 'job_attempts'::REGCLASS
+                   )
+               )
+               AND tgdeferrable
+               AND tginitdeferred),
+            (SELECT count(*)
+             FROM pg_proc
+             WHERE pronamespace = current_schema()::REGNAMESPACE
+               AND proname IN (
+                   'automata_github_runtime_authority_lease_horizon_is_tail',
+                   'automata_validate_github_runtime_authority_lease_renewal',
+                   'automata_github_runtime_authority_lease_final_exact',
+                   'automata_require_github_runtime_authority_lease_final_exact',
+                   'automata_require_github_runtime_authority_attempt_renewal',
+                   'automata_reject_github_runtime_authority_lease_renewal_mutation'
+               )),
+            (SELECT count(*) FROM _sqlx_migrations
+             WHERE version = 72 AND success)
+        ",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(catalog, (5, 4, 2, 6, 1));
+
+    let constraints: Vec<(String, String)> = sqlx::query_as(
+        r"
+        SELECT conname, contype::TEXT
+        FROM pg_constraint
+        WHERE conrelid =
+                  'github_runtime_authority_lease_renewal_receipts'::REGCLASS
+          AND conname IN (
+              'github_runtime_authority_lease_renewal_receipts_pk',
+              'github_runtime_authority_lease_renewal_predecessor_unique',
+              'github_runtime_authority_lease_renewal_receipts_authority_fk',
+              'github_runtime_authority_lease_renewal_receipts_interval',
+              'github_runtime_authority_lease_renewal_receipts_non_nil'
+          )
+        ORDER BY conname
+        ",
+    )
+    .fetch_all(database.pool())
+    .await?;
+    assert_eq!(
+        constraints,
+        vec![
+            (
+                "github_runtime_authority_lease_renewal_predecessor_unique".into(),
+                "u".into(),
+            ),
+            (
+                "github_runtime_authority_lease_renewal_receipts_authority_fk".into(),
+                "f".into(),
+            ),
+            (
+                "github_runtime_authority_lease_renewal_receipts_interval".into(),
+                "c".into(),
+            ),
+            (
+                "github_runtime_authority_lease_renewal_receipts_non_nil".into(),
+                "c".into(),
+            ),
+            (
+                "github_runtime_authority_lease_renewal_receipts_pk".into(),
+                "p".into(),
+            ),
+        ]
+    );
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RenewalFixture {
+    attempt_id: Uuid,
+    lease_id: Uuid,
+    runner_id: Uuid,
+    runner_session_id: Uuid,
+    runner_session_epoch: i64,
+    runner_generation: i64,
+    root_horizon: i64,
+    authorized_at: i64,
+}
+
+#[allow(clippy::too_many_lines)] // One exact READY row exercises the released 0071 schema.
+async fn seed_ready_authority(database: &TestDatabase) -> TestResult<RenewalFixture> {
+    let seed = seed_control_plane(database.pool(), 1).await?;
+    let runner_id = seed.runner_ids[0].as_uuid();
+    let session = seed.session_fences[0];
+    let runner_session_id = session.session_id().as_uuid();
+    let runner_session_epoch = i64::try_from(session.session_epoch().get())?;
+    let runner_generation = i64::try_from(session.runner_generation().get())?;
+    let attempt_id = Uuid::new_v4();
+    let lease_id = Uuid::new_v4();
+    let authorized_at: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(database.pool())
+            .await?;
+    let root_horizon = authorized_at + 120_000;
+    let provider_expires_at = authorized_at + 900_000;
+
+    let mut transaction = database.pool().begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = replica")
+        .execute(&mut *transaction)
+        .await?;
+    sqlx::query(
+        r"
+            INSERT INTO job_attempts (
+                id, job_id, attempt_number, lifecycle, fencing_token,
+                lease_id, runner_id, lease_issued_at_ms, lease_expires_at_ms,
+                lease_failures, queued_at_ms, changed_at_ms, started_at_ms,
+                runner_session_id, runner_session_epoch, runner_generation,
+                runner_slot
+            ) VALUES (
+                $1, $2, 1, 'running', 7, $3, $4, $5, $6,
+                0, $5, $5, $5, $7, $8, $9, 1
+            )
+            ",
+    )
+    .bind(attempt_id)
+    .bind(seed.job_id.as_uuid())
+    .bind(lease_id)
+    .bind(runner_id)
+    .bind(authorized_at)
+    .bind(root_horizon)
+    .bind(runner_session_id)
+    .bind(runner_session_epoch)
+    .bind(runner_generation)
+    .execute(&mut *transaction)
+    .await?;
+
+    let selection_id = Uuid::new_v4();
+    let selection_owner_id = Uuid::new_v4();
+    let mint_owner_id = Uuid::new_v4();
+    sqlx::query(
+        r"
+            INSERT INTO github_runtime_authority_issuances (
+                tenant_id, attempt_id, fencing_token, lease_id,
+                lease_issued_at_ms, lease_expires_at_ms, run_id, job_id,
+                runner_id, runner_session_id, runner_session_epoch,
+                runner_generation, runner_slot, job_ir_schema,
+                job_ir_size_bytes, job_ir_digest, repository_id,
+                provider_connection_id, provider_installation_id,
+                github_app_id, github_app_client_id,
+                github_app_jwt_issuer_kind, github_app_jwt_issuer_value,
+                github_repository_id, github_repository_name,
+                authority_namespace, policy_digest, issuer_fingerprint,
+                configuration_fingerprint,
+                preparation_selection_id, preparation_selection_owner_id,
+                preparation_selection_generation,
+                preparation_selection_descriptor_digest,
+                preparation_selection_claimed_at_ms,
+                preparation_selection_expires_at_ms,
+                activation_selection_id, activation_selection_owner_id,
+                activation_selection_generation, activation_selection_input_digest,
+                activation_selection_claimed_at_ms, activation_selection_expires_at_ms,
+                materialization_selection_id, materialization_selection_owner_id,
+                materialization_selection_generation,
+                materialization_selection_descriptor_digest,
+                materialization_selection_claimed_at_ms,
+                materialization_selection_expires_at_ms,
+                requested_at_ms, request_deadline_at_ms,
+                conservative_expiry_at_ms,
+                state, mint_claim_owner_id, mint_claimed_at_ms,
+                mint_claim_expires_at_ms, mint_started_at_ms,
+                mint_provider_request_millis,
+                provider_expires_at_ms, safe_erase_after_ms,
+                commit_disposition, plaintext_schema, plaintext_size_bytes,
+                plaintext_digest, aad_digest, envelope_schema,
+                wrapping_key_id, wrapped_data_key, nonce, ciphertext,
+                ready_at_ms, state_updated_at_ms
+            ) VALUES (
+                $1, $2, 7, $3, $4, $5, $6, $7,
+                $8, $9, $10, $11, 1, 5, 128, $12, $13,
+                $14, 9001, 9002, 'Iv1.renewal-migration',
+                'app_client_id', 'Iv1.renewal-migration',
+                4242, 'automata-ci/automata', 'github.repository',
+                $12, $15, $16,
+                $17, $18, 1, $12, $4, $5,
+                $17, $18, 1, $12, $4, $5,
+                $17, $18, 1, $12, $4, $5,
+                $4, $19, $19 + 3780000,
+                'ready', $20, $4, NULL, $4, 1,
+                $21, $21 + 120000, 'deliverable', 1, 32,
+                $22, $23, 1, 'renewal-migration-test-v1',
+                $24, $25, $26, $4, $4
+            )
+            ",
+    )
+    .bind(&seed.tenant_id)
+    .bind(attempt_id)
+    .bind(lease_id)
+    .bind(authorized_at)
+    .bind(root_horizon)
+    .bind(seed.run_id.as_uuid())
+    .bind(seed.job_id.as_uuid())
+    .bind(runner_id)
+    .bind(runner_session_id)
+    .bind(runner_session_epoch)
+    .bind(runner_generation)
+    .bind(vec![0x11_u8; 32])
+    .bind(seed.repository_id)
+    .bind(Uuid::new_v4())
+    .bind(vec![0x12_u8; 32])
+    .bind(vec![0x13_u8; 32])
+    .bind(selection_id)
+    .bind(selection_owner_id)
+    .bind(authorized_at + 60_000)
+    .bind(mint_owner_id)
+    .bind(provider_expires_at)
+    .bind(vec![0x21_u8; 32])
+    .bind(vec![0x22_u8; 32])
+    .bind(vec![0x23_u8; 48])
+    .bind(vec![0x24_u8; 12])
+    .bind(vec![0x25_u8; 48])
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+
+    Ok(RenewalFixture {
+        attempt_id,
+        lease_id,
+        runner_id,
+        runner_session_id,
+        runner_session_epoch,
+        runner_generation,
+        root_horizon,
+        authorized_at,
+    })
+}
+
+async fn insert_receipt(
+    transaction: &mut Transaction<'_, Postgres>,
+    fixture: &RenewalFixture,
+    previous: i64,
+    renewed: i64,
+    authorized_at: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r"
+        INSERT INTO github_runtime_authority_lease_renewal_receipts (
+            attempt_id, fencing_token, lease_id, runner_id,
+            runner_session_id, runner_session_epoch, runner_generation,
+            previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
+            authorized_at_ms
+        ) VALUES ($1, 7, $2, $3, $4, $5, $6, $7, $8, $9)
+        ",
+    )
+    .bind(fixture.attempt_id)
+    .bind(fixture.lease_id)
+    .bind(fixture.runner_id)
+    .bind(fixture.runner_session_id)
+    .bind(fixture.runner_session_epoch)
+    .bind(fixture.runner_generation)
+    .bind(previous)
+    .bind(renewed)
+    .bind(authorized_at)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+async fn insert_valid_edge(
+    database: &TestDatabase,
+    fixture: &RenewalFixture,
+    previous: i64,
+    renewed: i64,
+) -> TestResult {
+    let authorized_at: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(database.pool())
+            .await?;
+    let mut transaction = database.pool().begin().await?;
+    insert_receipt(&mut transaction, fixture, previous, renewed, authorized_at).await?;
+    let updated = sqlx::query(
+        "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+         WHERE id = $1 AND fencing_token = 7 AND lease_expires_at_ms = $4",
+    )
+    .bind(fixture.attempt_id)
+    .bind(renewed)
+    .bind(authorized_at)
+    .bind(previous)
+    .execute(&mut *transaction)
+    .await?;
+    assert_eq!(updated.rows_affected(), 1);
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn assert_predecessor_and_target_uniqueness(
+    database: &TestDatabase,
+    fixture: &RenewalFixture,
+    e1: i64,
+) -> TestResult {
+    let authorized_at = database_now(database.pool()).await?;
+    let mut predecessor = database.pool().begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = replica")
+        .execute(&mut *predecessor)
+        .await?;
+    let error = insert_receipt(
+        &mut predecessor,
+        fixture,
+        fixture.root_horizon,
+        e1 + 10_000,
+        authorized_at,
+    )
+    .await
+    .expect_err("one predecessor cannot have two successors");
+    assert_constraint(
+        &error,
+        "github_runtime_authority_lease_renewal_predecessor_unique",
+    );
+    predecessor.rollback().await?;
+
+    let mut target = database.pool().begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = replica")
+        .execute(&mut *target)
+        .await?;
+    let error = insert_receipt(&mut target, fixture, e1 - 1, e1, authorized_at)
+        .await
+        .expect_err("one renewed horizon cannot have two incoming edges");
+    assert_constraint(&error, "github_runtime_authority_lease_renewal_receipts_pk");
+    target.rollback().await?;
+    Ok(())
+}
+
+async fn assert_append_only(database: &TestDatabase) -> TestResult {
+    for statement in [
+        "UPDATE github_runtime_authority_lease_renewal_receipts \
+         SET authorized_at_ms = authorized_at_ms",
+        "DELETE FROM github_runtime_authority_lease_renewal_receipts",
+        "TRUNCATE github_runtime_authority_lease_renewal_receipts",
+    ] {
+        let error = sqlx::query(statement)
+            .execute(database.pool())
+            .await
+            .expect_err("renewal evidence must remain append-only");
+        assert_constraint(
+            &error,
+            "github_runtime_authority_lease_renewal_receipts_append_only",
+        );
+    }
+    Ok(())
+}
+
+fn assert_constraint(error: &sqlx::Error, expected: &str) {
+    assert_eq!(
+        error
+            .as_database_error()
+            .and_then(sqlx::error::DatabaseError::constraint),
+        Some(expected),
+        "unexpected PostgreSQL error: {error}"
+    );
+}
+
+fn assert_constraint_one_of(error: &sqlx::Error, expected: &[&str]) {
+    let actual = error
+        .as_database_error()
+        .and_then(sqlx::error::DatabaseError::constraint);
+    assert!(
+        actual.is_some_and(|actual| expected.contains(&actual)),
+        "unexpected PostgreSQL error: {error}"
+    );
+}
+
+async fn database_now(pool: &PgPool) -> TestResult<i64> {
+    Ok(
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(pool)
+            .await?,
+    )
+}
+
+async fn install_test_clock(pool: &PgPool, now: i64) -> TestResult {
+    sqlx::query(
+        "CREATE TABLE github_runtime_authority_renewal_test_clock (now_ms BIGINT NOT NULL)",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("INSERT INTO github_runtime_authority_renewal_test_clock VALUES ($1)")
+        .bind(now)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        r"
+        CREATE FUNCTION clock_timestamp()
+        RETURNS TIMESTAMPTZ
+        LANGUAGE SQL
+        VOLATILE
+        AS $test$
+            SELECT TIMESTAMPTZ 'epoch' + now_ms * INTERVAL '1 millisecond'
+            FROM github_runtime_authority_renewal_test_clock
+        $test$
+        ",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn remove_test_clock(pool: &PgPool) -> TestResult {
+    sqlx::query("DROP FUNCTION clock_timestamp()")
+        .execute(pool)
+        .await?;
+    sqlx::query("DROP TABLE github_runtime_authority_renewal_test_clock")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn assert_expired_horizon_rejected(
+    database: &TestDatabase,
+    fixture: &RenewalFixture,
+) -> TestResult {
+    install_test_clock(database.pool(), fixture.root_horizon).await?;
+    let mut expired = database.pool().begin().await?;
+    let error = insert_receipt(
+        &mut expired,
+        fixture,
+        fixture.root_horizon,
+        fixture.root_horizon + 2,
+        fixture.authorized_at,
+    )
+    .await
+    .expect_err("a predecessor expired at current database time must be rejected");
+    expired.rollback().await?;
+    assert_constraint(
+        &error,
+        "github_runtime_authority_lease_renewal_receipts_authority",
+    );
+    remove_test_clock(database.pool()).await?;
+
+    let mut equal = database.pool().begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = replica")
+        .execute(&mut *equal)
+        .await?;
+    let error = insert_receipt(
+        &mut equal,
+        fixture,
+        fixture.root_horizon,
+        fixture.root_horizon + 2,
+        fixture.root_horizon,
+    )
+    .await
+    .expect_err("a predecessor equal to authorization time must fail its interval");
+    equal.rollback().await?;
+    assert_constraint(
+        &error,
+        "github_runtime_authority_lease_renewal_receipts_interval",
+    );
+
+    let mut non_extending = database.pool().begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = replica")
+        .execute(&mut *non_extending)
+        .await?;
+    let error = insert_receipt(
+        &mut non_extending,
+        fixture,
+        fixture.root_horizon,
+        fixture.root_horizon,
+        fixture.authorized_at,
+    )
+    .await
+    .expect_err("a renewal target equal to its predecessor must fail its interval");
+    non_extending.rollback().await?;
+    assert_constraint(
+        &error,
+        "github_runtime_authority_lease_renewal_receipts_interval",
+    );
+    Ok(())
+}
+
+async fn assert_orphan_and_wrong_target_rejected(
+    database: &TestDatabase,
+    fixture: &RenewalFixture,
+) -> TestResult {
+    let authorized_at: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(database.pool())
+            .await?;
+    let target = fixture.root_horizon + 10_000;
+    let mut orphan = database.pool().begin().await?;
+    insert_receipt(
+        &mut orphan,
+        fixture,
+        fixture.root_horizon,
+        target,
+        authorized_at,
+    )
+    .await?;
+    let error = orphan
+        .commit()
+        .await
+        .expect_err("an orphan receipt must fail at deferred commit");
+    assert_constraint(&error, "github_runtime_authority_lease_renewal_final_exact");
+
+    let mut wrong_cas = database.pool().begin().await?;
+    insert_receipt(
+        &mut wrong_cas,
+        fixture,
+        fixture.root_horizon,
+        target,
+        authorized_at,
+    )
+    .await?;
+    let updated = sqlx::query(
+        "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+         WHERE id = $1 AND fencing_token = 7 AND lease_expires_at_ms = $4",
+    )
+    .bind(fixture.attempt_id)
+    .bind(target)
+    .bind(authorized_at)
+    .bind(fixture.root_horizon - 1)
+    .execute(&mut *wrong_cas)
+    .await?;
+    assert_eq!(updated.rows_affected(), 0);
+    let error = wrong_cas
+        .commit()
+        .await
+        .expect_err("a receipt whose exact-old CAS lost must fail at commit");
+    assert_constraint(&error, "github_runtime_authority_lease_renewal_final_exact");
+
+    let mut wrong_target = database.pool().begin().await?;
+    insert_receipt(
+        &mut wrong_target,
+        fixture,
+        fixture.root_horizon,
+        target,
+        authorized_at,
+    )
+    .await?;
+    sqlx::query(
+        "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+         WHERE id = $1 AND fencing_token = 7",
+    )
+    .bind(fixture.attempt_id)
+    .bind(target + 1)
+    .bind(authorized_at)
+    .execute(&mut *wrong_target)
+    .await?;
+    let error = wrong_target
+        .commit()
+        .await
+        .expect_err("a mismatched attempt target must fail at deferred commit");
+    assert_constraint_one_of(
+        &error,
+        &[
+            "github_runtime_authority_lease_renewal_final_exact",
+            "github_runtime_authority_attempt_renewal_final_exact",
+        ],
+    );
+    Ok(())
+}

--- a/crates/automata-ci-store/tests/postgres_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_runtime_authority.rs
@@ -3054,13 +3054,14 @@ async fn permanent_terminal_replay_precedes_mutable_issuance_and_graph_locks() -
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
-async fn lease_extension_invalidates_without_mutating_authority_horizons() -> TestResult {
+async fn unevidenced_lease_extension_is_rejected_without_mutating_authority_horizons() -> TestResult
+{
     run_with_database(|database| async move {
         let fixture = seed_authority(&database).await?;
         mint_ready_authority(&database, &fixture).await?;
         let extended_lease_expires_at = fixture.identity.lease_expires_at().get() + 60_000;
         let now = database_now(&database).await?;
-        sqlx::query(
+        let rejected = sqlx::query(
             r"
             UPDATE job_attempts
             SET lease_expires_at_ms = $2, changed_at_ms = $3
@@ -3071,7 +3072,16 @@ async fn lease_extension_invalidates_without_mutating_authority_horizons() -> Te
         .bind(extended_lease_expires_at)
         .bind(now.get())
         .execute(database.pool())
-        .await?;
+        .await
+        .expect_err("an unevidenced lease extension must fail at commit");
+        let database_error = rejected
+            .as_database_error()
+            .expect("PostgreSQL constraint error");
+        assert_eq!(database_error.code().as_deref(), Some("23514"));
+        assert_eq!(
+            database_error.constraint(),
+            Some("github_runtime_authority_attempt_renewal_final_exact")
+        );
         assert!(
             database
                 .store()
@@ -3080,7 +3090,24 @@ async fn lease_extension_invalidates_without_mutating_authority_horizons() -> Te
                     fixture.at(50),
                 )?)
                 .await?
-                .is_none()
+                .is_some()
+        );
+        let renewal_receipts: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM github_runtime_authority_lease_renewal_receipts \
+             WHERE attempt_id = $1 AND fencing_token = 7",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(renewal_receipts, 0);
+        let durable_attempt_lease: i64 =
+            sqlx::query_scalar("SELECT lease_expires_at_ms FROM job_attempts WHERE id = $1")
+                .bind(fixture.identity.key().attempt_id().as_uuid())
+                .fetch_one(database.pool())
+                .await?;
+        assert_eq!(
+            durable_attempt_lease,
+            fixture.identity.lease_expires_at().get()
         );
         let immutable_authority_lease: i64 = sqlx::query_scalar(
             "SELECT lease_expires_at_ms FROM github_runtime_authority_issuances \
@@ -3397,6 +3424,236 @@ async fn ready_authority_caps_renewal_and_revalidates_it_atomically() -> TestRes
     .await
 }
 
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn ready_authority_renewals_form_one_exact_e0_e1_e2_e3_chain() -> TestResult {
+    run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_400_000_000_000).await?;
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        let e0 = fixture.identity.lease_expires_at();
+        let horizons = [
+            e0,
+            UnixMillis::new(e0.get() + 60_000),
+            UnixMillis::new(e0.get() + 120_000),
+            UnixMillis::new(e0.get() + 180_000),
+        ];
+        assert_renewal_tail(&database, &fixture, horizons[0], true).await?;
+
+        for target in &horizons[1..] {
+            renew_ready_authority_to(&database, &fixture, *target).await?;
+        }
+
+        let receipts: Vec<(i64, i64)> = sqlx::query_as(
+            r"
+            SELECT previous_lease_expires_at_ms, renewed_lease_expires_at_ms
+            FROM github_runtime_authority_lease_renewal_receipts
+            WHERE attempt_id = $1 AND fencing_token = 7
+            ORDER BY renewed_lease_expires_at_ms
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_all(database.pool())
+        .await?;
+        assert_eq!(
+            receipts,
+            horizons
+                .windows(2)
+                .map(|edge| (edge[0].get(), edge[1].get()))
+                .collect::<Vec<_>>()
+        );
+        for historical in &horizons[..3] {
+            assert_renewal_tail(&database, &fixture, *historical, false).await?;
+        }
+        assert_renewal_tail(&database, &fixture, horizons[3], true).await?;
+        assert!(
+            database
+                .store()
+                .load_ready_github_runtime_authority(LoadGithubRuntimeAuthority::new(
+                    fixture.identity.clone(),
+                    database_now(&database).await?,
+                )?)
+                .await?
+                .is_some()
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn exact_ceiling_replay_fails_without_root_or_tail_evidence() -> TestResult {
+    run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_500_000_000_000).await?;
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        let ceiling = fixture.at(3_440_000);
+
+        let mut corruption = database.pool().begin().await?;
+        sqlx::query(
+            "ALTER TABLE job_attempts DISABLE TRIGGER \
+             job_attempts_github_runtime_authority_renewal_exact",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        sqlx::query(
+            "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+             WHERE id = $1 AND fencing_token = 7",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .bind(ceiling.get())
+        .bind(database_now(&database).await?.get())
+        .execute(&mut *corruption)
+        .await?;
+        sqlx::query(
+            "ALTER TABLE job_attempts ENABLE TRIGGER \
+             job_attempts_github_runtime_authority_renewal_exact",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        corruption.commit().await?;
+
+        let observed_at = database_now(&database).await?;
+        let missing_receipt = renewal_request(&fixture.identity, observed_at, ceiling)?;
+        let result = database
+            .store()
+            .authorize_lease_renewal(missing_receipt, JobLifecycle::Running)
+            .await;
+        assert_unavailable(&result, fixture.identity.key().attempt_id());
+        let receipts: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM github_runtime_authority_lease_renewal_receipts \
+             WHERE attempt_id = $1 AND fencing_token = 7",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(receipts, 0);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn concurrent_same_horizon_renewals_have_one_durable_winner() -> TestResult {
+    run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_600_000_000_000).await?;
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        let target = UnixMillis::new(fixture.identity.lease_expires_at().get() + 60_000);
+        let request = renewal_request(&fixture.identity, database_now(&database).await?, target)?;
+        let left = database.store().clone();
+        let right = database.store().clone();
+        let (left, right) = tokio::time::timeout(Duration::from_secs(5), async move {
+            tokio::join!(left.renew_lease(request), right.renew_lease(request))
+        })
+        .await
+        .map_err(|_| "concurrent renewals did not serialize")?;
+        let outcomes = [left, right];
+        assert_eq!(outcomes.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|result| matches!(result, Err(AttemptStoreError::RenewalDoesNotExtend(_))))
+                .count(),
+            1
+        );
+        let receipts: Vec<(i64, i64)> = sqlx::query_as(
+            "SELECT previous_lease_expires_at_ms, renewed_lease_expires_at_ms \
+             FROM github_runtime_authority_lease_renewal_receipts \
+             WHERE attempt_id = $1 AND fencing_token = 7",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_all(database.pool())
+        .await?;
+        assert_eq!(
+            receipts,
+            vec![(fixture.identity.lease_expires_at().get(), target.get())]
+        );
+        assert_renewal_tail(&database, &fixture, target, true).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn runtime_authority_renewals_form_one_exact_increasing_tail_chain() -> TestResult {
+    run_with_database(|database| async move {
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        let mut expected_previous = fixture.identity.lease_expires_at();
+
+        for duration_millis in [600_000_i64, 900_000, 1_200_000] {
+            let observed_at = database_now(&database).await?;
+            let requested = renewal_request(
+                &fixture.identity,
+                observed_at,
+                UnixMillis::new(observed_at.get() + duration_millis),
+            )?;
+            let authorized = database
+                .store()
+                .authorize_lease_renewal(requested, JobLifecycle::Running)
+                .await?;
+            assert!(authorized.expires_at() > expected_previous);
+            let renewed = database.store().renew_lease(authorized).await?;
+            assert_eq!(renewed.expires_at(), authorized.expires_at());
+            expected_previous = renewed.expires_at();
+        }
+
+        let receipts: Vec<(i64, i64)> = sqlx::query_as(
+            r"
+            SELECT previous_lease_expires_at_ms, renewed_lease_expires_at_ms
+            FROM github_runtime_authority_lease_renewal_receipts
+            WHERE attempt_id = $1 AND fencing_token = 7
+            ORDER BY renewed_lease_expires_at_ms
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_all(database.pool())
+        .await?;
+        assert_eq!(receipts.len(), 3);
+        assert_eq!(receipts[0].0, fixture.identity.lease_expires_at().get());
+        assert_eq!(receipts[1].0, receipts[0].1);
+        assert_eq!(receipts[2].0, receipts[1].1);
+        assert_eq!(receipts[2].1, expected_previous.get());
+
+        let historical_fork = sqlx::query(
+            r"
+            INSERT INTO github_runtime_authority_lease_renewal_receipts (
+                attempt_id, fencing_token, lease_id, runner_id,
+                runner_session_id, runner_session_epoch, runner_generation,
+                previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
+                authorized_at_ms
+            )
+            SELECT attempt_id, fencing_token, lease_id, runner_id,
+                   runner_session_id, runner_session_epoch, runner_generation,
+                   $2, $3, $4
+            FROM github_runtime_authority_issuances
+            WHERE attempt_id = $1 AND fencing_token = 7
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .bind(receipts[1].0)
+        .bind(expected_previous.get() + 1)
+        .bind(database_now(&database).await?.get())
+        .execute(database.pool())
+        .await
+        .expect_err("a historical horizon cannot fork");
+        let database_error = historical_fork
+            .as_database_error()
+            .expect("PostgreSQL constraint error");
+        assert_eq!(database_error.code().as_deref(), Some("23514"));
+        assert_eq!(
+            database_error.constraint(),
+            Some("github_runtime_authority_lease_renewal_receipts_authority")
+        );
+        Ok(())
+    })
+    .await
+}
+
 fn renewal_request(
     identity: &GithubRuntimeAuthorityIdentity,
     observed_at: UnixMillis,
@@ -3416,6 +3673,49 @@ fn renewal_request(
     )?)
 }
 
+async fn renew_ready_authority_to(
+    database: &TestDatabase,
+    fixture: &AuthorityFixture,
+    target: UnixMillis,
+) -> TestResult {
+    let request = renewal_request(&fixture.identity, database_now(database).await?, target)?;
+    let authorized = database
+        .store()
+        .authorize_lease_renewal(request, JobLifecycle::Running)
+        .await?;
+    assert_eq!(authorized.expires_at(), target);
+    assert_eq!(
+        database.store().renew_lease(authorized).await?.expires_at(),
+        target
+    );
+    Ok(())
+}
+
+async fn assert_renewal_tail(
+    database: &TestDatabase,
+    fixture: &AuthorityFixture,
+    horizon: UnixMillis,
+    expected: bool,
+) -> TestResult {
+    let is_tail: bool = sqlx::query_scalar(
+        r"
+        SELECT automata_github_runtime_authority_lease_horizon_is_tail(
+            authority, $3, $4
+        )
+        FROM github_runtime_authority_issuances AS authority
+        WHERE authority.attempt_id = $1 AND authority.fencing_token = $2
+        ",
+    )
+    .bind(fixture.identity.key().attempt_id().as_uuid())
+    .bind(i64::try_from(fixture.identity.key().fencing_token().get())?)
+    .bind(horizon.get())
+    .bind(database_now(database).await?.get())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(is_tail, expected, "unexpected tail state for {horizon:?}");
+    Ok(())
+}
+
 async fn assert_ready_renewal_ceiling(
     database: &TestDatabase,
     fixture: &AuthorityFixture,
@@ -3433,6 +3733,37 @@ async fn assert_ready_renewal_ceiling(
     assert_eq!(
         database.store().renew_lease(bounded).await?.expires_at(),
         fixture.at(3_440_000)
+    );
+    let renewal_receipts: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM github_runtime_authority_lease_renewal_receipts \
+         WHERE attempt_id = $1 AND fencing_token = 7",
+    )
+    .bind(request.attempt_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(renewal_receipts, 1);
+    assert!(
+        database
+            .store()
+            .load_ready_github_runtime_authority(LoadGithubRuntimeAuthority::new(
+                fixture.identity.clone(),
+                database_now(database).await?,
+            )?)
+            .await?
+            .is_some(),
+        "an evidenced lease extension must preserve deliverable authority"
+    );
+    let reconciliation = database
+        .store()
+        .reconcile_github_runtime_authorities(ReconcileGithubRuntimeAuthorities::new(
+            database_now(database).await?,
+            16,
+        )?)
+        .await?;
+    assert_eq!(
+        reconciliation.ready_marked_revoke_pending(),
+        0,
+        "reconciliation must retain authority backed by exact renewal evidence"
     );
     let first_changed_at: i64 =
         sqlx::query_scalar("SELECT changed_at_ms FROM job_attempts WHERE id = $1")

--- a/crates/automata-ci-store/tests/postgres_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_runtime_authority.rs
@@ -66,6 +66,20 @@ use uuid::Uuid;
 
 use common::{TestDatabase, TestResult, run_with_database};
 
+const INSERT_RENEWAL_RECEIPT: &str = r"
+    INSERT INTO github_runtime_authority_lease_renewal_receipts (
+        attempt_id, fencing_token, lease_id, runner_id,
+        runner_session_id, runner_session_epoch, runner_generation,
+        previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
+        authorized_at_ms
+    )
+    SELECT attempt_id, fencing_token, lease_id, runner_id,
+           runner_session_id, runner_session_epoch, runner_generation,
+           $2, $3, $4
+    FROM github_runtime_authority_issuances
+    WHERE attempt_id = $1 AND fencing_token = 7
+";
+
 fn digest(byte: u8) -> Sha256Digest {
     Sha256Digest::from_bytes([byte; 32])
 }
@@ -3426,6 +3440,62 @@ async fn ready_authority_caps_renewal_and_revalidates_it_atomically() -> TestRes
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn ready_authority_allows_a_finalizing_heartbeat_without_renewal_evidence() -> TestResult {
+    run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_900_000_000_000).await?;
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        sqlx::query("UPDATE job_attempts SET lifecycle = 'running' WHERE id = $1")
+            .bind(fixture.identity.key().attempt_id().as_uuid())
+            .execute(database.pool())
+            .await?;
+        let expires_at = commit_finalizing_heartbeat(&database, &fixture).await?;
+        let durable: (String, i64, String, i64) = sqlx::query_as(
+            r"
+            SELECT attempt.lifecycle, attempt.lease_expires_at_ms,
+                   authority.state, count(receipt.renewed_lease_expires_at_ms)
+            FROM job_attempts AS attempt
+            JOIN github_runtime_authority_issuances AS authority
+              ON authority.attempt_id = attempt.id
+             AND authority.fencing_token = attempt.fencing_token
+            LEFT JOIN github_runtime_authority_lease_renewal_receipts AS receipt
+              ON receipt.attempt_id = authority.attempt_id
+             AND receipt.fencing_token = authority.fencing_token
+            WHERE attempt.id = $1 AND attempt.fencing_token = 7
+            GROUP BY attempt.lifecycle, attempt.lease_expires_at_ms, authority.state
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            durable,
+            (
+                "finalizing".to_owned(),
+                expires_at.get(),
+                "ready".to_owned(),
+                0,
+            ),
+            "finalizing is quiescent and must not mint lease-renewal authority"
+        );
+        assert!(
+            database
+                .store()
+                .load_ready_github_runtime_authority(LoadGithubRuntimeAuthority::new(
+                    fixture.identity.clone(),
+                    database_now(&database).await?,
+                )?)
+                .await?
+                .is_none(),
+            "a finalizing attempt must not retain usable runtime authority"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn ready_authority_renewals_form_one_exact_e0_e1_e2_e3_chain() -> TestResult {
     run_with_database(|database| async move {
         install_database_test_clock(&database, 2_400_000_000_000).await?;
@@ -3475,6 +3545,36 @@ async fn ready_authority_renewals_form_one_exact_e0_e1_e2_e3_chain() -> TestResu
                 )?)
                 .await?
                 .is_some()
+        );
+        let historical_fork = sqlx::query(
+            r"
+            INSERT INTO github_runtime_authority_lease_renewal_receipts (
+                attempt_id, fencing_token, lease_id, runner_id,
+                runner_session_id, runner_session_epoch, runner_generation,
+                previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
+                authorized_at_ms
+            )
+            SELECT attempt_id, fencing_token, lease_id, runner_id,
+                   runner_session_id, runner_session_epoch, runner_generation,
+                   $2, $3, $4
+            FROM github_runtime_authority_issuances
+            WHERE attempt_id = $1 AND fencing_token = 7
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .bind(horizons[1].get())
+        .bind(horizons[3].get() + 1)
+        .bind(database_now(&database).await?.get())
+        .execute(database.pool())
+        .await
+        .expect_err("a historical renewal horizon cannot fork");
+        let database_error = historical_fork
+            .as_database_error()
+            .expect("PostgreSQL constraint error");
+        assert_eq!(database_error.code().as_deref(), Some("23514"));
+        assert_eq!(
+            database_error.constraint(),
+            Some("github_runtime_authority_lease_renewal_receipts_authority")
         );
         Ok(())
     })
@@ -3579,76 +3679,221 @@ async fn concurrent_same_horizon_renewals_have_one_durable_winner() -> TestResul
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
-async fn runtime_authority_renewals_form_one_exact_increasing_tail_chain() -> TestResult {
+#[allow(clippy::too_many_lines)] // One transaction matrix pins the complete renewal graph.
+async fn renewal_receipts_reject_expired_forks_orphans_rollbacks_and_mutation() -> TestResult {
     run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_700_000_000_000).await?;
         let fixture = seed_authority(&database).await?;
         mint_ready_authority(&database, &fixture).await?;
-        let mut expected_previous = fixture.identity.lease_expires_at();
+        let attempt_id = fixture.identity.key().attempt_id().as_uuid();
+        let e0 = fixture.identity.lease_expires_at();
 
-        for duration_millis in [600_000_i64, 900_000, 1_200_000] {
-            let observed_at = database_now(&database).await?;
-            let requested = renewal_request(
-                &fixture.identity,
-                observed_at,
-                UnixMillis::new(observed_at.get() + duration_millis),
-            )?;
-            let authorized = database
-                .store()
-                .authorize_lease_renewal(requested, JobLifecycle::Running)
+        for (authorized_at, expected_label) in [
+            (e0, "equal predecessor"),
+            (UnixMillis::new(e0.get() + 1), "expired predecessor"),
+        ] {
+            let mut interval = database.pool().begin().await?;
+            sqlx::query("SET LOCAL session_replication_role = replica")
+                .execute(&mut *interval)
                 .await?;
-            assert!(authorized.expires_at() > expected_previous);
-            let renewed = database.store().renew_lease(authorized).await?;
-            assert_eq!(renewed.expires_at(), authorized.expires_at());
-            expected_previous = renewed.expires_at();
+            let rejected = sqlx::query(INSERT_RENEWAL_RECEIPT)
+                .bind(attempt_id)
+                .bind(e0.get())
+                .bind(e0.get() + 2)
+                .bind(authorized_at.get())
+                .execute(&mut *interval)
+                .await
+                .expect_err(expected_label);
+            assert_postgres_constraint(
+                &rejected,
+                "github_runtime_authority_lease_renewal_receipts_interval",
+            );
+            interval.rollback().await?;
         }
 
-        let receipts: Vec<(i64, i64)> = sqlx::query_as(
-            r"
-            SELECT previous_lease_expires_at_ms, renewed_lease_expires_at_ms
-            FROM github_runtime_authority_lease_renewal_receipts
-            WHERE attempt_id = $1 AND fencing_token = 7
-            ORDER BY renewed_lease_expires_at_ms
-            ",
-        )
-        .bind(fixture.identity.key().attempt_id().as_uuid())
-        .fetch_all(database.pool())
-        .await?;
-        assert_eq!(receipts.len(), 3);
-        assert_eq!(receipts[0].0, fixture.identity.lease_expires_at().get());
-        assert_eq!(receipts[1].0, receipts[0].1);
-        assert_eq!(receipts[2].0, receipts[1].1);
-        assert_eq!(receipts[2].1, expected_previous.get());
-
-        let historical_fork = sqlx::query(
-            r"
-            INSERT INTO github_runtime_authority_lease_renewal_receipts (
-                attempt_id, fencing_token, lease_id, runner_id,
-                runner_session_id, runner_session_epoch, runner_generation,
-                previous_lease_expires_at_ms, renewed_lease_expires_at_ms,
-                authorized_at_ms
-            )
-            SELECT attempt_id, fencing_token, lease_id, runner_id,
-                   runner_session_id, runner_session_epoch, runner_generation,
-                   $2, $3, $4
-            FROM github_runtime_authority_issuances
-            WHERE attempt_id = $1 AND fencing_token = 7
-            ",
-        )
-        .bind(fixture.identity.key().attempt_id().as_uuid())
-        .bind(receipts[1].0)
-        .bind(expected_previous.get() + 1)
-        .bind(database_now(&database).await?.get())
-        .execute(database.pool())
-        .await
-        .expect_err("a historical horizon cannot fork");
-        let database_error = historical_fork
-            .as_database_error()
-            .expect("PostgreSQL constraint error");
-        assert_eq!(database_error.code().as_deref(), Some("23514"));
-        assert_eq!(
-            database_error.constraint(),
-            Some("github_runtime_authority_lease_renewal_receipts_authority")
+        let authorized_at = database_now(&database).await?;
+        let e1 = UnixMillis::new(e0.get() + 60_000);
+        let mut orphan = database.pool().begin().await?;
+        sqlx::query(INSERT_RENEWAL_RECEIPT)
+            .bind(attempt_id)
+            .bind(e0.get())
+            .bind(e1.get())
+            .bind(authorized_at.get())
+            .execute(&mut *orphan)
+            .await?;
+        let rejected = orphan
+            .commit()
+            .await
+            .expect_err("an orphan receipt must fail its deferred reciprocal check");
+        assert_postgres_constraint(
+            &rejected,
+            "github_runtime_authority_lease_renewal_final_exact",
         );
+
+        let e2 = UnixMillis::new(e0.get() + 120_000);
+        let mut wrong_target = database.pool().begin().await?;
+        sqlx::query(INSERT_RENEWAL_RECEIPT)
+            .bind(attempt_id)
+            .bind(e0.get())
+            .bind(e1.get())
+            .bind(authorized_at.get())
+            .execute(&mut *wrong_target)
+            .await?;
+        sqlx::query(
+            "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+             WHERE id = $1 AND fencing_token = 7",
+        )
+        .bind(attempt_id)
+        .bind(e2.get())
+        .bind(authorized_at.get())
+        .execute(&mut *wrong_target)
+        .await?;
+        let rejected = wrong_target
+            .commit()
+            .await
+            .expect_err("receipt and attempt targets must match at commit");
+        assert_postgres_constraint_one_of(
+            &rejected,
+            &[
+                "github_runtime_authority_lease_renewal_final_exact",
+                "github_runtime_authority_attempt_renewal_final_exact",
+            ],
+        );
+
+        renew_ready_authority_to(&database, &fixture, e1).await?;
+        renew_ready_authority_to(&database, &fixture, e2).await?;
+        for statement in [
+            "UPDATE github_runtime_authority_lease_renewal_receipts \
+             SET authorized_at_ms = authorized_at_ms",
+            "DELETE FROM github_runtime_authority_lease_renewal_receipts",
+            "TRUNCATE github_runtime_authority_lease_renewal_receipts",
+        ] {
+            let rejected = sqlx::query(statement)
+                .execute(database.pool())
+                .await
+                .expect_err("renewal evidence must be append-only");
+            assert_postgres_constraint(
+                &rejected,
+                "github_runtime_authority_lease_renewal_receipts_append_only",
+            );
+        }
+
+        for historical in [e0, e1] {
+            let rejected = sqlx::query(
+                "UPDATE job_attempts SET lease_expires_at_ms = $2, changed_at_ms = $3 \
+                 WHERE id = $1 AND fencing_token = 7",
+            )
+            .bind(attempt_id)
+            .bind(historical.get())
+            .bind(database_now(&database).await?.get())
+            .execute(database.pool())
+            .await
+            .expect_err("the current attempt cannot roll back to a historical horizon");
+            assert_postgres_constraint(
+                &rejected,
+                "github_runtime_authority_attempt_renewal_final_exact",
+            );
+        }
+        assert_renewal_tail(&database, &fixture, e2, true).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn queued_renewal_precedes_reconciliation_without_lock_inversion() -> TestResult {
+    run_with_database(|database| async move {
+        install_database_test_clock(&database, 2_800_000_000_000).await?;
+        let fixture = seed_authority(&database).await?;
+        mint_ready_authority(&database, &fixture).await?;
+        sqlx::query(
+            r"
+            UPDATE job_attempts
+            SET lifecycle = 'cancelling'
+            WHERE id = $1 AND fencing_token = 7
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .execute(database.pool())
+        .await?;
+
+        let mut blocker = database.pool().begin().await?;
+        let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *blocker)
+            .await?;
+        // Hold only the issuance. Renewal must acquire runner/session and the
+        // attempt before it queues here; reconciliation must then queue behind
+        // renewal's runner/session lock. This creates a deterministic wait
+        // chain instead of waking two compatible runner/session SHARE waiters
+        // at once and relying on backend scheduling order.
+        let locked: bool = sqlx::query_scalar(
+            r"
+            SELECT TRUE
+            FROM github_runtime_authority_issuances AS authority
+            WHERE authority.attempt_id = $1 AND authority.fencing_token = 7
+            FOR UPDATE OF authority
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_one(&mut *blocker)
+        .await?;
+        assert!(locked);
+
+        let target = UnixMillis::new(fixture.identity.lease_expires_at().get() + 60_000);
+        let renewal = renewal_request(&fixture.identity, database_now(&database).await?, target)?;
+        let renewal_store = database.store().clone();
+        let renewal_task = tokio::spawn(async move { renewal_store.renew_lease(renewal).await });
+        let renewal_backend = wait_for_blocked_backends(&database, blocker_pid, 1).await?[0];
+
+        let reconciliation_store = database.store().clone();
+        let reconciliation_at = database_now(&database).await?;
+        let reconciliation_task = tokio::spawn(async move {
+            reconciliation_store
+                .reconcile_github_runtime_authorities(
+                    ReconcileGithubRuntimeAuthorities::new(reconciliation_at, 1)
+                        .expect("reconciliation request"),
+                )
+                .await
+        });
+        let reconciliation_backends =
+            wait_for_blocked_backends(&database, renewal_backend, 1).await?;
+        assert_eq!(reconciliation_backends.len(), 1);
+        assert!(!renewal_task.is_finished());
+        assert!(!reconciliation_task.is_finished());
+        blocker.rollback().await?;
+
+        let (renewal_result, reconciliation_result) =
+            tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::join!(renewal_task, reconciliation_task)
+            })
+            .await
+            .map_err(|_| "lease renewal and reconciliation deadlocked")?;
+        let renewed = renewal_result??;
+        assert_eq!(renewed.expires_at(), target);
+        assert_eq!(
+            reconciliation_result??.ready_marked_revoke_pending(),
+            1,
+            "the non-current cancelling attempt must be reconciled"
+        );
+        let durable: (String, i64, i64) = sqlx::query_as(
+            r"
+            SELECT authority.state, attempt.lease_expires_at_ms,
+                   count(receipt.renewed_lease_expires_at_ms)
+            FROM github_runtime_authority_issuances AS authority
+            JOIN job_attempts AS attempt ON attempt.id = authority.attempt_id
+            LEFT JOIN github_runtime_authority_lease_renewal_receipts AS receipt
+              ON receipt.attempt_id = authority.attempt_id
+             AND receipt.fencing_token = authority.fencing_token
+            WHERE authority.attempt_id = $1 AND authority.fencing_token = 7
+            GROUP BY authority.state, attempt.lease_expires_at_ms
+            ",
+        )
+        .bind(fixture.identity.key().attempt_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(durable.0, "revoke_pending");
+        assert_eq!((durable.1, durable.2), (target.get(), 1));
         Ok(())
     })
     .await
@@ -3792,6 +4037,17 @@ async fn assert_ready_renewal_ceiling(
         changed_at, first_changed_at,
         "ceiling replay must not forge an extension"
     );
+    let replay_receipts: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM github_runtime_authority_lease_renewal_receipts \
+         WHERE attempt_id = $1 AND fencing_token = 7",
+    )
+    .bind(request.attempt_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(
+        replay_receipts, 1,
+        "ceiling replay must not forge renewal evidence"
+    );
     Ok(request)
 }
 
@@ -3900,29 +4156,7 @@ async fn assert_authority_transition_race(
         .await;
     assert_unavailable(&non_ready_result, request.attempt_id());
 
-    let finalizing = renewal_request(
-        &fixture.identity,
-        database_now(database).await?,
-        fixture.at(3_450_000),
-    )?;
-    let authorized = database
-        .store()
-        .authorize_lease_renewal(finalizing, JobLifecycle::Finalizing)
-        .await?;
-    let finalizing_expires_at = authorized.expires_at();
-    let transaction = CommitLeaseHeartbeat::new(
-        RunnerOperationRequest::new(
-            authorized.session(),
-            OperationId::new(),
-            RunnerOperationKind::new("automata.runner.lease-heartbeat.v1")?,
-            Sha256Digest::from_bytes([0x91; 32]),
-        ),
-        CommandCursor::initial(),
-        authorized,
-        RunnerOperationResponse::new(DocumentSchema::new(1)?, b"finalizing".to_vec())?,
-    )?
-    .with_reported_lifecycle(JobLifecycle::Finalizing)?;
-    database.store().commit_lease_heartbeat(transaction).await?;
+    let finalizing_expires_at = commit_finalizing_heartbeat(database, fixture).await?;
     let durable: (String, i64) =
         sqlx::query_as("SELECT lifecycle, lease_expires_at_ms FROM job_attempts WHERE id = $1")
             .bind(request.attempt_id().as_uuid())
@@ -3936,6 +4170,36 @@ async fn assert_authority_transition_race(
     Ok(())
 }
 
+async fn commit_finalizing_heartbeat(
+    database: &TestDatabase,
+    fixture: &AuthorityFixture,
+) -> TestResult<UnixMillis> {
+    let finalizing = renewal_request(
+        &fixture.identity,
+        database_now(database).await?,
+        fixture.at(3_450_000),
+    )?;
+    let authorized = database
+        .store()
+        .authorize_lease_renewal(finalizing, JobLifecycle::Finalizing)
+        .await?;
+    let expires_at = authorized.expires_at();
+    let transaction = CommitLeaseHeartbeat::new(
+        RunnerOperationRequest::new(
+            authorized.session(),
+            OperationId::new(),
+            RunnerOperationKind::new("automata.runner.lease-heartbeat.v1")?,
+            Sha256Digest::from_bytes([0x91; 32]),
+        ),
+        CommandCursor::initial(),
+        authorized,
+        RunnerOperationResponse::new(DocumentSchema::new(1)?, b"finalizing".to_vec())?,
+    )?
+    .with_reported_lifecycle(JobLifecycle::Finalizing)?;
+    database.store().commit_lease_heartbeat(transaction).await?;
+    Ok(expires_at)
+}
+
 fn assert_unavailable(result: &Result<RenewLease, StoreError>, expected_attempt_id: AttemptId) {
     assert!(
         matches!(
@@ -3944,5 +4208,56 @@ fn assert_unavailable(result: &Result<RenewLease, StoreError>, expected_attempt_
                 if *attempt_id == expected_attempt_id
         ),
         "unexpected unavailable result: {result:?}"
+    );
+}
+
+async fn wait_for_blocked_backends(
+    database: &TestDatabase,
+    blocker_pid: i32,
+    expected: usize,
+) -> TestResult<Vec<i32>> {
+    let blocked = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let pids: Vec<i32> = sqlx::query_scalar(
+                r"
+                SELECT pid
+                FROM pg_stat_activity
+                WHERE $1 = ANY(pg_blocking_pids(pid))
+                ORDER BY query_start, pid
+                ",
+            )
+            .bind(blocker_pid)
+            .fetch_all(database.pool())
+            .await?;
+            if pids.len() >= expected {
+                return Ok::<_, sqlx::Error>(pids);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| "Store operations did not reach the staged runner/session lock")??;
+    Ok(blocked)
+}
+
+fn assert_postgres_constraint(error: &sqlx::Error, expected: &str) {
+    let database_error = error
+        .as_database_error()
+        .expect("expected a PostgreSQL constraint error");
+    assert_eq!(database_error.code().as_deref(), Some("23514"));
+    assert_eq!(database_error.constraint(), Some(expected));
+}
+
+fn assert_postgres_constraint_one_of(error: &sqlx::Error, expected: &[&str]) {
+    let database_error = error
+        .as_database_error()
+        .expect("expected a PostgreSQL constraint error");
+    assert_eq!(database_error.code().as_deref(), Some("23514"));
+    assert!(
+        database_error
+            .constraint()
+            .is_some_and(|constraint| expected.contains(&constraint)),
+        "unexpected constraint: {:?}",
+        database_error.constraint()
     );
 }


### PR DESCRIPTION
Summary:
- retain immutable GitHub runtime-authority identity across database-authorized lease extensions using an append-only linear receipt chain
- enforce exact root-or-tail currentness, reciprocal final state, mixed-writer refusal, and consistent lock ordering
- preserve normal Running-to-Finalizing heartbeats without manufacturing renewal authority

Validation:
- PostgreSQL 18 migration upgrade/fresh/refusal and linearity suite
- focused runtime renewal, concurrency, reconciliation, exact-ceiling, and finalizing-heartbeat tests on an isolated PostgreSQL 18.4 server with default max_locks_per_transaction=64
- strict all-target/all-feature Store Clippy, rustdoc with warnings denied, migration inventory, rustfmt, and diff checks