### PR TITLE
Fence GitHub Check annotation appends

### DIFF
--- a/crates/automata-ci-github-delivery/src/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/src/checks_publisher.rs
@@ -22,8 +22,8 @@ use automata_ci_github::{
 };
 use automata_ci_scm::{ExactRevision, RepositoryId as ScmRepositoryId};
 use automata_ci_store::{
-    AdvanceGithubCheckAnnotations, BeginGithubCheckRunCreate, BindGithubCheckRun,
-    BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
+    AdvanceGithubCheckAnnotations, BeginGithubCheckAnnotationBatch, BeginGithubCheckRunCreate,
+    BindGithubCheckRun, BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
     BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
     ClaimedGithubCheckProjection, ClearGithubCheckAnnotationUncertainty,
     CompleteGithubCheckProjection, GithubCheckAppId, GithubCheckConclusion,
@@ -37,9 +37,9 @@ use automata_ci_store::{
     GithubServerServiceRevision, GithubServerServiceWorkerId, InitializeGithubCheckPresentation,
     MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS, MAX_GITHUB_CHECK_PROJECTION_CLAIM_MILLIS,
     MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS, ProviderConnectionId, ProviderInstallationId,
-    ProviderRepositoryId, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
-    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations,
-    TenantScope,
+    ProviderRepositoryId, ReleaseUnissuedGithubCheckAnnotationBatch,
+    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
+    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, TenantScope,
 };
 use thiserror::Error;
 use tokio::time::{Instant, timeout_at};
@@ -1253,13 +1253,107 @@ impl GithubChecksPublisher {
             }
         }
 
