### PR TITLE
Improve GitHub Checks and live job UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "tokio",
  "url",
  "zeroize",

--- a/crates/automata-ci-github-delivery/src/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/src/checks_publisher.rs
@@ -16,8 +16,8 @@ use automata_ci_github::{
     GithubCheckExternalId, GithubCheckName as HttpCheckName, GithubCheckRetryEvidence,
     GithubCheckRun, GithubCheckRunCreateOutcome, GithubCheckRunId as HttpRunId,
     GithubCheckRunIdentity, GithubCheckRunReconciliation, GithubCheckRunState,
-    GithubCheckSuiteCreateOutcome, GithubCheckSuiteId as HttpSuiteId, GithubChecksError,
-    GithubHttpEndpoint, GithubObservedCheckConclusion,
+    GithubCheckSuiteCreateOutcome, GithubCheckSuiteId as HttpSuiteId, GithubCheckTimestamp,
+    GithubChecksError, GithubHttpEndpoint, GithubObservedCheckConclusion,
 };
 use automata_ci_scm::{ExactRevision, RepositoryId as ScmRepositoryId};
 use automata_ci_store::{
@@ -935,6 +935,16 @@ impl GithubChecksPublisher {
             .run_id()
             .ok_or(GithubChecksPublisherError::InvalidClaim)?;
         let http_run_id = http_run_id(run_id)?;
+        let started_at = claimed
+            .started_at()
+            .map(|value| GithubCheckTimestamp::from_unix_millis(value.get()))
+            .transpose()
+            .map_err(|_| GithubChecksPublisherError::InvariantViolation)?;
+        let completed_at = claimed
+            .completed_at()
+            .map(|value| GithubCheckTimestamp::from_unix_millis(value.get()))
+            .transpose()
+            .map_err(|_| GithubChecksPublisherError::InvariantViolation)?;
         let current = match self
             .endpoint
             .get_check_run(
@@ -961,6 +971,9 @@ impl GithubChecksPublisher {
                             credential.repository(),
                             http_run_id,
                             &identity,
+                            started_at
+                                .as_ref()
+                                .ok_or(GithubChecksPublisherError::InvariantViolation)?,
                             credential.token(),
                         )
                         .await
@@ -986,6 +999,10 @@ impl GithubChecksPublisher {
                                 http_run_id,
                                 &identity,
                                 conclusion,
+                                started_at.as_ref(),
+                                completed_at
+                                    .as_ref()
+                                    .ok_or(GithubChecksPublisherError::InvariantViolation)?,
                                 credential.token(),
                             )
                             .await

--- a/crates/automata-ci-github-delivery/tests/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/tests/checks_publisher.rs
@@ -175,6 +175,14 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             fence,
         )
         .map_err(|_| GithubCheckStoreError::CorruptData)?;
+        let desired_updated_at = UnixMillis::new(claimed_at.get().saturating_sub(1));
+        let (started_at, completed_at) = match template.desired {
+            GithubCheckDesiredProjection::Queued => (None, None),
+            GithubCheckDesiredProjection::InProgress => (Some(desired_updated_at), None),
+            GithubCheckDesiredProjection::Terminal(_) => {
+                (Some(desired_updated_at), Some(desired_updated_at))
+            }
+        };
         ClaimedGithubCheckProjection::from_durable_parts(
             claim,
             template.action,
@@ -187,6 +195,10 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             template.revision,
             template.suite_id,
             template.run_id,
+            UnixMillis::new(claimed_at.get().saturating_sub(2)),
+            desired_updated_at,
+            started_at,
+            completed_at,
             claimed_at,
             expires_at,
         )

--- a/crates/automata-ci-github/Cargo.toml
+++ b/crates/automata-ci-github/Cargo.toml
@@ -21,6 +21,7 @@ ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+time = { workspace = true, features = ["formatting"] }
 url.workspace = true
 zeroize.workspace = true
 

--- a/crates/automata-ci-github/src/checks.rs
+++ b/crates/automata-ci-github/src/checks.rs
@@ -8,6 +8,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use url::Url;
 
 use crate::{
@@ -213,6 +214,44 @@ impl fmt::Debug for GithubCheckDetailsUrl {
     }
 }
 
+/// Canonical UTC timestamp accepted by GitHub's Checks API.
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct GithubCheckTimestamp(String);
+
+impl GithubCheckTimestamp {
+    /// Formats a non-negative Unix millisecond instant as RFC 3339 UTC.
+    ///
+    /// # Errors
+    ///
+    /// Rejects negative or out-of-range instants.
+    pub fn from_unix_millis(value: i64) -> Result<Self, GithubCheckModelError> {
+        if value < 0 {
+            return Err(GithubCheckModelError::InvalidTimestamp);
+        }
+        let nanos = i128::from(value)
+            .checked_mul(1_000_000)
+            .ok_or(GithubCheckModelError::InvalidTimestamp)?;
+        let instant = OffsetDateTime::from_unix_timestamp_nanos(nanos)
+            .map_err(|_| GithubCheckModelError::InvalidTimestamp)?;
+        let value = instant
+            .format(&Rfc3339)
+            .map_err(|_| GithubCheckModelError::InvalidTimestamp)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical provider value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for GithubCheckTimestamp {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("GithubCheckTimestamp([validated])")
+    }
+}
+
 /// Immutable identity expected on every response for one Automata Check Run.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubCheckRunIdentity {
@@ -311,6 +350,32 @@ impl GithubCheckConclusion {
             Self::Success => "success",
             Self::Skipped => "skipped",
             Self::TimedOut => "timed_out",
+        }
+    }
+
+    const fn title(self) -> &'static str {
+        match self {
+            Self::ActionRequired => "Action required",
+            Self::Cancelled => "Cancelled",
+            Self::Failure => "Failed",
+            Self::Neutral => "Completed",
+            Self::Success => "Passed",
+            Self::Skipped => "Skipped",
+            Self::TimedOut => "Timed out",
+        }
+    }
+
+    const fn summary(self) -> &'static str {
+        match self {
+            Self::ActionRequired => "Automata needs attention.",
+            Self::Cancelled => "The job was cancelled.",
+            Self::Failure => "The job failed. Diagnostics and logs are available in Automata.",
+            Self::Neutral => "The job completed with a neutral result.",
+            Self::Success => "The job completed successfully.",
+            Self::Skipped => "The job was skipped.",
+            Self::TimedOut => {
+                "The job timed out. Its last recorded progress is available in Automata."
+            }
         }
     }
 }
@@ -523,6 +588,9 @@ pub enum GithubCheckModelError {
     /// A Check Run details URL violates the bounded absolute-URL policy.
     #[error("the GitHub Check Run details URL is invalid")]
     InvalidDetailsUrl,
+    /// A lifecycle timestamp was negative or outside RFC 3339's range.
+    #[error("invalid GitHub Check timestamp")]
+    InvalidTimestamp,
 }
 
 /// Sanitized failure at the GitHub Checks HTTP boundary.
@@ -582,17 +650,30 @@ struct CreateRunBody<'a> {
     status: &'static str,
     external_id: &'a str,
     details_url: &'a str,
+    output: CheckOutputBody<'a>,
 }
 
 #[derive(Serialize)]
-struct StartRunBody {
+struct StartRunBody<'a> {
     status: &'static str,
+    started_at: &'a str,
+    output: CheckOutputBody<'a>,
 }
 
 #[derive(Serialize)]
