### PR TITLE
Resolve pull request path filters without crashing delivery

### DIFF
--- a/crates/automata-ci-github-delivery/src/changed_files.rs
+++ b/crates/automata-ci-github-delivery/src/changed_files.rs
@@ -2,17 +2,18 @@ use std::{fmt, time::Instant};
 
 use async_trait::async_trait;
 use automata_ci_github::{
-    GithubHttpEndpoint, GithubPushDiffAuthority, GithubPushDiffError, GithubPushDiffOutcome,
-    GithubPushDiffRange, GithubPushDiffRequest, GithubPushRefKind, GithubRepositoryVisibility,
-    VerifiedGithubPush,
+    GithubHttpEndpoint, GithubPullRequestDiffError, GithubPullRequestDiffOutcome,
+    GithubPullRequestDiffRequest, GithubPushDiffAuthority, GithubPushDiffError,
+    GithubPushDiffOutcome, GithubPushDiffRange, GithubPushDiffRequest, GithubPushRefKind,
+    GithubRepositoryVisibility, VerifiedGithubPullRequest, VerifiedGithubPush,
 };
 use automata_ci_scm::{ExactRevision, RepositoryId};
 use automata_ci_store::ProviderRepositoryVisibility;
 use automata_ci_workflow_github::GithubChangedFiles;
 
 use crate::{
-    GithubPushChangedFilesAuthority, GithubPushChangedFilesError, GithubPushChangedFilesProvider,
-    GithubPushChangedFilesRequest,
+    GithubPullRequestChangedFilesRequest, GithubPushChangedFilesAuthority,
+    GithubPushChangedFilesError, GithubPushChangedFilesProvider, GithubPushChangedFilesRequest,
 };
 
 /// Product-composed delivery adapter for GitHub's bounded Compare REST evidence.
@@ -52,6 +53,32 @@ impl GithubRestPushChangedFilesProvider {
             .map_err(map_http_error)?;
         translate_outcome(outcome)
     }
+
+    async fn resolve_pull_request(
+        &self,
+        request: &GithubPullRequestChangedFilesRequest<'_>,
+    ) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
+        validate_pull_request_delivery_binding(request)?;
+        let pull_request = request.pull_request();
+        let repository = RepositoryId::new(pull_request.repository().full_name())
+            .map_err(|_| GithubPushChangedFilesError::InvalidEvidence)?;
+        let authority = push_authority(request.authority());
+        let deadline = Instant::now()
+            .checked_add(self.endpoint.trusted_origins().limits().request_timeout())
+            .ok_or(GithubPushChangedFilesError::Unavailable)?;
+        let outcome = self
+            .endpoint
+            .pull_request_changed_files(GithubPullRequestDiffRequest::new(
+                &repository,
+                pull_request.base_revision(),
+                pull_request.head_revision(),
+                authority,
+                deadline,
+            ))
+            .await
+            .map_err(map_pull_request_http_error)?;
+        Ok(translate_pull_request_outcome(outcome))
+    }
 }
 
 impl fmt::Debug for GithubRestPushChangedFilesProvider {
@@ -70,6 +97,13 @@ impl GithubPushChangedFilesProvider for GithubRestPushChangedFilesProvider {
         request: GithubPushChangedFilesRequest<'_>,
     ) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
         self.resolve(&request).await
+    }
+
+    async fn pull_request_changed_files(
+        &self,
+        request: GithubPullRequestChangedFilesRequest<'_>,
+    ) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
+        self.resolve_pull_request(&request).await
     }
 }
 
@@ -102,6 +136,56 @@ fn validate_delivery_binding(
         || identity.repository_id().get() != push.repository().id().get()
         || identity.installation_id().get() != push.installation_id().get()
         || request.required_through() <= request.observed_at()
+    {
+        return Err(GithubPushChangedFilesError::InvalidEvidence);
+    }
+    Ok(())
+}
+
+fn validate_pull_request_delivery_binding(
+    request: &GithubPullRequestChangedFilesRequest<'_>,
+) -> Result<(), GithubPushChangedFilesError> {
+    let pull_request = request.pull_request();
+    validate_common_delivery_binding(
+        request.identity(),
+        pull_request,
+        request.authority(),
+        request.observed_at(),
+        request.required_through(),
+    )
+}
+
+fn validate_common_delivery_binding(
+    identity: &automata_ci_store::ProviderDeliveryIdentity,
+    pull_request: &VerifiedGithubPullRequest,
+    authority: &GithubPushChangedFilesAuthority<'_>,
+    observed_at: automata_ci_core::UnixMillis,
+    required_through: automata_ci_core::UnixMillis,
+) -> Result<(), GithubPushChangedFilesError> {
+    if identity.provider() != "github" || identity.delivery_id() != pull_request.delivery_id() {
+        return Err(GithubPushChangedFilesError::InvalidEvidence);
+    }
+    let visibility_matches = matches!(
+        (
+            identity.repository_visibility(),
+            pull_request.repository().visibility(),
+            authority,
+        ),
+        (
+            ProviderRepositoryVisibility::Public,
+            GithubRepositoryVisibility::Public,
+            GithubPushChangedFilesAuthority::PublicAnonymous,
+        ) | (
+            ProviderRepositoryVisibility::Private,
+            GithubRepositoryVisibility::Private,
+            GithubPushChangedFilesAuthority::PrivateInstallationContentsRead(_),
+        )
+    );
+    if !visibility_matches
+        || identity.repository_identity() != pull_request.repository().full_name()
+        || identity.repository_id().get() != pull_request.repository().id().get()
+        || identity.installation_id().get() != pull_request.installation_id().get()
+        || required_through <= observed_at
     {
         return Err(GithubPushChangedFilesError::InvalidEvidence);
     }
@@ -161,9 +245,24 @@ fn translate_outcome(
     }
 }
 
