### PR TITLE
Fix pinned action resolution, caching, and retried job logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "automata-ci-action-cache-file"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "automata-ci-action",
+ "automata-ci-blob",
+ "automata-ci-core",
+ "automata-ci-scm",
+ "bytes",
+ "flate2",
+ "libc",
+ "rustix",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "static_assertions",
+ "tar",
+ "tokio",
+]
+
+[[package]]
 name = "automata-ci-action-github"
 version = "0.1.0"
 dependencies = [
@@ -793,6 +814,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "automata-ci-action",
+ "automata-ci-action-cache-file",
  "automata-ci-action-github",
  "automata-ci-auth",
  "automata-ci-blob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/automata-ci-action",
+    "crates/automata-ci-action-cache-file",
     "crates/automata-ci-action-github",
     "crates/automata-ci",
     "crates/automata-ci-auth",
@@ -76,6 +77,7 @@ aws-sdk-s3 = { version = "=1.141.0", default-features = false, features = ["beha
 aws-smithy-http-client = { version = "=1.2.0", default-features = false, features = ["rustls-ring"] }
 automata-ci-auth = { path = "crates/automata-ci-auth", version = "0.1.0" }
 automata-ci-action = { path = "crates/automata-ci-action", version = "0.1.0" }
+automata-ci-action-cache-file = { path = "crates/automata-ci-action-cache-file", version = "0.1.0" }
 automata-ci-action-github = { path = "crates/automata-ci-action-github", version = "0.1.0" }
 automata-ci-blob = { path = "crates/automata-ci-blob", version = "0.1.0" }
 automata-ci-blob-s3 = { path = "crates/automata-ci-blob-s3", version = "0.1.0" }
@@ -136,6 +138,7 @@ hyper-util = { version = "=0.1.20", default-features = false, features = ["clien
 jiff = "0.2.35"
 k8s-openapi = { version = "0.28.0", features = ["v1_34"] }
 kube = { version = "4.2.0", default-features = false, features = ["client", "ring", "rustls-tls", "ws"] }
+libc = "0.2.189"
 pem-rfc7468 = { version = "1.0.0", default-features = false, features = ["std"] }
 processkit = { version = "=3.3.1", default-features = false, features = ["limits"] }
 prometheus-client = "=0.25.0"

--- a/crates/automata-ci-action-cache-file/Cargo.toml
+++ b/crates/automata-ci-action-cache-file/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "automata-ci-action-cache-file"
+description = "Crash-durable bounded action reference index for Automata runners"
+publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+automata-ci-action.workspace = true
+automata-ci-blob.workspace = true
+automata-ci-core.workspace = true
+automata-ci-scm.workspace = true
+bytes.workspace = true
+libc.workspace = true
+rustix.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+bytes.workspace = true
+flate2.workspace = true
+sha2.workspace = true
+static_assertions.workspace = true
+tar.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/automata-ci-action-cache-file/src/archive_cache.rs
+++ b/crates/automata-ci-action-cache-file/src/archive_cache.rs
@@ -1,0 +1,390 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Read as _, Write as _},
+    os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+
+use async_trait::async_trait;
+use automata_ci_blob::{
+    BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
+    PutBlobOutcome, VerifiedBlob,
+};
+use bytes::Bytes;
+use rustix::fs::{FlockOperation, flock};
+
+use crate::ActionReferenceIndexRoot;
+
+const ARCHIVE_PREFIX: &str = "action-archive-v1-";
+const ARCHIVE_SUFFIX: &str = ".tar.gz";
+const LOCK_FILE: &str = ".action-archive-cache.lock";
+const STAGING_PREFIX: &str = ".action-archive-cache.stage-";
+const ACTION_KEY_PREFIX: &str = "actions/v1/sha256/";
+const ACTION_MEDIA_TYPE: &str = "application/gzip";
+
+/// Default number of immutable action archives retained by each runner.
+pub const DEFAULT_MAXIMUM_ARCHIVE_ENTRIES: usize = 256;
+/// Default local archive-cache byte budget for each runner (512 MiB).
+pub const DEFAULT_MAXIMUM_ARCHIVE_BYTES: u64 = 512 * 1_024 * 1_024;
+/// Default ceiling for one compressed action archive (16 MiB).
+pub const DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES: u64 = 16 * 1_024 * 1_024;
+
+/// Explicit bounds for one runner-local immutable archive cache.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActionArchiveCacheLimits {
+    maximum_entries: usize,
+    maximum_bytes: u64,
+    maximum_single_archive_bytes: u64,
+}
+
+impl ActionArchiveCacheLimits {
+    /// Creates a bounded local archive policy.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero, inconsistent, or excessive bounds.
+    pub const fn new(
+        maximum_entries: usize,
+        maximum_bytes: u64,
+        maximum_single_archive_bytes: u64,
+    ) -> Result<Self, BlobStoreError> {
+        if maximum_entries == 0
+            || maximum_entries > 65_536
+            || maximum_bytes == 0
+            || maximum_bytes > 64 * 1_024 * 1_024 * 1_024
+            || maximum_single_archive_bytes == 0
+            || maximum_single_archive_bytes > maximum_bytes
+            || maximum_single_archive_bytes > 64 * 1_024 * 1_024
+        {
+            return Err(BlobStoreError::new(BlobStoreErrorKind::InvalidResponse));
+        }
+        Ok(Self {
+            maximum_entries,
+            maximum_bytes,
+            maximum_single_archive_bytes,
+        })
+    }
+
+    /// Returns the retained archive count ceiling.
+    #[must_use]
+    pub const fn maximum_entries(self) -> usize {
+        self.maximum_entries
+    }
+
+    /// Returns the aggregate encoded byte ceiling.
+    #[must_use]
+    pub const fn maximum_bytes(self) -> u64 {
+        self.maximum_bytes
+    }
+
+    /// Returns the per-archive encoded byte ceiling.
+    #[must_use]
+    pub const fn maximum_single_archive_bytes(self) -> u64 {
+        self.maximum_single_archive_bytes
+    }
+}
+
+impl Default for ActionArchiveCacheLimits {
+    fn default() -> Self {
+        Self {
+            maximum_entries: DEFAULT_MAXIMUM_ARCHIVE_ENTRIES,
+            maximum_bytes: DEFAULT_MAXIMUM_ARCHIVE_BYTES,
+            maximum_single_archive_bytes: DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES,
+        }
+    }
+}
+
+/// Validated non-temporary root for a runner-local archive cache.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActionArchiveCacheRoot(PathBuf);
+
+impl ActionArchiveCacheRoot {
+    /// Validates one explicitly configured archive-cache root.
+    ///
+    /// # Errors
+    ///
+    /// Rejects the same unsafe paths as [`ActionReferenceIndexRoot`].
+    pub fn explicit(path: impl Into<PathBuf>) -> Result<Self, BlobStoreError> {
+        let path = path.into();
+        ActionReferenceIndexRoot::explicit(path.clone())
+            .map_err(|_| BlobStoreError::new(BlobStoreErrorKind::InvalidResponse))?;
+        Ok(Self(path))
+    }
+
+    /// Returns the validated filesystem path.
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    root: ActionArchiveCacheRoot,
+    limits: ActionArchiveCacheLimits,
+    gate: Mutex<()>,
+    _lock: File,
+}
+
+/// Process-exclusive, bounded, content-verified local action archive cache.
+#[derive(Clone, Debug)]
+pub struct FileActionArchiveCache {
+    inner: Arc<Inner>,
+}
+
+impl FileActionArchiveCache {
+    /// Opens the cache, creates its private root, and removes incomplete writes.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed for unsafe files, lock contention, or I/O failures.
+    pub fn open(
+        root: ActionArchiveCacheRoot,
+        limits: ActionArchiveCacheLimits,
+    ) -> Result<Self, BlobStoreError> {
+        fs::create_dir_all(root.as_path()).map_err(|_| unavailable())?;
+        let metadata = fs::symlink_metadata(root.as_path()).map_err(|_| unavailable())?;
+        if !metadata.file_type().is_dir() || metadata.nlink() != 2 {
+            return Err(integrity());
+        }
+        fs::set_permissions(root.as_path(), fs::Permissions::from_mode(0o700))
+            .map_err(|_| unavailable())?;
+        let lock = open_file(&root.as_path().join(LOCK_FILE), true, false)?;
+        ensure_regular(&lock)?;
+        flock(&lock, FlockOperation::NonBlockingLockExclusive).map_err(|_| unavailable())?;
+        cleanup_staging(root.as_path())?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                root,
+                limits,
+                gate: Mutex::new(()),
+                _lock: lock,
+            }),
+        })
+    }
+
+    fn get_sync(
+        &self,
+        descriptor: &BlobDescriptor,
+        maximum_bytes: u64,
+    ) -> Result<VerifiedBlob, BlobStoreError> {
+        let _guard = self.inner.gate.lock().map_err(|_| unavailable())?;
+        validate_descriptor(descriptor, self.inner.limits, maximum_bytes)?;
+        read_verified(self.inner.root.as_path(), descriptor)
+    }
+
+    fn put_sync(&self, payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
+        let _guard = self.inner.gate.lock().map_err(|_| unavailable())?;
+        let descriptor = payload.descriptor();
+        validate_descriptor(
+            descriptor,
+            self.inner.limits,
+            self.inner.limits.maximum_single_archive_bytes(),
+        )?;
+        match read_verified(self.inner.root.as_path(), descriptor) {
+            Ok(existing) if existing.bytes() == payload.bytes() => {
+                return Ok(PutBlobOutcome::AlreadyPresent);
+            }
+            Ok(_) => return Err(integrity()),
+            Err(error) if error.kind() == BlobStoreErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        evict_for(
+            self.inner.root.as_path(),
+            self.inner.limits,
+            descriptor.size(),
+        )?;
+        let final_name = archive_name(descriptor);
+        let stage_name = format!("{STAGING_PREFIX}{}", descriptor.digest());
+        let stage_path = self.inner.root.as_path().join(&stage_name);
+        let mut stage = open_file(&stage_path, true, true)?;
+        ensure_regular(&stage)?;
+        stage
+            .write_all(payload.bytes())
+            .map_err(|_| unavailable())?;
+        stage.sync_all().map_err(|_| unavailable())?;
+        drop(stage);
+        fs::rename(&stage_path, self.inner.root.as_path().join(final_name))
+            .map_err(|_| unavailable())?;
+        sync_root(self.inner.root.as_path())?;
+        Ok(PutBlobOutcome::Created)
+    }
+}
+
+#[async_trait]
+impl ImmutableBlobStore for FileActionArchiveCache {
+    async fn put_if_absent(&self, payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
+        let cache = self.clone();
+        tokio::task::spawn_blocking(move || cache.put_sync(payload))
+            .await
+            .map_err(|_| unavailable())?
+    }
+
+    async fn get_verified(
+        &self,
+        descriptor: &BlobDescriptor,
+        maximum_bytes: u64,
+    ) -> Result<VerifiedBlob, BlobStoreError> {
+        let cache = self.clone();
+        let descriptor = descriptor.clone();
+        tokio::task::spawn_blocking(move || cache.get_sync(&descriptor, maximum_bytes))
+            .await
+            .map_err(|_| unavailable())?
+    }
+}
+
+fn validate_descriptor(
+    descriptor: &BlobDescriptor,
+    limits: ActionArchiveCacheLimits,
+    maximum_bytes: u64,
+) -> Result<(), BlobStoreError> {
+    if descriptor.size() == 0
+        || descriptor.size() > maximum_bytes
+        || descriptor.size() > limits.maximum_single_archive_bytes()
+        || descriptor.media_type().as_str() != ACTION_MEDIA_TYPE
+        || descriptor.key().as_str() != format!("{ACTION_KEY_PREFIX}{}.tar.gz", descriptor.digest())
+    {
+        return Err(BlobStoreError::new(BlobStoreErrorKind::InvalidResponse));
+    }
+    Ok(())
+}
+
+fn archive_name(descriptor: &BlobDescriptor) -> String {
+    format!("{ARCHIVE_PREFIX}{}{ARCHIVE_SUFFIX}", descriptor.digest())
+}
+
+fn read_verified(root: &Path, descriptor: &BlobDescriptor) -> Result<VerifiedBlob, BlobStoreError> {
+    let path = root.join(archive_name(descriptor));
+    let file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Err(not_found()),
+        Err(_) => return Err(unavailable()),
+    };
+    ensure_regular(&file)?;
+    let received = file.metadata().map_err(|_| unavailable())?.len();
+    if received != descriptor.size() {
+        return Err(integrity());
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(received).map_err(|_| too_large())?);
+    file.take(received.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| unavailable())?;
+    let payload =
+        BlobPayload::verify(descriptor.clone(), Bytes::from(bytes)).map_err(|_| integrity())?;
+    Ok(VerifiedBlob::from_payload(payload))
+}
+
+fn evict_for(
+    root: &Path,
+    limits: ActionArchiveCacheLimits,
+    incoming: u64,
+) -> Result<(), BlobStoreError> {
+    let mut entries = Vec::new();
+    let mut total = 0_u64;
+    for entry in fs::read_dir(root).map_err(|_| unavailable())? {
+        let entry = entry.map_err(|_| unavailable())?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(ARCHIVE_PREFIX) || !name.ends_with(ARCHIVE_SUFFIX) {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path()).map_err(|_| unavailable())?;
+        if !metadata.file_type().is_file() || metadata.nlink() != 1 {
+            return Err(integrity());
+        }
+        total = total.checked_add(metadata.len()).ok_or_else(too_large)?;
+        entries.push((
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            name.into_owned(),
+            metadata.len(),
+        ));
+    }
+    entries.sort_by(|left, right| (left.0, &left.1).cmp(&(right.0, &right.1)));
+    let mut changed = false;
+    while entries.len() >= limits.maximum_entries()
+        || total
+            .checked_add(incoming)
+            .is_none_or(|size| size > limits.maximum_bytes())
+    {
+        let (_, name, size) = entries.first().cloned().ok_or_else(too_large)?;
+        fs::remove_file(root.join(&name)).map_err(|_| unavailable())?;
+        entries.remove(0);
+        total = total.checked_sub(size).ok_or_else(integrity)?;
+        changed = true;
+    }
+    if changed {
+        sync_root(root)?;
+    }
+    Ok(())
+}
+
+fn cleanup_staging(root: &Path) -> Result<(), BlobStoreError> {
+    let mut changed = false;
+    for entry in fs::read_dir(root).map_err(|_| unavailable())? {
+        let entry = entry.map_err(|_| unavailable())?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(STAGING_PREFIX)
+        {
+            fs::remove_file(entry.path()).map_err(|_| unavailable())?;
+            changed = true;
+        }
+    }
+    if changed {
+        sync_root(root)?;
+    }
+    Ok(())
+}
+
+fn open_file(path: &Path, write: bool, create_new: bool) -> Result<File, BlobStoreError> {
+    let mut options = OpenOptions::new();
+    options
+        .read(!write)
+        .write(write)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    if create_new {
+        options.create_new(true);
+    } else {
+        options.create(true);
+    }
+    options.open(path).map_err(|_| unavailable())
+}
+
+fn ensure_regular(file: &File) -> Result<(), BlobStoreError> {
+    let metadata = file.metadata().map_err(|_| unavailable())?;
+    if metadata.file_type().is_file() && metadata.nlink() == 1 {
+        Ok(())
+    } else {
+        Err(integrity())
+    }
+}
+
+fn sync_root(root: &Path) -> Result<(), BlobStoreError> {
+    File::open(root)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| unavailable())
+}
+
+const fn not_found() -> BlobStoreError {
+    BlobStoreError::new(BlobStoreErrorKind::NotFound)
+}
+
+const fn integrity() -> BlobStoreError {
+    BlobStoreError::new(BlobStoreErrorKind::Integrity)
+}
+
+const fn too_large() -> BlobStoreError {
+    BlobStoreError::new(BlobStoreErrorKind::TooLarge)
+}
+
+const fn unavailable() -> BlobStoreError {
+    BlobStoreError::new(BlobStoreErrorKind::Unavailable)
+}

