### PR TITLE
refactor(auth): remove duplicate KMS contract

### DIFF
--- a/crates/automata-ci-auth/README.md
+++ b/crates/automata-ci-auth/README.md
@@ -4,21 +4,21 @@ This crate contains Automata's authentication and authorization domain contracts
 It deliberately has no HTTP client, database, web framework, or runtime dependency.
 
 Human identity providers, machine identity verification, session issuance, RBAC,
-provider-token custody, key encryption, and output publication policy are separate
-boundaries. The GitHub App module models the browser and device authorization
-protocols without deciding how HTTP or durable storage are implemented.
+provider-token custody, and output publication policy are separate boundaries. The
+GitHub App module models the browser and device authorization protocols without
+deciding how HTTP or durable storage are implemented.
 
 Provider access and refresh tokens are secret-bearing, non-serializable values.
 They must be handed to a `ProviderTokenVault` implementation backed by authenticated
-encryption. This crate exposes the vault and key-encryption ports; it does not pretend
-that encoding or redaction is encryption.
+encryption. This crate owns the provider-token custody values and vault port;
+`automata-ci-key-management` owns encryption and key wrapping.
 
-Durable identity, session, machine-certificate, token-metadata, vault-key, and
-key-encryption-context values have private fields and validated constructors. Their
-deserializers run the same validation, so storage and wire round trips cannot bypass
-domain invariants. Secret-bearing aggregates expose only focused borrowed accessors
-and deliberate consuming `into_parts` methods; they remain non-serializable and
-redacted in debug output.
+Durable identity, session, machine-certificate, token-metadata, and vault-key values
+have private fields and validated constructors. Their deserializers run the same
+validation, so storage and wire round trips cannot bypass domain invariants.
+Secret-bearing aggregates expose only focused borrowed accessors and deliberate
+consuming `into_parts` methods; they remain non-serializable and redacted in debug
+output.
 
 Control-plane adapters must keep browser/device transaction state in a shared,
 encrypted, single-use store so any orchestrator replica can finish a flow without

--- a/crates/automata-ci-auth/src/lib.rs
+++ b/crates/automata-ci-auth/src/lib.rs
@@ -38,5 +38,5 @@ pub mod session_credential;
 pub mod sign_in;
 /// Injectable clocks and bounded Unix timestamp arithmetic.
 pub mod time;
-/// Provider-token custody and key-encryption boundaries.
+/// Provider-token custody values and vault port.
 pub mod vault;

--- a/crates/automata-ci-auth/src/secret.rs
+++ b/crates/automata-ci-auth/src/secret.rs
@@ -170,7 +170,7 @@ fn constant_time_string_eq(left: &str, right: &str) -> bool {
     bool::from(equal)
 }
 
-/// Secret binary material, such as an unwrapped data-encryption key.
+/// Secret binary material, such as session-credential HMAC key material.
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub struct SecretBytes(Vec<u8>);
 

--- a/crates/automata-ci-auth/src/vault.rs
+++ b/crates/automata-ci-auth/src/vault.rs
@@ -5,13 +5,12 @@ use thiserror::Error;
 
 use crate::{
     human::{ProviderId, ProviderSubject, TenantId},
-    secret::{SecretBytes, SecretString},
+    secret::SecretString,
     time::UnixTimestamp,
 };
 
 const MAX_TOKEN_TYPE_LENGTH: usize = 255;
 const MAX_SCOPE_LENGTH: usize = 255;
-const MAX_KEY_ENCRYPTION_PURPOSE_LENGTH: usize = 128;
 
 /// A redacted provider access token with explicit plaintext exposure.
 pub struct ProviderAccessToken(SecretString);
