### PR TITLE
Add cross-platform local installation preflight and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 - Results artifacts, CacheService v2 current/default-branch lookup, immutable
   numeric run aliases, typed dispatch-input components, and value-level output
   sensitivity.
+- Read-only `automata local doctor` preflight for the initial x86-64 Linux,
+  Apple Silicon macOS, and x86-64 Windows host tuples, a local Linux Docker
+  Engine, Docker Compose plugin 2.20.0 or newer, and dedicated roots strictly
+  below platform-native user-state directories.
 
 ### Known limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "automata-ci-github",
  "automata-ci-github-delivery",
  "automata-ci-key-management",
+ "automata-ci-local",
  "automata-ci-metrics",
  "automata-ci-oidc-github",
  "automata-ci-oidc-github-control",
@@ -576,6 +577,17 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "automata-ci-local"
+version = "0.1.0"
+dependencies = [
+ "processkit",
+ "rustix",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/automata-ci-github-runtime",
     "crates/automata-ci-job-executor-github",
     "crates/automata-ci-key-management",
+    "crates/automata-ci-local",
     "crates/automata-ci-metrics",
     "crates/automata-ci-oidc-github",
     "crates/automata-ci-oidc-github-control",
@@ -90,6 +91,7 @@ automata-ci-github-delivery = { path = "crates/automata-ci-github-delivery", ver
 automata-ci-github-runtime = { path = "crates/automata-ci-github-runtime", version = "0.1.0" }
 automata-ci-job-executor-github = { path = "crates/automata-ci-job-executor-github", version = "0.1.0" }
 automata-ci-key-management = { path = "crates/automata-ci-key-management", version = "0.1.0" }
+automata-ci-local = { path = "crates/automata-ci-local", version = "0.1.0" }
 automata-ci-metrics = { path = "crates/automata-ci-metrics", version = "0.1.0" }
 automata-ci-oidc-github = { path = "crates/automata-ci-oidc-github", version = "0.1.0" }
 automata-ci-oidc-github-control = { path = "crates/automata-ci-oidc-github-control", version = "0.1.0" }

--- a/crates/automata-ci-local/Cargo.toml
+++ b/crates/automata-ci-local/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "automata-ci-local"
+description = "Cross-platform local installation lifecycle for Automata"
+publish.workspace = true
+readme = "README.md"
+keywords = ["ci", "github-actions", "local-development", "containers"]
+categories = ["development-tools"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+rustix.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+processkit.workspace = true
+
+[lints]
+workspace = true

--- a/crates/automata-ci-local/LICENSE
+++ b/crates/automata-ci-local/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexander Dzhoganov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-local/README.md
+++ b/crates/automata-ci-local/README.md
@@ -1,0 +1,16 @@
+# Automata local lifecycle
+
+`automata-ci-local` owns the cross-platform, disposable local-installation
+boundary used by `automata local`. It validates the initial x86-64 Linux, Apple
+Silicon macOS, or x86-64 Windows host tuple; a local Linux Docker Engine; Docker
+API compatibility; Compose plugin version 2.20.0 or newer; and an absolute,
+dedicated, non-broad platform state root. It will supervise the generated local
+Compose project without adding container-engine behavior to the control-plane
+crate.
+
+The first public slice is a read-only host preflight. It does not create local
+state or containers. Lifecycle mutations, generated configuration, workers,
+and GitHub connection are added only with their own tested contracts.
+
+This crate has no command-line parser. The `automata` product maps its public
+CLI into the typed requests exposed here.

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -1,0 +1,2035 @@
+//! Cross-platform lifecycle boundary for disposable local Automata installations.
+//!
+//! The crate owns Docker Engine discovery and platform state-directory policy
+//! without depending on the product CLI. Lifecycle mutation is added in
+//! separately reviewed slices; [`inspect`] is read-only and creates no state or
+//! containers.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    io,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt as _},
+    process::{Child, Command as ProcessCommand},
+    time::timeout,
+};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const COMMAND_TERMINATION_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_COMMAND_STREAM_BYTES: usize = 64 * 1024;
+const MIN_DOCKER_API: ApiVersion = ApiVersion {
+    major: 1,
+    minor: 44,
+};
+const MIN_COMPOSE_VERSION: (u64, u64, u64) = (2, 20, 0);
+
+/// Container engine requested by a local-installation operation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EngineRequest {
+    /// Select the portable Docker Engine path.
+    #[default]
+    Auto,
+    /// Require Docker Engine and the Docker Compose CLI plugin.
+    Docker,
+}
+
+/// Read-only host inspection request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DoctorRequest {
+    engine: EngineRequest,
+    state_directory: Option<PathBuf>,
+}
+
+impl DoctorRequest {
+    /// Creates a request with an optional explicit absolute, dedicated state root.
+    pub const fn new(engine: EngineRequest, state_directory: Option<PathBuf>) -> Self {
+        Self {
+            engine,
+            state_directory,
+        }
+    }
+}
+
+/// Inspects the local host without creating state or containers.
+pub async fn inspect(request: DoctorRequest) -> DoctorReport {
+    let state_environment = StateEnvironment::current();
+    let state_directory = resolve_state_directory(
+        request.state_directory.as_deref(),
+        std::env::consts::OS,
+        &state_environment,
+    );
+    let (context, version, info, compose) = tokio::join!(
+        capture_docker(
+            DoctorProbe::DockerContext,
+            &["context", "inspect", "--format", "{{json .}}"]
+        ),
+        capture_docker(DoctorProbe::DockerVersion, &["version", "--format", "json"]),
+        capture_docker(DoctorProbe::DockerInfo, &["info", "--format", "json"]),
+        capture_docker(
+            DoctorProbe::DockerCompose,
+            &["compose", "version", "--format", "json"]
+        ),
+    );
+    let probes = ProbeSet {
+        context,
+        version,
+        info,
+        compose,
+    };
+    build_report(
+        &request,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        state_directory,
+        process_is_root(),
+        std::env::var_os("DOCKER_API_VERSION").is_some(),
+        &probes,
+    )
+}
+
+/// Schema-versioned local preflight result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DoctorReport {
+    schema: u32,
+    ready: bool,
+    platform: Platform,
+    state_directory: Option<String>,
+    requested_engine: EngineRequest,
+    selected_engine: Option<EngineSelection>,
+    issues: Vec<DoctorIssue>,
+}
+
+impl DoctorReport {
+    /// Returns whether every mandatory preflight check passed.
+    pub const fn ready(&self) -> bool {
+        self.ready
+    }
+
+    /// Returns the compiled host operating-system identity.
+    pub fn operating_system(&self) -> &str {
+        &self.platform.operating_system
+    }
+
+    /// Returns the compiled host architecture identity.
+    pub fn architecture(&self) -> &str {
+        &self.platform.architecture
+    }
+
+    /// Returns the resolved absolute local state root, when available.
+    pub fn state_directory(&self) -> Option<&str> {
+        self.state_directory.as_deref()
+    }
+
+    /// Returns the validated engine and Compose selection, when available.
+    pub const fn selected_engine(&self) -> Option<&EngineSelection> {
+        self.selected_engine.as_ref()
+    }
+
+    /// Returns every typed preflight issue in deterministic probe order.
+    pub fn issues(&self) -> &[DoctorIssue] {
+        &self.issues
+    }
+}
+
+/// Docker probe that owns one preflight issue.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorProbe {
+    /// Platform state-directory resolution.
+    StateDirectory,
+    /// Host process identity.
+    ProcessIdentity,
+    /// Initially qualified host operating-system and architecture tuple.
+    HostPlatform,
+    /// Docker context and endpoint inspection.
+    DockerContext,
+    /// Docker client/server version inspection.
+    DockerVersion,
+    /// Docker Engine information inspection.
+    DockerInfo,
+    /// Docker Compose CLI plugin inspection.
+    DockerCompose,
+}
+
+/// Stable reason code for one failed preflight check.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorIssueCode {
+    /// No platform default state root could be resolved.
+    StateDirectoryUnavailable,
+    /// An explicit state root was not absolute.
+    StateDirectoryNotAbsolute,
+    /// The exact state root cannot be represented in the JSON/Compose contract.
+    StateDirectoryNotUnicode,
+    /// The state root is broad, ambiguous, or contains unsafe lexical traversal.
+    StateDirectoryUnsafe,
+    /// A Unix root process attempted to use the local lifecycle.
+    RootProcess,
+    /// The Docker command was not found on `PATH`.
+    CommandNotFound,
+    /// A Docker probe exceeded its deadline.
+    CommandTimedOut,
+    /// A Docker probe could not start, read, or exit successfully.
+    CommandFailed,
+    /// A Docker probe emitted more than the bounded output allowance.
+    CommandOutputTooLarge,
+    /// A Docker probe did not return its required JSON shape.
+    MalformedProbeResponse,
+    /// `DOCKER_API_VERSION` disabled normal client/server API negotiation.
+    DockerApiOverride,
+    /// The host operating-system and architecture tuple is not initially qualified.
+    UnsupportedHostPlatform,
+    /// The selected Docker context could not be inspected.
+    DockerContextUnavailable,
+    /// The selected Docker daemon was stopped, inaccessible, or otherwise unavailable.
+    DockerDaemonUnavailable,
+    /// The Docker Compose CLI plugin was absent or could not run.
+    DockerComposeUnavailable,
+    /// The selected context was not a supported local socket endpoint.
+    UntrustedDockerEndpoint,
+    /// The server did not identify as Docker Engine.
+    NonDockerEngine,
+    /// The selected Docker Engine was not in Linux-container mode.
+    NonLinuxEngine,
+    /// The engine architecture is not supported or differs from the host.
+    UnsupportedEngineArchitecture,
+    /// The engine cannot negotiate the minimum supported Docker API.
+    UnsupportedDockerApi,
+    /// The engine did not expose one stable non-secret identity.
+    MissingEngineIdentity,
+    /// Independently reported engine facts did not agree.
+    EngineIdentityMismatch,
+    /// The engine lacks a local volume or bridge-network capability.
+    MissingEngineCapability,
+    /// The Compose plugin version is malformed or below the tested floor.
+    UnsupportedComposeVersion,
+}
+
+impl DoctorIssueCode {
+    /// Returns one static, non-sensitive remediation message.
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::StateDirectoryUnavailable => {
+                "no absolute platform state directory could be resolved"
+            }
+            Self::StateDirectoryNotAbsolute => "the explicit state directory must be absolute",
+            Self::StateDirectoryNotUnicode => {
+                "the state directory must have an exact Unicode representation"
+            }
+            Self::StateDirectoryUnsafe => {
+                "choose a dedicated state root below a user-owned directory"
+            }
+            Self::RootProcess => "run the local lifecycle as an ordinary Unix user",
+            Self::CommandNotFound => "install the Docker CLI and make it available on PATH",
+            Self::CommandTimedOut => "the Docker probe timed out",
+            Self::CommandFailed => "the Docker probe failed",
+            Self::CommandOutputTooLarge => "the Docker probe exceeded its output limit",
+            Self::MalformedProbeResponse => "the Docker probe returned an unsupported JSON shape",
+            Self::DockerApiOverride => "unset DOCKER_API_VERSION so API negotiation is reliable",
+            Self::UnsupportedHostPlatform => {
+                "the initial local install supports x86-64 Linux, Apple Silicon macOS, and x86-64 Windows"
+            }
+            Self::DockerContextUnavailable => {
+                "select a valid local Docker context and retry the inspection"
+            }
+            Self::DockerDaemonUnavailable => {
+                "start Docker Engine and allow this user to access its local socket"
+            }
+            Self::DockerComposeUnavailable => {
+                "install Docker Compose CLI plugin version 2.20.0 or newer"
+            }
+            Self::UntrustedDockerEndpoint => {
+                "select a local Unix socket or Windows named-pipe Docker context"
+            }
+            Self::NonDockerEngine => "the selected endpoint is not a supported Docker Engine",
+            Self::NonLinuxEngine => "switch Docker Desktop to Linux-container mode",
+            Self::UnsupportedEngineArchitecture => {
+                "use a native amd64 or arm64 Linux Docker Engine"
+            }
+            Self::UnsupportedDockerApi => "upgrade Docker Engine to a supported API version",
+            Self::MissingEngineIdentity => "the Docker Engine did not report a stable identity",
+            Self::EngineIdentityMismatch => "Docker version and info responses disagree",
+            Self::MissingEngineCapability => {
+                "the Docker Engine requires local volumes and bridge networks"
+            }
+            Self::UnsupportedComposeVersion => {
+                "install Docker Compose plugin version 2.20.0 or newer"
+            }
+        }
+    }
+}
+
+/// One typed and probe-scoped preflight issue.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct DoctorIssue {
+    probe: DoctorProbe,
+    code: DoctorIssueCode,
+    message: &'static str,
+}
+
+impl DoctorIssue {
+    const fn new(probe: DoctorProbe, code: DoctorIssueCode) -> Self {
+        Self {
+            probe,
+            code,
+            message: code.message(),
+        }
+    }
+
+    /// Returns the probe that produced this issue.
+    pub const fn probe(self) -> DoctorProbe {
+        self.probe
+    }
+
+    /// Returns the stable machine-readable reason code.
+    pub const fn code(self) -> DoctorIssueCode {
+        self.code
+    }
+
+    /// Returns one static, non-sensitive remediation message.
+    pub const fn message(self) -> &'static str {
+        self.message
+    }
+}
+
+impl DoctorProbe {
+    const fn sort_key(self) -> u8 {
+        match self {
+            Self::StateDirectory => 0,
+            Self::ProcessIdentity => 1,
+            Self::HostPlatform => 2,
+            Self::DockerContext => 3,
+            Self::DockerVersion => 4,
+            Self::DockerInfo => 5,
+            Self::DockerCompose => 6,
+        }
+    }
+}
+
+/// Container engine selected by the preflight.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Engine {
+    /// Docker Engine.
+    Docker,
+}
+
+/// Compose frontend selected for lifecycle commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComposeFrontend {
+    /// The `docker compose` CLI plugin.
+    DockerPlugin,
+}
+
+/// Supported local Docker endpoint class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EngineEndpoint {
+    /// Local Unix-domain socket used on Linux and macOS.
+    UnixSocket,
+    /// Local Windows named pipe.
+    WindowsNamedPipe,
+}
+
+/// Supported Linux engine architecture.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EngineArchitecture {
+    /// AMD64/x86-64.
+    Amd64,
+    /// ARM64/AArch64.
+    Arm64,
+}
+
+/// Exact validated engine/frontend pair selected for an installation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EngineSelection {
+    engine: Engine,
+    compose: ComposeFrontend,
+    endpoint: EngineEndpoint,
+    engine_id: String,
+    server_version: String,
+    api_version: String,
+    architecture: EngineArchitecture,
+    compose_version: String,
+}
+
+impl EngineSelection {
+    /// Returns the selected container engine.
+    pub const fn engine(&self) -> Engine {
+        self.engine
+    }
+
+    /// Returns the selected Compose frontend.
+    pub const fn compose(&self) -> ComposeFrontend {
+        self.compose
+    }
+
+    /// Returns the validated local endpoint class.
+    pub const fn endpoint(&self) -> EngineEndpoint {
+        self.endpoint
+    }
+
+    /// Returns the exact non-secret engine identity.
+    pub fn engine_id(&self) -> &str {
+        &self.engine_id
+    }
+
+    /// Returns the exact Docker Engine version.
+    pub fn server_version(&self) -> &str {
+        &self.server_version
+    }
+
+    /// Returns the negotiated Docker API version reported by the client.
+    pub fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
+    /// Returns the normalized Linux engine architecture.
+    pub const fn architecture(&self) -> EngineArchitecture {
+        self.architecture
+    }
+
+    /// Returns the exact Docker Compose plugin version.
+    pub fn compose_version(&self) -> &str {
+        &self.compose_version
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct Platform {
+    operating_system: String,
+    architecture: String,
+}
+
+fn build_report(
+    request: &DoctorRequest,
+    operating_system: &str,
+    host_architecture: &str,
+    state_directory: Result<PathBuf, StateDirectoryError>,
+    root_process: bool,
+    docker_api_override: bool,
+    probes: &ProbeSet,
+) -> DoctorReport {
+    let mut issues = Vec::new();
+    let state_directory = match state_directory {
+        Ok(path) => {
+            if let Ok(path) = path.into_os_string().into_string() {
+                Some(path)
+            } else {
+                issues.push(DoctorIssue::new(
+                    DoctorProbe::StateDirectory,
+                    DoctorIssueCode::StateDirectoryNotUnicode,
+                ));
+                None
+            }
+        }
+        Err(error) => {
+            issues.push(DoctorIssue::new(
+                DoctorProbe::StateDirectory,
+                error.issue_code(),
+            ));
+            None
+        }
+    };
+    if root_process {
+        issues.push(DoctorIssue::new(
+            DoctorProbe::ProcessIdentity,
+            DoctorIssueCode::RootProcess,
+        ));
+    }
+    if docker_api_override {
+        issues.push(DoctorIssue::new(
+            DoctorProbe::DockerVersion,
+            DoctorIssueCode::DockerApiOverride,
+        ));
+    }
+    if !initial_host_platform_is_supported(operating_system, host_architecture) {
+        issues.push(DoctorIssue::new(
+            DoctorProbe::HostPlatform,
+            DoctorIssueCode::UnsupportedHostPlatform,
+        ));
+    }
+    let selected_engine = evaluate_engine(operating_system, host_architecture, probes, &mut issues);
+    issues.sort_by_key(|issue| issue.probe.sort_key());
+    DoctorReport {
+        schema: 1,
+        ready: state_directory.is_some() && selected_engine.is_some() && issues.is_empty(),
+        platform: Platform {
+            operating_system: operating_system.to_owned(),
+            architecture: host_architecture.to_owned(),
+        },
+        state_directory,
+        requested_engine: request.engine,
+        selected_engine,
+        issues,
+    }
+}
+
+fn initial_host_platform_is_supported(operating_system: &str, architecture: &str) -> bool {
+    matches!(
+        (operating_system, normalize_architecture(architecture)),
+        ("linux" | "windows", Some(EngineArchitecture::Amd64))
+            | ("macos", Some(EngineArchitecture::Arm64))
+    )
+}
+
+#[derive(Debug)]
+struct ProbeSet {
+    context: ProbeOutput,
+    version: ProbeOutput,
+    info: ProbeOutput,
+    compose: ProbeOutput,
+}
+
+#[derive(Debug)]
+enum ProbeOutput {
+    Success(Vec<u8>),
+    Failure(CommandFailure),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommandFailure {
+    NotFound,
+    TimedOut,
+    Failed,
+    OutputTooLarge,
+    ContextUnavailable,
+    DaemonUnavailable,
+    ComposeUnavailable,
+}
+
+async fn capture_docker(probe: DoctorProbe, arguments: &[&str]) -> ProbeOutput {
+    let mut command = ProcessCommand::new("docker");
+    command
+        .args(arguments)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let (mut child, mut containment) = match spawn_contained(command) {
+        Ok(spawned) => spawned,
+        Err(failure) => return ProbeOutput::Failure(failure),
+    };
+    let Some(stdout) = child.stdout.take() else {
+        terminate_process_tree(&mut child, &mut containment).await;
+        return ProbeOutput::Failure(CommandFailure::Failed);
+    };
+    let Some(stderr) = child.stderr.take() else {
+        terminate_process_tree(&mut child, &mut containment).await;
+        return ProbeOutput::Failure(CommandFailure::Failed);
+    };
+    let captured = timeout(COMMAND_TIMEOUT, async {
+        tokio::try_join!(read_bounded(stdout), read_bounded(stderr), async {
+            child.wait().await.map_err(|_error| CaptureFailure::Io)
+        })
+    })
+    .await;
+    let (stdout, stderr, status) = match captured {
+        Ok(Ok(captured)) => captured,
+        Ok(Err(CaptureFailure::OutputTooLarge)) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return ProbeOutput::Failure(CommandFailure::OutputTooLarge);
+        }
+        Ok(Err(CaptureFailure::Io)) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return ProbeOutput::Failure(CommandFailure::Failed);
+        }
+        Err(_) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return ProbeOutput::Failure(CommandFailure::TimedOut);
+        }
+    };
+    terminate_remaining_process_tree(&mut containment);
+    drop(stderr);
+    if !status.success() {
+        return ProbeOutput::Failure(unavailable_failure(probe));
+    }
+    ProbeOutput::Success(stdout)
+}
+
+const fn unavailable_failure(probe: DoctorProbe) -> CommandFailure {
+    match probe {
+        DoctorProbe::DockerContext => CommandFailure::ContextUnavailable,
+        DoctorProbe::DockerVersion | DoctorProbe::DockerInfo => CommandFailure::DaemonUnavailable,
+        DoctorProbe::DockerCompose => CommandFailure::ComposeUnavailable,
+        DoctorProbe::StateDirectory | DoctorProbe::ProcessIdentity | DoctorProbe::HostPlatform => {
+            CommandFailure::Failed
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CaptureFailure {
+    Io,
+    OutputTooLarge,
+}
+
+async fn read_bounded<R: AsyncRead + Unpin>(mut reader: R) -> Result<Vec<u8>, CaptureFailure> {
+    let mut bytes = Vec::with_capacity(MAX_COMMAND_STREAM_BYTES.min(4096));
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let count = reader
+            .read(&mut chunk)
+            .await
+            .map_err(|_error| CaptureFailure::Io)?;
+        if count == 0 {
+            break;
+        }
+        let remaining = MAX_COMMAND_STREAM_BYTES.saturating_sub(bytes.len());
+        if count > remaining {
+            return Err(CaptureFailure::OutputTooLarge);
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+    }
+    Ok(bytes)
+}
+
+#[cfg(unix)]
+struct ProcessContainment {
+    process_group: Option<u32>,
+}
+
+#[cfg(unix)]
+impl Drop for ProcessContainment {
+    fn drop(&mut self) {
+        self.terminate_and_disarm();
+    }
+}
+
+#[cfg(unix)]
+impl ProcessContainment {
+    fn signal(&self) {
+        if let Some(process_group) = self.process_group {
+            signal_process_group(process_group);
+        }
+    }
+
+    fn terminate_and_disarm(&mut self) {
+        if let Some(process_group) = self.process_group.take() {
+            signal_process_group(process_group);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct ProcessContainment {
+    group: processkit::ProcessGroup,
+}
+
+#[cfg(unix)]
+fn spawn_contained(
+    mut command: ProcessCommand,
+) -> Result<(Child, ProcessContainment), CommandFailure> {
+    command.process_group(0);
+    let child = command.spawn().map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            CommandFailure::NotFound
+        } else {
+            CommandFailure::Failed
+        }
+    })?;
+    let process_group = child.id().ok_or(CommandFailure::Failed)?;
+    Ok((
+        child,
+        ProcessContainment {
+            process_group: Some(process_group),
+        },
+    ))
+}
+
+#[cfg(windows)]
+fn spawn_contained(command: ProcessCommand) -> Result<(Child, ProcessContainment), CommandFailure> {
+    use std::error::Error as _;
+
+    let group = processkit::ProcessGroup::new().map_err(|_error| CommandFailure::Failed)?;
+    let child = group.spawn(command).map_err(|error| {
+        let mut source = error.source();
+        while let Some(current) = source {
+            if current
+                .downcast_ref::<io::Error>()
+                .is_some_and(|error| error.kind() == io::ErrorKind::NotFound)
+            {
+                return CommandFailure::NotFound;
+            }
+            source = current.source();
+        }
+        CommandFailure::Failed
+    })?;
+    Ok((child, ProcessContainment { group }))
+}
+
+#[cfg(unix)]
+async fn terminate_process_tree(child: &mut Child, containment: &mut ProcessContainment) {
+    containment.signal();
+    let _ignored = child.start_kill();
+    let _ignored = timeout(COMMAND_TERMINATION_TIMEOUT, child.wait()).await;
+    containment.terminate_and_disarm();
+}
+
+#[cfg(windows)]
+async fn terminate_process_tree(child: &mut Child, containment: &mut ProcessContainment) {
+    let _ignored = containment.group.kill_all();
+    let _ignored = child.start_kill();
+    let _ignored = timeout(COMMAND_TERMINATION_TIMEOUT, child.wait()).await;
+    let _ignored = containment.group.kill_all();
+}
+
+#[cfg(unix)]
+fn terminate_remaining_process_tree(containment: &mut ProcessContainment) {
+    containment.terminate_and_disarm();
+}
+
+#[cfg(windows)]
+fn terminate_remaining_process_tree(containment: &mut ProcessContainment) {
+    let _ignored = containment.group.kill_all();
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_group: u32) {
+    let Ok(raw_process_group) = i32::try_from(process_group) else {
+        return;
+    };
+    let Some(process_group) = rustix::process::Pid::from_raw(raw_process_group) else {
+        return;
+    };
+    let _ignored =
+        rustix::process::kill_process_group(process_group, rustix::process::Signal::KILL);
+}
+
+fn evaluate_engine(
+    operating_system: &str,
+    host_architecture: &str,
+    probes: &ProbeSet,
+    issues: &mut Vec<DoctorIssue>,
+) -> Option<EngineSelection> {
+    if matches!(
+        probes.context,
+        ProbeOutput::Failure(CommandFailure::NotFound)
+    ) {
+        issues.push(DoctorIssue::new(
+            DoctorProbe::DockerContext,
+            DoctorIssueCode::CommandNotFound,
+        ));
+        return None;
+    }
+
+    let context: Option<DockerContextDocument> =
+        parse_probe(DoctorProbe::DockerContext, &probes.context, issues);
+    let version: Option<DockerVersionDocument> =
+        parse_probe(DoctorProbe::DockerVersion, &probes.version, issues);
+    let info: Option<DockerInfoDocument> =
+        parse_probe(DoctorProbe::DockerInfo, &probes.info, issues);
+    let compose: Option<DockerComposeDocument> =
+        parse_probe(DoctorProbe::DockerCompose, &probes.compose, issues);
+
+    let endpoint = context.as_ref().and_then(|context| {
+        record_validation(
+            DoctorProbe::DockerContext,
+            validate_context(context, operating_system),
+            issues,
+        )
+    });
+    let version = version.as_ref().and_then(|version| {
+        record_validation(
+            DoctorProbe::DockerVersion,
+            validate_version(version, host_architecture),
+            issues,
+        )
+    });
+    let compose_version = compose.as_ref().and_then(|compose| {
+        record_validation(
+            DoctorProbe::DockerCompose,
+            validate_compose(compose),
+            issues,
+        )
+    });
+    let engine_id = info.as_ref().and_then(|info| {
+        version.as_ref().and_then(|version| {
+            record_validation(
+                DoctorProbe::DockerInfo,
+                validate_info(info, version),
+                issues,
+            )
+        })
+    });
+    Some(EngineSelection {
+        engine: Engine::Docker,
+        compose: ComposeFrontend::DockerPlugin,
+        endpoint: endpoint?,
+        engine_id: engine_id?,
+        server_version: version.as_ref()?.server_version.clone(),
+        api_version: version.as_ref()?.api_version.clone(),
+        architecture: version.as_ref()?.architecture,
+        compose_version: compose_version?,
+    })
+}
+
+fn parse_probe<T: DeserializeOwned>(
+    probe: DoctorProbe,
+    output: &ProbeOutput,
+    issues: &mut Vec<DoctorIssue>,
+) -> Option<T> {
+    let bytes = match output {
+        ProbeOutput::Success(bytes) => bytes,
+        ProbeOutput::Failure(failure) => {
+            issues.push(DoctorIssue::new(probe, failure.issue_code()));
+            return None;
+        }
+    };
+    if let Ok(document) = serde_json::from_slice(bytes) {
+        Some(document)
+    } else {
+        issues.push(DoctorIssue::new(
+            probe,
+            DoctorIssueCode::MalformedProbeResponse,
+        ));
+        None
+    }
+}
+
+impl CommandFailure {
+    const fn issue_code(self) -> DoctorIssueCode {
+        match self {
+            Self::NotFound => DoctorIssueCode::CommandNotFound,
+            Self::TimedOut => DoctorIssueCode::CommandTimedOut,
+            Self::Failed => DoctorIssueCode::CommandFailed,
+            Self::OutputTooLarge => DoctorIssueCode::CommandOutputTooLarge,
+            Self::ContextUnavailable => DoctorIssueCode::DockerContextUnavailable,
+            Self::DaemonUnavailable => DoctorIssueCode::DockerDaemonUnavailable,
+            Self::ComposeUnavailable => DoctorIssueCode::DockerComposeUnavailable,
+        }
+    }
+}
+
+fn record_validation<T>(
+    probe: DoctorProbe,
+    result: Result<T, DoctorIssueCode>,
+    issues: &mut Vec<DoctorIssue>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(code) => {
+            issues.push(DoctorIssue::new(probe, code));
+            None
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerContextDocument {
+    #[serde(default, rename = "Name")]
+    name: String,
+    #[serde(default, rename = "Endpoints")]
+    endpoints: DockerContextEndpoints,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerContextEndpoints {
+    #[serde(default)]
+    docker: DockerContextEndpoint,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerContextEndpoint {
+    #[serde(default, rename = "Host")]
+    host: String,
+    #[serde(default, rename = "SkipTLSVerify")]
+    skip_tls_verify: bool,
+}
+
+fn validate_context(
+    context: &DockerContextDocument,
+    operating_system: &str,
+) -> Result<EngineEndpoint, DoctorIssueCode> {
+    if context.name.is_empty() || context.endpoints.docker.skip_tls_verify {
+        return Err(DoctorIssueCode::UntrustedDockerEndpoint);
+    }
+    local_endpoint(&context.endpoints.docker.host, operating_system)
+        .ok_or(DoctorIssueCode::UntrustedDockerEndpoint)
+}
+
+fn local_endpoint(host: &str, operating_system: &str) -> Option<EngineEndpoint> {
+    if matches!(operating_system, "linux" | "macos") {
+        let path = host.strip_prefix("unix://")?;
+        return (path.starts_with('/') && path.len() > 1 && !path.contains(['\0', '?', '#']))
+            .then_some(EngineEndpoint::UnixSocket);
+    }
+    if operating_system == "windows" {
+        let pipe = host.strip_prefix("npipe:////./pipe/")?;
+        return (!pipe.is_empty()
+            && pipe
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')))
+        .then_some(EngineEndpoint::WindowsNamedPipe);
+    }
+    None
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerVersionDocument {
+    #[serde(default, rename = "Client")]
+    client: Option<DockerClientVersion>,
+    #[serde(default, rename = "Server")]
+    server: Option<DockerServerVersion>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerClientVersion {
+    #[serde(default, rename = "Version")]
+    version: String,
+    #[serde(default, rename = "ApiVersion")]
+    api_version: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerServerVersion {
+    #[serde(default, rename = "Version")]
+    version: String,
+    #[serde(default, rename = "ApiVersion")]
+    api_version: String,
+    #[serde(default, rename = "MinAPIVersion")]
+    minimum_api_version: String,
+    #[serde(default, rename = "Os")]
+    operating_system: String,
+    #[serde(default, rename = "Arch")]
+    architecture: String,
+    #[serde(default, rename = "GitCommit")]
+    git_commit: String,
+    #[serde(default, rename = "Components")]
+    components: Vec<DockerComponent>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerComponent {
+    #[serde(default, rename = "Name")]
+    name: String,
+    #[serde(default, rename = "Version")]
+    version: String,
+    #[serde(default, rename = "Details")]
+    details: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct ValidatedVersion {
+    server_version: String,
+    api_version: String,
+    architecture: EngineArchitecture,
+}
+
+fn validate_version(
+    document: &DockerVersionDocument,
+    host_architecture: &str,
+) -> Result<ValidatedVersion, DoctorIssueCode> {
+    let client = document
+        .client
+        .as_ref()
+        .ok_or(DoctorIssueCode::NonDockerEngine)?;
+    let server = document
+        .server
+        .as_ref()
+        .ok_or(DoctorIssueCode::NonDockerEngine)?;
+    let primary = server
+        .components
+        .first()
+        .filter(|component| component.name == "Engine")
+        .ok_or(DoctorIssueCode::NonDockerEngine)?;
+    let required_details = [
+        "ApiVersion",
+        "MinAPIVersion",
+        "Arch",
+        "Os",
+        "GitCommit",
+        "GoVersion",
+        "KernelVersion",
+    ];
+    if client.version.is_empty()
+        || client.api_version.is_empty()
+        || server.version.is_empty()
+        || server.git_commit.is_empty()
+        || required_details
+            .iter()
+            .any(|field| primary.details.get(*field).is_none_or(String::is_empty))
+        || !["containerd", "runc", "docker-init"].iter().all(|name| {
+            server
+                .components
+                .iter()
+                .skip(1)
+                .any(|component| component.name == *name)
+        })
+    {
+        return Err(DoctorIssueCode::NonDockerEngine);
+    }
+    if primary.version != server.version
+        || primary.details.get("GitCommit") != Some(&server.git_commit)
+    {
+        return Err(DoctorIssueCode::EngineIdentityMismatch);
+    }
+    if server.operating_system != "linux"
+        || primary.details.get("Os").map(String::as_str) != Some("linux")
+    {
+        return Err(DoctorIssueCode::NonLinuxEngine);
+    }
+    let architecture = normalize_architecture(&server.architecture)
+        .ok_or(DoctorIssueCode::UnsupportedEngineArchitecture)?;
+    let component_architecture = primary
+        .details
+        .get("Arch")
+        .and_then(|value| normalize_architecture(value))
+        .ok_or(DoctorIssueCode::UnsupportedEngineArchitecture)?;
+    let host_architecture = normalize_architecture(host_architecture)
+        .ok_or(DoctorIssueCode::UnsupportedEngineArchitecture)?;
+    if architecture != component_architecture || architecture != host_architecture {
+        return Err(DoctorIssueCode::UnsupportedEngineArchitecture);
+    }
+    let client_api =
+        ApiVersion::parse(&client.api_version).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    let server_api =
+        ApiVersion::parse(&server.api_version).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    let minimum_api = ApiVersion::parse(&server.minimum_api_version)
+        .ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    let component_api = primary
+        .details
+        .get("ApiVersion")
+        .and_then(|value| ApiVersion::parse(value))
+        .ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    let component_minimum_api = primary
+        .details
+        .get("MinAPIVersion")
+        .and_then(|value| ApiVersion::parse(value))
+        .ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    if client_api < MIN_DOCKER_API
+        || server_api < client_api
+        || minimum_api > client_api
+        || component_api != server_api
+        || component_minimum_api != minimum_api
+    {
+        return Err(DoctorIssueCode::UnsupportedDockerApi);
+    }
+    Ok(ValidatedVersion {
+        server_version: server.version.clone(),
+        api_version: client.api_version.clone(),
+        architecture,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct ApiVersion {
+    major: u16,
+    minor: u16,
+}
+
+impl ApiVersion {
+    fn parse(value: &str) -> Option<Self> {
+        let (major, minor) = value.split_once('.')?;
+        if major.is_empty()
+            || minor.is_empty()
+            || !major.bytes().all(|byte| byte.is_ascii_digit())
+            || !minor.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return None;
+        }
+        Some(Self {
+            major: major.parse().ok()?,
+            minor: minor.parse().ok()?,
+        })
+    }
+}
+
+const fn normalize_architecture(value: &str) -> Option<EngineArchitecture> {
+    match value.as_bytes() {
+        b"amd64" | b"x86_64" => Some(EngineArchitecture::Amd64),
+        b"arm64" | b"aarch64" => Some(EngineArchitecture::Arm64),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerInfoDocument {
+    #[serde(default, rename = "ID")]
+    id: String,
+    #[serde(default, rename = "OSType")]
+    operating_system: String,
+    #[serde(default, rename = "Architecture")]
+    architecture: String,
+    #[serde(default, rename = "ServerVersion")]
+    server_version: String,
+    #[serde(default, rename = "Plugins")]
+    plugins: DockerPlugins,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerPlugins {
+    #[serde(default, rename = "Volume")]
+    volumes: Vec<String>,
+    #[serde(default, rename = "Network")]
+    networks: Vec<String>,
+}
+
+fn validate_info(
+    info: &DockerInfoDocument,
+    version: &ValidatedVersion,
+) -> Result<String, DoctorIssueCode> {
+    if info.operating_system != "linux" {
+        return Err(DoctorIssueCode::NonLinuxEngine);
+    }
+    let architecture = normalize_architecture(&info.architecture)
+        .ok_or(DoctorIssueCode::UnsupportedEngineArchitecture)?;
+    if architecture != version.architecture || info.server_version != version.server_version {
+        return Err(DoctorIssueCode::EngineIdentityMismatch);
+    }
+    if info.id.is_empty()
+        || info.id.len() > 512
+        || info.id.trim() != info.id
+        || info.id.chars().any(char::is_control)
+    {
+        return Err(DoctorIssueCode::MissingEngineIdentity);
+    }
+    if !info.plugins.volumes.iter().any(|plugin| plugin == "local")
+        || !info
+            .plugins
+            .networks
+            .iter()
+            .any(|plugin| plugin == "bridge")
+    {
+        return Err(DoctorIssueCode::MissingEngineCapability);
+    }
+    Ok(info.id.clone())
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DockerComposeDocument {
+    #[serde(default)]
+    version: String,
+}
+
+fn validate_compose(document: &DockerComposeDocument) -> Result<String, DoctorIssueCode> {
+    let parsed = parse_compose_version(&document.version)
+        .ok_or(DoctorIssueCode::UnsupportedComposeVersion)?;
+    if parsed < MIN_COMPOSE_VERSION {
+        return Err(DoctorIssueCode::UnsupportedComposeVersion);
+    }
+    Ok(document.version.clone())
+}
+
+fn parse_compose_version(value: &str) -> Option<(u64, u64, u64)> {
+    let value = value.strip_prefix('v').unwrap_or(value);
+    let (version, _build) = value.split_once('+').unwrap_or((value, ""));
+    let (core, vendor) = version.split_once('-').unwrap_or((version, ""));
+    if !vendor.is_empty() {
+        let desktop_revision = vendor.strip_prefix("desktop.")?;
+        if desktop_revision.is_empty()
+            || desktop_revision.split('.').any(|component| {
+                component.is_empty() || !component.bytes().all(|b| b.is_ascii_digit())
+            })
+        {
+            return None;
+        }
+    } else if version.ends_with('-') {
+        return None;
+    }
+    let mut components = core.split('.');
+    let major = components.next()?.parse().ok()?;
+    let minor = components.next()?.parse().ok()?;
+    let patch = components.next()?.parse().ok()?;
+    (components.next().is_none()).then_some((major, minor, patch))
+}
+
+#[derive(Debug)]
+struct StateEnvironment {
+    local_app_data: Option<OsString>,
+    xdg_state_home: Option<OsString>,
+    home: Option<OsString>,
+}
+
+impl StateEnvironment {
+    fn current() -> Self {
+        Self {
+            local_app_data: std::env::var_os("LOCALAPPDATA"),
+            xdg_state_home: std::env::var_os("XDG_STATE_HOME"),
+            home: if cfg!(windows) {
+                std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))
+            } else {
+                std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StateDirectoryError {
+    Unavailable,
+    NotAbsolute,
+    Unsafe,
+}
+
+impl StateDirectoryError {
+    const fn issue_code(self) -> DoctorIssueCode {
+        match self {
+            Self::Unavailable => DoctorIssueCode::StateDirectoryUnavailable,
+            Self::NotAbsolute => DoctorIssueCode::StateDirectoryNotAbsolute,
+            Self::Unsafe => DoctorIssueCode::StateDirectoryUnsafe,
+        }
+    }
+}
+
+fn resolve_state_directory(
+    explicit: Option<&Path>,
+    operating_system: &str,
+    environment: &StateEnvironment,
+) -> Result<PathBuf, StateDirectoryError> {
+    let path = if let Some(path) = explicit {
+        if !path.is_absolute() {
+            return Err(StateDirectoryError::NotAbsolute);
+        }
+        path.to_path_buf()
+    } else if operating_system == "windows" {
+        environment
+            .local_app_data
+            .as_ref()
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .map(|path| path.join("Automata").join("local"))
+            .ok_or(StateDirectoryError::Unavailable)?
+    } else if operating_system == "macos" {
+        environment
+            .home
+            .as_ref()
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .map(|path| {
+                path.join("Library")
+                    .join("Application Support")
+                    .join("Automata")
+                    .join("local")
+            })
+            .ok_or(StateDirectoryError::Unavailable)?
+    } else {
+        environment
+            .xdg_state_home
+            .as_ref()
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .map(|path| path.join("automata").join("local"))
+            .or_else(|| {
+                environment
+                    .home
+                    .as_ref()
+                    .map(PathBuf::from)
+                    .filter(|path| path.is_absolute())
+                    .map(|path| {
+                        path.join(".local")
+                            .join("state")
+                            .join("automata")
+                            .join("local")
+                    })
+            })
+            .ok_or(StateDirectoryError::Unavailable)?
+    };
+    validate_state_directory(path, operating_system, environment)
+}
+
+fn validate_state_directory(
+    path: PathBuf,
+    operating_system: &str,
+    environment: &StateEnvironment,
+) -> Result<PathBuf, StateDirectoryError> {
+    use std::path::Component;
+
+    let mut normal_components = 0_usize;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => normal_components += 1,
+            Component::ParentDir => return Err(StateDirectoryError::Unsafe),
+            Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
+        }
+    }
+    if normal_components < 2 || path.parent().is_none() {
+        return Err(StateDirectoryError::Unsafe);
+    }
+    #[cfg(unix)]
+    if !nearest_existing_ancestor_is_user_owned(&path) {
+        return Err(StateDirectoryError::Unsafe);
+    }
+    let candidate_roots = match operating_system {
+        "linux" => [
+            environment.xdg_state_home.as_ref(),
+            environment.home.as_ref(),
+        ],
+        "macos" => [environment.home.as_ref(), None],
+        "windows" => [
+            environment.local_app_data.as_ref(),
+            environment.home.as_ref(),
+        ],
+        _ => [None, None],
+    };
+    let user_roots = candidate_roots
+        .into_iter()
+        .flatten()
+        .map(PathBuf::from)
+        .filter(|candidate| candidate_user_root_is_safe(candidate, operating_system))
+        .collect::<Vec<_>>();
+    if user_roots
+        .iter()
+        .any(|protected| path == *protected || protected.starts_with(&path))
+        || !user_roots
+            .iter()
+            .any(|protected| path.starts_with(protected))
+    {
+        return Err(StateDirectoryError::Unsafe);
+    }
+    Ok(path)
+}
+
+fn candidate_user_root_is_safe(path: &Path, operating_system: &str) -> bool {
+    use std::path::Component;
+
+    if !path.is_absolute() {
+        return false;
+    }
+    let mut normal = path.components().filter_map(|component| match component {
+        Component::Normal(value) => Some(value),
+        Component::ParentDir | Component::CurDir | Component::Prefix(_) | Component::RootDir => {
+            None
+        }
+    });
+    let Some(first) = normal.next() else {
+        return false;
+    };
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
+        return false;
+    }
+    let first = first.to_string_lossy();
+    let reserved = if operating_system == "windows" {
+        [
+            "program files",
+            "program files (x86)",
+            "programdata",
+            "recovery",
+            "system volume information",
+            "windows",
+        ]
+        .iter()
+        .any(|reserved| first.eq_ignore_ascii_case(reserved))
+    } else {
+        [
+            "bin", "boot", "dev", "etc", "lib", "lib64", "opt", "proc", "run", "sbin", "sys",
+            "tmp", "usr", "var",
+        ]
+        .iter()
+        .any(|reserved| first.as_ref() == *reserved)
+    };
+    if reserved {
+        return false;
+    }
+    #[cfg(unix)]
+    if !nearest_existing_ancestor_is_user_owned(path) {
+        return false;
+    }
+    #[cfg(windows)]
+    if normal.next().is_none() {
+        return false;
+    }
+    true
+}
+
+#[cfg(unix)]
+fn nearest_existing_ancestor_is_user_owned(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+
+    for ancestor in path.ancestors() {
+        match std::fs::symlink_metadata(ancestor) {
+            Ok(metadata) => {
+                return metadata.is_dir() && metadata.uid() == rustix::process::geteuid().as_raw();
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => return false,
+        }
+    }
+    false
+}
+
+#[cfg(unix)]
+fn process_is_root() -> bool {
+    rustix::process::geteuid().is_root()
+}
+
+#[cfg(not(unix))]
+const fn process_is_root() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CaptureFailure, CommandFailure, ComposeFrontend, DoctorIssueCode, DoctorProbe,
+        DoctorRequest, EngineArchitecture, EngineEndpoint, EngineRequest, MAX_COMMAND_STREAM_BYTES,
+        ProbeOutput, ProbeSet, StateDirectoryError, StateEnvironment, build_report, read_bounded,
+        resolve_state_directory,
+    };
+    #[cfg(target_os = "linux")]
+    use super::{spawn_contained, terminate_process_tree};
+    use serde_json::json;
+    use std::{
+        ffi::OsString,
+        path::{Path, PathBuf},
+    };
+    use tokio::io::AsyncReadExt as _;
+    #[cfg(target_os = "linux")]
+    use tokio::process::Command as ProcessCommand;
+
+    const CONTEXT_UNIX: &str = r#"{
+        "Name":"default",
+        "Endpoints":{"docker":{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}}
+    }"#;
+    const CONTEXT_WINDOWS: &str = r#"{
+        "Name":"desktop-linux",
+        "Endpoints":{"docker":{"Host":"npipe:////./pipe/dockerDesktopLinuxEngine","SkipTLSVerify":false}}
+    }"#;
+    const VERSION_AMD64: &str = r#"{
+        "Client":{"Version":"29.7.2","ApiVersion":"1.55"},
+        "Server":{
+            "Version":"29.7.2","ApiVersion":"1.55","MinAPIVersion":"1.40",
+            "Os":"linux","Arch":"amd64","GitCommit":"server-commit",
+            "Components":[
+                {"Name":"Engine","Version":"29.7.2","Details":{
+                    "ApiVersion":"1.55","MinAPIVersion":"1.40","Arch":"amd64",
+                    "Os":"linux","GitCommit":"server-commit","GoVersion":"go1.26",
+                    "KernelVersion":"6.12"
+                }},
+                {"Name":"containerd"},{"Name":"runc"},{"Name":"docker-init"}
+            ]
+        }
+    }"#;
+    const PODMAN_COMPAT_VERSION: &str = r#"{
+        "Client":{"Version":"29.7.2","ApiVersion":"1.44"},
+        "Server":{
+            "Version":"6.0.2","ApiVersion":"1.44","MinAPIVersion":"1.24",
+            "Os":"linux","Arch":"amd64","GitCommit":"compat",
+            "Components":[
+                {"Name":"Podman Engine","Version":"6.0.2","Details":{
+                    "ApiVersion":"6.0.2","MinAPIVersion":"4.0.0",
+                    "Arch":"amd64","Os":"linux"
+                }},
+                {"Name":"Conmon","Version":"2.1.13"},
+                {"Name":"OCI Runtime (crun)","Version":"1.23"},
+                {"Name":"Engine","Version":"6.0.2","Details":{
+                    "ApiVersion":"1.44","MinAPIVersion":"1.24",
+                    "Arch":"amd64","Os":"linux"
+                }}
+            ]
+        }
+    }"#;
+    const INFO_AMD64: &str = r#"{
+        "ID":"engine-identity","OSType":"linux","Architecture":"x86_64",
+        "ServerVersion":"29.7.2",
+        "Plugins":{"Volume":["local"],"Network":["bridge","host"]}
+    }"#;
+    const COMPOSE: &str = r#"{"version":"5.4.0"}"#;
+
+    fn success(value: impl Into<Vec<u8>>) -> ProbeOutput {
+        ProbeOutput::Success(value.into())
+    }
+
+    fn healthy_probes(context: &str) -> ProbeSet {
+        ProbeSet {
+            context: success(context.as_bytes()),
+            version: success(VERSION_AMD64.as_bytes()),
+            info: success(INFO_AMD64.as_bytes()),
+            compose: success(COMPOSE.as_bytes()),
+        }
+    }
+
+    fn report(
+        operating_system: &str,
+        host_architecture: &str,
+        probes: &ProbeSet,
+    ) -> super::DoctorReport {
+        build_report(
+            &DoctorRequest::new(EngineRequest::Auto, None),
+            operating_system,
+            host_architecture,
+            Ok(Path::new("/state/automata/local").to_path_buf()),
+            false,
+            false,
+            probes,
+        )
+    }
+
+    fn issue_codes(report: &super::DoctorReport) -> Vec<DoctorIssueCode> {
+        report.issues().iter().map(|issue| issue.code()).collect()
+    }
+
+    #[test]
+    fn validates_a_local_docker_engine_and_future_compose_major() {
+        let report = report("linux", "x86_64", &healthy_probes(CONTEXT_UNIX));
+        assert!(report.ready());
+        assert!(report.issues().is_empty());
+        let engine = report.selected_engine().expect("validated engine");
+        assert_eq!(engine.endpoint(), EngineEndpoint::UnixSocket);
+        assert_eq!(engine.architecture(), EngineArchitecture::Amd64);
+        assert_eq!(engine.compose(), ComposeFrontend::DockerPlugin);
+        assert_eq!(engine.engine_id(), "engine-identity");
+        assert_eq!(engine.api_version(), "1.55");
+        assert_eq!(engine.compose_version(), "5.4.0");
+    }
+
+    #[test]
+    fn validates_docker_desktop_linux_mode_on_windows() {
+        let report = report("windows", "x86_64", &healthy_probes(CONTEXT_WINDOWS));
+        assert!(report.ready());
+        assert_eq!(
+            report
+                .selected_engine()
+                .map(super::EngineSelection::endpoint),
+            Some(EngineEndpoint::WindowsNamedPipe)
+        );
+    }
+
+    #[test]
+    fn validates_native_arm64_engine_on_macos() {
+        let probes = ProbeSet {
+            context: success(
+                CONTEXT_UNIX
+                    .replace(
+                        "/var/run/docker.sock",
+                        "/Users/example/.docker/run/docker.sock",
+                    )
+                    .into_bytes(),
+            ),
+            version: success(VERSION_AMD64.replace("amd64", "arm64").into_bytes()),
+            info: success(INFO_AMD64.replace("x86_64", "aarch64").into_bytes()),
+            compose: success(COMPOSE.as_bytes()),
+        };
+        let report = report("macos", "aarch64", &probes);
+        assert!(report.ready());
+        assert_eq!(
+            report
+                .selected_engine()
+                .map(super::EngineSelection::architecture),
+            Some(EngineArchitecture::Arm64)
+        );
+    }
+
+    #[test]
+    fn rejects_remote_or_insecure_contexts() {
+        for context in [
+            CONTEXT_UNIX.replace("unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"),
+            CONTEXT_UNIX.replace("\"SkipTLSVerify\":false", "\"SkipTLSVerify\":true"),
+        ] {
+            let report = report("linux", "x86_64", &healthy_probes(&context));
+            assert_eq!(
+                issue_codes(&report),
+                vec![DoctorIssueCode::UntrustedDockerEndpoint]
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_podman_primary_component_and_native_cli_shape() {
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.version = success(PODMAN_COMPAT_VERSION.as_bytes());
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::NonDockerEngine]
+        );
+
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.version = success(br#"{"Client":{"Version":"6.0.2"}}"#.as_slice());
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::NonDockerEngine]
+        );
+    }
+
+    #[test]
+    fn rejects_windows_container_mode_and_unqualified_architecture() {
+        let mut windows = healthy_probes(CONTEXT_WINDOWS);
+        windows.version = success(
+            VERSION_AMD64
+                .replace("\"linux\"", "\"windows\"")
+                .into_bytes(),
+        );
+        windows.info = success(INFO_AMD64.replace("\"linux\"", "\"windows\"").into_bytes());
+        assert_eq!(
+            issue_codes(&report("windows", "x86_64", &windows)),
+            vec![DoctorIssueCode::NonLinuxEngine]
+        );
+
+        let mut architecture = healthy_probes(CONTEXT_UNIX);
+        architecture.version = success(VERSION_AMD64.replace("amd64", "s390x").into_bytes());
+        architecture.info = success(INFO_AMD64.replace("x86_64", "s390x").into_bytes());
+        assert_eq!(
+            issue_codes(&report("linux", "s390x", &architecture)),
+            vec![
+                DoctorIssueCode::UnsupportedHostPlatform,
+                DoctorIssueCode::UnsupportedEngineArchitecture,
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_an_engine_without_the_supported_api_overlap() {
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.version = success(
+            VERSION_AMD64
+                .replacen("\"ApiVersion\":\"1.55\"", "\"ApiVersion\":\"1.43\"", 1)
+                .into_bytes(),
+        );
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::UnsupportedDockerApi]
+        );
+    }
+
+    #[test]
+    fn reports_the_negotiated_client_api_not_the_server_ceiling() {
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.version = success(
+            VERSION_AMD64
+                .replacen("\"ApiVersion\":\"1.55\"", "\"ApiVersion\":\"1.44\"", 1)
+                .into_bytes(),
+        );
+        let report = report("linux", "x86_64", &probes);
+        assert!(report.ready());
+        assert_eq!(
+            report
+                .selected_engine()
+                .map(super::EngineSelection::api_version),
+            Some("1.44")
+        );
+    }
+
+    #[test]
+    fn rejects_unqualified_host_platform_tuples() {
+        for (operating_system, architecture, expected_engine_architecture) in [
+            ("macos", "x86_64", "amd64"),
+            ("windows", "aarch64", "arm64"),
+        ] {
+            let probes = ProbeSet {
+                context: success(if operating_system == "windows" {
+                    CONTEXT_WINDOWS.as_bytes()
+                } else {
+                    CONTEXT_UNIX.as_bytes()
+                }),
+                version: success(
+                    VERSION_AMD64
+                        .replace("amd64", expected_engine_architecture)
+                        .into_bytes(),
+                ),
+                info: success(INFO_AMD64.replace("x86_64", architecture).into_bytes()),
+                compose: success(COMPOSE.as_bytes()),
+            };
+            assert_eq!(
+                issue_codes(&report(operating_system, architecture, &probes)),
+                vec![DoctorIssueCode::UnsupportedHostPlatform]
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_forced_docker_api_version() {
+        let report = build_report(
+            &DoctorRequest::new(EngineRequest::Auto, None),
+            "linux",
+            "x86_64",
+            Ok(Path::new("/state/automata/local").to_path_buf()),
+            false,
+            true,
+            &healthy_probes(CONTEXT_UNIX),
+        );
+        assert!(!report.ready());
+        assert_eq!(
+            issue_codes(&report),
+            vec![DoctorIssueCode::DockerApiOverride]
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_engine_information_and_missing_capabilities() {
+        let mut component = healthy_probes(CONTEXT_UNIX);
+        component.version = success(
+            VERSION_AMD64
+                .replace(
+                    "\"Name\":\"Engine\",\"Version\":\"29.7.2\"",
+                    "\"Name\":\"Engine\",\"Version\":\"29.7.1\"",
+                )
+                .into_bytes(),
+        );
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &component)),
+            vec![DoctorIssueCode::EngineIdentityMismatch]
+        );
+
+        let mut mismatch = healthy_probes(CONTEXT_UNIX);
+        mismatch.info = success(INFO_AMD64.replace("29.7.2", "29.7.1").into_bytes());
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &mismatch)),
+            vec![DoctorIssueCode::EngineIdentityMismatch]
+        );
+
+        let mut capability = healthy_probes(CONTEXT_UNIX);
+        capability.info = success(INFO_AMD64.replace("\"bridge\",", "").into_bytes());
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &capability)),
+            vec![DoctorIssueCode::MissingEngineCapability]
+        );
+    }
+
+    #[test]
+    fn rejects_old_or_malformed_compose_versions() {
+        for version in ["1.29.2", "not-a-version", "2.20.0-rc.1", "2.20.0-"] {
+            let mut probes = healthy_probes(CONTEXT_UNIX);
+            probes.compose = success(format!(r#"{{"version":"{version}"}}"#).into_bytes());
+            assert_eq!(
+                issue_codes(&report("linux", "x86_64", &probes)),
+                vec![DoctorIssueCode::UnsupportedComposeVersion]
+            );
+        }
+
+        let mut desktop = healthy_probes(CONTEXT_UNIX);
+        desktop.compose = success(br#"{"version":"v2.32.4-desktop.1"}"#.as_slice());
+        assert!(report("linux", "x86_64", &desktop).ready());
+    }
+
+    #[test]
+    fn command_and_payload_failures_keep_typed_probe_identity() {
+        let cases = [
+            (CommandFailure::NotFound, DoctorIssueCode::CommandNotFound),
+            (CommandFailure::TimedOut, DoctorIssueCode::CommandTimedOut),
+            (CommandFailure::Failed, DoctorIssueCode::CommandFailed),
+            (
+                CommandFailure::OutputTooLarge,
+                DoctorIssueCode::CommandOutputTooLarge,
+            ),
+        ];
+        for (failure, expected) in cases {
+            let mut probes = healthy_probes(CONTEXT_UNIX);
+            probes.context = ProbeOutput::Failure(failure);
+            let report = report("linux", "x86_64", &probes);
+            assert_eq!(report.issues().len(), 1);
+            assert_eq!(report.issues()[0].probe(), DoctorProbe::DockerContext);
+            assert_eq!(report.issues()[0].code(), expected);
+        }
+
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.info = success(b"not-json".as_slice());
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::MalformedProbeResponse]
+        );
+
+        let probes = ProbeSet {
+            context: ProbeOutput::Failure(CommandFailure::ContextUnavailable),
+            version: ProbeOutput::Failure(CommandFailure::DaemonUnavailable),
+            info: ProbeOutput::Failure(CommandFailure::DaemonUnavailable),
+            compose: ProbeOutput::Failure(CommandFailure::ComposeUnavailable),
+        };
+        let failure_report = report("linux", "x86_64", &probes);
+        assert_eq!(
+            issue_codes(&failure_report),
+            vec![
+                DoctorIssueCode::DockerContextUnavailable,
+                DoctorIssueCode::DockerDaemonUnavailable,
+                DoctorIssueCode::DockerDaemonUnavailable,
+                DoctorIssueCode::DockerComposeUnavailable,
+            ]
+        );
+        let document = serde_json::to_value(failure_report).expect("failure report must serialize");
+        assert_eq!(
+            document["issues"][3]["message"],
+            "install Docker Compose CLI plugin version 2.20.0 or newer"
+        );
+
+        let probes = ProbeSet {
+            context: success(
+                CONTEXT_UNIX
+                    .replace("unix:///var/run/docker.sock", "tcp://127.0.0.1:2375")
+                    .into_bytes(),
+            ),
+            version: ProbeOutput::Failure(CommandFailure::DaemonUnavailable),
+            info: ProbeOutput::Failure(CommandFailure::DaemonUnavailable),
+            compose: ProbeOutput::Failure(CommandFailure::ComposeUnavailable),
+        };
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![
+                DoctorIssueCode::UntrustedDockerEndpoint,
+                DoctorIssueCode::DockerDaemonUnavailable,
+                DoctorIssueCode::DockerDaemonUnavailable,
+                DoctorIssueCode::DockerComposeUnavailable,
+            ],
+            "simultaneous failures remain in stable probe order"
+        );
+    }
+
+    #[tokio::test]
+    async fn command_capture_rejects_output_above_the_bound() {
+        let input = tokio::io::repeat(7).take((MAX_COMMAND_STREAM_BYTES + 1) as u64);
+        assert_eq!(
+            read_bounded(input).await,
+            Err(CaptureFailure::OutputTooLarge)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn process_containment_terminates_descendants() {
+        let mut command = ProcessCommand::new("/bin/sh");
+        command
+            .args(["-c", "sleep 30 & wait"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let (mut child, mut containment) = spawn_contained(command).expect("contained shell");
+        let leader = child.id().expect("shell process ID");
+        let children_path = PathBuf::from(format!("/proc/{leader}/task/{leader}/children"));
+        let descendant = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(children) = std::fs::read_to_string(&children_path)
+                    && let Some(pid) = children.split_whitespace().next()
+                {
+                    break pid.parse::<u32>().expect("descendant process ID");
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shell must spawn its descendant");
+
+        terminate_process_tree(&mut child, &mut containment).await;
+        let descendant_path = PathBuf::from(format!("/proc/{descendant}"));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while descendant_path.exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("descendant must be reaped after group termination");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn dropping_process_containment_terminates_descendants() {
+        let mut command = ProcessCommand::new("/bin/sh");
+        command
+            .args(["-c", "sleep 30 & wait"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let (mut child, containment) = spawn_contained(command).expect("contained shell");
+        let leader = child.id().expect("shell process ID");
+        let children_path = PathBuf::from(format!("/proc/{leader}/task/{leader}/children"));
+        let descendant = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(children) = std::fs::read_to_string(&children_path)
+                    && let Some(pid) = children.split_whitespace().next()
+                {
+                    break pid.parse::<u32>().expect("descendant process ID");
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shell must spawn its descendant");
+
+        drop(containment);
+        tokio::time::timeout(std::time::Duration::from_secs(1), child.wait())
+            .await
+            .expect("group leader must exit after containment is dropped")
+            .expect("group leader wait must succeed");
+        let descendant_path = PathBuf::from(format!("/proc/{descendant}"));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while descendant_path.exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("descendant must be reaped after containment is dropped");
+    }
+
+    fn native_absolute_root() -> PathBuf {
+        std::env::current_dir()
+            .expect("test current directory")
+            .join("target")
+            .join("automata-fixtures")
+    }
+
+    #[test]
+    fn state_directories_follow_each_platform_convention() {
+        let root = native_absolute_root();
+        let local_app_data = root.join("windows").join("local");
+        let xdg_state_home = root.join("xdg").join("state");
+        let home = root.join("users").join("example");
+        let environment = StateEnvironment {
+            local_app_data: Some(local_app_data.clone().into_os_string()),
+            xdg_state_home: Some(xdg_state_home.clone().into_os_string()),
+            home: Some(home.clone().into_os_string()),
+        };
+        assert_eq!(
+            resolve_state_directory(None, "windows", &environment)
+                .expect("Windows state directory"),
+            local_app_data.join("Automata").join("local")
+        );
+        assert_eq!(
+            resolve_state_directory(None, "macos", &environment).expect("macOS state directory"),
+            home.join("Library")
+                .join("Application Support")
+                .join("Automata")
+                .join("local")
+        );
+        assert_eq!(
+            resolve_state_directory(None, "linux", &environment).expect("Linux state directory"),
+            xdg_state_home.join("automata").join("local")
+        );
+    }
+
+    #[test]
+    fn explicit_state_directory_must_be_absolute() {
+        let root = native_absolute_root();
+        let environment = StateEnvironment {
+            local_app_data: None,
+            xdg_state_home: None,
+            home: Some(root.clone().into_os_string()),
+        };
+        assert_eq!(
+            resolve_state_directory(Some(Path::new("relative")), "linux", &environment),
+            Err(StateDirectoryError::NotAbsolute)
+        );
+        let absolute = root.join("state").join("automata");
+        assert_eq!(
+            resolve_state_directory(Some(&absolute), "linux", &environment)
+                .expect("absolute state directory"),
+            absolute
+        );
+    }
+
+    #[test]
+    fn explicit_state_directory_rejects_broad_or_ambiguous_roots() {
+        let root = native_absolute_root();
+        let home = root.join("users").join("example");
+        let environment = StateEnvironment {
+            local_app_data: None,
+            xdg_state_home: None,
+            home: Some(OsString::from(&home)),
+        };
+        let filesystem_root = root.ancestors().last().expect("filesystem root");
+        for unsafe_path in [
+            filesystem_root.to_path_buf(),
+            home.clone(),
+            home.parent().expect("home parent").to_path_buf(),
+            root.join("system").join("state"),
+            root.join("state").join("..").join("automata"),
+        ] {
+            assert_eq!(
+                resolve_state_directory(Some(&unsafe_path), "linux", &environment),
+                Err(StateDirectoryError::Unsafe),
+                "unsafe path: {}",
+                unsafe_path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn forged_environment_roots_cannot_authorize_a_broad_state_directory() {
+        let root = native_absolute_root();
+        let filesystem_root = root.ancestors().last().expect("filesystem root");
+        let broad_root = filesystem_root.join("var");
+        let broad_state = broad_root.join("lib");
+        let cases = [
+            (
+                "linux",
+                StateEnvironment {
+                    local_app_data: None,
+                    xdg_state_home: Some(broad_root.clone().into_os_string()),
+                    home: None,
+                },
+            ),
+            (
+                "linux",
+                StateEnvironment {
+                    local_app_data: None,
+                    xdg_state_home: None,
+                    home: Some(broad_root.clone().into_os_string()),
+                },
+            ),
+            (
+                "linux",
+                StateEnvironment {
+                    local_app_data: Some(broad_root.clone().into_os_string()),
+                    xdg_state_home: None,
+                    home: None,
+                },
+            ),
+            (
+                "macos",
+                StateEnvironment {
+                    local_app_data: None,
+                    xdg_state_home: None,
+                    home: Some(broad_root.clone().into_os_string()),
+                },
+            ),
+            (
+                "windows",
+                StateEnvironment {
+                    local_app_data: Some(broad_root.clone().into_os_string()),
+                    xdg_state_home: None,
+                    home: None,
+                },
+            ),
+        ];
+        for (operating_system, environment) in cases {
+            assert_eq!(
+                resolve_state_directory(Some(&broad_state), operating_system, &environment),
+                Err(StateDirectoryError::Unsafe),
+                "forged {operating_system} environment root must fail closed"
+            );
+        }
+    }
+
+    #[test]
+    fn report_contract_is_schema_versioned_and_actionable() {
+        let report = report("linux", "x86_64", &healthy_probes(CONTEXT_UNIX));
+        assert_eq!(
+            serde_json::to_value(report).expect("doctor report must serialize"),
+            json!({
+                "schema": 1,
+                "ready": true,
+                "platform": {
+                    "operating_system": "linux",
+                    "architecture": "x86_64"
+                },
+                "state_directory": "/state/automata/local",
+                "requested_engine": "auto",
+                "selected_engine": {
+                    "engine": "docker",
+                    "compose": "docker_plugin",
+                    "endpoint": "unix_socket",
+                    "engine_id": "engine-identity",
+                    "server_version": "29.7.2",
+                    "api_version": "1.55",
+                    "architecture": "amd64",
+                    "compose_version": "5.4.0"
+                },
+                "issues": []
+            })
+        );
+    }
+}

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -175,8 +175,8 @@ The three `runner.local-N.example.json` files assume:
 - durable journal and spool state below `/var/lib/automata-runner`;
 - Linux 6.4 or newer with three dedicated, bounded `tmpfs,noswap` mounts at
   `/run/automata_runner_1` through `/run/automata_runner_3`;
-- distinct TLS leaves/keys and spool keys below each
-  `/etc/automata-runner/instances/N` boundary;
+- dynamically enrolled TLS leaves/keys and operator-provisioned spool keys below
+  each `/etc/automata-runner/instances/N` boundary;
 - a control-plane runner listener reachable at the configured HTTPS URL;
 - the same RustFS bucket and prefix used by the server;
 - the pinned Ubuntu 24.04 OCI image is available by its exact digest; and
@@ -395,15 +395,16 @@ retries a mutable tag. The checked-in local example intentionally omits the
 field because the repository does not hardcode an unpublished or machine-local
 candidate digest.
 
-## 2. Provision runner inputs
+## 2. Provision runner inputs and enroll identity
 
-Each instance `N` expects:
+Before enrollment, each instance `N` expects:
 
-- `/etc/automata-runner/instances/N/tls/server-ca.pem` — server trust roots;
-- `/etc/automata-runner/instances/N/tls/runner.pem` — that instance's unique
-  runner certificate chain;
-- `/etc/automata-runner/instances/N/tls/runner-key.pem` — that instance's
-  unique private key, owned by the runner account with mode `0600`;
+- its reviewed JSON configuration installed at
+  `/etc/automata-runner/instances/N/runner.json`, root-owned with mode `0640`,
+  grouped to that runner's service group, and containing the final identity
+  and paths;
+- an empty `/etc/automata-runner/instances/N/tls` directory with mode `0700`,
+  owned by the exact `automata-runner-N` account that will run the daemon;
 - `/etc/automata-runner/instances/N/secrets/spool-key-v1.hex` — that instance's
   unique 64-hexadecimal-character key, owned by the runner account with mode
   `0600`;
@@ -420,11 +421,24 @@ Each instance `N` expects:
 - exact root-owned Podman, conmon, crun, catatonit, and seccomp-profile paths
   matching the JSON configuration.
 
-Before starting the host, follow the control-plane guide's
-[runner enrollment](https://github.com/automata-ci/automata/blob/main/docs/deployment.md#enroll-the-three-runners)
-for all three configurations. Create a separate one-use token for each process;
-each runner generates its private key locally, submits its canonical capability
-document, and installs the returned client-only chain and server roots.
+The TLS files are enrollment outputs, not inputs to issue or install manually.
+Run each enrollment as that instance's exact service account, using the same
+installed configuration, stable runner name, and account that systemd will use.
+Enrollment creates its private key and private recovery state inside the TLS
+directory, submits its canonical capability document, and installs
+`server-ca.pem`, `runner.pem`, and `runner-key.pem` there. Keep the parent
+instance path on trusted, non-group-writable ancestors, but do not make the TLS
+directory root-owned or group-writable. Never enroll as root or as an operator
+account and then copy the private key into place.
+
+Follow the host guide's
+[three-account dynamic enrollment procedure](../../../deploy/runner-host/README.md#dynamically-enroll-three-independent-identities)
+for all three configurations. It mints a separate one-use token for each
+process and starts the services only after every enrollment succeeds. If an
+enrollment is interrupted, repeat the same command as the same account with
+the same server, configuration, and runner name and with standard input from
+`/dev/null`. The private stage retains the original token and key; do not mint
+a replacement token or delete the stage.
 
 Use owner-only file sources or the process supervisor's private credential
 facility. Do not place secret values in the JSON file, shell history, service
@@ -472,15 +486,13 @@ GitHub origins and must leave `map_github_server_to_host_gateway` disabled.
 
 ## 4. Start the runner
 
-Run the installed binary as the dedicated account:
-
-```console
-automata-runner run \
-  --config /path/to/runner.local.json
-```
-
-The checked-in JSON uses conventional service paths and may be run directly
-only when those exact assumptions are true.
+After all three identities are enrolled, start and verify the checked-in
+systemd services as described in the
+[three-process host guide](../../../deploy/runner-host/README.md#start-and-observe-the-trio).
+Its `automata-runner run` process uses the exact service account and installed
+configuration that owned enrollment. The checked-in JSON uses conventional
+service paths; do not start it under a different account or before all of its
+host-path and mount assumptions are true.
 
 Public source repositories and actions use anonymous access. When the exact
 GitHub provider registry is configured, a materialized Standard job may instead

--- a/crates/automata-ci/Cargo.toml
+++ b/crates/automata-ci/Cargo.toml
@@ -30,6 +30,7 @@ automata-ci-credential-github.workspace = true
 automata-ci-github.workspace = true
 automata-ci-github-delivery.workspace = true
 automata-ci-key-management.workspace = true
+automata-ci-local.workspace = true
 automata-ci-metrics.workspace = true
 automata-ci-oidc-github.workspace = true
 automata-ci-oidc-github-control.workspace = true

--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -232,8 +232,10 @@ before applying the firewall policy.
 ## Workflow admission and autonomous progress
 
 The server exposes no local bearer workflow ingress. Configure the exact GitHub
-provider registry below to admit supported signed `push` webhooks for
-`.ci/workflows/ci.yml` on `refs/heads/main`.
+provider registry below to admit supported signed GitHub webhook deliveries.
+For an admitted revision, `all_direct` workflow discovery selects every direct
+lowercase `.yml` or `.yaml` file under `.ci/workflows/`; nested paths, other
+extensions, and unauthenticated revisions are rejected.
 
 Admission validates and persists immutable workflow evidence asynchronously.
 Its durable receipt does not mean a job has finished: the mandatory autonomous
@@ -385,13 +387,15 @@ compatibility mode.
 
 The GitHub App webhook URL is the public Automata origin plus
 `/webhooks/github`. Configure GitHub with the same HMAC secret referenced by the
-manifest, subscribe it to `push` events, and grant `checks:write` for every
-entry plus `contents:read` only for Private source. The current manifest and
-delivery contract admit only `.ci/workflows/ci.yml` on
-`refs/heads/main` for the `push` event; another workflow, ref, or event is
-rejected rather than silently generalized. Rotations advance the relevant
-configuration, verifier, manifest, policy, and authority revisions rather than
-reusing an old identity with changed bytes.
+manifest, subscribe only to the supported `push`, `pull_request`, `merge_group`,
+and `repository_dispatch` events selected for the installation. The App's
+registration-wide permissions are Checks write, Contents read, Pull requests
+read, and Merge queues read; Automata's private-source authority remains scoped
+separately per repository. Each event must satisfy its exact configured
+source-selection policy; an unconfigured event, source, or revision is rejected
+rather than silently generalized. Rotations advance the relevant configuration,
+verifier, manifest, policy, and authority revisions rather than reusing an old
+identity with changed bytes.
 
 ## Repository publication
 

--- a/crates/automata-ci/config/github-provider.example.json
+++ b/crates/automata-ci/config/github-provider.example.json
@@ -43,8 +43,8 @@
           {
             "selector": "ubuntu-24.04",
             "environment_profile": {
-              "id": "automata.dev/ubuntu-24-04-x64",
-              "manifest_sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+              "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
+              "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648"
             },
             "operating_system": "linux",
             "architecture": "x86_64",
@@ -151,8 +151,8 @@
           {
             "selector": "ubuntu-24.04",
             "environment_profile": {
-              "id": "automata.dev/ubuntu-24-04-x64",
-              "manifest_sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+              "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
+              "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648"
             },
             "operating_system": "linux",
             "architecture": "x86_64",

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -19,6 +19,8 @@ pub enum Command {
     /// This explicit mode is intended for release-image smoke tests and local
     /// UI previews. It never starts durable stores, Results, or runner control.
     Preview(PreviewArgs),
+    /// Inspect prerequisites for a disposable local Automata installation.
+    Local(LocalArgs),
     /// Authenticate the operator CLI and manage its server-scoped session.
     Auth(AuthArgs),
     /// Manage encrypted Actions secrets.
@@ -44,9 +46,50 @@ impl Command {
             Self::Rerun(args) => Some(&args.operator),
             Self::Runner(args) => Some(&args.operator),
             Self::Admin(args) => Some(&args.operator),
-            Self::Server(_) | Self::Preview(_) => None,
+            Self::Server(_) | Self::Preview(_) | Self::Local(_) => None,
         }
     }
+}
+
+#[derive(Debug, Args)]
+/// Disposable local-installation commands.
+pub struct LocalArgs {
+    /// Local-installation operation to perform.
+    #[command(subcommand)]
+    pub command: LocalCommand,
+}
+
+#[derive(Debug, Subcommand)]
+/// Operations supported by the local-installation supervisor.
+pub enum LocalCommand {
+    /// Check this host without creating containers or local state.
+    Doctor(LocalDoctorArgs),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+#[value(rename_all = "kebab-case")]
+/// Container engine selected for the disposable local installation.
+pub enum LocalContainerEngine {
+    /// Select the portable Docker Engine path.
+    #[default]
+    Auto,
+    /// Require Docker Engine and Compose plugin version 2.20.0 or newer.
+    Docker,
+}
+
+#[derive(Debug, Args)]
+/// Read-only local-installation preflight options.
+pub struct LocalDoctorArgs {
+    /// Container engine to inspect.
+    #[arg(long, env = "AUTOMATA_LOCAL_ENGINE", value_enum, default_value_t)]
+    pub engine: LocalContainerEngine,
+    /// Dedicated root below a platform user-state directory. A native default is used when omitted.
+    #[arg(long, env = "AUTOMATA_LOCAL_STATE_DIR", value_name = "USER_STATE_PATH")]
+    pub state_dir: Option<PathBuf>,
+    /// Render one stable JSON document instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/automata-ci/src/cli/execution.rs
+++ b/crates/automata-ci/src/cli/execution.rs
@@ -221,8 +221,8 @@ pub async fn execute_control_plane_command(
         }
         Command::Rerun(args) => execute_rerun_command(server_url, output, args).await,
         Command::Runner(args) => execute_runner_command(server_url, output, args).await,
-        Command::Server(_) | Command::Preview(_) => {
-            bail!("service commands cannot be sent to a running control plane")
+        Command::Server(_) | Command::Preview(_) | Command::Local(_) => {
+            bail!("local and service commands cannot be sent to a running control plane")
         }
     }
 }

--- a/crates/automata-ci/src/cli/mod.rs
+++ b/crates/automata-ci/src/cli/mod.rs
@@ -36,10 +36,10 @@ use clap::{CommandFactory, FromArgMatches, Parser, error::ErrorKind};
 
 pub use commands::{
     AdminArgs, AdminCommand, AuthArgs, AuthCommand, Command, DatabaseTransport,
-    EnvironmentReviewArgs, EnvironmentReviewDecision, OperatorArgs, PreviewArgs, RerunArgs,
-    RerunSelection, RunnerArgs, RunnerCommand, RunnerTokenArgs, SecretArgs, SecretCommand,
-    SecretCreateArgs, SecretDeleteArgs, SecretListArgs, SecretProviderArgs, SecretProviderCommand,
-    ServerArgs,
+    EnvironmentReviewArgs, EnvironmentReviewDecision, LocalArgs, LocalCommand,
+    LocalContainerEngine, LocalDoctorArgs, OperatorArgs, PreviewArgs, RerunArgs, RerunSelection,
+    RunnerArgs, RunnerCommand, RunnerTokenArgs, SecretArgs, SecretCommand, SecretCreateArgs,
+    SecretDeleteArgs, SecretListArgs, SecretProviderArgs, SecretProviderCommand, ServerArgs,
 };
 pub use output::OutputFormat;
 pub use values::{RepositoryRef, SecretScope};

--- a/crates/automata-ci/src/lib.rs
+++ b/crates/automata-ci/src/lib.rs
@@ -12,6 +12,7 @@ pub mod app;
 /// Immutable executable version and source-revision metadata.
 pub mod build_info;
 pub mod cli;
+mod local;
 pub mod preview;
 pub mod server;
 /// Cooperative process-shutdown coordination.
@@ -57,10 +58,11 @@ async fn execute(cli: Cli) -> Result<()> {
     match &cli.command {
         Command::Server(args) => Box::pin(server::serve(args)).await,
         Command::Preview(args) => preview::serve(args).await,
+        Command::Local(args) => Box::pin(local::execute(args)).await,
         command => {
             let operator = command
                 .operator()
-                .expect("service commands are handled before operator dispatch");
+                .expect("local and service commands are handled before operator dispatch");
             cli::execute_control_plane_command(&operator.server_url, operator.output, command).await
         }
     }

--- a/crates/automata-ci/src/local/mod.rs
+++ b/crates/automata-ci/src/local/mod.rs
@@ -1,0 +1,116 @@
+use anyhow::{Result, bail};
+use automata_ci_local::{
+    ComposeFrontend, DoctorReport, DoctorRequest, Engine, EngineArchitecture, EngineEndpoint,
+    EngineRequest, inspect,
+};
+
+use crate::cli::{LocalArgs, LocalCommand, LocalContainerEngine, LocalDoctorArgs};
+
+pub(crate) async fn execute(args: &LocalArgs) -> Result<()> {
+    match &args.command {
+        LocalCommand::Doctor(args) => Box::pin(doctor(args)).await,
+    }
+}
+
+async fn doctor(args: &LocalDoctorArgs) -> Result<()> {
+    let request = DoctorRequest::new(engine_request(args.engine), args.state_dir.clone());
+    let mut inspection = Box::pin(inspect(request));
+    let report = tokio::select! {
+        biased;
+        () = crate::shutdown::wait_without_logging() => {
+            drop(inspection);
+            bail!("local preflight interrupted by a process shutdown signal")
+        }
+        report = &mut inspection => report,
+    };
+    if args.json {
+        serde_json::to_writer_pretty(std::io::stdout().lock(), &report)?;
+        println!();
+    } else {
+        print_human_report(&report);
+    }
+
+    if !report.ready() {
+        bail!("local preflight failed; resolve the unavailable checks above")
+    }
+    Ok(())
+}
+
+const fn engine_request(engine: LocalContainerEngine) -> EngineRequest {
+    match engine {
+        LocalContainerEngine::Auto => EngineRequest::Auto,
+        LocalContainerEngine::Docker => EngineRequest::Docker,
+    }
+}
+
+fn print_human_report(report: &DoctorReport) {
+    println!(
+        "Automata local preflight: {}",
+        if report.ready() { "ready" } else { "not ready" }
+    );
+    println!(
+        "Platform: {}/{}",
+        report.operating_system(),
+        report.architecture()
+    );
+    match report.state_directory() {
+        Some(path) => println!("State directory: {path}"),
+        None => println!("State directory: unavailable"),
+    }
+    match report.selected_engine() {
+        Some(selection) => println!(
+            "Container engine: {} {} (API {})",
+            engine_name(selection.engine()),
+            selection.server_version(),
+            selection.api_version()
+        ),
+        None => println!("Container engine: unavailable"),
+    }
+    if let Some(selection) = report.selected_engine() {
+        println!("Engine endpoint: {}", endpoint_name(selection.endpoint()));
+        println!("Engine identity: {}", selection.engine_id());
+        println!(
+            "Execution platform: linux/{}",
+            architecture_name(selection.architecture())
+        );
+        println!(
+            "Compose frontend: {} {}",
+            compose_name(selection.compose()),
+            selection.compose_version()
+        );
+    }
+    for issue in report.issues() {
+        println!(
+            "Problem ({:?}/{:?}): {}",
+            issue.probe(),
+            issue.code(),
+            issue.message()
+        );
+    }
+}
+
+const fn engine_name(engine: Engine) -> &'static str {
+    match engine {
+        Engine::Docker => "docker",
+    }
+}
+
+const fn compose_name(frontend: ComposeFrontend) -> &'static str {
+    match frontend {
+        ComposeFrontend::DockerPlugin => "docker compose",
+    }
+}
+
+const fn endpoint_name(endpoint: EngineEndpoint) -> &'static str {
+    match endpoint {
+        EngineEndpoint::UnixSocket => "local Unix socket",
+        EngineEndpoint::WindowsNamedPipe => "local Windows named pipe",
+    }
+}
+
+const fn architecture_name(architecture: EngineArchitecture) -> &'static str {
+    match architecture {
+        EngineArchitecture::Amd64 => "amd64",
+        EngineArchitecture::Arm64 => "arm64",
+    }
+}

--- a/crates/automata-ci/src/shutdown.rs
+++ b/crates/automata-ci/src/shutdown.rs
@@ -5,47 +5,60 @@ use tracing::warn;
 
 /// Waits for the platform's normal process shutdown signal.
 pub async fn wait() {
-    wait_for_platform_signal().await;
+    wait_for_platform_signal(true).await;
+}
+
+pub(crate) async fn wait_without_logging() {
+    wait_for_platform_signal(false).await;
 }
 
 #[cfg(unix)]
-async fn wait_for_platform_signal() {
+async fn wait_for_platform_signal(log_signal: bool) {
     use tokio::signal::unix::{SignalKind, signal};
 
     let mut terminate = match signal(SignalKind::terminate()) {
         Ok(signal) => signal,
         Err(error) => {
-            error!(%error, "failed to install SIGTERM handler");
-            wait_for_ctrl_c().await;
+            if log_signal {
+                error!(%error, "failed to install SIGTERM handler");
+            }
+            wait_for_ctrl_c(log_signal).await;
             return;
         }
     };
 
     tokio::select! {
         result = tokio::signal::ctrl_c() => {
-            match result {
-                Ok(()) => info!("received interrupt signal; starting graceful shutdown"),
-                Err(error) => error!(%error, "failed to wait for interrupt signal"),
+            if log_signal {
+                match result {
+                    Ok(()) => info!("received interrupt signal; starting graceful shutdown"),
+                    Err(error) => error!(%error, "failed to wait for interrupt signal"),
+                }
             }
         }
         received = terminate.recv() => {
-            if received.is_some() {
-                info!("received SIGTERM; starting graceful shutdown");
-            } else {
-                warn!("SIGTERM signal stream ended; starting graceful shutdown");
+            if log_signal {
+                if received.is_some() {
+                    info!("received SIGTERM; starting graceful shutdown");
+                } else {
+                    warn!("SIGTERM signal stream ended; starting graceful shutdown");
+                }
             }
         }
     }
 }
 
 #[cfg(not(unix))]
-async fn wait_for_platform_signal() {
-    wait_for_ctrl_c().await;
+async fn wait_for_platform_signal(log_signal: bool) {
+    wait_for_ctrl_c(log_signal).await;
 }
 
-async fn wait_for_ctrl_c() {
-    match tokio::signal::ctrl_c().await {
-        Ok(()) => info!("received interrupt signal; starting graceful shutdown"),
-        Err(error) => error!(%error, "failed to wait for interrupt signal"),
+async fn wait_for_ctrl_c(log_signal: bool) {
+    let result = tokio::signal::ctrl_c().await;
+    if log_signal {
+        match result {
+            Ok(()) => info!("received interrupt signal; starting graceful shutdown"),
+            Err(error) => error!(%error, "failed to wait for interrupt signal"),
+        }
     }
 }

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -1,6 +1,6 @@
 use automata_ci::cli::{
-    AuthCommand, Cli, Command, EnvironmentReviewDecision, OutputFormat, RepositoryRef,
-    RerunSelection, SecretCommand, SecretProviderCommand, SecretScope,
+    AuthCommand, Cli, Command, EnvironmentReviewDecision, LocalCommand, LocalContainerEngine,
+    OutputFormat, RepositoryRef, RerunSelection, SecretCommand, SecretProviderCommand, SecretScope,
 };
 use automata_ci::server::{ServerConfig, ServerConfigError};
 use clap::{CommandFactory as _, Parser as _};
@@ -23,6 +23,52 @@ fn preview_is_an_explicit_dependency_free_mode() {
         panic!("preview command expected");
     };
     assert_eq!(args.listen.to_string(), "127.0.0.1:8080");
+}
+
+#[test]
+fn local_doctor_is_an_explicit_read_only_preflight() {
+    let cli = Cli::try_parse_from([
+        "automata",
+        "local",
+        "doctor",
+        "--engine",
+        "docker",
+        "--state-dir",
+        "/tmp/automata-local",
+        "--json",
+    ])
+    .expect("local doctor must parse");
+
+    let Command::Local(local) = cli.command else {
+        panic!("local command expected");
+    };
+    let LocalCommand::Doctor(args) = local.command;
+    assert_eq!(args.engine, LocalContainerEngine::Docker);
+    assert_eq!(
+        args.state_dir.as_deref(),
+        Some(std::path::Path::new("/tmp/automata-local"))
+    );
+    assert!(args.json);
+
+    assert!(
+        Cli::try_parse_from(["automata", "local", "doctor", "--engine", "podman"]).is_err(),
+        "an unqualified engine must not enter the local installation contract"
+    );
+    assert!(
+        Cli::try_parse_from([
+            "automata",
+            "local",
+            "doctor",
+            "--server-url",
+            "https://ci.example.test",
+        ])
+        .is_err(),
+        "local lifecycle commands must not inherit the remote operator endpoint"
+    );
+    assert!(
+        Cli::try_parse_from(["automata", "local", "doctor", "--output", "json"]).is_err(),
+        "local lifecycle output must remain an explicit command contract"
+    );
 }
 
 #[test]
@@ -161,6 +207,7 @@ fn only_operational_top_level_commands_are_advertised() {
         [
             "server",
             "preview",
+            "local",
             "auth",
             "secret",
             "environment-review",
@@ -583,9 +630,9 @@ fn operator_options_are_scoped_to_operator_commands() {
 }
 
 #[test]
-fn operator_options_are_not_advertised_or_accepted_by_service_commands() {
+fn operator_options_are_not_advertised_or_accepted_by_non_operator_commands() {
     let mut command = Cli::command();
-    for service in ["server", "preview"] {
+    for service in ["server", "preview", "local"] {
         let help = command
             .find_subcommand_mut(service)
             .expect("service command")

--- a/crates/automata-ci/tests/local_doctor_process.rs
+++ b/crates/automata-ci/tests/local_doctor_process.rs
@@ -1,0 +1,368 @@
+#![cfg(unix)]
+
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt as _,
+    path::{Path, PathBuf},
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use rustix::{
+    io::Errno,
+    process::{Pid, Signal, kill_process, test_kill_process},
+};
+use serde_json::Value;
+use uuid::Uuid;
+
+const FAILURE_SENTINEL: &str = "FAKE_DOCKER_FAILURE_MUST_NOT_ESCAPE";
+
+#[test]
+fn failed_local_doctor_is_typed_actionable_json_and_does_not_create_state() {
+    let fixture = Fixture::new();
+    let fake_bin = fixture.path().join("bin");
+    fs::create_dir(&fake_bin).expect("create isolated executable directory");
+    install_fake_docker(&fake_bin.join("docker"));
+    let state_directory = fixture.path().join("state");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_automata"))
+        .args(["local", "doctor", "--json", "--state-dir"])
+        .arg(&state_directory)
+        .env_clear()
+        .env("PATH", &fake_bin)
+        .env("HOME", fixture.path())
+        .output()
+        .expect("local doctor process must start");
+
+    assert!(!output.status.success());
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must contain one JSON document");
+    assert_eq!(report["schema"], 1);
+    assert_eq!(report["ready"], false);
+    assert!(report["selected_engine"].is_null());
+    assert_eq!(
+        report["state_directory"],
+        state_directory
+            .to_str()
+            .expect("fixture path must be Unicode")
+    );
+
+    let issues = report["issues"]
+        .as_array()
+        .expect("doctor issues must be an array");
+    assert_issue(
+        issues,
+        "docker_version",
+        "docker_daemon_unavailable",
+        "start Docker Engine and allow this user to access its local socket",
+    );
+    assert_issue(
+        issues,
+        "docker_info",
+        "docker_daemon_unavailable",
+        "start Docker Engine and allow this user to access its local socket",
+    );
+    assert_issue(
+        issues,
+        "docker_compose",
+        "docker_compose_unavailable",
+        "install Docker Compose CLI plugin version 2.20.0 or newer",
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("doctor JSON must be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("doctor diagnostics must be UTF-8");
+    assert!(!stdout.contains("Automata local preflight:"));
+    assert!(!stdout.contains(FAILURE_SENTINEL));
+    assert_eq!(
+        stderr,
+        "Error: local preflight failed; resolve the unavailable checks above\n"
+    );
+    assert!(!stderr.contains(FAILURE_SENTINEL));
+
+    assert!(
+        !state_directory.exists(),
+        "the read-only preflight must not create its resolved state directory"
+    );
+    let mut fixture_entries = fs::read_dir(fixture.path())
+        .expect("read fixture root")
+        .map(|entry| {
+            entry
+                .expect("read fixture entry")
+                .file_name()
+                .into_string()
+                .expect("fixture entry must be Unicode")
+        })
+        .collect::<Vec<_>>();
+    fixture_entries.sort();
+    assert_eq!(fixture_entries, ["bin"]);
+}
+
+#[test]
+fn interrupted_local_doctor_terminates_every_probe_process_tree() {
+    let fixture = Fixture::new();
+    let fake_bin = fixture.path().join("bin");
+    let process_directory = fixture.path().join("processes");
+    fs::create_dir(&fake_bin).expect("create isolated executable directory");
+    fs::create_dir(&process_directory).expect("create process evidence directory");
+    install_hanging_fake_docker(&fake_bin.join("docker"));
+    let state_directory = fixture.path().join("state");
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_automata"));
+    command
+        .args(["local", "doctor", "--json", "--state-dir"])
+        .arg(&state_directory)
+        .env_clear()
+        .env("PATH", &fake_bin)
+        .env("HOME", fixture.path())
+        .env("FAKE_DOCKER_PROCESS_DIRECTORY", &process_directory)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let process = ChildGuard::spawn(&mut command);
+    let probe_processes = wait_for_probe_processes(&process_directory);
+    let mut cleanup = ProcessCleanup::new(probe_processes.clone());
+
+    kill_process(process.pid(), Signal::INT).expect("interrupt local doctor");
+    let output = process.wait_for_output(Duration::from_secs(5));
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "an interrupted doctor emits no partial JSON: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8(output.stderr).expect("doctor diagnostics must be UTF-8");
+    assert!(
+        stderr.contains("local preflight interrupted by a process shutdown signal"),
+        "unexpected interrupted-doctor diagnostics: {stderr}"
+    );
+
+    wait_for_processes_to_exit(&probe_processes);
+    cleanup.disarm();
+    assert!(
+        !state_directory.exists(),
+        "an interrupted preflight must not create its resolved state directory"
+    );
+}
+
+fn assert_issue(issues: &[Value], probe: &str, code: &str, message: &str) {
+    assert!(
+        issues.iter().any(|issue| {
+            issue["probe"] == probe && issue["code"] == code && issue["message"] == message
+        }),
+        "missing {probe}/{code} issue in {issues:?}"
+    );
+}
+
+fn install_fake_docker(path: &Path) {
+    fs::write(
+        path,
+        format!(
+            r#"#!/bin/sh
+set -eu
+case "${{1-}}" in
+  context)
+    printf '%s\n' '{{"Name":"default","Endpoints":{{"docker":{{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}}}}}}'
+    ;;
+  version|info)
+    printf '%s\n' '{FAILURE_SENTINEL}' >&2
+    exit 1
+    ;;
+  compose)
+    printf '%s\n' '{FAILURE_SENTINEL}' >&2
+    exit 1
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+"#
+        ),
+    )
+    .expect("write fake docker executable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .expect("make fake docker executable owner-only");
+}
+
+fn install_hanging_fake_docker(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+/bin/sleep 30 &
+descendant=$!
+printf '%s %s\n' "$$" "$descendant" > "${FAKE_DOCKER_PROCESS_DIRECTORY}/$$"
+wait
+"#,
+    )
+    .expect("write hanging fake docker executable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .expect("make hanging fake docker executable owner-only");
+}
+
+fn wait_for_probe_processes(directory: &Path) -> Vec<Pid> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let processes = recorded_probe_processes(directory);
+        if processes.len() == 8 {
+            return processes;
+        }
+        if Instant::now() >= deadline {
+            for process in &processes {
+                let _ignored = kill_process(*process, Signal::KILL);
+            }
+            panic!("expected four probe leaders and descendants, found {processes:?}");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn recorded_probe_processes(directory: &Path) -> Vec<Pid> {
+    let mut processes = fs::read_dir(directory)
+        .expect("read process evidence directory")
+        .filter_map(|entry| fs::read_to_string(entry.ok()?.path()).ok())
+        .flat_map(|contents| {
+            contents
+                .split_whitespace()
+                .filter_map(|raw| raw.parse::<i32>().ok())
+                .filter_map(Pid::from_raw)
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    processes.sort_by_key(|process| process.as_raw_pid());
+    processes.dedup_by_key(|process| process.as_raw_pid());
+    processes
+}
+
+fn wait_for_processes_to_exit(processes: &[Pid]) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let running = processes
+            .iter()
+            .copied()
+            .filter(|process| process_exists(*process))
+            .collect::<Vec<_>>();
+        if running.is_empty() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "probe processes survived local-doctor interruption: {running:?}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn process_exists(process: Pid) -> bool {
+    match test_kill_process(process) {
+        Ok(()) => true,
+        Err(Errno::SRCH) => false,
+        Err(error) => panic!("could not inspect probe process {process:?}: {error}"),
+    }
+}
+
+struct ChildGuard {
+    child: Option<Child>,
+}
+
+impl ChildGuard {
+    fn spawn(command: &mut Command) -> Self {
+        let child = command.spawn().expect("local doctor process must start");
+        Self { child: Some(child) }
+    }
+
+    fn pid(&self) -> Pid {
+        let raw = i32::try_from(self.child.as_ref().expect("live child").id())
+            .expect("child process ID must fit pid_t");
+        Pid::from_raw(raw).expect("child process ID must be nonzero")
+    }
+
+    fn wait_for_output(mut self, timeout: Duration) -> Output {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self
+                .child
+                .as_mut()
+                .expect("live child")
+                .try_wait()
+                .expect("inspect local doctor status")
+                .is_some()
+            {
+                return self
+                    .child
+                    .take()
+                    .expect("completed child")
+                    .wait_with_output()
+                    .expect("collect local doctor output");
+            }
+            assert!(
+                Instant::now() < deadline,
+                "local doctor did not exit after its shutdown signal"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ignored = child.kill();
+            let _ignored = child.wait();
+        }
+    }
+}
+
+struct ProcessCleanup {
+    processes: Vec<Pid>,
+}
+
+impl ProcessCleanup {
+    fn new(processes: Vec<Pid>) -> Self {
+        Self { processes }
+    }
+
+    fn disarm(&mut self) {
+        self.processes.clear();
+    }
+}
+
+impl Drop for ProcessCleanup {
+    fn drop(&mut self) {
+        for process in &self.processes {
+            let _ignored = kill_process(*process, Signal::KILL);
+        }
+    }
+}
+
+struct Fixture {
+    parent: PathBuf,
+    path: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let parent = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("local-doctor-process");
+        fs::create_dir_all(&parent).expect("create target-local fixture parent");
+        let path = parent.join(format!("fixture-{}", Uuid::new_v4()));
+        fs::create_dir(&path).expect("create unique local doctor fixture");
+        Self { parent, path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let safe_name = self
+            .path
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .is_some_and(|name| name.starts_with("fixture-"));
+        if safe_name && self.path.parent() == Some(self.parent.as_path()) {
+            let _ignored = fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/deploy/runner-host/README.md
+++ b/deploy/runner-host/README.md
@@ -48,10 +48,12 @@ for instance in 1 2 3; do
 done
 ```
 
-Install the binary, units, and private directory declarations as root:
+Install the reviewed binary, units, and private directory declarations as root:
 
 ```console
-sudo install -o root -g root -m 0755 automata-runner /usr/bin/automata-runner
+runner_binary="$(command -v automata-runner)"
+test -n "$runner_binary"
+sudo install -o root -g root -m 0755 "$runner_binary" /usr/bin/automata-runner
 sudo install -o root -g root -m 0644 \
   deploy/runner-host/systemd/automata-runner@.service \
   deploy/runner-host/systemd/automata-runner-host.slice \
@@ -66,48 +68,49 @@ sudo install -o root -g root -m 0644 \
 sudo systemd-tmpfiles --create /etc/tmpfiles.d/automata-runner-host.conf
 ```
 
+The instance directory and configuration remain root-owned. Each `tls`
+directory is instead mode `0700` and owned by its exact runner account because
+that account creates its private enrollment stage, key, returned chain, and
+server roots there. The parent instance directory is not writable by the runner,
+and no other runner account can traverse the TLS directory. Do not change the
+TLS directory to a shared group-writable location and do not run enrollment as
+root or as the interactive operator.
+
 The three 20 GiB `tmpfs,noswap` mounts are separate capacity boundaries. They
 preserve the runner's exact-mount proof and prevent any instance from sharing
 Podman runtime or storage with another. They are transient provider storage,
 not advertised per-job disk quota; both `ephemeral_disk_bytes` values remain
 zero.
 
-Install one reviewed configuration per instance:
+Install one reviewed configuration per instance. Set
+`AUTOMATA_RUNNER_CONFIG_DIR` to the absolute ignored directory containing the
+three edited `runner-N.json` files; do not install the checked-in examples
+without reviewing their host-specific values. In particular, replace each
+runner ID, endpoint, profile digest/image, Git bridge, resource ceiling, and
+object-store setting as appropriate. Keep all instance-qualified paths and
+ports distinct, then install those reviewed copies:
 
 ```console
+test -n "${AUTOMATA_RUNNER_CONFIG_DIR:-}"
+test "$AUTOMATA_RUNNER_CONFIG_DIR" = "$(realpath "$AUTOMATA_RUNNER_CONFIG_DIR")"
 for instance in 1 2 3; do
   sudo install -o root -g "automata-runner-${instance}" -m 0640 \
-    "crates/automata-ci-runner/config/runner.local-${instance}.example.json" \
+    "$AUTOMATA_RUNNER_CONFIG_DIR/runner-${instance}.json" \
     "/etc/automata-runner/instances/${instance}/runner.json"
   sudo install -o root -g root -m 0600 /dev/null \
     "/etc/automata-runner/instances/${instance}/environment"
 done
 ```
 
-Review every example before starting it. In particular, replace its runner
-ID, endpoints, profile digest/image, Git bridge, resources, and object-store
-settings as appropriate. Keep all instance-qualified paths and ports distinct.
 Write the required S3 variables to each owner-only `environment` file; systemd
 reads that file before changing to the runner account.
 
-## Provision three independent identities
+## Provision non-TLS runner inputs
 
-Issue three different CA-signed `clientAuth` leaves and keys. A leaf or private
-key must never be reused between instances. Install the common server CA and
-the instance leaf/key beneath each instance boundary:
-
-```console
-for instance in 1 2 3; do
-  sudo install -o root -g root -m 0444 server-ca.pem \
-    "/etc/automata-runner/instances/${instance}/tls/server-ca.pem"
-  sudo install -o root -g root -m 0444 "runner-${instance}.pem" \
-    "/etc/automata-runner/instances/${instance}/tls/runner.pem"
-  sudo install \
-    -o "automata-runner-${instance}" -g "automata-runner-${instance}" -m 0600 \
-    "runner-${instance}-key.pem" \
-    "/etc/automata-runner/instances/${instance}/tls/runner-key.pem"
-done
-```
+Do not issue or install runner TLS leaves or keys manually. Do not create
+`server-ca.pem`, `runner.pem`, `runner-key.pem`, or any adjacent enrollment
+stage. The dynamic enrollment step below must observe all three configured TLS
+destinations as absent and creates them without overwriting.
 
 Generate and install a different 32-byte spool key for each instance. The
 example protection IDs are also distinct, so ciphertext cannot silently move
@@ -124,23 +127,62 @@ for instance in 1 2 3; do
 done
 ```
 
-Run `automata-runner capabilities --config ...` once for each configuration
-and build one server static-fleet document containing all three results. Every
-entry needs the matching runner ID, a distinct name and external identity,
-`slots: 1`, and the digest of its own active client leaf. The store deliberately
-allows only one live session per runner ID, so starting three processes against
-one registration is invalid.
-
-## Start and observe the trio
-
-Validate each configuration as the service account, then enable the target:
+Validate the installed configurations as the identities that will run them.
+This checks the immutable capability documents but does not create a
+registration or contact the control plane:
 
 ```console
 for instance in 1 2 3; do
-  sudo -u "automata-runner-${instance}" /usr/bin/automata-runner capabilities \
-    --config "/etc/automata-runner/instances/${instance}/runner.json" \
+  sudo --user="automata-runner-${instance}" -- \
+    /usr/bin/automata-runner capabilities \
+      --config "/etc/automata-runner/instances/${instance}/runner.json" \
     > /dev/null
 done
+```
+
+## Dynamically enroll three independent identities
+
+Complete the control-plane guide through administrator setup and the operator
+CLI login before continuing. The operator creates one short-lived token at a
+time, but the exact service account consumes it from standard input and creates
+its own key and private adjacent request stage. The token and key never enter a
+command argument, the configuration, or another account's custody:
+
+```console
+(
+  set -euo pipefail
+  for instance in 1 2 3; do
+    automata runner --server-url http://127.0.0.1:8080 --output json token \
+    | jq -er '.token | select(type == "string" and length > 0)' \
+    | sudo --user="automata-runner-${instance}" -- \
+        /usr/bin/automata-runner enroll \
+          --server http://127.0.0.1:8080 \
+          --config "/etc/automata-runner/instances/${instance}/runner.json" \
+          --name "local-runner-${instance}"
+  done
+)
+```
+
+Use the canonical HTTPS control-plane origin outside the explicit literal-
+loopback development case. Keep each runner name stable across recovery. If an
+enrollment was interrupted after its request stage was created, rerun the exact
+same `automata-runner enroll` command as the same service account with standard
+input redirected from `/dev/null`; the private stage retains the one-use token,
+operation, and key. Do not mint a replacement token or delete a stage whose
+server outcome is unknown. A retry fails safely when no matching stage exists.
+
+After each successful enrollment, the TLS directory contains the service-
+account-owned server roots and client chain plus a mode-`0600` private key. The
+private request and response stages are removed only after all three final files
+are durably reconciled. The service-account-owned process lock remains adjacent
+to prevent concurrent enrollment against the same destinations.
+
+## Start and observe the trio
+
+Only after all three enrollments succeed, enable the target and verify every
+service:
+
+```console
 sudo systemctl daemon-reload
 sudo systemctl enable --now automata-runner-host.target
 systemctl --no-pager --full status \

--- a/deploy/runner-host/systemd/automata-runner-host.tmpfiles
+++ b/deploy/runner-host/systemd/automata-runner-host.tmpfiles
@@ -8,11 +8,11 @@ d /var/lib/automata-runner/3/home 0700 automata-runner-3 automata-runner-3 -
 d /etc/automata-runner 0755 root root -
 d /etc/automata-runner/instances 0755 root root -
 d /etc/automata-runner/instances/1 0750 root automata-runner-1 -
-d /etc/automata-runner/instances/1/tls 0750 root automata-runner-1 -
+d /etc/automata-runner/instances/1/tls 0700 automata-runner-1 automata-runner-1 -
 d /etc/automata-runner/instances/1/secrets 0750 root automata-runner-1 -
 d /etc/automata-runner/instances/2 0750 root automata-runner-2 -
-d /etc/automata-runner/instances/2/tls 0750 root automata-runner-2 -
+d /etc/automata-runner/instances/2/tls 0700 automata-runner-2 automata-runner-2 -
 d /etc/automata-runner/instances/2/secrets 0750 root automata-runner-2 -
 d /etc/automata-runner/instances/3 0750 root automata-runner-3 -
-d /etc/automata-runner/instances/3/tls 0750 root automata-runner-3 -
+d /etc/automata-runner/instances/3/tls 0700 automata-runner-3 automata-runner-3 -
 d /etc/automata-runner/instances/3/secrets 0750 root automata-runner-3 -

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The quickest ways in are:
 | --- | --- |
 | Build from source and inspect the interface | [Getting started](getting-started.md) |
 | Check support for a workflow feature | [Compatibility](compatibility.md) |
-| Start the durable local composition | [Control-plane setup](deployment.md) |
+| Follow the current manual Arch development assembly | [Control-plane setup](deployment.md) |
 | Prepare a Linux execution host | [Runner bootstrap](../crates/automata-ci-runner/config/README.md) |
 
 The [hosted UI demo](https://automata-ci.github.io/automata/) uses sample data.
@@ -49,6 +49,9 @@ It does not connect to repositories or execute workflows.
   lanes, corpus graduation, and evidence handoff for those work packages.
 - [Implementation plan](implementation-plan.md) tracks completed foundations
   and the acceptance gates that still block a release.
+- [Local installation and deployment roadmap](maintainers/roadmaps/local-installation.md)
+  records the accepted cross-platform evaluation architecture, merge
+  checkpoints, host qualification gates, and later deployment tracks.
 - [Ubuntu 24.04 execution profile](../images/github-hosted-ubuntu-24.04-x64/README.md)
   describes the immutable runner image and its publication policy.
 - [React SSR UI](../ui/README.md) explains the build-time frontend and embedded

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,9 @@
 # Control-plane setup
 
 This guide starts `automata server`, PostgreSQL, RustFS, and three dynamically
-enrolled runner processes on a development machine. Optional sections add
-GitHub login, provider ingress, and the built-in secret provider.
+enrolled runner processes on an Arch Linux development machine. GitHub login is
+required for runner enrollment; repository provider ingress and the built-in
+secret provider remain optional.
 
 > [!CAUTION]
 > This is not a production deployment. Automated certificate rotation,
@@ -13,13 +14,15 @@ GitHub login, provider ingress, and the built-in secret provider.
 | Component | Default local address | Purpose |
 | --- | --- | --- |
 | Human HTTP and SSR | `127.0.0.1:8080` | Health, readiness, UI, authentication, and administration |
-| Results API | `127.0.0.1:8081` | GitHub Actions Results-compatible requests |
+| Results API | Exact firewall-constrained RFC 1918 address on port `8081` | GitHub Actions Results-compatible requests from rootless jobs |
 | Runner control | `127.0.0.1:9090` | Direct HTTP/2 with mandatory mutual TLS |
 | PostgreSQL | `127.0.0.1:5432` | Durable coordination and metadata |
 | RustFS S3 API | `127.0.0.1:9000` | Immutable blobs |
 | RustFS console | `127.0.0.1:9001` | Local object-store administration |
 
-You need Git, rustup, OpenSSL, rootless Podman, and `podman-compose`. The
+You need Git, rustup, OpenSSL, rootless Podman, `podman-compose`, `jq`,
+`secret-tool`, and an unlocked Secret Service with encrypted backing storage.
+The operator is responsible for the external keyring's at-rest protection. The
 repository checkout supplies the Compose definition, local tests, and example
 configuration used below.
 
@@ -126,10 +129,16 @@ for instance in 1 2 3; do
 done
 ```
 
-Finish the [runner host guide](../crates/automata-ci-runner/config/README.md):
-create the owner-only spool keys and service credentials, private state roots,
-rootless Podman mounts, and immutable profiles. Do not pre-create the three TLS
-files named by each configuration; enrollment creates them without overwriting.
+Use the [runner configuration reference](../crates/automata-ci-runner/config/README.md)
+to finish reviewing the three files, then follow the
+[three-process host guide](../deploy/runner-host/README.md) through installation
+of the dedicated accounts, reviewed binary and configurations, owner-only spool
+keys and service environment, private state roots, and rootless Podman mounts.
+Stop before its dynamic-enrollment section until the server and administrator
+setup below are complete. Do not pre-create any configured TLS destination or
+adjacent enrollment stage. Each TLS directory must be mode `0700` and owned by
+its exact service account so enrollment can stage and install that identity
+without giving either of the other accounts access.
 
 On Unix, every ordinary server `file:` secret-source reference must be an
 absolute path. Automata opens each path component without following symbolic
@@ -141,42 +150,16 @@ process arguments, but the service manager must still prevent inherited
 environment disclosure. Prefer a mounted owner-only secret file or a platform
 secret-injection facility for long-running deployments.
 
-## 4. Start the server
-
-```console
-automata server \
-  --results-public-url http://127.0.0.1:8081/ \
-  --results-allow-development-http \
-  --results-signing-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/results-hmac.key" \
-  --control-plane-encryption-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/control-plane-wrapping.key" \
-  --control-plane-encryption-key-id local-control-plane-2026 \
-  --database-url-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/database-url" \
-  --database-transport loopback-plaintext \
-  --s3-endpoint http://127.0.0.1:9000/ \
-  --s3-allow-loopback-http \
-  --s3-bucket automata-dev \
-  --s3-prefix automata/v1 \
-  --s3-kms-key-id default \
-  --s3-access-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-access-key" \
-  --s3-secret-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-secret-key" \
-  --runner-public-url https://localhost:9090/ \
-  --runner-client-ca-cert-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca.pem" \
-  --runner-client-ca-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca-key.pem" \
-  --runner-server-ca-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca.pem" \
-  --runner-server-cert-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/server-chain.pem" \
-  --runner-server-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/server-key.pem"
-```
-
-Startup applies embedded PostgreSQL migrations, verifies the database, and
-performs a conditional immutable write/read probe against RustFS. A failed
-dependency prevents the server from becoming ready.
+## 4. Configure authentication and start the server
 
 ### Enable GitHub human authentication for enrollment
 
-The base command can start without human authentication, but runner enrollment
-is intentionally available only after it is enabled. Create a GitHub App whose
-user callback is the external origin plus
-`/auth/github/callback`, then create local keys:
+Runner enrollment requires GitHub human authentication, and a fresh database
+cannot start without one complete installation bootstrap tuple. Create a
+GitHub App whose user callback is the external origin plus
+`/auth/github/callback`, and enable Device Flow in the App settings. Device
+Flow is opt-in and cannot be enabled by an App Manifest. Then create local
+keys:
 
 ```console
 openssl rand 32 > "$AUTOMATA_LOCAL_SECRET_DIR/auth-session-hmac.key"
@@ -193,7 +176,78 @@ export AUTOMATA_AUTH_KEY_ID=local-auth-2026
 ```
 
 Create `github-client-secret` as an owner-only file; do not export its value or
-put it in an option. Restart the complete server command with these variables.
+put it in an option. Create the one-use bootstrap tuple before the first server
+start:
+
+```console
+openssl rand -hex 32 > "$AUTOMATA_LOCAL_SECRET_DIR/auth-bootstrap.token"
+chmod 0600 "$AUTOMATA_LOCAL_SECRET_DIR/auth-bootstrap.token"
+
+export AUTOMATA_BOOTSTRAP_TOKEN_SOURCE="file:${AUTOMATA_LOCAL_SECRET_DIR}/auth-bootstrap.token"
+export AUTOMATA_BOOTSTRAP_GITHUB_USER_ID='replace-with-numeric-user-id'
+export AUTOMATA_BOOTSTRAP_TENANT_ID=local
+export AUTOMATA_BOOTSTRAP_TENANT_DISPLAY_NAME='Local development'
+```
+
+`AUTOMATA_BOOTSTRAP_GITHUB_USER_ID` is the permitted user's stable numeric
+GitHub ID, not a login. An incomplete tuple or a fresh database without it
+fails closed.
+
+### Apply the Results guard and start
+
+A rootless job cannot reach a Results listener bound to host loopback. Follow
+the [Arch Linux Results-listener firewall](platforms/arch-linux.md#local-results-listener-firewall)
+through its render, route, apply, and audit steps before starting the server.
+Choose the exact private address assigned to this host and export it; the
+example below uses the address from that guide:
+
+```console
+export AUTOMATA_RESULTS_LISTEN_IP=192.168.0.8
+```
+
+Never substitute `0.0.0.0`: this development-only HTTP endpoint must be
+restricted by the documented host firewall before it starts.
+
+```console
+automata server \
+  --results-listen "${AUTOMATA_RESULTS_LISTEN_IP}:8081" \
+  --results-public-url http://host.containers.internal:8081/ \
+  --results-allow-development-http \
+  --results-trusted-private-host host.containers.internal \
+  --results-signing-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/results-hmac.key" \
+  --control-plane-encryption-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/control-plane-wrapping.key" \
+  --control-plane-encryption-key-id local-control-plane-2026 \
+  --database-url-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/database-url" \
+  --database-transport loopback-plaintext \
+  --s3-endpoint http://127.0.0.1:9000/ \
+  --s3-allow-loopback-http \
+  --s3-bucket automata-dev \
+  --s3-prefix automata/v1 \
+  --s3-kms-key-id default \
+  --s3-access-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-access-key" \
+  --s3-secret-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/s3-secret-key" \
+  --runner-public-url https://127.0.0.1:9090/ \
+  --runner-client-ca-cert-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca.pem" \
+  --runner-client-ca-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca-key.pem" \
+  --runner-server-ca-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/runner-ca.pem" \
+  --runner-server-cert-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/server-chain.pem" \
+  --runner-server-key-source "file:${AUTOMATA_LOCAL_SECRET_DIR}/server-key.pem"
+```
+
+Startup applies embedded PostgreSQL migrations, verifies the database, and
+performs a conditional immutable write/read probe against RustFS. A failed
+dependency prevents the server from becoming ready.
+
+Before enrollment or job execution, return to the firewall guide and complete
+its post-start Podman-path capture and separate-LAN denial tests. If either
+fails, stop the server before changing or removing the exact guard.
+
+Finish the one-use `/setup` browser flow as the configured GitHub identity
+before attempting an ordinary CLI login. Remove the bootstrap tuple from future
+server starts after the durable installation reaches `configured`. See
+[Authentication and authorization](authentication.md#enable-github-human-authentication)
+for the complete state machine.
+
 Loopback HTTP works only because the origin is a literal loopback address and
 the development switch is set. Any non-local deployment requires a canonical
 HTTPS origin.
@@ -206,23 +260,32 @@ for setup state, sessions, and key rotation.
 
 ### Enroll the three runners
 
-After restarting the server with human authentication configured, sign in once
+After completing the one-use browser setup, sign in once through the Linux CLI
 and issue a separate 15-minute token for each process. Pipe it directly to the
 runner so it does not enter argv or a shell-history assignment. Literal
 loopback HTTP is accepted only for this explicit development case:
 
 ```console
-automata auth login --server http://127.0.0.1:8080
-for instance in 1 2 3; do
-  automata runner token \
-    --server http://127.0.0.1:8080 \
-    --output json \
-  | jq -r .token \
-  | automata-runner enroll \
-      --server http://127.0.0.1:8080 \
-      --config "$AUTOMATA_RUNNER_CONFIG_DIR/runner-${instance}.json" \
-      --name "local-runner-${instance}"
-done
+automata auth --server-url http://127.0.0.1:8080 login
+(
+  set -euo pipefail
+  for instance in 1 2 3; do
+    automata runner --server-url http://127.0.0.1:8080 --output json token \
+    | jq -er '.token | select(type == "string" and length > 0)' \
+    | sudo --user="automata-runner-${instance}" -- \
+        /usr/bin/automata-runner enroll \
+          --server http://127.0.0.1:8080 \
+          --config "/etc/automata-runner/instances/${instance}/runner.json" \
+          --name "local-runner-${instance}"
+  done
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now automata-runner-host.target
+  systemctl --no-pager --full status \
+    automata-runner@1.service \
+    automata-runner@2.service \
+    automata-runner@3.service
+)
 ```
 
 The runner generates its ECDSA P-256 key locally. The control plane receives a
@@ -232,7 +295,11 @@ and stored only as domain-separated digests. Interrupted enrollment can be
 rerun: a private adjacent stage retains the operation and key until all three
 credential files are durably reconciled, including when the exact server response
 had not yet been staged. The token source is not needed again after that request
-stage has been created. See the
+stage has been created. A retry must use the exact same server, configuration,
+name, and service account, with standard input redirected from `/dev/null`; do
+not create a replacement token or delete private staging after an indeterminate
+server response. The three services start only after every enrollment succeeds.
+See the
 [security and lifecycle plan](runner-control-plane-security-and-enrollment.md).
 
 ### Optional GitHub provider runtime
@@ -260,14 +327,16 @@ all authority UUIDs are unique, nested authority revisions equal the repository
 policy revision, and stable numeric GitHub installation/repository/owner IDs
 must match the App installation. The product reference documents every field,
 rotation rule, webhook path, and `standard` versus `credential_free` output-
-safety choice. Subscribe the App webhook to the configured supported events,
-grant `checks:write` for every registered repository, and grant `contents:read`
-only for Private source. The checked-in example uses the server-owned
-`{"mode":"all_direct"}` workflow selection. It discovers only canonical
-`.yml` and `.yaml` files directly beneath `.ci/workflows/` at the exact
-authenticated source revision; nested files and other extensions are not
-selected. Discovery is bounded by the manifest archive limits, and the sorted
-inventory and each path-local result are durable before the delivery completes.
+safety choice. Subscribe the App webhook to the configured supported events.
+The App's registration-wide permissions are Checks write, Contents read, Pull
+requests read, and Merge queues read; internal private-source authority remains
+scoped separately per repository. Workflow selection is server-owned and
+hardcoded to `all_direct`; it is not a provider-manifest field. That policy
+discovers only canonical `.yml` and `.yaml` files directly beneath
+`.ci/workflows/` at the exact authenticated source revision; nested files and
+other extensions are not selected. Discovery is bounded by the manifest archive
+limits, and the sorted inventory and each path-local result are durable before
+the delivery completes.
 
 The required top-level `transport` is a closed deployment policy. Production
 uses `{"mode":"github_dot_com"}`. The isolated integration suite may instead
@@ -331,43 +400,6 @@ fails startup before the App private key or webhook HMAC is loaded and before
 provider manifests or runtime state are constructed. Set the unauthenticated
 fallback with `--fallback-tenant-id` or `AUTOMATA_FALLBACK_TENANT_ID`; there is
 no tenant chooser or compatibility fallback.
-
-For a fresh database, also provide one complete installation tuple:
-
-```console
-openssl rand -hex 32 > "$AUTOMATA_LOCAL_SECRET_DIR/auth-bootstrap.token"
-chmod 0600 "$AUTOMATA_LOCAL_SECRET_DIR/auth-bootstrap.token"
-
-export AUTOMATA_BOOTSTRAP_TOKEN_SOURCE="file:${AUTOMATA_LOCAL_SECRET_DIR}/auth-bootstrap.token"
-export AUTOMATA_BOOTSTRAP_GITHUB_USER_ID='replace-with-numeric-user-id'
-export AUTOMATA_BOOTSTRAP_TENANT_ID=local
-export AUTOMATA_BOOTSTRAP_TENANT_DISPLAY_NAME='Local development'
-```
-
-`AUTOMATA_BOOTSTRAP_GITHUB_USER_ID` is the permitted user's stable numeric
-GitHub ID, not a login. The tuple arms a one-use challenge and can be removed
-after the durable installation reaches `configured`. While the installation is
-armed, the exact `/setup` page exposes the proof-bound browser setup flow; it is
-withdrawn immediately after setup completes. Device setup remains API-only and
-there is no setup CLI. The
-[authentication guide](authentication.md#enable-github-human-authentication)
-describes that lifecycle. An incomplete tuple or an unconfigured database with
-no tuple prevents startup.
-
-After setup has completed, a Linux workstation with `secret-tool` and an
-unlocked Secret Service can verify the CLI-audience path:
-
-```console
-automata auth --server-url http://127.0.0.1:8080 login
-automata auth --server-url http://127.0.0.1:8080 status
-automata auth --server-url http://127.0.0.1:8080 logout
-```
-
-The client has no plaintext credential-file fallback. It commits the device
-credential to Secret Service before activating the server's short-lived
-pending session. The selected Secret Service must itself provide encrypted
-backing storage; Automata cannot attest how that external keyring persists its
-database.
 
 The control-plane wrapping key is mandatory and must contain exactly 32 random
 bytes. It envelope-encrypts durable runner commands and RPC responses before
@@ -504,12 +536,11 @@ automata admin status
 
 The web interface at <http://127.0.0.1:8080> renders tenant-scoped workflow
 runs from PostgreSQL, with verified job logs and finalized artifacts loaded
-from immutable blob storage. This bootstrap composition uses the configured
-fallback tenant and exposes only data whose durable publication policy permits
-anonymous access. The command above intentionally leaves optional human
-authentication disabled. Private and authenticated views require the complete
-human-auth configuration and, for a new installation, the
-[one-use bootstrap tuple](#enable-github-human-authentication-for-enrollment).
+from immutable blob storage. This composition uses the tenant established by
+the completed one-use setup. Human authentication is enabled by the command
+above; the server exposes anonymously only data whose durable publication
+policy permits it, while private and authenticated views require the configured
+GitHub identity and active session.
 
 An authorized browser can change repository access at
 `/{owner}/{repository}/settings/access`. Dashboard metadata, logs, and artifacts

--- a/docs/development.md
+++ b/docs/development.md
@@ -262,6 +262,25 @@ the locked, reproducible profile environment:
 Read [the UI guide](../ui/README.md) before changing the render contract or
 adding a page kind.
 
+## Local installation preflight
+
+The first cross-platform local-installation slice is a read-only host check for
+x86-64 Linux, Apple Silicon macOS, and x86-64 Windows. It requires a local Linux
+Docker Engine with the supported API and matching architecture, Docker Compose
+plugin version 2.20.0 or newer, resolves a dedicated root below the native
+platform user-state directories, and rejects broad roots and a Unix root
+process:
+
+```console
+cargo run --locked -p automata-ci -- local doctor
+cargo run --locked -p automata-ci -- local doctor --json
+```
+
+The command does not create the state directory or any container resources.
+`local up` and the worker composition remain planned; follow the
+[local installation and deployment roadmap](maintainers/roadmaps/local-installation.md) for
+their merge and host-qualification gates.
+
 ## Local PostgreSQL and RustFS
 
 Start the pinned development services:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -155,15 +155,15 @@ gates have completed their agreed soak periods.
 
 ## Provider scope
 
-Rootless Podman on Linux, disposable macOS Virtualization.framework VMs, and the
-experimental trusted native Windows slice are current execution paths. The
-providers below are planned and must not appear in runner capability inventory
-before their gates pass.
+Rootless Podman on Linux, disposable macOS Virtualization.framework VMs, the
+experimental trusted native Windows slice, and an experimental Kubernetes
+adapter are current component paths. Kubernetes remains unavailable until its
+live cluster gate passes. The providers below are planned and must not appear
+in runner capability inventory before their gates pass.
 
 | Provider | Planned use | Isolation boundary |
 | --- | --- | --- |
 | Firecracker with jailer | Hostile Linux jobs | One KVM microVM per job |
-| Kubernetes | Ephemeral runner fleet | Node and runtime dependent |
 | Kubernetes with Kata | VM-backed pod sandbox | One VM-backed pod per runner |
 | KubeVirt | VM fleet or job sandbox | One VMI per runner or job |
 | Linux native | Trusted jobs | Account, cgroup, and LSM policy |

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -1,0 +1,622 @@
+# Local installation and deployment roadmap
+
+- Roadmap status: Planned
+- Available slice: read-only host preflight from a reviewed source checkout
+- Date: 2026-08-14
+
+This roadmap owns the work required to turn Automata into a product that a new
+user can run locally, connect to one GitHub repository, and later deploy using
+a production topology. Capability claims stay in
+[Compatibility](../../compatibility.md); this page records decisions, dependencies,
+merge checkpoints, and acceptance evidence.
+
+## Product outcome
+
+The first supported experience will run the complete control plane and `N`
+Linux workers on one machine. The host may be Arch Linux, Apple Silicon macOS,
+or Windows, but the quickstart jobs are Linux container jobs on every host.
+Native macOS and native Windows jobs remain separate, advanced execution
+profiles.
+
+The final quickstart contract is:
+
+```console
+automata local doctor
+automata local up --workers 3 --github OWNER/REPOSITORY
+```
+
+`up` is a resumable operation. It may pause for browser confirmation while the
+user creates a private GitHub App, limits its installation to the requested
+repository, and signs in. It must never ask the user to edit JSON, copy numeric
+GitHub IDs, generate UUIDs, or create certificates by hand.
+
+The same flow also has an explicit split form:
+
+```console
+automata local up --workers 3
+automata local github connect OWNER/REPOSITORY
+```
+
+The lifecycle surface will be:
+
+```console
+automata local status [--json]
+automata local logs [SERVICE] [--follow]
+automata local down
+automata local reset
+```
+
+`down` preserves the installation and durable data. `reset` is destructive,
+requires confirmation, and removes only resources owned by the exact local
+installation.
+
+## Current baseline
+
+The source tree does not yet provide that experience. The existing paths have
+different purposes and cannot be combined into a cross-platform quickstart by
+changing documentation alone.
+
+| Existing path | Evidence in the source tree | Why it is not the quickstart |
+| --- | --- | --- |
+| `automata preview` | Starts the SSR interface and health endpoints without dependencies | It does not accept webhooks, schedule jobs, or run workers |
+| `deploy/dev/compose.yaml` | Starts PostgreSQL and RustFS | It does not start the control plane, initialize the bucket, or start workers |
+| Manual control-plane guide | Starts the complete server with hand-created keys and certificates | It is long, Unix-oriented, and contains values that must be reconciled manually |
+| Rootless Podman runner | Hardened Linux provider and three example identities | It needs dedicated users, delegated cgroups, subordinate IDs, exact tmpfs mounts, helpers, and host networking policy |
+| Native Windows runner | Trusted host-process provider | Durable enrollment rejects non-Unix hosts and `uses:` actions are unsupported |
+| macOS runner | Disposable macOS VM provider | It requires Apple Silicon, signed helpers, a sealed image, and dedicated quota-managed APFS storage |
+| GitHub provider | Strict provider registry accepted by the server | No App creation, installation discovery, or repository-connect command exists |
+| Distribution | Linux x86-64 release automation with publication guards | No public product release or cross-platform installer exists |
+
+The first implemented slice is deliberately smaller: `automata local doctor`
+validates the initial host tuple, a local Linux Docker Engine, negotiated API
+and architecture agreement, Compose plugin version 2.20.0 or newer, a dedicated
+root strictly below the platform's user-state directories, and the Unix
+non-root process requirement. It is read-only and does not imply that `up` or
+workers are already available.
+
+## Accepted local architecture
+
+### One Linux container model on all hosts
+
+Every long-running local component runs in a generated Compose project:
+
+```text
+GitHub and browser
+        |
+ public HTTPS origin
+        |
+ loopback-published local gateway
+        |
+   control plane -------- PostgreSQL
+        |                     |
+        +--------------- object storage
+        |
+  runner mTLS and private Results route
+        |
+ worker-01 ... worker-N
+        |
+ Docker Engine API
+        |
+ sibling Linux job and service containers
+```
+
+Docker Engine is the initial supported engine on all three platforms. Arch
+uses Docker Engine directly; macOS and Windows use Docker Desktop's Linux
+engine. Podman may be added only after it passes the same provider and
+lifecycle conformance suite; it is not an automatic fallback in the supported
+quickstart.
+
+Docker Desktop is third-party software with terms that vary by organization
+and use. The macOS and Windows gates must verify and disclose the then-current
+prerequisites and must not imply universal free-use eligibility. A future
+alternative engine enters the quickstart only through the same conformance and
+support gate.
+
+The existing rootless Podman, Kubernetes, native Windows, and macOS VM
+providers retain their production or advanced contracts. The local path uses a
+separate evaluation-only container-engine provider instead of weakening any of
+those providers.
+
+Before public artifacts exist, the contributor lane builds a dedicated
+multi-stage local image from the reviewed checkout and records the source
+revision and image identity in state. The final reader quickstart replaces that
+development override with digest-pinned multi-architecture product images; it
+does not present an unpublished image name as downloadable.
+
+### Workers and jobs
+
+`--workers N` generates `N` explicit, one-slot runner services. Each worker
+has a stable runner ID, certificate, journal, encrypted spool, configuration,
+and engine-managed state volume. Compose scaling is not used because replica
+ordinals are not a durable identity contract.
+
+The first successful `up --workers N` fixes the worker count for that named
+installation. Repeating the same value is idempotent; requesting another value
+fails with reset/recreate instructions until runner drain, disable, and delete
+operations exist. This avoids inventing scale-down semantics that the current
+control plane cannot enforce safely.
+
+Worker containers use the host Docker Engine API to create sibling job and
+service containers. The worker is therefore engine-admin-equivalent. This is
+acceptable only for an explicitly local, trusted-repository evaluation mode.
+Job containers never receive the engine socket, control-plane credentials, or
+access to the Compose dependency network.
+
+The local provider must:
+
+- require an explicit runner `run-local` boundary that production `run` does
+  not accept;
+- accept only a local Unix socket from inside the Linux worker container;
+- verify a Linux engine, API version, engine identity, and architecture;
+- use digest-pinned, preloaded images and pull-never execution;
+- label every resource with installation, runner, operation, generation,
+  profile, and specification identities;
+- verify labels and the realized resource policy before every mutation;
+- reject foreign name collisions without deleting or adopting them;
+- prohibit privileged jobs, host namespaces, host binds, devices, and the
+  engine socket inside jobs; and
+- clean exact owned resources without a global prune or broad label delete.
+
+Initial profiles are truthful local container profiles rather than aliases for
+the existing hardened rootless profile:
+
+- `automata.local/ubuntu-24-04-amd64-container-v1`
+- `automata.local/ubuntu-24-04-arm64-container-v1`
+
+The ARM64 profile requires native ARM64 product, worker, job, and JavaScript
+action toolchain artifacts. Silent x86 emulation is not the supported macOS
+path.
+
+### Network boundary
+
+Only the human UI, OAuth callbacks, setup callbacks, and GitHub webhook route
+are reachable through the public HTTPS origin. PostgreSQL, object storage,
+Results, runner mTLS, and the Docker socket are never tunneled.
+
+The control plane and dependencies use a generated private Compose network.
+Current server validation accepts plaintext database and object-store endpoints
+only at literal loopback, while a containerized server sees those dependencies
+at private addresses. A single hidden local-container deployment context will
+allow only a complete, generated RFC1918 tuple and will leave standard server
+validation unchanged. Independent `allow private` flags are not part of the
+design.
+
+Job containers use a separate job network. They reach Results through an exact
+local gateway alias or a narrowly scoped private proxy; they do not join the
+control-plane network. This route must pass live tests independently on Docker
+Engine, Docker Desktop for macOS, and Docker Desktop for Windows.
+
+The tunnel is a pluggable boundary with a managed evaluation default and an
+escape hatch for a user-supplied HTTPS origin. The chosen default must preserve
+webhook method, headers, and bytes; redact credentials; and resume the exact
+persisted hostname across `down -> up`, sleep, and reboot on all three hosts.
+App creation is blocked unless that stability contract is available. Ephemeral
+origins are not a supported recovery mode because callback/setup URLs and old
+Check Details links cannot all be repaired through the webhook API; replacing
+an origin requires a separately tested complete App and configuration migration.
+
+### State and secrets
+
+The local supervisor owns a named installation below the native platform state
+root:
+
+| Host | Default state root |
+| --- | --- |
+| Linux | `${XDG_STATE_HOME:-$HOME/.local/state}/automata/local` |
+| macOS | `$HOME/Library/Application Support/Automata/local` |
+| Windows | `%LOCALAPPDATA%\Automata\local` |
+
+The state manifest is schema-versioned and records only non-secret identities:
+installation UUID, project name, engine identity, architecture, ports,
+network, image digests, desired worker count, public origin, GitHub connection
+revision, and lifecycle state. Every mutation takes a cross-platform advisory
+lock and writes state atomically.
+
+Secrets and Linux permission-sensitive runner material live in
+engine-managed volumes. Generated Compose YAML, process arguments, status JSON,
+logs, debug representations, and evidence bundles contain references or
+redacted values, never plaintext credentials. `reset` validates an exact
+installation marker and resource inventory before removing volumes. It does
+not uninstall or delete the external GitHub App silently.
+
+The caller-supplied state root must be a strict descendant of the current
+platform home, profile, or user-state directory. It is a container for named
+installations and is never itself recursively removed. Before host-file
+deletion, the manager rejects
+filesystem, drive, and share roots; home/profile roots and their ancestors;
+lexical parent traversal; Unix symlink components; and Windows junction or
+reparse components. It performs handle-anchored deletion only beneath the exact
+marked installation child and revalidates containment at each traversal step.
+
+Visible lifecycle states include `services_ready`, `awaiting_github`,
+`app_installed`, `authenticated`, `enrolling_workers`, `ready`, and `degraded`.
+An interrupted operation resumes from durable evidence instead of starting a
+second installation.
+
+## GitHub repository connection
+
+The GitHub App Manifest flow is the target setup path. The implementation will
+verify its exact permission and callback contract against GitHub's current
+official documentation when that checkpoint begins. The provisional minimum is
+`push`, `pull_request`, `merge_group`, and `repository_dispatch` events with
+Checks write, Contents read, Pull requests read, and Merge queues read. A
+webhook-only relay is insufficient because the dashboard and GitHub Check
+Details URL need the same public HTTPS origin.
+
+The resumable connect operation will:
+
+1. start or attach the public HTTPS origin;
+2. resolve `OWNER` through a bounded GitHub account lookup, retain its numeric
+   identity and `User`/`Organization` type, and choose the corresponding personal
+   or organization App Manifest endpoint without attempting to infer private
+   repository visibility;
+3. open the App Manifest flow with single-use, time-bounded local state and fail
+   actionably if the browser identity lacks App-manager authority;
+4. exchange the temporary manifest code and store the returned App key, App and
+   client IDs, webhook secret, and OAuth client secret in private state;
+5. open the new App's installation URL with `request_oauth_on_install=false`
+   and ask the user to select the exact repository;
+6. capture the exact HMAC-verified `installation` event, bind its sender as the
+   installer identity, and fail actionably when repository-install authority is
+   absent;
+7. verify the completed installation with an App JWT and a short-lived token
+   rather than trusting an `installation_id` query parameter, then discard that
+   token;
+8. list accessible repositories and select only the requested owner/name;
+9. discover canonical owner, repository, installation, visibility, and default
+   branch data;
+10. cross-check the signed event sender's stable numeric ID and login through a
+    bounded GitHub account lookup without asking the user to copy either value;
+11. generate connection UUIDs, authority revisions, the one-use installation
+   bootstrap tuple, human-auth configuration, and the strict provider registry;
+12. validate generated configuration through the production decoders before an
+    atomic install and control-plane reload or restart;
+13. open the anonymous `/setup` bootstrap, have the configured identity finish
+    its one permitted setup, and verify the first administrator browser session;
+14. use a new browser-approved, local-only handoff to authorize `N` one-use
+    runner enrollment credentials without depending on Linux Secret Service or
+    persisting a CLI bearer on macOS or Windows; and
+15. enroll/start the requested workers and report the dashboard and readiness
+    URLs.
+
+The current runner-token API accepts only CLI-audience sessions, and the
+operator CLI has no Windows credential-custody implementation. The local
+browser-to-manager handoff is therefore product work with its own single-use
+state, origin binding, CSRF protection, expiry, replay rejection, and secret
+redaction tests; ordinary browser login cannot be substituted for it.
+
+Reconnect is idempotent. Stable semantics reuse identities; changed policy or
+credentials increment the relevant revision. A multi-repository App
+installation never widens the local repository registry beyond the exact
+repository requested by the user.
+
+The quickstart warns that this local engine-admin mode is for repositories the
+operator trusts. The connect checkpoint adds an exact local admission rule that
+rejects a pull request whose head repository differs from its base repository;
+restricting fork credentials alone does not disable fork execution.
+
+The smoke repository contract is intentionally small and observable:
+
+- workflows are direct lowercase `.yml` or `.yaml` files under
+  `.ci/workflows/`;
+- no `.github/workflows/` copy exists that would also run on native GitHub
+  Actions;
+- `runs-on: automata-local` selects the host-native local profile without
+  redefining GitHub's `ubuntu-24.04` architecture semantics;
+- a three-entry matrix demonstrates three workers concurrently; and
+- `push`, `pull_request`, `merge_group`, and `repository_dispatch` live evidence
+  is added only when each event has an asserted product test.
+
+## Platform qualification matrix
+
+The initial qualified host tuples are Arch Linux x86-64, Apple Silicon macOS
+ARM64, and Windows x86-64. Preflight rejects Intel macOS and Windows on ARM for
+the supported quickstart; adding either requires native artifacts and its own
+clean-host evidence rather than merely passing Docker API inspection.
+
+| Gate | Arch Linux | Apple Silicon macOS | Windows |
+| --- | --- | --- | --- |
+| Host engine | Docker Engine | Docker Desktop Linux engine | Docker Desktop/WSL2 Linux engine |
+| Worker/job architecture | `linux/amd64` | `linux/arm64` | `linux/amd64` |
+| Orchestrator | Native `automata` | Native `automata` | Native `automata.exe` from PowerShell |
+| Durable sensitive state | Engine-managed volumes | Engine-managed volumes | Engine-managed volumes |
+| Host-specific proof | engine/socket ownership, restart, cleanup | paths with spaces, host gateway, sleep/reboot, native ARM64 | Linux-container mode, drive/path handling, CRLF, shutdown/reboot |
+| Job claim | Linux containers | Linux containers, not native macOS jobs | Linux containers, not native Windows jobs |
+
+A platform is qualified only after a clean host can:
+
+- run the documented command without hand-editing JSON, certificates, UUIDs,
+  revisions, or numeric GitHub IDs;
+- complete only the expected browser confirmations for App creation,
+  repository installation, and login;
+- produce a useful and redacted `status --json` document;
+- run three matrix jobs concurrently on three distinct runner identities;
+- show live logs, final results, and the exact GitHub Check Details page;
+- recover from one worker crash and a complete stack restart;
+- preserve data across `down` and remove only exact owned state on confirmed
+  `reset`; and
+- keep App keys, source credentials, webhook secrets, and enrollment tokens out
+  of command lines, logs, non-secret configuration, and test evidence.
+
+## Merge checkpoints
+
+Each checkpoint uses a sibling worktree created from the latest merged
+`origin/main`. A dependent checkpoint starts only after its predecessor merges.
+Every PR states its contract, security impact, non-goals, tests, and live
+evidence; it does not depend on issue linkage.
+
+### 1. Local host foundation and accepted design
+
+Add the dedicated local lifecycle crate, the `automata local doctor`
+command, platform state-root policy, Docker/Compose discovery, stable JSON
+preflight output, this roadmap, and CLI contract tests.
+
+Gate: Linux tests and a live Arch preflight pass; Windows x86-64 and Apple
+Silicon targets cross-check; Docker Desktop fixtures cover both endpoint forms;
+unsafe broad state roots are rejected; preflight makes no state or container
+changes; and the normal operator CLI cannot route `local` as a remote command.
+
+### 2. Durable lifecycle and state kernel
+
+Add the versioned installation manifest, transition state machine, advisory
+locking, atomic writes, exact resource inventory, backend trait, and anchored
+filesystem ownership/deletion primitives. Keep this internal and exercise it
+with a fake backend; do not advertise `up` before a real stack exists.
+
+Gate: interruption and concurrent-manager tests preserve one installation;
+filesystem roots, drive or share roots, home/profile roots, ancestors, and
+caller-supplied state roots themselves are never deletion targets; Unix
+symlinks and Windows junctions/reparse points fail closed; all recursive work is
+handle-anchored beneath the exact marked installation child; and adversarial
+Linux, macOS, and Windows fixtures prove that `reset` cannot escape it.
+
+### 3. Durable zero-worker service composition
+
+Add `up`, `status`, `logs`, `down`, and `reset`; generated configuration; random
+keys and certificates; Compose rendering; the scoped local-container server
+policy; a multi-stage source-checkout image; health waits; idempotent RustFS
+bucket creation; and interruption recovery. Stop in `awaiting_github` with zero
+workers.
+
+Gate: repeated `up` is idempotent, `down` preserves data, confirmed `reset`
+revalidates exact state and resource ownership, no secret reaches arguments or
+generated YAML, dependency failures become actionable degraded states, and
+`up -> down -> up -> reset` passes live on Arch.
+
+### 4. Local container-engine sandbox provider
+
+Add a separate Docker Engine API provider, fake-daemon contract tests, exact
+resource ownership, exec/copy/attach/cancel/destroy behavior, resource
+inspection, the truthful AMD64 local profile, and an ignored live Docker suite.
+
+Gate: restart attach works, cancellation kills exact owned containers,
+foreign collisions fail without mutation, copy and output bounds fail closed,
+and destroy leaves no owned job resources.
+
+### 5. Stable public-origin boundary
+
+Add the local HTTP gateway, persisted public-origin state, user-supplied origin
+support, a fake tunnel for tests, and one evaluated default tunnel after its
+privacy, licensing, and cross-platform behavior are accepted.
+
+Gate: only intended HTTP routes are forwarded; signed webhook headers and body
+remain byte-exact; the default hostname survives `down -> up`, sleep, and reboot
+for the installation lifetime; tunnel credentials are redacted. An origin that
+cannot be resumed fails before App creation. Ephemeral-hostname replacement is
+not the quickstart recovery path and would require a separately tested complete
+App/configuration migration.
+
+### 6. GitHub App creation and verified repository connection
+
+Resolve the owner type and numeric owner through a bounded GitHub account lookup,
+route App Manifest creation to the personal or organization settings endpoint,
+then add Manifest generation/conversion, callback state, HMAC-verified
+installation-event capture, installation/API verification, exact repository
+discovery, and generated provider/human-auth configuration. Stop at
+`app_installed`; do not start workers or claim a connected installation yet.
+
+Gate: protocol-emulator tests cover forged IDs, expired/replayed state,
+partial retries, public/private repositories, multi-repository installations,
+exact permissions/events, atomic writes, configuration decoding, and secret
+redaction. Personal and organization routing is exact; lack of App-manager or
+repository-install authority fails with an actionable browser recovery path;
+the signed `installation` event's sender identity is retained as the installer
+evidence and cross-checked by bounded API lookup. No manual App field, numeric
+ID, or registry JSON is required.
+
+### 7. Installation bootstrap and enrollment authorization
+
+Bind the one-use bootstrap tuple to the verified installer identity, complete
+the anonymous `/setup` flow, add exact local fork rejection, and add the
+browser-approved, local-manager enrollment-authorization handoff. Ordinary
+browser sessions remain unable to call the CLI-audience runner-token API.
+
+Gate: wrong GitHub identity, origin/CSRF mismatch, expiry, replay, restart, and
+partial-completion tests fail closed; setup creates exactly one first
+administrator; the local handoff authorizes only the recorded bounded worker
+count and never persists a CLI bearer. Provider configuration reload is atomic
+and rollback-safe.
+
+### 8. Runner local-only composition
+
+Add `automata-runner run-local`, the Linux worker image, engine-socket adapter,
+private Results route, `automata-local` selector, stable one-slot worker
+identities and volumes, automatic use of the approved enrollment handoff, and
+generated `N`-worker Compose services. Do not expose workers through ordinary
+production `run`.
+
+Gate: `N=1` and `N=3` start; shell and JavaScript-action jobs execute; three
+jobs overlap on three identities; worker restart reconciles exact sandboxes;
+job code cannot access the engine socket or dependency network. The first
+successful `up --workers N` makes `N` immutable until confirmed `reset`;
+repeating the same value is idempotent and a different value fails with exact
+reset/recreate guidance, avoiding stale runners before drain/delete exists.
+
+### 9. Arch end-to-end qualification
+
+Create the designated repository under `AlexanderDzhoganov` after confirming
+its exact name, install the App on only that repository, add the three-job
+fixture, and commit an executable redacted smoke harness/evidence format.
+
+Gate: a clean local state reaches its first completed GitHub Check; webhook
+delivery is durably accepted; queued/running/completed Check states and Details
+link work; three workers overlap; cancellation cleans owned resources; and
+`down -> up` preserves the installation.
+
+### 10. Native ARM64 artifacts and macOS qualification
+
+Build and privately stage native ARM64 control-plane, worker, job, and action
+toolchain candidates; qualify Docker Desktop, gateway/tunnel behavior, browser
+launch, paths with spaces, sleep, restart, and reboot on the Mac mini. Public
+publication remains disabled until checkpoint 13.
+
+Gate: the same command and GitHub fixture pass with `N=3` without x86
+emulation or Unix-host secret-file assumptions. The guide records Docker
+Desktop's current terms and licensing prerequisites and does not imply that its
+use is free for every organization.
+
+### 11. Windows orchestration and qualification
+
+Add the native Windows local-manager artifact and PowerShell UX; qualify Docker
+Desktop/WSL2 Linux-container mode, Windows state paths, CRLF, process shutdown,
+restart, and reset. The worker and jobs remain Linux containers.
+
+Gate: the same command and GitHub fixture pass with `N=3` from clean
+PowerShell, and no native Windows enrollment path is involved. The same Docker
+Desktop terms/licensing disclosure is verified for this host lane.
+
+### 12. Cross-platform release candidates and installers
+
+Build checksummed native local-manager artifacts and multi-architecture Linux
+images, SBOMs, provenance, and installer contract tests. Apply Developer ID
+signing, notarization, and stapling to the macOS candidate and Authenticode to
+the Windows candidate before qualification so the tested bytes are the bytes
+eventually published. Keep public publication disabled while candidates are
+qualified.
+
+Gate: clean-host installer tests consume exact final signed CI-produced
+candidates on all three operating systems, verify platform signatures,
+notarization where applicable, checksums, and provenance, and require no Rust
+toolchain.
+
+### 13. Publication authority and first public artifacts
+
+Resolve the release-authority design in a focused review, publish the exact
+qualified artifacts, and only then change release-status text and installer
+URLs. Do not remove the existing publication guard as a shortcut.
+
+Gate: exact registry/archive identities, signatures, checksums, SBOMs,
+provenance, rollback procedure, and public download smoke tests pass.
+
+### 14. README and documentation information architecture
+
+Make the now-public tested local flow the first root README procedure, split
+operator and maintainer material, and make the deployment chooser own topology
+selection.
+
+Gate: every quickstart command is exercised by the smoke harness; clean-reader
+tests consume the public artifacts on all three hosts; links and anchors pass;
+installation does not require a Rust toolchain; preview remains clearly
+dependency-free and separate.
+
+### 15. Durable Docker Compose deployment
+
+Build a production-oriented composition separate from the privileged local
+evaluation stack: TLS reverse proxy, external or explicitly development
+PostgreSQL/S3 choices, secret files, persistence, probes, backup/restore,
+upgrade/rollback, and optional hardened runner profiles. This topology must not
+reuse the engine-admin local evaluation provider.
+
+Gate: configuration validation, restart persistence, real TLS/webhooks,
+backup restoration, dependency failure recovery, non-root images, and exact
+version/digest pins pass.
+
+### 16. Linux systemd deployment
+
+Add control-plane units and credential/tmpfiles packaging; implement or require
+runner disable, drain, and delete lifecycle operations; generalize runner units
+beyond exactly three instances; and retain the hardened rootless Podman guide
+as an advanced host deployment. The local engine-admin provider is forbidden.
+
+Gate: clean-VM installation, `systemd-analyze verify`, reboot, key/certificate
+rotation, drain/recovery, and backup restoration pass. Unimplemented automatic
+runner certificate rotation remains an explicit production blocker.
+
+### 17. Helm/Kubernetes deployment
+
+Start with one control-plane replica, external PostgreSQL and object storage,
+existing secret references, ingress, a runner mTLS service, probes, metrics,
+NetworkPolicy, and explicit migration behavior. Kubernetes runners remain
+experimental until their independent live gate passes; the chart never mounts
+the local evaluation engine socket into a production runner.
+
+Gate: chart lint/schema/template validation, kind or k3d integration,
+upgrade/rollback, dependency outages, secret non-disclosure, and documented
+node-traffic exceptions pass.
+
+### 18. Cloud reference deployments
+
+Publish one provider-neutral validated topology, then one infrastructure PR per
+cloud. Start with AWS because PostgreSQL and S3 align with the existing storage
+boundaries. GCP and Azure require a proven S3-compatible store or a separately
+implemented native object-store adapter. Terraform or OpenTofu follows a real
+manual deployment rather than preceding it.
+
+Each cloud gate names a separately qualified hardened runner provider; the
+local engine-admin provider is not accepted. The gate includes DNS/TLS, webhook
+delivery, an `N`-worker run, backup/restore, upgrade, teardown, security review,
+and an explicit cost inventory.
+
+## Documentation migration
+
+User guides will be reorganized only as their product paths become real. Keep
+the stable high-traffic files as landing pages so existing links do not break.
+The target ownership is:
+
+```text
+docs/local/                    local quickstart, lifecycle, GitHub connect
+docs/deploy/                   chooser, Compose, systemd, Kubernetes, cloud
+docs/operations/               backup, restore, upgrade, observability
+docs/platforms/                advanced native execution-host guides
+docs/reference/                configuration and command reference
+docs/maintainers/roadmaps/     plans, audits, and conformance work
+```
+
+The current documentation has an explicit disposition so cleanup does not
+silently erase useful operational detail:
+
+| Current source | Disposition | Checkpoint |
+| --- | --- | --- |
+| Root `README.md` | Replace the opening procedure only after the three-host local smoke gate and public artifacts; retain project and security context | 14 |
+| `docs/getting-started.md` | Keep as a stable chooser; move the tested local procedure to `docs/local/` | 14 |
+| `docs/deployment.md` | Keep the manual development assembly truthful now; later convert it into the deployment chooser | 1, then 14 |
+| `deploy/dev/README.md` | Retain as contributor-only PostgreSQL/RustFS support, not a product deployment | 14 |
+| Runner configuration guide | Retain as the hardened Linux rootless-Podman host reference | 14 and 16 |
+| Arch and macOS platform guides | Retain as advanced execution-host references; do not use them as the portable local quickstart | 9, 10, and 16 |
+| Native Windows material in `docs/getting-started.md` | Move into a dedicated advanced Windows platform guide while keeping the chooser short | 11 and 14 |
+| Provider example and workflow claims | Reconcile against executable configuration, workflow discovery, and event tests | 1 and 6 |
+| Parity plans and dated audits | Move under maintainer ownership when touched; archive only after their remaining decisions are represented elsewhere | 14 |
+| Release documentation | Preserve publication authority and safeguards until qualified artifacts exist | 12 and 13 |
+
+The cleanup checkpoints will:
+
+- replace the preview-first root README only after the real local flow passes
+  all three host gates;
+- keep `docs/getting-started.md` as a short chooser instead of mixing preview,
+  source installation, and native execution experiments;
+- turn `docs/deployment.md` into a deployment chooser and move exact procedures
+  to topology-specific guides;
+- keep `deploy/dev` explicitly contributor-only;
+- retitle the runner configuration guide as the hardened Linux runner-host
+  reference rather than a local bootstrap;
+- reconcile the provider example and runner profiles from one generated source
+  of truth;
+- correct stale CLI examples and workflow-selection claims against executable
+  help and product tests;
+- move parity plans and dated audits out of the operator path;
+- delete or archive branch-status plans that no longer own a decision; and
+- preserve publication safeguards in release documentation and workflows.
+
+The final README quickstart is generated from or tested by the same commands as
+the Arch, macOS, and Windows smoke harness. Documentation is not the evidence
+that makes a platform available; the clean-host acceptance record is.

--- a/docs/platforms/arch-linux.md
+++ b/docs/platforms/arch-linux.md
@@ -485,16 +485,31 @@ table inet automata_results_guard {
 }
 ```
 
-Confirm the route and the real rootless Podman packet path before installing
-the guard. `ip route` must select host loopback for the bound address:
+Confirm the route before applying the guard. `ip route` must select host
+loopback for the bound address:
 
 ```console
 ip -4 route get 192.168.0.8
 # local 192.168.0.8 dev lo ...
 ```
 
-With the Results listener already running, capture one inbound request in one
-terminal (the `tcpdump` package is needed only for this diagnostic):
+Apply and audit the policy before starting the Results listener. Each creation
+is one atomic nftables transaction. Reapplying an exact policy is a no-op; a
+present table with any extra, missing, or changed object makes both `audit` and
+`apply` fail without modifying it.
+
+```console
+sudo ./scripts/dev/results-firewall.sh apply \
+  --listen-address 192.168.0.8 \
+  --port 8081
+sudo ./scripts/dev/results-firewall.sh audit \
+  --listen-address 192.168.0.8 \
+  --port 8081
+```
+
+Only after that audit succeeds, start the exact Results listener. With the
+guard and listener active, capture one inbound request in one terminal (the
+`tcpdump` package is needed only for this diagnostic):
 
 ```console
 sudo timeout 30s tcpdump -l -nn -i any -Q in -c 1 \
@@ -530,23 +545,10 @@ network:
 )
 ```
 
-The capture must identify `lo` as the input interface. Do not apply this
-policy if the packet arrives through any other interface: the guard is
-intentionally fail-closed and would make Results unreachable to jobs.
-
-Once the rendered rules and packet path have been reviewed, apply and audit
-the policy. Each creation is one atomic nftables transaction. Reapplying an
-exact policy is a no-op; a present table with any extra, missing, or changed
-object makes both `audit` and `apply` fail without modifying it.
-
-```console
-sudo ./scripts/dev/results-firewall.sh apply \
-  --listen-address 192.168.0.8 \
-  --port 8081
-sudo ./scripts/dev/results-firewall.sh audit \
-  --listen-address 192.168.0.8 \
-  --port 8081
-```
+The capture must identify `lo` as the input interface and the request must
+receive an HTTP response. If either check fails, stop the Results listener
+before changing or removing the guard. A non-loopback path is intentionally
+dropped; never weaken the rule to make that path work.
 
 Test denial from a separate LAN machine, not from the host itself. A request
 to `http://192.168.0.8:8081/` must time out while the Podman request above must


### PR DESCRIPTION
## Outcome

Adds the first reviewed checkpoint for the local-installation program:

- `automata local doctor` performs a read-only, schema-versioned host preflight for Arch/Linux x86-64, Apple Silicon macOS, and Windows x86-64.
- Structured probes validate the effective local Docker endpoint, Docker Engine identity/Linux mode/architecture/API, and Docker Compose plugin version 2.20.0 or newer. Podman shims, remote contexts, forged or malformed output, unsupported host tuples, and broad/untrusted state roots fail closed with typed remediation.
- Probe commands have bounded output and deadlines, and their complete process trees are reaped on timeout, cancellation, SIGINT, or SIGTERM.
- The accepted cross-platform architecture, GitHub App connection sequence, host qualification matrix, documentation disposition, and 18 review-sized merge checkpoints are recorded in the local-installation roadmap.
- Current deployment documentation is reconciled with executable behavior: GitHub permissions and Device Flow, bootstrap ordering, Results firewall sequencing, dynamic three-account runner enrollment/TLS custody, workflow discovery, provider profile pins, and Kubernetes status.

This PR does not add `local up`, compose services, GitHub connection, or workers. Those remain separate dependent checkpoints after this PR merges.

## Related issue

None

## Trust and compatibility impact

The doctor is read-only: it does not create its resolved state directory, containers, volumes, networks, or configuration. It invokes four bounded structured Docker CLI probes and accepts only a local Unix socket or Windows named pipe backed by a conforming Linux Docker Engine. Engine identity is treated as non-secret diagnostic state; captured stderr is never exposed.

Unix probes run in isolated process groups and Windows probes run in a kill-on-close Job Object. Signal and future cancellation terminate descendants before exit.

The checked-in three-runner host declarations now make each TLS directory mode `0700` and owned by its exact service account so dynamic enrollment can create and retain private staging/key material under the same identity that runs the daemon. Parent/configuration custody remains root-owned, and the guide removes the contradictory static-key workflow.

The quickstart remains unavailable until its later service, sandbox, tunnel, GitHub, worker, host-qualification, artifact, and publication gates pass. Production Podman/Kubernetes/native providers are not weakened or reused as the evaluation provider.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p automata-ci-local --locked` — 21 passed
- `cargo test -p automata-ci --test local_doctor_process --locked` — 2 passed, including SIGINT tree cleanup and no state mutation
- `cargo test -p automata-ci --test cli --locked` — 31 passed
- `cargo test -p automata-ci --test github_provider_config --locked` — 13 passed
- `cargo clippy -p automata-ci-local --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p automata-ci --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p automata-ci-local -p automata-ci --all-features --no-deps --locked`
- `cargo check -p automata-ci-local --target x86_64-pc-windows-msvc --all-targets --locked`
- `cargo check -p automata-ci-local --target aarch64-apple-darwin --all-targets --locked`
- `cargo package -p automata-ci-local --locked`
- Current publication inventory includes `automata-ci-local`.
- Live Arch Docker Engine 29.7.2 / Compose 5.4.0 preflight passed and left the state directory absent.
- Live fake-Docker, remote `DOCKER_HOST`, and forged `HOME=/var` state-root probes exited nonzero as designed.

Native macOS and Windows execution was not run in this checkpoint; those clean-host qualifications are explicit later gates. Full workspace/PostgreSQL/renderer lanes are left to repository CI.

## AI assistance

OpenAI Codex performed the code and documentation audit, architecture analysis, implementation, adversarial review, and test orchestration. Every submitted change was reviewed against the repository contracts and current primary Docker/GitHub documentation.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.