### PR TITLE
Fix runner schema version contract

### DIFF
--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -1427,7 +1427,7 @@ fn only_the_current_product_schema_is_accepted() {
     let current: serde_json::Value =
         serde_json::from_str(&valid_configuration()).expect("configuration JSON");
     assert!(parse_value(&current).is_ok());
-    for unsupported in [0, 2, u16::MAX] {
+    for unsupported in [0, 1, u16::MAX] {
         let mut document = current.clone();
         document["schema_version"] = serde_json::json!(unsupported);
         assert_eq!(


### PR DESCRIPTION
## Outcome

Repair the runner product-configuration schema contract after schema version 2 became current. The test now rejects the prior version 1 instead of incorrectly expecting the current version 2 to fail.

## Related issue

None.

## Trust and compatibility impact

Test-only change. Runtime parsing and the current schema remain unchanged; the contract continues to prove that old and future schema versions fail closed.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci-runner --test runner_product_config --locked --jobs 2` — 22 passed
- `git diff --check`

## AI assistance

OpenAI Codex reproduced the failure, traced the stale expectation to the schema-version bump, and prepared the one-line test correction.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.