### PR TITLE
ci: refresh Store suite inventory

### DIFF
--- a/scripts/ci/tests/store-test-suites.test.py
+++ b/scripts/ci/tests/store-test-suites.test.py
@@ -24,11 +24,11 @@ SUITES = (
 CURRENT_SUITES = set(SUITES[2:])
 SUPPORT_MODULES = {"github_manifest_fixture"}
 EXPECTED_SUITE_INVENTORY = {
-    "store_contracts": (33, 193, 0),
+    "store_contracts": (34, 194, 0),
     "store_migration_contracts": (1, 1, 0),
-    "store_postgres_execution": (8, 115, 114),
+    "store_postgres_execution": (9, 118, 117),
     "store_postgres_orchestration": (11, 53, 52),
-    "store_postgres_provider": (12, 101, 101),
+    "store_postgres_provider": (11, 91, 91),
     "store_postgres_security": (9, 43, 38),
 }
 TEST_ATTRIBUTE = re.compile(r"#\[(?:tokio::)?test\]")


### PR DESCRIPTION
Refresh the fail-closed Store suite inventory after merged runner enrollment moved and added reviewed tests.\n\nValidation: `python3 scripts/ci/tests/store-test-suites.test.py` verifies 75 leaves, 500 tests, and 298 PostgreSQL tests.