### PR TITLE
fix(ci): recognize Control adapter SPI test modules

### DIFF
--- a/scripts/ci/tests/integration-test-targets.test.py
+++ b/scripts/ci/tests/integration-test-targets.test.py
@@ -145,9 +145,26 @@ POSTGRES_TEST_SUPPORT_MODULES = frozenset({
     ("crates/automata-ci-postgres/tests/secret/mod.rs", "provider_replay"),
     ("crates/automata-ci-postgres/tests/runner_auth/mod.rs", "directory"),
 })
+
+# Control's adapter contract tests remain unavailable unless the package's
+# deliberately narrow adapter SPI is enabled.
+CONTROL_ADAPTER_SPI_MODULES = frozenset({
+    (
+        "crates/automata-ci-control/tests/control.rs",
+        "attempt_adapter_port",
+    ),
+    ("crates/automata-ci-control/tests/control.rs", "attempt_api"),
+    (
+        "crates/automata-ci-control/tests/control.rs",
+        "attempt_snapshot_api",
+    ),
+})
 REVIEWED_OUTER_ATTRIBUTES = {
     module: ('#[cfg(feature = "test-support")]',)
     for module in POSTGRES_TEST_SUPPORT_MODULES
+} | {
+    module: ('#[cfg(feature = "adapter-spi")]',)
+    for module in CONTROL_ADAPTER_SPI_MODULES
 }
 
 ASCII_RUST_WHITESPACE = " \t\n\r\x0b\x0c"


### PR DESCRIPTION
## Summary

- register the three feature-gated Control adapter-contract modules with the integration-test topology verifier
- require the exact `#[cfg(feature = "adapter-spi")]` attribute for each module
- leave parser logic and all existing exception data unchanged

## Cause

#136 and #138 were sibling branches from the same base. #136 added `attempt_adapter_port`, `attempt_api`, and `attempt_snapshot_api` behind Control's narrow `adapter-spi` feature. Seven seconds later, #138 merged the stricter topology verifier, which had been validated before those attributes existed and recognized only PostgreSQL's feature-gated routes.

The merged `main` verifier therefore exits immediately with:

```text
unsupported attribute on attempt_adapter_port in crates/automata-ci-control/tests/control.rs
```

All three modules import `automata_ci_control::adapter_spi`, so removing their gates would be incorrect. This patch adds only the exact reviewed module/attribute pairs.

## Validation

- topology verifier: 28 aggregate packages / 345 Rust sources / 33 targets
- exact mutation matrix: correct attributes accepted; missing, changed, duplicated, extra, or copied exceptions rejected
- Control aggregate default: 125 passed
- Control aggregate all features: 134 passed, including the 9 gated tests
- strict no-deps Control Clippy with warnings denied
- Python compile, rustfmt, and diff checks

The failure reproduces on untouched parent `ee5e7bb9`; the patched verifier passes without changing any Rust source or test target.
