### PR TITLE
feat: expose hosted shard capabilities

### DIFF
--- a/crates/automata-ci/src/app/mod.rs
+++ b/crates/automata-ci/src/app/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod rbac_management;
 pub(crate) mod repository_secrets;
 pub(crate) mod runner_enrollment_api;
 pub(crate) mod secret_api;
+pub(crate) mod shard_capabilities;
 pub(crate) mod web;
 pub(crate) mod workflow_dispatch_api;
 pub(crate) mod workflow_rerun_api;

--- a/crates/automata-ci/src/app/shard_capabilities.rs
+++ b/crates/automata-ci/src/app/shard_capabilities.rs
@@ -19,6 +19,7 @@ pub const SHARD_CAPABILITIES_PATH: &str = "/internal/v1/capabilities";
 
 const CAPABILITY_DOCUMENT_VERSION: u8 = 1;
 const CORE_HTTP_PROTOCOL_VERSION: u8 = 1;
+const MANAGEMENT_GRPC_PROTOCOL_VERSION: u8 = 1;
 
 #[derive(Clone, Debug)]
 struct ShardCapabilitiesState {
@@ -38,6 +39,7 @@ struct ShardCapabilities {
 #[derive(Debug, Serialize)]
 struct Protocols {
     core_http: [u8; 1],
+    management_grpc: [u8; 1],
 }
 
 #[derive(Debug, Serialize)]
@@ -61,6 +63,7 @@ async fn capabilities(State(state): State<ShardCapabilitiesState>) -> Response {
             release: BuildInfo::current(),
             protocols: Protocols {
                 core_http: [CORE_HTTP_PROTOCOL_VERSION],
+                management_grpc: [MANAGEMENT_GRPC_PROTOCOL_VERSION],
             },
             public_endpoints: PublicEndpoints {},
             server_time_ms: unix_time_millis(),
@@ -115,7 +118,10 @@ mod tests {
         assert_eq!(document["shard_id"], "eu-test-1");
         assert_eq!(document["release"]["version"], BuildInfo::current().version);
         assert_eq!(document["release"]["commit"], BuildInfo::current().commit);
-        assert_eq!(document["protocols"], serde_json::json!({"core_http": [1]}));
+        assert_eq!(
+            document["protocols"],
+            serde_json::json!({"core_http": [1], "management_grpc": [1]})
+        );
         assert_eq!(document["public_endpoints"], serde_json::json!({}));
         assert!(
             document["server_time_ms"]

--- a/crates/automata-ci/src/app/shard_capabilities.rs
+++ b/crates/automata-ci/src/app/shard_capabilities.rs
@@ -1,0 +1,143 @@
+//! Public, bounded capability discovery for one hosted Core shard.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use automata_ci_provisioning::ShardId;
+use axum::{
+    Json, Router,
+    extract::State,
+    http::header::CACHE_CONTROL,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use serde::Serialize;
+
+use crate::build_info::BuildInfo;
+
+/// Stable discovery endpoint consumed before Cloud admits a shard.
+pub const SHARD_CAPABILITIES_PATH: &str = "/internal/v1/capabilities";
+
+const CAPABILITY_DOCUMENT_VERSION: u8 = 1;
+const CORE_HTTP_PROTOCOL_VERSION: u8 = 1;
+
+#[derive(Clone, Debug)]
+struct ShardCapabilitiesState {
+    shard_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ShardCapabilities {
+    protocol_version: u8,
+    shard_id: String,
+    release: BuildInfo,
+    protocols: Protocols,
+    public_endpoints: PublicEndpoints,
+    server_time_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct Protocols {
+    core_http: [u8; 1],
+}
+
+#[derive(Debug, Serialize)]
+struct PublicEndpoints {}
+
+/// Builds the unauthenticated discovery surface for a configured hosted shard.
+pub(crate) fn router(shard_id: &ShardId) -> Router {
+    Router::new()
+        .route(SHARD_CAPABILITIES_PATH, get(capabilities))
+        .with_state(ShardCapabilitiesState {
+            shard_id: shard_id.as_str().to_owned(),
+        })
+}
+
+async fn capabilities(State(state): State<ShardCapabilitiesState>) -> Response {
+    (
+        [(CACHE_CONTROL, "no-store")],
+        Json(ShardCapabilities {
+            protocol_version: CAPABILITY_DOCUMENT_VERSION,
+            shard_id: state.shard_id,
+            release: BuildInfo::current(),
+            protocols: Protocols {
+                core_http: [CORE_HTTP_PROTOCOL_VERSION],
+            },
+            public_endpoints: PublicEndpoints {},
+            server_time_ms: unix_time_millis(),
+        }),
+    )
+        .into_response()
+}
+
+fn unix_time_millis() -> i64 {
+    let milliseconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    i64::try_from(milliseconds).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode, header},
+    };
+    use serde_json::Value;
+    use tower::ServiceExt as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn document_identifies_shard_and_only_advertises_implemented_protocols() {
+        let shard_id = ShardId::new("eu-test-1").expect("shard id");
+        let response = router(&shard_id)
+            .oneshot(
+                Request::builder()
+                    .uri(SHARD_CAPABILITIES_PATH)
+                    .body(Body::empty())
+                    .expect("capability request"),
+            )
+            .await
+            .expect("capability response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+
+        let document: Value = serde_json::from_slice(
+            &to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .expect("bounded body"),
+        )
+        .expect("JSON response");
+        assert_eq!(document["protocol_version"], 1);
+        assert_eq!(document["shard_id"], "eu-test-1");
+        assert_eq!(document["release"]["version"], BuildInfo::current().version);
+        assert_eq!(document["release"]["commit"], BuildInfo::current().commit);
+        assert_eq!(document["protocols"], serde_json::json!({"core_http": [1]}));
+        assert_eq!(document["public_endpoints"], serde_json::json!({}));
+        assert!(
+            document["server_time_ms"]
+                .as_i64()
+                .is_some_and(|value| value > 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn document_rejects_non_get_methods_without_redirecting() {
+        let shard_id = ShardId::new("eu-test-1").expect("shard id");
+        let response = router(&shard_id)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SHARD_CAPABILITIES_PATH)
+                    .body(Body::empty())
+                    .expect("capability request"),
+            )
+            .await
+            .expect("capability response");
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/automata-ci/src/server/metrics.rs
+++ b/crates/automata-ci/src/server/metrics.rs
@@ -67,6 +67,7 @@ use crate::{
             GITHUB_REPOSITORY_SECRET_RESOLUTION_PATH, REPOSITORY_SECRET_BY_NAME_PATH,
             REPOSITORY_SECRET_PATH, REPOSITORY_SECRETS_PATH,
         },
+        shard_capabilities::SHARD_CAPABILITIES_PATH,
         workflow_rerun_api::WORKFLOW_RERUN_PATH,
     },
     build_info::BuildInfo,
@@ -102,9 +103,10 @@ const RBAC_SETTINGS_ROUTE: &str = "/settings/access/{rbac}";
 const GITHUB_DEVICE_ROUTE: &str = "/api/v1/auth/device/{operation}";
 const REPOSITORY_SECRET_BROWSER_MUTATION_ROUTE: &str =
     "/{owner}/{repository}/settings/secrets/{mutation}";
-const HTTP_ROUTE_LABELS: [&str; 43] = [
+const HTTP_ROUTE_LABELS: [&str; 44] = [
     "/healthz",
     "/readyz",
+    SHARD_CAPABILITIES_PATH,
     "/",
     "/setup",
     "/repositories",
@@ -1781,6 +1783,7 @@ fn http_route(matched_path: Option<&str>) -> &'static str {
     match matched_path {
         Some("/healthz") => "/healthz",
         Some("/readyz") => "/readyz",
+        Some(SHARD_CAPABILITIES_PATH) => SHARD_CAPABILITIES_PATH,
         Some("/") => "/",
         Some("/setup") => "/setup",
         Some("/repositories") => "/repositories",
@@ -2548,6 +2551,7 @@ mod tests {
             BUILTIN_SECRET_PROVIDER_ACTIVATION_PATH,
             RUNNER_ENROLLMENTS_PATH,
             RUNNER_ENROLLMENT_REDEEM_PATH,
+            SHARD_CAPABILITIES_PATH,
         ];
 
         for route in operational_routes {

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -213,6 +213,12 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
                 )),
                 None => router,
             };
+            let router = match config.management() {
+                Some(management) => router.merge(crate::app::shard_capabilities::router(
+                    management.authority().shard_id(),
+                )),
+                None => router,
+            };
             let router = router_with_optional_github_webhook(router, github_provider_ingress);
             http::finalize_combined_router(router, metrics.clone())
         }


### PR DESCRIPTION
## Summary

- expose `GET /internal/v1/capabilities` for Core servers with shard management enabled
- identify the configured shard and embedded release provenance
- advertise only implemented cross-boundary protocols: `core_http` v1 and `management_grpc` v1
- keep capability discovery outside human session auth and inside the shared timeout, hardening, and fixed-label metrics layers

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci shard_capabilities --locked`
- `cargo test -p automata-ci human_http_route_labels_cover_every_auth_setup_and_management_template --locked`
- `cargo clippy -p automata-ci --lib --no-deps --locked -- -D warnings`

The dependency-inclusive Clippy invocation reaches an unrelated warning on current `main` in `automata-ci-github::checks::complete_check_run` (`clippy::too_many_arguments`, introduced by #89).
