### PR TITLE
fix(ci): restore UI release verification

### DIFF
--- a/scripts/ci/generate-sboms.sh
+++ b/scripts/ci/generate-sboms.sh
@@ -39,6 +39,9 @@ readonly output_directory
     die "Node.js 24.19.0 is required"
 [[ "$(npm --version)" == "${expected_npm_version}" ]] || \
     die "npm 11.17.0 is required"
+embedded_runtime_input="${repository_root}/ui/embedded-runtime"
+readonly embedded_runtime_input
+node "${script_directory}/verify-embedded-ui-runtime.mjs"
 
 source_date_epoch="${SOURCE_DATE_EPOCH:-}"
 if [[ -z "${source_date_epoch}" ]]; then
@@ -134,8 +137,9 @@ generate_rust_sbom \
     "${service_proxy_binary}" \
     automata-ci-service-proxy.cdx.json
 
-npm --prefix "${repository_root}/ui" sbom \
+npm --prefix "${embedded_runtime_input}" sbom \
     --omit=dev \
+    --offline \
     --package-lock-only \
     --sbom-format cyclonedx \
     --sbom-type application \

--- a/scripts/ci/generate-third-party-licenses.mjs
+++ b/scripts/ci/generate-third-party-licenses.mjs
@@ -21,6 +21,7 @@ import {
   resolveTargetChild,
   sha256,
 } from "./lib/third-party-licenses.mjs";
+import { verifyEmbeddedUiRuntime } from "./lib/embedded-ui-runtime.mjs";
 
 const expectedNodeVersion = "v24.19.0";
 const target = "x86_64-unknown-linux-musl";
@@ -84,7 +85,6 @@ function main() {
     repositoryRoot,
     "ui/renderer/wrapper.Cargo.lock",
   );
