### PR TITLE
feat(postgres): persist workspace usage feed

### DIFF
--- a/crates/automata-ci-postgres/README.md
+++ b/crates/automata-ci-postgres/README.md
@@ -5,7 +5,8 @@ crate groups concrete adapters behind five domain namespaces:
 
 - `auth` persists encrypted login state, sessions, provider tokens, GitHub
   authority, installation state, RBAC management, and runner enrollment;
-- `provisioning` atomically creates a workspace and its initial owner;
+- `provisioning` atomically creates a workspace and its initial owner, applies
+  entitlement snapshots, and reads authority-scoped immutable usage feeds;
 - `runner_auth` resolves server-owned runner-machine authority; and
 - `secret` stores the built-in provider's envelope-encrypted secret values;
 - `store` implements the durable workflow, runner, publication, and managed

--- a/crates/automata-ci-postgres/migrations/0027_workspace_usage_feed.sql
+++ b/crates/automata-ci-postgres/migrations/0027_workspace_usage_feed.sql
@@ -1,0 +1,58 @@
+CREATE TABLE workspace_usage_events (
+    sequence bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    event_id uuid NOT NULL UNIQUE,
+    authority_id text NOT NULL,
+    shard_id text NOT NULL,
+    workspace_id text NOT NULL,
+    attempt_id uuid NOT NULL,
+    entitlement_revision bigint NOT NULL,
+    interval_start_ms bigint NOT NULL,
+    interval_end_ms bigint NOT NULL,
+    consumed_compute_ms bigint NOT NULL,
+    recorded_at_ms bigint NOT NULL,
+    CONSTRAINT workspace_usage_events_binding
+        FOREIGN KEY (workspace_id, authority_id, shard_id)
+        REFERENCES workspace_management_bindings(workspace_id, authority_id, shard_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT workspace_usage_events_entitlement_revision
+        FOREIGN KEY (workspace_id, entitlement_revision)
+        REFERENCES workspace_entitlement_operations(workspace_id, revision)
+        ON DELETE RESTRICT,
+    CONSTRAINT workspace_usage_events_ids_non_nil CHECK (
+        event_id <> '00000000-0000-0000-0000-000000000000'::uuid
+        AND attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid
+    ),
+    CONSTRAINT workspace_usage_events_authority_shape CHECK (
+        octet_length(authority_id) BETWEEN 1 AND 255
+        AND authority_id !~ '[[:space:][:cntrl:]]'
+    ),
+    CONSTRAINT workspace_usage_events_shard_shape CHECK (
+        octet_length(shard_id) BETWEEN 1 AND 63
+        AND shard_id ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'
+    ),
+    CONSTRAINT workspace_usage_events_workspace_shape CHECK (
+        workspace_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        AND workspace_id <> '00000000-0000-0000-0000-000000000000'
+    ),
+    CONSTRAINT workspace_usage_events_revision_positive CHECK (entitlement_revision > 0),
+    CONSTRAINT workspace_usage_events_interval CHECK (
+        interval_start_ms >= 0
+        AND interval_end_ms > interval_start_ms
+        AND interval_end_ms <= 253402300799999
+    ),
+    CONSTRAINT workspace_usage_events_compute_positive CHECK (consumed_compute_ms > 0),
+    CONSTRAINT workspace_usage_events_recorded_after_interval CHECK (
+        recorded_at_ms >= interval_end_ms
+        AND recorded_at_ms <= 253402300799999
+    ),
+    CONSTRAINT workspace_usage_events_interval_unique UNIQUE (
+        workspace_id,
+        attempt_id,
+        entitlement_revision,
+        interval_start_ms,
+        interval_end_ms
+    )
+);
+
+CREATE INDEX workspace_usage_events_authority_feed_idx
+    ON workspace_usage_events(authority_id, shard_id, sequence);

--- a/crates/automata-ci-postgres/src/provisioning/mod.rs
+++ b/crates/automata-ci-postgres/src/provisioning/mod.rs
@@ -13,8 +13,10 @@ use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 mod entitlement;
+mod usage;
 
 pub use entitlement::PostgresWorkspaceEntitlementApplier;
+pub use usage::PostgresWorkspaceUsageExporter;
 
 const WORKSPACE_OWNER_ROLE_NAME: &str = "workspace-owner";
 const WORKSPACE_OWNER_ROLE_DISPLAY_NAME: &str = "Workspace owner";

--- a/crates/automata-ci-postgres/src/provisioning/usage.rs
+++ b/crates/automata-ci-postgres/src/provisioning/usage.rs
@@ -1,0 +1,188 @@
+use std::fmt;
+
+use automata_ci_provisioning::{
+    AuthorizedListWorkspaceUsage, ConsumedComputeMilliseconds, EntitlementRevision, ShardId,
+    UsageAttemptId, UsageEventId, UsageExportCursor, UsageExportFailure, UsageExportFailureKind,
+    UsageExportFuture, UsageTimestamp, WorkspaceId, WorkspaceUsageEvent, WorkspaceUsageExporter,
+    WorkspaceUsagePage,
+};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+const CURSOR_BYTES: usize = 16;
+
+/// Replica-safe `PostgreSQL` reader for an authority-scoped workspace usage feed.
+///
+/// The cursor is the raw UUID of the last event in a returned page. Resolving it
+/// through the authority and shard columns makes a cursor from another export
+/// namespace invalid without exposing the internal append sequence.
+#[derive(Clone)]
+pub struct PostgresWorkspaceUsageExporter {
+    pool: PgPool,
+}
+
+impl PostgresWorkspaceUsageExporter {
+    /// Binds usage export to `pool`.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    async fn list_inner(
+        &self,
+        request: AuthorizedListWorkspaceUsage,
+    ) -> Result<WorkspaceUsagePage, UsageExportFailure> {
+        let (authority, command) = request.into_parts();
+        let authority_id = authority.id().as_str();
+        let shard_id = command.shard_id();
+        let cursor = command.cursor().clone();
+        let page_size = i64::from(command.page_size().get());
+        let mut transaction = self.pool.begin().await.map_err(database_failure)?;
+        let after_sequence =
+            resolve_cursor(&mut transaction, authority_id, shard_id.as_str(), &cursor).await?;
+        let rows = sqlx::query_as::<_, StoredUsageEvent>(
+            r"
+            SELECT event_id, shard_id, workspace_id, attempt_id,
+                   entitlement_revision, interval_start_ms, interval_end_ms,
+                   consumed_compute_ms
+            FROM workspace_usage_events
+            WHERE authority_id=$1 AND shard_id=$2 AND sequence > $3
+            ORDER BY sequence
+            LIMIT $4
+            ",
+        )
+        .bind(authority_id)
+        .bind(shard_id.as_str())
+        .bind(after_sequence)
+        .bind(page_size)
+        .fetch_all(&mut *transaction)
+        .await
+        .map_err(database_failure)?;
+
+        let next_cursor = rows
+            .last()
+            .map(|row| UsageExportCursor::new(row.event_id.as_bytes().to_vec()))
+            .transpose()
+            .map_err(|_| failure(UsageExportFailureKind::Internal))?
+            .unwrap_or(cursor);
+        let events = rows
+            .into_iter()
+            .map(StoredUsageEvent::decode)
+            .collect::<Result<Vec<_>, _>>()?;
+        transaction.commit().await.map_err(database_failure)?;
+        WorkspaceUsagePage::new(events, next_cursor)
+            .map_err(|_| failure(UsageExportFailureKind::Internal))
+    }
+}
+
+impl fmt::Debug for PostgresWorkspaceUsageExporter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresWorkspaceUsageExporter")
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkspaceUsageExporter for PostgresWorkspaceUsageExporter {
+    fn list(&self, request: AuthorizedListWorkspaceUsage) -> UsageExportFuture<'_> {
+        Box::pin(self.list_inner(request))
+    }
+}
+
+#[derive(FromRow)]
+struct StoredUsageEvent {
+    event_id: Uuid,
+    shard_id: String,
+    workspace_id: String,
+    attempt_id: Uuid,
+    entitlement_revision: i64,
+    interval_start_ms: i64,
+    interval_end_ms: i64,
+    consumed_compute_ms: i64,
+}
+
+impl StoredUsageEvent {
+    fn decode(self) -> Result<WorkspaceUsageEvent, UsageExportFailure> {
+        WorkspaceUsageEvent::new(
+            UsageEventId::from_uuid(self.event_id).map_err(corrupt)?,
+            ShardId::new(self.shard_id).map_err(corrupt)?,
+            WorkspaceId::parse(&self.workspace_id).map_err(corrupt)?,
+            UsageAttemptId::from_uuid(self.attempt_id).map_err(corrupt)?,
+            EntitlementRevision::new(u64::try_from(self.entitlement_revision).map_err(corrupt)?)
+                .map_err(corrupt)?,
+            timestamp(self.interval_start_ms)?,
+            timestamp(self.interval_end_ms)?,
+            ConsumedComputeMilliseconds::new(
+                u64::try_from(self.consumed_compute_ms).map_err(corrupt)?,
+            )
+            .map_err(corrupt)?,
+        )
+        .map_err(corrupt)
+    }
+}
+
+async fn resolve_cursor(
+    transaction: &mut Transaction<'_, Postgres>,
+    authority_id: &str,
+    shard_id: &str,
+    cursor: &UsageExportCursor,
+) -> Result<i64, UsageExportFailure> {
+    if cursor.as_bytes().is_empty() {
+        return Ok(0);
+    }
+    if cursor.as_bytes().len() != CURSOR_BYTES {
+        return Err(failure(UsageExportFailureKind::InvalidCursor));
+    }
+    let event_id = Uuid::from_slice(cursor.as_bytes())
+        .map_err(|_| failure(UsageExportFailureKind::InvalidCursor))?;
+    sqlx::query_scalar(
+        r"
+        SELECT sequence FROM workspace_usage_events
+        WHERE event_id=$1 AND authority_id=$2 AND shard_id=$3
+        ",
+    )
+    .bind(event_id)
+    .bind(authority_id)
+    .bind(shard_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(database_failure)?
+    .ok_or_else(|| failure(UsageExportFailureKind::InvalidCursor))
+}
+
+fn timestamp(milliseconds: i64) -> Result<UsageTimestamp, UsageExportFailure> {
+    let seconds = milliseconds.div_euclid(1_000);
+    let remainder = milliseconds.rem_euclid(1_000);
+    let nanoseconds = u32::try_from(remainder)
+        .ok()
+        .and_then(|value| value.checked_mul(1_000_000))
+        .ok_or_else(|| failure(UsageExportFailureKind::Internal))?;
+    UsageTimestamp::new(seconds, nanoseconds).map_err(|_| failure(UsageExportFailureKind::Internal))
+}
+
+fn database_failure(error: sqlx::Error) -> UsageExportFailure {
+    let kind = match &error {
+        sqlx::Error::Io(_)
+        | sqlx::Error::Tls(_)
+        | sqlx::Error::PoolTimedOut
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::WorkerCrashed
+        | sqlx::Error::BeginFailed => UsageExportFailureKind::TemporarilyUnavailable,
+        sqlx::Error::Database(database)
+            if super::retryable_sqlstate(database.code().as_deref()) =>
+        {
+            UsageExportFailureKind::TemporarilyUnavailable
+        }
+        _ => UsageExportFailureKind::Internal,
+    };
+    drop(error);
+    failure(kind)
+}
+
+fn corrupt<T>(_error: T) -> UsageExportFailure {
+    failure(UsageExportFailureKind::Internal)
+}
+
+const fn failure(kind: UsageExportFailureKind) -> UsageExportFailure {
+    UsageExportFailure::new(kind)
+}

--- a/crates/automata-ci-postgres/tests/provisioning/mod.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/mod.rs
@@ -1,4 +1,5 @@
 //! Workspace provisioning adapter tests.
 
 mod entitlement;
+mod usage;
 mod workspace;

--- a/crates/automata-ci-postgres/tests/provisioning/usage.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/usage.rs
@@ -1,0 +1,321 @@
+use automata_ci_postgres::provisioning::{
+    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
+    PostgresWorkspaceUsageExporter,
+};
+use automata_ci_provisioning::{
+    ApplyWorkspaceEntitlementCommand, AuthorizedApplyWorkspaceEntitlement,
+    AuthorizedListWorkspaceUsage, AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName,
+    EntitlementRevision, ExternalAccountSubject, ListWorkspaceUsageCommand, OperationId,
+    ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId, ShardId,
+    UsageExportCursor, UsageExportFailureKind, UsageExportPageSize, WorkspaceEntitlementApplier,
+    WorkspaceExecutionEntitlement, WorkspaceId, WorkspaceProvisioner, WorkspaceUsageExporter,
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::support::{TestResult, run_with_database};
+
+const AUTHORITY_A: &str = "automata-cloud-production";
+const AUTHORITY_B: &str = "partner-control-plane";
+const ISSUER: &str = "https://cloud.automata.example";
+const SHARD: &str = "prod-us-east-1-001";
+
+fn authority(authority_id: &str) -> ProvisioningAuthority {
+    ProvisioningAuthority::new(
+        ProvisioningAuthorityId::new(authority_id).expect("authority"),
+        ShardId::new(SHARD).expect("shard"),
+        DelegatedActorIssuer::new(ISSUER).expect("issuer"),
+    )
+}
+
+fn provisioning_request(authority_id: &str, workspace_id: Uuid) -> AuthorizedProvisionWorkspace {
+    let command = ProvisionWorkspaceCommand::new(
+        OperationId::from_uuid(Uuid::new_v4()).expect("operation ID"),
+        ShardId::new(SHARD).expect("shard"),
+        WorkspaceId::from_uuid(workspace_id).expect("workspace ID"),
+        DisplayName::new("Acme Engineering").expect("workspace name"),
+        DelegatedActorIssuer::new(ISSUER).expect("issuer"),
+        ExternalAccountSubject::from_uuid(Uuid::new_v4()).expect("subject"),
+        DisplayName::new("The Octocat").expect("owner name"),
+    );
+    AuthorizedProvisionWorkspace::authorize(authority(authority_id), command)
+        .expect("authorized provisioning")
+}
+
+fn entitlement_request(
+    authority_id: &str,
+    workspace_id: Uuid,
+) -> AuthorizedApplyWorkspaceEntitlement {
+    let command = ApplyWorkspaceEntitlementCommand::new(
+        OperationId::from_uuid(Uuid::new_v4()).expect("operation ID"),
+        ShardId::new(SHARD).expect("shard"),
+        WorkspaceId::from_uuid(workspace_id).expect("workspace ID"),
+        EntitlementRevision::new(1).expect("revision"),
+        WorkspaceExecutionEntitlement::Uncapped,
+    );
+    AuthorizedApplyWorkspaceEntitlement::authorize(authority(authority_id), command)
+        .expect("authorized entitlement")
+}
+
+fn export_request(
+    authority_id: &str,
+    cursor: UsageExportCursor,
+    page_size: u32,
+) -> AuthorizedListWorkspaceUsage {
+    let command = ListWorkspaceUsageCommand::new(
+        ShardId::new(SHARD).expect("shard"),
+        cursor,
+        UsageExportPageSize::new(page_size).expect("page size"),
+    );
+    AuthorizedListWorkspaceUsage::authorize(authority(authority_id), command)
+        .expect("authorized usage export")
+}
+
+#[derive(Clone, Copy)]
+struct UsageFixture {
+    authority_id: &'static str,
+    workspace_id: Uuid,
+    event_id: Uuid,
+    attempt_id: Uuid,
+    start_ms: i64,
+    end_ms: i64,
+    consumed_ms: i64,
+}
+
+async fn insert_usage(pool: &PgPool, usage: UsageFixture) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r"
+        INSERT INTO workspace_usage_events (
+            event_id, authority_id, shard_id, workspace_id, attempt_id,
+            entitlement_revision, interval_start_ms, interval_end_ms,
+            consumed_compute_ms, recorded_at_ms
+        ) VALUES ($1,$2,$3,$4,$5,1,$6,$7,$8,$7)
+        ",
+    )
+    .bind(usage.event_id)
+    .bind(usage.authority_id)
+    .bind(SHARD)
+    .bind(usage.workspace_id.hyphenated().to_string())
+    .bind(usage.attempt_id)
+    .bind(usage.start_ms)
+    .bind(usage.end_ms)
+    .bind(usage.consumed_ms)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn provision_entitled_workspace(
+    pool: &PgPool,
+    authority_id: &'static str,
+) -> TestResult<Uuid> {
+    let workspace_id = Uuid::new_v4();
+    PostgresWorkspaceProvisioner::new(pool.clone())
+        .provision(provisioning_request(authority_id, workspace_id))
+        .await?;
+    PostgresWorkspaceEntitlementApplier::new(pool.clone())
+        .apply(entitlement_request(authority_id, workspace_id))
+        .await?;
+    Ok(workspace_id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn usage_pages_are_stable_replayable_and_append_visible() -> TestResult {
+    run_with_database(|database| async move {
+        let workspace_id = provision_entitled_workspace(database.pool(), AUTHORITY_A).await?;
+        let attempt_id = Uuid::new_v4();
+        let event_ids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+        for (index, event_id) in event_ids.into_iter().enumerate() {
+            let start_ms = 1_786_500_100_000 + i64::try_from(index)? * 1_000;
+            insert_usage(
+                database.pool(),
+                UsageFixture {
+                    authority_id: AUTHORITY_A,
+                    workspace_id,
+                    event_id,
+                    attempt_id,
+                    start_ms,
+                    end_ms: start_ms + 1_000,
+                    consumed_ms: 1_000,
+                },
+            )
+            .await?;
+        }
+
+        let exporter = PostgresWorkspaceUsageExporter::new(database.pool().clone());
+        let first = exporter
+            .list(export_request(
+                AUTHORITY_A,
+                UsageExportCursor::beginning(),
+                2,
+            ))
+            .await?;
+        let replay = exporter
+            .list(export_request(
+                AUTHORITY_A,
+                UsageExportCursor::beginning(),
+                2,
+            ))
+            .await?;
+        assert_eq!(replay, first);
+        assert_eq!(first.events().len(), 2);
+        assert_eq!(first.events()[0].event_id().as_uuid(), event_ids[0]);
+        assert_eq!(first.events()[1].event_id().as_uuid(), event_ids[1]);
+        assert_eq!(first.events()[0].workspace_id().as_uuid(), workspace_id);
+        assert_eq!(first.events()[0].attempt_id().as_uuid(), attempt_id);
+        assert_eq!(first.events()[0].entitlement_revision().get(), 1);
+        assert_eq!(first.events()[0].consumed_compute().get(), 1_000);
+
+        let second = exporter
+            .list(export_request(AUTHORITY_A, first.next_cursor().clone(), 2))
+            .await?;
+        assert_eq!(second.events().len(), 1);
+        assert_eq!(second.events()[0].event_id().as_uuid(), event_ids[2]);
+
+        let empty = exporter
+            .list(export_request(AUTHORITY_A, second.next_cursor().clone(), 2))
+            .await?;
+        assert!(empty.events().is_empty());
+        assert_eq!(empty.next_cursor(), second.next_cursor());
+
+        let appended_id = Uuid::new_v4();
+        insert_usage(
+            database.pool(),
+            UsageFixture {
+                authority_id: AUTHORITY_A,
+                workspace_id,
+                event_id: appended_id,
+                attempt_id,
+                start_ms: 1_786_500_103_000,
+                end_ms: 1_786_500_104_000,
+                consumed_ms: 1_000,
+            },
+        )
+        .await?;
+        let appended = exporter
+            .list(export_request(AUTHORITY_A, empty.next_cursor().clone(), 2))
+            .await?;
+        assert_eq!(appended.events().len(), 1);
+        assert_eq!(appended.events()[0].event_id().as_uuid(), appended_id);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn events_and_cursors_are_isolated_by_management_authority() -> TestResult {
+    run_with_database(|database| async move {
+        let workspace_a = provision_entitled_workspace(database.pool(), AUTHORITY_A).await?;
+        let workspace_b = provision_entitled_workspace(database.pool(), AUTHORITY_B).await?;
+        let event_a = Uuid::new_v4();
+        let event_b = Uuid::new_v4();
+        for (authority_id, workspace_id, event_id) in [
+            (AUTHORITY_A, workspace_a, event_a),
+            (AUTHORITY_B, workspace_b, event_b),
+        ] {
+            insert_usage(
+                database.pool(),
+                UsageFixture {
+                    authority_id,
+                    workspace_id,
+                    event_id,
+                    attempt_id: Uuid::new_v4(),
+                    start_ms: 1_786_500_100_000,
+                    end_ms: 1_786_500_101_000,
+                    consumed_ms: 1_000,
+                },
+            )
+            .await?;
+        }
+
+        let exporter = PostgresWorkspaceUsageExporter::new(database.pool().clone());
+        let page_a = exporter
+            .list(export_request(
+                AUTHORITY_A,
+                UsageExportCursor::beginning(),
+                100,
+            ))
+            .await?;
+        assert_eq!(page_a.events().len(), 1);
+        assert_eq!(page_a.events()[0].event_id().as_uuid(), event_a);
+
+        let crossed = exporter
+            .list(export_request(
+                AUTHORITY_B,
+                page_a.next_cursor().clone(),
+                100,
+            ))
+            .await
+            .expect_err("another authority's cursor must be invalid");
+        assert_eq!(crossed.kind(), UsageExportFailureKind::InvalidCursor);
+
+        let malformed = exporter
+            .list(export_request(
+                AUTHORITY_A,
+                UsageExportCursor::new(vec![1]).expect("bounded cursor"),
+                100,
+            ))
+            .await
+            .expect_err("malformed opaque cursor must fail");
+        assert_eq!(malformed.kind(), UsageExportFailureKind::InvalidCursor);
+
+        let unknown = exporter
+            .list(export_request(
+                AUTHORITY_A,
+                UsageExportCursor::new(Uuid::new_v4().as_bytes().to_vec()).expect("bounded cursor"),
+                100,
+            ))
+            .await
+            .expect_err("unknown opaque cursor must fail");
+        assert_eq!(unknown.kind(), UsageExportFailureKind::InvalidCursor);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn feed_constraints_reject_duplicate_intervals_and_wrong_bindings() -> TestResult {
+    run_with_database(|database| async move {
+        let workspace_id = provision_entitled_workspace(database.pool(), AUTHORITY_A).await?;
+        let base = UsageFixture {
+            authority_id: AUTHORITY_A,
+            workspace_id,
+            event_id: Uuid::new_v4(),
+            attempt_id: Uuid::new_v4(),
+            start_ms: 1_786_500_100_000,
+            end_ms: 1_786_500_101_000,
+            consumed_ms: 1_000,
+        };
+        insert_usage(database.pool(), base).await?;
+
+        let duplicate = insert_usage(
+            database.pool(),
+            UsageFixture {
+                event_id: Uuid::new_v4(),
+                ..base
+            },
+        )
+        .await
+        .expect_err("the same accounted interval must be immutable");
+        assert!(duplicate.as_database_error().is_some());
+
+        let wrong_authority = insert_usage(
+            database.pool(),
+            UsageFixture {
+                authority_id: AUTHORITY_B,
+                event_id: Uuid::new_v4(),
+                start_ms: base.end_ms,
+                end_ms: base.end_ms + 1_000,
+                ..base
+            },
+        )
+        .await
+        .expect_err("the event must match the workspace management binding");
+        assert!(wrong_authority.as_database_error().is_some());
+        Ok(())
+    })
+    .await
+}


### PR DESCRIPTION
## Outcome

Adds the durable PostgreSQL side of the public workspace-usage pull contract.

- Adds forward-only migration `0027_workspace_usage_feed.sql` with an append sequence, immutable event identities, workspace management/entitlement references, bounded timestamps, positive compute, and the authority feed index.
- Implements `PostgresWorkspaceUsageExporter` behind the transport-neutral `WorkspaceUsageExporter` port.
- Uses the last event UUID as an opaque continuation token and resolves it through the authenticated authority and shard before reading the internal append sequence.
- Covers stable replay, bounded pagination, later append visibility, authority isolation, invalid cursors, duplicate intervals, and binding constraints against PostgreSQL 18.

This does not compose the gRPC service, advertise a capability, or choose a runner lifecycle charging boundary. The subsequent accounting change can append to this table in its existing execution transaction after those semantics are agreed.

## Related issue

None.

## Trust and compatibility impact

The new feed is readable only through an already authorized management request. Both cursor resolution and page selection require the exact authority and shard, so moving a cursor between management authorities fails as `InvalidCursor`. The migration is additive and forward-only. No existing RPC, listener, runner path, entitlement mutation, or capability response changes.

## Verification

- PostgreSQL 18: `cargo test -p automata-ci-postgres --test postgres provisioning::usage -- --ignored --test-threads=1` — 3 passed.
- PostgreSQL 18: schema catalog redundant-index test — passed.
- Migration layout test — passed.
- `cargo test -p automata-ci-postgres --test postgres provisioning::usage --no-default-features` — compiled; the three database tests were correctly ignored without the database environment.
- `cargo clippy -p automata-ci-postgres --lib -- -D warnings` — passed.
- Integration target clippy with only the pre-existing `too_many_lines` lint suppressed — passed.
- Targeted `rustfmt --check` and `git diff --check` — passed.
- Full all-target clippy remains blocked on current `main` by pre-existing `items_after_test_module` in `src/store/github_subject_evidence.rs` and `too_many_lines` in `tests/store/provider/github_subject_evidence.rs`; neither file is changed here.

## AI assistance

Codex materially assisted with the cursor design, PostgreSQL adapter, migration, tests, and review. Every submitted change was reviewed and exercised locally against PostgreSQL 18.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.