### PR TITLE
refactor: move runner durability contracts into control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "uuid",
  "zeroize",
 ]
 

--- a/crates/automata-ci-control/Cargo.toml
+++ b/crates/automata-ci-control/Cargo.toml
@@ -35,6 +35,7 @@ sha2.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
+uuid.workspace = true
 # This crate uses zeroization types directly and does not need the workspace's derive macro.
 zeroize = "1.8.1"
 

--- a/crates/automata-ci-control/src/lease/mod.rs
+++ b/crates/automata-ci-control/src/lease/mod.rs
@@ -20,6 +20,10 @@ mod config;
 mod error;
 mod observer;
 mod port;
+/// Durable lease polling and runnable-attempt repositories.
+pub mod repository;
+/// Authoritative runner routing and slot-availability contracts.
+pub mod routing;
 mod service;
 
 pub use config::{LeasePollConfig, LeaseTimeToLive, LeaseTimeToLiveError};

--- a/crates/automata-ci-control/src/lease/port.rs
+++ b/crates/automata-ci-control/src/lease/port.rs
@@ -1,11 +1,11 @@
 use std::{fmt, time::SystemTime};
 
+use super::{
+    repository::{RunnableAttemptRepository, RunnerClaimRepository},
+    routing::{RunnerRoutingRepository, RunnerSlotAvailabilityRepository},
+};
 use async_trait::async_trait;
 use automata_ci_core::{AttemptId, LeaseId, UnixMillis};
-use automata_ci_store::{
-    RunnableAttemptRepository, RunnerClaimRepository, RunnerRoutingRepository,
-    RunnerSlotAvailabilityRepository,
-};
 
 /// Composite, object-safe durable port used by the G1 lease-poll service.
 ///

--- a/crates/automata-ci-control/src/lease/repository.rs
+++ b/crates/automata-ci-control/src/lease/repository.rs
@@ -1,0 +1,55 @@
+use async_trait::async_trait;
+use automata_ci_store::{
+    BeginLeaseRequest, BegunLeaseRequest, CompleteLeaseRequest, LeaseRequestCompletion,
+    LeaseRequestKey, NoWorkLeaseRequest, RunnableScanPage, RunnableScanRequest, StoreError,
+    TryClaimAttempt, TryClaimReceipt,
+};
+
+/// Bounded exact-response ledger for lease-request chains.
+#[async_trait]
+pub trait RunnerLeaseRequestRepository: Send + Sync {
+    /// Admits a first request, exact retry, or exact completed-head successor.
+    async fn begin_lease_request(
+        &self,
+        request: BeginLeaseRequest,
+    ) -> Result<BegunLeaseRequest, StoreError>;
+
+    /// Commits the exact response only if the request is still the slot head.
+    async fn complete_lease_request(
+        &self,
+        request: CompleteLeaseRequest,
+    ) -> Result<LeaseRequestCompletion, StoreError>;
+}
+
+/// Receipt-backed server-side claim port.
+#[async_trait]
+pub trait RunnerClaimRepository: Send + Sync {
+    /// Looks up a terminal receipt before candidate selection. This is the
+    /// mandatory first step for an at-least-once lease poll retry.
+    async fn lookup_lease_request(
+        &self,
+        request: LeaseRequestKey,
+    ) -> Result<Option<TryClaimReceipt>, StoreError>;
+
+    /// Claims one scheduler-selected candidate and records the answer in the
+    /// same transaction. Same-session retries replay; digest changes conflict.
+    async fn try_claim(&self, request: TryClaimAttempt) -> Result<TryClaimReceipt, StoreError>;
+
+    /// Durably records that the first execution observed no schedulable work.
+    /// A retry of the same key replays no-work even if work arrives later.
+    async fn record_no_work(
+        &self,
+        request: NoWorkLeaseRequest,
+    ) -> Result<TryClaimReceipt, StoreError>;
+}
+
+/// Authoritative scheduler queue port. Claims/no-work receipts atomically
+/// commit the opaque cursor advancement returned with a page.
+#[async_trait]
+pub trait RunnableAttemptRepository: Send + Sync {
+    /// Loads one bounded page of runnable attempts after the opaque scan cursor.
+    async fn scan_runnable(
+        &self,
+        request: RunnableScanRequest,
+    ) -> Result<RunnableScanPage, StoreError>;
+}

--- a/crates/automata-ci-control/src/lease/routing.rs
+++ b/crates/automata-ci-control/src/lease/routing.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use automata_ci_core::{AttemptId, JobIrVersion, UnixMillis};
 