-  const npmLockPath = path.join(repositoryRoot, "ui/package-lock.json");
   const rendererInputDirectory = resolveTargetChild({
     repositoryRoot,
     candidate:
@@ -133,17 +133,7 @@ function main() {
   if (policy.schema !== 1) {
     fail("unsupported third-party license policy schema");
   }
-  const embeddedRuntimeRoots = policy.npm?.embeddedRuntimeRoots;
-  if (
-    !Array.isArray(embeddedRuntimeRoots) ||
-    embeddedRuntimeRoots.length === 0 ||
-    embeddedRuntimeRoots.some(
-      (name) => typeof name !== "string" || name.length === 0,
-    ) ||
-    new Set(embeddedRuntimeRoots).size !== embeddedRuntimeRoots.length
-  ) {
-    fail("npm policy must define unique embedded runtime roots");
-  }
+  const npmInput = verifyEmbeddedUiRuntime({ policy, repositoryRoot });
 
   const commonMetadataArguments = [
     "--locked",
@@ -199,10 +189,10 @@ function main() {
       rootSource: "generated:wasm-rquickjs-cli@0.4.1+automata-ui",
     }),
     collectNpmComponents({
-      lock: JSON.parse(readFileSync(npmLockPath, "utf8")),
-      uiDirectory: path.join(repositoryRoot, "ui"),
+      lock: npmInput.lock,
+      uiDirectory: npmInput.inputDirectory,
       artifact: "embedded-ui-runtime",
-      embeddedRuntimeRoots,
+      embeddedRuntimeRoots: npmInput.embeddedRuntimeRoots,
     }),
   ];
 
@@ -210,7 +200,10 @@ function main() {
     componentMaps,
     inputHashes: {
       "Cargo.lock": sha256(readFileSync(workspaceLockPath)),
-      "ui/package-lock.json": sha256(readFileSync(npmLockPath)),
+      "ui/package.json": sha256(npmInput.uiManifestBytes),
+      "ui/package-lock.json": sha256(npmInput.uiLockBytes),
+      "ui/embedded-runtime/package.json": sha256(npmInput.manifestBytes),
+      "ui/embedded-runtime/package-lock.json": sha256(npmInput.lockBytes),
       "ui/renderer/wrapper.Cargo.lock": sha256(readFileSync(rendererLockPath)),
       "ui/renderer/vendor": hashRegularTree(
         rendererVendorSourceDirectory,

--- a/scripts/ci/lib/embedded-ui-runtime.mjs
+++ b/scripts/ci/lib/embedded-ui-runtime.mjs
@@ -1,0 +1,480 @@
+import {
+  lstatSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+const directRuntimeDependencies = [
+  "@phosphor-icons/web",
+  "react",
+  "react-dom",
+];
+const reviewedPeerDependencies = {
+  react: "^19.2.0",
+  "react-dom": "^19.2.0",
+};
+const reviewedRuntimeIdentity = {
+  engines: { node: "24.19.0" },
+  license: "MIT",
+  name: "@automata/embedded-ui-runtime",
+  private: true,
+  version: "0.0.0",
+};
+
+function compareText(left, right) {
+  if (left < right) {
+    return -1;
+  }
+  return left > right ? 1 : 0;
+}
+
+function comparePackage([leftName, leftVersion], [rightName, rightVersion]) {
+  return compareText(leftName, rightName) || compareText(leftVersion, rightVersion);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function record(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function optionalRecord(value, label) {
+  return value === undefined ? {} : record(value, label);
+}
+
+function readRegularFile(candidate, label) {
+  let metadata;
+  try {
+    metadata = lstatSync(candidate);
+  } catch {
+    fail(`${label} is missing`);
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    fail(`${label} must be a regular non-symbolic file`);
+  }
+  return readFileSync(candidate);
+}
+
+function parseJson(bytes, label) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (!isDeepStrictEqual(actual, expected)) {
+    fail(message);
+  }
+}
+
+function assertLockDocument(lock, manifest, label) {
+  assertEqual(
+    Object.keys(lock).sort(),
+    ["lockfileVersion", "name", "packages", "requires", "version"].sort(),
+    `${label} must retain its exact lockfileVersion 3 document shape`,
+  );
+  if (
+    lock.lockfileVersion !== 3 ||
+    lock.name !== manifest.name ||
+    lock.version !== manifest.version ||
+    lock.requires !== true
+  ) {
+    fail(`${label} identity differs from its manifest`);
+  }
+}
+
+function packageName(packagePath) {
+  const marker = "node_modules/";
+  const index = packagePath.lastIndexOf(marker);
+  if (index < 0) {
+    fail(`invalid npm lock package path ${packagePath}`);
+  }
+  const suffix = packagePath.slice(index + marker.length);
+  const parts = suffix.split("/");
+  const name = suffix.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+  if (name.length === 0) {
+    fail(`invalid npm lock package path ${packagePath}`);
+  }
+  return name;
+}
+
+function resolveDependency(packages, parentPath, name) {
+  let searchPath = parentPath;
+  while (true) {
+    const candidate = path.posix.join(searchPath, "node_modules", name);
+    if (packages[candidate] !== undefined) {
+      return candidate;
+    }
+    if (searchPath.length === 0) {
+      return null;
+    }
+    searchPath = path.posix.dirname(searchPath);
+    if (searchPath === ".") {
+      searchPath = "";
+    }
+  }
+}
+
+function enqueueDependencies(queue, packagePath, packageRecord) {
+  for (const name of Object.keys(packageRecord.dependencies ?? {})) {
+    queue.push({ name, optional: false, parentPath: packagePath });
+  }
+  for (const name of Object.keys(packageRecord.optionalDependencies ?? {})) {
+    queue.push({ name, optional: true, parentPath: packagePath });
+  }
+  for (const name of Object.keys(packageRecord.peerDependencies ?? {})) {
+    queue.push({
+      name,
+      optional: packageRecord.peerDependenciesMeta?.[name]?.optional === true,
+      parentPath: packagePath,
+    });
+  }
+}
+
+function lockedRuntimePackages(lock) {
+  if (lock.lockfileVersion !== 3) {
+    fail("embedded UI runtime lock must use lockfileVersion 3");
+  }
+  const packages = record(lock.packages, "embedded UI runtime lock packages");
+  const root = record(packages[""], "embedded UI runtime lock root");
+  const queue = [];
+  enqueueDependencies(queue, "", root);
+  const reachable = new Map();
+
+  while (queue.length > 0) {
+    const request = queue.shift();
+    const packagePath = resolveDependency(
+      packages,
+      request.parentPath,
+      request.name,
+    );
+    if (packagePath === null) {
+      if (request.optional) {
+        continue;
+      }
+      fail(`embedded UI runtime lock cannot resolve ${request.name}`);
+    }
+    if (reachable.has(packagePath)) {
+      continue;
+    }
+    const dependency = record(
+      packages[packagePath],
+      `embedded UI runtime lock package ${packagePath}`,
+    );
+    if (packageName(packagePath) !== request.name) {
+      fail(`embedded UI runtime lock aliases ${request.name} to ${packagePath}`);
+    }
+    if (
+      typeof dependency.version !== "string" ||
+      typeof dependency.integrity !== "string" ||
+      typeof dependency.resolved !== "string" ||
+      dependency.dev === true
+    ) {
+      fail(`embedded UI runtime lock has an invalid production package ${packagePath}`);
+    }
+    reachable.set(packagePath, {
+      name: request.name,
+      packagePath,
+      record: dependency,
+      version: dependency.version,
+    });
+    enqueueDependencies(queue, packagePath, dependency);
+  }
+
+  const lockedPaths = Object.keys(packages).filter((entry) => entry.length > 0);
+  assertEqual(
+    [...reachable.keys()].sort(),
+    lockedPaths.sort(),
+    "embedded UI runtime lock contains unreachable packages",
+  );
+  return { packages, reachable, root };
+}
+
+function comparableLockRecord(packageRecord) {
+  const comparable = { ...packageRecord };
+  delete comparable.dev;
+  return comparable;
+}
+
+function allowedRuntimePackages(policy) {
+  const allowed = policy?.npm?.allowedProductionPackages;
+  if (!Array.isArray(allowed)) {
+    fail("npm production package allowlist must be an array");
+  }
+  return allowed.map((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.name !== "string" ||
+      typeof entry.version !== "string"
+    ) {
+      fail("invalid npm production package allowlist entry");
+    }
+    return [entry.name, entry.version];
+  }).sort(comparePackage);
+}
+
+function embeddedRuntimeRoots(policy) {
+  const roots = policy?.npm?.embeddedRuntimeRoots;
+  if (
+    !Array.isArray(roots) ||
+    roots.length === 0 ||
+    roots.some((name) => typeof name !== "string" || name.length === 0) ||
+    new Set(roots).size !== roots.length
+  ) {
+    fail("npm policy must define unique embedded runtime roots");
+  }
+  assertEqual(
+    [...roots].sort(),
+    [...directRuntimeDependencies].sort(),
+    "npm embedded runtime roots differ from the reviewed direct dependency set",
+  );
+  return roots;
+}
+
+export function verifyEmbeddedUiRuntime({ policy, repositoryRoot }) {
+  const canonicalRoot = realpathSync(repositoryRoot);
+  const uiDirectory = path.join(canonicalRoot, "ui");
+  const inputDirectory = path.join(uiDirectory, "embedded-runtime");
+  let inputMetadata;
+  try {
+    inputMetadata = lstatSync(inputDirectory);
+  } catch {
+    fail("embedded UI runtime input is missing");
+  }
+  if (
+    !inputMetadata.isDirectory() ||
+    inputMetadata.isSymbolicLink() ||
+    realpathSync(inputDirectory) !== inputDirectory
+  ) {
+    fail("embedded UI runtime input must be a real repository directory");
+  }
+
+  const uiManifestPath = path.join(uiDirectory, "package.json");
+  const uiLockPath = path.join(uiDirectory, "package-lock.json");
+  const manifestPath = path.join(inputDirectory, "package.json");
+  const lockPath = path.join(inputDirectory, "package-lock.json");
+  const uiManifestBytes = readRegularFile(uiManifestPath, "UI package.json");
+  const uiLockBytes = readRegularFile(uiLockPath, "UI package-lock.json");
+  const manifestBytes = readRegularFile(
+    manifestPath,
+    "embedded UI runtime package.json",
+  );
+  const lockBytes = readRegularFile(
+    lockPath,
+    "embedded UI runtime package-lock.json",
+  );
+  const uiManifest = record(
+    parseJson(uiManifestBytes, "UI package.json"),
+    "UI package.json",
+  );
+  const uiLock = record(
+    parseJson(uiLockBytes, "UI package-lock.json"),
+    "UI package-lock.json",
+  );
+  const manifest = record(
+    parseJson(manifestBytes, "embedded UI runtime package.json"),
+    "embedded UI runtime package.json",
+  );
+  const lock = record(
+    parseJson(lockBytes, "embedded UI runtime package-lock.json"),
+    "embedded UI runtime package-lock.json",
+  );
+  const runtimeRoots = embeddedRuntimeRoots(policy);
+
+  assertEqual(
+    {
+      engines: manifest.engines,
+      license: manifest.license,
+      name: manifest.name,
+      private: manifest.private,
+      version: manifest.version,
+    },
+    reviewedRuntimeIdentity,
+    "embedded UI runtime manifest must retain its reviewed private identity",
+  );
+  assertLockDocument(lock, manifest, "embedded UI runtime lock");
+  const dependencies = record(
+    manifest.dependencies,
+    "embedded UI runtime dependencies",
+  );
+  assertEqual(
+    Object.keys(dependencies).sort(),
+    [...runtimeRoots].sort(),
+    "embedded UI runtime manifest must own the exact direct dependency set",
+  );
+  for (const section of [
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ]) {
+    if (manifest[section] !== undefined) {
+      fail(`embedded UI runtime manifest must not declare ${section}`);
+    }
+  }
+
+  const uiDependencies = optionalRecord(
+    uiManifest.dependencies,
+    "UI production dependencies",
+  );
+  const uiDevDependencies = record(
+    uiManifest.devDependencies,
+    "UI development dependencies",
+  );
+  const uiOptionalDependencies = optionalRecord(
+    uiManifest.optionalDependencies,
+    "UI optional dependencies",
+  );
+  const uiPeerDependencies = record(
+    uiManifest.peerDependencies,
+    "UI peer dependencies",
+  );
+  for (const name of directRuntimeDependencies) {
+    if (uiDependencies[name] !== undefined) {
+      fail(`UI package must not own embedded dependency ${name} as production`);
+    }
+    if (uiDevDependencies[name] !== dependencies[name]) {
+      fail(`embedded UI runtime ${name} differs from the UI build dependency`);
+    }
+    if (uiOptionalDependencies[name] !== undefined) {
+      fail(`UI package must not own embedded dependency ${name} as optional`);
+    }
+  }
+  assertEqual(
+    uiPeerDependencies,
+    reviewedPeerDependencies,
+    "UI package must retain its reviewed React peer dependency contract",
+  );
+  const uiPeerDependenciesMeta = optionalRecord(
+    uiManifest.peerDependenciesMeta,
+    "UI peer dependency metadata",
+  );
+  assertEqual(
+    uiPeerDependenciesMeta,
+    {},
+    "UI package must not weaken its reviewed React peer dependency contract",
+  );
+  for (const section of ["bundleDependencies", "bundledDependencies"]) {
+    if (uiManifest[section] !== undefined) {
+      fail(`UI package must not declare ${section}`);
+    }
+  }
+
+  assertLockDocument(uiLock, uiManifest, "UI lock");
+  const uiLockPackages = record(uiLock.packages, "UI lock packages");
+  const uiLockRoot = record(uiLockPackages[""], "UI lock root");
+  assertEqual(
+    {
+      engines: uiLockRoot.engines,
+      license: uiLockRoot.license,
+      name: uiLockRoot.name,
+      version: uiLockRoot.version,
+    },
+    {
+      engines: uiManifest.engines,
+      license: uiManifest.license,
+      name: uiManifest.name,
+      version: uiManifest.version,
+    },
+    "UI manifest and lock identity differ",
+  );
+  assertEqual(
+    optionalRecord(uiLockRoot.dependencies, "UI lock production dependencies"),
+    uiDependencies,
+    "UI manifest and lock production dependencies differ",
+  );
+  assertEqual(
+    uiLockRoot.devDependencies,
+    uiManifest.devDependencies,
+    "UI manifest and lock development dependencies differ",
+  );
+  assertEqual(
+    optionalRecord(uiLockRoot.optionalDependencies, "UI lock optional dependencies"),
+    uiOptionalDependencies,
+    "UI manifest and lock optional dependencies differ",
+  );
+  assertEqual(
+    uiLockRoot.peerDependencies,
+    uiManifest.peerDependencies,
+    "UI manifest and lock peer dependencies differ",
+  );
+  assertEqual(
+    optionalRecord(
+      uiLockRoot.peerDependenciesMeta,
+      "UI lock peer dependency metadata",
+    ),
+    {},
+    "UI lock must not weaken the reviewed React peer dependency contract",
+  );
+  for (const section of ["bundleDependencies", "bundledDependencies"]) {
+    if (uiLockRoot[section] !== undefined) {
+      fail(`UI lock must not declare ${section}`);
+    }
+  }
+
+  const inventory = lockedRuntimePackages(lock);
+  assertEqual(
+    inventory.root,
+    {
+      name: manifest.name,
+      version: manifest.version,
+      license: manifest.license,
+      dependencies,
+      engines: manifest.engines,
+    },
+    "embedded UI runtime manifest and lock root differ",
+  );
+  for (const name of directRuntimeDependencies) {
+    const component = [...inventory.reachable.values()].find(
+      (candidate) => candidate.name === name,
+    );
+    if (component === undefined || component.version !== dependencies[name]) {
+      fail(`embedded UI runtime ${name} is not pinned to its exact locked version`);
+    }
+  }
+  for (const [packagePath, component] of inventory.reachable) {
+    const bundled = uiLockPackages[packagePath];
+    if (bundled === undefined) {
+      fail(`UI build lock does not contain embedded package ${packagePath}`);
+    }
+    assertEqual(
+      comparableLockRecord(component.record),
+      comparableLockRecord(bundled),
+      `embedded package ${packagePath} differs from the UI build lock`,
+    );
+  }
+
+  const actualPackages = [...inventory.reachable.values()]
+    .map((component) => [component.name, component.version])
+    .sort(comparePackage);
+  assertEqual(
+    actualPackages,
+    allowedRuntimePackages(policy),
+    "embedded UI runtime packages differ from the npm production allowlist",
+  );
+
+  return {
+    embeddedRuntimeRoots: runtimeRoots,
+    inputDirectory,
+    lock,
+    lockBytes,
+    lockPath,
+    manifest,
+    manifestBytes,
+    manifestPath,
+    packages: actualPackages,
+    uiLockBytes,
+    uiLockPath,
+    uiManifestBytes,
+    uiManifestPath,
+  };
+}

--- a/scripts/ci/prepare-third-party-license-sources.sh
+++ b/scripts/ci/prepare-third-party-license-sources.sh
@@ -27,6 +27,9 @@ automata_set_target_tmpdir \
     die "Node.js 24.19.0 is required"
 [[ "$(npm --version)" == "${expected_npm_version}" ]] || \
     die "npm 11.17.0 is required"
+embedded_runtime_input="${repository_root}/ui/embedded-runtime"
+readonly embedded_runtime_input
+node "${script_directory}/verify-embedded-ui-runtime.mjs"
 renderer_input="$(automata_third_party_license_renderer_input "${repository_root}")"
 readonly renderer_input
 renderer_input_lock="$(automata_third_party_license_lock_path "${repository_root}")"
@@ -147,7 +150,9 @@ cargo fetch \
     --manifest-path "${renderer_manifest_input}" \
     --locked \
     --target wasm32-wasip2
-npm --prefix "${repository_root}/ui" ci \
-    --ignore-scripts
+npm --prefix "${embedded_runtime_input}" ci \
+    --omit=dev \
+    --ignore-scripts \
+    --no-audit
 
 printf 'Prepared locked Cargo and npm license sources\n'

--- a/scripts/ci/tests/embedded-ui-runtime.test.mjs
+++ b/scripts/ci/tests/embedded-ui-runtime.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { verifyEmbeddedUiRuntime } from "../lib/embedded-ui-runtime.mjs";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, "../../..");
+const expectedPackages = [
+  ["@phosphor-icons/web", "2.1.2"],
+  ["react", "19.2.8"],
+  ["react-dom", "19.2.8"],
+  ["scheduler", "0.27.0"],
+];
+const policy = JSON.parse(
+  readFileSync(
+    path.join(repositoryRoot, "scripts/ci/third-party-license-policy.json"),
+    "utf8",
+  ),
+);
+
+function scratch() {
+  const root = process.env.TMPDIR;
+  assert.ok(root, "tests require an explicit repository-local TMPDIR");
+  assert.ok(!path.resolve(root).startsWith(`${path.sep}tmp${path.sep}`));
+  mkdirSync(root, { recursive: true });
+  return mkdtempSync(path.join(root, "embedded-runtime-test."));
+}
+
+function fixture() {
+  const root = scratch();
+  const ui = path.join(root, "ui");
+  const runtime = path.join(ui, "embedded-runtime");
+  mkdirSync(runtime, { recursive: true });
+  for (const name of ["package.json", "package-lock.json"]) {
+    cpSync(path.join(repositoryRoot, "ui", name), path.join(ui, name));
+    cpSync(
+      path.join(repositoryRoot, "ui/embedded-runtime", name),
+      path.join(runtime, name),
+    );
+  }
+  return root;
+}
+
+function updateJson(candidate, update) {
+  const document = JSON.parse(readFileSync(candidate, "utf8"));
+  update(document);
+  writeFileSync(candidate, `${JSON.stringify(document, null, 2)}\n`);
+}
+
+test("embedded runtime inventory matches the reviewed bundle closure", () => {
+  const verified = verifyEmbeddedUiRuntime({ policy, repositoryRoot });
+  assert.deepEqual(verified.packages, expectedPackages);
+});
+
+test("offline runtime SBOM contains exactly the reviewed four packages", () => {
+  const verified = verifyEmbeddedUiRuntime({ policy, repositoryRoot });
+  const npm = path.join(path.dirname(process.execPath), "npm");
+  const result = spawnSync(
+    npm,
+    [
+      "--prefix",
+      verified.inputDirectory,
+      "sbom",
+      "--omit=dev",
+      "--offline",
+      "--package-lock-only",
+      "--sbom-format",
+      "cyclonedx",
+      "--sbom-type",
+      "application",
+    ],
+    { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const sbom = JSON.parse(result.stdout);
+  const packages = sbom.components
+    .map((component) => [component.name, component.version])
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+  assert.deepEqual(packages, expectedPackages);
+});
+
+test("verifier rejects a weakened React peer contract", () => {
+  const root = fixture();
+  for (const name of ["package.json", "package-lock.json"]) {
+    updateJson(path.join(root, "ui", name), (document) => {
+      const manifest = name === "package.json" ? document : document.packages[""];
+      manifest.peerDependencies.react = "*";
+      manifest.peerDependencies["react-dom"] = "*";
+    });
+  }
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy, repositoryRoot: root }),
+    /reviewed React peer dependency contract/,
+  );
+});
+
+test("verifier rejects drift in the reviewed runtime roots", () => {
+  const changedPolicy = structuredClone(policy);
+  changedPolicy.npm.embeddedRuntimeRoots = ["react", "react-dom"];
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy: changedPolicy, repositoryRoot }),
+    /roots differ from the reviewed direct dependency set/,
+  );
+});
+
+test("verifier rejects optional ownership of an embedded dependency", () => {
+  const root = fixture();
+  updateJson(path.join(root, "ui/package.json"), (document) => {
+    document.optionalDependencies = { react: "19.2.8" };
+  });
+  updateJson(path.join(root, "ui/package-lock.json"), (document) => {
+    document.packages[""].optionalDependencies = { react: "19.2.8" };
+  });
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy, repositoryRoot: root }),
+    /must not own embedded dependency react as optional/,
+  );
+});
+
+test("verifier rejects optional React peer metadata", () => {
+  const root = fixture();
+  for (const name of ["package.json", "package-lock.json"]) {
+    updateJson(path.join(root, "ui", name), (document) => {
+      const manifest = name === "package.json" ? document : document.packages[""];
+      manifest.peerDependenciesMeta = {
+        react: { optional: true },
+        "react-dom": { optional: true },
+      };
+    });
+  }
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy, repositoryRoot: root }),
+    /must not weaken its reviewed React peer dependency contract/,
+  );
+});
+
+test("verifier rejects runtime lock drift from the UI build lock", () => {
+  const root = fixture();
+  updateJson(
+    path.join(root, "ui/embedded-runtime/package-lock.json"),
+    (document) => {
+      document.packages["node_modules/scheduler"].integrity = "sha512-drift";
+    },
+  );
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy, repositoryRoot: root }),
+    /embedded package node_modules\/scheduler differs from the UI build lock/,
+  );
+});
+
+test("verifier rejects packages outside the reachable runtime closure", () => {
+  const root = fixture();
+  updateJson(
+    path.join(root, "ui/embedded-runtime/package-lock.json"),
+    (document) => {
+      document.packages["node_modules/unexpected"] = {
+        version: "1.0.0",
+        resolved: "https://registry.npmjs.org/unexpected/-/unexpected-1.0.0.tgz",
+        integrity: "sha512-unexpected",
+        license: "MIT",
+      };
+    },
+  );
+  assert.throws(
+    () => verifyEmbeddedUiRuntime({ policy, repositoryRoot: root }),
+    /contains unreachable packages/,
+  );
+});