+        if progress.is_complete() {
+            return Ok(None);
+        }
+
+        // An admitted PATCH must leave both the complete transport timeout and
+        // the configured post-request visibility margin inside this claim.
+        // That keeps timeout recovery behind the latest possible mutation.
+        let visibility_margin = Duration::from_millis(
+            u64::try_from(self.config.visibility_margin_millis())
+                .map_err(|_| GithubChecksPublisherError::InvariantViolation)?,
+        );
+        let recovery_tail = self
+            .endpoint
+            .trusted_origins()
+            .limits()
+            .request_timeout()
+            .checked_add(visibility_margin)
+            .ok_or(GithubChecksPublisherError::InvariantViolation)?;
+        let recovery_tail_millis = duration_millis_ceil(recovery_tail)?;
+        let Some(issue_deadline) = horizon
+            .deadline
+            .checked_sub(recovery_tail)
+            .filter(|deadline| *deadline > horizon.monotonic_started_at)
+        else {
+            return self
+                .schedule_retry(
+                    claimed,
+                    horizon,
+                    "github_annotation_issue_window_elapsed",
+                    None,
+                )
+                .await
+                .map(Some);
+        };
         while !progress.is_complete() {
+            if Instant::now() >= issue_deadline {
+                return self
+                    .schedule_retry(
+                        claimed,
+                        horizon,
+                        "github_annotation_issue_window_elapsed",
+                        None,
+                    )
+                    .await
+                    .map(Some);
+            }
             let from = usize::from(progress.next());
             let to = annotations
                 .len()
                 .min(from.saturating_add(MAX_ANNOTATIONS_PER_PATCH));
             let batch = &annotations[from..to];
-            match self
+            let batch_size = u8::try_from(batch.len())
+                .map_err(|_| GithubChecksPublisherError::InvariantViolation)?;
+            let batch_start = horizon.observed_at()?;
+            let begin = BeginGithubCheckAnnotationBatch::new(
+                claimed.claim(),
+                presentation.digest(),
+                u16::try_from(from).map_err(|_| GithubChecksPublisherError::InvariantViolation)?,
+                batch_size,
+                batch_start,
+            )
+            .map_err(invariant)?;
+            progress = self
+                .outbox
+                .begin_github_check_annotation_batch(begin)
+                .await?;
+            if progress.presentation_digest() != Some(presentation.digest())
+                || progress.total() != annotation_count
+                || progress.next()
+                    != u16::try_from(from)
+                        .map_err(|_| GithubChecksPublisherError::InvariantViolation)?
+                || progress.uncertain_batch_size() != Some(batch_size)
+            {
+                return Err(GithubChecksPublisherError::InvalidClaim);
+            }
+            if Instant::now() >= issue_deadline {
+                let released_at = horizon.observed_after(begin.started_at())?;
+                return self
+                    .release_unissued_annotation_batch(begin, released_at, claimed.attempts())
+                    .await
+                    .map(Some);
+            }
+            let request_admitted_at = horizon.observed_after(begin.started_at())?;
+            let mutation_visibility_not_before =
+                checked_add(request_admitted_at, recovery_tail_millis)?;
+            if mutation_visibility_not_before > horizon.expires_at {
+                return self
+                    .release_unissued_annotation_batch(
+                        begin,
+                        request_admitted_at,
+                        claimed.attempts(),
+                    )
+                    .await
+                    .map(Some);
+            }
+
+            // No await occurs between the final admission timestamp and
+            // polling the endpoint future. Provider I/O may have issued from
+            // this point, so cancellation or an ambiguous response retains
+            // the marker.
+            let append_outcome = self
                 .endpoint
                 .append_check_run_annotations(
                     credential.repository(),
@@ -1270,8 +1364,8 @@ impl GithubChecksPublisher {
                     batch,
                     credential.token(),
                 )
-                .await
-            {
+                .await;
+            match append_outcome {
                 Ok(_) => {
                     let observed_at = horizon.observed_at()?;
                     progress = self
@@ -1297,8 +1391,15 @@ impl GithubChecksPublisher {
                         claimed.attempts(),
                         Some(evidence),
                         failed_at,
-                    );
-                    let retry_at = checked_add(failed_at, delay)?;
+                    )
+                    .max(self.config.visibility_margin_millis());
+                    let backoff_not_before = checked_add(failed_at, delay)?;
+                    // A transport failure can return before the complete
+                    // request timeout while GitHub may still apply the PATCH.
+                    // Reconciliation therefore stays behind the entire
+                    // admitted request-and-visibility tail, not merely behind
+                    // the time at which the local error became observable.
+                    let retry_at = backoff_not_before.max(mutation_visibility_not_before);
                     let receipt = self
                         .outbox
                         .retry_uncertain_github_check_annotations(
@@ -1307,8 +1408,7 @@ impl GithubChecksPublisher {
                                 presentation.digest(),
                                 u16::try_from(from)
                                     .map_err(|_| GithubChecksPublisherError::InvariantViolation)?,
-                                u8::try_from(batch.len())
-                                    .map_err(|_| GithubChecksPublisherError::InvariantViolation)?,
+                                batch_size,
                                 failed_at,
                                 retry_at,
                             )
@@ -1326,6 +1426,24 @@ impl GithubChecksPublisher {
             }
         }
         Ok(None)
+    }
+
+    async fn release_unissued_annotation_batch(
+        &self,
+        batch: BeginGithubCheckAnnotationBatch,
+        released_at: UnixMillis,
+        attempts: u16,
+    ) -> Result<GithubChecksPublisherOutcome, GithubChecksPublisherError> {
+        let delay = retry_delay(self.config.retry_base_millis(), attempts, None, released_at);
+        let retry_at = checked_add(released_at, delay)?;
+        let receipt = self
+            .outbox
+            .release_unissued_github_check_annotation_batch(
+                ReleaseUnissuedGithubCheckAnnotationBatch::new(batch, released_at, retry_at)
+                    .map_err(invariant)?,
+            )
+            .await?;
+        Ok(GithubChecksPublisherOutcome::RetryScheduled(receipt))
     }
 
     async fn handle_http_error(

--- a/crates/automata-ci-github-delivery/tests/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/tests/checks_publisher.rs
@@ -26,8 +26,8 @@ use automata_ci_github_delivery::{
 };
 use automata_ci_scm::RepositoryId as ScmRepositoryId;
 use automata_ci_store::{
-    AdvanceGithubCheckAnnotations, BeginGithubCheckRunCreate, BindGithubCheckRun,
-    BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
+    AdvanceGithubCheckAnnotations, BeginGithubCheckAnnotationBatch, BeginGithubCheckRunCreate,
+    BindGithubCheckRun, BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
     BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
     ClaimedGithubCheckProjection, ClearGithubCheckAnnotationUncertainty,
     CompleteGithubCheckProjection, GithubCheckAnnotationProgress, GithubCheckAppId,
@@ -42,8 +42,9 @@ use automata_ci_store::{
     GithubServerServiceConsumerClaim, GithubServerServiceConsumerId, GithubServerServiceHandoffId,
     GithubServerServiceRevision, GithubServerServiceWorkerId, InitializeGithubCheckPresentation,
     ProviderConnectionId, ProviderDeliveryId, ProviderInstallationId, ProviderRepositoryId,
-    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
-    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, TenantScope,
+    ReleaseUnissuedGithubCheckAnnotationBatch, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
+    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations,
+    TenantScope,
 };
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
@@ -99,10 +100,13 @@ struct FakeOutbox {
     clock: Arc<StepClock>,
     clock_after_begin: AtomicI64,
     begin_delay_millis: AtomicUsize,
+    annotation_begin_delay_millis: AtomicUsize,
     claim_time_offset: AtomicI64,
     claim_delay_millis: AtomicUsize,
     terminal_result: Mutex<Option<BlobDescriptor>>,
     annotation_progress: Mutex<GithubCheckAnnotationProgress>,
+    annotation_batch_started_at: Mutex<Option<UnixMillis>>,
+    annotation_uncertain_retries: Mutex<Vec<RetryUncertainGithubCheckAnnotations>>,
     credential_rejection_blocks: Mutex<Vec<BlockGithubCheckProjectionForCredentialRejection>>,
     events: Arc<Mutex<Vec<String>>>,
 }
@@ -121,10 +125,13 @@ impl FakeOutbox {
             clock,
             clock_after_begin: AtomicI64::new(0),
             begin_delay_millis: AtomicUsize::new(0),
+            annotation_begin_delay_millis: AtomicUsize::new(0),
             claim_time_offset: AtomicI64::new(0),
             claim_delay_millis: AtomicUsize::new(0),
             terminal_result: Mutex::new(None),
             annotation_progress: Mutex::new(GithubCheckAnnotationProgress::default()),
+            annotation_batch_started_at: Mutex::new(None),
+            annotation_uncertain_retries: Mutex::new(Vec::new()),
             credential_rejection_blocks: Mutex::new(Vec::new()),
             events,
         }
@@ -352,6 +359,46 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
         Ok(*progress)
     }
 
+    async fn begin_github_check_annotation_batch(
+        &self,
+        request: BeginGithubCheckAnnotationBatch,
+    ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError> {
+        self.event(format!(
+            "store:annotations:begin:{}:{}",
+            request.from(),
+            request.batch_size()
+        ));
+        let delay_millis = self.annotation_begin_delay_millis.load(Ordering::SeqCst);
+        if delay_millis > 0 {
+            tokio::time::sleep(Duration::from_millis(
+                u64::try_from(delay_millis).map_err(|_| GithubCheckStoreError::CorruptData)?,
+            ))
+            .await;
+        }
+        let mut progress = self
+            .annotation_progress
+            .lock()
+            .expect("annotation progress lock");
+        if progress.presentation_digest() != Some(request.digest())
+            || progress.next() != request.from()
+            || progress.uncertain_batch_size().is_some()
+        {
+            return Err(GithubCheckStoreError::ProjectionMismatch);
+        }
+        *progress = GithubCheckAnnotationProgress::from_durable_parts(
+            Some(request.digest()),
+            progress.total(),
+            request.from(),
+            Some(request.batch_size()),
+        )
+        .map_err(|_| GithubCheckStoreError::CorruptData)?;
+        *self
+            .annotation_batch_started_at
+            .lock()
+            .expect("annotation batch start lock") = Some(request.started_at());
+        Ok(*progress)
+    }
+
     async fn advance_github_check_annotations(
         &self,
         request: AdvanceGithubCheckAnnotations,
@@ -365,8 +412,14 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             .annotation_progress
             .lock()
             .expect("annotation progress lock");
+        let mut batch_started_at = self
+            .annotation_batch_started_at
+            .lock()
+            .expect("annotation batch start lock");
         if progress.presentation_digest() != Some(request.digest())
             || progress.next() != request.from()
+            || progress.uncertain_batch_size() != u8::try_from(request.to() - request.from()).ok()
+            || batch_started_at.is_none()
         {
             return Err(GithubCheckStoreError::ProjectionMismatch);
         }
@@ -377,6 +430,7 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             None,
         )
         .map_err(|_| GithubCheckStoreError::CorruptData)?;
+        *batch_started_at = None;
         Ok(*progress)
     }
 
@@ -385,7 +439,42 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
         request: RetryUncertainGithubCheckAnnotations,
     ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
         self.event(format!(
-            "store:annotations:uncertain:{}:{}",
+            "store:annotations:uncertain:{}:{}:{}",
+            request.from(),
+            request.batch_size(),
+            request.retry_at().get() - request.failed_at().get()
+        ));
+        let progress = self
+            .annotation_progress
+            .lock()
+            .expect("annotation progress lock");
+        if progress.presentation_digest() != Some(request.digest())
+            || progress.next() != request.from()
+            || progress.uncertain_batch_size() != Some(request.batch_size())
+            || self
+                .annotation_batch_started_at
+                .lock()
+                .expect("annotation batch start lock")
+                .is_none()
+        {
+            return Err(GithubCheckStoreError::ProjectionMismatch);
+        }
+        self.annotation_uncertain_retries
+            .lock()
+            .expect("annotation uncertain retries lock")
+            .push(request);
+        Self::receipt(
+            request.claim().subject_id(),
+            GithubCheckDesiredProjection::Queued,
+        )
+    }
+
+    async fn release_unissued_github_check_annotation_batch(
+        &self,
+        request: ReleaseUnissuedGithubCheckAnnotationBatch,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
+        self.event(format!(
+            "store:annotations:release_unissued:{}:{}",
             request.from(),
             request.batch_size()
         ));
@@ -393,13 +482,25 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             .annotation_progress
             .lock()
             .expect("annotation progress lock");
+        let mut batch_started_at = self
+            .annotation_batch_started_at
+            .lock()
+            .expect("annotation batch start lock");
+        if progress.presentation_digest() != Some(request.digest())
+            || progress.next() != request.from()
+            || progress.uncertain_batch_size() != Some(request.batch_size())
+            || *batch_started_at != Some(request.started_at())
+        {
+            return Err(GithubCheckStoreError::ProjectionMismatch);
+        }
         *progress = GithubCheckAnnotationProgress::from_durable_parts(
             Some(request.digest()),
             progress.total(),
             request.from(),
-            Some(request.batch_size()),
+            None,
         )
         .map_err(|_| GithubCheckStoreError::CorruptData)?;
+        *batch_started_at = None;
         Self::receipt(
             request.claim().subject_id(),
             GithubCheckDesiredProjection::Queued,
@@ -415,7 +516,15 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             .annotation_progress
             .lock()
             .expect("annotation progress lock");
-        if progress.uncertain_batch_size() != Some(request.batch_size()) {
+        let mut batch_started_at = self
+            .annotation_batch_started_at
+            .lock()
+            .expect("annotation batch start lock");
+        if progress.presentation_digest() != Some(request.digest())
+            || progress.next() != request.from()
+            || progress.uncertain_batch_size() != Some(request.batch_size())
+            || batch_started_at.is_none()
+        {
             return Err(GithubCheckStoreError::ProjectionMismatch);
         }
         *progress = GithubCheckAnnotationProgress::from_durable_parts(
@@ -425,6 +534,7 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
             None,
         )
         .map_err(|_| GithubCheckStoreError::CorruptData)?;
+        *batch_started_at = None;
         Ok(*progress)
     }
 
@@ -739,7 +849,11 @@ struct FixtureServer {
 }
 
 impl FixtureServer {
-    async fn spawn(responses: Vec<ResponseSpec>, events: Arc<Mutex<Vec<String>>>) -> Self {
+    async fn spawn_with_limits(
+        responses: Vec<ResponseSpec>,
+        events: Arc<Mutex<Vec<String>>>,
+        limits: GithubHttpLimits,
+    ) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind fixture");
@@ -771,7 +885,7 @@ impl FixtureServer {
             oauth_origin,
             api_base,
             "automata-checks-publisher-test",
-            GithubHttpLimits::default(),
+            limits,
         )
         .expect("test endpoint");
         Self {
@@ -822,8 +936,26 @@ impl Harness {
         credential_mode: CredentialMode,
         config: GithubChecksPublisherConfig,
     ) -> Self {
+        Self::new_with_config_and_http_limits(
+            claims,
+            responses,
+            credential_mode,
+            config,
+            GithubHttpLimits::default(),
+        )
+        .await
+    }
+
+    async fn new_with_config_and_http_limits(
+        claims: impl IntoIterator<Item = ClaimTemplate>,
+        responses: Vec<ResponseSpec>,
+        credential_mode: CredentialMode,
+        config: GithubChecksPublisherConfig,
+        http_limits: GithubHttpLimits,
+    ) -> Self {
         let events = Arc::new(Mutex::new(Vec::new()));
-        let server = FixtureServer::spawn(responses, Arc::clone(&events)).await;
+        let server =
+            FixtureServer::spawn_with_limits(responses, Arc::clone(&events), http_limits).await;
         let clock = Arc::new(StepClock::new(1_000));
         let outbox = Arc::new(FakeOutbox::new(
             claims,
@@ -1298,7 +1430,7 @@ async fn terminal_annotations_are_published_in_durable_fifty_item_batches() {
         200,
         run_json_with_details(41, "completed", Some("failure"), &details_url),
     );
-    let harness = Harness::new(
+    let harness = Harness::new_with_config_and_http_limits(
         [claim_for_target(
             GithubCheckProjectionAction::Publish,
             GithubCheckDesiredProjection::Terminal(GithubCheckTerminalCause::WorkflowFailure),
@@ -1320,37 +1452,11 @@ async fn terminal_annotations_are_published_in_durable_fifty_item_batches() {
             completed,
         ],
         CredentialMode::Exact,
+        annotation_publisher_config(),
+        annotation_http_limits(),
     )
     .await;
-    let annotations = (1..=51)
-        .map(|line| {
-            StepAnnotation::new(
-                StepAnnotationLevel::Error,
-                format!("failure {line}"),
-                vec![
-                    StepAnnotationProperty::new("file", "src/lib.rs"),
-                    StepAnnotationProperty::new("line", line.to_string()),
-                ],
-            )
-        })
-        .collect();
-    let result = JobResult::new(
-        AttemptId::new(),
-        JobConclusion::Failure,
-        JobSecretExposure::Secretless,
-        UnixMillis::new(999),
-    )
-    .with_steps(vec![
-        StepResult::new(
-            StepId::new("test").expect("step ID"),
-            JobConclusion::Failure,
-            JobConclusion::Failure,
-            UnixMillis::new(300),
-            UnixMillis::new(999),
-        )
-        .with_annotations(annotations),
-    ]);
-    result.validate().expect("terminal result");
+    let result = terminal_result_with_annotations(51);
     harness.install_terminal_result(&result).await;
 
     assert!(matches!(
@@ -1381,6 +1487,235 @@ async fn terminal_annotations_are_published_in_durable_fifty_item_batches() {
             .count(),
         2
     );
+    let events = harness.events();
+    let beginnings: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            event
+                .starts_with("store:annotations:begin")
+                .then_some(index)
+        })
+        .collect();
+    let patches: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| event.starts_with("http:PATCH").then_some(index))
+        .collect();
+    assert_eq!(beginnings.len(), 2);
+    assert_eq!(patches.len(), 3);
+    assert!(beginnings[0] < patches[1] && beginnings[1] < patches[2]);
+}
+
+#[tokio::test]
+async fn ambiguous_patch_is_fenced_and_exact_prefix_avoids_a_duplicate() {
+    let dashboard_run_id = RunId::new();
+    let dashboard_job_id = JobId::new();
+    let details_url = format!(
+        "https://ci.automata.example/automata-ci/automata/actions/runs/{dashboard_run_id}/jobs/{dashboard_job_id}"
+    );
+    let publish = claim_for_target(
+        GithubCheckProjectionAction::Publish,
+        GithubCheckDesiredProjection::Terminal(GithubCheckTerminalCause::WorkflowFailure),
+        2,
+        Some(suite_id()),
+        Some(run_id()),
+        GithubCheckDetailsTarget::Job {
+            run_id: dashboard_run_id,
+            job_id: dashboard_job_id,
+        },
+    );
+    let completed = run_json_with_details(41, "completed", Some("failure"), &details_url);
+    let harness = Harness::new_with_config_and_http_limits(
+        [publish, publish],
+        vec![
+            ResponseSpec::json(
+                200,
+                run_json_with_details(41, "in_progress", None, &details_url),
+            ),
+            ResponseSpec::json(200, completed.clone()),
+            ResponseSpec::json(503, "{}"),
+            ResponseSpec::json(200, completed),
+            ResponseSpec::json(
+                200,
+                r#"[{"path":"src/lib.rs","start_line":1,"end_line":1,"start_column":null,"end_column":null,"annotation_level":"failure","message":"failure 1","title":null}]"#,
+            ),
+        ],
+        CredentialMode::Exact,
+        annotation_publisher_config(),
+        annotation_http_limits(),
+    )
+    .await;
+    harness
+        .install_terminal_result(&terminal_result_with_annotations(1))
+        .await;
+
+    assert!(matches!(
+        harness.run().await.expect("ambiguous first PATCH"),
+        GithubChecksPublisherOutcome::RetryScheduled(_)
+    ));
+    assert_eq!(
+        methods(&harness.server.requests()),
+        ["GET", "PATCH", "PATCH"]
+    );
+    let events = harness.events();
+    let annotation_begin = position(&events, "store:annotations:begin:0:1");
+    let annotation_patch = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| event.starts_with("http:PATCH").then_some(index))
+        .nth(1)
+        .expect("annotation PATCH");
+    let uncertain = position_prefix(&events, "store:annotations:uncertain:0:1:");
+    assert!(annotation_begin < annotation_patch && annotation_patch < uncertain);
+    assert_annotation_uncertain_retry_is_bounded(&harness);
+    {
+        let progress = harness
+            .outbox
+            .annotation_progress
+            .lock()
+            .expect("annotation progress lock");
+        assert_eq!(progress.next(), 0);
+        assert_eq!(progress.uncertain_batch_size(), Some(1));
+    }
+    // The fake derives desired timestamps from claim time; keep the same
+    // durable desired event across the recovery claim.
+    harness.outbox.clock.set(1_000);
+    assert!(matches!(
+        harness.run().await.expect("exact prefix recovery"),
+        GithubChecksPublisherOutcome::Advanced(_)
+    ));
+    assert_eq!(
+        methods(&harness.server.requests()),
+        ["GET", "PATCH", "PATCH", "GET", "GET"]
+    );
+    assert_eq!(
+        harness
+            .events()
+            .iter()
+            .filter(|event| event.starts_with("store:annotations:begin"))
+            .count(),
+        1
+    );
+    let progress = harness
+        .outbox
+        .annotation_progress
+        .lock()
+        .expect("annotation progress lock");
+    assert_eq!(progress.next(), 1);
+    assert_eq!(progress.uncertain_batch_size(), None);
+}
+
+#[tokio::test]
+async fn annotation_patch_waits_when_the_claim_cannot_fit_the_recovery_tail() {
+    let dashboard_run_id = RunId::new();
+    let dashboard_job_id = JobId::new();
+    let details_url = format!(
+        "https://ci.automata.example/automata-ci/automata/actions/runs/{dashboard_run_id}/jobs/{dashboard_job_id}"
+    );
+    let harness = Harness::new(
+        [claim_for_target(
+            GithubCheckProjectionAction::Publish,
+            GithubCheckDesiredProjection::Terminal(GithubCheckTerminalCause::WorkflowFailure),
+            2,
+            Some(suite_id()),
+            Some(run_id()),
+            GithubCheckDetailsTarget::Job {
+                run_id: dashboard_run_id,
+                job_id: dashboard_job_id,
+            },
+        )],
+        vec![ResponseSpec::json(
+            200,
+            run_json_with_details(41, "completed", Some("failure"), &details_url),
+        )],
+        CredentialMode::Exact,
+    )
+    .await;
+    harness
+        .install_terminal_result(&terminal_result_with_annotations(1))
+        .await;
+
+    assert!(matches!(
+        harness.run().await.expect("bounded no-issue retry"),
+        GithubChecksPublisherOutcome::RetryScheduled(_)
+    ));
+    assert_eq!(methods(&harness.server.requests()), ["GET"]);
+    let events = harness.events();
+    assert!(events.contains(&"store:retry:github_annotation_issue_window_elapsed:10".to_owned()));
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("store:annotations:begin"))
+    );
+    let progress = harness
+        .outbox
+        .annotation_progress
+        .lock()
+        .expect("annotation progress lock");
+    assert_eq!(progress.next(), 0);
+    assert_eq!(progress.uncertain_batch_size(), None);
+}
+
+#[tokio::test]
+async fn cutoff_that_finishes_after_the_issue_window_is_atomically_released() {
+    let dashboard_run_id = RunId::new();
+    let dashboard_job_id = JobId::new();
+    let details_url = format!(
+        "https://ci.automata.example/automata-ci/automata/actions/runs/{dashboard_run_id}/jobs/{dashboard_job_id}"
+    );
+    let harness = Harness::new_with_config_and_http_limits(
+        [claim_for_target(
+            GithubCheckProjectionAction::Publish,
+            GithubCheckDesiredProjection::Terminal(GithubCheckTerminalCause::WorkflowFailure),
+            2,
+            Some(suite_id()),
+            Some(run_id()),
+            GithubCheckDetailsTarget::Job {
+                run_id: dashboard_run_id,
+                job_id: dashboard_job_id,
+            },
+        )],
+        vec![
+            ResponseSpec::json(
+                200,
+                run_json_with_details(41, "in_progress", None, &details_url),
+            ),
+            ResponseSpec::json(
+                200,
+                run_json_with_details(41, "completed", Some("failure"), &details_url),
+            ),
+        ],
+        CredentialMode::Exact,
+        GithubChecksPublisherConfig::new(500, 50, 10).expect("short publisher config"),
+        annotation_http_limits(),
+    )
+    .await;
+    harness
+        .outbox
+        .annotation_begin_delay_millis
+        .store(325, Ordering::SeqCst);
+    harness
+        .install_terminal_result(&terminal_result_with_annotations(1))
+        .await;
+
+    assert!(matches!(
+        harness.run().await.expect("unissued cutoff release"),
+        GithubChecksPublisherOutcome::RetryScheduled(_)
+    ));
+    assert_eq!(methods(&harness.server.requests()), ["GET", "PATCH"]);
+    let events = harness.events();
+    assert!(
+        position(&events, "store:annotations:begin:0:1")
+            < position(&events, "store:annotations:release_unissued:0:1")
+    );
+    let progress = harness
+        .outbox
+        .annotation_progress
+        .lock()
+        .expect("annotation progress lock");
+    assert_eq!(progress.next(), 0);
+    assert_eq!(progress.uncertain_batch_size(), None);
 }
 
 #[tokio::test]
@@ -2369,6 +2704,74 @@ fn ambiguous_list_json() -> String {
         run_json(41, "queued", None),
         run_json(42, "queued", None)
     )
+}
+
+fn terminal_result_with_annotations(count: u32) -> JobResult {
+    let annotations = (1..=count)
+        .map(|line| {
+            StepAnnotation::new(
+                StepAnnotationLevel::Error,
+                format!("failure {line}"),
+                vec![
+                    StepAnnotationProperty::new("file", "src/lib.rs"),
+                    StepAnnotationProperty::new("line", line.to_string()),
+                ],
+            )
+        })
+        .collect();
+    let result = JobResult::new(
+        AttemptId::new(),
+        JobConclusion::Failure,
+        JobSecretExposure::Secretless,
+        UnixMillis::new(999),
+    )
+    .with_steps(vec![
+        StepResult::new(
+            StepId::new("test").expect("step ID"),
+            JobConclusion::Failure,
+            JobConclusion::Failure,
+            UnixMillis::new(300),
+            UnixMillis::new(999),
+        )
+        .with_annotations(annotations),
+    ]);
+    result.validate().expect("terminal result");
+    result
+}
+
+fn annotation_publisher_config() -> GithubChecksPublisherConfig {
+    GithubChecksPublisherConfig::new(1_000, 50, 10).expect("annotation publisher config")
+}
+
+fn annotation_http_limits() -> GithubHttpLimits {
+    GithubHttpLimits::new(
+        1_048_576,
+        128,
+        10_000,
+        Duration::from_millis(50),
+        Duration::from_millis(200),
+    )
+    .expect("annotation HTTP limits")
+}
+
+fn assert_annotation_uncertain_retry_is_bounded(harness: &Harness) {
+    let uncertain_request = harness
+        .outbox
+        .annotation_uncertain_retries
+        .lock()
+        .expect("annotation uncertain retries lock")
+        .first()
+        .copied()
+        .expect("uncertain retry request");
+    let batch_started_at = harness
+        .outbox
+        .annotation_batch_started_at
+        .lock()
+        .expect("annotation batch start lock")
+        .expect("durable annotation batch start");
+    assert!(uncertain_request.retry_at().get() >= batch_started_at.get() + 250);
+    assert!(uncertain_request.retry_at().get() >= uncertain_request.failed_at().get() + 50);
+    assert!(uncertain_request.retry_at().get() <= 2_000);
 }
 
 fn methods(requests: &[RecordedRequest]) -> Vec<&str> {

--- a/crates/automata-ci-postgres/src/store/github_checks.rs
+++ b/crates/automata-ci-postgres/src/store/github_checks.rs
@@ -5,13 +5,14 @@ use sqlx::{AssertSqlSafe, PgConnection, Postgres, Row as _, Transaction};
 use uuid::Uuid;
 
 use automata_ci_store::{
-    AdvanceGithubCheckAnnotations, AttemptStoreError, BeginGithubCheckRunCreate,
-    BindGithubCheckRun, BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
-    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
-    ClaimedGithubCheckProjection, ClearGithubCheckAnnotationUncertainty,
-    CompleteGithubCheckProjection, GithubCheckAnnotationProgress, GithubCheckAppId,
-    GithubCheckConclusion, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
-    GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
+    AdvanceGithubCheckAnnotations, AttemptStoreError, BeginGithubCheckAnnotationBatch,
+    BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
+    BlockGithubCheckAnnotationMismatch, BlockGithubCheckProjectionForCredentialRejection,
+    ClaimGithubCheckProjection, ClaimedGithubCheckProjection,
+    ClearGithubCheckAnnotationUncertainty, CompleteGithubCheckProjection,
+    GithubCheckAnnotationProgress, GithubCheckAppId, GithubCheckConclusion,
+    GithubCheckCreateReconciliation, GithubCheckDesiredProjection, GithubCheckDetailsTarget,
+    GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
     GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
     GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
     GithubCheckSubjectIdentity, GithubCheckSubjectKey, GithubCheckSubjectOrigin,
@@ -21,10 +22,10 @@ use automata_ci_store::{
     GithubServerServiceAuthoritySelector, GithubServerServiceRevision, HUMAN_JOB_RESULT_MEDIA_TYPE,
     InitializeGithubCheckPresentation, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
     MAX_TERMINAL_RESULT_BYTES, ProviderConnectionId, ProviderDeliveryId, ProviderInstallationId,
-    ProviderRepositoryId, RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckRunCreate,
-    RepositoryId, ResolveGithubCheckRunCreate, RetryGithubCheckProjection,
-    RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection, StoreError, TenantScope,
-    TerminalizeGithubCheck,
+    ProviderRepositoryId, RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckAnnotationBatch,
+    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
+    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection,
+    StoreError, TenantScope, TerminalizeGithubCheck,
 };
 
 use super::{PostgresStore, pg_bigint};
@@ -1286,151 +1287,231 @@ impl GithubCheckProjectionOutbox for PostgresStore {
             .ok_or(GithubCheckStoreError::ProjectionMismatch)
     }
 
+    async fn begin_github_check_annotation_batch(
+        &self,
+        request: BeginGithubCheckAnnotationBatch,
+    ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError> {
+        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
+        pin_read_committed(&mut transaction).await?;
+        let claim = request.claim();
+        lock_live_annotation_publish_claim(&mut transaction, claim, request.started_at()).await?;
+
+        let row = sqlx::query(
+            r"
+            UPDATE github_check_annotation_progress
+            SET uncertain_batch_size = $4,
+                updated_at_ms = $5
+            WHERE subject_id = $1
+              AND presentation_digest = $2
+              AND annotation_next = $3
+              AND uncertain_batch_size IS NULL
+              AND annotation_next + $4 <= annotation_total
+            RETURNING presentation_digest AS annotation_presentation_digest,
+                      annotation_total,
+                      annotation_next,
+                      uncertain_batch_size AS annotation_uncertain_batch_size
+            ",
+        )
+        .bind(claim.subject_id().as_uuid())
+        .bind(request.digest().as_bytes().as_slice())
+        .bind(i32::from(request.from()))
+        .bind(i16::from(request.batch_size()))
+        .bind(request.started_at().get())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(operation_error)?;
+        let progress = row
+            .map(|row| decode_annotation_progress(&row))
+            .transpose()?
+            .ok_or(GithubCheckStoreError::ProjectionMismatch)?;
+        transaction.commit().await.map_err(operation_error)?;
+        Ok(progress)
+    }
+
     async fn advance_github_check_annotations(
         &self,
         request: AdvanceGithubCheckAnnotations,
     ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError> {
+        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
+        pin_read_committed(&mut transaction).await?;
+        let claim = request.claim();
+        lock_live_annotation_publish_claim(&mut transaction, claim, request.observed_at()).await?;
+        let batch_size = request
+            .to()
+            .checked_sub(request.from())
+            .and_then(|size| u8::try_from(size).ok())
+            .ok_or(GithubCheckStoreError::ProjectionMismatch)?;
+        lock_exact_annotation_batch(
+            &mut transaction,
+            claim,
+            request.digest(),
+            request.from(),
+            batch_size,
+        )
+        .await?;
+
         let row = sqlx::query(
             r"
-            UPDATE github_check_annotation_progress AS progress
-            SET annotation_next = $6,
+            UPDATE github_check_annotation_progress
+            SET annotation_next = $4,
                 uncertain_batch_size = NULL,
-                updated_at_ms = $7
-            FROM github_check_projection_outbox AS outbox
-            WHERE progress.subject_id = $1
-              AND outbox.subject_id = progress.subject_id
-              AND outbox.state = 'claimed'
-              AND outbox.claim_owner_id = $2
-              AND outbox.claim_fence = $3
-              AND outbox.claim_action = 'publish'
-              AND outbox.claimed_at_ms <= $7
-              AND outbox.claim_expires_at_ms > $7
-              AND progress.presentation_digest = $4
-              AND progress.annotation_next = $5
-              AND progress.annotation_total >= $6
-              AND (progress.uncertain_batch_size IS NULL
-                   OR progress.uncertain_batch_size = $6 - $5)
-            RETURNING progress.presentation_digest AS annotation_presentation_digest,
-                      progress.annotation_total,
-                      progress.annotation_next,
-                      progress.uncertain_batch_size AS annotation_uncertain_batch_size
+                updated_at_ms = $6
+            WHERE subject_id = $1
+              AND presentation_digest = $2
+              AND annotation_next = $3
+              AND annotation_total >= $4
+              AND uncertain_batch_size = $5
+            RETURNING presentation_digest AS annotation_presentation_digest,
+                      annotation_total,
+                      annotation_next,
+                      uncertain_batch_size AS annotation_uncertain_batch_size
             ",
         )
-        .bind(request.claim().subject_id().as_uuid())
-        .bind(request.claim().owner().as_uuid())
-        .bind(pg_bigint(request.claim().fence()))
+        .bind(claim.subject_id().as_uuid())
         .bind(request.digest().as_bytes().as_slice())
         .bind(i32::from(request.from()))
         .bind(i32::from(request.to()))
+        .bind(i16::from(batch_size))
         .bind(request.observed_at().get())
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *transaction)
         .await
         .map_err(operation_error)?;
-        row.map(|row| decode_annotation_progress(&row))
+        let progress = row
+            .map(|row| decode_annotation_progress(&row))
             .transpose()?
-            .ok_or(GithubCheckStoreError::ProjectionMismatch)
+            .ok_or(GithubCheckStoreError::ProjectionMismatch)?;
+        transaction.commit().await.map_err(operation_error)?;
+        Ok(progress)
     }
 
     async fn retry_uncertain_github_check_annotations(
         &self,
         request: RetryUncertainGithubCheckAnnotations,
     ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
-        let query = format!(
+        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
+        pin_read_committed(&mut transaction).await?;
+        let claim = request.claim();
+        lock_live_annotation_publish_claim(&mut transaction, claim, request.failed_at()).await?;
+        lock_exact_annotation_batch(
+            &mut transaction,
+            claim,
+            request.digest(),
+            request.from(),
+            request.batch_size(),
+        )
+        .await?;
+
+        let receipt = retry_live_annotation_publish_claim(
+            &mut transaction,
+            claim,
+            request.failed_at(),
+            request.retry_at(),
+            "github_annotation_ambiguous",
+        )
+        .await?;
+        transaction.commit().await.map_err(operation_error)?;
+        Ok(receipt)
+    }
+
+    async fn release_unissued_github_check_annotation_batch(
+        &self,
+        request: ReleaseUnissuedGithubCheckAnnotationBatch,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
+        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
+        pin_read_committed(&mut transaction).await?;
+        let claim = request.claim();
+        lock_live_annotation_publish_claim(&mut transaction, claim, request.released_at()).await?;
+        lock_exact_annotation_batch(
+            &mut transaction,
+            claim,
+            request.digest(),
+            request.from(),
+            request.batch_size(),
+        )
+        .await?;
+
+        let cleared = sqlx::query(
             r"
-            WITH marked AS (
-                UPDATE github_check_annotation_progress AS progress
-                SET uncertain_batch_size = $6,
-                    updated_at_ms = $7
-                FROM github_check_projection_outbox AS claimed
-                WHERE progress.subject_id = $1
-                  AND claimed.subject_id = progress.subject_id
-                  AND claimed.state = 'claimed'
-                  AND claimed.claim_owner_id = $2
-                  AND claimed.claim_fence = $3
-                  AND claimed.claim_action = 'publish'
-                  AND claimed.claimed_at_ms <= $7
-                  AND claimed.claim_expires_at_ms > $7
-                  AND progress.presentation_digest = $4
-                  AND progress.annotation_next = $5
-                  AND progress.uncertain_batch_size IS NULL
-                  AND progress.annotation_next + $6 <= progress.annotation_total
-                RETURNING progress.subject_id
-            )
-            UPDATE github_check_projection_outbox AS outbox
-            SET state = CASE WHEN attempt_count >= 64 THEN 'blocked' ELSE 'retry' END,
-                next_attempt_at_ms = CASE WHEN attempt_count >= 64 THEN NULL ELSE $8 END,
-                last_failure_kind = CASE
-                    WHEN attempt_count >= 64 THEN NULL ELSE 'github_annotation_ambiguous'
-                END,
-                blocked_reason = CASE WHEN attempt_count >= 64 THEN 'attempt_limit' ELSE NULL END,
-                claim_owner_id = NULL, claim_action = NULL,
-                claimed_desired_revision = NULL, claimed_desired_state = NULL,
-                claimed_desired_conclusion = NULL,
-                claimed_at_ms = NULL, claim_expires_at_ms = NULL,
-                state_updated_at_ms = $7
-            FROM github_check_subjects AS subject, marked
-            WHERE outbox.subject_id = $1
-              AND subject.id = outbox.subject_id
-              AND marked.subject_id = outbox.subject_id
-            RETURNING {SUBJECT_COLUMNS}
-            "
-        );
-        let row = sqlx::query(AssertSqlSafe(query))
-            .bind(request.claim().subject_id().as_uuid())
-            .bind(request.claim().owner().as_uuid())
-            .bind(pg_bigint(request.claim().fence()))
-            .bind(request.digest().as_bytes().as_slice())
-            .bind(i32::from(request.from()))
-            .bind(i16::from(request.batch_size()))
-            .bind(request.failed_at().get())
-            .bind(request.retry_at().get())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(operation_error)?;
-        row.map(|row| decode_subject(&row).map(|subject| subject.receipt))
-            .transpose()?
-            .ok_or(GithubCheckStoreError::ProjectionMismatch)
+            UPDATE github_check_annotation_progress
+            SET uncertain_batch_size = NULL,
+                updated_at_ms = $6
+            WHERE subject_id = $1
+              AND presentation_digest = $2
+              AND annotation_next = $3
+              AND uncertain_batch_size = $4
+              AND updated_at_ms = $5
+            ",
+        )
+        .bind(claim.subject_id().as_uuid())
+        .bind(request.digest().as_bytes().as_slice())
+        .bind(i32::from(request.from()))
+        .bind(i16::from(request.batch_size()))
+        .bind(request.started_at().get())
+        .bind(request.released_at().get())
+        .execute(&mut *transaction)
+        .await
+        .map_err(operation_error)?;
+        if cleared.rows_affected() != 1 {
+            return Err(GithubCheckStoreError::ProjectionMismatch);
+        }
+
+        let receipt = retry_live_annotation_publish_claim(
+            &mut transaction,
+            claim,
+            request.released_at(),
+            request.retry_at(),
+            "github_annotation_not_issued",
+        )
+        .await?;
+        transaction.commit().await.map_err(operation_error)?;
+        Ok(receipt)
     }
 
     async fn clear_github_check_annotation_uncertainty(
         &self,
         request: ClearGithubCheckAnnotationUncertainty,
     ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError> {
+        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
+        pin_read_committed(&mut transaction).await?;
+        let claim = request.claim();
+        lock_live_annotation_publish_claim(&mut transaction, claim, request.observed_at()).await?;
+        lock_exact_annotation_batch(
+            &mut transaction,
+            claim,
+            request.digest(),
+            request.from(),
+            request.batch_size(),
+        )
+        .await?;
+
         let row = sqlx::query(
             r"
-            UPDATE github_check_annotation_progress AS progress
-            SET uncertain_batch_size = NULL, updated_at_ms = $7
-            FROM github_check_projection_outbox AS outbox
-            WHERE progress.subject_id = $1
-              AND outbox.subject_id = progress.subject_id
-              AND outbox.state = 'claimed'
-              AND outbox.claim_owner_id = $2
-              AND outbox.claim_fence = $3
-              AND outbox.claim_action = 'publish'
-              AND outbox.claimed_at_ms <= $7
-              AND outbox.claim_expires_at_ms > $7
-              AND progress.presentation_digest = $4
-              AND progress.annotation_next = $5
-              AND progress.uncertain_batch_size = $6
-            RETURNING progress.presentation_digest AS annotation_presentation_digest,
-                      progress.annotation_total,
-                      progress.annotation_next,
-                      progress.uncertain_batch_size AS annotation_uncertain_batch_size
+            UPDATE github_check_annotation_progress
+            SET uncertain_batch_size = NULL, updated_at_ms = $5
+            WHERE subject_id = $1
+              AND presentation_digest = $2
+              AND annotation_next = $3
+              AND uncertain_batch_size = $4
+            RETURNING presentation_digest AS annotation_presentation_digest,
+                      annotation_total,
+                      annotation_next,
+                      uncertain_batch_size AS annotation_uncertain_batch_size
             ",
         )
-        .bind(request.claim().subject_id().as_uuid())
-        .bind(request.claim().owner().as_uuid())
-        .bind(pg_bigint(request.claim().fence()))
+        .bind(claim.subject_id().as_uuid())
         .bind(request.digest().as_bytes().as_slice())
         .bind(i32::from(request.from()))
         .bind(i16::from(request.batch_size()))
         .bind(request.observed_at().get())
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *transaction)
         .await
         .map_err(operation_error)?;
-        row.map(|row| decode_annotation_progress(&row))
+        let progress = row
+            .map(|row| decode_annotation_progress(&row))
             .transpose()?
-            .ok_or(GithubCheckStoreError::ProjectionMismatch)
+            .ok_or(GithubCheckStoreError::ProjectionMismatch)?;
+        transaction.commit().await.map_err(operation_error)?;
+        Ok(progress)
     }
 
     async fn block_github_check_annotation_mismatch(
@@ -2397,6 +2478,113 @@ async fn block_exhausted_candidates(
     .await
     .map_err(operation_error)?;
     Ok(())
+}
+
+async fn lock_live_annotation_publish_claim(
+    transaction: &mut Transaction<'_, Postgres>,
+    claim: GithubCheckProjectionClaimFence,
+    observed_at: UnixMillis,
+) -> Result<(), GithubCheckStoreError> {
+    let locked: Option<Uuid> = sqlx::query_scalar(
+        r"
+        SELECT subject_id
+        FROM github_check_projection_outbox
+        WHERE subject_id = $1
+          AND state = 'claimed'
+          AND claim_owner_id = $2
+          AND claim_fence = $3
+          AND claim_action = 'publish'
+          AND claimed_at_ms <= $4
+          AND claim_expires_at_ms > $4
+        FOR UPDATE
+        ",
+    )
+    .bind(claim.subject_id().as_uuid())
+    .bind(claim.owner().as_uuid())
+    .bind(pg_bigint(claim.fence()))
+    .bind(observed_at.get())
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operation_error)?;
+    locked
+        .map(|_| ())
+        .ok_or(GithubCheckStoreError::ClaimRejected)
+}
+
+async fn lock_exact_annotation_batch(
+    transaction: &mut Transaction<'_, Postgres>,
+    claim: GithubCheckProjectionClaimFence,
+    digest: Sha256Digest,
+    from: u16,
+    batch_size: u8,
+) -> Result<(), GithubCheckStoreError> {
+    let locked: Option<Uuid> = sqlx::query_scalar(
+        r"
+        SELECT subject_id
+        FROM github_check_annotation_progress
+        WHERE subject_id = $1
+          AND presentation_digest = $2
+          AND annotation_next = $3
+          AND uncertain_batch_size = $4
+        FOR UPDATE
+        ",
+    )
+    .bind(claim.subject_id().as_uuid())
+    .bind(digest.as_bytes().as_slice())
+    .bind(i32::from(from))
+    .bind(i16::from(batch_size))
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operation_error)?;
+    locked
+        .map(|_| ())
+        .ok_or(GithubCheckStoreError::ProjectionMismatch)
+}
+
+async fn retry_live_annotation_publish_claim(
+    transaction: &mut Transaction<'_, Postgres>,
+    claim: GithubCheckProjectionClaimFence,
+    observed_at: UnixMillis,
+    retry_at: UnixMillis,
+    failure_kind: &str,
+) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
+    let query = format!(
+        r"
+        UPDATE github_check_projection_outbox AS outbox
+        SET state = CASE WHEN attempt_count >= 64 THEN 'blocked' ELSE 'retry' END,
+            next_attempt_at_ms = CASE WHEN attempt_count >= 64 THEN NULL ELSE $5 END,
+            last_failure_kind = CASE WHEN attempt_count >= 64 THEN NULL ELSE $6 END,
+            blocked_reason = CASE WHEN attempt_count >= 64 THEN 'attempt_limit' ELSE NULL END,
+            claim_owner_id = NULL, claim_action = NULL,
+            claimed_desired_revision = NULL, claimed_desired_state = NULL,
+            claimed_desired_conclusion = NULL,
+            claimed_at_ms = NULL, claim_expires_at_ms = NULL,
+            state_updated_at_ms = $4
+        FROM github_check_subjects AS subject
+        WHERE outbox.subject_id = $1
+          AND subject.id = outbox.subject_id
+          AND outbox.state = 'claimed'
+          AND outbox.claim_owner_id = $2
+          AND outbox.claim_fence = $3
+          AND outbox.claim_action = 'publish'
+          AND outbox.claimed_at_ms <= $4
+          AND outbox.claim_expires_at_ms > $4
+        RETURNING {SUBJECT_COLUMNS}
+        "
+    );
+    let row = sqlx::query(AssertSqlSafe(query))
+        .bind(claim.subject_id().as_uuid())
+        .bind(claim.owner().as_uuid())
+        .bind(pg_bigint(claim.fence()))
+        .bind(observed_at.get())
+        .bind(retry_at.get())
+        .bind(failure_kind)
+        .fetch_optional(&mut **transaction)
+        .await
+        .map_err(operation_error)?;
+    row.map(|row| decode_subject(&row).map(|subject| subject.receipt))
+        .transpose()?
+        .ok_or(GithubCheckStoreError::ClaimRejected)
 }
 
 async fn pin_read_committed(connection: &mut PgConnection) -> Result<(), GithubCheckStoreError> {

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -39,6 +39,8 @@ use uuid::Uuid;
 
 use crate::support::{TestDatabase, TestResult, run_with_database};
 
+mod annotation_fencing;
+
 const INSTALLATION_ID: u64 = 101;
 const REPOSITORY_ID: u64 = 202;
 const APP_ID: u64 = 303;

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence/annotation_fencing.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence/annotation_fencing.rs
@@ -1,0 +1,726 @@
+use std::time::Duration;
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_store::{
+    AdvanceGithubCheckAnnotations, BeginGithubCheckAnnotationBatch, BeginGithubCheckRunCreate,
+    BindGithubCheckRun, BindGithubCheckSuite, ClaimedGithubCheckProjection,
+    ClearGithubCheckAnnotationUncertainty, GithubCheckProjectionAction,
+    GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox as _,
+    GithubCheckProjectionWorkerId, GithubCheckRunBindingFence, GithubCheckRunId,
+    GithubCheckStoreError, GithubCheckSuiteId, GithubSubjectEvidenceRepository as _,
+    ProviderDeliveryFailureKind, ProviderDeliveryRepository as _, ProviderRepositoryVisibility,
+    RejectProviderDelivery, ReleaseUnissuedGithubCheckAnnotationBatch,
+    RetryUncertainGithubCheckAnnotations,
+};
+use uuid::Uuid;
+
+use super::{
+    HEAD_SHA, OWNER_ID, acceptance, bootstrap, checked_add_millis, claim_check_projection,
+    claim_delivery, database_now, wait_until_database_at_or_after,
+};
+use crate::support::{TestDatabase, TestResult, run_with_database};
+
+const PRESENTATION_DIGEST: Sha256Digest = Sha256Digest::from_bytes([0xa7; 32]);
+const ANNOTATION_COUNT: u16 = 10;
+const BATCH_SIZE: u8 = 10;
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn annotation_append_requires_one_fresh_durable_cutoff() -> TestResult {
+    run_with_database(|database| async move {
+        let publish = claimed_terminal_publish(&database, "annotation-cutoff", 0xa701).await?;
+        seed_annotation_progress(&database, &publish).await?;
+        let digest = PRESENTATION_DIGEST;
+
+        let unfenced = AdvanceGithubCheckAnnotations::new(
+            publish.claim(),
+            digest,
+            0,
+            ANNOTATION_COUNT,
+            publish.claimed_at(),
+        )?;
+        assert!(matches!(
+            database
+                .store()
+                .advance_github_check_annotations(unfenced)
+                .await,
+            Err(GithubCheckStoreError::ProjectionMismatch)
+        ));
+
+        let started_at = database_now(database.pool()).await?;
+        let begin = BeginGithubCheckAnnotationBatch::new(
+            publish.claim(),
+            digest,
+            0,
+            BATCH_SIZE,
+            started_at,
+        )?;
+        assert_markerless_requests_are_rejected(&database, &publish, begin).await?;
+        let fenced = database
+            .store()
+            .begin_github_check_annotation_batch(begin)
+            .await?;
+        assert_eq!(fenced.next(), 0);
+        assert_eq!(fenced.uncertain_batch_size(), Some(BATCH_SIZE));
+        assert!(matches!(
+            database
+                .store()
+                .begin_github_check_annotation_batch(begin)
+                .await,
+            Err(GithubCheckStoreError::ProjectionMismatch)
+        ));
+
+        let advanced = database
+            .store()
+            .advance_github_check_annotations(unfenced)
+            .await?;
+        assert_eq!(advanced.next(), ANNOTATION_COUNT);
+        assert_eq!(advanced.uncertain_batch_size(), None);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn unissued_annotation_cutoff_requires_exact_begin_before_bounded_retry() -> TestResult {
+    run_with_database(|database| async move {
+        let publish = claimed_terminal_publish(&database, "annotation-unissued", 0xa702).await?;
+        seed_annotation_progress(&database, &publish).await?;
+        let started_at = database_now(database.pool()).await?;
+        let begin = BeginGithubCheckAnnotationBatch::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            started_at,
+        )?;
+        database
+            .store()
+            .begin_github_check_annotation_batch(begin)
+            .await?;
+
+        let next_millisecond = checked_add_millis(started_at, 1)?;
+        wait_until_database_at_or_after(database.pool(), next_millisecond.get()).await?;
+        let forged_started_at = database_now(database.pool()).await?;
+        let forged_begin = BeginGithubCheckAnnotationBatch::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            forged_started_at,
+        )?;
+        let forged_released_at = database_now(database.pool()).await?;
+        let forged_release = ReleaseUnissuedGithubCheckAnnotationBatch::new(
+            forged_begin,
+            forged_released_at,
+            checked_add_millis(forged_released_at, 1)?,
+        )?;
+        assert!(matches!(
+            database
+                .store()
+                .release_unissued_github_check_annotation_batch(forged_release)
+                .await,
+            Err(GithubCheckStoreError::ProjectionMismatch)
+        ));
+
+        let released_at = database_now(database.pool()).await?;
+        let release = ReleaseUnissuedGithubCheckAnnotationBatch::new(
+            begin,
+            released_at,
+            checked_add_millis(released_at, 1)?,
+        )?;
+        database
+            .store()
+            .release_unissued_github_check_annotation_batch(release)
+            .await?;
+
+        let durable: (String, Option<String>, Option<i16>) = sqlx::query_as(
+            r"
+            SELECT outbox.state, outbox.last_failure_kind,
+                   progress.uncertain_batch_size
+            FROM github_check_projection_outbox AS outbox
+            JOIN github_check_annotation_progress AS progress
+              ON progress.subject_id = outbox.subject_id
+            WHERE outbox.subject_id = $1
+            ",
+        )
+        .bind(publish.claim().subject_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            durable,
+            (
+                "retry".to_owned(),
+                Some("github_annotation_not_issued".to_owned()),
+                None,
+            )
+        );
+        assert!(matches!(
+            database
+                .store()
+                .release_unissued_github_check_annotation_batch(release)
+                .await,
+            Err(GithubCheckStoreError::ClaimRejected)
+        ));
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)] // One lock race proves stale rejection and successor preservation.
+async fn stale_annotation_retry_waiter_cannot_release_successor_claim() -> TestResult {
+    run_with_database(|database| async move {
+        let publish = claimed_terminal_publish(&database, "annotation-race", 0xa703).await?;
+        seed_annotation_progress(&database, &publish).await?;
+        let started_at = database_now(database.pool()).await?;
+        let begin = BeginGithubCheckAnnotationBatch::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            started_at,
+        )?;
+        database
+            .store()
+            .begin_github_check_annotation_batch(begin)
+            .await?;
+        let stale_failed_at = database_now(database.pool()).await?;
+
+        let successor_owner = GithubCheckProjectionWorkerId::from_uuid(Uuid::from_u128(0xa7ff))?;
+        let successor_fence = publish
+            .claim()
+            .fence()
+            .checked_add(1)
+            .ok_or("test claim fence overflow")?;
+        let successor_claimed_at = publish.expires_at();
+        let successor_expires_at = checked_add_millis(successor_claimed_at, 30_000)?;
+        let mut successor = database.pool().begin().await?;
+        let blocking_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *successor)
+            .await?;
+        let successor_updated = sqlx::query(
+            r"
+            UPDATE github_check_projection_outbox
+            SET attempt_count = attempt_count + 1,
+                claim_fence = $2,
+                claim_owner_id = $3,
+                claimed_at_ms = $4,
+                claim_expires_at_ms = $5,
+                state_updated_at_ms = $4
+            WHERE subject_id = $1
+              AND state = 'claimed'
+              AND claim_owner_id = $6
+              AND claim_fence = $7
+              AND claim_action = 'publish'
+            ",
+        )
+        .bind(publish.claim().subject_id().as_uuid())
+        .bind(i64::try_from(successor_fence)?)
+        .bind(successor_owner.as_uuid())
+        .bind(successor_claimed_at.get())
+        .bind(successor_expires_at.get())
+        .bind(publish.claim().owner().as_uuid())
+        .bind(i64::try_from(publish.claim().fence())?)
+        .execute(&mut *successor)
+        .await?;
+        assert_eq!(successor_updated.rows_affected(), 1);
+
+        let stale_request = RetryUncertainGithubCheckAnnotations::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            stale_failed_at,
+            checked_add_millis(stale_failed_at, 1)?,
+        )?;
+        let stale_store = database.store().clone();
+        let stale = tokio::spawn(async move {
+            stale_store
+                .retry_uncertain_github_check_annotations(stale_request)
+                .await
+        });
+        wait_for_direct_blocker(database.pool(), blocking_pid).await?;
+        successor.commit().await?;
+        assert!(matches!(
+            stale.await?,
+            Err(GithubCheckStoreError::ClaimRejected)
+        ));
+
+        let current: (String, Uuid, i64, Option<i16>) = sqlx::query_as(
+            r"
+            SELECT outbox.state, outbox.claim_owner_id, outbox.claim_fence,
+                   progress.uncertain_batch_size
+            FROM github_check_projection_outbox AS outbox
+            JOIN github_check_annotation_progress AS progress
+              ON progress.subject_id = outbox.subject_id
+            WHERE outbox.subject_id = $1
+            ",
+        )
+        .bind(publish.claim().subject_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            current,
+            (
+                "claimed".to_owned(),
+                successor_owner.as_uuid(),
+                i64::try_from(successor_fence)?,
+                Some(i16::from(BATCH_SIZE)),
+            )
+        );
+
+        let successor_claim = GithubCheckProjectionClaimFence::from_durable_parts(
+            publish.claim().subject_id(),
+            successor_owner,
+            successor_fence,
+        )?;
+        database
+            .store()
+            .retry_uncertain_github_check_annotations(RetryUncertainGithubCheckAnnotations::new(
+                successor_claim,
+                PRESENTATION_DIGEST,
+                0,
+                BATCH_SIZE,
+                successor_claimed_at,
+                checked_add_millis(successor_claimed_at, 1)?,
+            )?)
+            .await?;
+        let retried: (String, Option<Uuid>, Option<String>, Option<i16>) = sqlx::query_as(
+            r"
+            SELECT outbox.state, outbox.claim_owner_id, outbox.last_failure_kind,
+                   progress.uncertain_batch_size
+            FROM github_check_projection_outbox AS outbox
+            JOIN github_check_annotation_progress AS progress
+              ON progress.subject_id = outbox.subject_id
+            WHERE outbox.subject_id = $1
+            ",
+        )
+        .bind(publish.claim().subject_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            retried,
+            (
+                "retry".to_owned(),
+                None,
+                Some("github_annotation_ambiguous".to_owned()),
+                Some(i16::from(BATCH_SIZE)),
+            )
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn stale_annotation_clear_cannot_erase_successor_fresh_batch() -> TestResult {
+    run_with_database(|database| async move {
+        let publish =
+            claimed_fenced_annotation_batch(&database, "annotation-clear-race", 0xa704).await?;
+        let stale_observed_at = database_now(database.pool()).await?;
+
+        let mut successor_transaction = database.pool().begin().await?;
+        let successor =
+            stage_fresh_annotation_successor(&mut successor_transaction, &publish, 0xa7fc).await?;
+        let stale_request = ClearGithubCheckAnnotationUncertainty::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            stale_observed_at,
+        )?;
+        let stale_store = database.store().clone();
+        let stale = tokio::spawn(async move {
+            stale_store
+                .clear_github_check_annotation_uncertainty(stale_request)
+                .await
+        });
+        wait_for_direct_blocker(database.pool(), successor.blocking_pid).await?;
+        successor_transaction.commit().await?;
+        assert!(matches!(
+            stale.await?,
+            Err(GithubCheckStoreError::ClaimRejected)
+        ));
+        assert_fresh_successor_batch(&database, &publish, successor).await?;
+
+        let successor_claim = GithubCheckProjectionClaimFence::from_durable_parts(
+            publish.claim().subject_id(),
+            successor.owner,
+            successor.fence,
+        )?;
+        let cleared = database
+            .store()
+            .clear_github_check_annotation_uncertainty(ClearGithubCheckAnnotationUncertainty::new(
+                successor_claim,
+                PRESENTATION_DIGEST,
+                0,
+                BATCH_SIZE,
+                successor.claimed_at,
+            )?)
+            .await?;
+        assert_eq!(cleared.next(), 0);
+        assert_eq!(cleared.uncertain_batch_size(), None);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn stale_annotation_advance_cannot_consume_successor_fresh_batch() -> TestResult {
+    run_with_database(|database| async move {
+        let publish =
+            claimed_fenced_annotation_batch(&database, "annotation-advance-race", 0xa705).await?;
+        let stale_observed_at = database_now(database.pool()).await?;
+
+        let mut successor_transaction = database.pool().begin().await?;
+        let successor =
+            stage_fresh_annotation_successor(&mut successor_transaction, &publish, 0xa7fa).await?;
+        let stale_request = AdvanceGithubCheckAnnotations::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            ANNOTATION_COUNT,
+            stale_observed_at,
+        )?;
+        let stale_store = database.store().clone();
+        let stale = tokio::spawn(async move {
+            stale_store
+                .advance_github_check_annotations(stale_request)
+                .await
+        });
+        wait_for_direct_blocker(database.pool(), successor.blocking_pid).await?;
+        successor_transaction.commit().await?;
+        assert!(matches!(
+            stale.await?,
+            Err(GithubCheckStoreError::ClaimRejected)
+        ));
+        assert_fresh_successor_batch(&database, &publish, successor).await?;
+
+        let successor_claim = GithubCheckProjectionClaimFence::from_durable_parts(
+            publish.claim().subject_id(),
+            successor.owner,
+            successor.fence,
+        )?;
+        let advanced = database
+            .store()
+            .advance_github_check_annotations(AdvanceGithubCheckAnnotations::new(
+                successor_claim,
+                PRESENTATION_DIGEST,
+                0,
+                ANNOTATION_COUNT,
+                successor.claimed_at,
+            )?)
+            .await?;
+        assert_eq!(advanced.next(), ANNOTATION_COUNT);
+        assert_eq!(advanced.uncertain_batch_size(), None);
+        Ok(())
+    })
+    .await
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FreshAnnotationSuccessor {
+    owner: GithubCheckProjectionWorkerId,
+    fence: u64,
+    claimed_at: UnixMillis,
+    blocking_pid: i32,
+}
+
+async fn claimed_fenced_annotation_batch(
+    database: &TestDatabase,
+    tenant_id: &str,
+    connection_seed: u128,
+) -> TestResult<ClaimedGithubCheckProjection> {
+    let publish = claimed_terminal_publish(database, tenant_id, connection_seed).await?;
+    seed_annotation_progress(database, &publish).await?;
+    let started_at = database_now(database.pool()).await?;
+    database
+        .store()
+        .begin_github_check_annotation_batch(BeginGithubCheckAnnotationBatch::new(
+            publish.claim(),
+            PRESENTATION_DIGEST,
+            0,
+            BATCH_SIZE,
+            started_at,
+        )?)
+        .await?;
+    Ok(publish)
+}
+
+async fn stage_fresh_annotation_successor(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    publish: &ClaimedGithubCheckProjection,
+    owner_seed: u128,
+) -> TestResult<FreshAnnotationSuccessor> {
+    // Commit the successor claim and its same-shaped fresh marker together so
+    // a stale joined UPDATE must recheck both durable rows after its lock wait.
+    let owner = GithubCheckProjectionWorkerId::from_uuid(Uuid::from_u128(owner_seed))?;
+    let fence = publish
+        .claim()
+        .fence()
+        .checked_add(1)
+        .ok_or("test claim fence overflow")?;
+    let claimed_at = publish.expires_at();
+    let expires_at = checked_add_millis(claimed_at, 30_000)?;
+    let blocking_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut **transaction)
+        .await?;
+    let outbox_updated = sqlx::query(
+        r"
+        UPDATE github_check_projection_outbox
+        SET attempt_count = attempt_count + 1,
+            claim_fence = $2,
+            claim_owner_id = $3,
+            claimed_at_ms = $4,
+            claim_expires_at_ms = $5,
+            state_updated_at_ms = $4
+        WHERE subject_id = $1
+          AND state = 'claimed'
+          AND claim_owner_id = $6
+          AND claim_fence = $7
+          AND claim_action = 'publish'
+        ",
+    )
+    .bind(publish.claim().subject_id().as_uuid())
+    .bind(i64::try_from(fence)?)
+    .bind(owner.as_uuid())
+    .bind(claimed_at.get())
+    .bind(expires_at.get())
+    .bind(publish.claim().owner().as_uuid())
+    .bind(i64::try_from(publish.claim().fence())?)
+    .execute(&mut **transaction)
+    .await?;
+    assert_eq!(outbox_updated.rows_affected(), 1);
+
+    let marker_updated = sqlx::query(
+        r"
+        UPDATE github_check_annotation_progress
+        SET uncertain_batch_size = $4,
+            updated_at_ms = $5
+        WHERE subject_id = $1
+          AND presentation_digest = $2
+          AND annotation_next = $3
+          AND uncertain_batch_size = $4
+          AND updated_at_ms < $5
+        ",
+    )
+    .bind(publish.claim().subject_id().as_uuid())
+    .bind(PRESENTATION_DIGEST.as_bytes().as_slice())
+    .bind(0_i32)
+    .bind(i16::from(BATCH_SIZE))
+    .bind(claimed_at.get())
+    .execute(&mut **transaction)
+    .await?;
+    assert_eq!(marker_updated.rows_affected(), 1);
+
+    Ok(FreshAnnotationSuccessor {
+        owner,
+        fence,
+        claimed_at,
+        blocking_pid,
+    })
+}
+
+async fn assert_fresh_successor_batch(
+    database: &TestDatabase,
+    publish: &ClaimedGithubCheckProjection,
+    successor: FreshAnnotationSuccessor,
+) -> TestResult {
+    let durable: (String, Uuid, i64, String, i32, Option<i16>, i64) = sqlx::query_as(
+        r"
+        SELECT outbox.state, outbox.claim_owner_id, outbox.claim_fence,
+               outbox.claim_action, progress.annotation_next,
+               progress.uncertain_batch_size, progress.updated_at_ms
+        FROM github_check_projection_outbox AS outbox
+        JOIN github_check_annotation_progress AS progress
+          ON progress.subject_id = outbox.subject_id
+        WHERE outbox.subject_id = $1
+        ",
+    )
+    .bind(publish.claim().subject_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(
+        durable,
+        (
+            "claimed".to_owned(),
+            successor.owner.as_uuid(),
+            i64::try_from(successor.fence)?,
+            "publish".to_owned(),
+            0,
+            Some(i16::from(BATCH_SIZE)),
+            successor.claimed_at.get(),
+        )
+    );
+    Ok(())
+}
+
+async fn claimed_terminal_publish(
+    database: &TestDatabase,
+    tenant_id: &str,
+    connection_seed: u128,
+) -> TestResult<ClaimedGithubCheckProjection> {
+    let fixture = bootstrap(
+        database,
+        tenant_id,
+        connection_seed,
+        ProviderRepositoryVisibility::Public,
+        100,
+    )
+    .await?;
+    let accepted = database
+        .store()
+        .accept_manifest_pinned_github_delivery(acceptance(
+            &fixture,
+            "annotation-delivery",
+            OWNER_ID,
+            OWNER_ID,
+            HEAD_SHA,
+            fixture.activated_at.get(),
+            0xa7,
+        ))
+        .await?;
+    let delivery = claim_delivery(
+        database,
+        accepted.delivery_id(),
+        connection_seed + 1,
+        60_000,
+    )
+    .await?;
+    database
+        .store()
+        .reject_provider_delivery(RejectProviderDelivery::new(
+            delivery.claim(),
+            ProviderDeliveryFailureKind::new("github.annotation.test")?,
+            delivery.claimed_at(),
+        )?)
+        .await?;
+
+    let ensure_suite = claim_check_projection(database, fixture.connection).await?;
+    assert_eq!(
+        ensure_suite.action(),
+        GithubCheckProjectionAction::EnsureSuite
+    );
+    let suite_id = GithubCheckSuiteId::new(70_000 + u64::from(BATCH_SIZE))?;
+    database
+        .store()
+        .bind_github_check_suite(BindGithubCheckSuite::new(
+            ensure_suite.claim(),
+            suite_id,
+            ensure_suite.claimed_at(),
+        )?)
+        .await?;
+
+    let create = claim_check_projection(database, fixture.connection).await?;
+    assert_eq!(
+        create.action(),
+        GithubCheckProjectionAction::PrepareRunCreate
+    );
+    let cutoff = database
+        .store()
+        .begin_github_check_run_create(BeginGithubCheckRunCreate::new(
+            &create,
+            create.claimed_at(),
+            checked_add_millis(create.expires_at(), 1)?,
+        )?)
+        .await?;
+    database
+        .store()
+        .bind_github_check_run(BindGithubCheckRun::new(
+            GithubCheckRunBindingFence::Create(cutoff),
+            suite_id,
+            GithubCheckRunId::new(80_000 + u64::from(BATCH_SIZE))?,
+            create.claimed_at(),
+        )?)
+        .await?;
+
+    let publish = claim_check_projection(database, fixture.connection).await?;
+    assert_eq!(publish.action(), GithubCheckProjectionAction::Publish);
+    Ok(publish)
+}
+
+async fn seed_annotation_progress(
+    database: &TestDatabase,
+    publish: &ClaimedGithubCheckProjection,
+) -> TestResult {
+    sqlx::query(
+        r"
+        INSERT INTO github_check_annotation_progress (
+            subject_id, presentation_digest, annotation_total,
+            annotation_next, uncertain_batch_size, updated_at_ms
+        ) VALUES ($1, $2, $3, 0, NULL, $4)
+        ",
+    )
+    .bind(publish.claim().subject_id().as_uuid())
+    .bind(PRESENTATION_DIGEST.as_bytes().as_slice())
+    .bind(i32::from(ANNOTATION_COUNT))
+    .bind(publish.claimed_at().get())
+    .execute(database.pool())
+    .await?;
+    Ok(())
+}
+
+async fn assert_markerless_requests_are_rejected(
+    database: &TestDatabase,
+    publish: &ClaimedGithubCheckProjection,
+    begin: BeginGithubCheckAnnotationBatch,
+) -> TestResult {
+    let observed_at = database_now(database.pool()).await?;
+    let retry_at = checked_add_millis(observed_at, 1)?;
+    assert!(matches!(
+        database
+            .store()
+            .retry_uncertain_github_check_annotations(RetryUncertainGithubCheckAnnotations::new(
+                publish.claim(),
+                PRESENTATION_DIGEST,
+                0,
+                BATCH_SIZE,
+                observed_at,
+                retry_at,
+            )?)
+            .await,
+        Err(GithubCheckStoreError::ProjectionMismatch)
+    ));
+    assert!(matches!(
+        database
+            .store()
+            .release_unissued_github_check_annotation_batch(
+                ReleaseUnissuedGithubCheckAnnotationBatch::new(begin, observed_at, retry_at)?,
+            )
+            .await,
+        Err(GithubCheckStoreError::ProjectionMismatch)
+    ));
+    Ok(())
+}
+
+async fn wait_for_direct_blocker(pool: &sqlx::PgPool, blocking_pid: i32) -> TestResult {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                r"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_stat_activity AS activity
+                    WHERE activity.datname = current_database()
+                      AND $1 = ANY(pg_blocking_pids(activity.pid))
+                )
+                ",
+            )
+            .bind(blocking_pid)
+            .fetch_one(pool)
+            .await?;
+            if waiting {
+                return Ok::<(), sqlx::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| "annotation mutation did not reach the expected outbox lock")??;
+    Ok(())
+}

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -914,14 +914,14 @@ impl GithubCheckAnnotationProgress {
     /// # Errors
     ///
     /// Rejects incomplete presentation identity, excessive counts, a cursor
-    /// beyond the total, or an uncertain batch outside the remaining suffix.
+    /// beyond the total, or a fenced batch outside the remaining suffix.
     pub fn from_durable_parts(
         presentation_digest: Option<Sha256Digest>,
         total: u16,
         next: u16,
         uncertain_batch_size: Option<u8>,
     ) -> Result<Self, GithubCheckValueError> {
-        let uncertainty_is_valid = uncertain_batch_size.is_none_or(|count| {
+        let batch_marker_is_valid = uncertain_batch_size.is_none_or(|count| {
             count > 0
                 && count <= 50
                 && next
@@ -930,7 +930,7 @@ impl GithubCheckAnnotationProgress {
         });
         if total > 4_096
             || next > total
-            || !uncertainty_is_valid
+            || !batch_marker_is_valid
             || presentation_digest.is_none()
                 && (total != 0 || next != 0 || uncertain_batch_size.is_some())
         {
@@ -962,7 +962,10 @@ impl GithubCheckAnnotationProgress {
         self.next
     }
 
-    /// Returns the size of a possibly appended batch requiring reconciliation.
+    /// Returns the durable in-flight batch size.
+    ///
+    /// A later claim must reconcile this marker before issuing another PATCH,
+    /// because the prior worker may have crossed the provider boundary.
     #[must_use]
     pub const fn uncertain_batch_size(self) -> Option<u8> {
         self.uncertain_batch_size
@@ -1625,6 +1628,81 @@ impl InitializeGithubCheckPresentation {
     }
 }
 
+/// Single-use durable cutoff before one annotation append may begin.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BeginGithubCheckAnnotationBatch {
+    claim: GithubCheckProjectionClaimFence,
+    digest: Sha256Digest,
+    from: u16,
+    batch_size: u8,
+    started_at: UnixMillis,
+}
+
+impl BeginGithubCheckAnnotationBatch {
+    /// Creates one bounded append cutoff under an exact publish claim.
+    ///
+    /// Committing this request authorizes at most one provider PATCH. An
+    /// already-present cutoff must not be replayed as fresh authorization.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty, excessive, or out-of-range batch and negative times.
+    pub fn new(
+        claim: GithubCheckProjectionClaimFence,
+        digest: Sha256Digest,
+        from: u16,
+        batch_size: u8,
+        started_at: UnixMillis,
+    ) -> Result<Self, GithubCheckValueError> {
+        if batch_size == 0
+            || batch_size > 50
+            || from
+                .checked_add(u16::from(batch_size))
+                .is_none_or(|to| to > 4_096)
+        {
+            return Err(GithubCheckValueError::InvalidProjectionBinding);
+        }
+        validate_timestamp(started_at, "GitHub Check annotation batch start time")?;
+        Ok(Self {
+            claim,
+            digest,
+            from,
+            batch_size,
+            started_at,
+        })
+    }
+
+    /// Returns the exact live publish claim.
+    #[must_use]
+    pub const fn claim(self) -> GithubCheckProjectionClaimFence {
+        self.claim
+    }
+
+    /// Returns the deterministic presentation digest.
+    #[must_use]
+    pub const fn digest(self) -> Sha256Digest {
+        self.digest
+    }
+
+    /// Returns the cursor immediately before this batch.
+    #[must_use]
+    pub const fn from(self) -> u16 {
+        self.from
+    }
+
+    /// Returns the number of annotations in this batch.
+    #[must_use]
+    pub const fn batch_size(self) -> u8 {
+        self.batch_size
+    }
+
+    /// Returns when the provider-call cutoff was crossed.
+    #[must_use]
+    pub const fn started_at(self) -> UnixMillis {
+        self.started_at
+    }
+}
+
 /// Monotonically confirms one exact annotation batch under a live claim.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AdvanceGithubCheckAnnotations {
@@ -1762,6 +1840,84 @@ impl RetryUncertainGithubCheckAnnotations {
         self.failed_at
     }
     /// Returns the reconcile-only retry time.
+    #[must_use]
+    pub const fn retry_at(self) -> UnixMillis {
+        self.retry_at
+    }
+}
+
+/// Releases one fenced batch only when its provider future never began.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReleaseUnissuedGithubCheckAnnotationBatch {
+    batch: BeginGithubCheckAnnotationBatch,
+    released_at: UnixMillis,
+    retry_at: UnixMillis,
+}
+
+impl ReleaseUnissuedGithubCheckAnnotationBatch {
+    /// Creates exact proof that a durable cutoff did not issue provider I/O.
+    ///
+    /// # Errors
+    ///
+    /// Rejects release before the cutoff or an invalid bounded retry delay.
+    pub fn new(
+        batch: BeginGithubCheckAnnotationBatch,
+        released_at: UnixMillis,
+        retry_at: UnixMillis,
+    ) -> Result<Self, GithubCheckValueError> {
+        if released_at < batch.started_at() {
+            return Err(GithubCheckValueError::InvalidClaimInterval);
+        }
+        retry_at
+            .get()
+            .checked_sub(released_at.get())
+            .filter(|delay| (1..=MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS).contains(delay))
+            .ok_or(GithubCheckValueError::InvalidRetryBackoff)?;
+        validate_timestamp(released_at, "GitHub Check annotation batch release time")?;
+        Ok(Self {
+            batch,
+            released_at,
+            retry_at,
+        })
+    }
+
+    /// Returns the exact live publish claim.
+    #[must_use]
+    pub const fn claim(self) -> GithubCheckProjectionClaimFence {
+        self.batch.claim()
+    }
+
+    /// Returns the deterministic presentation digest.
+    #[must_use]
+    pub const fn digest(self) -> Sha256Digest {
+        self.batch.digest()
+    }
+
+    /// Returns the unchanged cursor before the unissued batch.
+    #[must_use]
+    pub const fn from(self) -> u16 {
+        self.batch.from()
+    }
+
+    /// Returns the size of the unissued batch.
+    #[must_use]
+    pub const fn batch_size(self) -> u8 {
+        self.batch.batch_size()
+    }
+
+    /// Returns the exact durable cutoff being released.
+    #[must_use]
+    pub const fn started_at(self) -> UnixMillis {
+        self.batch.started_at()
+    }
+
+    /// Returns when the cutoff was safely released.
+    #[must_use]
+    pub const fn released_at(self) -> UnixMillis {
+        self.released_at
+    }
+
+    /// Returns the next eligible publish time.
     #[must_use]
     pub const fn retry_at(self) -> UnixMillis {
         self.retry_at
@@ -2182,6 +2338,12 @@ pub trait GithubCheckProjectionOutbox: Send + Sync {
         request: InitializeGithubCheckPresentation,
     ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError>;
 
+    /// Commits a single-use cutoff before one annotation PATCH may begin.
+    async fn begin_github_check_annotation_batch(
+        &self,
+        request: BeginGithubCheckAnnotationBatch,
+    ) -> Result<GithubCheckAnnotationProgress, GithubCheckStoreError>;
+
     /// Monotonically confirms one exact appended annotation batch.
     async fn advance_github_check_annotations(
         &self,
@@ -2192,6 +2354,12 @@ pub trait GithubCheckProjectionOutbox: Send + Sync {
     async fn retry_uncertain_github_check_annotations(
         &self,
         request: RetryUncertainGithubCheckAnnotations,
+    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
+
+    /// Atomically releases a cutoff whose provider future provably never began.
+    async fn release_unissued_github_check_annotation_batch(
+        &self,
+        request: ReleaseUnissuedGithubCheckAnnotationBatch,
     ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
 
     /// Clears uncertainty after proving GitHub retained the prior exact prefix.

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -99,8 +99,8 @@ pub use github_check_rerun::{
     GithubCheckRerunStoreError, GithubCheckRerunTarget, GithubCheckRerunValueError,
 };
 pub use github_checks::{
-    AdvanceGithubCheckAnnotations, BeginGithubCheckRunCreate, BindGithubCheckRun,
-    BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
+    AdvanceGithubCheckAnnotations, BeginGithubCheckAnnotationBatch, BeginGithubCheckRunCreate,
+    BindGithubCheckRun, BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
     BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
     ClaimedGithubCheckProjection, ClearGithubCheckAnnotationUncertainty,
     CompleteGithubCheckProjection, GithubCheckAnnotationProgress, GithubCheckAppId,
@@ -114,9 +114,9 @@ pub use github_checks::{
     GithubCheckTerminalizationRepository, GithubCheckValueError, InitializeGithubCheckPresentation,
     MAX_GITHUB_CHECK_CREATE_RECONCILE_GRACE_MILLIS, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
     MAX_GITHUB_CHECK_PROJECTION_CLAIM_MILLIS, MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS,
-    RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckRunCreate, ResolveGithubCheckRunCreate,
-    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection,
-    TerminalizeGithubCheck,
+    RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckAnnotationBatch,
+    ReleaseUnissuedGithubCheckRunCreate, ResolveGithubCheckRunCreate, RetryGithubCheckProjection,
+    RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection, TerminalizeGithubCheck,
 };
 pub use github_job_runtime_authority::{
     GithubJobRuntimeAuthorityEvidence, GithubJobRuntimeAuthorityExecution,


### PR DESCRIPTION
## Why

GitHub Check annotations are append-only. The publisher previously sent a PATCH before durably recording the batch, so a crash, invalid success response, or database failure could make recovery append the same annotations again. The uncertain-retry SQL also read the claim through a joined snapshot, allowing a stale worker to clear a successor claim.

## Summary

- Commit a single-use digest/cursor/size marker before any annotation PATCH can begin.
- Reserve the complete HTTP request timeout and configured visibility margin inside the live claim.
- Retain the marker after any possibly issued request and reconcile the exact provider prefix before another PATCH.
- Atomically release a marker only when the provider future provably never began.
- Lock the exact outbox owner/fence/action before begin, advance, clear, ambiguous retry, or unissued release.
- Require exact marker CAS for every cursor transition, preventing stale workers from clearing or advancing successor state.
- Reuse the existing bounded progress column; no migration or durable-schema change is required.

## Compatibility

This adds begin and unissued-release operations to the internal `GithubCheckProjectionOutbox` port and updates its first-party PostgreSQL and test implementations. No database schema, wire format, or provider API shape changes.

## Validation

Passed locally:

- GitHub Checks publisher integration tests: 33/33
- Store unit tests: 42/42
- Store contracts: 184/184
- formatting, diff, Cargo metadata, coverage-policy, and PostgreSQL lane-plan checks
- independent timing, locking, SQL, and stale-claim review

Five PostgreSQL 18 tests were added for single-use begin, exact unissued release, stale ambiguous retry, stale clear, and stale advance. They remain in the environment-gated ignored lane because `AUTOMATA_TEST_DATABASE_URL` is unavailable locally.

The extracted PostgreSQL crate repeatedly reached `Checking automata-ci-postgres` and was then killed by the host with exit 137, without a compiler diagnostic, including single-job attempts. CI on a clean runner is required to confirm the aggregate crate compile and execute the PostgreSQL lane.