### PR TITLE
refactor(control): own execution durability contracts

### DIFF
--- a/crates/automata-ci-control/Cargo.toml
+++ b/crates/automata-ci-control/Cargo.toml
@@ -12,6 +12,10 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
+[features]
+default = []
+adapter-spi = []
+
 [[test]]
 name = "control"
 path = "tests/control.rs"

--- a/crates/automata-ci-control/README.md
+++ b/crates/automata-ci-control/README.md
@@ -1,10 +1,17 @@
 # automata-ci-control
 
-`automata-ci-control` owns Automata's transport-neutral scheduling, lease, and
-authenticated runner-control services. Its scheduling domain reduces
-server-owned requirements and validated runner capabilities to deterministic
-placement decisions. Its application services compose those decisions with
-durable ports and versioned runner messages.
+`automata-ci-control` owns Automata's transport-neutral scheduling and
+authenticated runner-control services. It also owns the execution durability
+contracts for attempt lifecycle, lease polling and runnable queues,
+cancellation, replica-safe maintenance, and identifier-free control-plane
+state snapshots. Its scheduling domain reduces server-owned requirements and
+validated runner capabilities to deterministic placement decisions. Its
+application services compose those decisions with durable ports and versioned
+runner messages.
+
+First-party repository adapters use the feature-gated, documentation-hidden
+`adapter-spi` trust boundary. That module is not a supported general-purpose
+API.
 
 The public `runner_auth` module binds transport-validated mTLS evidence to
 durable runner registrations without trusting certificate contents or protocol

--- a/crates/automata-ci-control/src/adapter_spi.rs
+++ b/crates/automata-ci-control/src/adapter_spi.rs
@@ -1,0 +1,138 @@
+//! Unstable trust-boundary operations for Automata's first-party durable adapters.
+//!
+//! This is deliberately not a general-purpose construction API. Callers must
+//! establish the documented durable-row predicates before invoking these hooks.
+//! The feature and every item in this module may change without notice.
+
+use automata_ci_core::{AttemptId, OperationId, Sha256Digest, UnixMillis};
+
+pub use crate::attempt::durable::{
+    AcquireLease, ConcludeQueuedAttempt, InternalAttemptRepository, QueuedAttempt,
+    TenantAttemptQuery, TransitionAttempt,
+};
+pub use crate::attempt::snapshot::{AttemptSnapshot, AttemptSnapshotBuilder};
+pub use crate::maintenance::blocked::{
+    BlockedAttempt, BlockedAttemptRepository, BlockedConclusion, ConcludeBlockedAttempt,
+};
+
+/// Rehydrates one maintenance mutation from the same committed transaction.
+#[must_use]
+pub const fn expired_attempt_maintenance(
+    attempt_id: AttemptId,
+    disposition: crate::maintenance::ExpiredAttemptDisposition,
+    reconciliation: automata_ci_store::RunReconciliation,
+) -> crate::maintenance::ExpiredAttemptMaintenance {
+    crate::maintenance::ExpiredAttemptMaintenance::new(attempt_id, disposition, reconciliation)
+}
+
+/// Rehydrates the bounded result of one maintenance pass.
+#[must_use]
+pub const fn control_plane_maintenance_report(
+    expired_attempts: Vec<crate::maintenance::ExpiredAttemptMaintenance>,
+    skipped_blocked_attempts: u16,
+    closed_stale_sessions: u16,
+) -> crate::maintenance::ControlPlaneMaintenanceReport {
+    crate::maintenance::ControlPlaneMaintenanceReport::new(
+        expired_attempts,
+        skipped_blocked_attempts,
+        closed_stale_sessions,
+    )
+}
+
+/// Rehydrates and validates the versioned revoked-lease fallback representation.
+pub fn revoked_lease_offer_fallback(
+    representation_version: u16,
+    response_operation_id: OperationId,
+    retry_after_millis: u32,
+    response_schema: automata_ci_store::DocumentSchema,
+    response_digest: Sha256Digest,
+) -> Result<crate::lease::RevokedLeaseOfferFallback, crate::lease::LeaseOfferCompletionError> {
+    crate::lease::RevokedLeaseOfferFallback::from_persisted(
+        representation_version,
+        response_operation_id,
+        retry_after_millis,
+        response_schema,
+        response_digest,
+    )
+}
+
+/// Read-only durable cursor projection used by first-party adapters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RunnableCursorView {
+    cursor: crate::lease::RunnableCursorAdvance,
+}
+
+impl RunnableCursorView {
+    /// Returns the exact session fence.
+    #[must_use]
+    pub const fn session(self) -> automata_ci_store::RunnerSessionFence {
+        self.cursor.session()
+    }
+
+    /// Returns the stable runner slot.
+    #[must_use]
+    pub const fn slot(self) -> automata_ci_store::StableRunnerSlot {
+        self.cursor.slot()
+    }
+
+    /// Returns the routing proof root.
+    #[must_use]
+    pub const fn routing_fingerprint(self) -> Sha256Digest {
+        self.cursor.routing_fingerprint()
+    }
+
+    /// Returns the compare-and-swap version.
+    #[must_use]
+    pub const fn expected_version(self) -> u64 {
+        self.cursor.expected_version()
+    }
+
+    /// Returns the inclusive queue position scanned through.
+    #[must_use]
+    pub const fn through(self) -> Option<crate::lease::RunnableQueueKey> {
+        self.cursor.through()
+    }
+
+    /// Returns the cycle upper bound, if a cycle was established.
+    #[must_use]
+    pub const fn cycle_upper(self) -> Option<crate::lease::RunnableQueueKey> {
+        self.cursor.cycle_upper()
+    }
+}
+
+/// Inspects the cursor embedded in a successful claim request.
+#[must_use]
+pub const fn try_claim_attempt_cursor(
+    request: &crate::lease::TryClaimAttempt,
+) -> RunnableCursorView {
+    RunnableCursorView {
+        cursor: request.cursor(),
+    }
+}
+
+/// Rebuilds a claim at repository-issued times while preserving its validated
+/// request key, target, lease, and opaque authoritative scan cursor.
+pub fn rebase_try_claim_attempt(
+    request: &crate::lease::TryClaimAttempt,
+    observed_at: UnixMillis,
+    expires_at: UnixMillis,
+) -> Result<crate::lease::TryClaimAttempt, crate::lease::ClaimCommandError> {
+    crate::lease::TryClaimAttempt::new(
+        request.request_key(),
+        request.attempt_id(),
+        request.lease_id(),
+        observed_at,
+        expires_at,
+        request.cursor(),
+    )
+}
+
+/// Inspects the cursor embedded in a terminal no-work request.
+#[must_use]
+pub const fn no_work_lease_request_cursor(
+    request: &crate::lease::NoWorkLeaseRequest,
+) -> RunnableCursorView {
+    RunnableCursorView {
+        cursor: request.cursor(),
+    }
+}

--- a/crates/automata-ci-control/src/attempt/durable.rs
+++ b/crates/automata-ci-control/src/attempt/durable.rs
@@ -1,13 +1,16 @@
+//! Durable attempt lifecycle commands and repository ports.
+
 use async_trait::async_trait;
 use automata_ci_core::{
     AttemptId, AttemptNumber, JobId, JobLifecycle, Lease, LeaseGuard, LeaseId, RunnerId, UnixMillis,
 };
-
-use crate::{
-    AttemptCommandError, AttemptSnapshot, AttemptStoreError, RunnerSessionFence, StableRunnerSlot,
-    TenantScope,
+use automata_ci_store::{
+    AttemptCommandError, AttemptStoreError, RunnerSessionFence, StableRunnerSlot, TenantScope,
 };
 
+use super::{RenewLease, snapshot::AttemptSnapshot, validate_lease_interval};
+
+/// A newly queued durable job attempt.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct QueuedAttempt {
     pub(crate) attempt_id: AttemptId,
@@ -17,6 +20,7 @@ pub struct QueuedAttempt {
 }
 
 impl QueuedAttempt {
+    /// Creates a queued attempt descriptor.
     #[must_use]
     pub const fn new(
         attempt_id: AttemptId,
@@ -32,27 +36,32 @@ impl QueuedAttempt {
         }
     }
 
+    /// Returns the durable attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the owning job identity.
     #[must_use]
     pub const fn job_id(self) -> JobId {
         self.job_id
     }
 
+    /// Returns the one-based attempt number.
     #[must_use]
     pub const fn attempt_number(self) -> AttemptNumber {
         self.attempt_number
     }
 
+    /// Returns the time at which the attempt entered the queue.
     #[must_use]
     pub const fn queued_at(self) -> UnixMillis {
         self.queued_at
     }
 }
 
+/// A request to acquire a lease for a queued attempt.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AcquireLease {
     pub(crate) attempt_id: AttemptId,
@@ -90,42 +99,50 @@ impl AcquireLease {
         })
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the proposed lease identity.
     #[must_use]
     pub const fn lease_id(self) -> LeaseId {
         self.lease_id
     }
 
+    /// Returns the authenticated runner identity.
     #[must_use]
     pub const fn runner_id(self) -> RunnerId {
         self.session.runner_id()
     }
 
+    /// Returns the authenticated runner-session fence.
     #[must_use]
     pub const fn session(self) -> RunnerSessionFence {
         self.session
     }
 
+    /// Returns the stable runner slot receiving the lease.
     #[must_use]
     pub const fn slot(self) -> StableRunnerSlot {
         self.slot
     }
 
+    /// Returns the trusted observation time.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
     }
 
+    /// Returns the proposed lease expiration.
     #[must_use]
     pub const fn expires_at(self) -> UnixMillis {
         self.expires_at
     }
 }
 
+/// A request to transition an actively leased attempt.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TransitionAttempt {
     pub(crate) attempt_id: AttemptId,
@@ -138,6 +155,7 @@ pub struct TransitionAttempt {
 }
 
 impl TransitionAttempt {
+    /// Creates a fenced lifecycle-transition request.
     #[must_use]
     pub const fn new(
         attempt_id: AttemptId,
@@ -155,109 +173,40 @@ impl TransitionAttempt {
         }
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the authenticated runner identity.
     #[must_use]
     pub const fn runner_id(self) -> RunnerId {
         self.session.runner_id()
     }
 
+    /// Returns the authenticated runner-session fence.
     #[must_use]
     pub const fn session(self) -> RunnerSessionFence {
         self.session
     }
 
+    /// Returns the active lease guard.
     #[must_use]
     pub const fn guard(self) -> LeaseGuard {
         self.guard
     }
 
+    /// Returns the requested lifecycle state.
     #[must_use]
     pub const fn next(self) -> JobLifecycle {
         self.next
     }
 
+    /// Returns the trusted observation time.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
-    }
-}
-
-/// A request to renew an active lease at a control-plane-observed time.
-///
-/// Carrying `observed_at` prevents a runner from reviving an already expired
-/// lease merely because the expiry reaper has not processed it yet.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RenewLease {
-    pub(crate) attempt_id: AttemptId,
-    /// Identity established by the runner authentication boundary.
-    pub(crate) session: RunnerSessionFence,
-    pub(crate) guard: LeaseGuard,
-    /// Time at which the trusted control plane observed this renewal.
-    pub(crate) observed_at: UnixMillis,
-    pub(crate) expires_at: UnixMillis,
-}
-
-impl RenewLease {
-    /// Creates a lease renewal observed by the trusted control plane.
-    ///
-    /// The repository additionally verifies that `expires_at` strictly extends
-    /// the current durable expiration, except that a credential-bounded lease
-    /// already at its immutable authority ceiling may refresh liveness without
-    /// extending that ceiling.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AttemptCommandError::InvalidLeaseInterval`] unless expiration
-    /// is strictly later than observation.
-    pub fn new(
-        attempt_id: AttemptId,
-        session: RunnerSessionFence,
-        guard: LeaseGuard,
-        observed_at: UnixMillis,
-        expires_at: UnixMillis,
-    ) -> Result<Self, AttemptCommandError> {
-        validate_lease_interval(observed_at, expires_at)?;
-        Ok(Self {
-            attempt_id,
-            session,
-            guard,
-            observed_at,
-            expires_at,
-        })
-    }
-
-    #[must_use]
-    pub const fn attempt_id(self) -> AttemptId {
-        self.attempt_id
-    }
-
-    #[must_use]
-    pub const fn runner_id(self) -> RunnerId {
-        self.session.runner_id()
-    }
-
-    #[must_use]
-    pub const fn session(self) -> RunnerSessionFence {
-        self.session
-    }
-
-    #[must_use]
-    pub const fn guard(self) -> LeaseGuard {
-        self.guard
-    }
-
-    #[must_use]
-    pub const fn observed_at(self) -> UnixMillis {
-        self.observed_at
-    }
-
-    #[must_use]
-    pub const fn expires_at(self) -> UnixMillis {
-        self.expires_at
     }
 }
 
@@ -293,30 +242,23 @@ impl ConcludeQueuedAttempt {
         })
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the terminal queued-state conclusion.
     #[must_use]
     pub const fn conclusion(self) -> JobLifecycle {
         self.conclusion
     }
 
+    /// Returns the trusted observation time.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
     }
-}
-
-fn validate_lease_interval(
-    observed_at: UnixMillis,
-    expires_at: UnixMillis,
-) -> Result<(), AttemptCommandError> {
-    if expires_at <= observed_at {
-        return Err(AttemptCommandError::InvalidLeaseInterval);
-    }
-    Ok(())
 }
 
 /// Internal scheduling port.
@@ -326,24 +268,31 @@ fn validate_lease_interval(
 /// enforces tenant scope in the repository operation itself.
 #[async_trait]
 pub trait InternalAttemptRepository: Send + Sync {
+    /// Inserts a newly queued attempt.
     async fn insert_queued(&self, attempt: QueuedAttempt) -> Result<(), AttemptStoreError>;
 
+    /// Fetches an attempt by its internal identity.
     async fn get_attempt(
         &self,
         attempt_id: AttemptId,
     ) -> Result<AttemptSnapshot, AttemptStoreError>;
 
+    /// Atomically acquires a lease for a queued attempt.
     async fn acquire_lease(&self, request: AcquireLease) -> Result<Lease, AttemptStoreError>;
 
+    /// Concludes an unleased queued attempt.
     async fn conclude_queued(
         &self,
         request: ConcludeQueuedAttempt,
     ) -> Result<(), AttemptStoreError>;
 
+    /// Renews an active, correctly fenced lease.
     async fn renew_lease(&self, request: RenewLease) -> Result<Lease, AttemptStoreError>;
 
+    /// Applies a correctly fenced lifecycle transition.
     async fn transition(&self, request: TransitionAttempt) -> Result<(), AttemptStoreError>;
 
+    /// Requeues expired attempts within the supplied retry and batch bounds.
     async fn requeue_expired(
         &self,
         now: UnixMillis,

--- a/crates/automata-ci-control/src/attempt/mod.rs
+++ b/crates/automata-ci-control/src/attempt/mod.rs
@@ -1,0 +1,22 @@
+//! Durable attempt lifecycle values used by runner-control services.
+
+use automata_ci_core::UnixMillis;
+use automata_ci_store::AttemptCommandError;
+
+#[cfg(feature = "adapter-spi")]
+pub(crate) mod durable;
+mod renewal;
+#[cfg(feature = "adapter-spi")]
+pub(crate) mod snapshot;
+
+pub use renewal::RenewLease;
+
+fn validate_lease_interval(
+    observed_at: UnixMillis,
+    expires_at: UnixMillis,
+) -> Result<(), AttemptCommandError> {
+    if expires_at <= observed_at {
+        return Err(AttemptCommandError::InvalidLeaseInterval);
+    }
+    Ok(())
+}

--- a/crates/automata-ci-control/src/attempt/renewal.rs
+++ b/crates/automata-ci-control/src/attempt/renewal.rs
@@ -1,0 +1,85 @@
+use automata_ci_core::{AttemptId, LeaseGuard, RunnerId, UnixMillis};
+use automata_ci_store::{AttemptCommandError, RunnerSessionFence};
+
+use super::validate_lease_interval;
+
+/// A request to renew an active lease at a control-plane-observed time.
+///
+/// Carrying `observed_at` prevents a runner from reviving an already expired
+/// lease merely because the expiry reaper has not processed it yet.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RenewLease {
+    attempt_id: AttemptId,
+    /// Identity established by the runner authentication boundary.
+    session: RunnerSessionFence,
+    guard: LeaseGuard,
+    /// Time at which the trusted control plane observed this renewal.
+    observed_at: UnixMillis,
+    expires_at: UnixMillis,
+}
+
+impl RenewLease {
+    /// Creates a lease renewal observed by the trusted control plane.
+    ///
+    /// The repository additionally verifies that `expires_at` strictly extends
+    /// the current durable expiration, except that a credential-bounded lease
+    /// already at its immutable authority ceiling may refresh liveness without
+    /// extending that ceiling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AttemptCommandError::InvalidLeaseInterval`] unless expiration
+    /// is strictly later than observation.
+    pub fn new(
+        attempt_id: AttemptId,
+        session: RunnerSessionFence,
+        guard: LeaseGuard,
+        observed_at: UnixMillis,
+        expires_at: UnixMillis,
+    ) -> Result<Self, AttemptCommandError> {
+        validate_lease_interval(observed_at, expires_at)?;
+        Ok(Self {
+            attempt_id,
+            session,
+            guard,
+            observed_at,
+            expires_at,
+        })
+    }
+
+    /// Returns the target attempt identity.
+    #[must_use]
+    pub const fn attempt_id(self) -> AttemptId {
+        self.attempt_id
+    }
+
+    /// Returns the authenticated runner identity.
+    #[must_use]
+    pub const fn runner_id(self) -> RunnerId {
+        self.session.runner_id()
+    }
+
+    /// Returns the authenticated runner-session fence.
+    #[must_use]
+    pub const fn session(self) -> RunnerSessionFence {
+        self.session
+    }
+
+    /// Returns the active lease guard.
+    #[must_use]
+    pub const fn guard(self) -> LeaseGuard {
+        self.guard
+    }
+
+    /// Returns the trusted observation time.
+    #[must_use]
+    pub const fn observed_at(self) -> UnixMillis {
+        self.observed_at
+    }
+
+    /// Returns the proposed lease expiration.
+    #[must_use]
+    pub const fn expires_at(self) -> UnixMillis {
+        self.expires_at
+    }
+}

--- a/crates/automata-ci-control/src/attempt/snapshot.rs
+++ b/crates/automata-ci-control/src/attempt/snapshot.rs
@@ -1,10 +1,10 @@
+//! Validated durable attempt snapshots and their builder.
+
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, JobId, JobLifecycle, Lease, LeaseId, RunnerId,
     UnixMillis,
 };
-
-use crate::AttemptAssignment;
-use crate::AttemptSnapshotError;
+use automata_ci_store::{AttemptAssignment, AttemptSnapshotError};
 
 /// A validated, backend-neutral view of one durable job attempt.
 ///
@@ -54,21 +54,25 @@ impl AttemptSnapshot {
         }
     }
 
+    /// Returns the durable attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the owning job identity.
     #[must_use]
     pub const fn job_id(self) -> JobId {
         self.job_id
     }
 
+    /// Returns the one-based attempt number.
     #[must_use]
     pub const fn attempt_number(self) -> AttemptNumber {
         self.attempt_number
     }
 
