### PR TITLE
Refactor greenfield contract cleanup

### DIFF
--- a/crates/automata-ci-auth-postgres/src/github_mapping_management.rs
+++ b/crates/automata-ci-auth-postgres/src/github_mapping_management.rs
@@ -44,12 +44,12 @@ const RESOURCE_MAPPING: &str = "github_role_mapping";
 /// row locks through the mapping write and immutable audit append.
 ///
 /// Lists use the mapping primary-key keyset. Option result sets are capped by
-/// `LIMIT 501`, but migration 0010 has no supporting label-order indexes or
+/// `LIMIT 501`, but the current schema has no supporting label-order indexes or
 /// tenant cardinality ceilings, so those scans are only output-bounded.
-/// Successful mutations retain migration 0010's tenant-wide authorization-
-/// revision invalidation and likewise have tenant-cardinality-wide work. Product
-/// composition remains gated on the missing indexes/ceilings or equivalently
-/// fail-closed bounded designs.
+/// Successful mutations retain tenant-wide authorization-revision invalidation
+/// and likewise have tenant-cardinality-wide work. Product composition remains
+/// gated on the missing indexes/ceilings or equivalently fail-closed bounded
+/// designs.
 #[derive(Clone)]
 pub struct PostgresGithubMappingManagementRepository {
     pool: PgPool,

--- a/crates/automata-ci-core/src/job/result.rs
+++ b/crates/automata-ci-core/src/job/result.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
 use super::{MAX_JOB_OUTPUT_DEFINITIONS, StepId, instance::validate_logical_name};
@@ -183,10 +183,17 @@ pub struct StepResult {
     conclusion: JobConclusion,
     started_at: UnixMillis,
     completed_at: UnixMillis,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_required_option")]
     summary_markdown: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     annotations: Vec<StepAnnotation>,
+}
+
+fn deserialize_required_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer)
 }
 
 impl StepResult {

--- a/crates/automata-ci-core/tests/job_result_validation.rs
+++ b/crates/automata-ci-core/tests/job_result_validation.rs
@@ -31,7 +31,7 @@ fn valid_result_has_monotonic_unique_step_history() {
 }
 
 #[test]
-fn step_summaries_and_annotations_are_bounded_redacted_and_backward_compatible() {
+fn step_summaries_and_annotations_are_bounded_redacted_and_schema_complete() {
     let sensitive = "masked-attachment-value";
     let attached = step("build", 10, 20)
         .with_summary_markdown(format!("## Result\n{sensitive}\n"))
@@ -63,16 +63,21 @@ fn step_summaries_and_annotations_are_bounded_redacted_and_backward_compatible()
     let decoded: JobResult = serde_json::from_value(encoded).expect("decode attachments");
     assert_eq!(decoded, result);
 
-    let legacy = serde_json::json!({
-        "step_id": "build",
-        "outcome": "success",
-        "conclusion": "success",
-        "started_at": 10,
-        "completed_at": 20
-    });
-    let decoded: StepResult = serde_json::from_value(legacy).expect("decode legacy step");
+    let empty = serde_json::to_value(step("empty", 20, 30)).expect("serialize empty attachment");
+    assert_eq!(empty["summary_markdown"], serde_json::Value::Null);
+    assert_eq!(empty["annotations"], serde_json::json!([]));
+    let decoded: StepResult = serde_json::from_value(empty.clone()).expect("decode current step");
     assert_eq!(decoded.summary_markdown(), None);
     assert!(decoded.annotations().is_empty());
+
+    for required in ["summary_markdown", "annotations"] {
+        let mut incomplete = empty.clone();
+        incomplete
+            .as_object_mut()
+            .expect("step object")
+            .remove(required);
+        assert!(serde_json::from_value::<StepResult>(incomplete).is_err());
+    }
 }
 
 #[test]

--- a/crates/automata-ci-core/tests/logical_workflow_plan.rs
+++ b/crates/automata-ci-core/tests/logical_workflow_plan.rs
@@ -787,7 +787,7 @@ fn timeout_units_survive_deferred_values_and_literal_scaling_is_checked() {
 }
 
 #[test]
-fn unknown_fields_fail_closed_inside_v2_boundaries() {
+fn unknown_fields_fail_closed_inside_v1_boundaries() {
     let encoded = serde_json::to_value(valid_plan()).expect("serialize");
     for pointer in [
         "",

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -430,7 +430,8 @@ pub enum GithubServerServiceMintCutoffOutcome {
 
 /// Narrow durable port consumed by the credential lifecycle core.
 ///
-/// Every implementation must preserve the exact Store 0032 semantics. The
+/// Every implementation must preserve the exact Store server-service
+/// credential semantics. The
 /// blanket implementation delegates directly to
 /// [`GithubServerServiceAuthorityRepository`]; the narrower port also permits
 /// deterministic provider-boundary tests without constructing Store-private
@@ -676,7 +677,7 @@ pub enum GithubServerServiceCoordinationOutcome {
     RevocationCommitPending(Box<PendingGithubServerServiceRevocationCommit>),
 }
 
-/// Generic 0032 coordinator for Checks and private-source credentials.
+/// Generic coordinator for Checks and private-source credentials.
 pub struct GithubServerServiceCredentialCoordinator {
     repository: Arc<dyn GithubServerServiceCredentialRepository>,
     resolver: Arc<dyn GithubServerServiceCredentialRequestResolver>,
@@ -1145,7 +1146,7 @@ pub enum GithubServerServiceHandoffReleaseOutcome {
     Pending(PendingGithubServerServiceHandoffRelease),
 }
 
-/// Opens and releases exact action-bound 0032 credential handoffs.
+/// Opens and releases exact action-bound credential handoffs.
 pub struct GithubServerServiceCredentialIssuer {
     repository: Arc<dyn GithubServerServiceCredentialRepository>,
     envelopes: Arc<EnvelopeCodec>,

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -416,21 +416,6 @@ pub trait SandboxProvider: fmt::Debug + Send + Sync {
     /// Returns the provider's fixed, explicit capability declaration.
     fn capabilities(&self) -> &ProviderCapabilities;
 
-    /// Reconstructs the exact opaque identity reserved by a create operation.
-    ///
-    /// Providers with deterministic create identities should return the same
-    /// handle that an uncertain [`Self::create`] failure carries. The runtime
-    /// uses this only to recover legacy durable intents that predate custody of
-    /// that handle; returning `None` keeps the unresolved operation fenced.
-    #[must_use]
-    fn create_recovery_handle(
-        &self,
-        _operation_id: OperationId,
-        _generation: SandboxGeneration,
-    ) -> Option<SandboxHandle> {
-        None
-    }
-
     /// Creates or exactly replays one sandbox operation.
     ///
     /// Reusing an operation identifier with different request material must

--- a/crates/automata-ci-github-delivery/src/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/src/checks_publisher.rs
@@ -191,7 +191,7 @@ impl GithubChecksCredentialRequest<'_> {
         self.required_through
     }
 
-    /// Derives the exact 0032 consumer claim from this durable outbox claim.
+    /// Derives the exact consumer claim from this durable outbox claim.
     ///
     /// # Errors
     ///
@@ -331,7 +331,7 @@ impl GithubChecksServerServiceCredential {
         self.required_through
     }
 
-    /// Returns the trusted observation at which 0032 revalidated this handoff.
+    /// Returns the trusted observation at which Store revalidated this handoff.
     #[must_use]
     pub const fn acquired_at(&self) -> UnixMillis {
         self.acquired_at
@@ -428,7 +428,7 @@ pub enum GithubChecksCredentialValueError {
     /// The authority selector belongs to a different authenticated tenant.
     #[error("the GitHub Checks credential authority selector tenant is inconsistent")]
     AuthorityTenantMismatch,
-    /// The exact outbox claim cannot be represented at the 0032 boundary.
+    /// The exact outbox claim cannot be represented at the authority boundary.
     #[error("the GitHub Checks credential claim binding is invalid")]
     InvalidClaimBinding,
 }

--- a/crates/automata-ci-github-delivery/src/service.rs
+++ b/crates/automata-ci-github-delivery/src/service.rs
@@ -72,7 +72,7 @@ const fn server_service_action(
 
 /// Move-only capability that releases one exact durable server-service handoff.
 ///
-/// Implementations own the complete non-secret 0032 release binding. They must
+/// Implementations own the complete non-secret credential release binding. They must
 /// make one bounded exact release attempt and retain any replayable ambiguous
 /// release evidence internally until it is resolved or the immutable handoff
 /// horizon expires. The delivery credential drops its bearer before invoking
@@ -227,7 +227,7 @@ impl GithubDeliverySourceCredentialRequest<'_> {
         self.repository_owner_id
     }
 
-    /// Returns the immutable 0032 private-source authority pinned at acceptance.
+    /// Returns the immutable private-source authority pinned at acceptance.
     #[must_use]
     pub const fn authority_selector(&self) -> &GithubServerServiceAuthoritySelector {
         self.authority_selector
@@ -258,7 +258,7 @@ impl GithubDeliverySourceCredentialRequest<'_> {
         self.required_through
     }
 
-    /// Derives the exact 0032 consumer claim from this delivery lease.
+    /// Derives the exact consumer claim from this delivery lease.
     ///
     /// # Errors
     ///
@@ -482,7 +482,7 @@ impl GithubDeliverySourceCredential {
         &self.binding.repository
     }
 
-    /// Returns the immutable 0032 authority selector that granted this handoff.
+    /// Returns the immutable authority selector that granted this handoff.
     #[must_use]
     pub const fn authority_selector(&self) -> &GithubServerServiceAuthoritySelector {
         &self.binding.authority_selector

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -12,7 +12,7 @@ use std::{
 use automata_ci_action_github::GithubActionMetadataDecoder;
 use automata_ci_core::{
     ActionReference, AttemptId, JobAuthorityProfile, JobConclusion, JobIrEnvelope, JobLifecycle,
-    JobResult, JobResultOutput, JobResultValidationError, JobRuntimeContext, LeaseGuard,
+    JobResult, JobResultOutput, JobResultValidationError, JobRuntimeContext,
     MAX_JOB_RESULT_ANNOTATIONS, MAX_JOB_RESULT_ATTACHMENT_BYTES, MAX_STEP_ANNOTATION_PROPERTIES,
     MAX_STEP_ATTACHMENT_TEXT_BYTES, OperationId, OutputSensitivity, RuntimeBoolean,
     RuntimePositiveInteger, RuntimeTimeoutTemplate, SecretBinding, SemanticStep, ShellTemplate,
@@ -5311,23 +5311,6 @@ impl fmt::Debug for GithubJobExecutor {
 impl JobExecutor for GithubJobExecutor {
     fn admit(&self, job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
         self.validate_admission(job).map(ExecutionAdmission::new)
-    }
-
-    fn create_recovery_sandbox(
-        &self,
-        operation_id: OperationId,
-        guard: LeaseGuard,
-    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
-        let generation = SandboxGeneration::new(guard.fencing_token().get())
-            .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
-        self.ports
-            .provider
-            .create_recovery_handle(operation_id, generation)
-            .map(|handle| {
-                journal_identity(&handle)
-                    .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))
-            })
-            .transpose()
     }
 
     fn execute(

--- a/crates/automata-ci-job-executor-github/tests/provider_saga.rs
+++ b/crates/automata-ci-job-executor-github/tests/provider_saga.rs
@@ -269,21 +269,6 @@ async fn provider_failures_map_to_exact_executor_and_durable_domains() {
     }
 }
 
-#[test]
-fn deterministic_provider_identity_reconstructs_legacy_create_custody() {
-    let fixture = Fixture::new(Vec::new(), Vec::new());
-    let request = fixture.request(run_job("true\n"));
-    let operation_id = automata_ci_core::OperationId::new();
-
-    let recovered = fixture
-        .executor
-        .create_recovery_sandbox(operation_id, request.lease().guard())
-        .expect("recovery identity construction")
-        .expect("fake provider has deterministic identity");
-
-    assert_eq!(recovered, journal_identity());
-}
-
 #[tokio::test]
 async fn destroy_completion_commit_failure_retains_and_replays_exact_custody() {
     let fixture = Fixture::new(Vec::new(), vec![PhaseResponse::success()]);

--- a/crates/automata-ci-job-executor-github/tests/runtime_context.rs
+++ b/crates/automata-ci-job-executor-github/tests/runtime_context.rs
@@ -113,7 +113,7 @@ async fn exact_runtime_context_is_fetched_once_and_borrowed_by_phase_snapshots()
     fixture
         .executor
         .admit(&job)
-        .expect("valid v5 job is admitted");
+        .expect("valid v1 job is admitted");
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
 
     let result = fixture
@@ -146,7 +146,7 @@ async fn exact_runtime_context_is_fetched_once_and_borrowed_by_phase_snapshots()
 }
 
 #[tokio::test]
-async fn v5_step_templates_and_runtime_boolean_resolve_from_hydrated_context() {
+async fn v1_step_templates_and_runtime_boolean_resolve_from_hydrated_context() {
     let runtime_context = rich_runtime_context();
     let encoded = encode_runtime_context(&runtime_context);
     let reference = runtime_context_reference(&encoded);

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -1634,14 +1634,6 @@ impl SandboxProvider for FakeProvider {
         &self.capabilities
     }
 
-    fn create_recovery_handle(
-        &self,
-        _operation_id: OperationId,
-        _generation: automata_ci_execution::SandboxGeneration,
-    ) -> Option<SandboxHandle> {
-        Some(self.handle.clone())
-    }
-
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-protocol/src/message/lease.rs
+++ b/crates/automata-ci-protocol/src/message/lease.rs
@@ -4,7 +4,7 @@ use automata_ci_core::{
     AttemptId, FencingToken, JobIrEnvelope, JobLifecycle, Lease, LeaseGuard, LeaseId, OperationId,
     UnixMillis,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::MessageValidationError;
 use super::{MessageHeader, RunnerSlotOrdinal, ServerCommandHeader};
@@ -87,8 +87,16 @@ pub struct LeaseOffer {
     lease: Lease,
     job: JobIrEnvelope,
     runtime_authorities: Option<super::JobRuntimeAuthorities>,
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_required_option")]
     managed_secret_bindings: Option<super::ManagedSecretBindingOverlay>,
+}
+
+fn deserialize_required_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer)
 }
 
 impl LeaseOffer {

--- a/crates/automata-ci-protocol/src/message/validation.rs
+++ b/crates/automata-ci-protocol/src/message/validation.rs
@@ -846,7 +846,7 @@ pub enum MessageValidationError {
     #[error("command acknowledgement must advance through at least one command")]
     EmptyCommandAcknowledgement,
     /// A lease offer omits its protected runtime-authority bundle.
-    #[error("protocol v5 lease offers require protected runtime authority")]
+    #[error("current protocol lease offers require protected runtime authority")]
     MissingRuntimeAuthorities,
     /// A named scalar whose protocol contract requires a positive value is zero.
     #[error("{0} must be nonzero")]

--- a/crates/automata-ci-protocol/tests/codec_boundary.rs
+++ b/crates/automata-ci-protocol/tests/codec_boundary.rs
@@ -452,6 +452,24 @@ fn nested_job_and_result_domain_errors_are_rejected() {
 }
 
 #[test]
+fn current_lease_offer_requires_explicit_managed_secret_bindings() {
+    let attempt_id = AttemptId::new();
+    let offer = ServerToRunner::LeaseOffer(Box::new(lease_offer(
+        command_header(),
+        slot(),
+        lease(attempt_id, RunnerId::new()),
+        job_envelope(RunnerRequirements::default()),
+    )));
+    let mut incomplete = serde_json::to_value(offer).expect("serialize lease offer");
+    incomplete["payload"]
+        .as_object_mut()
+        .expect("lease-offer payload")
+        .remove("managed_secret_bindings");
+
+    assert!(serde_json::from_value::<ServerToRunner>(incomplete).is_err());
+}
+
+#[test]
 fn nested_requirement_collections_obey_the_configured_budget() {
     use automata_ci_core::RunnerLabel;
 

--- a/crates/automata-ci-protocol/tests/protocol_negotiation.rs
+++ b/crates/automata-ci-protocol/tests/protocol_negotiation.rs
@@ -29,17 +29,17 @@ fn disjoint_ranges_return_typed_error() {
 }
 
 #[test]
-fn current_resource_aware_protocol_is_exactly_v5_with_no_v4_downgrade() {
+fn current_protocol_is_exactly_v1_and_rejects_forward_skew() {
     assert_eq!(PROTOCOL_MIN_VERSION, version(1));
     assert_eq!(PROTOCOL_MAX_VERSION, version(1));
     assert_eq!(SUPPORTED_PROTOCOL_RANGE, range(1, 1));
 
-    let legacy = range(3, 3);
+    let unsupported = range(3, 3);
     assert_eq!(
-        negotiate_protocol(SUPPORTED_PROTOCOL_RANGE, legacy),
+        negotiate_protocol(SUPPORTED_PROTOCOL_RANGE, unsupported),
         Err(ProtocolNegotiationError::NoCommonVersion {
             local: SUPPORTED_PROTOCOL_RANGE,
-            remote: legacy,
+            remote: unsupported,
         })
     );
 }

--- a/crates/automata-ci-results-github/README.md
+++ b/crates/automata-ci-results-github/README.md
@@ -88,7 +88,7 @@ URLs use separate protocol domains and derived keys. Every metadata mutation
 rechecks the attempt lifecycle and fence.
 
 `GithubResultsRuntimeAuthorityIssuer` creates the JWT while building the
-durable lease offer. Runner protocol v5 requires the authority bundle. The
+durable lease offer. Runner protocol v1 requires the authority bundle. The
 runner stores it as separately authenticated content and injects it into that
 job only; there is no runner- or fleet-wide Results credential.
 

--- a/crates/automata-ci-results-github/tests/postgres_artifacts.rs
+++ b/crates/automata-ci-results-github/tests/postgres_artifacts.rs
@@ -18,6 +18,7 @@ use automata_ci_store::{
     AcquireLease, InternalAttemptRepository as _, QueuedAttempt, StableRunnerSlot,
 };
 use bytes::Bytes;
+use sqlx::PgPool;
 use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
 use uuid::Uuid;
 

--- a/crates/automata-ci-runner-journal/src/model/command.rs
+++ b/crates/automata-ci-runner-journal/src/model/command.rs
@@ -2,7 +2,7 @@ use automata_ci_core::{Lease, OperationId, Sha256Digest, UnixMillis};
 use automata_ci_protocol::{
     CommandSequence, LeaseRejectionReason, ManagedSecretBindingOverlay, RunnerSlotOrdinal,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{JobIrContentRef, JournalInvariantError, RuntimeAuthorityContentRef};
 
@@ -112,9 +112,17 @@ pub struct LeaseOfferRecord {
     lease: Lease,
     job_ir: JobIrContentRef,
     runtime_authorities: RuntimeAuthorityContentRef,
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_required_option")]
     managed_secret_bindings: Option<ManagedSecretBindingOverlay>,
     command: DurableCommand,
+}
+
+fn deserialize_required_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer)
 }
 
 impl LeaseOfferRecord {

--- a/crates/automata-ci-runner-journal/tests/journal_contract.rs
+++ b/crates/automata-ci-runner-journal/tests/journal_contract.rs
@@ -197,6 +197,20 @@ fn deserialized_offer_with_invalid_lease_interval_cannot_enter_journal() {
 }
 
 #[test]
+fn current_lease_offer_record_requires_explicit_managed_secret_bindings() {
+    let fixture = Fixture::new();
+    let mut incomplete = serde_json::to_value(fixture.offer(1)).expect("serialize offer");
+    incomplete
+        .as_object_mut()
+        .expect("lease-offer record")
+        .remove("managed_secret_bindings");
+
+    assert!(
+        serde_json::from_value::<automata_ci_runner_journal::LeaseOfferRecord>(incomplete).is_err()
+    );
+}
+
+#[test]
 fn exact_replays_are_noops_and_lease_expiration_only_moves_forward() {
     let scratch = Scratch::new("idempotent-replays");
     let fixture = Fixture::new();

--- a/crates/automata-ci-runner-runtime/src/port.rs
+++ b/crates/automata-ci-runner-runtime/src/port.rs
@@ -543,25 +543,6 @@ pub trait JobExecutor: fmt::Debug + Send + Sync {
     /// selected environment cannot be supported exactly.
     fn admit(&self, job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection>;
 
-    /// Reconstructs exact cleanup custody for a legacy uncertain create.
-    ///
-    /// New executions must durably retain the recovery handle returned by the
-    /// provider. This compatibility seam lets a provider with deterministic
-    /// create identities recover an older intent without broad enumeration or
-    /// weakening the journal's unresolved-operation fence.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ExecutorError`] if the durable operation identity cannot be
-    /// mapped to an exact provider-owned sandbox handle.
-    fn create_recovery_sandbox(
-        &self,
-        _operation_id: OperationId,
-        _guard: LeaseGuard,
-    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
-        Ok(None)
-    }
-
     /// Starts or reattaches to one admitted attempt.
     fn execute(
         &self,

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -2455,13 +2455,12 @@ impl RunnerSessionSupervisor {
         durable: &SlotSnapshot,
         cancellation: CancellationToken,
     ) -> Result<(), RunnerRuntimeError> {
-        let durable = self.recover_uncertain_create_custody(session, durable)?;
         if durable
             .terminal_result()
             .is_some_and(TerminalResultRecord::is_acknowledged)
         {
             return self
-                .finish_terminal_slot_delivery(session, &durable, cancellation)
+                .finish_terminal_slot_delivery(session, durable, cancellation)
                 .await;
         }
         let watchdog = Arc::new(LeaseWatchdog::new(self.local_lease_deadline(
@@ -2482,10 +2481,10 @@ impl RunnerSessionSupervisor {
         let result = self
             .finish_terminal_slot_maintained(
                 session,
-                &durable,
+                durable,
                 watchdog,
                 lease_expired,
-                Self::recovered_finalization_lifecycle(&durable),
+                Self::recovered_finalization_lifecycle(durable),
                 cancellation,
             )
             .await;
@@ -2494,39 +2493,20 @@ impl RunnerSessionSupervisor {
         result
     }
 
-    fn recover_uncertain_create_custody(
-        &self,
-        session: RuntimeSession,
-        durable: &SlotSnapshot,
-    ) -> Result<SlotSnapshot, RunnerRuntimeError> {
-        let Some(operation) = durable.provider_operations().last().copied() else {
-            return Ok(durable.clone());
-        };
-        if durable.sandbox().is_some()
-            || operation.kind() != ProviderOperationKind::CreateSandbox
-            || !operation.is_pending()
-        {
-            return Ok(durable.clone());
+    fn require_create_cleanup_custody(durable: &SlotSnapshot) -> Result<(), RunnerRuntimeError> {
+        let missing_custody = durable.sandbox().is_none()
+            && durable
+                .provider_operations()
+                .last()
+                .is_some_and(|operation| {
+                    operation.kind() == ProviderOperationKind::CreateSandbox
+                        && operation.is_pending()
+                });
+        if missing_custody {
+            Err(RunnerRuntimeError::ExecutorContract)
+        } else {
+            Ok(())
         }
-        let guard = durable.offer().lease().guard();
-        let sandbox = self
-            .inner
-            .ports
-            .executor
-            .create_recovery_sandbox(operation.operation_id(), guard)
-            .map_err(RunnerRuntimeError::Executor)?
-            .ok_or(RunnerRuntimeError::ExecutorContract)?;
-        let snapshot = self.inner.ports.journal.record_sandbox_created(
-            session.negotiated.session_id(),
-            durable.slot(),
-            guard,
-            operation.operation_id(),
-            sandbox,
-        )?;
-        snapshot
-            .slot(durable.slot())
-            .cloned()
-            .ok_or(RunnerRuntimeError::ExecutorContract)
     }
 
     async fn finish_terminal_slot_maintained(
@@ -2588,6 +2568,7 @@ impl RunnerSessionSupervisor {
         durable: &SlotSnapshot,
         cancellation: CancellationToken,
     ) -> Result<(), RunnerRuntimeError> {
+        Self::require_create_cleanup_custody(durable)?;
         let slot = durable.slot();
         let guard = durable.offer().lease().guard();
         self.flush_terminal_log_backlog(session, slot, guard, cancellation.clone())

--- a/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
+++ b/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
@@ -1233,8 +1233,8 @@ async fn executor_failure_is_terminalized_per_slot_while_sibling_and_supervisor_
 }
 
 #[tokio::test]
-async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_release() {
-    let scratch = support::Scratch::new("legacy-uncertain-create-recovery");
+async fn recovered_uncertain_create_without_exact_cleanup_custody_remains_fenced() {
+    let scratch = support::Scratch::new("missing-create-cleanup-custody");
     let runner_id = RunnerId::new();
     let (journal, spool) = support::durable_ports(&scratch, runner_id);
     let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
@@ -1246,7 +1246,7 @@ async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_rele
             guard,
             JobLifecycle::Preparing,
         )
-        .expect("begin legacy preparation");
+        .expect("begin preparation");
     let create = OperationId::new();
     journal
         .record_provider_intent(
@@ -1255,7 +1255,7 @@ async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_rele
             guard,
             ProviderOperation::intent(create, ProviderOperationKind::CreateSandbox),
         )
-        .expect("record legacy create intent");
+        .expect("record create intent");
     journal
         .fail_provider_operation(
             fixture.session_id,
@@ -1264,7 +1264,7 @@ async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_rele
             create,
             ProviderFailureOutcome::Uncertain(ProviderFailureKind::Internal),
         )
-        .expect("retain uncertain legacy create");
+        .expect("retain uncertain create");
     support::seed_failed_terminal_without_logs(journal.as_ref(), spool.as_ref(), &fixture);
     let terminal_operation = journal
         .snapshot()
@@ -1275,45 +1275,81 @@ async fn legacy_uncertain_create_recovers_exact_cleanup_custody_before_slot_rele
         .operation_id();
     journal
         .acknowledge_terminal_result(fixture.session_id, fixture.slot, guard, terminal_operation)
-        .expect("acknowledge legacy terminal result");
+        .expect("acknowledge terminal result");
 
-    let shutdown = CancellationToken::new();
+    let runtime = RunnerSessionSupervisor::new(
+        support::config(runner_id),
+        RunnerRuntimePorts::new(
+            Arc::new(support::FailureIsolationClient::new(fixture.session_id)),
+            journal.clone(),
+            spool,
+            Arc::new(support::FailureIsolationExecutor::default()),
+            Arc::new(support::FixedClock::new(10_000, 50)),
+            Arc::new(support::ImmediateSleeper),
+            Arc::new(SystemRuntimeIds),
+        ),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(1),
+        runtime.run(CancellationToken::new()),
+    )
+    .await
+    .expect("missing custody fails without retrying");
+    assert!(matches!(result, Err(RunnerRuntimeError::ExecutorContract)));
+    let snapshot = journal.snapshot().expect("fenced snapshot");
+    let slot = snapshot.slot(fixture.slot).expect("slot remains fenced");
+    assert!(slot.sandbox().is_none());
+    assert!(slot.provider_operations().last().is_some_and(|operation| {
+        operation.operation_id() == create
+            && operation.kind() == ProviderOperationKind::CreateSandbox
+            && operation.is_pending()
+    }));
+}
+
+#[tokio::test]
+async fn live_uncertain_create_without_exact_cleanup_custody_fails_before_terminal_delivery() {
+    let scratch = support::Scratch::new("live-missing-create-cleanup-custody");
+    let runner_id = RunnerId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
     let client = Arc::new(support::FailureIsolationClient::new(fixture.session_id));
-    let executor = Arc::new(support::LegacyUncertainCreateExecutor::default());
     let runtime = RunnerSessionSupervisor::new(
         support::config(runner_id),
         RunnerRuntimePorts::new(
             client.clone(),
             journal.clone(),
             spool,
-            executor.clone(),
+            Arc::new(support::MissingCreateCustodyExecutor),
             Arc::new(support::FixedClock::new(10_000, 50)),
             Arc::new(support::ImmediateSleeper),
             Arc::new(SystemRuntimeIds),
         ),
     );
-    let task_shutdown = shutdown.clone();
-    let task = tokio::spawn(async move { runtime.run(task_shutdown).await });
 
-    tokio::time::timeout(Duration::from_secs(5), client.wait_for_released_slot_poll())
-        .await
-        .expect("legacy create custody is destroyed and slot released");
-    assert_eq!(executor.recovery_calls(), vec![(create, guard)]);
-    assert_eq!(executor.cleanup_calls(), 1);
+    let result = tokio::time::timeout(
+        Duration::from_secs(1),
+        runtime.run(CancellationToken::new()),
+    )
+    .await
+    .expect("missing live custody fails without retrying");
+    assert!(matches!(result, Err(RunnerRuntimeError::ExecutorContract)));
     assert!(
-        journal
-            .snapshot()
-            .expect("released snapshot")
-            .slots()
-            .is_empty()
+        client.terminal_results().is_empty(),
+        "terminal delivery must not acknowledge a slot without cleanup custody"
     );
-
-    shutdown.cancel();
-    tokio::time::timeout(Duration::from_secs(1), task)
-        .await
-        .expect("runner shutdown")
-        .expect("runtime task")
-        .expect("clean shutdown after legacy recovery");
+    let snapshot = journal.snapshot().expect("fenced live snapshot");
+    let slot = snapshot
+        .slot(fixture.slot)
+        .expect("live slot remains fenced");
+    assert!(slot.sandbox().is_none());
+    assert!(
+        slot.terminal_result()
+            .is_some_and(|result| !result.is_acknowledged())
+    );
+    assert!(slot.provider_operations().last().is_some_and(|operation| {
+        operation.kind() == ProviderOperationKind::CreateSandbox && operation.is_pending()
+    }));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -1486,79 +1486,6 @@ impl JobExecutor for CancellationContentRaceExecutor {
 }
 
 #[derive(Debug, Default)]
-pub struct LegacyUncertainCreateExecutor {
-    recovery_calls: Mutex<Vec<(OperationId, automata_ci_core::LeaseGuard)>>,
-    cleanup_calls: AtomicUsize,
-}
-
-impl LegacyUncertainCreateExecutor {
-    pub fn recovery_calls(&self) -> Vec<(OperationId, automata_ci_core::LeaseGuard)> {
-        self.recovery_calls
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone()
-    }
-
-    pub fn cleanup_calls(&self) -> usize {
-        self.cleanup_calls.load(Ordering::SeqCst)
-    }
-
-    fn recovery_identity() -> SandboxIdentity {
-        SandboxIdentity::new(
-            ProviderName::new("legacy-recovery-provider").expect("provider name"),
-            JournalSandboxHandle::new("legacy-uncertain-create").expect("sandbox handle"),
-        )
-    }
-}
-
-impl JobExecutor for LegacyUncertainCreateExecutor {
-    fn admit(&self, _job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
-        Ok(ExecutionAdmission::new(sandbox_environment()))
-    }
-
-    fn create_recovery_sandbox(
-        &self,
-        operation_id: OperationId,
-        guard: automata_ci_core::LeaseGuard,
-    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
-        self.recovery_calls
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push((operation_id, guard));
-        Ok(Some(Self::recovery_identity()))
-    }
-
-    fn execute(
-        &self,
-        _request: ExecutionRequest,
-        _events: Arc<dyn ExecutionEvents>,
-        _cancellation: ExecutionCancellation,
-    ) -> ExecutorFuture<'_> {
-        Box::pin(async { Err(ExecutorError::new(ExecutorErrorKind::Internal)) })
-    }
-
-    fn cleanup(
-        &self,
-        request: CleanupRequest,
-        events: Arc<dyn ExecutionEvents>,
-        _cancellation: ExecutionCancellation,
-    ) -> CleanupFuture<'_> {
-        Box::pin(async move {
-            if request.sandbox() != &Self::recovery_identity() {
-                return Err(ExecutorError::new(ExecutorErrorKind::Internal));
-            }
-            self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
-            let destroy = events
-                .begin_provider_operation(ProviderOperationKind::DestroySandbox)
-                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
-            events
-                .provider_operation_completed(destroy)
-                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))
-        })
-    }
-}
-
-#[derive(Debug, Default)]
 pub struct FailureIsolationExecutor {
     survivor_started: AtomicBool,
 }
@@ -1603,6 +1530,44 @@ impl JobExecutor for FailureIsolationExecutor {
             self.survivor_started.store(true, Ordering::SeqCst);
             cancellation.token().cancelled().await;
             Err(ExecutorError::new(ExecutorErrorKind::Cancelled))
+        })
+    }
+
+    fn cleanup(
+        &self,
+        _request: CleanupRequest,
+        _events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> CleanupFuture<'_> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MissingCreateCustodyExecutor;
+
+impl JobExecutor for MissingCreateCustodyExecutor {
+    fn admit(&self, _job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
+        Ok(ExecutionAdmission::new(sandbox_environment()))
+    }
+
+    fn execute(
+        &self,
+        _request: ExecutionRequest,
+        events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> ExecutorFuture<'_> {
+        Box::pin(async move {
+            let create = events
+                .begin_provider_operation(ProviderOperationKind::CreateSandbox)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+            events
+                .provider_operation_failed(
+                    create,
+                    ProviderFailureOutcome::Uncertain(ProviderFailureKind::Internal),
+                )
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+            Err(ExecutorError::new(ExecutorErrorKind::Internal))
         })
     }
 

--- a/crates/automata-ci-runner/src/product/managed_secret_delivery.rs
+++ b/crates/automata-ci-runner/src/product/managed_secret_delivery.rs
@@ -4,12 +4,11 @@ use async_trait::async_trait;
 use automata_ci_auth::secret::{SecretString, SecureRandom};
 use std::collections::BTreeMap;
 
-use automata_ci_core::{LeaseGuard, OperationId, RunnerId, SecretBinding};
+use automata_ci_core::{RunnerId, SecretBinding};
 use automata_ci_job_executor_github::{
     EphemeralJobSecret, EphemeralJobSecrets, GithubJobExecutor, SecretCustodyAcknowledger,
 };
 use automata_ci_protocol::ManagedSecretBindingOverlay;
-use automata_ci_runner_journal::SandboxIdentity;
 use automata_ci_runner_runtime::{
     AdmissionRejection, CleanupFuture, CleanupRequest, ExecutionAdmission, ExecutionCancellation,
     ExecutionEvents, ExecutionRequest, ExecutorError, ExecutorErrorKind, ExecutorFuture,
@@ -123,14 +122,6 @@ impl JobExecutor for ManagedSecretJobExecutor {
         job: &automata_ci_core::JobIrEnvelope,
     ) -> Result<ExecutionAdmission, AdmissionRejection> {
         self.base.admit(job)
-    }
-
-    fn create_recovery_sandbox(
-        &self,
-        operation_id: OperationId,
-        guard: LeaseGuard,
-    ) -> Result<Option<SandboxIdentity>, ExecutorError> {
-        self.base.create_recovery_sandbox(operation_id, guard)
     }
 
     fn execute(

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -2211,14 +2211,6 @@ impl SandboxProvider for ObservedSandboxProvider {
         self.inner.capabilities()
     }
 
-    fn create_recovery_handle(
-        &self,
-        operation_id: automata_ci_execution::OperationId,
-        generation: automata_ci_execution::SandboxGeneration,
-    ) -> Option<SandboxHandle> {
-        self.inner.create_recovery_handle(operation_id, generation)
-    }
-
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -232,14 +232,6 @@ impl SandboxProvider for RootlessPodmanProvider {
         &self.inner.capabilities
     }
 
-    fn create_recovery_handle(
-        &self,
-        operation_id: automata_ci_execution::OperationId,
-        generation: automata_ci_execution::SandboxGeneration,
-    ) -> Option<SandboxHandle> {
-        Some(ResourceNames::for_create(operation_id, generation).handle())
-    }
-
     fn create(
         &self,
         spec: &SandboxSpec,

--- a/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
+++ b/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
@@ -37,24 +37,6 @@ impl PodmanLaunchTrust for ToggleLaunchTrust {
 }
 
 #[test]
-fn deterministic_create_recovery_handle_matches_the_created_sandbox() {
-    let fixture = Fixture::new("create-recovery-handle");
-    let operation_id = OperationId::new();
-    let spec = sample_spec(operation_id);
-    let recovered = fixture
-        .provider
-        .create_recovery_handle(operation_id, spec.generation())
-        .expect("Podman create identities are deterministic");
-
-    let created = fixture
-        .provider
-        .create(&spec, &NeverCancelled)
-        .expect("create sandbox");
-
-    assert_eq!(&recovered, created.handle());
-}
-
-#[test]
 fn provider_use_quarantines_before_dynamic_state_or_podman_work() {
     let admitted = Arc::new(AtomicBool::new(true));
     let trust = PodmanLaunchTrustHandle::new(Arc::new(ToggleLaunchTrust(Arc::clone(&admitted))));

--- a/crates/automata-ci-store/migrations/0001_initial_schema.sql
+++ b/crates/automata-ci-store/migrations/0001_initial_schema.sql
@@ -14441,7 +14441,7 @@ BEGIN
         WHERE run.id = NEW.run_id
           AND run.runner_requirements_schema = 1
     ) THEN
-        RAISE EXCEPTION 'new executable rows require runner-requirements schema v3'
+        RAISE EXCEPTION 'new executable rows require runner-requirements schema v1'
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'runner_requirements_current_new_rows_only';
     END IF;
@@ -14460,7 +14460,7 @@ BEGIN
           AND job.requirements @> '{"schema_version": 1}'::jsonb
           AND job.requirements ? 'resource_allocation'
     ) THEN
-        RAISE EXCEPTION 'new attempts require runner-requirements schema v3'
+        RAISE EXCEPTION 'new attempts require runner-requirements schema v1'
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'job_attempts_runner_requirements_current_new_only';
     END IF;
@@ -14714,7 +14714,7 @@ BEGIN
              AND run.runner_requirements_schema = 1
        )
     THEN
-        RAISE EXCEPTION 'new logical workflow runs require runner-requirements schema v3'
+        RAISE EXCEPTION 'new logical workflow runs require runner-requirements schema v1'
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'logical_workflow_runs_runner_requirements_current_new_only';
     END IF;

--- a/crates/automata-ci-store/src/github_subject_evidence.rs
+++ b/crates/automata-ci-store/src/github_subject_evidence.rs
@@ -293,7 +293,7 @@ pub struct ManifestPinnedGithubDeliveryEvidence {
 impl ManifestPinnedGithubDeliveryEvidence {
     /// Rehydrates one complete immutable GitHub delivery-evidence record.
     ///
-    /// The manifest is the complete historical 0035 policy, not merely a
+    /// The manifest is the complete accepted policy, not merely a
     /// revision number. The mandatory `checks_write` selector and visibility-
     /// dependent private-source selector are retained exactly as accepted.
     /// Public evidence must prove that no private-source selector was pinned.

--- a/crates/automata-ci-store/src/logical_job_result.rs
+++ b/crates/automata-ci-store/src/logical_job_result.rs
@@ -1463,7 +1463,7 @@ pub enum LogicalJobResultValueError {
     #[error("loaded workflow plan bytes disagree with the durable descriptor")]
     PlanBlobMismatch,
     /// The decoded plan was invalid, non-current, or noncanonical.
-    #[error("decoded workflow plan is invalid or not canonical v2 JSON")]
+    #[error("decoded workflow plan is invalid or not canonical v1 JSON")]
     InvalidPlan,
     /// The decoded plan did not contain the exact claimed step job.
     #[error("decoded workflow plan job disagrees with the durable descriptor")]

--- a/crates/automata-ci-store/src/logical_materialization.rs
+++ b/crates/automata-ci-store/src/logical_materialization.rs
@@ -2,7 +2,7 @@
 //!
 //! The repository returns an immutable instance descriptor and releases its
 //! transaction before any blob I/O. Callers load and decode the exact `JobIR`
-//! blob, then construct a commit that proves the current v5 envelope matches
+//! blob, then construct a commit that proves the current v1 envelope matches
 //! every store-authenticated identity and content reference.
 
 use std::num::NonZeroU64;

--- a/crates/automata-ci-store/src/observability.rs
+++ b/crates/automata-ci-store/src/observability.rs
@@ -233,7 +233,7 @@ impl WorkflowRunCounts {
     }
 }
 
-/// Closed durable state of a current `WorkflowPlan`-v2 orchestration marker.
+/// Closed durable state of a current `WorkflowPlan`-v1 orchestration marker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogicalWorkflowRunState {
     Pending,
@@ -263,7 +263,7 @@ impl LogicalWorkflowRunState {
     }
 }
 
-/// Counts for every closed `WorkflowPlan`-v2 orchestration-marker state.
+/// Counts for every closed `WorkflowPlan`-v1 orchestration-marker state.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct LogicalWorkflowRunCounts([u64; 5]);
 

--- a/crates/automata-ci-store/src/postgres/runtime_authority.rs
+++ b/crates/automata-ci-store/src/postgres/runtime_authority.rs
@@ -3459,7 +3459,7 @@ async fn lock_exact_authority_graph(
     Ok(true)
 }
 
-#[allow(clippy::too_many_lines)] // One phase-ordered lock boundary for three 0043 tails.
+#[allow(clippy::too_many_lines)] // One phase-ordered lock boundary for three selection tails.
 async fn lock_exact_selection_tails(
     transaction: &mut Transaction<'_, Postgres>,
     identity: &GithubRuntimeAuthorityIdentity,

--- a/crates/automata-ci-store/tests/github_oidc_api.rs
+++ b/crates/automata-ci-store/tests/github_oidc_api.rs
@@ -60,7 +60,7 @@ fn runtime_execution() -> GithubOidcExecutionIdentity {
             JobIrVersion::current(),
             1_024,
             digest(1),
-            ObjectKey::new("job-ir/v5/example").expect("object key"),
+            ObjectKey::new("job-ir/v1/example").expect("object key"),
         )
         .expect("JobIR metadata"),
     )

--- a/crates/automata-ci-store/tests/logical_job_result_api.rs
+++ b/crates/automata-ci-store/tests/logical_job_result_api.rs
@@ -286,7 +286,7 @@ fn fixture(
         1,
         AdmissionObject::new(
             Sha256Digest::from_bytes(Sha256::digest(&plan_bytes).into()),
-            ObjectKey::new("plans/workflow-v2.json").expect("plan key"),
+            ObjectKey::new("plans/workflow-v1.json").expect("plan key"),
             u64::try_from(plan_bytes.len()).expect("plan size"),
             "application/vnd.automata.workflow-plan+json",
         )

--- a/crates/automata-ci-store/tests/logical_materialization_api.rs
+++ b/crates/automata-ci-store/tests/logical_materialization_api.rs
@@ -23,7 +23,7 @@ use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 #[test]
-fn decoded_v5_commit_binds_exact_blob_identity_and_execution_references() {
+fn decoded_v1_commit_binds_exact_blob_identity_and_execution_references() {
     let fixture = fixture(0, 2, [0x44; 32]);
     let claim = claim(&fixture.descriptor, 10, 100);
     let claimed =

--- a/crates/automata-ci-store/tests/logical_orchestration_api.rs
+++ b/crates/automata-ci-store/tests/logical_orchestration_api.rs
@@ -56,7 +56,7 @@ fn command(
         "refs/heads/main",
         WorkflowSnapshotId::from_uuid(Uuid::from_u128(3)),
         object("source", 1),
-        object("plan-v2", 2),
+        object("plan-v1", 2),
         RunId::from_uuid(Uuid::from_u128(4)),
         1,
         LogicalWorkflowInvocationId::from_uuid(Uuid::from_u128(5)).expect("root invocation"),

--- a/crates/automata-ci-store/tests/postgres_github_job_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_github_job_runtime_authority.rs
@@ -773,7 +773,7 @@ fn prepare_instance(
     }
 }
 
-#[allow(clippy::too_many_lines)] // The fixture mirrors the complete immutable 0043 execution graph.
+#[allow(clippy::too_many_lines)] // The fixture mirrors the complete immutable execution graph.
 async fn seed_execution(
     database: &TestDatabase,
     namespace: u128,

--- a/crates/automata-ci-store/tests/postgres_github_subject_evidence.rs
+++ b/crates/automata-ci-store/tests/postgres_github_subject_evidence.rs
@@ -1821,7 +1821,7 @@ fn logical_command_at_path(
     .expect("source object");
     let plan = AdmissionObject::new(
         Sha256Digest::from_bytes([0x32; 32]),
-        ObjectKey::new(format!("logical/{namespace}/plan-v2")).expect("plan object key"),
+        ObjectKey::new(format!("logical/{namespace}/plan-v1")).expect("plan object key"),
         768,
         "application/json",
     )

--- a/crates/automata-ci-store/tests/postgres_logical_activation.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_activation.rs
@@ -159,7 +159,7 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
         snapshot_id,
         admission_object(format!("activation/{namespace}/source"), 1),
         admission_object_with_media(
-            format!("activation/{namespace}/plan-v2"),
+            format!("activation/{namespace}/plan-v1"),
             2,
             "application/vnd.automata.workflow-plan+json",
         ),

--- a/crates/automata-ci-store/tests/postgres_logical_materialization.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_materialization.rs
@@ -362,7 +362,7 @@ async fn sealed_reusable_child_reaches_materialization_and_tampering_fails_close
         .await?;
         assert!(materialized_child);
 
-        let session = open_v5_runner(&database, &fixture.tenant, 70_300).await?;
+        let session = open_current_runner(&database, &fixture.tenant, 70_300).await?;
         let terminal_at = database_now_ms(&database).await?;
         let result = successful_job_result(materialized.attempt_id(), terminal_at);
         let result_bytes = serde_json::to_vec(&result)?;
@@ -920,7 +920,7 @@ async fn exact_replay_takeover_and_duplicate_rows_publish_current_runnable_jobs(
         .fetch_all(database.pool())
         .await?;
         assert_eq!(routing_shape, vec![(1, 1, 1), (1, 1, 1)]);
-        let runner = open_v5_runner(&database, &fixture.tenant, 10_300).await?;
+        let runner = open_current_runner(&database, &fixture.tenant, 10_300).await?;
         let runnable = database
             .store()
             .scan_runnable(RunnableScanRequest::new(
@@ -1129,7 +1129,7 @@ async fn exact_receipt_replays_after_job_and_run_finalization() -> TestResult {
             .commit_logical_instance_materialization(exact_commit.clone())
             .await?;
 
-        let session = open_v5_runner(&database, &fixture.tenant, 50_300).await?;
+        let session = open_current_runner(&database, &fixture.tenant, 50_300).await?;
         let terminal_at = database_now_ms(&database).await?;
         let result = successful_job_result(materialized.attempt_id(), terminal_at);
         let result_bytes = serde_json::to_vec(&result)?;
@@ -2567,7 +2567,7 @@ fn standard_public_attempt_safety(classified_at: i64) -> DurableAttemptSafety {
     }
 }
 
-async fn open_v5_runner(
+async fn open_current_runner(
     database: &TestDatabase,
     tenant: &str,
     runner_identity: u128,

--- a/crates/automata-ci-store/tests/postgres_logical_orchestration.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_orchestration.rs
@@ -361,7 +361,7 @@ fn fixture_at(
         snapshot_id,
         object(format!("logical/{namespace}/source"), 1),
         object_with_media(
-            format!("logical/{namespace}/plan-v2"),
+            format!("logical/{namespace}/plan-v1"),
             2,
             "application/vnd.automata.workflow-plan+json",
         ),

--- a/crates/automata-ci-store/tests/postgres_logical_renewal_ack.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_renewal_ack.rs
@@ -2146,7 +2146,7 @@ async fn fixture(
         snapshot_id,
         admission_object(format!("renewal/{namespace}/source"), 1, "application/json"),
         admission_object(
-            format!("renewal/{namespace}/plan-v2"),
+            format!("renewal/{namespace}/plan-v1"),
             2,
             "application/vnd.automata.workflow-plan+json",
         ),

--- a/crates/automata-ci-store/tests/postgres_logical_run_finalization.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_run_finalization.rs
@@ -85,10 +85,10 @@ async fn incomplete_run_is_excluded_and_sql_precedence_matches_domain() -> TestR
         finalize_skipped_job(&database, &fixture, 1).await?;
         finalize_skipped_job(&database, &fixture, 2).await?;
 
-        // This test fixture changes already trusted 0025 rows only to exercise
+        // This test fixture changes already trusted result rows only to exercise
         // the run-level SQL precedence and transition mapping. The immutable
         // rejection trigger is disabled for the narrow update and restored
-        // before 0031 observes or claims any evidence.
+        // before finalization observes or claims any evidence.
         sqlx::query(
             "ALTER TABLE logical_workflow_job_results DISABLE TRIGGER logical_workflow_job_results_reject_update",
         )

--- a/crates/automata-ci-store/tests/postgres_logical_work_selection.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_work_selection.rs
@@ -51,7 +51,7 @@ fn migration_closes_reciprocal_quarantine_custody() {
     ] {
         assert!(
             MIGRATION_SQL.contains(required),
-            "0043 lost work-selection quarantine closure: {required}"
+            "initial schema lost work-selection quarantine closure: {required}"
         );
     }
 }
@@ -414,7 +414,7 @@ async fn admit_authenticated_fixture(
             "application/json",
         ),
         admission_object(
-            format!("admission/{namespace}/plan-v2"),
+            format!("admission/{namespace}/plan-v1"),
             2,
             "application/vnd.automata.workflow-plan+json",
         ),

--- a/crates/automata-ci-store/tests/postgres_managed_secret_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_managed_secret_authority.rs
@@ -2576,7 +2576,8 @@ async fn ready_authority_is_rechecked_at_inspection_lease_and_grant_boundaries()
         )
         .await?;
         // Variable value custody is independently fail-closed. Disable only
-        // that earlier guard so this case reaches the 0070 currentness proof.
+        // that earlier guard so this case reaches the selection-currentness
+        // proof.
         sqlx::query(
             "ALTER TABLE job_attempts DISABLE TRIGGER job_attempts_00_require_variable_custody_before_lease",
         )

--- a/crates/automata-ci-store/tests/postgres_observability.rs
+++ b/crates/automata-ci-store/tests/postgres_observability.rs
@@ -772,7 +772,7 @@ async fn build_logical_metrics_fixture(
             "application/yaml",
         ),
         logical_metrics_object(
-            format!("metrics/{suffix}/plan-v2.json"),
+            format!("metrics/{suffix}/plan-v1.json"),
             19,
             "application/vnd.automata.workflow-plan+json",
         ),

--- a/crates/automata-ci-store/tests/postgres_reusable_workflow_expansion.rs
+++ b/crates/automata-ci-store/tests/postgres_reusable_workflow_expansion.rs
@@ -7,7 +7,7 @@ const RUN_ID: &str = "10000000-0000-0000-0000-000000000004";
 
 // The reusable-ledger test starts from an already admitted and sealed root.
 // Provider-admission triggers are disabled only while constructing that base
-// fixture; all 0051 triggers are enabled before any ledger row is written.
+// fixture; all expansion triggers are enabled before any ledger row is written.
 const SEALED_ROOT_SQL: &str = r"
 ALTER TABLE repositories DISABLE TRIGGER USER;
 ALTER TABLE workflow_definitions DISABLE TRIGGER USER;
@@ -102,7 +102,7 @@ ALTER TABLE logical_workflow_jobs ENABLE TRIGGER USER;
 
 // The ordinary expansion fixture has one root call job. The identity-chain
 // matrix exercises seven independent callsites, so seed the other six exact
-// durable root jobs before sealing its 0051 expansion ledger.
+// durable root jobs before sealing its expansion ledger.
 const IDENTITY_ROOT_JOBS_SQL: &str = r"
 ALTER TABLE logical_workflow_jobs DISABLE TRIGGER USER;
 INSERT INTO logical_workflow_jobs (

--- a/crates/automata-ci-store/tests/postgres_runner_control.rs
+++ b/crates/automata-ci-store/tests/postgres_runner_control.rs
@@ -54,7 +54,7 @@ fn offer_receipt_migration_requires_a_complete_supported_fallback_projection() {
     ] {
         assert!(
             OFFER_HORIZON_MIGRATION.contains(required),
-            "0045 is missing fallback shape contract: {required}"
+            "initial schema is missing fallback shape contract: {required}"
         );
     }
 }

--- a/crates/automata-ci-store/tests/postgres_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_runtime_authority.rs
@@ -1594,7 +1594,7 @@ async fn race_retry_and_confirm_revocation(
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
-async fn migration_installs_and_retains_the_exact_v5_gate() -> TestResult {
+async fn initial_schema_installs_and_retains_the_exact_current_gate() -> TestResult {
     run_with_database(|database| async move {
         require_postgres_18(&database).await?;
 

--- a/crates/automata-ci-workflow-github/src/expression.rs
+++ b/crates/automata-ci-workflow-github/src/expression.rs
@@ -29,7 +29,7 @@ pub enum GithubConditionPhase {
     Step,
 }
 
-/// Field-specific availability used by the workflow-plan v2 lowering path.
+/// Field-specific availability used by the workflow-plan v1 lowering path.
 ///
 /// GitHub publishes context availability per workflow key. Keeping the policy
 /// explicit prevents a template accepted for a late runner field from being

--- a/crates/automata-ci-workflow-service/src/orchestration.rs
+++ b/crates/automata-ci-workflow-service/src/orchestration.rs
@@ -104,7 +104,7 @@ impl LogicalJobOrchestrationTarget {
 /// Store-authenticated descriptors and metadata prepared before a claim.
 ///
 /// The two context objects are canonical protobuf-encoded
-/// [`JobRuntimeContext`] v2 snapshots. `base_context` carries admission-bound
+/// [`JobRuntimeContext`] v1 snapshots. `base_context` carries admission-bound
 /// inputs, repository variables, and opaque secret locators;
 /// `prerequisite_context` carries direct `needs` results and
 /// sensitivity-classified outputs. Every unused field has a canonical empty

--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -141,12 +141,11 @@ stored outside PostgreSQL; protect their mounted host volume, and encrypt
 PostgreSQL data, WAL, replicas, snapshots, and backups at rest as separate
 controls.
 
-Migration `0013_encrypted_runner_payloads.sql` refuses to run while either
-obsolete pre-release plaintext retry table contains rows. Those databases are
-not supported upgrade sources for v0.1; recreate the current schema or restore
-a reviewed backup that already uses it. The migration never deletes those
-ledgers and must not be bypassed. See the deployment guide for the schema and
-rotation boundary.
+Only a fresh database initialized by the canonical
+`0001_initial_schema.sql` is supported. Never copy, relabel, or reinterpret
+plaintext `runner_command_outbox` or `runner_rpc_receipts` retry rows as
+current encrypted state. Recreate the database or restore a reviewed backup
+produced by the current encrypted schema.
 
 ## Object storage
 

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -735,7 +735,7 @@ impl fmt::Debug for StoreGithubProviderAuthorityLookup {
 impl GithubProviderCredentialAdapters {
     /// Constructs product adapters from a bootstrap-projected exact authority set.
     ///
-    /// Both repository ports must be views of the same durable 0032
+    /// Both repository ports must be views of the same durable credential
     /// implementation used by the issuer. The authority view revalidates exact
     /// current and historical descriptors before any handoff attempt; the
     /// credential view is retained inside redacted pending-release replay

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -581,15 +581,13 @@ omits `sslmode` or requests a fallback mode. Remote deployments must use a host
 name matching the database certificate and configure its trusted CA (for
 example with `sslrootcert` in the referenced URL).
 
-### Unsupported pre-release plaintext state
+### Greenfield database boundary
 
-Migration `0013_encrypted_runner_payloads.sql` deliberately fails with SQLSTATE
-`23514` if an obsolete pre-release database contains plaintext
-`runner_command_outbox` or `runner_rpc_receipts` rows. It never deletes a row or
-labels plaintext as encrypted. Such a database is not an upgrade source for
-v0.1: stop the obsolete installation and create a fresh current schema, or
-restore an explicitly reviewed backup that already uses the current encrypted
-schema. Do not bypass the guard or delete individual retry rows in place.
+Only a fresh database initialized by the canonical
+`0001_initial_schema.sql` is supported. Never copy, relabel, or reinterpret
+plaintext `runner_command_outbox` or `runner_rpc_receipts` retry rows as
+current encrypted state. Recreate the database or restore an explicitly
+reviewed backup produced by the current encrypted schema.
 
 ### Rotating the control-plane wrapping key
 

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -19,18 +19,21 @@ only in focused component tests, work only on Linux, lack production ingress or
 credentials, or deliberately diverge from GitHub.
 
 The 2026-08-12 refresh includes the runtime restoration merged in PR #29:
-runner protocol v5, runner-requirements schema v3, migrations through `0070`,
-three isolated single-slot Linux runner processes, the Kubernetes product
-configuration path, durable rerun and protected-environment authority,
+runner protocol v1, runner-requirements schema v1, one canonical greenfield
+store schema, three isolated single-slot Linux runner processes, the Kubernetes
+product configuration path, durable rerun and protected-environment authority,
 value-safe managed-secret delivery, and immutable multi-workflow fanout. These
 are component or experimental foundations unless a later item records product
 acceptance. Hosted Windows CI was removed from `main`; the native Windows path
 therefore remains source-tested but is not a release gate.
 
-The final baseline also retains exact cleanup custody when sandbox creation has
-an uncertain outcome and the provider returns a recovery handle. Legacy Podman
-intents reconstruct the deterministic handle from operation ID and lease
-generation, while unreconstructible legacy intents remain fenced.
+The final baseline retains exact cleanup custody when sandbox creation has an
+uncertain outcome and the provider returns a recovery handle. Missing custody
+is an executor-contract failure and remains fenced; the runtime never guesses
+or reconstructs a provider identity. Operators must drain that runner, use
+provider-owned evidence to prove absence or destroy any external resource, and
+then recreate its empty local state; deleting the journal alone must never
+release capacity.
 
 The companion
 [`automata-integration-tests`](https://github.com/automata-ci/automata-integration-tests)
@@ -573,11 +576,11 @@ case-insensitive groups, and FIFO-by-wait-start behavior. See
 - [ ] Test cancellation while a post action is running.
 - [ ] Test job and workflow timeouts during cleanup.
 - [x] When uncertain sandbox creation returns an exact recovery handle, journal
-  it as cleanup custody; reconstruct only deterministic legacy Podman identity,
-  and leave an unreconstructible legacy intent fenced.
-- [ ] For every shipped provider, prove returned or reconstructed sandbox
-  custody is destroyed before slot release and define exact reconstruction or
-  a drain/upgrade policy for pre-custody legacy intents.
+  it as cleanup custody and fence any missing-custody state without identity
+  reconstruction.
+- [ ] For every shipped provider, prove returned sandbox custody is destroyed
+  before slot release; document the bounded drain and provider-side
+  reconciliation required when custody is missing.
 - [x] Enforce the current 50-rerun limit (51 physical attempts including the
   original run).
 - [x] Implement authenticated, durable, idempotent rerun-all,
@@ -1094,7 +1097,7 @@ runner. There is no enrollment API.
 - [x] Load and atomically validate the current privileged static fleet at
   startup.
 - [x] Negotiate the runner protocol and JobIR ranges before a session or lease;
-  the current baseline admits protocol v5 only.
+  the current baseline admits protocol v1 only.
 - [ ] Preserve static loading as a migration and break-glass path when dynamic
   enrollment lands.
 
@@ -1205,7 +1208,7 @@ Windows CI is disabled on the current baseline.
 - [ ] Add ARM32 if supported.
 - [ ] Add Linux ARM64.
 - [ ] Add Windows ARM64.
-- [ ] Prove runner-requirements-schema-v3 CPU, memory, ephemeral-storage, GPU,
+- [ ] Prove runner-requirements-schema-v1 CPU, memory, ephemeral-storage, GPU,
   and per-runner PID-cap enforcement through production providers. These are
   structured `JobResourceAllocation` fields, not labels.
 - [ ] Add custom images.

--- a/docs/github-actions-parity-execution-plan.md
+++ b/docs/github-actions-parity-execution-plan.md
@@ -12,9 +12,9 @@ current support. The [implementation plan](implementation-plan.md) owns release
 gates. This page is an execution aid: unchecked tasks are planned work, not
 availability claims.
 
-The refreshed baseline uses runner protocol v5, JobIR schema v5,
-runner-requirements schema v3, and immutable migrations through `0070`. It also
-contains a real Kubernetes product-composition path, three independent
+The refreshed baseline uses runner protocol v1, JobIR schema v1,
+runner-requirements schema v1, and one canonical greenfield store migration. It
+also contains a real Kubernetes product-composition path, three independent
 single-slot Linux runner processes, durable workflow reruns and protected
 environment lease authority, and immutable multi-workflow fanout. These are
 component or experimental foundations unless their package records product
@@ -22,10 +22,11 @@ acceptance. Hosted Windows CI is currently disabled, so the Windows gate is an
 independent restoration task rather than a prerequisite for the repository's
 current Ubuntu-only CI workflow.
 
-The runtime also preserves exact sandbox cleanup custody when an uncertain
-create failure returns a recovery handle. Deterministic legacy Podman identities
-can be reconstructed; unreconstructible legacy provider intents remain fenced
-rather than being guessed or enumerated.
+The runtime preserves exact sandbox cleanup custody when an uncertain create
+failure returns a recovery handle. Missing-custody state remains fenced rather
+than being guessed, reconstructed, or enumerated. Recovery drains the runner
+until provider-owned evidence proves absence or cleanup and only then recreates
+empty local state; journal deletion alone is not reconciliation.
 
 The companion
 [`automata-integration-tests`](https://github.com/automata-ci/automata-integration-tests)
@@ -134,10 +135,11 @@ These files and contracts are merge hotspots. Assign one owner at a time.
 
 Additional coordination rules:
 
-- [ ] Reserve migration numbers before opening a branch.
-- [ ] Start new migration reservations at `0071`; migrations through `0070`
-  are immutable on this baseline.
-- [ ] Never edit a migration that has reached `main`.
+- [ ] Keep the unreleased greenfield store as one canonical
+  `0001_initial_schema.sql`; fold schema changes into that baseline and its
+  inventory test.
+- [ ] Introduce ordered upgrade migrations only after a released schema creates
+  durable state that the project commits to preserve.
 - [ ] Merge provider-neutral core, JobIR, protocol, or protobuf changes before
   provider implementations begin.
 - [ ] Give serialized-format changes one owner for the version bump,

--- a/docs/github-actions-parity/github-actions-parity-01-foundations.md
+++ b/docs/github-actions-parity/github-actions-parity-01-foundations.md
@@ -174,13 +174,15 @@ Acceptance:
 
 **Owner:** rotating integration owner. **Size:** S. **Dependencies:** none.
 
-Current baseline: runner protocol v5, message schema v3, JobIR schema v5,
-runner-requirements schema v3, and immutable migrations through `0070`.
+Current baseline: runner protocol v1, message schema v1, JobIR schema v1,
+runner-requirements schema v1, and one canonical greenfield
+`0001_initial_schema.sql` migration.
 
 Tasks:
 
-- [ ] Maintain an issue-level registry for reserved migration numbers,
-  beginning at `0071` for new work on this baseline.
+- [ ] Keep schema changes in the canonical greenfield migration and its
+  inventory test until the first released schema creates supported durable
+  upgrade state.
 - [ ] Record owners for JobIR, protobuf, result, event, and store schema
   versions.
 - [ ] Require compatibility readers for every durable or wire-format change.
@@ -192,7 +194,7 @@ Tasks:
 
 Acceptance:
 
-- [ ] Parallel branches never claim the same migration number.
+- [ ] Parallel schema branches coordinate changes to the canonical baseline.
 - [ ] No durable format changes without a version and compatibility test.
 - [ ] Limits have one owner and one enforcing phase.
 

--- a/docs/github-actions-parity/github-actions-parity-03-scheduling-reuse.md
+++ b/docs/github-actions-parity/github-actions-parity-03-scheduling-reuse.md
@@ -114,7 +114,7 @@ Tasks:
 - [ ] Reject reruns of deleted or expired source and changed authority rather
   than compiling new evidence under the old run.
 - [x] Preserve the current 50-rerun limit.
-- [x] Preserve runner-requirements schema v3 when cloning rerun jobs and fail
+- [x] Preserve runner-requirements schema v1 when cloning rerun jobs and fail
   closed when source requirements use a different schema.
 
 Acceptance:

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -264,9 +264,11 @@ Acceptance:
 Current component foundation:
 
 - [x] When provider create reports an uncertain outcome with an exact recovery
-  handle, journal that handle as sandbox cleanup custody; reconstruct only the
-  deterministic legacy Podman identity from operation ID plus lease generation,
-  and leave an unreconstructible legacy intent fenced.
+  handle, journal that handle as sandbox cleanup custody and fence any
+  missing-custody state without reconstructing a provider identity.
+- [ ] Document and exercise the bounded operator path for missing custody:
+  drain the runner, prove absence or cleanup from provider-owned evidence, then
+  recreate empty local state without treating journal deletion as cleanup.
 
 Tasks:
 

--- a/docs/github-actions-parity/github-actions-parity-05-containers-docker.md
+++ b/docs/github-actions-parity/github-actions-parity-05-containers-docker.md
@@ -110,8 +110,9 @@ Remaining tasks:
   capabilities are advertised.
 - [ ] Exercise cancellation, runner loss, guest loss, ambiguous Kubernetes API
   responses, stale generations, provider restart, and idempotent recovery;
-  prove cleanup before slot release and define deterministic reconstruction or
-  a drain policy for legacy pre-custody intents.
+  prove exact returned custody is cleaned before slot release and missing
+  custody remains fenced until a bounded provider-side reconciliation and
+  runner drain prove cleanup before empty state is recreated.
 - [ ] Publish bounded provider/guest diagnostics and RED/USE metrics without
   exposing Kubernetes credentials, tokens, object bodies, or user output.
 - [ ] Record the operator assertions and rollback procedure; keep cluster

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -37,7 +37,7 @@ commit `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` with
 Ignored offline tests import explicitly supplied local client modules and never
 download packages. They are focused client-library and protocol evidence, not
 ordinary-CI acceptance of every exact action wrapper or the production stores.
-Runner protocol v5 carries a required, per-attempt Results authority bundle;
+Runner protocol v1 carries a required, per-attempt Results authority bundle;
 there is no runner- or fleet-wide Results credential.
 
 Tasks:

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -107,7 +107,7 @@ Acceptance:
 
 Current component foundation:
 
-- [x] Requirements schema v3 carries run-pinned CPU, memory, ephemeral-disk,
+- [x] Requirements schema v1 carries run-pinned CPU, memory, ephemeral-disk,
   and optional GPU requests and limits through scheduler matching, executor
   admission, and `SandboxSpec`; the Kubernetes adapter renders exact resource
   quantities and mapped devices.

--- a/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
+++ b/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
@@ -89,9 +89,9 @@ per-job ceiling the trio advertises 12,000 CPU millicores, 48 GiB memory, and
 and 13,824 tasks. Inventory schema 3 admits a host only with slots 1, 2, and 3.
 
 Authenticated Handshake/Sync already negotiates the exact current runner
-protocol v5 and JobIR v5 contract before lease traffic; the supported protocol
-range is currently min=max v5. Dynamic enrollment, update channels, and a live
-version-skew policy remain separate work.
+protocol v1 and JobIR v1 contract before lease traffic; the supported protocol
+range is currently min=max v1. Dynamic enrollment and update channels remain
+separate work; version skew is unsupported.
 
 Tasks:
 
@@ -107,10 +107,10 @@ Tasks:
 - [ ] Preserve static fleet loading as a migration and break-glass path when
   dynamic enrollment becomes available.
 - [ ] Add disable, drain, replace, delete, and audit operations.
-- [x] Negotiate the exact protocol v5 and JobIR v5 range during authenticated
+- [x] Negotiate the exact protocol v1 and JobIR v1 range during authenticated
   Handshake/Sync before accepting lease traffic.
-- [ ] Define enrollment and update minimum/maximum compatibility, then block
-  automatic updates that cross the supported live-skew window.
+- [ ] Keep enrollment and updates pinned to the exact current protocol and
+  block mixed-version automatic replacement.
 - [ ] Reject capability or identity changes that were not authorized by the
   registration operation.
 - [ ] Add CLI/API/UI flows without returning private keys after creation.
@@ -196,11 +196,8 @@ Tasks:
 - [ ] Define network policies, pod security, volumes, disruption budgets,
   anti-affinity, probes, and upgrade ordering.
 - [ ] Produce signed Linux and Windows artifacts with checksums and provenance.
-- [ ] Add update channels, rollback, version-skew policy, and migration gates.
-- [ ] Encode migration `0054` as an explicit drain-required boundary: drain
-  live runner-requirements-v2 attempts and workflow runs, disconnect every
-  runner session, and only then move the cluster from protocol v4 to v5 and
-  runner-requirements schema v3.
+- [ ] Add update channels and define the supported current-version replacement
+  and rollback policy before the first release.
 - [ ] Verify supply-chain inputs and pin build images/actions by digest or SHA.
 - [ ] Add air-gapped installation and trust-root rotation procedures if kept in
   scope.
@@ -210,17 +207,16 @@ Acceptance:
 
 - [ ] A documented install reaches readiness without mutable or unsigned
   runtime downloads.
-- [ ] Live-compatible one-version-skew upgrades preserve jobs and durable state;
-  drain-required boundaries such as protocol v4 to v5 instead prove that no
-  old-schema live work or session crosses the migration.
+- [ ] The documented deployment path installs only the current protocol and
+  schema without hidden version-skew behavior.
 - [ ] Rollback behavior is explicit when database migrations are irreversible.
 
 ### LIM-01 — Limits, quotas, rate limiting, and overload behavior
 
 **Owner:** S with X and C review. **Size:** XL. **Dependencies:** FND-04.
 
-Current new work is pinned to JobIR v5 and runner-requirements schema v3.
-Schema v3 requires a resolved `resource_allocation` derived from an immutable,
+Current new work is pinned to JobIR v1 and runner-requirements schema v1.
+Schema v1 requires a resolved `resource_allocation` derived from an immutable,
 run-pinned default/minimum/maximum policy. The Automata-only workflow extension
 covers CPU, memory, ephemeral storage, and GPU request/limit values; the
 runner/provider contract separately carries a PIDs ceiling. Current cache
@@ -238,7 +234,7 @@ Tasks:
   annotations, summaries, artifacts, cache, API bodies, webhook rate, queue
   depth, runner slots, concurrent jobs, per-job CPU/memory/ephemeral-storage/GPU
   allocation, runner PIDs, and immutable resource-policy bounds.
-- [x] Require runner-requirements schema v3 and a run-pinned resolved resource
+- [x] Require runner-requirements schema v1 and a run-pinned resolved resource
   allocation for every new runnable/materialized job.
 - [ ] Enforce or explicitly diverge from the 35-day workflow-run lifetime, the
   24-hour self-hosted queue timeout, and the five-day self-hosted job maximum.
@@ -454,16 +450,13 @@ Tasks:
   independently.
 - [ ] Inject duplicate, delayed, reordered, truncated, corrupt, and
   uncertain-outcome operations, including sandbox-create failure before and
-  after durable handle custody; prove a returned or exactly reconstructed
-  handle is destroyed before slot release and an unreconstructible legacy
-  intent remains fenced.
+  after durable handle custody; prove exact returned custody is destroyed
+  before slot release and missing custody remains fenced until a bounded runner
+  drain and provider-side reconciliation prove absence or cleanup.
 - [ ] Saturate each configured quota and queue while measuring tenant fairness,
   bounded memory, recovery lag, and retry traffic.
-- [ ] Exercise deployment upgrades, one-version skew, certificate/key rotation,
-  backup/restore, and rollback where the declared migration supports live skew.
-- [ ] Exercise migration `0054` separately as a drain-required protocol-v4 to
-  v5 and runner-requirements-v2 to v3 transition; prove every old-schema live
-  attempt/run is drained and every runner session disconnected before upgrade.
+- [ ] Exercise current-version replacement, certificate/key rotation,
+  backup/restore, and rollback within the declared current schema boundary.
 - [ ] Verify repair tools converge state without bypassing authority or
   idempotency.
 

--- a/docs/github-actions-parity/github-actions-parity-11c-integration-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-11c-integration-platforms.md
@@ -141,8 +141,8 @@ Tasks:
   transition, observed invariant, and recovery time.
 - [ ] Keep fault controls outside product trust and credential paths; a test
   fault cannot forge successful evidence.
-- [ ] Support the drain-required protocol-v4/v5 transition separately from
-  live one-version-skew upgrade scenarios.
+- [ ] Exercise only the exact current runner protocol; mixed-version operation
+  is unsupported.
 - [ ] Tear down every replica, network rule, volume, namespace, credential, and
   retained process even when the test driver crashes.
 


### PR DESCRIPTION
## Outcome

Finishes the post-greenfield cleanup without restoring legacy provider identity reconstruction. It also tightens current v1 serialization contracts and removes stale migration/protocol wording.

## Changes

- remove obsolete sandbox recovery reconstruction APIs and keep exact provider-returned custody as the only cleanup authority
- fence terminal delivery, acknowledgement, and slot release when cleanup custody is missing
- require explicit nullable fields in current result, lease, and journal JSON while preserving explicit null
- normalize stale migration/protocol/schema labels to the current greenfield v1 and canonical 0001 boundary
- restore operator guidance for encrypted database state and bounded missing-custody drain/reconciliation
- repair the merged PostgreSQL artifact test PgPool import found by the workspace check

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked --offline -j 1
- focused provider saga, live/recovered runner custody, core result schema, protocol lease offer, and journal lease record tests: 6/6 passed
- git diff --check

All Rust validation ran one job at a time in the capped compiler slice; OOM counters remained zero.