### PR TITLE
fix(ci): build native service proxy candidate with Buildah

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -87,7 +87,10 @@ jobs:
           python3 scripts/ci/tests/integration-test-targets.test.py
           python3 scripts/ci/tests/release-handoff.test.py
           python3 scripts/ci/tests/rust-coverage.test.py
+          python3 scripts/ci/tests/service-proxy-buildah-containerfile.test.py
           python3 scripts/ci/tests/service-proxy-candidate.test.py
+          ./scripts/ci/tests/service-proxy-image.test.sh
+          python3 scripts/ci/tests/service-proxy-publication.test.py
 
       - name: Verify Prometheus metrics contract
         run: |
@@ -317,7 +320,8 @@ jobs:
         run: |
           install -d -m 0700 -- "$TMPDIR"
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends binutils musl-tools podman
+          sudo apt-get install --yes --no-install-recommends \
+            binutils buildah musl-tools podman
 
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -368,11 +372,9 @@ jobs:
 
       - name: Prepare digest-bound private service-proxy image candidate
         env:
-          AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME: podman
+          AUTOMATA_SERVICE_PROXY_OCI_BUILDER: buildah-chroot
+          AUTOMATA_SERVICE_PROXY_PROCESS_PROBE: metadata-only
         run: |
-          if [[ -n "${AUTOMATA_ENVIRONMENT_PROFILE_ID:-}" ]]; then
-            export AUTOMATA_SERVICE_PROXY_PROCESS_PROBE=metadata-only
-          fi
           ./scripts/ci/prepare-service-proxy-context.sh \
             target/service-proxy-context \
             "$AUTOMATA_EXPECTED_VERSION" \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -212,11 +212,29 @@ is in the [profile guide](../images/github-hosted-ubuntu-24.04-x64/README.md).
 ## Prepare a service-proxy candidate
 
 `.ci/workflows/service-proxy-image.yml` is disabled for the same issuer
-mismatch. The credential-free path below is the service-proxy portion of the
-ordinary CI [`dist_build` recipe](../.ci/workflows/ci.yml). It requires the
-pinned Rust toolchain, `binutils`, musl tools, Podman, Node.js 24.19.0 with npm
-11.17.0, and `cargo-cyclonedx` 0.5.9; see the
+mismatch. The credential-free path below mirrors the service-proxy artifact and
+policy checks in ordinary CI while retaining the manual and release default:
+Podman plus the required live process probe. It requires the pinned Rust
+toolchain, `binutils`, musl tools, Podman, Node.js 24.19.0 with npm 11.17.0, and
+`cargo-cyclonedx` 0.5.9; see the
 [development prerequisites](development.md#static-linux-distribution).
+
+The ordinary native CI `dist_build` job instead explicitly selects the
+`buildah-chroot` backend and `metadata-only` image verification. Nested Automata
+jobs cannot create the additional namespaces needed by Podman, so that backend
+uses Buildah's chroot isolation and host network. A fail-closed validator admits
+only the reviewed `FROM scratch`, metadata, local `COPY`, user, working-directory,
+and entrypoint instructions; it rejects executable or remote-input instructions
+before Buildah starts. The earlier static-binary check supplies the process
+contract. Buildah still inspects the image metadata, and
+`service-proxy-candidate.py` still validates the exported OCI descriptors,
+configuration, source bindings, and candidate provenance before the subsequent
+`prepare-candidate` policy gate accepts it.
+
+Reproducibility comparisons are backend-local: CI compares two Buildah outputs,
+while the manual and release paths compare Podman outputs. Both backends produce
+OCI candidates accepted by the same validators, but their output bytes are not
+claimed to match each other.
 
 Run it from a clean checkout where the four named `target/` output directories
 do not already exist:

--- a/scripts/ci/build-service-proxy-candidate.sh
+++ b/scripts/ci/build-service-proxy-candidate.sh
@@ -32,6 +32,31 @@ automata_set_target_tmpdir \
 readonly context output_directory
 [[ -d "$context" && ! -L "$context" ]] || die "prepared context is missing"
 [[ ! -e "$output_directory" ]] || die "output directory already exists"
+
+builder="${AUTOMATA_SERVICE_PROXY_OCI_BUILDER:-podman}"
+case "$builder" in
+  podman | buildah-chroot) ;;
+  *) die "AUTOMATA_SERVICE_PROXY_OCI_BUILDER must be podman or buildah-chroot" ;;
+esac
+process_probe="${AUTOMATA_SERVICE_PROXY_PROCESS_PROBE:-required}"
+case "$process_probe" in
+  required | metadata-only) ;;
+  *) die "AUTOMATA_SERVICE_PROXY_PROCESS_PROBE must be required or metadata-only" ;;
+esac
+if [[ "$builder" == podman ]]; then
+  runtime="${AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME:-podman}"
+  [[ "$runtime" == podman ]] || die "Podman candidate builds require the Podman runtime"
+  command -v podman >/dev/null 2>&1 || die "Podman is unavailable"
+else
+  runtime="${AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME:-buildah}"
+  [[ "$runtime" == buildah ]] || \
+    die "buildah-chroot candidate builds require the Buildah image runtime"
+  command -v buildah >/dev/null 2>&1 || die "Buildah is unavailable"
+  [[ "$process_probe" == metadata-only ]] || \
+    die "buildah-chroot candidate builds require metadata-only process verification"
+fi
+readonly builder process_probe runtime
+
 install -d -m 0700 -- "$output_directory"
 
 # Rootless OverlayFS records its private origin/impure bookkeeping as PAX
