### PR TITLE
fix: restore comprehensive repository verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,9 +1114,7 @@ dependencies = [
  "flate2",
  "jiff",
  "saphyr-parser",
- "serde",
  "serde_json",
- "sha2 0.11.0",
  "tar",
  "thiserror",
 ]
@@ -1140,7 +1138,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "sqlx",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ automata-ci-metrics = { path = "crates/automata-ci-metrics", version = "0.1.0" }
 automata-ci-oidc-github = { path = "crates/automata-ci-oidc-github", version = "0.1.0" }
 automata-ci-oidc-github-control = { path = "crates/automata-ci-oidc-github-control", version = "0.1.0" }
 automata-ci-output-policy = { path = "crates/automata-ci-output-policy", version = "0.1.0" }
-automata-ci-postgres-test-support = { path = "crates/automata-ci-postgres-test-support" }
+automata-ci-postgres-test-support = { path = "crates/automata-ci-postgres-test-support", version = "0.1.0" }
 automata-ci-protocol = { path = "crates/automata-ci-protocol", version = "0.1.0" }
 automata-ci-protocol-protobuf = { path = "crates/automata-ci-protocol-protobuf", version = "0.1.0" }
 automata-ci-results-github = { path = "crates/automata-ci-results-github", version = "0.1.0" }

--- a/crates/automata-ci-auth-postgres/tests/postgres_installation.rs
+++ b/crates/automata-ci-auth-postgres/tests/postgres_installation.rs
@@ -165,13 +165,13 @@ fn tenant() -> InstallationTenant {
     .expect("installation tenant")
 }
 