-struct CompleteRunBody {
+struct CompleteRunBody<'a> {
     status: &'static str,
     conclusion: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at: Option<&'a str>,
+    completed_at: &'a str,
+    output: CheckOutputBody<'a>,
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct CheckOutputBody<'a> {
+    title: &'a str,
+    summary: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -763,7 +844,7 @@ impl GithubHttpEndpoint {
             .transpose()
     }
 
-    /// Creates one queued Check Run with no output, annotations, actions, or images.
+    /// Creates one queued Check Run with a native summary and exact Details link.
     ///
     /// The POST is issued once. Any possibly-applied transport or provider outcome
     /// is explicit and must be reconciled with [`Self::reconcile_check_run_creation`].
@@ -779,12 +860,17 @@ impl GithubHttpEndpoint {
         server_service_token: &SecretString,
     ) -> Result<GithubCheckRunCreateOutcome, GithubChecksError> {
         let endpoint = self.checks_repository_url(repository, &["check-runs"])?;
+        let summary = check_summary("Waiting for a runner.", identity.details_url.as_str());
         let body = CreateRunBody {
             name: identity.name.as_str(),
             head_sha: identity.head_sha.as_str(),
             status: "queued",
             external_id: identity.external_id.as_str(),
             details_url: identity.details_url.as_str(),
+            output: CheckOutputBody {
+                title: "Queued",
+                summary: &summary,
+            },
         };
         let Ok(response) =
             authenticated_checks_request(self.client.post(endpoint), server_service_token)?
@@ -960,9 +1046,8 @@ impl GithubHttpEndpoint {
 
     /// Advances one exact queued Check Run to `in_progress`.
     ///
-    /// No output, annotations, actions, images, names, links, timestamps, logs,
-    /// artifacts, or terminal conclusion can be sent by this method. Repeating
-    /// the same exact state assignment is safe after a transport ambiguity.
+    /// Includes the durable execution start time and a compact native summary.
+    /// Repeating the same exact state assignment is safe after a transport ambiguity.
     ///
     /// # Errors
     ///
@@ -973,12 +1058,22 @@ impl GithubHttpEndpoint {
         repository: &RepositoryId,
         run_id: GithubCheckRunId,
         identity: &GithubCheckRunIdentity,
+        started_at: &GithubCheckTimestamp,
         server_service_token: &SecretString,
     ) -> Result<GithubCheckRun, GithubChecksError> {
         let run_id_segment = run_id.get().to_string();
         let endpoint = self.checks_repository_url(repository, &["check-runs", &run_id_segment])?;
+        let summary = check_summary(
+            "This job is running. Live progress and logs are available in Automata.",
+            identity.details_url.as_str(),
+        );
         let body = StartRunBody {
             status: "in_progress",
+            started_at: started_at.as_str(),
+            output: CheckOutputBody {
+                title: "Running",
+                summary: &summary,
+            },
         };
         let response =
             authenticated_checks_request(self.client.patch(endpoint), server_service_token)?
@@ -999,10 +1094,7 @@ impl GithubHttpEndpoint {
         Ok(into_public_run(&run, identity))
     }
 
-    /// Publishes only an immutable terminal status and conclusion for an exact run.
-    ///
-    /// No output, annotations, actions, images, names, links, logs, artifacts, or
-    /// other mutable presentation fields can be sent by this method.
+    /// Publishes an immutable terminal state, completion time, and native summary.
     ///
     /// # Errors
     ///
@@ -1014,13 +1106,22 @@ impl GithubHttpEndpoint {
         run_id: GithubCheckRunId,
         identity: &GithubCheckRunIdentity,
         conclusion: GithubCheckConclusion,
+        started_at: Option<&GithubCheckTimestamp>,
+        completed_at: &GithubCheckTimestamp,
         server_service_token: &SecretString,
     ) -> Result<GithubCheckRun, GithubChecksError> {
         let run_id_segment = run_id.get().to_string();
         let endpoint = self.checks_repository_url(repository, &["check-runs", &run_id_segment])?;
+        let summary = check_summary(conclusion.summary(), identity.details_url.as_str());
         let body = CompleteRunBody {
             status: "completed",
             conclusion: conclusion.as_str(),
+            started_at: started_at.map(GithubCheckTimestamp::as_str),
+            completed_at: completed_at.as_str(),
+            output: CheckOutputBody {
+                title: conclusion.title(),
+                summary: &summary,
+            },
         };
         let response =
             authenticated_checks_request(self.client.patch(endpoint), server_service_token)?
@@ -1091,6 +1192,10 @@ impl GithubHttpEndpoint {
         let wire: RunResponse = decode_json(&response.body).map_err(map_endpoint_error)?;
         validate_run(wire)
     }
+}
+
+fn check_summary(message: &str, details_url: &str) -> String {
+    format!("{message}\n\n[Open this job in Automata]({details_url})")
 }
 
 fn validate_suite(

--- a/crates/automata-ci-github/src/lib.rs
+++ b/crates/automata-ci-github/src/lib.rs
@@ -25,7 +25,7 @@ pub use checks::{
     GithubCheckModelError, GithubCheckName, GithubCheckRetryEvidence, GithubCheckRun,
     GithubCheckRunCreateOutcome, GithubCheckRunId, GithubCheckRunIdentity,
     GithubCheckRunReconciliation, GithubCheckRunState, GithubCheckSuite,
-    GithubCheckSuiteCreateOutcome, GithubCheckSuiteId, GithubChecksError,
+    GithubCheckSuiteCreateOutcome, GithubCheckSuiteId, GithubCheckTimestamp, GithubChecksError,
     GithubObservedCheckConclusion,
 };
 pub use config::{

--- a/crates/automata-ci-github/tests/checks.rs
+++ b/crates/automata-ci-github/tests/checks.rs
@@ -8,8 +8,8 @@ use automata_ci_github::{
     GithubCheckDetailsUrl, GithubCheckExternalId, GithubCheckModelError, GithubCheckName,
     GithubCheckRunCreateOutcome, GithubCheckRunId, GithubCheckRunIdentity,
     GithubCheckRunReconciliation, GithubCheckRunState, GithubCheckSuiteCreateOutcome,
-    GithubCheckSuiteId, GithubChecksError, GithubHttpEndpoint, GithubHttpLimits,
-    GithubObservedCheckConclusion,
+    GithubCheckSuiteId, GithubCheckTimestamp, GithubChecksError, GithubHttpEndpoint,
+    GithubHttpLimits, GithubObservedCheckConclusion,
 };
 use automata_ci_scm::{ExactRevision, RepositoryId};
 use serde_json::{Value, json};
@@ -38,6 +38,10 @@ fn revision() -> ExactRevision {
 
 fn token() -> SecretString {
     SecretString::new(TOKEN).expect("token")
+}
+
+fn lifecycle_timestamp() -> GithubCheckTimestamp {
+    GithubCheckTimestamp::from_unix_millis(1_786_666_505_000).expect("timestamp")
 }
 
 fn identity() -> GithubCheckRunIdentity {
@@ -261,17 +265,14 @@ async fn check_run_creation_sends_only_bounded_identity_and_accepts_exact_201() 
             "head_sha": SHA,
             "status": "queued",
             "external_id": EXTERNAL_ID,
-            "details_url": DETAILS_URL
+            "details_url": DETAILS_URL,
+            "output": {
+                "title": "Queued",
+                "summary": format!("Waiting for a runner.\n\n[Open this job in Automata]({DETAILS_URL})")
+            }
         })
     );
-    for forbidden in [
-        "output",
-        "annotations",
-        "actions",
-        "images",
-        "logs",
-        "artifacts",
-    ] {
+    for forbidden in ["annotations", "actions", "images", "logs", "artifacts"] {
         assert!(body.get(forbidden).is_none(), "forbidden field {forbidden}");
     }
 }
@@ -547,7 +548,7 @@ async fn get_validates_id_app_sha_name_external_suite_status_and_conclusion() {
 }
 
 #[tokio::test]
-async fn terminal_patch_can_send_only_terminal_state_and_validates_exact_response() {
+async fn terminal_patch_sends_completion_time_and_native_output_and_validates_exact_response() {
     let server = FixtureServer::spawn().await;
     server.enqueue(ResponseSpec::json(
         axum::http::StatusCode::OK,
@@ -564,6 +565,8 @@ async fn terminal_patch_can_send_only_terminal_state_and_validates_exact_respons
             GithubCheckRunId::new(41).expect("run id"),
             &identity(),
             GithubCheckConclusion::Success,
+            Some(&lifecycle_timestamp()),
+            &lifecycle_timestamp(),
             &token(),
         )
         .await
@@ -578,6 +581,8 @@ async fn terminal_patch_can_send_only_terminal_state_and_validates_exact_respons
             GithubCheckRunId::new(41).expect("run id"),
             &identity(),
             GithubCheckConclusion::Success,
+            Some(&lifecycle_timestamp()),
+            &lifecycle_timestamp(),
             &token(),
         )
         .await
@@ -590,13 +595,22 @@ async fn terminal_patch_can_send_only_terminal_state_and_validates_exact_respons
     let body: Value = serde_json::from_slice(&requests[0].body).expect("patch JSON");
     assert_eq!(
         body,
-        json!({"status": "completed", "conclusion": "success"})
+        json!({
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-08-14T00:15:05Z",
+            "completed_at": "2026-08-14T00:15:05Z",
+            "output": {
+                "title": "Passed",
+                "summary": format!("The job completed successfully.\n\n[Open this job in Automata]({DETAILS_URL})")
+            }
+        })
     );
-    assert_eq!(body.as_object().expect("object").len(), 2);
+    assert_eq!(body.as_object().expect("object").len(), 5);
 }
 
 #[tokio::test]
-async fn in_progress_patch_sends_only_the_nonterminal_state_and_validates_exact_response() {
+async fn in_progress_patch_sends_start_time_and_native_output_and_validates_exact_response() {
     let server = FixtureServer::spawn().await;
     server.enqueue(ResponseSpec::json(
         axum::http::StatusCode::OK,
@@ -612,6 +626,7 @@ async fn in_progress_patch_sends_only_the_nonterminal_state_and_validates_exact_
             &repository(),
             GithubCheckRunId::new(41).expect("run id"),
             &identity(),
+            &lifecycle_timestamp(),
             &token(),
         )
         .await
@@ -622,6 +637,7 @@ async fn in_progress_patch_sends_only_the_nonterminal_state_and_validates_exact_
             &repository(),
             GithubCheckRunId::new(41).expect("run id"),
             &identity(),
+            &lifecycle_timestamp(),
             &token(),
         )
         .await
@@ -632,8 +648,18 @@ async fn in_progress_patch_sends_only_the_nonterminal_state_and_validates_exact_
     assert_eq!(requests[0].method, "PATCH");
     assert_eq!(requests[0].uri, "/api/repos/acme/widget/check-runs/41");
     let body: Value = serde_json::from_slice(&requests[0].body).expect("patch JSON");
-    assert_eq!(body, json!({"status": "in_progress"}));
-    assert_eq!(body.as_object().expect("object").len(), 1);
+    assert_eq!(
+        body,
+        json!({
+            "status": "in_progress",
+            "started_at": "2026-08-14T00:15:05Z",
+            "output": {
+                "title": "Running",
+                "summary": format!("This job is running. Live progress and logs are available in Automata.\n\n[Open this job in Automata]({DETAILS_URL})")
+            }
+        })
+    );
+    assert_eq!(body.as_object().expect("object").len(), 3);
 }
 
 #[tokio::test]
@@ -1041,6 +1067,17 @@ fn bounded_models_and_diagnostics_are_redacted() {
     assert_eq!(
         GithubCheckExternalId::new("x".repeat(1_025)),
         Err(GithubCheckModelError::InvalidExternalId)
+    );
+    assert_eq!(
+        GithubCheckTimestamp::from_unix_millis(-1),
+        Err(GithubCheckModelError::InvalidTimestamp)
+    );
+    let fractional_timestamp =
+        GithubCheckTimestamp::from_unix_millis(1_786_666_505_123).expect("timestamp");
+    assert_eq!(fractional_timestamp.as_str(), "2026-08-14T00:15:05.123Z");
+    assert_eq!(
+        format!("{fractional_timestamp:?}"),
+        "GithubCheckTimestamp([validated])"
     );
 
     let name = GithubCheckName::new(NAME).expect("name");

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -920,6 +920,10 @@ pub struct ClaimedGithubCheckProjection {
     desired_revision: NonZeroU64,
     suite_id: Option<GithubCheckSuiteId>,
     run_id: Option<GithubCheckRunId>,
+    created_at: UnixMillis,
+    desired_updated_at: UnixMillis,
+    started_at: Option<UnixMillis>,
+    completed_at: Option<UnixMillis>,
     claimed_at: UnixMillis,
     expires_at: UnixMillis,
 }
@@ -947,6 +951,10 @@ impl ClaimedGithubCheckProjection {
         desired_revision: u64,
         suite_id: Option<GithubCheckSuiteId>,
         run_id: Option<GithubCheckRunId>,
+        created_at: UnixMillis,
+        desired_updated_at: UnixMillis,
+        started_at: Option<UnixMillis>,
+        completed_at: Option<UnixMillis>,
         claimed_at: UnixMillis,
         expires_at: UnixMillis,
     ) -> Result<Self, GithubCheckValueError> {
@@ -994,6 +1002,23 @@ impl ClaimedGithubCheckProjection {
             return Err(GithubCheckValueError::InvalidProjectionBinding);
         }
         validate_claim_interval(claimed_at, expires_at)?;
+        validate_timestamp(created_at, "GitHub Check creation time")?;
+        validate_timestamp(desired_updated_at, "GitHub Check desired update time")?;
+        if desired_updated_at < created_at || desired_updated_at > claimed_at {
+            return Err(GithubCheckValueError::InvalidClaimInterval);
+        }
+        if started_at.is_some_and(|value| value < created_at || value > claimed_at)
+            || completed_at
+                .is_some_and(|value| value < started_at.unwrap_or(created_at) || value > claimed_at)
+            || !matches!(
+                (desired, started_at, completed_at),
+                (GithubCheckDesiredProjection::Queued, None, None)
+                    | (GithubCheckDesiredProjection::InProgress, Some(_), None)
+                    | (GithubCheckDesiredProjection::Terminal(_), _, Some(_))
+            )
+        {
+            return Err(GithubCheckValueError::InvalidClaimInterval);
+        }
         Ok(Self {
             claim,
             action,
@@ -1006,6 +1031,10 @@ impl ClaimedGithubCheckProjection {
             desired_revision,
             suite_id,
             run_id,
+            created_at,
+            desired_updated_at,
+            started_at,
+            completed_at,
             claimed_at,
             expires_at,
         })
@@ -1065,6 +1094,26 @@ impl ClaimedGithubCheckProjection {
     #[must_use]
     pub const fn run_id(&self) -> Option<GithubCheckRunId> {
         self.run_id
+    }
+    /// Returns the durable time at which the Check first became queued.
+    #[must_use]
+    pub const fn created_at(&self) -> UnixMillis {
+        self.created_at
+    }
+    /// Returns the exact time of the desired lifecycle revision frozen by this claim.
+    #[must_use]
+    pub const fn desired_updated_at(&self) -> UnixMillis {
+        self.desired_updated_at
+    }
+    /// Returns the durable attempt start represented by this Check revision.
+    #[must_use]
+    pub const fn started_at(&self) -> Option<UnixMillis> {
+        self.started_at
+    }
+    /// Returns the durable terminal completion represented by this Check revision.
+    #[must_use]
+    pub const fn completed_at(&self) -> Option<UnixMillis> {
+        self.completed_at
     }
     /// Returns the durable time at which this exact fence was claimed.
     #[must_use]

--- a/crates/automata-ci-store/src/postgres/github_checks.rs
+++ b/crates/automata-ci-store/src/postgres/github_checks.rs
@@ -359,6 +359,12 @@ const CLAIM_LOCKED_DELIVERY_PROJECTION_SQL: &str = r"
         subject.desired_state, subject.desired_conclusion, subject.terminal_cause,
         subject.desired_revision, subject.created_at_ms,
         subject.desired_updated_at_ms,
+        (SELECT attempt.started_at_ms
+           FROM job_attempts AS attempt
+          WHERE attempt.id = subject.job_attempt_id) AS job_started_at_ms,
+        (SELECT terminal.completed_at_ms
+           FROM attempt_terminal_results AS terminal
+          WHERE terminal.attempt_id = subject.job_attempt_id) AS job_completed_at_ms,
         evidence.checks_authority_id,
         evidence.checks_authority_identity_digest,
         evidence.checks_authority_app_configuration_revision,
@@ -433,6 +439,12 @@ const CLAIM_LOCKED_SCHEDULE_PROJECTION_SQL: &str = r"
         subject.desired_state, subject.desired_conclusion, subject.terminal_cause,
         subject.desired_revision, subject.created_at_ms,
         subject.desired_updated_at_ms,
+        (SELECT attempt.started_at_ms
+           FROM job_attempts AS attempt
+          WHERE attempt.id = subject.job_attempt_id) AS job_started_at_ms,
+        (SELECT terminal.completed_at_ms
+           FROM attempt_terminal_results AS terminal
+          WHERE terminal.attempt_id = subject.job_attempt_id) AS job_completed_at_ms,
         evidence.checks_authority_id,
         evidence.checks_authority_identity_digest,
         evidence.checks_authority_app_configuration_revision,
@@ -508,6 +520,12 @@ const CLAIM_LOCKED_RERUN_PROJECTION_SQL: &str = r"
         subject.desired_state, subject.desired_conclusion, subject.terminal_cause,
         subject.desired_revision, subject.created_at_ms,
         subject.desired_updated_at_ms,
+        (SELECT attempt.started_at_ms
+           FROM job_attempts AS attempt
+          WHERE attempt.id = subject.job_attempt_id) AS job_started_at_ms,
+        (SELECT terminal.completed_at_ms
+           FROM attempt_terminal_results AS terminal
+          WHERE terminal.attempt_id = subject.job_attempt_id) AS job_completed_at_ms,
         evidence.checks_authority_id,
         evidence.checks_authority_identity_digest,
         evidence.checks_authority_app_configuration_revision,
@@ -1457,6 +1475,19 @@ fn decode_claimed(
         .map(GithubCheckRunId::new)
         .transpose()
         .map_err(|_| GithubCheckStoreError::CorruptData)?;
+    let job_started_at = optional_unix_millis_column(row, "job_started_at_ms")?;
+    let job_completed_at = optional_unix_millis_column(row, "job_completed_at_ms")?;
+    let (started_at, completed_at) = match subject.receipt.desired() {
+        GithubCheckDesiredProjection::Queued => (None, None),
+        GithubCheckDesiredProjection::InProgress => (
+            Some(job_started_at.unwrap_or(subject.desired_updated_at)),
+            None,
+        ),
+        GithubCheckDesiredProjection::Terminal(_) => (
+            Some(job_started_at.unwrap_or(subject.created_at)),
+            Some(job_completed_at.unwrap_or(subject.desired_updated_at)),
+        ),
+    };
     ClaimedGithubCheckProjection::from_durable_parts(
         claim,
         action,
@@ -1469,6 +1500,10 @@ fn decode_claimed(
         subject.receipt.desired_revision(),
         suite_id,
         run_id,
+        subject.created_at,
+        subject.desired_updated_at,
+        started_at,
+        completed_at,
         unix_millis_column(row, "claimed_at_ms")?,
         unix_millis_column(row, "claim_expires_at_ms")?,
     )

--- a/crates/automata-ci-store/tests/github_checks_api.rs
+++ b/crates/automata-ci-store/tests/github_checks_api.rs
@@ -251,6 +251,10 @@ fn prepare_projection(
         1,
         Some(GithubCheckSuiteId::new(19).expect("suite")),
         None,
+        UnixMillis::new(claimed_at.saturating_sub(2)),
+        UnixMillis::new(claimed_at.saturating_sub(1)),
+        None,
+        None,
         UnixMillis::new(claimed_at),
         UnixMillis::new(expires_at),
     )
@@ -333,11 +337,19 @@ fn claimed_projection_rehydrates_only_complete_current_state() {
         2,
         Some(suite),
         Some(run),
+        UnixMillis::new(50),
+        UnixMillis::new(75),
+        Some(UnixMillis::new(75)),
+        None,
         UnixMillis::new(100),
         UnixMillis::new(200),
     )
     .expect("complete durable claim");
     assert_eq!(claimed.claimed_at(), UnixMillis::new(100));
+    assert_eq!(claimed.created_at(), UnixMillis::new(50));
+    assert_eq!(claimed.desired_updated_at(), UnixMillis::new(75));
+    assert_eq!(claimed.started_at(), Some(UnixMillis::new(75)));
+    assert_eq!(claimed.completed_at(), None);
     assert_eq!(claimed.expires_at(), UnixMillis::new(200));
     assert_eq!(claimed.checks_authority(), &authority);
 
@@ -353,6 +365,10 @@ fn claimed_projection_rehydrates_only_complete_current_state() {
             GithubCheckDesiredProjection::InProgress,
             2,
             Some(suite),
+            None,
+            UnixMillis::new(50),
+            UnixMillis::new(75),
+            Some(UnixMillis::new(75)),
             None,
             UnixMillis::new(100),
             UnixMillis::new(200),
@@ -370,6 +386,10 @@ fn claimed_projection_rehydrates_only_complete_current_state() {
             external_id,
             GithubCheckDesiredProjection::Queued,
             (i64::MAX as u64) + 1,
+            None,
+            None,
+            UnixMillis::new(50),
+            UnixMillis::new(75),
             None,
             None,
             UnixMillis::new(100),
@@ -404,6 +424,10 @@ fn claimed_projection_rejects_cross_tenant_authority_selector() {
             claimed.desired_revision(),
             claimed.suite_id(),
             claimed.run_id(),
+            claimed.created_at(),
+            claimed.desired_updated_at(),
+            claimed.started_at(),
+            claimed.completed_at(),
             claimed.claimed_at(),
             claimed.expires_at(),
         ),

--- a/crates/automata-ci/src/app/web/data.rs
+++ b/crates/automata-ci/src/app/web/data.rs
@@ -1119,6 +1119,8 @@ pub(crate) struct JobLogPage {
     pub(crate) previous_navigation_job_id: Option<JobId>,
     pub(crate) next_navigation_job_id: Option<JobId>,
     pub(crate) job: JobSummary,
+    /// Authorization state for the independently protected log collection.
+    pub(crate) log_visibility: CollectionVisibility,
     pub(crate) lines: Vec<LogLine>,
     pub(crate) previous_cursor: Option<String>,
     pub(crate) next_cursor: Option<String>,

--- a/crates/automata-ci/src/app/web/live.rs
+++ b/crates/automata-ci/src/app/web/live.rs
@@ -1847,6 +1847,7 @@ impl LiveWebData {
         scope: HumanJobScope,
         detail: HumanJobDetail,
         dashboard_metadata_allowed: bool,
+        selected_log_access_allowed: bool,
         request: &JobLogRequest,
     ) -> Result<Option<JobLogPage>, WebDataError> {
         if detail.run.id != scope.run_id
@@ -1861,13 +1862,14 @@ impl LiveWebData {
         {
             return Err(WebDataError::Corrupt);
         }
-        let Some(log_stream) = detail.log_stream else {
-            return Ok(None);
-        };
-        if !log_stream_safety_is_valid(&log_stream) {
+        if detail
+            .log_stream
+            .as_ref()
+            .is_some_and(|stream| !log_stream_safety_is_valid(stream))
+        {
             return Err(WebDataError::Corrupt);
         }
-        let selected_job = map_job(&detail.job, true)?;
+        let selected_job = map_job(&detail.job, selected_log_access_allowed)?;
         let mut selected_navigation_rows = detail
             .navigation
             .iter()
@@ -1881,6 +1883,8 @@ impl LiveWebData {
         if selected_navigation_rows.next().is_some() {
             return Err(WebDataError::Corrupt);
         }
+        // Navigation targets the stable job-detail capability. Log access is
+        // represented independently by `selected_job.logs_available`.
         let selected_navigation = map_navigation(selected_navigation_row, true)?;
         if selected_navigation.name != selected_job.name
             || selected_navigation.status != selected_job.status
@@ -1894,59 +1898,43 @@ impl LiveWebData {
                     .saturating_add(MAX_RENDERED_JOBS)
                     .min(detail.navigation.len());
                 let mut jobs = Vec::with_capacity(page_end.saturating_sub(page_start));
-                let mut log_access_cache = Vec::new();
                 for job in &detail.navigation[page_start..page_end] {
                     if job.id == selected_job.id {
                         jobs.push(selected_navigation.clone());
                         continue;
                     }
-                    let logs_available = self
-                        .cached_log_access_allowed(
-                            context,
-                            tenant,
-                            repository,
-                            &mut log_access_cache,
-                            job.log_publication.as_ref(),
-                        )
-                        .await?;
-                    jobs.push(map_navigation(job, logs_available)?);
+                    jobs.push(map_navigation(job, true)?);
                 }
-                let mut previous_navigation_job_id = None;
-                for job in detail.navigation[..page_start].iter().rev() {
-                    if self
-                        .cached_log_access_allowed(
-                            context,
-                            tenant,
-                            repository,
-                            &mut log_access_cache,
-                            job.log_publication.as_ref(),
-                        )
-                        .await?
-                    {
-                        previous_navigation_job_id = Some(job.id);
-                        break;
-                    }
-                }
-                let mut next_navigation_job_id = None;
-                for job in &detail.navigation[page_end..] {
-                    if self
-                        .cached_log_access_allowed(
-                            context,
-                            tenant,
-                            repository,
-                            &mut log_access_cache,
-                            job.log_publication.as_ref(),
-                        )
-                        .await?
-                    {
-                        next_navigation_job_id = Some(job.id);
-                        break;
-                    }
-                }
+                let previous_navigation_job_id =
+                    detail.navigation[..page_start].last().map(|job| job.id);
+                let next_navigation_job_id =
+                    detail.navigation[page_end..].first().map(|job| job.id);
                 (jobs, previous_navigation_job_id, next_navigation_job_id)
             } else {
                 (vec![selected_navigation], None, None)
             };
+        if !selected_log_access_allowed {
+            if request.cursor.is_some() {
+                return Ok(None);
+            }
+            let settings_visible = dashboard_metadata_allowed
+                && self.settings_visible(context, tenant, repository).await?;
+            return Ok(Some(JobLogPage {
+                repository: map_repository(repository, settings_visible),
+                run: map_run(&detail.run)?,
+                jobs,
+                previous_navigation_job_id,
+                next_navigation_job_id,
+                job: selected_job,
+                log_visibility: CollectionVisibility::Restricted,
+                lines: Vec::new(),
+                previous_cursor: None,
+                next_cursor: None,
+            }));
+        }
+        let Some(log_stream) = detail.log_stream else {
+            return Err(WebDataError::Corrupt);
+        };
         let decoded_cursor = match request.cursor.as_deref() {
             None => None,
             Some(cursor) => match decode_log_cursor(
@@ -2142,6 +2130,7 @@ impl LiveWebData {
             previous_navigation_job_id,
             next_navigation_job_id,
             job: selected_job,
+            log_visibility: CollectionVisibility::Full,
             lines,
             previous_cursor,
             next_cursor,
@@ -2615,26 +2604,6 @@ impl WebData for LiveWebData {
         if detail.run.id != run_id || detail.job.id != job_id {
             return Err(WebDataError::Corrupt);
         }
-        let Some(log_stream) = detail.log_stream.as_ref() else {
-            return Ok(None);
-        };
-        if detail.job.log_publication.as_ref() != Some(&log_stream.publication)
-            || !log_stream_safety_is_valid(log_stream)
-        {
-            return Err(WebDataError::Corrupt);
-        }
-        let Some(attempt) = detail.job.latest_attempt.as_ref() else {
-            return Err(WebDataError::Corrupt);
-        };
-        if log_stream.attempt_id != attempt.id {
-            return Err(WebDataError::Corrupt);
-        }
-        if !self
-            .log_access_allowed(context, &tenant, &repository, Some(&log_stream.publication))
-            .await?
-        {
-            return Ok(None);
-        }
         let dashboard_metadata_allowed = self
             .dashboard_job_metadata_allowed(
                 context,
@@ -2642,8 +2611,33 @@ impl WebData for LiveWebData {
                 &repository,
                 detail.run.publication.effective_dashboard_visibility,
             )
-            .await
-            .unwrap_or(false);
+            .await?;
+        let selected_log_access_allowed = match detail.log_stream.as_ref() {
+            Some(log_stream) => {
+                if detail.job.log_publication.as_ref() != Some(&log_stream.publication)
+                    || !log_stream_safety_is_valid(log_stream)
+                {
+                    return Err(WebDataError::Corrupt);
+                }
+                let Some(attempt) = detail.job.latest_attempt.as_ref() else {
+                    return Err(WebDataError::Corrupt);
+                };
+                if log_stream.attempt_id != attempt.id {
+                    return Err(WebDataError::Corrupt);
+                }
+                self.log_access_allowed(
+                    context,
+                    &tenant,
+                    &repository,
+                    Some(&log_stream.publication),
+                )
+                .await?
+            }
+            None => false,
+        };
+        if !dashboard_metadata_allowed && !selected_log_access_allowed {
+            return Ok(None);
+        }
         self.map_job_log(
             context,
             &tenant,
@@ -2651,6 +2645,7 @@ impl WebData for LiveWebData {
             scope,
             detail,
             dashboard_metadata_allowed,
+            selected_log_access_allowed,
             request,
         )
         .await
@@ -2797,9 +2792,9 @@ mod tests {
         RepositorySecretsPageRequest, RepositorySecretsReadOutcome, VerifiedRepositorySecretForm,
     };
     use crate::app::web::data::{
-        JobLogPage, JobLogRequest, REPOSITORY_PAGE_SIZE, RepositoryDirectoryRequest,
-        RepositoryPath, RepositorySettingsDestination, RequestContext, RunListRequest, Status,
-        StatusFilter, Viewer, WebData, WebDataError,
+        CollectionVisibility, JobLogPage, JobLogRequest, REPOSITORY_PAGE_SIZE,
+        RepositoryDirectoryRequest, RepositoryPath, RepositorySettingsDestination, RequestContext,
+        RunListRequest, Status, StatusFilter, Viewer, WebData, WebDataError,
     };
 
     #[test]
@@ -3654,7 +3649,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn log_denial_and_invalid_cursor_are_indistinguishable_from_missing() {
+    async fn invalid_cursors_are_hidden_and_log_denial_restricts_only_the_collection() {
         let (data, context, repository, run_id, job_id) = fake_live_data(true).await;
         let invalid_cursor = JobLogRequest {
             cursor: Some("not-a-canonical-cursor".to_owned()),
@@ -3681,10 +3676,23 @@ mod tests {
             limit: 200,
             maximum_decoded_bytes: super::super::data::LOG_PAGE_DECODED_BYTES,
         };
+        let page = WebData::job_log(&data, &context, &repository, run_id, job_id, &first_page)
+            .await
+            .expect("job detail lookup")
+            .expect("dashboard-readable metadata remains visible");
+        assert_eq!(page.log_visibility, CollectionVisibility::Restricted);
+        assert!(page.lines.is_empty());
+        assert!(page.previous_cursor.is_none());
+        assert!(page.next_cursor.is_none());
+
+        let denied_cursor = JobLogRequest {
+            cursor: Some("not-a-canonical-cursor".to_owned()),
+            ..first_page
+        };
         assert!(
-            WebData::job_log(&data, &context, &repository, run_id, job_id, &first_page,)
+            WebData::job_log(&data, &context, &repository, run_id, job_id, &denied_cursor,)
                 .await
-                .expect("authorization denial is hidden")
+                .expect("restricted log cursors are hidden")
                 .is_none()
         );
     }
@@ -3735,19 +3743,26 @@ mod tests {
                 .count(),
             1
         );
+        assert_eq!(calls.len(), 2);
         assert_eq!(
             calls[0].request.permission().as_str(),
-            repository_read_permissions::LOG_READ
+            repository_read_permissions::REPOSITORY_READ
         );
-        assert_eq!(calls[0].durable_visibility, Some(OutputVisibility::Public));
+        let log_call = calls
+            .iter()
+            .find(|target| {
+                target.request.permission().as_str() == repository_read_permissions::LOG_READ
+            })
+            .expect("selected-log authorization");
+        assert_eq!(log_call.durable_visibility, Some(OutputVisibility::Public));
         assert_eq!(
-            calls[0].request.secret_exposure(),
+            log_call.request.secret_exposure(),
             SecretExposureClass::Secretless
         );
     }
 
     #[tokio::test]
-    async fn jobs_without_a_log_stream_never_advertise_a_log_destination() {
+    async fn jobs_without_a_log_stream_still_advertise_a_job_detail_destination() {
         let (data, _, repository, run_id, job_id, calls) =
             fake_live_data_with_policy(FakeLivePolicy {
                 dashboard_visibility: OutputVisibility::Public,
@@ -3777,7 +3792,7 @@ mod tests {
             .iter()
             .find(|job| job.name == "Pending without a log stream")
             .expect("pending job navigation");
-        assert!(!pending.logs_available);
+        assert!(pending.logs_available);
         assert_eq!(
             calls
                 .lock()
@@ -3787,8 +3802,42 @@ mod tests {
                     target.request.permission().as_str() == repository_read_permissions::LOG_READ
                 })
                 .count(),
-            2
+            1
         );
+    }
+
+    #[tokio::test]
+    async fn dashboard_readable_job_renders_when_logs_are_denied() {
+        let (data, context, repository, run_id, job_id, _) =
+            fake_live_data_with_policy(FakeLivePolicy {
+                dashboard_visibility: OutputVisibility::Public,
+                log_visibility: OutputVisibility::Private,
+                log_exposure: SecretExposureClass::Secretless,
+                raw_log_disposition: HumanRawLogDisposition::Persist,
+                allow_dashboard: true,
+                allow_logs: false,
+                allow_settings_read: false,
+                allow_settings_update: false,
+            })
+            .await;
+
+        let page = WebData::job_log(
+            &data,
+            &context,
+            &repository,
+            run_id,
+            job_id,
+            &first_log_page_request(),
+        )
+        .await
+        .expect("job detail read")
+        .expect("dashboard-readable job detail");
+
+        assert_eq!(page.job.id, job_id);
+        assert_eq!(page.log_visibility, CollectionVisibility::Restricted);
+        assert!(page.lines.is_empty());
+        assert!(page.previous_cursor.is_none());
+        assert!(page.next_cursor.is_none());
     }
 
     #[tokio::test]
@@ -3814,10 +3863,20 @@ mod tests {
         );
         {
             let mut calls = calls.lock().expect("authorization calls");
-            assert_eq!(calls.len(), 1);
-            assert_eq!(calls[0].durable_visibility, Some(OutputVisibility::Private));
+            assert_eq!(calls.len(), 2);
             assert_eq!(
-                calls[0].request.secret_exposure(),
+                calls[0].request.permission().as_str(),
+                repository_read_permissions::REPOSITORY_READ
+            );
+            let log_call = calls
+                .iter()
+                .find(|target| {
+                    target.request.permission().as_str() == repository_read_permissions::LOG_READ
+                })
+                .expect("private-log authorization");
+            assert_eq!(log_call.durable_visibility, Some(OutputVisibility::Private));
+            assert_eq!(
+                log_call.request.secret_exposure(),
                 SecretExposureClass::Secretless
             );
             calls.clear();
@@ -4089,7 +4148,7 @@ mod tests {
         assert_eq!(page.lines[0].text, "checkout ok");
         assert_eq!(page.job.status, Status::Lost);
         assert!(page.jobs[0].logs_available);
-        assert!(!page.jobs[1].logs_available);
+        assert!(page.jobs[1].logs_available);
         assert!(page.next_cursor.is_none());
     }
 

--- a/crates/automata-ci/src/app/web/model.rs
+++ b/crates/automata-ci/src/app/web/model.rs
@@ -453,10 +453,17 @@ struct JobLogPage {
     jobs: Vec<JobLogNavigationItem>,
     navigation_pagination: Pagination,
     job: JobLogJob,
+    log_visibility: &'static str,
     search: JobLogSearch,
     lines: Vec<JobLogLine>,
     notice: Option<&'static str>,
     pagination: JobLogPagination,
+}
+
+#[derive(Debug, Serialize)]
+struct DeepLinkSignInPage {
+    kind: &'static str,
+    shell: Shell,
 }
 
 #[derive(Debug, Serialize)]
@@ -2044,6 +2051,7 @@ pub(super) fn job_log(
             jobs: navigation,
             navigation_pagination,
             job: selected_job,
+            log_visibility: collection_visibility(data.log_visibility),
             search: JobLogSearch {
                 action: job_href.clone(),
                 query: query.to_owned(),
@@ -2052,6 +2060,32 @@ pub(super) fn job_log(
             lines,
             notice,
             pagination,
+        },
+    )
+}
+
+pub(super) fn deep_link_sign_in(
+    assets: ClientAssetManifest,
+    csp_nonce: String,
+    context: &RequestContext,
+    return_path: String,
+) -> Result<String, ModelError> {
+    if context.viewer().is_some() || context.sign_in_action().is_none() {
+        return Err(ModelError::InvalidData);
+    }
+    let return_path = LoginReturnPath::new(return_path).map_err(|_| ModelError::InvalidData)?;
+    serialize_request(
+        assets,
+        csp_nonce,
+        DeepLinkSignInPage {
+            kind: "deep-link-sign-in",
+            shell: global_shell(
+                context,
+                None,
+                REPOSITORIES_PATH,
+                &return_path,
+                "Sign in to view this run · Automata".to_owned(),
+            )?,
         },
     )
 }
@@ -2082,7 +2116,11 @@ fn valid_job_log_data(data: &JobLogData) -> bool {
             .is_some_and(|job| {
                 job.name == data.job.name && job.status == data.job.status && job.logs_available
             })
-        && data.job.logs_available
+        && (data.log_visibility == CollectionVisibility::Full) == data.job.logs_available
+        && (data.log_visibility == CollectionVisibility::Full
+            || (data.lines.is_empty()
+                && data.previous_cursor.is_none()
+                && data.next_cursor.is_none()))
         && data.lines.len() <= super::data::LOG_PAGE_SIZE
         && decoded_bytes.is_some_and(|bytes| bytes <= LOG_PAGE_DECODED_BYTES)
         && data.lines.iter().all(|line| {
@@ -2647,10 +2685,10 @@ fn status(value: DataStatus) -> Status {
 
 const fn job_log_notice(status: DataStatus) -> Option<&'static str> {
     match status {
-        DataStatus::Queued => Some("This job is queued. Refresh to check for logs."),
-        DataStatus::InProgress => {
-            Some("This job is still running. Refresh to load newly committed logs.")
-        }
+        DataStatus::Queued => Some("This job is queued. This page updates automatically."),
+        DataStatus::InProgress => Some(
+            "This job is still running. This page updates automatically as logs are committed.",
+        ),
         _ => None,
     }
 }
@@ -4605,11 +4643,13 @@ mod tests {
     fn job_log_notice_tracks_lifecycle_instead_of_pagination() {
         assert_eq!(
             job_log_notice(DataStatus::Queued),
-            Some("This job is queued. Refresh to check for logs.")
+            Some("This job is queued. This page updates automatically.")
         );
         assert_eq!(
             job_log_notice(DataStatus::InProgress),
-            Some("This job is still running. Refresh to load newly committed logs.")
+            Some(
+                "This job is still running. This page updates automatically as logs are committed."
+            )
         );
         for terminal in [
             DataStatus::Succeeded,

--- a/crates/automata-ci/src/app/web/routes.rs
+++ b/crates/automata-ci/src/app/web/routes.rs
@@ -24,6 +24,7 @@ use axum::routing::{get, post};
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
 use tokio::sync::Semaphore;
 use tracing::error;
 
@@ -267,6 +268,10 @@ fn router_with_optional_rbac_data(
         .route(
             "/{owner}/{repository}/actions/runs/{run_id}/jobs/{job_id}",
             get(job_log),
+        )
+        .route(
+            "/{owner}/{repository}/actions/runs/{run_id}/jobs/{job_id}/snapshot",
+            get(job_log_snapshot),
         )
         .route(
             "/{owner}/{repository}/actions/runs/{run_id}/artifacts/{artifact_id}",
@@ -1356,6 +1361,36 @@ async fn job_log(
         .await
     {
         Ok(Some(data)) => data,
+        Ok(None) if context.viewer().is_none() && context.sign_in_action().is_some() => {
+            let mut return_path = format!(
+                "/{}/{}/actions/runs/{run_id}/jobs/{job_id}",
+                repository_path.owner, repository_path.name
+            );
+            if let Some(query) = raw_query.as_deref().filter(|query| !query.is_empty()) {
+                return_path.push('?');
+                return_path.push_str(query);
+            }
+            let csp_nonce = match new_csp_nonce() {
+                Ok(nonce) => nonce,
+                Err(error) => {
+                    error!(%error, "failed to generate a CSP nonce");
+                    return internal_server_error();
+                }
+            };
+            let request_json = match model::deep_link_sign_in(
+                client_assets(),
+                csp_nonce.clone(),
+                &context,
+                return_path,
+            ) {
+                Ok(request) => request,
+                Err(error) => {
+                    error!(%error, "failed to assemble deep-link sign-in page");
+                    return internal_server_error();
+                }
+            };
+            return render(state, request_json, csp_nonce).await;
+        }
         Ok(None) => return not_found(),
         Err(error) => return data_error_response(error),
     };
@@ -1389,6 +1424,82 @@ async fn job_log(
         }
     };
     render(state, request_json, csp_nonce).await
+}
+
+async fn job_log_snapshot(
+    State(state): State<WebState>,
+    context: Option<Extension<RequestContext>>,
+    csrf: Option<Extension<Arc<CsrfToken>>>,
+    path: Result<Path<(String, String, String, String)>, PathRejection>,
+    request_headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
+    query: Result<Query<JobLogQuery>, QueryRejection>,
+) -> Response<Body> {
+    let (Ok(Path((owner, repository, run_id, job_id))), Ok(Query(query))) = (path, query) else {
+        return bad_request();
+    };
+    if !valid_raw_query_encoding(raw_query.as_deref()) {
+        return bad_request();
+    }
+    let Some(repository_path) = repository_path(owner, repository) else {
+        return bad_request();
+    };
+    let Some(run_id) = parse_run_id(&run_id) else {
+        return bad_request();
+    };
+    let Some(job_id) = parse_job_id(&job_id) else {
+        return bad_request();
+    };
+    let Some((search, cursor)) = validate_log_query(query) else {
+        return bad_request();
+    };
+    let context = request_context(&state, context);
+    let csrf = csrf.map(|Extension(csrf)| csrf);
+    let ShellMutationResolution::Valid(mutation) = shell_mutation(&context, csrf.as_deref()) else {
+        return internal_server_error();
+    };
+    let request = JobLogRequest {
+        cursor,
+        limit: LOG_PAGE_SIZE,
+        maximum_decoded_bytes: LOG_PAGE_DECODED_BYTES,
+    };
+    let data = match state
+        .data
+        .job_log(&context, &repository_path, run_id, job_id, &request)
+        .await
+    {
+        Ok(Some(data)) => data,
+        // This endpoint is consumed only after the viewer has loaded the HTML
+        // page. A generic 404 on expired/changed authority preserves the same
+        // non-enumerating boundary without returning login HTML to `fetch`.
+        Ok(None) => return not_found(),
+        Err(error) => return data_error_response(error),
+    };
+    if !repository_matches(&data.repository, &repository_path)
+        || data.run.id != run_id
+        || data.job.id != job_id
+    {
+        error!("job snapshot data did not preserve its requested scope");
+        return internal_server_error();
+    }
+    let request_json = match model::job_log(
+        client_assets(),
+        // The snapshot is JSON rather than executable HTML, but using the same
+        // validated model builder keeps its shape and limits identical.
+        "snapshot".to_owned(),
+        &context,
+        mutation,
+        &search,
+        request.cursor.as_deref(),
+        data,
+    ) {
+        Ok(request) => request,
+        Err(error) => {
+            error!(%error, "failed to assemble job snapshot");
+            return internal_server_error();
+        }
+    };
+    json_snapshot_response(request_json, &request_headers)
 }
 
 async fn artifact(
@@ -1833,6 +1944,43 @@ fn if_none_match_matches(value: &HeaderValue, etag: &str) -> bool {
                     .is_some_and(|candidate| candidate == etag)
         })
     })
+}
+
+fn json_snapshot_response(body: String, request_headers: &HeaderMap) -> Response<Body> {
+    let digest = Sha256::digest(body.as_bytes());
+    let mut etag = String::with_capacity(2 + "sha256-".len() + digest.len() * 2);
+    etag.push('"');
+    etag.push_str("sha256-");
+    for byte in digest {
+        write!(&mut etag, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    etag.push('"');
+
+    let not_modified = request_headers
+        .get(IF_NONE_MATCH)
+        .is_some_and(|value| if_none_match_matches(value, &etag));
+    let mut response = if not_modified {
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::NOT_MODIFIED;
+        response
+    } else {
+        Response::new(Body::from(body))
+    };
+    let headers = response.headers_mut();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/json; charset=utf-8"),
+    );
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static(PAGE_CACHE_CONTROL));
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    let Ok(etag) = HeaderValue::from_str(&etag) else {
+        return internal_server_error();
+    };
+    headers.insert(ETAG, etag);
+    response
 }
 
 fn artifact_response(download: super::data::ArtifactDownload) -> Response<Body> {
@@ -2951,6 +3099,7 @@ mod tests {
             previous_navigation_job_id: None,
             next_navigation_job_id: None,
             job,
+            log_visibility: CollectionVisibility::Full,
             lines: vec![
                 LogLine {
                     sequence: 38,
@@ -4720,6 +4869,100 @@ mod tests {
                 maximum_decoded_bytes: LOG_PAGE_DECODED_BYTES,
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn job_snapshot_is_bounded_no_store_json_with_conditional_revalidation() {
+        let (app, renderer, data) = test_router(FakeOutcome::Found);
+        let uri = format!(
+            "/acme-labs/payments-api/actions/runs/{RUN_ID}/jobs/{JOB_ID}/snapshot?q=retry%20warning&cursor=log_20"
+        );
+        let response = get(&app, &uri).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()[CONTENT_TYPE],
+            "application/json; charset=utf-8"
+        );
+        assert_eq!(response.headers()[CACHE_CONTROL], PAGE_CACHE_CONTROL);
+        assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+        let etag = response.headers()[ETAG]
+            .to_str()
+            .expect("snapshot ETag")
+            .to_owned();
+        assert!(etag.starts_with("\"sha256-"));
+        let body = to_bytes(response.into_body(), 8 * 1_024 * 1_024)
+            .await
+            .expect("snapshot body");
+        let snapshot: serde_json::Value =
+            serde_json::from_slice(&body).expect("snapshot render request");
+        assert_eq!(snapshot["page"]["kind"], "job-log");
+        assert_eq!(snapshot["page"]["job"]["id"], JOB_ID);
+        assert_eq!(snapshot["page"]["search"]["query"], "retry warning");
+        assert_eq!(snapshot["page"]["pagination"]["currentCursor"], "log_20");
+        assert!(renderer.requests().is_empty());
+
+        let not_modified = app
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri(&uri)
+                    .header(IF_NONE_MATCH, &etag)
+                    .body(Body::empty())
+                    .expect("conditional snapshot request"),
+            )
+            .await
+            .expect("snapshot route");
+        assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(not_modified.headers()[ETAG], etag);
+        assert_eq!(not_modified.headers()[CACHE_CONTROL], PAGE_CACHE_CONTROL);
+        assert!(
+            to_bytes(not_modified.into_body(), 1)
+                .await
+                .expect("empty 304 body")
+                .is_empty()
+        );
+        assert_eq!(data.calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn anonymous_missing_and_denied_job_links_share_an_exact_sign_in_handoff() {
+        for outcome in [FakeOutcome::Missing, FakeOutcome::Unauthorized] {
+            let (app, renderer, data) = test_router(outcome);
+            let context = RequestContext::new(
+                TenantId::new("acme-production").expect("tenant"),
+                AuthorizationContext::anonymous(),
+                None,
+                Some(crate::app::github_auth::GITHUB_WEB_BEGIN_PATH.to_owned()),
+            )
+            .expect("anonymous sign-in context");
+            let app = app.layer(Extension(context));
+            let uri = format!(
+                "/acme-labs/payments-api/actions/runs/{RUN_ID}/jobs/{JOB_ID}?q=retry%20warning"
+            );
+
+            let response = get(&app, &uri).await;
+            let page = renderer.page();
+
+            assert_page_headers(&response, &page);
+            assert_eq!(page["page"]["kind"], "deep-link-sign-in");
+            assert_eq!(
+                page["page"]["shell"]["signIn"]["action"],
+                crate::app::github_auth::GITHUB_WEB_BEGIN_PATH
+            );
+            assert_eq!(page["page"]["shell"]["signIn"]["returnPath"], uri);
+            assert_eq!(
+                data.calls(),
+                vec![RecordedCall::JobLog {
+                    repository: repository_path(),
+                    run_id: run_id(),
+                    job_id: job_id(),
+                    cursor: None,
+                    limit: LOG_PAGE_SIZE,
+                    maximum_decoded_bytes: LOG_PAGE_DECODED_BYTES,
+                }]
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/github-status-ux-plan.md
+++ b/docs/github-status-ux-plan.md
@@ -1,0 +1,517 @@
+# GitHub status and run UX plan
+
+Status: implementation in progress on `feature/github-checks-ux`. This document
+records the researched GitHub platform boundary, the gaps in Automata's current
+implementation, and the complete phased delivery plan.
+
+Implemented in the first branch slice:
+
+- stable exact-job Details pages with dashboard/log authorization split;
+- generic non-enumerating sign-in handoff back to the exact deep link;
+- bounded same-origin live snapshots with ETag revalidation, visibility pause,
+  terminal stop, request cancellation, and exponential failure backoff;
+- native queued/running/terminal Check output with exact Automata links;
+- durable execution start/completion timestamps projected as RFC 3339 UTC.
+
+Still intentionally pending are content-addressed terminal presentations,
+annotation batching/reconciliation, GitHub and browser rerun controls, optional
+commit-status/deployment projections, and the rollout observability described
+below. Those pieces require their own durable idempotency state and must not be
+simulated with unsafe best-effort provider mutations.
+
+## Outcome
+
+An Automata run should feel native from a pull request or commit:
+
+1. A job appears promptly as queued, changes to running when execution starts,
+   and shows an accurate terminal result and duration.
+2. GitHub's Checks view contains useful Markdown output and source annotations,
+   rather than only a state and conclusion.
+3. **Details** always targets the exact Automata job. A signed-in or public
+   viewer sees it immediately; an unauthenticated viewer gets a non-leaking
+   sign-in handoff that returns to that exact job.
+4. The Automata page updates while the job is running and shows live logs when
+   the viewer has log access.
+5. GitHub-native rerun controls call Automata's durable rerun machinery.
+6. Legacy commit statuses and GitHub deployments are projected only where they
+   add a distinct compatibility or environment UX benefit.
+
+Target service objectives after rollout:
+
+- p95 durable lifecycle-to-GitHub state lag below 5 seconds when GitHub is
+  healthy;
+- 100% of created Check Runs have a canonical HTTPS `details_url`;
+- no Check Run remains nonterminal after its durable Automata subject is
+  terminal, excluding visible retry/rate-limit backlog;
+- clicking **Details** never returns a raw-log authorization 404 for an
+  otherwise dashboard-readable job;
+- duplicate webhook delivery and publisher restart do not duplicate a Check
+  Run or a source annotation.
+
+## Platform boundary
+
+### What GitHub permits
+
+The Checks API is the primary third-party CI integration surface. A GitHub App
+with `checks:write` can publish Check Runs with:
+
+- `queued`, `in_progress`, and `completed` states (the additional `waiting`,
+  `pending`, and `requested` states are reserved to GitHub Actions);
+- `started_at`, `completed_at`, `details_url`, and `external_id`;
+- Markdown `output.title`, `output.summary`, and `output.text`;
+- source annotations, with at most 50 appended by one request;
+- up to three requested-action buttons;
+- `rerequested` and `requested_action` webhook-driven controls.
+
+Annotations appear in the pull request Checks UI and, when they refer to a
+line, in Files changed. GitHub automatically associates a Check Run with the
+App's suite for the repository and SHA. Current documented limits include
+50,000 Check Runs per suite and 1,000 Check Runs with the same name in a suite.
+
+Commit statuses are a smaller, separate compatibility surface: one context can
+be `pending`, `success`, `failure`, or `error`, with a short description and
+`target_url`. They do not populate the pull request Checks tab and should not
+duplicate every rich Check by default.
+
+Deployments are also separate. For jobs that genuinely target a declared
+environment, a deployment and its evolving status can provide repository
+environment/deployment history, `log_url`, and `environment_url`. Build and
+test jobs should not be mislabeled as deployments.
+
+References:
+
+- [Check Run endpoints](https://docs.github.com/en/rest/checks/runs)
+- [Using the Checks API](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks)
+- [Status checks](https://docs.github.com/en/pull-requests/reference/status-checks)
+- [Commit status endpoints](https://docs.github.com/en/rest/commits/statuses)
+- [Check webhook payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run)
+- [Deployment endpoints](https://docs.github.com/en/rest/deployments/deployments)
+- [Deployment status endpoints](https://docs.github.com/en/rest/deployments/statuses)
+- [Actions limits](https://docs.github.com/en/actions/reference/limits)
+
+### What GitHub does not permit
+
+There is no GitHub App registration or Checks API field that embeds an
+arbitrary application iframe in a repository, pull request, or Checks page.
+GitHub App registration exposes external homepage, setup, callback, and webhook
+URLs; it does not expose a repository UI iframe slot. Automata also cannot
+create native GitHub Actions workflow-run, job, log, or artifact records.
+
+Therefore the closest supported UX is:
+
+- render as much diagnosis as possible in GitHub's native Check output;
+- use native annotations and requested-action buttons;
+- deep-link to an excellent external job page for live logs and full detail.
+
+Automata should continue to send `frame-ancestors 'none'`. Weakening its CSP
+would not create a GitHub embedding surface and would make the dashboard
+clickjacking-prone.
+
+## Current Automata implementation
+
+The existing foundation is strong:
+
+- `crates/automata-ci-store/src/github_checks.rs` and
+  `src/postgres/github_checks.rs` persist fenced Check subjects and a durable,
+  restart-safe projection outbox.
+- `crates/automata-ci-github/src/checks.rs` creates/reconciles an exact Check
+  Suite and Check Run, validates App/suite/SHA/name/external ID/details URL, and
+  updates lifecycle state.
+- `crates/automata-ci-github-delivery/src/checks_publisher.rs` derives canonical
+  repository, run, and job URLs and handles bounded retries, rate limits,
+  mutation uncertainty, and credential fencing.
+- one child Check subject is inserted for each concrete job attempt; lifecycle
+  changes advance it from queued through in-progress to a terminal conclusion.
+- terminal `JobResult` already retains masked step summaries, step timelines,
+  and up to 4,096 structured annotations.
+- the dashboard already has run detail and paginated/searchable job log pages.
+- the durable rerun backend already supports whole-workflow, failed-job, and
+  selected-job reruns.
+
+The user-visible gaps are concentrated rather than architectural:
+
+1. Check create/start/complete payloads deliberately omit all output,
+   timestamps, annotations, actions, images, and presentation validation.
+2. The durable Check subject remembers only the latest state-transition time;
+   it does not preserve distinct start and completion timestamps or a frozen
+   presentation revision.
+3. The exact job URL is implemented as a raw-log page. Its read boundary checks
+   log publication first. A job can therefore be dashboard-readable but return
+   404 from **Details** because logs are private, unavailable, or not yet
+   created.
+4. An unauthenticated deep link to a private resource receives the same 404 as
+   a missing resource. This is safe against enumeration but offers no sign-in
+   handoff.
+5. Running run/job pages require a manual refresh; the hydrated React client
+   does not poll or stream state.
+6. webhook ingress normalizes `push`, `pull_request`, `merge_group`, and
+   `repository_dispatch`, but not `check_run`/`check_suite` rerun actions.
+7. no optional commit-status, deployment-status, or badge projector exists.
+
+## Design decisions
+
+### Checks remain authoritative
+
+Automata will continue to create one Check Run per concrete job attempt. The
+existing aggregate workflow Check remains the pre-admission/compile diagnostic
+until job expansion is known. We should evaluate hiding or neutralizing the
+aggregate after successful expansion in a GitHub.com fixture, but must not
+remove the only diagnostic for workflows that fail before jobs exist.
+
+Provider-facing job names remain the evaluated job display name to match
+GitHub's required-check convention. Installation documentation will warn that
+job names must be unique across workflows when used as required checks; GitHub
+itself applies that constraint without workflow, matrix, or trigger scope.
+
+### Job detail and logs become separate capabilities
+
+The canonical `/OWNER/REPO/actions/runs/RUN/jobs/JOB` route becomes a job-detail
+page authorized by dashboard metadata visibility. Log content inside that page
+has an independent `full`, `restricted`, or `unavailable` collection state.
+This makes the Check deep link stable without broadening access to logs.
+
+For an anonymous request to a syntactically valid run/job URL when human login
+is enabled, the server may render the same generic sign-in handoff for missing
+and unauthorized records. It must not query or reveal the resource name,
+status, existence, or repository privacy. The existing POST-based, login-bound
+flow remains intact and returns to the exact bounded local path. An authorized
+viewer still receives the normal indistinguishable 404 for a missing or denied
+resource after login.
+
+### Live UI uses bounded incremental polling first
+
+Add a same-origin, authorization-enforcing job snapshot/log-tail endpoint with
+an opaque cursor and `ETag`. While visible and nonterminal, the client polls
+every two seconds, stops on terminal state, aborts on navigation, pauses while
+the tab is hidden, and exponentially backs off to 30 seconds on transient
+failure. This fits the current HTTP deployment model and is easier to operate
+than immediately adding long-lived WebSocket/SSE connections. The protocol can
+later be transported over SSE without changing the snapshot model.
+
+### Presentation is deterministic durable data
+
+Provider Markdown and annotations must not be regenerated differently on each
+retry. A terminal result projector will load the verified immutable JobResult,
+convert it to a bounded provider presentation, store it as a content-addressed
+blob, and atomically attach its key/digest/revision to the Check subject before
+waking the outbox.
+
+The provider presentation contains:
+
+- exact start/completion timestamps;
+- bounded title, summary, and text plus explicit truncation counts;
+- deterministic annotations in step/result order;
+- a total annotation count and SHA-256 digest;
+- the exact requested actions permitted for that lifecycle;
+- no raw log text, secret-derived output value, credential, or signed URL.
+
+Queued and in-progress summaries are small server-owned templates. Terminal
+text includes masked step summaries and a compact step result table. Annotation
+paths must normalize to repository-relative slash paths; invalid/absolute/
+escaping paths are omitted and included in an omission count. Lines and columns
+must be positive and internally ordered. Levels map error→failure,
+warning→warning, and notice→notice.
+
+### Annotation publication has its own idempotent cursor
+
+GitHub appends annotations on every update, so retrying a successful but
+unobserved batch would create duplicates. The outbox therefore records a
+presentation revision, next batch index, and provider annotation count. Each
+batch is at most 50 annotations. After an uncertain PATCH, the publisher lists
+and fully paginates GitHub annotations and compares the exact deterministic
+prefix:
+
+- exact next prefix: commit the cursor without resending;
+- unchanged exact prefix: safely retry the batch;
+- any other content/count: block the projection with observable provider
+  mismatch instead of guessing.
+
+The final batch may be included with the terminal state transition. A Check is
+marked delivered only when lifecycle, timestamps, output digest, actions, and
+annotation cursor all match the desired presentation.
+
+### Requested actions are narrow and audited
+
+Use GitHub's native `rerequested` event and, where the desired distinct choices
+fit the three-button limit, requested actions with stable identifiers such as
+`rerun_all` and `rerun_failed`. A job Check rerequest maps to selected job and
+dependents. A workflow Check rerequest maps to the entire workflow.
+
+Webhook input is not sufficient authority by itself. The adapter must verify
+the webhook signature, installation/repository/App, external ID, Check Run ID,
+suite/SHA, sender identity, source terminality, retention, and current rerun
+authorization. It then calls the existing durable rerun service with an
+idempotency operation ID derived from the GitHub delivery ID plus action and
+Check identity. A successful rerun creates a fresh Automata physical run and
+fresh per-attempt Check Runs; it does not rewrite immutable old results.
+
+### Statuses and deployments are opt-in projections
+
+Do not publish a commit status for every Check by default. Add a repository
+manifest mode:
+
+- `checks_only` (default);
+- `checks_with_aggregate_status` for systems/rulesets that still require one
+  legacy context.
+
+The optional context is stable (for example `automata/ci`), uses the exact run
+URL as `target_url`, and maps any active work to pending, aggregate success to
+success, user/test failure to failure, and provider/system uncertainty to
+error. It requires a separately manifest-pinned `statuses:write` authority and
+its own append-only/idempotent projector; it must never silently share Checks
+authority.
+
+Deployment projection is enabled only for jobs with a resolved workflow
+environment and only after environment compatibility/security work is
+complete. Create with the exact SHA, `auto_merge:false`, and
+`required_contexts:[]`; publish queued/in-progress/terminal statuses with the
+job URL as `log_url` and a validated environment URL when the job emits one.
+This requires separately reviewed `deployments:write` authority and webhook
+loop prevention.
+
+## Delivery phases
+
+### Phase 1 — Make every Details link useful
+
+Primary files:
+
+- `crates/automata-ci/src/app/web/data.rs`
+- `crates/automata-ci/src/app/web/live.rs`
+- `crates/automata-ci/src/app/web/model.rs`
+- `crates/automata-ci/src/app/web/routes.rs`
+- `ui/src/pages/JobLogPage.tsx` (rename/evolve to job detail)
+- `ui/src/models.ts`, `ui/src/validation/*`, and UI fixtures/tests
+
+Work:
+
+- introduce `JobDetailPage`/`JobDetailData` whose metadata authorization uses
+  the dashboard policy and whose log collection is independently authorized;
+- keep the current canonical job path so all already-published Details links
+  improve without a redirect or migration;
+- render status, run/job attempt, start/duration, runner, steps/summary when
+  available, and a precise log-access placeholder when not;
+- render a generic deep-link sign-in page for anonymous syntactically valid
+  routes without existence disclosure and preserve the exact return path;
+- add a bounded JSON snapshot/log-tail endpoint and client polling lifecycle;
+- keep ordinary HTML navigation and manual Refresh as a no-JavaScript fallback;
+- add `Cache-Control: no-store` to private/live documents and API snapshots;
+- retain `frame-ancestors 'none'` and all existing same-origin/CSP constraints.
+
+Acceptance:
+
+- dashboard public/log private, dashboard authenticated/log private, fully
+  private, public, missing, wrong repository, and stale-session cases all have
+  explicit tests;
+- a GitHub Details URL opens the exact job for an authorized viewer;
+- login returns to the exact job and query without an open redirect;
+- a running job updates state and appends new log lines without full-page
+  navigation, duplicate lines, or losing search/scroll state;
+- terminal polling stops.
+
+### Phase 2 — Accurate lifecycle and native Check output
+
+Primary files:
+
+- `crates/automata-ci-core/src/job/result.rs`
+- `crates/automata-ci-store/src/github_checks.rs`
+- `crates/automata-ci-store/src/postgres/github_checks.rs`
+- `crates/automata-ci-store/migrations/0001_initial_schema.sql`
+- `crates/automata-ci-github/src/checks.rs`
+- `crates/automata-ci-github-delivery/src/checks_publisher.rs`
+- their focused integration tests
+
+Work:
+
+- persist `started_at_ms` and `completed_at_ms` independently on every Check
+  subject and include them in the claimed outbox snapshot/guards;
+- use the durable job attempt start and JobResult completion times, not publisher
+  wall-clock time;
+- define bounded `GithubCheckOutput`, annotation, image, and requested-action
+  request models with redacted Debug output and strict UTF-8/URL/path limits;
+- extend create/start/update payloads and response validation for timestamps,
+  output, action shape, and annotation count;
+- create queued output (`Waiting for a runner`) and in-progress output with an
+  exact Details Markdown link;
+- project terminal masked step summaries and compact result counts;
+- keep only third-party-permitted states; do not attempt Actions-reserved
+  waiting/pending/requested values;
+- preserve current state-before-mutation reconciliation and rate-limit policy.
+
+Acceptance:
+
+- captured GitHub requests prove exact ISO-8601 UTC timestamps and payloads for
+  every state/conclusion;
+- delayed publisher execution does not alter start/completion time;
+- malformed/oversized provider responses fail closed without exposing output;
+- process restart between durable transition and GitHub PATCH resumes exactly;
+- GitHub.com smoke evidence shows queued, running, duration, terminal title,
+  summary, and Details in the expected PR/commit UI.
+
+### Phase 3 — Full annotations and summaries
+
+Work:
+
+- implement the content-addressed presentation artifact and digest validation;
+- convert retained annotation properties (`file`, `line`, `endLine`, `col`,
+  `endColumn`, `title`) to GitHub's model with repository-path confinement;
+- publish 50-item batches in deterministic order with a durable batch cursor;
+- implement exact paginated annotation reconciliation after ambiguous updates;
+- expose truncation/omission counts in both GitHub summary and Automata job UI;
+- cap published Markdown below provider limits and truncate only on UTF-8 scalar
+  boundaries with a stable marker;
+- never publish annotations lacking a valid repository path and line; retain
+  them in Automata's step result display as non-source diagnostics.
+
+Acceptance:
+
+- 0, 1, 50, 51, and 4,096 annotation fixtures;
+- failures injected before send, after send/before response, after response/
+  before cursor commit, and during reconciliation;
+- no duplicate annotations after restart or rate limiting;
+- source annotations appear in both Checks and Files changed on GitHub.com;
+- secret masking and path traversal adversarial tests remain green.
+
+### Phase 4 — GitHub-native and browser controls
+
+Primary files:
+
+- `crates/automata-ci-github/src/webhook.rs`
+- `crates/automata-ci/src/server/github_webhook.rs`
+- `crates/automata-ci-github-delivery/src/*`
+- `crates/automata-ci/src/app/workflow_rerun_api.rs` and rerun composition
+- run/job UI models and pages
+
+Work:
+
+- normalize the minimum `check_run.rerequested`,
+  `check_run.requested_action`, and `check_suite.rerequested` payloads;
+- add immutable mapping from external Check identity to source run/logical job;
+- reauthorize sender and repository at durable rerun admission;
+- call existing whole/failed/specific-job rerun operations idempotently;
+- expose browser rerun-all/rerun-failed/rerun-job controls with CSRF, audit, and
+  stale-attempt guards so GitHub and Automata controls share one backend;
+- advertise only actions valid for the current lifecycle and authority;
+- return fast 2xx webhook acknowledgement after durable enqueue, not after the
+  rerun completes.
+
+Acceptance:
+
+- duplicate deliveries and repeated button clicks produce one physical rerun;
+- cross-App, cross-repository, stale Check, nonterminal source, unauthorized
+  sender, and expired-retention cases fail closed;
+- GitHub rerequest produces a fresh run and new exact Details links;
+- old Check output remains immutable and auditable.
+
+### Phase 5 — Compatibility status, deployments, and badges
+
+Work:
+
+- add the default-off aggregate commit-status projector and independently
+  pinned `statuses:write` manifest authority;
+- add environment-only deployment/deployment-status projection and independently
+  pinned `deployments:write` authority;
+- add repository/workflow badge endpoints derived from durable latest ref state,
+  with bounded caching and no credential-bearing redirects;
+- document required-check naming and App-source selection for branch protection
+  and rulesets;
+- add provider configuration migration and permission-upgrade guidance.
+
+Acceptance:
+
+- default installations show Checks only, with no duplicate legacy row;
+- opt-in legacy status has a working exact target URL and closed state mapping;
+- environment jobs appear in GitHub deployment history with correct log and
+  environment URLs; non-environment jobs never do;
+- badge responses are deterministic, cache bounded, and do not reveal private
+  repository state without authorization.
+
+## Schema and protocol changes
+
+The exact schema should be finalized during Phase 2, but it must preserve these
+invariants:
+
+- `github_check_subjects` owns immutable identity plus explicit desired start,
+  completion, and presentation reference/revision;
+- `github_check_projection_outbox` freezes all of those values in a claim so a
+  worker cannot publish a mixed revision;
+- a presentation reference is content-addressed and digest-verified before use;
+- annotation batch progress is durable and monotonic for one external Check Run
+  and presentation revision;
+- advancing lifecycle or presentation wakes a delivered/retry outbox row;
+- old lifecycle revisions cannot overwrite a terminal provider state;
+- existing Check Run IDs and already-published Details URLs remain valid.
+
+Because this repository currently uses a consolidated initial PostgreSQL
+migration, update that migration and its schema/trigger tests together. If
+released installations already consume it before implementation starts, first
+introduce a numbered forward migration rather than rewriting deployed history.
+
+## Observability and operations
+
+Add low-cardinality metrics:
+
+- projection queue depth/oldest age by action and state;
+- lifecycle-to-provider lag histogram;
+- GitHub requests by operation/status class;
+- rate-limit and retry delay counters;
+- presentation conversion omissions/truncations;
+- annotation batches published/reconciled/blocked;
+- Details route outcomes split into page, generic sign-in handoff, and 404 (no
+  owner/repository/run labels);
+- live polling active requests, unchanged responses, and backoff;
+- rerequest action accepted/rejected/replayed by reason class.
+
+Add a runbook for stuck queued/in-progress Checks, credential rejection,
+rate-limit exhaustion, ambiguous annotation batches, permission upgrades, and
+the suite/name limits. Structured logs must use internal IDs or hashes and must
+not include provider tokens, user Markdown, annotation messages, raw webhook
+payloads, or private URLs.
+
+## Test and rollout strategy
+
+Testing layers:
+
+1. pure model tests for limits, time formatting, Markdown truncation, path and
+   annotation conversion, conclusion mappings, and Debug redaction;
+2. HTTP capture tests in `automata-ci-github` for exact request/response and
+   pagination contracts;
+3. PostgreSQL transition/trigger/restart tests for every outbox phase;
+4. delivery publisher fault-injection tests around every mutation cutoff;
+5. SSR/unit/Playwright tests for deep links, access matrices, live updates,
+   responsive layout, keyboard focus, and reduced motion;
+6. isolated GitHub emulator acceptance for deterministic CI;
+7. a manual or gated GitHub.com App smoke repository for UI facts that an
+   emulator cannot prove: Checks rendering, Details behavior, annotations in
+   Files changed, and rerun buttons.
+
+Roll out behind independently reversible flags:
+
+1. job-detail route/access split;
+2. live polling;
+3. timestamps and output, initially without annotations/actions;
+4. annotation batching;
+5. rerequest/actions;
+6. opt-in statuses and deployments.
+
+During each provider phase, shadow-build and validate the desired presentation
+before enabling mutation. Compare Automata durable state with GitHub readback
+for canary installations. Stop rollout on duplicate Check/annotation evidence,
+increased Details 404s, projection age SLO breach, or unexpected rate-limit
+pressure.
+
+## Definition of done
+
+- A multi-job, matrix, failed, cancelled, skipped, timed-out, and rerun fixture
+  has coherent Check lifecycles and exact job links.
+- A reviewer can see state, duration, result summary, and line annotations in
+  GitHub without leaving the pull request.
+- **Details** reliably opens the exact live/terminal Automata job with correct
+  dashboard/log authorization behavior.
+- GitHub and Automata rerun controls use the same durable, audited operation.
+- every mutation is restart-safe and rate-limit aware; annotation append
+  ambiguity is reconciled rather than blindly retried.
+- optional statuses and deployments add no duplicate default UX and use only
+  their separately granted permissions.
+- documentation clearly states the remaining unavoidable divergence: Automata
+  is a GitHub App using Checks and its own run UI, not a producer of native
+  GitHub Actions run records or an iframe inside GitHub.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { PageModel } from "./models";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { JobLogPage } from "./pages/JobLogPage";
+import { DeepLinkSignInPage } from "./pages/DeepLinkSignInPage";
 import { RepositoryDirectoryPage } from "./pages/RepositoryDirectoryPage";
 import { RepositorySettingsPage } from "./pages/RepositorySettingsPage";
 import { RepositorySecretsPage } from "./pages/RepositorySecretsPage";
@@ -33,6 +34,8 @@ export function App({ page, shellUtility }: AppProps) {
       return <RunDetailPage model={page} shellUtility={utility} />;
     case "job-log":
       return <JobLogPage model={page} shellUtility={utility} />;
+    case "deep-link-sign-in":
+      return <DeepLinkSignInPage model={page} shellUtility={utility} />;
     case "repository-settings":
       return <RepositorySettingsPage model={page} shellUtility={utility} />;
     case "repository-secrets":

--- a/ui/src/models.ts
+++ b/ui/src/models.ts
@@ -268,10 +268,16 @@ export interface JobLogPageModel {
   readonly jobs: readonly JobLogNavigationItemModel[];
   readonly navigationPagination: PaginationModel;
   readonly job: JobLogJobModel;
+  readonly logVisibility: ResultCollectionVisibility;
   readonly search: JobLogSearchModel;
   readonly lines: readonly JobLogLineModel[];
   readonly notice: string | null;
   readonly pagination: JobLogPaginationModel;
+}
+
+export interface DeepLinkSignInPageModel {
+  readonly kind: "deep-link-sign-in";
+  readonly shell: ShellModel;
 }
 
 export type PublicationAudience = "private" | "authenticated" | "public";
@@ -623,6 +629,7 @@ export type PageModel =
   | RunListPageModel
   | RunDetailPageModel
   | JobLogPageModel
+  | DeepLinkSignInPageModel
   | RepositorySettingsPageModel
   | RepositorySecretsPageModel
   | UserListPageModel

--- a/ui/src/pages/DeepLinkSignInPage.tsx
+++ b/ui/src/pages/DeepLinkSignInPage.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import type { DeepLinkSignInPageModel } from "../models";
+import { Shell } from "../components/Shell";
+
+export interface DeepLinkSignInPageProps {
+  readonly model: DeepLinkSignInPageModel;
+  readonly shellUtility?: ReactNode;
+}
+
+export function DeepLinkSignInPage({
+  model,
+  shellUtility,
+}: DeepLinkSignInPageProps) {
+  return (
+    <Shell shell={model.shell} repository={null} utility={shellUtility}>
+      <main className="layout-width page" id="main-content" tabIndex={-1}>
+        <section className="panel empty-state" aria-labelledby="sign-in-heading">
+          <h1 id="sign-in-heading">Sign in to view this run</h1>
+          <p>
+            This run may require authentication. Sign in and Automata will
+            return you to this exact job.
+          </p>
+          {model.shell.signIn === null ? null : (
+            <form action={model.shell.signIn.action} method="post">
+              <input
+                name="return_path"
+                type="hidden"
+                value={model.shell.signIn.returnPath}
+              />
+              <button className="button button--primary" type="submit">
+                Sign in with GitHub
+              </button>
+            </form>
+          )}
+        </section>
+      </main>
+    </Shell>
+  );
+}

--- a/ui/src/pages/JobLogPage.tsx
+++ b/ui/src/pages/JobLogPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import type { JobLogLineModel, JobLogPageModel } from "../models";
 import { ActionsLayout } from "../components/ActionsLayout";
@@ -15,6 +15,7 @@ import {
 } from "../components/textInputConstraints";
 import { durationCopy, startTimeCopy } from "../presentation/runPresentation";
 import { encodeQueryComponent } from "../queryEncoding";
+import { parseRenderRequest } from "../serialization";
 import { RENDER_REQUEST_LIMITS } from "../validation/limits";
 
 export interface JobLogPageProps {
@@ -26,107 +27,203 @@ const LOG_OUTPUT_ID = "job-log-output";
 const LOG_RESULT_COUNT_ID = "job-log-result-count";
 
 export function JobLogPage({ model, shellUtility }: JobLogPageProps) {
+  const [liveModel, setLiveModel] = useState(model);
   const [query, setQuery] = useState(model.search.query);
   const normalizedQuery = normalizeQuery(query);
   const visibleLines = useMemo(
-    () => filterLogLines(model.lines, normalizedQuery),
-    [model.lines, normalizedQuery],
+    () => filterLogLines(liveModel.lines, normalizedQuery),
+    [liveModel.lines, normalizedQuery],
   );
   const resultLabel =
     normalizedQuery.length === 0
-      ? model.pagination.label
+      ? liveModel.pagination.label
       : matchingLineCount(visibleLines.length);
   const canRefresh =
-    model.job.status.tone === "queued" || model.job.status.tone === "running";
+    liveModel.job.status.tone === "queued" ||
+    liveModel.job.status.tone === "running";
   const navigationQuery = isValidLogQuery(query)
     ? query.trim()
-    : model.search.query;
+    : liveModel.search.query;
   const refreshHref = logQueryHref(
-    model.search.action,
+    liveModel.search.action,
     navigationQuery,
-    model.pagination.currentCursor,
+    liveModel.pagination.currentCursor,
   );
-  const clearHref = logQueryHref(
-    model.search.clearHref,
-    "",
+  useEffect(() => {
+    if (!canRefresh) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    let timeout: number | undefined;
+    let etag: string | null = null;
+    let delay = 2_000;
+    const snapshotHref = logQueryHref(
+      `${model.job.href}/snapshot`,
+      model.search.query,
+      model.pagination.currentCursor,
+    );
+    const schedule = (nextDelay = delay) => {
+      window.clearTimeout(timeout);
+      if (document.visibilityState === "visible") {
+        timeout = window.setTimeout(async () => {
+          try {
+            const headers = new Headers();
+            headers.set("Accept", "application/json");
+            if (etag !== null) {
+              headers.set("If-None-Match", etag);
+            }
+            const response = await fetch(snapshotHref, {
+              credentials: "same-origin",
+              headers,
+              signal: controller.signal,
+            });
+            if (response.status === 304) {
+              delay = 2_000;
+              schedule();
+              return;
+            }
+            if (!response.ok) {
+              throw new Error(`job snapshot returned ${response.status}`);
+            }
+            const next = parseRenderRequest(await response.text());
+            if (
+              next.page.kind !== "job-log" ||
+              next.page.job.id !== model.job.id ||
+              next.page.job.href !== model.job.href ||
+              next.page.run.href !== model.run.href
+            ) {
+              throw new Error("job snapshot changed request scope");
+            }
+            etag = response.headers.get("ETag");
+            delay = 2_000;
+            setLiveModel(next.page);
+            if (
+              next.page.job.status.tone === "queued" ||
+              next.page.job.status.tone === "running"
+            ) {
+              schedule();
+            }
+          } catch (error) {
+            if (controller.signal.aborted) {
+              return;
+            }
+            delay = Math.min(delay * 2, 30_000);
+            schedule(delay);
+          }
+        }, nextDelay);
+      }
+    };
+    const visibilityChanged = () => {
+      window.clearTimeout(timeout);
+      if (document.visibilityState === "visible") {
+        schedule(0);
+      }
+    };
+    document.addEventListener("visibilitychange", visibilityChanged);
+    schedule();
+    return () => {
+      document.removeEventListener("visibilitychange", visibilityChanged);
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, [
+    canRefresh,
+    model.job.href,
+    model.job.id,
     model.pagination.currentCursor,
+    model.run.href,
+    model.search.query,
+  ]);
+  const clearHref = logQueryHref(
+    liveModel.search.clearHref,
+    "",
+    liveModel.pagination.currentCursor,
   );
   const pagination = useMemo(
     () => ({
-      label: model.pagination.label,
+      label: liveModel.pagination.label,
       previousHref: cursorHref(
-        model.search.action,
+        liveModel.search.action,
         navigationQuery,
-        model.pagination.previousCursor,
+        liveModel.pagination.previousCursor,
       ),
       nextHref: cursorHref(
-        model.search.action,
+        liveModel.search.action,
         navigationQuery,
-        model.pagination.nextCursor,
+        liveModel.pagination.nextCursor,
       ),
     }),
-    [model.pagination, model.search.action, navigationQuery],
+    [liveModel.pagination, liveModel.search.action, navigationQuery],
   );
 
   return (
     <Shell
-      shell={model.shell}
-      repository={model.repository}
+      shell={liveModel.shell}
+      repository={liveModel.repository}
       utility={shellUtility}
     >
       <main className="layout-wide page">
         <ActionsLayout
           navigation={
             <RunNavigation
-              jobs={model.jobs}
+              jobs={liveModel.jobs}
               jobsVisibility="full"
-              pagination={model.navigationPagination}
-              selectedJobId={model.job.id}
-              summaryHref={model.run.href}
+              pagination={liveModel.navigationPagination}
+              selectedJobId={liveModel.job.id}
+              summaryHref={liveModel.run.href}
             />
           }
         >
           <Breadcrumbs
             items={[
-              { href: model.repository.runsHref, label: "Actions" },
-              { href: model.run.workflowHref, label: model.run.workflowName },
-              { href: model.run.href, label: `Run #${model.run.number}` },
-              { href: null, label: model.job.name },
+              { href: liveModel.repository.runsHref, label: "Actions" },
+              {
+                href: liveModel.run.workflowHref,
+                label: liveModel.run.workflowName,
+              },
+              {
+                href: liveModel.run.href,
+                label: `Run #${liveModel.run.number}`,
+              },
+              { href: null, label: liveModel.job.name },
             ]}
           />
 
           <header className="page-heading page-heading--run log-page-heading">
             <div>
               <div className="heading-status">
-                <StatusBadge status={model.job.status} />
-                <span>Run attempt {model.run.attempt}</span>
-                <span>Job attempt {model.job.attempt}</span>
-                {model.job.startedAt === null ? (
-                  <span>{startTimeCopy(model.job.status)}</span>
+                <StatusBadge status={liveModel.job.status} />
+                <span>Run attempt {liveModel.run.attempt}</span>
+                <span>Job attempt {liveModel.job.attempt}</span>
+                {liveModel.job.startedAt === null ? (
+                  <span>{startTimeCopy(liveModel.job.status)}</span>
                 ) : (
                   <span>
                     Started{" "}
-                    <time dateTime={model.job.startedAt.iso}>
-                      {model.job.startedAt.label}
+                    <time dateTime={liveModel.job.startedAt.iso}>
+                      {liveModel.job.startedAt.label}
                     </time>
                   </span>
                 )}
-                {model.job.status.tone === "queued" &&
-                model.job.durationLabel === null ? null : (
+                {liveModel.job.status.tone === "queued" &&
+                liveModel.job.durationLabel === null ? null : (
                   <span>
-                    {durationCopy(model.job.status, model.job.durationLabel)}
+                    {durationCopy(
+                      liveModel.job.status,
+                      liveModel.job.durationLabel,
+                    )}
                   </span>
                 )}
               </div>
-              <h1>{model.job.name}</h1>
+              <h1>{liveModel.job.name}</h1>
               <p>
-                <a href={model.run.href}>
-                  Run #{model.run.number}: {model.run.name}
+                <a href={liveModel.run.href}>
+                  Run #{liveModel.run.number}: {liveModel.run.name}
                 </a>
-                {model.job.runnerLabel === null ? null : (
+                {liveModel.job.runnerLabel === null ? null : (
                   <>
                     <MetadataSeparator />
-                    {model.job.runnerLabel}
+                    {liveModel.job.runnerLabel}
                   </>
                 )}
               </p>
@@ -149,86 +246,96 @@ export function JobLogPage({ model, shellUtility }: JobLogPageProps) {
                   {resultLabel}
                 </span>
               </div>
-              <form
-                action={model.search.action}
-                aria-label="Search job logs"
-                className="log-search-form"
-                method="get"
-                role="search"
-              >
-                {model.pagination.currentCursor === null ? null : (
-                  <input
-                    name="cursor"
-                    type="hidden"
-                    value={model.pagination.currentCursor}
-                  />
-                )}
-                <div className="filter-search log-search">
-                  <Icon name="search" />
-                  <label className="sr-only" htmlFor="log-search">
-                    Search job logs
-                  </label>
-                  <input
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    aria-controls={LOG_OUTPUT_ID}
-                    aria-describedby={LOG_RESULT_COUNT_ID}
-                    id="log-search"
-                    maxLength={RENDER_REQUEST_LIMITS.shortTextLength}
-                    name="q"
-                    onChange={(event) => setQuery(event.currentTarget.value)}
-                    onInput={(event) =>
-                      enforceLogQueryValidity(event.currentTarget)
-                    }
-                    placeholder="Search logs"
-                    spellCheck={false}
-                    type="search"
-                    value={query}
-                  />
-                </div>
-                <button className="button" type="submit">
-                  Search
-                </button>
-                {query.trim().length === 0 ? null : (
-                  <a className="text-link" href={clearHref}>
-                    Clear search
-                  </a>
-                )}
-              </form>
+              {liveModel.logVisibility === "full" ? (
+                <form
+                  action={liveModel.search.action}
+                  aria-label="Search job logs"
+                  className="log-search-form"
+                  method="get"
+                  role="search"
+                >
+                  {liveModel.pagination.currentCursor === null ? null : (
+                    <input
+                      name="cursor"
+                      type="hidden"
+                      value={liveModel.pagination.currentCursor}
+                    />
+                  )}
+                  <div className="filter-search log-search">
+                    <Icon name="search" />
+                    <label className="sr-only" htmlFor="log-search">
+                      Search job logs
+                    </label>
+                    <input
+                      autoCapitalize="none"
+                      autoComplete="off"
+                      autoCorrect="off"
+                      aria-controls={LOG_OUTPUT_ID}
+                      aria-describedby={LOG_RESULT_COUNT_ID}
+                      id="log-search"
+                      maxLength={RENDER_REQUEST_LIMITS.shortTextLength}
+                      name="q"
+                      onChange={(event) => setQuery(event.currentTarget.value)}
+                      onInput={(event) =>
+                        enforceLogQueryValidity(event.currentTarget)
+                      }
+                      placeholder="Search logs"
+                      spellCheck={false}
+                      type="search"
+                      value={query}
+                    />
+                  </div>
+                  <button className="button" type="submit">
+                    Search
+                  </button>
+                  {query.trim().length === 0 ? null : (
+                    <a className="text-link" href={clearHref}>
+                      Clear search
+                    </a>
+                  )}
+                </form>
+              ) : null}
             </div>
 
-            {model.notice === null ? null : (
+            {liveModel.notice === null ? null : (
               <p className="log-notice" role="status">
-                {model.notice}
+                {liveModel.notice}
               </p>
             )}
 
-            <div
-              aria-label={`${model.job.name} output`}
-              className="log-output"
-              id={LOG_OUTPUT_ID}
-              role="region"
-              tabIndex={0}
-            >
-              {visibleLines.length === 0 ? (
-                <p className="log-output__empty">
-                  {normalizedQuery.length === 0
-                    ? "No log lines are available on this page."
-                    : "No log lines on this page match your search."}
-                </p>
-              ) : (
-                visibleLines.map((line) => (
-                  <LogLine key={line.id} line={line} />
-                ))
-              )}
-            </div>
+            {liveModel.logVisibility === "restricted" ? (
+              <p className="log-output__empty" role="status">
+                Logs are unavailable or you do not have permission to view them.
+              </p>
+            ) : (
+              <div
+                aria-label={`${liveModel.job.name} output`}
+                className="log-output"
+                id={LOG_OUTPUT_ID}
+                role="region"
+                tabIndex={0}
+              >
+                {visibleLines.length === 0 ? (
+                  <p className="log-output__empty">
+                    {normalizedQuery.length === 0
+                      ? "No log lines are available on this page."
+                      : "No log lines on this page match your search."}
+                  </p>
+                ) : (
+                  visibleLines.map((line) => (
+                    <LogLine key={line.id} line={line} />
+                  ))
+                )}
+              </div>
+            )}
 
-            <Pagination
-              label="Job log pages"
-              pagination={pagination}
-              variant="log"
-            />
+            {liveModel.logVisibility === "full" ? (
+              <Pagination
+                label="Job log pages"
+                pagination={pagination}
+                variant="log"
+              />
+            ) : null}
           </section>
         </ActionsLayout>
       </main>

--- a/ui/src/preview/models.ts
+++ b/ui/src/preview/models.ts
@@ -345,6 +345,7 @@ export function previewJobLog(
       startedAt: selectedJob.startedAt,
       durationLabel: selectedJob.durationLabel,
     },
+    logVisibility: "full",
     search: {
       action: jobHref,
       query,
@@ -516,7 +517,7 @@ function logNotice(job: JobModel, lineCount: number): string {
     return "No log output was recorded for this job.";
   }
   return job.status.tone === "running"
-    ? "This job is still running. Refresh to load newly committed log entries."
+    ? "This job is still running. This page updates automatically as logs are committed."
     : "Log entries are shown as one ordered job-wide stream.";
 }
 

--- a/ui/src/validation/deepLinkSignInModel.ts
+++ b/ui/src/validation/deepLinkSignInModel.ts
@@ -1,0 +1,21 @@
+import { validateShell } from "./commonModels";
+import { expectLiteral, expectObject, invalid } from "./primitives";
+
+export function validateDeepLinkSignInPage(value: unknown, path: string): void {
+  const page = expectObject(value, path, ["kind", "shell"]);
+  expectLiteral(page.kind, `${path}.kind`, "deep-link-sign-in");
+  validateShell(page.shell, `${path}.shell`);
+  const shell = expectObject(page.shell, `${path}.shell`, [
+    "productName",
+    "homeHref",
+    "signIn",
+    "signOut",
+    "documentTitle",
+    "description",
+    "viewer",
+    "navigation",
+  ]);
+  if (shell.viewer !== null || shell.signIn === null || shell.signOut !== null) {
+    invalid(`${path}.shell`, "an anonymous shell with one sign-in capability");
+  }
+}

--- a/ui/src/validation/jobLogModel.ts
+++ b/ui/src/validation/jobLogModel.ts
@@ -60,6 +60,7 @@ export function validateJobLogPage(value: unknown, path: string): void {
     "jobs",
     "navigationPagination",
     "job",
+    "logVisibility",
     "search",
     "lines",
     "notice",
@@ -91,6 +92,11 @@ export function validateJobLogPage(value: unknown, path: string): void {
   });
 
   const selectedJob = validateSelectedJob(page.job, `${path}.job`);
+  const logVisibility = expectOneOf(
+    page.logVisibility,
+    `${path}.logVisibility`,
+    ["full", "restricted"],
+  );
   const navigationJob = jobsById.get(selectedJob.id);
   if (navigationJob === undefined) {
     invalid(`${path}.job.id`, "an ID present in jobs");
@@ -107,6 +113,9 @@ export function validateJobLogPage(value: unknown, path: string): void {
 
   const linesPath = `${path}.lines`;
   const lines = expectArray(page.lines, linesPath, RENDER_REQUEST_LIMITS.logLineCount);
+  if (logVisibility === "restricted" && lines.length !== 0) {
+    invalid(linesPath, "an empty restricted log collection");
+  }
   const seenLineIds = new Set<string>();
   let previousLine: LogLineIdentity | null = null;
   lines.forEach((line, index) => {

--- a/ui/src/validation/renderRequest.ts
+++ b/ui/src/validation/renderRequest.ts
@@ -1,5 +1,6 @@
 import type { RenderRequest } from "../models";
 import { validateJobLogPage } from "./jobLogModel";
+import { validateDeepLinkSignInPage } from "./deepLinkSignInModel";
 import { validateRepositoryDirectoryPage } from "./repositoryDirectoryModel";
 import { validateRepositorySettingsPage } from "./repositorySettingsModel";
 import { validateRepositorySecretsPage } from "./repositorySecretsModel";
@@ -93,6 +94,8 @@ function validatePage(value: unknown, path: string): void {
     validateRunDetailPage(page, path);
   } else if (kind === "job-log") {
     validateJobLogPage(page, path);
+  } else if (kind === "deep-link-sign-in") {
+    validateDeepLinkSignInPage(page, path);
   } else if (kind === "repository-settings") {
     validateRepositorySettingsPage(page, path);
   } else if (kind === "repository-secrets") {

--- a/ui/tests/fixtures/renderRequests.ts
+++ b/ui/tests/fixtures/renderRequests.ts
@@ -334,6 +334,7 @@ export const jobLogRequest: RenderRequest = {
       },
       durationLabel: null,
     },
+    logVisibility: "full",
     search: {
       action: `/automata-ci/automata/actions/runs/${PRIMARY_RUN_ID}/jobs/${PRIMARY_JOB_ID}`,
       query: "",
@@ -363,12 +364,32 @@ export const jobLogRequest: RenderRequest = {
       },
     ],
     notice:
-      "This job is still running. Refresh to load newly committed log segments.",
+      "This job is still running. This page updates automatically as logs are committed.",
     pagination: {
       currentCursor: null,
       previousCursor: null,
       nextCursor: "next",
       label: "3 log lines",
+    },
+  },
+};
+
+export const deepLinkSignInRequest: RenderRequest = {
+  ...common,
+  page: {
+    kind: "deep-link-sign-in",
+    shell: {
+      ...shell,
+      signIn: {
+        action: "/auth/github/login",
+        returnPath: `/automata-ci/automata/actions/runs/${PRIMARY_RUN_ID}/jobs/${PRIMARY_JOB_ID}`,
+      },
+      signOut: null,
+      documentTitle: "Sign in to view this run · Automata",
+      viewer: null,
+      navigation: [
+        { label: "Repositories", href: "/repositories", current: true },
+      ],
     },
   },
 };

--- a/ui/tests/integration/ssr.test.tsx
+++ b/ui/tests/integration/ssr.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../src/serialization";
 import { RENDER_REQUEST_LIMITS } from "../../src/validation";
 import {
+  deepLinkSignInRequest,
   directBindingListRequest,
   jobLogRequest,
   PRIMARY_JOB_ID,
@@ -34,6 +35,19 @@ import {
 const LOG_RESULT_COUNT_TEST_ID = "job-log-result-count";
 
 describe("server rendering", () => {
+  it("renders the generic deep-link handoff with an exact POST return path", () => {
+    const rendered = new DOMParser().parseFromString(
+      renderPage(deepLinkSignInRequest),
+      "text/html",
+    );
+    const form = rendered.querySelector('form[action="/auth/github/login"]');
+    expect(rendered.body.textContent).toContain("Sign in to view this run");
+    expect(form?.getAttribute("method")).toBe("post");
+    expect(
+      form?.querySelector<HTMLInputElement>('input[name="return_path"]')?.value,
+    ).toBe(deepLinkSignInRequest.page.shell.signIn?.returnPath);
+  });
+
   it("renders the repository directory with honest destinations and no repository header", () => {
     const rendered = new DOMParser().parseFromString(
       renderPage(repositoryDirectoryRequest),
@@ -1076,7 +1090,77 @@ describe("server rendering", () => {
 
 describe("hydration", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it("polls a running job in place and stops after its terminal snapshot", async () => {
+    if (jobLogRequest.page.kind !== "job-log") {
+      throw new Error("The job-log fixture is unavailable");
+    }
+    const page = jobLogRequest.page;
+    const terminalStatus = { label: "Succeeded", tone: "success" } as const;
+    const terminalRequest: RenderRequest = {
+      ...jobLogRequest,
+      page: {
+        ...page,
+        jobs: page.jobs.map((job) =>
+          job.id === page.job.id
+            ? { ...job, status: terminalStatus }
+            : job,
+        ),
+        job: {
+          ...page.job,
+          status: terminalStatus,
+          durationLabel: "3m 9s",
+        },
+        lines: page.lines.map((line, index) =>
+          index === 1 ? { ...line, text: "Operating System: updated live" } : line,
+        ),
+        notice: null,
+      },
+    };
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      new Response(JSON.stringify(terminalRequest), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          ETag: '"sha256-terminal"',
+        },
+      }),
+    );
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    document.open();
+    document.write(renderPage(jobLogRequest));
+    document.close();
+    const parsedRequest = readRenderRequest(document);
+
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(document, <HtmlDocument request={parsedRequest} />);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      `${page.job.href}/snapshot`,
+    );
+    expect(document.querySelector(".heading-status .status")?.textContent).toContain(
+      "Succeeded",
+    );
+    expect(document.querySelector(".log-output")?.textContent).toContain(
+      "Operating System: updated live",
+    );
+    expect(document.querySelector(".log-page-heading > a.button")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(async () => root?.unmount());
   });
 
   it.each([

--- a/ui/tests/unit/validation.test.ts
+++ b/ui/tests/unit/validation.test.ts
@@ -8,6 +8,7 @@ import {
   validateRenderRequest,
 } from "../../src/validation";
 import {
+  deepLinkSignInRequest,
   directBindingListRequest,
   jobLogRequest,
   PRIMARY_RUN_ID,
@@ -122,6 +123,7 @@ describe("render request validation", () => {
     ["run-list", runListRequest],
     ["run-detail", runDetailRequest],
     ["job-log", jobLogRequest],
+    ["deep-link-sign-in", deepLinkSignInRequest],
     ["repository-settings", repositorySettingsRequest],
   ])("deeply accepts the complete %s contract", (_kind, request) => {
     expect(parseRenderRequest(JSON.stringify(request))).toEqual(request);


### PR DESCRIPTION
## Summary

- publish native queued, running, and terminal Check output with exact Automata Details links
- project durable job start and completion times to GitHub as RFC 3339 timestamps
- make the canonical job Details page readable independently from its protected log collection
- add a generic, non-enumerating sign-in handoff that returns to the exact job deep link
- update running jobs in place through bounded, no-store JSON snapshots with ETag revalidation, visibility pausing, terminal stop, cancellation, and exponential backoff
- document GitHub platform boundaries and the complete phased path to annotations, rerun controls, optional statuses, and deployments

GitHub does not expose an iframe surface for third-party Apps, so this keeps clickjacking protection intact and uses native Checks output plus exact external deep links.

## Validation

- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=1 cargo test -p automata-ci --lib` — 464 passed
- `cargo test -p automata-ci-github --test checks` — 19 passed
- `cargo test -p automata-ci-store --test store_contracts github_checks_api` — 10 passed
- `cargo test -p automata-ci-github-delivery --test checks_publisher` — 27 passed
- `npm test` — 445 UI tests plus 8 build-verifier tests passed
- `npm run typecheck`

## Follow-up scope

The plan deliberately stages content-addressed terminal presentations, append-safe annotation batching/reconciliation, GitHub-native and browser rerun controls, optional aggregate commit statuses, environment deployments, and rollout observability. Those require additional durable idempotency state and are recorded in `docs/github-status-ux-plan.md`.