### PR TITLE
ci: verify redundant Automata deployment

### DIFF
--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -25,6 +25,7 @@ concurrency:
 # Pages deployment is intentionally omitted until Automata supports GitHub
 # deployment environments end to end; this repository must have one workflow
 # authority and therefore cannot also contain .github/workflows.
+# Live probe: verify the redundant Automata control plane and six-runner fleet.
 jobs:
   build:
     name: Build demo and capture screenshots


### PR DESCRIPTION
## Purpose

Live end-to-end probe after deploying Automata `1c5e97ff` to both control-plane hosts and all six Automata runners.

This comment-only change intentionally triggers both native CI workflows. Do not merge; close after verification.