### PR TITLE
fix: stabilize live GitHub workflow admission

### DIFF
--- a/crates/automata-ci-github-delivery/src/lib.rs
+++ b/crates/automata-ci-github-delivery/src/lib.rs
@@ -1101,7 +1101,7 @@ fn authenticated_event_coordinates(
         VerifiedGithubWebhook::PullRequest(pull_request) => (
             GithubAuthenticatedEventKind::PullRequest,
             pull_request.git_ref().to_owned(),
-            pull_request.merge_revision().as_str(),
+            pull_request.head_revision().as_str(),
         ),
         VerifiedGithubWebhook::MergeGroup(merge_group) => (
             GithubAuthenticatedEventKind::MergeGroup,

--- a/crates/automata-ci-github-delivery/src/tests.rs
+++ b/crates/automata-ci-github-delivery/src/tests.rs
@@ -57,6 +57,10 @@ const OTHER_SECRET: &[u8] = b"rotated-delivery-test-secret";
 const FINGERPRINT_SECRET: &[u8] = b"0123456789abcdef0123456789abcdef";
 const BEFORE_COMMIT: &str = "fedcba9876543210fedcba9876543210fedcba98";
 const AFTER_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+const AFTER_COMMIT_BYTES: [u8; 20] = [
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    0x01, 0x23, 0x45, 0x67,
+];
 const PULL_REQUEST_MERGE_COMMIT: &str = "89abcdef0123456789abcdef0123456789abcdef";
 const CONNECTION_UUID: Uuid = Uuid::from_u128(0x57d02be9_1ac4_4780_a573_48d21621c2de);
 const INSTALLATION_ID: u64 = 4_242;
@@ -1981,7 +1985,7 @@ async fn generic_ingress_persists_typed_event_coordinates_without_event_kind_ali
         let event = requests[0].authenticated_event();
         assert_eq!(event.kind(), expected_kind);
         assert_eq!(event.git_ref(), expected_ref);
-        assert_eq!(requests[0].head_sha().as_str(), AFTER_COMMIT);
+        assert_eq!(requests[0].head_sha().as_bytes(), AFTER_COMMIT_BYTES);
         assert_eq!(requests[0].delivery().identity().delivery_id(), delivery_id);
     }
 }

--- a/crates/automata-ci-github-delivery/src/tests.rs
+++ b/crates/automata-ci-github-delivery/src/tests.rs
@@ -57,6 +57,7 @@ const OTHER_SECRET: &[u8] = b"rotated-delivery-test-secret";
 const FINGERPRINT_SECRET: &[u8] = b"0123456789abcdef0123456789abcdef";
 const BEFORE_COMMIT: &str = "fedcba9876543210fedcba9876543210fedcba98";
 const AFTER_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+const PULL_REQUEST_MERGE_COMMIT: &str = "89abcdef0123456789abcdef0123456789abcdef";
 const CONNECTION_UUID: Uuid = Uuid::from_u128(0x57d02be9_1ac4_4780_a573_48d21621c2de);
 const INSTALLATION_ID: u64 = 4_242;
 const REPOSITORY_ID: u64 = 9_001;
@@ -827,7 +828,7 @@ fn check_run_control_body() -> Bytes {
 
 fn pull_request_body(action: &str, merged: bool) -> Bytes {
     Bytes::from(format!(
-        r#"{{"action":"{action}","number":7,"pull_request":{{"number":7,"merged":{merged},"merge_commit_sha":"{AFTER_COMMIT}","head":{{"ref":"feature/topic","sha":"{AFTER_COMMIT}","repo":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}}}},"base":{{"ref":"main","sha":"{BEFORE_COMMIT}","repo":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}}}}}},"repository":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}},"installation":{{"id":{INSTALLATION_ID}}},"sender":{{"id":301}}}}"#
+        r#"{{"action":"{action}","number":7,"pull_request":{{"number":7,"merged":{merged},"merge_commit_sha":"{PULL_REQUEST_MERGE_COMMIT}","head":{{"ref":"feature/topic","sha":"{AFTER_COMMIT}","repo":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}}}},"base":{{"ref":"main","sha":"{BEFORE_COMMIT}","repo":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}}}}}},"repository":{{"id":{REPOSITORY_ID},"private":true,"visibility":"private","name":"private-repository","full_name":"octo-private/private-repository","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"octo-private"}}}},"installation":{{"id":{INSTALLATION_ID}}},"sender":{{"id":301}}}}"#
     ))
 }
 
@@ -1980,6 +1981,7 @@ async fn generic_ingress_persists_typed_event_coordinates_without_event_kind_ali
         let event = requests[0].authenticated_event();
         assert_eq!(event.kind(), expected_kind);
         assert_eq!(event.git_ref(), expected_ref);
+        assert_eq!(requests[0].head_sha().as_str(), AFTER_COMMIT);
         assert_eq!(requests[0].delivery().identity().delivery_id(), delivery_id);
     }
 }

