### PR TITLE
Require current workflow metadata

### DIFF
--- a/crates/automata-ci-results-github/tests/postgres_artifacts.rs
+++ b/crates/automata-ci-results-github/tests/postgres_artifacts.rs
@@ -1371,7 +1371,9 @@ async fn active_attempt_with_safety(
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number,
-            event_name, event_object_key, head_sha, status,
+            event_name, event_object_key, event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             created_at_ms, updated_at_ms, publication_policy_revision,
             requested_dashboard_visibility, effective_dashboard_visibility,
             requested_log_visibility, requested_artifact_visibility,
@@ -1380,7 +1382,9 @@ async fn active_attempt_with_safety(
         )
         SELECT
             $1, repository_id, workflow_id, snapshot_id, run_number + 1,
-            event_name, 'test/artifact-safety-event', head_sha, status,
+            event_name, 'test/artifact-safety-event', event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             2, 2, 1, 'private', 'private', 'private', $3,
             'repository_policy', 1, runner_requirements_schema
         FROM workflow_runs

--- a/crates/automata-ci-results-github/tests/postgres_cache.rs
+++ b/crates/automata-ci-results-github/tests/postgres_cache.rs
@@ -1411,7 +1411,9 @@ async fn second_run_attempt(
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number,
-            event_name, event_object_key, head_sha, status,
+            event_name, event_object_key, event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             created_at_ms, updated_at_ms, publication_policy_revision,
             requested_dashboard_visibility, effective_dashboard_visibility,
             requested_log_visibility, requested_artifact_visibility,
@@ -1420,7 +1422,9 @@ async fn second_run_attempt(
         )
         SELECT
             $1, repository_id, workflow_id, snapshot_id, run_number + 1,
-            event_name, 'test/cache-reader-event', head_sha, status,
+            event_name, 'test/cache-reader-event', event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             2, 2, publication_policy_revision,
             requested_dashboard_visibility, effective_dashboard_visibility,
             requested_log_visibility, requested_artifact_visibility,

--- a/crates/automata-ci-results-github/tests/support/postgres.rs
+++ b/crates/automata-ci-results-github/tests/support/postgres.rs
@@ -153,10 +153,18 @@ pub async fn seed_control_plane(pool: &PgPool) -> TestResult<SeedData> {
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number, event_name,
-            event_object_key, head_sha, status, created_at_ms, updated_at_ms,
+            event_object_key, event_digest, event_size_bytes, event_media_type,
+            plan_digest, plan_object_key, plan_size_bytes, plan_media_type,
+            plan_schema, workflow_name, head_sha, status, created_at_ms, updated_at_ms,
             runner_requirements_schema
         )
-        VALUES ($1, $2, $3, $4, 1, 'push', 'test/results-event', $5, 'queued', 1, 1, 1)
+        VALUES (
+            $1, $2, $3, $4, 1, 'push', 'test/results-event',
+            decode(repeat('21', 32), 'hex'), 1, 'application/json',
+            decode(repeat('22', 32), 'hex'), 'test/results-plan', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1, 'Results test',
+            $5, 'queued', 1, 1, 1
+        )
         ",
     )
     .bind(run_id)

--- a/crates/automata-ci-store/migrations/0001_initial_schema.sql
+++ b/crates/automata-ci-store/migrations/0001_initial_schema.sql
@@ -24719,15 +24719,15 @@ CREATE TABLE workflow_runs (
     updated_at_ms bigint NOT NULL,
     concurrency_group_key text,
     admission_epoch integer DEFAULT 1 NOT NULL,
-    event_digest bytea,
-    event_size_bytes bigint,
-    event_media_type text,
-    plan_digest bytea,
-    plan_object_key text,
-    plan_size_bytes bigint,
-    plan_media_type text,
-    plan_schema integer,
-    workflow_name text,
+    event_digest bytea NOT NULL,
+    event_size_bytes bigint NOT NULL,
+    event_media_type text NOT NULL,
+    plan_digest bytea NOT NULL,
+    plan_object_key text NOT NULL,
+    plan_size_bytes bigint NOT NULL,
+    plan_media_type text NOT NULL,
+    plan_schema integer NOT NULL,
+    workflow_name text NOT NULL,
     git_ref text,
     actor text,
     display_title text,
@@ -24768,7 +24768,7 @@ CREATE TABLE workflow_runs (
     CONSTRAINT workflow_runs_sha CHECK ((octet_length(head_sha) = ANY (ARRAY[20, 32]))),
     CONSTRAINT workflow_runs_status CHECK ((status = ANY (ARRAY['queued'::text, 'in_progress'::text, 'completed'::text, 'cancelled'::text]))),
     CONSTRAINT workflow_runs_triggering_actor_shape CHECK (((triggering_actor IS NULL) OR (((octet_length(triggering_actor) >= 1) AND (octet_length(triggering_actor) <= 1024)) AND (triggering_actor !~ '[[:cntrl:]]'::text)))),
-    CONSTRAINT workflow_runs_workflow_name_shape CHECK (((workflow_name IS NULL) OR (((octet_length(workflow_name) >= 1) AND (octet_length(workflow_name) <= 1024)) AND (workflow_name !~ '[[:cntrl:]]'::text))))
+    CONSTRAINT workflow_runs_workflow_name_shape CHECK ((((octet_length(workflow_name) >= 1) AND (octet_length(workflow_name) <= 1024)) AND (workflow_name !~ '[[:cntrl:]]'::text)))
 );
 
 CREATE VIEW github_workflow_run_manifest_origins AS
@@ -25163,11 +25163,10 @@ CREATE TABLE jobs (
     requirements jsonb NOT NULL,
     created_at_ms bigint NOT NULL,
     admission_epoch integer NOT NULL,
-    job_ir_schema integer,
-    job_ir_size_bytes bigint,
+    job_ir_schema integer NOT NULL,
+    job_ir_size_bytes bigint NOT NULL,
     CONSTRAINT jobs_admission_epoch_exact CHECK ((admission_epoch = 1)),
     CONSTRAINT jobs_current_admission_metadata CHECK (((admission_epoch = 1) AND (job_ir_schema = 1) AND ((job_ir_size_bytes >= 1) AND (job_ir_size_bytes <= 16777216)) AND (requirements @> '{"schema_version": 1}'::jsonb) AND (requirements ? 'resource_allocation'::text))),
-    CONSTRAINT jobs_ir_metadata_complete CHECK (((job_ir_schema IS NULL) = (job_ir_size_bytes IS NULL))),
     CONSTRAINT jobs_ir_object_key_nonempty CHECK ((length(job_ir_object_key) > 0)),
     CONSTRAINT jobs_ir_sha256 CHECK ((octet_length(job_ir_digest) = 32)),
     CONSTRAINT jobs_key_nonempty CHECK ((length(job_key) > 0))
@@ -25708,12 +25707,8 @@ CREATE TABLE runner_sessions (
     CONSTRAINT runner_sessions_epoch_positive CHECK ((session_epoch > 0)),
     CONSTRAINT runner_sessions_generation_positive CHECK ((runner_generation > 0)),
     CONSTRAINT runner_sessions_heartbeat_monotonic CHECK ((heartbeat_at_ms >= connected_at_ms)),
-    CONSTRAINT runner_sessions_job_ir_positive CHECK ((job_ir_schema > 0)),
-    CONSTRAINT runner_sessions_job_ir_u16 CHECK ((job_ir_schema <= 65535)),
-    CONSTRAINT runner_sessions_live_job_ir_current CHECK (((disconnected_at_ms IS NOT NULL) OR (job_ir_schema = 1))),
-    CONSTRAINT runner_sessions_live_protocol_current CHECK (((disconnected_at_ms IS NOT NULL) OR (protocol_version = 1))),
-    CONSTRAINT runner_sessions_protocol_positive CHECK ((protocol_version > 0)),
-    CONSTRAINT runner_sessions_protocol_u16 CHECK ((protocol_version <= 65535))
+    CONSTRAINT runner_sessions_job_ir_current CHECK ((job_ir_schema = 1)),
+    CONSTRAINT runner_sessions_protocol_current CHECK ((protocol_version = 1))
 );
 
 CREATE TABLE runners (

--- a/crates/automata-ci-store/src/postgres.rs
+++ b/crates/automata-ci-store/src/postgres.rs
@@ -620,17 +620,14 @@ async fn output_safety_for_queued_attempt(
     .fetch_optional(&mut **transaction)
     .await
     .map_err(operation_error)?;
-    // Preserve the historical missing-job behavior: the caller's insert still
-    // reaches the foreign-key boundary. This fallback is never durable.
+    let job = job.ok_or_else(|| {
+        AttemptStoreError::corrupt_data("queued attempt references a missing workflow job")
+    })?;
     let requested_log_visibility = job
-        .as_ref()
-        .map(|row| row.try_get::<String, _>("requested_log_visibility"))
-        .transpose()
-        .map_err(operation_error)?
-        .unwrap_or_else(|| "private".to_owned());
-    let prior = if job.is_some() {
-        sqlx::query(
-            r"
+        .try_get::<String, _>("requested_log_visibility")
+        .map_err(operation_error)?;
+    let prior = sqlx::query(
+        r"
             SELECT secret_exposure_class, raw_log_disposition,
                    requested_log_visibility, effective_log_visibility,
                    output_safety_reason, output_safety_schema,
@@ -638,14 +635,11 @@ async fn output_safety_for_queued_attempt(
             FROM job_attempts
             WHERE job_id = $1 AND attempt_number = 1
             ",
-        )
-        .bind(attempt.job_id.as_uuid())
-        .fetch_optional(&mut **transaction)
-        .await
-        .map_err(operation_error)?
-    } else {
-        None
-    };
+    )
+    .bind(attempt.job_id.as_uuid())
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operation_error)?;
     let Some(row) = prior else {
         let safety =
             CurrentAttemptOutputSafety::readable(&requested_log_visibility).ok_or_else(|| {

--- a/crates/automata-ci-store/src/postgres/web.rs
+++ b/crates/automata-ci-store/src/postgres/web.rs
@@ -222,7 +222,6 @@ const WORKFLOWS_FIRST_SQL: &str = r"
         FROM workflow_runs AS run
         WHERE run.repository_id = repository.id
           AND run.workflow_id = workflow.id
-          AND run.workflow_name IS NOT NULL
         ORDER BY run.created_at_ms DESC, run.id DESC
         LIMIT 1
     ) AS projected ON TRUE
@@ -246,7 +245,6 @@ const WORKFLOWS_AFTER_SQL: &str = r"
         FROM workflow_runs AS run
         WHERE run.repository_id = repository.id
           AND run.workflow_id = workflow.id
-          AND run.workflow_name IS NOT NULL
         ORDER BY run.created_at_ms DESC, run.id DESC
         LIMIT 1
     ) AS projected ON TRUE
@@ -841,34 +839,26 @@ async fn load_jobs(
 
 fn decode_job(row: &PgRow, run_id: RunId) -> Result<HumanJob, StoreError> {
     let job_id = JobId::from_uuid(row.try_get("job_id").map_err(operation_error)?);
-    let job_ir_schema: Option<i32> = row.try_get("job_ir_schema").map_err(operation_error)?;
-    let job_ir_size: Option<i64> = row.try_get("job_ir_size_bytes").map_err(operation_error)?;
-    let job_ir_metadata = match (job_ir_schema, job_ir_size) {
-        (None, None) => None,
-        (Some(schema), Some(size)) => {
-            let version = JobIrVersion::new(positive_u16(schema, "JobIR schema")?)
-                .map_err(|_| StoreError::corrupt_data("JobIR schema is invalid"))?;
-            let size = positive_u64(size, "JobIR encoded size")?;
-            let digest = decode_digest(
-                row.try_get("job_ir_digest").map_err(operation_error)?,
-                "JobIR digest",
-            )?;
-            let key = crate::ObjectKey::new(
-                row.try_get::<String, _>("job_ir_object_key")
-                    .map_err(operation_error)?,
-            )
-            .map_err(|_| StoreError::corrupt_data("JobIR object key is invalid"))?;
-            Some(
-                JobIrMetadata::new(job_id, run_id, version, size, digest, key)
-                    .map_err(|_| StoreError::corrupt_data("JobIR descriptor is invalid"))?,
-            )
-        }
-        _ => {
-            return Err(StoreError::corrupt_data(
-                "legacy JobIR schema and size are inconsistently null",
-            ));
-        }
-    };
+    let version = JobIrVersion::new(positive_u16(
+        row.try_get("job_ir_schema").map_err(operation_error)?,
+        "JobIR schema",
+    )?)
+    .map_err(|_| StoreError::corrupt_data("JobIR schema is invalid"))?;
+    let size = positive_u64(
+        row.try_get("job_ir_size_bytes").map_err(operation_error)?,
+        "JobIR encoded size",
+    )?;
+    let digest = decode_digest(
+        row.try_get("job_ir_digest").map_err(operation_error)?,
+        "JobIR digest",
+    )?;
+    let key = crate::ObjectKey::new(
+        row.try_get::<String, _>("job_ir_object_key")
+            .map_err(operation_error)?,
+    )
+    .map_err(|_| StoreError::corrupt_data("JobIR object key is invalid"))?;
+    let job_ir_metadata = JobIrMetadata::new(job_id, run_id, version, size, digest, key)
+        .map_err(|_| StoreError::corrupt_data("JobIR descriptor is invalid"))?;
 
     let attempt_id: Option<Uuid> = row.try_get("attempt_id").map_err(operation_error)?;
     let latest_attempt = attempt_id

--- a/crates/automata-ci-store/src/postgres/workflow_rerun.rs
+++ b/crates/automata-ci-store/src/postgres/workflow_rerun.rs
@@ -3,7 +3,9 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use async_trait::async_trait;
-use automata_ci_core::{RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId};
+use automata_ci_core::{
+    JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId,
+};
 use sha2::{Digest as _, Sha256};
 use sqlx::{Postgres, Row as _, Transaction, postgres::PgRow};
 use uuid::Uuid;
@@ -14,8 +16,9 @@ use super::{
 };
 use crate::{
     MAX_WORKFLOW_RERUN_AGE_MILLIS, MAX_WORKFLOW_RERUN_ATTEMPTS, RepositoryId, RerunWorkflow,
-    RerunWorkflowByName, StoreError, WorkflowConcurrency, WorkflowRerunReceipt,
-    WorkflowRerunRepository, WorkflowRerunSelection, WorkflowRerunStoreError,
+    RerunWorkflowByName, StoreError, WORKFLOW_ADMISSION_EPOCH, WORKFLOW_PLAN_SCHEMA,
+    WorkflowConcurrency, WorkflowRerunReceipt, WorkflowRerunRepository, WorkflowRerunSelection,
+    WorkflowRerunStoreError,
 };
 
 const RERUN_PERMISSION: &str = "runs:rerun";
@@ -988,24 +991,12 @@ fn validate_source_row(row: &PgRow) -> Result<Uuid, WorkflowRerunStoreError> {
     if !terminal {
         return Err(WorkflowRerunStoreError::SourceNotTerminal);
     }
-    if row
-        .try_get::<i32, _>("admission_epoch")
-        .map_err(operation_error)?
-        != 4
-        || row
-            .try_get::<Option<i32>, _>("plan_schema")
-            .map_err(operation_error)?
-            != Some(2)
-    {
-        return Err(WorkflowRerunStoreError::UnsupportedSelection);
-    }
-    if row
-        .try_get::<Option<i16>, _>("base_context_schema")
-        .map_err(operation_error)?
-        != Some(2)
-    {
-        return Err(WorkflowRerunStoreError::UnsupportedSelection);
-    }
+    validate_current_source_contract(
+        row.try_get("admission_epoch").map_err(operation_error)?,
+        row.try_get("plan_schema").map_err(operation_error)?,
+        row.try_get("base_context_schema")
+            .map_err(operation_error)?,
+    )?;
     if row
         .try_get::<i64, _>("check_subject_count")
         .map_err(operation_error)?
@@ -1019,6 +1010,22 @@ fn validate_source_row(row: &PgRow) -> Result<Uuid, WorkflowRerunStoreError> {
     }
 
     Ok(root_run_id)
+}
+
+fn validate_current_source_contract(
+    admission_epoch: i32,
+    plan_schema: Option<i32>,
+    base_context_schema: Option<i16>,
+) -> Result<(), WorkflowRerunStoreError> {
+    let runtime_context_schema = i16::try_from(JOB_RUNTIME_CONTEXT_SCHEMA_VERSION)
+        .map_err(|_| StoreError::corrupt_data("current runtime context schema exceeds SMALLINT"))?;
+    if admission_epoch != i32::from(WORKFLOW_ADMISSION_EPOCH)
+        || plan_schema != Some(i32::from(WORKFLOW_PLAN_SCHEMA))
+        || base_context_schema != Some(runtime_context_schema)
+    {
+        return Err(WorkflowRerunStoreError::UnsupportedSelection);
+    }
+    Ok(())
 }
 
 fn decode_concurrency(row: &PgRow) -> Result<Option<WorkflowConcurrency>, WorkflowRerunStoreError> {
@@ -2242,4 +2249,42 @@ fn corrupt_value(error: impl std::fmt::Display) -> WorkflowRerunStoreError {
 
 fn operation_error(error: sqlx::Error) -> WorkflowRerunStoreError {
     StoreError::operation(error).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use automata_ci_core::JOB_RUNTIME_CONTEXT_SCHEMA_VERSION;
+
+    use crate::{WORKFLOW_ADMISSION_EPOCH, WORKFLOW_PLAN_SCHEMA, WorkflowRerunStoreError};
+
+    use super::validate_current_source_contract;
+
+    #[test]
+    fn post_terminal_source_contract_accepts_current_schema_and_rejects_skew() {
+        let admission_epoch = i32::from(WORKFLOW_ADMISSION_EPOCH);
+        let plan_schema = i32::from(WORKFLOW_PLAN_SCHEMA);
+        let context_schema =
+            i16::try_from(JOB_RUNTIME_CONTEXT_SCHEMA_VERSION).expect("current context schema");
+
+        assert!(
+            validate_current_source_contract(
+                admission_epoch,
+                Some(plan_schema),
+                Some(context_schema),
+            )
+            .is_ok()
+        );
+        for candidate in [
+            (admission_epoch + 1, Some(plan_schema), Some(context_schema)),
+            (admission_epoch, None, Some(context_schema)),
+            (admission_epoch, Some(plan_schema + 1), Some(context_schema)),
+            (admission_epoch, Some(plan_schema), None),
+            (admission_epoch, Some(plan_schema), Some(context_schema + 1)),
+        ] {
+            assert!(matches!(
+                validate_current_source_contract(candidate.0, candidate.1, candidate.2),
+                Err(WorkflowRerunStoreError::UnsupportedSelection)
+            ));
+        }
+    }
 }

--- a/crates/automata-ci-store/src/web.rs
+++ b/crates/automata-ci-store/src/web.rs
@@ -272,7 +272,7 @@ pub struct HumanWorkflow {
     pub path: String,
     /// Whether new events may select this workflow.
     pub enabled: bool,
-    /// The newest non-null run projection. Its visibility must be authorized
+    /// The newest run projection. Its visibility must be authorized
     /// independently before presentation; `path` remains the honest fallback.
     pub projected_name: Option<HumanWorkflowProjectedName>,
 }
@@ -417,7 +417,7 @@ impl HumanGitCommitId {
     }
 }
 
-/// Human-readable run row with legacy projection fields preserved as optional.
+/// Human-readable workflow run.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HumanRun {
     /// Durable run identity within its tenant and repository.
@@ -438,8 +438,8 @@ pub struct HumanRun {
     pub status: crate::WorkflowRunStatus,
     /// Stable aggregate conclusion once derivable from latest attempts.
     pub conclusion: Option<HumanRunConclusion>,
-    /// Optional immutable human-facing workflow-name projection.
-    pub workflow_name: Option<String>,
+    /// Immutable human-facing workflow name.
+    pub workflow_name: String,
     /// Optional exact canonical source ref.
     pub git_ref: Option<String>,
     /// Optional sanitized trigger actor label.
@@ -615,8 +615,8 @@ pub struct HumanJob {
     pub display_name: String,
     /// Time at which the durable job was created.
     pub created_at: UnixMillis,
-    /// Legacy jobs lack a trustworthy size/schema and therefore have no descriptor.
-    pub job_ir: Option<JobIrMetadata>,
+    /// Exact immutable `JobIR` descriptor.
+    pub job_ir: JobIrMetadata,
     /// Latest durable attempt, absent when the job has not entered the queue.
     pub latest_attempt: Option<HumanJobAttempt>,
     /// Publication ceiling for the latest attempt's log stream. Absence means

--- a/crates/automata-ci-store/tests/admission_event_limits.rs
+++ b/crates/automata-ci-store/tests/admission_event_limits.rs
@@ -7,6 +7,18 @@ fn constraint(name: &str) -> &'static str {
         .unwrap_or_else(|| panic!("initial schema must define {name}"))
 }
 
+fn table_definition(name: &str) -> &'static str {
+    let marker = format!("CREATE TABLE {name} (");
+    let start = INITIAL_SCHEMA
+        .find(&marker)
+        .unwrap_or_else(|| panic!("initial schema must define table {name}"));
+    let definition = &INITIAL_SCHEMA[start..];
+    let end = definition
+        .find("\n);")
+        .unwrap_or_else(|| panic!("initial schema must terminate table {name}"));
+    &definition[..end + "\n);".len()]
+}
+
 fn assert_bound(constraint_name: &str, column: &str, maximum: u64) {
     let definition = constraint(constraint_name);
     let expected = format!("({column} >= 1) AND ({column} <= {maximum})");
@@ -75,4 +87,48 @@ fn source_plan_and_runtime_objects_keep_the_sixteen_mib_ceiling() {
     ] {
         assert_bound(constraint_name, column, 16_777_216);
     }
+}
+
+#[test]
+fn canonical_rows_require_complete_current_contract_metadata() {
+    let workflow_runs = table_definition("workflow_runs");
+    for required_column in [
+        "event_digest bytea NOT NULL",
+        "event_size_bytes bigint NOT NULL",
+        "event_media_type text NOT NULL",
+        "plan_digest bytea NOT NULL",
+        "plan_object_key text NOT NULL",
+        "plan_size_bytes bigint NOT NULL",
+        "plan_media_type text NOT NULL",
+        "plan_schema integer NOT NULL",
+        "workflow_name text NOT NULL",
+    ] {
+        assert!(
+            workflow_runs.contains(required_column),
+            "canonical workflow_runs schema must require {required_column}"
+        );
+    }
+
+    let jobs = table_definition("jobs");
+    for required_column in [
+        "job_ir_schema integer NOT NULL",
+        "job_ir_size_bytes bigint NOT NULL",
+    ] {
+        assert!(
+            jobs.contains(required_column),
+            "canonical jobs schema must require {required_column}"
+        );
+    }
+
+    assert!(
+        INITIAL_SCHEMA
+            .contains("CONSTRAINT runner_sessions_job_ir_current CHECK ((job_ir_schema = 1))")
+    );
+    assert!(
+        INITIAL_SCHEMA
+            .contains("CONSTRAINT runner_sessions_protocol_current CHECK ((protocol_version = 1))")
+    );
+    assert!(!INITIAL_SCHEMA.contains("runner_sessions_live_job_ir_current"));
+    assert!(!INITIAL_SCHEMA.contains("runner_sessions_live_protocol_current"));
+    assert!(!INITIAL_SCHEMA.contains("jobs_ir_metadata_complete"));
 }

--- a/crates/automata-ci-store/tests/common/mod.rs
+++ b/crates/automata-ci-store/tests/common/mod.rs
@@ -14,7 +14,7 @@ use automata_ci_postgres_test_support::{
 };
 use automata_ci_store::{
     OpenRunnerSession, PostgresStore, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    RunnerSessionFence, RunnerSessionRepository as _, SessionEpoch,
+    RunnerSessionFence, RunnerSessionRepository as _,
 };
 use sqlx::PgPool;
 use tokio::sync::OnceCell;
@@ -89,7 +89,7 @@ where
     }
 }
 
-#[allow(dead_code)] // Only the migration integration-test crate uses the partial-upgrade fixture.
+#[allow(dead_code)] // Only integration tests that control migration application use this fixture.
 pub async fn run_with_unmigrated_database<Test, TestFuture>(test: Test) -> TestResult
 where
     Test: FnOnce(Arc<TestDatabase>) -> TestFuture,
@@ -213,31 +213,6 @@ async fn seed_control_plane_with_optional_concurrency(
         .fetch_one(pool)
         .await?;
     let job_ir_version = JobIrVersion::new(u16::try_from(job_ir_schema)?)?;
-    let current_runner_session_schema: bool = sqlx::query_scalar(
-        r"
-        SELECT EXISTS (
-            SELECT 1
-            FROM information_schema.columns
-            WHERE table_schema = current_schema()
-              AND table_name = 'runner_command_outbox'
-              AND column_name = 'payload_tombstone_reason'
-        )
-        ",
-    )
-    .fetch_one(pool)
-    .await?;
-    let workflow_run_requirements_column: bool = sqlx::query_scalar(
-        r"
-        SELECT EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = current_schema()
-              AND table_name = 'workflow_runs'
-              AND column_name = 'runner_requirements_schema'
-        )
-        ",
-    )
-    .fetch_one(pool)
-    .await?;
 
     let requirements = serde_json::to_value(RunnerRequirements::default())?;
 
@@ -304,70 +279,34 @@ async fn seed_control_plane_with_optional_concurrency(
     .bind(vec![7_u8; 32])
     .execute(pool)
     .await?;
-    if workflow_run_requirements_column {
-        sqlx::query(
-            r"
-            INSERT INTO workflow_runs (
-                id, repository_id, workflow_id, snapshot_id, run_number, event_name,
-                event_object_key, head_sha, status, created_at_ms, updated_at_ms,
-                concurrency_group_key, concurrency_queue_policy,
-                runner_requirements_schema
-            ) VALUES (
-                $1, $2, $3, $4, 1, 'push', 'test/event', $5, 'queued', 1, 1,
-                $6, $7, $8
-            )
-            ",
+    sqlx::query(
+        r"
+        INSERT INTO workflow_runs (
+            id, repository_id, workflow_id, snapshot_id, run_number, event_name,
+            event_object_key, event_digest, event_size_bytes, event_media_type,
+            plan_digest, plan_object_key, plan_size_bytes, plan_media_type,
+            plan_schema, workflow_name, head_sha, status, created_at_ms, updated_at_ms,
+            concurrency_group_key, concurrency_queue_policy,
+            runner_requirements_schema
+        ) VALUES (
+            $1, $2, $3, $4, 1, 'push', 'test/event',
+            decode(repeat('09', 32), 'hex'), 1, 'application/json',
+            decode(repeat('0a', 32), 'hex'), 'test/plan', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1, 'Store test',
+            $5, 'queued', 1, 1, $6, $7, $8
         )
-        .bind(run_id)
-        .bind(repository_id)
-        .bind(workflow_id)
-        .bind(snapshot_id)
-        .bind(vec![9_u8; 20])
-        .bind(concurrency.map(|(group, _)| group))
-        .bind(concurrency.map(|(_, queue_policy)| queue_policy))
-        .bind(i16::try_from(runner_requirements_schema)?)
-        .execute(pool)
-        .await?;
-    } else if let Some((group, queue_policy)) = concurrency {
-        sqlx::query(
-            r"
-            INSERT INTO workflow_runs (
-                id, repository_id, workflow_id, snapshot_id, run_number, event_name,
-                event_object_key, head_sha, status, created_at_ms, updated_at_ms,
-                concurrency_group_key, concurrency_queue_policy
-            ) VALUES (
-                $1, $2, $3, $4, 1, 'push', 'test/event', $5, 'queued', 1, 1,
-                $6, $7
-            )
-            ",
-        )
-        .bind(run_id)
-        .bind(repository_id)
-        .bind(workflow_id)
-        .bind(snapshot_id)
-        .bind(vec![9_u8; 20])
-        .bind(group)
-        .bind(queue_policy)
-        .execute(pool)
-        .await?;
-    } else {
-        sqlx::query(
-            r"
-            INSERT INTO workflow_runs (
-                id, repository_id, workflow_id, snapshot_id, run_number, event_name,
-                event_object_key, head_sha, status, created_at_ms, updated_at_ms
-            )
-            VALUES ($1, $2, $3, $4, 1, 'push', 'test/event', $5, 'queued', 1, 1)
-            ",
-        )
-        .bind(run_id)
-        .bind(repository_id)
-        .bind(workflow_id)
-        .bind(snapshot_id)
-        .bind(vec![9_u8; 20])
-        .execute(pool)
-        .await?;
-    }
+        ",
+    )
+    .bind(run_id)
+    .bind(repository_id)
+    .bind(workflow_id)
+    .bind(snapshot_id)
+    .bind(vec![9_u8; 20])
+    .bind(concurrency.map(|(group, _)| group))
+    .bind(concurrency.map(|(_, queue_policy)| queue_policy))
+    .bind(i16::try_from(runner_requirements_schema)?)
+    .execute(pool)
+    .await?;
     sqlx::query(
         r"
         INSERT INTO jobs (
@@ -396,58 +335,18 @@ async fn seed_control_plane_with_optional_concurrency(
         .with_runner_payload_encryption(test_runner_payload_key_provider());
     for runner_id in &runner_ids {
         let capabilities = runner_capability_document(pool, *runner_id).await?;
-        if current_runner_session_schema {
-            let session = store
-                .open_session(OpenRunnerSession::new(
-                    RunnerSessionId::new(),
-                    *runner_id,
-                    RunnerGeneration::new(1)?,
-                    RunnerProtocolVersion::new(1)?,
-                    job_ir_version,
-                    capabilities,
-                    UnixMillis::new(2),
-                ))
-                .await?;
-            session_fences.push(session.fence());
-        } else {
-            let session_id = RunnerSessionId::new();
-            let generation = RunnerGeneration::new(1)?;
-            let epoch = SessionEpoch::new(1)?;
-            let updated = sqlx::query(
-                "UPDATE runners SET session_epoch = $1 WHERE id = $2 AND generation = $3",
-            )
-            .bind(i64::try_from(epoch.get())?)
-            .bind(runner_id.as_uuid())
-            .bind(i64::try_from(generation.get())?)
-            .execute(pool)
+        let session = store
+            .open_session(OpenRunnerSession::new(
+                RunnerSessionId::new(),
+                *runner_id,
+                RunnerGeneration::new(1)?,
+                RunnerProtocolVersion::new(1)?,
+                job_ir_version,
+                capabilities,
+                UnixMillis::new(2),
+            ))
             .await?;
-            assert_eq!(
-                updated.rows_affected(),
-                1,
-                "fixture runner must remain exact"
-            );
-            sqlx::query(
-                r"
-                INSERT INTO runner_sessions (
-                    id, runner_id, protocol_version, job_ir_schema,
-                    capability_snapshot, connected_at_ms, heartbeat_at_ms,
-                    runner_generation, session_epoch
-                ) VALUES ($1, $2, $3, $4, $5::jsonb, 2, 2, $6, $7)
-                ",
-            )
-            .bind(session_id.as_uuid())
-            .bind(runner_id.as_uuid())
-            .bind(1)
-            .bind(job_ir_schema)
-            .bind(capabilities.as_str())
-            .bind(i64::try_from(generation.get())?)
-            .bind(i64::try_from(epoch.get())?)
-            .execute(pool)
-            .await?;
-            session_fences.push(RunnerSessionFence::new(
-                session_id, *runner_id, generation, epoch,
-            ));
-        }
+        session_fences.push(session.fence());
     }
 
     Ok(SeedData {

--- a/crates/automata-ci-store/tests/postgres_attempts.rs
+++ b/crates/automata-ci-store/tests/postgres_attempts.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use automata_ci_core::{
-    AttemptId, AttemptNumber, FencingToken, JobLifecycle, LeaseGuard, LeaseId, UnixMillis,
+    AttemptId, AttemptNumber, FencingToken, JobId, JobLifecycle, LeaseGuard, LeaseId, UnixMillis,
 };
 use automata_ci_store::{
     AcquireLease, AttemptCommandError, AttemptStoreError, ConcludeQueuedAttempt,
@@ -97,6 +97,40 @@ async fn queued_creation_persists_current_safety_and_retries_reuse_the_job_ceili
                 classified_at: 71,
             }
         );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn queued_creation_rejects_a_missing_job_without_writes() -> TestResult {
+    run_with_database(|database| async move {
+        let attempt_id = AttemptId::new();
+        let missing_job_id = JobId::new();
+        let result = database
+            .store()
+            .insert_queued(QueuedAttempt::new(
+                attempt_id,
+                missing_job_id,
+                AttemptNumber::new(1)?,
+                UnixMillis::new(70),
+            ))
+            .await;
+        assert!(matches!(
+            result,
+            Err(AttemptStoreError::CorruptData(message))
+                if message == "queued attempt references a missing workflow job"
+        ));
+
+        let persisted: i64 = sqlx::query_scalar(
+            "SELECT count(*)::BIGINT FROM job_attempts WHERE id = $1 OR job_id = $2",
+        )
+        .bind(attempt_id.as_uuid())
+        .bind(missing_job_id.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(persisted, 0);
         Ok(())
     })
     .await

--- a/crates/automata-ci-store/tests/postgres_logical_run_finalization.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_run_finalization.rs
@@ -618,11 +618,15 @@ async fn record_concurrency_cancellation(database: &TestDatabase, fixture: &Fixt
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number, run_attempt,
             event_name, event_object_key, head_sha, status, created_at_ms, updated_at_ms,
-            concurrency_group_key, concurrency_queue_policy, runner_requirements_schema
+            concurrency_group_key, concurrency_queue_policy, runner_requirements_schema,
+            event_digest, event_size_bytes, event_media_type, plan_digest,
+            plan_object_key, plan_size_bytes, plan_media_type, plan_schema, workflow_name
         )
         SELECT $2, repository_id, workflow_id, snapshot_id, run_number + 1, 1,
                event_name, event_object_key, head_sha, 'queued', $3, $3,
-               concurrency_group_key, concurrency_queue_policy, runner_requirements_schema
+               concurrency_group_key, concurrency_queue_policy, runner_requirements_schema,
+               event_digest, event_size_bytes, event_media_type, plan_digest,
+               plan_object_key, plan_size_bytes, plan_media_type, plan_schema, workflow_name
         FROM workflow_runs
         WHERE id = $1
         ",

--- a/crates/automata-ci-store/tests/postgres_maintenance.rs
+++ b/crates/automata-ci-store/tests/postgres_maintenance.rs
@@ -794,11 +794,15 @@ async fn insert_pending_concurrency_run(
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number, event_name,
             event_object_key, head_sha, status, created_at_ms, updated_at_ms,
-            concurrency_group_key, concurrency_queue_policy, runner_requirements_schema
+            concurrency_group_key, concurrency_queue_policy, runner_requirements_schema,
+            event_digest, event_size_bytes, event_media_type, plan_digest,
+            plan_object_key, plan_size_bytes, plan_media_type, plan_schema, workflow_name
         )
         SELECT $1, repository_id, workflow_id, snapshot_id, 2, event_name,
                event_object_key, head_sha, 'queued', 70, 70, 'dogfood', 'single',
-               runner_requirements_schema
+               runner_requirements_schema, event_digest, event_size_bytes,
+               event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+               plan_media_type, plan_schema, workflow_name
         FROM workflow_runs WHERE id = $2
         ",
     )

--- a/crates/automata-ci-store/tests/postgres_observability.rs
+++ b/crates/automata-ci-store/tests/postgres_observability.rs
@@ -1217,12 +1217,13 @@ async fn insert_metrics_workflow(
             id, repository_id, workflow_id, snapshot_id, run_number, event_name,
             event_object_key, event_digest, event_size_bytes, event_media_type,
             plan_digest, plan_object_key, plan_size_bytes, plan_media_type,
-            plan_schema, head_sha, status, admission_epoch, created_at_ms, updated_at_ms,
+            plan_schema, workflow_name, head_sha, status, admission_epoch,
+            created_at_ms, updated_at_ms,
             runner_requirements_schema
         ) VALUES (
             $1, $2, $3, $4, 1, 'push', 'metrics/event', $5, 128,
             'application/json', $6, 'metrics/plan', 128,
-            'application/vnd.automata.workflow-plan.protobuf', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1, 'Metrics',
             $7, 'queued', $8, 1, 1, 1
         )
         ",

--- a/crates/automata-ci-store/tests/postgres_provider_delivery.rs
+++ b/crates/automata-ci-store/tests/postgres_provider_delivery.rs
@@ -90,10 +90,18 @@ async fn seed_workflow_run(
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number,
-            event_name, event_object_key, head_sha, status,
+            event_name, event_object_key, event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             created_at_ms, updated_at_ms, runner_requirements_schema
         )
-        VALUES ($1, $2, $3, $4, 1, 'push', $5, $6, 'queued', 1, 1, 1)
+        VALUES (
+            $1, $2, $3, $4, 1, 'push', $5,
+            decode(repeat('31', 32), 'hex'), 1, 'application/json',
+            decode(repeat('32', 32), 'hex'), 'test/provider-delivery-plan', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1,
+            'Provider delivery', $6, 'queued', 1, 1, 1
+        )
         ",
     )
     .bind(run_id)

--- a/crates/automata-ci-store/tests/postgres_reusable_workflow_expansion.rs
+++ b/crates/automata-ci-store/tests/postgres_reusable_workflow_expansion.rs
@@ -41,7 +41,7 @@ INSERT INTO workflow_snapshots (
     '10000000-0000-0000-0000-000000000003',
     '10000000-0000-0000-0000-000000000002',
     decode(repeat('01', 32), 'hex'), 'reusable/root-source.yml', 1,
-    1, 4, 128, 'application/yaml'
+    1, 1, 128, 'application/yaml'
 );
 INSERT INTO workflow_runs (
     id, repository_id, workflow_id, snapshot_id, run_number, run_attempt,
@@ -56,11 +56,11 @@ INSERT INTO workflow_runs (
     '10000000-0000-0000-0000-000000000002',
     '10000000-0000-0000-0000-000000000003',
     1, 1, 1, 'push', 'reusable/event.json', decode(repeat('09', 20), 'hex'),
-    'in_progress', 1, 1, 4, decode(repeat('02', 32), 'hex'), 128,
+    'in_progress', 1, 1, 1, decode(repeat('02', 32), 'hex'), 128,
     'application/json', decode(repeat('03', 32), 'hex'),
     'reusable/root-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
-    'Root', 'refs/heads/main', 'synthetic-actor', 3
+    'application/vnd.automata.workflow-plan+json', 1,
+    'Root', 'refs/heads/main', 'synthetic-actor', 1
 );
 INSERT INTO logical_workflow_runs (
     run_id, root_invocation_id, admission_digest, state, admitted_at_ms,
@@ -68,7 +68,7 @@ INSERT INTO logical_workflow_runs (
 ) VALUES (
     '10000000-0000-0000-0000-000000000004',
     '10000000-0000-0000-0000-000000000005',
-    decode(repeat('04', 32), 'hex'), 'active', 1, 1, 1, 3
+    decode(repeat('04', 32), 'hex'), 'active', 1, 1, 1, 1
 );
 INSERT INTO logical_workflow_invocations (
     id, run_id, plan_digest, plan_object_key, plan_size_bytes,
@@ -77,7 +77,7 @@ INSERT INTO logical_workflow_invocations (
     '10000000-0000-0000-0000-000000000005',
     '10000000-0000-0000-0000-000000000004',
     decode(repeat('03', 32), 'hex'), 'reusable/root-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2, 'active', 1, 1
+    'application/vnd.automata.workflow-plan+json', 1, 'active', 1, 1
 );
 INSERT INTO logical_workflow_jobs (
     id, run_id, invocation_id, logical_key, source_order, execution_kind,
@@ -180,7 +180,7 @@ INSERT INTO logical_workflow_reusable_workflow_catalog (
     '.ci/workflows/root.yml', repeat('09', 20), decode(repeat('01', 32), 'hex'),
     'reusable/root-source.yml', 128, 'application/yaml',
     decode(repeat('03', 32), 'hex'), 'reusable/root-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
+    'application/vnd.automata.workflow-plan+json', 1,
     NULL, decode(repeat('11', 32), 'hex'), 1, 1, 2
 ),
 (
@@ -189,7 +189,7 @@ INSERT INTO logical_workflow_reusable_workflow_catalog (
     '.ci/workflows/child.yml', repeat('09', 20), decode(repeat('12', 32), 'hex'),
     'reusable/child-source.yml', 128, 'application/yaml',
     decode(repeat('13', 32), 'hex'), 'reusable/child-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
+    'application/vnd.automata.workflow-plan+json', 1,
     decode(repeat('14', 32), 'hex'), decode(repeat('15', 32), 'hex'), 2, 0, 2
 );
 INSERT INTO logical_workflow_reusable_invocation_expansions (
@@ -294,7 +294,7 @@ INSERT INTO logical_workflow_reusable_workflow_catalog (
     '.ci/workflows/root.yml', repeat('09', 20), decode(repeat('01', 32), 'hex'),
     'reusable/root-source.yml', 128, 'application/yaml',
     decode(repeat('03', 32), 'hex'), 'reusable/root-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
+    'application/vnd.automata.workflow-plan+json', 1,
     NULL, decode(repeat('51', 32), 'hex'), 7, 7, 2
 ),
 (
@@ -303,7 +303,7 @@ INSERT INTO logical_workflow_reusable_workflow_catalog (
     '.ci/workflows/child.yml', repeat('09', 20), decode(repeat('12', 32), 'hex'),
     'reusable/child-source.yml', 128, 'application/yaml',
     decode(repeat('13', 32), 'hex'), 'reusable/child-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
+    'application/vnd.automata.workflow-plan+json', 1,
     decode(repeat('52', 32), 'hex'), decode(repeat('53', 32), 'hex'), 1, 1, 2
 ),
 (
@@ -313,7 +313,7 @@ INSERT INTO logical_workflow_reusable_workflow_catalog (
     decode(repeat('16', 32), 'hex'), 'reusable/grandchild-source.yml', 128,
     'application/yaml', decode(repeat('17', 32), 'hex'),
     'reusable/grandchild-plan.json', 128,
-    'application/vnd.automata.workflow-plan+json', 2,
+    'application/vnd.automata.workflow-plan+json', 1,
     decode(repeat('54', 32), 'hex'), decode(repeat('55', 32), 'hex'), 1, 0, 2
 );
 INSERT INTO logical_workflow_reusable_invocation_expansions (

--- a/crates/automata-ci-store/tests/postgres_secrets_output_safety.rs
+++ b/crates/automata-ci-store/tests/postgres_secrets_output_safety.rs
@@ -2143,7 +2143,9 @@ async fn create_public_run_and_job(pool: &PgPool, seed: &SeedData) -> TestResult
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id, run_number,
-            event_name, event_object_key, head_sha, status,
+            event_name, event_object_key, event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             created_at_ms, updated_at_ms, publication_policy_revision,
             requested_dashboard_visibility, effective_dashboard_visibility,
             requested_log_visibility, requested_artifact_visibility,
@@ -2152,7 +2154,9 @@ async fn create_public_run_and_job(pool: &PgPool, seed: &SeedData) -> TestResult
         )
         SELECT
             $1, repository_id, workflow_id, snapshot_id, run_number + 1,
-            event_name, 'test/public-event', head_sha, status,
+            event_name, 'test/public-event', event_digest, event_size_bytes,
+            event_media_type, plan_digest, plan_object_key, plan_size_bytes,
+            plan_media_type, plan_schema, workflow_name, head_sha, status,
             2, 2, 2, 'public', 'public', 'public', 'public',
             'repository_policy', 1, runner_requirements_schema
         FROM workflow_runs

--- a/crates/automata-ci-store/tests/postgres_web_reads.rs
+++ b/crates/automata-ci-store/tests/postgres_web_reads.rs
@@ -98,7 +98,7 @@ async fn tenant_scoped_human_reads_preserve_exact_descriptors_and_visibility() -
         assert_eq!(runs.runs[0].id, fixture.run_id);
         assert_eq!(runs.runs[0].run_number, 2);
         assert_eq!(runs.runs[0].run_attempt, 3);
-        assert_eq!(runs.runs[0].workflow_name.as_deref(), Some("CI"));
+        assert_eq!(runs.runs[0].workflow_name, "CI");
         assert_eq!(runs.runs[0].actor.as_deref(), Some("octocat"));
         assert_eq!(
             runs.runs[0].publication.effective_dashboard_visibility,
@@ -121,7 +121,7 @@ async fn tenant_scoped_human_reads_preserve_exact_descriptors_and_visibility() -
                 .effective_visibility,
             OutputVisibility::Public
         );
-        let job_ir = detail.jobs[0].job_ir.as_ref().expect("current JobIR");
+        let job_ir = &detail.jobs[0].job_ir;
         assert_eq!(job_ir.encoded_size(), 128);
         let attempt = detail.jobs[0]
             .latest_attempt
@@ -1210,14 +1210,19 @@ async fn seed_public_completed_run(
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id,
             run_number, run_attempt, event_name, event_object_key,
-            head_sha, status, created_at_ms, updated_at_ms,
+            event_digest, event_size_bytes, event_media_type,
+            plan_digest, plan_object_key, plan_size_bytes, plan_media_type,
+            plan_schema, head_sha, status, created_at_ms, updated_at_ms,
             workflow_name, git_ref, actor, display_title, commit_subject,
             publication_policy_revision, requested_dashboard_visibility,
             effective_dashboard_visibility, requested_log_visibility,
             requested_artifact_visibility, publication_safety_reason,
             publication_safety_schema, runner_requirements_schema
         ) VALUES (
-            $1, $2, $3, $4, 2, 3, 'push', 'web/event', $5,
+            $1, $2, $3, $4, 2, 3, 'push', 'web/event',
+            decode(repeat('41', 32), 'hex'), 1, 'application/json',
+            decode(repeat('42', 32), 'hex'), 'web/plan', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1, $5,
             'completed', 10, 21, 'CI', 'refs/heads/main', 'octocat',
             'Typed dashboard reads', 'Preserve immutable descriptors',
             2, 'public', 'public', 'public', 'public', 'repository_policy', 1, 1
@@ -1504,12 +1509,17 @@ async fn insert_queued_run(
         r"
         INSERT INTO workflow_runs (
             id, repository_id, workflow_id, snapshot_id,
-            run_number, event_name, event_object_key, head_sha,
+            run_number, event_name, event_object_key, event_digest,
+            event_size_bytes, event_media_type, plan_digest, plan_object_key,
+            plan_size_bytes, plan_media_type, plan_schema, workflow_name, head_sha,
             status, created_at_ms, updated_at_ms,
             requested_dashboard_visibility, effective_dashboard_visibility,
             publication_safety_reason, runner_requirements_schema
         ) VALUES (
-            $1, $2, $3, $4, $5, 'push', 'web/keyset-event', $6,
+            $1, $2, $3, $4, $5, 'push', 'web/keyset-event',
+            decode(repeat('43', 32), 'hex'), 1, 'application/json',
+            decode(repeat('44', 32), 'hex'), 'web/keyset-plan', 1,
+            'application/vnd.automata.workflow-plan.protobuf', 1, 'Keyset', $6,
             'queued', $7, $7, $8, $8, 'repository_policy', 1
         )
         ",

--- a/crates/automata-ci-store/tests/postgres_workflow_run_ui_projection.rs
+++ b/crates/automata-ci-store/tests/postgres_workflow_run_ui_projection.rs
@@ -14,7 +14,7 @@ use common::{TestResult, run_with_database};
 
 #[derive(Debug, Eq, PartialEq, sqlx::FromRow)]
 struct ProjectionRow {
-    workflow_name: Option<String>,
+    workflow_name: String,
     git_ref: Option<String>,
     actor: Option<String>,
     display_title: Option<String>,
@@ -98,7 +98,7 @@ async fn admission_persists_human_projection_and_requested_run_attempt() -> Test
         assert_eq!(
             persisted,
             ProjectionRow {
-                workflow_name: Some("CI".into()),
+                workflow_name: "CI".into(),
                 git_ref: Some("refs/heads/main".into()),
                 actor: Some("octocat".into()),
                 display_title: Some("Keep admission metadata durable".into()),

--- a/crates/automata-ci/src/app/conformance_api.rs
+++ b/crates/automata-ci/src/app/conformance_api.rs
@@ -294,9 +294,7 @@ async fn export_run(
 ) -> Result<RunDocument, ApiError> {
     let mut blob_budget = 0_u64;
     for job in &detail.jobs {
-        if let Some(metadata) = &job.job_ir {
-            blob_budget = add_blob_budget(blob_budget, metadata.encoded_size())?;
-        }
+        blob_budget = add_blob_budget(blob_budget, job.job_ir.encoded_size())?;
         if let Some(result) = job
             .latest_attempt
             .as_ref()
@@ -311,22 +309,16 @@ async fn export_run(
     let workflow_path = detail.run.workflow_path.clone();
     let mut jobs = Vec::with_capacity(detail.jobs.len());
     for job in detail.jobs {
-        let (job_ir, runtime_context) = match &job.job_ir {
-            Some(metadata) => {
-                let (job_ir, runtime_context) = load_job_ir(
-                    state.blobs.as_ref(),
-                    metadata,
-                    run_id,
-                    workflow_id,
-                    &workflow_path,
-                    job.id,
-                    &mut blob_budget,
-                )
-                .await?;
-                (Some(job_ir), Some(runtime_context))
-            }
-            None => (None, None),
-        };
+        let (job_ir, runtime_context) = load_job_ir(
+            state.blobs.as_ref(),
+            &job.job_ir,
+            run_id,
+            workflow_id,
+            &workflow_path,
+            job.id,
+            &mut blob_budget,
+        )
+        .await?;
         let latest_attempt = match job.latest_attempt.as_ref() {
             Some(attempt) => Some(load_attempt(state.blobs.as_ref(), attempt).await?),
             None => None,
@@ -679,7 +671,7 @@ struct RunDocument {
     id: String,
     workflow_id: String,
     workflow_path: String,
-    workflow_name: Option<String>,
+    workflow_name: String,
     run_number: u64,
     run_attempt: u32,
     event_name: String,
@@ -701,8 +693,8 @@ struct JobDocument {
     logical_key: String,
     display_name: String,
     created_at_ms: i64,
-    job_ir: Option<JobIrEnvelope>,
-    runtime_context: Option<RuntimeContextDocument>,
+    job_ir: JobIrEnvelope,
+    runtime_context: RuntimeContextDocument,
     latest_attempt: Option<AttemptDocument>,
 }
 

--- a/crates/automata-ci/src/app/web/live.rs
+++ b/crates/automata-ci/src/app/web/live.rs
@@ -1113,11 +1113,7 @@ fn map_workflow(workflow: &HumanWorkflow) -> WorkflowDefinition {
 fn workflow_from_run(run: &HumanRun) -> Workflow {
     Workflow {
         id: run.workflow_id,
-        name: run
-            .workflow_name
-            .as_ref()
-            .and_then(|name| visible_text(name))
-            .unwrap_or_else(|| run.workflow_path.clone()),
+        name: visible_text(&run.workflow_name).unwrap_or_else(|| run.workflow_path.clone()),
         path: run.workflow_path.clone(),
     }
 }
@@ -2772,16 +2768,16 @@ mod tests {
     };
     use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType, MemoryBlobStore};
     use automata_ci_core::{
-        AttemptId, AttemptNumber, JobId, JobLifecycle, LogChannel as CoreLogChannel, LogFrame,
-        LogSequence, LogStreamId, RunId, UnixMillis, WorkflowId,
+        AttemptId, AttemptNumber, JobId, JobIrVersion, JobLifecycle, LogChannel as CoreLogChannel,
+        LogFrame, LogSequence, LogStreamId, RunId, Sha256Digest, UnixMillis, WorkflowId,
     };
     use automata_ci_store::{
         DocumentSchema, HumanAuthorizationTarget, HumanGitCommitId, HumanJob, HumanJobAttempt,
         HumanJobDetail, HumanJobNavigation, HumanLogSegment, HumanLogSegmentPage, HumanLogStream,
         HumanOutputPublication, HumanRawLogDisposition, HumanRepository, HumanRepositoryCursor,
         HumanRepositoryPage, HumanRun, HumanRunConclusion, HumanRunCursor, HumanRunPageDirection,
-        HumanRunPublication, HumanWorkflow, HumanWorkflowReadRepository, RepositoryCoordinate,
-        RepositoryId, StoreError, TenantScope, WorkflowRunStatus,
+        HumanRunPublication, HumanWorkflow, HumanWorkflowReadRepository, JobIrMetadata, ObjectKey,
+        RepositoryCoordinate, RepositoryId, StoreError, TenantScope, WorkflowRunStatus,
     };
 
     use super::{
@@ -3306,7 +3302,7 @@ mod tests {
             head_commit: HumanGitCommitId::new(vec![7; 20]).expect("commit ID"),
             status: WorkflowRunStatus::Completed,
             conclusion: Some(HumanRunConclusion::Lost),
-            workflow_name: Some("CI".to_owned()),
+            workflow_name: "CI".to_owned(),
             git_ref: Some("refs/heads/main".to_owned()),
             actor: Some("octocat".to_owned()),
             display_title: Some("Validate checkout flow".to_owned()),
@@ -3324,6 +3320,18 @@ mod tests {
                 safety_schema: 1,
             },
         }
+    }
+
+    fn fixture_job_ir(job_id: JobId, run_id: RunId) -> JobIrMetadata {
+        JobIrMetadata::new(
+            job_id,
+            run_id,
+            JobIrVersion::new(1).expect("JobIR version"),
+            1,
+            Sha256Digest::from_bytes([7; 32]),
+            ObjectKey::new(format!("tests/job-ir/{job_id}")).expect("JobIR object key"),
+        )
+        .expect("JobIR metadata")
     }
 
     fn fixture_output_publication(
@@ -3372,7 +3380,7 @@ mod tests {
             key: "build".to_owned(),
             display_name: "Build".to_owned(),
             created_at: UnixMillis::new(1_050),
-            job_ir: None,
+            job_ir: fixture_job_ir(job_id, run.id),
             latest_attempt: Some(attempt),
             log_publication: Some(log_stream.publication.clone()),
         };
@@ -4366,7 +4374,7 @@ mod tests {
             head_commit: HumanGitCommitId::new(vec![7; 20]).expect("commit ID"),
             status: WorkflowRunStatus::Completed,
             conclusion: Some(HumanRunConclusion::Success),
-            workflow_name: Some("\u{200b}".to_owned()),
+            workflow_name: "\u{200b}".to_owned(),
             git_ref: Some("\u{202e}".to_owned()),
             actor: Some("\u{202e}octocat".to_owned()),
             display_title: Some(" \u{200b}".to_owned()),
@@ -4392,12 +4400,13 @@ mod tests {
         assert!(mapped.actor.is_none());
         assert!(mapped.commit_subject.is_none());
 
+        let job_id = JobId::new();
         let job = HumanJob {
-            id: JobId::new(),
+            id: job_id,
             key: "build".to_owned(),
             display_name: "\u{200b}".to_owned(),
             created_at: UnixMillis::new(1),
-            job_ir: None,
+            job_ir: fixture_job_ir(job_id, run.id),
             latest_attempt: None,
             log_publication: None,
         };

--- a/docs/workflow-reruns.md
+++ b/docs/workflow-reruns.md
@@ -96,14 +96,11 @@ selection is unavailable when any source job has multiple matrix instances;
 the entire workflow can still be rerun. Sources using workflow-level
 concurrency currently fail closed because rerun admission does not yet retain
 an immutable pre-transition witness proving queue replacement or cancellation
-semantics. Legacy sources without the complete Admission V2 base runtime
-context also fail closed; rerun admission does not synthesize a new context or
-change the source activation semantics. Requests
+semantics. Sources without the complete current base runtime context also fail
+closed; rerun admission does not synthesize a new context or change the source
+activation semantics. Requests
 outside those boundaries fail closed as conflicts instead of constructing a
-best-effort graph. Schema-valid runs created before durable rerun lineage was
-introduced with an attempt number greater than one cannot be grouped safely;
-they also fail closed as an unsupported-selection conflict rather than being
-treated as corrupt data.
+best-effort graph.
 
 The PostgreSQL integration tests cover complete reruns, partial and nested
 reruns, exact replay, carry-forward, Check projection claims, terminal Check


### PR DESCRIPTION
## Summary

- make current workflow/run and JobIR metadata required throughout the canonical schema and human-read projections
- remove legacy partial-schema fixture paths and stale schema-version assumptions
- enforce current rerun contracts and reject missing-job attempt creation without writes

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- exact table-scoped canonical schema contract test
- typed post-terminal rerun contract unit test
- `automata-ci --lib --no-run`
- Store PostgreSQL aggregate target `--no-run`
- live PostgreSQL missing-job/no-write regression
- strict `-D warnings` Clippy for affected Store, Results-GitHub, and app libraries

A broader all-target Clippy run reaches 24 pre-existing doc-markdown warnings in unchanged `automata-ci-postgres-test-support`; the affected libraries are clean.