### PR TITLE
Test fail-closed runner resource invariants

### DIFF
--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -1143,7 +1143,7 @@ fn mutable_images_and_overlapping_state_roots_fail_closed() {
 }
 
 #[test]
-fn unenforced_ephemeral_disk_capacity_fails_closed() {
+fn unenforced_extended_resource_capacity_fails_closed() {
     let mut value: serde_json::Value =
         serde_json::from_str(&valid_configuration()).expect("configuration JSON");
     value["inventory"]["resources_per_job"]["ephemeral_disk_bytes"] =
@@ -1159,6 +1159,22 @@ fn unenforced_ephemeral_disk_capacity_fails_closed() {
         serde_json::json!(20_u64 * 1024 * 1024 * 1024);
     assert_eq!(
         parse_value(&value).expect_err("unenforced executor disk limit must fail"),
+        RunnerProductConfigError::InvalidExecutor
+    );
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&valid_configuration()).expect("configuration JSON");
+    value["inventory"]["resources_per_job"]["gpu_count"] = serde_json::json!(1);
+    assert_eq!(
+        parse_value(&value).expect_err("unenforced advertised GPU capacity must fail"),
+        RunnerProductConfigError::InvalidInventory
+    );
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&valid_configuration()).expect("configuration JSON");
+    value["executor"]["resources"]["gpu_count"] = serde_json::json!(1);
+    assert_eq!(
+        parse_value(&value).expect_err("unenforced executor GPU limit must fail"),
         RunnerProductConfigError::InvalidExecutor
     );
 }

--- a/crates/automata-ci-store/tests/runner_requirements_schema_migration.rs
+++ b/crates/automata-ci-store/tests/runner_requirements_schema_migration.rs
@@ -60,6 +60,7 @@ fn migration_0054_drains_v2_and_requires_v3_for_new_work() {
         "SET runner_requirements_schema = 3",
         "requirements @> '{\"schema_version\": 3}'::jsonb",
         "requirements ? 'resource_allocation'",
+        "run.runner_requirements_schema = 3",
         "jobs_00_require_runner_requirements_v3",
         "workflow_plan_v2_concrete_jobs_00_require_runner_requirements_v3",
         "job_attempts_00_require_runner_requirements_v3",


### PR DESCRIPTION
Summary:
- pin migration 0054 to the owning workflow run schema-3 contract
- prove Podman inventory and executor GPU requests fail closed when GPU enforcement is unavailable
- rename the existing resource-capacity case to reflect disk and GPU coverage

Validation:
- runner requirements migration static tests and live PostgreSQL 18 upgrade test
- runner product configuration tests 22/22
- strict targeted Store and runner Clippy, rustfmt, and diff checks