### PR TITLE
feat: add workspace entitlement management

### DIFF
--- a/crates/automata-ci-postgres/migrations/0001_initial_schema.sql
+++ b/crates/automata-ci-postgres/migrations/0001_initial_schema.sql
@@ -24148,7 +24148,7 @@ END)),
 );
 
 CREATE TABLE github_check_annotation_progress (
-    subject_id uuid PRIMARY KEY REFERENCES github_check_subjects(id) ON DELETE RESTRICT,
+    subject_id uuid PRIMARY KEY,
     presentation_digest bytea NOT NULL,
     annotation_total integer NOT NULL,
     annotation_next integer DEFAULT 0 NOT NULL,
@@ -26547,6 +26547,66 @@ CREATE TABLE workspace_provisioning_operations (
     CONSTRAINT workspace_provisioning_operations_state_shape CHECK (((((state = 'pending'::text) AND (initial_owner_principal_id IS NULL) AND (provisioned_at_ms IS NULL)) OR ((state = 'completed'::text) AND (initial_owner_principal_id IS NOT NULL) AND (provisioned_at_ms >= created_at_ms))) IS TRUE)),
     CONSTRAINT workspace_provisioning_operations_time_nonnegative CHECK ((created_at_ms >= 0)),
     CONSTRAINT workspace_provisioning_operations_workspace_shape CHECK ((((octet_length(workspace_id) = 36) AND (workspace_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'::text))))
+);
+
+CREATE TABLE workspace_management_bindings (
+    workspace_id text PRIMARY KEY,
+    authority_id text NOT NULL,
+    shard_id text NOT NULL,
+    created_at_ms bigint NOT NULL,
+    CONSTRAINT workspace_management_bindings_authority_shape CHECK ((((octet_length(authority_id) >= 1) AND (octet_length(authority_id) <= 255)) AND (authority_id !~ '[[:space:][:cntrl:]]'::text))),
+    CONSTRAINT workspace_management_bindings_shard_shape CHECK ((((octet_length(shard_id) >= 1) AND (octet_length(shard_id) <= 63)) AND (shard_id ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'::text))),
+    CONSTRAINT workspace_management_bindings_time_nonnegative CHECK ((created_at_ms >= 0)),
+    CONSTRAINT workspace_management_bindings_exact_authority UNIQUE (workspace_id, authority_id, shard_id)
+);
+
+CREATE TABLE workspace_entitlement_operations (
+    authority_id text NOT NULL,
+    operation_id uuid NOT NULL,
+    shard_id text NOT NULL,
+    workspace_id text NOT NULL,
+    revision bigint NOT NULL,
+    policy_kind text NOT NULL,
+    compute_limit_ms bigint,
+    valid_for_ms bigint,
+    applied_at_ms bigint NOT NULL,
+    expires_at_ms bigint,
+    CONSTRAINT workspace_entitlement_operations_pkey PRIMARY KEY (authority_id, operation_id),
+    CONSTRAINT workspace_entitlement_operations_exact_revision UNIQUE (authority_id, operation_id, workspace_id, revision),
+    CONSTRAINT workspace_entitlement_operations_workspace_revision_unique UNIQUE (workspace_id, revision),
+    CONSTRAINT workspace_entitlement_operations_binding FOREIGN KEY (workspace_id, authority_id, shard_id) REFERENCES workspace_management_bindings(workspace_id, authority_id, shard_id) ON DELETE RESTRICT,
+    CONSTRAINT workspace_entitlement_operations_ids_non_nil CHECK ((operation_id <> '00000000-0000-0000-0000-000000000000'::uuid)),
+    CONSTRAINT workspace_entitlement_operations_revision_positive CHECK ((revision > 0)),
+    CONSTRAINT workspace_entitlement_operations_policy CHECK ((policy_kind = ANY (ARRAY['capped'::text, 'uncapped'::text, 'paused'::text]))),
+    CONSTRAINT workspace_entitlement_operations_policy_shape CHECK (((((policy_kind = 'capped'::text) AND (compute_limit_ms > 0)) OR ((policy_kind = ANY (ARRAY['uncapped'::text, 'paused'::text])) AND (compute_limit_ms IS NULL) AND (valid_for_ms IS NULL) AND (expires_at_ms IS NULL))) IS TRUE)),
+    CONSTRAINT workspace_entitlement_operations_validity_shape CHECK (((((valid_for_ms IS NULL) AND (expires_at_ms IS NULL)) OR ((valid_for_ms > 0) AND (expires_at_ms = applied_at_ms + valid_for_ms))) IS TRUE)),
+    CONSTRAINT workspace_entitlement_operations_time_nonnegative CHECK ((applied_at_ms >= 0))
+);
+
+CREATE TABLE workspace_execution_entitlements (
+    workspace_id text PRIMARY KEY,
+    authority_id text NOT NULL,
+    shard_id text NOT NULL,
+    revision bigint NOT NULL,
+    operation_id uuid NOT NULL,
+    policy_kind text NOT NULL,
+    compute_limit_ms bigint,
+    valid_for_ms bigint,
+    consumed_compute_ms bigint DEFAULT 0 NOT NULL,
+    state text NOT NULL,
+    applied_at_ms bigint NOT NULL,
+    expires_at_ms bigint,
+    exhausted_at_ms bigint,
+    CONSTRAINT workspace_execution_entitlements_binding FOREIGN KEY (workspace_id, authority_id, shard_id) REFERENCES workspace_management_bindings(workspace_id, authority_id, shard_id) ON DELETE RESTRICT,
+    CONSTRAINT workspace_execution_entitlements_operation FOREIGN KEY (authority_id, operation_id, workspace_id, revision) REFERENCES workspace_entitlement_operations(authority_id, operation_id, workspace_id, revision) ON DELETE RESTRICT,
+    CONSTRAINT workspace_execution_entitlements_revision_positive CHECK ((revision > 0)),
+    CONSTRAINT workspace_execution_entitlements_compute_nonnegative CHECK ((consumed_compute_ms >= 0)),
+    CONSTRAINT workspace_execution_entitlements_policy CHECK ((policy_kind = ANY (ARRAY['capped'::text, 'uncapped'::text, 'paused'::text]))),
+    CONSTRAINT workspace_execution_entitlements_policy_shape CHECK (((((policy_kind = 'capped'::text) AND (compute_limit_ms > 0)) OR ((policy_kind = ANY (ARRAY['uncapped'::text, 'paused'::text])) AND (compute_limit_ms IS NULL) AND (valid_for_ms IS NULL) AND (expires_at_ms IS NULL))) IS TRUE)),
+    CONSTRAINT workspace_execution_entitlements_validity_shape CHECK (((((valid_for_ms IS NULL) AND (expires_at_ms IS NULL)) OR ((valid_for_ms > 0) AND (expires_at_ms = applied_at_ms + valid_for_ms))) IS TRUE)),
+    CONSTRAINT workspace_execution_entitlements_state CHECK ((state = ANY (ARRAY['active'::text, 'paused'::text, 'exhausted'::text]))),
+    CONSTRAINT workspace_execution_entitlements_state_shape CHECK (((((state = 'active'::text) AND (policy_kind <> 'paused'::text) AND (exhausted_at_ms IS NULL)) OR ((state = 'paused'::text) AND (policy_kind = 'paused'::text) AND (consumed_compute_ms = 0) AND (exhausted_at_ms IS NULL)) OR ((state = 'exhausted'::text) AND (policy_kind = 'capped'::text) AND (exhausted_at_ms >= applied_at_ms))) IS TRUE)),
+    CONSTRAINT workspace_execution_entitlements_time_nonnegative CHECK ((applied_at_ms >= 0))
 );
 
 CREATE TABLE workflow_admission_receipts (
@@ -30934,6 +30994,9 @@ ALTER TABLE ONLY github_actions_cache_blocks
 ALTER TABLE ONLY github_check_projection_outbox
     ADD CONSTRAINT github_check_projection_outbox_subject_id_fkey FOREIGN KEY (subject_id) REFERENCES github_check_subjects(id) ON DELETE RESTRICT;
 
+ALTER TABLE ONLY github_check_annotation_progress
+    ADD CONSTRAINT github_check_annotation_progress_subject_id_fkey FOREIGN KEY (subject_id) REFERENCES github_check_subjects(id) ON DELETE RESTRICT;
+
 ALTER TABLE ONLY github_check_subjects
     ADD CONSTRAINT github_check_subjects_repository_run FOREIGN KEY (repository_id, workflow_run_id) REFERENCES workflow_runs(repository_id, id) ON DELETE RESTRICT;
 
@@ -31761,6 +31824,9 @@ ALTER TABLE ONLY workspace_provisioning_operations
 
 ALTER TABLE ONLY workspace_provisioning_operations
     ADD CONSTRAINT workspace_provisioning_operations_workspace FOREIGN KEY (workspace_id) REFERENCES tenants(id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE ONLY workspace_management_bindings
+    ADD CONSTRAINT workspace_management_bindings_workspace FOREIGN KEY (workspace_id) REFERENCES tenants(id) ON DELETE RESTRICT;
 
 ALTER TABLE ONLY workflow_admission_receipts
     ADD CONSTRAINT workflow_admission_receipts_repository_tenant FOREIGN KEY (tenant_id, repository_id) REFERENCES repositories(tenant_id, id) ON DELETE RESTRICT;

--- a/crates/automata-ci-postgres/src/lib.rs
+++ b/crates/automata-ci-postgres/src/lib.rs
@@ -6,7 +6,7 @@ mod migration;
 
 /// Human authentication, authorization, and runner-enrollment adapters.
 pub mod auth;
-/// Atomic workspace-provisioning adapter.
+/// Atomic external workspace-management adapters.
 pub mod provisioning;
 /// Durable runner-machine authentication adapter.
 pub mod runner_auth;

--- a/crates/automata-ci-postgres/src/provisioning/entitlement.rs
+++ b/crates/automata-ci-postgres/src/provisioning/entitlement.rs
@@ -1,0 +1,411 @@
+use std::fmt;
+
+use automata_ci_provisioning::{
+    ApplyWorkspaceEntitlementResult, AuthorizedApplyWorkspaceEntitlement, EntitlementFailure,
+    EntitlementFailureKind, EntitlementTimestamp, WorkspaceEntitlementApplier,
+    WorkspaceExecutionEntitlement,
+};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+const WORKSPACE_ENTITLEMENT_APPLIED_AUDIT_ACTION: &str = "workspace.entitlement.applied";
+
+/// Replica-safe `PostgreSQL` implementation of workspace entitlement application.
+///
+/// The adapter serializes mutations through the immutable workspace management
+/// binding, verifies its exact authority and shard, and atomically stores both
+/// the current snapshot and stable operation receipt. It deliberately performs
+/// no per-job budget allocation.
+#[derive(Clone)]
+pub struct PostgresWorkspaceEntitlementApplier {
+    pool: PgPool,
+}
+
+impl PostgresWorkspaceEntitlementApplier {
+    /// Binds entitlement application to `pool`.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[allow(clippy::too_many_lines)] // One ordered transaction owns every entitlement effect.
+    async fn apply_inner(
+        &self,
+        request: AuthorizedApplyWorkspaceEntitlement,
+    ) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
+        let (authority, command) = request.into_parts();
+        let authority_id = authority.id().as_str();
+        let operation_id = command.operation_id();
+        let shard_id = command.shard_id();
+        let workspace_id = command.workspace_id();
+        let workspace_text = workspace_id.to_string();
+        let revision = i64::try_from(command.revision().get())
+            .map_err(|_| failure(EntitlementFailureKind::Internal))?;
+        let policy = PolicyFields::from(command.execution())?;
+
+        let mut transaction = self.pool.begin().await.map_err(database_failure)?;
+        let binding = lock_management_binding(&mut transaction, &workspace_text).await?;
+        if binding.as_ref().is_none_or(|binding| {
+            binding.authority_id != authority_id || binding.shard_id != shard_id.as_str()
+        }) {
+            return Err(failure(EntitlementFailureKind::WorkspaceUnavailable));
+        }
+
+        if let Some(stored) =
+            load_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?
+        {
+            if !stored.matches(shard_id.as_str(), &workspace_text, revision, policy) {
+                return Err(failure(EntitlementFailureKind::OperationConflict));
+            }
+            return stored.result(operation_id, shard_id.clone(), workspace_id);
+        }
+
+        let current_revision: Option<i64> = sqlx::query_scalar(
+            r"
+            SELECT revision FROM workspace_execution_entitlements
+            WHERE workspace_id=$1
+            FOR UPDATE
+            ",
+        )
+        .bind(&workspace_text)
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        if current_revision.is_some_and(|current| revision <= current) {
+            return Err(failure(EntitlementFailureKind::StaleRevision));
+        }
+
+        let applied_at_ms = database_time_milliseconds(&mut transaction).await?;
+        let expires_at_ms = policy
+            .valid_for_ms
+            .map(|duration| {
+                applied_at_ms
+                    .checked_add(duration)
+                    .ok_or_else(|| failure(EntitlementFailureKind::Internal))
+            })
+            .transpose()?;
+        let inserted = sqlx::query(
+            r"
+            INSERT INTO workspace_entitlement_operations (
+                authority_id, operation_id, shard_id, workspace_id, revision,
+                policy_kind, compute_limit_ms, valid_for_ms, applied_at_ms,
+                expires_at_ms
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+            ON CONFLICT (authority_id, operation_id) DO NOTHING
+            ",
+        )
+        .bind(authority_id)
+        .bind(operation_id.as_uuid())
+        .bind(shard_id.as_str())
+        .bind(&workspace_text)
+        .bind(revision)
+        .bind(policy.kind)
+        .bind(policy.compute_limit_ms)
+        .bind(policy.valid_for_ms)
+        .bind(applied_at_ms)
+        .bind(expires_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+
+        if inserted.rows_affected() == 0 {
+            let stored = load_operation(&mut transaction, authority_id, operation_id.as_uuid())
+                .await?
+                .ok_or_else(|| failure(EntitlementFailureKind::Internal))?;
+            if !stored.matches(shard_id.as_str(), &workspace_text, revision, policy) {
+                return Err(failure(EntitlementFailureKind::OperationConflict));
+            }
+            return stored.result(operation_id, shard_id.clone(), workspace_id);
+        }
+
+        let state = if policy.kind == "paused" {
+            "paused"
+        } else {
+            "active"
+        };
+        let updated = sqlx::query(
+            r"
+            INSERT INTO workspace_execution_entitlements (
+                workspace_id, authority_id, shard_id, revision, operation_id,
+                policy_kind, compute_limit_ms, valid_for_ms,
+                consumed_compute_ms, state, applied_at_ms, expires_at_ms,
+                exhausted_at_ms
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,0,$9,$10,$11,NULL)
+            ON CONFLICT (workspace_id) DO UPDATE SET
+                authority_id=EXCLUDED.authority_id,
+                shard_id=EXCLUDED.shard_id,
+                revision=EXCLUDED.revision,
+                operation_id=EXCLUDED.operation_id,
+                policy_kind=EXCLUDED.policy_kind,
+                compute_limit_ms=EXCLUDED.compute_limit_ms,
+                valid_for_ms=EXCLUDED.valid_for_ms,
+                consumed_compute_ms=0,
+                state=EXCLUDED.state,
+                applied_at_ms=EXCLUDED.applied_at_ms,
+                expires_at_ms=EXCLUDED.expires_at_ms,
+                exhausted_at_ms=NULL
+            WHERE workspace_execution_entitlements.revision < EXCLUDED.revision
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(authority_id)
+        .bind(shard_id.as_str())
+        .bind(revision)
+        .bind(operation_id.as_uuid())
+        .bind(policy.kind)
+        .bind(policy.compute_limit_ms)
+        .bind(policy.valid_for_ms)
+        .bind(state)
+        .bind(applied_at_ms)
+        .bind(expires_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        if updated.rows_affected() != 1 {
+            return Err(failure(EntitlementFailureKind::StaleRevision));
+        }
+
+        sqlx::query(
+            r"
+            INSERT INTO security_audit_events (
+                event_id, tenant_id, occurred_at_ms, actor_kind, action,
+                outcome, resource_kind, resource_id
+            ) VALUES ($1,$2,$3,'system',$4,'succeeded','workspace',$2)
+            ",
+        )
+        .bind(Uuid::new_v4())
+        .bind(&workspace_text)
+        .bind(applied_at_ms)
+        .bind(WORKSPACE_ENTITLEMENT_APPLIED_AUDIT_ACTION)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+        transaction.commit().await.map_err(database_failure)?;
+
+        result(
+            operation_id,
+            shard_id.clone(),
+            workspace_id,
+            command.revision(),
+            applied_at_ms,
+            expires_at_ms,
+        )
+    }
+}
+
+impl fmt::Debug for PostgresWorkspaceEntitlementApplier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresWorkspaceEntitlementApplier")
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkspaceEntitlementApplier for PostgresWorkspaceEntitlementApplier {
+    fn apply(
+        &self,
+        request: AuthorizedApplyWorkspaceEntitlement,
+    ) -> automata_ci_provisioning::EntitlementApplicationFuture<'_> {
+        Box::pin(self.apply_inner(request))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PolicyFields {
+    kind: &'static str,
+    compute_limit_ms: Option<i64>,
+    valid_for_ms: Option<i64>,
+}
+
+impl PolicyFields {
+    fn from(value: WorkspaceExecutionEntitlement) -> Result<Self, EntitlementFailure> {
+        match value {
+            WorkspaceExecutionEntitlement::Capped {
+                compute_seconds,
+                valid_for,
+            } => Ok(Self {
+                kind: "capped",
+                compute_limit_ms: Some(seconds_to_milliseconds(compute_seconds.get())?),
+                valid_for_ms: valid_for
+                    .map(|duration| seconds_to_milliseconds(duration.get()))
+                    .transpose()?,
+            }),
+            WorkspaceExecutionEntitlement::Uncapped => Ok(Self {
+                kind: "uncapped",
+                compute_limit_ms: None,
+                valid_for_ms: None,
+            }),
+            WorkspaceExecutionEntitlement::Paused => Ok(Self {
+                kind: "paused",
+                compute_limit_ms: None,
+                valid_for_ms: None,
+            }),
+        }
+    }
+}
+
+#[derive(FromRow)]
+struct ManagementBinding {
+    authority_id: String,
+    shard_id: String,
+}
+
+async fn lock_management_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    workspace_id: &str,
+) -> Result<Option<ManagementBinding>, EntitlementFailure> {
+    sqlx::query_as::<_, ManagementBinding>(
+        r"
+        SELECT authority_id, shard_id FROM workspace_management_bindings
+        WHERE workspace_id=$1
+        FOR UPDATE
+        ",
+    )
+    .bind(workspace_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(database_failure)
+}
+
+#[derive(FromRow)]
+struct StoredOperation {
+    shard_id: String,
+    workspace_id: String,
+    revision: i64,
+    policy_kind: String,
+    compute_limit_ms: Option<i64>,
+    valid_for_ms: Option<i64>,
+    applied_at_ms: i64,
+    expires_at_ms: Option<i64>,
+}
+
+impl StoredOperation {
+    fn matches(
+        &self,
+        shard_id: &str,
+        workspace_id: &str,
+        revision: i64,
+        policy: PolicyFields,
+    ) -> bool {
+        self.shard_id == shard_id
+            && self.workspace_id == workspace_id
+            && self.revision == revision
+            && self.policy_kind == policy.kind
+            && self.compute_limit_ms == policy.compute_limit_ms
+            && self.valid_for_ms == policy.valid_for_ms
+    }
+
+    fn result(
+        self,
+        operation_id: automata_ci_provisioning::OperationId,
+        shard_id: automata_ci_provisioning::ShardId,
+        workspace_id: automata_ci_provisioning::WorkspaceId,
+    ) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
+        result(
+            operation_id,
+            shard_id,
+            workspace_id,
+            automata_ci_provisioning::EntitlementRevision::new(
+                u64::try_from(self.revision)
+                    .map_err(|_| failure(EntitlementFailureKind::Internal))?,
+            )
+            .map_err(|_| failure(EntitlementFailureKind::Internal))?,
+            self.applied_at_ms,
+            self.expires_at_ms,
+        )
+    }
+}
+
+async fn load_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    authority_id: &str,
+    operation_id: Uuid,
+) -> Result<Option<StoredOperation>, EntitlementFailure> {
+    sqlx::query_as::<_, StoredOperation>(
+        r"
+        SELECT shard_id, workspace_id, revision, policy_kind,
+               compute_limit_ms, valid_for_ms, applied_at_ms, expires_at_ms
+        FROM workspace_entitlement_operations
+        WHERE authority_id=$1 AND operation_id=$2
+        FOR UPDATE
+        ",
+    )
+    .bind(authority_id)
+    .bind(operation_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(database_failure)
+}
+
+fn result(
+    operation_id: automata_ci_provisioning::OperationId,
+    shard_id: automata_ci_provisioning::ShardId,
+    workspace_id: automata_ci_provisioning::WorkspaceId,
+    revision: automata_ci_provisioning::EntitlementRevision,
+    applied_at_ms: i64,
+    expires_at_ms: Option<i64>,
+) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
+    Ok(ApplyWorkspaceEntitlementResult::new(
+        operation_id,
+        shard_id,
+        workspace_id,
+        revision,
+        timestamp(applied_at_ms)?,
+        expires_at_ms.map(timestamp).transpose()?,
+    ))
+}
+
+fn seconds_to_milliseconds(seconds: u64) -> Result<i64, EntitlementFailure> {
+    seconds
+        .checked_mul(1_000)
+        .and_then(|value| i64::try_from(value).ok())
+        .ok_or_else(|| failure(EntitlementFailureKind::Internal))
+}
+
+async fn database_time_milliseconds(
+    transaction: &mut Transaction<'_, Postgres>,
+) -> Result<i64, EntitlementFailure> {
+    let now: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(&mut **transaction)
+            .await
+            .map_err(database_failure)?;
+    if now < 0 {
+        return Err(failure(EntitlementFailureKind::Internal));
+    }
+    Ok(now)
+}
+
+fn timestamp(milliseconds: i64) -> Result<EntitlementTimestamp, EntitlementFailure> {
+    let seconds = milliseconds.div_euclid(1_000);
+    let remainder = milliseconds.rem_euclid(1_000);
+    let nanoseconds = u32::try_from(remainder)
+        .ok()
+        .and_then(|value| value.checked_mul(1_000_000))
+        .ok_or_else(|| failure(EntitlementFailureKind::Internal))?;
+    EntitlementTimestamp::new(seconds, nanoseconds)
+        .map_err(|_| failure(EntitlementFailureKind::Internal))
+}
+
+fn database_failure(error: sqlx::Error) -> EntitlementFailure {
+    let kind = match &error {
+        sqlx::Error::Io(_)
+        | sqlx::Error::Tls(_)
+        | sqlx::Error::PoolTimedOut
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::WorkerCrashed
+        | sqlx::Error::BeginFailed => EntitlementFailureKind::TemporarilyUnavailable,
+        sqlx::Error::Database(database)
+            if super::retryable_sqlstate(database.code().as_deref()) =>
+        {
+            EntitlementFailureKind::TemporarilyUnavailable
+        }
+        _ => EntitlementFailureKind::Internal,
+    };
+    drop(error);
+    failure(kind)
+}
+
+const fn failure(kind: EntitlementFailureKind) -> EntitlementFailure {
+    EntitlementFailure::new(kind)
+}

--- a/crates/automata-ci-postgres/src/provisioning/mod.rs
+++ b/crates/automata-ci-postgres/src/provisioning/mod.rs
@@ -12,6 +12,10 @@ use automata_ci_provisioning::{
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
+mod entitlement;
+
+pub use entitlement::PostgresWorkspaceEntitlementApplier;
+
 const WORKSPACE_OWNER_ROLE_NAME: &str = "workspace-owner";
 const WORKSPACE_OWNER_ROLE_DISPLAY_NAME: &str = "Workspace owner";
 const WORKSPACE_PROVISIONED_AUDIT_ACTION: &str = "workspace.provisioned";
@@ -107,6 +111,20 @@ impl PostgresWorkspaceProvisioner {
         if tenant_inserted.rows_affected() != 1 {
             return Err(failure(ProvisioningFailureKind::WorkspaceConflict));
         }
+        sqlx::query(
+            r"
+            INSERT INTO workspace_management_bindings (
+                workspace_id, authority_id, shard_id, created_at_ms
+            ) VALUES ($1,$2,$3,$4)
+            ",
+        )
+        .bind(&workspace_text)
+        .bind(authority_id)
+        .bind(shard_id.as_str())
+        .bind(created_at_ms)
+        .execute(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
 
         let principal_id = resolve_or_create_principal(
             &mut transaction,

--- a/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
+++ b/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
@@ -117,7 +117,7 @@ async fn resolves_current_core_membership_and_direct_rbac() -> TestResult {
                 .map(automata_ci_auth::human::PrincipalId::as_str),
             Some(PRINCIPAL_ID)
         );
-        assert_eq!(snapshot.authorization().authorization_revision(), Some(7));
+        assert_eq!(snapshot.authorization().authorization_revision(), Some(8));
         let grants = snapshot
             .authorization()
             .role_grants()

--- a/crates/automata-ci-postgres/tests/provisioning/entitlement.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/entitlement.rs
@@ -1,0 +1,232 @@
+use automata_ci_postgres::provisioning::{
+    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
+};
+use automata_ci_provisioning::{
+    ApplyWorkspaceEntitlementCommand, AuthorizedApplyWorkspaceEntitlement,
+    AuthorizedProvisionWorkspace, ComputeSeconds, DelegatedActorIssuer, DisplayName,
+    EntitlementDurationSeconds, EntitlementFailureKind, EntitlementRevision,
+    ExternalAccountSubject, OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority,
+    ProvisioningAuthorityId, ShardId, WorkspaceEntitlementApplier, WorkspaceExecutionEntitlement,
+    WorkspaceId, WorkspaceProvisioner,
+};
+use uuid::Uuid;
+
+use crate::support::{TestResult, run_with_database};
+
+const AUTHORITY: &str = "automata-cloud-production";
+const ISSUER: &str = "https://cloud.automata.example";
+const SHARD: &str = "prod-us-east-1-001";
+
+fn authority(authority_id: &str) -> ProvisioningAuthority {
+    ProvisioningAuthority::new(
+        ProvisioningAuthorityId::new(authority_id).expect("authority"),
+        ShardId::new(SHARD).expect("shard"),
+        DelegatedActorIssuer::new(ISSUER).expect("issuer"),
+    )
+}
+
+fn provisioning_request(workspace_id: Uuid) -> AuthorizedProvisionWorkspace {
+    let command = ProvisionWorkspaceCommand::new(
+        OperationId::from_uuid(Uuid::new_v4()).expect("operation ID"),
+        ShardId::new(SHARD).expect("shard"),
+        WorkspaceId::from_uuid(workspace_id).expect("workspace ID"),
+        DisplayName::new("Acme Engineering").expect("workspace name"),
+        DelegatedActorIssuer::new(ISSUER).expect("issuer"),
+        ExternalAccountSubject::from_uuid(Uuid::new_v4()).expect("subject"),
+        DisplayName::new("The Octocat").expect("owner name"),
+    );
+    AuthorizedProvisionWorkspace::authorize(authority(AUTHORITY), command)
+        .expect("authorized provisioning")
+}
+
+fn entitlement_request(
+    authority_id: &str,
+    operation_id: Uuid,
+    workspace_id: Uuid,
+    revision: u64,
+    execution: WorkspaceExecutionEntitlement,
+) -> AuthorizedApplyWorkspaceEntitlement {
+    let command = ApplyWorkspaceEntitlementCommand::new(
+        OperationId::from_uuid(operation_id).expect("operation ID"),
+        ShardId::new(SHARD).expect("shard"),
+        WorkspaceId::from_uuid(workspace_id).expect("workspace ID"),
+        EntitlementRevision::new(revision).expect("revision"),
+        execution,
+    );
+    AuthorizedApplyWorkspaceEntitlement::authorize(authority(authority_id), command)
+        .expect("authorized entitlement")
+}
+
+fn trial() -> WorkspaceExecutionEntitlement {
+    WorkspaceExecutionEntitlement::capped(
+        ComputeSeconds::new(6_000).expect("compute"),
+        Some(EntitlementDurationSeconds::new(604_800).expect("duration")),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+#[allow(clippy::too_many_lines)] // One scenario proves receipt, revision, and snapshot invariants.
+async fn capped_entitlement_is_atomic_replayable_and_revisioned() -> TestResult {
+    run_with_database(|database| async move {
+        let provisioner = PostgresWorkspaceProvisioner::new(database.pool().clone());
+        let applier = PostgresWorkspaceEntitlementApplier::new(database.pool().clone());
+        let workspace_id = Uuid::new_v4();
+        provisioner
+            .provision(provisioning_request(workspace_id))
+            .await?;
+
+        let operation_id = Uuid::new_v4();
+        let first = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                operation_id,
+                workspace_id,
+                1,
+                trial(),
+            ))
+            .await?;
+        let replay = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                operation_id,
+                workspace_id,
+                1,
+                trial(),
+            ))
+            .await?;
+        assert_eq!(replay, first);
+        assert_eq!(
+            first.expires_at().expect("trial expiry").seconds() - first.applied_at().seconds(),
+            604_800
+        );
+
+        let operation_conflict = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                operation_id,
+                workspace_id,
+                1,
+                WorkspaceExecutionEntitlement::capped(
+                    ComputeSeconds::new(3_000).expect("compute"),
+                    None,
+                ),
+            ))
+            .await
+            .expect_err("changed operation semantics must conflict");
+        assert_eq!(
+            operation_conflict.kind(),
+            EntitlementFailureKind::OperationConflict
+        );
+
+        let stale = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                Uuid::new_v4(),
+                workspace_id,
+                1,
+                trial(),
+            ))
+            .await
+            .expect_err("another operation cannot reuse the current revision");
+        assert_eq!(stale.kind(), EntitlementFailureKind::StaleRevision);
+
+        let paused = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                Uuid::new_v4(),
+                workspace_id,
+                3,
+                WorkspaceExecutionEntitlement::Paused,
+            ))
+            .await?;
+        assert_eq!(paused.revision().get(), 3, "revision gaps are allowed");
+        assert_eq!(paused.expires_at(), None);
+
+        let persisted: (i64, String, Option<i64>, i64, String) = sqlx::query_as(
+            r"
+            SELECT revision, policy_kind, compute_limit_ms,
+                   consumed_compute_ms, state
+            FROM workspace_execution_entitlements
+            WHERE workspace_id=$1
+            ",
+        )
+        .bind(workspace_id.hyphenated().to_string())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            persisted,
+            (3, "paused".to_owned(), None, 0, "paused".to_owned())
+        );
+
+        let counts: (i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+              (SELECT count(*) FROM workspace_entitlement_operations),
+              (SELECT count(*) FROM security_audit_events
+               WHERE action='workspace.entitlement.applied')
+            ",
+        )
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(counts, (2, 2));
+
+        let old_replay = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                operation_id,
+                workspace_id,
+                1,
+                trial(),
+            ))
+            .await?;
+        assert_eq!(old_replay, first, "old exact receipts remain stable");
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn only_the_workspace_management_authority_can_apply_entitlements() -> TestResult {
+    run_with_database(|database| async move {
+        let provisioner = PostgresWorkspaceProvisioner::new(database.pool().clone());
+        let applier = PostgresWorkspaceEntitlementApplier::new(database.pool().clone());
+        let workspace_id = Uuid::new_v4();
+        provisioner
+            .provision(provisioning_request(workspace_id))
+            .await?;
+
+        let wrong_authority = applier
+            .apply(entitlement_request(
+                "another-control-plane",
+                Uuid::new_v4(),
+                workspace_id,
+                1,
+                trial(),
+            ))
+            .await
+            .expect_err("another authority must not manage the workspace");
+        assert_eq!(
+            wrong_authority.kind(),
+            EntitlementFailureKind::WorkspaceUnavailable
+        );
+
+        let unmanaged_workspace = applier
+            .apply(entitlement_request(
+                AUTHORITY,
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                1,
+                trial(),
+            ))
+            .await
+            .expect_err("an unmanaged workspace must not accept external policy");
+        assert_eq!(
+            unmanaged_workspace.kind(),
+            EntitlementFailureKind::WorkspaceUnavailable
+        );
+        Ok(())
+    })
+    .await
+}

--- a/crates/automata-ci-postgres/tests/provisioning/mod.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/mod.rs
@@ -1,3 +1,4 @@
 //! Workspace provisioning adapter tests.
 
+mod entitlement;
 mod workspace;

--- a/crates/automata-ci-postgres/tests/provisioning/workspace.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/workspace.rs
@@ -90,20 +90,21 @@ async fn provisioning_is_atomic_replayable_and_conflict_safe() -> TestResult {
             ProvisioningFailureKind::WorkspaceConflict
         );
 
-        let counts: (i64, i64, i64, i64, i64) = sqlx::query_as(
+        let counts: (i64, i64, i64, i64, i64, i64) = sqlx::query_as(
             r"
             SELECT
               (SELECT count(*) FROM workspace_provisioning_operations),
               (SELECT count(*) FROM tenants),
               (SELECT count(*) FROM delegated_actor_identities),
               (SELECT count(*) FROM tenant_human_memberships),
+              (SELECT count(*) FROM workspace_management_bindings),
               (SELECT count(*) FROM security_audit_events
                WHERE action='workspace.provisioned')
             ",
         )
         .fetch_one(database.pool())
         .await?;
-        assert_eq!(counts, (1, 1, 1, 1, 1));
+        assert_eq!(counts, (1, 1, 1, 1, 1, 1));
 
         let role_permission_counts: (i64, i64) = sqlx::query_as(
             r"

--- a/crates/automata-ci-provisioning-grpc/README.md
+++ b/crates/automata-ci-provisioning-grpc/README.md
@@ -4,8 +4,8 @@ This crate owns and serves the public
 [`automata.management.v1.ShardManagementService`](proto/automata/management/v1/shard_management.proto)
 schema over gRPC/HTTP/2. It requires a client certificate at the TLS handshake,
 authenticates that verified certificate chain for every request, validates and
-scope-checks the domain command, and calls the transport-neutral provisioning
-port.
+scope-checks the domain command, and calls transport-neutral workspace
+provisioning or entitlement-application ports.
 
 The server accepts a pre-bound listener so the product composition root retains
 ownership of startup ordering and port conflicts. The Automata binary composes
@@ -13,7 +13,9 @@ it only when a complete private management-listener configuration is supplied;
 standalone self-hosted deployments expose no placeholder endpoint. The product
 maps a dedicated-CA-verified leaf certificate through an exact SHA-256 pin to a
 stable shard-scoped authority, and supplies the durable
-`automata-ci-postgres` provisioning transaction adapter.
+`automata-ci-postgres` management transaction adapters. Entitlement snapshots
+are complete, monotonically revisioned workspace aggregates; the contract does
+not allocate rolling per-job budget slices.
 
 Cargo generates the private Rust wire module into `OUT_DIR` with Protox and
 Tonic. Building therefore needs no separately installed `protoc` or Buf binary,

--- a/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_management.proto
+++ b/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_management.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package automata.management.v1;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 // Administers one Automata Core shard on behalf of an authorized external
 // control plane. This service is not exposed to browsers, runners, or human
@@ -12,6 +13,13 @@ service ShardManagementService {
   // Replaying the same operation and semantic request returns the original
   // stable response without repeating effects.
   rpc ProvisionWorkspace(ProvisionWorkspaceRequest) returns (ProvisionWorkspaceResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+
+  // Applies a complete, monotonically revisioned execution-entitlement
+  // snapshot to a workspace managed by this external authority. This is a
+  // workspace aggregate, not a per-job rolling execution lease.
+  rpc ApplyWorkspaceEntitlement(ApplyWorkspaceEntitlementRequest) returns (ApplyWorkspaceEntitlementResponse) {
     option idempotency_level = IDEMPOTENT;
   }
 }
@@ -95,4 +103,88 @@ message ProvisionWorkspaceFailure {
 
   // Opaque request correlation identifier safe to expose to the caller.
   string request_id = 2;
+}
+
+// A finite aggregate compute allowance. Core accounts actual execution and
+// may exceed the allowance by a small bounded amount while it observes the
+// threshold and delivers cancellation. That enforcement tolerance does not
+// increase the configured allowance.
+message CappedWorkspaceExecution {
+  // Positive aggregate compute allowance at whole-second API granularity.
+  uint64 compute_seconds = 1;
+
+  // Optional positive relative lifetime. Core anchors this duration to its
+  // database time when the revision commits and returns the resulting deadline.
+  google.protobuf.Duration valid_for = 2;
+}
+
+// Metered execution with no Core-enforced aggregate compute ceiling.
+message UncappedWorkspaceExecution {}
+
+// Execution is disabled. Core rejects new work and cancels active work when
+// enforcement observes this policy.
+message PausedWorkspaceExecution {}
+
+// Complete execution policy for one workspace entitlement revision.
+message WorkspaceExecutionEntitlement {
+  oneof policy {
+    CappedWorkspaceExecution capped = 1;
+    UncappedWorkspaceExecution uncapped = 2;
+    PausedWorkspaceExecution paused = 3;
+  }
+}
+
+// Durable, idempotent request to replace one workspace's entitlement snapshot.
+message ApplyWorkspaceEntitlementRequest {
+  // Stable non-nil canonical lower-case UUID generated before the first
+  // network attempt and reused across every retry.
+  string operation_id = 1;
+
+  // Expected immutable shard identity, already verified through capability
+  // discovery.
+  string shard_id = 2;
+
+  // Externally managed workspace as a non-nil canonical lower-case UUID.
+  string workspace_id = 3;
+
+  // Positive, monotonically increasing workspace revision. Gaps are allowed;
+  // a revision at or below the current value is stale.
+  uint64 revision = 4;
+
+  // Complete execution policy replacing the prior policy.
+  WorkspaceExecutionEntitlement execution = 5;
+}
+
+// Stable result stored by Core in the entitlement transaction.
+message ApplyWorkspaceEntitlementResponse {
+  string operation_id = 1;
+  string shard_id = 2;
+  string workspace_id = 3;
+  uint64 revision = 4;
+
+  // Canonical Core database time. This value remains stable on replay.
+  google.protobuf.Timestamp applied_at = 5;
+
+  // Present only when the applied snapshot has a relative validity period.
+  google.protobuf.Timestamp expires_at = 6;
+}
+
+// Stable machine-readable reason attached to a failed entitlement RPC.
+enum ApplyWorkspaceEntitlementFailureReason {
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_UNSPECIFIED = 0;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_INVALID_REQUEST = 1;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_UNAUTHENTICATED = 2;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_FORBIDDEN = 3;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_OPERATION_CONFLICT = 4;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_STALE_REVISION = 5;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_WORKSPACE_UNAVAILABLE = 6;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_RATE_LIMITED = 7;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_INTERNAL_ERROR = 8;
+  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 9;
+}
+
+// Typed detail carried in google.rpc.Status.details after Core can safely
+// construct contract-specific details.
+message ApplyWorkspaceEntitlementFailure {
+  ApplyWorkspaceEntitlementFailureReason reason = 1;
 }

--- a/crates/automata-ci-provisioning-grpc/src/lib.rs
+++ b/crates/automata-ci-provisioning-grpc/src/lib.rs
@@ -10,11 +10,14 @@
 use std::{fmt, sync::Arc};
 
 use automata_ci_provisioning::{
-    AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
-    OperationId, ProvisionWorkspaceCommand, ProvisionWorkspaceResult,
-    ProvisioningAuthenticationError, ProvisioningFailure, ProvisioningFailureKind,
-    ProvisioningWorkloadAuthenticator, ShardId, WorkloadAuthenticationEvidence, WorkspaceId,
-    WorkspaceProvisioner,
+    ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
+    AuthorizedApplyWorkspaceEntitlement, AuthorizedProvisionWorkspace, ComputeSeconds,
+    DelegatedActorIssuer, DisplayName, EntitlementDurationSeconds, EntitlementFailure,
+    EntitlementFailureKind, EntitlementRevision, ExternalAccountSubject, OperationId,
+    ProvisionWorkspaceCommand, ProvisionWorkspaceResult, ProvisioningAuthenticationError,
+    ProvisioningFailure, ProvisioningFailureKind, ProvisioningWorkloadAuthenticator, ShardId,
+    WorkloadAuthenticationEvidence, WorkspaceEntitlementApplier, WorkspaceExecutionEntitlement,
+    WorkspaceId, WorkspaceProvisioner,
 };
 use bytes::Bytes;
 use prost::Message as _;
@@ -38,6 +41,8 @@ const MAX_SERVER_CERTIFICATE_PEM_BYTES: usize = 4 * 1024 * 1024;
 const MAX_SERVER_PRIVATE_KEY_PEM_BYTES: usize = 1024 * 1024;
 const FAILURE_TYPE_URL: &str =
     "type.googleapis.com/automata.management.v1.ProvisionWorkspaceFailure";
+const ENTITLEMENT_FAILURE_TYPE_URL: &str =
+    "type.googleapis.com/automata.management.v1.ApplyWorkspaceEntitlementFailure";
 
 /// Bounded PEM inputs for an mTLS-only management listener.
 pub struct ManagementServerTlsConfig {
@@ -109,6 +114,7 @@ pub struct ManagementGrpcServer {
     tls: ManagementServerTlsConfig,
     authenticator: Arc<dyn ProvisioningWorkloadAuthenticator>,
     provisioner: Arc<dyn WorkspaceProvisioner>,
+    entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
 }
 
 impl ManagementGrpcServer {
@@ -118,12 +124,14 @@ impl ManagementGrpcServer {
         tls: ManagementServerTlsConfig,
         authenticator: Arc<dyn ProvisioningWorkloadAuthenticator>,
         provisioner: Arc<dyn WorkspaceProvisioner>,
+        entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
     ) -> Self {
         Self {
             listener,
             tls,
             authenticator,
             provisioner,
+            entitlement_applier,
         }
     }
 
@@ -140,6 +148,7 @@ impl ManagementGrpcServer {
         let adapter = ManagementGrpcAdapter {
             authenticator: self.authenticator,
             provisioner: self.provisioner,
+            entitlement_applier: self.entitlement_applier,
         };
         let service =
             wire::shard_management_service_server::ShardManagementServiceServer::new(adapter)
@@ -166,6 +175,7 @@ impl fmt::Debug for ManagementGrpcServer {
             .field("tls", &self.tls)
             .field("authenticator", &self.authenticator)
             .field("provisioner", &self.provisioner)
+            .field("entitlement_applier", &self.entitlement_applier)
             .finish_non_exhaustive()
     }
 }
@@ -174,6 +184,7 @@ impl fmt::Debug for ManagementGrpcServer {
 struct ManagementGrpcAdapter {
     authenticator: Arc<dyn ProvisioningWorkloadAuthenticator>,
     provisioner: Arc<dyn WorkspaceProvisioner>,
+    entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
 }
 
 impl fmt::Debug for ManagementGrpcAdapter {
@@ -182,6 +193,7 @@ impl fmt::Debug for ManagementGrpcAdapter {
             .debug_struct("ManagementGrpcAdapter")
             .field("authenticator", &self.authenticator)
             .field("provisioner", &self.provisioner)
+            .field("entitlement_applier", &self.entitlement_applier)
             .finish()
     }
 }
@@ -245,6 +257,63 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
         }
         Ok(Response::new(encode_result(&result)))
     }
+
+    async fn apply_workspace_entitlement(
+        &self,
+        request: Request<wire::ApplyWorkspaceEntitlementRequest>,
+    ) -> Result<Response<wire::ApplyWorkspaceEntitlementResponse>, Status> {
+        let certificates = request
+            .peer_certs()
+            .ok_or_else(|| Status::unauthenticated("workload authentication is required"))?;
+        let evidence = WorkloadAuthenticationEvidence::new(
+            certificates
+                .iter()
+                .map(|certificate| certificate.as_ref().to_vec())
+                .collect(),
+        )
+        .map_err(authentication_status)?;
+        let authority = self
+            .authenticator
+            .authenticate(&evidence)
+            .await
+            .map_err(authentication_status)?;
+        let command = decode_entitlement_command(request.into_inner()).map_err(|()| {
+            entitlement_contract_status(
+                Code::InvalidArgument,
+                wire::ApplyWorkspaceEntitlementFailureReason::InvalidRequest,
+                "workspace entitlement request is invalid",
+            )
+        })?;
+        let authorized = AuthorizedApplyWorkspaceEntitlement::authorize(authority, command)
+            .map_err(|_| {
+                entitlement_contract_status(
+                    Code::PermissionDenied,
+                    wire::ApplyWorkspaceEntitlementFailureReason::Forbidden,
+                    "workspace entitlement is outside the workload authority",
+                )
+            })?;
+        let expected_operation_id = authorized.command().operation_id();
+        let expected_shard_id = authorized.command().shard_id().clone();
+        let expected_workspace_id = authorized.command().workspace_id();
+        let expected_revision = authorized.command().revision();
+        let result = self
+            .entitlement_applier
+            .apply(authorized)
+            .await
+            .map_err(entitlement_status)?;
+        if result.operation_id() != expected_operation_id
+            || result.shard_id() != &expected_shard_id
+            || result.workspace_id() != expected_workspace_id
+            || result.revision() != expected_revision
+        {
+            return Err(entitlement_contract_status(
+                Code::Internal,
+                wire::ApplyWorkspaceEntitlementFailureReason::InternalError,
+                "workspace entitlement application returned an inconsistent result",
+            ));
+        }
+        Ok(Response::new(encode_entitlement_result(&result)))
+    }
 }
 
 fn decode_command(
@@ -275,6 +344,61 @@ fn encode_result(result: &ProvisionWorkspaceResult) -> wire::ProvisionWorkspaceR
             nanos: i32::try_from(provisioned_at.nanoseconds())
                 .expect("validated nanoseconds fit i32"),
         }),
+    }
+}
+
+fn decode_entitlement_command(
+    request: wire::ApplyWorkspaceEntitlementRequest,
+) -> Result<ApplyWorkspaceEntitlementCommand, ()> {
+    let execution = request.execution.ok_or(())?.policy.ok_or(())?;
+    let execution = match execution {
+        wire::workspace_execution_entitlement::Policy::Capped(capped) => {
+            let compute_seconds = ComputeSeconds::new(capped.compute_seconds).map_err(|_| ())?;
+            let valid_for = capped
+                .valid_for
+                .map(|duration| {
+                    if duration.seconds <= 0 || duration.nanos != 0 {
+                        return Err(());
+                    }
+                    EntitlementDurationSeconds::new(
+                        u64::try_from(duration.seconds).map_err(|_| ())?,
+                    )
+                    .map_err(|_| ())
+                })
+                .transpose()?;
+            WorkspaceExecutionEntitlement::capped(compute_seconds, valid_for)
+        }
+        wire::workspace_execution_entitlement::Policy::Uncapped(_) => {
+            WorkspaceExecutionEntitlement::Uncapped
+        }
+        wire::workspace_execution_entitlement::Policy::Paused(_) => {
+            WorkspaceExecutionEntitlement::Paused
+        }
+    };
+    Ok(ApplyWorkspaceEntitlementCommand::new(
+        OperationId::parse(&request.operation_id).map_err(|_| ())?,
+        ShardId::new(request.shard_id).map_err(|_| ())?,
+        WorkspaceId::parse(&request.workspace_id).map_err(|_| ())?,
+        EntitlementRevision::new(request.revision).map_err(|_| ())?,
+        execution,
+    ))
+}
+
+fn encode_entitlement_result(
+    result: &ApplyWorkspaceEntitlementResult,
+) -> wire::ApplyWorkspaceEntitlementResponse {
+    let timestamp =
+        |value: automata_ci_provisioning::EntitlementTimestamp| prost_types::Timestamp {
+            seconds: value.seconds(),
+            nanos: i32::try_from(value.nanoseconds()).expect("validated nanoseconds fit i32"),
+        };
+    wire::ApplyWorkspaceEntitlementResponse {
+        operation_id: result.operation_id().to_string(),
+        shard_id: result.shard_id().as_str().to_owned(),
+        workspace_id: result.workspace_id().to_string(),
+        revision: result.revision().get(),
+        applied_at: Some(timestamp(result.applied_at())),
+        expires_at: result.expires_at().map(timestamp),
     }
 }
 
@@ -330,6 +454,42 @@ fn provisioning_status(error: &ProvisioningFailure) -> Status {
     contract_status(code, reason, message, request_id)
 }
 
+fn entitlement_status(error: EntitlementFailure) -> Status {
+    let (code, reason, message) = match error.kind() {
+        EntitlementFailureKind::OperationConflict => (
+            Code::Aborted,
+            wire::ApplyWorkspaceEntitlementFailureReason::OperationConflict,
+            "entitlement operation conflicts with its durable receipt",
+        ),
+        EntitlementFailureKind::StaleRevision => (
+            Code::FailedPrecondition,
+            wire::ApplyWorkspaceEntitlementFailureReason::StaleRevision,
+            "entitlement revision is stale",
+        ),
+        EntitlementFailureKind::WorkspaceUnavailable => (
+            Code::PermissionDenied,
+            wire::ApplyWorkspaceEntitlementFailureReason::WorkspaceUnavailable,
+            "workspace is unavailable to this management authority",
+        ),
+        EntitlementFailureKind::RateLimited => (
+            Code::ResourceExhausted,
+            wire::ApplyWorkspaceEntitlementFailureReason::RateLimited,
+            "workspace entitlement mutation rate is exhausted",
+        ),
+        EntitlementFailureKind::Internal => (
+            Code::Internal,
+            wire::ApplyWorkspaceEntitlementFailureReason::InternalError,
+            "workspace entitlement application failed internally",
+        ),
+        EntitlementFailureKind::TemporarilyUnavailable => (
+            Code::Unavailable,
+            wire::ApplyWorkspaceEntitlementFailureReason::TemporarilyUnavailable,
+            "workspace entitlement application is temporarily unavailable",
+        ),
+    };
+    entitlement_contract_status(code, reason, message)
+}
+
 fn contract_status(
     code: Code,
     reason: wire::ProvisionWorkspaceFailureReason,
@@ -345,6 +505,25 @@ fn contract_status(
         message: message.to_owned(),
         details: vec![prost_types::Any {
             type_url: FAILURE_TYPE_URL.to_owned(),
+            value: detail.encode_to_vec(),
+        }],
+    };
+    Status::with_details(code, message, Bytes::from(rich_status.encode_to_vec()))
+}
+
+fn entitlement_contract_status(
+    code: Code,
+    reason: wire::ApplyWorkspaceEntitlementFailureReason,
+    message: &'static str,
+) -> Status {
+    let detail = wire::ApplyWorkspaceEntitlementFailure {
+        reason: reason as i32,
+    };
+    let rich_status = tonic_types::pb::Status {
+        code: code as i32,
+        message: message.to_owned(),
+        details: vec![prost_types::Any {
+            type_url: ENTITLEMENT_FAILURE_TYPE_URL.to_owned(),
             value: detail.encode_to_vec(),
         }],
     };
@@ -386,8 +565,8 @@ mod tests {
 
     use super::*;
     use automata_ci_provisioning::{
-        InitialOwnerPrincipalId, ProvisionedAt, ProvisioningAuthenticationFuture,
-        ProvisioningAuthority, WorkspaceProvisioningFuture,
+        EntitlementApplicationFuture, EntitlementTimestamp, InitialOwnerPrincipalId, ProvisionedAt,
+        ProvisioningAuthenticationFuture, ProvisioningAuthority, WorkspaceProvisioningFuture,
     };
     use rcgen::{
         BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose,
@@ -541,6 +720,46 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct RecordingEntitlementApplier {
+        calls: AtomicUsize,
+        result: ApplyWorkspaceEntitlementResult,
+    }
+
+    impl RecordingEntitlementApplier {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result: ApplyWorkspaceEntitlementResult::new(
+                    OperationId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
+                    ShardId::new("prod-us-east-1-001").unwrap(),
+                    WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                    EntitlementRevision::new(1).unwrap(),
+                    EntitlementTimestamp::new(1_786_500_100, 0).unwrap(),
+                    Some(EntitlementTimestamp::new(1_787_104_900, 0).unwrap()),
+                ),
+            }
+        }
+    }
+
+    impl WorkspaceEntitlementApplier for RecordingEntitlementApplier {
+        fn apply(
+            &self,
+            request: AuthorizedApplyWorkspaceEntitlement,
+        ) -> EntitlementApplicationFuture<'_> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(request.command().revision().get(), 1);
+            assert_eq!(
+                request.command().execution(),
+                WorkspaceExecutionEntitlement::capped(
+                    ComputeSeconds::new(6_000).unwrap(),
+                    Some(EntitlementDurationSeconds::new(604_800).unwrap())
+                )
+            );
+            Box::pin(future::ready(Ok(self.result.clone())))
+        }
+    }
+
     fn valid_wire_request() -> wire::ProvisionWorkspaceRequest {
         wire::ProvisionWorkspaceRequest {
             operation_id: "55555555-5555-4555-8555-555555555555".to_owned(),
@@ -553,6 +772,26 @@ mod tests {
                 issuer: "https://cloud.automata.example".to_owned(),
                 subject: "11111111-1111-4111-8111-111111111111".to_owned(),
                 display_name: "The Octocat".to_owned(),
+            }),
+        }
+    }
+
+    fn valid_entitlement_wire_request() -> wire::ApplyWorkspaceEntitlementRequest {
+        wire::ApplyWorkspaceEntitlementRequest {
+            operation_id: "77777777-7777-4777-8777-777777777777".to_owned(),
+            shard_id: "prod-us-east-1-001".to_owned(),
+            workspace_id: "22222222-2222-4222-8222-222222222222".to_owned(),
+            revision: 1,
+            execution: Some(wire::WorkspaceExecutionEntitlement {
+                policy: Some(wire::workspace_execution_entitlement::Policy::Capped(
+                    wire::CappedWorkspaceExecution {
+                        compute_seconds: 6_000,
+                        valid_for: Some(prost_types::Duration {
+                            seconds: 604_800,
+                            nanos: 0,
+                        }),
+                    },
+                )),
             }),
         }
     }
@@ -580,6 +819,37 @@ mod tests {
         let mut request = valid_wire_request();
         request.operation_id = "55555555555545558555555555555555".to_owned();
         assert!(decode_command(request).is_err());
+    }
+
+    #[test]
+    fn entitlement_wire_request_decodes_a_workspace_aggregate() {
+        let command = decode_entitlement_command(valid_entitlement_wire_request()).unwrap();
+        assert_eq!(command.revision().get(), 1);
+        assert_eq!(
+            command.execution(),
+            WorkspaceExecutionEntitlement::capped(
+                ComputeSeconds::new(6_000).unwrap(),
+                Some(EntitlementDurationSeconds::new(604_800).unwrap())
+            )
+        );
+    }
+
+    #[test]
+    fn entitlement_rejects_fractional_or_missing_policy() {
+        let mut request = valid_entitlement_wire_request();
+        let Some(wire::workspace_execution_entitlement::Policy::Capped(capped)) = request
+            .execution
+            .as_mut()
+            .and_then(|value| value.policy.as_mut())
+        else {
+            panic!("capped fixture")
+        };
+        capped.valid_for.as_mut().expect("duration").nanos = 1;
+        assert!(decode_entitlement_command(request).is_err());
+
+        let mut request = valid_entitlement_wire_request();
+        request.execution = None;
+        assert!(decode_entitlement_command(request).is_err());
     }
 
     #[test]
@@ -650,6 +920,7 @@ mod tests {
         let address = listener.local_addr().expect("listener address");
         let authenticator = Arc::new(RecordingAuthenticator::new());
         let provisioner = Arc::new(RecordingProvisioner::new());
+        let entitlement_applier = Arc::new(RecordingEntitlementApplier::new());
         let server = ManagementGrpcServer::new(
             listener,
             ManagementServerTlsConfig::new(
@@ -660,6 +931,7 @@ mod tests {
             .unwrap(),
             authenticator.clone(),
             provisioner.clone(),
+            entitlement_applier.clone(),
         );
         let cancellation = CancellationToken::new();
         let server_cancellation = cancellation.clone();
@@ -734,8 +1006,25 @@ mod tests {
             response.into_inner().initial_owner_principal_id,
             "66666666-6666-4666-8666-666666666666"
         );
-        assert_eq!(authenticator.calls.load(Ordering::SeqCst), 1);
         assert_eq!(provisioner.calls.load(Ordering::SeqCst), 1);
+
+        client.ready().await.expect("ready entitlement client");
+        let entitlement: Response<wire::ApplyWorkspaceEntitlementResponse> = client
+            .unary(
+                Request::new(valid_entitlement_wire_request()),
+                tonic::codegen::http::uri::PathAndQuery::from_static(
+                    "/automata.management.v1.ShardManagementService/ApplyWorkspaceEntitlement",
+                ),
+                tonic_prost::ProstCodec::<
+                    wire::ApplyWorkspaceEntitlementRequest,
+                    wire::ApplyWorkspaceEntitlementResponse,
+                >::default(),
+            )
+            .await
+            .expect("successful entitlement RPC");
+        assert_eq!(entitlement.into_inner().revision, 1);
+        assert_eq!(entitlement_applier.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(authenticator.calls.load(Ordering::SeqCst), 2);
         assert_eq!(
             *authenticator.leaf_der.lock().expect("leaf lock"),
             Some(pki.client.leaf_der)

--- a/crates/automata-ci-provisioning/README.md
+++ b/crates/automata-ci-provisioning/README.md
@@ -1,9 +1,10 @@
 # automata-ci-provisioning
 
 This crate owns the transport-neutral application boundary for an authorized
-external control plane to provision a workspace on one Automata Core shard. It
-validates the public contract's domain values and keeps workload authority,
-idempotency identity, and durable provisioning behind explicit ports.
+external control plane to provision and apply execution-entitlement snapshots
+to a workspace on one Automata Core shard. It validates the public contract's
+domain values and keeps workload authority, idempotency identity, provisioning,
+and entitlement mutation behind explicit ports.
 
 It contains no gRPC, HTTP, SQL, Cloud billing, or private Automata Cloud code.
 The public versioned wire schema lives beside its gRPC adapter in

--- a/crates/automata-ci-provisioning/src/entitlement.rs
+++ b/crates/automata-ci-provisioning/src/entitlement.rs
@@ -1,0 +1,463 @@
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::{OperationId, ProvisioningAuthority, ShardId, WorkspaceId};
+
+const MILLIS_PER_SECOND: u64 = 1_000;
+const MAX_DURABLE_SECONDS: u64 = (i64::MAX as u64) / MILLIS_PER_SECOND;
+const MAX_ENTITLEMENT_DURATION_SECONDS: u64 = 10 * 366 * 24 * 60 * 60;
+const PROTOBUF_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
+const PROTOBUF_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
+const NANOS_PER_SECOND: u32 = 1_000_000_000;
+
+/// Monotonically increasing version of one workspace entitlement snapshot.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct EntitlementRevision(u64);
+
+impl EntitlementRevision {
+    /// Creates a positive revision representable by the durable `PostgreSQL` boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values larger than a signed 64-bit integer.
+    pub const fn new(value: u64) -> Result<Self, EntitlementValueError> {
+        if value == 0 || value > i64::MAX as u64 {
+            return Err(EntitlementValueError::InvalidRevision);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the numeric revision.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Positive workspace compute allowance measured at whole-second granularity.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComputeSeconds(u64);
+
+impl ComputeSeconds {
+    /// Creates an allowance representable internally as durable milliseconds.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values whose millisecond representation would overflow.
+    pub const fn new(value: u64) -> Result<Self, EntitlementValueError> {
+        if value == 0 || value > MAX_DURABLE_SECONDS {
+            return Err(EntitlementValueError::InvalidComputeSeconds);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the whole-second allowance.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Positive relative validity period measured at whole-second granularity.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct EntitlementDurationSeconds(u64);
+
+impl EntitlementDurationSeconds {
+    /// Creates a duration representable internally as durable milliseconds.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values longer than ten conservative leap years.
+    pub const fn new(value: u64) -> Result<Self, EntitlementValueError> {
+        if value == 0 || value > MAX_ENTITLEMENT_DURATION_SECONDS {
+            return Err(EntitlementValueError::InvalidDuration);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the whole-second duration.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Complete execution policy installed for one workspace revision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceExecutionEntitlement {
+    /// Execution is bounded by aggregate workspace compute, optionally until a deadline.
+    Capped {
+        /// Total compute available to this entitlement revision.
+        compute_seconds: ComputeSeconds,
+        /// Optional validity period anchored by Core when the revision commits.
+        valid_for: Option<EntitlementDurationSeconds>,
+    },
+    /// Execution is metered but has no Core-enforced workspace compute ceiling.
+    Uncapped,
+    /// New and running execution is not permitted.
+    Paused,
+}
+
+impl WorkspaceExecutionEntitlement {
+    /// Creates a capped aggregate workspace allowance.
+    #[must_use]
+    pub const fn capped(
+        compute_seconds: ComputeSeconds,
+        valid_for: Option<EntitlementDurationSeconds>,
+    ) -> Self {
+        Self::Capped {
+            compute_seconds,
+            valid_for,
+        }
+    }
+}
+
+/// Complete validated semantic input for one workspace entitlement revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApplyWorkspaceEntitlementCommand {
+    operation_id: OperationId,
+    shard_id: ShardId,
+    workspace_id: WorkspaceId,
+    revision: EntitlementRevision,
+    execution: WorkspaceExecutionEntitlement,
+}
+
+impl ApplyWorkspaceEntitlementCommand {
+    /// Creates a complete entitlement snapshot command.
+    #[must_use]
+    pub const fn new(
+        operation_id: OperationId,
+        shard_id: ShardId,
+        workspace_id: WorkspaceId,
+        revision: EntitlementRevision,
+        execution: WorkspaceExecutionEntitlement,
+    ) -> Self {
+        Self {
+            operation_id,
+            shard_id,
+            workspace_id,
+            revision,
+            execution,
+        }
+    }
+
+    /// Returns the durable caller-generated operation identity.
+    #[must_use]
+    pub const fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Returns the expected shard identity.
+    #[must_use]
+    pub const fn shard_id(&self) -> &ShardId {
+        &self.shard_id
+    }
+
+    /// Returns the workspace receiving this snapshot.
+    #[must_use]
+    pub const fn workspace_id(&self) -> WorkspaceId {
+        self.workspace_id
+    }
+
+    /// Returns the monotonic workspace revision.
+    #[must_use]
+    pub const fn revision(&self) -> EntitlementRevision {
+        self.revision
+    }
+
+    /// Returns the complete execution policy.
+    #[must_use]
+    pub const fn execution(&self) -> WorkspaceExecutionEntitlement {
+        self.execution
+    }
+}
+
+/// Entitlement command proven to target the authority's configured shard.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorizedApplyWorkspaceEntitlement {
+    authority: ProvisioningAuthority,
+    command: ApplyWorkspaceEntitlementCommand,
+}
+
+impl AuthorizedApplyWorkspaceEntitlement {
+    /// Authorizes a command against the server-derived shard binding.
+    ///
+    /// Durable persistence additionally requires the same authority to own the
+    /// workspace's external-management binding.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a command for another shard.
+    pub fn authorize(
+        authority: ProvisioningAuthority,
+        command: ApplyWorkspaceEntitlementCommand,
+    ) -> Result<Self, EntitlementAuthorizationError> {
+        if authority.shard_id() != command.shard_id() {
+            return Err(EntitlementAuthorizationError::Forbidden);
+        }
+        Ok(Self { authority, command })
+    }
+
+    /// Returns the stable server-derived authority.
+    #[must_use]
+    pub const fn authority(&self) -> &ProvisioningAuthority {
+        &self.authority
+    }
+
+    /// Returns the validated semantic command.
+    #[must_use]
+    pub const fn command(&self) -> &ApplyWorkspaceEntitlementCommand {
+        &self.command
+    }
+
+    /// Consumes the request into its authority and command.
+    #[must_use]
+    pub fn into_parts(self) -> (ProvisioningAuthority, ApplyWorkspaceEntitlementCommand) {
+        (self.authority, self.command)
+    }
+}
+
+/// Protobuf-compatible UTC instant returned by the durable entitlement transaction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EntitlementTimestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl EntitlementTimestamp {
+    /// Creates an instant within the Protobuf Timestamp range.
+    ///
+    /// # Errors
+    ///
+    /// Rejects out-of-range seconds or one billion or more nanoseconds.
+    pub const fn new(seconds: i64, nanoseconds: u32) -> Result<Self, EntitlementValueError> {
+        if seconds < PROTOBUF_TIMESTAMP_MIN_SECONDS
+            || seconds > PROTOBUF_TIMESTAMP_MAX_SECONDS
+            || nanoseconds >= NANOS_PER_SECOND
+        {
+            return Err(EntitlementValueError::InvalidTimestamp);
+        }
+        Ok(Self {
+            seconds,
+            nanoseconds,
+        })
+    }
+
+    /// Returns whole Unix seconds.
+    #[must_use]
+    pub const fn seconds(self) -> i64 {
+        self.seconds
+    }
+
+    /// Returns fractional nanoseconds within the second.
+    #[must_use]
+    pub const fn nanoseconds(self) -> u32 {
+        self.nanoseconds
+    }
+}
+
+/// Stable result committed atomically with one entitlement revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApplyWorkspaceEntitlementResult {
+    operation_id: OperationId,
+    shard_id: ShardId,
+    workspace_id: WorkspaceId,
+    revision: EntitlementRevision,
+    applied_at: EntitlementTimestamp,
+    expires_at: Option<EntitlementTimestamp>,
+}
+
+impl ApplyWorkspaceEntitlementResult {
+    /// Creates a durable first-attempt or replay result.
+    #[must_use]
+    pub const fn new(
+        operation_id: OperationId,
+        shard_id: ShardId,
+        workspace_id: WorkspaceId,
+        revision: EntitlementRevision,
+        applied_at: EntitlementTimestamp,
+        expires_at: Option<EntitlementTimestamp>,
+    ) -> Self {
+        Self {
+            operation_id,
+            shard_id,
+            workspace_id,
+            revision,
+            applied_at,
+            expires_at,
+        }
+    }
+
+    /// Returns the request operation identity.
+    #[must_use]
+    pub const fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Returns the shard that committed the operation.
+    #[must_use]
+    pub const fn shard_id(&self) -> &ShardId {
+        &self.shard_id
+    }
+
+    /// Returns the workspace receiving the snapshot.
+    #[must_use]
+    pub const fn workspace_id(&self) -> WorkspaceId {
+        self.workspace_id
+    }
+
+    /// Returns the committed workspace revision.
+    #[must_use]
+    pub const fn revision(&self) -> EntitlementRevision {
+        self.revision
+    }
+
+    /// Returns Core's canonical database commit time.
+    #[must_use]
+    pub const fn applied_at(&self) -> EntitlementTimestamp {
+        self.applied_at
+    }
+
+    /// Returns the Core-anchored deadline, when the snapshot has one.
+    #[must_use]
+    pub const fn expires_at(&self) -> Option<EntitlementTimestamp> {
+        self.expires_at
+    }
+}
+
+/// Closed failures returned by durable entitlement application.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EntitlementFailureKind {
+    /// The operation identity is already bound to different semantic input.
+    OperationConflict,
+    /// The revision is not newer than the workspace's current revision.
+    StaleRevision,
+    /// The workspace is not managed by this exact external authority.
+    WorkspaceUnavailable,
+    /// The authority exceeded a bounded mutation rate.
+    RateLimited,
+    /// Core failed without a safer specific result.
+    Internal,
+    /// A required durable dependency is temporarily unavailable.
+    TemporarilyUnavailable,
+}
+
+/// Sanitized durable entitlement failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("workspace entitlement application failed: {kind:?}")]
+pub struct EntitlementFailure {
+    kind: EntitlementFailureKind,
+}
+
+impl EntitlementFailure {
+    /// Creates one closed application failure.
+    #[must_use]
+    pub const fn new(kind: EntitlementFailureKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the stable failure kind.
+    #[must_use]
+    pub const fn kind(self) -> EntitlementFailureKind {
+        self.kind
+    }
+}
+
+/// Server-derived scope rejection for a valid entitlement command.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum EntitlementAuthorizationError {
+    /// The authority is not bound to the requested shard.
+    #[error("the management authority is outside the requested shard")]
+    Forbidden,
+}
+
+/// Validation failure for an entitlement domain value.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum EntitlementValueError {
+    /// The revision is zero or outside the durable range.
+    #[error("entitlement revision is invalid")]
+    InvalidRevision,
+    /// The compute allowance is zero or outside the durable range.
+    #[error("compute seconds are invalid")]
+    InvalidComputeSeconds,
+    /// The relative duration is zero or outside the durable range.
+    #[error("entitlement duration is invalid")]
+    InvalidDuration,
+    /// The durable timestamp cannot be represented by Protobuf.
+    #[error("entitlement timestamp is invalid")]
+    InvalidTimestamp,
+}
+
+impl fmt::Display for EntitlementRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DelegatedActorIssuer, ProvisioningAuthorityId};
+
+    fn authority() -> ProvisioningAuthority {
+        ProvisioningAuthority::new(
+            ProvisioningAuthorityId::new("automata-cloud-production").unwrap(),
+            ShardId::new("prod-us-east-1-001").unwrap(),
+            DelegatedActorIssuer::new("https://cloud.automata.example").unwrap(),
+        )
+    }
+
+    fn command() -> ApplyWorkspaceEntitlementCommand {
+        ApplyWorkspaceEntitlementCommand::new(
+            OperationId::parse("55555555-5555-4555-8555-555555555555").unwrap(),
+            ShardId::new("prod-us-east-1-001").unwrap(),
+            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            EntitlementRevision::new(1).unwrap(),
+            WorkspaceExecutionEntitlement::capped(
+                ComputeSeconds::new(6_000).unwrap(),
+                Some(EntitlementDurationSeconds::new(7 * 24 * 60 * 60).unwrap()),
+            ),
+        )
+    }
+
+    #[test]
+    fn capped_snapshot_authorizes_for_exact_shard() {
+        let authorized =
+            AuthorizedApplyWorkspaceEntitlement::authorize(authority(), command()).unwrap();
+        assert_eq!(authorized.command().revision().get(), 1);
+        assert_eq!(
+            authorized.command().execution(),
+            WorkspaceExecutionEntitlement::capped(
+                ComputeSeconds::new(6_000).unwrap(),
+                Some(EntitlementDurationSeconds::new(604_800).unwrap())
+            )
+        );
+    }
+
+    #[test]
+    fn another_shard_is_forbidden() {
+        let mut command = command();
+        command.shard_id = ShardId::new("prod-eu-west-1-001").unwrap();
+        assert_eq!(
+            AuthorizedApplyWorkspaceEntitlement::authorize(authority(), command),
+            Err(EntitlementAuthorizationError::Forbidden)
+        );
+    }
+
+    #[test]
+    fn budget_values_are_positive_and_durably_bounded() {
+        assert_eq!(
+            EntitlementRevision::new(0),
+            Err(EntitlementValueError::InvalidRevision)
+        );
+        assert_eq!(
+            ComputeSeconds::new(0),
+            Err(EntitlementValueError::InvalidComputeSeconds)
+        );
+        assert_eq!(
+            EntitlementDurationSeconds::new(MAX_ENTITLEMENT_DURATION_SECONDS + 1),
+            Err(EntitlementValueError::InvalidDuration)
+        );
+    }
+}

--- a/crates/automata-ci-provisioning/src/lib.rs
+++ b/crates/automata-ci-provisioning/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-//! Transport-neutral workspace provisioning for an Automata Core shard.
+//! Transport-neutral external management for an Automata Core shard.
 //!
 //! The external control plane authenticates independently of the human it is
 //! installing. A transport maps verified workload evidence to a stable
@@ -10,11 +10,19 @@
 //!
 //! Certificate rotations do not alter the authority ID. Durable adapters must
 //! namespace idempotency by that stable authority and the operation ID, never by
-//! a certificate, connection, pod, or replica.
+//! a certificate, connection, pod, or replica. Workspace entitlement snapshots
+//! use the same authority and remain independent of Cloud billing concepts.
 
+mod entitlement;
 mod model;
 mod port;
 
+pub use entitlement::{
+    ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
+    AuthorizedApplyWorkspaceEntitlement, ComputeSeconds, EntitlementAuthorizationError,
+    EntitlementDurationSeconds, EntitlementFailure, EntitlementFailureKind, EntitlementRevision,
+    EntitlementTimestamp, EntitlementValueError, WorkspaceExecutionEntitlement,
+};
 pub use model::{
     AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
     InitialOwnerPrincipalId, OperationId, ProvisionWorkspaceCommand, ProvisionWorkspaceResult,
@@ -23,7 +31,8 @@ pub use model::{
     ShardId, WorkspaceId,
 };
 pub use port::{
-    ProvisioningAuthenticationError, ProvisioningAuthenticationFuture,
-    ProvisioningWorkloadAuthenticator, WorkloadAuthenticationEvidence, WorkspaceProvisioner,
+    EntitlementApplicationFuture, ProvisioningAuthenticationError,
+    ProvisioningAuthenticationFuture, ProvisioningWorkloadAuthenticator,
+    WorkloadAuthenticationEvidence, WorkspaceEntitlementApplier, WorkspaceProvisioner,
     WorkspaceProvisioningFuture,
 };

--- a/crates/automata-ci-provisioning/src/port.rs
+++ b/crates/automata-ci-provisioning/src/port.rs
@@ -3,8 +3,9 @@ use std::{fmt, future::Future, pin::Pin};
 use thiserror::Error;
 
 use crate::{
-    AuthorizedProvisionWorkspace, ProvisionWorkspaceResult, ProvisioningAuthority,
-    ProvisioningFailure,
+    ApplyWorkspaceEntitlementResult, AuthorizedApplyWorkspaceEntitlement,
+    AuthorizedProvisionWorkspace, EntitlementFailure, ProvisionWorkspaceResult,
+    ProvisioningAuthority, ProvisioningFailure,
 };
 
 const MAX_CERTIFICATE_COUNT: usize = 32;
@@ -112,6 +113,28 @@ pub type WorkspaceProvisioningFuture<'a> = Pin<
 pub trait WorkspaceProvisioner: fmt::Debug + Send + Sync {
     /// Applies one authorized workspace provisioning command.
     fn provision(&self, request: AuthorizedProvisionWorkspace) -> WorkspaceProvisioningFuture<'_>;
+}
+
+/// Boxed durable workspace entitlement operation.
+pub type EntitlementApplicationFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ApplyWorkspaceEntitlementResult, EntitlementFailure>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Atomic, idempotent workspace entitlement application port.
+///
+/// Implementations must verify the workspace's durable external-management
+/// binding, reject stale revisions, and commit the current snapshot and stable
+/// operation response in one transaction.
+pub trait WorkspaceEntitlementApplier: fmt::Debug + Send + Sync {
+    /// Applies one authorized complete entitlement snapshot.
+    fn apply(
+        &self,
+        request: AuthorizedApplyWorkspaceEntitlement,
+    ) -> EntitlementApplicationFuture<'_>;
 }
 
 #[cfg(test)]

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -32,7 +32,7 @@ use automata_ci_github::MAX_GITHUB_WEBHOOK_SECRET_BYTES;
 use automata_ci_key_management::KeyEncryptionProvider;
 use automata_ci_postgres::{
     auth::{PostgresDelegatedActorResolver, PostgresHumanRbacManagementRepository},
-    provisioning::PostgresWorkspaceProvisioner,
+    provisioning::{PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner},
     runner_auth::PostgresRunnerMachineDirectory,
     secret::PostgresSecretProvider,
     store::{
@@ -41,7 +41,9 @@ use automata_ci_postgres::{
     },
 };
 use automata_ci_protocol::ProtocolLimits;
-use automata_ci_provisioning::{ProvisioningWorkloadAuthenticator, WorkspaceProvisioner};
+use automata_ci_provisioning::{
+    ProvisioningWorkloadAuthenticator, WorkspaceEntitlementApplier, WorkspaceProvisioner,
+};
 use automata_ci_provisioning_grpc::{ManagementGrpcServer, ManagementServerTlsConfig};
 use automata_ci_results_github::{
     ArtifactRepository, ArtifactService, CacheLimits, CacheRepository, CacheService,
@@ -615,11 +617,15 @@ fn build_management_server(
     let provisioner: Arc<dyn WorkspaceProvisioner> = Arc::new(PostgresWorkspaceProvisioner::new(
         store.postgres_pool().clone(),
     ));
+    let entitlement_applier: Arc<dyn WorkspaceEntitlementApplier> = Arc::new(
+        PostgresWorkspaceEntitlementApplier::new(store.postgres_pool().clone()),
+    );
     Ok(Some(ManagementGrpcServer::new(
         listener,
         tls,
         authenticator,
         provisioner,
+        entitlement_applier,
     )))
 }
 

--- a/docs/architecture-decisions/0002-workspace-entitlement-enforcement.md
+++ b/docs/architecture-decisions/0002-workspace-entitlement-enforcement.md
@@ -1,0 +1,81 @@
+# ADR 0002: Enforce aggregate workspace entitlements with periodic accounting
+
+- Status: Accepted
+- Date: 2026-08-14
+
+## Context
+
+An externally managed Automata workspace can receive a finite compute allowance,
+an uncapped metered policy, or a paused policy. A finite allowance must work
+across concurrent jobs whose durations cannot be predicted. Core must continue
+to operate when its external control plane is temporarily unavailable, and
+self-hosted workspaces must remain fully functional without a SaaS entitlement
+provider.
+
+Automata already assigns each attempt through a short-lived, fenced runner
+lease. That lease proves execution ownership and bounds recovery after a runner
+or control-plane failure. Reusing the word "lease" for short per-job budget
+slices would combine unrelated liveness and commercial-policy concepts.
+
+An exact aggregate cutoff across concurrent jobs would require rolling budget
+reservations, renewal, unused-reservation reclamation, crash recovery, and
+fairness decisions. The trial and future user-configured spend-limit products
+can tolerate a small bounded enforcement overshoot.
+
+## Decision
+
+Core receives a complete, monotonically revisioned workspace entitlement from
+an authorized external control plane. The public management contract is
+provider-neutral and supports:
+
+- capped aggregate compute, with an optional Core-anchored validity period;
+- uncapped metered execution; and
+- paused execution.
+
+The capped policy is a workspace aggregate. It does not distribute time to jobs
+in advance and does not introduce rolling per-job budget leases. Core accounts
+actual execution periodically against the active entitlement revision. When a
+compute allowance or validity period is exhausted, Core durably marks the
+workspace exhausted, rejects new execution, and issues ordinary durable
+cancellation commands for active attempts.
+
+Jobs do not pause when an entitlement is exhausted. Runners follow the existing
+cancellation and sandbox-cleanup path. Existing runner leases remain solely an
+execution-ownership, liveness, and fencing mechanism.
+
+Threshold observation and cancellation delivery are asynchronous, so aggregate
+execution can exceed a configured allowance by a small bounded amount. That
+tolerance does not increase the configured allowance. A SaaS implementation
+must not retroactively bill trial overshoot; a future product marketed as a
+hard monetary cap must either absorb the termination overshoot or clearly
+define a different customer-visible guarantee.
+
+Externally provisioned workspaces carry an immutable durable binding to their
+management authority. Only that authority can apply entitlement snapshots.
+Managed workspaces fail closed until they have a usable snapshot. Workspaces
+without an external-management binding are self-hosted and remain unrestricted
+by this mechanism.
+
+Core uses database time to anchor relative validity periods and returns the
+stable applied and expiry timestamps. Exact operation retries return their
+original response; stale revisions fail; gaps between increasing revisions are
+allowed.
+
+## Consequences
+
+- Ordinary paid metering and finite trials share execution accounting without
+  imposing reservation machinery on uncapped jobs.
+- Concurrent control-plane replicas coordinate entitlement changes and
+  exhaustion through PostgreSQL rather than process-local state.
+- Enforcement latency, active concurrency, heartbeat cadence, and cancellation
+  cleanup bound overshoot and must be observable.
+- A later prepaid-credit product requiring an exact aggregate cutoff may add
+  rolling reservations without changing existing runner-lease semantics.
+
+## Alternatives considered
+
+Rolling per-job budget slices provide a tighter aggregate limit but add
+reservation and recovery complexity that the accepted tolerance does not
+justify. Restricting trials to one concurrent job reduces overshoot but gives a
+poor CI evaluation experience. Accounting only at job completion cannot stop a
+runaway job and was rejected.


### PR DESCRIPTION
## Summary

- add a public, provider-neutral `ApplyWorkspaceEntitlement` management RPC for capped aggregate compute, uncapped metering, and paused execution
- bind externally provisioned workspaces to their immutable management authority and persist revisioned entitlement snapshots plus stable idempotency receipts in PostgreSQL
- anchor optional validity periods to Core database time and wire the adapter into the management server
- record the periodic-accounting/cancellation decision: no rolling per-job budget leases, bounded overshoot is acceptable, and self-hosted workspaces remain unrestricted
- repair the existing fresh-schema ordering issue for `github_check_annotation_progress` without dropping its foreign key, and correct the delegated-actor test's post-trigger revision expectation

## Scope boundary

This establishes entitlement authority, transport, and durable state. It intentionally does **not** yet account billable execution, gate new claims, or fan out cancellation when a cap is exhausted. Core must not advertise an entitlement-enforcement capability until that follow-up is composed and tested.

The next slice should define the exact billable-runtime boundary, periodically account active execution, atomically exhaust capped workspaces, reject new execution, and use the existing durable cancellation path for active attempts.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci-provisioning -p automata-ci-provisioning-grpc` (9 + 8 tests passed)
- focused PostgreSQL entitlement suite (2 tests passed on PostgreSQL 18)
- strict Clippy passed for provisioning, provisioning gRPC, the PostgreSQL library, and the Automata binary with dependency linting excluded
- the full PostgreSQL CI lane ran 389 tests: 386 passed; three failures were in unrelated existing Store tests. The two deterministic failures reproduce on a clean `origin/main` worktree, while the random provider-delivery ID assertion passed when rerun alone.