@@ -572,159 +571,4 @@ pub enum ProviderTokenVaultError {
     /// Authenticated ciphertext or its bound context failed validation.
     #[error("provider token ciphertext failed authentication")]
     IntegrityFailure,
-}
-
-/// Stable separation label for one use of a data-encryption key.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(try_from = "String", into = "String")]
-pub struct KeyEncryptionPurpose(String);
-
-impl KeyEncryptionPurpose {
-    /// Creates a portable, bounded key-encryption purpose.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for an empty, oversized, or non-portable purpose.
-    pub fn new(value: impl Into<String>) -> Result<Self, KeyEncryptionContextError> {
-        let value = value.into();
-        if value.is_empty()
-            || value.len() > MAX_KEY_ENCRYPTION_PURPOSE_LENGTH
-            || !value.bytes().all(|character| {
-                character.is_ascii_alphanumeric()
-                    || matches!(character, b'-' | b'_' | b':' | b'.' | b'/')
-            })
-        {
-            return Err(KeyEncryptionContextError::InvalidPurpose);
-        }
-        Ok(Self(value))
-    }
-
-    /// Returns the stable domain-separation label.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl TryFrom<String> for KeyEncryptionPurpose {
-    type Error = KeyEncryptionContextError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl From<KeyEncryptionPurpose> for String {
-    fn from(value: KeyEncryptionPurpose) -> Self {
-        value.0
-    }
-}
-
-/// Non-secret, authenticated context bound to a wrapped data-encryption key.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct KeyEncryptionContext {
-    tenant_id: TenantId,
-    purpose: KeyEncryptionPurpose,
-}
-
-impl KeyEncryptionContext {
-    /// Binds a data-encryption key to one tenant and domain-separation purpose.
-    pub const fn new(tenant_id: TenantId, purpose: KeyEncryptionPurpose) -> Self {
-        Self { tenant_id, purpose }
-    }
-
-    /// Returns the tenant authenticated by key wrapping.
-    pub const fn tenant_id(&self) -> &TenantId {
-        &self.tenant_id
-    }
-
-    /// Returns the operation-specific domain-separation purpose.
-    pub const fn purpose(&self) -> &KeyEncryptionPurpose {
-        &self.purpose
-    }
-
-    /// Consumes the context into its authenticated components.
-    pub fn into_parts(self) -> (TenantId, KeyEncryptionPurpose) {
-        (self.tenant_id, self.purpose)
-    }
-}
-
-/// Opaque KMS/HSM output. It is ciphertext, but debug output still omits its bytes.
-pub struct WrappedDataKey(Vec<u8>);
-
-impl WrappedDataKey {
-    /// Creates an opaque wrapped data key from non-empty ciphertext.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for empty ciphertext.
-    pub fn new(bytes: Vec<u8>) -> Result<Self, KeyEncryptionError> {
-        if bytes.is_empty() {
-            return Err(KeyEncryptionError::InvalidCiphertext);
-        }
-        Ok(Self(bytes))
-    }
-
-    /// Borrows the opaque wrapped-key ciphertext.
-    pub fn ciphertext(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// Consumes the wrapper into its opaque ciphertext bytes.
-    pub fn into_ciphertext(self) -> Vec<u8> {
-        self.0
-    }
-}
-
-impl fmt::Debug for WrappedDataKey {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("WrappedDataKey")
-            .field("ciphertext_length", &self.0.len())
-            .finish()
-    }
-}
-
-/// A key-encryption operation whose failures never include key bytes.
-pub type KeyEncryptionFuture<'a, T> =
-    Pin<Box<dyn Future<Output = Result<T, KeyEncryptionError>> + Send + 'a>>;
-
-/// Port implemented by a KMS, HSM, Vault transit engine, or equivalent KEK service.
-/// Token-vault adapters use it to wrap data-encryption keys; this is not itself an
-/// encryption implementation.
-pub trait KeyEncryptionProvider: fmt::Debug + Send + Sync {
-    /// Wraps a plaintext data-encryption key under authenticated context.
-    fn wrap_data_key<'a>(
-        &'a self,
-        plaintext_key: &'a SecretBytes,
-        context: &'a KeyEncryptionContext,
-    ) -> KeyEncryptionFuture<'a, WrappedDataKey>;
-
-    /// Unwraps a data-encryption key only under the identical context.
-    fn unwrap_data_key<'a>(
-        &'a self,
-        wrapped_key: &'a WrappedDataKey,
-        context: &'a KeyEncryptionContext,
-    ) -> KeyEncryptionFuture<'a, SecretBytes>;
-}
-
-/// Sanitized failures from the key-encryption provider boundary.
-#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum KeyEncryptionError {
-    /// Wrapped-key ciphertext is empty, malformed, or unauthenticated.
-    #[error("wrapped data key is invalid")]
-    InvalidCiphertext,
-    #[error("key-encryption provider rejected the authenticated context")]
-    /// The ciphertext is not bound to the supplied tenant and purpose.
-    ContextMismatch,
-    /// The KMS, HSM, or equivalent provider is temporarily unavailable.
-    #[error("key-encryption provider is unavailable")]
-    Unavailable,
-}
-
-/// Validation failures for key-encryption domain separation.
-#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum KeyEncryptionContextError {
-    /// The purpose is empty, oversized, or outside the portable alphabet.
-    #[error("key-encryption purpose is invalid")]
-    InvalidPurpose,
 }