+fn translate_pull_request_outcome(outcome: GithubPullRequestDiffOutcome) -> GithubChangedFiles {
+    match outcome {
+        GithubPullRequestDiffOutcome::Complete(evidence) => {
+            GithubChangedFiles::complete(evidence.into_changed_paths())
+        }
+        _ => GithubChangedFiles::bypass_path_filters(),
+    }
+}
+
 fn map_http_error(error: GithubPushDiffError) -> GithubPushChangedFilesError {
     match error {
         GithubPushDiffError::Unavailable => GithubPushChangedFilesError::Unavailable,
+    }
+}
+
+fn map_pull_request_http_error(error: GithubPullRequestDiffError) -> GithubPushChangedFilesError {
+    match error {
+        GithubPullRequestDiffError::Unavailable => GithubPushChangedFilesError::Unavailable,
     }
 }
 

--- a/crates/automata-ci-github-delivery/src/lib.rs
+++ b/crates/automata-ci-github-delivery/src/lib.rs
@@ -44,7 +44,8 @@ pub use checks_publisher::{
 pub use changed_files::GithubRestPushChangedFilesProvider;
 
 pub use processor::{
-    GithubDeliveryWorkflowAdmissionProcessor, GithubPushChangedFilesAuthority,
+    GithubDeliveryWorkflowAdmissionProcessor, GithubPullRequestChangedFilesAuthority,
+    GithubPullRequestChangedFilesRequest, GithubPushChangedFilesAuthority,
     GithubPushChangedFilesError, GithubPushChangedFilesProvider, GithubPushChangedFilesRequest,
 };
 

--- a/crates/automata-ci-github-delivery/src/processor.rs
+++ b/crates/automata-ci-github-delivery/src/processor.rs
@@ -71,6 +71,10 @@ pub enum GithubPushChangedFilesAuthority<'credential> {
     PrivateInstallationContentsRead(&'credential SecretString),
 }
 
+/// Exact repository authority supplied to a pull-request changed-files call.
+pub type GithubPullRequestChangedFilesAuthority<'credential> =
+    GithubPushChangedFilesAuthority<'credential>;
+
 #[cfg(test)]
 mod changed_files_provider_tests;
 
@@ -99,6 +103,87 @@ pub struct GithubPushChangedFilesRequest<'a> {
     observed_at: UnixMillis,
     required_through: UnixMillis,
     authority: GithubPushChangedFilesAuthority<'a>,
+}
+
+/// Exact authenticated pull-request coordinates for provider path selection.
+pub struct GithubPullRequestChangedFilesRequest<'a> {
+    identity: &'a ProviderDeliveryIdentity,
+    request_digest: Sha256Digest,
+    pull_request: &'a automata_ci_github::VerifiedGithubPullRequest,
+    snapshot: GithubDeliveryClaimSnapshot,
+    observed_at: UnixMillis,
+    required_through: UnixMillis,
+    authority: GithubPullRequestChangedFilesAuthority<'a>,
+}
+
+impl GithubPullRequestChangedFilesRequest<'_> {
+    /// Returns the exact durable tenant, connection, installation, and repository identity.
+    #[must_use]
+    pub const fn identity(&self) -> &ProviderDeliveryIdentity {
+        self.identity
+    }
+
+    /// Returns the authenticated ingress request digest.
+    #[must_use]
+    pub const fn request_digest(&self) -> Sha256Digest {
+        self.request_digest
+    }
+
+    /// Returns the strictly rehydrated authenticated pull-request evidence.
+    #[must_use]
+    pub const fn pull_request(&self) -> &automata_ci_github::VerifiedGithubPullRequest {
+        self.pull_request
+    }
+
+    /// Returns the exact live delivery consumer snapshot revalidated before provider I/O.
+    #[must_use]
+    pub const fn snapshot(&self) -> GithubDeliveryClaimSnapshot {
+        self.snapshot
+    }
+
+    /// Returns the trusted immediate provider-operation observation.
+    #[must_use]
+    pub const fn observed_at(&self) -> UnixMillis {
+        self.observed_at
+    }
+
+    /// Returns the lease expiry plus the bounded provider uncertainty tail.
+    #[must_use]
+    pub const fn required_through(&self) -> UnixMillis {
+        self.required_through
+    }
+
+    /// Returns the exact anonymous or request-scoped private authority.
+    #[must_use]
+    pub const fn authority(&self) -> &GithubPullRequestChangedFilesAuthority<'_> {
+        &self.authority
+    }
+
+    /// Returns the disjoint server-service action for a private request.
+    #[must_use]
+    pub const fn private_action(&self) -> Option<GithubDeliveryPrivateRepositoryAction> {
+        match self.authority {
+            GithubPullRequestChangedFilesAuthority::PublicAnonymous => None,
+            GithubPullRequestChangedFilesAuthority::PrivateInstallationContentsRead(_) => {
+                Some(GithubDeliveryPrivateRepositoryAction::FetchPrivateRepositoryChangedFiles)
+            }
+        }
+    }
+}
+
+impl fmt::Debug for GithubPullRequestChangedFilesRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GithubPullRequestChangedFilesRequest")
+            .field("identity", &"[redacted]")
+            .field("request_digest", &self.request_digest)
+            .field("pull_request", &"[redacted]")
+            .field("snapshot", &self.snapshot)
+            .field("observed_at", &self.observed_at)
+            .field("required_through", &self.required_through)
+            .field("authority", &self.authority)
+            .finish()
+    }
 }
 
 impl GithubPushChangedFilesRequest<'_> {