+    /// Returns the current durable lifecycle state.
     #[must_use]
     pub const fn lifecycle(self) -> JobLifecycle {
         self.lifecycle
@@ -81,11 +85,13 @@ impl AttemptSnapshot {
         self.fencing_token
     }
 
+    /// Returns the active lease identity, if any.
     #[must_use]
     pub const fn lease_id(self) -> Option<LeaseId> {
         self.lease_id
     }
 
+    /// Returns the active runner identity, if any.
     #[must_use]
     pub const fn runner_id(self) -> Option<RunnerId> {
         self.runner_id
@@ -97,26 +103,31 @@ impl AttemptSnapshot {
         self.assignment
     }
 
+    /// Returns the active lease issuance time, if any.
     #[must_use]
     pub const fn lease_issued_at(self) -> Option<UnixMillis> {
         self.lease_issued_at
     }
 
+    /// Returns the active lease expiration, if any.
     #[must_use]
     pub const fn lease_expires_at(self) -> Option<UnixMillis> {
         self.lease_expires_at
     }
 
+    /// Returns the number of prior lease failures.
     #[must_use]
     pub const fn lease_failures(self) -> u32 {
         self.lease_failures
     }
 
+    /// Returns the original queue time.
     #[must_use]
     pub const fn queued_at(self) -> UnixMillis {
         self.queued_at
     }
 
+    /// Returns the latest durable state-change time.
     #[must_use]
     pub const fn changed_at(self) -> UnixMillis {
         self.changed_at
@@ -155,6 +166,7 @@ impl AttemptSnapshotBuilder {
         self
     }
 
+    /// Sets the durable lease-failure count.
     #[must_use]
     pub const fn with_lease_failures(mut self, lease_failures: u32) -> Self {
         self.lease_failures = lease_failures;

--- a/crates/automata-ci-control/src/cancellation.rs
+++ b/crates/automata-ci-control/src/cancellation.rs
@@ -1,12 +1,12 @@
+//! Durable cancellation intent values, runner commands, and repository port.
+
 use async_trait::async_trait;
 use automata_ci_core::{AttemptId, LeaseGuard, OperationId, UnixMillis};
+use automata_ci_store::{
+    DurableRunnerCommand, EnqueueRunnerCommand, RunnerProtocolVersion, StoreError,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-use crate::{
-    DurableRunnerCommand, EnqueueRunnerCommand, RunnerProtocolVersion, StoreError,
-    value::validate_text,
-};
 
 const MAX_CANCELLATION_ACTOR_BYTES: usize = 255;
 const MAX_CANCELLATION_REASON_BYTES: usize = 1024;
@@ -86,26 +86,31 @@ impl CancelJobCommandPayload {
         serde_json::to_vec(self).map_err(|_| CancellationValueError::InvalidCommand)
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the active lease guard.
     #[must_use]
     pub const fn guard(&self) -> LeaseGuard {
         self.guard
     }
 
+    /// Returns the selected runner protocol version.
     #[must_use]
     pub const fn protocol_version(&self) -> u16 {
         self.protocol_version
     }
 
+    /// Returns the wire-visible cancellation reason.
     #[must_use]
     pub fn reason(&self) -> &str {
         &self.reason
     }
 
+    /// Returns the trusted cancellation-request time.
     #[must_use]
     pub const fn requested_at(&self) -> UnixMillis {
         self.requested_at
@@ -124,11 +129,13 @@ impl CancellationActor {
     /// Rejects empty, oversized, or control-bearing values.
     pub fn new(value: impl Into<String>) -> Result<Self, CancellationValueError> {
         let value = value.into();
-        validate_text(&value, MAX_CANCELLATION_ACTOR_BYTES, "cancellation actor")
-            .map_err(|_| CancellationValueError::InvalidActor)?;
+        if !is_valid_text(&value, MAX_CANCELLATION_ACTOR_BYTES) {
+            return Err(CancellationValueError::InvalidActor);
+        }
         Ok(Self(value))
     }
 
+    /// Returns the validated actor identifier.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -147,23 +154,33 @@ impl CancellationReason {
     /// Rejects empty, oversized, or control-bearing values.
     pub fn new(value: impl Into<String>) -> Result<Self, CancellationValueError> {
         let value = value.into();
-        validate_text(&value, MAX_CANCELLATION_REASON_BYTES, "cancellation reason")
-            .map_err(|_| CancellationValueError::InvalidReason)?;
+        if !is_valid_text(&value, MAX_CANCELLATION_REASON_BYTES) {
+            return Err(CancellationValueError::InvalidReason);
+        }
         Ok(Self(value))
     }
 
+    /// Returns the validated human-facing reason.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
+fn is_valid_text(value: &str, maximum: usize) -> bool {
+    !value.is_empty() && value.len() <= maximum && !value.chars().any(char::is_control)
+}
+
+/// Invalid cancellation actor, reason, or durable command payload.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum CancellationValueError {
+    /// The cancellation actor is empty, oversized, or control-bearing.
     #[error("cancellation actor is invalid")]
     InvalidActor,
+    /// The cancellation reason is empty, oversized, or control-bearing.
     #[error("cancellation reason is invalid")]
     InvalidReason,
+    /// The durable runner command is malformed or uses an unsupported schema.
     #[error("durable cancellation command is invalid")]
     InvalidCommand,
 }
@@ -180,6 +197,7 @@ pub struct RequestCancellation {
 }
 
 impl RequestCancellation {
+    /// Creates a cancellation request without runner delivery metadata.
     #[must_use]
     pub const fn new(
         operation_id: OperationId,
@@ -206,31 +224,37 @@ impl RequestCancellation {
         self
     }
 
+    /// Returns the idempotent cancellation operation identity.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the principal or subsystem requesting cancellation.
     #[must_use]
     pub const fn actor(&self) -> &CancellationActor {
         &self.actor
     }
 
+    /// Returns the optional human-facing cancellation reason.
     #[must_use]
     pub const fn reason(&self) -> Option<&CancellationReason> {
         self.reason.as_ref()
     }
 
+    /// Returns the trusted request time.
     #[must_use]
     pub const fn requested_at(&self) -> UnixMillis {
         self.requested_at
     }
 
+    /// Returns the runner command to enqueue atomically, if any.
     #[must_use]
     pub const fn delivery(&self) -> Option<&EnqueueRunnerCommand> {
         self.delivery.as_ref()
@@ -269,29 +293,35 @@ impl CancellationIntent {
         })
     }
 
+    /// Returns the immutable first cancellation request.
     #[must_use]
     pub const fn request(&self) -> &RequestCancellation {
         &self.request
     }
 
+    /// Returns the runner acknowledgement time, if acknowledged.
     #[must_use]
     pub const fn acknowledged_at(&self) -> Option<UnixMillis> {
         self.acknowledged_at
     }
 
+    /// Reports whether the repository replayed a prior intent.
     #[must_use]
     pub const fn was_replayed(&self) -> bool {
         self.replayed
     }
 
+    /// Returns the durable runner command associated with the intent, if any.
     #[must_use]
     pub const fn delivery(&self) -> Option<&DurableRunnerCommand> {
         self.delivery.as_ref()
     }
 }
 
+/// Invalid timing in a decoded cancellation intent.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum CancellationIntentError {
+    /// The acknowledgement time precedes the original request.
     #[error("cancellation acknowledgement precedes its durable request")]
     AcknowledgedBeforeRequest,
 }
@@ -306,6 +336,7 @@ pub trait CancellationRepository: Send + Sync {
         request: RequestCancellation,
     ) -> Result<CancellationIntent, StoreError>;
 
+    /// Fetches the immutable cancellation intent for an attempt, if present.
     async fn cancellation_for_attempt(
         &self,
         attempt_id: AttemptId,

--- a/crates/automata-ci-control/src/lease/config.rs
+++ b/crates/automata-ci-control/src/lease/config.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroI64;
 
-use automata_ci_store::RunnableScanLimit;
+use crate::lease::RunnableScanLimit;
 use thiserror::Error;
 
 /// Positive lease lifetime measured in milliseconds.

--- a/crates/automata-ci-control/src/lease/error.rs
+++ b/crates/automata-ci-control/src/lease/error.rs
@@ -1,12 +1,11 @@
+use crate::lease::{ClaimCommandError, LeaseRequestKeyError, RunnableScanError};
 use crate::scheduling::{
     EffectiveRunnerError, RoutingRequirementsError, RunnerCapabilityIntersectionError,
     RunnerEvidenceError, SchedulingInputError,
 };
 use automata_ci_core::{RunnerSessionId, SelectorError};
 use automata_ci_protocol::{MessageValidationError, ProtocolVersion};
-use automata_ci_store::{
-    ClaimCommandError, DurabilityValueError, LeaseRequestKeyError, RunnableScanError, StoreError,
-};
+use automata_ci_store::{DurabilityValueError, StoreError};
 use thiserror::Error;
 
 /// Which durable capability document failed decoding or validation.

--- a/crates/automata-ci-control/src/lease/mod.rs
+++ b/crates/automata-ci-control/src/lease/mod.rs
@@ -19,11 +19,13 @@
 mod config;
 mod error;
 mod observer;
+mod operation;
 mod port;
 /// Durable lease polling and runnable-attempt repositories.
 pub mod repository;
 /// Authoritative runner routing and slot-availability contracts.
 pub mod routing;
+mod runnable;
 mod service;
 
 pub use config::{LeasePollConfig, LeaseTimeToLive, LeaseTimeToLiveError};
@@ -32,9 +34,19 @@ pub(crate) use observer::NoopLeasePollObserver;
 pub use observer::{
     LeaseClaimRejection, LeasePollFailure, LeasePollObservation, LeasePollObserver,
 };
+pub use operation::{
+    BeginLeaseRequest, BegunLeaseRequest, ClaimCommandError, ClaimRejection, ClaimedAttempt,
+    CompleteLeaseRequest, LeaseOfferCompletionError, LeaseRequestCompletion, LeaseRequestKey,
+    LeaseRequestKeyError, NoWorkLeaseRequest, RevokedLeaseOfferFallback, TryClaimAttempt,
+    TryClaimOutcome, TryClaimReceipt,
+};
 pub use port::{
     LeaseClock, LeaseIdGenerator, LeasePollRepository, RandomLeaseIdGenerator, RunnableAttemptGate,
     RunnableAttemptGateDisposition, SystemLeaseClock,
+};
+pub use runnable::{
+    RunnableAttempt, RunnableAttemptError, RunnableCursorAdvance, RunnableQueueKey,
+    RunnableScanError, RunnableScanLimit, RunnableScanPage, RunnableScanRequest,
 };
 pub use service::{
     AuthenticatedRunnerSession, ClaimedLeasePoll, LeasePollOutcome, LeasePollService,

--- a/crates/automata-ci-control/src/lease/operation.rs
+++ b/crates/automata-ci-control/src/lease/operation.rs
@@ -1,11 +1,15 @@
+//! Idempotent lease-poll operation values and durable claim outcomes.
+
 use automata_ci_core::{AttemptId, JobLifecycle, Lease, LeaseId, OperationId, UnixMillis};
+use automata_ci_store::{
+    AttemptAssignment, AttemptAssignmentError, DocumentSchema, JobIrMetadata,
+    LeaseOfferCommandIdentity, RunnerOperationResponse, RunnerSessionFence, Sha256Digest,
+    StableRunnerSlot,
+};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
-use crate::{
-    AttemptAssignment, JobIrMetadata, LeaseOfferCommandIdentity, RunnableCursorAdvance,
-    RunnerOperationResponse, RunnerSessionFence, Sha256Digest, StableRunnerSlot,
-};
+use super::runnable::RunnableCursorAdvance;
 
 const LEASE_REQUEST_DIGEST_DOMAIN: &[u8] = b"automata.store.lease-request.v2\0";
 
@@ -56,21 +60,25 @@ impl LeaseRequestKey {
         })
     }
 
+    /// Returns the authenticated runner-session fence.
     #[must_use]
     pub const fn session(self) -> RunnerSessionFence {
         self.session
     }
 
+    /// Returns this request's idempotency identity.
     #[must_use]
     pub const fn operation_id(self) -> OperationId {
         self.operation_id
     }
 
+    /// Returns the stable runner slot being polled.
     #[must_use]
     pub const fn slot(self) -> StableRunnerSlot {
         self.slot
     }
 
+    /// Returns the preceding operation acknowledged by this request, if any.
     #[must_use]
     pub const fn acknowledges_operation_id(self) -> Option<OperationId> {
         self.acknowledges_operation_id
@@ -100,8 +108,10 @@ impl LeaseRequestKey {
     }
 }
 
+/// Invalid lease-request chain identity.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum LeaseRequestKeyError {
+    /// The request acknowledges its own operation identity.
     #[error("a lease request cannot acknowledge its own operation identity")]
     SelfAcknowledgement,
 }
@@ -114,6 +124,7 @@ pub struct BeginLeaseRequest {
 }
 
 impl BeginLeaseRequest {
+    /// Creates an admitted request from its canonical key and digest.
     #[must_use]
     pub const fn new(request_key: LeaseRequestKey, request_digest: Sha256Digest) -> Self {
         Self {
@@ -122,11 +133,13 @@ impl BeginLeaseRequest {
         }
     }
 
+    /// Returns the canonical request key.
     #[must_use]
     pub const fn request_key(self) -> LeaseRequestKey {
         self.request_key
     }
 
+    /// Returns the request digest admitted at the durable head.
     #[must_use]
     pub const fn request_digest(self) -> Sha256Digest {
         self.request_digest
@@ -141,6 +154,7 @@ pub struct BegunLeaseRequest {
 }
 
 impl BegunLeaseRequest {
+    /// Builds an admission result from a legacy response-only completion.
     #[must_use]
     pub fn new(
         request: BeginLeaseRequest,
@@ -177,11 +191,13 @@ impl BegunLeaseRequest {
         )
     }
 
+    /// Returns the request that was admitted.
     #[must_use]
     pub const fn request(&self) -> BeginLeaseRequest {
         self.request
     }
 
+    /// Returns a previously completed replayable response, if present.
     #[must_use]
     pub const fn completed_response(&self) -> Option<&RunnerOperationResponse> {
         match &self.completion {
@@ -212,7 +228,7 @@ impl BegunLeaseRequest {
 }
 
 /// Version of the canonical structured fallback retained for a revoked lease offer.
-pub const REVOKED_LEASE_OFFER_FALLBACK_VERSION: u16 = 1;
+const REVOKED_LEASE_OFFER_FALLBACK_VERSION: u16 = 1;
 
 /// Minimal durable data needed to rebuild one canonical revoked-offer `NoWork` response.
 ///
@@ -224,7 +240,7 @@ pub struct RevokedLeaseOfferFallback {
     representation_version: u16,
     response_operation_id: OperationId,
     retry_after_millis: u32,
-    response_schema: crate::DocumentSchema,
+    response_schema: DocumentSchema,
     response_digest: Sha256Digest,
 }
 
@@ -237,7 +253,7 @@ impl RevokedLeaseOfferFallback {
     pub fn new(
         response_operation_id: OperationId,
         retry_after_millis: u32,
-        response_schema: crate::DocumentSchema,
+        response_schema: DocumentSchema,
         response_digest: Sha256Digest,
     ) -> Result<Self, LeaseOfferCompletionError> {
         Self::from_persisted(
@@ -249,11 +265,17 @@ impl RevokedLeaseOfferFallback {
         )
     }
 
+    /// Rehydrates and validates a versioned durable fallback representation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsupported representation, nil operation identity, or zero
+    /// retry delay.
     pub(crate) fn from_persisted(
         representation_version: u16,
         response_operation_id: OperationId,
         retry_after_millis: u32,
-        response_schema: crate::DocumentSchema,
+        response_schema: DocumentSchema,
         response_digest: Sha256Digest,
     ) -> Result<Self, LeaseOfferCompletionError> {
         if representation_version != REVOKED_LEASE_OFFER_FALLBACK_VERSION {
@@ -274,26 +296,31 @@ impl RevokedLeaseOfferFallback {
         })
     }
 
+    /// Returns the durable representation version.
     #[must_use]
     pub const fn representation_version(self) -> u16 {
         self.representation_version
     }
 
+    /// Returns the operation identity used for the rebuilt response.
     #[must_use]
     pub const fn response_operation_id(self) -> OperationId {
         self.response_operation_id
     }
 
+    /// Returns the retry delay carried by the rebuilt response.
     #[must_use]
     pub const fn retry_after_millis(self) -> u32 {
         self.retry_after_millis
     }
 
+    /// Returns the expected canonical response schema.
     #[must_use]
-    pub const fn response_schema(self) -> crate::DocumentSchema {
+    pub const fn response_schema(self) -> DocumentSchema {
         self.response_schema
     }
 
+    /// Returns the expected canonical response digest.
     #[must_use]
     pub const fn response_digest(self) -> Sha256Digest {
         self.response_digest
@@ -307,17 +334,22 @@ pub enum LeaseRequestCompletion {
     Response(RunnerOperationResponse),
     /// A still-live lease offer plus the already-persisted fallback needed if it later revokes.
     LiveLeaseOffer {
+        /// The replayable live-offer response.
         response: RunnerOperationResponse,
+        /// The canonical fallback retained for later revocation.
         fallback: RevokedLeaseOfferFallback,
     },
     /// A lease offer whose bearer response is no longer eligible for replay.
     RevokedLeaseOffer {
+        /// The operation identity of the revoked offer.
         offer_operation_id: OperationId,
+        /// The canonical replacement response projection.
         fallback: RevokedLeaseOfferFallback,
     },
 }
 
 impl LeaseRequestCompletion {
+    /// Returns the replayable response when this completion still has one.
     #[must_use]
     pub const fn response(&self) -> Option<&RunnerOperationResponse> {
         match self {
@@ -326,6 +358,7 @@ impl LeaseRequestCompletion {
         }
     }
 
+    /// Returns the retained revoked-offer fallback, if any.
     #[must_use]
     pub const fn revoked_offer_fallback(&self) -> Option<RevokedLeaseOfferFallback> {
         match self {
@@ -352,14 +385,19 @@ impl PartialEq<LeaseRequestCompletion> for RunnerOperationResponse {
 /// Invalid typed composition of a lease offer and its canonical revocation fallback.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum LeaseOfferCompletionError {
+    /// The offer command belongs to another durable session.
     #[error("lease-offer completion crosses durable sessions")]
     SessionMismatch,
+    /// The persisted fallback representation version is unsupported.
     #[error("lease-offer fallback representation version is unsupported")]
     UnsupportedFallbackVersion,
+    /// The fallback response operation identity is nil.
     #[error("lease-offer fallback response operation identity is nil")]
     NilFallbackOperationId,
+    /// The fallback retry delay is zero.
     #[error("lease-offer fallback retry delay is zero")]
     ZeroFallbackRetry,
+    /// The fallback projection disagrees with the canonical response.
     #[error("lease-offer fallback response metadata does not match its canonical bytes")]
     FallbackResponseMismatch,
 }
@@ -430,16 +468,19 @@ impl CompleteLeaseRequest {
         })
     }
 
+    /// Returns the admitted request being completed.
     #[must_use]
     pub const fn request(&self) -> BeginLeaseRequest {
         self.request
     }
 
+    /// Returns the canonical response being committed.
     #[must_use]
     pub const fn response(&self) -> &RunnerOperationResponse {
         &self.response
     }
 
+    /// Returns the trusted completion time.
     #[must_use]
     pub const fn completed_at(&self) -> UnixMillis {
         self.completed_at
@@ -523,41 +564,49 @@ impl TryClaimAttempt {
         })
     }
 
+    /// Returns the claim operation identity.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.request_key.operation_id()
     }
 
+    /// Returns the target attempt identity.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the authenticated runner-session fence.
     #[must_use]
     pub const fn session(&self) -> RunnerSessionFence {
         self.request_key.session()
     }
 
+    /// Returns the stable runner slot receiving the claim.
     #[must_use]
     pub const fn slot(&self) -> StableRunnerSlot {
         self.request_key.slot()
     }
 
+    /// Returns the proposed lease identity.
     #[must_use]
     pub const fn lease_id(&self) -> LeaseId {
         self.lease_id
     }
 
+    /// Returns the trusted observation time.
     #[must_use]
     pub const fn observed_at(&self) -> UnixMillis {
         self.observed_at
     }
 
+    /// Returns the proposed lease expiration.
     #[must_use]
     pub const fn expires_at(&self) -> UnixMillis {
         self.expires_at
     }
 
+    /// Returns the canonical lease-request key.
     #[must_use]
     pub const fn request_key(&self) -> LeaseRequestKey {
         self.request_key
@@ -569,7 +618,9 @@ impl TryClaimAttempt {
         self.request_key.request_digest()
     }
 
+    /// Returns the opaque authoritative scan cursor used by an adapter.
     #[cfg(feature = "adapter-spi")]
+    #[must_use]
     pub(crate) const fn cursor(&self) -> RunnableCursorAdvance {
         self.cursor
     }
@@ -604,26 +655,33 @@ impl NoWorkLeaseRequest {
         })
     }
 
+    /// Returns the canonical lease-request key.
     #[must_use]
     pub const fn request_key(&self) -> LeaseRequestKey {
         self.request_key
     }
 
+    /// Returns the trusted no-work observation time.
     #[must_use]
     pub const fn observed_at(&self) -> UnixMillis {
         self.observed_at
     }
 
+    /// Returns the opaque authoritative scan cursor used by an adapter.
     #[cfg(feature = "adapter-spi")]
+    #[must_use]
     pub(crate) const fn cursor(&self) -> RunnableCursorAdvance {
         self.cursor
     }
 }
 
+/// Invalid composition of a durable attempt-claim command.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum ClaimCommandError {
+    /// The proposed lease does not extend past trusted observation time.
     #[error("lease expiration must be strictly later than trusted observation time")]
     InvalidLeaseInterval,
+    /// The cursor proof belongs to another request, slot, or attempt.
     #[error("queue cursor proof does not match the lease request")]
     CursorMismatch,
 }
@@ -646,7 +704,7 @@ impl ClaimedAttempt {
         lease: Lease,
         assignment: AttemptAssignment,
         job_ir: JobIrMetadata,
-    ) -> Result<Self, crate::AttemptAssignmentError> {
+    ) -> Result<Self, AttemptAssignmentError> {
         assignment.validate_lease(&lease)?;
         Ok(Self {
             lease,
@@ -655,16 +713,19 @@ impl ClaimedAttempt {
         })
     }
 
+    /// Returns the acquired lease.
     #[must_use]
     pub const fn lease(&self) -> &Lease {
         &self.lease
     }
 
+    /// Returns the stable runner-session assignment.
     #[must_use]
     pub const fn assignment(&self) -> AttemptAssignment {
         self.assignment
     }
 
+    /// Returns the selected job intermediate-representation metadata.
     #[must_use]
     pub const fn job_ir(&self) -> &JobIrMetadata {
         &self.job_ir
@@ -674,12 +735,19 @@ impl ClaimedAttempt {
 /// Durable negative claim decision. Retrying the same operation replays it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ClaimRejection {
+    /// The selected attempt no longer exists.
     AttemptNotFound,
+    /// The selected attempt is no longer queued.
     AttemptNotQueued(JobLifecycle),
+    /// Durable execution gates no longer consider the attempt runnable.
     NoLongerRunnable,
+    /// The attempt no longer routes to this runner.
     NotRoutable,
+    /// The requested stable slot is outside the registered capacity.
     SlotOutOfRange,
+    /// The requested stable slot already owns another attempt.
     SlotOccupied {
+        /// The attempt currently occupying the stable slot.
         attempt_id: AttemptId,
     },
     /// Another operation advanced this slot's cursor after the page was read.
@@ -689,12 +757,16 @@ pub enum ClaimRejection {
 /// Exact durable outcome of a claim operation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TryClaimOutcome {
+    /// The attempt was claimed and fenced successfully.
     Claimed(Box<ClaimedAttempt>),
+    /// The durable claim was rejected without a repository failure.
     Rejected(ClaimRejection),
+    /// The authoritative scan produced no claimable work.
     NoWork,
 }
 
 impl TryClaimOutcome {
+    /// Returns selected job metadata for a successful claim.
     #[must_use]
     pub const fn claimed_job_ir(&self) -> Option<&JobIrMetadata> {
         match self {
@@ -713,6 +785,7 @@ pub struct TryClaimReceipt {
 }
 
 impl TryClaimReceipt {
+    /// Creates a durable claim receipt.
     #[must_use]
     pub const fn new(
         request_key: LeaseRequestKey,
@@ -726,31 +799,37 @@ impl TryClaimReceipt {
         }
     }
 
+    /// Returns the runner-session identity owning the request.
     #[must_use]
     pub const fn session_id(&self) -> automata_ci_core::RunnerSessionId {
         self.request_key.session().session_id()
     }
 
+    /// Returns the claim operation identity.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.request_key.operation_id()
     }
 
+    /// Returns the canonical lease-request digest.
     #[must_use]
     pub fn request_digest(&self) -> Sha256Digest {
         self.request_key.request_digest()
     }
 
+    /// Returns the canonical lease-request key.
     #[must_use]
     pub const fn request_key(&self) -> LeaseRequestKey {
         self.request_key
     }
 
+    /// Returns the durable claim outcome.
     #[must_use]
     pub const fn outcome(&self) -> &TryClaimOutcome {
         &self.outcome
     }
 
+    /// Reports whether this receipt came from an exact retry.
     #[must_use]
     pub const fn was_replayed(&self) -> bool {
         self.replayed

--- a/crates/automata-ci-control/src/lease/repository.rs
+++ b/crates/automata-ci-control/src/lease/repository.rs
@@ -1,9 +1,10 @@
-use async_trait::async_trait;
-use automata_ci_store::{
+use crate::lease::{
     BeginLeaseRequest, BegunLeaseRequest, CompleteLeaseRequest, LeaseRequestCompletion,
-    LeaseRequestKey, NoWorkLeaseRequest, RunnableScanPage, RunnableScanRequest, StoreError,
-    TryClaimAttempt, TryClaimReceipt,
+    LeaseRequestKey, NoWorkLeaseRequest, RunnableScanPage, RunnableScanRequest, TryClaimAttempt,
+    TryClaimReceipt,
 };
+use async_trait::async_trait;
+use automata_ci_store::StoreError;
 
 /// Bounded exact-response ledger for lease-request chains.
 #[async_trait]

--- a/crates/automata-ci-control/src/lease/runnable.rs
+++ b/crates/automata-ci-control/src/lease/runnable.rs
@@ -1,12 +1,13 @@
+//! Runnable-queue scan values and opaque cursor proofs.
+
 use std::num::NonZeroU16;
 
 use automata_ci_core::{AttemptId, JobId, RunId, RunnerRequirements, Sha256Digest, UnixMillis};
+use automata_ci_store::{JobIrMetadata, RunnerSessionFence, StableRunnerSlot};
 use thiserror::Error;
 
-use crate::{JobIrMetadata, RunnerSessionFence, StableRunnerSlot};
-
 /// Maximum records returned by one scheduler queue scan.
-pub const MAX_RUNNABLE_SCAN_LIMIT: u16 = 1000;
+const MAX_RUNNABLE_SCAN_LIMIT: u16 = 1000;
 
 /// Bounded scheduler scan size.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -27,6 +28,7 @@ impl RunnableScanLimit {
             .ok_or(RunnableScanError::InvalidLimit)
     }
 
+    /// Returns the validated scan size.
     #[must_use]
     pub const fn get(self) -> u16 {
         self.0.get()
@@ -47,6 +49,7 @@ pub struct RunnableScanRequest {
 }
 
 impl RunnableScanRequest {
+    /// Creates a bounded authoritative scan request.
     #[must_use]
     pub const fn new(
         session: RunnerSessionFence,
@@ -62,21 +65,25 @@ impl RunnableScanRequest {
         }
     }
 
+    /// Returns the authenticated runner-session fence.
     #[must_use]
     pub const fn session(self) -> RunnerSessionFence {
         self.session
     }
 
+    /// Returns the stable runner slot requesting work.
     #[must_use]
     pub const fn slot(self) -> StableRunnerSlot {
         self.slot
     }
 
+    /// Returns the maximum queue records to scan.
     #[must_use]
     pub const fn limit(self) -> RunnableScanLimit {
         self.limit
     }
 
+    /// Returns the trusted scan observation time.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
@@ -91,6 +98,7 @@ pub struct RunnableQueueKey {
 }
 
 impl RunnableQueueKey {
+    /// Creates a stable FIFO keyset position.
     #[must_use]
     pub const fn new(queued_at: UnixMillis, attempt_id: AttemptId) -> Self {
         Self {
@@ -99,11 +107,13 @@ impl RunnableQueueKey {
         }
     }
 
+    /// Returns the queue time component.
     #[must_use]
     pub const fn queued_at(self) -> UnixMillis {
         self.queued_at
     }
 
+    /// Returns the attempt identity component.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
@@ -126,28 +136,40 @@ pub struct RunnableCursorAdvance {
 }
 
 impl RunnableCursorAdvance {
+    /// Returns the exact session fence.
+    #[must_use]
     pub(crate) const fn session(self) -> RunnerSessionFence {
         self.session
     }
 
+    /// Returns the stable runner slot.
+    #[must_use]
     pub(crate) const fn slot(self) -> StableRunnerSlot {
         self.slot
     }
 
+    /// Returns the server-derived routing proof root.
+    #[must_use]
     #[cfg(feature = "adapter-spi")]
     pub(crate) const fn routing_fingerprint(self) -> Sha256Digest {
         self.routing_fingerprint
     }
 
+    /// Returns the compare-and-swap cursor version.
+    #[must_use]
     #[cfg(feature = "adapter-spi")]
     pub(crate) const fn expected_version(self) -> u64 {
         self.expected_version
     }
 
+    /// Returns the inclusive queue position scanned through.
+    #[must_use]
     pub(crate) const fn through(self) -> Option<RunnableQueueKey> {
         self.through
     }
 
+    /// Returns the finite scan-cycle upper bound, if established.
+    #[must_use]
     #[cfg(feature = "adapter-spi")]
     pub(crate) const fn cycle_upper(self) -> Option<RunnableQueueKey> {
         self.cycle_upper
@@ -196,36 +218,43 @@ impl RunnableAttempt {
         })
     }
 
+    /// Returns the runnable attempt identity.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the owning job identity.
     #[must_use]
     pub const fn job_id(&self) -> JobId {
         self.job_id
     }
 
+    /// Returns the owning workflow-run identity.
     #[must_use]
     pub const fn run_id(&self) -> RunId {
         self.run_id
     }
 
+    /// Returns the durable queue time.
     #[must_use]
     pub const fn queued_at(&self) -> UnixMillis {
         self.queued_at
     }
 
+    /// Returns the stable FIFO keyset position.
     #[must_use]
     pub const fn queue_key(&self) -> RunnableQueueKey {
         RunnableQueueKey::new(self.queued_at, self.attempt_id)
     }
 
+    /// Returns the runner requirements used for routing.
     #[must_use]
     pub const fn requirements(&self) -> &RunnerRequirements {
         &self.requirements
     }
 
+    /// Returns the selected job intermediate-representation metadata.
     #[must_use]
     pub const fn job_ir(&self) -> &JobIrMetadata {
         &self.ir_metadata
@@ -286,11 +315,13 @@ impl RunnableScanPage {
         })
     }
 
+    /// Returns the strictly ordered runnable candidates.
     #[must_use]
     pub fn candidates(&self) -> &[RunnableAttempt] {
         &self.candidates
     }
 
+    /// Returns the cursor version expected by the page.
     #[must_use]
     pub const fn expected_cursor_version(&self) -> u64 {
         self.cursor.expected_version
@@ -324,24 +355,33 @@ impl RunnableScanPage {
     }
 }
 
+/// Invalid runnable scan request, page, or cursor advancement.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum RunnableScanError {
+    /// The requested scan limit is zero or exceeds the maximum.
     #[error("runnable scan limit must be in 1..=1000")]
     InvalidLimit,
+    /// The cursor version exceeds the signed durable-storage range.
     #[error("runnable cursor version exceeds durable range")]
     InvalidCursorVersion,
+    /// Page candidates are not strictly FIFO ordered.
     #[error("runnable page candidates are not strictly queue ordered")]
     CandidatesNotOrdered,
+    /// A page candidate exceeds the finite scan-cycle upper bound.
     #[error("runnable page candidate exceeds its cycle high-water mark")]
     CandidateOutsideCycle,
+    /// The selected attempt is absent from the authoritative page.
     #[error("selected attempt is not in the scanned runnable page")]
     CandidateNotInPage,
 }
 
+/// Inconsistent identity in a runnable attempt projection.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum RunnableAttemptError {
+    /// The candidate and job metadata identify different jobs.
     #[error("runnable attempt and JobIR metadata identify different jobs")]
     JobMetadataMismatch,
+    /// The candidate and job metadata identify different workflow runs.
     #[error("runnable attempt and JobIR metadata identify different runs")]
     RunMetadataMismatch,
 }

--- a/crates/automata-ci-control/src/lease/service.rs
+++ b/crates/automata-ci-control/src/lease/service.rs
@@ -3,6 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::lease::{
+    ClaimRejection, LeaseRequestKey, NoWorkLeaseRequest, RunnableAttempt, RunnableScanPage,
+    RunnableScanRequest, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
+};
 use crate::scheduling::{
     AuthorizedRunnerRouting, EffectiveRunner, Placement, PlacementDecision, RoutingRequirements,
     RunnableCandidate, RunnerEvidence, RunnerSlot, SchedulerPolicy, SchedulingInput, SessionGuard,
@@ -12,11 +16,7 @@ use automata_ci_core::{
     JobIrVersion, Lease, RunnerCapabilities, RunnerGroup, RunnerLabel, UnixMillis,
 };
 use automata_ci_protocol::{LeaseRequest, ProtocolVersion, RunnerSlotOrdinal};
-use automata_ci_store::{
-    ClaimRejection, JobIrMetadata, LeaseRequestKey, NoWorkLeaseRequest, RoutingDocument,
-    RunnableAttempt, RunnableScanPage, RunnableScanRequest, RunnerSessionFence, StableRunnerSlot,
-    TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
-};
+use automata_ci_store::{JobIrMetadata, RoutingDocument, RunnerSessionFence, StableRunnerSlot};
 
 use super::{
     CapabilityDocument, LeaseClock, LeaseIdGenerator, LeasePollConfig, LeasePollError,

--- a/crates/automata-ci-control/src/lib.rs
+++ b/crates/automata-ci-control/src/lib.rs
@@ -1,9 +1,25 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-//! Scheduling, lease orchestration, and authenticated runner control for Automata.
+//! Scheduling, execution durability, maintenance, observability, and
+//! authenticated runner control for Automata.
 
+pub mod attempt;
+pub mod cancellation;
 pub mod github_oidc;
 pub mod lease;
+pub mod maintenance;
+pub mod observability;
 pub mod runner_auth;
 pub mod runner_control;
 pub mod scheduling;
+
+/// Unstable construction and inspection hooks for Automata's first-party
+/// durable adapters.
+///
+/// This module is not a supported public API. It is feature-gated so ordinary
+/// Control consumers cannot accidentally depend on repository trust-boundary
+/// operations, and it may change without notice alongside first-party
+/// adapters.
+#[cfg(feature = "adapter-spi")]
+#[doc(hidden)]
+pub mod adapter_spi;

--- a/crates/automata-ci-control/src/maintenance/blocked.rs
+++ b/crates/automata-ci-control/src/maintenance/blocked.rs
@@ -1,7 +1,10 @@
+//! Default-success dependency reconciliation values and repository port.
+
 use async_trait::async_trait;
 use automata_ci_core::{AttemptId, JobId, JobLifecycle, RunId, UnixMillis};
+use automata_ci_store::StoreError;
 
-use crate::{RunnableScanLimit, StoreError};
+use crate::lease::RunnableScanLimit;
 
 /// Queued work whose complete latest-prerequisite set contains a terminal
 /// non-success conclusion and therefore cannot satisfy default `success()`.
@@ -14,6 +17,7 @@ pub struct BlockedAttempt {
 }
 
 impl BlockedAttempt {
+    /// Records one deterministic blocked-attempt candidate.
     #[must_use]
     pub const fn new(
         attempt_id: AttemptId,
@@ -29,21 +33,25 @@ impl BlockedAttempt {
         }
     }
 
+    /// Returns the queued attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the job containing the attempt.
     #[must_use]
     pub const fn job_id(self) -> JobId {
         self.job_id
     }
 
+    /// Returns the run containing the job.
     #[must_use]
     pub const fn run_id(self) -> RunId {
         self.run_id
     }
 
+    /// Returns when the attempt entered the queue.
     #[must_use]
     pub const fn queued_at(self) -> UnixMillis {
         self.queued_at
@@ -58,6 +66,7 @@ pub struct ConcludeBlockedAttempt {
 }
 
 impl ConcludeBlockedAttempt {
+    /// Binds an attempt to the trusted time of its transactional recheck.
     #[must_use]
     pub const fn new(attempt_id: AttemptId, observed_at: UnixMillis) -> Self {
         Self {
@@ -66,11 +75,13 @@ impl ConcludeBlockedAttempt {
         }
     }
 
+    /// Returns the attempt selected for rechecking.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the trusted recheck time.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
@@ -80,9 +91,13 @@ impl ConcludeBlockedAttempt {
 /// Result after re-checking dependency state under durable locks.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockedConclusion {
+    /// The queued attempt was newly concluded as skipped.
     Skipped,
+    /// The attempt had already been concluded as skipped.
     AlreadySkipped,
+    /// The attempt was no longer queued and retained its current lifecycle.
     NotQueued(JobLifecycle),
+    /// Current prerequisite state no longer blocks the attempt.
     NoLongerBlocked,
 }
 

--- a/crates/automata-ci-control/src/maintenance/mod.rs
+++ b/crates/automata-ci-control/src/maintenance/mod.rs
@@ -1,13 +1,18 @@
+//! Replica-safe control-plane maintenance values and repository ports.
+
+#[cfg(feature = "adapter-spi")]
+pub(crate) mod blocked;
+
 use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
 
 use async_trait::async_trait;
 use automata_ci_core::{AttemptId, RunId, UnixMillis};
 use thiserror::Error;
 
-use crate::{RunReconciliation, StoreError};
+use automata_ci_store::{RunReconciliation, StoreError};
 
 /// Largest number of records handled per work category in one maintenance pass.
-pub const MAX_MAINTENANCE_BATCH_SIZE: u16 = 1_000;
+const MAX_MAINTENANCE_BATCH_SIZE: u16 = 1_000;
 
 /// Positive, defensively bounded maintenance work limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -28,6 +33,7 @@ impl MaintenanceBatchSize {
             .ok_or(MaintenanceValueError::InvalidBatchSize)
     }
 
+    /// Returns the bounded batch size.
     #[must_use]
     pub const fn get(self) -> u16 {
         self.0.get()
@@ -53,6 +59,7 @@ impl LeaseFailureLimit {
             .ok_or(MaintenanceValueError::InvalidLeaseFailureLimit)
     }
 
+    /// Returns the durable lease-failure limit.
     #[must_use]
     pub const fn get(self) -> u32 {
         self.0.get()
@@ -78,6 +85,7 @@ impl StaleSessionTimeoutMillis {
             .ok_or(MaintenanceValueError::InvalidStaleSessionTimeout)
     }
 
+    /// Returns the stale-session timeout in milliseconds.
     #[must_use]
     pub const fn get(self) -> u64 {
         self.0.get()
@@ -124,21 +132,25 @@ impl ControlPlaneMaintenanceRequest {
         })
     }
 
+    /// Returns the trusted observation time for this pass.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
     }
 
+    /// Returns the lease-failure budget applied by this pass.
     #[must_use]
     pub const fn maximum_lease_failures(self) -> LeaseFailureLimit {
         self.maximum_lease_failures
     }
 
+    /// Returns the per-category maintenance batch size.
     #[must_use]
     pub const fn batch_size(self) -> MaintenanceBatchSize {
         self.batch_size
     }
 
+    /// Returns the oldest session heartbeat still considered live.
     #[must_use]
     pub const fn stale_session_cutoff(self) -> UnixMillis {
         self.stale_session_cutoff
@@ -176,21 +188,25 @@ impl ExpiredAttemptMaintenance {
         }
     }
 
+    /// Returns the changed attempt identity.
     #[must_use]
     pub const fn attempt_id(self) -> AttemptId {
         self.attempt_id
     }
 
+    /// Returns the atomically reconciled run identity.
     #[must_use]
     pub const fn run_id(self) -> RunId {
         self.reconciliation.run_id()
     }
 
+    /// Returns the durable disposition selected for the attempt.
     #[must_use]
     pub const fn disposition(self) -> ExpiredAttemptDisposition {
         self.disposition
     }
 
+    /// Returns the aggregate run reconciliation committed with the attempt.
     #[must_use]
     pub const fn reconciliation(self) -> RunReconciliation {
         self.reconciliation
@@ -225,16 +241,19 @@ impl ControlPlaneMaintenanceReport {
         &self.expired_attempts
     }
 
+    /// Returns the number of stale sessions closed by this pass.
     #[must_use]
     pub const fn closed_stale_sessions(&self) -> u16 {
         self.closed_stale_sessions
     }
 
+    /// Returns the number of dependency-blocked attempts skipped by this pass.
     #[must_use]
     pub const fn skipped_blocked_attempts(&self) -> u16 {
         self.skipped_blocked_attempts
     }
 
+    /// Returns whether the pass committed no maintenance changes.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.expired_attempts.is_empty()

--- a/crates/automata-ci-control/src/observability.rs
+++ b/crates/automata-ci-control/src/observability.rs
@@ -1,3 +1,5 @@
+//! Durable control-plane snapshots used for bounded, identifier-free metrics.
+
 use std::{collections::BTreeSet, fmt, time::Duration};
 
 use async_trait::async_trait;
@@ -6,7 +8,7 @@ use automata_ci_core::{
 };
 use thiserror::Error;
 
-use crate::{
+use automata_ci_store::{
     RoutingLabel, RunnerSessionFence, RunnerSlotCount, StableRunnerSlot, StoreError,
     WorkflowRunStatus,
 };
@@ -59,11 +61,13 @@ impl ControlPlaneStateSnapshotRequest {
         })
     }
 
+    /// Returns the trusted time at which the snapshot is observed.
     #[must_use]
     pub const fn observed_at(self) -> UnixMillis {
         self.observed_at
     }
 
+    /// Returns the inclusive upper bound for near-expiry leases.
     #[must_use]
     pub const fn near_expiry_at(self) -> UnixMillis {
         self.near_expiry_at
@@ -73,11 +77,14 @@ impl ControlPlaneStateSnapshotRequest {
 /// Closed observed connectivity state persisted for a runner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RunnerObservedState {
+    /// The runner has no live observed connection.
     Offline,
+    /// The runner has a live observed connection.
     Online,
 }
 
 impl RunnerObservedState {
+    /// Every observed runner state in stable metric order.
     pub const ALL: [Self; 2] = [Self::Offline, Self::Online];
 
     const fn index(self) -> usize {
@@ -91,12 +98,16 @@ impl RunnerObservedState {
 /// Closed operator intent persisted for a runner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RunnerDesiredState {
+    /// The runner may accept work.
     Active,
+    /// The runner is draining existing work without accepting more.
     Draining,
+    /// The runner is administratively disabled.
     Disabled,
 }
 
 impl RunnerDesiredState {
+    /// Every desired runner state in stable metric order.
     pub const ALL: [Self; 3] = [Self::Active, Self::Draining, Self::Disabled];
 
     const fn index(self) -> usize {
@@ -111,11 +122,14 @@ impl RunnerDesiredState {
 /// Closed durable runner-session state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RunnerSessionState {
+    /// The session is live.
     Live,
+    /// The session is durably disconnected.
     Disconnected,
 }
 
 impl RunnerSessionState {
+    /// Every durable runner-session state in stable metric order.
     pub const ALL: [Self; 2] = [Self::Live, Self::Disconnected];
 
     const fn index(self) -> usize {
@@ -129,12 +143,16 @@ impl RunnerSessionState {
 /// Closed lease-expiration band relative to one trusted observation time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LeaseState {
+    /// The lease remains outside the near-expiry window.
     Active,
+    /// The lease remains valid but falls within the near-expiry window.
     NearExpiry,
+    /// The lease has expired at the observation time.
     Expired,
 }
 
 impl LeaseState {
+    /// Every lease-expiration band in stable metric order.
     pub const ALL: [Self; 3] = [Self::Active, Self::NearExpiry, Self::Expired];
 
     const fn index(self) -> usize {
@@ -158,6 +176,7 @@ pub enum ArtifactState {
 }
 
 impl ArtifactState {
+    /// Every artifact publication state in stable metric order.
     pub const ALL: [Self; 3] = [
         Self::PendingUpload,
         Self::PublicationReserved,
@@ -176,11 +195,14 @@ impl ArtifactState {
 /// Closed immutable artifact-reservation kind.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ArtifactReservationKind {
+    /// An immutable artifact block reservation.
     Block,
+    /// An immutable artifact manifest reservation.
     Manifest,
 }
 
 impl ArtifactReservationKind {
+    /// Every artifact reservation kind in stable metric order.
     pub const ALL: [Self; 2] = [Self::Block, Self::Manifest];
 
     const fn index(self) -> usize {
@@ -194,12 +216,16 @@ impl ArtifactReservationKind {
 /// Closed durable status of a built-in secret-version cleanup operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BuiltinSecretCleanupStatus {
+    /// Cleanup is waiting to start.
     Pending,
+    /// Cleanup is currently being processed.
     InProgress,
+    /// Cleanup exhausted its retry policy.
     DeadLetter,
 }
 
 impl BuiltinSecretCleanupStatus {
+    /// Every built-in cleanup status in stable metric order.
     pub const ALL: [Self; 3] = [Self::Pending, Self::InProgress, Self::DeadLetter];
 
     const fn index(self) -> usize {
@@ -216,6 +242,7 @@ impl BuiltinSecretCleanupStatus {
 pub struct WorkflowRunCounts([u64; 4]);
 
 impl WorkflowRunCounts {
+    /// Every workflow-run status in stable metric order.
     pub const ALL: [WorkflowRunStatus; 4] = [
         WorkflowRunStatus::Queued,
         WorkflowRunStatus::InProgress,
@@ -223,10 +250,12 @@ impl WorkflowRunCounts {
         WorkflowRunStatus::Cancelled,
     ];
 
+    /// Sets the count for one workflow-run status.
     pub fn set(&mut self, status: WorkflowRunStatus, count: u64) {
         self.0[workflow_run_status_index(status)] = count;
     }
 
+    /// Returns the count for one workflow-run status.
     #[must_use]
     pub const fn get(self, status: WorkflowRunStatus) -> u64 {
         self.0[workflow_run_status_index(status)]
@@ -236,14 +265,20 @@ impl WorkflowRunCounts {
 /// Closed durable state of a current `WorkflowPlan`-v1 orchestration marker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogicalWorkflowRunState {
+    /// The orchestration marker is waiting for activation.
     Pending,
+    /// The logical workflow run is active.
     Active,
+    /// The logical workflow run completed successfully.
     Completed,
+    /// The logical workflow run was cancelled.
     Cancelled,
+    /// The logical workflow run failed.
     Failed,
 }
 
 impl LogicalWorkflowRunState {
+    /// Every logical workflow-run state in stable metric order.
     pub const ALL: [Self; 5] = [
         Self::Pending,
         Self::Active,
@@ -268,10 +303,12 @@ impl LogicalWorkflowRunState {
 pub struct LogicalWorkflowRunCounts([u64; 5]);
 
 impl LogicalWorkflowRunCounts {
+    /// Sets the count for one logical workflow-run state.
     pub fn set(&mut self, state: LogicalWorkflowRunState, count: u64) {
         self.0[state.index()] = count;
     }
 
+    /// Returns the count for one logical workflow-run state.
     #[must_use]
     pub const fn get(self, state: LogicalWorkflowRunState) -> u64 {
         self.0[state.index()]
@@ -281,16 +318,24 @@ impl LogicalWorkflowRunCounts {
 /// Closed durable state of one current logical workflow job.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogicalJobState {
+    /// The logical job is waiting for activation.
     Pending,
+    /// Activation of the logical job is in progress.
     Activating,
+    /// The logical job has produced its current physical job.
     Activated,
+    /// The logical job completed successfully.
     Completed,
+    /// The logical job was skipped.
     Skipped,
+    /// The logical job was cancelled.
     Cancelled,
+    /// The logical job failed.
     Failed,
 }
 
 impl LogicalJobState {
+    /// Every logical-job state in stable metric order.
     pub const ALL: [Self; 7] = [
         Self::Pending,
         Self::Activating,
@@ -319,10 +364,12 @@ impl LogicalJobState {
 pub struct LogicalJobCounts([u64; 7]);
 
 impl LogicalJobCounts {
+    /// Sets the count for one logical-job state.
     pub fn set(&mut self, state: LogicalJobState, count: u64) {
         self.0[state.index()] = count;
     }
 
+    /// Returns the count for one logical-job state.
     #[must_use]
     pub const fn get(self, state: LogicalJobState) -> u64 {
         self.0[state.index()]
@@ -332,12 +379,16 @@ impl LogicalJobCounts {
 /// Closed activation backlog/claim band at one trusted observation time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogicalActivationState {
+    /// Activation work is waiting to be claimed.
     Pending,
+    /// Activation work has a live claim.
     Activating,
+    /// Activation work has an expired claim.
     Expired,
 }
 
 impl LogicalActivationState {
+    /// Every logical-activation state in stable metric order.
     pub const ALL: [Self; 3] = [Self::Pending, Self::Activating, Self::Expired];
 
     const fn index(self) -> usize {
@@ -374,11 +425,13 @@ impl LogicalActivationCounts {
         Ok(())
     }
 
+    /// Returns the count for one logical-activation state.
     #[must_use]
     pub const fn get(self, state: LogicalActivationState) -> u64 {
         self.counts[state.index()]
     }
 
+    /// Returns the oldest timestamp for one logical-activation state.
     #[must_use]
     pub const fn oldest_at(self, state: LogicalActivationState) -> Option<UnixMillis> {
         self.oldest_at[state.index()]
@@ -390,6 +443,7 @@ impl LogicalActivationCounts {
 pub struct JobAttemptCounts([u64; 12]);
 
 impl JobAttemptCounts {
+    /// Every job-attempt lifecycle in stable metric order.
     pub const ALL: [JobLifecycle; 12] = [
         JobLifecycle::Queued,
         JobLifecycle::Leased,
@@ -405,10 +459,12 @@ impl JobAttemptCounts {
         JobLifecycle::Lost,
     ];
 
+    /// Sets the count for one job-attempt lifecycle.
     pub fn set(&mut self, lifecycle: JobLifecycle, count: u64) {
         self.0[job_lifecycle_index(lifecycle)] = count;
     }
 
+    /// Returns the count for one job-attempt lifecycle.
     #[must_use]
     pub const fn get(self, lifecycle: JobLifecycle) -> u64 {
         self.0[job_lifecycle_index(lifecycle)]
@@ -420,10 +476,12 @@ impl JobAttemptCounts {
 pub struct RunnerCounts([[u64; 3]; 2]);
 
 impl RunnerCounts {
+    /// Sets the count for one observed/desired runner-state pair.
     pub fn set(&mut self, observed: RunnerObservedState, desired: RunnerDesiredState, count: u64) {
         self.0[observed.index()][desired.index()] = count;
     }
 
+    /// Returns the count for one observed/desired runner-state pair.
     #[must_use]
     pub const fn get(self, observed: RunnerObservedState, desired: RunnerDesiredState) -> u64 {
         self.0[observed.index()][desired.index()]
@@ -435,10 +493,12 @@ impl RunnerCounts {
 pub struct RunnerSessionCounts([u64; 2]);
 
 impl RunnerSessionCounts {
+    /// Sets the count for one runner-session state.
     pub fn set(&mut self, state: RunnerSessionState, count: u64) {
         self.0[state.index()] = count;
     }
 
+    /// Returns the count for one runner-session state.
     #[must_use]
     pub const fn get(self, state: RunnerSessionState) -> u64 {
         self.0[state.index()]
@@ -450,10 +510,12 @@ impl RunnerSessionCounts {
 pub struct LeaseCounts([u64; 3]);
 
 impl LeaseCounts {
+    /// Sets the count for one lease-expiration band.
     pub fn set(&mut self, state: LeaseState, count: u64) {
         self.0[state.index()] = count;
     }
 
+    /// Returns the count for one lease-expiration band.
     #[must_use]
     pub const fn get(self, state: LeaseState) -> u64 {
         self.0[state.index()]
@@ -465,10 +527,12 @@ impl LeaseCounts {
 pub struct ArtifactCounts([u64; 3]);
 
 impl ArtifactCounts {
+    /// Sets the count for one artifact publication state.
     pub fn set(&mut self, state: ArtifactState, count: u64) {
         self.0[state.index()] = count;
     }
 
+    /// Returns the count for one artifact publication state.
     #[must_use]
     pub const fn get(self, state: ArtifactState) -> u64 {
         self.0[state.index()]
@@ -501,11 +565,13 @@ impl ArtifactReservations {
         Ok(())
     }
 
+    /// Returns the outstanding reservation count for one kind.
     #[must_use]
     pub const fn get(self, kind: ArtifactReservationKind) -> u64 {
         self.counts[kind.index()]
     }
 
+    /// Returns the oldest outstanding reservation time for one kind.
     #[must_use]
     pub const fn oldest_at(self, kind: ArtifactReservationKind) -> Option<UnixMillis> {
         self.oldest_at[kind.index()]
@@ -538,11 +604,13 @@ impl BuiltinSecretCleanupCounts {
         Ok(())
     }
 
+    /// Returns the operation count for one cleanup status.
     #[must_use]
     pub const fn get(self, status: BuiltinSecretCleanupStatus) -> u64 {
         self.counts[status.index()]
     }
 
+    /// Returns the oldest creation time for one cleanup status.
     #[must_use]
     pub const fn oldest_created_at(self, status: BuiltinSecretCleanupStatus) -> Option<UnixMillis> {
         self.oldest_created_at[status.index()]
@@ -922,6 +990,7 @@ impl ControlPlaneStateSnapshot {
         self
     }
 
+    /// Returns an identifier-free snapshot with every aggregate empty.
     #[must_use]
     pub const fn empty() -> Self {
         Self {
@@ -962,111 +1031,133 @@ impl ControlPlaneStateSnapshot {
         }
     }
 
+    /// Returns workflow-run counts.
     #[must_use]
     pub const fn workflow_runs(&self) -> WorkflowRunCounts {
         self.workflow_runs
     }
 
+    /// Returns logical workflow-run counts.
     #[must_use]
     pub const fn logical_workflow_runs(&self) -> LogicalWorkflowRunCounts {
         self.logical_workflow_runs
     }
 
+    /// Returns current logical-job counts.
     #[must_use]
     pub const fn logical_jobs(&self) -> LogicalJobCounts {
         self.logical_jobs
     }
 
+    /// Returns logical-activation counts and oldest timestamps.
     #[must_use]
     pub const fn logical_activations(&self) -> LogicalActivationCounts {
         self.logical_activations
     }
 
+    /// Returns the current activation-publication count.
     #[must_use]
     pub const fn activation_publications(&self) -> u64 {
         self.activation_publications
     }
 
+    /// Returns the current materialized-instance count.
     #[must_use]
     pub const fn materialized_instances(&self) -> u64 {
         self.materialized_instances
     }
 
+    /// Returns job-attempt lifecycle counts.
     #[must_use]
     pub const fn job_attempts(&self) -> JobAttemptCounts {
         self.job_attempts
     }
 
+    /// Returns runner counts by observed and desired state.
     #[must_use]
     pub const fn runners(&self) -> RunnerCounts {
         self.runners
     }
 
+    /// Returns durable runner-session counts.
     #[must_use]
     pub const fn runner_sessions(&self) -> RunnerSessionCounts {
         self.runner_sessions
     }
 
+    /// Returns the total queued-attempt depth.
     #[must_use]
     pub const fn queue_depth(&self) -> u64 {
         self.queue_depth
     }
 
+    /// Returns the oldest queued-attempt timestamp, when the queue is non-empty.
     #[must_use]
     pub const fn queue_oldest_at(&self) -> Option<UnixMillis> {
         self.queue_oldest_at
     }
 
+    /// Returns the exact scheduler-eligible queue depth.
     #[must_use]
     pub const fn eligible_queue_depth(&self) -> u64 {
         self.eligible_queue_depth
     }
 
+    /// Returns the oldest eligible queued-attempt timestamp, when present.
     #[must_use]
     pub const fn eligible_queue_oldest_at(&self) -> Option<UnixMillis> {
         self.eligible_queue_oldest_at
     }
 
+    /// Returns bounded inputs for scheduler-capacity classification.
     #[must_use]
     pub const fn capacity(&self) -> &ControlPlaneCapacitySnapshot {
         &self.capacity
     }
 
+    /// Returns active-lease counts by expiry band.
     #[must_use]
     pub const fn leases(&self) -> LeaseCounts {
         self.leases
     }
 
+    /// Returns the pending runner-command count.
     #[must_use]
     pub const fn pending_commands(&self) -> u64 {
         self.pending_commands
     }
 
+    /// Returns the oldest pending runner-command timestamp, when present.
     #[must_use]
     pub const fn pending_commands_oldest_at(&self) -> Option<UnixMillis> {
         self.pending_commands_oldest_at
     }
 
+    /// Returns the pending cancellation-intent count.
     #[must_use]
     pub const fn pending_cancellation_intents(&self) -> u64 {
         self.pending_cancellation_intents
     }
 
+    /// Returns the oldest pending cancellation-intent timestamp, when present.
     #[must_use]
     pub const fn pending_cancellation_intents_oldest_at(&self) -> Option<UnixMillis> {
         self.pending_cancellation_intents_oldest_at
     }
 
+    /// Returns built-in secret-version cleanup counts and oldest timestamps.
     #[must_use]
     pub const fn builtin_secret_cleanup(&self) -> BuiltinSecretCleanupCounts {
         self.builtin_secret_cleanup
     }
 
+    /// Returns artifact publication counts.
     #[must_use]
     pub const fn artifacts(&self) -> ArtifactCounts {
         self.artifacts
     }
 
+    /// Returns artifact-reservation counts and oldest timestamps.
     #[must_use]
     pub const fn artifact_reservations(&self) -> ArtifactReservations {
         self.artifact_reservations
@@ -1107,21 +1198,25 @@ impl DatabasePoolSnapshot {
         })
     }
 
+    /// Returns the configured maximum pool size.
     #[must_use]
     pub const fn maximum(self) -> u32 {
         self.maximum
     }
 
+    /// Returns the number of open pool connections.
     #[must_use]
     pub const fn open(self) -> u32 {
         self.open
     }
 
+    /// Returns the number of idle pool connections.
     #[must_use]
     pub const fn idle(self) -> u32 {
         self.idle
     }
 
+    /// Returns the number of checked-out pool connections.
     #[must_use]
     pub const fn in_use(self) -> u32 {
         self.in_use
@@ -1131,16 +1226,22 @@ impl DatabasePoolSnapshot {
 /// Invalid input or durable aggregate shape.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum ControlPlaneStateValueError {
+    /// The lease near-expiry window was not a positive whole-millisecond duration.
     #[error("lease near-expiry window must be a positive whole-millisecond duration")]
     InvalidNearExpiryWindow,
+    /// Adding the near-expiry window overflowed the durable timestamp range.
     #[error("lease near-expiry cutoff is outside the durable timestamp range")]
     NearExpiryCutoffOutOfRange,
+    /// An aggregate count and its optional oldest timestamp disagreed.
     #[error("oldest timestamp presence does not match aggregate work count")]
     InconsistentOldestTimestamp,
+    /// Pool occupancy exceeded its configured or open-connection bounds.
     #[error("database pool occupancy is inconsistent")]
     InvalidPoolOccupancy,
+    /// Effective runner capacity state was invalid or outside its bounded contract.
     #[error("capacity runner state is invalid or outside the bounded product contract")]
     InvalidCapacityRunner,
+    /// Exact capacity inputs exceeded their bounded in-memory contract.
     #[error("exact capacity snapshot exceeds its bounded in-memory contract")]
     CapacitySnapshotTooLarge,
 }

--- a/crates/automata-ci-control/src/runner_control/durable.rs
+++ b/crates/automata-ci-control/src/runner_control/durable.rs
@@ -1,3 +1,4 @@
+use crate::attempt::RenewLease;
 use async_trait::async_trait;
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
 use automata_ci_core::{
@@ -7,7 +8,7 @@ use automata_ci_core::{
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CommandCursor, DocumentSchema, DurableRunnerCommand,
     EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, MAX_LOG_SEGMENT_BYTES,
-    MAX_TERMINAL_RESULT_BYTES, ObjectKey, RenewLease, RunnerGeneration, RunnerOperationReceipt,
+    MAX_TERMINAL_RESULT_BYTES, ObjectKey, RunnerGeneration, RunnerOperationReceipt,
     RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence,
     StableRunnerSlot, StoreError,
 };

--- a/crates/automata-ci-control/src/runner_control/handler.rs
+++ b/crates/automata-ci-control/src/runner_control/handler.rs
@@ -1,8 +1,10 @@
 use std::{fmt, io::Write as _, sync::Arc, time::Instant};
 
+use crate::attempt::RenewLease;
 use crate::lease::{
-    AuthenticatedRunnerSession, ClaimedLeasePoll, LeaseClock, LeasePollError, LeasePollOutcome,
-    repository::RunnerLeaseRequestRepository,
+    AuthenticatedRunnerSession, BeginLeaseRequest, ClaimedLeasePoll, CompleteLeaseRequest,
+    LeaseClock, LeasePollError, LeasePollOutcome, LeaseRequestCompletion, LeaseRequestKey,
+    RevokedLeaseOfferFallback, repository::RunnerLeaseRequestRepository,
 };
 use automata_ci_auth::machine::AuthenticatedMachine;
 use automata_ci_blob::{
@@ -29,13 +31,12 @@ use automata_ci_runner_transport::{
     RunnerControlHandler,
 };
 use automata_ci_store::{
-    AcknowledgeRunnerCommands, AttemptStoreError, BeginLeaseRequest,
-    CommandCursor as StoreCommandCursor, CommandReplayDisposition, CommandReplayLimit,
-    CommandSequence as StoreCommandSequence, CompleteLeaseRequest, DocumentSchema,
-    HeartbeatRunnerSession, LeaseRequestCompletion, LeaseRequestKey, ObjectKey, OpenRunnerSession,
-    RenewLease, ResumeRunnerSession, RevokedLeaseOfferFallback, RoutingDocument,
-    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot, StableRunnerSlot, StoreError,
+    AcknowledgeRunnerCommands, AttemptStoreError, CommandCursor as StoreCommandCursor,
+    CommandReplayDisposition, CommandReplayLimit, CommandSequence as StoreCommandSequence,
+    DocumentSchema, HeartbeatRunnerSession, ObjectKey, OpenRunnerSession, ResumeRunnerSession,
+    RoutingDocument, RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot,
+    StableRunnerSlot, StoreError,
 };
 use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;

--- a/crates/automata-ci-control/src/runner_control/port.rs
+++ b/crates/automata-ci-control/src/runner_control/port.rs
@@ -1,5 +1,8 @@
 use std::{fmt, sync::Arc};
 
+use crate::cancellation::{
+    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+};
 use crate::lease::{
     AuthenticatedRunnerSession, LeaseClock, LeaseIdGenerator, LeasePollConfig, LeasePollError,
     LeasePollObserver, LeasePollOutcome, LeasePollRepository, LeasePollService,
@@ -22,7 +25,6 @@ use automata_ci_protocol::{
 };
 use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_store::{
-    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
     CommandSequence as StoreCommandSequence, DocumentSchema, DurableRunnerCommand,
     EnqueueRunnerCommand, JobIrMetadata,
     LeaseOfferCommandIdentity as StoreLeaseOfferCommandIdentity, RunnerCommandPayload,

--- a/crates/automata-ci-control/tests/attempt_adapter_port.rs
+++ b/crates/automata-ci-control/tests/attempt_adapter_port.rs
@@ -1,12 +1,15 @@
 use std::{error::Error, fmt};
 
 use async_trait::async_trait;
-use automata_ci_core::{AttemptId, AttemptNumber, JobId, JobLifecycle, Lease, UnixMillis};
-use automata_ci_store::{
-    AcquireLease, AttemptSnapshot, AttemptStoreError, ConcludeQueuedAttempt,
-    InternalAttemptRepository, QueuedAttempt, RenewLease, TenantAttemptQuery, TenantScope,
-    TransitionAttempt,
+use automata_ci_control::{
+    adapter_spi::{
+        AcquireLease, AttemptSnapshot, ConcludeQueuedAttempt, InternalAttemptRepository,
+        QueuedAttempt, TenantAttemptQuery, TransitionAttempt,
+    },
+    attempt::RenewLease,
 };
+use automata_ci_core::{AttemptId, AttemptNumber, JobId, JobLifecycle, Lease, UnixMillis};
+use automata_ci_store::{AttemptStoreError, TenantScope};
 
 #[derive(Debug)]
 struct AlternativeBackendError(&'static str);

--- a/crates/automata-ci-control/tests/attempt_api.rs
+++ b/crates/automata-ci-control/tests/attempt_api.rs
@@ -1,11 +1,16 @@
+use automata_ci_control::{
+    adapter_spi::{
+        AcquireLease, ConcludeQueuedAttempt, InternalAttemptRepository, QueuedAttempt,
+        TenantAttemptQuery, TransitionAttempt,
+    },
+    attempt::RenewLease,
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, JobId, JobLifecycle, LeaseGuard, LeaseId, RunnerId,
     RunnerSessionId, UnixMillis,
 };
 use automata_ci_store::{
-    AcquireLease, AttemptCommandError, ConcludeQueuedAttempt, InternalAttemptRepository,
-    QueuedAttempt, RenewLease, RunnerGeneration, RunnerSessionFence, SessionEpoch,
-    StableRunnerSlot, TenantAttemptQuery, TransitionAttempt,
+    AttemptCommandError, RunnerGeneration, RunnerSessionFence, SessionEpoch, StableRunnerSlot,
 };
 
 fn session(runner_id: RunnerId) -> RunnerSessionFence {

--- a/crates/automata-ci-control/tests/attempt_snapshot_api.rs
+++ b/crates/automata-ci-control/tests/attempt_snapshot_api.rs
@@ -1,10 +1,11 @@
+use automata_ci_control::adapter_spi::AttemptSnapshot;
 use automata_ci_core::{
     AttemptId, AttemptNumber, CORE_SCHEMA_VERSION, FencingToken, JobId, JobLifecycle, Lease,
     LeaseError, LeaseId, RunnerId, RunnerSessionId, UnixMillis,
 };
 use automata_ci_store::{
-    AttemptAssignment, AttemptSnapshot, AttemptSnapshotError, RunnerGeneration, RunnerSessionFence,
-    SessionEpoch, StableRunnerSlot,
+    AttemptAssignment, AttemptSnapshotError, RunnerGeneration, RunnerSessionFence, SessionEpoch,
+    StableRunnerSlot,
 };
 
 fn attempt_number() -> AttemptNumber {

--- a/crates/automata-ci-control/tests/control.rs
+++ b/crates/automata-ci-control/tests/control.rs
@@ -4,8 +4,17 @@ mod runner_auth_support;
 mod runner_control_support;
 mod scheduling_support;
 
+#[cfg(feature = "adapter-spi")]
+mod attempt_adapter_port;
+#[cfg(feature = "adapter-spi")]
+mod attempt_api;
+#[cfg(feature = "adapter-spi")]
+mod attempt_snapshot_api;
+mod durability_values;
 mod github_oidc_runtime_authority;
 mod lease_poll;
+mod maintenance_api;
+mod observability_api;
 mod runner_auth_authentication;
 mod runner_auth_authorization;
 mod runner_auth_contracts;

--- a/crates/automata-ci-control/tests/durability_values.rs
+++ b/crates/automata-ci-control/tests/durability_values.rs
@@ -1,0 +1,150 @@
+use automata_ci_control::{
+    cancellation::{CancelJobCommandPayload, CancellationRepository},
+    lease::{
+        BeginLeaseRequest, CompleteLeaseRequest, LeaseRequestKey, RevokedLeaseOfferFallback,
+        RunnableAttempt, RunnableScanLimit,
+    },
+};
+use automata_ci_core::{
+    AttemptId, FencingToken, JobId, JobIrVersion, LeaseGuard, LeaseId, OperationId, RunId,
+    RunnerId, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
+};
+use automata_ci_store::{
+    CommandSequence, DocumentSchema, JobIrMetadata, LeaseOfferCommandIdentity, ObjectKey,
+    RunnerGeneration, RunnerOperationResponse, RunnerProtocolVersion, RunnerSessionFence,
+    SessionEpoch, StableRunnerSlot,
+};
+
+#[test]
+fn cancel_job_command_payload_is_exact_versioned_and_closed_to_extensions() {
+    let payload = CancelJobCommandPayload::new(
+        AttemptId::new(),
+        LeaseGuard::new(LeaseId::new(), FencingToken::new(7).expect("fencing token")),
+        RunnerProtocolVersion::new(1).expect("protocol"),
+        "superseded by a newer run",
+        UnixMillis::new(42),
+    )
+    .expect("typed cancellation");
+    let encoded = payload.encode_json().expect("canonical JSON");
+    assert_eq!(
+        CancelJobCommandPayload::decode_json(&encoded).expect("round trip"),
+        payload
+    );
+
+    let mut extended: serde_json::Value = serde_json::from_slice(&encoded).expect("JSON value");
+    extended
+        .as_object_mut()
+        .expect("JSON object")
+        .insert("future_field".to_owned(), serde_json::json!(true));
+    assert!(
+        CancelJobCommandPayload::decode_json(
+            &serde_json::to_vec(&extended).expect("extended JSON")
+        )
+        .is_err()
+    );
+
+    extended
+        .as_object_mut()
+        .expect("JSON object")
+        .remove("future_field");
+    extended["schema"] = serde_json::json!(2);
+    assert!(
+        CancelJobCommandPayload::decode_json(
+            &serde_json::to_vec(&extended).expect("wrong-schema JSON")
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn lease_request_chain_values_bind_predecessor_and_exact_rpc_digest() {
+    let fence = RunnerSessionFence::new(
+        RunnerSessionId::new(),
+        RunnerId::new(),
+        RunnerGeneration::new(1).expect("generation"),
+        SessionEpoch::new(1).expect("epoch"),
+    );
+    let slot = StableRunnerSlot::new(1).expect("slot");
+    let first_operation = OperationId::new();
+    let first = LeaseRequestKey::first(fence, first_operation, slot);
+    let successor = LeaseRequestKey::successor(fence, OperationId::new(), slot, first_operation)
+        .expect("successor");
+    assert_eq!(first.acknowledges_operation_id(), None);
+    assert_eq!(successor.acknowledges_operation_id(), Some(first_operation));
+    assert_ne!(first.request_digest(), successor.request_digest());
+    assert!(LeaseRequestKey::successor(fence, first_operation, slot, first_operation).is_err());
+
+    let begin = BeginLeaseRequest::new(successor, Sha256Digest::from_bytes([8; 32]));
+    assert_eq!(begin.request_key(), successor);
+    assert_eq!(begin.request_digest(), Sha256Digest::from_bytes([8; 32]));
+    let response = RunnerOperationResponse::new(DocumentSchema::new(1).expect("schema"), vec![1])
+        .expect("response");
+    let complete =
+        CompleteLeaseRequest::without_lease_offer(begin, response.clone(), UnixMillis::new(9));
+    assert_eq!(complete.request(), begin);
+    assert_eq!(complete.response(), &response);
+    assert_eq!(complete.completed_at(), UnixMillis::new(9));
+    assert!(complete.lease_offer_command().is_none());
+    assert!(complete.revoked_lease_offer_response().is_none());
+
+    let offer_identity = LeaseOfferCommandIdentity::new(
+        fence,
+        OperationId::new(),
+        CommandSequence::new(1).expect("sequence"),
+    );
+    let revoked_response =
+        RunnerOperationResponse::new(DocumentSchema::new(1).expect("schema"), vec![2])
+            .expect("revoked response");
+    let fallback = RevokedLeaseOfferFallback::new(
+        OperationId::new(),
+        1_000,
+        revoked_response.schema(),
+        revoked_response.digest(),
+    )
+    .expect("typed fallback");
+    let complete = CompleteLeaseRequest::for_lease_offer_with_fallback(
+        begin,
+        response,
+        revoked_response.clone(),
+        fallback,
+        UnixMillis::new(10),
+        offer_identity,
+    )
+    .expect("lease-offer completion");
+    assert_eq!(complete.lease_offer_command(), Some(offer_identity));
+    assert_eq!(
+        complete.revoked_lease_offer_response(),
+        Some(&revoked_response)
+    );
+    assert_eq!(complete.revoked_lease_offer_fallback(), Some(fallback));
+}
+
+#[test]
+fn control_values_and_ports_remain_backend_neutral_and_dyn_compatible() {
+    fn assert_port(_: &dyn CancellationRepository) {}
+    let _ = assert_port;
+
+    assert!(RunnableScanLimit::new(0).is_err());
+    assert!(RunnableScanLimit::new(1001).is_err());
+
+    let candidate_job_id = JobId::new();
+    let candidate_run_id = RunId::new();
+    let candidate = RunnableAttempt::try_new(
+        AttemptId::new(),
+        candidate_job_id,
+        candidate_run_id,
+        UnixMillis::new(1),
+        RunnerRequirements::default(),
+        JobIrMetadata::new(
+            candidate_job_id,
+            candidate_run_id,
+            JobIrVersion::current(),
+            1,
+            Sha256Digest::from_bytes([1; 32]),
+            ObjectKey::new("job-ir").expect("key"),
+        )
+        .expect("metadata"),
+    )
+    .expect("candidate");
+    assert_eq!(candidate.requirements(), &RunnerRequirements::default());
+}

--- a/crates/automata-ci-control/tests/lease_poll.rs
+++ b/crates/automata-ci-control/tests/lease_poll.rs
@@ -2,9 +2,11 @@ use std::{sync::Mutex, time::Duration};
 
 use async_trait::async_trait;
 use automata_ci_control::lease::{
-    AuthenticatedRunnerSession, LeaseClock, LeaseIdGenerator, LeasePollConfig,
+    AuthenticatedRunnerSession, ClaimedAttempt, LeaseClock, LeaseIdGenerator, LeasePollConfig,
     LeasePollObservation, LeasePollObserver, LeasePollOutcome, LeasePollRepository,
-    LeasePollService, LeaseTimeToLive, RunnableAttemptGate, RunnableAttemptGateDisposition,
+    LeasePollService, LeaseRequestKey, LeaseTimeToLive, NoWorkLeaseRequest, RunnableAttempt,
+    RunnableAttemptGate, RunnableAttemptGateDisposition, RunnableScanLimit, RunnableScanPage,
+    RunnableScanRequest, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
     repository::{RunnableAttemptRepository, RunnerClaimRepository},
     routing::{
         RunnerGroupId, RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSlotAvailability,
@@ -21,10 +23,8 @@ use automata_ci_core::{
 };
 use automata_ci_protocol::{LeaseRequest, MessageHeader, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal};
 use automata_ci_store::{
-    AttemptAssignment, JobIrMetadata, NoWorkLeaseRequest, ObjectKey, RoutingDocument, RoutingLabel,
-    RunnableAttempt, RunnableScanLimit, RunnableScanPage, RunnableScanRequest, RunnerGeneration,
+    AttemptAssignment, JobIrMetadata, ObjectKey, RoutingDocument, RoutingLabel, RunnerGeneration,
     RunnerSessionFence, RunnerSlotCount, SessionEpoch, StableRunnerSlot, StoreError,
-    TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
 };
 
 #[derive(Debug)]
@@ -100,7 +100,7 @@ impl RunnableAttemptGate for IneligibleAttemptGate {
 #[derive(Debug)]
 struct FakeRepository {
     calls: Mutex<Vec<&'static str>>,
-    lease_keys: Mutex<Vec<automata_ci_store::LeaseRequestKey>>,
+    lease_keys: Mutex<Vec<LeaseRequestKey>>,
     lookup: Option<TryClaimReceipt>,
     routing: RunnerRoutingSnapshot,
     availability: RunnerSlotAvailability,
@@ -122,7 +122,7 @@ impl FakeRepository {
 impl RunnerClaimRepository for FakeRepository {
     async fn lookup_lease_request(
         &self,
-        request: automata_ci_store::LeaseRequestKey,
+        request: LeaseRequestKey,
     ) -> Result<Option<TryClaimReceipt>, StoreError> {
         self.called("lookup");
         self.lease_keys
@@ -143,7 +143,7 @@ impl RunnerClaimRepository for FakeRepository {
             request.expires_at(),
         )
         .expect("fake claim interval");
-        let claimed = automata_ci_store::ClaimedAttempt::try_new(
+        let claimed = ClaimedAttempt::try_new(
             lease,
             AttemptAssignment::new(request.session(), request.slot()),
             self.metadata.clone(),
@@ -533,7 +533,7 @@ async fn configured_slot_beyond_negotiated_capacity_is_no_work_not_corrupt_state
 #[tokio::test]
 async fn exact_no_work_retry_returns_before_every_scheduling_read() {
     let mut fixture = fixture(RunnerSlotAvailability::Available, true);
-    let key = automata_ci_store::LeaseRequestKey::first(
+    let key = LeaseRequestKey::first(
         fixture.authenticated.fence(),
         fixture.request.header().operation_id(),
         StableRunnerSlot::new(fixture.request.slot().get()).expect("slot"),
@@ -558,7 +558,7 @@ async fn protocol_successor_is_carried_into_the_durable_key_and_digest() {
         fixture.request.slot(),
         predecessor,
     );
-    let first = automata_ci_store::LeaseRequestKey::first(
+    let first = LeaseRequestKey::first(
         fixture.authenticated.fence(),
         fixture.request.header().operation_id(),
         StableRunnerSlot::new(fixture.request.slot().get()).expect("slot"),
@@ -581,7 +581,7 @@ async fn protocol_successor_is_carried_into_the_durable_key_and_digest() {
 #[tokio::test]
 async fn exact_claim_retry_uses_self_contained_receipt_and_never_reschedules() {
     let mut fixture = fixture(RunnerSlotAvailability::Available, true);
-    let key = automata_ci_store::LeaseRequestKey::first(
+    let key = LeaseRequestKey::first(
         fixture.authenticated.fence(),
         fixture.request.header().operation_id(),
         StableRunnerSlot::new(fixture.request.slot().get()).expect("slot"),
@@ -601,12 +601,8 @@ async fn exact_claim_retry_uses_self_contained_receipt_and_never_reschedules() {
         fixture.authenticated.fence(),
         StableRunnerSlot::new(1).expect("slot"),
     );
-    let claimed = automata_ci_store::ClaimedAttempt::try_new(
-        lease,
-        assignment,
-        fixture.repository.metadata.clone(),
-    )
-    .expect("claimed attempt");
+    let claimed = ClaimedAttempt::try_new(lease, assignment, fixture.repository.metadata.clone())
+        .expect("claimed attempt");
     fixture.repository.lookup = Some(TryClaimReceipt::new(
         key,
         TryClaimOutcome::Claimed(Box::new(claimed)),
@@ -638,7 +634,7 @@ async fn observer_separates_physical_replay_from_one_new_claim_transition() {
     assert!(matches!(outcome, LeasePollOutcome::Claimed(_)));
 
     let mut replay = fixture(RunnerSlotAvailability::Available, true);
-    let key = automata_ci_store::LeaseRequestKey::first(
+    let key = LeaseRequestKey::first(
         replay.authenticated.fence(),
         replay.request.header().operation_id(),
         StableRunnerSlot::new(replay.request.slot().get()).expect("slot"),
@@ -652,7 +648,7 @@ async fn observer_separates_physical_replay_from_one_new_claim_transition() {
         UnixMillis::new(2_000),
     )
     .expect("lease");
-    let claimed = automata_ci_store::ClaimedAttempt::try_new(
+    let claimed = ClaimedAttempt::try_new(
         lease,
         AttemptAssignment::new(
             replay.authenticated.fence(),

--- a/crates/automata-ci-control/tests/maintenance_api.rs
+++ b/crates/automata-ci-control/tests/maintenance_api.rs
@@ -1,9 +1,8 @@
-use automata_ci_core::UnixMillis;
-use automata_ci_store::{
+use automata_ci_control::maintenance::{
     ControlPlaneMaintenanceRepository, ControlPlaneMaintenanceRequest, LeaseFailureLimit,
-    MAX_MAINTENANCE_BATCH_SIZE, MaintenanceBatchSize, MaintenanceValueError,
-    StaleSessionTimeoutMillis,
+    MaintenanceBatchSize, MaintenanceValueError, StaleSessionTimeoutMillis,
 };
+use automata_ci_core::UnixMillis;
 
 fn require_send_sync<T: ?Sized + Send + Sync>() {}
 
@@ -18,8 +17,8 @@ fn maintenance_policy_values_are_positive_bounded_and_exact() {
         MaintenanceBatchSize::new(0),
         Err(MaintenanceValueError::InvalidBatchSize)
     ));
-    assert!(MaintenanceBatchSize::new(MAX_MAINTENANCE_BATCH_SIZE).is_ok());
-    assert!(MaintenanceBatchSize::new(MAX_MAINTENANCE_BATCH_SIZE + 1).is_err());
+    assert!(MaintenanceBatchSize::new(1_000).is_ok());
+    assert!(MaintenanceBatchSize::new(1_001).is_err());
     assert!(LeaseFailureLimit::new(0).is_err());
     assert!(LeaseFailureLimit::new(i32::MAX as u32).is_ok());
     assert!(LeaseFailureLimit::new(i32::MAX as u32 + 1).is_err());

--- a/crates/automata-ci-control/tests/observability_api.rs
+++ b/crates/automata-ci-control/tests/observability_api.rs
@@ -1,10 +1,6 @@
 use std::time::Duration;
 
-use automata_ci_core::{
-    Architecture, AttemptId, JobId, JobLifecycle, OperatingSystem, RunnerCapabilities, RunnerId,
-    RunnerPlatform, RunnerRequirements, RunnerSessionId, UnixMillis,
-};
-use automata_ci_store::{
+use automata_ci_control::observability::{
     ArtifactCounts, ArtifactReservationKind, ArtifactReservations, ArtifactState,
     BuiltinSecretCleanupCounts, BuiltinSecretCleanupStatus, ControlPlaneCapacityCandidate,
     ControlPlaneCapacityRunner, ControlPlaneCapacitySnapshot, ControlPlaneStateSnapshot,
@@ -13,8 +9,14 @@ use automata_ci_store::{
     LogicalJobCounts, LogicalJobState, LogicalWorkflowRunCounts, LogicalWorkflowRunState,
     MAX_CONTROL_PLANE_CAPACITY_CANDIDATES, MAX_CONTROL_PLANE_CAPACITY_RUNNERS,
     MAX_CONTROL_PLANE_CAPACITY_SLOTS_PER_RUNNER, RunnerCounts, RunnerDesiredState,
-    RunnerGeneration, RunnerObservedState, RunnerSessionCounts, RunnerSessionFence,
-    RunnerSessionState, RunnerSlotCount, SessionEpoch, WorkflowRunCounts, WorkflowRunStatus,
+    RunnerObservedState, RunnerSessionCounts, RunnerSessionState, WorkflowRunCounts,
+};
+use automata_ci_core::{
+    Architecture, AttemptId, JobId, JobLifecycle, OperatingSystem, RunnerCapabilities, RunnerId,
+    RunnerPlatform, RunnerRequirements, RunnerSessionId, UnixMillis,
+};
+use automata_ci_store::{
+    RunnerGeneration, RunnerSessionFence, RunnerSlotCount, SessionEpoch, WorkflowRunStatus,
 };
 
 #[test]

--- a/crates/automata-ci-control/tests/runner_control_handler_security.rs
+++ b/crates/automata-ci-control/tests/runner_control_handler_security.rs
@@ -9,7 +9,13 @@ use automata_ci_auth::{
     machine::{AuthenticatedMachine, ExternalRunnerIdentity},
     time::UnixTimestamp,
 };
-use automata_ci_control::lease::{ClaimedLeasePoll, LeasePollOutcome};
+use automata_ci_control::cancellation::{
+    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+};
+use automata_ci_control::lease::{
+    BeginLeaseRequest, ClaimedLeasePoll, LeasePollOutcome, LeaseRequestCompletion, LeaseRequestKey,
+    RevokedLeaseOfferFallback,
+};
 use automata_ci_control::runner_control::{
     AuthorizedRunnerRegistration, ControlPortError, DesiredRunnerState,
     DurableRunnerControlHandler, LeaseOfferClaimStatus, LeaseOfferObservation,
@@ -41,13 +47,12 @@ use automata_ci_protocol::{
 use automata_ci_protocol_protobuf::{encode_job_ir, encode_runner_frame, encode_server_frame};
 use automata_ci_runner_transport::ApplicationErrorKind;
 use automata_ci_store::{
-    BeginLeaseRequest, CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
     CommandCursor as StoreCommandCursor, CommandReplayDisposition,
     CommandSequence as StoreCommandSequence, DocumentSchema, DurableRunnerCommand,
-    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, LeaseRequestCompletion,
-    LeaseRequestKey, ObjectKey, RevokedLeaseOfferFallback, RoutingDocument, RunnerCommandPayload,
-    RunnerGeneration, RunnerOperationKind, RunnerOperationResponse, RunnerProtocolVersion,
-    RunnerSessionFence, RunnerSessionSnapshot, SessionEpoch, StableRunnerSlot,
+    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, ObjectKey, RoutingDocument,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerOperationResponse,
+    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot, SessionEpoch,
+    StableRunnerSlot,
 };
 use sha2::{Digest as _, Sha256};
 use tokio_util::sync::CancellationToken;

--- a/crates/automata-ci-control/tests/runner_control_store_adapters.rs
+++ b/crates/automata-ci-control/tests/runner_control_store_adapters.rs
@@ -4,6 +4,7 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
+use automata_ci_control::cancellation::CANCEL_JOB_COMMAND_KIND;
 use automata_ci_control::runner_control::{
     ControlIdGenerator, ControlPortError, LeaseOfferClaim as ControlLeaseOfferClaim,
     LeaseOfferClaimStatus as ControlLeaseOfferClaimStatus, LeaseOfferCommand,
@@ -29,10 +30,9 @@ use automata_ci_protocol::{
 };
 use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_store::{
-    CANCEL_JOB_COMMAND_KIND, CommandSequence, DocumentSchema, DurableRunnerCommand,
-    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, ObjectKey,
-    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerSessionFence, SessionEpoch,
-    StoreError,
+    CommandSequence, DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand, JobIrMetadata,
+    LeaseOfferCommandIdentity, ObjectKey, RunnerCommandPayload, RunnerGeneration,
+    RunnerOperationKind, RunnerSessionFence, SessionEpoch, StoreError,
 };
 use sha2::{Digest as _, Sha256};
 

--- a/crates/automata-ci-control/tests/runner_control_support.rs
+++ b/crates/automata-ci-control/tests/runner_control_support.rs
@@ -14,8 +14,10 @@ use automata_ci_blob::{
     BlobDescriptor, BlobPayload, BlobStoreError, ImmutableBlobStore, MemoryBlobStore,
     PutBlobOutcome, VerifiedBlob,
 };
+use automata_ci_control::attempt::RenewLease;
 use automata_ci_control::lease::{
-    AuthenticatedRunnerSession, LeaseClock, LeasePollError, LeasePollOutcome,
+    AuthenticatedRunnerSession, BeginLeaseRequest, BegunLeaseRequest, CompleteLeaseRequest,
+    LeaseClock, LeasePollError, LeasePollOutcome, LeaseRequestCompletion,
     repository::RunnerLeaseRequestRepository,
 };
 use automata_ci_control::runner_control::{
@@ -39,13 +41,11 @@ use automata_ci_protocol::{
     CommandSequence as ProtocolCommandSequence, JobRuntimeAuthorities, LeaseRequest,
 };
 use automata_ci_store::{
-    AcknowledgeRunnerCommands, BeginLeaseRequest, BegunLeaseRequest, CommandCursor,
-    CommandReplayDisposition, CommandReplayLimit, CommandReplayPage, CommandSequence,
-    CompleteLeaseRequest, DurableRunnerCommand, EnqueueRunnerCommand, HeartbeatRunnerSession,
-    JobIrMetadata, LeaseOfferCommandIdentity, LeaseRequestCompletion, OpenRunnerSession,
-    RenewLease, ResumeRunnerSession, RunnerOperationReceipt, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerSessionFence, RunnerSessionSnapshot, StableRunnerSlot,
-    StoreError,
+    AcknowledgeRunnerCommands, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
+    CommandReplayPage, CommandSequence, DurableRunnerCommand, EnqueueRunnerCommand,
+    HeartbeatRunnerSession, JobIrMetadata, LeaseOfferCommandIdentity, OpenRunnerSession,
+    ResumeRunnerSession, RunnerOperationReceipt, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerSessionFence, RunnerSessionSnapshot, StableRunnerSlot, StoreError,
 };
 
 #[derive(Debug, Default)]

--- a/crates/automata-ci-postgres/Cargo.toml
+++ b/crates/automata-ci-postgres/Cargo.toml
@@ -29,7 +29,7 @@ required-features = ["test-support"]
 async-trait.workspace = true
 automata-ci-auth.workspace = true
 automata-ci-blob.workspace = true
-automata-ci-control.workspace = true
+automata-ci-control = { workspace = true, features = ["adapter-spi"] }
 automata-ci-core.workspace = true
 automata-ci-key-management.workspace = true
 automata-ci-oidc-github.workspace = true

--- a/crates/automata-ci-postgres/src/store/admission.rs
+++ b/crates/automata-ci-postgres/src/store/admission.rs
@@ -1,4 +1,8 @@
 use async_trait::async_trait;
+use automata_ci_control::cancellation::{
+    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor,
+    CancellationReason, RequestCancellation,
+};
 use automata_ci_core::{
     AttemptId, FencingToken, JOB_IR_SCHEMA_VERSION, LeaseGuard, LeaseId, OperationId,
     RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId, RunnerId, RunnerSessionId, UnixMillis, WorkflowId,
@@ -13,13 +17,12 @@ use super::{
     github_checks::{GithubJobCheckInsertError, insert_github_job_check_subject},
 };
 use automata_ci_store::{
-    AdmissionObject, AdmitWorkflowRun, CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA,
-    CancelJobCommandPayload, CancellationActor, CancellationReason, DocumentSchema,
-    EnqueueRunnerCommand, RepositoryId, RequestCancellation, RunReconciliation,
-    RunReconciliationRepository, RunnerCommandPayload, RunnerGeneration, RunnerOperationKind,
-    RunnerProtocolVersion, RunnerSessionFence, SessionEpoch, StoreError, WORKFLOW_ADMISSION_EPOCH,
-    WORKFLOW_PLAN_SCHEMA, WorkflowAdmissionReceipt, WorkflowAdmissionRepository,
-    WorkflowAdmissionStoreError, WorkflowConcurrency, WorkflowRunStatus, WorkflowSnapshotId,
+    AdmissionObject, AdmitWorkflowRun, DocumentSchema, EnqueueRunnerCommand, RepositoryId,
+    RunReconciliation, RunReconciliationRepository, RunnerCommandPayload, RunnerGeneration,
+    RunnerOperationKind, RunnerProtocolVersion, RunnerSessionFence, SessionEpoch, StoreError,
+    WORKFLOW_ADMISSION_EPOCH, WORKFLOW_PLAN_SCHEMA, WorkflowAdmissionReceipt,
+    WorkflowAdmissionRepository, WorkflowAdmissionStoreError, WorkflowConcurrency,
+    WorkflowRunStatus, WorkflowSnapshotId,
 };
 
 const CONCURRENCY_CANCELLATION_ACTOR: &str = "automata.concurrency";

--- a/crates/automata-ci-postgres/src/store/g1.rs
+++ b/crates/automata-ci-postgres/src/store/g1.rs
@@ -3,7 +3,20 @@ use std::collections::BTreeSet;
 use async_trait::async_trait;
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
 use automata_ci_control::{
+    adapter_spi::{
+        BlockedAttempt, BlockedAttemptRepository, BlockedConclusion, ConcludeBlockedAttempt,
+    },
+    attempt::RenewLease,
+    cancellation::{
+        CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+        CancellationActor, CancellationIntent, CancellationReason, CancellationRepository,
+        DEFAULT_CANCELLATION_REASON, RequestCancellation,
+    },
     lease::{
+        BeginLeaseRequest, BegunLeaseRequest, ClaimRejection, ClaimedAttempt, CompleteLeaseRequest,
+        LeaseRequestCompletion, LeaseRequestKey, NoWorkLeaseRequest, RevokedLeaseOfferFallback,
+        RunnableAttempt, RunnableQueueKey, RunnableScanLimit, RunnableScanPage,
+        RunnableScanRequest, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
         repository::{
             RunnableAttemptRepository, RunnerClaimRepository, RunnerLeaseRequestRepository,
         },
@@ -42,23 +55,16 @@ use uuid::Uuid;
 
 use super::{PostgresStore, RunnerPayloadEncryption, lifecycle_name, parse_lifecycle};
 use automata_ci_store::{
-    AcknowledgeRunnerCommands, AttemptAssignment, AttemptStoreError, BeginLeaseRequest,
-    BegunLeaseRequest, BlockedAttempt, BlockedAttemptRepository, BlockedConclusion,
-    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor,
-    CancellationIntent, CancellationReason, CancellationRepository, ClaimRejection, ClaimedAttempt,
-    CloseRunnerSession, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
-    CommandReplayPage, CommandSequence, CompleteLeaseRequest, ConcludeBlockedAttempt,
-    DEFAULT_CANCELLATION_REASON, DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand,
+    AcknowledgeRunnerCommands, AttemptAssignment, AttemptStoreError, CloseRunnerSession,
+    CommandCursor, CommandReplayDisposition, CommandReplayLimit, CommandReplayPage,
+    CommandSequence, DocumentSchema, DurableRunnerCommand, EnqueueRunnerCommand,
     HeartbeatRunnerSession, JobDependency, JobIrMetadata, LeaseOfferCommandIdentity,
-    LeaseRequestCompletion, LeaseRequestKey, MAX_COMMAND_REPLAY_BYTES, MAX_COMMAND_REPLAY_LIMIT,
-    NoWorkLeaseRequest, ObjectKey, OpenRunnerSession, RequestCancellation, ResumeRunnerSession,
-    RevokedLeaseOfferFallback, RoutingDocument, RoutingLabel, RunnableAttempt, RunnableQueueKey,
-    RunnableScanLimit, RunnableScanPage, RunnableScanRequest, RunnerCommandPayload,
-    RunnerGeneration, RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerPayloadTombstone, RunnerPayloadTombstoneReason,
-    RunnerProtocolVersion, RunnerSessionFence, RunnerSessionSnapshot, RunnerSlotCount,
-    SessionEpoch, StableRunnerSlot, StoreError, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
-    WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository,
+    MAX_COMMAND_REPLAY_BYTES, MAX_COMMAND_REPLAY_LIMIT, ObjectKey, OpenRunnerSession,
+    ResumeRunnerSession, RoutingDocument, RoutingLabel, RunnerCommandPayload, RunnerGeneration,
+    RunnerOperationKind, RunnerOperationReceipt, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerPayloadTombstone, RunnerPayloadTombstoneReason, RunnerProtocolVersion,
+    RunnerSessionFence, RunnerSessionSnapshot, RunnerSlotCount, SessionEpoch, StableRunnerSlot,
+    StoreError, WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository,
 };
 
 const LEASE_OPERATION_KIND: &str = "automata.lease-request.v1";
@@ -1802,9 +1808,9 @@ impl RunnerControlTransactionRepository for PostgresStore {
 
     async fn authorize_lease_renewal(
         &self,
-        request: automata_ci_store::RenewLease,
+        request: RenewLease,
         reported_lifecycle: JobLifecycle,
-    ) -> Result<automata_ci_store::RenewLease, StoreError> {
+    ) -> Result<RenewLease, StoreError> {
         let mut transaction = self.pool.begin().await.map_err(operation_error)?;
         super::pin_runner_attempt_read_committed(&mut transaction).await?;
         let authorized = super::authorize_lease_renewal_in_transaction(
@@ -2320,7 +2326,7 @@ async fn apply_lease_response(
 
 async fn require_live_renewal_attempt(
     transaction: &mut Transaction<'_, Postgres>,
-    renewal: automata_ci_store::RenewLease,
+    renewal: RenewLease,
 ) -> Result<UnixMillis, StoreError> {
     let session = renewal.session();
     let row = sqlx::query(
@@ -2371,7 +2377,7 @@ async fn require_live_renewal_attempt(
 
 async fn commit_reported_lifecycle(
     transaction: &mut Transaction<'_, Postgres>,
-    renewal: automata_ci_store::RenewLease,
+    renewal: RenewLease,
     reported: JobLifecycle,
     decision_now: UnixMillis,
 ) -> Result<(), StoreError> {
@@ -4432,7 +4438,7 @@ fn decode_receipt_lease_offer_completion(
             Some(fallback_schema),
             Some(fallback_digest),
         ) => {
-            let fallback = automata_ci_store::adapter_spi::revoked_lease_offer_fallback(
+            let fallback = automata_ci_control::adapter_spi::revoked_lease_offer_fallback(
                 u16::try_from(fallback_version).map_err(|_| {
                     StoreError::corrupt_data(
                         "runner RPC receipt fallback version is outside the durable range",
@@ -5697,7 +5703,7 @@ impl RunnerClaimRepository for PostgresStore {
 
     async fn try_claim(&self, mut request: TryClaimAttempt) -> Result<TryClaimReceipt, StoreError> {
         let caller_observed_at = request.observed_at();
-        let cursor = automata_ci_store::adapter_spi::try_claim_attempt_cursor(&request);
+        let cursor = automata_ci_control::adapter_spi::try_claim_attempt_cursor(&request);
         let requested_duration =
             super::runner_attempt_requested_duration(request.observed_at(), request.expires_at())?;
         let digest = request.request_digest();
@@ -5783,7 +5789,7 @@ impl RunnerClaimRepository for PostgresStore {
         request: NoWorkLeaseRequest,
     ) -> Result<TryClaimReceipt, StoreError> {
         let request_key = request.request_key();
-        let cursor = automata_ci_store::adapter_spi::no_work_lease_request_cursor(&request);
+        let cursor = automata_ci_control::adapter_spi::no_work_lease_request_cursor(&request);
         let digest = request_key.request_digest();
         let mut transaction = self.pool.begin().await.map_err(operation_error)?;
         super::pin_runner_attempt_read_committed(&mut transaction).await?;
@@ -7352,7 +7358,7 @@ async fn cleanup_disconnected_runner_lease_request_state(
 
 async fn advance_scan_cursor(
     transaction: &mut Transaction<'_, Postgres>,
-    cursor: automata_ci_store::adapter_spi::RunnableCursorView,
+    cursor: automata_ci_control::adapter_spi::RunnableCursorView,
     routing: &LockedRouting,
     observed_at: UnixMillis,
 ) -> Result<Option<u64>, StoreError> {
@@ -7440,7 +7446,7 @@ fn rebase_claim_request(
 ) -> Result<(), StoreError> {
     let database_expires_at =
         super::runner_attempt_database_expiry(database_now, requested_duration)?;
-    *request = automata_ci_store::adapter_spi::rebase_try_claim_attempt(
+    *request = automata_ci_control::adapter_spi::rebase_try_claim_attempt(
         request,
         database_now,
         database_expires_at,

--- a/crates/automata-ci-postgres/src/store/maintenance.rs
+++ b/crates/automata-ci-postgres/src/store/maintenance.rs
@@ -1,15 +1,18 @@
 use async_trait::async_trait;
+use automata_ci_control::{
+    adapter_spi::{BlockedAttemptRepository, BlockedConclusion, ConcludeBlockedAttempt},
+    lease::RunnableScanLimit,
+    maintenance::{
+        ControlPlaneMaintenanceReport, ControlPlaneMaintenanceRepository,
+        ControlPlaneMaintenanceRequest, ExpiredAttemptDisposition, ExpiredAttemptMaintenance,
+    },
+};
 use automata_ci_core::{AttemptId, JobLifecycle, RunId};
 use sqlx::{Postgres, Row as _, Transaction};
 use uuid::Uuid;
 
 use super::{PostgresStore, parse_lifecycle};
-use automata_ci_store::{
-    BlockedAttemptRepository, BlockedConclusion, ConcludeBlockedAttempt,
-    ControlPlaneMaintenanceReport, ControlPlaneMaintenanceRepository,
-    ControlPlaneMaintenanceRequest, ExpiredAttemptDisposition, ExpiredAttemptMaintenance,
-    RunnableScanLimit, RunnerPayloadTombstoneReason, StoreError,
-};
+use automata_ci_store::{RunnerPayloadTombstoneReason, StoreError};
 
 #[async_trait]
 impl ControlPlaneMaintenanceRepository for PostgresStore {
@@ -38,7 +41,7 @@ impl ControlPlaneMaintenanceRepository for PostgresStore {
         }
 
         Ok(
-            automata_ci_store::adapter_spi::control_plane_maintenance_report(
+            automata_ci_control::adapter_spi::control_plane_maintenance_report(
                 expired_attempts,
                 skipped_blocked_attempts,
                 closed_stale_sessions,
@@ -144,7 +147,7 @@ async fn reap_expired_attempt(
     .await?;
     transaction.commit().await.map_err(StoreError::operation)?;
     Ok(Some(
-        automata_ci_store::adapter_spi::expired_attempt_maintenance(
+        automata_ci_control::adapter_spi::expired_attempt_maintenance(
             attempt_id,
             mutation.disposition,
             reconciliation,

--- a/crates/automata-ci-postgres/src/store/mod.rs
+++ b/crates/automata-ci-postgres/src/store/mod.rs
@@ -2,6 +2,13 @@ use std::{fmt, net::IpAddr, str::FromStr as _, sync::Arc};
 
 use async_trait::async_trait;
 use automata_ci_auth::authorization::{OutputVisibility, SecretExposureClass};
+use automata_ci_control::{
+    adapter_spi::{
+        AcquireLease, AttemptSnapshot, ConcludeQueuedAttempt, InternalAttemptRepository,
+        QueuedAttempt, TenantAttemptQuery, TransitionAttempt,
+    },
+    attempt::RenewLease,
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, IdentifierError, JobAuthorityProfile, JobId,
     JobLifecycle, Lease, LeaseGuard, LeaseId, RunnerId, RunnerSessionId, UnixMillis,
@@ -16,10 +23,8 @@ use uuid::Uuid;
 
 use crate::migration::MIGRATOR;
 use automata_ci_store::{
-    AcquireLease, AttemptAssignment, AttemptSnapshot, AttemptSnapshotError, AttemptStoreError,
-    ConcludeQueuedAttempt, InternalAttemptRepository, QueuedAttempt, RenewLease, RunnerGeneration,
-    RunnerSessionFence, SessionEpoch, StableRunnerSlot, TenantAttemptQuery, TenantScope,
-    TransitionAttempt,
+    AttemptAssignment, AttemptSnapshotError, AttemptStoreError, RunnerGeneration,
+    RunnerSessionFence, SessionEpoch, StableRunnerSlot, TenantScope,
 };
 
 mod admission;

--- a/crates/automata-ci-postgres/src/store/observability.rs
+++ b/crates/automata-ci-postgres/src/store/observability.rs
@@ -1,4 +1,15 @@
 use async_trait::async_trait;
+use automata_ci_control::observability::{
+    ArtifactCounts, ArtifactReservationKind, ArtifactReservations, ArtifactState,
+    BuiltinSecretCleanupCounts, BuiltinSecretCleanupStatus, ControlPlaneCapacityCandidate,
+    ControlPlaneCapacityRunner, ControlPlaneStateRepository, ControlPlaneStateSnapshot,
+    ControlPlaneStateSnapshotRequest, DatabasePoolSnapshot, JobAttemptCounts, LeaseCounts,
+    LeaseState, LogicalActivationCounts, LogicalActivationState, LogicalJobCounts, LogicalJobState,
+    LogicalWorkflowRunCounts, LogicalWorkflowRunState, MAX_CONTROL_PLANE_CAPACITY_CANDIDATES,
+    MAX_CONTROL_PLANE_CAPACITY_RUNNERS, MAX_CONTROL_PLANE_CAPACITY_SLOTS_PER_RUNNER, RunnerCounts,
+    RunnerDesiredState, RunnerObservedState, RunnerSessionCounts, RunnerSessionState,
+    WorkflowRunCounts,
+};
 use automata_ci_core::{
     AttemptId, JOB_IR_SCHEMA_VERSION, JobId, JobLifecycle, RunnerCapabilities, RunnerId,
     RunnerRequirements, RunnerSessionId, UnixMillis,
@@ -8,16 +19,8 @@ use uuid::Uuid;
 
 use super::PostgresStore;
 use automata_ci_store::{
-    ArtifactCounts, ArtifactReservationKind, ArtifactReservations, ArtifactState,
-    BuiltinSecretCleanupCounts, BuiltinSecretCleanupStatus, ControlPlaneCapacityCandidate,
-    ControlPlaneCapacityRunner, ControlPlaneStateRepository, ControlPlaneStateSnapshot,
-    ControlPlaneStateSnapshotRequest, DatabasePoolSnapshot, JobAttemptCounts, LeaseCounts,
-    LeaseState, LogicalActivationCounts, LogicalActivationState, LogicalJobCounts, LogicalJobState,
-    LogicalWorkflowRunCounts, LogicalWorkflowRunState, MAX_CONTROL_PLANE_CAPACITY_CANDIDATES,
-    MAX_CONTROL_PLANE_CAPACITY_RUNNERS, MAX_CONTROL_PLANE_CAPACITY_SLOTS_PER_RUNNER, RoutingLabel,
-    RunnerCounts, RunnerDesiredState, RunnerGeneration, RunnerObservedState, RunnerSessionCounts,
-    RunnerSessionFence, RunnerSessionState, RunnerSlotCount, SessionEpoch, StableRunnerSlot,
-    StoreError, WORKFLOW_ADMISSION_EPOCH, WorkflowRunCounts, WorkflowRunStatus,
+    RoutingLabel, RunnerGeneration, RunnerSessionFence, RunnerSlotCount, SessionEpoch,
+    StableRunnerSlot, StoreError, WORKFLOW_ADMISSION_EPOCH, WorkflowRunStatus,
 };
 
 const STATE_TRANSACTION_MODE: &str = "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY";

--- a/crates/automata-ci-postgres/src/store/protected_environment.rs
+++ b/crates/automata-ci-postgres/src/store/protected_environment.rs
@@ -3,17 +3,20 @@
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
+use automata_ci_control::cancellation::{
+    CancellationActor, CancellationReason, RequestCancellation,
+};
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Row as _, Transaction, postgres::PgRow};
 use uuid::Uuid;
 
 use automata_ci_store::{
-    BindLeasedJobSecrets, CancellationActor, CancellationReason, DeploymentEnvironmentName,
-    EnvironmentReviewDecision, InspectLeasedJobSecretBindings, IssueLeasedJobSecretGrants,
-    IssuedLeasedJobSecretBinding, JobEnvironmentActivationEvidence, JobEnvironmentGatePhase,
-    JobEnvironmentGateSnapshot, JobEnvironmentGateState, JobEventTrust, JobSourceKind,
-    PrepareJobEnvironment, ProtectedEnvironmentRepository, ProtectedEnvironmentStoreError,
-    RequestCancellation, ReusableSecretPermission, ReviewJobEnvironment, StoreError, TenantScope,
+    BindLeasedJobSecrets, DeploymentEnvironmentName, EnvironmentReviewDecision,
+    InspectLeasedJobSecretBindings, IssueLeasedJobSecretGrants, IssuedLeasedJobSecretBinding,
+    JobEnvironmentActivationEvidence, JobEnvironmentGatePhase, JobEnvironmentGateSnapshot,
+    JobEnvironmentGateState, JobEventTrust, JobSourceKind, PrepareJobEnvironment,
+    ProtectedEnvironmentRepository, ProtectedEnvironmentStoreError, ReusableSecretPermission,
+    ReviewJobEnvironment, StoreError, TenantScope,
 };
 
 use super::{PostgresStore, secret_management::authorize_human_repository_action};

--- a/crates/automata-ci-postgres/src/store/server_cancellation_terminal.rs
+++ b/crates/automata-ci-postgres/src/store/server_cancellation_terminal.rs
@@ -1,8 +1,9 @@
 use sqlx::{Postgres, Row as _, Transaction};
 
+use automata_ci_control::cancellation::{CancellationReason, RequestCancellation};
 use automata_ci_core::AttemptId;
 
-use automata_ci_store::{RequestCancellation, StoreError};
+use automata_ci_store::StoreError;
 
 pub(super) async fn server_cancellation_terminal_exists(
     transaction: &mut Transaction<'_, Postgres>,
@@ -59,11 +60,7 @@ pub(super) async fn insert_queued_server_cancellation_terminal(
     .bind(request.attempt_id().as_uuid())
     .bind(request.operation_id().as_uuid())
     .bind(request.actor().as_str())
-    .bind(
-        request
-            .reason()
-            .map(automata_ci_store::CancellationReason::as_str),
-    )
+    .bind(request.reason().map(CancellationReason::as_str))
     .bind(request.requested_at().get())
     .execute(&mut **transaction)
     .await
@@ -117,11 +114,7 @@ pub(super) async fn verify_queued_server_cancellation_terminal(
     .bind(request.attempt_id().as_uuid())
     .bind(request.operation_id().as_uuid())
     .bind(request.actor().as_str())
-    .bind(
-        request
-            .reason()
-            .map(automata_ci_store::CancellationReason::as_str),
-    )
+    .bind(request.reason().map(CancellationReason::as_str))
     .bind(request.requested_at().get())
     .fetch_optional(&mut **transaction)
     .await

--- a/crates/automata-ci-postgres/tests/store/execution/attempts.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/attempts.rs
@@ -5,13 +5,18 @@ use std::{
 };
 
 use crate::support::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+use automata_ci_control::{
+    adapter_spi::{
+        AcquireLease, ConcludeQueuedAttempt, InternalAttemptRepository as _, QueuedAttempt,
+        TenantAttemptQuery as _, TransitionAttempt,
+    },
+    attempt::RenewLease,
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, JobId, JobLifecycle, LeaseGuard, LeaseId, UnixMillis,
 };
 use automata_ci_store::{
-    AcquireLease, AttemptCommandError, AttemptStoreError, ConcludeQueuedAttempt,
-    InternalAttemptRepository as _, QueuedAttempt, RenewLease, RunnerSessionFence,
-    StableRunnerSlot, TenantAttemptQuery as _, TenantScope, TransitionAttempt,
+    AttemptCommandError, AttemptStoreError, RunnerSessionFence, StableRunnerSlot, TenantScope,
 };
 
 const LIVE_LEASE_MILLIS: i64 = 60_000;

--- a/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
@@ -3,9 +3,17 @@ use crate::support::{
     seed_control_plane,
 };
 use automata_ci_control::{
-    lease::repository::{
-        RunnableAttemptRepository as _, RunnerClaimRepository as _,
-        RunnerLeaseRequestRepository as _,
+    cancellation::{
+        CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+        CancellationRepository as _,
+    },
+    lease::{
+        BeginLeaseRequest, LeaseRequestKey, RunnableScanLimit, RunnableScanRequest,
+        TryClaimAttempt, TryClaimOutcome,
+        repository::{
+            RunnableAttemptRepository as _, RunnerClaimRepository as _,
+            RunnerLeaseRequestRepository as _,
+        },
     },
     runner_control::{
         durable::{CommitCommandAcknowledgement, RunnerControlTransactionRepository as _},
@@ -19,14 +27,12 @@ use automata_ci_core::{
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, AdmissionObject, AdmissionRepository, AdmitWorkflowRun,
-    AdmittedWorkflowJob, BeginLeaseRequest, CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA,
-    CancelJobCommandPayload, CancellationRepository as _, CommandCursor, CommandReplayLimit,
-    DocumentSchema, HumanRunScope, HumanWorkflowReadRepository as _, LeaseRequestKey, ObjectKey,
-    OpenRunnerSession, RepositoryId, RoutingDocument, RunnableScanLimit, RunnableScanRequest,
+    AdmittedWorkflowJob, CommandCursor, CommandReplayLimit, DocumentSchema, HumanRunScope,
+    HumanWorkflowReadRepository as _, ObjectKey, OpenRunnerSession, RepositoryId, RoutingDocument,
     RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, TryClaimAttempt,
-    TryClaimOutcome, WorkflowAdmissionIdempotency, WorkflowAdmissionRepository as _,
-    WorkflowAdmissionStoreError, WorkflowConcurrency, WorkflowSnapshotId,
+    RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowAdmissionRepository as _, WorkflowAdmissionStoreError, WorkflowConcurrency,
+    WorkflowSnapshotId,
 };
 
 const GROUP: &str = "deploy-main";

--- a/crates/automata-ci-postgres/tests/store/execution/g1.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/g1.rs
@@ -1,5 +1,16 @@
 use automata_ci_control::{
+    adapter_spi::{
+        BlockedAttemptRepository as _, BlockedConclusion, ConcludeBlockedAttempt,
+        InternalAttemptRepository as _, QueuedAttempt, TransitionAttempt,
+    },
+    cancellation::{
+        CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+        CancellationActor, CancellationReason, CancellationRepository as _, RequestCancellation,
+    },
     lease::{
+        BeginLeaseRequest, ClaimRejection, ClaimedAttempt, LeaseRequestKey, NoWorkLeaseRequest,
+        RunnableAttempt, RunnableScanLimit, RunnableScanPage, RunnableScanRequest, TryClaimAttempt,
+        TryClaimOutcome, TryClaimReceipt,
         repository::{
             RunnableAttemptRepository as _, RunnerClaimRepository as _,
             RunnerLeaseRequestRepository as _,
@@ -21,17 +32,11 @@ use automata_ci_core::{
 };
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
-    AcknowledgeRunnerCommands, BeginLeaseRequest, BlockedAttemptRepository as _, BlockedConclusion,
-    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor,
-    CancellationReason, CancellationRepository as _, ClaimRejection, CloseRunnerSession,
-    CommandCursor, CommandReplayLimit, CommandSequence, ConcludeBlockedAttempt, DocumentSchema,
-    EnqueueRunnerCommand, HeartbeatRunnerSession, InternalAttemptRepository as _, JobDependency,
-    LeaseRequestKey, MAX_COMMAND_REPLAY_BYTES, NoWorkLeaseRequest, OpenRunnerSession,
-    QueuedAttempt, RequestCancellation, ResumeRunnerSession, RunnableScanLimit,
-    RunnableScanRequest, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot, StoreError,
-    TransitionAttempt, TryClaimAttempt, TryClaimOutcome, WORKFLOW_ADMISSION_EPOCH,
-    WorkflowPlanRepository as _,
+    AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
+    CommandSequence, DocumentSchema, EnqueueRunnerCommand, HeartbeatRunnerSession, JobDependency,
+    MAX_COMMAND_REPLAY_BYTES, OpenRunnerSession, ResumeRunnerSession, RunnerGeneration,
+    RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
+    StableRunnerSlot, StoreError, WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository as _,
 };
 
 use crate::support::{
@@ -603,7 +608,7 @@ async fn lease_poll_receipts_replay_selection_and_no_work_before_rescheduling() 
             runnable
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             vec![attempt_b],
             "the original selection is no longer a runnable candidate"
@@ -708,7 +713,7 @@ async fn runnable_scan_is_authoritatively_tenant_scoped() -> TestResult {
             first_page
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             vec![first_attempt]
         );
@@ -722,7 +727,7 @@ async fn runnable_scan_is_authoritatively_tenant_scoped() -> TestResult {
             second_page
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             vec![second_attempt]
         );
@@ -759,7 +764,7 @@ async fn bounded_cursor_progresses_past_more_than_one_page_of_incompatible_work(
             first
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             incompatible_attempts[..2]
         );
@@ -775,7 +780,7 @@ async fn bounded_cursor_progresses_past_more_than_one_page_of_incompatible_work(
             second
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             incompatible_attempts[2..]
         );
@@ -1746,7 +1751,7 @@ async fn runnable_scan_and_claim_recheck_run_dag_cancellation_and_concurrency() 
             runnable
                 .candidates()
                 .iter()
-                .map(automata_ci_store::RunnableAttempt::attempt_id)
+                .map(RunnableAttempt::attempt_id)
                 .collect::<Vec<_>>(),
             vec![prerequisite_attempt]
         );
@@ -2528,7 +2533,7 @@ async fn scan(
     database: &TestDatabase,
     fence: automata_ci_store::RunnerSessionFence,
     slot: u16,
-) -> TestResult<automata_ci_store::RunnableScanPage> {
+) -> TestResult<RunnableScanPage> {
     scan_with_limit(database, fence, slot, 10).await
 }
 
@@ -2537,7 +2542,7 @@ async fn scan_with_limit(
     fence: automata_ci_store::RunnerSessionFence,
     slot: u16,
     limit: u16,
-) -> TestResult<automata_ci_store::RunnableScanPage> {
+) -> TestResult<RunnableScanPage> {
     let observed_at = database_now(database).await?;
     Ok(database
         .store()
@@ -2554,8 +2559,8 @@ async fn record_page_no_work(
     database: &TestDatabase,
     fence: automata_ci_store::RunnerSessionFence,
     slot: u16,
-    page: &automata_ci_store::RunnableScanPage,
-) -> TestResult<automata_ci_store::TryClaimReceipt> {
+    page: &RunnableScanPage,
+) -> TestResult<TryClaimReceipt> {
     let request_key =
         LeaseRequestKey::first(fence, OperationId::new(), StableRunnerSlot::new(slot)?);
     begin_isolated_lease_request(database, request_key).await?;
@@ -2586,7 +2591,7 @@ async fn fresh_claim_from_page(
     database: &TestDatabase,
     request_key: LeaseRequestKey,
     attempt_id: AttemptId,
-    page: &automata_ci_store::RunnableScanPage,
+    page: &RunnableScanPage,
 ) -> TestResult<TryClaimAttempt> {
     let observed_at = database_now(database).await?;
     Ok(TryClaimAttempt::new(
@@ -2838,7 +2843,7 @@ async fn insert_job_with_requirements(
 async fn transition_path(
     database: &TestDatabase,
     attempt_id: AttemptId,
-    claimed: &automata_ci_store::ClaimedAttempt,
+    claimed: &ClaimedAttempt,
     path: &[JobLifecycle],
 ) -> TestResult {
     let first_observed_at = database_now(database).await?;
@@ -2860,7 +2865,7 @@ async fn transition_path(
 async fn claim_success(
     database: &TestDatabase,
     request: TryClaimAttempt,
-) -> TestResult<automata_ci_store::ClaimedAttempt> {
+) -> TestResult<ClaimedAttempt> {
     let receipt = database.store().try_claim(request).await?;
     match receipt.outcome() {
         TryClaimOutcome::Claimed(claimed) => Ok(claimed.as_ref().clone()),

--- a/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
@@ -1,7 +1,17 @@
 use automata_ci_control::{
-    lease::repository::{
-        RunnableAttemptRepository as _, RunnerClaimRepository as _,
-        RunnerLeaseRequestRepository as _,
+    adapter_spi::{AcquireLease, InternalAttemptRepository as _, QueuedAttempt, TransitionAttempt},
+    lease::{
+        BeginLeaseRequest, CompleteLeaseRequest, LeaseRequestKey, NoWorkLeaseRequest,
+        RunnableScanLimit, RunnableScanRequest, TryClaimOutcome,
+        repository::{
+            RunnableAttemptRepository as _, RunnerClaimRepository as _,
+            RunnerLeaseRequestRepository as _,
+        },
+    },
+    maintenance::{
+        ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest,
+        ExpiredAttemptDisposition, LeaseFailureLimit, MaintenanceBatchSize,
+        StaleSessionTimeoutMillis,
     },
     runner_control::repository::RunnerSessionRepository as _,
 };
@@ -10,14 +20,10 @@ use automata_ci_core::{
     RunId, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
 };
 use automata_ci_store::{
-    AcquireLease, BeginLeaseRequest, CommandCursor, CompleteLeaseRequest,
-    ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
-    ExpiredAttemptDisposition, HeartbeatRunnerSession, InternalAttemptRepository as _,
-    JobDependency, LeaseFailureLimit, LeaseRequestKey, MaintenanceBatchSize, NoWorkLeaseRequest,
-    OpenRunnerSession, QueuedAttempt, RunReconciliationRepository as _, RunnableScanLimit,
-    RunnableScanRequest, RunnerGeneration, RunnerOperationResponse, RunnerProtocolVersion,
-    StableRunnerSlot, StaleSessionTimeoutMillis, TransitionAttempt, TryClaimOutcome,
-    WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository as _, WorkflowRunStatus,
+    CommandCursor, DocumentSchema, HeartbeatRunnerSession, JobDependency, OpenRunnerSession,
+    RunReconciliationRepository as _, RunnerGeneration, RunnerOperationResponse,
+    RunnerProtocolVersion, StableRunnerSlot, WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository as _,
+    WorkflowRunStatus,
 };
 use std::time::Duration;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
@@ -8,9 +8,20 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_control::{
-    lease::repository::{
-        RunnableAttemptRepository as _, RunnerClaimRepository as _,
-        RunnerLeaseRequestRepository as _,
+    adapter_spi::{AcquireLease, InternalAttemptRepository as _, QueuedAttempt},
+    attempt::RenewLease,
+    lease::{
+        BeginLeaseRequest, CompleteLeaseRequest, LeaseRequestCompletion, LeaseRequestKey,
+        RevokedLeaseOfferFallback, RunnableCursorAdvance, RunnableScanLimit, RunnableScanRequest,
+        TryClaimAttempt, TryClaimOutcome,
+        repository::{
+            RunnableAttemptRepository as _, RunnerClaimRepository as _,
+            RunnerLeaseRequestRepository as _,
+        },
+    },
+    maintenance::{
+        ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, LeaseFailureLimit,
+        MaintenanceBatchSize, StaleSessionTimeoutMillis,
     },
     runner_control::{
         durable::{
@@ -30,16 +41,12 @@ use automata_ci_key_management::{
 };
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
-    AcquireLease, AttemptStoreError, BeginLeaseRequest, CommandCursor, CommandReplayDisposition,
-    CommandReplayLimit, CommandSequence, CompleteLeaseRequest,
-    ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
-    EnqueueRunnerCommand, GITHUB_AUTHORITY_PROVIDER_CLOCK_SKEW_MILLIS, HeartbeatRunnerSession,
-    InternalAttemptRepository as _, JobIrMetadata, LeaseFailureLimit, LeaseOfferCommandIdentity,
-    LeaseRequestCompletion, LeaseRequestKey, MaintenanceBatchSize, OpenRunnerSession,
-    QueuedAttempt, RenewLease, ResumeRunnerSession, RevokedLeaseOfferFallback, RunnableScanLimit,
-    RunnableScanRequest, RunnerCommandPayload, RunnerOperationKind, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot, StaleSessionTimeoutMillis,
-    StoreError, TryClaimAttempt, TryClaimOutcome,
+    AttemptStoreError, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
+    CommandSequence, DocumentSchema, EnqueueRunnerCommand,
+    GITHUB_AUTHORITY_PROVIDER_CLOCK_SKEW_MILLIS, HeartbeatRunnerSession, JobIrMetadata,
+    LeaseOfferCommandIdentity, OpenRunnerSession, ResumeRunnerSession, RunnerCommandPayload,
+    RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
+    StableRunnerSlot, StoreError,
 };
 use sqlx::PgPool;
 use tokio::sync::Semaphore;
@@ -2371,7 +2378,7 @@ async fn stale_session_close_rereads_a_heartbeat_after_waiting_for_its_lock() ->
 struct PreparedClaim {
     attempt_id: AttemptId,
     request_key: LeaseRequestKey,
-    cursor: automata_ci_store::RunnableCursorAdvance,
+    cursor: RunnableCursorAdvance,
     duration_millis: i64,
 }
 

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -1,8 +1,22 @@
 use automata_ci_auth::{authorization::SecretExposureClass, human::TenantId};
 use automata_ci_control::{
-    lease::repository::{
-        RunnableAttemptRepository as _, RunnerClaimRepository as _,
-        RunnerLeaseRequestRepository as _,
+    adapter_spi::{InternalAttemptRepository as _, QueuedAttempt},
+    attempt::RenewLease,
+    cancellation::{
+        CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload,
+        CancellationActor, CancellationReason, CancellationRepository as _, RequestCancellation,
+    },
+    lease::{
+        BeginLeaseRequest, CompleteLeaseRequest, LeaseRequestKey, NoWorkLeaseRequest,
+        RunnableScanLimit, RunnableScanRequest, TryClaimAttempt, TryClaimOutcome,
+        repository::{
+            RunnableAttemptRepository as _, RunnerClaimRepository as _,
+            RunnerLeaseRequestRepository as _,
+        },
+    },
+    maintenance::{
+        ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, LeaseFailureLimit,
+        MaintenanceBatchSize, StaleSessionTimeoutMillis,
     },
     runner_control::{
         durable::{
@@ -23,17 +37,10 @@ use automata_ci_core::{
     LeaseId, LogSequence, LogStreamId, OperationId, Sha256Digest, UnixMillis,
 };
 use automata_ci_store::{
-    AcknowledgeRunnerCommands, BeginLeaseRequest, CANCEL_JOB_COMMAND_KIND,
-    CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor, CancellationReason,
-    CancellationRepository as _, CloseRunnerSession, CommandCursor, CommandSequence,
-    CompleteLeaseRequest, ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest,
-    DocumentSchema, EnqueueRunnerCommand, InternalAttemptRepository as _, JobIrMetadata,
-    LeaseFailureLimit, LeaseOfferCommandIdentity, LeaseRequestKey, MaintenanceBatchSize,
-    NoWorkLeaseRequest, ObjectKey, OpenRunnerSession, QueuedAttempt, RenewLease,
-    RequestCancellation, RunnableScanLimit, RunnableScanRequest, RunnerCommandPayload,
-    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
-    RunnerProtocolVersion, StableRunnerSlot, StaleSessionTimeoutMillis, StoreError,
-    TryClaimAttempt, TryClaimOutcome,
+    AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandSequence, DocumentSchema,
+    EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity, ObjectKey, OpenRunnerSession,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
+    RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot, StoreError,
 };
 
 use crate::support::{

--- a/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
@@ -1,17 +1,22 @@
 use std::sync::Arc;
 
-use automata_ci_control::runner_control::repository::{
-    RunnerCommandOutbox as _, RunnerOperationReceiptRepository as _, RunnerSessionRepository as _,
+use automata_ci_control::{
+    maintenance::{
+        ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, LeaseFailureLimit,
+        MaintenanceBatchSize, StaleSessionTimeoutMillis,
+    },
+    runner_control::repository::{
+        RunnerCommandOutbox as _, RunnerOperationReceiptRepository as _,
+        RunnerSessionRepository as _,
+    },
 };
 use automata_ci_core::{JobIrVersion, OperationId, RunnerSessionId, Sha256Digest, UnixMillis};
 use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
-    ControlPlaneMaintenanceRepository as _, ControlPlaneMaintenanceRequest, DocumentSchema,
-    EnqueueRunnerCommand, LeaseFailureLimit, MaintenanceBatchSize, OpenRunnerSession,
-    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerOperationRequest,
-    RunnerOperationResponse, RunnerPayloadTombstoneReason, RunnerProtocolVersion,
-    RunnerSessionFence, StaleSessionTimeoutMillis, StoreError,
+    DocumentSchema, EnqueueRunnerCommand, OpenRunnerSession, RunnerCommandPayload,
+    RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
+    RunnerPayloadTombstoneReason, RunnerProtocolVersion, RunnerSessionFence, StoreError,
 };
 
 use crate::support::{

--- a/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
@@ -2,9 +2,13 @@ use crate::github_manifest_fixture;
 
 use std::{collections::BTreeMap, time::Duration};
 
-use automata_ci_control::runner_control::{
-    durable::{CommitLeaseHeartbeat, RunnerControlTransactionRepository as _},
-    repository::RunnerSessionRepository as _,
+use automata_ci_control::{
+    adapter_spi::InternalAttemptRepository as _,
+    attempt::RenewLease,
+    runner_control::{
+        durable::{CommitLeaseHeartbeat, RunnerControlTransactionRepository as _},
+        repository::RunnerSessionRepository as _,
+    },
 };
 use automata_ci_core::{
     Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
@@ -45,8 +49,8 @@ use automata_ci_store::{
     GithubServerServiceAuthorityIdentity, GithubServerServiceAuthorityRepository as _,
     GithubServerServiceJwtIssuer, GithubServerServiceRevision, GithubServerServiceScope,
     GithubSubjectEvidenceRepository as _, InspectGithubRuntimeAuthority,
-    InternalAttemptRepository as _, JobEnvironmentActivationEvidence, JobEventTrust, JobSourceKind,
-    LoadGithubRuntimeAuthority, LogicalActivationObject, LogicalActivationPreparationStore as _,
+    JobEnvironmentActivationEvidence, JobEventTrust, JobSourceKind, LoadGithubRuntimeAuthority,
+    LogicalActivationObject, LogicalActivationPreparationStore as _,
     LogicalActivationPreparationTarget, LogicalActivationRepository as _,
     LogicalActivationWorkerId, LogicalInstanceMaterializationSelectionOutcome,
     LogicalInstanceMaterializationTarget, LogicalJobOrchestrationSelectionOutcome,
@@ -60,7 +64,7 @@ use automata_ci_store::{
     ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
     ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
     QuarantineGithubRuntimeAuthority, ReconcileGithubRuntimeAuthorities,
-    RegisterProviderDeliveryWorkflowInventory, RejectGithubRuntimeAuthorityMint, RenewLease,
+    RegisterProviderDeliveryWorkflowInventory, RejectGithubRuntimeAuthorityMint,
     RetryGithubRuntimeAuthorityMint, RetryGithubRuntimeAuthorityRevocation,
     ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerOperationKind,
     RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot,

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -2,7 +2,12 @@ use crate::github_manifest_fixture;
 
 use std::collections::BTreeMap;
 
-use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
+use automata_ci_control::{
+    cancellation::{
+        CancellationActor, CancellationReason, CancellationRepository as _, RequestCancellation,
+    },
+    runner_control::repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     Architecture, ContextValue, JobAuthorityProfile, JobConclusion, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
@@ -15,8 +20,7 @@ use automata_ci_core::{
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
     AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun, AdmittedLogicalWorkflowJob,
-    AuthenticatedGithubDeliveryClaim, BindLogicalActivationPreparation, CancellationActor,
-    CancellationReason, CancellationRepository as _, ClaimLogicalInstanceResult,
+    AuthenticatedGithubDeliveryClaim, BindLogicalActivationPreparation, ClaimLogicalInstanceResult,
     ClaimNextLogicalInstanceMaterialization, ClaimNextLogicalInstanceResult,
     ClaimNextLogicalJobOrchestration, ClaimProviderDelivery, ClaimedLogicalInstanceMaterialization,
     ClaimedLogicalJobActivation, CommitLogicalInstanceMaterialization, CommitLogicalInstanceResult,
@@ -45,8 +49,8 @@ use automata_ci_store::{
     ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     PublishLogicalJobActivation, QuarantineLogicalInstanceResult,
-    RegisterProviderDeliveryWorkflowInventory, RequestCancellation, ReusableSecretPermission,
-    RoutingDocument, RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, TenantScope,
+    RegisterProviderDeliveryWorkflowInventory, ReusableSecretPermission, RoutingDocument,
+    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, TenantScope,
     WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -3,7 +3,8 @@ use crate::github_manifest_fixture;
 use std::{collections::BTreeMap, time::Duration};
 
 use automata_ci_control::{
-    lease::repository::RunnableAttemptRepository as _,
+    adapter_spi::{InternalAttemptRepository as _, QueuedAttempt},
+    lease::{RunnableScanLimit, RunnableScanRequest, repository::RunnableAttemptRepository as _},
     runner_control::repository::RunnerSessionRepository as _,
 };
 use automata_ci_core::{
@@ -38,7 +39,7 @@ use automata_ci_store::{
     GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
     GithubServerServiceAuthorityRepository as _, GithubServerServiceJwtIssuer,
     GithubServerServiceRevision, GithubServerServiceScope, GithubSubjectEvidenceRepository as _,
-    InternalAttemptRepository as _, JobEnvironmentActivationEvidence, JobEventTrust, JobSourceKind,
+    JobEnvironmentActivationEvidence, JobEventTrust, JobSourceKind,
     LOGICAL_JOB_RESULT_PLAN_MEDIA_TYPE, LogicalActivationObject,
     LogicalActivationPreparationStore as _, LogicalActivationRepository as _,
     LogicalActivationWorkerId, LogicalInstanceMaterializationSelectionOutcome,
@@ -56,14 +57,14 @@ use automata_ci_store::{
     ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
     ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, PublishReusableWorkflowCall, QueuedAttempt,
+    PublishLogicalJobActivation, PublishReusableWorkflowCall,
     RegisterProviderDeliveryWorkflowInventory, ReusableCallOutputMapping, ReusableSecretPermission,
     ReusableWorkflowOperationId, ReusableWorkflowRuntimeRepository as _,
     ReusableWorkflowRuntimeStoreError, RoutingDocument, RunReconciliationRepository as _,
-    RunnableScanLimit, RunnableScanRequest, RunnerGeneration, RunnerProtocolVersion,
-    RunnerSessionFence, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
-    WorkflowAdmissionRepository as _, WorkflowConcurrency, WorkflowPlanRepository as _,
-    WorkflowRunStatus, WorkflowRuntimePolicyPin, WorkflowSnapshotId,
+    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, StableRunnerSlot, StoreError,
+    TenantScope, WorkflowAdmissionIdempotency, WorkflowAdmissionRepository as _,
+    WorkflowConcurrency, WorkflowPlanRepository as _, WorkflowRunStatus, WorkflowRuntimePolicyPin,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;

--- a/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
@@ -8,7 +8,12 @@ use automata_ci_auth::{
     session::SessionId,
     time::UnixTimestamp,
 };
-use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
+use automata_ci_control::{
+    cancellation::{
+        CancellationActor, CancellationReason, CancellationRepository as _, RequestCancellation,
+    },
+    runner_control::repository::RunnerSessionRepository as _,
+};
 use automata_ci_core::{
     Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
     JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
@@ -28,16 +33,15 @@ use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AcknowledgeManagedSecretDelivery,
     ActivatedLogicalInstanceDescriptor, AdmissionObject, AdmissionRepository,
     AdmitLogicalWorkflowRun, AdmittedLogicalWorkflowJob, AuthenticatedGithubDeliveryClaim,
-    BindLogicalActivationPreparation, BuiltinRepositorySecretVersion, CancellationActor,
-    CancellationReason, CancellationRepository as _, ClaimNextLogicalInstanceMaterialization,
-    ClaimNextLogicalJobOrchestration, ClaimProviderDelivery, ClaimedLogicalInstanceMaterialization,
-    ClaimedLogicalJobActivation, CommitLogicalInstanceMaterialization,
-    ConfirmRepositorySecretVersionMutation, ConfirmRepositorySecretVersionMutationOutcome,
-    ConsumeSelectedLogicalInstanceMaterialization, ConsumeSelectedLogicalJobOrchestration,
-    ConsumedLogicalJobOrchestrationAuthority, EnsureGithubServerServiceAuthority,
-    EnvironmentReviewDecision, GithubCheckHeadSha, GithubCheckName, GithubProviderManifest,
-    GithubProviderManifestLimits, GithubProviderManifestRepository as _,
-    GithubProviderManifestRevision, GithubProviderOrigins,
+    BindLogicalActivationPreparation, BuiltinRepositorySecretVersion,
+    ClaimNextLogicalInstanceMaterialization, ClaimNextLogicalJobOrchestration,
+    ClaimProviderDelivery, ClaimedLogicalInstanceMaterialization, ClaimedLogicalJobActivation,
+    CommitLogicalInstanceMaterialization, ConfirmRepositorySecretVersionMutation,
+    ConfirmRepositorySecretVersionMutationOutcome, ConsumeSelectedLogicalInstanceMaterialization,
+    ConsumeSelectedLogicalJobOrchestration, ConsumedLogicalJobOrchestrationAuthority,
+    EnsureGithubServerServiceAuthority, EnvironmentReviewDecision, GithubCheckHeadSha,
+    GithubCheckName, GithubProviderManifest, GithubProviderManifestLimits,
+    GithubProviderManifestRepository as _, GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubRepositoryName, GithubServerServiceAppClientId,
     GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
     GithubServerServiceAuthorityRepository as _, GithubServerServiceJwtIssuer,
@@ -62,12 +66,12 @@ use automata_ci_store::{
     PublishLogicalJobActivation, RegisterProviderDeliveryWorkflowInventory, RepositoryId,
     RepositorySecretId, RepositorySecretManagementRepository as _, RepositorySecretMutationId,
     RepositorySecretName, RepositorySecretProviderMutationResult, RepositorySecretVersionId,
-    RequestCancellation, ReserveRepositorySecretVersionMutation,
-    ReserveRepositorySecretVersionMutationOutcome, ResolveManagedSecretAuthority,
-    ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet, SecretCustodyRepository as _,
-    SecretWorkloadGrantId, StableRunnerSlot, TenantScope, VerifySecretCustody,
-    VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    ReserveRepositorySecretVersionMutation, ReserveRepositorySecretVersionMutationOutcome,
+    ResolveManagedSecretAuthority, ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument,
+    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet,
+    SecretCustodyRepository as _, SecretWorkloadGrantId, StableRunnerSlot, TenantScope,
+    VerifySecretCustody, VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Transaction};

--- a/crates/automata-ci-postgres/tests/store/security/observability.rs
+++ b/crates/automata-ci-postgres/tests/store/security/observability.rs
@@ -2,7 +2,15 @@ use crate::github_manifest_fixture;
 
 use std::time::Duration;
 
-use automata_ci_control::runner_control::repository::RunnerCommandOutbox as _;
+use automata_ci_control::{
+    observability::{
+        ArtifactReservationKind, ArtifactState, BuiltinSecretCleanupStatus,
+        ControlPlaneStateRepository as _, ControlPlaneStateSnapshot,
+        ControlPlaneStateSnapshotRequest, LeaseState, LogicalActivationState, LogicalJobState,
+        LogicalWorkflowRunState, RunnerDesiredState, RunnerObservedState, RunnerSessionState,
+    },
+    runner_control::repository::RunnerCommandOutbox as _,
+};
 use automata_ci_core::{
     Architecture, JobAuthorityProfile, JobId, JobIrVersion, JobLifecycle, OperatingSystem,
     OperationId, RunId, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
@@ -11,19 +19,17 @@ use automata_ci_core::{
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AcknowledgeRunnerCommands,
     AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun, AdmittedLogicalWorkflowJob,
-    ArtifactReservationKind, ArtifactState, AuthenticatedGithubDeliveryClaim,
-    BindLogicalActivationPreparation, BuiltinSecretCleanupStatus, ClaimNextLogicalJobOrchestration,
-    ClaimProviderDelivery, CommandCursor, ConsumeSelectedLogicalJobOrchestration,
-    ConsumedLogicalJobOrchestrationAuthority, ControlPlaneStateRepository as _,
-    ControlPlaneStateSnapshot, ControlPlaneStateSnapshotRequest, DocumentSchema,
-    EnqueueRunnerCommand, EnsureGithubServerServiceAuthority, GithubCheckHeadSha, GithubCheckName,
-    GithubProviderManifest, GithubProviderManifestLimits, GithubProviderManifestRepository as _,
-    GithubProviderManifestRevision, GithubProviderOrigins,
+    AuthenticatedGithubDeliveryClaim, BindLogicalActivationPreparation,
+    ClaimNextLogicalJobOrchestration, ClaimProviderDelivery, CommandCursor,
+    ConsumeSelectedLogicalJobOrchestration, ConsumedLogicalJobOrchestrationAuthority,
+    DocumentSchema, EnqueueRunnerCommand, EnsureGithubServerServiceAuthority, GithubCheckHeadSha,
+    GithubCheckName, GithubProviderManifest, GithubProviderManifestLimits,
+    GithubProviderManifestRepository as _, GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubRepositoryName, GithubServerServiceAppClientId,
     GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
     GithubServerServiceAuthorityRepository as _, GithubServerServiceJwtIssuer,
     GithubServerServiceRevision, GithubServerServiceScope, GithubSubjectEvidenceRepository as _,
-    LeaseState, LogicalActivationPreparationStore as _, LogicalActivationWorkerId,
+    LogicalActivationPreparationStore as _, LogicalActivationWorkerId,
     LogicalJobOrchestrationSelectionOutcome, LogicalWorkSelectionId,
     LogicalWorkSelectionRepository as _, LogicalWorkflowAdmissionRepository as _,
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
@@ -32,9 +38,8 @@ use automata_ci_store::{
     ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
     ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
     ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, RunnerCommandPayload, RunnerDesiredState,
-    RunnerGeneration, RunnerObservedState, RunnerOperationKind, RunnerSessionFence,
-    RunnerSessionState, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
+    RegisterProviderDeliveryWorkflowInventory, RunnerCommandPayload, RunnerGeneration,
+    RunnerOperationKind, RunnerSessionFence, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
     WorkflowAdmissionIdempotency, WorkflowRunStatus, WorkflowSnapshotId,
 };
 use uuid::Uuid;
@@ -201,37 +206,27 @@ fn assert_logical_snapshot(
     assert_eq!(
         snapshot
             .logical_workflow_runs()
-            .get(automata_ci_store::LogicalWorkflowRunState::Active),
+            .get(LogicalWorkflowRunState::Active),
         1
     );
-    assert_eq!(
-        snapshot
-            .logical_jobs()
-            .get(automata_ci_store::LogicalJobState::Pending),
-        1
-    );
-    assert_eq!(
-        snapshot
-            .logical_jobs()
-            .get(automata_ci_store::LogicalJobState::Activating),
-        2
-    );
+    assert_eq!(snapshot.logical_jobs().get(LogicalJobState::Pending), 1);
+    assert_eq!(snapshot.logical_jobs().get(LogicalJobState::Activating), 2);
     assert_eq!(
         snapshot
             .logical_activations()
-            .oldest_at(automata_ci_store::LogicalActivationState::Pending),
+            .oldest_at(LogicalActivationState::Pending),
         Some(logical.pending_since)
     );
     assert_eq!(
         snapshot
             .logical_activations()
-            .get(automata_ci_store::LogicalActivationState::Expired),
+            .get(LogicalActivationState::Expired),
         1
     );
     assert_eq!(
         snapshot
             .logical_activations()
-            .oldest_at(automata_ci_store::LogicalActivationState::Expired),
+            .oldest_at(LogicalActivationState::Expired),
         Some(logical.expired_since)
     );
     assert_eq!(snapshot.activation_publications(), 0);

--- a/crates/automata-ci-results-github/Cargo.toml
+++ b/crates/automata-ci-results-github/Cargo.toml
@@ -35,6 +35,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 automata-ci-blob-s3.workspace = true
+automata-ci-control = { workspace = true, features = ["adapter-spi"] }
 automata-ci-postgres = { workspace = true, features = ["test-support"] }
 automata-ci-protocol-protobuf.workspace = true
 automata-ci-store.workspace = true

--- a/crates/automata-ci-results-github/tests/cache_rustfs.rs
+++ b/crates/automata-ci-results-github/tests/cache_rustfs.rs
@@ -5,14 +5,15 @@ use std::{env, sync::Arc, time::Duration};
 use automata_ci_blob_s3::{
     S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
 };
+use automata_ci_control::adapter_spi::{
+    AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
+};
 use automata_ci_core::{AttemptId, AttemptNumber, LeaseId, UnixMillis};
 use automata_ci_results_github::{
     CacheAccessScope, CacheAuthority, CacheLimits, CachePermission, CacheRepository, CacheService,
     ExecutionAuthority, PostgresCacheRepository, ResultsClock, ResultsIdGenerator, UploadId,
 };
-use automata_ci_store::{
-    AcquireLease, InternalAttemptRepository as _, QueuedAttempt, StableRunnerSlot,
-};
+use automata_ci_store::StableRunnerSlot;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};

--- a/crates/automata-ci-results-github/tests/postgres_artifacts.rs
+++ b/crates/automata-ci-results-github/tests/postgres_artifacts.rs
@@ -3,6 +3,9 @@ mod support;
 use std::time::Duration;
 
 use automata_ci_blob::{BlobDescriptor, BlobKey, BlobPayload, MediaType};
+use automata_ci_control::adapter_spi::{
+    AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
+};
 use automata_ci_core::{AttemptId, AttemptNumber, LeaseId, Sha256Digest, UnixMillis};
 use automata_ci_postgres::test_support::TestClock;
 use automata_ci_results_github::{
@@ -14,9 +17,7 @@ use automata_ci_results_github::{
     RecordArtifactVerification, RenewArtifactFinalization, ReserveArtifactBlock,
     ResolveArtifactDownload, UploadId,
 };
-use automata_ci_store::{
-    AcquireLease, InternalAttemptRepository as _, QueuedAttempt, StableRunnerSlot,
-};
+use automata_ci_store::StableRunnerSlot;
 use bytes::Bytes;
 use sqlx::PgPool;
 use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};

--- a/crates/automata-ci-results-github/tests/postgres_cache.rs
+++ b/crates/automata-ci-results-github/tests/postgres_cache.rs
@@ -3,6 +3,9 @@ mod support;
 use std::{io, time::Duration};
 
 use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
+use automata_ci_control::adapter_spi::{
+    AcquireLease, InternalAttemptRepository as _, QueuedAttempt, TransitionAttempt,
+};
 use automata_ci_core::{
     AttemptId, AttemptNumber, JobLifecycle, LeaseGuard, LeaseId, Sha256Digest, UnixMillis,
 };
@@ -14,10 +17,7 @@ use automata_ci_results_github::{
     ExecutionAuthority, LookupCacheEntry, PostgresCacheRepository, PrepareCacheFinalization,
     ReserveCacheBlock, ResolveCacheDownload,
 };
-use automata_ci_store::{
-    AcquireLease, InternalAttemptRepository as _, QueuedAttempt, RunnerSessionFence,
-    StableRunnerSlot, TransitionAttempt,
-};
+use automata_ci_store::{RunnerSessionFence, StableRunnerSlot};
 use sqlx::PgPool;
 use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
 use uuid::Uuid;

--- a/crates/automata-ci-results-github/tests/rustfs_results.rs
+++ b/crates/automata-ci-results-github/tests/rustfs_results.rs
@@ -6,14 +6,15 @@ use automata_ci_blob::ImmutableBlobStore as _;
 use automata_ci_blob_s3::{
     S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
 };
+use automata_ci_control::adapter_spi::{
+    AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
+};
 use automata_ci_core::{AttemptId, AttemptNumber, LeaseId, Sha256Digest, UnixMillis};
 use automata_ci_results_github::{
     ArtifactRepository as _, ArtifactService, ExecutionAuthority, PostgresArtifactRepository,
     ResolveArtifactDownload, ResultsClock, ResultsIdGenerator, ResultsLimits, UploadId,
 };
-use automata_ci_store::{
-    AcquireLease, InternalAttemptRepository as _, QueuedAttempt, StableRunnerSlot,
-};
+use automata_ci_store::StableRunnerSlot;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use sha2::{Digest as _, Sha256};

--- a/crates/automata-ci-store/README.md
+++ b/crates/automata-ci-store/README.md
@@ -1,10 +1,12 @@
 # automata-ci-store
 
 `automata-ci-store` defines backend-neutral durable values and repository ports
-for workflow admission, scheduling, leases, runner sessions, receipts,
-outboxes, reconciliation, publication, and managed-secret metadata. Domain
-invariants and validated request/receipt types remain here; database drivers,
-schema migrations, and concrete repositories live in `automata-ci-postgres`.
+for workflow admission and planning, runner sessions, receipts, outboxes,
+reconciliation, publication, and managed-secret metadata. Execution-control
+contracts for attempts, lease polling and runnable queues, cancellation,
+maintenance, and identifier-free state snapshots live in
+`automata-ci-control`. Database drivers, schema migrations, and concrete
+repositories live in `automata-ci-postgres`.
 
 ## Tests
 

--- a/crates/automata-ci-store/src/adapter_spi.rs
+++ b/crates/automata-ci-store/src/adapter_spi.rs
@@ -6,7 +6,7 @@
 
 use automata_ci_auth::management::ManagementActor;
 use automata_ci_core::{
-    AttemptId, FencingToken, JobConclusion, JobId, JobSecretExposure, Lease, LeaseId, OperationId,
+    AttemptId, FencingToken, JobConclusion, JobId, JobSecretExposure, Lease, LeaseId,
     OutputSensitivity, RunId, Sha256Digest, UnixMillis, WorkflowOutputKey,
 };
 use automata_ci_key_management::KeyId;
@@ -208,30 +208,6 @@ pub fn repository_verified_logical_instance_materialization(
     )
 }
 
-/// Rehydrates one maintenance mutation from the same committed transaction.
-#[must_use]
-pub const fn expired_attempt_maintenance(
-    attempt_id: AttemptId,
-    disposition: crate::ExpiredAttemptDisposition,
-    reconciliation: crate::RunReconciliation,
-) -> crate::ExpiredAttemptMaintenance {
-    crate::ExpiredAttemptMaintenance::new(attempt_id, disposition, reconciliation)
-}
-
-/// Rehydrates the bounded result of one maintenance pass.
-#[must_use]
-pub const fn control_plane_maintenance_report(
-    expired_attempts: Vec<crate::ExpiredAttemptMaintenance>,
-    skipped_blocked_attempts: u16,
-    closed_stale_sessions: u16,
-) -> crate::ControlPlaneMaintenanceReport {
-    crate::ControlPlaneMaintenanceReport::new(
-        expired_attempts,
-        skipped_blocked_attempts,
-        closed_stale_sessions,
-    )
-}
-
 /// Rehydrates server-derived tenant/repository execution scope.
 #[must_use]
 pub const fn managed_secret_execution_scope(
@@ -302,23 +278,6 @@ pub const fn managed_secret_delivery_acknowledgement(
     acknowledged_at: UnixMillis,
 ) -> crate::ManagedSecretDeliveryAcknowledgement {
     crate::ManagedSecretDeliveryAcknowledgement::from_durable(operation_id, acknowledged_at)
-}
-
-/// Rehydrates and validates the versioned revoked-lease fallback representation.
-pub fn revoked_lease_offer_fallback(
-    representation_version: u16,
-    response_operation_id: OperationId,
-    retry_after_millis: u32,
-    response_schema: crate::DocumentSchema,
-    response_digest: Sha256Digest,
-) -> Result<crate::RevokedLeaseOfferFallback, crate::LeaseOfferCompletionError> {
-    crate::RevokedLeaseOfferFallback::from_persisted(
-        representation_version,
-        response_operation_id,
-        retry_after_millis,
-        response_schema,
-        response_digest,
-    )
 }
 
 /// Rehydrates one value-free leased secret binding after its durable binding
@@ -651,80 +610,6 @@ pub fn logical_job_result_commit_digest(
         outputs_digest,
         finalized_at,
     )
-}
-
-/// Read-only durable cursor projection used by first-party adapters.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RunnableCursorView {
-    cursor: crate::RunnableCursorAdvance,
-}
-
-impl RunnableCursorView {
-    /// Returns the exact session fence.
-    #[must_use]
-    pub const fn session(self) -> crate::RunnerSessionFence {
-        self.cursor.session()
-    }
-    /// Returns the stable runner slot.
-    #[must_use]
-    pub const fn slot(self) -> crate::StableRunnerSlot {
-        self.cursor.slot()
-    }
-    /// Returns the routing proof root.
-    #[must_use]
-    pub const fn routing_fingerprint(self) -> Sha256Digest {
-        self.cursor.routing_fingerprint()
-    }
-    /// Returns the compare-and-swap version.
-    #[must_use]
-    pub const fn expected_version(self) -> u64 {
-        self.cursor.expected_version()
-    }
-    /// Returns the inclusive queue position scanned through.
-    #[must_use]
-    pub const fn through(self) -> Option<crate::RunnableQueueKey> {
-        self.cursor.through()
-    }
-    /// Returns the cycle upper bound, if a cycle was established.
-    #[must_use]
-    pub const fn cycle_upper(self) -> Option<crate::RunnableQueueKey> {
-        self.cursor.cycle_upper()
-    }
-}
-
-/// Inspects the cursor embedded in a successful claim request.
-#[must_use]
-pub const fn try_claim_attempt_cursor(request: &crate::TryClaimAttempt) -> RunnableCursorView {
-    RunnableCursorView {
-        cursor: request.cursor(),
-    }
-}
-
-/// Rebuilds a claim at database-issued times while preserving its validated
-/// request key, target, lease, and opaque authoritative scan cursor.
-pub fn rebase_try_claim_attempt(
-    request: &crate::TryClaimAttempt,
-    observed_at: UnixMillis,
-    expires_at: UnixMillis,
-) -> Result<crate::TryClaimAttempt, crate::ClaimCommandError> {
-    crate::TryClaimAttempt::new(
-        request.request_key(),
-        request.attempt_id(),
-        request.lease_id(),
-        observed_at,
-        expires_at,
-        request.cursor(),
-    )
-}
-
-/// Inspects the cursor embedded in a terminal no-work request.
-#[must_use]
-pub const fn no_work_lease_request_cursor(
-    request: &crate::NoWorkLeaseRequest,
-) -> RunnableCursorView {
-    RunnableCursorView {
-        cursor: request.cursor(),
-    }
 }
 
 /// Read-only view of a prepared environment request.

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -3,9 +3,6 @@
 
 mod admission;
 mod assignment;
-mod attempt;
-mod blocked;
-mod cancellation;
 mod conformance;
 mod error;
 mod github_check_rerun;
@@ -25,10 +22,7 @@ mod logical_materialization;
 mod logical_orchestration;
 mod logical_run_finalization;
 mod logical_work_selection;
-mod maintenance;
 mod managed_secret_authority;
-mod observability;
-mod operation;
 mod outbox;
 mod plan;
 mod protected_environment;
@@ -38,13 +32,11 @@ mod receipt;
 mod reconciliation;
 mod reusable_workflow_admission;
 mod reusable_workflow_runtime;
-mod runnable;
 mod runner_payload;
 mod runtime_authority;
 mod secret_custody;
 mod secret_management;
 mod session;
-mod snapshot;
 mod store_error;
 mod tenant;
 mod value;
@@ -70,19 +62,7 @@ pub use admission::{
     WorkflowAdmissionValueError, WorkflowConcurrency, WorkflowSnapshotId,
 };
 pub use assignment::{AttemptAssignment, AttemptAssignmentError};
-pub use attempt::{
-    AcquireLease, ConcludeQueuedAttempt, InternalAttemptRepository, QueuedAttempt, RenewLease,
-    TenantAttemptQuery, TransitionAttempt,
-};
 pub use automata_ci_core::Sha256Digest;
-pub use blocked::{
-    BlockedAttempt, BlockedAttemptRepository, BlockedConclusion, ConcludeBlockedAttempt,
-};
-pub use cancellation::{
-    CANCEL_JOB_COMMAND_KIND, CANCEL_JOB_COMMAND_SCHEMA, CancelJobCommandPayload, CancellationActor,
-    CancellationIntent, CancellationIntentError, CancellationReason, CancellationRepository,
-    CancellationValueError, DEFAULT_CANCELLATION_REASON, RequestCancellation,
-};
 pub use conformance::{
     ConformanceDelivery, ConformanceDeliveryQuery, ConformanceDeliveryState,
     ConformanceReadRepository, ConformanceReadValueError, ConformanceWorkflowOutcome,
@@ -303,12 +283,6 @@ pub use logical_work_selection::{
     QuarantineLogicalInstanceMaterialization, QuarantineLogicalJobOrchestration,
     SelectedLogicalInstanceMaterialization, SelectedLogicalJobOrchestration,
 };
-pub use maintenance::{
-    ControlPlaneMaintenanceReport, ControlPlaneMaintenanceRepository,
-    ControlPlaneMaintenanceRequest, ExpiredAttemptDisposition, ExpiredAttemptMaintenance,
-    LeaseFailureLimit, MAX_MAINTENANCE_BATCH_SIZE, MaintenanceBatchSize, MaintenanceValueError,
-    StaleSessionTimeoutMillis,
-};
 pub use managed_secret_authority::{
     AcknowledgeManagedSecretDelivery, MANAGED_SECRET_AUTHORITY_SCHEMA, MAX_MANAGED_SECRET_BINDINGS,
     ManagedSecretAuthorityBinding, ManagedSecretAuthorityReceipt, ManagedSecretAuthorityRepository,
@@ -317,24 +291,6 @@ pub use managed_secret_authority::{
     ManagedSecretDeliveryOperationId, ManagedSecretDeliveryProposal, ManagedSecretExecutionScope,
     ManagedSecretGrantMode, ManagedSecretScope, ResolveManagedSecretAuthority,
     ResolveManagedSecretDeliverySession, ResolveManagedSecretExecutionScope, SecretWorkloadGrantId,
-};
-pub use observability::{
-    ArtifactCounts, ArtifactReservationKind, ArtifactReservations, ArtifactState,
-    BuiltinSecretCleanupCounts, BuiltinSecretCleanupStatus, ControlPlaneCapacityCandidate,
-    ControlPlaneCapacityRunner, ControlPlaneCapacitySnapshot, ControlPlaneStateRepository,
-    ControlPlaneStateSnapshot, ControlPlaneStateSnapshotRequest, ControlPlaneStateValueError,
-    DatabasePoolSnapshot, JobAttemptCounts, LEASE_NEAR_EXPIRY_WINDOW, LeaseCounts, LeaseState,
-    LogicalActivationCounts, LogicalActivationState, LogicalJobCounts, LogicalJobState,
-    LogicalWorkflowRunCounts, LogicalWorkflowRunState, MAX_CONTROL_PLANE_CAPACITY_CANDIDATES,
-    MAX_CONTROL_PLANE_CAPACITY_RUNNERS, MAX_CONTROL_PLANE_CAPACITY_SLOTS_PER_RUNNER, RunnerCounts,
-    RunnerDesiredState, RunnerObservedState, RunnerSessionCounts, RunnerSessionState,
-    WorkflowRunCounts,
-};
-pub use operation::{
-    BeginLeaseRequest, BegunLeaseRequest, ClaimCommandError, ClaimRejection, ClaimedAttempt,
-    CompleteLeaseRequest, LeaseOfferCompletionError, LeaseRequestCompletion, LeaseRequestKey,
-    LeaseRequestKeyError, NoWorkLeaseRequest, REVOKED_LEASE_OFFER_FALLBACK_VERSION,
-    RevokedLeaseOfferFallback, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
 };
 pub use outbox::{
     AcknowledgeRunnerCommands, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
@@ -396,10 +352,6 @@ pub use reusable_workflow_runtime::{
     ReusableWorkflowResultOutput, ReusableWorkflowRuntimeRepository,
     ReusableWorkflowRuntimeStoreError, ReusableWorkflowRuntimeValueError,
     ReusableWorkflowSecretBindingEvidence,
-};
-pub use runnable::{
-    MAX_RUNNABLE_SCAN_LIMIT, RunnableAttempt, RunnableAttemptError, RunnableCursorAdvance,
-    RunnableQueueKey, RunnableScanError, RunnableScanLimit, RunnableScanPage, RunnableScanRequest,
 };
 pub use runner_payload::{RunnerPayloadTombstone, RunnerPayloadTombstoneReason};
 pub use runtime_authority::{
@@ -470,7 +422,6 @@ pub use session::{
     CloseRunnerSession, HeartbeatRunnerSession, OpenRunnerSession, ResumeRunnerSession,
     RunnerSessionFence, RunnerSessionSnapshot, RunnerSessionSnapshotError,
 };
-pub use snapshot::{AttemptSnapshot, AttemptSnapshotBuilder};
 pub use store_error::StoreError;
 pub use tenant::{TenantScope, TenantScopeError};
 pub use value::{

--- a/crates/automata-ci-store/tests/g1_api.rs
+++ b/crates/automata-ci-store/tests/g1_api.rs
@@ -1,15 +1,13 @@
 use automata_ci_core::{
-    AttemptId, FencingToken, JobId, JobIrVersion, Lease, LeaseGuard, LeaseId, OperationId, RunId,
-    RunnerId, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
+    AttemptId, FencingToken, JobId, JobIrVersion, Lease, LeaseId, RunId, RunnerId, RunnerSessionId,
+    Sha256Digest, UnixMillis,
 };
 use automata_ci_store::{
-    AttemptAssignment, BeginLeaseRequest, CancelJobCommandPayload, CancellationRepository,
-    CommandCursor, CommandReplayDisposition, CommandReplayLimit, CommandReplayPage,
-    CommandSequence, CompleteLeaseRequest, DocumentSchema, JobDependency, JobIrMetadata,
-    LeaseOfferCommandIdentity, LeaseRequestKey, MAX_JOB_IR_BYTES, ObjectKey,
-    RevokedLeaseOfferFallback, RoutingDocument, RoutingLabel, RunnableAttempt, RunnableScanLimit,
-    RunnerGeneration, RunnerOperationKind, RunnerProtocolVersion, RunnerSessionFence,
-    RunnerSlotCount, SessionEpoch, StableRunnerSlot, WorkflowPlanRepository,
+    AttemptAssignment, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
+    CommandReplayPage, CommandSequence, DocumentSchema, JobDependency, JobIrMetadata,
+    MAX_JOB_IR_BYTES, ObjectKey, RoutingDocument, RoutingLabel, RunnerGeneration,
+    RunnerOperationKind, RunnerProtocolVersion, RunnerSessionFence, RunnerSlotCount, SessionEpoch,
+    StableRunnerSlot, WorkflowPlanRepository,
 };
 
 #[test]
@@ -71,115 +69,6 @@ fn durable_command_and_receipt_debug_never_expose_payload_bytes() {
     .expect("receipt response");
     assert!(!format!("{command:?}").contains(secret));
     assert!(!format!("{response:?}").contains(secret));
-}
-
-#[test]
-fn cancel_job_command_payload_is_exact_versioned_and_closed_to_extensions() {
-    let payload = CancelJobCommandPayload::new(
-        AttemptId::new(),
-        LeaseGuard::new(LeaseId::new(), FencingToken::new(7).expect("fencing token")),
-        RunnerProtocolVersion::new(1).expect("protocol"),
-        "superseded by a newer run",
-        UnixMillis::new(42),
-    )
-    .expect("typed cancellation");
-    let encoded = payload.encode_json().expect("canonical JSON");
-    assert_eq!(
-        CancelJobCommandPayload::decode_json(&encoded).expect("round trip"),
-        payload
-    );
-
-    let mut extended: serde_json::Value = serde_json::from_slice(&encoded).expect("JSON value");
-    extended
-        .as_object_mut()
-        .expect("JSON object")
-        .insert("future_field".to_owned(), serde_json::json!(true));
-    assert!(
-        CancelJobCommandPayload::decode_json(
-            &serde_json::to_vec(&extended).expect("extended JSON")
-        )
-        .is_err()
-    );
-
-    extended
-        .as_object_mut()
-        .expect("JSON object")
-        .remove("future_field");
-    extended["schema"] = serde_json::json!(2);
-    assert!(
-        CancelJobCommandPayload::decode_json(
-            &serde_json::to_vec(&extended).expect("wrong-schema JSON")
-        )
-        .is_err()
-    );
-}
-
-#[test]
-fn lease_request_chain_values_bind_predecessor_and_exact_rpc_digest() {
-    let fence = RunnerSessionFence::new(
-        RunnerSessionId::new(),
-        RunnerId::new(),
-        RunnerGeneration::new(1).expect("generation"),
-        SessionEpoch::new(1).expect("epoch"),
-    );
-    let slot = StableRunnerSlot::new(1).expect("slot");
-    let first_operation = OperationId::new();
-    let first = LeaseRequestKey::first(fence, first_operation, slot);
-    let successor = LeaseRequestKey::successor(fence, OperationId::new(), slot, first_operation)
-        .expect("successor");
-    assert_eq!(first.acknowledges_operation_id(), None);
-    assert_eq!(successor.acknowledges_operation_id(), Some(first_operation));
-    assert_ne!(first.request_digest(), successor.request_digest());
-    assert!(LeaseRequestKey::successor(fence, first_operation, slot, first_operation).is_err());
-
-    let begin = BeginLeaseRequest::new(successor, Sha256Digest::from_bytes([8; 32]));
-    assert_eq!(begin.request_key(), successor);
-    assert_eq!(begin.request_digest(), Sha256Digest::from_bytes([8; 32]));
-    let response = automata_ci_store::RunnerOperationResponse::new(
-        DocumentSchema::new(1).expect("schema"),
-        vec![1],
-    )
-    .expect("response");
-    let complete =
-        CompleteLeaseRequest::without_lease_offer(begin, response.clone(), UnixMillis::new(9));
-    assert_eq!(complete.request(), begin);
-    assert_eq!(complete.response(), &response);
-    assert_eq!(complete.completed_at(), UnixMillis::new(9));
-    assert!(complete.lease_offer_command().is_none());
-    assert!(complete.revoked_lease_offer_response().is_none());
-
-    let offer_identity = LeaseOfferCommandIdentity::new(
-        fence,
-        OperationId::new(),
-        CommandSequence::new(1).expect("sequence"),
-    );
-    let revoked_response = automata_ci_store::RunnerOperationResponse::new(
-        DocumentSchema::new(1).expect("schema"),
-        vec![2],
-    )
-    .expect("revoked response");
-    let fallback = RevokedLeaseOfferFallback::new(
-        OperationId::new(),
-        1_000,
-        revoked_response.schema(),
-        revoked_response.digest(),
-    )
-    .expect("typed fallback");
-    let complete = CompleteLeaseRequest::for_lease_offer_with_fallback(
-        begin,
-        response,
-        revoked_response.clone(),
-        fallback,
-        UnixMillis::new(10),
-        offer_identity,
-    )
-    .expect("lease-offer completion");
-    assert_eq!(complete.lease_offer_command(), Some(offer_identity));
-    assert_eq!(
-        complete.revoked_lease_offer_response(),
-        Some(&revoked_response)
-    );
-    assert_eq!(complete.revoked_lease_offer_fallback(), Some(fallback));
 }
 
 #[test]
@@ -245,32 +134,9 @@ fn immutable_scheduler_metadata_is_bounded_and_fenced() {
 
 #[test]
 fn store_values_and_ports_remain_backend_neutral_and_dyn_compatible() {
-    fn assert_ports(_: &dyn WorkflowPlanRepository, _: &dyn CancellationRepository) {}
-    let _ = assert_ports;
+    fn assert_port(_: &dyn WorkflowPlanRepository) {}
+    let _ = assert_port;
 
-    assert!(RunnableScanLimit::new(0).is_err());
-    assert!(RunnableScanLimit::new(1001).is_err());
     assert!(RunnerOperationKind::new("Automata.Invalid").is_err());
-
-    let candidate_job_id = JobId::new();
-    let candidate_run_id = RunId::new();
-    let candidate = RunnableAttempt::try_new(
-        AttemptId::new(),
-        candidate_job_id,
-        candidate_run_id,
-        UnixMillis::new(1),
-        RunnerRequirements::default(),
-        JobIrMetadata::new(
-            candidate_job_id,
-            candidate_run_id,
-            JobIrVersion::current(),
-            1,
-            Sha256Digest::from_bytes([1; 32]),
-            ObjectKey::new("job-ir").expect("key"),
-        )
-        .expect("metadata"),
-    )
-    .expect("candidate");
-    assert_eq!(candidate.requirements(), &RunnerRequirements::default());
     assert_eq!(CommandCursor::initial().durable_value(), 0);
 }

--- a/crates/automata-ci-store/tests/store_contracts.rs
+++ b/crates/automata-ci-store/tests/store_contracts.rs
@@ -3,10 +3,6 @@
 #[path = "github_manifest_fixture.rs"]
 mod github_manifest_fixture;
 
-#[path = "adapter_port.rs"]
-mod adapter_port;
-#[path = "attempt_api.rs"]
-mod attempt_api;
 #[path = "g1_api.rs"]
 mod g1_api;
 #[path = "github_authenticated_event.rs"]
@@ -41,12 +37,8 @@ mod logical_orchestration_api;
 mod logical_run_finalization_api;
 #[path = "logical_work_selection_api.rs"]
 mod logical_work_selection_api;
-#[path = "maintenance_api.rs"]
-mod maintenance_api;
 #[path = "managed_secret_authority_api.rs"]
 mod managed_secret_authority_api;
-#[path = "observability_api.rs"]
-mod observability_api;
 #[path = "provider_delivery_api.rs"]
 mod provider_delivery_api;
 #[path = "provider_delivery_receipt.rs"]
@@ -61,8 +53,6 @@ mod runtime_authority_api;
 mod secret_custody_api;
 #[path = "secret_management_api.rs"]
 mod secret_management_api;
-#[path = "snapshot_api.rs"]
-mod snapshot_api;
 #[path = "tenant_scope.rs"]
 mod tenant_scope;
 #[path = "workflow_admission.rs"]

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -20,6 +20,8 @@ use automata_ci_control::lease::{
     LeaseClock, LeaseIdGenerator, LeasePollConfig, RandomLeaseIdGenerator, SystemLeaseClock,
     repository::RunnerLeaseRequestRepository,
 };
+use automata_ci_control::maintenance::ControlPlaneMaintenanceRepository;
+use automata_ci_control::observability::ControlPlaneStateRepository;
 use automata_ci_control::runner_auth::{
     DurableRunnerMachineAuthenticator, RunnerMachineAuthLimits,
 };
@@ -69,11 +71,10 @@ use automata_ci_runner_transport::{
 };
 use automata_ci_secret::{SecretProvider, SecretProviderRegistry};
 use automata_ci_store::{
-    BuiltinSecretCleanupRepository, ConformanceReadRepository, ControlPlaneMaintenanceRepository,
-    ControlPlaneStateRepository, HumanWorkflowReadRepository, LogicalActivationPreparationStore,
-    LogicalActivationRepository, LogicalActivationWorkerId, LogicalInstanceResultRepository,
-    LogicalInstanceResultWorkerId, LogicalJobResultRepository, LogicalJobResultWorkerId,
-    LogicalMaterializationRepository, LogicalMaterializationWorkerId,
+    BuiltinSecretCleanupRepository, ConformanceReadRepository, HumanWorkflowReadRepository,
+    LogicalActivationPreparationStore, LogicalActivationRepository, LogicalActivationWorkerId,
+    LogicalInstanceResultRepository, LogicalInstanceResultWorkerId, LogicalJobResultRepository,
+    LogicalJobResultWorkerId, LogicalMaterializationRepository, LogicalMaterializationWorkerId,
     LogicalRunFinalizationRepository, LogicalRunFinalizationWorkerId,
     LogicalWorkSelectionRepository, LogicalWorkflowAdmissionRepository,
     ManagedSecretAuthorityRepository, ProtectedEnvironmentRepository,

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -18,6 +18,9 @@ use zeroize::Zeroizing;
 
 use automata_ci_auth::{github::GithubClientId, installation::InstallationTenant};
 use automata_ci_blob_s3::S3AtRestEncryption;
+use automata_ci_control::maintenance::{
+    LeaseFailureLimit, MaintenanceBatchSize, StaleSessionTimeoutMillis,
+};
 use automata_ci_key_management::{
     KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes as KeySecretBytes,
 };
@@ -26,7 +29,6 @@ use automata_ci_provisioning::{
     DelegatedActorIssuer, ProvisioningAuthority, ProvisioningAuthorityId, ShardId,
 };
 use automata_ci_results_github::ResultsPublicEndpoint;
-use automata_ci_store::{LeaseFailureLimit, MaintenanceBatchSize, StaleSessionTimeoutMillis};
 
 use crate::cli::{DatabaseTransport, ServerArgs};
 

--- a/crates/automata-ci/src/server/maintenance.rs
+++ b/crates/automata-ci/src/server/maintenance.rs
@@ -7,11 +7,11 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
-use automata_ci_core::UnixMillis;
-use automata_ci_store::{
-    ControlPlaneMaintenanceRepository, ControlPlaneMaintenanceRequest, LeaseFailureLimit,
-    MaintenanceBatchSize, StaleSessionTimeoutMillis,
+use automata_ci_control::maintenance::{
+    ControlPlaneMaintenanceRepository, ControlPlaneMaintenanceRequest, ExpiredAttemptDisposition,
+    LeaseFailureLimit, MaintenanceBatchSize, StaleSessionTimeoutMillis,
 };
+use automata_ci_core::UnixMillis;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 
@@ -129,10 +129,7 @@ impl ControlPlaneMaintenanceLoop {
                 let requeued = report
                     .expired_attempts()
                     .iter()
-                    .filter(|attempt| {
-                        attempt.disposition()
-                            == automata_ci_store::ExpiredAttemptDisposition::Requeued
-                    })
+                    .filter(|attempt| attempt.disposition() == ExpiredAttemptDisposition::Requeued)
                     .count();
                 let lost = report.expired_attempts().len().saturating_sub(requeued);
                 let batch_size = usize::from(self.batch_size.get());

--- a/crates/automata-ci/src/server/metrics.rs
+++ b/crates/automata-ci/src/server/metrics.rs
@@ -7,6 +7,7 @@ use std::{
 use automata_ci_control::lease::{
     LeaseClaimRejection, LeasePollFailure, LeasePollObservation, LeasePollObserver,
 };
+use automata_ci_control::observability::ControlPlaneStateRepository;
 use automata_ci_control::runner_control::{
     LeaseOfferObservation, RunnerControlFailure, RunnerControlMessageKind,
     RunnerControlMessageOutcome, RunnerControlObserver, RunnerDurableDisposition,
@@ -30,7 +31,6 @@ use automata_ci_runner_transport::{
     RunnerTransportRequestObservation, RunnerTransportResponseRejection, RunnerTransportRoute,
     RunnerTransportTlsOutcome,
 };
-use automata_ci_store::ControlPlaneStateRepository;
 use automata_ci_workflow_service::{
     WorkflowAdmissionFailure, WorkflowAdmissionObservation, WorkflowAdmissionObserver,
     WorkflowAdmissionStage, WorkflowAdmissionStageOutcome,

--- a/crates/automata-ci/src/server/state_metrics.rs
+++ b/crates/automata-ci/src/server/state_metrics.rs
@@ -5,6 +5,14 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use automata_ci_control::observability::{
+    ArtifactReservationKind, ArtifactState, BuiltinSecretCleanupStatus, ControlPlaneCapacityRunner,
+    ControlPlaneStateRepository, ControlPlaneStateSnapshot, ControlPlaneStateSnapshotRequest,
+    DatabasePoolSnapshot, JobAttemptCounts, LEASE_NEAR_EXPIRY_WINDOW, LeaseCounts, LeaseState,
+    LogicalActivationState, LogicalJobState, LogicalWorkflowRunState, RunnerCounts,
+    RunnerDesiredState, RunnerObservedState, RunnerSessionCounts, RunnerSessionState,
+    WorkflowRunCounts,
+};
 use automata_ci_control::scheduling::{
     AuthorizedRunnerRouting, CandidateCapacity, EffectiveRunner, RoutingRequirements,
     RunnableCandidate, RunnerEvidence, RunnerSlot, SessionGuard, classify_candidate_capacity,
@@ -14,13 +22,7 @@ use automata_ci_core::{JobLifecycle, RunnerGroup, RunnerLabel, UnixMillis};
 use automata_ci_metrics::{
     Counter, Family, Gauge, Histogram, Registry, Unit, classic_and_native_histogram,
 };
-use automata_ci_store::{
-    ArtifactReservationKind, ArtifactState, BuiltinSecretCleanupStatus,
-    ControlPlaneStateRepository, ControlPlaneStateSnapshot, ControlPlaneStateSnapshotRequest,
-    DatabasePoolSnapshot, JobAttemptCounts, LEASE_NEAR_EXPIRY_WINDOW, LeaseState,
-    LogicalActivationState, LogicalJobState, LogicalWorkflowRunState, RunnerDesiredState,
-    RunnerObservedState, RunnerSessionState, WorkflowRunCounts, WorkflowRunStatus,
-};
+use automata_ci_store::WorkflowRunStatus;
 use prometheus_client::{
     collector::Collector,
     encoding::{
@@ -431,7 +433,7 @@ fn compatible_capacity_snapshot(
 }
 
 fn effective_capacity_runner(
-    durable: &automata_ci_store::ControlPlaneCapacityRunner,
+    durable: &ControlPlaneCapacityRunner,
     observed_at: UnixMillis,
 ) -> Option<EffectiveRunner> {
     let machine_capabilities = intersect_runner_capabilities(
@@ -597,7 +599,7 @@ fn encode_job_attempts(
 
 fn encode_runners(
     encoder: &mut DescriptorEncoder<'_>,
-    counts: automata_ci_store::RunnerCounts,
+    counts: RunnerCounts,
 ) -> Result<(), fmt::Error> {
     let family = Family::<RunnerStateLabels, UnsignedGauge>::default();
     for observed in RunnerObservedState::ALL {
@@ -621,7 +623,7 @@ fn encode_runners(
 
 fn encode_runner_sessions(
     encoder: &mut DescriptorEncoder<'_>,
-    counts: automata_ci_store::RunnerSessionCounts,
+    counts: RunnerSessionCounts,
 ) -> Result<(), fmt::Error> {
     let family = Family::<StateLabels, UnsignedGauge>::default();
     for state in RunnerSessionState::ALL {
@@ -713,7 +715,7 @@ fn encode_compatible_capacity(
 
 fn encode_leases(
     encoder: &mut DescriptorEncoder<'_>,
-    counts: automata_ci_store::LeaseCounts,
+    counts: LeaseCounts,
 ) -> Result<(), fmt::Error> {
     let family = Family::<StateLabels, UnsignedGauge>::default();
     for state in LeaseState::ALL {
@@ -1041,17 +1043,20 @@ mod tests {
     };
 
     use async_trait::async_trait;
+    use automata_ci_control::observability::{
+        ArtifactCounts, ArtifactReservations, BuiltinSecretCleanupCounts,
+        ControlPlaneCapacityCandidate, ControlPlaneCapacityRunner, ControlPlaneStateValueError,
+        JobAttemptCounts, LeaseCounts, LogicalActivationCounts, LogicalJobCounts,
+        LogicalWorkflowRunCounts, RunnerCounts, RunnerSessionCounts,
+    };
     use automata_ci_core::{
         Architecture, AttemptId, JobId, OperatingSystem, RunnerCapabilities, RunnerId,
         RunnerPlatform, RunnerRequirements, RunnerSessionId,
     };
     use automata_ci_metrics::{BuildInfo, ExporterLimits, Metrics, MetricsBuilder, ProcessRole};
     use automata_ci_store::{
-        ArtifactCounts, ArtifactReservations, BuiltinSecretCleanupCounts,
-        ControlPlaneCapacityCandidate, ControlPlaneCapacityRunner, ControlPlaneStateValueError,
-        JobAttemptCounts, LeaseCounts, LogicalActivationCounts, LogicalJobCounts,
-        LogicalWorkflowRunCounts, RoutingLabel, RunnerCounts, RunnerGeneration,
-        RunnerSessionCounts, RunnerSessionFence, RunnerSlotCount, SessionEpoch, StableRunnerSlot,
+        RoutingLabel, RunnerGeneration, RunnerSessionFence, RunnerSlotCount, SessionEpoch,
+        StableRunnerSlot,
     };
     use tokio::sync::Notify;
     use tokio_util::sync::CancellationToken;

--- a/crates/automata-ci/tests/maintenance_loop.rs
+++ b/crates/automata-ci/tests/maintenance_loop.rs
@@ -10,12 +10,13 @@ use automata_ci::build_info::BuildInfo;
 use automata_ci::server::{
     ControlPlaneMaintenanceLoop, ControlPlaneMetrics, MaintenanceClock, MaintenanceLoopConfigError,
 };
-use automata_ci_core::UnixMillis;
-use automata_ci_store::{
+use automata_ci_control::maintenance::{
     ControlPlaneMaintenanceReport, ControlPlaneMaintenanceRepository,
     ControlPlaneMaintenanceRequest, LeaseFailureLimit, MaintenanceBatchSize,
-    StaleSessionTimeoutMillis, StoreError,
+    StaleSessionTimeoutMillis,
 };
+use automata_ci_core::UnixMillis;
+use automata_ci_store::StoreError;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 


### PR DESCRIPTION
## Summary

- move attempt, snapshot, lease-operation, runnable, cancellation, maintenance, blocked-work, and observability contracts from Store into namespaced Control modules
- remove 92 flat Store exports; retain 77 as normal Control APIs, confine 12 adapter-only values and 7 repository trust-boundary helpers to the feature-gated hidden Control adapter SPI, and retire 3 zero-caller constants
- migrate every production consumer and preserve five contract suites through history-detected moves plus a focused split of the mixed G1 contract
- keep the dependency direction Control -> Store; no Store -> Control edge, package change, lockfile change, schema change, wire change, digest-domain change, or runtime behavior change

## Shape

- 69 files, +1,269/-796 (2,065 reviewed lines)
- 13 history-preserving renames
- Store source: 46,251 -> 42,430 physical lines (-3,821)
- whole-workspace Rust: +459 lines, primarily missing-docs coverage, the explicit adapter boundary, and namespaced consumer imports
- aggregate integration topology remains 18 targets; owned Rust test sources 219 -> 220
- Control tests 96 -> 115 with all features; Store tests 225 -> 207; workspace declarations net +1

This is intentionally source-breaking for git/path users of the former Store-root names. The affected crates have not yet been published, so no registry compatibility shim or Store -> Control cycle is introduced.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --offline`
- `cargo test --locked --all-targets --all-features --no-fail-fast -p automata-ci-store -p automata-ci-control -p automata-ci-postgres -p automata-ci-results-github -p automata-ci`
- `cargo clippy --locked --all-targets --all-features -p automata-ci-store -p automata-ci-control -p automata-ci-postgres -p automata-ci-results-github -p automata-ci -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --all-features -p automata-ci-store -p automata-ci-control -p automata-ci-postgres -p automata-ci-results-github -p automata-ci`
- integration-target ownership, Rust coverage-policy, publish-script, and release-handoff tests
- locked metadata and Control/Store package-content inventories
- generated 99-name stale ownership and cycle scan