### PR TITLE
Fix browser setup origin and expose safe device diagnostics

### DIFF
--- a/crates/automata-ci/src/app/github_auth.rs
+++ b/crates/automata-ci/src/app/github_auth.rs
@@ -1672,7 +1672,13 @@ async fn poll_setup_device(
     drop(document);
     match state.service.poll_device(credential).await {
         Ok(outcome) => setup_device_poll_response(&state, outcome, state.clock.now()),
-        Err(error) => setup_error_response(error, state.clock.now()),
+        Err(error) => {
+            tracing::warn!(
+                error = ?error,
+                "installation setup device authorization poll failed"
+            );
+            setup_error_response(error, state.clock.now())
+        }
     }
 }
 

--- a/crates/automata-ci/src/app/web/routes.rs
+++ b/crates/automata-ci/src/app/web/routes.rs
@@ -1044,7 +1044,17 @@ async fn installation_setup(
             return internal_server_error();
         }
     };
-    render(state, request_json, csp_nonce).await
+    let mut response = render(state, request_json, csp_nonce).await;
+    // A form POST uses the document's referrer policy when serializing its
+    // Origin header. `no-referrer` therefore produces `Origin: null`, which
+    // cannot satisfy the setup route's exact same-origin admission check.
+    // Keep every cross-origin request opaque while preserving this page's
+    // same-origin setup submission.
+    response.headers_mut().insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("same-origin"),
+    );
+    response
 }
 
 async fn root_redirect(RawQuery(raw_query): RawQuery) -> Response<Body> {
@@ -3319,7 +3329,7 @@ mod tests {
         let response = get(&app, "/setup").await;
         let page = renderer.page();
 
-        assert_page_headers(&response, &page);
+        assert_page_headers_with_referrer(&response, &page, "same-origin");
         assert_eq!(page["page"]["kind"], "setup");
         assert_eq!(page["page"]["form"]["action"], "/setup/auth/github");
         assert_eq!(page["page"]["form"]["returnPath"], "/");
@@ -3422,12 +3432,23 @@ mod tests {
     }
 
     fn assert_page_headers(response: &Response<Body>, page: &Value) {
+        assert_page_headers_with_referrer(response, page, "no-referrer");
+    }
+
+    fn assert_page_headers_with_referrer(
+        response: &Response<Body>,
+        page: &Value,
+        expected_referrer_policy: &str,
+    ) {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers()[CONTENT_TYPE], "text/html; charset=utf-8");
         assert_eq!(response.headers()[CACHE_CONTROL], PAGE_CACHE_CONTROL);
         assert_eq!(response.headers()["x-content-type-options"], "nosniff");
         assert_eq!(response.headers()["x-frame-options"], "DENY");
-        assert_eq!(response.headers()["referrer-policy"], "no-referrer");
+        assert_eq!(
+            response.headers()["referrer-policy"],
+            expected_referrer_policy
+        );
         let nonce = page["host"]["cspNonce"]
             .as_str()
             .expect("page model must contain its CSP nonce");


### PR DESCRIPTION
## Summary
- preserve same-origin referrers on the installation setup document so browser form POSTs satisfy the exact Origin check
- keep the default no-referrer policy on every other rendered page
- log only the sanitized installation device-poll error class before returning the existing public error response

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p automata-ci --lib armed_setup_get_is_queryless_uncached_and_value_free`
- `git diff --check`