### PR TITLE
Reconcile control-plane metrics budget

### DIFF
--- a/crates/automata-ci/tests/metrics_semantics.rs
+++ b/crates/automata-ci/tests/metrics_semantics.rs
@@ -87,7 +87,7 @@ fn semantic_metrics_have_an_exact_bounded_privacy_safe_exposition() {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_280,
+        all_series, 5_344,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(

--- a/crates/automata-ci/tests/results_metrics.rs
+++ b/crates/automata-ci/tests/results_metrics.rs
@@ -84,7 +84,7 @@ fn results_and_storage_schema_is_exact_bounded_and_identifier_free() {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_280,
+        all_series, 5_344,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -19,7 +19,7 @@ scrape_configs:
     native_histogram_bucket_limit: 160
     native_histogram_min_bucket_factor: 1.09
     body_size_limit: 2MB
-    sample_limit: 5400
+    sample_limit: 5600
     label_limit: 24
     label_name_length_limit: 128
     label_value_length_limit: 256

--- a/deploy/observability/rules/automata-ci-alerts.yml
+++ b/deploy/observability/rules/automata-ci-alerts.yml
@@ -119,7 +119,7 @@ groups:
         expr: >-
           scrape_samples_post_metric_relabeling{job="automata-runner"} > 980
           or
-          scrape_samples_post_metric_relabeling{job="automata-control-plane"} > 4860
+          scrape_samples_post_metric_relabeling{job="automata-control-plane"} > 5040
         for: 15m
         labels:
           severity: warning

--- a/deploy/observability/rules/tests/automata-ci.test.yml
+++ b/deploy/observability/rules/tests/automata-ci.test.yml
@@ -959,9 +959,9 @@ tests:
       - series: scrape_samples_post_metric_relabeling{job="automata-runner",instance="runner-cardinality"}
         values: 981x25
       - series: scrape_samples_post_metric_relabeling{job="automata-control-plane",instance="cp-cardinality"}
-        values: 4861x25
+        values: 5041x25
       - series: scrape_samples_post_metric_relabeling{job="automata-control-plane",instance="cp-cardinality-boundary"}
-        values: 4860x25
+        values: 5040x25
       - series: automata_ci_control_plane_ready{job="automata-control-plane",instance="cp-unready"}
         values: 0x25
       - series: automata_ci_control_plane_dependency_ready{job="automata-control-plane",instance="cp-dependency",dependency="postgres"}
@@ -998,7 +998,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: Automata target is near its series budget
-              description: Target cp-cardinality exposes 4861 post-relabel samples.
+              description: Target cp-cardinality exposes 5041 post-relabel samples.
               runbook_url: https://github.com/automata-ci/automata/blob/main/deploy/observability/runbooks/metrics-budget.md
       - eval_time: 6m
         alertname: AutomataControlPlaneUnready

--- a/deploy/observability/runbooks/metrics-budget.md
+++ b/deploy/observability/runbooks/metrics-budget.md
@@ -1,9 +1,9 @@
 # Metrics budget pressure
 
-This warning means a target is approaching its 1,000-runner or 5,400-control-
+This warning means a target is approaching its 1,000-runner or 5,600-control-
 plane sample limit. The current reviewed classic maxima are 939 runner and
-5,152 control-plane series. With native and classic histograms ingested
-together, the reviewed Prometheus maxima are 969 runner and 5,299
+5,344 control-plane series. With native and classic histograms ingested
+together, the reviewed Prometheus maxima are 969 runner and 5,494
 control-plane samples per scrape, before Prometheus-generated target metadata.
 
 1. Compare `scrape_samples_post_metric_relabeling` and response size before and
@@ -20,7 +20,7 @@ control-plane samples per scrape, before Prometheus-generated target metadata.
 
 The runner warning starts above 980 post-relabel samples, leaving a small but
 intentional margin below the 1,000 hard limit; the control-plane warning starts
-above 4,860. If a scrape exceeds its hard `sample_limit`, Prometheus rejects the
+above 5,040. If a scrape exceeds its hard `sample_limit`, Prometheus rejects the
 entire scrape. Do not increase either limit until both application cardinality
 and native bucket/storage cost have been reviewed.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -115,7 +115,7 @@ scrape. Initial limits are:
 | Concurrent scrapes | 2 | 2 |
 | Handler deadline | 5 seconds | 5 seconds |
 | Encoded response | 2 MiB | 2 MiB |
-| Post-relabel samples per scrape | 5,400 | 1,000 |
+| Post-relabel samples per scrape | 5,600 | 1,000 |
 
 The scrape limits are release gates. New metrics must remain within them, and
 remaining headroom is not an invitation to add unbounded labels.


### PR DESCRIPTION
## Summary

- ratchet the reviewed control-plane exposition to 5,344 classic series
- raise the native-plus-classic scrape ceiling to 5,600, preserving the prior ~1.9% headroom
- move the 90% pressure alert to 5,040 and update its rule tests and operator documentation

The missing 64 series are bounded: the workflow rerun browser route adds 48 request-counter series, 15 histogram series, and one in-flight gauge. With native histograms the reviewed maximum is 5,494 samples, which exceeded the old 5,400 hard limit and could reject the entire scrape.

## Verification

- scripts/ci/verify-metrics.sh
- scripts/ci/verify-native-metrics.sh
- focused promtool config, rule, and rule-test checks
- rustfmt on the changed Rust tests
- git diff --check

The two focused Rust tests independently reported the deterministic 5,344 actual cardinality on main; their full recompilation was constrained by host OOM pressure, so CI remains the authoritative clean-host run.