@@ -56,7 +81,10 @@ readonly storage_directory storage_config storage_graphroot storage_runroot
 tag="localhost/automata-ci/service-proxy:candidate-${BASHPID}"
 readonly tag
 cleanup() {
-  podman image rm --force "$tag" >/dev/null 2>&1 || true
+  case "$builder" in
+    podman) podman image rm --force "$tag" >/dev/null 2>&1 || true ;;
+    buildah-chroot) buildah rmi --force "$tag" >/dev/null 2>&1 || true ;;
+  esac
   if [[ "$storage_directory" == "$TMPDIR"/podman-vfs.* \
     && -d "$storage_directory" \
     && ! -L "$storage_directory" ]]; then
@@ -64,10 +92,6 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-
-runtime="${AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME:-podman}"
-[[ "$runtime" == podman ]] || die "candidate builds require the Podman OCI builder"
-command -v podman >/dev/null 2>&1 || die "Podman is unavailable"
 
 mapfile -t source_values < <(python3 - "$context/source-provenance.json" <<'PY'
 import hashlib
@@ -97,29 +121,54 @@ sbom_sha256="${source_values[5]}"
 source_sha256="${source_values[6]}"
 readonly version revision created source_date_epoch binary_sha256 sbom_sha256 source_sha256
 
-env -u SOURCE_DATE_EPOCH podman build \
-  --build-arg "AUTOMATA_CREATED=${created}" \
-  --build-arg "AUTOMATA_REVISION=${revision}" \
-  --build-arg "AUTOMATA_SERVICE_PROXY_BINARY_SHA256=${binary_sha256}" \
-  --build-arg "AUTOMATA_SERVICE_PROXY_SBOM_SHA256=${sbom_sha256}" \
-  --build-arg "AUTOMATA_SERVICE_PROXY_SOURCE_SHA256=${source_sha256}" \
-  --build-arg "AUTOMATA_VERSION=${version}" \
-  --file "$context/Containerfile" \
-  --format oci \
-  --identity-label=false \
-  --network none \
-  --pull=never \
-  --timestamp "$source_date_epoch" \
-  --tag "$tag" \
-  "$context"
-
-AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME=podman \
-  "${script_directory}/verify-service-proxy-image.sh" \
-  "$tag" "$version" "$revision" "$created"
+build_arguments=(
+  --build-arg "AUTOMATA_CREATED=${created}"
+  --build-arg "AUTOMATA_REVISION=${revision}"
+  --build-arg "AUTOMATA_SERVICE_PROXY_BINARY_SHA256=${binary_sha256}"
+  --build-arg "AUTOMATA_SERVICE_PROXY_SBOM_SHA256=${sbom_sha256}"
+  --build-arg "AUTOMATA_SERVICE_PROXY_SOURCE_SHA256=${source_sha256}"
+  --build-arg "AUTOMATA_VERSION=${version}"
+  --file "$context/Containerfile"
+  --format oci
+  --identity-label=false
+  --pull=never
+  --timestamp "$source_date_epoch"
+  --tag "$tag"
+)
+readonly -a build_arguments
+if [[ "$builder" == podman ]]; then
+  env -u SOURCE_DATE_EPOCH podman build \
+    "${build_arguments[@]}" \
+    --network none \
+    "$context"
+  AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME="$runtime" \
+    AUTOMATA_SERVICE_PROXY_PROCESS_PROBE="$process_probe" \
+    "${script_directory}/verify-service-proxy-image.sh" \
+    "$tag" "$version" "$revision" "$created"
+else
+  # Chroot isolation in the nested Automata job cannot create another network
+  # namespace. Host networking is inert because this exact reviewed scratch
+  # Containerfile contains metadata and local COPY instructions, but no RUN.
+  python3 "${script_directory}/validate-service-proxy-buildah-containerfile.py" \
+    "$context/Containerfile"
+  env -u SOURCE_DATE_EPOCH buildah bud \
+    "${build_arguments[@]}" \
+    --isolation chroot \
+    --network host \
+    "$context"
+  AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME="$runtime" \
+    AUTOMATA_SERVICE_PROXY_PROCESS_PROBE="$process_probe" \
+    "${script_directory}/verify-service-proxy-image.sh" \
+    "$tag" "$version" "$revision" "$created"
+fi
 
 oci_archive="$output_directory/automata-service-proxy.oci.tar"
 candidate="$output_directory/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
-podman save --format oci-archive --output "$oci_archive" "$tag"
+if [[ "$builder" == podman ]]; then
+  podman save --format oci-archive --output "$oci_archive" "$tag"
+else
+  buildah push "$tag" "oci-archive:${oci_archive}"
+fi
 candidate_arguments=(
   --context "$context"
   --oci-archive "$oci_archive"

--- a/scripts/ci/tests/service-proxy-buildah-containerfile.test.py
+++ b/scripts/ci/tests/service-proxy-buildah-containerfile.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for the non-executing service-proxy Buildah policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import shutil
+import sys
+import unittest
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
+SCRIPT = REPOSITORY_ROOT / "scripts/ci/validate-service-proxy-buildah-containerfile.py"
+SPEC = importlib.util.spec_from_file_location(
+    "service_proxy_buildah_containerfile", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = validator
+SPEC.loader.exec_module(validator)
+
+
+class BuildahContainerfileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scratch = REPOSITORY_ROOT / "target/service-proxy-buildah-policy-tests"
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        self.scratch.mkdir(parents=True)
+        self.containerfile = self.scratch / "Containerfile"
+        self.reviewed = (
+            REPOSITORY_ROOT / "images/service-proxy/Containerfile"
+        ).read_bytes()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+
+    def write(self, contents: bytes) -> pathlib.Path:
+        self.containerfile.write_bytes(contents)
+        return self.containerfile
+
+    def assert_rejected(self, contents: bytes) -> None:
+        with self.assertRaisesRegex(
+            SystemExit, "instructions differ from the reviewed non-executing policy"
+        ):
+            validator.validate(self.write(contents))
+
+    def test_accepts_the_reviewed_containerfile(self) -> None:
+        validator.validate(self.write(self.reviewed))
+
+    def test_rejects_run_even_when_the_rest_is_reviewed(self) -> None:
+        self.assert_rejected(self.reviewed + b"RUN echo network-capable-step\n")
+
+    def test_rejects_add_even_when_the_rest_is_reviewed(self) -> None:
+        self.assert_rejected(self.reviewed + b"ADD https://example.invalid/payload /\n")
+
+    def test_rejects_an_extra_build_stage(self) -> None:
+        self.assert_rejected(self.reviewed + b"FROM scratch AS extra\n")
+
+    def test_rejects_copy_from_an_unreviewed_stage(self) -> None:
+        self.assert_rejected(
+            self.reviewed
+            + b"COPY --from=unreviewed /payload /usr/libexec/unreviewed\n"
+        )
+
+    def test_rejects_comments_and_parser_directives(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "unsupported comment"):
+            validator.validate(
+                self.write(b"# syntax=example.invalid/frontend\n" + self.reviewed)
+            )
+
+    def test_rejects_non_lf_control_bytes(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "control bytes"):
+            validator.validate(self.write(self.reviewed + b"\x0b"))
+
+    def test_rejects_malformed_continuations(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "ends inside a continued instruction"):
+            validator.validate(self.write(self.reviewed + b"LABEL unexpected=value \\\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/service-proxy-image.test.sh
+++ b/scripts/ci/tests/service-proxy-image.test.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../../.." && pwd)"
+verifier="${repository_root}/scripts/ci/verify-service-proxy-image.sh"
+candidate_builder="${repository_root}/scripts/ci/build-service-proxy-candidate.sh"
+readonly repository_root verifier candidate_builder
+
+install -d -m 0755 -- "${repository_root}/target"
+scratch_directory="$(
+  mktemp -d "${repository_root}/target/service-proxy-image-test.XXXXXXXX"
+)"
+readonly scratch_directory
+cleanup() {
+  rm -rf -- "$scratch_directory"
+}
+trap cleanup EXIT
+
+fake_bin="${scratch_directory}/bin"
+runtime_tmp="${scratch_directory}/tmp"
+invocation_log="${scratch_directory}/podman.log"
+stdout_log="${scratch_directory}/stdout"
+stderr_log="${scratch_directory}/stderr"
+install -d -m 0700 -- "$fake_bin" "$runtime_tmp"
+readonly fake_bin runtime_tmp invocation_log stdout_log stderr_log
+
+cat >"${fake_bin}/podman" <<'PODMAN'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  printf '%s' "$1"
+  for argument in "${@:2}"; do
+    printf ' %s' "$argument"
+  done
+  printf '\n'
+} >>"${AUTOMATA_FAKE_PODMAN_LOG:?}"
+
+if [[ "$1" == image && "${2:-}" == inspect && $# -eq 3 ]]; then
+  cat -- "${AUTOMATA_FAKE_PODMAN_INSPECTION:?}"
+  exit 0
+fi
+if [[ "$1" == inspect && "${2:-}" == --type && "${3:-}" == image && $# -eq 4 ]]; then
+  cat -- "${AUTOMATA_FAKE_PODMAN_INSPECTION:?}"
+  exit 0
+fi
+
+if [[ "$1" == run ]]; then
+  case "${AUTOMATA_FAKE_PODMAN_RUN_RESULT:?}" in
+    cgroup)
+      printf 'Error: OCI runtime error: read-only cgroup filesystem\n' >&2
+      exit 125
+      ;;
+    stdout)
+      printf 'unexpected process output\n'
+      printf 'automata-ci-service-proxy: usage-invalid\n' >&2
+      exit 64
+      ;;
+    success)
+      exit 0
+      ;;
+    usage-invalid)
+      printf 'automata-ci-service-proxy: usage-invalid\n' >&2
+      exit 64
+      ;;
+    *)
+      printf 'fake-podman: unsupported run result\n' >&2
+      exit 70
+      ;;
+  esac
+fi
+
+printf 'fake-podman: unsupported invocation\n' >&2
+exit 70
+PODMAN
+chmod 0700 "${fake_bin}/podman"
+ln -s podman "${fake_bin}/buildah"
+
+valid_inspection="${scratch_directory}/valid-inspection.json"
+buildah_inspection="${scratch_directory}/buildah-inspection.json"
+bad_label_inspection="${scratch_directory}/bad-label-inspection.json"
+bad_config_inspection="${scratch_directory}/bad-config-inspection.json"
+readonly valid_inspection buildah_inspection bad_label_inspection bad_config_inspection
+python3 - \
+  "$valid_inspection" \
+  "$buildah_inspection" \
+  "$bad_label_inspection" \
+  "$bad_config_inspection" <<'PY'
+import copy
+import json
+import pathlib
+import sys
+
+valid_path, buildah_path, bad_label_path, bad_config_path = map(
+    pathlib.Path, sys.argv[1:]
+)
+labels = {
+    "org.opencontainers.image.created": "2026-08-15T08:00:00+00:00",
+    "org.opencontainers.image.licenses": "MIT",
+    "org.opencontainers.image.revision": "0123456789abcdef0123456789abcdef01234567",
+    "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+    "org.opencontainers.image.version": "0.1.0",
+    "io.automata.service-proxy.protocol-version": "1",
+    "io.automata.service-proxy.binary.sha256": "0" * 64,
+    "io.automata.service-proxy.sbom.sha256": "1" * 64,
+    "io.automata.service-proxy.source.sha256": "2" * 64,
+}
+document = [
+    {
+        "Config": {
+            "Entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
+            "Labels": labels,
+            "User": "65532:65532",
+        }
+    }
+]
+
+
+def write(path: pathlib.Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+
+
+write(valid_path, document)
+write(buildah_path, {"OCIv1": {"config": document[0]["Config"]}})
+bad_label = copy.deepcopy(document)
+bad_label[0]["Config"]["Labels"]["org.opencontainers.image.version"] = "9.9.9"
+write(bad_label_path, bad_label)
+bad_config = copy.deepcopy(document)
+bad_config[0]["Config"]["Entrypoint"] = ["/bin/not-the-service-proxy"]
+write(bad_config_path, bad_config)
+PY
+
+case_status=0
+run_verifier() {
+  local process_probe="$1"
+  local run_result="$2"
+  local inspection="$3"
+  local runtime="${4:-podman}"
+  local -a command=(
+    env
+    -u AUTOMATA_SERVICE_PROXY_PROCESS_PROBE
+    "AUTOMATA_FAKE_PODMAN_INSPECTION=${inspection}"
+    "AUTOMATA_FAKE_PODMAN_LOG=${invocation_log}"
+    "AUTOMATA_FAKE_PODMAN_RUN_RESULT=${run_result}"
+    "AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME=${runtime}"
+    "PATH=${fake_bin}:${PATH}"
+    "TMPDIR=${runtime_tmp}"
+  )
+  if [[ "$process_probe" != default ]]; then
+    command+=("AUTOMATA_SERVICE_PROXY_PROCESS_PROBE=${process_probe}")
+  fi
+  : >"$invocation_log"
+  set +e
+  "${command[@]}" "$verifier" \
+    localhost/automata-ci/service-proxy:test \
+    0.1.0 \
+    0123456789abcdef0123456789abcdef01234567 \
+    2026-08-15T08:00:00+00:00 \
+    >"$stdout_log" 2>"$stderr_log"
+  case_status=$?
+  set -e
+}
+
+expect_status() {
+  local expected="$1"
+  if (( case_status != expected )); then
+    printf 'service-proxy image verifier returned %d, expected %d\n' \
+      "$case_status" "$expected" >&2
+    printf '%s\n' '--- stdout ---' >&2
+    sed -n '1,120p' "$stdout_log" >&2
+    printf '%s\n' '--- stderr ---' >&2
+    sed -n '1,120p' "$stderr_log" >&2
+    exit 1
+  fi
+}
+
+expect_exact_stdout() {
+  local expected="$1"
+  cmp -s "$stdout_log" <(printf '%s\n' "$expected") || {
+    printf 'service-proxy image verifier stdout differed\n' >&2
+    exit 1
+  }
+}
+
+expect_exact_stderr() {
+  local expected="$1"
+  cmp -s "$stderr_log" <(printf '%s\n' "$expected") || {
+    printf 'service-proxy image verifier stderr differed\n' >&2
+    exit 1
+  }
+}
+
+expect_valid_metadata_log() {
+  mapfile -t invocations <"$invocation_log"
+  (( ${#invocations[@]} == 1 )) || {
+    printf 'metadata-only verification did not inspect exactly once\n' >&2
+    exit 1
+  }
+  [[ "${invocations[0]}" == \
+    'image inspect localhost/automata-ci/service-proxy:test' ]] || {
+    printf 'metadata-only verification used an unexpected runtime command\n' >&2
+    exit 1
+  }
+}
+
+expect_valid_buildah_metadata_log() {
+  mapfile -t invocations <"$invocation_log"
+  (( ${#invocations[@]} == 1 )) || {
+    printf 'Buildah metadata verification did not inspect exactly once\n' >&2
+    exit 1
+  }
+  [[ "${invocations[0]}" == \
+    'inspect --type image localhost/automata-ci/service-proxy:test' ]] || {
+    printf 'Buildah metadata verification used an unexpected command\n' >&2
+    exit 1
+  }
+}
+
+expect_required_log() {
+  mapfile -t invocations <"$invocation_log"
+  (( ${#invocations[@]} == 2 )) || {
+    printf 'required verification did not inspect and run exactly once\n' >&2
+    exit 1
+  }
+  [[ "${invocations[0]}" == \
+    'image inspect localhost/automata-ci/service-proxy:test' ]]
+  [[ "${invocations[1]}" == \
+    'run --rm --network none --read-only localhost/automata-ci/service-proxy:test' ]]
+}
+
+run_verifier metadata-only usage-invalid "$valid_inspection"
+expect_status 0
+expect_exact_stdout \
+  'Service-proxy image metadata verified; process probe is covered by the static binary contract'
+[[ ! -s "$stderr_log" ]]
+expect_valid_metadata_log
+
+run_verifier metadata-only usage-invalid "$buildah_inspection" buildah
+expect_status 0
+expect_exact_stdout \
+  'Service-proxy image metadata verified; process probe is covered by the static binary contract'
+[[ ! -s "$stderr_log" ]]
+expect_valid_buildah_metadata_log
+
+run_verifier default usage-invalid "$buildah_inspection" buildah
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: Buildah supports only metadata-only image verification'
+[[ ! -s "$invocation_log" ]]
+
+run_verifier metadata-only usage-invalid "$valid_inspection" buildah
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: image configuration is missing'
+expect_valid_buildah_metadata_log
+
+run_verifier metadata-only usage-invalid "$bad_label_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate labels differ'
+expect_valid_metadata_log
+
+run_verifier metadata-only usage-invalid "$bad_config_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate entrypoint differs'
+expect_valid_metadata_log
+
+run_verifier default usage-invalid "$valid_inspection"
+expect_status 0
+expect_exact_stdout 'Service-proxy image process and metadata verified'
+[[ ! -s "$stderr_log" ]]
+expect_required_log
+
+run_verifier default success "$valid_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate accepted an absent protocol command'
+expect_required_log
+
+run_verifier default stdout "$valid_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate failure wrote to stdout'
+expect_required_log
+
+run_verifier default cgroup "$valid_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate process diagnostic differs'
+expect_required_log
+
+run_verifier unsupported usage-invalid "$valid_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr \
+  'service-proxy-image: AUTOMATA_SERVICE_PROXY_PROCESS_PROBE must be required or metadata-only'
+[[ ! -s "$invocation_log" ]] || {
+  printf 'invalid process-probe mode invoked the container runtime\n' >&2
+  exit 1
+}
+
+builder_context="${scratch_directory}/builder-context"
+builder_output="${scratch_directory}/builder-output"
+install -d -m 0700 -- "$builder_context"
+: >"$invocation_log"
+set +e
+env \
+  "AUTOMATA_FAKE_PODMAN_INSPECTION=${valid_inspection}" \
+  "AUTOMATA_FAKE_PODMAN_LOG=${invocation_log}" \
+  AUTOMATA_FAKE_PODMAN_RUN_RESULT=usage-invalid \
+  AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME=podman \
+  AUTOMATA_SERVICE_PROXY_OCI_BUILDER=buildah-chroot \
+  AUTOMATA_SERVICE_PROXY_PROCESS_PROBE=metadata-only \
+  "PATH=${fake_bin}:${PATH}" \
+  "TMPDIR=${runtime_tmp}" \
+  "$candidate_builder" "$builder_context" "$builder_output" \
+  >"$stdout_log" 2>"$stderr_log"
+case_status=$?
+set -e
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr \
+  'service-proxy-candidate: buildah-chroot candidate builds require the Buildah image runtime'
+[[ ! -s "$invocation_log" ]] || {
+  printf 'rejected Buildah runtime selection performed image work\n' >&2
+  exit 1
+}
+[[ ! -e "$builder_output" ]] || {
+  printf 'rejected Buildah runtime selection created its output directory\n' >&2
+  exit 1
+}
+if find "$runtime_tmp" -mindepth 1 -maxdepth 1 \
+  -name 'podman-vfs.*' -print -quit | grep . >/dev/null; then
+  printf 'rejected Buildah runtime selection leaked a VFS store\n' >&2
+  exit 1
+fi
+
+python3 - "$repository_root" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+ci_path = root / ".ci/workflows/ci.yml"
+ci = ci_path.read_text(encoding="utf-8")
+
+
+def step(contents: str, name: str) -> tuple[int, str]:
+    marker = f"      - name: {name}\n"
+    start = contents.find(marker)
+    if start < 0:
+        raise SystemExit(f"service-proxy-image-test: workflow step is missing: {name}")
+    end = contents.find("\n      - name: ", start + len(marker))
+    if end < 0:
+        end = len(contents)
+    return start, contents[start:end]
+
+
+static_offset, static_step = step(ci, "Verify static binaries")
+candidate_offset, candidate_step = step(
+    ci, "Prepare digest-bound private service-proxy image candidate"
+)
+if (
+    static_offset >= candidate_offset
+    or "./scripts/ci/verify-service-proxy-static.sh" not in static_step
+):
+    raise SystemExit(
+        "service-proxy-image-test: static process verification must precede the image candidate"
+    )
+
+required_environment = (
+    "        env:\n"
+    "          AUTOMATA_SERVICE_PROXY_OCI_BUILDER: buildah-chroot\n"
+    "          AUTOMATA_SERVICE_PROXY_PROCESS_PROBE: metadata-only\n"
+    "        run: |\n"
+)
+if required_environment not in candidate_step:
+    raise SystemExit(
+        "service-proxy-image-test: CI candidate does not pin the Buildah chroot contract"
+    )
+if (
+    "AUTOMATA_ENVIRONMENT_PROFILE_ID" in candidate_step
+    or "AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME" in candidate_step
+    or "if [[" in candidate_step
+):
+    raise SystemExit(
+        "service-proxy-image-test: CI candidate contains a conditional or stale runtime"
+    )
+
+build = "./scripts/ci/build-service-proxy-candidate.sh"
+if candidate_step.count(build) != 2:
+    raise SystemExit(
+        "service-proxy-image-test: CI must build and reproduce exactly two candidates"
+    )
+policy_review = "python3 scripts/ci/service-proxy-publication.py prepare-candidate"
+if candidate_step.find(policy_review) <= candidate_step.rfind(build):
+    raise SystemExit(
+        "service-proxy-image-test: publication policy review must follow candidate builds"
+    )
+
+verify_tooling = step(ci, "Lint workflows and shell scripts")[1]
+for invocation in (
+    "./scripts/ci/tests/service-proxy-image.test.sh",
+    "python3 scripts/ci/tests/service-proxy-publication.test.py",
+):
+    if invocation not in verify_tooling:
+        raise SystemExit(
+            f"service-proxy-image-test: Verify does not run {invocation}"
+        )
+
+for relative in (".ci/workflows/release.yml", ".ci/workflows/service-proxy-image.yml"):
+    publication = (root / relative).read_text(encoding="utf-8")
+    if build not in publication:
+        raise SystemExit(
+            f"service-proxy-image-test: {relative} does not build a service-proxy candidate"
+        )
+    if (
+        "AUTOMATA_SERVICE_PROXY_OCI_BUILDER" in publication
+        or "AUTOMATA_SERVICE_PROXY_PROCESS_PROBE" in publication
+    ):
+        raise SystemExit(
+            f"service-proxy-image-test: {relative} overrides Podman required-process defaults"
+        )
+    if "AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME: podman" not in publication:
+        raise SystemExit(
+            f"service-proxy-image-test: {relative} does not pin the Podman runtime"
+        )
+PY
+
+printf 'Service-proxy image verifier contract verified\n'

--- a/scripts/ci/validate-service-proxy-buildah-containerfile.py
+++ b/scripts/ci/validate-service-proxy-buildah-containerfile.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Admit the exact non-executing Containerfile used by Buildah chroot CI."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import NoReturn
+
+
+EXPECTED_INSTRUCTIONS = (
+    "FROM scratch",
+    "ARG AUTOMATA_CREATED",
+    "ARG AUTOMATA_REVISION",
+    "ARG AUTOMATA_SERVICE_PROXY_BINARY_SHA256",
+    "ARG AUTOMATA_SERVICE_PROXY_SBOM_SHA256",
+    "ARG AUTOMATA_SERVICE_PROXY_SOURCE_SHA256",
+    "ARG AUTOMATA_VERSION",
+    (
+        'LABEL org.opencontainers.image.title="Automata CI service proxy" '
+        'org.opencontainers.image.description="Namespace-local bounded TCP and UDP proxy '
+        'for job service containers" '
+        'org.opencontainers.image.source="https://github.com/automata-ci/automata" '
+        'org.opencontainers.image.licenses="MIT" '
+        'org.opencontainers.image.created="${AUTOMATA_CREATED}" '
+        'org.opencontainers.image.revision="${AUTOMATA_REVISION}" '
+        'org.opencontainers.image.version="${AUTOMATA_VERSION}" '
+        'io.automata.service-proxy.protocol-version="1" '
+        'io.automata.service-proxy.binary.sha256='
+        '"${AUTOMATA_SERVICE_PROXY_BINARY_SHA256}" '
+        'io.automata.service-proxy.sbom.sha256='
+        '"${AUTOMATA_SERVICE_PROXY_SBOM_SHA256}" '
+        'io.automata.service-proxy.source.sha256='
+        '"${AUTOMATA_SERVICE_PROXY_SOURCE_SHA256}"'
+    ),
+    (
+        "COPY --chmod=0555 automata-ci-service-proxy "
+        "/usr/libexec/automata-ci-service-proxy"
+    ),
+    (
+        "COPY --chmod=0444 LICENSE "
+        "/usr/share/licenses/automata-ci-service-proxy/LICENSE"
+    ),
+    (
+        "COPY --chmod=0444 THIRD_PARTY_LICENSES.txt "
+        "/usr/share/licenses/automata-ci-service-proxy/THIRD_PARTY_LICENSES.txt"
+    ),
+    (
+        "COPY --chmod=0444 THIRD_PARTY_NOTICES.txt "
+        "/usr/share/licenses/automata-ci-service-proxy/THIRD_PARTY_NOTICES.txt"
+    ),
+    (
+        "COPY --chmod=0444 VERSION "
+        "/usr/share/doc/automata-ci-service-proxy/VERSION"
+    ),
+    (
+        "COPY --chmod=0444 source-provenance.json "
+        "/usr/share/doc/automata-ci-service-proxy/source-provenance.json"
+    ),
+    (
+        "COPY --chmod=0444 sbom/automata-ci-service-proxy.cdx.json "
+        "/usr/share/sbom/automata-ci-service-proxy.cdx.json"
+    ),
+    "WORKDIR /",
+    "USER 65532:65532",
+    'ENTRYPOINT ["/usr/libexec/automata-ci-service-proxy"]',
+)
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"service-proxy-buildah-containerfile: {message}")
+
+
+def logical_instructions(contents: bytes) -> tuple[str, ...]:
+    if any(byte != 0x0A and not 0x20 <= byte <= 0x7E for byte in contents):
+        fail("Containerfile contains non-ASCII or control bytes")
+    text = contents.decode("ascii")
+    if not text.endswith("\n"):
+        fail("Containerfile must end with one LF")
+
+    instructions: list[str] = []
+    fragments: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line:
+            if fragments:
+                fail(f"line {line_number} interrupts a continued instruction")
+            continue
+        if line != line.rstrip() or "\t" in line:
+            fail(f"line {line_number} contains unsupported whitespace")
+        if "#" in line:
+            fail(f"line {line_number} contains an unsupported comment")
+        if fragments:
+            if not line.startswith(" "):
+                fail(f"line {line_number} is not an indented continuation")
+        elif line.startswith(" "):
+            fail(f"line {line_number} has unexpected indentation")
+        if "\\" in line[:-1]:
+            fail(f"line {line_number} contains an unsupported escape")
+
+        continued = line.endswith("\\")
+        fragment = line[:-1] if continued else line
+        fragment = fragment.strip()
+        if not fragment:
+            fail(f"line {line_number} is an empty instruction fragment")
+        fragments.append(fragment)
+        if not continued:
+            instructions.append(" ".join(fragments))
+            fragments = []
+
+    if fragments:
+        fail("Containerfile ends inside a continued instruction")
+    return tuple(instructions)
+
+
+def validate(path: pathlib.Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        fail("Containerfile must be a regular file")
+    try:
+        contents = path.read_bytes()
+    except OSError as error:
+        fail(f"could not read Containerfile: {error}")
+    if logical_instructions(contents) != EXPECTED_INSTRUCTIONS:
+        fail("instructions differ from the reviewed non-executing policy")
+
+
+def main(arguments: list[str]) -> int:
+    if len(arguments) != 1:
+        fail("usage: validate-service-proxy-buildah-containerfile.py CONTAINERFILE")
+    validate(pathlib.Path(arguments[0]))
+    print("Service-proxy Buildah Containerfile policy verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/verify-service-proxy-image.sh
+++ b/scripts/ci/verify-service-proxy-image.sh
@@ -32,8 +32,8 @@ if [[ "$runtime" == auto ]]; then
   fi
 fi
 case "$runtime" in
-  docker | podman) ;;
-  *) die "container runtime must be docker, podman, or auto" ;;
+  buildah | docker | podman) ;;
+  *) die "container runtime must be buildah, docker, podman, or auto" ;;
 esac
 command -v "$runtime" >/dev/null 2>&1 || die "requested runtime is unavailable"
 
@@ -42,7 +42,10 @@ case "$process_probe" in
   required | metadata-only) ;;
   *) die "AUTOMATA_SERVICE_PROXY_PROCESS_PROBE must be required or metadata-only" ;;
 esac
-readonly process_probe
+if [[ "$runtime" == buildah && "$process_probe" != metadata-only ]]; then
+  die "Buildah supports only metadata-only image verification"
+fi
+readonly runtime process_probe
 
 automata_init_target_root "$repository_root"
 automata_set_target_tmpdir \
@@ -54,18 +57,32 @@ cleanup() {
   rm -rf -- "$scratch_directory"
 }
 trap cleanup EXIT
-"$runtime" image inspect "$image" > "$scratch_directory/inspection.json" \
-  || die "candidate image is unavailable"
-python3 - "$scratch_directory/inspection.json" "$version" "$revision" "$created" <<'PY'
+if [[ "$runtime" == buildah ]]; then
+  buildah inspect --type image "$image" > "$scratch_directory/inspection.json" \
+    || die "candidate image is unavailable"
+else
+  "$runtime" image inspect "$image" > "$scratch_directory/inspection.json" \
+    || die "candidate image is unavailable"
+fi
+python3 - \
+  "$scratch_directory/inspection.json" \
+  "$version" \
+  "$revision" \
+  "$created" \
+  "$runtime" <<'PY'
 import json
 import pathlib
 import sys
 
-version, revision, created = sys.argv[2:5]
-documents = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
-if not isinstance(documents, list) or len(documents) != 1:
-    raise SystemExit("service-proxy-image: image inspection was not singular")
-config = documents[0].get("Config")
+version, revision, created, runtime = sys.argv[2:6]
+inspection = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+if runtime == "buildah":
+    oci = inspection.get("OCIv1") if isinstance(inspection, dict) else None
+    config = oci.get("config") if isinstance(oci, dict) else None
+else:
+    if not isinstance(inspection, list) or len(inspection) != 1:
+        raise SystemExit("service-proxy-image: image inspection was not singular")
+    config = inspection[0].get("Config")
 if not isinstance(config, dict):
     raise SystemExit("service-proxy-image: image configuration is missing")
 labels = config.get("Labels")


### PR DESCRIPTION
## Outcome

Native static-distribution CI can build and verify the private service-proxy OCI candidate inside Automata's nested provider pod. The job now uses a private-VFS Buildah chroot backend for the metadata-only native-CI path, avoiding nested Podman user-namespace creation that is unavailable in that topology.

The previous environment-profile conditional was removed because runner environment sanitization does not preserve that marker. Selection is now explicit and step-local. The exact production stderr was not exposed by the check API, but the provider pod topology reproduces the nested Podman namespace failure and the new path completed twice there with byte-identical Buildah outputs.

## Related issue

Closes #147.

## Trust and compatibility impact

The native CI job installs Buildah, pins the `buildah-chroot` builder, and uses metadata-only image verification after the existing static-binary process check. Buildah chroot requires host networking, so a fail-closed validator runs before the build and admits only the exact reviewed `FROM scratch` Containerfile instruction sequence: build arguments, labels, local copies, working directory, non-root user, and entrypoint. It rejects executable, remote-input, multi-stage, parser-directive, and malformed instruction forms.

The exported OCI archive still passes the existing descriptor, configuration, layer, file-mode, source-binding, SBOM, and publication-policy validators. Manual, release, and publication workflows remain on the Podman default with the required live process probe. Reproducibility is asserted within each backend; Buildah and Podman byte identity is intentionally not claimed.

No application dependency, credential, storage, protocol, or published artifact format changes.

## Verification

- Exact provider-pod replay: two Buildah chroot builds, metadata inspection, OCI export, candidate validation, byte comparison, image cleanup, and VFS cleanup passed; candidate SHA-256 `27c0263dd6c574870cc7131114fc8560b745b7199b00ba6f528a742b0195d12d`.
- Buildah-produced OCI loaded outside the nested sandbox and passed the existing required Podman process and metadata verifier.
- Buildah Containerfile policy tests: 8/8 passed.
- Candidate contract tests: 7/7 passed.
- Service-proxy publication tests: 11/11 passed and are now wired into Verify.
- Release handoff tests: 9/9 passed.
- Publish planner tests: 17/17 passed.
- Fake Podman/Buildah image verifier and workflow contract passed.
- Container-context contract passed.
- `cargo fmt --all -- --check` passed.
- Shellcheck over CI scripts passed.
- Actionlint over every workflow passed.
- Python compilation and `git diff --check` passed.

## AI assistance

OpenAI Codex implemented the change, reproduced the runner topology, designed adversarial policy tests, and performed independent security and diff reviews. Every submitted change was reviewed and the critical path was replayed independently.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.