--- a/crates/automata-ci-action-cache-file/src/archive_cache.rs
+++ b/crates/automata-ci-action-cache-file/src/archive_cache.rs
@@ -34,9 +34,9 @@ pub const DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES: u64 = 16 * 1_024 * 1_024;
 /// Explicit bounds for one runner-local immutable archive cache.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ActionArchiveCacheLimits {
-    maximum_entries: usize,
-    maximum_bytes: u64,
-    maximum_single_archive_bytes: u64,
+    entries: usize,
+    bytes: u64,
+    single_archive_bytes: u64,
 }
 
 impl ActionArchiveCacheLimits {
@@ -61,37 +61,37 @@ impl ActionArchiveCacheLimits {
             return Err(BlobStoreError::new(BlobStoreErrorKind::InvalidResponse));
         }
         Ok(Self {
-            maximum_entries,
-            maximum_bytes,
-            maximum_single_archive_bytes,
+            entries: maximum_entries,
+            bytes: maximum_bytes,
+            single_archive_bytes: maximum_single_archive_bytes,
         })
     }
 
     /// Returns the retained archive count ceiling.
     #[must_use]
     pub const fn maximum_entries(self) -> usize {
-        self.maximum_entries
+        self.entries
     }
 
     /// Returns the aggregate encoded byte ceiling.
     #[must_use]
     pub const fn maximum_bytes(self) -> u64 {
-        self.maximum_bytes
+        self.bytes
     }
 
     /// Returns the per-archive encoded byte ceiling.
     #[must_use]
     pub const fn maximum_single_archive_bytes(self) -> u64 {
-        self.maximum_single_archive_bytes
+        self.single_archive_bytes
     }
 }
 
 impl Default for ActionArchiveCacheLimits {
     fn default() -> Self {
         Self {
-            maximum_entries: DEFAULT_MAXIMUM_ARCHIVE_ENTRIES,
-            maximum_bytes: DEFAULT_MAXIMUM_ARCHIVE_BYTES,
-            maximum_single_archive_bytes: DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES,
+            entries: DEFAULT_MAXIMUM_ARCHIVE_ENTRIES,
+            bytes: DEFAULT_MAXIMUM_ARCHIVE_BYTES,
+            single_archive_bytes: DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES,
         }
     }
 }
@@ -175,7 +175,7 @@ impl FileActionArchiveCache {
         read_verified(self.inner.root.as_path(), descriptor)
     }
 
