### PR TITLE
Fix control-plane metrics series contract

### DIFF
--- a/crates/automata-ci/tests/metrics_semantics.rs
+++ b/crates/automata-ci/tests/metrics_semantics.rs
@@ -87,7 +87,7 @@ fn semantic_metrics_have_an_exact_bounded_privacy_safe_exposition() {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_152,
+        all_series, 5_280,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(

--- a/crates/automata-ci/tests/results_metrics.rs
+++ b/crates/automata-ci/tests/results_metrics.rs
@@ -84,7 +84,7 @@ fn results_and_storage_schema_is_exact_bounded_and_identifier_free() {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_152,
+        all_series, 5_280,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- update both full-registry cardinality assertions for the two internal routes now present on main
- account for the exact 128 additional preinitialized HTTP metric series: 64 for shard capabilities and 64 for delegated workspace viewers

The canonical label domains and per-family maxima are already correct after #96, but the aggregate series assertions remained at 5,152 instead of 5,280.

## Verification

- cargo fmt --all -- --check
- metrics_schema, metrics_semantics, and results_metrics integration targets
- production_histogram_preserves_classic_buckets_and_exports_native_spans
- git diff --check