### PR TITLE
fix(runner): protect runner-owned environment defaults

### DIFF
--- a/crates/automata-ci-github-runtime/src/environment.rs
+++ b/crates/automata-ci-github-runtime/src/environment.rs
@@ -1,0 +1,117 @@
+use crate::model::CommandFilePlatform;
+
+const GITHUB_DEFAULT_ENVIRONMENT_NAMES: &[&str] = &[
+    "GITHUB_ACTION",
+    "GITHUB_ACTION_PATH",
+    "GITHUB_ACTION_REF",
+    "GITHUB_ACTION_REPOSITORY",
+    "GITHUB_ACTIONS",
+    "GITHUB_ACTOR",
+    "GITHUB_ACTOR_ID",
+    "GITHUB_API_URL",
+    "GITHUB_ARTIFACTS",
+    "GITHUB_ARTIFACTS_LIST",
+    "GITHUB_BASE_REF",
+    "GITHUB_ENV",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_EVENT_PATH",
+    "GITHUB_GRAPHQL_URL",
+    "GITHUB_HEAD_REF",
+    "GITHUB_JOB",
+    "GITHUB_OUTPUT",
+    "GITHUB_PATH",
+    "GITHUB_REF",
+    "GITHUB_REF_NAME",
+    "GITHUB_REF_PROTECTED",
+    "GITHUB_REF_TYPE",
+    "GITHUB_REPOSITORY",
+    "GITHUB_REPOSITORY_ID",
+    "GITHUB_REPOSITORY_OWNER",
+    "GITHUB_REPOSITORY_OWNER_ID",
+    "GITHUB_RETENTION_DAYS",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_NUMBER",
+    "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_STATE",
+    "GITHUB_STEP_SUMMARY",
+    "GITHUB_TRIGGERING_ACTOR",
+    "GITHUB_WORKFLOW",
+    "GITHUB_WORKFLOW_REF",
+    "GITHUB_WORKFLOW_SHA",
+    "GITHUB_WORKSPACE",
+];
+
+const RUNNER_DEFAULT_ENVIRONMENT_NAMES: &[&str] = &[
+    "RUNNER_ARCH",
+    "RUNNER_DEBUG",
+    "RUNNER_ENVIRONMENT",
+    "RUNNER_NAME",
+    "RUNNER_OS",
+    "RUNNER_TEMP",
+    "RUNNER_TOOL_CACHE",
+];
+
+/// Namespace containing runner-owned default environment variables.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReservedEnvironmentNamespace {
+    /// Protected defaults whose canonical names begin with `GITHUB_`.
+    Github,
+    /// Protected defaults whose canonical names begin with `RUNNER_`.
+    Runner,
+}
+
+/// Reason an attempted step environment mutation must be ignored.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EnvironmentMutationBlockReason {
+    /// The name is a runner-owned default in the identified namespace.
+    Reserved(ReservedEnvironmentNamespace),
+    /// The name is `NODE_OPTIONS`, which GitHub blocks specifically for
+    /// `GITHUB_ENV` and legacy `set-env` mutations.
+    NodeOptions,
+}
+
+/// Classifies an environment mutation using the target platform's name
+/// comparison semantics.
+///
+/// The finite catalog of runner-owned `GITHUB_*` and `RUNNER_*` defaults is
+/// matched exactly on Unix and with ASCII case folding on Windows. Other names
+/// in those namespaces, including `GITHUB_TOKEN` and `RUNNER_DIGEST`, remain
+/// available to workflows. `NODE_OPTIONS` is matched case-insensitively on
+/// every platform, preserving upstream runner behavior. `CI` is intentionally
+/// mutable and therefore returns `None`.
+#[must_use]
+pub fn classify_environment_mutation(
+    platform: CommandFilePlatform,
+    name: &str,
+) -> Option<EnvironmentMutationBlockReason> {
+    if name.eq_ignore_ascii_case("NODE_OPTIONS") {
+        return Some(EnvironmentMutationBlockReason::NodeOptions);
+    }
+
+    if catalog_contains(platform, name, GITHUB_DEFAULT_ENVIRONMENT_NAMES) {
+        return Some(EnvironmentMutationBlockReason::Reserved(
+            ReservedEnvironmentNamespace::Github,
+        ));
+    }
+    if catalog_contains(platform, name, RUNNER_DEFAULT_ENVIRONMENT_NAMES) {
+        return Some(EnvironmentMutationBlockReason::Reserved(
+            ReservedEnvironmentNamespace::Runner,
+        ));
+    }
+    None
+}
+
+fn catalog_contains(platform: CommandFilePlatform, name: &str, catalog: &[&str]) -> bool {
+    catalog
+        .iter()
+        .any(|candidate| names_equal(platform, name, candidate))
+}
+
+fn names_equal(platform: CommandFilePlatform, left: &str, right: &str) -> bool {
+    match platform {
+        CommandFilePlatform::Unix => left == right,
+        CommandFilePlatform::Windows => left.eq_ignore_ascii_case(right),
+    }
+}

--- a/crates/automata-ci-github-runtime/src/lib.rs
+++ b/crates/automata-ci-github-runtime/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(missing_docs)]
 
 mod artifact;
+mod environment;
 mod error;
 mod file_command;
 mod limits;
@@ -16,6 +17,9 @@ mod model;
 mod phase;
 mod workflow_command;
 
