### PR TITLE
docs: refresh project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,6 @@ isolated runner provider on infrastructure you control.
 > checkout; do not use the documented crate or container names as if artifacts
 > had been published.
 
-## Explore Automata
-
-The [hosted UI demo](https://automata-ci.github.io/automata/) shows repositories,
-runs, jobs, logs, and administration screens with sample data. It is static: it
-cannot authenticate users, connect to repositories, or execute workflows.
-
-To run the same server-rendered interface locally, install
-[Git](https://git-scm.com/), [rustup](https://rustup.rs/), and a native C/C++
-build toolchain, then run:
-
-```console
-git clone https://github.com/automata-ci/automata.git
-cd automata
-cargo run --locked --bin automata -- preview
-```
-
-Open <http://127.0.0.1:8080>. Verify the process from another terminal:
-
-```console
-curl --fail http://127.0.0.1:8080/healthz
-curl --fail http://127.0.0.1:8080/readyz
-```
-
-Preview mode has no external dependencies. It does not accept webhooks, use
-durable storage, schedule jobs, or listen for runners. Continue with
-[Getting started](docs/getting-started.md) to install both commands, or use
-[Control-plane setup](docs/deployment.md) for the manual development
-composition backed by PostgreSQL and S3-compatible storage.
-
 ## Implementation status
 
 Automata reads GitHub Actions workflow and action syntax, but parsing a feature

--- a/README.md
+++ b/README.md
@@ -2,19 +2,27 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-2f6f68.svg)](LICENSE)
 
-Automata is a self-hosted control plane and runner for GitHub Actions
-workflows. It reads standard workflow files and is being built to schedule and
-run them on infrastructure you control.
+Automata is a self-hosted control plane and runner for GitHub Actions-compatible
+workflows. It accepts authenticated GitHub events, plans work from
+`.ci/workflows/`, schedules fenced job attempts, and executes them through an
+isolated runner provider on infrastructure you control.
 
 > [!WARNING]
-> Automata is early software. No public release has been published, and the
-> full end-to-end compatibility gate has not passed. Use a reviewed source
-> checkout for development and evaluation.
+> Automata is pre-1.0 software for development and evaluation. No public
+> release has been published, and the complete production composition has not
+> passed its end-to-end compatibility gate. Build from a reviewed source
+> checkout; do not use the documented crate or container names as if artifacts
+> had been published.
 
-## Try the interface
+## Explore Automata
 
