### PR TITLE
Defer macOS CI to self-hosted runners

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -309,91 +309,6 @@ jobs:
           cargo test -p automata-ci-results-github --test postgres_cache --all-features --locked -- --ignored --test-threads=1
           cargo test -p automata-ci --test github_provider_end_to_end_matrix --all-features --locked -- --ignored --test-threads=1
 
-  macos:
-    name: macOS native runner
-    runs-on: macos-15
-    timeout-minutes: 45
-    env:
-      CARGO_BUILD_JOBS: "2"
-      CARGO_PROFILE_DEV_DEBUG: "0"
-      CARGO_PROFILE_TEST_DEBUG: "0"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Require pinned Apple Silicon toolchain
-        run: |
-          install -d -m 0700 -- "$TMPDIR"
-          rustc --version --verbose
-          cargo --version --verbose
-          host_triple="$(rustc --version --verbose | sed -n 's/^host: //p')"
-          test "$host_triple" = "aarch64-apple-darwin"
-          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 15
-
-      - name: Check shipped macOS binaries
-        run: cargo check --locked --bin automata --bin automata-runner
-
-      - name: Lint macOS provider, executor, and runner
-        run: >-
-          cargo clippy
-          --locked
-          -p automata-ci-metrics
-          -p automata-ci-sandbox-macos
-          -p automata-ci-job-executor-github
-          -p automata-ci-runner
-          --all-targets
-          --no-deps
-          --
-          -D warnings
-
-      - name: Record GitHub-hosted Bash shell reference
-        id: macos_shell_reference
-        shell: bash
-        run: |
-          reference="$RUNNER_TEMP/automata-macos-shell-reference.txt"
-          printf 'differential.bash=ok\n' > "$reference"
-          printf 'AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE=%s\n' "$reference" >> "$GITHUB_ENV"
-          printf 'AUTOMATA_DIFFERENTIAL_ENV=command-file\n' >> "$GITHUB_ENV"
-          printf 'fixture=native-output\n' >> "$GITHUB_OUTPUT"
-
-      - name: Record GitHub-hosted sh shell reference
-        shell: sh
-        env:
-          FROM_OUTPUT: ${{ steps.macos_shell_reference.outputs.fixture }}
-        run: |
-          test "$AUTOMATA_DIFFERENTIAL_ENV" = command-file
-          test "$FROM_OUTPUT" = native-output
-          test "$PWD" = "$GITHUB_WORKSPACE"
-          {
-            printf 'differential.sh=ok\n'
-            printf 'differential.environment=%s\n' "$AUTOMATA_DIFFERENTIAL_ENV"
-            printf 'differential.output=%s\n' "$FROM_OUTPUT"
-            printf 'differential.workspace=true\n'
-            printf 'differential.conclusion=success\n'
-          } >> "$AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE"
-
-      - name: Test macOS execution contracts
-        run: |
-          cargo test --locked -p automata-ci-execution
-          cargo test --locked -p automata-ci-job-executor-github --all-targets
-          cargo test --locked -p automata-ci-sandbox-macos --all-targets
-          cargo test --locked -p automata-ci-runner --lib
-          cargo test --locked -p automata-ci-runner --test product_context
-          cargo test --locked -p automata-ci-runner --test runner_product_config_macos
-          cargo test --locked -p automata-ci-runner --test capabilities_cli --test cli
-
-      - name: Test shipped macOS runner process
-        run: cargo test --locked -p automata-ci-runner --test native_runner_process_e2e -- --nocapture
-
-      - name: Exercise hidden shipped-binary supervisor
-        run: |
-          cargo build --locked --bin automata-runner
-          python3 scripts/ci/tests/macos-supervisor-smoke.py \
-            target/debug/automata-runner
-
   frontend:
     name: React SSR frontend
     runs-on: ubuntu-24.04
@@ -595,7 +510,6 @@ jobs:
           && needs.renderer_tests.result == 'success'
           && needs.postgres_store.result == 'success'
           && needs.postgres_integrations.result == 'success'
