### PR TITLE
fix: reconcile control-plane metrics budget

### DIFF
--- a/deploy/observability/cardinality.json
+++ b/deploy/observability/cardinality.json
@@ -235,7 +235,7 @@
       ]
     },
     "control_plane": {
-      "series_budget": 5250,
+      "series_budget": 5400,
       "families": [
         {
           "help": "Unix timestamp of the oldest outstanding artifact reservation by kind, or zero when empty.",

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -19,7 +19,7 @@ scrape_configs:
     native_histogram_bucket_limit: 160
     native_histogram_min_bucket_factor: 1.09
     body_size_limit: 2MB
-    sample_limit: 5250
+    sample_limit: 5400
     label_limit: 24
     label_name_length_limit: 128
     label_value_length_limit: 256

--- a/deploy/observability/rules/automata-ci-alerts.yml
+++ b/deploy/observability/rules/automata-ci-alerts.yml
@@ -119,7 +119,7 @@ groups:
         expr: >-
           scrape_samples_post_metric_relabeling{job="automata-runner"} > 980
           or
-          scrape_samples_post_metric_relabeling{job="automata-control-plane"} > 4725
+          scrape_samples_post_metric_relabeling{job="automata-control-plane"} > 4860
         for: 15m
         labels:
           severity: warning

--- a/deploy/observability/rules/tests/automata-ci.test.yml
+++ b/deploy/observability/rules/tests/automata-ci.test.yml
@@ -959,7 +959,9 @@ tests:
       - series: scrape_samples_post_metric_relabeling{job="automata-runner",instance="runner-cardinality"}
         values: 981x25
       - series: scrape_samples_post_metric_relabeling{job="automata-control-plane",instance="cp-cardinality"}
-        values: 4726x25
+        values: 4861x25
+      - series: scrape_samples_post_metric_relabeling{job="automata-control-plane",instance="cp-cardinality-boundary"}
+        values: 4860x25
       - series: automata_ci_control_plane_ready{job="automata-control-plane",instance="cp-unready"}
         values: 0x25
       - series: automata_ci_control_plane_dependency_ready{job="automata-control-plane",instance="cp-dependency",dependency="postgres"}
@@ -996,7 +998,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: Automata target is near its series budget
-              description: Target cp-cardinality exposes 4726 post-relabel samples.
+              description: Target cp-cardinality exposes 4861 post-relabel samples.
               runbook_url: https://github.com/automata-ci/automata/blob/main/deploy/observability/runbooks/metrics-budget.md
       - eval_time: 6m
         alertname: AutomataControlPlaneUnready

--- a/deploy/observability/runbooks/metrics-budget.md
+++ b/deploy/observability/runbooks/metrics-budget.md
@@ -1,9 +1,9 @@
 # Metrics budget pressure
 
-This warning means a target is approaching its 1,000-runner or 5,250-control-
+This warning means a target is approaching its 1,000-runner or 5,400-control-
 plane sample limit. The current reviewed classic maxima are 939 runner and
-5,024 control-plane series. With native and classic histograms ingested
-together, the reviewed Prometheus maxima are 969 runner and 5,169
+5,152 control-plane series. With native and classic histograms ingested
+together, the reviewed Prometheus maxima are 969 runner and 5,299
 control-plane samples per scrape, before Prometheus-generated target metadata.
 
 1. Compare `scrape_samples_post_metric_relabeling` and response size before and
@@ -20,7 +20,7 @@ control-plane samples per scrape, before Prometheus-generated target metadata.
 
 The runner warning starts above 980 post-relabel samples, leaving a small but
 intentional margin below the 1,000 hard limit; the control-plane warning starts
-above 4,725. If a scrape reaches its hard `sample_limit`, Prometheus rejects the
+above 4,860. If a scrape exceeds its hard `sample_limit`, Prometheus rejects the
 entire scrape. Do not increase either limit until both application cardinality
 and native bucket/storage cost have been reviewed.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -116,12 +116,12 @@ scrape. Initial limits are:
 | Concurrent scrapes | 2 | 2 |
 | Handler deadline | 5 seconds | 5 seconds |
 | Encoded response | 2 MiB | 2 MiB |
-| Series per target | 5,250 | 1,000 |
+| Post-relabel samples per scrape | 5,400 | 1,000 |
 
-The canonical schema currently uses at most 5,024 control-plane series and 939
+The canonical schema currently uses at most 5,152 control-plane series and 939
 runner series per Linux target. With native and classic histograms ingested
-together, the Prometheus maxima are 5,169 control-plane samples and 969 runner
-samples per scrape. Both remain below the same 5,250 and 1,000 limits. The
+together, the Prometheus maxima are 5,299 control-plane samples and 969 runner
+samples per scrape. Both remain below the 5,400 and 1,000 limits. The
 limits are release gates; remaining headroom is not an invitation to add
 unbounded labels.
 

--- a/scripts/ci/verify-metrics.sh
+++ b/scripts/ci/verify-metrics.sh
@@ -503,7 +503,7 @@ verify_canonical_prometheus_inventory_job() {
   current_job == "control-plane" && $1 == "sample_limit:" {
     control_raw_sample_limits += 1
   }
-  current_job == "control-plane" && $0 == "    sample_limit: 5250" {
+  current_job == "control-plane" && $0 == "    sample_limit: 5400" {
     control_sample_limits += 1
   }
   current_job == "runner" && $1 == "sample_limit:" {
@@ -958,15 +958,15 @@ jq --exit-status '
   )
   and (
   .profiles as $profiles
-  | ($profiles.control_plane.series_budget == 5250)
+  | ($profiles.control_plane.series_budget == 5400)
     and ($profiles.runner.series_budget == 1000)
     and (($profiles.common.families | map(.maximum_series) | add) == 49)
-    and (($profiles.control_plane.families | map(.maximum_series) | add) == 4975)
+    and (($profiles.control_plane.families | map(.maximum_series) | add) == 5103)
     and (($profiles.runner.families | map(.maximum_series) | add) == 890)
     and (
       (($profiles.common.families | map(.maximum_series) | add)
        + ($profiles.control_plane.families | map(.maximum_series) | add))
-      == 5024
+      == 5152
     )
     and (
       (($profiles.common.families | map(.maximum_series) | add)
@@ -974,14 +974,14 @@ jq --exit-status '
       == 939
     )
     and (($profiles.common | native_label_sets) == 2)
-    and (($profiles.control_plane | native_label_sets) == 143)
+    and (($profiles.control_plane | native_label_sets) == 145)
     and (($profiles.runner | native_label_sets) == 28)
     and (
       (($profiles.common.families | map(.maximum_series) | add)
        + ($profiles.control_plane.families | map(.maximum_series) | add)
        + ($profiles.common | native_label_sets)
        + ($profiles.control_plane | native_label_sets))
-      == 5169
+      == 5299
     )
     and (
       (($profiles.common.families | map(.maximum_series) | add)
@@ -1003,7 +1003,7 @@ jq --exit-status '
          + ($profiles.control_plane.families | map(.maximum_series) | add)
          + ($profiles.common | native_label_sets)
          + ($profiles.control_plane | native_label_sets))
-      == 81
+      == 101
     )
     and (
       (($profiles.common.families | map(.maximum_series) | add)


### PR DESCRIPTION
## Summary

- raise the control-plane Prometheus sample limit to 5,400
- pin the current 5,299-sample maximum and retain 101 samples of headroom
- move the 90% warning boundary to 4,860 with boundary coverage
- align the verifier, docs, runbook, and alert fixtures

## Validation

- independent source review: GO
- JSON/YAML parsing, shell syntax, stale-reference census, and diff checks pass
- full metrics execution remains serialized behind the active audit-owned Rust lane