-You need [Git](https://git-scm.com/) and [rustup](https://rustup.rs/). The
-repository selects the required Rust toolchain.
+The [hosted UI demo](https://automata-ci.github.io/automata/) shows repositories,
+runs, jobs, logs, and administration screens with sample data. It is static: it
+cannot authenticate users, connect to repositories, or execute workflows.
+
+To run the same server-rendered interface locally, install
+[Git](https://git-scm.com/), [rustup](https://rustup.rs/), and a native C/C++
+build toolchain, then run:
 
 ```console
 git clone https://github.com/automata-ci/automata.git
@@ -22,87 +30,127 @@ cd automata
 cargo run --locked --bin automata -- preview
 ```
 
-Open <http://127.0.0.1:8080>, or check the process from another terminal:
+Open <http://127.0.0.1:8080>. Verify the process from another terminal:
 
 ```console
 curl --fail http://127.0.0.1:8080/healthz
 curl --fail http://127.0.0.1:8080/readyz
 ```
 
-Preview mode needs no database or object store. It serves the web interface and
-health endpoints, but it does not schedule or run workflows.
+Preview mode has no external dependencies. It does not accept webhooks, use
+durable storage, schedule jobs, or listen for runners. Continue with
+[Getting started](docs/getting-started.md) to install both commands, or use
+[Control-plane setup](docs/deployment.md) for the manual development
+composition backed by PostgreSQL and S3-compatible storage.
 
-The [hosted UI demo](https://automata-ci.github.io/automata/) shows the same
-interface with sample data. It is a static demonstration and cannot execute
-workflows or connect to your repositories.
+## Implementation status
 
-See [Getting started](docs/getting-started.md) to install both commands from
-source. Use [Control-plane setup](docs/deployment.md) when you are ready to run
-the durable local composition.
+Automata reads GitHub Actions workflow and action syntax, but parsing a feature
+does not make it compatible. The status below describes the strongest evidence
+in this repository; the [compatibility contract](docs/compatibility.md) owns the
+detailed feature matrix and acceptance criteria.
 
-## Current status
+| Product area | Status | Implemented boundary |
+| --- | --- | --- |
+| Workflow parsing and planning | Component complete | Strict YAML diagnostics, expressions, matrices, dependencies, conditions, outputs, workflow concurrency, reusable-workflow foundations, and per-job resource requests compile into immutable logical plans and JobIR. |
+| GitHub integration | Experimental | Signed `push`, `pull_request`, `merge_group`, and `repository_dispatch` ingress; public and private source delivery; scheduled-workflow foundations; scoped GitHub App credentials; and fenced Check Runs are composed. |
+| Scheduling and runner control | Experimental | PostgreSQL-backed orchestration, leases, fencing, cancellation, log replay, restart recovery, one-use runner enrollment, and direct HTTP/2 over mutual TLS are composed. |
+| Actions, artifacts, and cache | Component complete | JavaScript and nested composite action execution, exact-commit public action resolution with verified shared and runner-local caches, job summaries, annotations, the Results artifact protocol used by `actions/upload-artifact` v7.0.1, and CacheService v2 used by `actions/cache` 5.0.5 have focused coverage. |
+| Authentication and UI | Component complete | GitHub browser and device login, tenant RBAC, CLI sessions, repository visibility, management APIs, and server-rendered repository, run, job, and administration pages are composed. |
+| Secrets and workload identity | Experimental | Versioned managed-secret custody and delivery, protected-environment review contracts, and GitHub-compatible workload OIDC are implemented behind eligibility and capability gates. |
+| Operations | Component complete | Dependency-aware health and readiness, bounded Prometheus/OpenMetrics schemas, PostgreSQL migrations, immutable S3-compatible storage, optional private shard-management gRPC, workspace provisioning, and entitlement application have boundary or PostgreSQL coverage. |
 
-The repository contains the control plane, PostgreSQL schema, S3-compatible
-storage boundary, GitHub integration, Results and cache services,
-server-rendered web interface, mTLS runner transport, and a rootless Podman
-execution path for Linux.
+The primary Linux execution path creates rootless Podman sandboxes without
+giving jobs the host Podman socket or control-plane credentials. The workspace
+also contains an experimental Kubernetes provider, disposable
+Virtualization.framework macOS VMs, and Hyper-V-isolated Windows containers.
+Those platform paths still require the acceptance evidence described in their
+operator guides. The Windows path admits only `run:` steps and is not approved
+for hostile or production workloads.
 
-These components have unit and boundary coverage, but the repository's normal
-CI workflow has not yet passed through the complete production composition.
-Automata therefore does not claim general GitHub Actions compatibility. The
-[compatibility contract](docs/compatibility.md) records the supported subsets
-and the remaining acceptance gates.
+Notable unsupported workflow features include container actions, job
+containers, job-level concurrency, and deployment-environment syntax. Service
+containers, workflow reruns, scheduled workflows, reusable workflows, managed
+secrets, OIDC, and Buildx/BuildKit have narrower experimental or component-only
+boundaries. Check [Compatibility](docs/compatibility.md) before evaluating a
+workflow.
 
-No public archive, crates.io package, or product container image is available.
-Their names and release process are documented so the publication pipeline can
-be reviewed before the first release; a documented name is not evidence that
-an artifact exists.
+## Check a local host
+
+Automata includes a read-only preflight for the planned disposable local
+installation. It checks the supported host tuple, Docker Engine, Docker Compose
+2.20.0 or newer, and a safe platform-native state root without creating the
+root or any containers:
+
+```console
+cargo run --locked -p automata-ci -- local doctor
+cargo run --locked -p automata-ci -- local doctor --json
+```
+
+`automata local up` is planned and is not present in the command. The durable
+development assembly remains the supported way to exercise the complete
+control plane from a source checkout.
 
 ## How it works
 
 ```text
-GitHub events                                  Browser / CLI
-     |                                               |
-     +------------------- automata ------------------+
-                              |       |
-                        PostgreSQL   object storage
-                              |
-                         fenced lease
-                              |
-                       automata-runner
-                              |
-                    isolated job environment
+ GitHub webhooks and source                 Browser / operator CLI
+              |                                      |
+              +-------------- automata --------------+
+                              |   |   |
+                       PostgreSQL | S3-compatible storage
+                                  |
+                  fenced JobIR leases over direct mTLS
+                                  |
+                         automata-runner
+                                  |
+                    configured sandbox provider
+                    /            |             \
+          rootless Podman   Kubernetes Pod   macOS VM / Windows
 ```
 
-`automata` ingests and plans workflows, schedules jobs, serves the Results and
-management APIs, and renders the web interface. `automata-runner` accepts
-fenced leases, validates the execution host, runs jobs through a configured
-sandbox provider, streams logs, and reconciles interrupted work.
+`automata` owns event admission, workflow planning, durable orchestration,
+Results and management APIs, GitHub publication, and the web interface.
+`automata-runner` proves its live capabilities, accepts fenced leases, executes
+steps through one configured sandbox provider, streams redacted logs, and
+reconciles interrupted work.
 
-Jobs do not receive the host Podman socket or control-plane credentials. Read
-the [architecture overview](docs/architecture.md) for the trust and storage
-boundaries.
+PostgreSQL coordinates mutable state. S3-compatible storage holds immutable
+workflow and action bundles, log segments, artifacts, cache objects, and final
+manifests. The React interface renders on the server inside a resource-limited
+WASI component; Node.js is a build dependency, not a server dependency.
+
+Read [Architecture](docs/architecture.md) for the workflow, storage, protocol,
+and trust boundaries.
 
 ## Documentation
 
 | Goal | Guide |
 | --- | --- |
-| Build from source and run the preview | [Getting started](docs/getting-started.md) |
-| Check whether a workflow feature is supported | [Compatibility](docs/compatibility.md) |
-| Configure login, permissions, and repository visibility | [Authentication and authorization](docs/authentication.md) |
-| Rerun a completed workflow safely | [Workflow reruns](docs/workflow-reruns.md) |
-| Start the durable control plane | [Control-plane setup](docs/deployment.md) |
-| Configure a Linux execution host | [Runner bootstrap](crates/automata-ci-runner/config/README.md) |
+| Build from source and inspect the interface | [Getting started](docs/getting-started.md) |
+| Check support for a workflow feature | [Compatibility](docs/compatibility.md) |
+| Start the durable development composition | [Control-plane setup](docs/deployment.md) |
+| Configure the control-plane command | [`automata` configuration](crates/automata-ci/README.md) |
+| Enroll and configure an execution host | [Runner bootstrap](crates/automata-ci-runner/config/README.md) |
+| Configure login, authorization, secrets, and repository visibility | [Authentication and authorization](docs/authentication.md) |
+| Monitor the control plane and runners | [Prometheus and OpenMetrics](docs/observability.md) |
+| Rerun a completed workflow | [Workflow reruns](docs/workflow-reruns.md) |
 | Understand the system design | [Architecture](docs/architecture.md) |
 | Build, test, or change the code | [Development](docs/development.md) |
 | Find every document | [Documentation index](docs/README.md) |
 
+Platform-specific guides document the current host contracts for
+[Arch Linux and rootless Podman](docs/platforms/arch-linux.md),
+[macOS VMs](docs/platforms/macos.md), and
+[Windows Hyper-V containers](docs/platforms/windows.md).
+
 ## Contributing
 
-Bug reports, design feedback, compatibility fixtures, and focused code changes
-are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) and the
-[implementation plan](docs/implementation-plan.md) before starting a larger
-change. See [SECURITY.md](SECURITY.md) to report a vulnerability privately.
+Bug reports, compatibility fixtures, design feedback, and focused code changes
+are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before changing the code
+and [SECURITY.md](SECURITY.md) to report a vulnerability privately. Larger
+changes should start with the open gates in the
+[implementation plan](docs/implementation-plan.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

- lead with the runnable preview, source-build requirements, and pre-1.0 release boundary
- replace the stale component inventory with evidence-qualified status for workflow planning, GitHub integration, runner control, actions, Results, authentication, secrets, operations, and sandbox providers
- document `automata local doctor`, the main unsupported workflow features, and the expanded architecture and operator documentation paths
- incorporate the exact-commit public action resolution and verified cache behavior merged in #123

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- verified every relative Markdown link in `README.md` resolves in the worktree

Documentation-only change; no product code or generated assets changed.