### PR TITLE
Bypass GitHub API for public exact source archives

### DIFF
--- a/crates/automata-ci-github/src/repository.rs
+++ b/crates/automata-ci-github/src/repository.rs
@@ -255,6 +255,20 @@ impl RepositorySourcePort for GithubHttpEndpoint {
         &self,
         request: RepositorySourceRequest<'_>,
     ) -> Result<RepositorySource, ScmError> {
+        if request.credential().is_none() {
+            let location =
+                self.exact_public_archive_location(request.repository(), request.revision())?;
+            let bytes = self
+                .download_archive(location, request.limits().maximum_bytes())
+                .await?;
+            return Ok(RepositorySource::from_bytes(
+                self.scm_provider_id.clone(),
+                request.repository().clone(),
+                request.revision().clone(),
+                ArchiveFormat::TarGzip,
+                bytes,
+            ));
+        }
         self.prove_exact_revision(&request).await?;
         let location = self.exact_archive_redirect(&request).await?;
         let bytes = self

--- a/crates/automata-ci-github/tests/repository_snapshots.rs
+++ b/crates/automata-ci-github/tests/repository_snapshots.rs
@@ -99,11 +99,13 @@ async fn exact_source_rejects_malformed_or_mismatched_commit_evidence_without_fa
         let endpoint = fixture.endpoint();
         let repository = RepositoryId::new("automata-ci/automata").unwrap();
         let revision = ExactRevision::new(SHA).unwrap();
+        let token = token();
 
         let error = endpoint
-            .fetch_repository_source(RepositorySourceRequest::public(
+            .fetch_repository_source(RepositorySourceRequest::authenticated(
                 &repository,
                 &revision,
+                &token,
                 ArchiveLimits::default(),
             ))
             .await
@@ -131,10 +133,12 @@ async fn exact_source_rejects_untrusted_redirects_and_invalid_archive_media() {
     let endpoint = untrusted.endpoint();
     let repository = RepositoryId::new("automata-ci/automata").unwrap();
     let revision = ExactRevision::new(SHA).unwrap();
+    let token = token();
     let error = endpoint
-        .fetch_repository_source(RepositorySourceRequest::public(
+        .fetch_repository_source(RepositorySourceRequest::authenticated(
             &repository,
             &revision,
+            &token,
             ArchiveLimits::default(),
         ))
         .await
@@ -158,9 +162,10 @@ async fn exact_source_rejects_untrusted_redirects_and_invalid_archive_media() {
     ));
     let endpoint = invalid_media.endpoint();
     let error = endpoint
-        .fetch_repository_source(RepositorySourceRequest::public(
+        .fetch_repository_source(RepositorySourceRequest::authenticated(
             &repository,
             &revision,
+            &token,
             ArchiveLimits::default(),
         ))
         .await
@@ -189,11 +194,13 @@ async fn exact_source_enforces_the_incremental_archive_byte_ceiling() {
     let endpoint = fixture.endpoint();
     let repository = RepositoryId::new("automata-ci/automata").unwrap();
     let revision = ExactRevision::new(SHA).unwrap();
+    let token = token();
 
     let error = endpoint
-        .fetch_repository_source(RepositorySourceRequest::public(
+        .fetch_repository_source(RepositorySourceRequest::authenticated(
             &repository,
             &revision,
+            &token,
             ArchiveLimits::new(16).unwrap(),
         ))
         .await
@@ -236,6 +243,38 @@ async fn public_exact_revision_uses_the_immutable_archive_origin_without_api_req
     assert_eq!(
         requests[0].uri,
         format!("/actions/checkout/legacy.tar.gz/{SHA}")
+    );
+    assert!(!requests[0].headers.contains_key("authorization"));
+}
+
+#[tokio::test]
+async fn public_exact_source_uses_the_immutable_archive_origin_without_api_requests() {
+    let fixture = FixtureServer::spawn().await;
+    fixture.enqueue(ResponseSpec::binary(
+        StatusCode::OK,
+        "application/x-gzip",
+        vec![0x1f, 0x8b, 0x08, 0x00, 1, 2, 3, 4],
+    ));
+    let endpoint = fixture.endpoint();
+    let repository = RepositoryId::new("automata-ci/automata").unwrap();
+    let revision = ExactRevision::new(SHA).unwrap();
+
+    let source = endpoint
+        .fetch_repository_source(RepositorySourceRequest::public(
+            &repository,
+            &revision,
+            ArchiveLimits::new(1024).unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(source.revision(), &revision);
+    assert_eq!(source.size(), 8);
+    let requests = fixture.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].uri,
+        format!("/automata-ci/automata/legacy.tar.gz/{SHA}")
     );
     assert!(!requests[0].headers.contains_key("authorization"));
 }


### PR DESCRIPTION
## Summary
- fetch anonymous public repository sources directly from the immutable codeload SHA URL
- avoid REST API proof/redirect calls that can exhaust the shared anonymous rate limit during webhook admission
- preserve the authenticated GitHub App flow for private repository sources

## Verification
- `cargo test -p automata-ci-github --test repository_snapshots`
- `cargo clippy -p automata-ci-github --all-targets -- -D warnings`
- regression proves public exact source resolution performs one codeload request with no Authorization header