+pub use environment::{
+    EnvironmentMutationBlockReason, ReservedEnvironmentNamespace, classify_environment_mutation,
+};
 pub use error::{
     ArtifactListEncodingError, ArtifactSubjectError, CommandFileError, CommandScopeIdError,
     PhaseApplicationError, WorkflowCommandError,

--- a/crates/automata-ci-github-runtime/src/model.rs
+++ b/crates/automata-ci-github-runtime/src/model.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use serde::Serialize;
 
+use crate::environment::ReservedEnvironmentNamespace;
 use crate::{ArtifactListEncodingError, ArtifactSubjectError, CommandScopeIdError};
 
 const MAX_SCOPE_ID_BYTES: usize = 512;
@@ -802,6 +803,8 @@ impl fmt::Debug for JobCommandState {
 pub enum PhaseApplicationNotice {
     /// A `NODE_OPTIONS` environment mutation was intentionally ignored.
     BlockedNodeOptions,
+    /// A mutation of a runner-owned default environment variable was ignored.
+    BlockedReservedEnvironment(ReservedEnvironmentNamespace),
     /// `GITHUB_STATE` content was ignored because a plain run step has no post phase.
     StateIgnoredForRunStep,
 }

--- a/crates/automata-ci-github-runtime/src/phase.rs
+++ b/crates/automata-ci-github-runtime/src/phase.rs
@@ -2,9 +2,10 @@ use std::fmt::Debug;
 
 use crate::model::{ActionState, SensitiveText, StepOutputState, artifact_list_byte_rejection};
 use crate::{
-    CommandFilePlatform, CompletedStepCommands, JobCommandState, MAX_ARTIFACT_LIST_BYTES,
-    MAX_ARTIFACT_SUBJECTS, NameValueCommand, PhaseApplication, PhaseApplicationError,
-    PhaseApplicationLimits, PhaseApplicationNotice, StepPhase, StepScope,
+    CommandFilePlatform, CompletedStepCommands, EnvironmentMutationBlockReason, JobCommandState,
+    MAX_ARTIFACT_LIST_BYTES, MAX_ARTIFACT_SUBJECTS, NameValueCommand, PhaseApplication,
+    PhaseApplicationError, PhaseApplicationLimits, PhaseApplicationNotice, StepPhase, StepScope,
+    classify_environment_mutation,
 };
 
 /// Object-safe pure port for committing command effects after step completion.
@@ -63,9 +64,18 @@ impl CompletedStepApplicator for GithubCompletedStepApplicator {
 
         let platform = next.platform;
         for command in commands.environment().commands() {
-            if command.name().eq_ignore_ascii_case("NODE_OPTIONS") {
-                notices.push(PhaseApplicationNotice::BlockedNodeOptions);
-                continue;
+            match classify_environment_mutation(platform, command.name()) {
+                Some(EnvironmentMutationBlockReason::NodeOptions) => {
+                    notices.push(PhaseApplicationNotice::BlockedNodeOptions);
+                    continue;
+                }
+                Some(EnvironmentMutationBlockReason::Reserved(namespace)) => {
+                    notices.push(PhaseApplicationNotice::BlockedReservedEnvironment(
+                        namespace,
+                    ));
+                    continue;
+                }
+                None => {}
             }
             replace_name_value(&mut next.environment, command.clone(), |left, right| {
                 environment_names_equal(platform, left, right)

--- a/crates/automata-ci-github-runtime/src/workflow_command.rs
+++ b/crates/automata-ci-github-runtime/src/workflow_command.rs
@@ -264,6 +264,9 @@ impl GithubWorkflowCommandSession {
             if command.name().eq_ignore_ascii_case("NODE_OPTIONS") {
                 WorkflowCommandEvent::Notice(CommandNotice::BlockedNodeOptions)
             } else {
+                // Runner-owned default matching depends on the target
+                // platform. Preserve the mutation until the completed-step
+                // applicator can enforce Unix or Windows name semantics.
                 WorkflowCommandEvent::LegacyMutation(LegacyStepMutation::Environment(command))
             }
         } else if raw.name.eq_ignore_ascii_case("add-path") {

--- a/crates/automata-ci-github-runtime/tests/phase_application.rs
+++ b/crates/automata-ci-github-runtime/tests/phase_application.rs
@@ -1,9 +1,65 @@
 use automata_ci_github_runtime::{
     ActionInvocationId, CommandFileDecoder, CommandFileKind, CommandFilePlatform,
-    CompletedStepApplicator, CompletedStepCommands, GithubCommandFileDecoder,
-    GithubCompletedStepApplicator, JobCommandState, ParsedCommandFile, PhaseApplicationNotice,
-    StepId, StepPhase, StepScope,
+    CompletedStepApplicator, CompletedStepCommands, EnvironmentMutationBlockReason,
+    GithubCommandFileDecoder, GithubCompletedStepApplicator, GithubWorkflowCommandSession,
+    JobCommandState, LegacyStepMutation, ParsedCommandFile, PhaseApplicationNotice,
+    ReservedEnvironmentNamespace, StepId, StepPhase, StepScope, WorkflowCommandEvent,
+    WorkflowCommandLimits, WorkflowCommandPolicy, WorkflowCommandProcessor, WorkflowLine,
+    classify_environment_mutation,
 };
+
+const GITHUB_PROTECTED_ENVIRONMENT_NAMES: &[&str] = &[
+    "GITHUB_ACTION",
+    "GITHUB_ACTION_PATH",
+    "GITHUB_ACTION_REF",
+    "GITHUB_ACTION_REPOSITORY",
+    "GITHUB_ACTIONS",
+    "GITHUB_ACTOR",
+    "GITHUB_ACTOR_ID",
+    "GITHUB_API_URL",
+    "GITHUB_ARTIFACTS",
+    "GITHUB_ARTIFACTS_LIST",
+    "GITHUB_BASE_REF",
+    "GITHUB_ENV",
+    "GITHUB_EVENT_NAME",
+    "GITHUB_EVENT_PATH",
+    "GITHUB_GRAPHQL_URL",
+    "GITHUB_HEAD_REF",
+    "GITHUB_JOB",
+    "GITHUB_OUTPUT",
+    "GITHUB_PATH",
+    "GITHUB_REF",
+    "GITHUB_REF_NAME",
+    "GITHUB_REF_PROTECTED",
+    "GITHUB_REF_TYPE",
+    "GITHUB_REPOSITORY",
+    "GITHUB_REPOSITORY_ID",
+    "GITHUB_REPOSITORY_OWNER",
+    "GITHUB_REPOSITORY_OWNER_ID",
+    "GITHUB_RETENTION_DAYS",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_NUMBER",
+    "GITHUB_SERVER_URL",
+    "GITHUB_SHA",
+    "GITHUB_STATE",
+    "GITHUB_STEP_SUMMARY",
+    "GITHUB_TRIGGERING_ACTOR",
+    "GITHUB_WORKFLOW",
+    "GITHUB_WORKFLOW_REF",
+    "GITHUB_WORKFLOW_SHA",
+    "GITHUB_WORKSPACE",
+];
+
+const RUNNER_PROTECTED_ENVIRONMENT_NAMES: &[&str] = &[
+    "RUNNER_ARCH",
+    "RUNNER_DEBUG",
+    "RUNNER_ENVIRONMENT",
+    "RUNNER_NAME",
+    "RUNNER_OS",
+    "RUNNER_TEMP",
+    "RUNNER_TOOL_CACHE",
+];
 
 fn commands(
     environment: &[u8],
@@ -272,4 +328,331 @@ fn environment_key_semantics_follow_target_platform() {
     // a later assignment replaces its value.
     assert_eq!(windows.environment()[0].name(), "Name");
     assert_eq!(windows.environment()[0].value(), "two");
+}
+
+#[test]
+fn protected_environment_classifier_covers_case_and_namespace_boundaries() {
+    for (catalog, namespace) in [
+        (
+            GITHUB_PROTECTED_ENVIRONMENT_NAMES,
+            ReservedEnvironmentNamespace::Github,
+        ),
+        (
+            RUNNER_PROTECTED_ENVIRONMENT_NAMES,
+            ReservedEnvironmentNamespace::Runner,
+        ),
+    ] {
+        for canonical in catalog {
+            assert_eq!(
+                classify_environment_mutation(CommandFilePlatform::Unix, canonical),
+                Some(EnvironmentMutationBlockReason::Reserved(namespace)),
+                "Unix must protect exact canonical name {canonical}"
+            );
+            for variant in [
+                canonical.to_ascii_lowercase(),
+                alternating_ascii_case(canonical),
+            ] {
+                assert_eq!(
+                    classify_environment_mutation(CommandFilePlatform::Windows, &variant),
+                    Some(EnvironmentMutationBlockReason::Reserved(namespace)),
+                    "Windows must protect case variant {variant}"
+                );
+                assert_eq!(
+                    classify_environment_mutation(CommandFilePlatform::Unix, &variant),
+                    None,
+                    "Unix must preserve distinct case variant {variant}"
+                );
+            }
+            assert_eq!(
+                classify_environment_mutation(CommandFilePlatform::Windows, canonical),
+                Some(EnvironmentMutationBlockReason::Reserved(namespace)),
+                "Windows must protect exact canonical name {canonical}"
+            );
+        }
+    }
+
+    for variant in ascii_case_variants("NODE_OPTIONS") {
+        for platform in [CommandFilePlatform::Unix, CommandFilePlatform::Windows] {
+            assert_eq!(
+                classify_environment_mutation(platform, &variant),
+                Some(EnvironmentMutationBlockReason::NodeOptions),
+                "NODE_OPTIONS protection must ignore ASCII case for {variant}"
+            );
+        }
+    }
+
+    for allowed in [
+        "CI",
+        "ci",
+        "Ci",
+        "cI",
+        "GITHUB",
+        "GITHUBX",
+        "GITHUB_TOKEN",
+        "GITHUB_CUSTOM",
+        "RUNNER",
+        "RUNNERX",
+        "RUNNER_DIGEST",
+        "RUNNER_CUSTOM",
+    ] {
+        for platform in [CommandFilePlatform::Unix, CommandFilePlatform::Windows] {
+            assert_eq!(
+                classify_environment_mutation(platform, allowed),
+                None,
+                "{allowed} is outside the protected default-variable catalog"
+            );
+        }
+    }
+}
+
+#[test]
+fn github_env_ignores_reserved_names_and_preserves_the_ci_exception() {
+    let files = commands(
+        b"GITHUB_ENV=attacker\nRUNNER_TEMP=attacker\nCI=custom\nGITHUB_TOKEN=token\nGITHUB_CUSTOM=github\nRUNNER_DIGEST=digest\nRUNNER_CUSTOM=runner\n",
+        b"",
+        b"",
+        b"",
+        b"",
+    );
+    let applied = GithubCompletedStepApplicator::default()
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Unix),
+            &StepScope::new(
+                StepId::new("environment").expect("valid step ID"),
+                StepPhase::Run,
+            ),
+            &files,
+        )
+        .expect("bounded state");
+
+    assert_eq!(
+        value(applied.next_state().environment(), "GITHUB_ENV"),
+        None
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "RUNNER_TEMP"),
+        None
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "CI"),
+        Some("custom")
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "GITHUB_TOKEN"),
+        Some("token")
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "GITHUB_CUSTOM"),
+        Some("github")
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "RUNNER_DIGEST"),
+        Some("digest")
+    );
+    assert_eq!(
+        value(applied.next_state().environment(), "RUNNER_CUSTOM"),
+        Some("runner")
+    );
+    assert_eq!(
+        applied.notices(),
+        [
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Github,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Runner,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn github_env_default_name_case_follows_the_target_platform() {
+    let files = commands(
+        b"gItHuB_eNv=attacker\nrUnNeR_tEmP=attacker\nnode_options=attacker\nci=custom\n",
+        b"",
+        b"",
+        b"",
+        b"",
+    );
+    let scope = StepScope::new(
+        StepId::new("environment").expect("valid step ID"),
+        StepPhase::Run,
+    );
+    let applicator = GithubCompletedStepApplicator::default();
+
+    let unix = applicator
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Unix),
+            &scope,
+            &files,
+        )
+        .expect("bounded Unix state");
+    assert_eq!(
+        value(unix.next_state().environment(), "gItHuB_eNv"),
+        Some("attacker")
+    );
+    assert_eq!(
+        value(unix.next_state().environment(), "rUnNeR_tEmP"),
+        Some("attacker")
+    );
+    assert_eq!(value(unix.next_state().environment(), "node_options"), None);
+    assert_eq!(value(unix.next_state().environment(), "ci"), Some("custom"));
+    assert_eq!(unix.notices(), [PhaseApplicationNotice::BlockedNodeOptions]);
+
+    let windows = applicator
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Windows),
+            &scope,
+            &files,
+        )
+        .expect("bounded Windows state");
+    assert_eq!(windows.next_state().environment().len(), 1);
+    assert_eq!(
+        value(windows.next_state().environment(), "ci"),
+        Some("custom")
+    );
+    assert_eq!(
+        windows.notices(),
+        [
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Github,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Runner,
+            ),
+            PhaseApplicationNotice::BlockedNodeOptions,
+        ]
+    );
+}
+
+#[test]
+fn legacy_set_env_default_names_are_applied_with_target_platform_semantics() {
+    let mutations = [
+        legacy_environment_mutation("GITHUB_ENV", "attacker"),
+        legacy_environment_mutation("RUNNER_TEMP", "attacker"),
+        legacy_environment_mutation("github_path", "unix-value"),
+        legacy_environment_mutation("runner_arch", "unix-value"),
+        legacy_environment_mutation("CI", "custom"),
+    ];
+    let files = commands(b"", b"", b"", b"", b"").with_legacy_mutations(&mutations);
+    let scope = StepScope::new(
+        StepId::new("legacy-environment").expect("valid step ID"),
+        StepPhase::Run,
+    );
+    let applicator = GithubCompletedStepApplicator::default();
+
+    let unix = applicator
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Unix),
+            &scope,
+            &files,
+        )
+        .expect("bounded Unix state");
+    assert_eq!(
+        value(unix.next_state().environment(), "github_path"),
+        Some("unix-value")
+    );
+    assert_eq!(
+        value(unix.next_state().environment(), "runner_arch"),
+        Some("unix-value")
+    );
+    assert_eq!(value(unix.next_state().environment(), "CI"), Some("custom"));
+    assert_eq!(
+        unix.notices(),
+        [
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Github,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Runner,
+            ),
+        ]
+    );
+
+    let windows = applicator
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Windows),
+            &scope,
+            &files,
+        )
+        .expect("bounded Windows state");
+    assert_eq!(windows.next_state().environment().len(), 1);
+    assert_eq!(
+        value(windows.next_state().environment(), "CI"),
+        Some("custom")
+    );
+    assert_eq!(
+        windows.notices(),
+        [
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Github,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Runner,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Github,
+            ),
+            PhaseApplicationNotice::BlockedReservedEnvironment(
+                ReservedEnvironmentNamespace::Runner,
+            ),
+        ]
+    );
+}
+
+fn legacy_environment_mutation(name: &str, value: &str) -> LegacyStepMutation {
+    let mut session = GithubWorkflowCommandSession::new(
+        WorkflowCommandLimits::default(),
+        WorkflowCommandPolicy::new(true, true),
+    );
+    let line = format!("::set-env name={name}::{value}");
+    let event = session
+        .process_line(line.as_bytes())
+        .expect("valid legacy environment command");
+    let WorkflowLine::Command(WorkflowCommandEvent::LegacyMutation(mutation)) = event else {
+        panic!("expected a deferred legacy mutation for {name}");
+    };
+    mutation
+}
+
+fn ascii_case_variants(value: &str) -> Vec<String> {
+    value
+        .chars()
+        .fold(vec![String::new()], |variants, character| {
+            if character.is_ascii_alphabetic() {
+                variants
+                    .into_iter()
+                    .flat_map(|variant| {
+                        let mut lowercase = variant.clone();
+                        lowercase.push(character.to_ascii_lowercase());
+                        let mut uppercase = variant;
+                        uppercase.push(character.to_ascii_uppercase());
+                        [lowercase, uppercase]
+                    })
+                    .collect()
+            } else {
+                variants
+                    .into_iter()
+                    .map(|mut variant| {
+                        variant.push(character);
+                        variant
+                    })
+                    .collect()
+            }
+        })
+}
+
+fn alternating_ascii_case(value: &str) -> String {
+    value
+        .chars()
+        .enumerate()
+        .map(|(index, character)| {
+            if index.is_multiple_of(2) {
+                character.to_ascii_lowercase()
+            } else {
+                character.to_ascii_uppercase()
+            }
+        })
+        .collect()
 }

