### PR TITLE
Fix tagged digest ownership after Podman inspection

### DIFF
--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -1215,7 +1215,7 @@ impl PodmanInner {
         let alias = lines.next();
         let create_command = lines.next();
         if lines.next().is_some()
-            || image != Some(entry.image())
+            || image.is_none_or(|value| !same_immutable_image(entry.image(), value))
             || publication != Some("unpublished")
             || alias != Some("alias")
             || create_command
@@ -3911,6 +3911,29 @@ mod command_completion_tests {
     }
 
     #[test]
+    fn immutable_image_comparison_accepts_only_podmans_tag_normalization() {
+        let digest = format!("sha256:{}", "a7".repeat(32));
+        let tagged = format!("registry.example.invalid:5443/team/postgres:18.4@{digest}");
+        let normalized = format!("registry.example.invalid:5443/team/postgres@{digest}");
+
+        assert!(same_immutable_image(&tagged, &normalized));
+        assert!(same_immutable_image(&normalized, &tagged));
+        assert!(same_immutable_image(&tagged, &tagged));
+
+        for rejected in [
+            format!("registry.example.invalid:5443/other/postgres@{digest}"),
+            format!("registry.example.invalid/team/postgres@{digest}"),
+            format!(
+                "registry.example.invalid:5443/team/postgres@sha256:{}",
+                "b8".repeat(32)
+            ),
+            "registry.example.invalid:5443/team/postgres:18.4".to_owned(),
+        ] {
+            assert!(!same_immutable_image(&tagged, &rejected));
+        }
+    }
+
+    #[test]
     fn owned_cgroup_path_accepts_exact_systemd_hex_escapes() {
         let delegated = r"/system.slice/system-automata\x2drunner.slice/automata-runner@2.service";
         let reported = format!("{delegated}/62c1f632b461fadf3d4cd0e8ac330ad1b\n");
@@ -4628,6 +4651,38 @@ fn service_configuration_format(network: &str, alias: &str) -> String {
          {{{{else}}}}missing{{{{end}}}}\n\
          {{{{json .Config.CreateCommand}}}}"
     )
+}
+
+fn same_immutable_image(expected: &str, observed: &str) -> bool {
+    if expected == observed {
+        return true;
+    }
+    let Some((expected_name, expected_digest)) = expected.rsplit_once('@') else {
+        return false;
+    };
+    let Some((observed_name, observed_digest)) = observed.rsplit_once('@') else {
+        return false;
+    };
+    !expected_name.contains('@')
+        && !observed_name.contains('@')
+        && expected_digest == observed_digest
+        && expected_digest
+            .strip_prefix("sha256:")
+            .is_some_and(|value| {
+                value.len() == 64
+                    && value
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            })
+        && image_repository(expected_name) == image_repository(observed_name)
+}
+
+fn image_repository(name: &str) -> &str {
+    let final_slash = name.rfind('/');
+    match name.rfind(':') {
+        Some(tag) if final_slash.is_none_or(|slash| tag > slash) => &name[..tag],
+        _ => name,
+    }
 }
 
 fn creation_command_has_exact_network_sysctl(bytes: &[u8]) -> bool {

--- a/crates/automata-ci-sandbox-podman/tests/service_containers.rs
+++ b/crates/automata-ci-sandbox-podman/tests/service_containers.rs
@@ -101,6 +101,29 @@ fn services_use_one_job_network_hardened_argv_and_restart_durable_bindings() {
 }
 
 #[test]
+fn podman_normalized_tagged_digest_remains_exactly_owned() {
+    let fixture = Fixture::new_with_service_proxy("service-tagged-digest-normalization");
+    fixture.fake.normalize_tagged_digest_image_names();
+    let record = fixture
+        .provider
+        .create(&service_spec(OperationId::new()), &NeverCancelled)
+        .expect("create services after Podman normalizes tagged digest names");
+
+    fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                record.handle().clone(),
+                record.generation(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("normalized immutable image remains safely destroyable");
+    assert!(fixture.fake.is_empty());
+}
+
+#[test]
 fn stopped_proxy_is_recreated_with_fresh_logs_and_the_durable_listener_ports() {
     let fixture = Fixture::new_with_service_proxy("service-proxy-restart");
     let spec = service_spec(OperationId::new());
@@ -933,7 +956,7 @@ fn service_spec_with_database_variable(
 
 fn service_image(byte: u8) -> ImmutableImage {
     ImmutableImage::new(format!(
-        "registry.example.invalid/synthetic/service@sha256:{}",
+        "registry.example.invalid/synthetic/service:stable@sha256:{}",
         format!("{byte:02x}").repeat(32)
     ))
     .expect("immutable service image")

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -123,6 +123,7 @@ struct FakeState {
     wrong_proxy_identifier_once: bool,
     drift_health_configuration_once: bool,
     replace_network_before_remove: bool,
+    normalize_tagged_digest_image_names: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -149,6 +150,13 @@ impl std::fmt::Debug for FakePodman {
 impl FakePodman {
     pub(crate) fn commands(&self) -> Vec<Vec<String>> {
         self.state.lock().expect("fake lock").commands.clone()
+    }
+
+    pub(crate) fn normalize_tagged_digest_image_names(&self) {
+        self.state
+            .lock()
+            .expect("fake lock")
+            .normalize_tagged_digest_image_names = true;
     }
 
     pub(crate) fn fail_once(&self, command: &[&str]) {
@@ -1008,6 +1016,9 @@ fn create_fake_container(state: &mut FakeState, arguments: &[String]) -> Command
         .find(|value| value.contains("@sha256:"))
         .cloned()
         .unwrap_or_default();
+    if state.normalize_tagged_digest_image_names {
+        resource.image_name = podman_normalized_digest_reference(&resource.image_name);
+    }
     if arguments.iter().any(|value| value == "--network-alias") {
         state.next_service_address = state.next_service_address.max(10).saturating_add(1);
         resource.network_address = Some(format!("10.89.0.{}", state.next_service_address));
@@ -1101,6 +1112,18 @@ fn create_fake_container(state: &mut FakeState, arguments: &[String]) -> Command
     } else {
         CommandOutput::success(format!("{identifier}\n").into_bytes())
     }
+}
+
+fn podman_normalized_digest_reference(reference: &str) -> String {
+    let Some((name, digest)) = reference.rsplit_once('@') else {
+        return reference.to_owned();
+    };
+    let final_slash = name.rfind('/');
+    let repository = match name.rfind(':') {
+        Some(tag) if final_slash.is_none_or(|slash| tag > slash) => &name[..tag],
+        _ => name,
+    };
+    format!("{repository}@{digest}")
 }
 
 fn execute_fake_copy(


### PR DESCRIPTION
## Summary

- accept Podman inspection normalization that drops a tag from a digest-pinned image reference
- continue requiring the exact repository and lowercase SHA-256 digest
- cover create and exact cleanup through the service-container regression harness

## Validation

- `cargo fmt --check`
- `cargo test -p automata-ci-sandbox-podman`
- `cargo clippy -p automata-ci-sandbox-podman --all-targets -- -D warnings`