@@ -202,6 +287,33 @@ pub trait GithubPushChangedFilesProvider: fmt::Debug + Send + Sync {
         &self,
         request: GithubPushChangedFilesRequest<'_>,
     ) -> Result<GithubChangedFiles, GithubPushChangedFilesError>;
+
+    /// Resolves provider-verified changed-file evidence for one exact pull request.
+    ///
+    /// # Errors
+    ///
+    /// Returns only a sanitized transient or invalid-evidence classification.
+    async fn pull_request_changed_files(
+        &self,
+        _request: GithubPullRequestChangedFilesRequest<'_>,
+    ) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
+        Err(GithubPushChangedFilesError::InvalidEvidence)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ChangedFilesEvent<'event> {
+    Push(&'event automata_ci_github::VerifiedGithubPush),
+    PullRequest(&'event automata_ci_github::VerifiedGithubPullRequest),
+}
+
+impl ChangedFilesEvent<'_> {
+    fn repository_owner_id(self) -> u64 {
+        match self {
+            Self::Push(push) => push.repository().owner_id().get(),
+            Self::PullRequest(pull_request) => pull_request.repository().owner_id().get(),
+        }
+    }
 }
 
 /// Product-composed GitHub delivery processor backed by logical admission.
@@ -289,48 +401,74 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
             report.disposition(),
             CompilationDisposition::RequiresChangedFiles
         ) {
-            match request.event() {
-                automata_ci_github::VerifiedGithubWebhook::Push(push) => {
-                    let changed_files = self.resolve_changed_files(request, push).await?;
-                    let Some(changed_files) = changed_files else {
-                        return Ok(failed("github.workflow.changed_files_invalid"));
-                    };
-                    let selected = compile(
-                        source_plan,
-                        authenticated_event_provenance(request),
-                        GithubEventMetadata::push_with_changed_files(push.deleted(), changed_files),
-                    );
-                    return Box::pin(
-                        self.finish_authenticated_event_compilation(request, selected),
-                    )
-                    .await;
-                }
-                automata_ci_github::VerifiedGithubWebhook::RepositoryDispatch(_) => {
-                    return Ok(failed(
-                        "github.workflow.repository_dispatch_changed_files_unsupported",
-                    ));
-                }
-                _ => {}
-            }
-            return Err(GithubDeliveryWorkflowProcessorError::Prerequisite(
-                GithubDeliveryWorkerPrerequisite::ProviderChangedFiles,
-            ));
+            return self
+                .process_changed_files_compilation(request, source_plan)
+                .await;
         }
         Box::pin(self.finish_authenticated_event_compilation(request, report)).await
