### PR TITLE
feat: persist workspace provisioning atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "automata-ci-provisioning-postgres"
+version = "0.1.0"
+dependencies = [
+ "automata-ci-postgres-test-support",
+ "automata-ci-provisioning",
+ "automata-ci-store",
+ "sqlx",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "automata-ci-results-github"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/automata-ci-protocol-protobuf",
     "crates/automata-ci-provisioning",
     "crates/automata-ci-provisioning-grpc",
+    "crates/automata-ci-provisioning-postgres",
     "crates/automata-ci-results-github",
     "crates/automata-ci-runner",
     "crates/automata-ci-runner-auth",
@@ -105,6 +106,7 @@ automata-ci-protocol = { path = "crates/automata-ci-protocol", version = "0.1.0"
 automata-ci-protocol-protobuf = { path = "crates/automata-ci-protocol-protobuf", version = "0.1.0" }
 automata-ci-provisioning = { path = "crates/automata-ci-provisioning", version = "0.1.0" }
 automata-ci-provisioning-grpc = { path = "crates/automata-ci-provisioning-grpc", version = "0.1.0" }
+automata-ci-provisioning-postgres = { path = "crates/automata-ci-provisioning-postgres", version = "0.1.0" }
 automata-ci-results-github = { path = "crates/automata-ci-results-github", version = "0.1.0" }
 automata-ci-runner-auth = { path = "crates/automata-ci-runner-auth", version = "0.1.0" }
 automata-ci-runner-auth-postgres = { path = "crates/automata-ci-runner-auth-postgres", version = "0.1.0" }

--- a/crates/automata-ci-provisioning-grpc/LICENSE
+++ b/crates/automata-ci-provisioning-grpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexander Dzhoganov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-provisioning-grpc/README.md
+++ b/crates/automata-ci-provisioning-grpc/README.md
@@ -9,8 +9,10 @@ port.
 
 The server accepts a pre-bound listener so the product composition root retains
 ownership of startup ordering and port conflicts. It is not yet wired into the
-Automata binary: that happens with the durable workspace provisioning adapter,
-so Core never advertises an endpoint that cannot perform its transaction.
+Automata binary. The durable transaction is implemented by
+`automata-ci-provisioning-postgres`; listener configuration and process
+composition remain a separate product change, so Core does not advertise an
+unconfigured management endpoint.
 
 Cargo generates the private Rust wire module into `OUT_DIR` with Protox and
 Tonic. Building therefore needs no separately installed `protoc` or Buf binary,

--- a/crates/automata-ci-provisioning-postgres/Cargo.toml
+++ b/crates/automata-ci-provisioning-postgres/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "automata-ci-provisioning-postgres"
+description = "PostgreSQL workspace provisioning adapter for Automata Core"
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+automata-ci-provisioning.workspace = true
+sqlx.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+automata-ci-postgres-test-support.workspace = true
+automata-ci-store.workspace = true
+tokio.workspace = true
+

--- a/crates/automata-ci-provisioning-postgres/LICENSE
+++ b/crates/automata-ci-provisioning-postgres/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexander Dzhoganov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-provisioning-postgres/README.md
+++ b/crates/automata-ci-provisioning-postgres/README.md
@@ -1,0 +1,11 @@
+# automata-ci-provisioning-postgres
+
+This crate implements the transport-neutral Core workspace-provisioning port
+against PostgreSQL. One transaction creates the workspace tenant, maps or
+reuses the delegated external actor, grants the initial owner role, appends an
+audit event, and commits an idempotent operation receipt.
+
+It contains no gRPC, TLS, Cloud billing, or private Automata Cloud code. The
+product composition root supplies this adapter to the public management gRPC
+transport.
+

--- a/crates/automata-ci-provisioning-postgres/src/lib.rs
+++ b/crates/automata-ci-provisioning-postgres/src/lib.rs
@@ -1,0 +1,485 @@
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+//! `PostgreSQL` persistence for atomic Core workspace provisioning.
+
+use std::fmt;
+
+use automata_ci_provisioning::{
+    AuthorizedProvisionWorkspace, InitialOwnerPrincipalId, ProvisionWorkspaceResult, ProvisionedAt,
+    ProvisioningFailure, ProvisioningFailureKind, WorkspaceProvisioner,
+    WorkspaceProvisioningFuture,
+};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+const WORKSPACE_OWNER_ROLE_NAME: &str = "workspace-owner";
+const WORKSPACE_OWNER_ROLE_DISPLAY_NAME: &str = "Workspace owner";
+const WORKSPACE_PROVISIONED_AUDIT_ACTION: &str = "workspace.provisioned";
+
+/// Replica-safe `PostgreSQL` implementation of the workspace provisioning port.
+///
+/// The adapter stores the idempotency receipt and every workspace, identity,
+/// membership, authorization, and audit effect in one transaction. An exact
+/// retry returns the original stable result; a reused operation or workspace
+/// identity fails without changing durable state.
+#[derive(Clone)]
+pub struct PostgresWorkspaceProvisioner {
+    pool: PgPool,
+}
+
+impl PostgresWorkspaceProvisioner {
+    /// Binds workspace provisioning to `pool`.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[allow(clippy::too_many_lines)] // The ordered statements intentionally form one transaction.
+    async fn provision_inner(
+        &self,
+        request: AuthorizedProvisionWorkspace,
+    ) -> Result<ProvisionWorkspaceResult, ProvisioningFailure> {
+        let (authority, command) = request.into_parts();
+        let authority_id = authority.id().as_str();
+        let operation_id = command.operation_id();
+        let shard_id = command.shard_id();
+        let workspace_id = command.workspace_id();
+        let workspace_text = workspace_id.to_string();
+        let workspace_display_name = command.workspace_display_name().as_str();
+        let owner_issuer = command.initial_owner_issuer().as_str();
+        let owner_subject = command.initial_owner_subject();
+        let owner_display_name = command.initial_owner_display_name().as_str();
+
+        let mut transaction = self.pool.begin().await.map_err(database_failure)?;
+        let created_at_ms = database_time_milliseconds(&mut transaction).await?;
+        let inserted = sqlx::query(
+            r"
+            INSERT INTO workspace_provisioning_operations (
+                authority_id, operation_id, shard_id, workspace_id,
+                workspace_display_name, initial_owner_issuer,
+                initial_owner_subject, initial_owner_display_name, state,
+                created_at_ms
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'pending',$9)
+            ON CONFLICT (authority_id, operation_id) DO NOTHING
+            ",
+        )
+        .bind(authority_id)
+        .bind(operation_id.as_uuid())
+        .bind(shard_id.as_str())
+        .bind(&workspace_text)
+        .bind(workspace_display_name)
+        .bind(owner_issuer)
+        .bind(owner_subject.as_uuid())
+        .bind(owner_display_name)
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+
+        if inserted.rows_affected() == 0 {
+            let stored =
+                load_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?;
+            if !stored.matches(
+                shard_id.as_str(),
+                &workspace_text,
+                workspace_display_name,
+                owner_issuer,
+                owner_subject.as_uuid(),
+                owner_display_name,
+            ) {
+                return Err(failure(ProvisioningFailureKind::OperationConflict));
+            }
+            return stored.result(operation_id, shard_id.clone(), workspace_id);
+        }
+
+        let tenant_inserted = sqlx::query(
+            r"
+            INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms)
+            VALUES ($1,$2,$3,$3) ON CONFLICT (id) DO NOTHING
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(workspace_display_name)
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        if tenant_inserted.rows_affected() != 1 {
+            return Err(failure(ProvisioningFailureKind::WorkspaceConflict));
+        }
+
+        let principal_id = resolve_or_create_principal(
+            &mut transaction,
+            owner_issuer,
+            owner_subject.as_uuid(),
+            owner_display_name,
+            created_at_ms,
+        )
+        .await?;
+        let role_id = Uuid::new_v4();
+        let binding_id = Uuid::new_v4();
+
+        sqlx::query(
+            r"
+            INSERT INTO tenant_human_memberships (
+                tenant_id, principal_id, status, authorization_revision,
+                revision, created_at_ms, updated_at_ms
+            ) VALUES ($1,$2,'active',1,1,$3,$3)
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(principal_id)
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        sqlx::query(
+            r"
+            INSERT INTO rbac_roles (
+                tenant_id, id, name, display_name, role_kind, immutable,
+                revision, created_by_principal_id, created_at_ms, updated_at_ms
+            ) VALUES ($1,$2,$3,$4,'built_in',TRUE,1,$5,$6,$6)
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(role_id)
+        .bind(WORKSPACE_OWNER_ROLE_NAME)
+        .bind(WORKSPACE_OWNER_ROLE_DISPLAY_NAME)
+        .bind(principal_id)
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        let granted_permissions: i64 = sqlx::query_scalar(
+            r"
+            WITH granted AS (
+                INSERT INTO rbac_role_permissions (
+                    tenant_id, role_id, permission_name,
+                    granted_by_principal_id, granted_at_ms
+                )
+                SELECT $1,$2,name,$3,$4 FROM rbac_permissions
+                RETURNING 1
+            )
+            SELECT count(*) FROM granted
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(role_id)
+        .bind(principal_id)
+        .bind(created_at_ms)
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        if granted_permissions <= 0 {
+            return Err(failure(ProvisioningFailureKind::Internal));
+        }
+        sqlx::query(
+            r"
+            INSERT INTO rbac_role_bindings (
+                tenant_id, id, principal_id, role_id, scope_kind,
+                assignment_source, status, created_by_principal_id,
+                created_at_ms, revision
+            ) VALUES ($1,$2,$3,$4,'tenant','bootstrap','active',$3,$5,1)
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(binding_id)
+        .bind(principal_id)
+        .bind(role_id)
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+
+        let provisioned_at_ms = database_time_milliseconds(&mut transaction).await?;
+        sqlx::query(
+            r"
+            INSERT INTO security_audit_events (
+                event_id, tenant_id, occurred_at_ms, actor_kind, action,
+                outcome, resource_kind, resource_id
+            ) VALUES ($1,$2,$3,'system',$4,'succeeded','workspace',$2)
+            ",
+        )
+        .bind(Uuid::new_v4())
+        .bind(&workspace_text)
+        .bind(provisioned_at_ms)
+        .bind(WORKSPACE_PROVISIONED_AUDIT_ACTION)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        let completed = sqlx::query(
+            r"
+            UPDATE workspace_provisioning_operations
+            SET state='completed', initial_owner_principal_id=$3,
+                provisioned_at_ms=$4
+            WHERE authority_id=$1 AND operation_id=$2 AND state='pending'
+            ",
+        )
+        .bind(authority_id)
+        .bind(operation_id.as_uuid())
+        .bind(principal_id)
+        .bind(provisioned_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        if completed.rows_affected() != 1 {
+            return Err(failure(ProvisioningFailureKind::Internal));
+        }
+        transaction.commit().await.map_err(database_failure)?;
+
+        let initial_owner_principal_id = InitialOwnerPrincipalId::from_uuid(principal_id)
+            .map_err(|_| failure(ProvisioningFailureKind::Internal))?;
+        Ok(ProvisionWorkspaceResult::new(
+            operation_id,
+            shard_id.clone(),
+            workspace_id,
+            initial_owner_principal_id,
+            provisioned_at(provisioned_at_ms)?,
+        ))
+    }
+}
+
+impl fmt::Debug for PostgresWorkspaceProvisioner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresWorkspaceProvisioner")
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkspaceProvisioner for PostgresWorkspaceProvisioner {
+    fn provision(&self, request: AuthorizedProvisionWorkspace) -> WorkspaceProvisioningFuture<'_> {
+        Box::pin(self.provision_inner(request))
+    }
+}
+
+#[derive(FromRow)]
+struct StoredOperation {
+    shard_id: String,
+    workspace_id: String,
+    workspace_display_name: String,
+    initial_owner_issuer: String,
+    initial_owner_subject: Uuid,
+    initial_owner_display_name: String,
+    state: String,
+    initial_owner_principal_id: Option<Uuid>,
+    provisioned_at_ms: Option<i64>,
+}
+
+impl StoredOperation {
+    #[allow(clippy::too_many_arguments)]
+    fn matches(
+        &self,
+        shard_id: &str,
+        workspace_id: &str,
+        workspace_display_name: &str,
+        owner_issuer: &str,
+        owner_subject: Uuid,
+        owner_display_name: &str,
+    ) -> bool {
+        self.shard_id == shard_id
+            && self.workspace_id == workspace_id
+            && self.workspace_display_name == workspace_display_name
+            && self.initial_owner_issuer == owner_issuer
+            && self.initial_owner_subject == owner_subject
+            && self.initial_owner_display_name == owner_display_name
+    }
+
+    fn result(
+        self,
+        operation_id: automata_ci_provisioning::OperationId,
+        shard_id: automata_ci_provisioning::ShardId,
+        workspace_id: automata_ci_provisioning::WorkspaceId,
+    ) -> Result<ProvisionWorkspaceResult, ProvisioningFailure> {
+        if self.state != "completed" {
+            return Err(failure(ProvisioningFailureKind::Internal));
+        }
+        let principal_id = self
+            .initial_owner_principal_id
+            .ok_or_else(|| failure(ProvisioningFailureKind::Internal))?;
+        let provisioned_at_ms = self
+            .provisioned_at_ms
+            .ok_or_else(|| failure(ProvisioningFailureKind::Internal))?;
+        Ok(ProvisionWorkspaceResult::new(
+            operation_id,
+            shard_id,
+            workspace_id,
+            InitialOwnerPrincipalId::from_uuid(principal_id)
+                .map_err(|_| failure(ProvisioningFailureKind::Internal))?,
+            provisioned_at(provisioned_at_ms)?,
+        ))
+    }
+}
+
+#[derive(FromRow)]
+struct StoredPrincipal {
+    principal_id: Uuid,
+    status: String,
+}
+
+async fn load_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    authority_id: &str,
+    operation_id: Uuid,
+) -> Result<StoredOperation, ProvisioningFailure> {
+    sqlx::query_as::<_, StoredOperation>(
+        r"
+        SELECT shard_id, workspace_id, workspace_display_name,
+               initial_owner_issuer, initial_owner_subject,
+               initial_owner_display_name, state,
+               initial_owner_principal_id, provisioned_at_ms
+        FROM workspace_provisioning_operations
+        WHERE authority_id=$1 AND operation_id=$2
+        FOR UPDATE
+        ",
+    )
+    .bind(authority_id)
+    .bind(operation_id)
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(database_failure)
+}
+
+async fn resolve_or_create_principal(
+    transaction: &mut Transaction<'_, Postgres>,
+    issuer: &str,
+    subject: Uuid,
+    display_name: &str,
+    now_ms: i64,
+) -> Result<Uuid, ProvisioningFailure> {
+    if let Some(stored) = load_principal(transaction, issuer, subject).await? {
+        return active_principal(&stored);
+    }
+
+    let candidate = Uuid::new_v4();
+    sqlx::query(
+        r"
+        INSERT INTO human_principals (
+            id, status, display_name, revision, created_at_ms, updated_at_ms
+        ) VALUES ($1,'active',$2,1,$3,$3)
+        ",
+    )
+    .bind(candidate)
+    .bind(display_name)
+    .bind(now_ms)
+    .execute(&mut **transaction)
+    .await
+    .map_err(database_failure)?;
+    let mapping = sqlx::query(
+        r"
+        INSERT INTO delegated_actor_identities (
+            issuer, subject, principal_id, display_name,
+            created_at_ms, updated_at_ms
+        ) VALUES ($1,$2,$3,$4,$5,$5)
+        ON CONFLICT (issuer, subject) DO NOTHING
+        ",
+    )
+    .bind(issuer)
+    .bind(subject)
+    .bind(candidate)
+    .bind(display_name)
+    .bind(now_ms)
+    .execute(&mut **transaction)
+    .await
+    .map_err(database_failure)?;
+    if mapping.rows_affected() == 1 {
+        return Ok(candidate);
+    }
+
+    let deleted = sqlx::query("DELETE FROM human_principals WHERE id=$1")
+        .bind(candidate)
+        .execute(&mut **transaction)
+        .await
+        .map_err(database_failure)?;
+    if deleted.rows_affected() != 1 {
+        return Err(failure(ProvisioningFailureKind::Internal));
+    }
+    let stored = load_principal(transaction, issuer, subject)
+        .await?
+        .ok_or_else(|| failure(ProvisioningFailureKind::Internal))?;
+    active_principal(&stored)
+}
+
+async fn load_principal(
+    transaction: &mut Transaction<'_, Postgres>,
+    issuer: &str,
+    subject: Uuid,
+) -> Result<Option<StoredPrincipal>, ProvisioningFailure> {
+    sqlx::query_as::<_, StoredPrincipal>(
+        r"
+        SELECT identity.principal_id, principal.status
+        FROM delegated_actor_identities AS identity
+        JOIN human_principals AS principal ON principal.id=identity.principal_id
+        WHERE identity.issuer=$1 AND identity.subject=$2
+        FOR UPDATE OF identity, principal
+        ",
+    )
+    .bind(issuer)
+    .bind(subject)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(database_failure)
+}
+
+fn active_principal(stored: &StoredPrincipal) -> Result<Uuid, ProvisioningFailure> {
+    match stored.status.as_str() {
+        "active" => Ok(stored.principal_id),
+        "disabled" => Err(failure(ProvisioningFailureKind::PrincipalUnavailable)),
+        _ => Err(failure(ProvisioningFailureKind::Internal)),
+    }
+}
+
+async fn database_time_milliseconds(
+    transaction: &mut Transaction<'_, Postgres>,
+) -> Result<i64, ProvisioningFailure> {
+    let now: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(&mut **transaction)
+            .await
+            .map_err(database_failure)?;
+    if now < 0 {
+        return Err(failure(ProvisioningFailureKind::Internal));
+    }
+    Ok(now)
+}
+
+fn provisioned_at(milliseconds: i64) -> Result<ProvisionedAt, ProvisioningFailure> {
+    let seconds = milliseconds.div_euclid(1_000);
+    let remainder = milliseconds.rem_euclid(1_000);
+    let nanoseconds = u32::try_from(remainder)
+        .ok()
+        .and_then(|value| value.checked_mul(1_000_000))
+        .ok_or_else(|| failure(ProvisioningFailureKind::Internal))?;
+    ProvisionedAt::new(seconds, nanoseconds).map_err(|_| failure(ProvisioningFailureKind::Internal))
+}
+
+fn database_failure(error: sqlx::Error) -> ProvisioningFailure {
+    let kind = match &error {
+        sqlx::Error::Io(_)
+        | sqlx::Error::Tls(_)
+        | sqlx::Error::PoolTimedOut
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::WorkerCrashed
+        | sqlx::Error::BeginFailed => ProvisioningFailureKind::TemporarilyUnavailable,
+        sqlx::Error::Database(database) if retryable_sqlstate(database.code().as_deref()) => {
+            ProvisioningFailureKind::TemporarilyUnavailable
+        }
+        _ => ProvisioningFailureKind::Internal,
+    };
+    drop(error);
+    failure(kind)
+}
+
+fn retryable_sqlstate(code: Option<&str>) -> bool {
+    code.is_some_and(|code| {
+        code.starts_with("08")
+            || matches!(
+                code,
+                "40001" | "40P01" | "53000" | "53300" | "53400" | "57P01" | "57P02" | "57P03"
+            )
+    })
+}
+
+const fn failure(kind: ProvisioningFailureKind) -> ProvisioningFailure {
+    ProvisioningFailure::new(kind, None)
+}

--- a/crates/automata-ci-provisioning-postgres/tests/postgres_workspace_provisioning.rs
+++ b/crates/automata-ci-provisioning-postgres/tests/postgres_workspace_provisioning.rs
@@ -1,0 +1,272 @@
+use std::{error::Error, future::Future, sync::Arc};
+
+use automata_ci_postgres_test_support::{
+    PostgresTestHarness, PreparedTemplate, TestDatabase as IsolatedTestDatabase,
+};
+use automata_ci_provisioning::{
+    AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
+    OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId,
+    ProvisioningFailureKind, ShardId, WorkspaceId, WorkspaceProvisioner,
+};
+use automata_ci_provisioning_postgres::PostgresWorkspaceProvisioner;
+use automata_ci_store::PostgresStore;
+use sqlx::PgPool;
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+type TestError = Box<dyn Error + Send + Sync>;
+type TestResult<T = ()> = Result<T, TestError>;
+
+const ISSUER: &str = "https://cloud.automata.example";
+const SHARD: &str = "prod-us-east-1-001";
+
+static PREPARED_TEMPLATE: OnceCell<PreparedTemplate> = OnceCell::const_new();
+
+#[derive(Debug)]
+struct TestDatabase {
+    database: IsolatedTestDatabase,
+    pool: PgPool,
+}
+
+impl TestDatabase {
+    async fn create() -> TestResult<Self> {
+        let harness = PostgresTestHarness::from_environment()?;
+        let template = PREPARED_TEMPLATE
+            .get_or_try_init(|| async {
+                harness
+                    .prepare_template(|pool| async move {
+                        PostgresStore::from_postgres_pool(pool).migrate().await?;
+                        Ok(())
+                    })
+                    .await
+            })
+            .await?;
+        let database = template.create_database().await?;
+        let pool = database.pool().clone();
+        Ok(Self { database, pool })
+    }
+
+    async fn cleanup(&self) -> TestResult {
+        self.pool.close().await;
+        self.database.cleanup().await
+    }
+}
+
+async fn run_with_database<Test, TestFuture>(test: Test) -> TestResult
+where
+    Test: FnOnce(Arc<TestDatabase>) -> TestFuture,
+    TestFuture: Future<Output = TestResult> + Send + 'static,
+{
+    let database = Arc::new(TestDatabase::create().await?);
+    let outcome = tokio::spawn(test(Arc::clone(&database))).await;
+    let cleanup = database.cleanup().await;
+    match outcome {
+        Ok(result) => {
+            result?;
+            cleanup
+        }
+        Err(join_error) => {
+            cleanup?;
+            if join_error.is_panic() {
+                std::panic::resume_unwind(join_error.into_panic());
+            }
+            Err(join_error.into())
+        }
+    }
+}
+
+fn authorized_request(
+    operation_id: Uuid,
+    workspace_id: Uuid,
+    workspace_name: &str,
+    subject: Uuid,
+) -> AuthorizedProvisionWorkspace {
+    let issuer = DelegatedActorIssuer::new(ISSUER).expect("issuer");
+    let authority = ProvisioningAuthority::new(
+        ProvisioningAuthorityId::new("automata-cloud-production").expect("authority"),
+        ShardId::new(SHARD).expect("shard"),
+        issuer.clone(),
+    );
+    let command = ProvisionWorkspaceCommand::new(
+        OperationId::from_uuid(operation_id).expect("operation ID"),
+        ShardId::new(SHARD).expect("shard"),
+        WorkspaceId::from_uuid(workspace_id).expect("workspace ID"),
+        DisplayName::new(workspace_name).expect("workspace name"),
+        issuer,
+        ExternalAccountSubject::from_uuid(subject).expect("subject"),
+        DisplayName::new("The Octocat").expect("owner name"),
+    );
+    AuthorizedProvisionWorkspace::authorize(authority, command).expect("authorized command")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provisioning_is_atomic_replayable_and_conflict_safe() -> TestResult {
+    run_with_database(|database| async move {
+        let provisioner = PostgresWorkspaceProvisioner::new(database.pool.clone());
+        let operation_id = Uuid::new_v4();
+        let workspace_id = Uuid::new_v4();
+        let subject = Uuid::new_v4();
+
+        let first = provisioner
+            .provision(authorized_request(
+                operation_id,
+                workspace_id,
+                "Acme Engineering",
+                subject,
+            ))
+            .await?;
+        let replay = provisioner
+            .provision(authorized_request(
+                operation_id,
+                workspace_id,
+                "Acme Engineering",
+                subject,
+            ))
+            .await?;
+        assert_eq!(replay, first);
+
+        let operation_conflict = provisioner
+            .provision(authorized_request(
+                operation_id,
+                workspace_id,
+                "Changed name",
+                subject,
+            ))
+            .await
+            .expect_err("changed operation semantics must fail");
+        assert_eq!(
+            operation_conflict.kind(),
+            ProvisioningFailureKind::OperationConflict
+        );
+
+        let workspace_conflict = provisioner
+            .provision(authorized_request(
+                Uuid::new_v4(),
+                workspace_id,
+                "Acme Engineering",
+                subject,
+            ))
+            .await
+            .expect_err("a second operation must not own the workspace");
+        assert_eq!(
+            workspace_conflict.kind(),
+            ProvisioningFailureKind::WorkspaceConflict
+        );
+
+        let counts: (i64, i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+              (SELECT count(*) FROM workspace_provisioning_operations),
+              (SELECT count(*) FROM tenants),
+              (SELECT count(*) FROM delegated_actor_identities),
+              (SELECT count(*) FROM tenant_human_memberships),
+              (SELECT count(*) FROM security_audit_events
+               WHERE action='workspace.provisioned')
+            ",
+        )
+        .fetch_one(&database.pool)
+        .await?;
+        assert_eq!(counts, (1, 1, 1, 1, 1));
+
+        let role_permission_counts: (i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+              (SELECT count(*) FROM rbac_permissions),
+              (SELECT count(*) FROM rbac_role_permissions
+               WHERE tenant_id=$1)
+            ",
+        )
+        .bind(workspace_id.hyphenated().to_string())
+        .fetch_one(&database.pool)
+        .await?;
+        assert!(role_permission_counts.0 > 0);
+        assert_eq!(role_permission_counts.1, role_permission_counts.0);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_workspaces_reuse_one_external_principal() -> TestResult {
+    run_with_database(|database| async move {
+        let provisioner = PostgresWorkspaceProvisioner::new(database.pool.clone());
+        let subject = Uuid::new_v4();
+        let first_request =
+            authorized_request(Uuid::new_v4(), Uuid::new_v4(), "Acme Engineering", subject);
+        let second_request =
+            authorized_request(Uuid::new_v4(), Uuid::new_v4(), "Example Labs", subject);
+
+        let (first, second) = tokio::join!(
+            provisioner.provision(first_request),
+            provisioner.provision(second_request)
+        );
+        let first = first?;
+        let second = second?;
+        assert_eq!(
+            first.initial_owner_principal_id(),
+            second.initial_owner_principal_id()
+        );
+
+        let counts: (i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+              (SELECT count(*) FROM human_principals),
+              (SELECT count(*) FROM delegated_actor_identities),
+              (SELECT count(*) FROM tenants),
+              (SELECT count(*) FROM tenant_human_memberships)
+            ",
+        )
+        .fetch_one(&database.pool)
+        .await?;
+        assert_eq!(counts, (1, 1, 2, 2));
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_disabled_mapped_principal_cannot_receive_another_workspace() -> TestResult {
+    run_with_database(|database| async move {
+        let provisioner = PostgresWorkspaceProvisioner::new(database.pool.clone());
+        let subject = Uuid::new_v4();
+        let first = provisioner
+            .provision(authorized_request(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                "Acme Engineering",
+                subject,
+            ))
+            .await?;
+        sqlx::query(
+            r"
+            UPDATE human_principals
+            SET status='disabled', disabled_at_ms=updated_at_ms,
+                disabled_reason='test disable', revision=revision+1
+            WHERE id=$1
+            ",
+        )
+        .bind(first.initial_owner_principal_id().as_uuid())
+        .execute(&database.pool)
+        .await?;
+
+        let failure = provisioner
+            .provision(authorized_request(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                "Blocked workspace",
+                subject,
+            ))
+            .await
+            .expect_err("disabled principal must fail closed");
+        assert_eq!(
+            failure.kind(),
+            ProvisioningFailureKind::PrincipalUnavailable
+        );
+        let workspace_count: i64 = sqlx::query_scalar("SELECT count(*) FROM tenants")
+            .fetch_one(&database.pool)
+            .await?;
+        assert_eq!(workspace_count, 1);
+        Ok(())
+    })
+    .await
+}

--- a/crates/automata-ci-provisioning/LICENSE
+++ b/crates/automata-ci-provisioning/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexander Dzhoganov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-provisioning/README.md
+++ b/crates/automata-ci-provisioning/README.md
@@ -7,4 +7,5 @@ idempotency identity, and durable provisioning behind explicit ports.
 
 It contains no gRPC, HTTP, SQL, Cloud billing, or private Automata Cloud code.
 The public versioned wire schema lives beside its gRPC adapter in
-`automata-ci-provisioning-grpc`.
+`automata-ci-provisioning-grpc`; the atomic PostgreSQL adapter lives in
+`automata-ci-provisioning-postgres`.

--- a/crates/automata-ci-store/migrations/0001_initial_schema.sql
+++ b/crates/automata-ci-store/migrations/0001_initial_schema.sql
@@ -23958,6 +23958,19 @@ CREATE TABLE concurrency_groups (
     CONSTRAINT concurrency_groups_key_nonempty CHECK ((length(normalized_key) > 0))
 );
 
+CREATE TABLE delegated_actor_identities (
+    issuer text NOT NULL,
+    subject uuid NOT NULL,
+    principal_id uuid NOT NULL,
+    display_name text NOT NULL,
+    created_at_ms bigint NOT NULL,
+    updated_at_ms bigint NOT NULL,
+    CONSTRAINT delegated_actor_identities_display_name_shape CHECK ((((char_length(display_name) >= 1) AND (char_length(display_name) <= 255)) AND (btrim(display_name) = display_name) AND (display_name !~ '[[:cntrl:]]'::text))),
+    CONSTRAINT delegated_actor_identities_issuer_shape CHECK ((((octet_length(issuer) >= 9) AND (octet_length(issuer) <= 2048)) AND (issuer ~ '^https://'::text) AND (issuer !~ '[[:cntrl:][:space:]]'::text))),
+    CONSTRAINT delegated_actor_identities_subject_non_nil CHECK ((subject <> '00000000-0000-0000-0000-000000000000'::uuid)),
+    CONSTRAINT delegated_actor_identities_time_monotonic CHECK (((created_at_ms >= 0) AND (updated_at_ms >= created_at_ms)))
+);
+
 CREATE TABLE github_actions_cache_block_commits (
     entry_id uuid NOT NULL,
     list_digest bytea NOT NULL,
@@ -26496,6 +26509,30 @@ CREATE TABLE tenants (
     CONSTRAINT tenants_login_admission_mode CHECK ((login_admission_mode = ANY (ARRAY['restricted'::text, 'open_sign_in'::text])))
 );
 
+CREATE TABLE workspace_provisioning_operations (
+    authority_id text NOT NULL,
+    operation_id uuid NOT NULL,
+    shard_id text NOT NULL,
+    workspace_id text NOT NULL,
+    workspace_display_name text NOT NULL,
+    initial_owner_issuer text NOT NULL,
+    initial_owner_subject uuid NOT NULL,
+    initial_owner_display_name text NOT NULL,
+    state text DEFAULT 'pending'::text NOT NULL,
+    initial_owner_principal_id uuid,
+    created_at_ms bigint NOT NULL,
+    provisioned_at_ms bigint,
+    CONSTRAINT workspace_provisioning_operations_authority_shape CHECK ((((octet_length(authority_id) >= 1) AND (octet_length(authority_id) <= 255)) AND (authority_id !~ '[[:space:][:cntrl:]]'::text))),
+    CONSTRAINT workspace_provisioning_operations_display_name_shape CHECK (((char_length(workspace_display_name) >= 1) AND (char_length(workspace_display_name) <= 255) AND (btrim(workspace_display_name) = workspace_display_name) AND (workspace_display_name !~ '[[:cntrl:]]'::text) AND (char_length(initial_owner_display_name) >= 1) AND (char_length(initial_owner_display_name) <= 255) AND (btrim(initial_owner_display_name) = initial_owner_display_name) AND (initial_owner_display_name !~ '[[:cntrl:]]'::text))),
+    CONSTRAINT workspace_provisioning_operations_ids_non_nil CHECK (((operation_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (initial_owner_subject <> '00000000-0000-0000-0000-000000000000'::uuid) AND ((initial_owner_principal_id IS NULL) OR (initial_owner_principal_id <> '00000000-0000-0000-0000-000000000000'::uuid)))),
+    CONSTRAINT workspace_provisioning_operations_issuer_shape CHECK ((((octet_length(initial_owner_issuer) >= 9) AND (octet_length(initial_owner_issuer) <= 2048)) AND (initial_owner_issuer ~ '^https://'::text) AND (initial_owner_issuer !~ '[[:cntrl:][:space:]]'::text))),
+    CONSTRAINT workspace_provisioning_operations_shard_shape CHECK ((((octet_length(shard_id) >= 1) AND (octet_length(shard_id) <= 63)) AND (shard_id ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'::text))),
+    CONSTRAINT workspace_provisioning_operations_state CHECK ((state = ANY (ARRAY['pending'::text, 'completed'::text]))),
+    CONSTRAINT workspace_provisioning_operations_state_shape CHECK (((((state = 'pending'::text) AND (initial_owner_principal_id IS NULL) AND (provisioned_at_ms IS NULL)) OR ((state = 'completed'::text) AND (initial_owner_principal_id IS NOT NULL) AND (provisioned_at_ms >= created_at_ms))) IS TRUE)),
+    CONSTRAINT workspace_provisioning_operations_time_nonnegative CHECK ((created_at_ms >= 0)),
+    CONSTRAINT workspace_provisioning_operations_workspace_shape CHECK ((((octet_length(workspace_id) = 36) AND (workspace_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'::text))))
+);
+
 CREATE TABLE workflow_admission_receipts (
     tenant_id text NOT NULL,
     idempotency_kind text NOT NULL,
@@ -28468,6 +28505,15 @@ ALTER TABLE ONLY github_workflow_run_subject_evidence
 ALTER TABLE ONLY github_workflow_run_subject_evidence
     ADD CONSTRAINT github_workflow_run_subject_evidence_primary_key PRIMARY KEY (repository_id, run_id);
 
+ALTER TABLE ONLY delegated_actor_identities
+    ADD CONSTRAINT delegated_actor_identities_pkey PRIMARY KEY (issuer, subject);
+
+ALTER TABLE ONLY delegated_actor_identities
+    ADD CONSTRAINT delegated_actor_identities_principal_key UNIQUE (principal_id);
+
+ALTER TABLE ONLY delegated_actor_identities
+    ADD CONSTRAINT delegated_actor_identities_mapping_key UNIQUE (issuer, subject, principal_id);
+
 ALTER TABLE ONLY human_auth_installation_state
     ADD CONSTRAINT human_auth_installation_state_pkey PRIMARY KEY (singleton);
 
@@ -28854,6 +28900,9 @@ ALTER TABLE ONLY tenant_human_memberships
 
 ALTER TABLE ONLY tenants
     ADD CONSTRAINT tenants_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY workspace_provisioning_operations
+    ADD CONSTRAINT workspace_provisioning_operations_pkey PRIMARY KEY (authority_id, operation_id);
 
 ALTER TABLE ONLY workflow_admission_receipts
     ADD CONSTRAINT workflow_admission_receipts_primary_key PRIMARY KEY (tenant_id, idempotency_kind, idempotency_key);
@@ -31196,6 +31245,9 @@ ALTER TABLE ONLY github_workflow_run_subject_evidence
 ALTER TABLE ONLY github_workflow_run_subject_evidence
     ADD CONSTRAINT github_workflow_run_subject_evidence_workflow FOREIGN KEY (repository_id, workflow_id) REFERENCES workflow_definitions(repository_id, id) ON DELETE RESTRICT;
 
+ALTER TABLE ONLY delegated_actor_identities
+    ADD CONSTRAINT delegated_actor_identities_principal_id_fkey FOREIGN KEY (principal_id) REFERENCES human_principals(id) ON DELETE RESTRICT;
+
 ALTER TABLE ONLY human_auth_installation_state
     ADD CONSTRAINT human_auth_installation_state_identity FOREIGN KEY (configured_principal_id, expected_provider_id, expected_provider_subject) REFERENCES human_provider_identities(principal_id, provider_id, provider_subject) ON DELETE RESTRICT;
 
@@ -31687,6 +31739,12 @@ ALTER TABLE ONLY tenant_human_memberships
 
 ALTER TABLE ONLY tenant_human_memberships
     ADD CONSTRAINT tenant_human_memberships_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE RESTRICT;
+
+ALTER TABLE ONLY workspace_provisioning_operations
+    ADD CONSTRAINT workspace_provisioning_operations_identity FOREIGN KEY (initial_owner_issuer, initial_owner_subject, initial_owner_principal_id) REFERENCES delegated_actor_identities(issuer, subject, principal_id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE ONLY workspace_provisioning_operations
+    ADD CONSTRAINT workspace_provisioning_operations_workspace FOREIGN KEY (workspace_id) REFERENCES tenants(id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE ONLY workflow_admission_receipts
     ADD CONSTRAINT workflow_admission_receipts_repository_tenant FOREIGN KEY (tenant_id, repository_id) REFERENCES repositories(tenant_id, id) ON DELETE RESTRICT;


### PR DESCRIPTION
## Summary

- add a PostgreSQL adapter for the public `WorkspaceProvisioner` port
- atomically create the Core tenant, delegated external-identity mapping, initial membership, built-in owner role, audit event, and idempotency receipt
- make exact retries return the original stable result while rejecting operation, workspace, and disabled-principal conflicts without partial state
- reuse one Core principal when the same external issuer/subject provisions multiple workspaces

## Boundary

This remains public, provider-neutral Core behavior. Automata Cloud is one external control plane and supplies no billing or private code to this crate.

The PR intentionally does not start the management gRPC listener from the product binary. Listener configuration, mTLS authority composition, and lifecycle wiring are the next Core slice; Core still does not advertise an unconfigured management endpoint.

## Verification

- PostgreSQL 18 integration tests cover creation, exact replay, operation/workspace conflicts, disabled principals, full initial-owner permissions, audit persistence, and concurrent identity reuse
- `cargo fmt --all -- --check`
- `cargo clippy -p automata-ci-provisioning-postgres --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p automata-ci-provisioning-postgres --all-features --no-deps --locked`
- `cargo test -p automata-ci-provisioning -p automata-ci-provisioning-grpc -p automata-ci-provisioning-postgres --all-targets --all-features --locked`
- `cargo test -p automata-ci-store --test store_migration_contracts --locked`
- `cargo check --workspace --all-targets --all-features --locked`
