### PR TITLE
fix: reconcile runner enrollment recovery

### DIFF
--- a/crates/automata-ci-runner/src/enrollment.rs
+++ b/crates/automata-ci-runner/src/enrollment.rs
@@ -28,6 +28,7 @@ const REDEEM_PATH: &str = "/api/v1/runner-enrollments/redeem";
 const TOKEN_PREFIX: &str = "atm_re_";
 const TOKEN_BYTES: usize = 32;
 const TOKEN_ENCODED_BYTES: usize = 43;
+const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
 const MAX_TOKEN_BYTES: usize = TOKEN_PREFIX.len() + TOKEN_ENCODED_BYTES;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -38,8 +39,8 @@ pub(super) async fn enroll(args: &EnrollArgs) -> Result<()> {
         .context("runner enrollment could not load the product configuration")?;
     let destinations = CredentialDestinations::from_config(&config)?;
     let origin = enrollment_origin(&args.server)?;
-    let validation_time_seconds = current_unix_time_seconds()?;
-    if destinations.finish_interrupted_cleanup(&config, validation_time_seconds)? {
+    let cleanup_validation_time_seconds = current_unix_time_seconds()?;
+    if destinations.finish_interrupted_cleanup(&config, cleanup_validation_time_seconds)? {
         println!("runner enrollment was already completed");
         return Ok(());
     }
@@ -47,56 +48,57 @@ pub(super) async fn enroll(args: &EnrollArgs) -> Result<()> {
         Some(stage) => stage,
         None => destinations.create_stage(&config, &origin, &args.name, load_token(args)?)?,
     };
-    let bytes = if let Some(bytes) = destinations.load_response()? {
-        bytes
-    } else {
-        let endpoint = origin
-            .join(REDEEM_PATH)
-            .context("runner enrollment endpoint is invalid")?;
-        let body = RedeemRequest {
-            operation_id: stage.operation_id,
-            token: stage.token.as_str(),
-            runner_name: &stage.runner_name,
-            capabilities: &stage.capabilities,
-            csr_pem: &stage.csr_pem,
-        };
-        let client = Client::builder()
-            .https_only(origin.scheme() == "https")
-            .redirect(Policy::none())
-            .connect_timeout(CONNECT_TIMEOUT)
-            .timeout(REQUEST_TIMEOUT)
-            .retry(reqwest::retry::never())
-            .no_proxy()
-            .build()
-            .context("runner enrollment HTTP client could not be configured")?;
-        let request_body = Zeroizing::new(
-            serde_json::to_vec(&body).context("runner enrollment request could not be encoded")?,
-        );
-        let response = client
-            .post(endpoint)
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Bytes::from_owner(request_body))
-            .send()
-            .await
-            .map_err(reqwest::Error::without_url)
-            .context("runner enrollment request failed")?;
-        if response.status() != StatusCode::CREATED {
-            let status = response.status();
-            bail!("runner enrollment was rejected with HTTP {status}");
-        }
-        if !response.headers().get_all(header::CONTENT_TYPE).iter().eq([
-            &header::HeaderValue::from_static("application/json; charset=utf-8"),
-        ]) {
-            bail!("runner enrollment response has an invalid content type");
-        }
-        let bytes = read_bounded_response(response).await?;
-        destinations.persist_response(&bytes)?;
-        bytes
+    let staged_response = destinations.load_response()?;
+    let endpoint = origin
+        .join(REDEEM_PATH)
+        .context("runner enrollment endpoint is invalid")?;
+    let body = RedeemRequest {
+        operation_id: stage.operation_id,
+        token: stage.token.as_str(),
+        runner_name: &stage.runner_name,
+        capabilities: &stage.capabilities,
+        csr_pem: &stage.csr_pem,
     };
+    let client = Client::builder()
+        .https_only(origin.scheme() == "https")
+        .redirect(Policy::none())
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .retry(reqwest::retry::never())
+        .no_proxy()
+        .build()
+        .context("runner enrollment HTTP client could not be configured")?;
+    let request_body = Zeroizing::new(
+        serde_json::to_vec(&body).context("runner enrollment request could not be encoded")?,
+    );
+    let response = client
+        .post(endpoint)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Bytes::from_owner(request_body))
+        .send()
+        .await
+        .map_err(reqwest::Error::without_url)
+        .context("runner enrollment request failed")?;
+    if response.status() != StatusCode::CREATED {
+        let status = response.status();
+        bail!("runner enrollment was rejected with HTTP {status}");
+    }
+    if !response.headers().get_all(header::CONTENT_TYPE).iter().eq([
+        &header::HeaderValue::from_static("application/json; charset=utf-8"),
+    ]) {
+        bail!("runner enrollment response has an invalid content type");
+    }
+    let bytes = read_bounded_response(response).await?;
+    if let Some(staged_response) = staged_response {
+        validate_staged_response(&staged_response, &bytes)?;
+    } else {
+        destinations.persist_response(&bytes)?;
+    }
+    let response_validation_time_seconds = current_unix_time_seconds()?;
     let enrolled: RedeemResponse =
         serde_json::from_slice(&bytes).context("runner enrollment returned an invalid response")?;
-    validate_response(&config, &enrolled, validation_time_seconds)?;
-    stage.validate_certificate(&config, &enrolled, validation_time_seconds)?;
+    validate_response(&config, &enrolled, response_validation_time_seconds)?;
+    stage.validate_certificate(&config, &enrolled, response_validation_time_seconds)?;
     destinations.persist_exact(
         enrolled.server_ca_pem.as_bytes(),
         enrolled.certificate_chain_pem.as_bytes(),
@@ -107,6 +109,13 @@ pub(super) async fn enroll(args: &EnrollArgs) -> Result<()> {
         "enrolled runner {} in group {} (certificate expires at {})",
         enrolled.runner_id, enrolled.runner_group, enrolled.certificate_expires_at_seconds
     );
+    Ok(())
+}
+
+fn validate_staged_response(staged: &[u8], replayed: &[u8]) -> Result<()> {
+    if staged != replayed {
+        bail!("runner enrollment replay did not match its durable response receipt");
+    }
     Ok(())
 }
 
@@ -202,11 +211,17 @@ fn current_unix_time_seconds() -> Result<i64> {
 }
 
 fn validate_token(value: &str) -> Result<()> {
-    let decoded = value
+    let Some(encoded) = value
         .strip_prefix(TOKEN_PREFIX)
         .filter(|encoded| encoded.len() == TOKEN_ENCODED_BYTES)
-        .and_then(|encoded| URL_SAFE_NO_PAD.decode(encoded).ok());
-    if decoded.is_none_or(|decoded| decoded.len() != TOKEN_BYTES) {
+    else {
+        bail!("runner enrollment token is invalid");
+    };
+    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
+    if !matches!(
+        URL_SAFE_NO_PAD.decode_slice(encoded, &mut *decoded),
+        Ok(TOKEN_BYTES)
+    ) {
         bail!("runner enrollment token is invalid");
     }
     Ok(())
@@ -236,7 +251,7 @@ struct RedeemResponse {
 mod tests {
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 
-    use super::{TOKEN_PREFIX, enrollment_origin, validate_token};
+    use super::{TOKEN_PREFIX, enrollment_origin, validate_staged_response, validate_token};
 
     #[test]
     fn enrollment_origin_requires_tls_except_for_literal_loopback() {
@@ -255,5 +270,11 @@ mod tests {
         assert!(validate_token("plain-secret").is_err());
         assert!(validate_token(&format!("{token}A")).is_err());
         assert!(validate_token(&format!("{token}\n")).is_err());
+    }
+
+    #[test]
+    fn staged_response_requires_a_byte_exact_replay() {
+        validate_staged_response(b"exact", b"exact").expect("exact replay");
+        assert!(validate_staged_response(b"staged", b"different").is_err());
     }
 }

--- a/crates/automata-ci-runner/src/enrollment/custody.rs
+++ b/crates/automata-ci-runner/src/enrollment/custody.rs
@@ -868,6 +868,32 @@ mod tests {
         validate_certificate_response, validate_destination_set,
     };
     use crate::enrollment::RedeemResponse;
+    #[cfg(target_os = "linux")]
+    use crate::product::RunnerProductConfig;
+
+    #[cfg(target_os = "linux")]
+    fn product_config(root: &std::path::Path, runner_id: Uuid) -> RunnerProductConfig {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(include_bytes!("../../config/runner.local-1.example.json"))
+                .expect("example runner configuration");
+        document["runner_id"] = serde_json::json!(runner_id);
+        for (field, filename) in [
+            ("server_roots", "server-roots.pem"),
+            ("certificate_chain", "runner-chain.pem"),
+            ("private_key", "runner-key.pem"),
+        ] {
+            let path = root.join(filename);
+            document["tls"][field]["path"] = serde_json::Value::String(
+                path.to_str()
+                    .expect("test credential path is UTF-8")
+                    .to_owned(),
+            );
+        }
+        RunnerProductConfig::from_json(
+            &serde_json::to_vec(&document).expect("runner configuration JSON"),
+        )
+        .expect("runner product configuration")
+    }
 
     #[test]
     fn partial_credential_publication_is_reconciled_exactly_without_overwrite() {
@@ -903,6 +929,77 @@ mod tests {
         assert!(error.to_string().contains("does not match"));
         assert_eq!(fs::read(&destinations.server_roots).unwrap(), b"roots");
         fs::remove_dir_all(&root).expect("remove exact test root");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn persisted_completion_response_is_rejected_at_expiry_and_recovers_before_it() {
+        let root = std::env::current_dir()
+            .expect("current directory")
+            .join(format!(".automata-enroll-expiry-test-{}", Uuid::new_v4()));
+        fs::create_dir(&root).expect("test root");
+        let runner_id = Uuid::new_v4();
+        let config = product_config(&root, runner_id);
+        let destinations =
+            CredentialDestinations::from_config(&config).expect("credential destinations");
+
+        let not_before = 1_800_000_000;
+        let expires_at = 1_900_000_000;
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).expect("CA key");
+        let mut ca_params = CertificateParams::default();
+        ca_params.not_before =
+            time::OffsetDateTime::from_unix_timestamp(not_before).expect("CA not-before");
+        ca_params.not_after =
+            time::OffsetDateTime::from_unix_timestamp(expires_at + 60).expect("CA not-after");
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let issuer = CertifiedIssuer::self_signed(ca_params, ca_key).expect("CA");
+
+        let runner_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).expect("runner key");
+        let mut leaf_params = CertificateParams::default();
+        leaf_params
+            .distinguished_name
+            .push(DnType::CommonName, runner_id.hyphenated().to_string());
+        leaf_params.not_before =
+            time::OffsetDateTime::from_unix_timestamp(not_before).expect("leaf not-before");
+        leaf_params.not_after =
+            time::OffsetDateTime::from_unix_timestamp(expires_at).expect("leaf not-after");
+        leaf_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let leaf = leaf_params
+            .signed_by(&runner_key, &issuer)
+            .expect("runner leaf");
+        let runner_private_key_pem = zeroize::Zeroizing::new(runner_key.serialize_pem());
+        let response = RedeemResponse {
+            runner_id,
+            runner_group: "default".to_owned(),
+            control_endpoint: config.control_endpoint().to_string(),
+            certificate_chain_pem: format!("{}{}", leaf.pem(), issuer.pem()),
+            server_ca_pem: issuer.pem(),
+            certificate_expires_at_seconds: expires_at,
+        };
+        destinations
+            .persist_response(&serde_json::to_vec(&response).expect("response JSON"))
+            .expect("persist response");
+        destinations
+            .persist_exact(
+                response.server_ca_pem.as_bytes(),
+                response.certificate_chain_pem.as_bytes(),
+                runner_private_key_pem.as_bytes(),
+            )
+            .expect("persist credentials");
+
+        destinations
+            .finish_interrupted_cleanup(&config, expires_at)
+            .expect_err("expired completion response must remain fail-closed");
+        assert!(destinations.response_stage.exists());
+        assert!(
+            destinations
+                .finish_interrupted_cleanup(&config, expires_at - 1)
+                .expect("fresh completion recovery")
+        );
+        assert!(!destinations.response_stage.exists());
+        fs::remove_dir_all(&root).expect("remove expiry test root");
     }
 
     #[test]

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -400,8 +400,7 @@ pub use runnable::{
     RunnableScanPage, RunnableScanRequest,
 };
 pub use runner_capability_admission::{
-    MAX_REGISTERED_RUNNERS, RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository,
-    RunnerCapabilityReadiness,
+    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository, RunnerCapabilityReadiness,
 };
 pub use runner_control::{
     CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,

--- a/crates/automata-ci-store/src/postgres/runner_capability_admission.rs
+++ b/crates/automata-ci-store/src/postgres/runner_capability_admission.rs
@@ -3,11 +3,10 @@ use serde_json::Value;
 use sqlx::Row as _;
 use uuid::Uuid;
 
-use automata_ci_core::{RunnerCapabilities, RunnerFeature};
+use automata_ci_core::{MAX_REGISTERED_RUNNERS, RunnerCapabilities, RunnerFeature};
 
 use crate::{
-    MAX_REGISTERED_RUNNERS, RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository,
-    RunnerCapabilityReadiness,
+    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository, RunnerCapabilityReadiness,
 };
 
 use super::PostgresStore;

--- a/crates/automata-ci-store/src/runner_capability_admission.rs
+++ b/crates/automata-ci-store/src/runner_capability_admission.rs
@@ -3,8 +3,6 @@ use thiserror::Error;
 
 use crate::RepositoryOperationError;
 
-pub use automata_ci_core::MAX_REGISTERED_RUNNERS;
-
 /// Failures from the narrow runner-capability admission boundary.
 #[derive(Debug, Error)]
 pub enum RunnerCapabilityAdmissionError {

--- a/crates/automata-ci-store/tests/postgres_runner_capability_admission.rs
+++ b/crates/automata-ci-store/tests/postgres_runner_capability_admission.rs
@@ -1,10 +1,10 @@
 use automata_ci_core::{
-    Architecture, OperatingSystem, RunnerCapabilities, RunnerFeature, RunnerGroup, RunnerId,
-    RunnerLabel, RunnerPlatform,
+    Architecture, MAX_REGISTERED_RUNNERS, OperatingSystem, RunnerCapabilities, RunnerFeature,
+    RunnerGroup, RunnerId, RunnerLabel, RunnerPlatform,
 };
 use automata_ci_store::{
-    MAX_REGISTERED_RUNNERS, RunnerCapabilityAdmissionError,
-    RunnerCapabilityAdmissionRepository as _, RunnerCapabilityReadiness,
+    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository as _,
+    RunnerCapabilityReadiness,
 };
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci/src/app/runner_enrollment_api.rs
+++ b/crates/automata-ci/src/app/runner_enrollment_api.rs
@@ -46,6 +46,7 @@ pub(crate) const RUNNER_ENROLLMENT_REDEEM_PATH: &str = "/api/v1/runner-enrollmen
 const TOKEN_PREFIX: &str = "atm_re_";
 const TOKEN_BYTES: usize = 32;
 const TOKEN_ENCODED_BYTES: usize = 43;
+const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
 const TOKEN_DOMAIN: &[u8] = b"automata.runner-enrollment-token.v1\0";
 const REDEEM_REQUEST_DOMAIN: &[u8] = b"automata.runner-enrollment-request.v1\0";
 const MAX_REQUEST_BYTES: usize = 384 * 1_024;
@@ -549,10 +550,11 @@ fn token_digest(token: &[u8]) -> Result<[u8; 32], ApiError> {
     if encoded.len() != TOKEN_ENCODED_BYTES {
         return Err(ApiError::EnrollmentRejected);
     }
-    let decoded = URL_SAFE_NO_PAD
-        .decode(encoded)
+    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
+    let decoded_length = URL_SAFE_NO_PAD
+        .decode_slice(encoded, &mut *decoded)
         .map_err(|_| ApiError::EnrollmentRejected)?;
-    if decoded.len() != TOKEN_BYTES {
+    if decoded_length != TOKEN_BYTES {
         return Err(ApiError::EnrollmentRejected);
     }
     let mut digest = Sha256::new();

--- a/crates/automata-ci/src/cli/runner.rs
+++ b/crates/automata-ci/src/cli/runner.rs
@@ -20,7 +20,9 @@ use super::{
 
 const ENROLLMENTS_PATH: &str = "/api/v1/runner-enrollments";
 const TOKEN_PREFIX: &str = "atm_re_";
+const TOKEN_BYTES: usize = 32;
 const TOKEN_ENCODED_BYTES: usize = 43;
+const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
 const CREATE_ATTEMPTS: usize = 3;
 
 pub(crate) async fn execute_runner_command(
@@ -185,20 +187,28 @@ async fn send(
 }
 
 fn generate_token() -> Result<Zeroizing<String>> {
-    let mut entropy = Zeroizing::new([0_u8; 32]);
+    let mut entropy = Zeroizing::new([0_u8; TOKEN_BYTES]);
     getrandom::fill(&mut *entropy).context("runner enrollment token entropy is unavailable")?;
-    Ok(Zeroizing::new(format!(
-        "{TOKEN_PREFIX}{}",
-        URL_SAFE_NO_PAD.encode(entropy.as_slice())
-    )))
+    let mut token = Zeroizing::new(String::with_capacity(
+        TOKEN_PREFIX.len() + TOKEN_ENCODED_BYTES,
+    ));
+    token.push_str(TOKEN_PREFIX);
+    URL_SAFE_NO_PAD.encode_string(entropy.as_slice(), &mut token);
+    Ok(token)
 }
 
 fn valid_generated_token(token: &str) -> bool {
-    token
+    let Some(encoded) = token
         .strip_prefix(TOKEN_PREFIX)
         .filter(|encoded| encoded.len() == TOKEN_ENCODED_BYTES)
-        .and_then(|encoded| URL_SAFE_NO_PAD.decode(encoded).ok())
-        .is_some_and(|decoded| decoded.len() == 32)
+    else {
+        return false;
+    };
+    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
+    matches!(
+        URL_SAFE_NO_PAD.decode_slice(encoded, &mut *decoded),
+        Ok(TOKEN_BYTES)
+    )
 }
 
 fn print_token(output: OutputFormat, issued: &IssuedToken) -> Result<()> {
@@ -286,4 +296,19 @@ struct IssuedTokenOutput<'a> {
     token: &'a str,
     runner_group: &'a str,
     expires_at_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    use super::{TOKEN_PREFIX, valid_generated_token};
+
+    #[test]
+    fn pending_token_validation_accepts_only_the_canonical_secret_shape() {
+        let token = format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode([7_u8; 32]));
+        assert!(valid_generated_token(&token));
+        assert!(!valid_generated_token("plain-secret"));
+        assert!(!valid_generated_token(&format!("{token}A")));
+    }
 }

--- a/docs/github-actions-parity/github-actions-parity-11-integration-tests.md
+++ b/docs/github-actions-parity/github-actions-parity-11-integration-tests.md
@@ -30,8 +30,9 @@ This plan was prepared from these exact revisions:
 
 The integration repository contains a useful manual product-path E2E harness.
 It can start real Automata control-plane and runner binaries with PostgreSQL,
-S3-compatible storage, mTLS-enrolled runners, and rootless Podman; send a signed
-webhook through real product ingress; execute locked workflow bytes; and
+S3-compatible storage, pre-enrollment statically provisioned mTLS runners, and
+rootless Podman; send a signed webhook through real product ingress; execute
+locked workflow bytes; and
 require terminal GitHub-compatible Checks plus Automata-native run/job
 evidence. Its default provider is a strict loopback GitHub emulator, not
 GitHub.com. That harness must migrate to the enrollment API before it can gate

--- a/docs/runner-control-plane-security-and-enrollment.md
+++ b/docs/runner-control-plane-security-and-enrollment.md
@@ -50,9 +50,9 @@ are independent of transport TLS.
    digest, consumption marker, exact response receipt, and audit event commit atomically.
 6. The runner verifies the response against local identity/configuration and creates new
    file-backed roots, chain, and private-key destinations without overwriting different material.
-   Matching partial publication is resumed after a crash, and the durable request stage is removed
-   only after all credential files and directory entries are synchronized. The private key never
-   crosses the runner boundary.
+   After a crash, any staged response must match a byte-exact server replay before matching partial
+   publication is resumed. The durable request stage is removed only after all credential files and
+   directory entries are synchronized. The private key never crosses the runner boundary.
 
 Absent, expired, and mismatched consumed tokens return the same error. A matching retry receives
 the byte-exact response committed by the first operation, including after an ambiguous HTTP


### PR DESCRIPTION
## Summary

Follow-up to #63, reconciling the useful hardening from the competing #68 implementation without regressing the stricter enrollment authority now on `main`.

- revalidate time after the enrollment HTTP exchange instead of using a pre-request clock sample
- require a staged enrollment response to match the byte-exact durable server replay before publishing credentials
- decode enrollment tokens into fixed-capacity zeroizing buffers on the operator, runner, and API paths
- build generated token strings directly inside zeroizing storage
- add recovery-at-certificate-expiry and canonical pending-token regression coverage
- expose the fleet ceiling from core only, removing the redundant store re-export
- correct the integration-plan description of its remaining static pre-enrollment harness

## Deliberately retained from #63

- strict single-attribute certificate subjects
- removal and recovery of malformed final response stages
- issuer and server-root validity-window enforcement
- certificate expiry capped to the earliest trust-root expiry
- refactored transactional enrollment creation and conflict handling
- corrected route-cardinality assertions

## Validation

- `CARGO_BUILD_JOBS=2 cargo check --workspace --all-targets`
- `cargo test -p automata-ci-runner --lib` — 98 passed, 3 explicitly host-dependent ignored
- `cargo test -p automata-ci --lib` — 459 passed before the additional focused CLI regression
- focused CLI token regression — passed
- strict `-D warnings` Clippy for changed production crates and tests
- `cargo fmt --all -- --check`
- `git diff --check`

#68 is superseded by #63 plus this focused reconciliation.