### PR TITLE
feat: define workspace usage export contract

### DIFF
--- a/crates/automata-ci-provisioning-grpc/README.md
+++ b/crates/automata-ci-provisioning-grpc/README.md
@@ -1,11 +1,14 @@
 # automata-ci-provisioning-grpc
 
-This crate owns and serves the public
+This crate owns the public
 [`automata.management.v1.ShardManagementService`](proto/automata/management/v1/shard_management.proto)
-schema over gRPC/HTTP/2. It requires a client certificate at the TLS handshake,
-authenticates that verified certificate chain for every request, validates and
-scope-checks the domain command, and calls transport-neutral workspace
-provisioning or entitlement-application ports.
+and
+[`automata.management.v1.ShardUsageExportService`](proto/automata/management/v1/shard_usage.proto)
+schemas over gRPC/HTTP/2. The currently composed management service requires a
+client certificate at the TLS handshake, authenticates that verified
+certificate chain for every request, validates and scope-checks the domain
+command, and calls transport-neutral workspace provisioning or
+entitlement-application ports.
 
 The server accepts a pre-bound listener so the product composition root retains
 ownership of startup ordering and port conflicts. The Automata binary composes
@@ -16,6 +19,12 @@ stable shard-scoped authority, and supplies the durable
 `automata-ci-postgres` management transaction adapters. Entitlement snapshots
 are complete, monotonically revisioned workspace aggregates; the contract does
 not allocate rolling per-job budget slices.
+
+The usage-export schema defines an authority-scoped, cursor-paginated feed of
+immutable actual-execution facts. It is intentionally not registered or
+advertised yet. A later change will add the durable feed adapter and compose the
+service atomically with Core accounting before capability discovery announces
+support.
 
 Cargo generates the private Rust wire module into `OUT_DIR` with Protox and
 Tonic. Building therefore needs no separately installed `protoc` or Buf binary,