+    }
+
+    async fn process_changed_files_compilation(
+        &self,
+        request: &GithubDeliveryWorkflowRequest<'_>,
+        source_plan: &GithubWorkflowSourcePlan,
+    ) -> Result<ProviderDeliveryWorkflowConclusion, GithubDeliveryWorkflowProcessorError> {
+        let metadata = match request.event() {
+            automata_ci_github::VerifiedGithubWebhook::Push(push) => {
+                let Some(changed_files) = self
+                    .resolve_changed_files(request, ChangedFilesEvent::Push(push))
+                    .await?
+                else {
+                    return Ok(failed("github.workflow.changed_files_invalid"));
+                };
+                GithubEventMetadata::push_with_changed_files(push.deleted(), changed_files)
+            }
+            automata_ci_github::VerifiedGithubWebhook::PullRequest(pull_request) => {
+                let Some(changed_files) = self
+                    .resolve_changed_files(request, ChangedFilesEvent::PullRequest(pull_request))
+                    .await?
+                else {
+                    return Ok(failed("github.workflow.changed_files_invalid"));
+                };
+                GithubEventMetadata::pull_request_with_changed_files(
+                    pull_request.action().as_str(),
+                    pull_request.base_ref(),
+                    changed_files,
+                )
+            }
+            automata_ci_github::VerifiedGithubWebhook::RepositoryDispatch(_) => {
+                return Ok(failed(
+                    "github.workflow.repository_dispatch_changed_files_unsupported",
+                ));
+            }
+            _ => {
+                return Err(GithubDeliveryWorkflowProcessorError::Prerequisite(
+                    GithubDeliveryWorkerPrerequisite::ProviderChangedFiles,
+                ));
+            }
+        };
+        let selected = compile(
+            source_plan,
+            authenticated_event_provenance(request),
+            metadata,
+        );
+        Box::pin(self.finish_authenticated_event_compilation(request, selected)).await
     }
 
     async fn resolve_changed_files(
         &self,
         request: &GithubDeliveryWorkflowRequest<'_>,
-        push: &automata_ci_github::VerifiedGithubPush,
+        event: ChangedFilesEvent<'_>,
     ) -> Result<Option<GithubChangedFiles>, GithubDeliveryWorkflowProcessorError> {
-        let path_filter_commit_limit = request
-            .manifest_pinned_evidence()
-            .manifest()
-            .limits()
-            .path_filter_max_commits();
-        if u64::try_from(push.commit_count()).unwrap_or(u64::MAX) > path_filter_commit_limit {
-            return Ok(Some(GithubChangedFiles::bypass_path_filters()));
+        if let ChangedFilesEvent::Push(push) = event {
+            let path_filter_commit_limit = request
+                .manifest_pinned_evidence()
+                .manifest()
+                .limits()
+                .path_filter_max_commits();
+            if u64::try_from(push.commit_count()).unwrap_or(u64::MAX) > path_filter_commit_limit {
+                return Ok(Some(GithubChangedFiles::bypass_path_filters()));
+            }
         }
         let provider = self.changed_files.as_ref().ok_or(
             GithubDeliveryWorkflowProcessorError::Prerequisite(
@@ -339,11 +477,11 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
         )?;
         match request.identity().repository_visibility() {
             ProviderRepositoryVisibility::Public => {
-                self.resolve_public_changed_files(request, push, provider.as_ref())
+                self.resolve_public_changed_files(request, event, provider.as_ref())
                     .await
             }
             ProviderRepositoryVisibility::Private => {
-                self.resolve_private_changed_files(request, push, provider.as_ref())
+                self.resolve_private_changed_files(request, event, provider.as_ref())
                     .await
             }
         }
@@ -352,7 +490,7 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
     async fn resolve_public_changed_files(
         &self,
         request: &GithubDeliveryWorkflowRequest<'_>,
-        push: &automata_ci_github::VerifiedGithubPush,
+        event: ChangedFilesEvent<'_>,
         provider: &dyn GithubPushChangedFilesProvider,
     ) -> Result<Option<GithubChangedFiles>, GithubDeliveryWorkflowProcessorError> {
         if request
@@ -373,18 +511,36 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
         }
         let required_through = provider_required_through(snapshot, observed_at)
             .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)?;
-        let provider_call = tokio::time::timeout(
-            provider_tail(),
-            provider.changed_files(GithubPushChangedFilesRequest {
-                identity: request.identity(),
-                request_digest: request.request_digest(),
-                push,
-                snapshot,
-                observed_at,
-                required_through,
-                authority: GithubPushChangedFilesAuthority::PublicAnonymous,
-            }),
-        );
+        let provider_call = tokio::time::timeout(provider_tail(), async {
+            match event {
+                ChangedFilesEvent::Push(push) => {
+                    provider
+                        .changed_files(GithubPushChangedFilesRequest {
+                            identity: request.identity(),
+                            request_digest: request.request_digest(),
+                            push,
+                            snapshot,
+                            observed_at,
+                            required_through,
+                            authority: GithubPushChangedFilesAuthority::PublicAnonymous,
+                        })
+                        .await
+                }
+                ChangedFilesEvent::PullRequest(pull_request) => {
+                    provider
+                        .pull_request_changed_files(GithubPullRequestChangedFilesRequest {
+                            identity: request.identity(),
+                            request_digest: request.request_digest(),
+                            pull_request,
+                            snapshot,
+                            observed_at,
+                            required_through,
+                            authority: GithubPullRequestChangedFilesAuthority::PublicAnonymous,
+                        })
+                        .await
+                }
+            }
+        });
         tokio::pin!(provider_call);
         let ready = poll_provider_once(request.lease(), provider_call.as_mut())
             .await
@@ -416,7 +572,7 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
     async fn resolve_private_changed_files(
         &self,
         request: &GithubDeliveryWorkflowRequest<'_>,
-        push: &automata_ci_github::VerifiedGithubPush,
+        event: ChangedFilesEvent<'_>,
         provider: &dyn GithubPushChangedFilesProvider,
     ) -> Result<Option<GithubChangedFiles>, GithubDeliveryWorkflowProcessorError> {
         let (authority_selector, credentials) = private_changed_files_context(request)?;
@@ -430,7 +586,7 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
         }
         let credential_request = private_changed_files_credential_request(
             request.identity(),
-            push.repository().owner_id().get(),
+            event.repository_owner_id(),
             authority_selector,
             requested_snapshot,
             observed_at,
@@ -446,17 +602,15 @@ impl GithubDeliveryWorkflowAdmissionProcessor {
         let result = {
             let provider_call = tokio::time::timeout(
                 provider_tail(),
-                provider.changed_files(GithubPushChangedFilesRequest {
-                    identity: request.identity(),
-                    request_digest: request.request_digest(),
-                    push,
-                    snapshot: requested_snapshot,
-                    observed_at: provider_observed_at,
-                    required_through: credential_request.required_through(),
-                    authority: GithubPushChangedFilesAuthority::PrivateInstallationContentsRead(
-                        credential.token(),
-                    ),
-                }),
+                request_private_changed_files(
+                    provider,
+                    request,
+                    event,
+                    requested_snapshot,
+                    provider_observed_at,
+                    credential_request.required_through(),
+                    credential.token(),
+                ),
             );
             tokio::pin!(provider_call);
             let ready = poll_provider_once(request.lease(), provider_call.as_mut()).await;
@@ -821,6 +975,50 @@ fn provider_tail() -> std::time::Duration {
         u64::try_from(MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS)
             .expect("fixed GitHub provider tail is positive"),
     )
+}
+
+async fn request_private_changed_files(
+    provider: &dyn GithubPushChangedFilesProvider,
+    request: &GithubDeliveryWorkflowRequest<'_>,
+    event: ChangedFilesEvent<'_>,
+    snapshot: GithubDeliveryClaimSnapshot,
+    observed_at: UnixMillis,
+    required_through: UnixMillis,
+    token: &SecretString,
+) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
+    match event {
+        ChangedFilesEvent::Push(push) => {
+            provider
+                .changed_files(GithubPushChangedFilesRequest {
+                    identity: request.identity(),
+                    request_digest: request.request_digest(),
+                    push,
+                    snapshot,
+                    observed_at,
+                    required_through,
+                    authority: GithubPushChangedFilesAuthority::PrivateInstallationContentsRead(
+                        token,
+                    ),
+                })
+                .await
+        }
+        ChangedFilesEvent::PullRequest(pull_request) => {
+            provider
+                .pull_request_changed_files(GithubPullRequestChangedFilesRequest {
+                    identity: request.identity(),
+                    request_digest: request.request_digest(),
+                    pull_request,
+                    snapshot,
+                    observed_at,
+                    required_through,
+                    authority:
+                        GithubPullRequestChangedFilesAuthority::PrivateInstallationContentsRead(
+                            token,
+                        ),
+                })
+                .await
+        }
+    }
 }
 
 fn authenticated_event_source_provenance(

--- a/crates/automata-ci-github-delivery/tests/workflow_processor.rs
+++ b/crates/automata-ci-github-delivery/tests/workflow_processor.rs
@@ -21,9 +21,9 @@ use automata_ci_github_delivery::{
     GithubDeliverySourceCredentialProvider, GithubDeliverySourceCredentialProviderError,
     GithubDeliverySourceCredentialRequest, GithubDeliveryWorker, GithubDeliveryWorkerConfig,
     GithubDeliveryWorkerError, GithubDeliveryWorkerOutcome, GithubDeliveryWorkerPrerequisite,
-    GithubDeliveryWorkflowAdmissionProcessor, GithubPushChangedFilesAuthority,
-    GithubPushChangedFilesError, GithubPushChangedFilesProvider, GithubPushChangedFilesRequest,
-    GithubServerServiceCredentialRelease,
+    GithubDeliveryWorkflowAdmissionProcessor, GithubPullRequestChangedFilesRequest,
+    GithubPushChangedFilesAuthority, GithubPushChangedFilesError, GithubPushChangedFilesProvider,
+    GithubPushChangedFilesRequest, GithubServerServiceCredentialRelease,
 };
 use automata_ci_scm::{
     ArchiveFormat, ExactRevision, RepositoryId as ScmRepositoryId, RepositorySource,
@@ -73,6 +73,7 @@ const DIFF_CREDENTIAL: &str = "installation-token-private-diff-marker";
 const ACCEPTED_WORKFLOW: &[u8] = b"name: Exact CI\non: push\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: echo exact\n";
 const PATH_WORKFLOW: &[u8] = b"name: Paths CI\non:\n  push:\n    paths: ['src/**']\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: echo paths\n";
 const PULL_REQUEST_WORKFLOW: &[u8] = b"name: Pull Request CI\non: pull_request\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: echo pull-request\n";
+const PULL_REQUEST_PATH_WORKFLOW: &[u8] = b"name: Pull Request Paths CI\non:\n  pull_request:\n    paths: ['src/**']\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: echo pull-request-paths\n";
 
 #[derive(Debug)]
 struct FixedClock;
@@ -536,6 +537,20 @@ impl GithubPushChangedFilesProvider for ChangedFiles {
             });
         self.result.clone()
     }
+
+    async fn pull_request_changed_files(
+        &self,
+        request: GithubPullRequestChangedFilesRequest<'_>,
+    ) -> Result<GithubChangedFiles, GithubPushChangedFilesError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(request.pull_request().base_revision().as_str(), BEFORE);
+        assert_eq!(request.pull_request().head_revision().as_str(), AFTER);
+        assert_eq!(
+            request.private_action(),
+            Some(GithubDeliveryPrivateRepositoryAction::FetchPrivateRepositoryChangedFiles)
+        );
+        self.result.clone()
+    }
 }
 
 struct Harness {
@@ -628,7 +643,10 @@ async fn harness_with_visibility(
     }
 }
 
-async fn pull_request_harness(files: BTreeMap<&str, &[u8]>) -> Harness {
+async fn pull_request_harness(
+    files: BTreeMap<&str, &[u8]>,
+    changed_files: Option<Arc<ChangedFiles>>,
+) -> Harness {
     let blobs = Arc::new(MemoryBlobStore::default());
     let body = pull_request_body();
     let raw_key = "provider-deliveries/github/event/pull-request-fixture.json";
@@ -670,13 +688,17 @@ async fn pull_request_harness(files: BTreeMap<&str, &[u8]>) -> Harness {
         GithubAuthenticatedEventKind::PullRequest,
         "refs/pull/7/merge",
     ));
+    let mut processor = GithubDeliveryWorkflowAdmissionProcessor::new(admission);
+    if let Some(changed_files) = changed_files {
+        processor = processor.with_changed_files_provider(changed_files);
+    }
     let worker = GithubDeliveryWorker::new(
         blobs.clone(),
         Arc::new(FixedSource {
             source,
             visibility: ProviderRepositoryVisibility::Private,
         }),
-        Arc::new(GithubDeliveryWorkflowAdmissionProcessor::new(admission)),
+        Arc::new(processor),
         deliveries.clone(),
         subject_evidence,
         Arc::new(FixedClock),
@@ -891,8 +913,11 @@ async fn accepted_path_replays_durable_progress_without_readmission() {
 
 #[tokio::test]
 async fn pull_request_metadata_and_raw_event_reach_logical_admission_exactly() {
-    let harness =
-        pull_request_harness(BTreeMap::from([(WORKFLOW_PATH, PULL_REQUEST_WORKFLOW)])).await;
+    let harness = pull_request_harness(
+        BTreeMap::from([(WORKFLOW_PATH, PULL_REQUEST_WORKFLOW)]),
+        None,
+    )
+    .await;
 
     assert!(matches!(
         process(&harness).await.expect("pull-request processing"),
@@ -915,6 +940,33 @@ async fn pull_request_metadata_and_raw_event_reach_logical_admission_exactly() {
         read_admission_object(&harness.blobs, command.event()).await,
         pull_request_body()
     );
+    assert_eq!(
+        outcome_kind(harness.deliveries.completions()[0].outcomes()[0].conclusion()),
+        ("admitted", None)
+    );
+}
+
+#[tokio::test]
+async fn pull_request_path_filters_resolve_changed_files_and_admit_without_a_prerequisite() {
+    let changed = Arc::new(ChangedFiles::new(Ok(GithubChangedFiles::complete([
+        "src/lib.rs",
+    ]))));
+    let harness = pull_request_harness(
+        BTreeMap::from([(WORKFLOW_PATH, PULL_REQUEST_PATH_WORKFLOW)]),
+        Some(changed.clone()),
+    )
+    .await;
+
+    assert!(matches!(
+        process(&harness)
+            .await
+            .expect("pull-request path processing"),
+        GithubDeliveryWorkerOutcome::Completed(_)
+    ));
+    assert_eq!(changed.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.credentials.releases.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.logical.commands().len(), 1);
     assert_eq!(
         outcome_kind(harness.deliveries.completions()[0].outcomes()[0].conclusion()),
         ("admitted", None)

--- a/crates/automata-ci-github/src/changed_files.rs
+++ b/crates/automata-ci-github/src/changed_files.rs
@@ -34,6 +34,51 @@ pub enum GithubPushDiffAuthority<'credential> {
     PrivateInstallationContentsRead(&'credential SecretString),
 }
 
+/// Least-authority authentication for one GitHub pull-request comparison.
+pub type GithubPullRequestDiffAuthority<'credential> = GithubPushDiffAuthority<'credential>;
+
+/// One bounded, exact GitHub pull-request three-dot comparison.
+pub struct GithubPullRequestDiffRequest<'request> {
+    repository: &'request RepositoryId,
+    base: &'request ExactRevision,
+    head: &'request ExactRevision,
+    authority: GithubPullRequestDiffAuthority<'request>,
+    deadline: Instant,
+}
+
+impl<'request> GithubPullRequestDiffRequest<'request> {
+    /// Creates a request bound to the webhook's exact base and head revisions.
+    #[must_use]
+    pub const fn new(
+        repository: &'request RepositoryId,
+        base: &'request ExactRevision,
+        head: &'request ExactRevision,
+        authority: GithubPullRequestDiffAuthority<'request>,
+        deadline: Instant,
+    ) -> Self {
+        Self {
+            repository,
+            base,
+            head,
+            authority,
+            deadline,
+        }
+    }
+}
+
+impl fmt::Debug for GithubPullRequestDiffRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GithubPullRequestDiffRequest")
+            .field("repository", &"[redacted]")
+            .field("base", &"[redacted]")
+            .field("head", &"[redacted]")
+            .field("authority", &self.authority)
+            .field("deadline", &"[monotonic deadline]")
+            .finish()
+    }
+}
+
 impl fmt::Debug for GithubPushDiffAuthority<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -144,6 +189,69 @@ pub struct GithubCompletePushDiff {
     changed_paths: Vec<String>,
 }
 
+/// Complete, exact provider evidence for one pull-request three-dot diff.
+#[derive(Clone, Eq, PartialEq)]
+pub struct GithubCompletePullRequestDiff {
+    base: ExactRevision,
+    head: ExactRevision,
+    changed_paths: Vec<String>,
+}
+
+impl GithubCompletePullRequestDiff {
+    /// Returns the exact webhook base revision proven by the response.
+    #[must_use]
+    pub const fn base(&self) -> &ExactRevision {
+        &self.base
+    }
+
+    /// Returns the exact webhook head revision proven by the response.
+    #[must_use]
+    pub const fn head(&self) -> &ExactRevision {
+        &self.head
+    }
+
+    /// Returns the canonical lexicographically sorted changed paths.
+    #[must_use]
+    pub fn changed_paths(&self) -> &[String] {
+        &self.changed_paths
+    }
+
+    /// Consumes the evidence and returns its canonical changed paths.
+    #[must_use]
+    pub fn into_changed_paths(self) -> Vec<String> {
+        self.changed_paths
+    }
+}
+
+impl fmt::Debug for GithubCompletePullRequestDiff {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GithubCompletePullRequestDiff")
+            .field("base", &"[redacted]")
+            .field("head", &"[redacted]")
+            .field("changed_path_count", &self.changed_paths.len())
+            .finish()
+    }
+}
+
+/// Provider disposition for an exact pull-request three-dot diff.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum GithubPullRequestDiffOutcome {
+    /// Complete evidence safe for path-filter evaluation.
+    Complete(GithubCompletePullRequestDiff),
+    /// The public API did not prove a complete Actions-equivalent path set.
+    Incomplete(GithubPushDiffIncompleteReason),
+}
+
+/// Sanitized temporary failure while obtaining pull-request diff evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum GithubPullRequestDiffError {
+    /// The provider, rate-limit budget, transport, or overall deadline is unavailable.
+    #[error("GitHub pull-request diff evidence is temporarily unavailable")]
+    Unavailable,
+}
+
 impl GithubCompletePushDiff {
     /// Returns the exact pre-push commit proven by the response.
     #[must_use]
@@ -240,6 +348,14 @@ struct ExistingDiff<'request> {
     deadline: Instant,
 }
 
+struct PullRequestDiff<'request> {
+    repository: &'request RepositoryId,
+    base: &'request ExactRevision,
+    head: &'request ExactRevision,
+    authority: &'request GithubPullRequestDiffAuthority<'request>,
+    deadline: Instant,
+}
+
 impl GithubHttpEndpoint {
     /// Resolves demonstrably complete changed-file evidence for one signed push.
     ///
@@ -288,6 +404,38 @@ impl GithubHttpEndpoint {
         }
     }
 
+    /// Resolves complete changed-file evidence for one pull request.
+    ///
+    /// GitHub Actions evaluates pull-request path filters with a three-dot
+    /// comparison. This operation uses the webhook's immutable base and head
+    /// revisions, verifies every comparison page remains bound to them, and
+    /// accepts fewer than 300 unique non-renamed paths. An ambiguous capped or
+    /// renamed result is returned as incomplete instead of a truncated list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GithubPullRequestDiffError::Unavailable`] for an expired
+    /// deadline, transport/server failure, or rate limiting.
+    pub async fn pull_request_changed_files(
+        &self,
+        request: GithubPullRequestDiffRequest<'_>,
+    ) -> Result<GithubPullRequestDiffOutcome, GithubPullRequestDiffError> {
+        let request = PullRequestDiff {
+            repository: request.repository,
+            base: request.base,
+            head: request.head,
+            authority: &request.authority,
+            deadline: request.deadline,
+        };
+        match self.compare_pull_request(request).await {
+            Ok(evidence) => Ok(GithubPullRequestDiffOutcome::Complete(evidence)),
+            Err(CompareFailure::Incomplete(reason)) => {
+                Ok(GithubPullRequestDiffOutcome::Incomplete(reason))
+            }
+            Err(CompareFailure::Unavailable) => Err(GithubPullRequestDiffError::Unavailable),
+        }
+    }
+
     async fn compare_existing_push(
         &self,
         request: ExistingDiff<'_>,
@@ -323,6 +471,50 @@ impl GithubHttpEndpoint {
             before: request.before.clone(),
             after: request.after.clone(),
             changed_paths: changed_paths.ok_or_else(invalid_evidence)?,
+        })
+    }
+
+    async fn compare_pull_request(
+        &self,
+        request: PullRequestDiff<'_>,
+    ) -> Result<GithubCompletePullRequestDiff, CompareFailure> {
+        if request.base == request.head {
+            return Err(invalid_evidence());
+        }
+        let deadline = self.effective_compare_deadline(request.deadline)?;
+        let first_endpoint = self.compare_url(request.repository, request.base, request.head, 1)?;
+        let first = self
+            .fetch_compare_page(first_endpoint, request.authority, deadline)
+            .await?;
+        let total_commits = usize::try_from(first.total_commits).map_err(|_| invalid_evidence())?;
+        let page_count = comparison_page_count(total_commits, self.trusted.limits().max_pages)?;
+        let identity = validate_pull_request_page_identity(&first, request.base, total_commits)?;
+        validate_page_length(&first, 1, page_count, total_commits)?;
+        let changed_paths = complete_changed_paths(first.files)?;
+        let mut observed_commits = first
+            .commits
+            .into_iter()
+            .map(|commit| commit.sha)
+            .collect::<Vec<_>>();
+        for page_number in 2..=page_count {
+            let endpoint =
+                self.compare_url(request.repository, request.base, request.head, page_number)?;
+            let page = self
+                .fetch_compare_page(endpoint, request.authority, deadline)
+                .await?;
+            if validate_pull_request_page_identity(&page, request.base, total_commits)? != identity
+                || page.files.is_some()
+            {
+                return Err(invalid_evidence());
+            }
+            validate_page_length(&page, page_number, page_count, total_commits)?;
+            observed_commits.extend(page.commits.into_iter().map(|commit| commit.sha));
+        }
+        validate_pull_request_commits(&observed_commits, request.head)?;
+        Ok(GithubCompletePullRequestDiff {
+            base: request.base.clone(),
+            head: request.head.clone(),
+            changed_paths,
         })
     }
 