--- a/crates/automata-ci-github/src/webhook_event.rs
+++ b/crates/automata-ci-github/src/webhook_event.rs
@@ -667,6 +667,10 @@ impl VerifiedGithubPullRequest {
     }
 
     /// Returns the merge-branch commit used as `GITHUB_SHA` for this event.
+    ///
+    /// GitHub may send `null` before it has materialized the pull-request merge
+    /// commit. In that case an unmerged event uses the exact head revision as
+    /// the deterministic execution fallback.
     #[must_use]
     pub const fn merge_revision(&self) -> &ExactRevision {
         &self.merge_revision
@@ -832,9 +836,25 @@ struct PullRequestPayload {
 struct PullRequestObjectPayload {
     number: u64,
     merged: bool,
-    merge_commit_sha: Option<String>,
+    #[serde(default)]
+    merge_commit_sha: PullRequestMergeCommitShaPayload,
     head: PullRequestBranchPayload,
     base: PullRequestBranchPayload,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PullRequestMergeCommitShaPayload {
+    Revision(String),
+    Null(()),
+    #[serde(skip)]
+    Missing,
+}
+
+impl Default for PullRequestMergeCommitShaPayload {
+    fn default() -> Self {
+        Self::Missing
+    }
 }
 
 #[derive(Deserialize)]
@@ -1071,11 +1091,18 @@ pub(crate) fn normalize_pull_request(
     let head_repository = payload.pull_request.head.repo.normalize()?;
     let head_revision = exact_revision(payload.pull_request.head.sha)?;
     let base_revision = exact_revision(payload.pull_request.base.sha)?;
-    let merge_revision = payload
-        .pull_request
-        .merge_commit_sha
-        .ok_or(GithubWebhookError::InvalidPayload)
-        .and_then(exact_revision)?;
+    let merge_revision = match payload.pull_request.merge_commit_sha {
+        PullRequestMergeCommitShaPayload::Revision(revision) => exact_revision(revision)?,
+        PullRequestMergeCommitShaPayload::Null(()) if !payload.pull_request.merged => {
+            head_revision.clone()
+        }
+        PullRequestMergeCommitShaPayload::Null(()) => {
+            return Err(GithubWebhookError::InvalidPayload);
+        }
+        PullRequestMergeCommitShaPayload::Missing => {
+            return Err(GithubWebhookError::InvalidPayload);
+        }
+    };
     let head_ref = normalize_branch_name(payload.pull_request.head.git_ref)?;
     let base_ref = normalize_branch_name(payload.pull_request.base.git_ref)?;
     if payload.pull_request.merged && action != GithubPullRequestAction::Closed {

--- a/crates/automata-ci-github/tests/webhook_event_normalization.rs
+++ b/crates/automata-ci-github/tests/webhook_event_normalization.rs
@@ -144,6 +144,26 @@ fn merged_pull_request_uses_the_target_branch_workflow_ref() {
 }
 
 #[test]
+fn unmerged_pull_request_without_materialized_merge_revision_uses_head_revision() {
+    let mut payload = pull_request_payload();
+    payload["pull_request"]["merge_commit_sha"] = Value::Null;
+
+    let event = normalize_payload(&payload, "pull_request")
+        .expect("GitHub may not have materialized the merge revision yet");
+    let VerifiedGithubWebhook::PullRequest(event) = event else {
+        panic!("expected pull-request evidence");
+    };
+    assert!(!event.merged());
+    assert_eq!(event.head_revision().as_str(), HEAD_SHA);
+    assert_eq!(event.merge_revision().as_str(), HEAD_SHA);
+    assert_eq!(event.git_ref(), "refs/pull/7/merge");
+
+    payload["action"] = json!("closed");
+    payload["pull_request"]["merged"] = json!(true);
+    assert_invalid_pull_request(&payload);
+}
+
+#[test]
 fn merge_group_normalization_retains_exact_dispatch_evidence() {
     let body = encode(&merge_group_payload());
     let event =

--- a/crates/automata-ci-postgres/src/store/github_schedule.rs
+++ b/crates/automata-ci-postgres/src/store/github_schedule.rs
@@ -314,6 +314,7 @@ async fn insert_schedule_discovery_claim(
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
             $13, 1, 'claimed', $14, $15, $14, $14
         )
+        ON CONFLICT DO NOTHING
         ",
     )
     .bind(request.registry_id().as_uuid())
@@ -352,6 +353,7 @@ async fn insert_schedule_discovery_claim(
             )
             .map_err(|_| GithubScheduleStoreError::CorruptData)
         }
+        Ok(result) if result.rows_affected() == 0 => Err(GithubScheduleStoreError::Conflict),
         Ok(_) => Err(GithubScheduleStoreError::CorruptData),
         Err(error) if integrity_violation(&error) => Err(GithubScheduleStoreError::Conflict),
         Err(error) => Err(operation_error(error)),

--- a/crates/automata-ci-postgres/src/store/logical_work_selection.rs
+++ b/crates/automata-ci-postgres/src/store/logical_work_selection.rs
@@ -975,6 +975,16 @@ async fn cleanup_receipts(
                       FROM logical_workflow_activation_work_quarantines AS quarantine
                       WHERE quarantine.selection_id = receipt.selection_id
                   )
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM github_runtime_authority_issuances AS authority
+                      WHERE authority.preparation_selection_id = receipt.selection_id
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM github_runtime_authority_issuances AS authority
+                      WHERE authority.activation_selection_id = receipt.selection_id
+                  )
                 ORDER BY expires_at_ms, selection_id
                 FOR UPDATE SKIP LOCKED
                 LIMIT $2
@@ -1003,6 +1013,11 @@ async fn cleanup_receipts(
                       SELECT 1
                       FROM logical_workflow_materialization_work_quarantines AS quarantine
                       WHERE quarantine.selection_id = receipt.selection_id
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM github_runtime_authority_issuances AS authority
+                      WHERE authority.materialization_selection_id = receipt.selection_id
                   )
                 ORDER BY expires_at_ms, selection_id
                 FOR UPDATE SKIP LOCKED

--- a/crates/automata-ci-workflow-github/src/compiler/logical.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/logical.rs
@@ -224,6 +224,9 @@ pub(super) fn compile(request: CompileWorkflowRequest<'_>) -> CompilationReport 
     let workflow = request.source_plan.workflow();
     context.reject_extensions(workflow.extensions());
     let event = compile_event(request.event, &request.selection, &mut context);
+    if !matches!(event, CompiledEvent::Selected { .. }) {
+        return finish_compilation(event, None, context.diagnostics);
+    }
     let source = compile_source(&context);
     let name = compile_workflow_name(workflow.name(), &mut context);
     let mut workflow_references = BTreeMap::new();

--- a/crates/automata-ci-workflow-github/tests/trigger_selection.rs
+++ b/crates/automata-ci-workflow-github/tests/trigger_selection.rs
@@ -115,6 +115,51 @@ fn event_absence_is_structured_non_selection_without_diagnostics() {
 }
 
 #[test]
+fn event_absence_does_not_compile_an_unrelated_workflow_body() {
+    let source = "on: workflow_dispatch\njobs:\n  test:\n    runs-on: linux\n    environment: production\n    steps:\n      - run: true\n";
+    assert_not_selected(
+        &compile(
+            source,
+            event("pull_request", "refs/pull/1/merge"),
+            Some(GithubEventMetadata::pull_request("opened", "main")),
+        ),
+        WorkflowNotSelectedReason::EventNotConfigured,
+    );
+}
+
+#[test]
+fn path_filter_demand_does_not_compile_the_workflow_body() {
+    let source = "on:\n  pull_request:\n    paths: [ui/**]\njobs:\n  test:\n    runs-on: linux\n    environment: production\n    steps:\n      - run: true\n";
+    let report = compile(
+        source,
+        event("pull_request", "refs/pull/1/merge"),
+        Some(GithubEventMetadata::pull_request("opened", "main")),
+    );
+    assert_eq!(
+        report.disposition(),
+        CompilationDisposition::RequiresChangedFiles
+    );
+    assert!(
+        report.diagnostics().is_empty(),
+        "{:#?}",
+        report.diagnostics()
+    );
+}
+
+#[test]
+fn a_selected_event_still_rejects_an_unsupported_workflow_body() {
+    let source = "on: pull_request\njobs:\n  test:\n    runs-on: linux\n    environment: production\n    steps:\n      - run: true\n";
+    assert_rejected_with(
+        &compile(
+            source,
+            event("pull_request", "refs/pull/1/merge"),
+            Some(GithubEventMetadata::pull_request("opened", "main")),
+        ),
+        "github.compile.deployment_environment_unavailable",
+    );
+}
+
+#[test]
 fn repository_dispatch_types_select_only_the_exact_custom_event() {
     let filtered = "on:\n  repository_dispatch:\n    types: [synthetic_signal, secondary_signal]\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
     let matching = compile(


### PR DESCRIPTION
## Summary

- accept unmerged pull request webhooks whose GitHub merge commit SHA is explicitly null, while retaining strict rejection for missing or invalid merged revisions
- attach pull request check runs to the PR head SHA while continuing to check out the synthetic merge revision
- stop lowering unrelated workflow bodies after trigger selection rejects or defers them
- retain logical selection evidence referenced by runtime authority records during cleanup
- make redundant schedule-claim races conflict quietly instead of logging PostgreSQL uniqueness errors

## Live findings addressed

The live probe demonstrated end-to-end webhook delivery, redundant control-plane scheduling, and runners on both Hetzner hosts. It also exposed four correctness issues fixed here: null pre-merge revisions, unrelated workflow compilation overriding selection, check runs attached to the merge SHA, and cleanup racing retained runtime-authority evidence.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci-github --test webhook_event_normalization` (18 passed)
- `cargo test -p automata-ci-workflow-github --test trigger_selection` (21 passed)
- `cargo test -p automata-ci-workflow-github --test compiler` (4 passed)
- `cargo test -p automata-ci-github-delivery generic_ingress_persists_typed_event_coordinates_without_event_kind_aliasing`
- `cargo check -p automata-ci-postgres`
- `git diff --check origin/main...HEAD`