-    fn put_sync(&self, payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
+    fn put_sync(&self, payload: &BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
         let _guard = self.inner.gate.lock().map_err(|_| unavailable())?;
         let descriptor = payload.descriptor();
         validate_descriptor(
@@ -217,7 +217,7 @@ impl FileActionArchiveCache {
 impl ImmutableBlobStore for FileActionArchiveCache {
     async fn put_if_absent(&self, payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
         let cache = self.clone();
-        tokio::task::spawn_blocking(move || cache.put_sync(payload))
+        tokio::task::spawn_blocking(move || cache.put_sync(&payload))
             .await
             .map_err(|_| unavailable())?
     }

--- a/crates/automata-ci-action-cache-file/src/codec.rs
+++ b/crates/automata-ci-action-cache-file/src/codec.rs
@@ -1,0 +1,213 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    str::FromStr as _,
+};
+
+use automata_ci_action::{
+    ActionReferenceIndexError, ActionReferenceIndexErrorKind, ActionSubpath,
+    ImmutableActionReference, IndexedActionBundle,
+};
+use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
+use automata_ci_core::Sha256Digest;
+use automata_ci_scm::{RepositoryId, ResolvedRevision, RevisionSpec, ScmProviderId};
+use serde::{Deserialize, Serialize};
+
+use crate::ACTION_REFERENCE_INDEX_SCHEMA_VERSION;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StoredIndex {
+    generation: u64,
+    entries: BTreeMap<ImmutableActionReference, SequencedBundle>,
+}
+
+#[derive(Clone, Debug)]
+struct SequencedBundle {
+    sequence: u64,
+    bundle: IndexedActionBundle,
+}
+
+impl StoredIndex {
+    pub(crate) fn decode(
+        bytes: &[u8],
+        maximum_entries: usize,
+    ) -> Result<Self, ActionReferenceIndexError> {
+        if bytes.is_empty() {
+            return Err(corrupt());
+        }
+        let document: StoredIndexDocument = serde_json::from_slice(bytes).map_err(|_| corrupt())?;
+        if document.schema_version != ACTION_REFERENCE_INDEX_SCHEMA_VERSION
+            || document.entries.len() > maximum_entries
+        {
+            return Err(corrupt());
+        }
+        let mut entries = BTreeMap::new();
+        let mut sequences = BTreeSet::new();
+        for raw in document.entries {
+            if raw.sequence == 0
+                || raw.sequence > document.generation
+                || !sequences.insert(raw.sequence)
+            {
+                return Err(corrupt());
+            }
+            let bundle = raw.try_into_bundle()?;
+            let reference = bundle.reference().clone();
+            if entries
+                .insert(
+                    reference,
+                    SequencedBundle {
+                        sequence: raw.sequence,
+                        bundle,
+                    },
+                )
+                .is_some()
+            {
+                return Err(corrupt());
+            }
+        }
+        Ok(Self {
+            generation: document.generation,
+            entries,
+        })
+    }
+
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, ActionReferenceIndexError> {
+        let document = StoredIndexDocument {
+            schema_version: ACTION_REFERENCE_INDEX_SCHEMA_VERSION,
+            generation: self.generation,
+            entries: self
+                .entries
+                .values()
+                .map(StoredEntry::from_bundle)
+                .collect(),
+        };
+        serde_json::to_vec(&document).map_err(|_| corrupt())
+    }
+
+    pub(crate) fn get(&self, reference: &ImmutableActionReference) -> Option<&IndexedActionBundle> {
+        self.entries.get(reference).map(|entry| &entry.bundle)
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        bundle: IndexedActionBundle,
+    ) -> Result<(), ActionReferenceIndexError> {
+        self.generation = self.generation.checked_add(1).ok_or_else(exhausted)?;
+        self.entries.insert(
+            bundle.reference().clone(),
+            SequencedBundle {
+                sequence: self.generation,
+                bundle,
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn evict_to_entry_bound(
+        &mut self,
+        maximum_entries: usize,
+    ) -> Result<(), ActionReferenceIndexError> {
+        while self.entries.len() > maximum_entries {
+            self.evict_oldest()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn evict_oldest(&mut self) -> Result<(), ActionReferenceIndexError> {
+        let reference = self
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.sequence)
+            .map(|(reference, _)| reference.clone())
+            .ok_or_else(corrupt)?;
+        self.entries.remove(&reference);
+        Ok(())
+    }
+
+    pub(crate) const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredIndexDocument {
+    schema_version: u16,
+    generation: u64,
+    entries: Vec<StoredEntry>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredEntry {
+    sequence: u64,
+    provider: String,
+    repository: String,
+    revision: String,
+    subpath: String,
+    resolved_revision: String,
+    archive: StoredBlobDescriptor,
+}
+
+impl StoredEntry {
+    fn from_bundle(entry: &SequencedBundle) -> Self {
+        let reference = entry.bundle.reference();
+        let archive = entry.bundle.archive();
+        Self {
+            sequence: entry.sequence,
+            provider: reference.provider().as_str().to_owned(),
+            repository: reference.repository().as_str().to_owned(),
+            revision: reference.revision().as_str().to_owned(),
+            subpath: reference.subpath().as_str().to_owned(),
+            resolved_revision: entry.bundle.resolved_revision().as_str().to_owned(),
+            archive: StoredBlobDescriptor {
+                key: archive.key().as_str().to_owned(),
+                digest: archive.digest().to_string(),
+                size: archive.size(),
+                media_type: archive.media_type().as_str().to_owned(),
+            },
+        }
+    }
+
+    fn try_into_bundle(&self) -> Result<IndexedActionBundle, ActionReferenceIndexError> {
+        let provider = ScmProviderId::new(self.provider.clone()).map_err(|_| corrupt())?;
+        let repository = RepositoryId::new(self.repository.clone()).map_err(|_| corrupt())?;
+        let revision = RevisionSpec::new(self.revision.clone()).map_err(|_| corrupt())?;
+        let subpath = if self.subpath.is_empty() {
+            ActionSubpath::root()
+        } else {
+            ActionSubpath::new(self.subpath.clone()).map_err(|_| corrupt())?
+        };
+        let reference = ImmutableActionReference::new(provider, repository, revision, subpath)
+            .map_err(|_| corrupt())?;
+        let resolved_revision =
+            ResolvedRevision::new(self.resolved_revision.clone()).map_err(|_| corrupt())?;
+        let archive = BlobDescriptor::new(
+            BlobKey::new(self.archive.key.clone()).map_err(|_| corrupt())?,
+            Sha256Digest::from_str(&self.archive.digest).map_err(|_| corrupt())?,
+            self.archive.size,
+            MediaType::new(self.archive.media_type.clone()).map_err(|_| corrupt())?,
+        );
+        IndexedActionBundle::new(reference, resolved_revision, archive).map_err(|_| corrupt())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBlobDescriptor {
+    key: String,
+    digest: String,
+    size: u64,
+    media_type: String,
+}
+
+const fn corrupt() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Corrupt)
+}
+
+const fn exhausted() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::ResourceExhausted)
+}

--- a/crates/automata-ci-action-cache-file/src/lib.rs
+++ b/crates/automata-ci-action-cache-file/src/lib.rs
@@ -1,0 +1,243 @@
+#![forbid(unsafe_code)]
+//! Crash-durable local index for immutable repository action bundles.
+//!
+//! The index stores only credential-free provenance and exact blob
+//! descriptors. Archive content remains in the configured immutable blob
+//! store. A process-exclusive lock, bounded canonical JSON, and atomic
+//! file-plus-directory synchronization provide a small local authority that
+//! can be safely consulted before contacting SCM.
+
+#[cfg(unix)]
+mod archive_cache;
+mod codec;
+mod platform;
+mod root;
+
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use automata_ci_action::{
+    ActionReferenceIndex, ActionReferenceIndexError, ActionReferenceIndexErrorKind,
+    ImmutableActionReference, IndexedActionBundle, PutActionReferenceOutcome,
+};
+
+use self::{codec::StoredIndex, platform::PlatformDirectory};
+#[cfg(unix)]
+pub use archive_cache::{
+    ActionArchiveCacheLimits, ActionArchiveCacheRoot, DEFAULT_MAXIMUM_ARCHIVE_BYTES,
+    DEFAULT_MAXIMUM_ARCHIVE_ENTRIES, DEFAULT_MAXIMUM_SINGLE_ARCHIVE_BYTES, FileActionArchiveCache,
+};
+pub use root::ActionReferenceIndexRoot;
+
+/// Current durable action-reference index schema.
+pub const ACTION_REFERENCE_INDEX_SCHEMA_VERSION: u16 = 1;
+/// Default retained immutable reference count.
+pub const DEFAULT_MAXIMUM_INDEX_ENTRIES: usize = 4_096;
+/// Default hard ceiling for the canonical index document.
+pub const DEFAULT_MAXIMUM_INDEX_BYTES: usize = 8 * 1_024 * 1_024;
+
+const HARD_MAXIMUM_INDEX_ENTRIES: usize = 65_536;
+const HARD_MAXIMUM_INDEX_BYTES: usize = 64 * 1_024 * 1_024;
+const MINIMUM_INDEX_BYTES: usize = 1_024;
+
+/// Explicit bounds for one file-backed action reference index.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActionReferenceIndexLimits {
+    maximum_entries: usize,
+    maximum_bytes: usize,
+}
+
+impl ActionReferenceIndexLimits {
+    /// Creates defensive entry and encoded-file ceilings.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero, tiny, or excessive bounds.
+    pub const fn new(
+        maximum_entries: usize,
+        maximum_bytes: usize,
+    ) -> Result<Self, ActionReferenceIndexError> {
+        if maximum_entries == 0
+            || maximum_entries > HARD_MAXIMUM_INDEX_ENTRIES
+            || maximum_bytes < MINIMUM_INDEX_BYTES
+            || maximum_bytes > HARD_MAXIMUM_INDEX_BYTES
+        {
+            return Err(ActionReferenceIndexError::new(
+                ActionReferenceIndexErrorKind::ResourceExhausted,
+            ));
+        }
+        Ok(Self {
+            maximum_entries,
+            maximum_bytes,
+        })
+    }
+
+    #[must_use]
+    pub const fn maximum_entries(self) -> usize {
+        self.maximum_entries
+    }
+
+    #[must_use]
+    pub const fn maximum_bytes(self) -> usize {
+        self.maximum_bytes
+    }
+}
+
+impl Default for ActionReferenceIndexLimits {
+    fn default() -> Self {
+        Self {
+            maximum_entries: DEFAULT_MAXIMUM_INDEX_ENTRIES,
+            maximum_bytes: DEFAULT_MAXIMUM_INDEX_BYTES,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MemoryState {
+    index: StoredIndex,
+    poisoned: bool,
+}
+
+struct Inner {
+    root: ActionReferenceIndexRoot,
+    directory: PlatformDirectory,
+    limits: ActionReferenceIndexLimits,
+    memory: Mutex<MemoryState>,
+}
+
+impl fmt::Debug for Inner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FileActionReferenceIndexInner")
+            .field("root", &self.root)
+            .field("limits", &self.limits)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Secure, bounded, crash-durable immutable action reference index.
+#[derive(Clone, Debug)]
+pub struct FileActionReferenceIndex {
+    inner: Arc<Inner>,
+}
+
+impl FileActionReferenceIndex {
+    /// Opens and process-exclusively locks an index at an existing runner state
+    /// root, creating an empty index when none exists.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed for path-policy violations, lock contention, malformed or
+    /// oversized state, unsafe files, and I/O failures.
+    pub fn open(
+        root: ActionReferenceIndexRoot,
+        limits: ActionReferenceIndexLimits,
+    ) -> Result<Self, ActionReferenceIndexError> {
+        let directory = PlatformDirectory::open(&root)?;
+        directory.cleanup_staging()?;
+        let index = directory.read_index(limits.maximum_bytes())?.map_or_else(
+            || Ok(StoredIndex::default()),
+            |bytes| StoredIndex::decode(&bytes, limits.maximum_entries()),
+        )?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                root,
+                directory,
+                limits,
+                memory: Mutex::new(MemoryState {
+                    index,
+                    poisoned: false,
+                }),
+            }),
+        })
+    }
+
+    fn get_sync(
+        &self,
+        reference: &ImmutableActionReference,
+    ) -> Result<Option<IndexedActionBundle>, ActionReferenceIndexError> {
+        let memory = self.inner.memory.lock().map_err(|_| unavailable())?;
+        if memory.poisoned {
+            return Err(unavailable());
+        }
+        Ok(memory.index.get(reference).cloned())
+    }
+
+    fn put_sync(
+        &self,
+        bundle: IndexedActionBundle,
+    ) -> Result<PutActionReferenceOutcome, ActionReferenceIndexError> {
+        let mut memory = self.inner.memory.lock().map_err(|_| unavailable())?;
+        if memory.poisoned {
+            return Err(unavailable());
+        }
+        if let Some(existing) = memory.index.get(bundle.reference()) {
+            return if existing == &bundle {
+                Ok(PutActionReferenceOutcome::AlreadyPresent)
+            } else {
+                Err(ActionReferenceIndexError::new(
+                    ActionReferenceIndexErrorKind::Conflict,
+                ))
+            };
+        }
+
+        let mut candidate = memory.index.clone();
+        candidate.insert(bundle)?;
+        candidate.evict_to_entry_bound(self.inner.limits.maximum_entries())?;
+        let encoded = loop {
+            let encoded = candidate.encode()?;
+            if encoded.len() <= self.inner.limits.maximum_bytes() {
+                break encoded;
+            }
+            if candidate.len() <= 1 {
+                return Err(ActionReferenceIndexError::new(
+                    ActionReferenceIndexErrorKind::ResourceExhausted,
+                ));
+            }
+            candidate.evict_oldest()?;
+        };
+
+        match self
+            .inner
+            .directory
+            .commit(candidate.generation(), &encoded)
+        {
+            Ok(()) => {
+                memory.index = candidate;
+                Ok(PutActionReferenceOutcome::Created)
+            }
+            Err(failure) if failure.renamed() => {
+                memory.poisoned = true;
+                Err(unavailable())
+            }
+            Err(_) => Err(unavailable()),
+        }
+    }
+}
+
+#[async_trait]
+impl ActionReferenceIndex for FileActionReferenceIndex {
+    async fn get(
+        &self,
+        reference: &ImmutableActionReference,
+    ) -> Result<Option<IndexedActionBundle>, ActionReferenceIndexError> {
+        self.get_sync(reference)
+    }
+
+    async fn put_if_absent(
+        &self,
+        bundle: IndexedActionBundle,
+    ) -> Result<PutActionReferenceOutcome, ActionReferenceIndexError> {
+        let index = self.clone();
+        tokio::task::spawn_blocking(move || index.put_sync(bundle))
+            .await
+            .map_err(|_| unavailable())?
+    }
+}
+
+const fn unavailable() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unavailable)
+}

--- a/crates/automata-ci-action-cache-file/src/platform.rs
+++ b/crates/automata-ci-action-cache-file/src/platform.rs
@@ -1,0 +1,11 @@
+#[cfg(unix)]
+mod unix;
+
+#[cfg(unix)]
+pub(crate) use unix::PlatformDirectory;
+
+#[cfg(not(unix))]
+mod unsupported;
+
+#[cfg(not(unix))]
+pub(crate) use unsupported::PlatformDirectory;

--- a/crates/automata-ci-action-cache-file/src/platform/unix.rs
+++ b/crates/automata-ci-action-cache-file/src/platform/unix.rs
@@ -1,0 +1,225 @@
+use std::{
+    ffi::OsString,
+    fs::File,
+    io::{Read as _, Write as _},
+};
+
+use automata_ci_action::{ActionReferenceIndexError, ActionReferenceIndexErrorKind};
+use rustix::{
+    fd::OwnedFd,
+    fs::{
+        self, AtFlags, Dir, FileType, FlockOperation, Mode, OFlags, fchmod, flock, fstat, mkdirat,
+        openat, renameat, unlinkat,
+    },
+    io::Errno,
+};
+
+use crate::ActionReferenceIndexRoot;
+
+const INDEX_FILE: &str = "action-reference-index-v1.json";
+const LOCK_FILE: &str = ".action-reference-index.lock";
+const STAGING_PREFIX: &[u8] = b".action-reference-index.stage-";
+const DIRECTORY_MODE: Mode = Mode::from_raw_mode(0o700);
+const FILE_MODE: Mode = Mode::from_raw_mode(0o600);
+
+pub(crate) struct PlatformDirectory {
+    root_fd: OwnedFd,
+    _lock_fd: OwnedFd,
+}
+
+impl PlatformDirectory {
+    pub(crate) fn open(root: &ActionReferenceIndexRoot) -> Result<Self, ActionReferenceIndexError> {
+        let components: Vec<OsString> = root
+            .as_path()
+            .components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(value) => Some(value.to_os_string()),
+                _ => None,
+            })
+            .collect();
+        let directory_flags =
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW;
+        let mut current =
+            fs::open("/", directory_flags, Mode::empty()).map_err(|_| unavailable())?;
+        for component in components {
+            current = match openat(&current, &component, directory_flags, Mode::empty()) {
+                Ok(next) => next,
+                Err(Errno::NOENT) => {
+                    match mkdirat(&current, &component, DIRECTORY_MODE) {
+                        Ok(()) => fs::fsync(&current).map_err(|_| unavailable())?,
+                        Err(Errno::EXIST) => {}
+                        Err(_) => return Err(unavailable()),
+                    }
+                    openat(&current, &component, directory_flags, Mode::empty())
+                        .map_err(map_open_error)?
+                }
+                Err(error) => return Err(map_open_error(error)),
+            };
+        }
+        ensure_directory(&current)?;
+        fchmod(&current, DIRECTORY_MODE).map_err(|_| unavailable())?;
+
+        let lock_fd = openat(
+            &current,
+            LOCK_FILE,
+            OFlags::RDWR | OFlags::CREATE | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+            FILE_MODE,
+        )
+        .map_err(map_open_error)?;
+        ensure_regular_file(&lock_fd)?;
+        fchmod(&lock_fd, FILE_MODE).map_err(|_| unavailable())?;
+        if let Err(error) = flock(&lock_fd, FlockOperation::NonBlockingLockExclusive) {
+            if error == Errno::AGAIN || error == Errno::WOULDBLOCK {
+                return Err(ActionReferenceIndexError::new(
+                    ActionReferenceIndexErrorKind::AlreadyLocked,
+                ));
+            }
+            return Err(unavailable());
+        }
+        Ok(Self {
+            root_fd: current,
+            _lock_fd: lock_fd,
+        })
+    }
+
+    pub(crate) fn cleanup_staging(&self) -> Result<(), ActionReferenceIndexError> {
+        let mut directory = Dir::read_from(&self.root_fd).map_err(|_| unavailable())?;
+        let mut removed = false;
+        while let Some(entry) = directory.read() {
+            let entry = entry.map_err(|_| unavailable())?;
+            if entry.file_name().to_bytes().starts_with(STAGING_PREFIX) {
+                match unlinkat(&self.root_fd, entry.file_name(), AtFlags::empty()) {
+                    Ok(()) | Err(Errno::NOENT) => removed = true,
+                    Err(_) => return Err(unavailable()),
+                }
+            }
+        }
+        if removed {
+            fs::fsync(&self.root_fd).map_err(|_| unavailable())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn read_index(
+        &self,
+        maximum_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, ActionReferenceIndexError> {
+        let file = match openat(
+            &self.root_fd,
+            INDEX_FILE,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+            Mode::empty(),
+        ) {
+            Ok(file) => file,
+            Err(Errno::NOENT) => return Ok(None),
+            Err(error) => return Err(map_open_error(error)),
+        };
+        ensure_regular_file(&file)?;
+        fchmod(&file, FILE_MODE).map_err(|_| unavailable())?;
+        let metadata = fstat(&file).map_err(|_| unavailable())?;
+        let received = usize::try_from(metadata.st_size).map_err(|_| exhausted())?;
+        if received > maximum_bytes {
+            return Err(exhausted());
+        }
+        let mut bytes = Vec::with_capacity(received);
+        File::from(file)
+            .take(u64::try_from(maximum_bytes).unwrap_or(u64::MAX) + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| unavailable())?;
+        if bytes.len() > maximum_bytes {
+            return Err(exhausted());
+        }
+        Ok(Some(bytes))
+    }
+
+    pub(crate) fn commit(&self, generation: u64, bytes: &[u8]) -> Result<(), CommitFailure> {
+        let staging_name = format!(".action-reference-index.stage-{generation}");
+        let staging_fd = openat(
+            &self.root_fd,
+            staging_name.as_str(),
+            OFlags::WRONLY
+                | OFlags::CREATE
+                | OFlags::EXCL
+                | OFlags::CLOEXEC
+                | OFlags::NOFOLLOW
+                | OFlags::NONBLOCK,
+            FILE_MODE,
+        )
+        .map_err(|error| CommitFailure::new(map_open_error(error), false))?;
+        ensure_regular_file(&staging_fd).map_err(|error| CommitFailure::new(error, false))?;
+        fchmod(&staging_fd, FILE_MODE).map_err(|_| CommitFailure::new(unavailable(), false))?;
+        let mut staging = File::from(staging_fd);
+        staging
+            .write_all(bytes)
+            .map_err(|_| CommitFailure::new(unavailable(), false))?;
+        staging
+            .sync_all()
+            .map_err(|_| CommitFailure::new(unavailable(), false))?;
+        drop(staging);
+        renameat(
+            &self.root_fd,
+            staging_name.as_str(),
+            &self.root_fd,
+            INDEX_FILE,
+        )
+        .map_err(|_| CommitFailure::new(unavailable(), false))?;
+        fs::fsync(&self.root_fd).map_err(|_| CommitFailure::new(unavailable(), true))?;
+        Ok(())
+    }
+}
+
+pub(crate) struct CommitFailure {
+    _error: ActionReferenceIndexError,
+    renamed: bool,
+}
+
+impl CommitFailure {
+    const fn new(error: ActionReferenceIndexError, renamed: bool) -> Self {
+        Self {
+            _error: error,
+            renamed,
+        }
+    }
+
+    pub(crate) const fn renamed(&self) -> bool {
+        self.renamed
+    }
+}
+
+fn ensure_directory(fd: &OwnedFd) -> Result<(), ActionReferenceIndexError> {
+    let metadata = fstat(fd).map_err(|_| unavailable())?;
+    if FileType::from_raw_mode(metadata.st_mode).is_dir() {
+        Ok(())
+    } else {
+        Err(corrupt())
+    }
+}
+
+fn ensure_regular_file(fd: &OwnedFd) -> Result<(), ActionReferenceIndexError> {
+    let metadata = fstat(fd).map_err(|_| unavailable())?;
+    if FileType::from_raw_mode(metadata.st_mode).is_file() && metadata.st_nlink == 1 {
+        Ok(())
+    } else {
+        Err(corrupt())
+    }
+}
+
+fn map_open_error(error: Errno) -> ActionReferenceIndexError {
+    if error == Errno::LOOP || error == Errno::NOTDIR {
+        corrupt()
+    } else {
+        unavailable()
+    }
+}
+
+const fn corrupt() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Corrupt)
+}
+
+const fn exhausted() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::ResourceExhausted)
+}
+
+const fn unavailable() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unavailable)
+}

