### PR TITLE
Allow cancellation after a failed lease retry

### DIFF
--- a/crates/automata-ci-postgres/migrations/0028_allow_queued_cancellation_after_lease_retry.sql
+++ b/crates/automata-ci-postgres/migrations/0028_allow_queued_cancellation_after_lease_retry.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION automata_validate_server_cancellation_terminal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    cancellation attempt_cancellation_intents%ROWTYPE;
+    attempt job_attempts%ROWTYPE;
+    expected_digest BYTEA;
+BEGIN
+    IF NEW.terminal_authority IS DISTINCT FROM 'server_cancellation' THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT * INTO STRICT cancellation
+    FROM attempt_cancellation_intents
+    WHERE attempt_id = NEW.attempt_id
+      AND operation_id = NEW.server_cancellation_operation_id;
+
+    SELECT * INTO STRICT attempt
+    FROM job_attempts
+    WHERE id = NEW.attempt_id;
+
+    expected_digest := automata_server_cancellation_terminal_digest(
+        cancellation.attempt_id,
+        cancellation.operation_id,
+        cancellation.requested_by,
+        cancellation.reason,
+        cancellation.requested_at_ms
+    );
+    IF cancellation.delivery_session_id IS NOT NULL
+       OR cancellation.delivery_command_sequence IS NOT NULL
+       OR cancellation.acknowledged_at_ms IS NOT NULL
+       OR attempt.lifecycle <> 'queued'
+       OR attempt.lease_id IS NOT NULL
+       OR attempt.runner_id IS NOT NULL
+       OR attempt.runner_session_id IS NOT NULL
+       OR attempt.runner_session_epoch IS NOT NULL
+       OR attempt.runner_generation IS NOT NULL
+       OR attempt.runner_slot IS NOT NULL
+       OR attempt.lease_issued_at_ms IS NOT NULL
+       OR attempt.lease_expires_at_ms IS NOT NULL
+       OR NEW.server_cancellation_digest IS DISTINCT FROM expected_digest
+       OR NEW.conclusion <> 'cancelled'
+       OR NEW.completed_at_ms <> cancellation.requested_at_ms
+       OR NEW.committed_at_ms <> cancellation.requested_at_ms
+    THEN
+        RAISE EXCEPTION 'server cancellation terminal lacks exact queued intent authority'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+EXCEPTION
+    WHEN NO_DATA_FOUND OR TOO_MANY_ROWS THEN
+        RAISE EXCEPTION 'server cancellation terminal lacks exact queued intent authority'
+            USING ERRCODE = '23514';
+END;
+$$;
+
+COMMENT ON FUNCTION automata_validate_server_cancellation_terminal() IS
+    'Validates blob-free server cancellation authority for any unleased queued attempt, including attempts returned to the queue after a fenced lease failure.';

--- a/crates/automata-ci-postgres/tests/store/contracts/migration_layout.rs
+++ b/crates/automata-ci-postgres/tests/store/contracts/migration_layout.rs
@@ -113,6 +113,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0027_workspace_usage_feed.sql",
         "23d9d52552f960e0b8015cedacf8bbe591773dbb82856e73eb4e436c4840be5475887da0ebbe6330185fee13f835734f",
     ),
+    (
+        "0028_allow_queued_cancellation_after_lease_retry.sql",
+        "4841124d150802cd51308c78f1f9607e9ca04c4b077e08eb89936ed5aa7ab527fc1add96b34bb95b0825286191a17d0e",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -114,6 +114,49 @@ async fn queued_cancellation_projects_exact_blob_free_server_authority() -> Test
     .await
 }
 
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn queued_cancellation_accepts_released_lease_fencing_history() -> TestResult {
+    run_with_database(|database| async move {
+        let (fixture, _, attempt_id) =
+            seed_materialized_instance_for_cancellation(&database).await?;
+        let updated = sqlx::query(
+            r"
+            UPDATE job_attempts
+            SET fencing_token = 2, lease_failures = 2
+            WHERE id = $1
+              AND lifecycle = 'queued'
+              AND lease_id IS NULL
+              AND runner_id IS NULL
+              AND runner_session_id IS NULL
+              AND runner_session_epoch IS NULL
+              AND runner_generation IS NULL
+              AND runner_slot IS NULL
+              AND lease_issued_at_ms IS NULL
+              AND lease_expires_at_ms IS NULL
+            ",
+        )
+        .bind(attempt_id.as_uuid())
+        .execute(database.pool())
+        .await?
+        .rows_affected();
+        assert_eq!(updated, 1, "fixture must be a released queued attempt");
+
+        let (operation_id, cancelled_at) =
+            request_server_cancellation(&database, attempt_id).await?;
+        assert_server_cancellation_terminal(
+            &database,
+            &fixture,
+            attempt_id,
+            operation_id,
+            cancelled_at,
+        )
+        .await?;
+        Ok(())
+    })
+    .await
+}
+
 async fn seed_materialized_instance_for_cancellation(
     database: &TestDatabase,
 ) -> TestResult<(Fixture, PreparedInstance, automata_ci_core::AttemptId)> {


### PR DESCRIPTION
Fixes the production GitHub delivery admission failure seen on the live CI probe.

A queued attempt may retain a monotonically advanced fencing token after a failed lease is released. The server-cancellation trigger previously rejected that valid unleased state, which caused cancel-in-progress admission to retry until GitHub received a failed aggregate check.

This adds a forward-only migration that accepts queued attempts with fencing history while retaining every no-live-lease/session/runner check, plus a PostgreSQL regression test for the exact state observed in production.

Validated with:
- cargo fmt --all -- --check
- migration lineage/layout tests
- live PostgreSQL regression on PostgreSQL 18.4