--- a/crates/automata-ci-github-runtime/tests/workflow_commands.rs
+++ b/crates/automata-ci-github-runtime/tests/workflow_commands.rs
@@ -242,6 +242,38 @@ fn insecure_legacy_env_and_path_commands_require_explicit_policy() {
 }
 
 #[test]
+fn legacy_set_env_defers_reserved_names_to_target_aware_application() {
+    let mut enabled = GithubWorkflowCommandSession::new(
+        WorkflowCommandLimits::default(),
+        WorkflowCommandPolicy::new(true, true),
+    );
+
+    for name in [
+        "GITHUB_ENV",
+        "github_path",
+        "gItHuB_workspace",
+        "RUNNER_OS",
+        "runner_temp",
+        "rUnNeR_arch",
+        "CI",
+        "ci",
+    ] {
+        let line = format!("::set-env name={name}::attacker");
+        let event = enabled
+            .process_line(line.as_bytes())
+            .expect("target-dependent name is preserved");
+        let WorkflowLine::Command(WorkflowCommandEvent::LegacyMutation(
+            LegacyStepMutation::Environment(command),
+        )) = event
+        else {
+            panic!("expected deferred environment mutation for {name}");
+        };
+        assert_eq!(command.name(), name);
+        assert_eq!(command.value(), "attacker");
+    }
+}
+
+#[test]
 fn v2_only_trims_leading_space_while_legacy_can_have_a_prefix() {
     let mut session = GithubWorkflowCommandSession::default();
     assert!(matches!(

--- a/crates/automata-ci-job-executor-github/src/environment.rs
+++ b/crates/automata-ci-job-executor-github/src/environment.rs
@@ -9,7 +9,10 @@ use automata_ci_expression_github::{
     GithubEvaluationContext, GithubExpressionEvaluator, GithubExpressionFunctionProvider,
     GithubObject, GithubStatus, GithubValue,
 };
-use automata_ci_github_runtime::{CommandFilePlatform, JobCommandState};
+use automata_ci_github_runtime::{
+    CommandFilePlatform, EnvironmentMutationBlockReason, JobCommandState,
+    classify_environment_mutation,
+};
 
 use crate::{
     ExecutorAdapterError, GithubContextSnapshot, PreparedActionDefinition, PreparedValue,
@@ -167,6 +170,15 @@ impl<'a> EnvironmentBuilder<'a> {
         masker: &mut SecretMasker,
     ) -> Result<ResolvedPhaseValues, ExecutorAdapterError> {
         let platform = commands.platform();
+        validate_environment_overlay_names(platform, job.keys().map(String::as_str))?;
+        validate_environment_overlay_names(
+            platform,
+            commands
+                .environment()
+                .iter()
+                .map(automata_ci_github_runtime::NameValueCommand::name),
+        )?;
+        validate_environment_overlay_names(platform, step.keys().map(String::as_str))?;
         let mut values = BTreeMap::new();
         for variable in self.defaults.values() {
             if variable.is_secret() {
@@ -423,6 +435,28 @@ impl<'a> EnvironmentBuilder<'a> {
             .map(|value| value.coerce_to_string())
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))
     }
+}
+
+/// Rejects workflow-controlled names in the runner-owned default catalog.
+///
+/// `NODE_OPTIONS` remains valid in declarative environment maps. GitHub only
+/// blocks that name when it is written through `GITHUB_ENV` or legacy
+/// `set-env`, which is enforced by the runtime command applicator.
+pub(crate) fn validate_environment_overlay_names<'name>(
+    platform: CommandFilePlatform,
+    names: impl IntoIterator<Item = &'name str>,
+) -> Result<(), ExecutorAdapterError> {
+    if names.into_iter().any(|name| {
+        matches!(
+            classify_environment_mutation(platform, name),
+            Some(EnvironmentMutationBlockReason::Reserved(_))
+        )
+    }) {
+        return Err(ExecutorAdapterError::new(
+            ExecutorAdapterErrorKind::InvalidJob,
+        ));
+    }
+    Ok(())
 }
 
 struct EnvironmentEvaluationContext<'a> {

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -60,7 +60,10 @@ use crate::{
     PreparedBoolean, PreparedCompositeAction, PreparedCompositeStep, PreparedKeyValue,
     PreparedLocalAction, PreparedValue, SandboxEnvironmentCatalog, SecretCustodyAcknowledger,
     SecretPort, action_content, container_runtime,
-    environment::{EnvironmentBuilder, ResolvedActionInputs, ResolvedEnvironmentValue},
+    environment::{
+        EnvironmentBuilder, ResolvedActionInputs, ResolvedEnvironmentValue,
+        validate_environment_overlay_names,
+    },
     error::{ExecutorAdapterError, ExecutorAdapterErrorKind, PortErrorKind},
     output::{SecretMasker, emit_system, parse_output_with_cancellation, process_output},
     shell::{composite_shell, resolve_shell_template, shell_argv},
@@ -417,6 +420,16 @@ impl GithubJobExecutor {
         }
         let workspace =
             job_workspace(job, &environment).map_err(|_| AdmissionRejection::InvalidJob)?;
+        validate_environment_overlay_names(
+            command_file_platform(workspace.platform()),
+            job.job().environment().keys().map(String::as_str).chain(
+                job.job()
+                    .steps()
+                    .iter()
+                    .flat_map(|step| step.environment().keys().map(String::as_str)),
+            ),
+        )
+        .map_err(|_| AdmissionRejection::InvalidJob)?;
         let event = job.execution().event();
         if event.media_type() != WORKFLOW_EVENT_MEDIA_TYPE
             || event.encoded_size() > automata_ci_execution::MAX_COPY_BYTES as u64
@@ -2916,6 +2929,10 @@ impl GithubJobExecutor {
         state: Vec<(String, ResolvedEnvironmentValue)>,
         masker: &mut SecretMasker,
     ) -> Result<automata_ci_execution::ExecutionEnvironment, ExecutorAdapterError> {
+        validate_environment_overlay_names(
+            commands.platform(),
+            action_environment.iter().map(|(name, _)| name.as_str()),
+        )?;
         let mut extra = action_environment.to_vec();
         extra.extend(action_extra_environment(
             input_environment,
@@ -3031,17 +3048,19 @@ impl GithubJobExecutor {
             )?;
             let child_environment = cancellation_dominant(
                 match child {
-                    PreparedCompositeStep::Run(step) => Self::resolve_composite_values(
+                    PreparedCompositeStep::Run(step) => Self::resolve_composite_environment(
                         &builder,
                         step.environment(),
                         &environment_context,
                         budget,
+                        commands.platform(),
                     ),
-                    PreparedCompositeStep::Uses(step) => Self::resolve_composite_values(
+                    PreparedCompositeStep::Uses(step) => Self::resolve_composite_environment(
                         &builder,
                         step.environment(),
                         &environment_context,
                         budget,
+                        commands.platform(),
                     ),
                 },
                 cancellation,
@@ -3331,6 +3350,17 @@ impl GithubJobExecutor {
                 Ok((value.name().to_owned(), resolved))
             })
             .collect()
+    }
+
+    fn resolve_composite_environment(
+        builder: &EnvironmentBuilder<'_>,
+        values: &[PreparedKeyValue],
+        context: &dyn GithubEvaluationContext,
+        budget: &mut ActionExecutionBudget,
+        platform: CommandFilePlatform,
+    ) -> Result<Vec<(String, ResolvedEnvironmentValue)>, ExecutorAdapterError> {
+        validate_environment_overlay_names(platform, values.iter().map(PreparedKeyValue::name))?;
+        Self::resolve_composite_values(builder, values, context, budget)
     }
 
     fn resolve_composite_value_map(
@@ -5233,6 +5263,14 @@ impl ExecutionAttachments {
                 PhaseApplicationNotice::BlockedNodeOptions => {
                     "NODE_OPTIONS from a command file was ignored"
                 }
+                PhaseApplicationNotice::BlockedReservedEnvironment(namespace) => match namespace {
+                    automata_ci_github_runtime::ReservedEnvironmentNamespace::Github => {
+                        "a runner-owned GITHUB default from a command file was ignored"
+                    }
+                    automata_ci_github_runtime::ReservedEnvironmentNamespace::Runner => {
+                        "a runner-owned RUNNER default from a command file was ignored"
+                    }
+                },
                 PhaseApplicationNotice::StateIgnoredForRunStep => {
                     "GITHUB_STATE from a run step was ignored"
                 }

--- a/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
+++ b/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
@@ -13,7 +13,9 @@ use automata_ci_core::{
 use automata_ci_job_executor_github::{
     CheckedOutLocalActionPreparer, LocalActionPreparationRequest, PreparedAction,
 };
-use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionEvents, JobExecutor};
+use automata_ci_runner_runtime::{
+    ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
+};
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 use bytes::Bytes;
 use sha2::{Digest as _, Sha256};
@@ -121,6 +123,18 @@ runs:
       shell: bash
 ";
 
+const RESERVED_ENVIRONMENT_COMPOSITE: &str = r"
+name: Reserved environment
+runs:
+  using: composite
+  steps:
+    - id: malicious
+      run: true
+      shell: bash
+      env:
+        GITHUB_ENV: /tmp/shadow
+";
+
 #[tokio::test]
 async fn repository_composite_runs_children_and_publishes_outputs() {
     let mut failed = PhaseResponse::success().with_file(
@@ -194,6 +208,37 @@ async fn repository_composite_runs_children_and_publishes_outputs() {
         );
     }
     assert!(environment["GITHUB_ACTION_PATH"].ends_with("/actions/action-0/root"));
+}
+
+#[tokio::test]
+async fn composite_action_environment_cannot_shadow_runner_names() {
+    let fixture = Fixture::new(
+        vec![prepared_metadata(RESERVED_ENVIRONMENT_COMPOSITE)],
+        Vec::new(),
+    );
+    let action = repository_step("composite", "owner/composite", BTreeMap::new());
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(
+            fixture.request(envelope(vec![action])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect_err("reserved composite environment must fail before its process starts");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::InvalidJob);
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    assert!(state.scripts.is_empty());
+    assert!(state.commands.iter().all(|command| {
+        command
+            .environment()
+            .values()
+            .iter()
+            .all(|variable| variable.name().as_str() != "GITHUB_ENV")
+    }));
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/contracts.rs
+++ b/crates/automata-ci-job-executor-github/tests/contracts.rs
@@ -4,7 +4,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use automata_ci_core::{
     ActionReference, AttemptId, ExpressionDialect, ExpressionInstruction, ExpressionProgram,
-    JobIrEnvelope, RuntimeBoolean, SemanticStep, Sha256Digest, StepId, StepIr, ValueTemplate,
+    JobIrEnvelope, RuntimeBoolean, SemanticStep, Sha256Digest, StepId, StepIr, ValueSource,
+    ValueTemplate,
 };
 use automata_ci_job_executor_github::{
     ActionPreparationPort, DeterministicOperationIds, ExecutionClock, ExecutionOperationIds,
@@ -13,11 +14,11 @@ use automata_ci_job_executor_github::{
     PreparedCompositeUsesStep, PreparedKeyValue, PreparedValue, RepositoryCredentialPort,
     SandboxEnvironmentCatalog, SecretPort,
 };
-use automata_ci_runner_runtime::JobExecutor;
+use automata_ci_runner_runtime::{AdmissionRejection, JobExecutor};
 use bytes::Bytes;
 use static_assertions::assert_obj_safe;
 
-use support::{Fixture, envelope, prepared_node24_action, run_step};
+use support::{Fixture, envelope, envelope_with_environment, prepared_node24_action, run_step};
 
 assert_obj_safe!(ActionPreparationPort);
 assert_obj_safe!(RepositoryCredentialPort);
@@ -229,6 +230,79 @@ fn safe_local_actions_admit_while_container_actions_fail_closed() {
         ),
     )]);
     assert!(fixture.executor.admit(&container).is_err());
+}
+
+#[test]
+fn reserved_planned_environment_names_fail_admission_before_provider_work() {
+    let fixture = Fixture::new(Vec::new(), Vec::new());
+    let reserved = [
+        "GITHUB_WORKSPACE",
+        "RUNNER_OS",
+        "GITHUB_ENV",
+        "GITHUB_OUTPUT",
+        "GITHUB_PATH",
+        "GITHUB_STATE",
+        "GITHUB_STEP_SUMMARY",
+        "GITHUB_ARTIFACTS",
+        "GITHUB_ARTIFACTS_LIST",
+    ];
+
+    // Workflow and job environment are flattened into the planned job map, so
+    // this admission boundary protects both declaration levels.
+    for name in reserved {
+        let job = envelope_with_environment(
+            vec![run_step("run", "Run", "true")],
+            BTreeMap::from([(name.to_owned(), ValueSource::Literal("shadow".to_owned()))]),
+        );
+        assert_eq!(
+            fixture.executor.admit(&job),
+            Err(AdmissionRejection::InvalidJob),
+            "planned {name} must not shadow runner state"
+        );
+    }
+
+    for name in ["GITHUB_WORKSPACE", "RUNNER_OS", "GITHUB_ENV"] {
+        let step = run_step("run", "Run", "true").with_environment(BTreeMap::from([(
+            name.to_owned(),
+            ValueSource::Literal("shadow".to_owned()),
+        )]));
+        assert_eq!(
+            fixture.executor.admit(&envelope(vec![step])),
+            Err(AdmissionRejection::InvalidJob),
+            "step {name} must not shadow runner state"
+        );
+    }
+
+    let allowed = envelope_with_environment(
+        vec![
+            run_step("run", "Run", "true").with_environment(BTreeMap::from([(
+                "CI".to_owned(),
+                ValueSource::Literal("step-ci".to_owned()),
+            )])),
+        ],
+        BTreeMap::from([
+            (
+                "NODE_OPTIONS".to_owned(),
+                ValueSource::Literal("--no-warnings".to_owned()),
+            ),
+            (
+                "GITHUB_TOKEN".to_owned(),
+                ValueSource::Literal("workflow-mapped-token".to_owned()),
+            ),
+            (
+                "RUNNER_DIGEST".to_owned(),
+                ValueSource::Literal("custom-release-value".to_owned()),
+            ),
+            (
+                "github_workspace".to_owned(),
+                ValueSource::Literal("case-distinct-on-posix".to_owned()),
+            ),
+        ]),
+    );
+    fixture.executor.admit(&allowed).expect(
+        "CI, custom prefixed names, declarative NODE_OPTIONS, and POSIX case variants remain valid",
+    );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
 }
 
 #[test]

--- a/crates/automata-ci-job-executor-github/tests/javascript_actions.rs
+++ b/crates/automata-ci-job-executor-github/tests/javascript_actions.rs
@@ -50,16 +50,10 @@ async fn sandbox_profile_defaults_are_the_lowest_execution_environment_layer() {
     let fixture =
         Fixture::with_default_environment(vec![prepared_node24_action()], responses, defaults);
     let setup = run_step("setup", "Setup", "true");
-    let action = action_step("checkout", "actions/example").with_environment(BTreeMap::from([
-        (
-            "STEP_WINS".to_owned(),
-            ValueSource::Literal("step".to_owned()),
-        ),
-        (
-            "GITHUB_ACTION_PATH".to_owned(),
-            ValueSource::Literal("step".to_owned()),
-        ),
-    ]));
+    let action = action_step("checkout", "actions/example").with_environment(BTreeMap::from([(
+        "STEP_WINS".to_owned(),
+        ValueSource::Literal("step".to_owned()),
+    )]));
     let job = envelope_with_environment(
         vec![setup, action],
         BTreeMap::from([
@@ -75,10 +69,6 @@ async fn sandbox_profile_defaults_are_the_lowest_execution_environment_layer() {
                 "STEP_WINS".to_owned(),
                 ValueSource::Literal("job".to_owned()),
             ),
-            (
-                "GITHUB_ACTION_PATH".to_owned(),
-                ValueSource::Literal("job".to_owned()),
-            ),
         ]),
     );
     let request = fixture.request(job);
@@ -91,6 +81,10 @@ async fn sandbox_profile_defaults_are_the_lowest_execution_environment_layer() {
         .expect("run and action steps execute");
 
     assert_eq!(result.conclusion(), JobConclusion::Success);
+    assert_eq!(
+        result.steps()[0].annotations()[0].message(),
+        "a runner-owned GITHUB default from a command file was ignored"
+    );
     let state = fixture.endpoint_state.lock().expect("endpoint lock");
     let run = state
         .commands

--- a/crates/automata-ci-job-executor-github/tests/windows_run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/windows_run_steps.rs
@@ -63,18 +63,7 @@ async fn windows_default_shell_maps_paths_and_applies_crlf_command_files() {
             .with_file(CommandFileKind::Output, b"digest=abc123\r\n".to_vec()),
         PhaseResponse::success(),
     ]);
-    let producer = run_step("producer", "Producer", "Write-Output 'producer'").with_environment(
-        BTreeMap::from([
-            (
-                "github_artifacts".to_owned(),
-                ValueSource::Literal("shadow-artifacts".to_owned()),
-            ),
-            (
-                "github_artifacts_list".to_owned(),
-                ValueSource::Literal("shadow-artifacts-list".to_owned()),
-            ),
-        ]),
-    );
+    let producer = run_step("producer", "Producer", "Write-Output 'producer'");
     let second = run_step_with_working_directory(
         "consumer",
         "Consumer",
@@ -139,9 +128,7 @@ async fn windows_default_shell_maps_paths_and_applies_crlf_command_files() {
             1,
             "artifact control variables must replace case-insensitive aliases"
         );
-        assert!(
-            !environment_value(commands[0], name).is_some_and(|value| value.starts_with("shadow"))
-        );
+        assert!(environment_value(commands[0], name).is_some());
     }
     assert_eq!(
         commands[1]
@@ -248,6 +235,45 @@ fn windows_action_steps_are_rejected_during_admission() {
         fixture.executor.admit(&job),
         Err(AdmissionRejection::InvalidJob)
     );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
+}
+
+#[test]
+fn windows_reserved_environment_aliases_fail_admission() {
+    let fixture = Fixture::windows(Vec::new());
+
+    for name in ["github_workspace", "Github_Env", "runner_os", "RuNnEr_TeMp"] {
+        let step = run_step("run", "Run", "Write-Output run").with_environment(BTreeMap::from([(
+            name.to_owned(),
+            ValueSource::Literal("shadow".to_owned()),
+        )]));
+        let job = windows_envelope(vec![step]);
+        assert_eq!(
+            fixture.executor.admit(&job),
+            Err(AdmissionRejection::InvalidJob),
+            "Windows alias {name} must not shadow runner state"
+        );
+    }
+
+    let allowed = run_step("run", "Run", "Write-Output run").with_environment(BTreeMap::from([
+        ("ci".to_owned(), ValueSource::Literal("false".to_owned())),
+        (
+            "node_options".to_owned(),
+            ValueSource::Literal("--no-warnings".to_owned()),
+        ),
+        (
+            "github_token".to_owned(),
+            ValueSource::Literal("workflow-mapped-token".to_owned()),
+        ),
+        (
+            "runner_digest".to_owned(),
+            ValueSource::Literal("custom-release-value".to_owned()),
+        ),
+    ]));
+    fixture
+        .executor
+        .admit(&windows_envelope(vec![allowed]))
+        .expect("CI, custom prefixed names, and declarative NODE_OPTIONS remain valid on Windows");
     assert_eq!(fixture.provider.counts(), (0, 0, 0));
 }
 

--- a/crates/automata-ci-runner/tests/product_context.rs
+++ b/crates/automata-ci-runner/tests/product_context.rs
@@ -16,7 +16,10 @@ use automata_ci_execution::{
 use automata_ci_expression_github::{
     GithubExpressionEvaluator, GithubObject, GithubStatus, GithubValue,
 };
-use automata_ci_github_runtime::{CommandFilePlatform, JobCommandState};
+use automata_ci_github_runtime::{
+    CommandFilePlatform, EnvironmentMutationBlockReason, JobCommandState,
+    classify_environment_mutation,
+};
 use automata_ci_job_executor_github::{
     GithubContextPort, GithubContextRequest, GithubExecutionIdentity, GithubExecutionPhase,
     PortErrorKind,
@@ -31,6 +34,25 @@ use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase}
 const REPOSITORY_TOKEN: &str = "ghs_exact_job_repository_token";
 const OIDC_REQUEST_TOKEN: &str = "oidc_exact_job_request_token";
 const SECRET_DERIVED_NEED_SENTINEL: &str = "must-not-enter-expression-context";
+
+#[test]
+fn every_emitted_github_and_runner_default_is_protected_from_workflow_overlays() {
+    let fixture = ContextFixture::new();
+    let snapshot = fixture.snapshot().expect("context snapshot");
+
+    for variable in snapshot.environment().iter().filter(|variable| {
+        variable.name().starts_with("GITHUB_") || variable.name().starts_with("RUNNER_")
+    }) {
+        assert!(
+            matches!(
+                classify_environment_mutation(CommandFilePlatform::Unix, variable.name()),
+                Some(EnvironmentMutationBlockReason::Reserved(_))
+            ),
+            "emitted default {} is missing from the protected catalog",
+            variable.name()
+        );
+    }
+}
 
 #[test]
 fn admitted_execution_context_is_exposed_without_workspace_or_ref_rederivation() {

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -499,9 +499,11 @@ ID, but the corresponding runtime context/default variables remain missing.
   - [ ] 256 KB combined repository/organization delivery.
 - [ ] Treat configuration-variable names case-insensitively.
 - [ ] Prevent configuration variables from using the `GITHUB_` prefix.
-- [ ] Prevent jobs from overwriting `GITHUB_*` and `RUNNER_*`.
-- [ ] Continue allowing `CI` only as the documented exception.
-- [ ] Prevent `GITHUB_ENV` from setting `NODE_OPTIONS`.
+- [x] Prevent jobs from overwriting documented default variables in the
+  `GITHUB_*` and `RUNNER_*` namespaces without reserving custom names such as
+  `GITHUB_TOKEN` or `RUNNER_DIGEST`.
+- [x] Continue allowing `CI` only as the documented exception.
+- [x] Prevent `GITHUB_ENV` from setting `NODE_OPTIONS`.
 - [ ] Add a generated field-by-field context conformance suite.
 
 ## 8. Matrices, dependencies, and job graph execution
@@ -810,8 +812,9 @@ GitHub documents annotations, groups, masks, command stopping, state, and the
 - [ ] Preserve stop and resume command behavior across stdout and stderr.
 - [ ] Verify command parsing across fragmented output records.
 - [ ] Enforce annotation metadata fields and path, line, and column validation.
-- [ ] Enforce reserved `GITHUB_*` and `RUNNER_*` immutability.
-- [ ] Keep `NODE_OPTIONS` blocked through `GITHUB_ENV`.
+- [x] Enforce immutability for the documented default `GITHUB_*` and
+  `RUNNER_*` variables.
+- [x] Keep `NODE_OPTIONS` blocked through `GITHUB_ENV`.
 - [ ] Decide whether to support `ACTIONS_ALLOW_UNSECURE_COMMANDS`.
 - [ ] Match multiline environment/output delimiter parsing.
 - [ ] Match UTF-8 BOM behavior.
@@ -1333,7 +1336,7 @@ stating that a behavior is unsupported.
 - [ ] Correct `GITHUB_TOKEN` defaults, deny-all, OIDC-only, fork, and
   Dependabot behavior.
 - [ ] Make pull-request path filters runnable.
-- [ ] Enforce reserved environment variables.
+- [x] Enforce reserved runner-owned default environment variables.
 - [ ] Implement cancellation-aware cleanup and action posts.
 - [ ] Reject every parsed-but-unrunnable feature before scheduling.
 - [ ] Add the layered capability matrix.

--- a/docs/github-actions-parity-execution-plan.md
+++ b/docs/github-actions-parity-execution-plan.md
@@ -228,7 +228,7 @@ Exit criteria:
 
 - [ ] fork and Dependabot authority is reduced correctly;
 - [ ] pull-request path filters are runnable;
-- [ ] reserved runner environment names cannot be overwritten;
+- [x] reserved runner environment names cannot be overwritten;
 - [ ] matrix and expression behavior has differential fixtures;
 - [ ] official artifact/cache clients run against real product adapters;
 - [ ] unsupported jobs fail before a lease.

--- a/docs/github-actions-parity/github-actions-parity-02-workflow-language.md
+++ b/docs/github-actions-parity/github-actions-parity-02-workflow-language.md
@@ -175,8 +175,9 @@ Tasks:
 - [ ] Rotate command-file paths per phase.
 - [ ] Implement complete `steps` outcome/conclusion and reusable `jobs`
   context behavior.
-- [ ] Enforce `GITHUB_*` and `RUNNER_*` immutability while preserving the
-  documented `CI` exception.
+- [x] Enforce immutability for documented default variables in the `GITHUB_*`
+  and `RUNNER_*` namespaces while preserving custom names and the documented
+  `CI` exception.
 - [ ] Apply organization, repository, and environment variable precedence and
   limits.
 
@@ -184,7 +185,7 @@ Acceptance:
 
 - [ ] A generated field-by-field suite validates values and phase
   availability.
-- [ ] Lowercase or case-variant attempts cannot shadow reserved Windows
+- [x] Lowercase or case-variant attempts cannot shadow reserved Windows
   variables.
 - [ ] Unset values match GitHub empty/null behavior.
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -79,10 +79,12 @@ Acceptance:
 
 Tasks:
 
-- [ ] Reject `GITHUB_*` and `RUNNER_*` writes from workflow and command-file
-  environments, case-insensitively on Windows.
-- [ ] Preserve the documented `CI` exception.
-- [ ] Continue blocking `NODE_OPTIONS` through `GITHUB_ENV`.
+- [x] Reject writes to documented default variables in the `GITHUB_*` and
+  `RUNNER_*` namespaces from workflow and command-file environments,
+  case-insensitively on Windows, without reserving custom names that merely
+  share those prefixes.
+- [x] Preserve the documented `CI` exception.
+- [x] Continue blocking `NODE_OPTIONS` through `GITHUB_ENV`.
 - [ ] Rotate environment, output, path, state, summary, and artifact files for
   every phase.
 - [ ] Match BOM, CRLF, multiline delimiter, duplicate-key, and invalid-name
@@ -96,7 +98,7 @@ Tasks:
 
 Acceptance:
 
-- [ ] A step cannot shadow runner identity or command-file paths.
+- [x] A step cannot shadow runner identity or command-file paths.
 - [ ] Phase files never leak between steps or action occurrences.
 
 ### ACT-01 — Checked-out local action `pre`


### PR DESCRIPTION
## Summary

Closes the Wave 1 reserved-environment security slice without claiming the whole wave complete.

- adds one finite catalog of runner-owned GitHub default environment variables
- rejects attempts to shadow those defaults in planned job/step environments before provider work
- applies the same defense to composite-action environments and completed command-file state
- uses exact-case matching on Unix and ASCII-case-insensitive matching on Windows
- defers legacy `set-env` mutations to the target-aware phase boundary and retains sanitized notices for blocked writes
- keeps `CI`, `GITHUB_TOKEN`, `RUNNER_DIGEST`, and other custom prefixed names writable
- continues blocking `NODE_OPTIONS` through `GITHUB_ENV` and legacy `set-env`, while preserving declarative `NODE_OPTIONS`

The finite catalog follows GitHub's documented default-variable contract and the official runner's environment allowlist:

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
- https://github.com/actions/runner/blob/main/src/Runner.Worker/GitHubContext.cs
- https://github.com/actions/runner/blob/main/src/Runner.Worker/FileCommandManager.cs

## Security behavior

- workflow/job/step default-name collisions fail executor admission before sandbox/provider operations
- composite child environment names are checked before expression resolution, file copy, or execution
- runtime environment construction repeats the validation as defense in depth
- `GITHUB_ENV` and enabled legacy `set-env` writes to protected defaults are ignored and reported as sanitized step notices
- command-file paths and runner identity defaults cannot be replaced through case aliases on Windows

This intentionally does **not** reserve the entire `GITHUB_` or `RUNNER_` namespace. GitHub documents immutability for its default variables; custom names such as `GITHUB_TOKEN` and this repository's `RUNNER_DIGEST` remain compatible.

## Plan status

This changes the documented Wave 1 exit checklist from 0/6 to 1/6 complete. It marks only the reserved-runner-environment criterion complete.

Still open in RUN-03: phase-file rotation, full parser/duplicate-name closure, collection after timeout/cancellation, and deterministic summary lifecycle/truncation. The other five Wave 1 exit criteria also remain open.

## Verification

- `cargo test --locked -p automata-ci-job-executor-github` — pass
- `cargo clippy --locked -p automata-ci-job-executor-github --all-targets --no-deps -- -D warnings` — pass
- `cargo test --locked -p automata-ci-github-runtime --test phase_application` — 10/10 pass
- exact legacy `set-env` target-semantics test — pass
- `cargo clippy --locked -p automata-ci-github-runtime --all-targets --no-deps -- -D warnings` — pass
- exact emitted-product-context catalog coverage test — pass
- changed-file rustfmt check and `git diff --check` — pass

The full runtime package test was also attempted on Windows. All modified/focused tests pass; two unrelated tracked golden tests remain newline-sensitive to the local LF/CRLF checkout (`file_commands` and `workflow_commands`).