### PR TITLE
Add safe runtime authority stage diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
  "uuid",
  "zeroize",
@@ -1107,6 +1108,7 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
  "zeroize",
 ]

--- a/crates/automata-ci-credential-github/Cargo.toml
+++ b/crates/automata-ci-credential-github/Cargo.toml
@@ -32,6 +32,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
 url.workspace = true
 zeroize.workspace = true
 

--- a/crates/automata-ci-credential-github/src/authority_issuer.rs
+++ b/crates/automata-ci-credential-github/src/authority_issuer.rs
@@ -284,12 +284,18 @@ impl GithubRepositoryRuntimeAuthorityIssuer {
     ) -> Result<JobRuntimeAuthorities, ControlPortError> {
         let resolved =
             ResolvedGithubRuntimeAuthorityIdentity::new(request, resolved.identity().clone())
+                .inspect_err(|_| observe_issuance_failure("identity_cross_bind", "corrupt"))
                 .map_err(|_| ControlPortError::Corrupt)?;
         let identity = resolved.identity();
         if identity.namespace().as_str() != GITHUB_REPOSITORY_AUTHORITY_NAMESPACE {
+            observe_issuance_failure("namespace", "corrupt");
             return Err(ControlPortError::Corrupt);
         }
-        if let Some(authority) = self.load_ready(request, identity).await? {
+        if let Some(authority) = self
+            .load_ready(request, identity)
+            .await
+            .inspect_err(|error| observe_control_failure("initial_ready_load", *error))?
+        {
             return Ok(authority);
         }
 
@@ -297,6 +303,33 @@ impl GithubRepositoryRuntimeAuthorityIssuer {
             .coordinator
             .coordinate_once(identity.clone())
             .await
+            .inspect_err(|error| {
+                let failure = match error {
+                    GithubRuntimeAuthorityCoordinatorError::Repository => "repository",
+                    GithubRuntimeAuthorityCoordinatorError::Resolution => "resolution",
+                    GithubRuntimeAuthorityCoordinatorError::Unauthorized => "unauthorized",
+                    GithubRuntimeAuthorityCoordinatorError::ResolutionIdentityMismatch => {
+                        "resolution_identity_mismatch"
+                    }
+                    GithubRuntimeAuthorityCoordinatorError::BrokerIdentityMismatch => {
+                        "broker_identity_mismatch"
+                    }
+                    GithubRuntimeAuthorityCoordinatorError::SupervisionCapacity => {
+                        "supervision_capacity"
+                    }
+                    GithubRuntimeAuthorityCoordinatorError::EnvelopePreparation => {
+                        "envelope_preparation"
+                    }
+                    GithubRuntimeAuthorityCoordinatorError::CandidateProtection => {
+                        "candidate_protection"
+                    }
+                    GithubRuntimeAuthorityCoordinatorError::InvalidTime => "invalid_time",
+                    GithubRuntimeAuthorityCoordinatorError::MintWindowExhausted => {
+                        "mint_window_exhausted"
+                    }
+                };
+                observe_issuance_failure("mint_coordination", failure);
+            })
             .map_err(coordinator_error)?;
 
         self.load_ready(request, identity)
@@ -416,6 +449,23 @@ impl GithubRepositoryRuntimeAuthorityIssuer {
             .map(|_| ())
             .map_err(|error| store_error(&error))
     }
+}
+
+fn observe_issuance_failure(stage: &'static str, failure: &'static str) {
+    tracing::warn!(
+        stage,
+        failure,
+        "GitHub repository runtime-authority issuance failed"
+    );
+}
+
+fn observe_control_failure(stage: &'static str, error: ControlPortError) {
+    let failure = match error {
+        ControlPortError::Unavailable => "unavailable",
+        ControlPortError::Corrupt => "corrupt",
+        ControlPortError::Conflict => "conflict",
+    };
+    observe_issuance_failure(stage, failure);
 }
 
 fn protected_envelope_digest(

--- a/crates/automata-ci-store/Cargo.toml
+++ b/crates/automata-ci-store/Cargo.toml
@@ -51,6 +51,7 @@ sqlx.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 zeroize.workspace = true
 

--- a/crates/automata-ci-store/src/postgres/github_job_runtime_authority.rs
+++ b/crates/automata-ci-store/src/postgres/github_job_runtime_authority.rs
@@ -168,11 +168,20 @@ impl GithubJobRuntimeAuthorityRepository for PostgresStore {
             .begin()
             .await
             .map_err(GithubJobRuntimeAuthorityStoreError::operation)?;
-        let row = lock_exact_execution(&mut transaction, &selector).await?;
-        lock_exact_selection_lineage(&mut transaction, &selector, &row).await?;
-        lock_exact_private_source_authority(&mut transaction, &row).await?;
-        ensure_database_live_lease(&mut transaction, &selector).await?;
-        let evidence = decode_evidence(&selector, &row)?;
+        let row = lock_exact_execution(&mut transaction, &selector)
+            .await
+            .inspect_err(|error| observe_resolution_failure("exact_execution", error))?;
+        lock_exact_selection_lineage(&mut transaction, &selector, &row)
+            .await
+            .inspect_err(|error| observe_resolution_failure("selection_lineage", error))?;
+        lock_exact_private_source_authority(&mut transaction, &row)
+            .await
+            .inspect_err(|error| observe_resolution_failure("private_source", error))?;
+        ensure_database_live_lease(&mut transaction, &selector)
+            .await
+            .inspect_err(|error| observe_resolution_failure("live_lease", error))?;
+        let evidence = decode_evidence(&selector, &row)
+            .inspect_err(|error| observe_resolution_failure("evidence_decode", error))?;
         transaction
             .commit()
             .await
@@ -211,6 +220,19 @@ impl GithubJobRuntimeAuthorityRepository for PostgresStore {
             .map_err(GithubJobRuntimeAuthorityStoreError::operation)?;
         Ok(evidence)
     }
+}
+
+fn observe_resolution_failure(stage: &'static str, error: &GithubJobRuntimeAuthorityStoreError) {
+    let failure = match error {
+        GithubJobRuntimeAuthorityStoreError::Operation(_) => "operation",
+        GithubJobRuntimeAuthorityStoreError::Unauthorized => "unauthorized",
+        GithubJobRuntimeAuthorityStoreError::CorruptData => "corrupt_data",
+    };
+    tracing::warn!(
+        stage,
+        failure,
+        "GitHub job runtime-authority resolution failed"
+    );
 }
 
 // Every mutable execution dependency and every immutable historical authority


### PR DESCRIPTION
Adds redacted static stage labels for GitHub job runtime-authority resolution and issuance failures. No identifiers, credentials, or secret material are logged.\n\nValidation:\n- cargo check -p automata-ci-store -p automata-ci-credential-github -p automata-ci\n- cargo test -p automata-ci-credential-github --test authority_issuer