### PR TITLE
Restore workspace Clippy gate

### DIFF
--- a/crates/automata-ci-github/src/checks.rs
+++ b/crates/automata-ci-github/src/checks.rs
@@ -1100,6 +1100,7 @@ impl GithubHttpEndpoint {
     ///
     /// Returns a sanitized error unless GitHub returns exact `200` JSON matching
     /// the run ID, immutable identity, completed state, and requested conclusion.
+    #[allow(clippy::too_many_arguments)]
     pub async fn complete_check_run(
         &self,
         repository: &RepositoryId,

--- a/crates/automata-ci-store/tests/github_checks_api.rs
+++ b/crates/automata-ci-store/tests/github_checks_api.rs
@@ -279,6 +279,34 @@ fn projection_claim_rejects_invalid_window() {
 }
 
 #[test]
+fn subject_receipt_rehydrates_and_rejects_nil_workflow_run_id() {
+    let subject = GithubCheckSubjectId::from_uuid(Uuid::new_v4()).expect("subject ID");
+    let external_id = format!("automata-check:{}", subject.as_uuid());
+
+    let receipt = GithubCheckSubjectReceipt::from_durable_parts(
+        subject,
+        external_id.clone(),
+        None,
+        GithubCheckDesiredProjection::Queued,
+        1,
+    )
+    .expect("complete durable receipt");
+    assert_eq!(receipt.subject_id(), subject);
+    assert_eq!(
+        GithubCheckSubjectReceipt::from_durable_parts(
+            subject,
+            external_id,
+            Some(RunId::from_uuid(Uuid::nil())),
+            GithubCheckDesiredProjection::Queued,
+            1,
+        ),
+        Err(GithubCheckValueError::NilUuid(
+            "GitHub Check workflow run ID"
+        ))
+    );
+}
+
+#[test]
 fn claimed_projection_rehydrates_only_complete_current_state() {
     let subject = GithubCheckSubjectId::from_uuid(Uuid::new_v4()).expect("subject ID");
     let worker = GithubCheckProjectionWorkerId::from_uuid(Uuid::new_v4()).expect("worker ID");
@@ -302,28 +330,6 @@ fn claimed_projection_rehydrates_only_complete_current_state() {
     let run = GithubCheckRunId::new(23).expect("run");
     let external_id = format!("automata-check:{}", subject.as_uuid());
     let authority = checks_authority(identity.tenant());
-
-    let receipt = GithubCheckSubjectReceipt::from_durable_parts(
-        subject,
-        external_id.clone(),
-        None,
-        GithubCheckDesiredProjection::Queued,
-        1,
-    )
-    .expect("complete durable receipt");
-    assert_eq!(receipt.subject_id(), subject);
-    assert_eq!(
-        GithubCheckSubjectReceipt::from_durable_parts(
-            subject,
-            external_id.clone(),
-            Some(RunId::from_uuid(Uuid::nil())),
-            GithubCheckDesiredProjection::Queued,
-            1,
-        ),
-        Err(GithubCheckValueError::NilUuid(
-            "GitHub Check workflow run ID"
-        ))
-    );
 
     let claimed = ClaimedGithubCheckProjection::from_durable_parts(
         claim,


### PR DESCRIPTION
## Outcome

Restore the exact workspace Clippy gate after the GitHub Checks lifecycle additions in #89:

- Keep the strongly typed check-completion boundary explicit with a method-local `too_many_arguments` allowance.
- Separate the subject-receipt durable contract from the claimed-projection test, reducing that projection test from 114 to 93 lines and giving the receipt behavior its own test name.

## Related issue

None.

## Trust and compatibility impact

No runtime behavior, wire format, durable format, or public signature changes. One existing test is split along the two durable types it already covered.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci-github --all-targets --all-features --locked` — 95 passed, 1 network test ignored
- `cargo test -p automata-ci-store --test store_contracts --all-features --locked github_checks_api` — 11 passed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

## AI assistance

OpenAI Codex reproduced both current-main lint failures, traced them to #89, verified no diagnostics remained behind them, and prepared the scoped boundary allowance and test split.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
