### PR TITLE
Package the shared React UI for external hosts

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -217,3 +217,20 @@ target shapes fail closed. Script and CSS assets must be rooted, fragment-free
 paths with the expected file type. Adding a route means adding a discriminated
 `PageModel` variant, its validator, and complete rendering in `App`; unknown
 variants fail rather than falling back to an empty client shell.
+
+## Reusable package boundary
+
+`npm run build` also assembles the private, registry-neutral `@automata/ui`
+package beneath `dist/package`. Its deliberately small public surface contains
+the existing Core page renderer, the shared application shell, the theme
+control and bootstrap script, the page-model types, and a stable compiled
+stylesheet at `@automata/ui/styles.css`. A separate host can render its own page
+content inside `Shell`; the package does not contain transport, authentication,
+data loading, Cloud-only pages, or a plugin system.
+
+`npm run verify:package` renders consumer-owned content through the packaged
+shell, checks the compiled stylesheet, creates the npm archive twice, and
+requires byte-identical tarballs with a bounded file set. The package remains
+`private` and version `0.0.0`: those guards intentionally defer its final name,
+versioning policy, registry, and release mechanism. `npm pack` can still produce
+a local archive for integration work without allowing accidental publication.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,12 +7,9 @@
     "": {
       "name": "@automata/ui",
       "version": "0.0.0",
-      "dependencies": {
-        "@phosphor-icons/web": "2.1.2",
-        "react": "19.2.8",
-        "react-dom": "19.2.8"
-      },
+      "license": "MIT",
       "devDependencies": {
+        "@phosphor-icons/web": "2.1.2",
         "@playwright/test": "1.62.1",
         "@types/node": "24.13.3",
         "@types/react": "19.2.18",
@@ -20,12 +17,18 @@
         "@vitejs/plugin-react": "6.0.5",
         "@vitest/coverage-v8": "4.1.10",
         "jsdom": "30.0.1",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "typescript": "7.0.2",
         "vite": "8.2.1",
         "vitest": "4.1.10"
       },
       "engines": {
         "node": "^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -334,6 +337,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/web/-/web-2.1.2.tgz",
       "integrity": "sha512-rPAR9o/bEcp4Cw4DEeZHXf+nlGCMNGkNDRizYHM47NLxz9vvEHp/Tt6FMK1NcWadzw/pFDPnRBGi/ofRya958A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
@@ -1991,6 +1995,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2000,6 +2005,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -2068,6 +2074,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,22 @@
   "name": "@automata/ui",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
+  "files": [
+    "dist/package"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/package/public.d.ts",
+      "import": "./dist/package/index.js"
+    },
+    "./styles.css": "./dist/package/styles.css",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": [
+    "./dist/package/styles.css"
+  ],
   "engines": {
     "node": "^22.13.0 || >=24.0.0"
   },
@@ -23,17 +38,19 @@
     "test:watch": "vitest",
     "build:client": "vite build",
     "build:ssr": "vite build --ssr src/entry-server.tsx",
+    "build:package": "vite build --config vite.package.config.ts && tsc --project tsconfig.package.json && node scripts/assemble-package.mjs",
     "verify:build": "node scripts/verify-build.mjs",
+    "verify:package": "node scripts/verify-package.mjs",
     "verify:preview": "node scripts/verify-preview-build.mjs",
-    "build": "npm run clean:production && npm run typecheck && npm run build:client && npm run build:ssr && npm run verify:build",
+    "build": "npm run clean:production && npm run typecheck && npm run build:client && npm run build:ssr && npm run build:package && npm run verify:build && npm run verify:package",
     "check": "npm run test && npm run build"
   },