--- a/crates/automata-ci-action-cache-file/src/platform/unsupported.rs
+++ b/crates/automata-ci-action-cache-file/src/platform/unsupported.rs
@@ -1,0 +1,40 @@
+use automata_ci_action::{ActionReferenceIndexError, ActionReferenceIndexErrorKind};
+
+use crate::ActionReferenceIndexRoot;
+
+pub(crate) struct PlatformDirectory;
+
+impl PlatformDirectory {
+    pub(crate) fn open(
+        _root: &ActionReferenceIndexRoot,
+    ) -> Result<Self, ActionReferenceIndexError> {
+        Err(unsupported())
+    }
+
+    pub(crate) fn cleanup_staging(&self) -> Result<(), ActionReferenceIndexError> {
+        Err(unsupported())
+    }
+
+    pub(crate) fn read_index(
+        &self,
+        _maximum_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, ActionReferenceIndexError> {
+        Err(unsupported())
+    }
+
+    pub(crate) fn commit(&self, _generation: u64, _bytes: &[u8]) -> Result<(), CommitFailure> {
+        Err(CommitFailure)
+    }
+}
+
+pub(crate) struct CommitFailure;
+
+impl CommitFailure {
+    pub(crate) const fn renamed(&self) -> bool {
+        false
+    }
+}
+
+const fn unsupported() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unsupported)
+}

--- a/crates/automata-ci-action-cache-file/src/root.rs
+++ b/crates/automata-ci-action-cache-file/src/root.rs
@@ -1,0 +1,56 @@
+use std::{
+    ffi::OsStr,
+    path::{Component, Path, PathBuf},
+};
+
+use automata_ci_action::{ActionReferenceIndexError, ActionReferenceIndexErrorKind};
+
+/// Validated non-temporary root for the durable action-reference index.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActionReferenceIndexRoot(PathBuf);
+
+impl ActionReferenceIndexRoot {
+    /// Validates one explicitly configured state root.
+    ///
+    /// # Errors
+    ///
+    /// Rejects relative paths, filesystem root, traversal components, and any
+    /// system temporary hierarchy.
+    pub fn explicit(path: impl Into<PathBuf>) -> Result<Self, ActionReferenceIndexError> {
+        let path = path.into();
+        validate(&path)?;
+        Ok(Self(path))
+    }
+
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn validate(path: &Path) -> Result<(), ActionReferenceIndexError> {
+    if !path.is_absolute() {
+        return Err(unsupported());
+    }
+    let mut normal_components = 0_usize;
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) => {}
+            Component::Normal(value) => {
+                normal_components += 1;
+                if value == OsStr::new("tmp") {
+                    return Err(unsupported());
+                }
+            }
+            Component::CurDir | Component::ParentDir => return Err(unsupported()),
+        }
+    }
+    if normal_components == 0 {
+        return Err(unsupported());
+    }
+    Ok(())
+}
+
+const fn unsupported() -> ActionReferenceIndexError {
+    ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unsupported)
+}

