### PR TITLE
Use verified local action cache payload directly

### DIFF
--- a/crates/automata-ci-action/src/model.rs
+++ b/crates/automata-ci-action/src/model.rs
@@ -545,6 +545,7 @@ pub struct ResolvedActionBundle {
     resolved_revision: ResolvedRevision,
     subpath: ActionSubpath,
     archive: BlobDescriptor,
+    archive_bytes: Bytes,
     definition: ActionDefinitionDocument,
 }
 
@@ -579,6 +580,7 @@ impl ResolvedActionBundle {
     pub(crate) fn new(
         identity: ResolvedActionIdentity,
         archive: BlobDescriptor,
+        archive_bytes: Bytes,
         definition: ActionDefinitionDocument,
     ) -> Self {
         let ResolvedActionIdentity {
@@ -595,6 +597,7 @@ impl ResolvedActionBundle {
             resolved_revision,
             subpath,
             archive,
+            archive_bytes,
             definition,
         }
     }
@@ -633,6 +636,15 @@ impl ResolvedActionBundle {
     #[must_use]
     pub const fn archive(&self) -> &BlobDescriptor {
         &self.archive
+    }
+
+    /// Returns the verified archive bytes selected by the resolver.
+    ///
+    /// Cache hits retain the already-verified local or shared-cache payload so
+    /// downstream preparation does not repeat an object-store read.
+    #[must_use]
+    pub const fn archive_bytes(&self) -> &Bytes {
+        &self.archive_bytes
     }
 
     /// Returns the bounded, inspected definition selected from the archive.

--- a/crates/automata-ci-action/src/resolver.rs
+++ b/crates/automata-ci-action/src/resolver.rs
@@ -106,6 +106,7 @@ impl ActionResolver for ImmutableActionResolver {
             let definition =
                 inspect_archive_bytes(archive.bytes(), request.subpath(), request.limits())
                     .map_err(|_| ActionResolveError::new(ActionResolveErrorKind::Archive))?;
+            let archive_bytes = archive.into_bytes();
             return Ok(ResolvedActionBundle::new(
                 ResolvedActionIdentity::new(
                     reference.provider().clone(),
@@ -115,6 +116,7 @@ impl ActionResolver for ImmutableActionResolver {
                     reference.subpath().clone(),
                 ),
                 indexed.archive().clone(),
+                archive_bytes,
                 definition,
             ));
         }
@@ -174,6 +176,7 @@ impl ActionResolver for ImmutableActionResolver {
                 request.subpath().clone(),
             ),
             archive,
+            snapshot.bytes().clone(),
             definition,
         ))
     }

--- a/crates/automata-ci-action/tests/resolution.rs
+++ b/crates/automata-ci-action/tests/resolution.rs
@@ -80,6 +80,7 @@ async fn resolution_validates_then_publishes_one_content_addressed_archive() {
         .await
         .unwrap();
     assert_eq!(stored.descriptor(), first.archive());
+    assert_eq!(first.archive_bytes(), stored.bytes());
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/src/action.rs
+++ b/crates/automata-ci-job-executor-github/src/action.rs
@@ -10,7 +10,6 @@ use automata_ci_action_github::{
     GithubActionMetadata, MetadataDecodeErrorKind, MetadataKeyValue, MetadataScalar,
     MetadataScalarKind,
 };
-use automata_ci_blob::ImmutableBlobStore;
 use automata_ci_core::{ActionReference, StepId};
 use automata_ci_execution::{TargetPath, TargetPlatform};
 use automata_ci_scm::{RepositoryId, RevisionSpec};
@@ -237,11 +236,10 @@ impl fmt::Debug for CheckedOutLocalActionPreparer {
     }
 }
 
-/// Concrete composition of immutable action resolution, blob reads, credential
-/// lookup, GitHub metadata decoding, and condition compilation.
+/// Concrete composition of immutable action resolution, credential lookup,
+/// GitHub metadata decoding, and condition compilation.
 pub struct ResolvedBundleActionPreparer {
     resolver: Arc<dyn ActionResolver>,
-    blobs: Arc<dyn ImmutableBlobStore>,
     credentials: Arc<dyn RepositoryCredentialPort>,
     decoder: Arc<dyn ActionMetadataDecoder>,
     conditions: GithubConditionCompiler,
@@ -252,8 +250,9 @@ pub struct ResolvedBundleActionPreparer {
 impl ResolvedBundleActionPreparer {
     /// Creates a repository-action preparation adapter.
     ///
-    /// `maximum_archive_bytes` must not exceed the provider-neutral endpoint
-    /// copy ceiling; larger bundles require a future streaming copy capability.
+    /// `maximum_archive_bytes` is the materialization ceiling and must not
+    /// exceed the provider-neutral endpoint copy limit. The resolver's
+    /// compressed-input ceiling must fit within it.
     ///
     /// # Errors
     ///
@@ -261,7 +260,6 @@ impl ResolvedBundleActionPreparer {
     /// the resolver's compressed-input ceiling exceeds that read bound.
     pub fn new(
         resolver: Arc<dyn ActionResolver>,
-        blobs: Arc<dyn ImmutableBlobStore>,
         credentials: Arc<dyn RepositoryCredentialPort>,
         decoder: Arc<dyn ActionMetadataDecoder>,
         conditions: GithubConditionCompiler,
@@ -278,7 +276,6 @@ impl ResolvedBundleActionPreparer {
         }
         Ok(Self {
             resolver,
-            blobs,
             credentials,
             decoder,
             conditions,
@@ -293,7 +290,6 @@ impl fmt::Debug for ResolvedBundleActionPreparer {
         formatter
             .debug_struct("ResolvedBundleActionPreparer")
             .field("resolver", &self.resolver)
-            .field("blobs", &self.blobs)
             .field("credentials", &self.credentials)
             .field("decoder", &self.decoder)
             .field("conditions", &self.conditions)
@@ -375,15 +371,10 @@ impl ActionPreparationPort for ResolvedBundleActionPreparer {
             .decoder
             .decode(bundle.definition())
             .map_err(|_| ActionPreparationError::new(ActionPreparationErrorKind::Metadata))?;
-        let archive = self
-            .blobs
-            .get_verified(bundle.archive(), self.maximum_archive_bytes)
-            .await
-            .map_err(|_| ActionPreparationError::new(ActionPreparationErrorKind::Content))?;
         prepare_metadata(
             &metadata,
             bundle.archive().digest(),
-            archive.into_bytes(),
+            bundle.archive_bytes().clone(),
             bundle.subpath().as_str(),
             &self.conditions,
         )

--- a/crates/automata-ci-job-executor-github/tests/action_preparation_errors.rs
+++ b/crates/automata-ci-job-executor-github/tests/action_preparation_errors.rs
@@ -31,7 +31,6 @@ async fn public_and_arbitrary_action_fetches_never_receive_an_ambient_credential
     ));
     let preparer = ResolvedBundleActionPreparer::new(
         resolver,
-        blobs,
         Arc::new(NoRepositoryCredentials),
         Arc::new(GithubActionMetadataDecoder::default()),
         GithubConditionCompiler::default(),
@@ -85,7 +84,6 @@ async fn resolver_failures_map_to_their_sanitized_preparation_layer() {
     ] {
         let preparer = ResolvedBundleActionPreparer::new(
             Arc::new(FailingResolver(resolution)),
-            Arc::new(MemoryBlobStore::default()),
             Arc::new(NoRepositoryCredentials),
             Arc::new(GithubActionMetadataDecoder::default()),
             GithubConditionCompiler::default(),
@@ -117,7 +115,6 @@ fn preparer_rejects_incoherent_archive_transfer_limits_before_resolution() {
     let create = |limits, maximum_archive_bytes| {
         ResolvedBundleActionPreparer::new(
             Arc::new(FailingResolver(ActionResolveErrorKind::Internal)),
-            Arc::new(MemoryBlobStore::default()),
             Arc::new(NoRepositoryCredentials),
             Arc::new(GithubActionMetadataDecoder::default()),
             GithubConditionCompiler::default(),

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -975,7 +975,7 @@ fn build_executor(
     ephemeral: Arc<dyn RunnerEphemeralClient>,
 ) -> Result<Arc<dyn JobExecutor>, RunnerProductError> {
     let blobs = build_object_store(config)?;
-    let action_preparer = build_action_preparer(config, Arc::clone(&blobs))?;
+    let action_preparer = build_action_preparer(config, &blobs)?;
     let job_content = Arc::new(ImmutableJobContent::new(
         blobs,
         automata_ci_execution::MAX_COPY_BYTES as u64,
@@ -1026,11 +1026,11 @@ fn build_executor(
 
 fn build_action_preparer(
     config: &RunnerProductConfig,
-    blobs: Arc<dyn ImmutableBlobStore>,
+    blobs: &Arc<dyn ImmutableBlobStore>,
 ) -> Result<Arc<dyn ActionPreparationPort>, RunnerProductError> {
     let github_endpoint = config.github().http_endpoint()?;
     let scm: Arc<dyn ScmProvider> = Arc::new(github_endpoint);
-    let resolver = ImmutableActionResolver::new(scm, Arc::clone(&blobs));
+    let resolver = ImmutableActionResolver::new(scm, Arc::clone(blobs));
     #[cfg(unix)]
     let resolver = {
         let state_root = config.state().journal().as_path();
@@ -1052,7 +1052,6 @@ fn build_action_preparer(
     let resolver: Arc<dyn ActionResolver> = Arc::new(resolver);
     Ok(Arc::new(ResolvedBundleActionPreparer::new(
         resolver,
-        blobs,
         Arc::new(NoRepositoryCredentials),
         Arc::new(GithubActionMetadataDecoder::new(
             GithubActionMetadataLimits::default(),


### PR DESCRIPTION
## Summary
- carry resolver-verified action archive bytes into preparation
- avoid a redundant shared object-store GET after a local-cache hit
- retain the shared immutable object store as the authoritative cross-host cache

## Validation
- cargo test -p automata-ci-action -p automata-ci-job-executor-github -p automata-ci-runner
- cargo clippy -p automata-ci-action -p automata-ci-job-executor-github -p automata-ci-runner --all-targets -- -D warnings
- production Rust S3 adapter verified the cached checkout object metadata, encryption, size, and digest
- cached checkout/setup-node/upload-artifact archives pass the production archive inspector