--- a/crates/automata-ci-auth/tests/domain_value_contracts.rs
+++ b/crates/automata-ci-auth/tests/domain_value_contracts.rs
@@ -15,10 +15,9 @@ use automata_ci_auth::{
     },
     time::UnixTimestamp,
     vault::{
-        KeyEncryptionContext, KeyEncryptionPurpose, ProviderAccessToken, ProviderGrantKind,
-        ProviderRefreshToken, ProviderTokenKey, ProviderTokenMetadata, ProviderTokenMetadataError,
-        ProviderTokenSet, ProviderTokenSetError, TokenVersion, VersionedProviderTokens,
-        WrappedDataKey,
+        ProviderAccessToken, ProviderGrantKind, ProviderRefreshToken, ProviderTokenKey,
+        ProviderTokenMetadata, ProviderTokenMetadataError, ProviderTokenSet, ProviderTokenSetError,
+        TokenVersion, VersionedProviderTokens,
     },
 };
 use serde_json::json;
@@ -256,7 +255,7 @@ fn token_metadata_and_secret_material_cannot_become_inconsistent() {
 }
 
 #[test]
-fn vault_keys_and_encryption_purposes_are_typed_and_round_trip_safely() {
+fn vault_keys_are_typed_and_round_trip_safely() {
     let credential = ProviderCredential::new(provider_id(), secret("provider-access-secret"));
     assert_eq!(credential.provider_id().as_str(), "github");
     assert!(!format!("{credential:?}").contains("provider-access-secret"));
@@ -272,15 +271,4 @@ fn vault_keys_and_encryption_purposes_are_typed_and_round_trip_safely() {
         serde_json::from_value::<ProviderTokenKey>(encoded).expect("deserialize token key"),
         key
     );
-
-    assert!(KeyEncryptionPurpose::new("").is_err());
-    assert!(KeyEncryptionPurpose::new("provider tokens").is_err());
-    let purpose = KeyEncryptionPurpose::new("auth/provider-tokens:v1").expect("encryption purpose");
-    let context = KeyEncryptionContext::new(TenantId::new("tenant-1").expect("tenant ID"), purpose);
-    assert_eq!(context.tenant_id().as_str(), "tenant-1");
-    assert_eq!(context.purpose().as_str(), "auth/provider-tokens:v1");
-
-    let wrapped = WrappedDataKey::new(vec![11, 22, 33]).expect("wrapped data key");
-    assert!(!format!("{wrapped:?}").contains("11, 22, 33"));
-    assert_eq!(wrapped.into_ciphertext(), vec![11, 22, 33]);
 }

--- a/crates/automata-ci-auth/tests/port_contracts.rs
+++ b/crates/automata-ci-auth/tests/port_contracts.rs
@@ -6,7 +6,7 @@ use automata_ci_auth::{
     login::LoginTransactionRepository,
     machine::MachineIdentityVerifier,
     session::{HumanSessionRepository, SessionIssuer},
-    vault::{KeyEncryptionProvider, ProviderTokenVault},
+    vault::ProviderTokenVault,
 };
 use static_assertions::assert_obj_safe;
 
@@ -20,7 +20,6 @@ assert_obj_safe!(HumanSessionRepository);
 assert_obj_safe!(LoginTransactionRepository);
 assert_obj_safe!(GithubEndpoint);
 assert_obj_safe!(ProviderTokenVault);
-assert_obj_safe!(KeyEncryptionProvider);
 
 #[test]
 fn runtime_plugin_ports_remain_object_safe() {

--- a/crates/automata-ci-auth/tests/secret_safety.rs
+++ b/crates/automata-ci-auth/tests/secret_safety.rs
@@ -9,10 +9,7 @@ use automata_ci_auth::{
         CsrfToken, PkceVerifier, SecretBytes, SecretString, SessionToken, SharedSensitiveString,
     },
     session::IssuedSession,
-    vault::{
-        ProviderAccessToken, ProviderRefreshToken, ProviderTokenSet, VersionedProviderTokens,
-        WrappedDataKey,
-    },
+    vault::{ProviderAccessToken, ProviderRefreshToken, ProviderTokenSet, VersionedProviderTokens},
 };
 use static_assertions::{assert_impl_all, assert_not_impl_any};
 use support::{DeterministicRandom, secret, token_response};
@@ -25,7 +22,6 @@ assert_not_impl_any!(ProviderTokenSet: serde::Serialize, Clone);
 assert_not_impl_any!(ProviderCredential: serde::Serialize, Clone);
 assert_not_impl_any!(IssuedSession: serde::Serialize, Clone);
 assert_not_impl_any!(VersionedProviderTokens: serde::Serialize, Clone);
-assert_not_impl_any!(WrappedDataKey: serde::Serialize, Clone);
 assert_not_impl_any!(GithubTokenResponse: serde::Serialize, Clone);
 assert_not_impl_any!(SessionToken: serde::Serialize, Clone);
 assert_impl_all!(SharedSensitiveString: Clone, Send, Sync);


### PR DESCRIPTION
Closes #149

## Summary

- remove the unused auth-owned KMS surface from `automata_ci_auth::vault`
- keep `ProviderTokenVault` and every provider-token custody value/operation unchanged
- point auth ownership docs at the canonical `automata-ci-key-management` boundary
- retain `SecretBytes` for active auth state and session-credential key material, with no behavior change

The removed module-level items are:

- `KeyEncryptionPurpose`
- `KeyEncryptionContext`
- `WrappedDataKey`
- `KeyEncryptionFuture`
- `KeyEncryptionProvider`
- `KeyEncryptionError`
- `KeyEncryptionContextError`

These had no production consumer or implementation. All repository implementations of `KeyEncryptionProvider` already target `automata-ci-key-management`, whose context, key identity, bounds, envelope, rotation, and authenticated-ciphertext contracts are the actual production boundary.

## Scope and compatibility

- 7 files
- 21 insertions / 194 deletions (net -173)
- no manifest, lockfile, dependency, runtime, schema, migration, wire, or durable-format change
- `ProviderTokenVault`, `VaultFuture`, provider token models, vault error semantics, and auth `SecretBytes` behavior are byte-for-byte unchanged

This intentionally removes public Rust source API from an unpublished `0.1.0` crate. Neither auth nor key-management has a crates.io release, repository tag, or GitHub release. The canonical API is stronger but not source-compatible, so this PR deliberately does not add a misleading compatibility re-export or a new auth dependency.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- auth all-target/all-feature tests: 139 passed
- key-management all-target/all-feature tests: 20 passed
- strict auth all-target/all-feature Clippy with `-D warnings`
- auth rustdoc with `-D warnings`
- workspace all-target check across all consumers
- filtered PostgreSQL auth trait-object/redaction contracts passed
- auth package archive inventory includes every changed source/test/doc file
- exhaustive reference scan found no remaining auth-vault KMS imports or implementations
- independent API/release review: pass

## Rebase note

Rebased onto current main after #131/#134/#143/#144/#151. The #131 auth README conflict was resolved as a strict ownership union: auth keeps the merged output-policy boundary, while encryption/key wrapping is assigned only to `automata-ci-key-management`.