--- a/crates/automata-ci-action-cache-file/tests/archive_cache.rs
+++ b/crates/automata-ci-action-cache-file/tests/archive_cache.rs
@@ -1,0 +1,126 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use automata_ci_action_cache_file::{
+    ActionArchiveCacheLimits, ActionArchiveCacheRoot, FileActionArchiveCache,
+};
+use automata_ci_blob::{
+    BlobKey, BlobPayload, BlobStoreErrorKind, ImmutableBlobStore, MediaType, PutBlobOutcome,
+};
+use bytes::Bytes;
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(1);
+
+#[tokio::test]
+async fn archive_bytes_survive_reopen_and_are_verified() {
+    let scratch = Scratch::new("reopen");
+    let payload = payload(b"immutable action archive");
+    let descriptor = payload.descriptor().clone();
+    let limits = ActionArchiveCacheLimits::new(4, 4096, 1024).unwrap();
+    {
+        let cache = FileActionArchiveCache::open(scratch.root(), limits).unwrap();
+        assert_eq!(
+            cache.put_if_absent(payload).await.unwrap(),
+            PutBlobOutcome::Created
+        );
+    }
+    let reopened = FileActionArchiveCache::open(scratch.root(), limits).unwrap();
+    let loaded = reopened.get_verified(&descriptor, 1024).await.unwrap();
+    assert_eq!(loaded.bytes().as_ref(), b"immutable action archive");
+}
+
+#[tokio::test]
+async fn archive_cache_evicts_to_both_entry_and_byte_bounds() {
+    let scratch = Scratch::new("eviction");
+    let cache = FileActionArchiveCache::open(
+        scratch.root(),
+        ActionArchiveCacheLimits::new(2, 8, 8).unwrap(),
+    )
+    .unwrap();
+    let first = payload(b"1111");
+    let first_descriptor = first.descriptor().clone();
+    let second = payload(b"2222");
+    let second_descriptor = second.descriptor().clone();
+    let third = payload(b"3333");
+    let third_descriptor = third.descriptor().clone();
+    cache.put_if_absent(first).await.unwrap();
+    cache.put_if_absent(second).await.unwrap();
+    cache.put_if_absent(third).await.unwrap();
+    assert_eq!(
+        cache
+            .get_verified(&first_descriptor, 8)
+            .await
+            .unwrap_err()
+            .kind(),
+        BlobStoreErrorKind::NotFound
+    );
+    assert_eq!(
+        cache
+            .get_verified(&second_descriptor, 8)
+            .await
+            .unwrap()
+            .bytes()
+            .as_ref(),
+        b"2222"
+    );
+    assert_eq!(
+        cache
+            .get_verified(&third_descriptor, 8)
+            .await
+            .unwrap()
+            .bytes()
+            .as_ref(),
+        b"3333"
+    );
+}
+
+fn payload(bytes: &'static [u8]) -> BlobPayload {
+    let preliminary = BlobPayload::from_bytes(
+        BlobKey::new("actions/v1/sha256/preliminary.tar.gz").unwrap(),
+        MediaType::new("application/gzip").unwrap(),
+        Bytes::from_static(bytes),
+    );
+    BlobPayload::from_bytes(
+        BlobKey::new(format!(
+            "actions/v1/sha256/{}.tar.gz",
+            preliminary.descriptor().digest()
+        ))
+        .unwrap(),
+        MediaType::new("application/gzip").unwrap(),
+        Bytes::from_static(bytes),
+    )
+}
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let sequence = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate is inside workspace crates directory");
+        let path = workspace
+            .join("target/agent-scratch/action-archive-cache")
+            .join(format!("{}-{label}-{sequence}", std::process::id()));
+        if path.exists() {
+            fs::remove_dir_all(&path).unwrap();
+        }
+        Self(path)
+    }
+
+    fn root(&self) -> ActionArchiveCacheRoot {
+        ActionArchiveCacheRoot::explicit(self.0.clone()).unwrap()
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        if self.0.exists() {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+}

--- a/crates/automata-ci-action-cache-file/tests/file_index.rs
+++ b/crates/automata-ci-action-cache-file/tests/file_index.rs
@@ -1,0 +1,232 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use automata_ci_action::{
+    ActionReferenceIndex, ActionReferenceIndexErrorKind, ActionSubpath, ImmutableActionReference,
+    IndexedActionBundle, PutActionReferenceOutcome,
+};
+use automata_ci_action_cache_file::{
+    ActionReferenceIndexLimits, ActionReferenceIndexRoot, FileActionReferenceIndex,
+};
+use automata_ci_blob::{BlobKey, BlobPayload, MediaType};
+use automata_ci_scm::{RepositoryId, ResolvedRevision, RevisionSpec, ScmProviderId};
+use bytes::Bytes;
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(1);
+
+#[tokio::test]
+async fn bounded_index_survives_reopen_and_evicts_oldest_reference() {
+    let scratch = Scratch::new("bounded-reopen");
+    let root = scratch.root();
+    let limits = ActionReferenceIndexLimits::new(2, 16 * 1_024).unwrap();
+    let index = FileActionReferenceIndex::open(root.clone(), limits).unwrap();
+    let first = bundle(1, b"one");
+    let second = bundle(2, b"two");
+    let third = bundle(3, b"three");
+    index.put_if_absent(first.clone()).await.unwrap();
+    index.put_if_absent(second.clone()).await.unwrap();
+    index.put_if_absent(third.clone()).await.unwrap();
+    assert!(index.get(first.reference()).await.unwrap().is_none());
+    assert_eq!(index.get(second.reference()).await.unwrap(), Some(second));
+    assert_eq!(index.get(third.reference()).await.unwrap(), Some(third));
+    drop(index);
+
+    let reopened = FileActionReferenceIndex::open(root, limits).unwrap();
+    assert!(reopened.get(first.reference()).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn concurrent_identical_fill_creates_exactly_one_mapping() {
+    let scratch = Scratch::new("concurrent-fill");
+    let index = Arc::new(
+        FileActionReferenceIndex::open(scratch.root(), ActionReferenceIndexLimits::default())
+            .unwrap(),
+    );
+    let expected = bundle(7, b"same immutable archive");
+    let mut tasks = Vec::new();
+    for _ in 0..16 {
+        let index = index.clone();
+        let bundle = expected.clone();
+        tasks.push(tokio::spawn(async move {
+            index.put_if_absent(bundle).await.unwrap()
+        }));
+    }
+    let mut created = 0_usize;
+    let mut already_present = 0_usize;
+    for task in tasks {
+        match task.await.unwrap() {
+            PutActionReferenceOutcome::Created => created += 1,
+            PutActionReferenceOutcome::AlreadyPresent => already_present += 1,
+        }
+    }
+    assert_eq!(created, 1);
+    assert_eq!(already_present, 15);
+    assert_eq!(
+        index.get(expected.reference()).await.unwrap(),
+        Some(expected)
+    );
+}
+
+#[tokio::test]
+async fn conflicting_fill_is_rejected_without_overwriting_authority() {
+    let scratch = Scratch::new("conflicting-fill");
+    let root = scratch.root();
+    let index = FileActionReferenceIndex::open(root.clone(), ActionReferenceIndexLimits::default())
+        .unwrap();
+    let first = bundle(11, b"first bytes");
+    let mut conflict = bundle(12, b"different bytes");
+    conflict = IndexedActionBundle::new(
+        first.reference().clone(),
+        first.resolved_revision().clone(),
+        conflict.archive().clone(),
+    )
+    .unwrap();
+    index.put_if_absent(first.clone()).await.unwrap();
+    let error = index.put_if_absent(conflict).await.unwrap_err();
+    assert_eq!(error.kind(), ActionReferenceIndexErrorKind::Conflict);
+    assert_eq!(
+        index.get(first.reference()).await.unwrap(),
+        Some(first.clone())
+    );
+    drop(index);
+
+    let reopened =
+        FileActionReferenceIndex::open(root, ActionReferenceIndexLimits::default()).unwrap();
+    assert_eq!(reopened.get(first.reference()).await.unwrap(), Some(first));
+}
+
+#[test]
+fn corrupt_or_oversized_state_and_second_owner_fail_closed() {
+    let scratch = Scratch::new("fail-closed-open");
+    let root = scratch.root();
+    let index = FileActionReferenceIndex::open(root.clone(), ActionReferenceIndexLimits::default())
+        .unwrap();
+    let error = FileActionReferenceIndex::open(root.clone(), ActionReferenceIndexLimits::default())
+        .unwrap_err();
+    assert_eq!(error.kind(), ActionReferenceIndexErrorKind::AlreadyLocked);
+    drop(index);
+
+    fs::write(
+        root.as_path().join("action-reference-index-v1.json"),
+        b"{\"schema_version\":1,\"generation\":1,\"entries\":[",
+    )
+    .unwrap();
+    let error = FileActionReferenceIndex::open(root.clone(), ActionReferenceIndexLimits::default())
+        .unwrap_err();
+    assert_eq!(error.kind(), ActionReferenceIndexErrorKind::Corrupt);
+
+    fs::write(
+        root.as_path().join("action-reference-index-v1.json"),
+        br#"{"schema_version":1,"generation":1,"entries":[{"sequence":1,"provider":"github","repository":"actions/example","revision":"0000000000000000000000000000000000000001","subpath":"packages/action","resolved_revision":"0000000000000000000000000000000000000002","archive":{"key":"actions/v1/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tar.gz","digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1,"media_type":"application/gzip"}}]}"#,
+    )
+    .unwrap();
+    let error = FileActionReferenceIndex::open(root.clone(), ActionReferenceIndexLimits::default())
+        .unwrap_err();
+    assert_eq!(error.kind(), ActionReferenceIndexErrorKind::Corrupt);
+
+    fs::write(
+        root.as_path().join("action-reference-index-v1.json"),
+        vec![b'x'; 1_025],
+    )
+    .unwrap();
+    let error =
+        FileActionReferenceIndex::open(root, ActionReferenceIndexLimits::new(4, 1_024).unwrap())
+            .unwrap_err();
+    assert_eq!(
+        error.kind(),
+        ActionReferenceIndexErrorKind::ResourceExhausted
+    );
+}
+
+#[test]
+fn abandoned_staging_file_is_recovered_inside_state_root() {
+    let scratch = Scratch::new("staging-recovery");
+    let root = scratch.root();
+    let staging = root
+        .as_path()
+        .join(".action-reference-index.stage-abandoned");
+    fs::create_dir_all(root.as_path()).unwrap();
+    fs::write(&staging, b"incomplete").unwrap();
+    let index =
+        FileActionReferenceIndex::open(root, ActionReferenceIndexLimits::default()).unwrap();
+    assert!(!staging.exists());
+    drop(index);
+}
+
+#[test]
+fn root_policy_rejects_relative_root_filesystem_and_temporary_hierarchy() {
+    for path in [
+        PathBuf::from("relative/cache"),
+        PathBuf::from("/"),
+        PathBuf::from("/var/tmp/automata-cache"),
+    ] {
+        let error = ActionReferenceIndexRoot::explicit(path).unwrap_err();
+        assert_eq!(error.kind(), ActionReferenceIndexErrorKind::Unsupported);
+    }
+}
+
+fn bundle(sequence: u64, bytes: &[u8]) -> IndexedActionBundle {
+    let revision = format!("{sequence:040x}");
+    let reference = ImmutableActionReference::new(
+        ScmProviderId::new("github").unwrap(),
+        RepositoryId::new(format!("actions/example-{sequence}")).unwrap(),
+        RevisionSpec::new(revision.clone()).unwrap(),
+        ActionSubpath::new("packages/action").unwrap(),
+    )
+    .unwrap();
+    let payload = BlobPayload::from_bytes(
+        BlobKey::new("actions/v1/sha256/placeholder.tar.gz").unwrap(),
+        MediaType::new("application/gzip").unwrap(),
+        Bytes::copy_from_slice(bytes),
+    );
+    let archive = automata_ci_blob::BlobDescriptor::new(
+        BlobKey::new(format!(
+            "actions/v1/sha256/{}.tar.gz",
+            payload.descriptor().digest()
+        ))
+        .unwrap(),
+        payload.descriptor().digest(),
+        payload.descriptor().size(),
+        payload.descriptor().media_type().clone(),
+    );
+    IndexedActionBundle::new(reference, ResolvedRevision::new(revision).unwrap(), archive).unwrap()
+}
+
+struct Scratch {
+    path: PathBuf,
+}
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let sequence = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate is inside workspace crates directory");
+        let path = workspace
+            .join("target/agent-scratch/action-reference-index")
+            .join(format!("{}-{label}-{sequence}", std::process::id()));
+        if path.exists() {
+            fs::remove_dir_all(&path).unwrap();
+        }
+        Self { path }
+    }
+
+    fn root(&self) -> ActionReferenceIndexRoot {
+        ActionReferenceIndexRoot::explicit(self.path.clone()).unwrap()
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            fs::remove_dir_all(&self.path).unwrap();
+        }
+    }
+}