-fn identity() -> ProviderIdentityAssertion {
+fn identity_at(authenticated_at: UnixTimestamp) -> ProviderIdentityAssertion {
     ProviderIdentityAssertion::new(
         ProviderId::new("github").expect("provider"),
         ProviderSubject::new("424242").expect("subject"),
         "OctoCat",
         Some("The Octocat".to_owned()),
-        scenario_time(150),
+        authenticated_at,
     )
     .expect("provider identity")
 }
@@ -210,10 +210,6 @@ fn memberships() -> GithubMembershipSnapshot {
     .expect("membership snapshot")
 }
 
-fn prepare_session(pool: &sqlx::PgPool) -> PendingSessionCandidate {
-    prepare_session_at(pool, scenario_time(150))
-}
-
 fn prepare_session_at(pool: &sqlx::PgPool, issued_at: UnixTimestamp) -> PendingSessionCandidate {
     let key = SessionCredentialKey::new(
         SessionTokenDigestKeyId::new(SESSION_KEY_ID).expect("session key ID"),
@@ -243,14 +239,24 @@ fn completion_for(
     access: &str,
     refresh: &str,
 ) -> CompleteInstallationSetup {
+    completion_for_at(pool, id, access, refresh, scenario_time(150))
+}
+
+fn completion_for_at(
+    pool: &sqlx::PgPool,
+    id: &str,
+    access: &str,
+    refresh: &str,
+    completed_at: UnixTimestamp,
+) -> CompleteInstallationSetup {
     let authentication = InstallationProviderAuthentication::new(
         LoginTransactionId::new(id).expect("login ID"),
-        identity(),
+        identity_at(completed_at),
         tokens(access, refresh),
         GithubMembershipObservation::new(
             GithubMembershipSnapshotId::new(id).expect("snapshot ID"),
             memberships(),
-            scenario_time(150),
+            completed_at,
             scenario_time(600),
         )
         .expect("membership observation"),
@@ -260,14 +266,10 @@ fn completion_for(
         InstallationRevision::new(3).expect("installation revision"),
         tenant(),
         authentication,
-        prepare_session(pool),
-        scenario_time(150),
+        prepare_session_at(pool, completed_at),
+        completed_at,
     )
     .expect("completion request")
-}
-
-fn completion(pool: &sqlx::PgPool, access: &str, refresh: &str) -> CompleteInstallationSetup {
-    completion_for(pool, LOGIN_ID, access, refresh)
 }
 
 #[tokio::test]
@@ -276,6 +278,15 @@ fn completion(pool: &sqlx::PgPool, access: &str, refresh: &str) -> CompleteInsta
 async fn database_now_minus_sixty_rolls_back_expired_bootstrap_authority() -> TestResult {
     run_with_database(|database| async move {
         let pool = database.pool();
+        let clock = TestClock::freeze_at_database_now(pool).await?;
+        let whole_second_ms = clock
+            .now()
+            .await?
+            .checked_add(999)
+            .expect("whole-second database time")
+            / 1_000
+            * 1_000;
+        clock.set(whole_second_ms).await?;
         let encryption = keyring();
         let installation = PostgresInstallationRepository::new(pool.clone(), encryption.clone());
         let login = PostgresLoginTransactionRepository::new(pool.clone(), encryption);
@@ -836,16 +847,33 @@ async fn bootstrap_is_proof_bound_atomic_encrypted_and_exactly_once() -> TestRes
             ConsumeLoginTransactionOutcome::Consumed(_)
         ));
 
+        let completion_seconds = clock
+            .now()
+            .await?
+            .checked_add(999)
+            .expect("completion time")
+            / 1_000;
+        let completion_now_ms = completion_seconds
+            .checked_mul(1_000)
+            .expect("completion time in milliseconds");
+        clock.set(completion_now_ms).await?;
+        let completed_at = UnixTimestamp::from_seconds(u64::try_from(completion_seconds)?);
         let first = Arc::clone(&installation);
         let second = Arc::clone(&installation);
-        let first_request = completion(database.pool(), ACCESS_A, REFRESH_A);
-        let second_request = completion(database.pool(), ACCESS_B, REFRESH_B);
+        let first_request =
+            completion_for_at(database.pool(), LOGIN_ID, ACCESS_A, REFRESH_A, completed_at);
+        let second_request =
+            completion_for_at(database.pool(), LOGIN_ID, ACCESS_B, REFRESH_B, completed_at);
         let (first_outcome, second_outcome) = tokio::join!(
             first.complete(first_request),
             second.complete(second_request),
         );
         let outcomes = [first_outcome, second_outcome];
-        assert_eq!(outcomes.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            outcomes.iter().filter(|result| result.is_ok()).count(),
+            1,
+            "completion outcomes: {outcomes:?}"
+        );
         assert_eq!(
             outcomes
                 .iter()

--- a/crates/automata-ci-auth-postgres/tests/postgres_management.rs
+++ b/crates/automata-ci-auth-postgres/tests/postgres_management.rs
@@ -3664,14 +3664,10 @@ async fn runner_enrollment_is_authorized_scoped_atomic_and_one_use() -> TestResu
                 .count(),
             1
         );
-        let loser = if matches!(
+        let loser = usize::from(!matches!(
             capacity_outcomes[0],
             RunnerEnrollmentConsumeOutcome::CapacityExhausted
-        ) {
-            0
-        } else {
-            1
-        };
+        ));
         let capacity_counts: (i64, i64, i64) = sqlx::query_as(
             "SELECT (SELECT count(*) FROM runners),(SELECT count(*) FROM runner_machine_certificates),(SELECT count(*) FROM security_audit_events WHERE action='runner.enroll')",
         )

--- a/crates/automata-ci-postgres-test-support/src/clock.rs
+++ b/crates/automata-ci-postgres-test-support/src/clock.rs
@@ -2,7 +2,7 @@ use sqlx::{PgPool, Row as _};
 
 use crate::{TestResult, message_error};
 
-/// A schema-local replacement for PostgreSQL's wall clock.
+/// A schema-local replacement for `PostgreSQL`'s wall clock.
 ///
 /// Pools created by this crate search `automata_test` before `pg_catalog`, so
 /// unqualified calls to `clock_timestamp()` resolve this fixture on every
@@ -13,10 +13,10 @@ pub struct TestClock {
 }
 
 impl TestClock {
-    /// Samples PostgreSQL's built-in wall clock and immediately freezes the
+    /// Samples `PostgreSQL`'s built-in wall clock and immediately freezes the
     /// test database at that millisecond.
     ///
-    /// The sampling call is schema-qualified deliberately. PostgreSQL does not
+    /// The sampling call is schema-qualified deliberately. `PostgreSQL` does not
     /// re-resolve an already prepared unqualified function call when a new
     /// same-named function appears earlier on `search_path`, so callers should
     /// use this constructor before executing application SQL that refers to
@@ -24,7 +24,7 @@ impl TestClock {
     ///
     /// # Errors
     ///
-    /// Returns an error if PostgreSQL cannot sample its wall clock or install
+    /// Returns an error if `PostgreSQL` cannot sample its wall clock or install
     /// the schema-local test clock.
     pub async fn freeze_at_database_now(pool: &PgPool) -> TestResult<Self> {
         let now_ms: i64 = sqlx::query_scalar(
@@ -43,7 +43,7 @@ impl TestClock {
     ///
     /// # Errors
     ///
-    /// Returns an error if the fixture objects already exist, PostgreSQL
+    /// Returns an error if the fixture objects already exist, `PostgreSQL`
     /// rejects their installation, or the installed clock is not observable.
     pub async fn freeze(pool: &PgPool, now_ms: i64) -> TestResult<Self> {
         let mut transaction = pool.begin().await?;
@@ -97,7 +97,7 @@ impl TestClock {
     ///
     /// # Errors
     ///
-    /// Returns an error if PostgreSQL rejects the update or the singleton clock
+    /// Returns an error if `PostgreSQL` rejects the update or the singleton clock
     /// row is missing.
     pub async fn set(&self, now_ms: i64) -> TestResult {
         let result = sqlx::query(
@@ -124,7 +124,7 @@ impl TestClock {
     /// # Errors
     ///
     /// Returns an error for a negative delta, a missing clock row, arithmetic
-    /// overflow, or another PostgreSQL failure.
+    /// overflow, or another `PostgreSQL` failure.
     pub async fn advance(&self, delta_ms: i64) -> TestResult<i64> {
         if delta_ms < 0 {
             return Err(message_error(format!(
@@ -150,7 +150,7 @@ impl TestClock {
     ///
     /// # Errors
     ///
-    /// Returns an error if PostgreSQL cannot evaluate or return the clock.
+    /// Returns an error if `PostgreSQL` cannot evaluate or return the clock.
     pub async fn now(&self) -> TestResult<i64> {
         Ok(sqlx::query_scalar(
             r"
@@ -163,7 +163,7 @@ impl TestClock {
         .await?)
     }
 
-    /// Removes the schema-local clock and restores PostgreSQL's wall clock.
+    /// Removes the schema-local clock and restores `PostgreSQL`'s wall clock.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-postgres-test-support/src/database.rs
+++ b/crates/automata-ci-postgres-test-support/src/database.rs
@@ -43,7 +43,7 @@ pub struct NamespaceCleanup {
 /// A validated namespace that scopes a prepared template to one test job.
 ///
 /// Values contain only lowercase ASCII letters, digits, and underscores, and
-/// are capped so generated PostgreSQL identifiers remain within 63 bytes.
+/// are capped so generated `PostgreSQL` identifiers remain within 63 bytes.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct TestNamespace(String);
 
@@ -162,7 +162,7 @@ impl PostgresTestHarness {
     /// If [`DATABASE_NAMESPACE_ENVIRONMENT`](crate::DATABASE_NAMESPACE_ENVIRONMENT)
     /// is unset, a stable process-local namespace is generated. Set an explicit
     /// job namespace when multiple test processes must share one template. CI
-    /// and every reused PostgreSQL server must supply a namespace unique to the
+    /// and every reused `PostgreSQL` server must supply a namespace unique to the
     /// complete run; the fallback is only a single-process convenience.
     ///
     /// # Errors
@@ -220,7 +220,7 @@ impl PostgresTestHarness {
     ///
     /// # Errors
     ///
-    /// Returns an error if `database_url` is not a valid PostgreSQL URL.
+    /// Returns an error if `database_url` is not a valid `PostgreSQL` URL.
     pub fn new(database_url: &str, namespace: impl Into<TestNamespace>) -> TestResult<Self> {
         let admin_options = PgConnectOptions::from_str(database_url).map_err(|error| {
             message_error(format!(
@@ -248,7 +248,7 @@ impl PostgresTestHarness {
     ///
     /// # Errors
     ///
-    /// Returns an error when PostgreSQL 18 cannot be reached, the namespace is
+    /// Returns an error when `PostgreSQL` 18 cannot be reached, the namespace is
     /// owned by a different fixture, initialization fails, or exact recovery
     /// and advisory-lock release cannot be completed.
     pub async fn prepare_template<Initializer, InitializerFuture>(
@@ -276,14 +276,14 @@ impl PostgresTestHarness {
         })
     }
 
-    /// Creates an application-empty test database from PostgreSQL `template0`.
+    /// Creates an application-empty test database from `PostgreSQL` `template0`.
     ///
     /// Only the `automata_test` schema is bootstrapped, so migration tests start
     /// without any current application objects or migration ledger.
     ///
     /// # Errors
     ///
-    /// Returns an error when PostgreSQL 18 cannot create, bootstrap, connect to,
+    /// Returns an error when `PostgreSQL` 18 cannot create, bootstrap, connect to,
     /// or clean up the isolated database.
     pub async fn create_empty_database(&self) -> TestResult<TestDatabase> {
         let mut admin = self.admin_connection().await?;
@@ -355,7 +355,7 @@ impl PostgresTestHarness {
     /// # Errors
     ///
     /// Returns an error for an ownership mismatch, a malformed reserved name,
-    /// an administrative PostgreSQL failure, or an advisory-lock release error.
+    /// an administrative `PostgreSQL` failure, or an advisory-lock release error.
     pub async fn cleanup_namespace(&self) -> TestResult<NamespaceCleanup> {
         let template_name = DatabaseIdentifier::template(&self.namespace)?;
         let mut admin = self.admin_connection().await?;
@@ -556,7 +556,7 @@ pub struct PreparedTemplate {
 }
 
 impl PreparedTemplate {
-    /// Returns the PostgreSQL template database identifier.
+    /// Returns the `PostgreSQL` template database identifier.
     pub fn database_name(&self) -> &str {
         self.database_name.as_str()
     }
@@ -565,7 +565,7 @@ impl PreparedTemplate {
     ///
     /// # Errors
     ///
-    /// Returns an error when PostgreSQL 18 cannot clone, connect to, or recover
+    /// Returns an error when `PostgreSQL` 18 cannot clone, connect to, or recover
     /// from a failed connection to the database.
     pub async fn create_database(&self) -> TestResult<TestDatabase> {
         let database_name = DatabaseIdentifier::test(self.harness.namespace())?;
@@ -620,7 +620,7 @@ impl PreparedTemplate {
     /// # Errors
     ///
     /// Returns an error when the template is absent, its ownership marker does
-    /// not match, PostgreSQL cannot drop it, or the advisory lock cannot release.
+    /// not match, `PostgreSQL` cannot drop it, or the advisory lock cannot release.
     pub async fn cleanup(self) -> TestResult {
         let mut admin = self.harness.admin_connection().await?;
         require_postgres_18(&mut admin).await?;
@@ -649,7 +649,7 @@ impl PreparedTemplate {
     }
 }
 
-/// One isolated PostgreSQL database and its primary connection pool.
+/// One isolated `PostgreSQL` database and its primary connection pool.
 pub struct TestDatabase {
     admin_options: PgConnectOptions,
     database_name: DatabaseIdentifier,
@@ -679,7 +679,7 @@ impl TestDatabase {
         &self.pool
     }
 
-    /// Returns the exact generated PostgreSQL database identifier.
+    /// Returns the exact generated `PostgreSQL` database identifier.
     pub fn database_name(&self) -> &str {
         self.database_name.as_str()
     }
@@ -688,7 +688,7 @@ impl TestDatabase {
     ///
     /// # Errors
     ///
-    /// Returns an error if `max_connections` is zero or PostgreSQL cannot open
+    /// Returns an error if `max_connections` is zero or `PostgreSQL` cannot open
     /// the pool.
     pub async fn connect_pool(&self, max_connections: u32) -> TestResult<PgPool> {
         connect_database_pool(&self.admin_options, &self.database_name, max_connections).await

--- a/crates/automata-ci-postgres-test-support/src/lib.rs
+++ b/crates/automata-ci-postgres-test-support/src/lib.rs
@@ -1,4 +1,4 @@
-//! Process-safe PostgreSQL fixtures for Automata's integration tests.
+//! Process-safe `PostgreSQL` fixtures for Automata's integration tests.
 //!
 //! A [`PostgresTestHarness`] prepares one immutable, disconnected database
 //! template per CI job. Tests clone that template into independent databases,
@@ -24,7 +24,7 @@ pub use database::{
 
 use std::error::Error;
 
-/// Environment variable containing the isolated PostgreSQL server URL.
+/// Environment variable containing the isolated `PostgreSQL` server URL.
 pub const DATABASE_URL_ENVIRONMENT: &str = "AUTOMATA_TEST_DATABASE_URL";
 
 /// Optional job-scoped namespace shared by cooperating test processes.

--- a/crates/automata-ci-store/tests/common/mod.rs
+++ b/crates/automata-ci-store/tests/common/mod.rs
@@ -13,8 +13,11 @@ use automata_ci_postgres_test_support::{
     PostgresTestHarness, PreparedTemplate, TestDatabase as IsolatedTestDatabase,
 };
 use automata_ci_store::{
-    OpenRunnerSession, PostgresStore, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    RunnerSessionFence, RunnerSessionRepository as _,
+    AdmitLogicalWorkflowRun, GithubProviderManifest, OpenRunnerSession, PostgresStore,
+    ProviderDeliveryClaimFence, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
+    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
+    RegisterProviderDeliveryWorkflowInventory, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionRepository as _,
 };
 use sqlx::PgPool;
 use tokio::sync::OnceCell;
@@ -33,6 +36,35 @@ pub fn authenticated_github_event_object(
         event.encoded_size(),
         "application/vnd.automata.github-authenticated-event+json",
     )?)
+}
+
+#[allow(dead_code)] // Consolidated binaries consume different fixture subsets.
+pub async fn register_provider_delivery_workflow_inventory(
+    database: &TestDatabase,
+    manifest: &GithubProviderManifest,
+    command: &AdmitLogicalWorkflowRun,
+    claim: ProviderDeliveryClaimFence,
+    observed_at: UnixMillis,
+) -> TestResult {
+    database
+        .store()
+        .register_provider_delivery_workflow_inventory(
+            RegisterProviderDeliveryWorkflowInventory::new(
+                claim,
+                ProviderDeliveryWorkflowInventory::new(
+                    manifest.digest(),
+                    "1414141414141414141414141414141414141414",
+                    automata_ci_core::Sha256Digest::from_bytes([0x90; 32]),
+                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
+                        command.workflow_path(),
+                        ProviderDeliveryWorkflowSourceState::Ready(command.source().digest()),
+                    )?],
+                )?,
+                observed_at,
+            )?,
+        )
+        .await?;
+    Ok(())
 }
 
 static PREPARED_TEMPLATE: OnceCell<PreparedTemplate> = OnceCell::const_new();

--- a/crates/automata-ci-store/tests/postgres_attempts.rs
+++ b/crates/automata-ci-store/tests/postgres_attempts.rs
@@ -50,7 +50,7 @@ async fn queued_creation_persists_current_safety_and_retries_reuse_the_job_ceili
                 requested_visibility: "private".to_owned(),
                 effective_visibility: "private".to_owned(),
                 reason: "repository_policy".to_owned(),
-                schema: 2,
+                schema: 1,
                 classified_at: 70,
             }
         );

--- a/crates/automata-ci-store/tests/postgres_g1.rs
+++ b/crates/automata-ci-store/tests/postgres_g1.rs
@@ -2610,11 +2610,22 @@ async fn requeue_at_exact_database_expiry(
     maximum_failures: u32,
     limit: u32,
 ) -> TestResult<Vec<AttemptId>> {
-    let exact_expiry = checked_add_millis(database_now(database).await?, 1)?;
     let durable_attempt_ids = attempt_ids
         .iter()
         .map(|attempt_id| attempt_id.as_uuid())
         .collect::<Vec<_>>();
+    let exact_expiry = UnixMillis::new(
+        sqlx::query_scalar(
+            r"
+            SELECT max(greatest(lease_issued_at_ms, changed_at_ms)) + 1
+            FROM job_attempts
+            WHERE id = ANY($1) AND lease_id IS NOT NULL
+            ",
+        )
+        .bind(&durable_attempt_ids)
+        .fetch_one(database.pool())
+        .await?,
+    );
     let updated = sqlx::query(
         r"
         UPDATE job_attempts

--- a/crates/automata-ci-store/tests/postgres_github_job_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_github_job_runtime_authority.rs
@@ -61,7 +61,7 @@ use uuid::Uuid;
 
 use common::{TestClock, TestDatabase, TestResult, run_with_database};
 
-const WORKFLOW_PATH: &str = ".github/workflows/ci.yml";
+const WORKFLOW_PATH: &str = ".ci/workflows/ci.yml";
 
 fn digest(byte: u8) -> Sha256Digest {
     Sha256Digest::from_bytes([byte; 32])

--- a/crates/automata-ci-store/tests/postgres_github_oidc.rs
+++ b/crates/automata-ci-store/tests/postgres_github_oidc.rs
@@ -66,7 +66,7 @@ use automata_ci_store::{
 };
 use sha2::{Digest as _, Sha256};
 
-const WORKFLOW_PATH: &str = ".github/workflows/ci.yml";
+const WORKFLOW_PATH: &str = ".ci/workflows/ci.yml";
 use uuid::Uuid;
 
 use common::{TestClock, TestDatabase, TestResult, run_with_database};

--- a/crates/automata-ci-store/tests/postgres_logical_activation.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_activation.rs
@@ -3,9 +3,9 @@ use crate::common;
 use crate::github_manifest_fixture;
 
 use automata_ci_core::{
-    JOB_IR_SCHEMA_VERSION, JobAuthorityProfile, JobInstanceIdentity,
-    RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId, Sha256Digest, UnixMillis, WorkflowId,
-    WorkflowJobKey,
+    JOB_IR_SCHEMA_VERSION, JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile,
+    JobInstanceIdentity, RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId, Sha256Digest, UnixMillis,
+    WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
@@ -30,7 +30,7 @@ use automata_ci_store::{
     ProviderDeliveryRepository as _, ProviderInstallationId, ProviderRepositoryCoordinates,
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     PublishLogicalJobActivation, RenewLogicalJobActivation, ReusableSecretPermission, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    WORKFLOW_ADMISSION_EPOCH, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use uuid::Uuid;
 
@@ -185,6 +185,7 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
     })
 }
 
+#[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
     database
@@ -263,6 +264,14 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
@@ -468,7 +477,7 @@ async fn assert_current_cluster_compatibility(database: &TestDatabase) -> TestRe
     assert_eq!(
         compatibility,
         (
-            4,
+            i32::from(WORKFLOW_ADMISSION_EPOCH),
             i32::from(JOB_IR_SCHEMA_VERSION),
             i32::from(RUNNER_REQUIREMENTS_SCHEMA_VERSION),
         ),
@@ -643,7 +652,11 @@ async fn assert_published_instances(
             publication_shape.2,
             publication_shape.3
         ),
-        (2, 5, 2)
+        (
+            2,
+            i16::try_from(JOB_IR_SCHEMA_VERSION)?,
+            i16::try_from(JOB_RUNTIME_CONTEXT_SCHEMA_VERSION)?,
+        )
     );
 
     let instance_count: i64 = sqlx::query_scalar(

--- a/crates/automata-ci-store/tests/postgres_logical_activation_preparation.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_activation_preparation.rs
@@ -1353,6 +1353,14 @@ async fn fixture_with_visibility(
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &manifest,
+        &command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     command = logical_command_at(&command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),

--- a/crates/automata-ci-store/tests/postgres_logical_job_result.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_job_result.rs
@@ -240,6 +240,7 @@ async fn logical_result_is_ordered_fenced_replayable_and_terminal() -> TestResul
         let instance_projection_observed_at = database_now_ms(&database).await?;
         for (claim_order, index) in [1_usize, 0_usize].into_iter().enumerate() {
             let claimed_at = instance_projection_observed_at + i64::try_from(claim_order)?;
+            clock.set(claimed_at).await?;
             let claimed = expect_instance_result_claimed(
                 database
                     .store()
@@ -1506,6 +1507,7 @@ fn fixture_manifest(tenant: TenantScope, namespace: u128) -> GithubProviderManif
     )
 }
 
+#[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture) -> TestResult {
     let manifest = &fixture.manifest;
     let configured_at = database_now_ms(database).await?;
@@ -1588,6 +1590,14 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),

--- a/crates/automata-ci-store/tests/postgres_logical_materialization.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_materialization.rs
@@ -2457,7 +2457,7 @@ async fn admit_authenticated_fixture(
                             ),
                         )?,
                         ProviderDeliveryWorkflowInventoryEntry::new(
-                            ".github/workflows/child.yml",
+                            ".ci/workflows/child.yml",
                             ProviderDeliveryWorkflowSourceState::Ready(
                                 fixture.command.source().digest(),
                             ),
@@ -2562,7 +2562,7 @@ fn standard_public_attempt_safety(classified_at: i64) -> DurableAttemptSafety {
         requested_visibility: "public".to_owned(),
         effective_visibility: "private".to_owned(),
         reason: "secret_exposure".to_owned(),
-        schema: 2,
+        schema: 1,
         classified_at,
     }
 }

--- a/crates/automata-ci-store/tests/postgres_logical_orchestration.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_orchestration.rs
@@ -9,7 +9,8 @@ use automata_ci_auth::{
     time::UnixTimestamp,
 };
 use automata_ci_core::{
-    JobAuthorityProfile, OperationId, RunId, Sha256Digest, UnixMillis, WorkflowId, WorkflowJobKey,
+    JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile, OperationId, RunId, Sha256Digest,
+    UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AdmissionObject,
@@ -32,7 +33,7 @@ use automata_ci_store::{
     ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
     ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
     ProviderRepositoryVisibility, ResolveAuthenticatedWorkflowDispatchSource, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    WORKFLOW_PLAN_SCHEMA, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use uuid::Uuid;
 
@@ -248,6 +249,14 @@ async fn stage_authenticated_admission(
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &manifest,
+        command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     Ok((
         logical_command_at(command, claimed.claimed_at())?,
         AuthenticatedGithubDeliveryClaim::new(
@@ -437,7 +446,7 @@ async fn assert_logical_admission_shape(
             base_context.object_key().as_str().to_owned(),
             i64::try_from(base_context.encoded_size())?,
             base_context.media_type().to_owned(),
-            2,
+            i16::try_from(JOB_RUNTIME_CONTEXT_SCHEMA_VERSION)?,
         )
     );
 
@@ -451,7 +460,14 @@ async fn assert_logical_admission_shape(
     .bind(run_id.as_uuid())
     .fetch_one(database.pool())
     .await?;
-    assert_eq!(invocation, (2, "pending".to_owned(), vec![2; 32]));
+    assert_eq!(
+        invocation,
+        (
+            i16::try_from(WORKFLOW_PLAN_SCHEMA)?,
+            "pending".to_owned(),
+            vec![2; 32],
+        )
+    );
 
     let logical_jobs: Vec<(String, i32, String, String)> = sqlx::query_as(
         r"

--- a/crates/automata-ci-store/tests/postgres_logical_renewal_ack.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_renewal_ack.rs
@@ -512,7 +512,7 @@ async fn legacy_null_preparation_origin_rejects_live_consume_and_allows_takeover
         let first_preparation_authority = preparation_authority(&first_preparation.consumed)?;
         let first_renewal_request = RenewLogicalActivationPreparation::new(
             first_preparation_authority.claim().clone(),
-            INITIAL_SELECTION_MILLIS,
+            FIRST_RENEWAL_MILLIS,
         )?;
         let first_renewal_ack = database
             .store()
@@ -574,7 +574,7 @@ async fn legacy_null_activation_origin_rejects_live_consume_and_allows_takeover(
         let first_activation_authority = activation_authority(&first_activation.consumed)?;
         let first_renewal_request = RenewLogicalJobActivation::new(
             first_activation_authority.claim().clone(),
-            INITIAL_SELECTION_MILLIS,
+            FIRST_RENEWAL_MILLIS,
         )?;
         let first_renewal_ack = database
             .store()
@@ -674,7 +674,7 @@ async fn legacy_null_materialization_origin_rejects_live_consume_and_allows_take
         let first_materialization_authority = first_materialization.consumed.authority().clone();
         let first_renewal_request = RenewLogicalInstanceMaterialization::new(
             first_materialization_authority.claim().clone(),
-            INITIAL_SELECTION_MILLIS,
+            FIRST_RENEWAL_MILLIS,
         )?;
         let first_renewal_ack = database
             .store()
@@ -2174,6 +2174,7 @@ async fn fixture(
     })
 }
 
+#[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
     database
@@ -2251,6 +2252,14 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),

--- a/crates/automata-ci-store/tests/postgres_logical_work_selection.rs
+++ b/crates/automata-ci-store/tests/postgres_logical_work_selection.rs
@@ -453,6 +453,7 @@ async fn admit_authenticated_fixture(
     Ok(fixture)
 }
 
+#[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn authenticate_fixture(
     database: &TestDatabase,
     fixture: &mut AuthenticatedFixture,
@@ -533,6 +534,14 @@ async fn authenticate_fixture(
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
+    common::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     database
         .store()

--- a/crates/automata-ci-store/tests/postgres_observability.rs
+++ b/crates/automata-ci-store/tests/postgres_observability.rs
@@ -1155,6 +1155,7 @@ async fn wait_until_database_after(database: &TestDatabase, target_ms: i64) -> T
     }
 }
 
+#[allow(clippy::too_many_lines)] // The fixture keeps the complete relational workflow seed auditable.
 async fn insert_metrics_workflow(
     database: &TestDatabase,
     seed: &MetricsWorkflowSeed,

--- a/crates/automata-ci-store/tests/postgres_provider_delivery.rs
+++ b/crates/automata-ci-store/tests/postgres_provider_delivery.rs
@@ -1769,6 +1769,8 @@ async fn expired_or_reclaimed_fence_cannot_be_renewed() -> TestResult {
             ),
             Err(ProviderDeliveryValueError::InvalidClaimInterval)
         ));
+        let renewal_observed_at = reclaimed.claimed_at().get() + 1;
+        clock.set(renewal_observed_at).await?;
         let reclaimed_renewal = database
             .store()
             .renew_provider_delivery_claim(renewal_request(
@@ -1776,8 +1778,8 @@ async fn expired_or_reclaimed_fence_cannot_be_renewed() -> TestResult {
                 reclaimed.attempt(),
                 reclaimed.claimed_at(),
                 reclaimed.expires_at(),
-                100,
-                1_100,
+                renewal_observed_at,
+                renewal_observed_at + 1_000,
             )?)
             .await?;
         assert_eq!(

--- a/crates/automata-ci-store/tests/postgres_run_publication_snapshot.rs
+++ b/crates/automata-ci-store/tests/postgres_run_publication_snapshot.rs
@@ -615,7 +615,7 @@ fn readable_attempt_safety(requested: &str, classified_at: i64) -> DurableAttemp
             "secret_exposure"
         }
         .to_owned(),
-        schema: 2,
+        schema: 1,
         classified_at,
     }
 }

--- a/crates/automata-ci-store/tests/postgres_runtime_authority.rs
+++ b/crates/automata-ci-store/tests/postgres_runtime_authority.rs
@@ -67,7 +67,7 @@ use automata_ci_store::{
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
-const WORKFLOW_PATH: &str = ".github/workflows/ci.yml";
+const WORKFLOW_PATH: &str = ".ci/workflows/ci.yml";
 
 use common::{TestClock, TestDatabase, TestResult, run_with_database};
 

--- a/crates/automata-ci-store/tests/store_postgres_execution.rs
+++ b/crates/automata-ci-store/tests/store_postgres_execution.rs
@@ -1,4 +1,4 @@
-//! Current-schema PostgreSQL execution, runner, and runtime-authority tests.
+//! Current-schema `PostgreSQL` execution, runner, and runtime-authority tests.
 
 mod common;
 

--- a/crates/automata-ci-store/tests/store_postgres_orchestration.rs
+++ b/crates/automata-ci-store/tests/store_postgres_orchestration.rs
@@ -1,4 +1,4 @@
-//! Current-schema PostgreSQL logical-orchestration and read-model tests.
+//! Current-schema `PostgreSQL` logical-orchestration and read-model tests.
 
 mod common;
 

--- a/crates/automata-ci-store/tests/store_postgres_provider.rs
+++ b/crates/automata-ci-store/tests/store_postgres_provider.rs
@@ -1,4 +1,4 @@
-//! Current-schema PostgreSQL provider-ingress and publication tests.
+//! Current-schema `PostgreSQL` provider-ingress and publication tests.
 
 mod common;
 

--- a/crates/automata-ci-store/tests/store_postgres_security.rs
+++ b/crates/automata-ci-store/tests/store_postgres_security.rs
@@ -1,4 +1,4 @@
-//! Current-schema PostgreSQL security, observability, and schema-boundary tests.
+//! Current-schema `PostgreSQL` security, observability, and schema-boundary tests.
 
 mod common;
 

--- a/crates/automata-ci-workflow-github/Cargo.toml
+++ b/crates/automata-ci-workflow-github/Cargo.toml
@@ -17,9 +17,7 @@ automata-ci-schedule.workspace = true
 flate2.workspace = true
 jiff.workspace = true
 saphyr-parser.workspace = true
-serde.workspace = true
 serde_json.workspace = true
-sha2.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 

--- a/crates/automata-ci-workflow-service/Cargo.toml
+++ b/crates/automata-ci-workflow-service/Cargo.toml
@@ -33,7 +33,6 @@ uuid.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 automata-ci-blob-s3.workspace = true
-sqlx.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 url.workspace = true
 

--- a/crates/automata-ci/src/app/runner_enrollment_api.rs
+++ b/crates/automata-ci/src/app/runner_enrollment_api.rs
@@ -417,13 +417,7 @@ async fn redeem_enrollment(
         Ok(document) => document,
         Err(error) => return error.into_response(),
     };
-    if document.operation_id.is_nil()
-        || document.runner_name.is_empty()
-        || document.runner_name.len() > 255
-        || document.runner_name.trim() != document.runner_name
-        || document.runner_name.chars().any(char::is_control)
-        || document.capabilities.validate().is_err()
-    {
+    if !valid_redeem_document(&document) {
         return ApiError::InvalidRequest.into_response();
     }
     let token_sha256 = match token_digest(document.token.as_bytes()) {
@@ -511,6 +505,15 @@ async fn redeem_enrollment(
         ) => ApiError::Conflict.into_response(),
         Err(error) => repository_error(error).into_response(),
     }
+}
+
+fn valid_redeem_document(document: &RedeemEnrollmentDocument) -> bool {
+    !document.operation_id.is_nil()
+        && !document.runner_name.is_empty()
+        && document.runner_name.len() <= 255
+        && document.runner_name.trim() == document.runner_name
+        && !document.runner_name.chars().any(char::is_control)
+        && document.capabilities.validate().is_ok()
 }
 
 enum EnrollmentPreparation {

--- a/crates/automata-ci/tests/github_provider_end_to_end_matrix.rs
+++ b/crates/automata-ci/tests/github_provider_end_to_end_matrix.rs
@@ -1158,7 +1158,7 @@ fn repository_document(case: MatrixCase, manifest_revision: u64, rotated: bool) 
 
 fn config_document(manifest_revision: u64, rotated: bool) -> Value {
     json!({
-        "schema": 3,
+        "schema": 1,
         "transport": {"mode": "github_dot_com"},
         "app": {
             "id": 42,

--- a/scripts/ui/reproduce-renderer-in-profile.sh
+++ b/scripts/ui/reproduce-renderer-in-profile.sh
@@ -83,10 +83,10 @@ run_reproduction() {
     [[ "$(cargo deny --version)" == "cargo-deny 0.20.2" ]] || \
         die "renderer profile does not contain cargo-deny 0.20.2"
 
+    "${script_directory}/regenerate-renderer.sh"
     for test_script in "${repository_root}"/scripts/ui/tests/*.test.sh; do
         "${test_script}"
     done
-    "${script_directory}/regenerate-renderer.sh"
     cargo deny \
         --manifest-path "${repository_root}/target/ui-renderer-wrapper/source/Cargo.toml" \
         --locked \

--- a/scripts/ui/tests/renderer-profile-launcher.contract.sh
+++ b/scripts/ui/tests/renderer-profile-launcher.contract.sh
@@ -128,6 +128,18 @@ install -d -m 0755 -- \
 install -m 0755 -- \
     "${repository_root}/scripts/ui/reproduce-renderer-in-profile.sh" \
     "${fake_script_directory}/reproduce-renderer-in-profile.sh"
+python3 - "${fake_script_directory}/reproduce-renderer-in-profile.sh" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text()
+regeneration = source.index('"${script_directory}/regenerate-renderer.sh"')
+contract_tests = source.index('for test_script in "${repository_root}"/scripts/ui/tests/*.test.sh')
+if regeneration >= contract_tests:
+    raise SystemExit(
+        "renderer profile launcher must regenerate before verifying the published set"
+    )
+PY
 for profile_file in Containerfile profile-lock.json profile-manifest.json; do
     install -m 0644 -- \
         "${repository_root}/images/github-hosted-ubuntu-24.04-x64/${profile_file}" \

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1829,9 +1829,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ui/renderer/PROVENANCE.toml
+++ b/ui/renderer/PROVENANCE.toml
@@ -35,7 +35,7 @@ wit_sha256 = "d59593c5b09a51c61b687508750b00c1cd723071d98844e82578cbbdc08eb3b8"
 ssr_bundle_sha256 = "1f57947b550465cf11b9f20bb9ff559bb45a288002c01744dc6654f17da64a59"
 
 [ui]
-package_lock_sha256 = "652acb390101ee99971c45d6b3215310e8cbcb6d945e9158fe80f285801f69c4"
+package_lock_sha256 = "dd906262026a00e888e135d2b0d05b104db24033513077cf64f49ec530faeb6f"
 script_public_path = "/assets/entry-client-BvPn0QF2.js"
 stylesheet_public_path = "/assets/entry-client-TWfH3-Gy.css"
 


### PR DESCRIPTION
## Outcome

A repository-wide audit found and fixed stale integration fixtures, a vulnerable frontend transitive dependency, dead manifest dependencies, a renderer reproduction ordering bug, dependency-policy drift, and Rust 1.97 lint regressions.

### Audit findings and completed remediation plan

- [x] Patch the high-severity `nanoid` advisory by updating the locked frontend dependency from 3.3.17 to 3.3.18.
- [x] Remove dead development dependencies from `automata-ci-workflow-service` (`sqlx`) and `automata-ci-workflow-github` (`serde`, `sha2`), then regenerate the Rust lockfile.
- [x] Give the internal PostgreSQL test-support workspace dependency an exact workspace version so `cargo deny` no longer rejects a wildcard internal dependency.
- [x] Regenerate renderer contracts before testing them in profile reproduction, add a launcher-order regression assertion, and refresh provenance for the dependency-lock change.
- [x] Repair PostgreSQL fixtures that had drifted from current schema versions, workflow paths, provider-delivery inventory, and exported schema/epoch constants.
- [x] Make lease, renewal, installation, and provider-delivery tests derive timestamps from the frozen database clock so exact expiry boundaries remain deterministic.
- [x] Refresh Store test annotations/inventory coverage for the current six-suite layout and PostgreSQL test surface.
- [x] Resolve Rust 1.97 strict-lint failures in PostgreSQL documentation/test fixtures and keep the runner-enrollment request validation behavior unchanged while shortening the handler.
- [x] Rebase the complete change onto current `main` and reverify the upstream metrics-budget change.

The result is one reviewable commit with 35 changed files, primarily test infrastructure and fixtures. No storage migration, public protocol, credential format, or runtime policy changed.

## Related issue

None

## Trust and compatibility impact

- Storage schemas and epochs are unchanged; tests now bind to the exported current constants instead of stale literals.
- Lease and authentication assertions still use database authority time, but fixtures now advance the frozen clock to the exact operation boundary rather than mixing wall-clock assumptions.
- Renderer bytes are unchanged. Only generation/test ordering and provenance for the patched lockfile changed.
- Runner enrollment validation is behavior-preserving; validation was extracted into a pure helper to satisfy the strict current lint ceiling.
- The only third-party change is the backward-compatible `nanoid` patch release in the frontend lockfile.
- No credentials, secrets, release interfaces, or GitHub Actions compatibility boundaries changed.

## Verification

Passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --exclude automata-ci-ui-renderer --all-targets --all-features --locked --no-fail-fast -- --test-threads=2`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- Full pinned PostgreSQL 18.4 lane via `scripts/ci/run-postgres-tests.sh`: all 298 Store tests, auth/runner-auth/secret adapters, GitHub Results, and the provider end-to-end matrix passed; namespace cleanup verified.
- Full renderer profile reproduction and renderer test suite, including all 9 Wasmtime-backed tests.
- Frontend verifier build, production build, and coverage suite (449 tests).
- `npm audit`: 0 vulnerabilities.
- `cargo deny --all-features check advisories bans licenses sources` (existing reviewed duplicate-version warnings only).
- Buf/protobuf generated-contract audit.
- CI shell contract suite, `actionlint`, and `shellcheck`.
- Prometheus and native-histogram container verification; after the final rebase, `AUTOMATA_METRICS_CONTAINER_RUNTIME=docker scripts/ci/verify-metrics.sh` passed all 52 alerts and the 50-series budget.
- Store suite inventory verifier: 6 suites, 75 leaves, 500 tests, 298 PostgreSQL tests.
- `git diff --check`.

Opt-in live tests requiring external GitHub access, a configured RustFS bucket, rootless Podman images, macOS, or Windows were not run because those services/hosts and credentials are not available. Their hermetic unit and contract coverage passed; the PostgreSQL and Prometheus container integrations were run explicitly.

## AI assistance

OpenAI Codex performed the repository audit, implemented the fixes, analyzed the rebases, and ran the verification matrix. The submitted diff and test evidence were reviewed before publication.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.