--- a/crates/automata-ci-provisioning-grpc/build.rs
+++ b/crates/automata-ci-provisioning-grpc/build.rs
@@ -1,13 +1,18 @@
 use std::{error::Error, path::Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    const SCHEMA: &str = "proto/automata/management/v1/shard_management.proto";
+    const SCHEMAS: [&str; 2] = [
+        "proto/automata/management/v1/shard_management.proto",
+        "proto/automata/management/v1/shard_usage.proto",
+    ];
     const INCLUDE_ROOT: &str = "proto";
 
-    println!("cargo::rerun-if-changed={SCHEMA}");
+    for schema in SCHEMAS {
+        println!("cargo::rerun-if-changed={schema}");
+    }
     println!("cargo::rerun-if-changed={INCLUDE_ROOT}");
 
-    let descriptors = protox::compile([Path::new(SCHEMA)], [Path::new(INCLUDE_ROOT)])?;
+    let descriptors = protox::compile(SCHEMAS.map(Path::new), [Path::new(INCLUDE_ROOT)])?;
     tonic_prost_build::configure()
         .build_client(false)
         .build_server(true)

--- a/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_usage.proto
+++ b/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_usage.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+package automata.management.v1;
+
+import "google/protobuf/timestamp.proto";
+
+// Exports immutable execution-accounting facts from one Automata Core shard to
+// an authorized external control plane. This service shares the management
+// trust domain but is not exposed to browsers, runners, or human sessions.
+service ShardUsageExportService {
+  // Returns a stable page after an opaque exclusive cursor. Retrying a page is
+  // safe: consumers deduplicate by event_id and advance their stored cursor in
+  // the same transaction that durably accepts the returned events.
+  rpc ListWorkspaceUsage(ListWorkspaceUsageRequest) returns (ListWorkspaceUsageResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+// Authority-scoped cursor-pull request for one shard.
+message ListWorkspaceUsageRequest {
+  // Expected immutable shard identity, already verified through capability
+  // discovery and checked against the authenticated workload authority.
+  string shard_id = 1;
+
+  // Opaque exclusive position returned by the preceding response. Empty means
+  // the beginning of the authority's retained feed. A cursor cannot be moved
+  // between authorities or shards.
+  bytes cursor = 2;
+
+  // Positive maximum number of events to return, no greater than 1000.
+  uint32 page_size = 3;
+}
+
+// One immutable actual-execution fact. This is provider-neutral usage, not a
+// price, Stripe meter event, invoice line, or guarantee that usage is billable.
+message WorkspaceUsageEvent {
+  // Globally stable, non-nil canonical lower-case UUID used for idempotency.
+  string event_id = 1;
+
+  // Immutable identity of the shard that recorded the event.
+  string shard_id = 2;
+
+  // Externally managed workspace as a non-nil canonical lower-case UUID.
+  string workspace_id = 3;
+
+  // Core execution attempt as a non-nil canonical lower-case UUID. Several
+  // events may cover non-overlapping intervals of one attempt.
+  string attempt_id = 4;
+
+  // Entitlement revision against which Core accounted this interval.
+  uint64 entitlement_revision = 5;
+
+  // Inclusive start and exclusive end of the positive accounted interval.
+  google.protobuf.Timestamp interval_start = 6;
+  google.protobuf.Timestamp interval_end = 7;
+
+  // Positive actual compute consumption. Cloud may aggregate this into
+  // customer-visible whole-second billing independently of Core enforcement.
+  uint64 consumed_compute_milliseconds = 8;
+}
+
+// Stable feed page. An empty page is valid and retains a continuation cursor
+// from which a later poll can observe newly appended events.
+message ListWorkspaceUsageResponse {
+  // Events in stable append order after the request cursor.
+  repeated WorkspaceUsageEvent events = 1;
+
+  // Opaque exclusive position after every event in this response.
+  bytes next_cursor = 2;
+}
+
+// Stable machine-readable reason attached to a failed usage-export RPC.
+enum ListWorkspaceUsageFailureReason {
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_UNSPECIFIED = 0;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_INVALID_REQUEST = 1;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_UNAUTHENTICATED = 2;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_FORBIDDEN = 3;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_INVALID_CURSOR = 4;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_RATE_LIMITED = 5;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_INTERNAL_ERROR = 6;
+  LIST_WORKSPACE_USAGE_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 7;
+}
+
+// Typed detail carried in google.rpc.Status.details after Core can safely
+// construct contract-specific details.
+message ListWorkspaceUsageFailure {
+  ListWorkspaceUsageFailureReason reason = 1;
+}

--- a/crates/automata-ci-provisioning/README.md
+++ b/crates/automata-ci-provisioning/README.md
@@ -1,12 +1,16 @@
 # automata-ci-provisioning
 
 This crate owns the transport-neutral application boundary for an authorized
-external control plane to provision and apply execution-entitlement snapshots
-to a workspace on one Automata Core shard. It validates the public contract's
-domain values and keeps workload authority, idempotency identity, provisioning,
-and entitlement mutation behind explicit ports.
+external control plane to provision workspaces, apply execution-entitlement
+snapshots, and pull immutable usage events from one Automata Core shard. It
+validates the public contract's domain values and keeps workload authority,
+idempotency identity, mutations, and export behind explicit ports.
 
 It contains no gRPC, HTTP, SQL, Cloud billing, or private Automata Cloud code.
 The public versioned wire schema lives beside its gRPC adapter in
 `automata-ci-provisioning-grpc`; the atomic PostgreSQL adapter lives in
 the `provisioning` namespace of `automata-ci-postgres`.
+
+Usage export contains provider-neutral actual execution facts rather than
+prices, invoices, or Stripe objects. A consumer deduplicates stable event IDs
+and commits its continuation cursor with the accepted events.

--- a/crates/automata-ci-provisioning/src/lib.rs
+++ b/crates/automata-ci-provisioning/src/lib.rs
@@ -11,11 +11,13 @@
 //! Certificate rotations do not alter the authority ID. Durable adapters must
 //! namespace idempotency by that stable authority and the operation ID, never by
 //! a certificate, connection, pod, or replica. Workspace entitlement snapshots
-//! use the same authority and remain independent of Cloud billing concepts.
+//! and usage-export cursors use the same authority and remain independent of
+//! Cloud billing concepts.
 
 mod entitlement;
 mod model;
 mod port;
+mod usage;
 
 pub use entitlement::{
     ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
@@ -32,7 +34,13 @@ pub use model::{
 };
 pub use port::{
     EntitlementApplicationFuture, ProvisioningAuthenticationError,
-    ProvisioningAuthenticationFuture, ProvisioningWorkloadAuthenticator,
+    ProvisioningAuthenticationFuture, ProvisioningWorkloadAuthenticator, UsageExportFuture,
     WorkloadAuthenticationEvidence, WorkspaceEntitlementApplier, WorkspaceProvisioner,
-    WorkspaceProvisioningFuture,
+    WorkspaceProvisioningFuture, WorkspaceUsageExporter,
+};
+pub use usage::{
+    AuthorizedListWorkspaceUsage, ConsumedComputeMilliseconds, ListWorkspaceUsageCommand,
+    UsageAttemptId, UsageAuthorizationError, UsageEventId, UsageExportCursor, UsageExportFailure,
+    UsageExportFailureKind, UsageExportPageSize, UsageTimestamp, UsageValueError,
+    WorkspaceUsageEvent, WorkspaceUsagePage,
 };

--- a/crates/automata-ci-provisioning/src/port.rs
+++ b/crates/automata-ci-provisioning/src/port.rs
@@ -4,8 +4,9 @@ use thiserror::Error;
 
 use crate::{
     ApplyWorkspaceEntitlementResult, AuthorizedApplyWorkspaceEntitlement,
-    AuthorizedProvisionWorkspace, EntitlementFailure, ProvisionWorkspaceResult,
-    ProvisioningAuthority, ProvisioningFailure,
+    AuthorizedListWorkspaceUsage, AuthorizedProvisionWorkspace, EntitlementFailure,
+    ProvisionWorkspaceResult, ProvisioningAuthority, ProvisioningFailure, UsageExportFailure,
+    WorkspaceUsagePage,
 };
 
 const MAX_CERTIFICATE_COUNT: usize = 32;
@@ -135,6 +136,21 @@ pub trait WorkspaceEntitlementApplier: fmt::Debug + Send + Sync {
         &self,
         request: AuthorizedApplyWorkspaceEntitlement,
     ) -> EntitlementApplicationFuture<'_>;
+}
+
+/// Boxed durable workspace usage-export operation.
+pub type UsageExportFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<WorkspaceUsagePage, UsageExportFailure>> + Send + 'a>>;
+
+/// Stable cursor-pull port for immutable execution-accounting facts.
+///
+/// Implementations must scope both cursors and events to the authenticated
+/// authority, return events in stable append order, and never reuse an event ID
+/// for different facts. A consumer can therefore commit event ingestion and
+/// its continuation cursor atomically for at-least-once delivery.
+pub trait WorkspaceUsageExporter: fmt::Debug + Send + Sync {
+    /// Lists one authority-scoped page after the request's exclusive cursor.
+    fn list(&self, request: AuthorizedListWorkspaceUsage) -> UsageExportFuture<'_>;
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-provisioning/src/usage.rs
+++ b/crates/automata-ci-provisioning/src/usage.rs
@@ -1,0 +1,608 @@
+use std::fmt;
+
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{EntitlementRevision, ProvisioningAuthority, ShardId, WorkspaceId};
+
+const MAX_CURSOR_BYTES: usize = 512;
+const MAX_PAGE_SIZE: u32 = 1_000;
+const PROTOBUF_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
+const PROTOBUF_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
+const NANOS_PER_SECOND: u32 = 1_000_000_000;
+
+macro_rules! usage_uuid_identifier {
+    ($name:ident, $error:ident, $label:literal) => {
+        #[doc = concat!("A validated, non-nil canonical UUID identifying ", $label, ".")]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            #[doc = concat!("Parses the canonical UUID for ", $label, ".")]
+            ///
+            /// # Errors
+            ///
+            /// Rejects nil, non-hyphenated, upper-case, or otherwise
+            /// non-canonical UUID text.
+            pub fn parse(value: &str) -> Result<Self, UsageValueError> {
+                let parsed = Uuid::parse_str(value).map_err(|_| UsageValueError::$error)?;
+                if parsed.is_nil() || parsed.hyphenated().to_string() != value {
+                    return Err(UsageValueError::$error);
+                }
+                Ok(Self(parsed))
+            }
+
+            #[doc = concat!("Creates ", $label, " from a trusted non-nil UUID.")]
+            ///
+            /// # Errors
+            ///
+            /// Rejects the nil UUID.
+            pub const fn from_uuid(value: Uuid) -> Result<Self, UsageValueError> {
+                if value.is_nil() {
+                    return Err(UsageValueError::$error);
+                }
+                Ok(Self(value))
+            }
+
+            #[doc = concat!("Returns the UUID for ", $label, ".")]
+            #[must_use]
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "{}", self.0.hyphenated())
+            }
+        }
+    };
+}
+
+usage_uuid_identifier!(UsageEventId, InvalidEventId, "an immutable usage event");
+usage_uuid_identifier!(UsageAttemptId, InvalidAttemptId, "an execution attempt");
+
+/// Opaque position after the last usage event durably accepted by a consumer.
+///
+/// Cursors are scoped to the authenticated authority and shard. Consumers must
+/// not inspect, synthesize, or transfer them between authorities or shards.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UsageExportCursor(Vec<u8>);
+
+impl UsageExportCursor {
+    /// Creates a bounded opaque cursor. Empty means the start of the feed.
+    ///
+    /// # Errors
+    ///
+    /// Rejects values larger than the public contract bound.
+    pub fn new(value: impl Into<Vec<u8>>) -> Result<Self, UsageValueError> {
+        let value = value.into();
+        if value.len() > MAX_CURSOR_BYTES {
+            return Err(UsageValueError::InvalidCursor);
+        }
+        Ok(Self(value))
+    }
+
+    /// Creates the initial position before the first event.
+    #[must_use]
+    pub const fn beginning() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Returns the opaque cursor bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Consumes the cursor into its opaque bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+/// Positive maximum number of usage events requested in one page.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UsageExportPageSize(u32);
+
+impl UsageExportPageSize {
+    /// Largest page supported by the version-one contract.
+    pub const MAX: u32 = MAX_PAGE_SIZE;
+
+    /// Creates a bounded page size.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values larger than [`Self::MAX`].
+    pub const fn new(value: u32) -> Result<Self, UsageValueError> {
+        if value == 0 || value > Self::MAX {
+            return Err(UsageValueError::InvalidPageSize);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the requested event count.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// Protobuf-compatible UTC instant delimiting an accounted execution interval.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UsageTimestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl UsageTimestamp {
+    /// Creates an instant within the Protobuf Timestamp range.
+    ///
+    /// # Errors
+    ///
+    /// Rejects out-of-range seconds or one billion or more nanoseconds.
+    pub const fn new(seconds: i64, nanoseconds: u32) -> Result<Self, UsageValueError> {
+        if seconds < PROTOBUF_TIMESTAMP_MIN_SECONDS
+            || seconds > PROTOBUF_TIMESTAMP_MAX_SECONDS
+            || nanoseconds >= NANOS_PER_SECOND
+        {
+            return Err(UsageValueError::InvalidTimestamp);
+        }
+        Ok(Self {
+            seconds,
+            nanoseconds,
+        })
+    }
+
+    /// Returns whole Unix seconds.
+    #[must_use]
+    pub const fn seconds(self) -> i64 {
+        self.seconds
+    }
+
+    /// Returns fractional nanoseconds within the second.
+    #[must_use]
+    pub const fn nanoseconds(self) -> u32 {
+        self.nanoseconds
+    }
+}
+
+/// Positive actual compute consumption measured in milliseconds.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ConsumedComputeMilliseconds(u64);
+
+impl ConsumedComputeMilliseconds {
+    /// Creates a duration representable by the durable signed boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values larger than a signed 64-bit integer.
+    pub const fn new(value: u64) -> Result<Self, UsageValueError> {
+        if value == 0 || value > i64::MAX as u64 {
+            return Err(UsageValueError::InvalidConsumedCompute);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the consumed milliseconds.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// One immutable, idempotently consumable execution-accounting fact.
+///
+/// Multiple events may describe non-overlapping intervals of the same attempt.
+/// The event is provider-neutral actual usage, not a price, invoice line, or
+/// promise that a commercial provider will bill the interval.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceUsageEvent {
+    event_id: UsageEventId,
+    shard_id: ShardId,
+    workspace_id: WorkspaceId,
+    attempt_id: UsageAttemptId,
+    entitlement_revision: EntitlementRevision,
+    interval_start: UsageTimestamp,
+    interval_end: UsageTimestamp,
+    consumed_compute: ConsumedComputeMilliseconds,
+}
+
+impl WorkspaceUsageEvent {
+    /// Creates one positive accounted interval under an entitlement revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an interval whose end is not strictly after its start.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        event_id: UsageEventId,
+        shard_id: ShardId,
+        workspace_id: WorkspaceId,
+        attempt_id: UsageAttemptId,
+        entitlement_revision: EntitlementRevision,
+        interval_start: UsageTimestamp,
+        interval_end: UsageTimestamp,
+        consumed_compute: ConsumedComputeMilliseconds,
+    ) -> Result<Self, UsageValueError> {
+        if interval_end <= interval_start {
+            return Err(UsageValueError::InvalidInterval);
+        }
+        Ok(Self {
+            event_id,
+            shard_id,
+            workspace_id,
+            attempt_id,
+            entitlement_revision,
+            interval_start,
+            interval_end,
+            consumed_compute,
+        })
+    }
+
+    /// Returns the global idempotency identity for this fact.
+    #[must_use]
+    pub const fn event_id(&self) -> UsageEventId {
+        self.event_id
+    }
+
+    /// Returns the shard that recorded the fact.
+    #[must_use]
+    pub const fn shard_id(&self) -> &ShardId {
+        &self.shard_id
+    }
+
+    /// Returns the workspace that consumed the compute.
+    #[must_use]
+    pub const fn workspace_id(&self) -> WorkspaceId {
+        self.workspace_id
+    }
+
+    /// Returns the execution attempt that consumed the compute.
+    #[must_use]
+    pub const fn attempt_id(&self) -> UsageAttemptId {
+        self.attempt_id
+    }
+
+    /// Returns the entitlement revision charged by Core accounting.
+    #[must_use]
+    pub const fn entitlement_revision(&self) -> EntitlementRevision {
+        self.entitlement_revision
+    }
+
+    /// Returns the inclusive beginning of the accounted interval.
+    #[must_use]
+    pub const fn interval_start(&self) -> UsageTimestamp {
+        self.interval_start
+    }
+
+    /// Returns the exclusive end of the accounted interval.
+    #[must_use]
+    pub const fn interval_end(&self) -> UsageTimestamp {
+        self.interval_end
+    }
+
+    /// Returns actual compute consumed during the interval.
+    #[must_use]
+    pub const fn consumed_compute(&self) -> ConsumedComputeMilliseconds {
+        self.consumed_compute
+    }
+}
+
+/// Validated request for an authority-scoped page of immutable usage events.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ListWorkspaceUsageCommand {
+    shard_id: ShardId,
+    cursor: UsageExportCursor,
+    page_size: UsageExportPageSize,
+}
+
+impl ListWorkspaceUsageCommand {
+    /// Creates one cursor-pull request.
+    #[must_use]
+    pub const fn new(
+        shard_id: ShardId,
+        cursor: UsageExportCursor,
+        page_size: UsageExportPageSize,
+    ) -> Self {
+        Self {
+            shard_id,
+            cursor,
+            page_size,
+        }
+    }
+
+    /// Returns the expected immutable shard identity.
+    #[must_use]
+    pub const fn shard_id(&self) -> &ShardId {
+        &self.shard_id
+    }
+
+    /// Returns the exclusive cursor after the last durably accepted event.
+    #[must_use]
+    pub const fn cursor(&self) -> &UsageExportCursor {
+        &self.cursor
+    }
+
+    /// Returns the maximum number of events requested.
+    #[must_use]
+    pub const fn page_size(&self) -> UsageExportPageSize {
+        self.page_size
+    }
+}
+
+/// Usage request proven to target the authenticated authority's configured shard.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorizedListWorkspaceUsage {
+    authority: ProvisioningAuthority,
+    command: ListWorkspaceUsageCommand,
+}
+
+impl AuthorizedListWorkspaceUsage {
+    /// Authorizes a usage request against the server-derived shard binding.
+    ///
+    /// Durable export additionally filters events by this exact authority so
+    /// two authorities sharing a shard cannot observe each other's workspaces.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a command for another shard.
+    pub fn authorize(
+        authority: ProvisioningAuthority,
+        command: ListWorkspaceUsageCommand,
+    ) -> Result<Self, UsageAuthorizationError> {
+        if authority.shard_id() != command.shard_id() {
+            return Err(UsageAuthorizationError::Forbidden);
+        }
+        Ok(Self { authority, command })
+    }
+
+    /// Returns the stable server-derived authority and export namespace.
+    #[must_use]
+    pub const fn authority(&self) -> &ProvisioningAuthority {
+        &self.authority
+    }
+
+    /// Returns the validated semantic command.
+    #[must_use]
+    pub const fn command(&self) -> &ListWorkspaceUsageCommand {
+        &self.command
+    }
+
+    /// Consumes the request into its authority and command.
+    #[must_use]
+    pub fn into_parts(self) -> (ProvisioningAuthority, ListWorkspaceUsageCommand) {
+        (self.authority, self.command)
+    }
+}
+
+/// Stable page returned from the durable authority-scoped usage feed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceUsagePage {
+    events: Vec<WorkspaceUsageEvent>,
+    next_cursor: UsageExportCursor,
+}
+
+impl WorkspaceUsagePage {
+    /// Creates one bounded page and its exclusive continuation cursor.
+    ///
+    /// # Errors
+    ///
+    /// Rejects more events than the version-one page bound.
+    pub fn new(
+        events: Vec<WorkspaceUsageEvent>,
+        next_cursor: UsageExportCursor,
+    ) -> Result<Self, UsageValueError> {
+        if events.len() > MAX_PAGE_SIZE as usize {
+            return Err(UsageValueError::TooManyEvents);
+        }
+        Ok(Self {
+            events,
+            next_cursor,
+        })
+    }
+
+    /// Returns the immutable events in stable feed order.
+    #[must_use]
+    pub fn events(&self) -> &[WorkspaceUsageEvent] {
+        &self.events
+    }
+
+    /// Returns the exclusive cursor to use for the next request.
+    #[must_use]
+    pub const fn next_cursor(&self) -> &UsageExportCursor {
+        &self.next_cursor
+    }
+
+    /// Consumes the page into its events and continuation cursor.
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<WorkspaceUsageEvent>, UsageExportCursor) {
+        (self.events, self.next_cursor)
+    }
+}
+
+/// Closed failures returned by the durable usage feed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UsageExportFailureKind {
+    /// The cursor is unknown, malformed internally, or no longer retained.
+    InvalidCursor,
+    /// The authority exceeded a bounded export rate.
+    RateLimited,
+    /// Core failed without a safer specific result.
+    Internal,
+    /// A required durable dependency is temporarily unavailable.
+    TemporarilyUnavailable,
+}
+
+/// Sanitized durable usage-export failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("workspace usage export failed: {kind:?}")]
+pub struct UsageExportFailure {
+    kind: UsageExportFailureKind,
+}
+
+impl UsageExportFailure {
+    /// Creates one closed export failure.
+    #[must_use]
+    pub const fn new(kind: UsageExportFailureKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the stable failure kind.
+    #[must_use]
+    pub const fn kind(self) -> UsageExportFailureKind {
+        self.kind
+    }
+}
+
+/// Server-derived scope rejection for a valid usage request.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum UsageAuthorizationError {
+    /// The authority is not bound to the requested shard.
+    #[error("the management authority is outside the requested shard")]
+    Forbidden,
+}
+
+/// Validation failure for a usage-export domain value.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum UsageValueError {
+    /// The immutable event UUID is invalid.
+    #[error("usage event ID is invalid")]
+    InvalidEventId,
+    /// The execution-attempt UUID is invalid.
+    #[error("usage attempt ID is invalid")]
+    InvalidAttemptId,
+    /// The opaque cursor exceeds the public bound.
+    #[error("usage export cursor is invalid")]
+    InvalidCursor,
+    /// The requested page size is zero or above the public bound.
+    #[error("usage export page size is invalid")]
+    InvalidPageSize,
+    /// The timestamp cannot be represented by Protobuf.
+    #[error("usage timestamp is invalid")]
+    InvalidTimestamp,
+    /// The accounted interval is empty or reversed.
+    #[error("usage interval is invalid")]
+    InvalidInterval,
+    /// The actual compute duration is zero or outside the durable range.
+    #[error("consumed compute is invalid")]
+    InvalidConsumedCompute,
+    /// A durable adapter returned more events than the contract permits.
+    #[error("usage export page contains too many events")]
+    TooManyEvents,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DelegatedActorIssuer, ProvisioningAuthorityId};
+
+    fn authority() -> ProvisioningAuthority {
+        ProvisioningAuthority::new(
+            ProvisioningAuthorityId::new("automata-cloud-production").unwrap(),
+            ShardId::new("prod-us-east-1-001").unwrap(),
+            DelegatedActorIssuer::new("https://cloud.automata.example").unwrap(),
+        )
+    }
+
+    fn event() -> WorkspaceUsageEvent {
+        WorkspaceUsageEvent::new(
+            UsageEventId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
+            ShardId::new("prod-us-east-1-001").unwrap(),
+            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            UsageAttemptId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
+            EntitlementRevision::new(3).unwrap(),
+            UsageTimestamp::new(1_786_500_100, 0).unwrap(),
+            UsageTimestamp::new(1_786_500_105, 0).unwrap(),
+            ConsumedComputeMilliseconds::new(5_000).unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cursor_pull_authorizes_for_exact_shard() {
+        let command = ListWorkspaceUsageCommand::new(
+            ShardId::new("prod-us-east-1-001").unwrap(),
+            UsageExportCursor::beginning(),
+            UsageExportPageSize::new(250).unwrap(),
+        );
+        let authorized = AuthorizedListWorkspaceUsage::authorize(authority(), command).unwrap();
+        assert_eq!(authorized.command().page_size().get(), 250);
+        assert!(authorized.command().cursor().as_bytes().is_empty());
+
+        let page = WorkspaceUsagePage::new(
+            vec![event()],
+            UsageExportCursor::new(vec![0, 0, 0, 1]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(page.events().len(), 1);
+        assert_eq!(page.next_cursor().as_bytes(), &[0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn another_shard_is_forbidden() {
+        let command = ListWorkspaceUsageCommand::new(
+            ShardId::new("prod-eu-west-1-001").unwrap(),
+            UsageExportCursor::beginning(),
+            UsageExportPageSize::new(100).unwrap(),
+        );
+        assert_eq!(
+            AuthorizedListWorkspaceUsage::authorize(authority(), command),
+            Err(UsageAuthorizationError::Forbidden)
+        );
+    }
+
+    #[test]
+    fn identifiers_cursor_and_page_size_are_bounded() {
+        assert_eq!(
+            UsageEventId::parse("00000000-0000-0000-0000-000000000000"),
+            Err(UsageValueError::InvalidEventId)
+        );
+        assert_eq!(
+            UsageAttemptId::parse("66666666666646668666666666666666"),
+            Err(UsageValueError::InvalidAttemptId)
+        );
+        assert_eq!(
+            UsageExportCursor::new(vec![0; MAX_CURSOR_BYTES + 1]),
+            Err(UsageValueError::InvalidCursor)
+        );
+        assert_eq!(
+            UsageExportPageSize::new(0),
+            Err(UsageValueError::InvalidPageSize)
+        );
+        assert_eq!(
+            UsageExportPageSize::new(MAX_PAGE_SIZE + 1),
+            Err(UsageValueError::InvalidPageSize)
+        );
+        assert_eq!(
+            WorkspaceUsagePage::new(
+                vec![event(); MAX_PAGE_SIZE as usize + 1],
+                UsageExportCursor::beginning(),
+            ),
+            Err(UsageValueError::TooManyEvents)
+        );
+    }
+
+    #[test]
+    fn usage_intervals_and_compute_are_positive() {
+        let start = UsageTimestamp::new(1_786_500_100, 0).unwrap();
+        assert_eq!(
+            WorkspaceUsageEvent::new(
+                UsageEventId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
+                ShardId::new("prod-us-east-1-001").unwrap(),
+                WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                UsageAttemptId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
+                EntitlementRevision::new(3).unwrap(),
+                start,
+                start,
+                ConsumedComputeMilliseconds::new(1).unwrap(),
+            ),
+            Err(UsageValueError::InvalidInterval)
+        );
+        assert_eq!(
+            ConsumedComputeMilliseconds::new(0),
+            Err(UsageValueError::InvalidConsumedCompute)
+        );
+    }
+}

--- a/docs/architecture-decisions/0001-protocol-boundaries.md
+++ b/docs/architecture-decisions/0001-protocol-boundaries.md
@@ -50,11 +50,15 @@ in a centralized contracts directory.
 
 Core does not synchronously consult Cloud while admitting jobs. Cloud pushes
 durable configuration such as entitlement snapshots to Core. Core records
-usage in a transactional outbox and delivers bounded, idempotent batches to
-Cloud asynchronously.
+immutable usage events transactionally. An authorized external control plane
+pulls bounded pages from a stable, opaque cursor and commits its continuation
+cursor atomically with idempotent event ingestion. Core does not make outbound
+calls to Cloud.
 
 The initial management schema is
 [`automata.management.v1.ShardManagementService`](../../crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_management.proto).
+The usage feed is
+[`automata.management.v1.ShardUsageExportService`](../../crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_usage.proto).
 
 ## Consequences
 

--- a/docs/architecture-decisions/0003-pull-workspace-usage.md
+++ b/docs/architecture-decisions/0003-pull-workspace-usage.md
@@ -1,0 +1,75 @@
+# ADR 0003: Pull immutable workspace usage by cursor
+
+- Status: Accepted
+- Date: 2026-08-14
+
+## Context
+
+Core accounts actual execution locally so entitlement enforcement does not
+depend on a synchronous SaaS request. An external control plane such as Automata
+Cloud also needs those facts for trial state, customer usage views, spend
+controls, and provider-specific billing. The public Core product must remain
+fully functional with a self-hosted control plane and must not contain Cloud or
+Stripe code.
+
+Usage delivery crosses a failure-prone network. Either side may restart after
+accepting a batch but before acknowledging it. The protocol therefore needs an
+explicit replay and idempotency model rather than assuming exactly-once network
+delivery.
+
+## Decision
+
+Core exposes a privileged, authority-scoped gRPC usage feed on the management
+trust boundary. The external control plane pulls bounded pages after an opaque,
+exclusive cursor. An empty cursor means the beginning of the retained feed.
+The cursor is meaningful only for the exact authenticated authority and shard
+that issued it.
+
+Each immutable event has a globally stable event ID, workspace and attempt
+identity, entitlement revision, positive accounting interval, and actual
+consumed compute in milliseconds. Events are raw provider-neutral accounting
+facts. They contain no plan, price, currency, invoice, Stripe identifier, or
+decision that the usage is commercially billable.
+
+Core returns events in stable append order and a cursor after the returned page.
+The consumer deduplicates by event ID and advances its cursor in the same local
+transaction that accepts the events. A response lost after delivery can
+therefore be retried safely. Delivery is at least once; exactly-once effects are
+created by the consumer transaction rather than promised by the network.
+
+Core derives the authority from verified workload identity on every request.
+The durable feed filters by that exact authority even if multiple authorities
+can manage workspaces on one shard. Cursors and page sizes are bounded. A stale
+or unknown cursor fails explicitly; a consumer must alert and reconcile rather
+than skip silently.
+
+The schema and transport-neutral domain are introduced before the endpoint is
+composed. Core advertises the capability only after accounting writes the
+durable feed transactionally, the gRPC adapter is registered, and end-to-end
+replay tests pass.
+
+## Consequences
+
+- Core never needs Cloud network reachability, credentials, retry workers, or
+  provider-specific billing dependencies.
+- Cloud controls polling rate and backpressure and can ingest several shards
+  with independent cursors.
+- Cursor lag and oldest retained event age become required operational signals.
+- Both Core's event feed and the consumer's deduplication/cursor state are
+  durable data that need backup and recovery procedures.
+- Schema evolution is additive under normal Protobuf compatibility rules;
+  future execution dimensions can be added without redefining existing facts.
+
+## Alternatives considered
+
+Core pushing batches to Cloud can reduce idle polling, but it gives every Core
+shard outbound Cloud credentials and couples the public binary to destination
+configuration and retry behavior. It was rejected for the initial design.
+
+Cloud querying mutable aggregate counters is simpler but cannot safely recover
+which intervals were already billed or explain corrections. It was rejected in
+favor of immutable facts.
+
+A bidirectional streaming RPC could reduce steady-state latency but complicates
+reconnect, flow control, and checkpoint semantics without improving the billing
+correctness model. Bounded unary pages are sufficient for the initial scale.


### PR DESCRIPTION
## Outcome

Defines the first public Core boundary for an external control plane to pull immutable workspace execution usage in bounded cursor pages.

- Adds the provider-neutral `ShardUsageExportService` protobuf schema and generates it at build time with Protox/Tonic.
- Adds validated authority-scoped cursor, event, page, failure, and exporter domain types/port.
- Records the at-least-once delivery and consumer checkpoint transaction in ADR 0003.
- Replaces the earlier outbound-push wording in ADR 0001.
- Deliberately does not register the service or advertise a capability until durable accounting feeds it.

## Related issue

None.

## Trust and compatibility impact

This adds an unadvertised public protobuf service definition. Usage requests are scoped to the server-authenticated management authority and shard; durable implementations must additionally filter events and cursors by that exact authority. Events contain raw actual usage only and no Cloud billing, pricing, or Stripe data. Existing management RPCs and composed listeners are unchanged.

## Verification

- `cargo test -p automata-ci-provisioning -p automata-ci-provisioning-grpc` — passed (21 tests plus doc tests).
- `cargo clippy -p automata-ci-provisioning -p automata-ci-provisioning-grpc --all-targets -- -D warnings` — passed.
- Targeted `rustfmt --check` for all changed Rust files — passed.
- `git diff --check` — passed.
- Full `cargo fmt --all -- --check` is currently blocked by a pre-existing module-order diff in `crates/automata-ci-postgres/tests/store/contracts/mod.rs` on `main`; this PR does not modify that file.

## AI assistance

Codex materially assisted with the contract design, Rust implementation, tests, and documentation. Every submitted change was reviewed and verified locally.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.