### PR TITLE
test: align runtime context rejection fixture

### DIFF
--- a/crates/automata-ci-job-executor-github/tests/runtime_context.rs
+++ b/crates/automata-ci-job-executor-github/tests/runtime_context.rs
@@ -11,10 +11,11 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_core::{
-    ContextValue, JobConclusion, JobContentReference, JobRuntimeContext, NeedContext, NeedOutput,
-    OutputSensitivity, RunValueTemplates, RuntimeBoolean, RuntimePositiveInteger,
-    RuntimeTimeoutTemplate, SecretBinding, SemanticStep, Sha256Digest, ShellTemplate, StepId,
-    StepIr, StrategyContext, ValueTemplate, ValueTemplateSegment,
+    ContextValue, JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobConclusion, JobContentReference,
+    JobRuntimeContext, NeedContext, NeedOutput, OutputSensitivity, RunValueTemplates,
+    RuntimeBoolean, RuntimePositiveInteger, RuntimeTimeoutTemplate, SecretBinding, SemanticStep,
+    Sha256Digest, ShellTemplate, StepId, StepIr, StrategyContext, ValueTemplate,
+    ValueTemplateSegment,
 };
 use automata_ci_expression_github::{GithubObject, GithubValue, MapContext};
 use automata_ci_job_executor_github::{
@@ -340,8 +341,18 @@ async fn malformed_and_unsupported_context_versions_fail_before_sandbox_creation
         Some(&0x08),
         "schema field must be first"
     );
-    assert_eq!(unsupported.get(1), Some(&0x02), "fixture schema is v2");
-    unsupported[1] = 0x03;
+    let current_schema = u8::try_from(JOB_RUNTIME_CONTEXT_SCHEMA_VERSION)
+        .expect("current schema uses a one-byte protobuf varint");
+    let unsupported_schema = current_schema
+        .checked_add(1)
+        .filter(|version| *version < 0x80)
+        .expect("next schema uses a one-byte protobuf varint");
+    assert_eq!(
+        unsupported.get(1),
+        Some(&current_schema),
+        "fixture schema matches the canonical runtime-context schema"
+    );
+    unsupported[1] = unsupported_schema;
     let unsupported = Bytes::from(unsupported);
     assert_pre_sandbox_failure(
         runtime_context_reference(&unsupported),


### PR DESCRIPTION
## Outcome

Restore the GitHub job executor test baseline after the canonical greenfield reset changed the internal runtime-context schema from v2 to v1. The unsupported-version fixture now derives the current schema constant and mutates it to the next single-byte protobuf version instead of carrying stale hard-coded v2/v3 bytes.

The rejection still proves malformed or unsupported runtime context fails before sandbox creation.

## Related issue

None. This is a focused regression fix discovered on current `main`.

## Trust and compatibility impact

No production schema, protocol, storage, credential, isolation, release, or GitHub Actions compatibility behavior changes. The canonical runtime-context schema remains v1.

## Verification

Passed:

- `cargo test --locked -p automata-ci-job-executor-github --test runtime_context malformed_and_unsupported_context_versions_fail_before_sandbox_creation -- --exact`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p automata-ci-job-executor-github --all-targets --no-fail-fast` (139 passed)
- `CARGO_BUILD_JOBS=2 cargo clippy --locked -p automata-ci-job-executor-github --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

OpenAI Codex audited the current roadmap and test baseline, identified the stale post-#39 fixture, implemented the version-derived rejection case, and ran the verification listed above. The submitted diff was reviewed against the canonical schema and pre-sandbox failure contract.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.