### PR TITLE
feat: configure S3 KMS encryption identity

### DIFF
--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -178,11 +178,18 @@ automata server \
   --s3-allow-loopback-http \
   --s3-bucket automata-dev \
   --s3-prefix automata/v1 \
+  --s3-kms-key-id default \
   # ...required secret, Results, and runner TLS references...
 ```
 
 Plain HTTP object-store endpoints anywhere other than literal loopback are
 rejected even when the development option is present.
+
+Object writes use provider-managed AES-256 (`SSE-S3`) by default. Set
+`--s3-kms-key-id` to select `SSE-KMS` with one exact non-secret key identity;
+reads then fail closed unless the object store reports both `aws:kms` and that
+same identity. The pinned local RustFS service exposes its configured local
+master key as `default`, so the development command selects that identity.
 
 ## Results, artifacts, and cache
 

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -520,6 +520,14 @@ pub struct ServerArgs {
     #[arg(long, env = "AUTOMATA_S3_FORCE_PATH_STYLE")]
     pub s3_force_path_style: bool,
 
+    /// Exact KMS key identity for S3 server-side encryption.
+    ///
+    /// Omitting this option selects provider-managed AES-256 (`SSE-S3`).
+    /// Supplying it selects `SSE-KMS`, and every read must report this exact
+    /// key identity as well as the expected encryption algorithm.
+    #[arg(long, env = "AUTOMATA_S3_KMS_KEY_ID", value_name = "KEY_ID")]
+    pub s3_kms_key_id: Option<String>,
+
     /// Permit plain HTTP only when the S3 endpoint is a literal loopback host.
     #[arg(long, env = "AUTOMATA_S3_ALLOW_LOOPBACK_HTTP")]
     pub s3_allow_loopback_http: bool,

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -1810,6 +1810,7 @@ fn build_blob_store(
             config.s3_operation_timeout,
         )?
     };
+    let blob_config = blob_config.with_at_rest_encryption(config.s3_at_rest_encryption.clone());
     let access_key = config.load_s3_access_key()?;
     let secret_key = config.load_s3_secret_key()?;
     let session_token = config.load_s3_session_token()?;

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -17,6 +17,7 @@ use url::Url;
 use zeroize::Zeroizing;
 
 use automata_ci_auth::{github::GithubClientId, installation::InstallationTenant};
+use automata_ci_blob_s3::S3AtRestEncryption;
 use automata_ci_key_management::{
     KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes as KeySecretBytes,
 };
@@ -319,6 +320,7 @@ pub struct ServerConfig {
     pub(crate) s3_bucket: String,
     pub(crate) s3_prefix: Option<String>,
     pub(crate) s3_force_path_style: bool,
+    pub(crate) s3_at_rest_encryption: S3AtRestEncryption,
     pub(crate) s3_allow_loopback_http: bool,
     pub(crate) s3_operation_timeout: Duration,
     pub(crate) s3_access_key: SecretSource,
@@ -625,6 +627,7 @@ impl ServerConfig {
         validate_fallback_tenant(&args.fallback_tenant_id)?;
         let s3_endpoint =
             Url::parse(&args.s3_endpoint).map_err(|_| ServerConfigError::InvalidS3Endpoint)?;
+        let s3_at_rest_encryption = s3_at_rest_encryption(args.s3_kms_key_id.as_deref())?;
         if args.database_max_connections == 0 {
             return Err(ServerConfigError::InvalidDatabaseConnections);
         }
@@ -696,6 +699,7 @@ impl ServerConfig {
             s3_bucket: args.s3_bucket.clone(),
             s3_prefix: args.s3_prefix.clone(),
             s3_force_path_style: args.s3_force_path_style,
+            s3_at_rest_encryption,
             s3_allow_loopback_http: args.s3_allow_loopback_http,
             s3_operation_timeout,
             s3_access_key: args.s3_access_key_source.clone(),
@@ -1058,6 +1062,16 @@ fn load_exact_bytes(
     Ok(bytes)
 }
 
+fn s3_at_rest_encryption(
+    kms_key_id: Option<&str>,
+) -> Result<S3AtRestEncryption, ServerConfigError> {
+    kms_key_id
+        .map(S3AtRestEncryption::aws_kms)
+        .transpose()
+        .map_err(|_| ServerConfigError::InvalidS3Encryption)
+        .map(|encryption| encryption.unwrap_or_else(S3AtRestEncryption::aes256))
+}
+
 fn human_auth_configuration(
     args: &ServerArgs,
 ) -> Result<Option<HumanAuthConfig>, ServerConfigError> {
@@ -1328,6 +1342,9 @@ pub enum ServerConfigError {
     /// The S3 endpoint is not an absolute URL.
     #[error("S3 endpoint is not a valid URL")]
     InvalidS3Endpoint,
+    /// The configured server-side encryption key identity is malformed.
+    #[error("S3 server-side encryption configuration is invalid")]
+    InvalidS3Encryption,
     /// The `PostgreSQL` pool size is zero.
     #[error("database maximum connections must be greater than zero")]
     InvalidDatabaseConnections,

--- a/crates/automata-ci/tests/server_config.rs
+++ b/crates/automata-ci/tests/server_config.rs
@@ -215,6 +215,42 @@ fn server_configuration_validates_non_secret_endpoint_fields() {
 }
 
 #[test]
+fn server_configuration_accepts_one_exact_s3_kms_key_identity() {
+    let cli = Cli::try_parse_from([
+        "automata",
+        "server",
+        "--results-public-url",
+        "https://results.example.test/",
+        "--s3-kms-key-id",
+        "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000001",
+    ])
+    .expect("S3 KMS identity syntax must parse");
+    let Command::Server(args) = cli.command else {
+        panic!("server command expected");
+    };
+    ServerConfig::from_args(&args).expect("exact non-secret KMS identity must be accepted");
+
+    for invalid in ["", " leading-space", "line\nbreak"] {
+        let cli = Cli::try_parse_from([
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--s3-kms-key-id",
+            invalid,
+        ])
+        .expect("value validation belongs to server configuration");
+        let Command::Server(args) = cli.command else {
+            panic!("server command expected");
+        };
+        assert!(matches!(
+            ServerConfig::from_args(&args),
+            Err(ServerConfigError::InvalidS3Encryption)
+        ));
+    }
+}
+
+#[test]
 fn human_auth_configuration_is_atomic_and_derives_a_fixed_callback() {
     let args = configured_human_auth_args();
     let config = ServerConfig::from_args(&args).expect("complete secure auth configuration");

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -156,6 +156,7 @@ automata server \
   --s3-allow-loopback-http \
   --s3-bucket automata-dev \
   --s3-prefix automata/v1 \
+  --s3-kms-key-id default \
   --s3-access-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-access-key" \
   --s3-secret-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-secret-key" \
   --runner-public-url https://localhost:9090/ \


### PR DESCRIPTION
## Summary

- add an explicit `--s3-kms-key-id` / `AUTOMATA_S3_KMS_KEY_ID` server setting
- select the existing strict SSE-KMS adapter policy when configured, while preserving SSE-S3 as the default
- document the pinned local RustFS `default` key identity and cover bounded configuration validation

## Why

The pinned RustFS development service reports its configured local master-key identity on encrypted reads. The immutable adapter correctly rejects that evidence under the default SSE-S3 policy, while the repository’s RustFS contract already passes in strict SSE-KMS mode. Exposing the existing policy at server composition keeps read verification fail-closed and makes the documented local deployment runnable.

## Verification

- `cargo test -p automata-ci --test server_config --locked`
- `cargo test -p automata-ci --test cli --locked -- --nocapture`
- `cargo clippy -p automata-ci --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- full Automata Cloud -> worker -> mTLS management gRPC -> Core workspace provisioning smoke test