@@ -498,6 +690,36 @@ fn validate_page_identity(
     Ok(())
 }
 
+#[derive(Eq, PartialEq)]
+struct PullRequestPageIdentity {
+    status: String,
+    ahead_by: u64,
+    behind_by: u64,
+    merge_base: String,
+}
+
+fn validate_pull_request_page_identity(
+    page: &ComparePage,
+    base: &ExactRevision,
+    expected_commits: usize,
+) -> Result<PullRequestPageIdentity, CompareFailure> {
+    let expected_commits = u64::try_from(expected_commits).map_err(|_| invalid_evidence())?;
+    if !matches!(page.status.as_str(), "ahead" | "diverged")
+        || page.ahead_by != expected_commits
+        || page.total_commits != expected_commits
+        || page.base_commit.sha != base.as_str()
+        || ExactRevision::new(&page.merge_base_commit.sha).is_err()
+    {
+        return Err(invalid_evidence());
+    }
+    Ok(PullRequestPageIdentity {
+        status: page.status.clone(),
+        ahead_by: page.ahead_by,
+        behind_by: page.behind_by,
+        merge_base: page.merge_base_commit.sha.clone(),
+    })
+}
+
 fn validate_page_length(
     page: &ComparePage,
     page_number: usize,
@@ -526,6 +748,24 @@ fn validate_observed_commits(
     let mut canonical = observed.iter().map(String::as_str).collect::<Vec<_>>();
     canonical.sort_unstable();
     if canonical != expected || canonical.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(invalid_evidence());
+    }
+    Ok(())
+}
+
+fn validate_pull_request_commits(
+    observed: &[String],
+    head: &ExactRevision,
+) -> Result<(), CompareFailure> {
+    if observed.last().map(String::as_str) != Some(head.as_str())
+        || observed
+            .iter()
+            .any(|commit| ExactRevision::new(commit).is_err())
+    {
+        return Err(invalid_evidence());
+    }
+    let unique = observed.iter().map(String::as_str).collect::<HashSet<_>>();
+    if unique.len() != observed.len() {
         return Err(invalid_evidence());
     }
     Ok(())

--- a/crates/automata-ci-github/src/lib.rs
+++ b/crates/automata-ci-github/src/lib.rs
@@ -16,9 +16,11 @@ mod webhook;
 mod webhook_event;
 
 pub use changed_files::{
-    GithubCompletePushDiff, GithubPushDiffAuthority, GithubPushDiffError,
-    GithubPushDiffIncompleteReason, GithubPushDiffOutcome, GithubPushDiffRange,
-    GithubPushDiffRequest, MAX_COMPLETE_GITHUB_COMPARE_FILES,
+    GithubCompletePullRequestDiff, GithubCompletePushDiff, GithubPullRequestDiffAuthority,
+    GithubPullRequestDiffError, GithubPullRequestDiffOutcome, GithubPullRequestDiffRequest,
+    GithubPushDiffAuthority, GithubPushDiffError, GithubPushDiffIncompleteReason,
+    GithubPushDiffOutcome, GithubPushDiffRange, GithubPushDiffRequest,
+    MAX_COMPLETE_GITHUB_COMPARE_FILES,
 };
 pub use checks::{
     GithubCheckAnnotation, GithubCheckAnnotationLevel, GithubCheckAppId, GithubCheckCompletion,

--- a/crates/automata-ci-github/tests/changed_files.rs
+++ b/crates/automata-ci-github/tests/changed_files.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, Instant};
 
 use automata_ci_auth::secret::SecretString;
 use automata_ci_github::{
-    GithubHttpEndpoint, GithubHttpLimits, GithubPushDiffAuthority, GithubPushDiffError,
+    GithubHttpEndpoint, GithubHttpLimits, GithubPullRequestDiffOutcome,
+    GithubPullRequestDiffRequest, GithubPushDiffAuthority, GithubPushDiffError,
     GithubPushDiffIncompleteReason, GithubPushDiffOutcome, GithubPushDiffRange,
     GithubPushDiffRequest, MAX_COMPLETE_GITHUB_COMPARE_FILES,
 };
@@ -55,6 +56,20 @@ fn compare_page(
     serde_json::to_string(&body).expect("comparison JSON")
 }
 
+fn pull_request_compare_page(base: &str, merge_base: &str, head: &str, files: &[Value]) -> String {
+    serde_json::to_string(&json!({
+        "status": "diverged",
+        "ahead_by": 1,
+        "behind_by": 2,
+        "total_commits": 1,
+        "base_commit": {"sha": base},
+        "merge_base_commit": {"sha": merge_base},
+        "commits": [{"sha": head}],
+        "files": files,
+    }))
+    .expect("pull-request comparison JSON")
+}
+
 async fn existing_diff<'a>(
     endpoint: &'a GithubHttpEndpoint,
     repository: &'a RepositoryId,
@@ -75,6 +90,77 @@ async fn existing_diff<'a>(
             Instant::now() + Duration::from_secs(2),
         ))
         .await