-  "dependencies": {
-    "@phosphor-icons/web": "2.1.2",
-    "react": "19.2.8",
-    "react-dom": "19.2.8"
+  "peerDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@phosphor-icons/web": "2.1.2",
     "@playwright/test": "1.62.1",
     "@types/node": "24.13.3",
     "@types/react": "19.2.18",
@@ -41,6 +58,8 @@
     "@vitejs/plugin-react": "6.0.5",
     "@vitest/coverage-v8": "4.1.10",
     "jsdom": "30.0.1",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "typescript": "7.0.2",
     "vite": "8.2.1",
     "vitest": "4.1.10"

--- a/ui/scripts/assemble-package.mjs
+++ b/ui/scripts/assemble-package.mjs
@@ -1,0 +1,22 @@
+import { copyFile, readFile } from "node:fs/promises";
+
+const root = new URL("../", import.meta.url);
+const manifest = JSON.parse(
+  await readFile(new URL("dist/client/manifest.json", root), "utf8"),
+);
+const entry = manifest["src/entry-client.tsx"];
+
+if (
+  !Array.isArray(entry?.css) ||
+  entry.css.length !== 1 ||
+  typeof entry.css[0] !== "string"
+) {
+  throw new Error(
+    "Client manifest must contain exactly one compiled UI stylesheet",
+  );
+}
+
+await copyFile(
+  new URL(`dist/client/${entry.css[0]}`, root),
+  new URL("dist/package/styles.css", root),
+);

--- a/ui/scripts/clean.mjs
+++ b/ui/scripts/clean.mjs
@@ -8,7 +8,7 @@ if (arguments_.length === 0) {
   await rm(outputDirectory, { recursive: true, force: true });
 } else if (arguments_.length === 1 && arguments_[0] === "--production") {
   await Promise.all(
-    ["client", "ssr"].map((directory) =>
+    ["client", "package", "ssr"].map((directory) =>
       rm(`${outputDirectory}/${directory}`, { recursive: true, force: true }),
     ),
   );

--- a/ui/scripts/verify-package.mjs
+++ b/ui/scripts/verify-package.mjs
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const execute = promisify(execFile);
+const root = new URL("../", import.meta.url);
+const packageApi = await import(
+  `${new URL("dist/package/index.js", root).href}?verify=${Date.now()}`
+);
+const expectedExports = [
+  "App",
+  "Shell",
+  "THEME_BOOTSTRAP_SCRIPT",
+  "ThemeToggle",
+];
+
+if (JSON.stringify(Object.keys(packageApi).sort()) !== JSON.stringify(expectedExports)) {
+  throw new Error(
+    `Unexpected public UI runtime exports: ${Object.keys(packageApi).sort().join(", ")}`,
+  );
+}
+
+const shellHtml = renderToStaticMarkup(
+  createElement(
+    packageApi.Shell,
+    {
+      repository: null,
+      shell: {
+        productName: "Automata",
+        homeHref: "/",
+        signIn: null,
+        signOut: null,
+        documentTitle: "Automata Cloud",
+        description: "Automata Cloud",
+        viewer: { displayName: "Package consumer" },
+        navigation: [{ label: "Workspaces", href: "/", current: true }],
+      },
+      utility: null,
+    },
+    createElement("main", { id: "main-content" }, "Consumer content"),
+  ),
+);
+if (
+  !shellHtml.includes("Package consumer") ||
+  !shellHtml.includes("Consumer content")
+) {
+  throw new Error("Public Shell did not render consumer-owned content");
+}
+
+const stylesheet = await readFile(
+  new URL("dist/package/styles.css", root),
+  "utf8",
+);
+if (
+  !stylesheet.includes(".site-header") ||
+  !stylesheet.includes("data:font/woff2;base64,")
+) {
+  throw new Error("Packaged stylesheet is missing the shared shell or icon font");
+}
+
+const packageDirectory = new URL(".", root);
+const firstDirectory = await mkdtemp(join(tmpdir(), "automata-ui-pack-a-"));
+const secondDirectory = await mkdtemp(join(tmpdir(), "automata-ui-pack-b-"));
+try {
+  const first = await pack(packageDirectory, firstDirectory);
+  const second = await pack(packageDirectory, secondDirectory);
+  const firstArchive = await readFile(join(firstDirectory, first.filename));
+  const secondArchive = await readFile(join(secondDirectory, second.filename));
+  const firstDigest = digest(firstArchive);
+  const secondDigest = digest(secondArchive);
+
+  if (firstDigest !== secondDigest) {
+    throw new Error(
+      `Repeated npm pack output was not deterministic: ${firstDigest} != ${secondDigest}`,
+    );
+  }
+
+  const files = first.files.map(({ path }) => path);
+  for (const required of [
+    "dist/package/index.js",
+    "dist/package/public.d.ts",
+    "dist/package/styles.css",
+    "package.json",
+    "README.md",
+  ]) {
+    if (!files.includes(required)) {
+      throw new Error(`npm package is missing ${required}`);
+    }
+  }
+  const unexpected = files.filter(
+    (file) =>
+      file !== "package.json" &&
+      file !== "README.md" &&
+      !file.startsWith("dist/package/"),
+  );
+  if (unexpected.length > 0) {
+    throw new Error(`npm package contains unexpected files: ${unexpected.join(", ")}`);
+  }
+
+  process.stdout.write(
+    `Verified composable UI package (${files.length} files, sha256:${firstDigest}).\n`,
+  );
+} finally {
+  await Promise.all([
+    rm(firstDirectory, { recursive: true, force: true }),
+    rm(secondDirectory, { recursive: true, force: true }),
+  ]);
+}
+
+async function pack(directory, destination) {
+  const { stdout } = await execute(
+    "npm",
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", destination],
+    { cwd: directory },
+  );
+  const result = JSON.parse(stdout);
+  if (!Array.isArray(result) || result.length !== 1) {
+    throw new Error("npm pack did not report exactly one archive");
+  }
+  return result[0];
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -3,7 +3,7 @@ import type { RepositoryModel, ShellModel } from "../models";
 import { isVisibleDisplayCodePoint } from "../unicode";
 import { Icon } from "./Icon";
 
-interface ShellProps extends PropsWithChildren {
+export interface ShellProps extends PropsWithChildren {
   readonly shell: ShellModel;
   readonly repository: RepositoryModel | null;
   readonly currentRepositoryView?: "actions" | "settings";

--- a/ui/src/public.ts
+++ b/ui/src/public.ts
@@ -1,0 +1,5 @@
+export { App, type AppProps } from "./App";
+export { Shell, type ShellProps } from "./components/Shell";
+export { ThemeToggle } from "./components/ThemeToggle";
+export { THEME_BOOTSTRAP_SCRIPT } from "./components/useThemePreference";
+export type * from "./models";

--- a/ui/tsconfig.package.json
+++ b/ui/tsconfig.package.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist/package",
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "rootDir": "src"
+  },
+  "include": ["src/public.ts"]
+}

--- a/ui/vite.package.config.ts
+++ b/ui/vite.package.config.ts
@@ -1,0 +1,22 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  publicDir: false,
+  build: {
+    copyPublicDir: false,
+    emptyOutDir: true,
+    lib: {
+      entry: "src/public.ts",
+      fileName: "index",
+      formats: ["es"],
+    },
+    minify: true,
+    outDir: "dist/package",
+    rollupOptions: {
+      external: (id) => id === "react" || id.startsWith("react/"),
+    },
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
## Summary

- expose a deliberately small, host-neutral React API for Core pages, the shared shell, theme behavior, and page-model types
- assemble a stable compiled stylesheet and ESM/type package without changing the existing Rust/WASI renderer or client assets
- verify consumer-owned shell composition, a bounded npm archive, and byte-identical repeated `npm pack` output

## Distribution boundary

The package intentionally remains `private`, version `0.0.0`, and named `@automata/ui`. This permits local `npm pack` integration while preventing accidental publication. Its final package name, versioning policy, registry versus GitHub Release delivery, and publication workflow remain a separate decision.

The package contains no transport, authentication, data loading, Cloud-only UI, or plugin mechanism. React and React DOM are peers so a future Node SSR host owns its runtime.

## Validation

- `npm ci --ignore-scripts`
- `npm run check`
  - 19 Vitest files / 446 tests
  - 8 JavaScript module-boundary tests
  - TypeScript type-check
  - existing client and closed SSR builds
  - existing embedded-renderer verification
  - composable package render and deterministic archive verification