--- a/scripts/ci/tests/third-party-licenses.test.mjs
+++ b/scripts/ci/tests/third-party-licenses.test.mjs
@@ -173,7 +173,17 @@ test("concurrent preparation is isolated and stages exact input before Cargo fet
   mkdirSync(fakeBin, { recursive: true });
   writeFileSync(
     path.join(fakeBin, "node"),
-    "#!/usr/bin/env bash\nset -euo pipefail\n[[ \"${1:-}\" == --version ]]\nprintf 'v24.19.0\\n'\n",
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [[ \"${1:-}\" == --version ]]; then",
+      "    printf 'v24.19.0\\n'",
+      "    exit 0",
+      "fi",
+      "[[ \"${1:-}\" == \"${AUTOMATA_TEST_RUNTIME_VERIFIER}\" ]]",
+      "exec \"${AUTOMATA_TEST_REAL_NODE}\" \"$@\"",
+      "",
+    ].join("\n"),
     { mode: 0o755 },
   );
   writeFileSync(
@@ -185,6 +195,13 @@ test("concurrent preparation is isolated and stages exact input before Cargo fet
       "    printf '11.17.0\\n'",
       "    exit 0",
       "fi",
+      "[[ $# == 6 ]]",
+      "[[ \"$1\" == --prefix ]]",
+      "[[ \"$2\" == \"${AUTOMATA_TEST_EMBEDDED_RUNTIME_INPUT}\" ]]",
+      "[[ \"$3\" == ci ]]",
+      "[[ \"$4\" == --omit=dev ]]",
+      "[[ \"$5\" == --ignore-scripts ]]",
+      "[[ \"$6\" == --no-audit ]]",
       "install -m 0644 -- /dev/null \"${AUTOMATA_TEST_NPM_MARKER}\"",
       "",
     ].join("\n"),
@@ -233,7 +250,16 @@ test("concurrent preparation is isolated and stages exact input before Cargo fet
           env: {
             ...process.env,
             AUTOMATA_TEST_CARGO_MARKER: cargoMarker,
+            AUTOMATA_TEST_EMBEDDED_RUNTIME_INPUT: path.join(
+              repositoryRoot,
+              "ui/embedded-runtime",
+            ),
             AUTOMATA_TEST_NPM_MARKER: npmMarker,
+            AUTOMATA_TEST_REAL_NODE: realpathSync(process.execPath),
+            AUTOMATA_TEST_RUNTIME_VERIFIER: path.join(
+              repositoryRoot,
+              "scripts/ci/verify-embedded-ui-runtime.mjs",
+            ),
             AUTOMATA_TEST_THIRD_PARTY_LICENSE_RENDERER_INPUT: rendererInput,
             AUTOMATA_TEST_VENDOR_SOURCE: path.join(
               repositoryRoot,

--- a/scripts/ci/verify-embedded-ui-runtime.mjs
+++ b/scripts/ci/verify-embedded-ui-runtime.mjs
@@ -1,0 +1,19 @@
+import { readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { verifyEmbeddedUiRuntime } from "./lib/embedded-ui-runtime.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = realpathSync(path.join(scriptDirectory, "../.."));
+const policy = JSON.parse(
+  readFileSync(
+    path.join(scriptDirectory, "third-party-license-policy.json"),
+    "utf8",
+  ),
+);
+const verified = verifyEmbeddedUiRuntime({ policy, repositoryRoot });
+
+console.log(
+  `Verified ${verified.packages.length} locked embedded UI runtime packages`,
+);

--- a/ui/README.md
+++ b/ui/README.md
@@ -90,14 +90,14 @@ Node 24.19.0 baseline:
 
 | Metric | Baseline | Enforced floor | Headroom |
 | --- | ---: | ---: | ---: |
-| Statements | 93.99% | 93% | 0.99 points |
-| Branches | 85.29% | 84% | 1.29 points |
-| Functions | 97.18% | 96% | 1.18 points |
-| Lines | 94.00% | 93% | 1.00 point |
+| Statements | 94.02% | 93% | 1.02 points |
+| Branches | 85.18% | 84% | 1.18 points |
+| Functions | 97.27% | 96% | 1.27 points |
+| Lines | 94.07% | 93% | 1.07 points |
 
 Each floor is a whole-number percentage below the measured result and leaves at
-least 0.99 points of margin. Branches and functions use the next lower whole
-number because truncating those baselines would leave only 0.29 and 0.18 points
+least 1.02 points of margin. Branches and functions use the next lower whole
+number because truncating those baselines would leave only 0.18 and 0.27 points
 of margin. CI runs this threshold check; raise the floors after reviewed
 coverage improvements, and lower them only with a new reproducible baseline and
 an explicit justification. These aggregate floors are a regression guard, not

--- a/ui/embedded-runtime/package-lock.json
+++ b/ui/embedded-runtime/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "@automata/embedded-ui-runtime",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@automata/embedded-ui-runtime",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@phosphor-icons/web": "2.1.2",
+        "react": "19.2.8",
+        "react-dom": "19.2.8"
+      },
+      "engines": {
+        "node": "24.19.0"
+      }
+    },
+    "node_modules/@phosphor-icons/web": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/web/-/web-2.1.2.tgz",
+      "integrity": "sha512-rPAR9o/bEcp4Cw4DEeZHXf+nlGCMNGkNDRizYHM47NLxz9vvEHp/Tt6FMK1NcWadzw/pFDPnRBGi/ofRya958A==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    }
+  }
+}

--- a/ui/embedded-runtime/package.json
+++ b/ui/embedded-runtime/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@automata/embedded-ui-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "engines": {
+    "node": "24.19.0"
+  },
+  "dependencies": {
+    "@phosphor-icons/web": "2.1.2",
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  }
+}

--- a/ui/tests/integration/ssr.test.tsx
+++ b/ui/tests/integration/ssr.test.tsx
@@ -1241,6 +1241,77 @@ describe("hydration", () => {
     await act(async () => root?.unmount());
   });
 
+  it("revalidates live logs and retries rejected snapshots with bounded backoff", async () => {
+    if (jobLogRequest.page.kind !== "job-log") {
+      throw new Error("The job-log fixture is unavailable");
+    }
+    const snapshotHref = `${jobLogRequest.page.job.href}/snapshot`;
+    const responses = [
+      () =>
+        new Response(JSON.stringify(jobLogRequest), {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            ETag: '"sha256-running"',
+          },
+        }),
+      () => new Response(null, { status: 304 }),
+      () =>
+        new Response(JSON.stringify(runDetailRequest), {
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+        }),
+      () => new Response(null, { status: 503 }),
+    ];
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        const response = responses.shift();
+        if (response === undefined) {
+          throw new Error("unexpected job-log snapshot request");
+        }
+        return response();
+      },
+    );
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    document.open();
+    document.write(renderPage(jobLogRequest));
+    document.close();
+    const parsedRequest = readRenderRequest(document);
+
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(document, <HtmlDocument request={parsedRequest} />);
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(snapshotHref);
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers;
+    const revalidationHeaders = fetchMock.mock.calls[1]?.[1]?.headers;
+    expect(firstHeaders).toBeInstanceOf(Headers);
+    expect(revalidationHeaders).toBeInstanceOf(Headers);
+    expect((firstHeaders as Headers).get("If-None-Match")).toBeNull();
+    expect((revalidationHeaders as Headers).get("If-None-Match")).toBe(
+      '"sha256-running"',
+    );
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await act(async () => vi.advanceTimersByTimeAsync(3_999));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    await act(async () => vi.advanceTimersByTimeAsync(7_999));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    await act(async () => root?.unmount());
+  });
+
   it.each([
     ["run list", runListRequest, "Workflow runs"],
     ["run detail", runDetailRequest, "Build and test release candidate"],
@@ -1265,6 +1336,86 @@ describe("hydration", () => {
 
       expect(errors).toEqual([]);
       expect(document.querySelector("h1")?.textContent).toBe(heading);
+
+      await act(async () => root?.unmount());
+    },
+  );
+
+  it.each([
+    [
+      "all jobs after an HTTP rejection",
+      "Re-run all jobs",
+      "entire_workflow",
+      () => new Response(null, { status: 503 }),
+    ],
+    [
+      "failed jobs after an invalid success response",
+      "Re-run failed jobs",
+      "failed_jobs_and_dependents",
+      () =>
+        new Response(JSON.stringify({ run_id: "not-a-run-uuid" }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+    ],
+  ] as const)(
+    "recovers rerun controls for %s",
+    async (_case, buttonLabel, mode, response) => {
+      if (runDetailRequest.page.kind !== "run-detail") {
+        throw new Error("The run-detail fixture is unavailable");
+      }
+      const endpoint = `/automata-ci/automata/actions/runs/${PRIMARY_RUN_ID}/reruns`;
+      const request: RenderRequest = {
+        ...runDetailRequest,
+        page: {
+          ...runDetailRequest.page,
+          rerun: {
+            endpoint,
+            csrfToken: SHELL_CSRF_TOKEN,
+            failedJobsAvailable: true,
+          },
+        },
+      };
+      const operationId = "11111111-1111-4111-8111-111111111111";
+      const fetchMock = vi.fn(async () => response());
+      vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(operationId);
+      vi.stubGlobal("fetch", fetchMock);
+      vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+      document.open();
+      document.write(renderPage(request));
+      document.close();
+      const parsedRequest = readRenderRequest(document);
+
+      let root: ReturnType<typeof hydrateRoot> | undefined;
+      await act(async () => {
+        root = hydrateRoot(document, <HtmlDocument request={parsedRequest} />);
+      });
+      const button = [
+        ...document.querySelectorAll<HTMLButtonElement>(
+          '[aria-label="Rerun controls"] button',
+        ),
+      ].find((candidate) => candidate.textContent === buttonLabel);
+      expect(button).toBeDefined();
+
+      await act(async () => {
+        button?.click();
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(endpoint, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "content-type": "application/json",
+          "x-automata-csrf-token": SHELL_CSRF_TOKEN,
+        },
+        body: JSON.stringify({
+          operation_id: operationId,
+          selection: { mode },
+        }),
+      });
+      expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+        "The rerun could not be started. Refresh and try again.",
+      );
+      expect(button?.disabled).toBe(false);
 
       await act(async () => root?.unmount());
     },


### PR DESCRIPTION
## Summary

- restore the reviewed frontend coverage baseline with behavior-focused hydration coverage for live-log revalidation/backoff and rerun failure recovery
- add a private nested production manifest and lock as exact license and SBOM evidence for the embedded UI runtime instead of treating the full frontend development lock as shipped evidence
- fail closed when the nested runtime drifts from the UI manifest or lock, the explicit runtime-root policy now on main, the exact four-package allowlist, or the reviewed React/ReactDOM peer contract
- preserve the current-main native license fixes, including the locked `tonic-prost` fallback, while binding release output to both UI lock documents and the nested runtime evidence

## Evidence

- Node 24.19.0 frontend coverage: 452 tests; 94.02% statements, 85.18% branches, 97.27% functions, 94.07% lines
- embedded runtime inventory: `@phosphor-icons/web`, `react`, `react-dom`, and `scheduler`, with exact versions, resolution URLs, integrity hashes, and equality to the corresponding UI build-lock records
- deterministic notice generation covers 471/471 components and reproduces byte-for-byte across two runs
- the five-artifact SBOM wrapper produces an embedded-runtime SBOM with exactly the reviewed four components
- React and ReactDOM remain peer dependencies; production ownership, optional ownership, optional peer metadata, and peer-range weakening are rejected

## Validation

- `npm --prefix ui run check`
- `npm --prefix ui run test:coverage` (452 passed)
- `node --test scripts/ci/tests/*.test.mjs` (25 passed)
- `node scripts/ci/verify-embedded-ui-runtime.mjs`
- `./scripts/ci/prepare-third-party-license-sources.sh`
- two independent `./scripts/ci/generate-third-party-licenses.sh` runs plus exact tree comparison
- `./scripts/ci/generate-sboms.sh` with disposable target-local executable fixtures; CI remains authoritative for the real musl binary hashes
- npm audits for the UI build graph and nested runtime graph (0 vulnerabilities)
- ShellCheck, `bash -n`, `cargo fmt --all -- --check`, the release-handoff tests, and `git diff --check`
