### PR TITLE
Authenticate delegated Cloud actors in Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4128,6 +4128,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -4148,12 +4149,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -5538,6 +5541,19 @@ checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ pem-rfc7468 = { version = "1.0.0", default-features = false, features = ["std"] 
 processkit = { version = "=3.3.1", default-features = false, features = ["limits"] }
 prometheus-client = "=0.25.0"
 rcgen = { version = "=0.14.8", default-features = false, features = ["pem", "ring", "x509-parser"] }
-reqwest = { version = "0.12.23", default-features = false, features = ["http2", "json", "rustls-tls-webpki-roots"] }
+reqwest = { version = "0.12.23", default-features = false, features = ["http2", "json", "rustls-tls-webpki-roots", "stream"] }
 ring = { version = "=0.17.14", default-features = false, features = ["std"] }
 rustls = { version = "=0.23.43", default-features = false, features = ["ring", "std"] }
 rustix = { version = "1.1.4", features = ["fs", "process"] }

--- a/crates/automata-ci-auth-postgres/src/delegated_actor.rs
+++ b/crates/automata-ci-auth-postgres/src/delegated_actor.rs
@@ -1,0 +1,330 @@
+use std::{collections::BTreeSet, fmt};
+
+use automata_ci_auth::{
+    authorization::{
+        AuthorizationContext, AuthorizationScope, RepositoryResource, RepositoryResourceId,
+        RoleName, RunnerGroupResource, RunnerGroupResourceId, ScopedRoleGrant,
+    },
+    delegated_actor::{
+        DelegatedActorRequestSnapshot, DelegatedActorResolutionFuture, DelegatedActorResolver,
+        DelegatedActorResolverError, ResolveDelegatedActorOutcome, ResolveDelegatedActorRequest,
+    },
+    human::{PrincipalId, TenantId},
+    request_auth::ViewerDisplayMetadata,
+};
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::session::database_time_milliseconds;
+
+const MAX_DELEGATED_ACTOR_ROLE_GRANTS: usize = 10_000;
+
+/// `PostgreSQL` resolver for externally delegated actor identities.
+///
+/// The external assertion is only identity evidence. This adapter always reloads
+/// the Core-owned principal, current workspace membership, authorization
+/// revision, and direct scoped role grants in one transaction.
+#[derive(Clone)]
+pub struct PostgresDelegatedActorResolver {
+    pool: PgPool,
+}
+
+impl PostgresDelegatedActorResolver {
+    /// Creates a delegated-actor resolver backed by `pool`.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl fmt::Debug for PostgresDelegatedActorResolver {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresDelegatedActorResolver")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(FromRow)]
+struct IdentityRow {
+    issuer: String,
+    subject: Uuid,
+    principal_id: Uuid,
+    display_name: String,
+    principal_status: String,
+}
+
+#[derive(FromRow)]
+struct MembershipRow {
+    tenant_id: String,
+    principal_id: Uuid,
+    status: String,
+    authorization_revision: i64,
+}
+
+#[derive(FromRow)]
+struct ScopedGrantRow {
+    binding_tenant_id: String,
+    binding_principal_id: Uuid,
+    role_tenant_id: Option<String>,
+    role_name: Option<String>,
+    scope_kind: String,
+    repository_id: Option<Uuid>,
+    repository_tenant_id: Option<String>,
+    runner_group_id: Option<Uuid>,
+    runner_group_tenant_id: Option<String>,
+}
+
+impl ScopedGrantRow {
+    fn to_grant(
+        &self,
+        expected_tenant_id: &TenantId,
+        expected_principal_id: Uuid,
+    ) -> Result<ScopedRoleGrant, DelegatedActorResolverError> {
+        let role_tenant_id = self
+            .role_tenant_id
+            .as_deref()
+            .ok_or(DelegatedActorResolverError::CorruptData)?;
+        let role_name = self
+            .role_name
+            .as_deref()
+            .ok_or(DelegatedActorResolverError::CorruptData)?;
+        if self.binding_tenant_id != expected_tenant_id.as_str()
+            || role_tenant_id != expected_tenant_id.as_str()
+            || self.binding_principal_id != expected_principal_id
+        {
+            return Err(DelegatedActorResolverError::CorruptData);
+        }
+        let role =
+            RoleName::new(role_name).map_err(|_| DelegatedActorResolverError::CorruptData)?;
+        let scope = match self.scope_kind.as_str() {
+            "tenant"
+                if self.repository_id.is_none()
+                    && self.repository_tenant_id.is_none()
+                    && self.runner_group_id.is_none()
+                    && self.runner_group_tenant_id.is_none() =>
+            {
+                AuthorizationScope::tenant(expected_tenant_id.clone())
+            }
+            "repository"
+                if self.runner_group_id.is_none()
+                    && self.runner_group_tenant_id.is_none()
+                    && self.repository_tenant_id.as_deref()
+                        == Some(expected_tenant_id.as_str()) =>
+            {
+                let repository_id = self
+                    .repository_id
+                    .ok_or(DelegatedActorResolverError::CorruptData)?;
+                let resource_id = RepositoryResourceId::from_uuid(repository_id)
+                    .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+                AuthorizationScope::repository(RepositoryResource::new(
+                    expected_tenant_id.clone(),
+                    resource_id,
+                ))
+            }
+            "runner_group"
+                if self.repository_id.is_none()
+                    && self.repository_tenant_id.is_none()
+                    && self.runner_group_tenant_id.as_deref()
+                        == Some(expected_tenant_id.as_str()) =>
+            {
+                let runner_group_id = self
+                    .runner_group_id
+                    .ok_or(DelegatedActorResolverError::CorruptData)?;
+                let resource_id = RunnerGroupResourceId::from_uuid(runner_group_id)
+                    .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+                AuthorizationScope::runner_group(RunnerGroupResource::new(
+                    expected_tenant_id.clone(),
+                    resource_id,
+                ))
+            }
+            _ => return Err(DelegatedActorResolverError::CorruptData),
+        };
+        Ok(ScopedRoleGrant::new(scope, role))
+    }
+}
+
+const IDENTITY_SELECT: &str = r"
+    SELECT identity.issuer, identity.subject, identity.principal_id,
+           identity.display_name, principal.status AS principal_status
+    FROM delegated_actor_identities AS identity
+    JOIN human_principals AS principal ON principal.id = identity.principal_id
+    WHERE identity.issuer = $1 AND identity.subject = $2
+    FOR SHARE OF identity, principal
+";
+
+const MEMBERSHIP_SELECT: &str = r"
+    SELECT tenant_id, principal_id, status, authorization_revision
+    FROM tenant_human_memberships
+    WHERE tenant_id = $1 AND principal_id = $2
+    FOR SHARE
+";
+
+const ACTIVE_GRANTS_SELECT: &str = r"
+    SELECT binding.tenant_id AS binding_tenant_id,
+           binding.principal_id AS binding_principal_id,
+           role.tenant_id AS role_tenant_id,
+           role.name AS role_name,
+           binding.scope_kind,
+           binding.repository_id,
+           repository.tenant_id AS repository_tenant_id,
+           binding.runner_group_id,
+           runner_group.tenant_id AS runner_group_tenant_id
+    FROM rbac_role_bindings AS binding
+    LEFT JOIN rbac_roles AS role
+      ON role.tenant_id = binding.tenant_id AND role.id = binding.role_id
+    LEFT JOIN repositories AS repository
+      ON repository.tenant_id = binding.tenant_id
+     AND repository.id = binding.repository_id
+    LEFT JOIN runner_groups AS runner_group
+      ON runner_group.tenant_id = binding.tenant_id
+     AND runner_group.id = binding.runner_group_id
+    WHERE binding.tenant_id = $1
+      AND binding.principal_id = $2
+      AND binding.status = 'active'
+      AND (binding.valid_until_ms IS NULL OR binding.valid_until_ms > $3)
+    LIMIT $4
+";
+
+async fn commit(
+    transaction: sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(), DelegatedActorResolverError> {
+    transaction
+        .commit()
+        .await
+        .map_err(|_| DelegatedActorResolverError::Unavailable)
+}
+
+fn row_limit_plus_one() -> Result<i64, DelegatedActorResolverError> {
+    i64::try_from(MAX_DELEGATED_ACTOR_ROLE_GRANTS + 1)
+        .map_err(|_| DelegatedActorResolverError::CorruptData)
+}
+
+impl DelegatedActorResolver for PostgresDelegatedActorResolver {
+    #[allow(clippy::too_many_lines)]
+    fn resolve<'a>(
+        &'a self,
+        request: &'a ResolveDelegatedActorRequest,
+    ) -> DelegatedActorResolutionFuture<'a> {
+        Box::pin(async move {
+            let mut transaction = self
+                .pool
+                .begin()
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+            sqlx::query("SELECT pg_advisory_xact_lock_shared(hashtextextended($1, 731662009))")
+                .bind(request.tenant_id().as_str())
+                .execute(&mut *transaction)
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+
+            let identity = sqlx::query_as::<_, IdentityRow>(IDENTITY_SELECT)
+                .bind(request.assertion().issuer())
+                .bind(request.assertion().subject())
+                .fetch_optional(&mut *transaction)
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+            let Some(identity) = identity else {
+                commit(transaction).await?;
+                return Ok(ResolveDelegatedActorOutcome::NotFound);
+            };
+            if identity.issuer != request.assertion().issuer()
+                || identity.subject != request.assertion().subject()
+                || identity.principal_id.is_nil()
+            {
+                return Err(DelegatedActorResolverError::CorruptData);
+            }
+            match identity.principal_status.as_str() {
+                "active" => {}
+                "disabled" => {
+                    commit(transaction).await?;
+                    return Ok(ResolveDelegatedActorOutcome::PrincipalDisabled);
+                }
+                _ => return Err(DelegatedActorResolverError::CorruptData),
+            }
+
+            let membership = sqlx::query_as::<_, MembershipRow>(MEMBERSHIP_SELECT)
+                .bind(request.tenant_id().as_str())
+                .bind(identity.principal_id)
+                .fetch_optional(&mut *transaction)
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+            let Some(membership) = membership else {
+                commit(transaction).await?;
+                return Ok(ResolveDelegatedActorOutcome::NotFound);
+            };
+            if membership.tenant_id != request.tenant_id().as_str()
+                || membership.principal_id != identity.principal_id
+            {
+                return Err(DelegatedActorResolverError::CorruptData);
+            }
+            match membership.status.as_str() {
+                "active" => {}
+                "suspended" => {
+                    commit(transaction).await?;
+                    return Ok(ResolveDelegatedActorOutcome::MembershipSuspended);
+                }
+                _ => return Err(DelegatedActorResolverError::CorruptData),
+            }
+            let authorization_revision = u64::try_from(membership.authorization_revision)
+                .ok()
+                .filter(|revision| *revision > 0)
+                .ok_or(DelegatedActorResolverError::CorruptData)?;
+            let database_time_ms = database_time_milliseconds(&mut transaction)
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+            let rows = sqlx::query_as::<_, ScopedGrantRow>(ACTIVE_GRANTS_SELECT)
+                .bind(request.tenant_id().as_str())
+                .bind(identity.principal_id)
+                .bind(database_time_ms)
+                .bind(row_limit_plus_one()?)
+                .fetch_all(&mut *transaction)
+                .await
+                .map_err(|_| DelegatedActorResolverError::Unavailable)?;
+            if rows.len() > MAX_DELEGATED_ACTOR_ROLE_GRANTS {
+                return Err(DelegatedActorResolverError::CorruptData);
+            }
+            let mut grants = BTreeSet::new();
+            for row in rows {
+                let grant = row.to_grant(request.tenant_id(), identity.principal_id)?;
+                if !grants.insert(grant) {
+                    return Err(DelegatedActorResolverError::CorruptData);
+                }
+            }
+            let principal_id = PrincipalId::new(identity.principal_id.hyphenated().to_string())
+                .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+            let authorization = AuthorizationContext::authenticated_at_revision(
+                request.tenant_id().clone(),
+                principal_id,
+                grants,
+                authorization_revision,
+            )
+            .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+            let viewer = ViewerDisplayMetadata::new(identity.display_name)
+                .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+            let snapshot = DelegatedActorRequestSnapshot::new(
+                request.assertion().clone(),
+                request.tenant_id(),
+                viewer,
+                authorization,
+            )
+            .map_err(|_| DelegatedActorResolverError::CorruptData)?;
+            commit(transaction).await?;
+            Ok(ResolveDelegatedActorOutcome::Authenticated(Box::new(
+                snapshot,
+            )))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_query_is_bounded_and_scoped_to_the_exact_principal() {
+        assert!(ACTIVE_GRANTS_SELECT.contains("binding.tenant_id = $1"));
+        assert!(ACTIVE_GRANTS_SELECT.contains("binding.principal_id = $2"));
+        assert!(ACTIVE_GRANTS_SELECT.contains("LIMIT $4"));
+    }
+}

--- a/crates/automata-ci-auth-postgres/src/lib.rs
+++ b/crates/automata-ci-auth-postgres/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+mod delegated_actor;
 mod github_mapping_management;
 mod github_membership;
 mod installation;
@@ -15,6 +16,7 @@ mod session;
 mod sign_in;
 mod support;
 
+pub use delegated_actor::PostgresDelegatedActorResolver;
 pub use github_mapping_management::PostgresGithubMappingManagementRepository;
 pub use github_membership::PostgresGithubMembershipRepository;
 pub use installation::PostgresInstallationRepository;

--- a/crates/automata-ci-auth-postgres/tests/auth_postgres.rs
+++ b/crates/automata-ci-auth-postgres/tests/auth_postgres.rs
@@ -4,6 +4,8 @@ mod support;
 
 #[path = "postgres_cli_session_activation.rs"]
 mod postgres_cli_session_activation;
+#[path = "postgres_delegated_actor.rs"]
+mod postgres_delegated_actor;
 #[path = "postgres_github_mapping_management.rs"]
 mod postgres_github_mapping_management;
 #[path = "postgres_github_membership.rs"]

--- a/crates/automata-ci-auth-postgres/tests/postgres_delegated_actor.rs
+++ b/crates/automata-ci-auth-postgres/tests/postgres_delegated_actor.rs
@@ -1,0 +1,149 @@
+use automata_ci_auth::{
+    delegated_actor::{
+        DelegatedActorAssertion, DelegatedActorResolver, ResolveDelegatedActorOutcome,
+        ResolveDelegatedActorRequest,
+    },
+    human::TenantId,
+    time::UnixTimestamp,
+};
+use automata_ci_auth_postgres::PostgresDelegatedActorResolver;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::support::{TestResult, run_with_database};
+
+const WORKSPACE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const PRINCIPAL_ID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const SUBJECT: &str = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const ISSUER: &str = "https://cloud.automata.example";
+
+async fn seed_delegated_actor(pool: &PgPool) -> TestResult {
+    let principal = Uuid::parse_str(PRINCIPAL_ID)?;
+    let subject = Uuid::parse_str(SUBJECT)?;
+    let role = Uuid::parse_str("dddddddd-dddd-4ddd-8ddd-dddddddddddd")?;
+    sqlx::query(
+        "INSERT INTO tenants (id,display_name,created_at_ms,updated_at_ms) VALUES ($1,'Workspace A',100000,100000)",
+    )
+    .bind(WORKSPACE_ID)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO human_principals (id,status,display_name,created_at_ms,updated_at_ms)
+        VALUES ($1,'active','Cloud User',100000,100000)
+        ",
+    )
+    .bind(principal)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO delegated_actor_identities (
+            issuer,subject,principal_id,display_name,created_at_ms,updated_at_ms
+        ) VALUES ($1,$2,$3,'Cloud User',100000,100000)
+        ",
+    )
+    .bind(ISSUER)
+    .bind(subject)
+    .bind(principal)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO tenant_human_memberships (
+            tenant_id,principal_id,status,authorization_revision,created_at_ms,updated_at_ms
+        ) VALUES ($1,$2,'active',7,100000,100000)
+        ",
+    )
+    .bind(WORKSPACE_ID)
+    .bind(principal)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO rbac_roles (tenant_id,id,name,display_name,created_at_ms,updated_at_ms)
+        VALUES ($1,$2,'owner','Owner',100000,100000)
+        ",
+    )
+    .bind(WORKSPACE_ID)
+    .bind(role)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO rbac_role_bindings (
+            tenant_id,id,principal_id,role_id,scope_kind,created_at_ms
+        ) VALUES ($1,$2,$3,$4,'tenant',100000)
+        ",
+    )
+    .bind(WORKSPACE_ID)
+    .bind(Uuid::parse_str("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")?)
+    .bind(principal)
+    .bind(role)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn request() -> ResolveDelegatedActorRequest {
+    let assertion = DelegatedActorAssertion::new(
+        ISSUER,
+        Uuid::parse_str(SUBJECT).expect("subject"),
+        Uuid::parse_str("ffffffff-ffff-4fff-8fff-ffffffffffff").expect("session"),
+        Uuid::parse_str("12345678-1234-4234-8234-123456789abc").expect("assertion"),
+        UnixTimestamp::from_seconds(900),
+        UnixTimestamp::from_seconds(1_000),
+        UnixTimestamp::from_seconds(1_120),
+    )
+    .expect("delegated assertion");
+    ResolveDelegatedActorRequest::new(assertion, TenantId::new(WORKSPACE_ID).expect("workspace"))
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn resolves_current_core_membership_and_direct_rbac() -> TestResult {
+    run_with_database(|database| async move {
+        seed_delegated_actor(database.pool()).await?;
+        let resolver = PostgresDelegatedActorResolver::new(database.pool().clone());
+        let outcome = resolver.resolve(&request()).await?;
+        let ResolveDelegatedActorOutcome::Authenticated(snapshot) = outcome else {
+            panic!("delegated actor should resolve");
+        };
+        assert_eq!(snapshot.viewer().display_name(), "Cloud User");
+        assert_eq!(
+            snapshot
+                .authorization()
+                .principal_id()
+                .map(automata_ci_auth::human::PrincipalId::as_str),
+            Some(PRINCIPAL_ID)
+        );
+        assert_eq!(snapshot.authorization().authorization_revision(), Some(7));
+        let grants = snapshot
+            .authorization()
+            .role_grants()
+            .expect("authenticated grants");
+        assert_eq!(grants.len(), 1);
+        assert_eq!(
+            grants.iter().next().map(|grant| grant.role().as_str()),
+            Some("owner")
+        );
+
+        sqlx::query(
+            r"
+            UPDATE tenant_human_memberships
+            SET status='suspended',suspended_at_ms=updated_at_ms,suspended_reason='test'
+            WHERE tenant_id=$1 AND principal_id=$2
+            ",
+        )
+        .bind(WORKSPACE_ID)
+        .bind(Uuid::parse_str(PRINCIPAL_ID)?)
+        .execute(database.pool())
+        .await?;
+        assert!(matches!(
+            resolver.resolve(&request()).await?,
+            ResolveDelegatedActorOutcome::MembershipSuspended
+        ));
+        Ok(())
+    })
+    .await
+}

--- a/crates/automata-ci-auth/src/delegated_actor.rs
+++ b/crates/automata-ci-auth/src/delegated_actor.rs
@@ -1,0 +1,320 @@
+//! Request authentication for short-lived identities delegated by a trusted authority.
+//!
+//! Delegated assertions are deliberately separate from durable browser and CLI
+//! sessions. The issuer authenticates an external actor, while Core remains the
+//! authority for principal mapping, workspace membership, and RBAC.
+
+use std::{fmt, future::Future, pin::Pin};
+
+use thiserror::Error;
+use url::Url;
+use uuid::Uuid;
+
+use crate::{
+    authorization::AuthorizationContext, human::TenantId, request_auth::ViewerDisplayMetadata,
+    time::UnixTimestamp,
+};
+
+const MAX_ASSERTION_LIFETIME_SECONDS: u64 = 5 * 60;
+
+/// The signed, provider-owned identity metadata accepted by Core.
+#[derive(Clone, Eq, PartialEq)]
+pub struct DelegatedActorAssertion {
+    issuer: String,
+    subject: Uuid,
+    session_id: Uuid,
+    assertion_id: Uuid,
+    authenticated_at: UnixTimestamp,
+    issued_at: UnixTimestamp,
+    expires_at: UnixTimestamp,
+}
+
+impl DelegatedActorAssertion {
+    /// Creates a bounded, internally consistent delegated assertion.
+    ///
+    /// Signature, audience, and current-time checks remain the responsibility of
+    /// the protocol adapter before this domain value is constructed.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a non-canonical HTTPS origin, nil identities, non-monotonic times,
+    /// or an assertion lifetime longer than five minutes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        issuer: impl Into<String>,
+        subject: Uuid,
+        session_id: Uuid,
+        assertion_id: Uuid,
+        authenticated_at: UnixTimestamp,
+        issued_at: UnixTimestamp,
+        expires_at: UnixTimestamp,
+    ) -> Result<Self, DelegatedActorAssertionError> {
+        let issuer = issuer.into();
+        let parsed = Url::parse(&issuer).map_err(|_| DelegatedActorAssertionError)?;
+        expires_at
+            .as_seconds()
+            .checked_sub(issued_at.as_seconds())
+            .filter(|lifetime| *lifetime > 0 && *lifetime <= MAX_ASSERTION_LIFETIME_SECONDS)
+            .ok_or(DelegatedActorAssertionError)?;
+        if parsed.scheme() != "https"
+            || parsed.host().is_none()
+            || !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.path() != "/"
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.origin().ascii_serialization() != issuer
+            || subject.is_nil()
+            || session_id.is_nil()
+            || assertion_id.is_nil()
+            || authenticated_at > issued_at
+        {
+            return Err(DelegatedActorAssertionError);
+        }
+        Ok(Self {
+            issuer,
+            subject,
+            session_id,
+            assertion_id,
+            authenticated_at,
+            issued_at,
+            expires_at,
+        })
+    }
+
+    /// Returns the exact configured authority origin.
+    #[must_use]
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Returns the authority-owned stable account UUID.
+    #[must_use]
+    pub const fn subject(&self) -> Uuid {
+        self.subject
+    }
+
+    /// Returns the authority session that performed the request.
+    #[must_use]
+    pub const fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    /// Returns this assertion's unique replay-correlation identity.
+    #[must_use]
+    pub const fn assertion_id(&self) -> Uuid {
+        self.assertion_id
+    }
+
+    /// Returns when the authority last authenticated the actor.
+    #[must_use]
+    pub const fn authenticated_at(&self) -> UnixTimestamp {
+        self.authenticated_at
+    }
+
+    /// Returns when the authority issued this assertion.
+    #[must_use]
+    pub const fn issued_at(&self) -> UnixTimestamp {
+        self.issued_at
+    }
+
+    /// Returns the assertion's exclusive expiry.
+    #[must_use]
+    pub const fn expires_at(&self) -> UnixTimestamp {
+        self.expires_at
+    }
+}
+
+impl fmt::Debug for DelegatedActorAssertion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DelegatedActorAssertion")
+            .field("issuer", &self.issuer)
+            .field("subject", &self.subject)
+            .field("session_id", &self.session_id)
+            .field("assertion_id", &self.assertion_id)
+            .field("authenticated_at", &self.authenticated_at)
+            .field("issued_at", &self.issued_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+/// Sanitized delegated-assertion validation failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("delegated actor assertion is invalid")]
+pub struct DelegatedActorAssertionError;
+
+/// One external assertion resolved against current Core-owned authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegatedActorRequestSnapshot {
+    assertion: DelegatedActorAssertion,
+    viewer: ViewerDisplayMetadata,
+    authorization: AuthorizationContext,
+}
+
+impl DelegatedActorRequestSnapshot {
+    /// Creates a workspace-consistent delegated request snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Rejects anonymous or cross-workspace authorization evidence.
+    pub fn new(
+        assertion: DelegatedActorAssertion,
+        expected_tenant_id: &TenantId,
+        viewer: ViewerDisplayMetadata,
+        authorization: AuthorizationContext,
+    ) -> Result<Self, DelegatedActorRequestSnapshotError> {
+        if authorization.tenant_id() != Some(expected_tenant_id)
+            || authorization.principal_id().is_none()
+        {
+            return Err(DelegatedActorRequestSnapshotError);
+        }
+        Ok(Self {
+            assertion,
+            viewer,
+            authorization,
+        })
+    }
+
+    /// Returns the verified external assertion metadata.
+    #[must_use]
+    pub const fn assertion(&self) -> &DelegatedActorAssertion {
+        &self.assertion
+    }
+
+    /// Returns bounded display-only viewer metadata.
+    #[must_use]
+    pub const fn viewer(&self) -> &ViewerDisplayMetadata {
+        &self.viewer
+    }
+
+    /// Returns Core's current workspace-scoped RBAC evidence.
+    #[must_use]
+    pub const fn authorization(&self) -> &AuthorizationContext {
+        &self.authorization
+    }
+}
+
+/// Sanitized inconsistent delegated snapshot failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("delegated actor request snapshot is inconsistent")]
+pub struct DelegatedActorRequestSnapshotError;
+
+/// A verified assertion paired with the exact requested workspace.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolveDelegatedActorRequest {
+    assertion: DelegatedActorAssertion,
+    tenant_id: TenantId,
+}
+
+impl ResolveDelegatedActorRequest {
+    /// Creates a delegated-actor resolution request.
+    #[must_use]
+    pub const fn new(assertion: DelegatedActorAssertion, tenant_id: TenantId) -> Self {
+        Self {
+            assertion,
+            tenant_id,
+        }
+    }
+
+    /// Returns the verified authority assertion.
+    #[must_use]
+    pub const fn assertion(&self) -> &DelegatedActorAssertion {
+        &self.assertion
+    }
+
+    /// Returns the requested Core workspace identity.
+    #[must_use]
+    pub const fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+}
+
+/// Closed durable resolution result for a verified delegated assertion.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResolveDelegatedActorOutcome {
+    /// The external identity resolved to current Core membership and RBAC.
+    Authenticated(Box<DelegatedActorRequestSnapshot>),
+    /// The external identity or requested workspace membership does not exist.
+    NotFound,
+    /// The mapped Core principal is disabled.
+    PrincipalDisabled,
+    /// The mapped workspace membership is suspended.
+    MembershipSuspended,
+}
+
+/// A delegated-actor resolution operation.
+pub type DelegatedActorResolutionFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ResolveDelegatedActorOutcome, DelegatedActorResolverError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Resolves verified external identities against current Core-owned authority.
+pub trait DelegatedActorResolver: fmt::Debug + Send + Sync {
+    /// Loads the principal mapping, workspace membership, and RBAC snapshot.
+    fn resolve<'a>(
+        &'a self,
+        request: &'a ResolveDelegatedActorRequest,
+    ) -> DelegatedActorResolutionFuture<'a>;
+}
+
+/// Sanitized delegated-actor storage failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum DelegatedActorResolverError {
+    /// Durable identity storage is temporarily unavailable.
+    #[error("delegated actor storage is unavailable")]
+    Unavailable,
+    /// Durable identity or authorization data violates an invariant.
+    #[error("durable delegated actor data violates an invariant")]
+    CorruptData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assertion_is_short_lived_and_uses_an_https_origin() {
+        let subject = Uuid::from_u128(1);
+        let session = Uuid::from_u128(2);
+        let assertion = Uuid::from_u128(3);
+        let valid = DelegatedActorAssertion::new(
+            "https://cloud.automata.example",
+            subject,
+            session,
+            assertion,
+            UnixTimestamp::from_seconds(90),
+            UnixTimestamp::from_seconds(100),
+            UnixTimestamp::from_seconds(220),
+        );
+        assert!(valid.is_ok());
+        assert!(
+            DelegatedActorAssertion::new(
+                "http://cloud.automata.example",
+                subject,
+                session,
+                assertion,
+                UnixTimestamp::from_seconds(90),
+                UnixTimestamp::from_seconds(100),
+                UnixTimestamp::from_seconds(220),
+            )
+            .is_err()
+        );
+        assert!(
+            DelegatedActorAssertion::new(
+                "https://cloud.automata.example",
+                subject,
+                session,
+                assertion,
+                UnixTimestamp::from_seconds(90),
+                UnixTimestamp::from_seconds(100),
+                UnixTimestamp::from_seconds(401),
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/automata-ci-auth/src/lib.rs
+++ b/crates/automata-ci-auth/src/lib.rs
@@ -8,6 +8,8 @@
 
 /// Role-based and resource-scoped authorization policy contracts.
 pub mod authorization;
+/// Short-lived identities delegated by an external control-plane authority.
+pub mod delegated_actor;
 /// GitHub-backed human authentication flows and provider ports.
 pub mod github;
 /// Numeric GitHub organization/team role-mapping management contracts.

--- a/crates/automata-ci/Cargo.toml
+++ b/crates/automata-ci/Cargo.toml
@@ -59,6 +59,7 @@ getrandom.workspace = true
 futures.workspace = true
 http.workspace = true
 reqwest.workspace = true
+ring.workspace = true
 rcgen.workspace = true
 prometheus-client.workspace = true
 rustls.workspace = true
@@ -89,7 +90,6 @@ automata-ci-postgres-test-support.workspace = true
 automata-ci-scm.workspace = true
 pem-rfc7468.workspace = true
 rcgen.workspace = true
-ring.workspace = true
 sqlx.workspace = true
 tar.workspace = true
 

--- a/crates/automata-ci/src/app/delegated_actor_api.rs
+++ b/crates/automata-ci/src/app/delegated_actor_api.rs
@@ -1,0 +1,610 @@
+//! Hosted Core HTTP ingress for short-lived Cloud actor assertions.
+
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use automata_ci_auth::{
+    delegated_actor::{
+        DelegatedActorAssertion, DelegatedActorResolver, DelegatedActorResolverError,
+        ResolveDelegatedActorOutcome, ResolveDelegatedActorRequest,
+    },
+    human::TenantId,
+    time::UnixTimestamp,
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use futures::StreamExt as _;
+use reqwest::Client;
+use ring::signature::{ECDSA_P256_SHA256_FIXED, UnparsedPublicKey};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use url::Url;
+use uuid::Uuid;
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse as _, Response},
+    routing::get,
+};
+
+/// Protected Core endpoint used by Cloud to resolve the current viewer.
+pub const DELEGATED_ACTOR_VIEWER_PATH: &str = "/internal/v1/workspaces/{workspace_id}/viewer";
+
+const MAX_ASSERTION_BYTES: usize = 8 * 1024;
+const MAX_JWT_SEGMENT_BYTES: usize = 6 * 1024;
+const MAX_JWKS_BYTES: usize = 64 * 1024;
+const MAX_JWKS_KEYS: usize = 32;
+const MAX_KEY_ID_BYTES: usize = 128;
+const ALLOWED_CLOCK_SKEW_SECONDS: u64 = 30;
+const JWKS_CACHE_LIFETIME: Duration = Duration::from_mins(5);
+
+/// Exact trust configuration for Cloud delegated actor assertions.
+#[derive(Clone, Debug)]
+pub(crate) struct DelegatedActorVerifierConfig {
+    pub(crate) issuer: String,
+    pub(crate) audience: String,
+    pub(crate) jwks_url: Url,
+}
+
+/// Cached ES256 verifier for one explicitly configured Cloud authority.
+pub(crate) struct DelegatedActorVerifier {
+    config: DelegatedActorVerifierConfig,
+    client: Client,
+    cache: Mutex<Option<CachedJwks>>,
+}
+
+impl std::fmt::Debug for DelegatedActorVerifier {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DelegatedActorVerifier")
+            .field("issuer", &self.config.issuer)
+            .field("audience", &self.config.audience)
+            .field("jwks_url", &self.config.jwks_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DelegatedActorVerifier {
+    /// Constructs an outbound client that never follows authority redirects.
+    pub(crate) fn new(
+        config: DelegatedActorVerifierConfig,
+    ) -> Result<Self, DelegatedActorVerificationError> {
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(3))
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+        Ok(Self {
+            config,
+            client,
+            cache: Mutex::new(None),
+        })
+    }
+
+    async fn verify(
+        &self,
+        token: &str,
+        now: UnixTimestamp,
+    ) -> Result<VerifiedDelegatedActor, DelegatedActorVerificationError> {
+        if token.is_empty() || token.len() > MAX_ASSERTION_BYTES || !token.is_ascii() {
+            return Err(DelegatedActorVerificationError::Rejected);
+        }
+        let mut segments = token.split('.');
+        let encoded_header = segments
+            .next()
+            .ok_or(DelegatedActorVerificationError::Rejected)?;
+        let encoded_claims = segments
+            .next()
+            .ok_or(DelegatedActorVerificationError::Rejected)?;
+        let encoded_signature = segments
+            .next()
+            .ok_or(DelegatedActorVerificationError::Rejected)?;
+        if segments.next().is_some()
+            || encoded_header.len() > MAX_JWT_SEGMENT_BYTES
+            || encoded_claims.len() > MAX_JWT_SEGMENT_BYTES
+            || encoded_signature.len() > MAX_JWT_SEGMENT_BYTES
+        {
+            return Err(DelegatedActorVerificationError::Rejected);
+        }
+        let header: ProtectedHeader = parse_canonical_segment(encoded_header)?;
+        if header.alg != "ES256" || header.typ != "at+jwt" || !valid_key_id(&header.kid) {
+            return Err(DelegatedActorVerificationError::Rejected);
+        }
+        let signature = decode_canonical_segment(encoded_signature)?;
+        if signature.len() != 64 {
+            return Err(DelegatedActorVerificationError::Rejected);
+        }
+        let public_key = self.public_key(&header.kid).await?;
+        let signing_input = format!("{encoded_header}.{encoded_claims}");
+        UnparsedPublicKey::new(&ECDSA_P256_SHA256_FIXED, public_key)
+            .verify(signing_input.as_bytes(), &signature)
+            .map_err(|_| DelegatedActorVerificationError::Rejected)?;
+
+        let claims: DelegatedActorClaims = parse_canonical_segment(encoded_claims)?;
+        if claims.ver != 1
+            || claims.iss != self.config.issuer
+            || claims.aud != self.config.audience
+            || claims.iat > now.as_seconds().saturating_add(ALLOWED_CLOCK_SKEW_SECONDS)
+            || claims.exp <= now.as_seconds().saturating_sub(ALLOWED_CLOCK_SKEW_SECONDS)
+        {
+            return Err(DelegatedActorVerificationError::Rejected);
+        }
+        let subject = canonical_uuid(&claims.sub)?;
+        let workspace_id = canonical_uuid(&claims.workspace_id)?;
+        let session_id = canonical_uuid(&claims.session_id)?;
+        let assertion_id = canonical_uuid(&claims.jti)?;
+        let assertion = DelegatedActorAssertion::new(
+            claims.iss,
+            subject,
+            session_id,
+            assertion_id,
+            UnixTimestamp::from_seconds(claims.auth_time),
+            UnixTimestamp::from_seconds(claims.iat),
+            UnixTimestamp::from_seconds(claims.exp),
+        )
+        .map_err(|_| DelegatedActorVerificationError::Rejected)?;
+        Ok(VerifiedDelegatedActor {
+            assertion,
+            workspace_id,
+        })
+    }
+
+    async fn public_key(&self, key_id: &str) -> Result<[u8; 65], DelegatedActorVerificationError> {
+        let mut cache = self.cache.lock().await;
+        if let Some(cached) = cache.as_ref()
+            && cached.fetched_at.elapsed() < JWKS_CACHE_LIFETIME
+        {
+            return cached
+                .keys
+                .get(key_id)
+                .copied()
+                .ok_or(DelegatedActorVerificationError::Rejected);
+        }
+        let fetched = self.fetch_jwks().await?;
+        let key = fetched.keys.get(key_id).copied();
+        *cache = Some(fetched);
+        key.ok_or(DelegatedActorVerificationError::Rejected)
+    }
+
+    async fn fetch_jwks(&self) -> Result<CachedJwks, DelegatedActorVerificationError> {
+        let response = self
+            .client
+            .get(self.config.jwks_url.clone())
+            .header(header::ACCEPT, "application/json")
+            .send()
+            .await
+            .map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+        if response.status() != StatusCode::OK
+            || response
+                .content_length()
+                .is_some_and(|length| length > MAX_JWKS_BYTES as u64)
+            || response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_none_or(|value| !is_json_content_type(value))
+        {
+            return Err(DelegatedActorVerificationError::Unavailable);
+        }
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+            if body.len().saturating_add(chunk.len()) > MAX_JWKS_BYTES {
+                return Err(DelegatedActorVerificationError::Unavailable);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        parse_jwks(&body)
+    }
+}
+
+#[derive(Debug)]
+struct VerifiedDelegatedActor {
+    assertion: DelegatedActorAssertion,
+    workspace_id: Uuid,
+}
+
+#[derive(Debug)]
+struct CachedJwks {
+    fetched_at: Instant,
+    keys: BTreeMap<String, [u8; 65]>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProtectedHeader {
+    alg: String,
+    kid: String,
+    typ: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DelegatedActorClaims {
+    ver: u8,
+    iss: String,
+    sub: String,
+    aud: String,
+    workspace_id: String,
+    session_id: String,
+    auth_time: u64,
+    iat: u64,
+    exp: u64,
+    jti: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JwkSet {
+    keys: Vec<PublicJwk>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublicJwk {
+    kty: String,
+    crv: String,
+    alg: String,
+    #[serde(rename = "use")]
+    usage: String,
+    kid: String,
+    x: String,
+    y: String,
+}
+
+fn parse_jwks(body: &[u8]) -> Result<CachedJwks, DelegatedActorVerificationError> {
+    let document: JwkSet =
+        serde_json::from_slice(body).map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+    if document.keys.is_empty() || document.keys.len() > MAX_JWKS_KEYS {
+        return Err(DelegatedActorVerificationError::Unavailable);
+    }
+    let mut keys = BTreeMap::new();
+    for key in document.keys {
+        if key.kty != "EC"
+            || key.crv != "P-256"
+            || key.alg != "ES256"
+            || key.usage != "sig"
+            || !valid_key_id(&key.kid)
+        {
+            return Err(DelegatedActorVerificationError::Unavailable);
+        }
+        let x = decode_canonical_segment(&key.x)
+            .map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+        let y = decode_canonical_segment(&key.y)
+            .map_err(|_| DelegatedActorVerificationError::Unavailable)?;
+        if x.len() != 32 || y.len() != 32 {
+            return Err(DelegatedActorVerificationError::Unavailable);
+        }
+        let mut public_key = [0_u8; 65];
+        public_key[0] = 4;
+        public_key[1..33].copy_from_slice(&x);
+        public_key[33..].copy_from_slice(&y);
+        if keys.insert(key.kid, public_key).is_some() {
+            return Err(DelegatedActorVerificationError::Unavailable);
+        }
+    }
+    Ok(CachedJwks {
+        fetched_at: Instant::now(),
+        keys,
+    })
+}
+
+fn parse_canonical_segment<T: for<'de> Deserialize<'de>>(
+    segment: &str,
+) -> Result<T, DelegatedActorVerificationError> {
+    let decoded = decode_canonical_segment(segment)?;
+    serde_json::from_slice(&decoded).map_err(|_| DelegatedActorVerificationError::Rejected)
+}
+
+fn decode_canonical_segment(segment: &str) -> Result<Vec<u8>, DelegatedActorVerificationError> {
+    if segment.is_empty() || segment.len() > MAX_JWT_SEGMENT_BYTES {
+        return Err(DelegatedActorVerificationError::Rejected);
+    }
+    let decoded = URL_SAFE_NO_PAD
+        .decode(segment)
+        .map_err(|_| DelegatedActorVerificationError::Rejected)?;
+    if URL_SAFE_NO_PAD.encode(&decoded) != segment {
+        return Err(DelegatedActorVerificationError::Rejected);
+    }
+    Ok(decoded)
+}
+
+fn canonical_uuid(value: &str) -> Result<Uuid, DelegatedActorVerificationError> {
+    let parsed = Uuid::parse_str(value).map_err(|_| DelegatedActorVerificationError::Rejected)?;
+    if parsed.is_nil() || parsed.hyphenated().to_string() != value {
+        return Err(DelegatedActorVerificationError::Rejected);
+    }
+    Ok(parsed)
+}
+
+fn valid_key_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_KEY_ID_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'~' | b'-'))
+}
+
+fn is_json_content_type(value: &str) -> bool {
+    value
+        .split_once(';')
+        .map_or(value, |(media_type, _)| media_type)
+        .trim()
+        .eq_ignore_ascii_case("application/json")
+}
+
+/// Sanitized assertion verification result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DelegatedActorVerificationError {
+    Rejected,
+    Unavailable,
+}
+
+#[derive(Clone)]
+struct DelegatedActorApiState {
+    verifier: Arc<DelegatedActorVerifier>,
+    resolver: Arc<dyn DelegatedActorResolver>,
+}
+
+impl std::fmt::Debug for DelegatedActorApiState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DelegatedActorApiState")
+            .field("verifier", &self.verifier)
+            .field("resolver", &self.resolver)
+            .finish()
+    }
+}
+
+#[derive(Serialize)]
+struct WorkspaceViewerResponse {
+    protocol_version: u8,
+    workspace_id: String,
+    principal_id: String,
+    display_name: String,
+    authorization_revision: u64,
+}
+
+/// Builds the Cloud-authenticated hosted Core API surface.
+pub(crate) fn router(
+    verifier: Arc<DelegatedActorVerifier>,
+    resolver: Arc<dyn DelegatedActorResolver>,
+) -> Router {
+    Router::new()
+        .route(DELEGATED_ACTOR_VIEWER_PATH, get(workspace_viewer))
+        .with_state(DelegatedActorApiState { verifier, resolver })
+}
+
+async fn workspace_viewer(
+    State(state): State<DelegatedActorApiState>,
+    Path(workspace_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let Some(token) = bearer_token(&headers) else {
+        return unauthorized();
+    };
+    let now = unix_time();
+    let verified = match state.verifier.verify(token, now).await {
+        Ok(value) if value.workspace_id == workspace_uuid => value,
+        Ok(_) | Err(DelegatedActorVerificationError::Rejected) => return unauthorized(),
+        Err(DelegatedActorVerificationError::Unavailable) => {
+            return status_response(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+    let Ok(tenant_id) = TenantId::new(workspace_id.clone()) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let request = ResolveDelegatedActorRequest::new(verified.assertion, tenant_id);
+    let snapshot = match state.resolver.resolve(&request).await {
+        Ok(ResolveDelegatedActorOutcome::Authenticated(snapshot)) => snapshot,
+        Ok(
+            ResolveDelegatedActorOutcome::NotFound
+            | ResolveDelegatedActorOutcome::PrincipalDisabled
+            | ResolveDelegatedActorOutcome::MembershipSuspended,
+        ) => return status_response(StatusCode::FORBIDDEN),
+        Err(DelegatedActorResolverError::Unavailable) => {
+            return status_response(StatusCode::SERVICE_UNAVAILABLE);
+        }
+        Err(DelegatedActorResolverError::CorruptData) => {
+            return status_response(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+    let authorization = snapshot.authorization();
+    let Some(principal_id) = authorization.principal_id() else {
+        return status_response(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    let Some(authorization_revision) = authorization.authorization_revision() else {
+        return status_response(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    (
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::CONTENT_TYPE, "application/json"),
+        ],
+        Json(WorkspaceViewerResponse {
+            protocol_version: 1,
+            workspace_id,
+            principal_id: principal_id.as_str().to_owned(),
+            display_name: snapshot.viewer().display_name().to_owned(),
+            authorization_revision,
+        }),
+    )
+        .into_response()
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let mut values = headers.get_all(header::AUTHORIZATION).iter();
+    let value = values.next()?.to_str().ok()?;
+    if values.next().is_some() {
+        return None;
+    }
+    let token = value.strip_prefix("Bearer ")?;
+    if token.is_empty() || token.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return None;
+    }
+    Some(token)
+}
+
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [
+            (header::WWW_AUTHENTICATE, "Bearer"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+    )
+        .into_response()
+}
+
+fn status_response(status: StatusCode) -> Response {
+    (status, [(header::CACHE_CONTROL, "no-store")]).into_response()
+}
+
+fn unix_time() -> UnixTimestamp {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs());
+    UnixTimestamp::from_seconds(seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::{
+        rand::SystemRandom,
+        signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair as _},
+    };
+
+    #[test]
+    fn jwks_parser_accepts_only_unique_exact_es256_keys() {
+        let coordinate = URL_SAFE_NO_PAD.encode([7_u8; 32]);
+        let body = serde_json::json!({
+            "keys": [{
+                "kty": "EC", "crv": "P-256", "alg": "ES256", "use": "sig",
+                "kid": "key_1", "x": coordinate, "y": coordinate
+            }]
+        });
+        let parsed = parse_jwks(&serde_json::to_vec(&body).expect("JWKS JSON"));
+        assert!(parsed.is_ok());
+
+        let duplicate = serde_json::json!({"keys": [body["keys"][0], body["keys"][0]]});
+        assert!(parse_jwks(&serde_json::to_vec(&duplicate).expect("JWKS JSON")).is_err());
+    }
+
+    #[test]
+    fn bearer_parser_rejects_ambiguous_or_whitespace_bearing_credentials() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            "Bearer a.b.c".parse().expect("header"),
+        );
+        assert_eq!(bearer_token(&headers), Some("a.b.c"));
+        headers.append(
+            header::AUTHORIZATION,
+            "Bearer d.e.f".parse().expect("header"),
+        );
+        assert_eq!(bearer_token(&headers), None);
+        headers.clear();
+        headers.insert(header::AUTHORIZATION, "Bearer a b".parse().expect("header"));
+        assert_eq!(bearer_token(&headers), None);
+    }
+
+    #[test]
+    fn uuid_parser_requires_canonical_non_nil_text() {
+        let canonical = "2c097e58-e4d0-4de2-b79b-bcf059b9b00a";
+        assert!(canonical_uuid(canonical).is_ok());
+        assert!(canonical_uuid(&canonical.to_uppercase()).is_err());
+        assert!(canonical_uuid("00000000-0000-0000-0000-000000000000").is_err());
+    }
+
+    #[tokio::test]
+    async fn verifier_accepts_only_the_configured_signed_claim_shape() {
+        let random = SystemRandom::new();
+        let document = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &random)
+            .expect("test key document");
+        let key =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, document.as_ref(), &random)
+                .expect("test signing key");
+        let mut public_key = [0_u8; 65];
+        public_key.copy_from_slice(key.public_key().as_ref());
+        let verifier = DelegatedActorVerifier::new(DelegatedActorVerifierConfig {
+            issuer: "https://cloud.automata.example".to_owned(),
+            audience: "prod-us-east-1".to_owned(),
+            jwks_url: Url::parse("https://cloud.automata.example/.well-known/jwks.json")
+                .expect("JWKS URL"),
+        })
+        .expect("verifier");
+        *verifier.cache.lock().await = Some(CachedJwks {
+            fetched_at: Instant::now(),
+            keys: BTreeMap::from([("key_1".to_owned(), public_key)]),
+        });
+        let header = serde_json::json!({"alg": "ES256", "kid": "key_1", "typ": "at+jwt"});
+        let claims = serde_json::json!({
+            "ver": 1,
+            "iss": "https://cloud.automata.example",
+            "sub": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "aud": "prod-us-east-1",
+            "workspace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "session_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "auth_time": 900,
+            "iat": 1_000,
+            "exp": 1_120,
+            "jti": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+        });
+        let token = sign_test_token(&key, &random, &header, &claims);
+        let verified_actor = verifier
+            .verify(&token, UnixTimestamp::from_seconds(1_010))
+            .await
+            .expect("valid assertion");
+        assert_eq!(
+            verified_actor.workspace_id,
+            Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").expect("workspace")
+        );
+
+        let mut wrong_audience = claims.clone();
+        wrong_audience["aud"] = serde_json::json!("another-shard");
+        let token = sign_test_token(&key, &random, &header, &wrong_audience);
+        assert!(matches!(
+            verifier
+                .verify(&token, UnixTimestamp::from_seconds(1_010))
+                .await,
+            Err(DelegatedActorVerificationError::Rejected)
+        ));
+        let mut authorization_claim = claims;
+        authorization_claim["roles"] = serde_json::json!(["owner"]);
+        let token = sign_test_token(&key, &random, &header, &authorization_claim);
+        assert!(matches!(
+            verifier
+                .verify(&token, UnixTimestamp::from_seconds(1_010))
+                .await,
+            Err(DelegatedActorVerificationError::Rejected)
+        ));
+    }
+
+    fn sign_test_token(
+        key: &EcdsaKeyPair,
+        random: &SystemRandom,
+        header: &serde_json::Value,
+        claims: &serde_json::Value,
+    ) -> String {
+        let header = URL_SAFE_NO_PAD.encode(serde_json::to_vec(header).expect("header JSON"));
+        let claims = URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).expect("claims JSON"));
+        let signing_input = format!("{header}.{claims}");
+        let signature = key
+            .sign(random, signing_input.as_bytes())
+            .expect("test signature");
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.as_ref())
+        )
+    }
+}

--- a/crates/automata-ci/src/app/mod.rs
+++ b/crates/automata-ci/src/app/mod.rs
@@ -1,5 +1,6 @@
 mod api_security;
 pub(crate) mod conformance_api;
+pub(crate) mod delegated_actor_api;
 mod form;
 pub(crate) mod github_auth;
 pub mod http;

--- a/crates/automata-ci/src/app/shard_capabilities.rs
+++ b/crates/automata-ci/src/app/shard_capabilities.rs
@@ -20,6 +20,7 @@ pub const SHARD_CAPABILITIES_PATH: &str = "/internal/v1/capabilities";
 const CAPABILITY_DOCUMENT_VERSION: u8 = 1;
 const CORE_HTTP_PROTOCOL_VERSION: u8 = 1;
 const MANAGEMENT_GRPC_PROTOCOL_VERSION: u8 = 1;
+const DELEGATED_ACTOR_PROTOCOL_VERSION: u8 = 1;
 
 #[derive(Clone, Debug)]
 struct ShardCapabilitiesState {
@@ -40,6 +41,7 @@ struct ShardCapabilities {
 struct Protocols {
     core_http: [u8; 1],
     management_grpc: [u8; 1],
+    delegated_actor: [u8; 1],
 }
 
 #[derive(Debug, Serialize)]
@@ -64,6 +66,7 @@ async fn capabilities(State(state): State<ShardCapabilitiesState>) -> Response {
             protocols: Protocols {
                 core_http: [CORE_HTTP_PROTOCOL_VERSION],
                 management_grpc: [MANAGEMENT_GRPC_PROTOCOL_VERSION],
+                delegated_actor: [DELEGATED_ACTOR_PROTOCOL_VERSION],
             },
             public_endpoints: PublicEndpoints {},
             server_time_ms: unix_time_millis(),
@@ -120,7 +123,11 @@ mod tests {
         assert_eq!(document["release"]["commit"], BuildInfo::current().commit);
         assert_eq!(
             document["protocols"],
-            serde_json::json!({"core_http": [1], "management_grpc": [1]})
+            serde_json::json!({
+                "core_http": [1],
+                "management_grpc": [1],
+                "delegated_actor": [1]
+            })
         );
         assert_eq!(document["public_endpoints"], serde_json::json!({}));
         assert!(

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -640,6 +640,22 @@ pub struct ServerArgs {
     )]
     pub management_delegated_actor_issuer: Option<String>,
 
+    /// Exact JWKS endpoint used to verify delegated actor assertions.
+    #[arg(
+        long,
+        env = "AUTOMATA_MANAGEMENT_DELEGATED_ACTOR_JWKS_URL",
+        value_name = "URL"
+    )]
+    pub management_delegated_actor_jwks_url: Option<String>,
+
+    /// Permit a literal loopback HTTP JWKS endpoint for local development.
+    #[arg(
+        long,
+        env = "AUTOMATA_MANAGEMENT_DELEGATED_ACTOR_JWKS_ALLOW_LOOPBACK_HTTP",
+        default_value_t = false
+    )]
+    pub management_delegated_actor_jwks_allow_loopback_http: bool,
+
     /// SHA-256 fingerprint of an allowed leaf client certificate, in hex.
     ///
     /// Repeat the option, or provide a comma-separated environment value, to

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -12,7 +12,9 @@ use automata_ci_auth::{
     session::SessionKind,
     time::{Clock, SystemClock},
 };
-use automata_ci_auth_postgres::PostgresHumanRbacManagementRepository;
+use automata_ci_auth_postgres::{
+    PostgresDelegatedActorResolver, PostgresHumanRbacManagementRepository,
+};
 use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType};
 use automata_ci_blob_s3::{
     S3BlobStore, S3BlobStoreConfig, S3BlobStoreConfigError, StaticS3Credentials,
@@ -99,6 +101,9 @@ use super::{
 };
 use crate::app::{
     conformance_api::{conformance_api_router, deployment_conformance_api_router},
+    delegated_actor_api::{
+        DelegatedActorVerifier, DelegatedActorVerifierConfig, router as delegated_actor_api_router,
+    },
     github_auth::{
         GithubAuthHttpState, GithubProviderOrigin, GithubSetupHttpState,
         OperationalGithubAuthBackend, router as github_auth_router,
@@ -170,6 +175,7 @@ pub(crate) struct ProductionComponents {
     pub(crate) secret_mutation_recovery_loop: Option<SecretMutationRecoveryLoop>,
     pub(crate) state_sampler: ControlPlaneStateSampler,
     pub(crate) human_api: Router,
+    pub(crate) delegated_actor_api: Option<Router>,
     pub(crate) human_request_authentication: Option<HumanRequestAuthentication>,
     pub(crate) rbac_web_data: Option<Arc<dyn RbacWebData>>,
     pub(crate) setup_page_availability: Option<Arc<dyn SetupPageAvailability>>,
@@ -198,6 +204,7 @@ impl fmt::Debug for ProductionComponents {
             )
             .field("state_sampler", &self.state_sampler)
             .field("human_api", &self.human_api)
+            .field("delegated_actor_api", &self.delegated_actor_api)
             .field(
                 "human_request_authentication",
                 &self.human_request_authentication,
@@ -238,6 +245,26 @@ impl ProductionComponents {
         // the migrator on every readiness tick repeatedly acquires migration
         // locks and emits expected duplicate-table diagnostics under SQLx.
         store.migrate().await?;
+        let delegated_actor_api = config
+            .management()
+            .map(|management| -> Result<Router, ServerCompositionError> {
+                let verifier = DelegatedActorVerifier::new(DelegatedActorVerifierConfig {
+                    issuer: management
+                        .authority()
+                        .delegated_actor_issuer()
+                        .as_str()
+                        .to_owned(),
+                    audience: management.authority().shard_id().as_str().to_owned(),
+                    jwks_url: management.delegated_actor_jwks_url().clone(),
+                })
+                .map_err(|_| ServerCompositionError::InvalidManagementConfiguration)?;
+                let resolver: Arc<dyn automata_ci_auth::delegated_actor::DelegatedActorResolver> =
+                    Arc::new(PostgresDelegatedActorResolver::new(
+                        store.postgres_pool().clone(),
+                    ));
+                Ok(delegated_actor_api_router(Arc::new(verifier), resolver))
+            })
+            .transpose()?;
         let management_server =
             build_management_server(config, management_listener, store.as_ref())?;
         let workflow_clock: Arc<dyn AdmissionClock> = Arc::new(SystemAdmissionClock);
@@ -543,6 +570,7 @@ impl ProductionComponents {
             secret_mutation_recovery_loop,
             state_sampler,
             human_api: human.router,
+            delegated_actor_api,
             human_request_authentication: human.request_authentication,
             rbac_web_data: human.rbac_web_data,
             setup_page_availability: human.setup_page_availability,

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -46,6 +46,7 @@ const MAX_GITHUB_CLIENT_SECRET_BYTES: usize = 16 * 1024;
 const MAX_BOOTSTRAP_TOKEN_BYTES: usize = 4 * 1024;
 const MAX_CONFORMANCE_EXPORT_TOKEN_BYTES: usize = 4 * 1024;
 const MAX_MANAGEMENT_CLIENT_CERTIFICATES: usize = 8;
+const MAX_DELEGATED_ACTOR_JWKS_URL_BYTES: usize = 2_048;
 const SECRET_ENCRYPTION_KEY_BYTES: usize = 32;
 const SESSION_HASH_KEY_BYTES: usize = 32;
 const MIN_BOOTSTRAP_TOKEN_BYTES: usize = 32;
@@ -345,6 +346,7 @@ pub struct ServerConfig {
 pub struct ManagementConfig {
     pub(crate) listen: SocketAddr,
     authority: ProvisioningAuthority,
+    delegated_actor_jwks_url: Url,
     client_certificate_sha256: Vec<[u8; 32]>,
     client_ca_certificate: SecretSource,
     server_certificate: SecretSource,
@@ -355,6 +357,11 @@ impl ManagementConfig {
     /// Returns the stable authority and its exact shard and delegated-issuer scope.
     pub const fn authority(&self) -> &ProvisioningAuthority {
         &self.authority
+    }
+
+    /// Returns the exact, deployment-configured delegated actor key endpoint.
+    pub const fn delegated_actor_jwks_url(&self) -> &Url {
+        &self.delegated_actor_jwks_url
     }
 
     pub(crate) fn client_certificate_sha256(&self) -> &[[u8; 32]] {
@@ -868,6 +875,8 @@ fn management_configuration(
         || args.management_shard_id.is_some()
         || args.management_authority_id.is_some()
         || args.management_delegated_actor_issuer.is_some()
+        || args.management_delegated_actor_jwks_url.is_some()
+        || args.management_delegated_actor_jwks_allow_loopback_http
         || !args.management_client_certificate_sha256.is_empty()
         || args.management_client_ca_certificate_source.is_some()
         || args.management_server_certificate_source.is_some()
@@ -904,6 +913,18 @@ fn management_configuration(
             DelegatedActorIssuer::new(value.to_owned())
                 .map_err(|_| ServerConfigError::InvalidManagementConfiguration)
         })?;
+    let delegated_actor_jwks_url = args
+        .management_delegated_actor_jwks_url
+        .as_deref()
+        .filter(|value| value.len() <= MAX_DELEGATED_ACTOR_JWKS_URL_BYTES)
+        .ok_or(ServerConfigError::InvalidManagementConfiguration)
+        .and_then(|value| {
+            Url::parse(value).map_err(|_| ServerConfigError::InvalidManagementConfiguration)
+        })?;
+    validate_delegated_actor_jwks_url(
+        &delegated_actor_jwks_url,
+        args.management_delegated_actor_jwks_allow_loopback_http,
+    )?;
     if args.management_client_certificate_sha256.is_empty()
         || args.management_client_certificate_sha256.len() > MAX_MANAGEMENT_CLIENT_CERTIFICATES
     {
@@ -933,11 +954,37 @@ fn management_configuration(
     Ok(Some(ManagementConfig {
         listen,
         authority: ProvisioningAuthority::new(authority_id, shard_id, delegated_actor_issuer),
+        delegated_actor_jwks_url,
         client_certificate_sha256: unique_fingerprints.into_iter().collect(),
         client_ca_certificate,
         server_certificate,
         server_private_key,
     }))
+}
+
+fn validate_delegated_actor_jwks_url(
+    url: &Url,
+    allow_loopback_http: bool,
+) -> Result<(), ServerConfigError> {
+    let has_safe_shape = url.host().is_some()
+        && url.port_or_known_default().is_some()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none();
+    let transport_allowed = match url.scheme() {
+        "https" => true,
+        "http" if allow_loopback_http => match url.host() {
+            Some(url::Host::Ipv4(address)) => address.is_loopback(),
+            Some(url::Host::Ipv6(address)) => address.is_loopback(),
+            Some(url::Host::Domain(_)) | None => false,
+        },
+        _ => false,
+    };
+    if !has_safe_shape || !transport_allowed {
+        return Err(ServerConfigError::InvalidManagementConfiguration);
+    }
+    Ok(())
 }
 
 fn decode_sha256_fingerprint(encoded: &str) -> Option<[u8; 32]> {

--- a/crates/automata-ci/src/server/metrics.rs
+++ b/crates/automata-ci/src/server/metrics.rs
@@ -46,6 +46,7 @@ use prometheus_client::encoding::EncodeLabelSet;
 
 use crate::{
     app::{
+        delegated_actor_api::DELEGATED_ACTOR_VIEWER_PATH,
         github_auth::{
             CLI_SESSION_PATH, GITHUB_DEVICE_BEGIN_PATH, GITHUB_DEVICE_POLL_PATH,
             GITHUB_SETUP_DEVICE_BEGIN_PATH, GITHUB_SETUP_DEVICE_POLL_PATH,
@@ -103,10 +104,11 @@ const RBAC_SETTINGS_ROUTE: &str = "/settings/access/{rbac}";
 const GITHUB_DEVICE_ROUTE: &str = "/api/v1/auth/device/{operation}";
 const REPOSITORY_SECRET_BROWSER_MUTATION_ROUTE: &str =
     "/{owner}/{repository}/settings/secrets/{mutation}";
-const HTTP_ROUTE_LABELS: [&str; 44] = [
+const HTTP_ROUTE_LABELS: [&str; 45] = [
     "/healthz",
     "/readyz",
     SHARD_CAPABILITIES_PATH,
+    DELEGATED_ACTOR_VIEWER_PATH,
     "/",
     "/setup",
     "/repositories",
@@ -1784,6 +1786,7 @@ fn http_route(matched_path: Option<&str>) -> &'static str {
         Some("/healthz") => "/healthz",
         Some("/readyz") => "/readyz",
         Some(SHARD_CAPABILITIES_PATH) => SHARD_CAPABILITIES_PATH,
+        Some(DELEGATED_ACTOR_VIEWER_PATH) => DELEGATED_ACTOR_VIEWER_PATH,
         Some("/") => "/",
         Some("/setup") => "/setup",
         Some("/repositories") => "/repositories",
@@ -2552,6 +2555,7 @@ mod tests {
             RUNNER_ENROLLMENTS_PATH,
             RUNNER_ENROLLMENT_REDEEM_PATH,
             SHARD_CAPABILITIES_PATH,
+            DELEGATED_ACTOR_VIEWER_PATH,
         ];
 
         for route in operational_routes {

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -214,9 +214,15 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
                 None => router,
             };
             let router = match config.management() {
-                Some(management) => router.merge(crate::app::shard_capabilities::router(
-                    management.authority().shard_id(),
-                )),
+                Some(management) => {
+                    let router = router.merge(crate::app::shard_capabilities::router(
+                        management.authority().shard_id(),
+                    ));
+                    match components.delegated_actor_api.clone() {
+                        Some(delegated_actor_api) => router.merge(delegated_actor_api),
+                        None => router,
+                    }
+                }
                 None => router,
             };
             let router = router_with_optional_github_webhook(router, github_provider_ingress);

--- a/crates/automata-ci/tests/server_config.rs
+++ b/crates/automata-ci/tests/server_config.rs
@@ -1220,6 +1220,8 @@ fn private_management_listener_accepts_bounded_certificate_rotation_overlap() {
         "automata-cloud".to_owned(),
         "--management-delegated-actor-issuer".to_owned(),
         "https://cloud.example.test".to_owned(),
+        "--management-delegated-actor-jwks-url".to_owned(),
+        "https://cloud.example.test/.well-known/jwks.json".to_owned(),
         "--management-client-cert-sha256".to_owned(),
         format!("{old_fingerprint},{new_fingerprint}"),
         "--management-client-ca-cert-source".to_owned(),
@@ -1242,6 +1244,53 @@ fn private_management_listener_accepts_bounded_certificate_rotation_overlap() {
         management.authority().delegated_actor_issuer().as_str(),
         "https://cloud.example.test"
     );
+    assert_eq!(
+        management.delegated_actor_jwks_url().as_str(),
+        "https://cloud.example.test/.well-known/jwks.json"
+    );
+}
+
+#[test]
+fn delegated_actor_jwks_plaintext_is_limited_to_explicit_literal_loopback() {
+    let mut arguments = vec![
+        "automata".to_owned(),
+        "server".to_owned(),
+        "--results-public-url".to_owned(),
+        "https://results.example.test/".to_owned(),
+        "--management-listen".to_owned(),
+        "127.0.0.1:9443".to_owned(),
+        "--management-shard-id".to_owned(),
+        "shard-a".to_owned(),
+        "--management-authority-id".to_owned(),
+        "automata-cloud".to_owned(),
+        "--management-delegated-actor-issuer".to_owned(),
+        "https://cloud.example.test".to_owned(),
+        "--management-delegated-actor-jwks-url".to_owned(),
+        "http://127.0.0.1:8080/.well-known/jwks.json".to_owned(),
+        "--management-client-cert-sha256".to_owned(),
+        "11".repeat(32),
+        "--management-client-ca-cert-source".to_owned(),
+        "file:/run/automata/management-client-ca.pem".to_owned(),
+        "--management-server-cert-source".to_owned(),
+        "file:/run/automata/management-server.pem".to_owned(),
+        "--management-server-key-source".to_owned(),
+        "file:/run/automata/management-server-key.pem".to_owned(),
+    ];
+    let cli = Cli::try_parse_from(arguments.clone()).expect("JWKS syntax must parse");
+    let Command::Server(args) = cli.command else {
+        panic!("server command expected");
+    };
+    assert!(matches!(
+        ServerConfig::from_args(&args),
+        Err(ServerConfigError::InvalidManagementConfiguration)
+    ));
+
+    arguments.push("--management-delegated-actor-jwks-allow-loopback-http".to_owned());
+    let cli = Cli::try_parse_from(arguments).expect("loopback opt-in syntax must parse");
+    let Command::Server(args) = cli.command else {
+        panic!("server command expected");
+    };
+    assert!(ServerConfig::from_args(&args).is_ok());
 }
 
 #[test]

--- a/deploy/observability/cardinality.json
+++ b/deploy/observability/cardinality.json
@@ -581,6 +581,8 @@
                 "/auth/github/login",
                 "/auth/logout",
                 "/healthz",
+                "/internal/v1/capabilities",
+                "/internal/v1/workspaces/{workspace_id}/viewer",
                 "/readyz",
                 "/repositories",
                 "/settings/access/{rbac}",
@@ -600,7 +602,7 @@
               ]
             }
           ],
-          "maximum_series": 645,
+          "maximum_series": 675,
           "name": "automata_ci_control_plane_http_request_duration_seconds",
           "type": "histogram",
           "unit": "seconds"
@@ -641,6 +643,8 @@
                 "/auth/github/login",
                 "/auth/logout",
                 "/healthz",
+                "/internal/v1/capabilities",
+                "/internal/v1/workspaces/{workspace_id}/viewer",
                 "/readyz",
                 "/repositories",
                 "/settings/access/{rbac}",
@@ -660,7 +664,7 @@
               ]
             }
           ],
-          "maximum_series": 43,
+          "maximum_series": 45,
           "name": "automata_ci_control_plane_http_requests_in_flight",
           "type": "gauge"
         },
@@ -713,6 +717,8 @@
                 "/auth/github/login",
                 "/auth/logout",
                 "/healthz",
+                "/internal/v1/capabilities",
+                "/internal/v1/workspaces/{workspace_id}/viewer",
                 "/readyz",
                 "/repositories",
                 "/settings/access/{rbac}",
@@ -743,7 +749,7 @@
               ]
             }
           ],
-          "maximum_series": 2064,
+          "maximum_series": 2160,
           "name": "automata_ci_control_plane_http_requests_total",
           "type": "counter"
         },


### PR DESCRIPTION
## Summary
- add a delegated-actor domain and PostgreSQL resolver that maps the configured Cloud issuer/account subject to a Core principal, then reloads current workspace membership and direct RBAC
- verify short-lived ES256 actor assertions against an explicitly configured, bounded, cached JWKS endpoint
- expose a protected hosted-Core workspace viewer endpoint and advertise delegated actor protocol v1
- keep delegated identities separate from durable browser and CLI sessions

## Security properties
- exact configured issuer, shard audience, and route workspace binding
- fixed `at+jwt`/ES256 protected header with no unknown header or claim fields
- canonical non-nil UUID identities, five-minute maximum token lifetime, and bounded clock skew
- no redirects or token-controlled JWKS discovery; HTTPS is mandatory except explicit literal-loopback development mode
- bounded JWKS/token/response data and current Core-owned principal, membership, authorization revision, and role grants

## Verification
- `cargo test -p automata-ci-auth --lib`
- `cargo test -p automata-ci-auth-postgres --lib`
- `cargo test -p automata-ci-auth-postgres --test auth_postgres --no-run`
- `cargo test -p automata-ci --test server_config`
- `cargo test -p automata-ci app::delegated_actor_api::tests --lib`
- `cargo test -p automata-ci server::metrics::tests::production_histogram_preserves_classic_buckets_and_exports_native_spans --lib`
- `cargo clippy -p automata-ci-auth -p automata-ci-auth-postgres -p automata-ci --all-targets -- -D warnings`

The full `automata-ci` library suite reached 474/475 passing before the observability manifest was updated for the two internal routes; the previously failing cardinality test passes after that update.