+}
+
+async fn pull_request_diff<'a>(
+    endpoint: &'a GithubHttpEndpoint,
+    repository: &'a RepositoryId,
+    base: &'a ExactRevision,
+    head: &'a ExactRevision,
+) -> GithubPullRequestDiffOutcome {
+    endpoint
+        .pull_request_changed_files(GithubPullRequestDiffRequest::new(
+            repository,
+            base,
+            head,
+            GithubPushDiffAuthority::PublicAnonymous,
+            Instant::now() + Duration::from_secs(2),
+        ))
+        .await
+        .expect("pull-request comparison")
+}
+
+#[tokio::test]
+async fn pull_request_three_dot_comparison_accepts_divergence_and_binds_exact_revisions() {
+    let fixture = FixtureServer::spawn().await;
+    fixture.enqueue(ResponseSpec::json(
+        StatusCode::OK,
+        pull_request_compare_page(
+            BEFORE,
+            OTHER,
+            AFTER,
+            &[
+                changed_file("web/index.html", "modified"),
+                changed_file("src/lib.rs", "added"),
+            ],
+        ),
+    ));
+    let repository = repository();
+    let base = revision(BEFORE);
+    let head = revision(AFTER);
+
+    let outcome = pull_request_diff(&fixture.endpoint(), &repository, &base, &head).await;
+    let GithubPullRequestDiffOutcome::Complete(evidence) = outcome else {
+        panic!("expected complete pull-request comparison");
+    };
+    assert_eq!(evidence.base(), &base);
+    assert_eq!(evidence.head(), &head);
+    assert_eq!(evidence.changed_paths(), ["src/lib.rs", "web/index.html"]);
+    assert_eq!(fixture.requests().len(), 1);
+    assert_eq!(
+        fixture.requests()[0].uri,
+        format!("/api/repos/octo-org/private-repo/compare/{BEFORE}...{AFTER}?per_page=100&page=1")
+    );
+}
+
+#[tokio::test]
+async fn pull_request_comparison_rejects_a_response_not_ending_at_signed_head() {
+    let fixture = FixtureServer::spawn().await;
+    fixture.enqueue(ResponseSpec::json(
+        StatusCode::OK,
+        pull_request_compare_page(BEFORE, OTHER, OTHER, &[]),
+    ));
+    let outcome = pull_request_diff(
+        &fixture.endpoint(),
+        &repository(),
+        &revision(BEFORE),
+        &revision(AFTER),
+    )
+    .await;
+    assert_eq!(
+        outcome,
+        GithubPullRequestDiffOutcome::Incomplete(GithubPushDiffIncompleteReason::InvalidEvidence)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- resolve GitHub pull-request changed files using the signed three-dot base/head comparison
- bind pagination and the final commit to the webhook revisions
- conservatively bypass path filters when GitHub cannot provide a complete diff
- keep private repository access on the existing installation token path

## Validation

- `cargo test -p automata-ci-github --test changed_files`
- `cargo test -p automata-ci-github-delivery --test workflow_processor`
- `cargo clippy -p automata-ci-github -p automata-ci-github-delivery -p automata-ci --all-targets -- -D warnings`