-use crate::{
+use automata_ci_store::{
     RoutingDocument, RoutingLabel, RunnerSessionFence, RunnerSlotCount, StableRunnerSlot,
     StoreError,
 };
@@ -15,11 +15,13 @@ use crate::{
 pub struct RunnerGroupId(Uuid);
 
 impl RunnerGroupId {
+    /// Wraps the durable runner-group UUID.
     #[must_use]
     pub const fn from_uuid(value: Uuid) -> Self {
         Self(value)
     }
 
+    /// Returns the durable runner-group UUID.
     #[must_use]
     pub const fn as_uuid(self) -> Uuid {
         self.0
@@ -80,36 +82,43 @@ impl RunnerRoutingSnapshot {
         })
     }
 
+    /// Returns the exact live runner-session fence.
     #[must_use]
     pub const fn fence(&self) -> RunnerSessionFence {
         self.fence
     }
 
+    /// Returns the optional administrative runner-group ID.
     #[must_use]
     pub const fn group_id(&self) -> Option<RunnerGroupId> {
         self.group_id
     }
 
+    /// Returns the optional administrative runner-group name.
     #[must_use]
     pub fn group_name(&self) -> Option<&str> {
         self.group_name.as_deref()
     }
 
+    /// Returns the runner's authoritative routing labels.
     #[must_use]
     pub const fn labels(&self) -> &BTreeSet<RoutingLabel> {
         &self.labels
     }
 
+    /// Returns the administratively registered capabilities.
     #[must_use]
     pub const fn registered_capabilities(&self) -> &RoutingDocument {
         &self.registered_capabilities
     }
 
+    /// Returns the session-negotiated capabilities.
     #[must_use]
     pub const fn negotiated_capabilities(&self) -> &RoutingDocument {
         &self.negotiated_capabilities
     }
 
+    /// Returns the registered slot capacity.
     #[must_use]
     pub const fn slots(&self) -> RunnerSlotCount {
         self.slots
@@ -125,8 +134,10 @@ impl RunnerRoutingSnapshot {
 /// Invalid routing evidence returned by a storage adapter.
 #[derive(Clone, Copy, Debug, Eq, thiserror::Error, PartialEq)]
 pub enum RoutingSnapshotError {
+    /// The routing snapshot repeats a label.
     #[error("runner routing snapshot contains a duplicate label")]
     DuplicateLabel,
+    /// A runner group is present with an empty name.
     #[error("runner routing snapshot contains an empty group name")]
     EmptyGroupName,
 }
@@ -134,6 +145,7 @@ pub enum RoutingSnapshotError {
 /// Server-side access to authoritative routing state.
 #[async_trait]
 pub trait RunnerRoutingRepository: Send + Sync {
+    /// Loads authoritative routing state for an exact live session.
     async fn routing_for_session(
         &self,
         fence: RunnerSessionFence,
@@ -149,7 +161,10 @@ pub enum RunnerSlotAvailability {
     /// No live assignment currently owns the slot.
     Available,
     /// A live assignment currently owns the slot.
-    Occupied { attempt_id: AttemptId },
+    Occupied {
+        /// The attempt currently assigned to the slot.
+        attempt_id: AttemptId,
+    },
     /// The slot is outside the durable registration's configured capacity.
     OutOfRange,
     /// The durable runner registration is not currently online for new work.

--- a/crates/automata-ci-control/src/lease/service.rs
+++ b/crates/automata-ci-control/src/lease/service.rs
@@ -14,16 +14,17 @@ use automata_ci_core::{
 use automata_ci_protocol::{LeaseRequest, ProtocolVersion, RunnerSlotOrdinal};
 use automata_ci_store::{
     ClaimRejection, JobIrMetadata, LeaseRequestKey, NoWorkLeaseRequest, RoutingDocument,
-    RunnableAttempt, RunnableScanPage, RunnableScanRequest, RunnerRoutingSnapshot,
-    RunnerSessionFence, RunnerSlotAvailability, StableRunnerSlot, TryClaimAttempt, TryClaimOutcome,
-    TryClaimReceipt,
+    RunnableAttempt, RunnableScanPage, RunnableScanRequest, RunnerSessionFence, StableRunnerSlot,
+    TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
 };
 
 use super::{
     CapabilityDocument, LeaseClock, LeaseIdGenerator, LeasePollConfig, LeasePollError,
     LeasePollFailure, LeasePollInvariant, LeasePollObservation, LeasePollObserver,
     LeasePollRepository, RequestCorrelationError, RunnableAttemptGate,
-    RunnableAttemptGateDisposition, observer::NOOP_LEASE_POLL_OBSERVER,
+    RunnableAttemptGateDisposition,
+    observer::NOOP_LEASE_POLL_OBSERVER,
+    routing::{RunnerRoutingSnapshot, RunnerSlotAvailability},
 };
 
 /// Exact authenticated connection context established before request dispatch.

--- a/crates/automata-ci-control/src/runner_control/capability_admission.rs
+++ b/crates/automata-ci-control/src/runner_control/capability_admission.rs
@@ -1,25 +1,33 @@
 use async_trait::async_trait;
 use thiserror::Error;
 
-use crate::RepositoryOperationError;
+use automata_ci_store::RepositoryOperationError;
 
 /// Failures from the narrow runner-capability admission boundary.
 #[derive(Debug, Error)]
 pub enum RunnerCapabilityAdmissionError {
+    /// The durable repository operation failed.
     #[error(transparent)]
     Operation(#[from] RepositoryOperationError),
+    /// Durable inventory conflicts with a currently composed resource.
     #[error("durable runner inventory conflicts with current {resource}")]
-    ConfigurationDrift { resource: &'static str },
+    ConfigurationDrift {
+        /// The unavailable or incompatible resource.
+        resource: &'static str,
+    },
+    /// Durable inventory violates an internal invariant.
     #[error("durable runner inventory violates an Automata invariant")]
     CorruptData,
 }
 
 impl RunnerCapabilityAdmissionError {
+    /// Wraps an infrastructure failure at the repository boundary.
     #[must_use]
     pub fn operation(source: impl std::error::Error + Send + Sync + 'static) -> Self {
         RepositoryOperationError::from_source(source).into()
     }
 
+    /// Reports durable inventory drift for a named resource.
     #[must_use]
     pub const fn drift(resource: &'static str) -> Self {
         Self::ConfigurationDrift { resource }

--- a/crates/automata-ci-control/src/runner_control/durable.rs
+++ b/crates/automata-ci-control/src/runner_control/durable.rs
@@ -2,17 +2,16 @@ use async_trait::async_trait;
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
 use automata_ci_core::{
     AttemptId, JobConclusion, JobIrVersion, JobLifecycle, Lease, LeaseGuard, LogSequence,
-    LogStreamId, OperationId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
+    LogStreamId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
+};
+use automata_ci_store::{
+    AcknowledgeRunnerCommands, CommandCursor, DocumentSchema, DurableRunnerCommand,
+    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, MAX_LOG_SEGMENT_BYTES,
+    MAX_TERMINAL_RESULT_BYTES, ObjectKey, RenewLease, RunnerGeneration, RunnerOperationReceipt,
+    RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence,
+    StableRunnerSlot, StoreError,
 };
 use thiserror::Error;
-
-use crate::{
-    AcknowledgeRunnerCommands, CommandCursor, CommandSequence, DocumentSchema,
-    DurableRunnerCommand, EnqueueRunnerCommand, JobIrMetadata, MAX_LOG_SEGMENT_BYTES, ObjectKey,
-    RenewLease, RunnerGeneration, RunnerOperationReceipt, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence, StableRunnerSlot,
-    StoreError, value::terminal_result_bytes_rejection,
-};
 
 const MAX_UNCOMPRESSED_RUNNER_LOG_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_DURABLE_LOG_SEQUENCE: u64 = 9_223_372_036_854_775_807;
@@ -77,7 +76,7 @@ pub trait CurrentRunnerSessionRepository: Send + Sync {
 pub struct LeaseOfferClaim {
     request: RunnerOperationRequest,
     protocol_version: RunnerProtocolVersion,
-    slot: crate::StableRunnerSlot,
+    slot: StableRunnerSlot,
     lease: Lease,
     job_ir: JobIrMetadata,
 }
@@ -90,7 +89,7 @@ impl LeaseOfferClaim {
     pub fn new(
         request: RunnerOperationRequest,
         protocol_version: RunnerProtocolVersion,
-        slot: crate::StableRunnerSlot,
+        slot: StableRunnerSlot,
         lease: Lease,
         job_ir: JobIrMetadata,
     ) -> Result<Self, RunnerControlValueError> {
@@ -123,7 +122,7 @@ impl LeaseOfferClaim {
 
     /// Returns the stable runner slot.
     #[must_use]
-    pub const fn slot(&self) -> crate::StableRunnerSlot {
+    pub const fn slot(&self) -> StableRunnerSlot {
         self.slot
     }
 
@@ -151,44 +150,6 @@ pub enum LeaseOfferClaimStatus {
     ClaimSuperseded,
 }
 
-/// Exact server-command identity used to resolve a replay to one typed offer publication.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct LeaseOfferCommandIdentity {
-    session: RunnerSessionFence,
-    operation_id: OperationId,
-    sequence: CommandSequence,
-}
-
-impl LeaseOfferCommandIdentity {
-    #[must_use]
-    pub const fn new(
-        session: RunnerSessionFence,
-        operation_id: OperationId,
-        sequence: CommandSequence,
-    ) -> Self {
-        Self {
-            session,
-            operation_id,
-            sequence,
-        }
-    }
-
-    #[must_use]
-    pub const fn session(self) -> RunnerSessionFence {
-        self.session
-    }
-
-    #[must_use]
-    pub const fn operation_id(self) -> OperationId {
-        self.operation_id
-    }
-
-    #[must_use]
-    pub const fn sequence(self) -> CommandSequence {
-        self.sequence
-    }
-}
-
 /// Complete verified lease-offer command awaiting an atomic durable publication.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublishLeaseOffer {
@@ -205,7 +166,7 @@ impl PublishLeaseOffer {
     pub fn new(
         request: RunnerOperationRequest,
         protocol_version: RunnerProtocolVersion,
-        slot: crate::StableRunnerSlot,
+        slot: StableRunnerSlot,
         lease: Lease,
         job_ir: JobIrMetadata,
         offer_valid_until: UnixMillis,
@@ -243,7 +204,7 @@ impl PublishLeaseOffer {
 
     /// Returns the stable runner slot.
     #[must_use]
-    pub const fn slot(&self) -> crate::StableRunnerSlot {
+    pub const fn slot(&self) -> StableRunnerSlot {
         self.claim.slot()
     }
 
@@ -278,7 +239,7 @@ impl PublishLeaseOffer {
 pub struct PublishedLeaseOffer {
     request: RunnerOperationRequest,
     protocol_version: RunnerProtocolVersion,
-    slot: crate::StableRunnerSlot,
+    slot: StableRunnerSlot,
     lease: Lease,
     job_ir: JobIrMetadata,
     offer_valid_until: UnixMillis,
@@ -293,7 +254,7 @@ impl PublishedLeaseOffer {
     pub fn new(
         request: RunnerOperationRequest,
         protocol_version: RunnerProtocolVersion,
-        slot: crate::StableRunnerSlot,
+        slot: StableRunnerSlot,
         lease: Lease,
         job_ir: JobIrMetadata,
         offer_valid_until: UnixMillis,
@@ -325,7 +286,7 @@ impl PublishedLeaseOffer {
 
     /// Returns the stable runner slot.
     #[must_use]
-    pub const fn slot(&self) -> crate::StableRunnerSlot {
+    pub const fn slot(&self) -> StableRunnerSlot {
         self.slot
     }
 
@@ -531,34 +492,42 @@ impl CommitLeaseResponse {
         }
     }
 
+    /// Returns the idempotent runner operation.
     #[must_use]
     pub const fn request(&self) -> &RunnerOperationRequest {
         &self.request
     }
+    /// Returns the acknowledged command cursor.
     #[must_use]
     pub const fn command_cursor(&self) -> CommandCursor {
         self.command_cursor
     }
+    /// Returns the attempt responding to the offer.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
+    /// Returns the offered runner slot.
     #[must_use]
     pub const fn slot(&self) -> StableRunnerSlot {
         self.slot
     }
+    /// Returns the exclusive lease guard.
     #[must_use]
     pub const fn guard(&self) -> LeaseGuard {
         self.guard
     }
+    /// Returns the durable response action.
     #[must_use]
     pub const fn action(&self) -> LeaseResponseAction {
         self.action
     }
+    /// Returns the trusted observation time.
     #[must_use]
     pub const fn observed_at(&self) -> UnixMillis {
         self.observed_at
     }
+    /// Returns the canonical response bytes.
     #[must_use]
     pub const fn response(&self) -> &RunnerOperationResponse {
         &self.response
@@ -600,7 +569,7 @@ impl CommitRunnerTerminalResult {
         committed_at: UnixMillis,
         response: RunnerOperationResponse,
     ) -> Result<Self, RunnerControlValueError> {
-        if encoded_size == 0 || terminal_result_bytes_rejection(encoded_size).is_some() {
+        if !(1..=MAX_TERMINAL_RESULT_BYTES).contains(&encoded_size) {
             return Err(RunnerControlValueError::InvalidObjectSize);
         }
         if committed_at < completed_at {
@@ -621,46 +590,57 @@ impl CommitRunnerTerminalResult {
         })
     }
 
+    /// Returns the idempotent runner operation.
     #[must_use]
     pub const fn request(&self) -> &RunnerOperationRequest {
         &self.request
     }
+    /// Returns the completed attempt.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
+    /// Returns the exclusive lease guard.
     #[must_use]
     pub const fn guard(&self) -> LeaseGuard {
         self.guard
     }
+    /// Returns the terminal-result schema.
     #[must_use]
     pub const fn schema(&self) -> DocumentSchema {
         self.schema
     }
+    /// Returns the encoded object size.
     #[must_use]
     pub const fn encoded_size(&self) -> u64 {
         self.encoded_size
     }
+    /// Returns the terminal-result digest.
     #[must_use]
     pub const fn digest(&self) -> Sha256Digest {
         self.digest
     }
+    /// Returns the immutable object key.
     #[must_use]
     pub const fn object_key(&self) -> &ObjectKey {
         &self.object_key
     }
+    /// Returns the job conclusion.
     #[must_use]
     pub const fn conclusion(&self) -> JobConclusion {
         self.conclusion
     }
+    /// Returns the runner-reported completion time.
     #[must_use]
     pub const fn completed_at(&self) -> UnixMillis {
         self.completed_at
     }
+    /// Returns the trusted commit time.
     #[must_use]
     pub const fn committed_at(&self) -> UnixMillis {
         self.committed_at
     }
+    /// Returns the canonical response bytes.
     #[must_use]
     pub const fn response(&self) -> &RunnerOperationResponse {
         &self.response
@@ -893,58 +873,72 @@ impl CommitRunnerLogSegment {
         &self.admission
     }
 
+    /// Returns the idempotent runner operation.
     #[must_use]
     pub const fn request(&self) -> &RunnerOperationRequest {
         self.admission.request().request()
     }
+    /// Returns the attempt receiving the segment.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.admission.request().attempt_id()
     }
+    /// Returns the exclusive lease guard.
     #[must_use]
     pub const fn guard(&self) -> LeaseGuard {
         self.admission.request().guard()
     }
+    /// Returns the immutable log stream.
     #[must_use]
     pub const fn stream_id(&self) -> LogStreamId {
         self.admission.request().stream_id()
     }
+    /// Returns the log document schema.
     #[must_use]
     pub const fn schema(&self) -> DocumentSchema {
         self.admission.request().schema()
     }
+    /// Returns the first sequence in the segment.
     #[must_use]
     pub const fn first_sequence(&self) -> LogSequence {
         self.admission.request().first_sequence()
     }
+    /// Returns the last sequence in the segment.
     #[must_use]
     pub const fn last_sequence(&self) -> LogSequence {
         self.admission.request().last_sequence()
     }
+    /// Returns the immutable object key.
     #[must_use]
     pub const fn object_key(&self) -> &ObjectKey {
         &self.object_key
     }
+    /// Returns the encoded segment digest.
     #[must_use]
     pub const fn digest(&self) -> Sha256Digest {
         self.digest
     }
+    /// Returns the encoded segment size.
     #[must_use]
     pub const fn encoded_size(&self) -> u64 {
         self.encoded_size
     }
+    /// Returns the uncompressed segment size.
     #[must_use]
     pub const fn uncompressed_size(&self) -> u64 {
         self.uncompressed_size
     }
+    /// Returns the trusted storage time.
     #[must_use]
     pub const fn stored_at(&self) -> UnixMillis {
         self.admission.request().observed_at()
     }
+    /// Reports whether this segment closes the stream.
     #[must_use]
     pub const fn is_end_of_stream(&self) -> bool {
         self.admission.request().is_end_of_stream()
     }
+    /// Returns the canonical response bytes.
     #[must_use]
     pub const fn response(&self) -> &RunnerOperationResponse {
         &self.response

--- a/crates/automata-ci-control/src/runner_control/handler.rs
+++ b/crates/automata-ci-control/src/runner_control/handler.rs
@@ -2,6 +2,7 @@ use std::{fmt, io::Write as _, sync::Arc, time::Instant};
 
 use crate::lease::{
     AuthenticatedRunnerSession, ClaimedLeasePoll, LeaseClock, LeasePollError, LeasePollOutcome,
+    repository::RunnerLeaseRequestRepository,
 };
 use automata_ci_auth::machine::AuthenticatedMachine;
 use automata_ci_blob::{
@@ -30,15 +31,11 @@ use automata_ci_runner_transport::{
 use automata_ci_store::{
     AcknowledgeRunnerCommands, AttemptStoreError, BeginLeaseRequest,
     CommandCursor as StoreCommandCursor, CommandReplayDisposition, CommandReplayLimit,
-    CommandSequence as StoreCommandSequence, CommitCommandAcknowledgement, CommitLeaseHeartbeat,
-    CommitLeaseResponse, CommitRunnerLogSegment, CommitRunnerTerminalResult, CompleteLeaseRequest,
-    DocumentSchema, HeartbeatRunnerSession, LeaseRequestCompletion, LeaseRequestKey,
-    LeaseResponseAction, ObjectKey, OpenRunnerSession, RenewLease, ResumeRunnerSession,
-    RevokedLeaseOfferFallback, RoutingDocument, RunnerCommandOutbox,
-    RunnerControlTransactionRepository, RunnerLeaseRequestRepository, RunnerLogAdmissionRequest,
-    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationReceiptRepository,
-    RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence,
-    RunnerSessionRepository, RunnerSessionSnapshot, StableRunnerSlot, StoreError,
+    CommandSequence as StoreCommandSequence, CompleteLeaseRequest, DocumentSchema,
+    HeartbeatRunnerSession, LeaseRequestCompletion, LeaseRequestKey, ObjectKey, OpenRunnerSession,
+    RenewLease, ResumeRunnerSession, RevokedLeaseOfferFallback, RoutingDocument,
+    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot, StableRunnerSlot, StoreError,
 };
 use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;
@@ -46,6 +43,11 @@ use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use zeroize::Zeroizing;
 
+use super::durable::{
+    CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
+    CommitRunnerLogSegment, CommitRunnerTerminalResult, LeaseResponseAction,
+    RunnerControlTransactionRepository, RunnerLogAdmissionRequest,
+};
 use super::observer::NoopRunnerControlObserver;
 use super::port::{
     AuthorizedRunnerRegistration, ControlIdGenerator, ControlPortError, DesiredRunnerState,
@@ -54,6 +56,9 @@ use super::port::{
     ManagedSecretBindingIssuer, RunnerRegistrationAuthorizer, RunnerSessionFenceResolver,
     RuntimeAuthorityIssueRequest, RuntimeAuthorityIssuer, decode_durable_server_command,
     is_durable_lease_offer_command,
+};
+use super::repository::{
+    RunnerCommandOutbox, RunnerOperationReceiptRepository, RunnerSessionRepository,
 };
 use super::verify::verify_job_ir_blob;
 use super::{

--- a/crates/automata-ci-control/src/runner_control/mod.rs
+++ b/crates/automata-ci-control/src/runner_control/mod.rs
@@ -14,9 +14,15 @@
 //! uses the same key, digest, and bytes. `PostgreSQL` then commits the fenced lifecycle/metadata and
 //! exact response receipt together, preventing visible partial ingestion.
 
+/// Startup checks for durable runner capabilities used by this control plane.
+pub mod capability_admission;
+/// Durable models and repositories for authenticated runner-control operations.
+pub mod durable;
 mod handler;
 mod observer;
 mod port;
+/// Durable runner sessions, operation receipts, and command delivery repositories.
+pub mod repository;
 mod verify;
 
 pub use handler::{

--- a/crates/automata-ci-control/src/runner_control/port.rs
+++ b/crates/automata-ci-control/src/runner_control/port.rs
@@ -23,17 +23,21 @@ use automata_ci_protocol::{
 use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_store::{
     CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
-    CommandSequence as StoreCommandSequence, CurrentRunnerSession, CurrentRunnerSessionRepository,
-    DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand, JobIrMetadata,
-    LeaseOfferClaim as StoreLeaseOfferClaim, LeaseOfferClaimStatus as StoreLeaseOfferClaimStatus,
-    LeaseOfferCommandIdentity as StoreLeaseOfferCommandIdentity, PublishLeaseOffer,
-    PublishedLeaseOffer, RunnerCommandPayload, RunnerGeneration, RunnerLeaseOfferRepository,
-    RunnerOperationKind, RunnerOperationRequest, RunnerProtocolVersion, RunnerSessionFence,
-    StableRunnerSlot,
+    CommandSequence as StoreCommandSequence, DocumentSchema, DurableRunnerCommand,
+    EnqueueRunnerCommand, JobIrMetadata,
+    LeaseOfferCommandIdentity as StoreLeaseOfferCommandIdentity, RunnerCommandPayload,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerProtocolVersion,
+    RunnerSessionFence, StableRunnerSlot,
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use zeroize::Zeroizing;
+
+use super::durable::{
+    CurrentRunnerSession, CurrentRunnerSessionRepository, LeaseOfferClaim as StoreLeaseOfferClaim,
+    LeaseOfferClaimStatus as StoreLeaseOfferClaimStatus, PublishLeaseOffer, PublishedLeaseOffer,
+    RunnerLeaseOfferRepository,
+};
 
 /// Immutable media type used for standalone protobuf `JobIR` objects.
 pub const JOB_IR_PROTOBUF_MEDIA_TYPE: &str = "application/vnd.automata.job-ir.protobuf";

--- a/crates/automata-ci-control/src/runner_control/repository.rs
+++ b/crates/automata-ci-control/src/runner_control/repository.rs
@@ -1,0 +1,92 @@
+use async_trait::async_trait;
+use automata_ci_core::UnixMillis;
+use automata_ci_store::{
+    AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
+    CommandReplayPage, DurableRunnerCommand, EnqueueRunnerCommand, HeartbeatRunnerSession,
+    OpenRunnerSession, ResumeRunnerSession, RunnerOperationReceipt, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerSessionFence, RunnerSessionSnapshot, StoreError,
+};
+
+/// Durable server-command delivery and cumulative acknowledgement port.
+#[async_trait]
+pub trait RunnerCommandOutbox: Send + Sync {
+    /// Enqueues a command for one exact live runner session.
+    async fn enqueue_command(
+        &self,
+        command: EnqueueRunnerCommand,
+    ) -> Result<DurableRunnerCommand, StoreError>;
+
+    /// Replays bounded commands after a durable acknowledgement cursor.
+    async fn replay_commands(
+        &self,
+        session: RunnerSessionFence,
+        after: CommandCursor,
+        limit: CommandReplayLimit,
+    ) -> Result<CommandReplayPage, StoreError>;
+
+    /// Advances the cumulative cursor. Duplicate/older cursors are idempotent;
+    /// a cursor beyond the largest allocated sequence is rejected.
+    async fn acknowledge_commands(
+        &self,
+        acknowledgement: AcknowledgeRunnerCommands,
+    ) -> Result<CommandCursor, StoreError>;
+}
+
+/// Durable session lifecycle port used after runner machine authentication.
+#[async_trait]
+pub trait RunnerSessionRepository: Send + Sync {
+    /// Atomically replaces any prior live connection and allocates a new epoch.
+    async fn open_session(
+        &self,
+        request: OpenRunnerSession,
+    ) -> Result<RunnerSessionSnapshot, StoreError>;
+
+    /// Ends the exact authenticated epoch; stale epochs cannot close a newer one.
+    async fn close_session(&self, request: CloseRunnerSession) -> Result<(), StoreError>;
+
+    /// Updates the exact live fence without allocating a new session epoch.
+    ///
+    /// Implementations keep the durable heartbeat monotonic when concurrent
+    /// trusted observations acquire the fence in reverse sampling order.
+    async fn heartbeat_session(
+        &self,
+        request: HeartbeatRunnerSession,
+    ) -> Result<RunnerSessionSnapshot, StoreError>;
+
+    /// Resumes an already-live durable epoch by authenticated runner identity.
+    async fn resume_session(
+        &self,
+        request: ResumeRunnerSession,
+    ) -> Result<RunnerSessionSnapshot, StoreError>;
+
+    /// Loads the exact durable session identified by its complete fence.
+    async fn get_session(
+        &self,
+        fence: RunnerSessionFence,
+    ) -> Result<RunnerSessionSnapshot, StoreError>;
+}
+
+/// Generic exact-response ledger for runner RPC mutations.
+///
+/// Callers must look up a receipt before executing a side effect and must use
+/// the same operation ID at the provider boundary. This generic two-call seam
+/// cannot by itself make an unrelated external side effect atomic with durable
+/// repository state. Specialized repositories use a single transaction where
+/// that stronger guarantee is required.
+#[async_trait]
+pub trait RunnerOperationReceiptRepository: Send + Sync {
+    /// Looks up the response already committed for the exact runner request.
+    async fn lookup_operation(
+        &self,
+        request: &RunnerOperationRequest,
+    ) -> Result<Option<RunnerOperationReceipt>, StoreError>;
+
+    /// Persists the first exact response. A same-request retry returns the
+    /// original response; a different digest or kind for the key conflicts.
+    async fn record_operation(
+        &self,
+        request: RunnerOperationRequest,
+        response: RunnerOperationResponse,
+        committed_at: UnixMillis,
+    ) -> Result<RunnerOperationReceipt, StoreError>;
+}

--- a/crates/automata-ci-control/tests/control.rs
+++ b/crates/automata-ci-control/tests/control.rs
@@ -4,7 +4,9 @@ mod runner_control_support;
 mod scheduling_support;
 
 mod lease_poll;
+mod runner_control_capability_admission;
 mod runner_control_contracts;
+mod runner_control_durable_contracts;
 mod runner_control_handler_security;
 mod runner_control_runtime_authority_composite;
 mod runner_control_store_adapters;

--- a/crates/automata-ci-control/tests/lease_poll.rs
+++ b/crates/automata-ci-control/tests/lease_poll.rs
@@ -5,6 +5,11 @@ use automata_ci_control::lease::{
     AuthenticatedRunnerSession, LeaseClock, LeaseIdGenerator, LeasePollConfig,
     LeasePollObservation, LeasePollObserver, LeasePollOutcome, LeasePollRepository,
     LeasePollService, LeaseTimeToLive, RunnableAttemptGate, RunnableAttemptGateDisposition,
+    repository::{RunnableAttemptRepository, RunnerClaimRepository},
+    routing::{
+        RunnerGroupId, RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSlotAvailability,
+        RunnerSlotAvailabilityRepository,
+    },
 };
 use automata_ci_control::scheduling::DeterministicScheduler;
 use automata_ci_core::{
@@ -17,10 +22,8 @@ use automata_ci_core::{
 use automata_ci_protocol::{LeaseRequest, MessageHeader, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal};
 use automata_ci_store::{
     AttemptAssignment, JobIrMetadata, NoWorkLeaseRequest, ObjectKey, RoutingDocument, RoutingLabel,
-    RunnableAttempt, RunnableAttemptRepository, RunnableScanLimit, RunnableScanPage,
-    RunnableScanRequest, RunnerClaimRepository, RunnerGeneration, RunnerGroupId,
-    RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSessionFence, RunnerSlotAvailability,
-    RunnerSlotAvailabilityRepository, RunnerSlotCount, SessionEpoch, StableRunnerSlot, StoreError,
+    RunnableAttempt, RunnableScanLimit, RunnableScanPage, RunnableScanRequest, RunnerGeneration,
+    RunnerSessionFence, RunnerSlotCount, SessionEpoch, StableRunnerSlot, StoreError,
     TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
 };
 

--- a/crates/automata-ci-control/tests/runner_control_capability_admission.rs
+++ b/crates/automata-ci-control/tests/runner_control_capability_admission.rs
@@ -1,4 +1,4 @@
-use automata_ci_store::{
+use automata_ci_control::runner_control::capability_admission::{
     RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository, RunnerCapabilityReadiness,
 };
 

--- a/crates/automata-ci-control/tests/runner_control_durable_contracts.rs
+++ b/crates/automata-ci-control/tests/runner_control_durable_contracts.rs
@@ -1,0 +1,76 @@
+use automata_ci_control::{
+    lease::{
+        repository::{
+            RunnableAttemptRepository, RunnerClaimRepository, RunnerLeaseRequestRepository,
+        },
+        routing::{RunnerRoutingRepository, RunnerSlotAvailabilityRepository},
+    },
+    runner_control::{
+        durable::{
+            CurrentRunnerSessionRepository, RunnerControlTransactionRepository,
+            RunnerLeaseOfferRepository, RunnerLogAdmissionRequest,
+        },
+        repository::{
+            RunnerCommandOutbox, RunnerOperationReceiptRepository, RunnerSessionRepository,
+        },
+    },
+};
+use automata_ci_core::{
+    AttemptId, FencingToken, LeaseGuard, LeaseId, LogSequence, LogStreamId, OperationId, RunnerId,
+    RunnerSessionId, Sha256Digest, UnixMillis,
+};
+use automata_ci_store::{
+    DocumentSchema, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
+    RunnerSessionFence, SessionEpoch,
+};
+
+#[test]
+fn control_owned_repository_ports_are_object_safe() {
+    #[allow(clippy::too_many_arguments)]
+    fn accepts_ports(
+        _: &dyn RunnerClaimRepository,
+        _: &dyn RunnerLeaseRequestRepository,
+        _: &dyn RunnerRoutingRepository,
+        _: &dyn RunnerSlotAvailabilityRepository,
+        _: &dyn RunnableAttemptRepository,
+        _: &dyn RunnerSessionRepository,
+        _: &dyn CurrentRunnerSessionRepository,
+        _: &dyn RunnerLeaseOfferRepository,
+        _: &dyn RunnerControlTransactionRepository,
+        _: &dyn RunnerCommandOutbox,
+        _: &dyn RunnerOperationReceiptRepository,
+    ) {
+    }
+
+    let _ = accepts_ports;
+}
+
+#[test]
+fn durable_log_sequence_stays_within_signed_storage_range() {
+    let request = RunnerOperationRequest::new(
+        RunnerSessionFence::new(
+            RunnerSessionId::new(),
+            RunnerId::new(),
+            RunnerGeneration::new(1).expect("generation"),
+            SessionEpoch::new(1).expect("epoch"),
+        ),
+        OperationId::new(),
+        RunnerOperationKind::new("automata.runner.log-batch.v1").expect("kind"),
+        Sha256Digest::from_bytes([5; 32]),
+    );
+
+    assert!(
+        RunnerLogAdmissionRequest::new(
+            request,
+            AttemptId::new(),
+            LeaseGuard::new(LeaseId::new(), FencingToken::new(1).expect("fencing token")),
+            LogStreamId::new(),
+            DocumentSchema::new(1).expect("schema"),
+            LogSequence::new(0),
+            LogSequence::new(i64::MAX as u64 + 1),
+            UnixMillis::new(1),
+            false,
+        )
+        .is_err()
+    );
+}

--- a/crates/automata-ci-control/tests/runner_control_handler_security.rs
+++ b/crates/automata-ci-control/tests/runner_control_handler_security.rs
@@ -17,7 +17,8 @@ use automata_ci_control::runner_control::{
     RunnerControlFailure, RunnerControlMessageKind, RunnerControlMessageOutcome,
     RunnerControlObserver, RunnerControlPorts, RunnerDurabilityPorts, RunnerDurableDisposition,
     RunnerDurableMessageKind, RunnerHandshakeOutcome, RunnerHandshakeRejection,
-    RunnerIdentityPorts, RunnerLeasePorts, RunnerLeaseRequestStage,
+    RunnerIdentityPorts, RunnerLeasePorts, RunnerLeaseRequestStage, durable::LeaseResponseAction,
+    repository::RunnerCommandOutbox as _,
 };
 use automata_ci_core::{
     Architecture, AttemptId, FencingToken, JobAuthorityProfile, JobConclusion, JobId,
@@ -44,10 +45,9 @@ use automata_ci_store::{
     CommandCursor as StoreCommandCursor, CommandReplayDisposition,
     CommandSequence as StoreCommandSequence, DocumentSchema, DurableRunnerCommand,
     EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, LeaseRequestCompletion,
-    LeaseRequestKey, LeaseResponseAction, ObjectKey, RevokedLeaseOfferFallback, RoutingDocument,
-    RunnerCommandOutbox as _, RunnerCommandPayload, RunnerGeneration, RunnerOperationKind,
-    RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot,
-    SessionEpoch, StableRunnerSlot,
+    LeaseRequestKey, ObjectKey, RevokedLeaseOfferFallback, RoutingDocument, RunnerCommandPayload,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationResponse, RunnerProtocolVersion,
+    RunnerSessionFence, RunnerSessionSnapshot, SessionEpoch, StableRunnerSlot,
 };
 use sha2::{Digest as _, Sha256};
 use tokio_util::sync::CancellationToken;

--- a/crates/automata-ci-control/tests/runner_control_store_adapters.rs
+++ b/crates/automata-ci-control/tests/runner_control_store_adapters.rs
@@ -10,6 +10,11 @@ use automata_ci_control::runner_control::{
     LeaseOfferCommandError, LeaseOfferCommandPublisher as _, LeaseOfferPublishOutcome,
     LeaseOfferReplayResolution, RunnerSessionFenceResolver as _, StoreLeaseOfferCommandPublisher,
     StoreRunnerSessionFenceResolver,
+    durable::{
+        CurrentRunnerSession, CurrentRunnerSessionRepository, LeaseOfferClaim,
+        LeaseOfferClaimStatus, PublishLeaseOffer, PublishedLeaseOffer, RunnerControlValueError,
+        RunnerLeaseOfferRepository,
+    },
 };
 use automata_ci_core::{
     AttemptId, FencingToken, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobSource, Lease,
@@ -24,11 +29,10 @@ use automata_ci_protocol::{
 };
 use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_store::{
-    CANCEL_JOB_COMMAND_KIND, CommandSequence, CurrentRunnerSession, CurrentRunnerSessionRepository,
-    DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand, JobIrMetadata, LeaseOfferClaim,
-    LeaseOfferClaimStatus, LeaseOfferCommandIdentity, ObjectKey, PublishLeaseOffer,
-    PublishedLeaseOffer, RunnerCommandPayload, RunnerControlValueError, RunnerGeneration,
-    RunnerLeaseOfferRepository, RunnerOperationKind, RunnerSessionFence, SessionEpoch, StoreError,
+    CANCEL_JOB_COMMAND_KIND, CommandSequence, DocumentSchema, DurableRunnerCommand,
+    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, ObjectKey,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerSessionFence, SessionEpoch,
+    StoreError,
 };
 use sha2::{Digest as _, Sha256};
 

--- a/crates/automata-ci-control/tests/runner_control_support.rs
+++ b/crates/automata-ci-control/tests/runner_control_support.rs
@@ -16,6 +16,7 @@ use automata_ci_blob::{
 };
 use automata_ci_control::lease::{
     AuthenticatedRunnerSession, LeaseClock, LeasePollError, LeasePollOutcome,
+    repository::RunnerLeaseRequestRepository,
 };
 use automata_ci_control::runner_control::{
     AuthorizedRunnerRegistration, ControlIdGenerator, ControlPortError, JobIrObjectReader,
@@ -23,6 +24,12 @@ use automata_ci_control::runner_control::{
     LeaseOfferPublishOutcome, LeaseOfferReplayResolution, LeasePoller,
     RunnerRegistrationAuthorizer, RunnerSessionFenceResolver, RuntimeAuthorityIssueRequest,
     RuntimeAuthorityIssuer,
+    durable::{
+        CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
+        CommitRunnerLogSegment, CommitRunnerTerminalResult, LeaseResponseAction, RawLogDisposition,
+        RunnerControlTransactionRepository, RunnerLogAdmission, RunnerLogAdmissionRequest,
+    },
+    repository::{RunnerCommandOutbox, RunnerOperationReceiptRepository, RunnerSessionRepository},
 };
 use automata_ci_core::{
     AttemptId, JobId, JobIrVersion, Lease, OperationId, RunId, RunnerId, RunnerSessionId,
@@ -34,15 +41,11 @@ use automata_ci_protocol::{
 use automata_ci_store::{
     AcknowledgeRunnerCommands, BeginLeaseRequest, BegunLeaseRequest, CommandCursor,
     CommandReplayDisposition, CommandReplayLimit, CommandReplayPage, CommandSequence,
-    CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
-    CommitRunnerLogSegment, CommitRunnerTerminalResult, CompleteLeaseRequest, DurableRunnerCommand,
-    EnqueueRunnerCommand, HeartbeatRunnerSession, JobIrMetadata, LeaseOfferCommandIdentity,
-    LeaseRequestCompletion, LeaseResponseAction, OpenRunnerSession, RawLogDisposition, RenewLease,
-    ResumeRunnerSession, RunnerCommandOutbox, RunnerControlTransactionRepository,
-    RunnerLeaseRequestRepository, RunnerLogAdmission, RunnerLogAdmissionRequest,
-    RunnerOperationReceipt, RunnerOperationReceiptRepository, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerSessionFence, RunnerSessionRepository, RunnerSessionSnapshot,
-    StableRunnerSlot, StoreError,
+    CompleteLeaseRequest, DurableRunnerCommand, EnqueueRunnerCommand, HeartbeatRunnerSession,
+    JobIrMetadata, LeaseOfferCommandIdentity, LeaseRequestCompletion, OpenRunnerSession,
+    RenewLease, ResumeRunnerSession, RunnerOperationReceipt, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerSessionFence, RunnerSessionSnapshot, StableRunnerSlot,
+    StoreError,
 };
 
 #[derive(Debug, Default)]

--- a/crates/automata-ci-postgres/src/store/g1.rs
+++ b/crates/automata-ci-postgres/src/store/g1.rs
@@ -2,6 +2,30 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
+use automata_ci_control::{
+    lease::{
+        repository::{
+            RunnableAttemptRepository, RunnerClaimRepository, RunnerLeaseRequestRepository,
+        },
+        routing::{
+            RunnerGroupId, RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSlotAvailability,
+            RunnerSlotAvailabilityRepository,
+        },
+    },
+    runner_control::{
+        durable::{
+            CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
+            CommitRunnerLogSegment, CommitRunnerTerminalResult, CurrentRunnerSession,
+            CurrentRunnerSessionRepository, LeaseOfferClaim, LeaseOfferClaimStatus,
+            LeaseResponseAction, PublishLeaseOffer, PublishedLeaseOffer, RawLogDisposition,
+            RunnerControlTransactionRepository, RunnerLeaseOfferRepository, RunnerLogAdmission,
+            RunnerLogAdmissionRequest,
+        },
+        repository::{
+            RunnerCommandOutbox, RunnerOperationReceiptRepository, RunnerSessionRepository,
+        },
+    },
+};
 use automata_ci_core::{
     AttemptId, FencingToken, JobConclusion, JobId, JobIrVersion, JobLifecycle, Lease, LeaseGuard,
     LeaseId, LogSequence, OperationId, RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId,
@@ -23,26 +47,18 @@ use automata_ci_store::{
     CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor,
     CancellationIntent, CancellationReason, CancellationRepository, ClaimRejection, ClaimedAttempt,
     CloseRunnerSession, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
-    CommandReplayPage, CommandSequence, CommitCommandAcknowledgement, CommitLeaseHeartbeat,
-    CommitLeaseResponse, CommitRunnerLogSegment, CommitRunnerTerminalResult, CompleteLeaseRequest,
-    ConcludeBlockedAttempt, CurrentRunnerSession, CurrentRunnerSessionRepository,
+    CommandReplayPage, CommandSequence, CompleteLeaseRequest, ConcludeBlockedAttempt,
     DEFAULT_CANCELLATION_REASON, DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand,
-    HeartbeatRunnerSession, JobDependency, JobIrMetadata, LeaseOfferClaim, LeaseOfferClaimStatus,
-    LeaseOfferCommandIdentity, LeaseRequestCompletion, LeaseRequestKey, LeaseResponseAction,
-    MAX_COMMAND_REPLAY_BYTES, MAX_COMMAND_REPLAY_LIMIT, NoWorkLeaseRequest, ObjectKey,
-    OpenRunnerSession, PublishLeaseOffer, PublishedLeaseOffer, RawLogDisposition,
-    RequestCancellation, ResumeRunnerSession, RevokedLeaseOfferFallback, RoutingDocument,
-    RoutingLabel, RunnableAttempt, RunnableAttemptRepository, RunnableQueueKey, RunnableScanLimit,
-    RunnableScanPage, RunnableScanRequest, RunnerClaimRepository, RunnerCommandOutbox,
-    RunnerCommandPayload, RunnerControlTransactionRepository, RunnerGeneration, RunnerGroupId,
-    RunnerLeaseOfferRepository, RunnerLeaseRequestRepository, RunnerLogAdmission,
-    RunnerLogAdmissionRequest, RunnerOperationKind, RunnerOperationReceipt,
-    RunnerOperationReceiptRepository, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerPayloadTombstone, RunnerPayloadTombstoneReason, RunnerProtocolVersion,
-    RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSessionFence, RunnerSessionRepository,
-    RunnerSessionSnapshot, RunnerSlotAvailability, RunnerSlotAvailabilityRepository,
-    RunnerSlotCount, SessionEpoch, StableRunnerSlot, StoreError, TryClaimAttempt, TryClaimOutcome,
-    TryClaimReceipt, WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository,
+    HeartbeatRunnerSession, JobDependency, JobIrMetadata, LeaseOfferCommandIdentity,
+    LeaseRequestCompletion, LeaseRequestKey, MAX_COMMAND_REPLAY_BYTES, MAX_COMMAND_REPLAY_LIMIT,
+    NoWorkLeaseRequest, ObjectKey, OpenRunnerSession, RequestCancellation, ResumeRunnerSession,
+    RevokedLeaseOfferFallback, RoutingDocument, RoutingLabel, RunnableAttempt, RunnableQueueKey,
+    RunnableScanLimit, RunnableScanPage, RunnableScanRequest, RunnerCommandPayload,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerPayloadTombstone, RunnerPayloadTombstoneReason,
+    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot, RunnerSlotCount,
+    SessionEpoch, StableRunnerSlot, StoreError, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
+    WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository,
 };
 
 const LEASE_OPERATION_KIND: &str = "automata.lease-request.v1";

--- a/crates/automata-ci-postgres/src/store/runner_capability_admission.rs
+++ b/crates/automata-ci-postgres/src/store/runner_capability_admission.rs
@@ -3,11 +3,10 @@ use serde_json::Value;
 use sqlx::Row as _;
 use uuid::Uuid;
 
-use automata_ci_core::{MAX_REGISTERED_RUNNERS, RunnerCapabilities, RunnerFeature};
-
-use automata_ci_store::{
+use automata_ci_control::runner_control::capability_admission::{
     RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository, RunnerCapabilityReadiness,
 };
+use automata_ci_core::{MAX_REGISTERED_RUNNERS, RunnerCapabilities, RunnerFeature};
 
 use super::PostgresStore;
 

--- a/crates/automata-ci-postgres/tests/runner_auth/directory.rs
+++ b/crates/automata-ci-postgres/tests/runner_auth/directory.rs
@@ -7,7 +7,11 @@ use automata_ci_auth::{
     },
     time::{Clock, UnixTimestamp},
 };
-use automata_ci_control::runner_control::{DesiredRunnerState, RunnerRegistrationAuthorizer as _};
+use automata_ci_control::runner_control::{
+    DesiredRunnerState, RunnerRegistrationAuthorizer as _,
+    durable::{CurrentRunnerSession, CurrentRunnerSessionRepository as _},
+    repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     JOB_IR_SCHEMA_VERSION, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
 };
@@ -18,10 +22,7 @@ use automata_ci_runner_auth::{
     DurableRunnerMachineAuthenticator, RunnerMachineAuthLimits, RunnerMachineDirectory,
     RunnerMachineDirectoryError,
 };
-use automata_ci_store::{
-    CommandCursor, CurrentRunnerSession, CurrentRunnerSessionRepository as _,
-    HeartbeatRunnerSession, RunnerGeneration, RunnerSessionRepository as _, StoreError,
-};
+use automata_ci_store::{CommandCursor, HeartbeatRunnerSession, RunnerGeneration, StoreError};
 use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
@@ -2,6 +2,16 @@ use crate::support::{
     SeedData, TestDatabase, TestResult, run_with_database, runner_capability_document,
     seed_control_plane,
 };
+use automata_ci_control::{
+    lease::repository::{
+        RunnableAttemptRepository as _, RunnerClaimRepository as _,
+        RunnerLeaseRequestRepository as _,
+    },
+    runner_control::{
+        durable::{CommitCommandAcknowledgement, RunnerControlTransactionRepository as _},
+        repository::{RunnerCommandOutbox as _, RunnerSessionRepository as _},
+    },
+};
 use automata_ci_core::{
     AttemptId, FencingToken, JobId, JobIrVersion, LeaseGuard, LeaseId, OperationId, QueuePolicy,
     RunId, RunnerRequirements, Sha256Digest, UnixMillis, WorkflowId,
@@ -10,13 +20,10 @@ use automata_ci_store::{
     AcknowledgeRunnerCommands, AdmissionObject, AdmissionRepository, AdmitWorkflowRun,
     AdmittedWorkflowJob, BeginLeaseRequest, CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA,
     CancelJobCommandPayload, CancellationRepository as _, CommandCursor, CommandReplayLimit,
-    CommitCommandAcknowledgement, DocumentSchema, HumanRunScope, HumanWorkflowReadRepository as _,
-    LeaseRequestKey, ObjectKey, OpenRunnerSession, RepositoryId, RoutingDocument,
-    RunnableAttemptRepository as _, RunnableScanLimit, RunnableScanRequest,
-    RunnerClaimRepository as _, RunnerCommandOutbox as _, RunnerControlTransactionRepository as _,
-    RunnerGeneration, RunnerLeaseRequestRepository as _, RunnerOperationKind,
-    RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
-    RunnerSessionRepository as _, StableRunnerSlot, StoreError, TenantScope, TryClaimAttempt,
+    DocumentSchema, HumanRunScope, HumanWorkflowReadRepository as _, LeaseRequestKey, ObjectKey,
+    OpenRunnerSession, RepositoryId, RoutingDocument, RunnableScanLimit, RunnableScanRequest,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, TryClaimAttempt,
     TryClaimOutcome, WorkflowAdmissionIdempotency, WorkflowAdmissionRepository as _,
     WorkflowConcurrency, WorkflowSnapshotId,
 };

--- a/crates/automata-ci-postgres/tests/store/execution/g1.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/g1.rs
@@ -1,3 +1,19 @@
+use automata_ci_control::{
+    lease::{
+        repository::{
+            RunnableAttemptRepository as _, RunnerClaimRepository as _,
+            RunnerLeaseRequestRepository as _,
+        },
+        routing::{
+            RunnerRoutingRepository as _, RunnerSlotAvailability,
+            RunnerSlotAvailabilityRepository as _,
+        },
+    },
+    runner_control::repository::{
+        RunnerCommandOutbox as _, RunnerOperationReceiptRepository as _,
+        RunnerSessionRepository as _,
+    },
+};
 use automata_ci_core::{
     Architecture, AttemptId, AttemptNumber, JobId, JobIrVersion, JobLifecycle, LeaseId,
     OperatingSystem, OperationId, RunnerCapabilities, RunnerFeature, RunnerGroup, RunnerLabel,
@@ -11,12 +27,9 @@ use automata_ci_store::{
     CommandCursor, CommandReplayLimit, CommandSequence, ConcludeBlockedAttempt, DocumentSchema,
     EnqueueRunnerCommand, HeartbeatRunnerSession, InternalAttemptRepository as _, JobDependency,
     LeaseRequestKey, MAX_COMMAND_REPLAY_BYTES, NoWorkLeaseRequest, OpenRunnerSession,
-    QueuedAttempt, RequestCancellation, ResumeRunnerSession, RunnableAttemptRepository as _,
-    RunnableScanLimit, RunnableScanRequest, RunnerClaimRepository as _, RunnerCommandOutbox as _,
-    RunnerGeneration, RunnerLeaseRequestRepository as _, RunnerOperationKind,
-    RunnerOperationReceiptRepository as _, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerProtocolVersion, RunnerRoutingRepository as _, RunnerSessionRepository as _,
-    RunnerSlotAvailability, RunnerSlotAvailabilityRepository as _, StableRunnerSlot, StoreError,
+    QueuedAttempt, RequestCancellation, ResumeRunnerSession, RunnableScanLimit,
+    RunnableScanRequest, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot, StoreError,
     TransitionAttempt, TryClaimAttempt, TryClaimOutcome, WORKFLOW_ADMISSION_EPOCH,
     WorkflowPlanRepository as _,
 };

--- a/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
@@ -1,3 +1,10 @@
+use automata_ci_control::{
+    lease::repository::{
+        RunnableAttemptRepository as _, RunnerClaimRepository as _,
+        RunnerLeaseRequestRepository as _,
+    },
+    runner_control::repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, JobId, JobIrVersion, JobLifecycle, LeaseGuard, LeaseId, OperationId,
     RunId, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
@@ -7,12 +14,10 @@ use automata_ci_store::{
     ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
     ExpiredAttemptDisposition, HeartbeatRunnerSession, InternalAttemptRepository as _,
     JobDependency, LeaseFailureLimit, LeaseRequestKey, MaintenanceBatchSize, NoWorkLeaseRequest,
-    OpenRunnerSession, QueuedAttempt, RunReconciliationRepository as _,
-    RunnableAttemptRepository as _, RunnableScanLimit, RunnableScanRequest,
-    RunnerClaimRepository as _, RunnerGeneration, RunnerLeaseRequestRepository as _,
-    RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionRepository as _, StableRunnerSlot,
-    StaleSessionTimeoutMillis, TransitionAttempt, TryClaimOutcome, WORKFLOW_ADMISSION_EPOCH,
-    WorkflowPlanRepository as _, WorkflowRunStatus,
+    OpenRunnerSession, QueuedAttempt, RunReconciliationRepository as _, RunnableScanLimit,
+    RunnableScanRequest, RunnerGeneration, RunnerOperationResponse, RunnerProtocolVersion,
+    StableRunnerSlot, StaleSessionTimeoutMillis, TransitionAttempt, TryClaimOutcome,
+    WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository as _, WorkflowRunStatus,
 };
 use std::time::Duration;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/execution/runner_capability_admission.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_capability_admission.rs
@@ -1,10 +1,10 @@
+use automata_ci_control::runner_control::capability_admission::{
+    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository as _,
+    RunnerCapabilityReadiness,
+};
 use automata_ci_core::{
     Architecture, MAX_REGISTERED_RUNNERS, OperatingSystem, RunnerCapabilities, RunnerFeature,
     RunnerGroup, RunnerId, RunnerLabel, RunnerPlatform,
-};
-use automata_ci_store::{
-    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository as _,
-    RunnerCapabilityReadiness,
 };
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
@@ -7,6 +7,20 @@ use std::{
 };
 
 use async_trait::async_trait;
+use automata_ci_control::{
+    lease::repository::{
+        RunnableAttemptRepository as _, RunnerClaimRepository as _,
+        RunnerLeaseRequestRepository as _,
+    },
+    runner_control::{
+        durable::{
+            CommitLeaseHeartbeat, CommitLeaseResponse, LeaseOfferClaimStatus, LeaseResponseAction,
+            PublishLeaseOffer, RunnerControlTransactionRepository as _,
+            RunnerLeaseOfferRepository as _,
+        },
+        repository::{RunnerCommandOutbox as _, RunnerSessionRepository as _},
+    },
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, Lease, LeaseId, OperationId, RunnerSessionId, Sha256Digest,
     UnixMillis,
@@ -17,18 +31,15 @@ use automata_ci_key_management::{
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcquireLease, AttemptStoreError, BeginLeaseRequest, CommandCursor, CommandReplayDisposition,
-    CommandReplayLimit, CommandSequence, CommitLeaseHeartbeat, CommitLeaseResponse,
-    CompleteLeaseRequest, ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest,
-    DocumentSchema, EnqueueRunnerCommand, GITHUB_AUTHORITY_PROVIDER_CLOCK_SKEW_MILLIS,
-    HeartbeatRunnerSession, InternalAttemptRepository as _, JobIrMetadata, LeaseFailureLimit,
-    LeaseOfferClaimStatus, LeaseOfferCommandIdentity, LeaseRequestCompletion, LeaseRequestKey,
-    LeaseResponseAction, MaintenanceBatchSize, OpenRunnerSession, PublishLeaseOffer, QueuedAttempt,
-    RenewLease, ResumeRunnerSession, RevokedLeaseOfferFallback, RunnableAttemptRepository as _,
-    RunnableScanLimit, RunnableScanRequest, RunnerClaimRepository as _, RunnerCommandOutbox as _,
-    RunnerCommandPayload, RunnerControlTransactionRepository as _, RunnerLeaseOfferRepository as _,
-    RunnerLeaseRequestRepository as _, RunnerOperationKind, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionRepository as _, StableRunnerSlot,
-    StaleSessionTimeoutMillis, StoreError, TryClaimAttempt, TryClaimOutcome,
+    CommandReplayLimit, CommandSequence, CompleteLeaseRequest,
+    ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
+    EnqueueRunnerCommand, GITHUB_AUTHORITY_PROVIDER_CLOCK_SKEW_MILLIS, HeartbeatRunnerSession,
+    InternalAttemptRepository as _, JobIrMetadata, LeaseFailureLimit, LeaseOfferCommandIdentity,
+    LeaseRequestCompletion, LeaseRequestKey, MaintenanceBatchSize, OpenRunnerSession,
+    QueuedAttempt, RenewLease, ResumeRunnerSession, RevokedLeaseOfferFallback, RunnableScanLimit,
+    RunnableScanRequest, RunnerCommandPayload, RunnerOperationKind, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot, StaleSessionTimeoutMillis,
+    StoreError, TryClaimAttempt, TryClaimOutcome,
 };
 use sqlx::PgPool;
 use tokio::sync::Semaphore;

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -1,4 +1,23 @@
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
+use automata_ci_control::{
+    lease::repository::{
+        RunnableAttemptRepository as _, RunnerClaimRepository as _,
+        RunnerLeaseRequestRepository as _,
+    },
+    runner_control::{
+        durable::{
+            CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
+            CommitRunnerLogSegment, CommitRunnerTerminalResult, CurrentRunnerSession,
+            CurrentRunnerSessionRepository as _, LeaseOfferClaimStatus, LeaseResponseAction,
+            PublishLeaseOffer, RawLogDisposition, RunnerControlTransactionRepository as _,
+            RunnerLeaseOfferRepository as _, RunnerLogAdmission, RunnerLogAdmissionRequest,
+        },
+        repository::{
+            RunnerCommandOutbox as _, RunnerOperationReceiptRepository as _,
+            RunnerSessionRepository as _,
+        },
+    },
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, JobConclusion, JobLifecycle, Lease, LeaseGuard,
     LeaseId, LogSequence, LogStreamId, OperationId, Sha256Digest, UnixMillis,
@@ -7,20 +26,13 @@ use automata_ci_store::{
     AcknowledgeRunnerCommands, BeginLeaseRequest, CANCEL_JOB_COMMAND_KIND,
     CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor, CancellationReason,
     CancellationRepository as _, CloseRunnerSession, CommandCursor, CommandSequence,
-    CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
-    CommitRunnerLogSegment, CommitRunnerTerminalResult, CompleteLeaseRequest,
-    ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, CurrentRunnerSession,
-    CurrentRunnerSessionRepository as _, DocumentSchema, EnqueueRunnerCommand,
-    InternalAttemptRepository as _, JobIrMetadata, LeaseFailureLimit, LeaseOfferClaimStatus,
-    LeaseOfferCommandIdentity, LeaseRequestKey, LeaseResponseAction, MaintenanceBatchSize,
-    NoWorkLeaseRequest, ObjectKey, OpenRunnerSession, PublishLeaseOffer, QueuedAttempt,
-    RawLogDisposition, RenewLease, RequestCancellation, RunnableAttemptRepository as _,
-    RunnableScanLimit, RunnableScanRequest, RunnerClaimRepository as _, RunnerCommandOutbox as _,
-    RunnerCommandPayload, RunnerControlTransactionRepository as _, RunnerGeneration,
-    RunnerLeaseOfferRepository as _, RunnerLeaseRequestRepository as _, RunnerLogAdmission,
-    RunnerLogAdmissionRequest, RunnerOperationKind, RunnerOperationReceiptRepository as _,
-    RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
-    RunnerSessionRepository as _, StableRunnerSlot, StaleSessionTimeoutMillis, StoreError,
+    CompleteLeaseRequest, ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest,
+    DocumentSchema, EnqueueRunnerCommand, InternalAttemptRepository as _, JobIrMetadata,
+    LeaseFailureLimit, LeaseOfferCommandIdentity, LeaseRequestKey, MaintenanceBatchSize,
+    NoWorkLeaseRequest, ObjectKey, OpenRunnerSession, QueuedAttempt, RenewLease,
+    RequestCancellation, RunnableScanLimit, RunnableScanRequest, RunnerCommandPayload,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerProtocolVersion, StableRunnerSlot, StaleSessionTimeoutMillis, StoreError,
     TryClaimAttempt, TryClaimOutcome,
 };
 

--- a/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
@@ -1,15 +1,17 @@
 use std::sync::Arc;
 
+use automata_ci_control::runner_control::repository::{
+    RunnerCommandOutbox as _, RunnerOperationReceiptRepository as _, RunnerSessionRepository as _,
+};
 use automata_ci_core::{JobIrVersion, OperationId, RunnerSessionId, Sha256Digest, UnixMillis};
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
     ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
     EnqueueRunnerCommand, LeaseFailureLimit, MaintenanceBatchSize, OpenRunnerSession,
-    RunnerCommandOutbox as _, RunnerCommandPayload, RunnerGeneration, RunnerOperationKind,
-    RunnerOperationReceiptRepository as _, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerPayloadTombstoneReason, RunnerProtocolVersion, RunnerSessionFence,
-    RunnerSessionRepository as _, StaleSessionTimeoutMillis, StoreError,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerPayloadTombstoneReason, RunnerProtocolVersion,
+    RunnerSessionFence, StaleSessionTimeoutMillis, StoreError,
 };
 
 use crate::support::{

--- a/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
@@ -2,6 +2,10 @@ use crate::github_manifest_fixture;
 
 use std::{collections::BTreeMap, time::Duration};
 
+use automata_ci_control::runner_control::{
+    durable::{CommitLeaseHeartbeat, RunnerControlTransactionRepository as _},
+    repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
@@ -22,7 +26,7 @@ use automata_ci_store::{
     ClaimProviderDelivery, ClaimedGithubRuntimeAuthorityMint,
     ClaimedGithubRuntimeAuthorityRevocation, ClaimedLogicalInstanceMaterialization,
     ClaimedLogicalJobActivation, ClaimedProviderDelivery, CommandCursor,
-    CommitGithubRuntimeAuthority, CommitLeaseHeartbeat, CommitLogicalInstanceMaterialization,
+    CommitGithubRuntimeAuthority, CommitLogicalInstanceMaterialization,
     ConfirmGithubRuntimeAuthorityRevocation, ConsumeSelectedLogicalInstanceMaterialization,
     ConsumeSelectedLogicalJobOrchestration, ConsumedLogicalJobOrchestrationAuthority,
     DeferGithubRuntimeAuthorityRevocation, DocumentSchema, EnsureGithubServerServiceAuthority,
@@ -58,10 +62,10 @@ use automata_ci_store::{
     QuarantineGithubRuntimeAuthority, ReconcileGithubRuntimeAuthorities,
     RegisterProviderDeliveryWorkflowInventory, RejectGithubRuntimeAuthorityMint, RenewLease,
     RetryGithubRuntimeAuthorityMint, RetryGithubRuntimeAuthorityRevocation,
-    ReusableSecretPermission, RoutingDocument, RunnerControlTransactionRepository as _,
-    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerProtocolVersion, RunnerSessionRepository as _, StableRunnerSlot, StoreError, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowPlanRepository as _, WorkflowSnapshotId,
+    ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerOperationKind,
+    RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot,
+    StoreError, TenantScope, WorkflowAdmissionIdempotency, WorkflowPlanRepository as _,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -2,6 +2,7 @@ use crate::github_manifest_fixture;
 
 use std::collections::BTreeMap;
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, ContextValue, JobAuthorityProfile, JobConclusion, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
@@ -45,8 +46,8 @@ use automata_ci_store::{
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     PublishLogicalJobActivation, QuarantineLogicalInstanceResult,
     RegisterProviderDeliveryWorkflowInventory, RequestCancellation, ReusableSecretPermission,
-    RoutingDocument, RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence,
-    RunnerSessionRepository as _, TenantScope, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    RoutingDocument, RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, TenantScope,
+    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
@@ -2,6 +2,7 @@ use crate::github_manifest_fixture;
 
 use std::collections::BTreeMap;
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, CompiledValueTemplate, ContextValue, JobAuthorityProfile, JobConclusion,
     JobContentReference, JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope,
@@ -50,9 +51,8 @@ use automata_ci_store::{
     ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
     ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
     ProviderRepositoryVisibility, PublishLogicalJobActivation, ReusableSecretPermission,
-    RoutingDocument, RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence,
-    RunnerSessionRepository as _, StoreError, TenantScope, WorkflowAdmissionIdempotency,
-    WorkflowSnapshotId,
+    RoutingDocument, RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, StoreError,
+    TenantScope, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -2,6 +2,10 @@ use crate::github_manifest_fixture;
 
 use std::{collections::BTreeMap, time::Duration};
 
+use automata_ci_control::{
+    lease::repository::RunnableAttemptRepository as _,
+    runner_control::repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     Architecture, AttemptId, AttemptNumber, CompiledValueTemplate, ContextValue,
     JobAuthorityProfile, JobConclusion, JobContentReference, JobExecutionContext, JobId,
@@ -56,11 +60,10 @@ use automata_ci_store::{
     RegisterProviderDeliveryWorkflowInventory, ReusableCallOutputMapping, ReusableSecretPermission,
     ReusableWorkflowOperationId, ReusableWorkflowRuntimeRepository as _,
     ReusableWorkflowRuntimeStoreError, RoutingDocument, RunReconciliationRepository as _,
-    RunnableAttemptRepository as _, RunnableScanLimit, RunnableScanRequest, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionRepository as _, StableRunnerSlot,
-    StoreError, TenantScope, WorkflowAdmissionIdempotency, WorkflowAdmissionRepository as _,
-    WorkflowConcurrency, WorkflowPlanRepository as _, WorkflowRunStatus, WorkflowRuntimePolicyPin,
-    WorkflowSnapshotId,
+    RunnableScanLimit, RunnableScanRequest, RunnerGeneration, RunnerProtocolVersion,
+    RunnerSessionFence, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowAdmissionRepository as _, WorkflowConcurrency, WorkflowPlanRepository as _,
+    WorkflowRunStatus, WorkflowRuntimePolicyPin, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;

--- a/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
@@ -2,6 +2,7 @@ use crate::github_manifest_fixture;
 
 use std::{collections::BTreeMap, time::Duration};
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobRuntimeContext,
@@ -51,8 +52,8 @@ use automata_ci_store::{
     RenewLogicalActivationPreparation, RenewLogicalInstanceMaterialization,
     RenewLogicalJobActivation, ReusableSecretPermission,
     RevalidateGithubRuntimeAuthorityRevocation, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionRepository as _, StableRunnerSlot,
-    TenantScope, WorkflowAdmissionIdempotency, WorkflowPlanRepository as _, WorkflowSnapshotId,
+    RunnerProtocolVersion, RunnerSessionFence, StableRunnerSlot, TenantScope,
+    WorkflowAdmissionIdempotency, WorkflowPlanRepository as _, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
@@ -9,6 +9,7 @@ use std::{
     time::Duration,
 };
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, ContextValue, FencingToken, JobContentReference, JobExecutionContext, JobId,
     JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion, JobPermissionRequest,
@@ -60,9 +61,8 @@ use automata_ci_store::{
     ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
     RegisterProviderDeliveryWorkflowInventory, ReserveGithubOidcAuthority, RetainGithubOidcKey,
     ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    RunnerSessionRepository as _, StableRunnerSlot, StoreError, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowPlanRepository as _, WorkflowSnapshotId,
-    github_oidc_rs256_public_key_fingerprint,
+    StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowPlanRepository as _, WorkflowSnapshotId, github_oidc_rs256_public_key_fingerprint,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
@@ -8,6 +8,7 @@ use automata_ci_auth::{
     session::SessionId,
     time::UnixTimestamp,
 };
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
@@ -64,10 +65,9 @@ use automata_ci_store::{
     RequestCancellation, ReserveRepositorySecretVersionMutation,
     ReserveRepositorySecretVersionMutationOutcome, ResolveManagedSecretAuthority,
     ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionRepository as _, SecretCustodyKeySet,
-    SecretCustodyRepository as _, SecretWorkloadGrantId, StableRunnerSlot, TenantScope,
-    VerifySecretCustody, VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency,
-    WorkflowSnapshotId,
+    RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet, SecretCustodyRepository as _,
+    SecretWorkloadGrantId, StableRunnerSlot, TenantScope, VerifySecretCustody,
+    VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Transaction};

--- a/crates/automata-ci-postgres/tests/store/security/observability.rs
+++ b/crates/automata-ci-postgres/tests/store/security/observability.rs
@@ -2,6 +2,7 @@ use crate::github_manifest_fixture;
 
 use std::time::Duration;
 
+use automata_ci_control::runner_control::repository::RunnerCommandOutbox as _;
 use automata_ci_core::{
     Architecture, JobAuthorityProfile, JobId, JobIrVersion, JobLifecycle, OperatingSystem,
     OperationId, RunId, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
@@ -31,9 +32,9 @@ use automata_ci_store::{
     ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
     ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
     ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, RunnerCommandOutbox as _, RunnerCommandPayload,
-    RunnerDesiredState, RunnerGeneration, RunnerObservedState, RunnerOperationKind,
-    RunnerSessionFence, RunnerSessionState, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
+    RegisterProviderDeliveryWorkflowInventory, RunnerCommandPayload, RunnerDesiredState,
+    RunnerGeneration, RunnerObservedState, RunnerOperationKind, RunnerSessionFence,
+    RunnerSessionState, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
     WorkflowAdmissionIdempotency, WorkflowRunStatus, WorkflowSnapshotId,
 };
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/support/mod.rs
+++ b/crates/automata-ci-postgres/tests/support/mod.rs
@@ -1,5 +1,6 @@
 use std::{error::Error, future::Future, sync::Arc};
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, JobId, JobIrVersion, OperatingSystem, RunId, RunnerCapabilities, RunnerId,
     RunnerPlatform, RunnerRequirements, RunnerSessionId, UnixMillis,
@@ -18,7 +19,7 @@ use automata_ci_store::{
     ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
     ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
     RegisterProviderDeliveryWorkflowInventory, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionRepository as _,
+    RunnerProtocolVersion, RunnerSessionFence,
 };
 use sqlx::PgPool;
 use tokio::sync::OnceCell;

--- a/crates/automata-ci-results-github/tests/support/postgres.rs
+++ b/crates/automata-ci-results-github/tests/support/postgres.rs
@@ -1,5 +1,6 @@
 use std::{error::Error, future::Future, sync::Arc};
 
+use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, JobId, JobIrVersion, OperatingSystem, RunId, RunnerCapabilities, RunnerId,
     RunnerPlatform, RunnerRequirements, RunnerSessionId, UnixMillis,
@@ -10,7 +11,7 @@ use automata_ci_postgres_test_support::{
 };
 use automata_ci_store::{
     OpenRunnerSession, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    RunnerSessionFence, RunnerSessionRepository as _, WORKFLOW_ADMISSION_EPOCH,
+    RunnerSessionFence, WORKFLOW_ADMISSION_EPOCH,
 };
 use sqlx::PgPool;
 use tokio::sync::OnceCell;

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -38,10 +38,7 @@ mod receipt;
 mod reconciliation;
 mod reusable_workflow_admission;
 mod reusable_workflow_runtime;
-mod routing;
 mod runnable;
-mod runner_capability_admission;
-mod runner_control;
 mod runner_payload;
 mod runtime_authority;
 mod secret_custody;
@@ -337,14 +334,13 @@ pub use operation::{
     BeginLeaseRequest, BegunLeaseRequest, ClaimCommandError, ClaimRejection, ClaimedAttempt,
     CompleteLeaseRequest, LeaseOfferCompletionError, LeaseRequestCompletion, LeaseRequestKey,
     LeaseRequestKeyError, NoWorkLeaseRequest, REVOKED_LEASE_OFFER_FALLBACK_VERSION,
-    RevokedLeaseOfferFallback, RunnerClaimRepository, RunnerLeaseRequestRepository,
-    TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
+    RevokedLeaseOfferFallback, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
 };
 pub use outbox::{
     AcknowledgeRunnerCommands, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
     CommandReplayPage, CommandSequence, CommandValueError, DurableRunnerCommand,
-    EnqueueRunnerCommand, MAX_COMMAND_REPLAY_BYTES, MAX_COMMAND_REPLAY_LIMIT, RunnerCommandOutbox,
-    RunnerCommandPayload,
+    EnqueueRunnerCommand, LeaseOfferCommandIdentity, MAX_COMMAND_REPLAY_BYTES,
+    MAX_COMMAND_REPLAY_LIMIT, RunnerCommandPayload,
 };
 pub use plan::{
     JobDependency, JobDependencyError, JobIrMetadata, JobIrMetadataError, WorkflowPlanRepository,
@@ -381,8 +377,8 @@ pub use publication::{
     UpdateRepositoryPublication, UpdateRepositoryPublicationOutcome,
 };
 pub use receipt::{
-    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationReceiptRepository,
-    RunnerOperationRequest, RunnerOperationResponse, RunnerReceiptValueError,
+    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerReceiptValueError,
 };
 pub use reconciliation::{RunReconciliation, RunReconciliationRepository, WorkflowRunStatus};
 pub use reusable_workflow_admission::{
@@ -401,25 +397,9 @@ pub use reusable_workflow_runtime::{
     ReusableWorkflowRuntimeStoreError, ReusableWorkflowRuntimeValueError,
     ReusableWorkflowSecretBindingEvidence,
 };
-pub use routing::{
-    RoutingSnapshotError, RunnerGroupId, RunnerRoutingRepository, RunnerRoutingSnapshot,
-    RunnerSlotAvailability, RunnerSlotAvailabilityRepository,
-};
 pub use runnable::{
-    MAX_RUNNABLE_SCAN_LIMIT, RunnableAttempt, RunnableAttemptError, RunnableAttemptRepository,
-    RunnableCursorAdvance, RunnableQueueKey, RunnableScanError, RunnableScanLimit,
-    RunnableScanPage, RunnableScanRequest,
-};
-pub use runner_capability_admission::{
-    RunnerCapabilityAdmissionError, RunnerCapabilityAdmissionRepository, RunnerCapabilityReadiness,
-};
-pub use runner_control::{
-    CommitCommandAcknowledgement, CommitLeaseHeartbeat, CommitLeaseResponse,
-    CommitRunnerLogSegment, CommitRunnerTerminalResult, CurrentRunnerSession,
-    CurrentRunnerSessionRepository, LeaseOfferClaim, LeaseOfferClaimStatus,
-    LeaseOfferCommandIdentity, LeaseResponseAction, PublishLeaseOffer, PublishedLeaseOffer,
-    RawLogDisposition, RunnerControlTransactionRepository, RunnerControlValueError,
-    RunnerLeaseOfferRepository, RunnerLogAdmission, RunnerLogAdmissionRequest,
+    MAX_RUNNABLE_SCAN_LIMIT, RunnableAttempt, RunnableAttemptError, RunnableCursorAdvance,
+    RunnableQueueKey, RunnableScanError, RunnableScanLimit, RunnableScanPage, RunnableScanRequest,
 };
 pub use runner_payload::{RunnerPayloadTombstone, RunnerPayloadTombstoneReason};
 pub use runtime_authority::{
@@ -488,7 +468,7 @@ pub use secret_management::{
 };
 pub use session::{
     CloseRunnerSession, HeartbeatRunnerSession, OpenRunnerSession, ResumeRunnerSession,
-    RunnerSessionFence, RunnerSessionRepository, RunnerSessionSnapshot, RunnerSessionSnapshotError,
+    RunnerSessionFence, RunnerSessionSnapshot, RunnerSessionSnapshotError,
 };
 pub use snapshot::{AttemptSnapshot, AttemptSnapshotBuilder};
 pub use store_error::StoreError;

--- a/crates/automata-ci-store/src/operation.rs
+++ b/crates/automata-ci-store/src/operation.rs
@@ -1,11 +1,10 @@
-use async_trait::async_trait;
 use automata_ci_core::{AttemptId, JobLifecycle, Lease, LeaseId, OperationId, UnixMillis};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
 use crate::{
     AttemptAssignment, JobIrMetadata, LeaseOfferCommandIdentity, RunnableCursorAdvance,
-    RunnerOperationResponse, RunnerSessionFence, Sha256Digest, StableRunnerSlot, StoreError,
+    RunnerOperationResponse, RunnerSessionFence, Sha256Digest, StableRunnerSlot,
 };
 
 const LEASE_REQUEST_DIGEST_DOMAIN: &[u8] = b"automata.store.lease-request.v2\0";
@@ -475,22 +474,6 @@ impl CompleteLeaseRequest {
     }
 }
 
-/// Bounded exact-response ledger for lease-request chains.
-#[async_trait]
-pub trait RunnerLeaseRequestRepository: Send + Sync {
-    /// Admits a first request, exact retry, or exact completed-head successor.
-    async fn begin_lease_request(
-        &self,
-        request: BeginLeaseRequest,
-    ) -> Result<BegunLeaseRequest, StoreError>;
-
-    /// Commits the exact response only if the request is still the slot head.
-    async fn complete_lease_request(
-        &self,
-        request: CompleteLeaseRequest,
-    ) -> Result<LeaseRequestCompletion, StoreError>;
-}
-
 /// Idempotent, server-routed attempt claim.
 ///
 /// It intentionally contains no labels, groups, or capability claims. Those
@@ -772,26 +755,4 @@ impl TryClaimReceipt {
     pub const fn was_replayed(&self) -> bool {
         self.replayed
     }
-}
-
-/// Receipt-backed server-side claim port.
-#[async_trait]
-pub trait RunnerClaimRepository: Send + Sync {
-    /// Looks up a terminal receipt before candidate selection. This is the
-    /// mandatory first step for an at-least-once lease poll retry.
-    async fn lookup_lease_request(
-        &self,
-        request: LeaseRequestKey,
-    ) -> Result<Option<TryClaimReceipt>, StoreError>;
-
-    /// Claims one scheduler-selected candidate and records the answer in the
-    /// same transaction. Same-session retries replay; digest changes conflict.
-    async fn try_claim(&self, request: TryClaimAttempt) -> Result<TryClaimReceipt, StoreError>;
-
-    /// Durably records that the first execution observed no schedulable work.
-    /// A retry of the same key replays no-work even if work arrives later.
-    async fn record_no_work(
-        &self,
-        request: NoWorkLeaseRequest,
-    ) -> Result<TryClaimReceipt, StoreError>;
 }

--- a/crates/automata-ci-store/src/outbox.rs
+++ b/crates/automata-ci-store/src/outbox.rs
@@ -3,20 +3,55 @@ use std::{
     num::{NonZeroU16, NonZeroU64},
 };
 
-use async_trait::async_trait;
 use automata_ci_core::{OperationId, Sha256Digest, UnixMillis};
 use thiserror::Error;
 use zeroize::Zeroize as _;
 
-use crate::{
-    DocumentSchema, RunnerOperationKind, RunnerSessionFence, StoreError, value::sha256_digest,
-};
+use crate::{DocumentSchema, RunnerOperationKind, RunnerSessionFence, value::sha256_digest};
 
 const MAX_COMMAND_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
 /// Maximum commands returned by one bounded outbox replay.
 pub const MAX_COMMAND_REPLAY_LIMIT: u16 = 256;
 /// Maximum aggregate command payload bytes returned by one outbox replay.
 pub const MAX_COMMAND_REPLAY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Exact server-command identity used to resolve a replay to one typed offer publication.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LeaseOfferCommandIdentity {
+    session: RunnerSessionFence,
+    operation_id: OperationId,
+    sequence: CommandSequence,
+}
+
+impl LeaseOfferCommandIdentity {
+    #[must_use]
+    pub const fn new(
+        session: RunnerSessionFence,
+        operation_id: OperationId,
+        sequence: CommandSequence,
+    ) -> Self {
+        Self {
+            session,
+            operation_id,
+            sequence,
+        }
+    }
+
+    #[must_use]
+    pub const fn session(self) -> RunnerSessionFence {
+        self.session
+    }
+
+    #[must_use]
+    pub const fn operation_id(self) -> OperationId {
+        self.operation_id
+    }
+
+    #[must_use]
+    pub const fn sequence(self) -> CommandSequence {
+        self.sequence
+    }
+}
 
 /// Whether one fixed-total replay transaction proved that no later candidate exists.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -365,27 +400,4 @@ pub enum CommandValueError {
     InvalidPayloadSize { size: usize, maximum: usize },
     #[error("server command replay limit must be in 1..={maximum}")]
     InvalidReplayLimit { maximum: u16 },
-}
-
-/// Durable server-command delivery and cumulative acknowledgement port.
-#[async_trait]
-pub trait RunnerCommandOutbox: Send + Sync {
-    async fn enqueue_command(
-        &self,
-        command: EnqueueRunnerCommand,
-    ) -> Result<DurableRunnerCommand, StoreError>;
-
-    async fn replay_commands(
-        &self,
-        session: RunnerSessionFence,
-        after: CommandCursor,
-        limit: CommandReplayLimit,
-    ) -> Result<CommandReplayPage, StoreError>;
-
-    /// Advances the cumulative cursor. Duplicate/older cursors are idempotent;
-    /// a cursor beyond the largest allocated sequence is rejected.
-    async fn acknowledge_commands(
-        &self,
-        acknowledgement: AcknowledgeRunnerCommands,
-    ) -> Result<CommandCursor, StoreError>;
 }

--- a/crates/automata-ci-store/src/receipt.rs
+++ b/crates/automata-ci-store/src/receipt.rs
@@ -1,11 +1,10 @@
-use async_trait::async_trait;
 use std::fmt;
 
 use automata_ci_core::{OperationId, Sha256Digest, UnixMillis};
 use thiserror::Error;
 use zeroize::Zeroize as _;
 
-use crate::{DocumentSchema, RunnerSessionFence, StoreError, value::sha256_digest};
+use crate::{DocumentSchema, RunnerSessionFence, value::sha256_digest};
 
 const MAX_OPERATION_KIND_BYTES: usize = 128;
 const MAX_RECEIPT_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
@@ -208,28 +207,4 @@ pub enum RunnerReceiptValueError {
     InvalidOperationKind,
     #[error("runner operation response has {size} bytes; expected 1..={maximum}")]
     InvalidResponseSize { size: usize, maximum: usize },
-}
-
-/// Generic exact-response ledger for runner RPC mutations.
-///
-/// Callers must look up a receipt before executing a side effect and must use
-/// the same `OperationId` at the provider boundary. This generic two-call seam
-/// cannot by itself make an unrelated external side effect atomic with durable
-/// repository state. Operations such as [`crate::RunnerClaimRepository::try_claim`]
-/// use a stronger, single-transaction specialized receipt.
-#[async_trait]
-pub trait RunnerOperationReceiptRepository: Send + Sync {
-    async fn lookup_operation(
-        &self,
-        request: &RunnerOperationRequest,
-    ) -> Result<Option<RunnerOperationReceipt>, StoreError>;
-
-    /// Persists the first exact response. A same-request retry returns the
-    /// original response; a different digest/kind for the key conflicts.
-    async fn record_operation(
-        &self,
-        request: RunnerOperationRequest,
-        response: RunnerOperationResponse,
-        committed_at: UnixMillis,
-    ) -> Result<RunnerOperationReceipt, StoreError>;
 }

--- a/crates/automata-ci-store/src/runnable.rs
+++ b/crates/automata-ci-store/src/runnable.rs
@@ -1,10 +1,9 @@
 use std::num::NonZeroU16;
 
-use async_trait::async_trait;
 use automata_ci_core::{AttemptId, JobId, RunId, RunnerRequirements, Sha256Digest, UnixMillis};
 use thiserror::Error;
 
-use crate::{JobIrMetadata, RunnerSessionFence, StableRunnerSlot, StoreError};
+use crate::{JobIrMetadata, RunnerSessionFence, StableRunnerSlot};
 
 /// Maximum records returned by one scheduler queue scan.
 pub const MAX_RUNNABLE_SCAN_LIMIT: u16 = 1000;
@@ -345,14 +344,4 @@ pub enum RunnableAttemptError {
     JobMetadataMismatch,
     #[error("runnable attempt and JobIR metadata identify different runs")]
     RunMetadataMismatch,
-}
-
-/// Authoritative scheduler queue port. Claims/no-work receipts atomically
-/// commit the opaque cursor advancement returned with a page.
-#[async_trait]
-pub trait RunnableAttemptRepository: Send + Sync {
-    async fn scan_runnable(
-        &self,
-        request: RunnableScanRequest,
-    ) -> Result<RunnableScanPage, StoreError>;
 }

--- a/crates/automata-ci-store/src/session.rs
+++ b/crates/automata-ci-store/src/session.rs
@@ -1,9 +1,7 @@
-use async_trait::async_trait;
 use automata_ci_core::{JobIrVersion, RunnerId, RunnerSessionId, UnixMillis};
 
 use crate::{
     CommandCursor, RoutingDocument, RunnerGeneration, RunnerProtocolVersion, SessionEpoch,
-    StoreError,
 };
 
 /// Immutable identity fence for one authenticated runner connection.
@@ -339,37 +337,4 @@ pub enum RunnerSessionSnapshotError {
     HeartbeatBeforeConnection,
     #[error("runner session disconnect precedes its last heartbeat")]
     DisconnectBeforeHeartbeat,
-}
-
-/// Durable session lifecycle port used after runner machine authentication.
-#[async_trait]
-pub trait RunnerSessionRepository: Send + Sync {
-    /// Atomically replaces any prior live connection and allocates a new epoch.
-    async fn open_session(
-        &self,
-        request: OpenRunnerSession,
-    ) -> Result<RunnerSessionSnapshot, StoreError>;
-
-    /// Ends the exact authenticated epoch; stale epochs cannot close a newer one.
-    async fn close_session(&self, request: CloseRunnerSession) -> Result<(), StoreError>;
-
-    /// Updates the exact live fence without allocating a new session epoch.
-    ///
-    /// Implementations keep the durable heartbeat monotonic when concurrent
-    /// trusted observations acquire the fence in reverse sampling order.
-    async fn heartbeat_session(
-        &self,
-        request: HeartbeatRunnerSession,
-    ) -> Result<RunnerSessionSnapshot, StoreError>;
-
-    /// Resumes an already-live durable epoch by authenticated runner identity.
-    async fn resume_session(
-        &self,
-        request: ResumeRunnerSession,
-    ) -> Result<RunnerSessionSnapshot, StoreError>;
-
-    async fn get_session(
-        &self,
-        fence: RunnerSessionFence,
-    ) -> Result<RunnerSessionSnapshot, StoreError>;
 }

--- a/crates/automata-ci-store/src/workflow_rerun.rs
+++ b/crates/automata-ci-store/src/workflow_rerun.rs
@@ -601,7 +601,7 @@ mod tests {
         );
         assert_eq!(
             workflow_rerun_repository_segment_byte_rejection(
-                MAX_WORKFLOW_RERUN_REPOSITORY_SEGMENT_BYTES + 0
+                MAX_WORKFLOW_RERUN_REPOSITORY_SEGMENT_BYTES
             ),
             None
         );

--- a/crates/automata-ci-store/tests/g1_api.rs
+++ b/crates/automata-ci-store/tests/g1_api.rs
@@ -1,20 +1,15 @@
 use automata_ci_core::{
-    AttemptId, FencingToken, JobId, JobIrVersion, Lease, LeaseGuard, LeaseId, LogSequence,
-    LogStreamId, OperationId, RunId, RunnerId, RunnerRequirements, RunnerSessionId, Sha256Digest,
-    UnixMillis,
+    AttemptId, FencingToken, JobId, JobIrVersion, Lease, LeaseGuard, LeaseId, OperationId, RunId,
+    RunnerId, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
 };
 use automata_ci_store::{
     AttemptAssignment, BeginLeaseRequest, CancelJobCommandPayload, CancellationRepository,
     CommandCursor, CommandReplayDisposition, CommandReplayLimit, CommandReplayPage,
-    CommandSequence, CompleteLeaseRequest, CurrentRunnerSessionRepository, DocumentSchema,
-    JobDependency, JobIrMetadata, LeaseOfferCommandIdentity, LeaseRequestKey, MAX_JOB_IR_BYTES,
-    ObjectKey, RevokedLeaseOfferFallback, RoutingDocument, RoutingLabel, RunnableAttempt,
-    RunnableAttemptRepository, RunnableScanLimit, RunnerClaimRepository, RunnerCommandOutbox,
-    RunnerControlTransactionRepository, RunnerGeneration, RunnerLeaseOfferRepository,
-    RunnerLeaseRequestRepository, RunnerLogAdmissionRequest, RunnerOperationKind,
-    RunnerOperationReceiptRepository, RunnerProtocolVersion, RunnerRoutingRepository,
-    RunnerSessionFence, RunnerSessionRepository, RunnerSlotCount, SessionEpoch, StableRunnerSlot,
-    WorkflowPlanRepository,
+    CommandSequence, CompleteLeaseRequest, DocumentSchema, JobDependency, JobIrMetadata,
+    LeaseOfferCommandIdentity, LeaseRequestKey, MAX_JOB_IR_BYTES, ObjectKey,
+    RevokedLeaseOfferFallback, RoutingDocument, RoutingLabel, RunnableAttempt, RunnableScanLimit,
+    RunnerGeneration, RunnerOperationKind, RunnerProtocolVersion, RunnerSessionFence,
+    RunnerSlotCount, SessionEpoch, StableRunnerSlot, WorkflowPlanRepository,
 };
 
 #[test]
@@ -249,54 +244,13 @@ fn immutable_scheduler_metadata_is_bounded_and_fenced() {
 }
 
 #[test]
-fn scheduler_and_durability_ports_remain_backend_neutral_and_dyn_compatible() {
-    #[allow(clippy::too_many_arguments)]
-    fn assert_ports(
-        _: &dyn RunnerSessionRepository,
-        _: &dyn RunnerRoutingRepository,
-        _: &dyn RunnerCommandOutbox,
-        _: &dyn RunnerOperationReceiptRepository,
-        _: &dyn RunnerLeaseRequestRepository,
-        _: &dyn RunnerClaimRepository,
-        _: &dyn WorkflowPlanRepository,
-        _: &dyn RunnableAttemptRepository,
-        _: &dyn CancellationRepository,
-        _: &dyn CurrentRunnerSessionRepository,
-        _: &dyn RunnerLeaseOfferRepository,
-        _: &dyn RunnerControlTransactionRepository,
-    ) {
-    }
+fn store_values_and_ports_remain_backend_neutral_and_dyn_compatible() {
+    fn assert_ports(_: &dyn WorkflowPlanRepository, _: &dyn CancellationRepository) {}
     let _ = assert_ports;
 
     assert!(RunnableScanLimit::new(0).is_err());
     assert!(RunnableScanLimit::new(1001).is_err());
     assert!(RunnerOperationKind::new("Automata.Invalid").is_err());
-
-    let ingress_request = automata_ci_store::RunnerOperationRequest::new(
-        RunnerSessionFence::new(
-            RunnerSessionId::new(),
-            RunnerId::new(),
-            RunnerGeneration::new(1).expect("generation"),
-            SessionEpoch::new(1).expect("epoch"),
-        ),
-        OperationId::new(),
-        RunnerOperationKind::new("automata.runner.log-batch.v1").expect("kind"),
-        Sha256Digest::from_bytes([5; 32]),
-    );
-    assert!(
-        RunnerLogAdmissionRequest::new(
-            ingress_request,
-            AttemptId::new(),
-            LeaseGuard::new(LeaseId::new(), FencingToken::new(1).expect("fencing token")),
-            LogStreamId::new(),
-            DocumentSchema::new(1).expect("schema"),
-            LogSequence::new(0),
-            LogSequence::new(9_223_372_036_854_775_808),
-            UnixMillis::new(1),
-            false,
-        )
-        .is_err()
-    );
 
     let candidate_job_id = JobId::new();
     let candidate_run_id = RunId::new();

--- a/crates/automata-ci-store/tests/store_contracts.rs
+++ b/crates/automata-ci-store/tests/store_contracts.rs
@@ -53,8 +53,6 @@ mod provider_delivery_api;
 mod provider_delivery_receipt;
 #[path = "reusable_workflow_admission_api.rs"]
 mod reusable_workflow_admission_api;
-#[path = "runner_capability_admission_api.rs"]
-mod runner_capability_admission_api;
 #[path = "runner_payload_tombstone_api.rs"]
 mod runner_payload_tombstone_api;
 #[path = "runtime_authority_api.rs"]

--- a/crates/automata-ci/src/app/runner_enrollment_api.rs
+++ b/crates/automata-ci/src/app/runner_enrollment_api.rs
@@ -10,6 +10,7 @@ use automata_ci_auth::{
     session::SessionKind,
     time::Clock,
 };
+use automata_ci_control::runner_control::capability_admission::RunnerCapabilityReadiness;
 use automata_ci_core::{RunnerCapabilities, RunnerFeature, RunnerGroup};
 use automata_ci_postgres::auth::management::{
     ConsumeRunnerEnrollment, CreateRunnerEnrollmentToken, MAX_RUNNER_CERTIFICATE_LIFETIME_SECONDS,
@@ -17,7 +18,6 @@ use automata_ci_postgres::auth::management::{
     PrepareRunnerEnrollment, PreparedRunnerEnrollment, RunnerEnrollmentConsumeOutcome,
     RunnerEnrollmentPrepareOutcome,
 };
-use automata_ci_store::RunnerCapabilityReadiness;
 use axum::{
     Router,
     body::Bytes,

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -18,6 +18,7 @@ use automata_ci_blob_s3::{
 };
 use automata_ci_control::lease::{
     LeaseClock, LeaseIdGenerator, LeasePollConfig, RandomLeaseIdGenerator, SystemLeaseClock,
+    repository::RunnerLeaseRequestRepository,
 };
 use automata_ci_control::runner_control::{
     ControlIdGenerator, DurableRunnerControlHandler, ImmutableBlobJobIrReader, JobIrObjectReader,
@@ -25,6 +26,12 @@ use automata_ci_control::runner_control::{
     RandomControlIdGenerator, RunnerControlConfig, RunnerControlPorts, RunnerDurabilityPorts,
     RunnerIdentityPorts, RunnerLeasePorts, RunnerRegistrationAuthorizer,
     RunnerSessionFenceResolver, StoreLeaseOfferCommandPublisher, StoreRunnerSessionFenceResolver,
+    capability_admission::{RunnerCapabilityAdmissionRepository as _, RunnerCapabilityReadiness},
+    durable::{
+        CurrentRunnerSessionRepository, RunnerControlTransactionRepository,
+        RunnerLeaseOfferRepository,
+    },
+    repository::{RunnerCommandOutbox, RunnerOperationReceiptRepository, RunnerSessionRepository},
 };
 use automata_ci_control::scheduling::{DeterministicScheduler, SchedulerPolicy};
 use automata_ci_core::RunId;
@@ -59,18 +66,15 @@ use automata_ci_runner_transport::{
 use automata_ci_secret::{SecretProvider, SecretProviderRegistry};
 use automata_ci_store::{
     BuiltinSecretCleanupRepository, ConformanceReadRepository, ControlPlaneMaintenanceRepository,
-    ControlPlaneStateRepository, CurrentRunnerSessionRepository, HumanWorkflowReadRepository,
-    LogicalActivationPreparationStore, LogicalActivationRepository, LogicalActivationWorkerId,
-    LogicalInstanceResultRepository, LogicalInstanceResultWorkerId, LogicalJobResultRepository,
-    LogicalJobResultWorkerId, LogicalMaterializationRepository, LogicalMaterializationWorkerId,
+    ControlPlaneStateRepository, HumanWorkflowReadRepository, LogicalActivationPreparationStore,
+    LogicalActivationRepository, LogicalActivationWorkerId, LogicalInstanceResultRepository,
+    LogicalInstanceResultWorkerId, LogicalJobResultRepository, LogicalJobResultWorkerId,
+    LogicalMaterializationRepository, LogicalMaterializationWorkerId,
     LogicalRunFinalizationRepository, LogicalRunFinalizationWorkerId,
     LogicalWorkSelectionRepository, LogicalWorkflowAdmissionRepository,
     ManagedSecretAuthorityRepository, ProtectedEnvironmentRepository,
     RepositoryPublicationRepository, RepositorySecretManagementReadRepository,
-    RepositorySecretManagementRepository, ReusableWorkflowRuntimeRepository,
-    RunnerCapabilityAdmissionRepository as _, RunnerCapabilityReadiness, RunnerCommandOutbox,
-    RunnerControlTransactionRepository, RunnerLeaseOfferRepository, RunnerLeaseRequestRepository,
-    RunnerOperationReceiptRepository, RunnerSessionRepository, SecretCleanupWorkerId,
+    RepositorySecretManagementRepository, ReusableWorkflowRuntimeRepository, SecretCleanupWorkerId,
     SecretCustodyKeySet, SecretCustodyRepository, SecretMutationRecoveryRepository, TenantScope,
     WorkflowRerunRepository,
 };


### PR DESCRIPTION
## Summary

- move runner-control durability models, routing contracts, capability admission, and all 11 Control-owned repository ports out of automata-ci-store
- expose them through explicit automata-ci-control lease and runner_control namespaces, then migrate every production and test consumer
- keep generic durable values in Store and preserve the automata_ci_store::LeaseOfferCommandIdentity path, avoiding a Store-to-Control dependency cycle
- remove 33 misplaced Store-root exports and 1,520 Rust LOC from the Store crate ownership surface
- repair the existing Store test identity operation that blocked strict Clippy

This is an intentional pre-release Rust API path change. It does not alter SQL, migrations, wire formats, durable schemas, or runtime behavior. No internal Cargo dependency edge is added; Control only gains the direct uuid declaration required by its relocated RunnerGroupId.

Reviewed size: 642 additions + 452 deletions (1,094 lines; history-preserving renames).

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo metadata --locked --no-deps --format-version 1
- cargo test -p automata-ci-control --test control --all-features --locked (96 passed)
- cargo test -p automata-ci-store --test store_contracts --all-features --locked (182 passed)
- cargo clippy -p automata-ci-store -p automata-ci-control --all-targets --all-features --locked -- -D warnings
- strict Rustdoc for Store and Control
- Rust coverage policy tests
- publish-crates tests (17 passed)

Local cargo check for automata-ci-postgres repeatedly reaches Checking automata-ci-postgres and is then killed by the host with exit 137 and no Rust diagnostic. CI remains the required proof for that monolithic crate.