### PR TITLE
Retain runtime authority lineage for delayed runner offers

### DIFF
--- a/crates/automata-ci-postgres/src/store/logical_work_selection.rs
+++ b/crates/automata-ci-postgres/src/store/logical_work_selection.rs
@@ -950,6 +950,8 @@ async fn cleanup_receipts(
                 SELECT selection_id
                 FROM logical_workflow_activation_work_selections AS receipt
                 WHERE expires_at_ms <= $1 AND requested_at_ms < $1
+                  -- Completed orchestration remains the immutable lineage for
+                  -- a first runner offer that may be delayed behind other jobs.
                   AND NOT EXISTS (
                       SELECT 1
                       FROM logical_workflow_activation_preparation_claims AS preparation
@@ -958,7 +960,6 @@ async fn cleanup_receipts(
                         AND preparation.origin_selection_id = receipt.selection_id
                         AND preparation.generation >= receipt.generation
                         AND preparation.descriptor_digest = receipt.authority_digest
-                        AND preparation.state = 'preparing'
                   )
                   AND NOT EXISTS (
                       SELECT 1
@@ -968,7 +969,6 @@ async fn cleanup_receipts(
                         AND job.activation_origin_selection_id = receipt.selection_id
                         AND job.activation_fence >= receipt.generation
                         AND job.activation_input_digest = receipt.authority_digest
-                        AND job.state = 'activating'
                   )
                   AND NOT EXISTS (
                       SELECT 1
@@ -1000,6 +1000,8 @@ async fn cleanup_receipts(
                 SELECT selection_id
                 FROM logical_workflow_materialization_work_selections AS receipt
                 WHERE expires_at_ms <= $1 AND requested_at_ms < $1
+                  -- Materialized jobs may wait beyond the selection lease
+                  -- before their first runtime authority is issued.
                   AND NOT EXISTS (
                       SELECT 1
                       FROM logical_workflow_materialization_claims AS claim
@@ -1007,7 +1009,6 @@ async fn cleanup_receipts(
                         AND claim.origin_selection_id = receipt.selection_id
                         AND claim.generation >= receipt.generation
                         AND claim.descriptor_digest = receipt.authority_digest
-                        AND claim.state = 'materializing'
                   )
                   AND NOT EXISTS (
                       SELECT 1

--- a/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
@@ -1723,6 +1723,82 @@ async fn public_resolution_is_exact_and_rejects_every_execution_substitution() -
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn delayed_first_authority_issue_retains_completed_selection_lineage() -> TestResult {
+    run_with_database(|database| async move {
+        const FROZEN_NOW: i64 = 2_300_000_000_000;
+        let clock = install_database_test_clock(&database, FROZEN_NOW).await?;
+        let (execution, manifest) =
+            seed_execution(&database, 150_000, ProviderRepositoryVisibility::Public).await?;
+
+        set_database_test_clock(&clock, FROZEN_NOW + 240_000).await?;
+        for _ in 0..2 {
+            let observed_at = database_now(&database).await?;
+            let activation = database
+                .store()
+                .claim_next_logical_job_orchestration(ClaimNextLogicalJobOrchestration::new(
+                    LogicalWorkSelectionId::from_uuid(Uuid::new_v4())?,
+                    LogicalActivationWorkerId::from_uuid(Uuid::new_v4())?,
+                    observed_at,
+                    60_000,
+                )?)
+                .await?;
+            assert!(matches!(
+                activation,
+                LogicalJobOrchestrationSelectionOutcome::Idle
+            ));
+
+            let materialization = database
+                .store()
+                .claim_next_logical_instance_materialization(
+                    ClaimNextLogicalInstanceMaterialization::new(
+                        LogicalWorkSelectionId::from_uuid(Uuid::new_v4())?,
+                        LogicalMaterializationWorkerId::from_uuid(Uuid::new_v4())?,
+                        observed_at,
+                        60_000,
+                    )?,
+                )
+                .await?;
+            assert!(matches!(
+                materialization,
+                LogicalInstanceMaterializationSelectionOutcome::Idle
+            ));
+        }
+
+        let retained: (i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+                (SELECT count(*)::BIGINT
+                 FROM logical_workflow_activation_work_selections AS selection
+                 JOIN logical_workflow_concrete_jobs AS concrete
+                   ON concrete.run_id = selection.run_id
+                  AND concrete.invocation_id = selection.invocation_id
+                  AND concrete.logical_job_id = selection.logical_job_id
+                 WHERE concrete.job_id = $1 AND selection.outcome = 'claimed'),
+                (SELECT count(*)::BIGINT
+                 FROM logical_workflow_materialization_work_selections AS selection
+                 JOIN logical_workflow_materialization_claims AS materialization
+                   ON materialization.origin_selection_id = selection.selection_id
+                 WHERE materialization.expected_job_id = $1
+                   AND selection.outcome = 'claimed')
+            ",
+        )
+        .bind(execution.job_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(retained, (2, 1));
+
+        let resolution = database
+            .store()
+            .resolve_github_job_runtime_authority(&execution)
+            .await?;
+        exact_standard_identity(resolution, &execution, &manifest)?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn private_resolution_requires_and_returns_the_exact_historical_installation() -> TestResult {
     run_with_database(|database| async move {
         let (execution, manifest) =


### PR DESCRIPTION
Fixes live runner failures when standard jobs wait longer than the logical work-selection lease before their first runner offer.

The cleanup path now retains claimed preparation, activation, and materialization selection receipts whenever their durable descendants still reference them, including after orchestration completes. This preserves the immutable evidence needed for first-time and retried runtime-authority issuance.

Regression coverage advances the database clock past receipt expiry, exercises both cleanup queues twice, and verifies the completed lineage still resolves exactly.

Validation:
- targeted regression passes on PostgreSQL 18
- regression fails on the previous cleanup behavior (`(0, 0)` retained instead of `(2, 1)`)
- existing exact runtime-authority substitution test passes
- `cargo clippy -p automata-ci-postgres --all-features --lib --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`