--- a/crates/automata-ci-action-cache-file/tests/resolver_restart.rs
+++ b/crates/automata-ci-action-cache-file/tests/resolver_restart.rs
@@ -1,0 +1,153 @@
+use std::{
+    fs,
+    io::Cursor,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use automata_ci_action::{
+    ActionBundleLimits, ActionResolver, ActionSubpath, ImmutableActionResolver,
+    RepositoryActionRequest,
+};
+use automata_ci_action_cache_file::{
+    ActionReferenceIndexLimits, ActionReferenceIndexRoot, FileActionReferenceIndex,
+};
+use automata_ci_blob::MemoryBlobStore;
+use automata_ci_scm::{
+    ArchiveFormat, RepositoryId, RepositorySnapshot, ResolvedRevision, RevisionSpec, ScmError,
+    ScmErrorKind, ScmProvider, ScmProviderId, SnapshotRequest,
+};
+use bytes::Bytes;
+use flate2::{Compression, write::GzEncoder};
+use tar::{Builder, EntryType, Header};
+
+const SHA: &str = "de0fac2e4500dabe0009e67214ff5f5447ce83dd";
+
+#[derive(Debug)]
+struct OfflineSwitchScm {
+    provider: ScmProviderId,
+    archive: Bytes,
+    offline: AtomicBool,
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ScmProvider for OfflineSwitchScm {
+    fn provider_id(&self) -> &ScmProviderId {
+        &self.provider
+    }
+
+    async fn fetch_snapshot(
+        &self,
+        request: SnapshotRequest<'_>,
+    ) -> Result<RepositorySnapshot, ScmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.offline.load(Ordering::SeqCst) {
+            return Err(ScmError::new(ScmErrorKind::Unavailable));
+        }
+        Ok(RepositorySnapshot::from_bytes(
+            self.provider.clone(),
+            request.repository().clone(),
+            request.revision().clone(),
+            ResolvedRevision::new(SHA).unwrap(),
+            ArchiveFormat::TarGzip,
+            self.archive.clone(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn durable_warm_hit_survives_resolver_restart_with_scm_offline() {
+    let scratch = Scratch::new();
+    let root = scratch.root();
+    let limits = ActionReferenceIndexLimits::default();
+    let scm = Arc::new(OfflineSwitchScm {
+        provider: ScmProviderId::new("github").unwrap(),
+        archive: action_archive(),
+        offline: AtomicBool::new(false),
+        calls: AtomicUsize::new(0),
+    });
+    let blobs = Arc::new(MemoryBlobStore::default());
+    let repository = RepositoryId::new("actions/checkout").unwrap();
+    let revision = RevisionSpec::new(SHA).unwrap();
+    let subpath = ActionSubpath::root();
+
+    let index = Arc::new(FileActionReferenceIndex::open(root.clone(), limits).unwrap());
+    let resolver =
+        ImmutableActionResolver::new(scm.clone(), blobs.clone()).with_reference_index(index);
+    let first = resolver
+        .resolve(request(&repository, &revision, &subpath))
+        .await
+        .unwrap();
+    drop(resolver);
+
+    scm.offline.store(true, Ordering::SeqCst);
+    let reopened = Arc::new(FileActionReferenceIndex::open(root, limits).unwrap());
+    let resolver = ImmutableActionResolver::new(scm.clone(), blobs).with_reference_index(reopened);
+    let replay = resolver
+        .resolve(request(&repository, &revision, &subpath))
+        .await
+        .unwrap();
+    assert_eq!(replay, first);
+    assert_eq!(scm.calls.load(Ordering::SeqCst), 1);
+}
+
+fn request<'a>(
+    repository: &'a RepositoryId,
+    revision: &'a RevisionSpec,
+    subpath: &'a ActionSubpath,
+) -> RepositoryActionRequest<'a> {
+    RepositoryActionRequest::public(repository, revision, subpath, ActionBundleLimits::default())
+}
+
+fn action_archive() -> Bytes {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut archive = Builder::new(&mut encoder);
+        let contents = b"name: checkout\nruns:\n  using: node24\n  main: dist/index.js\n";
+        let mut header = Header::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(u64::try_from(contents.len()).unwrap());
+        header.set_entry_type(EntryType::Regular);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "root/action.yml", Cursor::new(contents))
+            .unwrap();
+        archive.finish().unwrap();
+    }
+    Bytes::from(encoder.finish().unwrap())
+}
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new() -> Self {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate is inside workspace crates directory");
+        let path = workspace
+            .join("target/agent-scratch/action-reference-index")
+            .join(format!("{}-resolver-restart", std::process::id()));
+        if path.exists() {
+            fs::remove_dir_all(&path).unwrap();
+        }
+        Self(path)
+    }
+
+    fn root(&self) -> ActionReferenceIndexRoot {
+        ActionReferenceIndexRoot::explicit(self.0.clone()).unwrap()
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        if self.0.exists() {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+}

--- a/crates/automata-ci-action/src/archive.rs
+++ b/crates/automata-ci-action/src/archive.rs
@@ -54,7 +54,7 @@ pub fn inspect_archive(
 /// # Errors
 ///
 /// Returns the same fail-closed errors as [`inspect_archive`].
-fn inspect_archive_bytes(
+pub(crate) fn inspect_archive_bytes(
     bytes: &Bytes,
     subpath: &ActionSubpath,
     limits: ActionBundleLimits,

--- a/crates/automata-ci-action/src/cache.rs
+++ b/crates/automata-ci-action/src/cache.rs
@@ -1,0 +1,272 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
+
+use async_trait::async_trait;
+use automata_ci_blob::BlobDescriptor;
+use automata_ci_scm::{RepositoryId, ResolvedRevision, RevisionSpec, ScmProviderId};
+use thiserror::Error;
+
+use crate::ActionSubpath;
+
+const GIT_COMMIT_SHA_HEX_BYTES: usize = 40;
+
+/// Exact immutable action identity eligible for reference-index reuse.
+///
+/// Mutable tags and branches cannot construct this value. The requested commit
+/// is retained alongside provider, repository, and action subpath so an index
+/// adapter cannot alias content across provenance boundaries.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ImmutableActionReference {
+    provider: ScmProviderId,
+    repository: RepositoryId,
+    revision: RevisionSpec,
+    subpath: ActionSubpath,
+}
+
+impl ImmutableActionReference {
+    /// Creates a reference pinned to one canonical full Git commit SHA.
+    ///
+    /// # Errors
+    ///
+    /// Rejects revisions other than exactly 40 lowercase hexadecimal bytes.
+    /// This canonical spelling prevents aliases from entering the public cache.
+    pub fn new(
+        provider: ScmProviderId,
+        repository: RepositoryId,
+        revision: RevisionSpec,
+        subpath: ActionSubpath,
+    ) -> Result<Self, ImmutableActionReferenceError> {
+        if !is_canonical_full_commit_sha(revision.as_str()) {
+            return Err(ImmutableActionReferenceError);
+        }
+        Ok(Self {
+            provider,
+            repository,
+            revision,
+            subpath,
+        })
+    }
+
+    /// Returns the SCM provider identity.
+    #[must_use]
+    pub const fn provider(&self) -> &ScmProviderId {
+        &self.provider
+    }
+
+    /// Returns the canonical repository identity.
+    #[must_use]
+    pub const fn repository(&self) -> &RepositoryId {
+        &self.repository
+    }
+
+    /// Returns the exact requested commit revision.
+    #[must_use]
+    pub const fn revision(&self) -> &RevisionSpec {
+        &self.revision
+    }
+
+    /// Returns the selected action subpath.
+    #[must_use]
+    pub const fn subpath(&self) -> &ActionSubpath {
+        &self.subpath
+    }
+}
+
+/// Complete immutable mapping stored by an action reference index.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexedActionBundle {
+    reference: ImmutableActionReference,
+    resolved_revision: ResolvedRevision,
+    archive: BlobDescriptor,
+}
+
+impl IndexedActionBundle {
+    /// Binds an immutable reference to an exact verified archive descriptor.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a provider result that does not exactly match the requested
+    /// commit or a descriptor that does not use the canonical action key and
+    /// media type.
+    pub fn new(
+        reference: ImmutableActionReference,
+        resolved_revision: ResolvedRevision,
+        archive: BlobDescriptor,
+    ) -> Result<Self, ImmutableActionReferenceError> {
+        if reference.revision().as_str() != resolved_revision.as_str()
+            || archive.size() == 0
+            || archive.media_type().as_str() != "application/gzip"
+            || archive.key().as_str() != format!("actions/v1/sha256/{}.tar.gz", archive.digest())
+        {
+            return Err(ImmutableActionReferenceError);
+        }
+        Ok(Self {
+            reference,
+            resolved_revision,
+            archive,
+        })
+    }
+
+    /// Returns the indexed immutable reference.
+    #[must_use]
+    pub const fn reference(&self) -> &ImmutableActionReference {
+        &self.reference
+    }
+
+    /// Returns the provider-confirmed immutable revision.
+    #[must_use]
+    pub const fn resolved_revision(&self) -> &ResolvedRevision {
+        &self.resolved_revision
+    }
+
+    /// Returns the verified shared archive descriptor.
+    #[must_use]
+    pub const fn archive(&self) -> &BlobDescriptor {
+        &self.archive
+    }
+}
+
+/// Object-safe authoritative mapping from immutable references to content.
+///
+/// Implementations must make `put_if_absent` atomic for one reference. An
+/// existing non-identical mapping is a conflict and must never be overwritten.
+#[async_trait]
+pub trait ActionReferenceIndex: std::fmt::Debug + Send + Sync {
+    /// Looks up one exact provider/repository/revision/subpath tuple.
+    async fn get(
+        &self,
+        reference: &ImmutableActionReference,
+    ) -> Result<Option<IndexedActionBundle>, ActionReferenceIndexError>;
+
+    /// Publishes one mapping exactly once or verifies the existing mapping.
+    async fn put_if_absent(
+        &self,
+        bundle: IndexedActionBundle,
+    ) -> Result<PutActionReferenceOutcome, ActionReferenceIndexError>;
+}
+
+/// Idempotent immutable-reference publication result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PutActionReferenceOutcome {
+    /// The mapping was created.
+    Created,
+    /// The identical mapping already existed.
+    AlreadyPresent,
+}
+
+/// Stable action-reference index failure class.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ActionReferenceIndexErrorKind {
+    /// An existing mapping contradicts the proposed immutable mapping.
+    Conflict,
+    /// Durable index content failed integrity validation.
+    Corrupt,
+    /// A configured or durable resource bound was exceeded.
+    ResourceExhausted,
+    /// The local index could not complete the operation.
+    Unavailable,
+    /// Another process already holds the index lock.
+    AlreadyLocked,
+    /// The platform or configured root is unsupported.
+    Unsupported,
+}
+
+/// Sanitized index error that does not expose repository identities or paths.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("immutable action reference index failed: {kind:?}")]
+pub struct ActionReferenceIndexError {
+    kind: ActionReferenceIndexErrorKind,
+}
+
+impl ActionReferenceIndexError {
+    /// Creates a sanitized index error.
+    #[must_use]
+    pub const fn new(kind: ActionReferenceIndexErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the stable failure class.
+    #[must_use]
+    pub const fn kind(self) -> ActionReferenceIndexErrorKind {
+        self.kind
+    }
+}
+
+/// A revision or indexed record was not an exact immutable action identity.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("action reference is not one exact immutable commit and archive")]
+pub struct ImmutableActionReferenceError;
+
+/// Deterministic bounded in-memory index for contracts and embedded adapters.
+#[derive(Clone, Debug)]
+pub struct MemoryActionReferenceIndex {
+    maximum_entries: usize,
+    entries: Arc<RwLock<BTreeMap<ImmutableActionReference, IndexedActionBundle>>>,
+}
+
+impl MemoryActionReferenceIndex {
+    /// Creates a bounded index using deterministic oldest-key eviction.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero entry bound.
+    pub fn new(maximum_entries: usize) -> Result<Self, ActionReferenceIndexError> {
+        if maximum_entries == 0 {
+            return Err(ActionReferenceIndexError::new(
+                ActionReferenceIndexErrorKind::ResourceExhausted,
+            ));
+        }
+        Ok(Self {
+            maximum_entries,
+            entries: Arc::new(RwLock::new(BTreeMap::new())),
+        })
+    }
+}
+
+#[async_trait]
+impl ActionReferenceIndex for MemoryActionReferenceIndex {
+    async fn get(
+        &self,
+        reference: &ImmutableActionReference,
+    ) -> Result<Option<IndexedActionBundle>, ActionReferenceIndexError> {
+        let entries = self.entries.read().map_err(|_| {
+            ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unavailable)
+        })?;
+        Ok(entries.get(reference).cloned())
+    }
+
+    async fn put_if_absent(
+        &self,
+        bundle: IndexedActionBundle,
+    ) -> Result<PutActionReferenceOutcome, ActionReferenceIndexError> {
+        let mut entries = self.entries.write().map_err(|_| {
+            ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Unavailable)
+        })?;
+        if let Some(existing) = entries.get(bundle.reference()) {
+            return if existing == &bundle {
+                Ok(PutActionReferenceOutcome::AlreadyPresent)
+            } else {
+                Err(ActionReferenceIndexError::new(
+                    ActionReferenceIndexErrorKind::Conflict,
+                ))
+            };
+        }
+        if entries.len() == self.maximum_entries {
+            let oldest = entries.keys().next().cloned().ok_or_else(|| {
+                ActionReferenceIndexError::new(ActionReferenceIndexErrorKind::Corrupt)
+            })?;
+            entries.remove(&oldest);
+        }
+        entries.insert(bundle.reference().clone(), bundle);
+        Ok(PutActionReferenceOutcome::Created)
+    }
+}
+
+fn is_canonical_full_commit_sha(value: &str) -> bool {
+    value.len() == GIT_COMMIT_SHA_HEX_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}

--- a/crates/automata-ci-action/src/lib.rs
+++ b/crates/automata-ci-action/src/lib.rs
@@ -13,10 +13,16 @@
 #![deny(missing_docs)]
 
 mod archive;
+mod cache;
 mod model;
 mod resolver;
 
 pub use archive::inspect_archive;
+pub use cache::{
+    ActionReferenceIndex, ActionReferenceIndexError, ActionReferenceIndexErrorKind,
+    ImmutableActionReference, ImmutableActionReferenceError, IndexedActionBundle,
+    MemoryActionReferenceIndex, PutActionReferenceOutcome,
+};
 pub use model::{
     ActionArchiveError, ActionBundleLimits, ActionBundleLimitsError, ActionDefinitionDocument,
     ActionDefinitionKind, ActionResolveError, ActionResolveErrorKind, ActionSubpath,

--- a/crates/automata-ci-action/src/model.rs
+++ b/crates/automata-ci-action/src/model.rs
@@ -425,6 +425,15 @@ impl<'a> RepositoryActionRequest<'a> {
         self.limits
     }
 
+    /// Reports whether this request carries no repository credential.
+    ///
+    /// Only credential-free requests may use the public immutable-action
+    /// cache. Authenticated requests must always re-authorize through SCM.
+    #[must_use]
+    pub const fn is_public(&self) -> bool {
+        self.credential.is_none()
+    }
+
     pub(crate) const fn snapshot_request(&self) -> SnapshotRequest<'_> {
         if let Some(credential) = self.credential {
             SnapshotRequest::authenticated(
@@ -691,6 +700,8 @@ pub enum ActionResolveErrorKind {
     Archive,
     /// Immutable blob verification or publication failed.
     BlobStore,
+    /// The local immutable-reference index failed or contradicted provenance.
+    ReferenceCache,
     /// A provider result or locally constructed identity violated an invariant.
     Internal,
 }

--- a/crates/automata-ci-action/src/resolver.rs
+++ b/crates/automata-ci-action/src/resolver.rs
@@ -5,8 +5,9 @@ use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType};
 use automata_ci_scm::ScmProvider;
 
 use crate::{
-    ActionResolveError, ActionResolveErrorKind, RepositoryActionRequest, ResolvedActionBundle,
-    inspect_archive, model::ResolvedActionIdentity,
+    ActionReferenceIndex, ActionResolveError, ActionResolveErrorKind, ImmutableActionReference,
+    IndexedActionBundle, RepositoryActionRequest, ResolvedActionBundle,
+    archive::inspect_archive_bytes, inspect_archive, model::ResolvedActionIdentity,
 };
 
 /// Resolves an action reference into one immutable, persisted bundle.
@@ -33,6 +34,8 @@ pub trait ActionResolver: std::fmt::Debug + Send + Sync {
 pub struct ImmutableActionResolver {
     scm: Arc<dyn ScmProvider>,
     blobs: Arc<dyn ImmutableBlobStore>,
+    local_blobs: Option<Arc<dyn ImmutableBlobStore>>,
+    references: Option<Arc<dyn ActionReferenceIndex>>,
 }
 
 impl ImmutableActionResolver {
@@ -42,7 +45,26 @@ impl ImmutableActionResolver {
     /// idempotently to the content-addressed `blobs` store.
     #[must_use]
     pub fn new(scm: Arc<dyn ScmProvider>, blobs: Arc<dyn ImmutableBlobStore>) -> Self {
-        Self { scm, blobs }
+        Self {
+            scm,
+            blobs,
+            local_blobs: None,
+            references: None,
+        }
+    }
+
+    /// Adds a best-effort host-local immutable archive cache.
+    #[must_use]
+    pub fn with_local_blob_cache(mut self, local_blobs: Arc<dyn ImmutableBlobStore>) -> Self {
+        self.local_blobs = Some(local_blobs);
+        self
+    }
+
+    /// Adds a durable index for credential-free exact public references.
+    #[must_use]
+    pub fn with_reference_index(mut self, references: Arc<dyn ActionReferenceIndex>) -> Self {
+        self.references = Some(references);
+        self
     }
 }
 
@@ -52,6 +74,51 @@ impl ActionResolver for ImmutableActionResolver {
         &self,
         request: RepositoryActionRequest<'_>,
     ) -> Result<ResolvedActionBundle, ActionResolveError> {
+        // A cache hit is authorization-safe only for an unauthenticated,
+        // canonical exact commit. Credentialed/private and mutable requests
+        // always cross the SCM authority boundary.
+        let immutable_reference = if request.is_public() {
+            ImmutableActionReference::new(
+                self.scm.provider_id().clone(),
+                request.repository().clone(),
+                request.revision().clone(),
+                request.subpath().clone(),
+            )
+            .ok()
+        } else {
+            None
+        };
+        if let (Some(references), Some(reference)) =
+            (self.references.as_ref(), immutable_reference.as_ref())
+            && let Some(indexed) = references
+                .get(reference)
+                .await
+                .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::ReferenceCache))?
+        {
+            if indexed.reference() != reference {
+                return Err(ActionResolveError::new(
+                    ActionResolveErrorKind::ReferenceCache,
+                ));
+            }
+            let archive = self
+                .load_cached_blob(indexed.archive(), request.limits())
+                .await?;
+            let definition =
+                inspect_archive_bytes(archive.bytes(), request.subpath(), request.limits())
+                    .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::Archive))?;
+            return Ok(ResolvedActionBundle::new(
+                ResolvedActionIdentity::new(
+                    reference.provider().clone(),
+                    reference.repository().clone(),
+                    reference.revision().clone(),
+                    indexed.resolved_revision().clone(),
+                    reference.subpath().clone(),
+                ),
+                indexed.archive().clone(),
+                definition,
+            ));
+        }
+
         let snapshot = self
             .scm
             .fetch_snapshot(request.snapshot_request())
@@ -75,9 +142,28 @@ impl ActionResolver for ImmutableActionResolver {
         let payload = BlobPayload::from_bytes(key, media_type, snapshot.bytes().clone());
         let archive = payload.descriptor().clone();
         self.blobs
-            .put_if_absent(payload)
+            .put_if_absent(payload.clone())
             .await
             .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::BlobStore))?;
+        if let Some(local) = &self.local_blobs {
+            // Shared immutable storage is authoritative. A local cache failure
+            // cannot fail an otherwise valid resolution.
+            let _ = local.put_if_absent(payload).await;
+        }
+
+        if let (Some(references), Some(reference)) = (self.references.as_ref(), immutable_reference)
+        {
+            let indexed = IndexedActionBundle::new(
+                reference,
+                snapshot.resolved_revision().clone(),
+                archive.clone(),
+            )
+            .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::Internal))?;
+            references
+                .put_if_absent(indexed)
+                .await
+                .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::ReferenceCache))?;
+        }
 
         Ok(ResolvedActionBundle::new(
             ResolvedActionIdentity::new(
@@ -90,5 +176,31 @@ impl ActionResolver for ImmutableActionResolver {
             archive,
             definition,
         ))
+    }
+}
+
+impl ImmutableActionResolver {
+    async fn load_cached_blob(
+        &self,
+        descriptor: &automata_ci_blob::BlobDescriptor,
+        limits: crate::ActionBundleLimits,
+    ) -> Result<automata_ci_blob::VerifiedBlob, ActionResolveError> {
+        let maximum = limits.compressed().maximum_bytes();
+        if let Some(local) = &self.local_blobs
+            && let Ok(blob) = local.get_verified(descriptor, maximum).await
+        {
+            return Ok(blob);
+        }
+        let blob = self
+            .blobs
+            .get_verified(descriptor, maximum)
+            .await
+            .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::BlobStore))?;
+        if let Some(local) = &self.local_blobs {
+            let payload = BlobPayload::verify(descriptor.clone(), blob.bytes().clone())
+                .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::Internal))?;
+            let _ = local.put_if_absent(payload).await;
+        }
+        Ok(blob)
     }
 }