-          && needs.macos.result == 'success'
           && needs.frontend.result == 'success'
           && (needs.renderer.result == 'success'
               || (github.event_name == 'pull_request'
@@ -608,7 +522,6 @@ jobs:
       - renderer_tests
       - postgres_store
       - postgres_integrations
-      - macos
       - frontend
       - renderer
     runs-on: ubuntu-24.04

--- a/crates/automata-ci-workflow-github/tests/ci_workflow.rs
+++ b/crates/automata-ci-workflow-github/tests/ci_workflow.rs
@@ -33,7 +33,7 @@ fn repository_ci_produces_an_accepted_source_plan() {
         plan.workflow().name().map(|name| name.value().as_str()),
         Some("CI")
     );
-    assert_eq!(plan.workflow().jobs().len(), 11);
+    assert_eq!(plan.workflow().jobs().len(), 10);
     assert_eq!(
         plan.workflow()
             .jobs()
@@ -47,7 +47,6 @@ fn repository_ci_produces_an_accepted_source_plan() {
             "renderer_tests",
             "postgres_store",
             "postgres_integrations",
-            "macos",
             "frontend",
             "renderer",
             "dist_build",
@@ -102,7 +101,6 @@ fn repository_ci_produces_an_accepted_source_plan() {
     && needs.renderer_tests.result == 'success'
     && needs.postgres_store.result == 'success'
     && needs.postgres_integrations.result == 'success'
-    && needs.macos.result == 'success'
     && needs.frontend.result == 'success'
     && (needs.renderer.result == 'success'
         || (github.event_name == 'pull_request'

--- a/crates/automata-ci-workflow-github/tests/fixtures/repository-ci.yml
+++ b/crates/automata-ci-workflow-github/tests/fixtures/repository-ci.yml
@@ -309,91 +309,6 @@ jobs:
           cargo test -p automata-ci-results-github --test postgres_cache --all-features --locked -- --ignored --test-threads=1
           cargo test -p automata-ci --test github_provider_end_to_end_matrix --all-features --locked -- --ignored --test-threads=1
 
-  macos:
-    name: macOS native runner
-    runs-on: macos-15
-    timeout-minutes: 45
-    env:
-      CARGO_BUILD_JOBS: "2"
-      CARGO_PROFILE_DEV_DEBUG: "0"
-      CARGO_PROFILE_TEST_DEBUG: "0"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Require pinned Apple Silicon toolchain
-        run: |
-          install -d -m 0700 -- "$TMPDIR"
-          rustc --version --verbose
-          cargo --version --verbose
-          host_triple="$(rustc --version --verbose | sed -n 's/^host: //p')"
-          test "$host_triple" = "aarch64-apple-darwin"
-          test "$(sw_vers -productVersion | cut -d. -f1)" -ge 15
-
-      - name: Check shipped macOS binaries
-        run: cargo check --locked --bin automata --bin automata-runner
-
-      - name: Lint macOS provider, executor, and runner
-        run: >-
-          cargo clippy
-          --locked
-          -p automata-ci-metrics
-          -p automata-ci-sandbox-macos
-          -p automata-ci-job-executor-github
-          -p automata-ci-runner
-          --all-targets
-          --no-deps
-          --
-          -D warnings
-
-      - name: Record GitHub-hosted Bash shell reference
-        id: macos_shell_reference
-        shell: bash
-        run: |
-          reference="$RUNNER_TEMP/automata-macos-shell-reference.txt"
-          printf 'differential.bash=ok\n' > "$reference"
-          printf 'AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE=%s\n' "$reference" >> "$GITHUB_ENV"
-          printf 'AUTOMATA_DIFFERENTIAL_ENV=command-file\n' >> "$GITHUB_ENV"
-          printf 'fixture=native-output\n' >> "$GITHUB_OUTPUT"
-
-      - name: Record GitHub-hosted sh shell reference
-        shell: sh
-        env:
-          FROM_OUTPUT: ${{ steps.macos_shell_reference.outputs.fixture }}
-        run: |
-          test "$AUTOMATA_DIFFERENTIAL_ENV" = command-file
-          test "$FROM_OUTPUT" = native-output
-          test "$PWD" = "$GITHUB_WORKSPACE"
-          {
-            printf 'differential.sh=ok\n'
-            printf 'differential.environment=%s\n' "$AUTOMATA_DIFFERENTIAL_ENV"
-            printf 'differential.output=%s\n' "$FROM_OUTPUT"
-            printf 'differential.workspace=true\n'
-            printf 'differential.conclusion=success\n'
-          } >> "$AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE"
-
-      - name: Test macOS execution contracts
-        run: |
-          cargo test --locked -p automata-ci-execution
-          cargo test --locked -p automata-ci-job-executor-github --all-targets
-          cargo test --locked -p automata-ci-sandbox-macos --all-targets
-          cargo test --locked -p automata-ci-runner --lib
-          cargo test --locked -p automata-ci-runner --test product_context
-          cargo test --locked -p automata-ci-runner --test runner_product_config_macos
-          cargo test --locked -p automata-ci-runner --test capabilities_cli --test cli
-
-      - name: Test shipped macOS runner process
-        run: cargo test --locked -p automata-ci-runner --test native_runner_process_e2e -- --nocapture
-
-      - name: Exercise hidden shipped-binary supervisor
-        run: |
-          cargo build --locked --bin automata-runner
-          python3 scripts/ci/tests/macos-supervisor-smoke.py \
-            target/debug/automata-runner
-
   frontend:
     name: React SSR frontend
     runs-on: ubuntu-24.04
@@ -595,7 +510,6 @@ jobs:
           && needs.renderer_tests.result == 'success'
           && needs.postgres_store.result == 'success'
           && needs.postgres_integrations.result == 'success'
-          && needs.macos.result == 'success'
           && needs.frontend.result == 'success'
           && (needs.renderer.result == 'success'
               || (github.event_name == 'pull_request'
@@ -608,7 +522,6 @@ jobs:
       - renderer_tests
       - postgres_store
       - postgres_integrations
-      - macos
       - frontend
       - renderer
     runs-on: ubuntu-24.04

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -1185,8 +1185,8 @@ Windows CI is disabled on the current baseline.
 ### macOS
 
 - [x] Select and document the staged macOS direction: Apple Silicon macOS 15+
-  trusted-native Bash/sh first, then hosted `macos-15` validation, followed by
-  Virtualization.framework isolation.
+  trusted-native Bash/sh first, then repository-scoped self-hosted validation,
+  followed by Virtualization.framework isolation.
 
 - [ ] Add a macOS provider.
 - [ ] Report `runner.os=macOS`, not Linux.

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -153,9 +153,9 @@ Current design foundation:
 - [x] The first target is Apple Silicon on macOS 15 or newer, with Bash and
   `sh` as the required shell surface and configured Python or PowerShell Core
   optional.
-- [x] Delivery is staged as trusted native execution, hosted `macos-15`
-  validation, and then Virtualization.framework isolation on physical Apple
-  Silicon.
+- [x] Delivery is staged as trusted native execution, repository-scoped
+  self-hosted validation, and then Virtualization.framework isolation on
+  physical Apple Silicon. Paid GitHub-hosted macOS execution remains disabled.
 
 Remaining tasks:
 
@@ -165,8 +165,9 @@ Remaining tasks:
   dedicated account and runner-only Keychain inputs, owned process supervisor,
   descriptor-relative workspace access, durable recovery, and explicit
   host-shared zero-resource policy.
-- [ ] Add the ARM64-only hosted `macos-15` build, provider, product-config,
-  shell, cancellation, recovery, and shipped-runner differential lane.
+- [ ] Add an ARM64-only, repository-scoped self-hosted macOS 15 build,
+  provider, product-config, shell, cancellation, recovery, and shipped-runner
+  differential lane when dedicated capacity is available.
 - [ ] Implement the `macos_virtualization` provider with an attested macOS 15
   ARM64 template, private guest protocol, APFS clone cleanup, resource
   enforcement, and self-hosted physical-machine acceptance.
@@ -179,7 +180,7 @@ Acceptance:
 - [ ] The shipped native runner on Apple Silicon macOS 15 reports
   `runner.os=macOS` and `runner.arch=ARM64`, completes zero-resource Bash and
   `sh` jobs, and rejects actions, services, and containers before launch.
-- [ ] Hosted `macos-15` differential fixtures cover stable environment,
+- [ ] Self-hosted macOS 15 differential fixtures cover stable environment,
   working-directory, command-file, output, timeout, cancellation, and
   conclusion behavior.
 - [ ] Physical Apple Silicon acceptance proves VM template identity,

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -1,8 +1,10 @@
 # macOS runner implementation plan
 
 This page records the accepted implementation order for macOS runner support.
-The trusted-native slice described in stages 1 and 2 is experimental. The
-Virtualization.framework isolation boundary in stage 3 remains planned.
+The trusted-native slice described in stage 1 is experimental. Native macOS
+validation is deferred until repository-scoped self-hosted capacity is
+available, and the Virtualization.framework boundary in stage 3 remains
+planned.
 
 The first supported host is Apple Silicon running macOS 15 or newer. Workflow
 syntax does not change: the first slice executes GitHub-compatible `run:` steps
@@ -36,18 +38,24 @@ Runner-only secrets may be loaded from an exact macOS Keychain service/account
 pair without authentication UI. This source is limited to runner mTLS, spool,
 and object-store inputs and is never made available through a job-secret port.
 
-## Stage 2: hosted macOS validation
+## Stage 2: self-hosted macOS validation (deferred)
 
-Add an explicit GitHub-hosted `macos-15` lane and fail closed unless Rust's host
-triple is `aarch64-apple-darwin`. It builds the shipped binaries and exercises
-the macOS provider, product configuration, context, Keychain, shell executor,
-durable state, supervisor cleanup, and a shipped-runner process smoke test.
-The lane uses system tools and pinned actions; it requires neither Homebrew nor
-repository secrets.
+The GitHub-hosted `macos-15` lane is intentionally absent because its recurring
+cost is not justified during the project's current stage. The macOS provider,
+configuration, platform-specific tests, differential support, and supervisor
+smoke script remain in the repository so validation can resume without
+reimplementing the runner.
 
-A deterministic differential fixture runs the same Bash and `sh` cases under
-GitHub Actions and Automata and compares stable environment, working-directory,
-command-file, output, timeout, cancellation, and conclusion behavior.
+When repository-scoped self-hosted Apple Silicon capacity is available, add an
+explicitly labeled macOS 15 lane and fail closed unless Rust's host triple is
+`aarch64-apple-darwin`. It should build the shipped binaries and exercise the
+macOS provider, product configuration, context, Keychain, shell executor,
+durable state, supervisor cleanup, and shipped-runner process smoke test.
+
+A deterministic differential fixture should run the same Bash and `sh` cases
+under the self-hosted workflow and Automata and compare stable environment,
+working-directory, command-file, output, timeout, cancellation, and conclusion
+behavior.
 
 ## Stage 3: Virtualization.framework isolation
 
@@ -62,10 +70,10 @@ omits the virtual NIC, while private egress uses provider-owned NAT. Runner or
 helper failure stops the VM and removes the clone through replay-safe provider
 recovery.
 
-GitHub-hosted ARM64 macOS runners do not provide nested virtualization. Unit,
-protocol, build, and fake-helper tests run in hosted CI; boot, isolation,
-resource, crash-recovery, and repeated-clean-job tests require a repository-
-scoped self-hosted Apple Silicon runner.
+GitHub-hosted ARM64 macOS runners do not provide nested virtualization. macOS-
+specific build, Keychain, shell-differential, native-process, boot, isolation,
+resource, crash-recovery, and repeated-clean-job coverage requires repository-
+scoped self-hosted Apple Silicon capacity.
 
 ## Contract changes
 
@@ -86,6 +94,8 @@ scoped self-hosted Apple Silicon runner.
 
 - Existing Linux and Windows provider, executor, configuration, and workflow
   tests remain unchanged and green.
+- Repository workflows do not schedule paid GitHub-hosted macOS runners while
+  self-hosted Apple Silicon capacity is unavailable.
 - Native configuration rejects the wrong OS/architecture, macOS below 15,
   parallel slots, overlapping roots, nonzero ephemeral-disk or GPU capacity,
   unsupported network/filesystem/privilege policies, and unsupported workflow

--- a/scripts/ci/tests/workflow-safety.test.mjs
+++ b/scripts/ci/tests/workflow-safety.test.mjs
@@ -377,24 +377,15 @@ test("repository CI omits the hosted Windows job and retains fixture parity", ()
   assert.doesNotMatch(ci, /^[ \t]+runs-on: windows-/m);
 });
 
-test("CI runs the native macOS contract on pinned Apple Silicon", () => {
+test("repository CI omits paid GitHub-hosted macOS execution", () => {
   const ci = source(".ci/workflows/ci.yml");
-  const macos = workflowJob(ci, "macos");
 
-  assert.match(macos, /runs-on: macos-15/);
-  assert.match(macos, /host_triple[^\n]+aarch64-apple-darwin/);
-  assert.match(macos, /sw_vers -productVersion/);
-  assert.match(macos, /-p automata-ci-metrics/);
-  assert.match(macos, /-p automata-ci-sandbox-macos/);
-  assert.match(macos, /--test product_context/);
-  assert.match(macos, /--test runner_product_config_macos/);
-  assert.match(macos, /--test native_runner_process_e2e/);
-  assert.match(macos, /macos-supervisor-smoke\.py/);
-  assert.match(macos, /Record GitHub-hosted Bash shell reference/);
-  assert.match(macos, /Record GitHub-hosted sh shell reference/);
-  assert.match(macos, /AUTOMATA_MACOS_DIFFERENTIAL_REFERENCE/);
-  assert.match(macos, /steps\.macos_shell_reference\.outputs\.fixture/);
-  assert.doesNotMatch(macos, /self-hosted/);
+  assert.doesNotMatch(
+    ci,
+    /^  macos:[ \t]*\r?$/m,
+    "macOS validation waits for repository-scoped self-hosted capacity",
+  );
+  assert.doesNotMatch(ci, /^[ \t]+runs-on: macos-/m);
 });
 
 test("Rust CI publishes an ordinary-lane report with a service-aware guard", () => {
@@ -515,7 +506,7 @@ test("distribution build overlaps validation while the final gate retains every 
   );
   assert.match(
     dist,
-    /needs:\n      - dist_build\n      - verify\n      - rust_tests\n      - rust_coverage\n      - renderer_tests\n      - postgres_store\n      - postgres_integrations\n      - macos\n      - frontend\n      - renderer/,
+    /needs:\n      - dist_build\n      - verify\n      - rust_tests\n      - rust_coverage\n      - renderer_tests\n      - postgres_store\n      - postgres_integrations\n      - frontend\n      - renderer/,
   );
   assert.match(dist, /needs\.dist_build\.result == 'success'/);
   assert.match(dist, /needs\.verify\.result == 'success'/);
@@ -524,7 +515,6 @@ test("distribution build overlaps validation while the final gate retains every 
   assert.match(dist, /needs\.renderer_tests\.result == 'success'/);
   assert.match(dist, /needs\.postgres_store\.result == 'success'/);
   assert.match(dist, /needs\.postgres_integrations\.result == 'success'/);
-  assert.match(dist, /needs\.macos\.result == 'success'/);
   assert.match(dist, /needs\.frontend\.result == 'success'/);
   assert.match(
     dist,


### PR DESCRIPTION
## Summary

- remove the paid GitHub-hosted macOS 15 validation job
- remove macOS from the final distribution gate while preserving every other prerequisite
- retain all macOS runner implementation, configuration, platform tests, differential support, and supervisor tooling
- document repository-scoped self-hosted Apple Silicon as the future validation path

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p automata-ci-workflow-github --tests`
- `node --test scripts/ci/tests/workflow-safety.test.mjs`
- `python3 scripts/ci/verify-documentation.py`
- actionlint 1.7.12 on `.ci/workflows/ci.yml`
- exact CI workflow fixture parity and `git diff --check`