--- a/crates/automata-ci-action/tests/reference_cache.rs
+++ b/crates/automata-ci-action/tests/reference_cache.rs
@@ -1,0 +1,142 @@
+mod support;
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use async_trait::async_trait;
+use automata_ci_action::{
+    ActionBundleLimits, ActionResolver, ActionSubpath, ImmutableActionResolver,
+    MemoryActionReferenceIndex, RepositoryActionRequest,
+};
+use automata_ci_auth::secret::SecretString;
+use automata_ci_blob::MemoryBlobStore;
+use automata_ci_scm::{
+    ArchiveFormat, RepositoryId, RepositorySnapshot, ResolvedRevision, RevisionSpec, ScmError,
+    ScmProvider, ScmProviderId, SnapshotRequest,
+};
+use bytes::Bytes;
+use support::{SHA, TestEntry, build_archive};
+
+#[derive(Debug)]
+struct CountingScm {
+    provider: ScmProviderId,
+    archive: Bytes,
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ScmProvider for CountingScm {
+    fn provider_id(&self) -> &ScmProviderId {
+        &self.provider
+    }
+
+    async fn fetch_snapshot(
+        &self,
+        request: SnapshotRequest<'_>,
+    ) -> Result<RepositorySnapshot, ScmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(RepositorySnapshot::from_bytes(
+            self.provider.clone(),
+            request.repository().clone(),
+            request.revision().clone(),
+            ResolvedRevision::new(request.revision().as_str()).unwrap_or_else(|_| {
+                ResolvedRevision::new(SHA).expect("fixture commit is an exact revision")
+            }),
+            ArchiveFormat::TarGzip,
+            self.archive.clone(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn public_exact_commit_warm_hit_skips_scm() {
+    let (resolver, scm, repository, revision, subpath) = fixture(SHA);
+    resolver
+        .resolve(RepositoryActionRequest::public(
+            &repository,
+            &revision,
+            &subpath,
+            ActionBundleLimits::default(),
+        ))
+        .await
+        .unwrap();
+    resolver
+        .resolve(RepositoryActionRequest::public(
+            &repository,
+            &revision,
+            &subpath,
+            ActionBundleLimits::default(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(scm.calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn mutable_reference_never_enters_public_cache() {
+    let (resolver, scm, repository, revision, subpath) = fixture("v6");
+    for _ in 0..2 {
+        resolver
+            .resolve(RepositoryActionRequest::public(
+                &repository,
+                &revision,
+                &subpath,
+                ActionBundleLimits::default(),
+            ))
+            .await
+            .unwrap();
+    }
+    assert_eq!(scm.calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn authenticated_exact_commit_never_consults_public_cache() {
+    let (resolver, scm, repository, revision, subpath) = fixture(SHA);
+    let credential = SecretString::new("private-job-scoped-token").unwrap();
+    for _ in 0..2 {
+        resolver
+            .resolve(RepositoryActionRequest::authenticated(
+                &repository,
+                &revision,
+                &subpath,
+                &credential,
+                ActionBundleLimits::default(),
+            ))
+            .await
+            .unwrap();
+    }
+    assert_eq!(scm.calls.load(Ordering::SeqCst), 2);
+}
+
+fn fixture(
+    revision: &str,
+) -> (
+    ImmutableActionResolver,
+    Arc<CountingScm>,
+    RepositoryId,
+    RevisionSpec,
+    ActionSubpath,
+) {
+    let scm = Arc::new(CountingScm {
+        provider: ScmProviderId::new("github").unwrap(),
+        archive: build_archive(&[
+            TestEntry::File(
+                "root/action.yml",
+                b"name: cached\nruns:\n  using: node24\n  main: dist/index.js\n",
+            ),
+            TestEntry::File("root/dist/index.js", b"console.log('cached')"),
+        ]),
+        calls: AtomicUsize::new(0),
+    });
+    let resolver = ImmutableActionResolver::new(scm.clone(), Arc::new(MemoryBlobStore::default()))
+        .with_reference_index(Arc::new(MemoryActionReferenceIndex::new(8).unwrap()));
+    (
+        resolver,
+        scm,
+        RepositoryId::new("actions/example").unwrap(),
+        RevisionSpec::new(revision).unwrap(),
+        ActionSubpath::root(),
+    )
+}

--- a/crates/automata-ci-github/src/repository.rs
+++ b/crates/automata-ci-github/src/repository.rs
@@ -177,6 +177,26 @@ impl GithubHttpEndpoint {
         validate_content_length(&response, maximum_bytes)?;
         read_archive(response, maximum_bytes).await
     }
+
+    fn exact_public_archive_location(
+        &self,
+        repository: &automata_ci_scm::RepositoryId,
+        revision: &ExactRevision,
+    ) -> Result<Url, ScmError> {
+        let (owner, name) = repository_path::split(repository.as_str())
+            .ok_or_else(|| ScmError::new(ScmErrorKind::InvalidResponse))?;
+        let mut location = self.archive_origin.clone();
+        let mut segments = location
+            .path_segments_mut()
+            .map_err(|()| ScmError::new(ScmErrorKind::InvalidResponse))?;
+        segments.pop_if_empty();
+        segments.push(owner);
+        segments.push(name);
+        segments.push("legacy.tar.gz");
+        segments.push(revision.as_str());
+        drop(segments);
+        self.validate_archive_location(location)
+    }
 }
 
 #[async_trait::async_trait]
@@ -189,6 +209,24 @@ impl ScmProvider for GithubHttpEndpoint {
         &self,
         request: SnapshotRequest<'_>,
     ) -> Result<RepositorySnapshot, ScmError> {
+        if request.credential().is_none()
+            && let Ok(exact) = ExactRevision::new(request.revision().as_str().to_owned())
+        {
+            let location = self.exact_public_archive_location(request.repository(), &exact)?;
+            let bytes = self
+                .download_archive(location, request.limits().maximum_bytes())
+                .await?;
+            let resolved_revision = ResolvedRevision::new(exact.as_str().to_owned())
+                .map_err(|_| ScmError::new(ScmErrorKind::InvalidResponse))?;
+            return Ok(RepositorySnapshot::from_bytes(
+                self.scm_provider_id.clone(),
+                request.repository().clone(),
+                request.revision().clone(),
+                resolved_revision,
+                ArchiveFormat::TarGzip,
+                bytes,
+            ));
+        }
         let resolved = self.resolve_revision(&request).await?;
         let location = self.archive_redirect(&request, &resolved).await?;
         let bytes = self

--- a/crates/automata-ci-github/src/webhook_event.rs
+++ b/crates/automata-ci-github/src/webhook_event.rs
@@ -842,19 +842,14 @@ struct PullRequestObjectPayload {
     base: PullRequestBranchPayload,
 }
 
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 #[serde(untagged)]
 enum PullRequestMergeCommitShaPayload {
     Revision(String),
     Null(()),
     #[serde(skip)]
+    #[default]
     Missing,
-}
-
-impl Default for PullRequestMergeCommitShaPayload {
-    fn default() -> Self {
-        Self::Missing
-    }
 }
 
 #[derive(Deserialize)]
@@ -1096,10 +1091,7 @@ pub(crate) fn normalize_pull_request(
         PullRequestMergeCommitShaPayload::Null(()) if !payload.pull_request.merged => {
             head_revision.clone()
         }
-        PullRequestMergeCommitShaPayload::Null(()) => {
-            return Err(GithubWebhookError::InvalidPayload);
-        }
-        PullRequestMergeCommitShaPayload::Missing => {
+        PullRequestMergeCommitShaPayload::Null(()) | PullRequestMergeCommitShaPayload::Missing => {
             return Err(GithubWebhookError::InvalidPayload);
         }
     };

--- a/crates/automata-ci-github/tests/repository_snapshots.rs
+++ b/crates/automata-ci-github/tests/repository_snapshots.rs
@@ -209,6 +209,38 @@ fn request_values() -> (RepositoryId, RevisionSpec) {
 }
 
 #[tokio::test]
+async fn public_exact_revision_uses_the_immutable_archive_origin_without_api_requests() {
+    let fixture = FixtureServer::spawn().await;
+    fixture.enqueue(ResponseSpec::binary(
+        StatusCode::OK,
+        "application/x-gzip",
+        vec![0x1f, 0x8b, 0x08, 0x00, 1, 2, 3, 4],
+    ));
+    let endpoint = fixture.endpoint();
+    let repository = RepositoryId::new("actions/checkout").unwrap();
+    let revision = RevisionSpec::new(SHA).unwrap();
+
+    let snapshot = endpoint
+        .fetch_snapshot(SnapshotRequest::public(
+            &repository,
+            &revision,
+            ArchiveLimits::new(1024).unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.resolved_revision().as_str(), SHA);
+    assert_eq!(snapshot.size(), 8);
+    let requests = fixture.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].uri,
+        format!("/actions/checkout/legacy.tar.gz/{SHA}")
+    );
+    assert!(!requests[0].headers.contains_key("authorization"));
+}
+
+#[tokio::test]
 async fn resolves_then_downloads_without_forwarding_the_credential() {
     let fixture = FixtureServer::spawn().await;
     fixture.enqueue(ResponseSpec::json(

--- a/crates/automata-ci-job-executor-github/src/action.rs
+++ b/crates/automata-ci-job-executor-github/src/action.rs
@@ -356,20 +356,21 @@ impl ActionPreparationPort for ResolvedBundleActionPreparer {
                 )
             },
         );
-        let bundle = self
-            .resolver
-            .resolve(action_request)
-            .await
-            .map_err(|error| {
-                let kind = match error.kind() {
-                    ActionResolveErrorKind::Scm => ActionPreparationErrorKind::Resolution,
-                    ActionResolveErrorKind::Archive | ActionResolveErrorKind::BlobStore => {
-                        ActionPreparationErrorKind::Content
-                    }
-                    ActionResolveErrorKind::Internal => ActionPreparationErrorKind::Internal,
-                };
-                ActionPreparationError::new(kind)
-            })?;
+        let bundle =
+            self.resolver
+                .resolve(action_request)
+                .await
+                .map_err(|error| {
+                    let kind = match error.kind() {
+                        ActionResolveErrorKind::Scm => ActionPreparationErrorKind::Resolution,
+                        ActionResolveErrorKind::Archive | ActionResolveErrorKind::BlobStore => {
+                            ActionPreparationErrorKind::Content
+                        }
+                        ActionResolveErrorKind::ReferenceCache
+                        | ActionResolveErrorKind::Internal => ActionPreparationErrorKind::Internal,
+                    };
+                    ActionPreparationError::new(kind)
+                })?;
         let metadata = self
             .decoder
             .decode(bundle.definition())

--- a/crates/automata-ci-postgres/src/store/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/src/store/github_subject_evidence.rs
@@ -2093,6 +2093,7 @@ fn decode_delivery_event_evidence(
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod schema_tests {
     use super::{
         AUTHENTICATED_EVENT_ENVELOPE_SCHEMA_VERSION, authenticated_event_envelope_schema_is_current,

--- a/crates/automata-ci-postgres/src/store/web.rs
+++ b/crates/automata-ci-postgres/src/store/web.rs
@@ -795,7 +795,8 @@ async fn load_jobs(
         LEFT JOIN LATERAL (
             SELECT attempt.id, attempt.attempt_number, attempt.lifecycle,
                    attempt.queued_at_ms, attempt.changed_at_ms,
-                   attempt.started_at_ms, attempt.runner_id
+                   attempt.started_at_ms, attempt.runner_id,
+                   attempt.lease_id, attempt.fencing_token
             FROM job_attempts AS attempt
             WHERE attempt.job_id = job.id
             ORDER BY attempt.attempt_number DESC, attempt.id DESC
@@ -808,6 +809,8 @@ async fn load_jobs(
          AND runner.id = coalesce(terminal.runner_id, latest.runner_id)
         LEFT JOIN attempt_log_streams AS stream
           ON stream.attempt_id = latest.id
+         AND stream.lease_id = coalesce(terminal.lease_id, latest.lease_id)
+         AND stream.fencing_token = coalesce(terminal.fencing_token, latest.fencing_token)
         WHERE repository.tenant_id = $1
           AND repository.id = $2
           AND run.id = $3
@@ -1211,14 +1214,18 @@ async fn load_log_stream(
         JOIN jobs AS job
           ON job.run_id = run.id
         JOIN LATERAL (
-            SELECT attempt.id
+            SELECT attempt.id, attempt.lease_id, attempt.fencing_token
             FROM job_attempts AS attempt
             WHERE attempt.job_id = job.id
             ORDER BY attempt.attempt_number DESC, attempt.id DESC
             LIMIT 1
         ) AS latest ON TRUE
+        LEFT JOIN attempt_terminal_results AS terminal
+          ON terminal.attempt_id = latest.id
         JOIN attempt_log_streams AS stream
           ON stream.attempt_id = latest.id
+         AND stream.lease_id = coalesce(terminal.lease_id, latest.lease_id)
+         AND stream.fencing_token = coalesce(terminal.fencing_token, latest.fencing_token)
         LEFT JOIN LATERAL (
             SELECT count(*) AS segment_count,
                    min(ordered.first_sequence) AS first_sequence,

--- a/crates/automata-ci-postgres/tests/store/contracts/mod.rs
+++ b/crates/automata-ci-postgres/tests/store/contracts/mod.rs
@@ -2,6 +2,6 @@
 
 mod github_oidc;
 mod migration_layout;
-mod schema_catalog;
 mod schema_bindings;
+mod schema_catalog;
 mod secret_management;

--- a/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
@@ -1117,11 +1117,36 @@ async fn workflow_authorization_and_rows_share_one_repeatable_read_snapshot() ->
 
 #[tokio::test]
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
-async fn duplicate_latest_attempt_log_streams_fail_as_corrupt_data() -> TestResult {
+async fn a_stale_prior_lease_log_stream_does_not_poison_the_terminal_job() -> TestResult {
     run_with_database(|database| async move {
         let seed = seed_control_plane(database.pool(), 1).await?;
         let fixture = seed_public_completed_run(&database, &seed).await?;
         insert_duplicate_stream(&database, &seed, fixture).await?;
+        let scope = HumanJobScope::new(
+            TenantScope::from_authenticated_tenant_id(&seed.tenant_id)?,
+            RepositoryId::from_uuid(seed.repository_id),
+            fixture.run_id,
+            fixture.job_id,
+        );
+        let detail = database
+            .store()
+            .get_job(&scope)
+            .await?
+            .expect("terminal job remains readable");
+        assert_eq!(detail.job.id, fixture.job_id);
+        assert!(detail.log_stream.is_some());
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn duplicate_authoritative_log_streams_still_fail_closed() -> TestResult {
+    run_with_database(|database| async move {
+        let seed = seed_control_plane(database.pool(), 1).await?;
+        let fixture = seed_public_completed_run(&database, &seed).await?;
+        insert_duplicate_authoritative_stream(&database, fixture).await?;
         let scope = HumanJobScope::new(
             TenantScope::from_authenticated_tenant_id(&seed.tenant_id)?,
             RepositoryId::from_uuid(seed.repository_id),
@@ -1570,6 +1595,44 @@ async fn insert_duplicate_stream(
     .bind(i64::try_from(fence.session_epoch().get())?)
     .bind(i64::try_from(fence.runner_generation().get())?)
     .bind(Uuid::new_v4())
+    .execute(database.pool())
+    .await?;
+    Ok(())
+}
+
+async fn insert_duplicate_authoritative_stream(
+    database: &TestDatabase,
+    fixture: PublicFixture,
+) -> TestResult {
+    let attempt_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM job_attempts WHERE job_id = $1 ORDER BY attempt_number DESC LIMIT 1",
+    )
+    .bind(fixture.job_id.as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO attempt_log_streams (
+            id, attempt_id, runner_session_id, operation_id, runner_id,
+            runner_session_epoch, runner_generation, runner_slot,
+            lease_id, fencing_token, log_schema, opened_at_ms,
+            secret_exposure_class, raw_log_disposition,
+            requested_visibility, effective_visibility,
+            output_safety_reason, output_safety_schema
+        )
+        SELECT $1, terminal.attempt_id, terminal.runner_session_id, $2,
+               terminal.runner_id, terminal.runner_session_epoch,
+               terminal.runner_generation, terminal.runner_slot,
+               terminal.lease_id, terminal.fencing_token, 1, 22,
+               'secretless', 'persist', 'public', 'public',
+               'repository_policy', 1
+        FROM attempt_terminal_results AS terminal
+        WHERE terminal.attempt_id = $3
+        ",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(attempt_id)
     .execute(database.pool())
     .await?;
     Ok(())

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -439,6 +439,7 @@ async fn repository_dispatch_resolution_is_claim_fenced_atomic_and_exactly_repla
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)]
 async fn authenticated_event_readers_reject_forward_envelope_schemas() -> TestResult {
     run_with_database(|database| async move {
         let fixture = bootstrap(

--- a/crates/automata-ci-runner/Cargo.toml
+++ b/crates/automata-ci-runner/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 async-trait.workspace = true
 automata-ci-action.workspace = true
+automata-ci-action-cache-file.workspace = true
 automata-ci-action-github.workspace = true
 automata-ci-blob.workspace = true
 automata-ci-blob-s3.workspace = true

--- a/crates/automata-ci-runner/README.md
+++ b/crates/automata-ci-runner/README.md
@@ -145,6 +145,30 @@ job.
 Additional provider work remains listed in the
 [implementation plan](https://github.com/automata-ci/automata/blob/main/docs/implementation-plan.md#provider-scope).
 
+## Repository action cache
+
+Linux runners resolve credential-free repository actions pinned to one
+canonical lowercase 40-character Git commit without consuming the GitHub REST
+API quota. The first resolution downloads the immutable GitHub archive,
+performs the normal bounded archive inspection, and publishes the verified
+content-addressed bytes to the configured shared object store. Each runner also
+retains a verified local copy under its private journal state root. A warm job
+therefore reads local disk first and falls back to the shared object store; it
+does not contact GitHub again.
+
+The local archive cache is bounded to 256 entries, 512 MiB total, and 16 MiB per
+compressed archive. Its sibling reference index is crash-durable and retains at
+most 4,096 exact references. Both are recreated automatically and require no
+separate operator configuration or migration. Removing either cache directory
+only discards acceleration data; the next exact public resolution repopulates
+it from shared storage or GitHub.
+
+This fast path is deliberately narrower than general repository action
+resolution. Tags, branches, noncanonical commit spellings, and every request
+carrying a repository credential bypass both reference reuse and the public
+archive cache. Private and internal actions therefore cannot inherit authority
+from an older cache entry.
+
 ## Configure a host
 
 The complete configuration, certificate, spool, object-storage, network, and

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -1,6 +1,11 @@
 use std::{future::Future, path::Path, pin::Pin, sync::Arc};
 
 use automata_ci_action::{ActionBundleLimits, ActionResolver, ImmutableActionResolver};
+#[cfg(unix)]
+use automata_ci_action_cache_file::{
+    ActionArchiveCacheLimits, ActionArchiveCacheRoot, ActionReferenceIndexLimits,
+    ActionReferenceIndexRoot, FileActionArchiveCache, FileActionReferenceIndex,
+};
 use automata_ci_action_github::{
     GithubActionMetadataDecoder, GithubActionMetadataLimits, JavascriptRuntime,
 };
@@ -1025,13 +1030,26 @@ fn build_action_preparer(
 ) -> Result<Arc<dyn ActionPreparationPort>, RunnerProductError> {
     let github_endpoint = config.github().http_endpoint()?;
     let scm: Arc<dyn ScmProvider> = Arc::new(github_endpoint);
-    // Do not consult the legacy durable reference index here. Older runner
-    // builds could populate it through an ambient repository credential, so a
-    // warm hit is not proof that this job may read a private action archive.
-    // Anonymous SCM resolution is the authority check until the server supplies
-    // a job- and repository-scoped credential with cacheable provenance.
-    let resolver: Arc<dyn ActionResolver> =
-        Arc::new(ImmutableActionResolver::new(scm, Arc::clone(&blobs)));
+    let resolver = ImmutableActionResolver::new(scm, Arc::clone(&blobs));
+    #[cfg(unix)]
+    let resolver = {
+        let state_root = config.state().journal().as_path();
+        let references = Arc::new(FileActionReferenceIndex::open(
+            ActionReferenceIndexRoot::explicit(state_root.join("action-reference-cache"))?,
+            ActionReferenceIndexLimits::default(),
+        )?);
+        let archives = Arc::new(FileActionArchiveCache::open(
+            ActionArchiveCacheRoot::explicit(state_root.join("action-archive-cache"))?,
+            ActionArchiveCacheLimits::default(),
+        )?);
+        // The resolver itself enforces that only credential-free, canonical
+        // exact commits can consult or populate these caches. Private and
+        // mutable references always re-authorize through SCM.
+        resolver
+            .with_reference_index(references)
+            .with_local_blob_cache(archives)
+    };
+    let resolver: Arc<dyn ActionResolver> = Arc::new(resolver);
     Ok(Arc::new(ResolvedBundleActionPreparer::new(
         resolver,
         blobs,
@@ -1275,6 +1293,14 @@ pub enum RunnerProductError {
     /// Crash-durable journal initialization failed.
     #[error("runner durable journal initialization failed")]
     Journal(#[from] automata_ci_runner_journal::JournalError),
+    /// Local immutable action-reference cache initialization failed.
+    #[cfg(unix)]
+    #[error("runner action reference cache initialization failed")]
+    ActionReferenceCache(#[from] automata_ci_action::ActionReferenceIndexError),
+    /// Local immutable action archive cache initialization failed.
+    #[cfg(unix)]
+    #[error("runner action archive cache initialization failed")]
+    ActionArchiveCache(#[from] automata_ci_blob::BlobStoreError),
     /// Protected spool initialization failed.
     #[error("runner protected spool initialization failed")]
     Spool(#[from] automata_ci_runner_spool::SpoolError),


### PR DESCRIPTION
## Summary
- resolve credential-free exact public action SHAs through the immutable GitHub archive endpoint instead of the anonymous REST API quota
- persist verified action archives in shared object storage and a bounded per-runner local filesystem cache, with a durable exact-reference index
- keep mutable and authenticated/private action requests outside the public cache
- select the authoritative fenced log stream after a job lease retry so job Details pages remain readable
- document cache behavior and recovery

## Validation
- `cargo test -p automata-ci-action -p automata-ci-action-cache-file -p automata-ci-github`
- `cargo check -p automata-ci -p automata-ci-postgres -p automata-ci-runner`
- `cargo test -p automata-ci-postgres --test postgres --no-run`
- exact production read query returns one authoritative stream for all six jobs in run `c25c673f-3234-8ee5-8c75-f4c7c509485b`

The independent `sparq-ci-runner@…` GitHub Actions services are out of scope and are not managed by this change.