### PR TITLE
refactor(app): share private JSON API contracts

### DIFF
--- a/crates/automata-ci/src/app/api_support.rs
+++ b/crates/automata-ci/src/app/api_support.rs
@@ -1,0 +1,316 @@
+//! Shared wire contracts for authenticated JSON application APIs.
+
+use axum::{
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ApiError {
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    InvalidRequest,
+    UnsupportedMediaType,
+    TooLarge,
+    Conflict,
+    Unavailable,
+    Internal,
+}
+
+impl ApiError {
+    const fn status(self) -> StatusCode {
+        match self {
+            Self::Unauthorized => StatusCode::UNAUTHORIZED,
+            Self::Forbidden => StatusCode::FORBIDDEN,
+            Self::NotFound => StatusCode::NOT_FOUND,
+            Self::InvalidRequest => StatusCode::BAD_REQUEST,
+            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            Self::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::Conflict => StatusCode::CONFLICT,
+            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    const fn code(self) -> &'static str {
+        match self {
+            Self::Unauthorized => "unauthorized",
+            Self::Forbidden => "forbidden",
+            Self::NotFound => "not_found",
+            Self::InvalidRequest => "invalid_request",
+            Self::UnsupportedMediaType => "unsupported_media_type",
+            Self::TooLarge => "request_too_large",
+            Self::Conflict => "conflict",
+            Self::Unavailable => "dependency_unavailable",
+            Self::Internal => "internal_error",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let mut response = json_response(self.status(), &ErrorDocument { error: self.code() });
+        if self == Self::Unauthorized {
+            response.headers_mut().insert(
+                header::WWW_AUTHENTICATE,
+                HeaderValue::from_static("Bearer realm=\"automata\""),
+            );
+        }
+        if self == Self::Unavailable {
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+        }
+        response
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorDocument {
+    error: &'static str,
+}
+
+pub(super) fn canonical_uuid(value: &str) -> Result<Uuid, ApiError> {
+    let parsed = Uuid::parse_str(value).map_err(|_| ApiError::InvalidRequest)?;
+    if parsed.is_nil() || parsed.hyphenated().to_string() != value {
+        return Err(ApiError::InvalidRequest);
+    }
+    Ok(parsed)
+}
+
+pub(super) fn is_json_content_type(headers: &HeaderMap) -> bool {
+    let mut values = headers.get_all(header::CONTENT_TYPE).iter();
+    let Some(value) = values.next() else {
+        return false;
+    };
+    if values.next().is_some() {
+        return false;
+    }
+    value.to_str().is_ok_and(|value| {
+        let mut parts = value.split(';');
+        if !parts
+            .next()
+            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
+        {
+            return false;
+        }
+        let Some(parameter) = parts.next() else {
+            return true;
+        };
+        parts.next().is_none()
+            && parameter
+                .trim()
+                .split_once('=')
+                .is_some_and(|(name, value)| {
+                    name.trim().eq_ignore_ascii_case("charset")
+                        && value.trim().eq_ignore_ascii_case("utf-8")
+                })
+    })
+}
+
+pub(super) fn json_response<T: Serialize>(status: StatusCode, document: &T) -> Response {
+    match serde_json::to_vec(document) {
+        Ok(body) => (
+            status,
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            body,
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            br#"{"error":"internal_error"}"#.as_slice(),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+
+    use super::*;
+
+    #[test]
+    fn json_content_type_accepts_only_one_exact_json_media_type() {
+        for valid in [
+            "application/json",
+            "APPLICATION/JSON",
+            "application/json; charset=utf-8",
+            "application/json ; CHARSET = UTF-8",
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::CONTENT_TYPE, HeaderValue::from_str(valid).unwrap());
+            assert!(is_json_content_type(&headers), "rejected {valid}");
+        }
+
+        assert!(!is_json_content_type(&HeaderMap::new()));
+        for invalid in [
+            "text/json",
+            "application/json; charset=iso-8859-1",
+            "application/json; profile=x",
+            "application/json; charset=utf-8; charset=utf-8",
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_str(invalid).unwrap(),
+            );
+            assert!(!is_json_content_type(&headers), "accepted {invalid}");
+        }
+
+        let mut duplicate = HeaderMap::new();
+        duplicate.append(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        duplicate.append(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        assert!(!is_json_content_type(&duplicate));
+
+        let mut opaque = HeaderMap::new();
+        opaque.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        );
+        assert!(!is_json_content_type(&opaque));
+    }
+
+    #[test]
+    fn canonical_uuid_accepts_only_lowercase_hyphenated_non_nil_text() {
+        const VALUE: &str = "aaaaaaaa-1111-4111-8111-111111111111";
+
+        assert_eq!(
+            canonical_uuid(VALUE).unwrap().hyphenated().to_string(),
+            VALUE
+        );
+        for invalid in [
+            "not-a-uuid",
+            "00000000-0000-0000-0000-000000000000",
+            "AAAAAAAA-1111-4111-8111-111111111111",
+            "aaaaaaaa111141118111111111111111",
+            "{aaaaaaaa-1111-4111-8111-111111111111}",
+        ] {
+            assert_eq!(canonical_uuid(invalid), Err(ApiError::InvalidRequest));
+        }
+    }
+
+    #[tokio::test]
+    async fn every_api_error_has_the_exact_closed_wire_contract() {
+        for (error, status, code) in [
+            (
+                ApiError::Unauthorized,
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+            ),
+            (ApiError::Forbidden, StatusCode::FORBIDDEN, "forbidden"),
+            (ApiError::NotFound, StatusCode::NOT_FOUND, "not_found"),
+            (
+                ApiError::InvalidRequest,
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+            ),
+            (
+                ApiError::UnsupportedMediaType,
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported_media_type",
+            ),
+            (
+                ApiError::TooLarge,
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "request_too_large",
+            ),
+            (ApiError::Conflict, StatusCode::CONFLICT, "conflict"),
+            (
+                ApiError::Unavailable,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "dependency_unavailable",
+            ),
+            (
+                ApiError::Internal,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+            ),
+        ] {
+            assert_eq!(error.status(), status);
+            assert_eq!(error.code(), code);
+
+            let response = error.into_response();
+            assert_eq!(response.status(), status);
+            assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+            assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+            if error == ApiError::Unauthorized {
+                assert_eq!(
+                    response.headers()[header::WWW_AUTHENTICATE],
+                    "Bearer realm=\"automata\""
+                );
+            } else {
+                assert!(!response.headers().contains_key(header::WWW_AUTHENTICATE));
+            }
+            if error == ApiError::Unavailable {
+                assert_eq!(response.headers()[header::RETRY_AFTER], "1");
+            } else {
+                assert!(!response.headers().contains_key(header::RETRY_AFTER));
+            }
+
+            let body = to_bytes(response.into_body(), 1_024)
+                .await
+                .expect("error response body");
+            assert_eq!(body.as_ref(), format!(r#"{{"error":"{code}"}}"#).as_bytes());
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct SuccessDocument {
+        result: &'static str,
+    }
+
+    #[tokio::test]
+    async fn json_response_is_compact_non_cacheable_json() {
+        let response = json_response(StatusCode::CREATED, &SuccessDocument { result: "created" });
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let body = to_bytes(response.into_body(), 1_024)
+            .await
+            .expect("success response body");
+        assert_eq!(body.as_ref(), br#"{"result":"created"}"#);
+    }
+
+    #[derive(Debug)]
+    struct SerializationFailure;
+
+    impl Serialize for SerializationFailure {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(<S::Error as serde::ser::Error>::custom(
+                "intentional serialization failure",
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn serialization_failure_uses_the_exact_internal_error_fallback() {
+        let response = json_response(StatusCode::CREATED, &SerializationFailure);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let body = to_bytes(response.into_body(), 1_024)
+            .await
+            .expect("fallback response body");
+        assert_eq!(body.as_ref(), br#"{"error":"internal_error"}"#);
+    }
+}

--- a/crates/automata-ci/src/app/management_api.rs
+++ b/crates/automata-ci/src/app/management_api.rs
@@ -36,6 +36,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use super::api_support::{is_json_content_type, json_response};
+
 const MAX_REQUEST_BYTES: usize = 16 * 1024;
 const MAX_QUERY_BYTES: usize = 1_024;
 const DEFAULT_PAGE_SIZE: u16 = 50;
@@ -700,36 +702,6 @@ async fn json_document<T: DeserializeOwned>(request: Request) -> Result<T, ApiEr
     serde_json::from_slice(&body).map_err(|_| ApiError::InvalidRequest)
 }
 
-fn is_json_content_type(headers: &HeaderMap) -> bool {
-    let mut values = headers.get_all(header::CONTENT_TYPE).iter();
-    let Some(value) = values.next() else {
-        return false;
-    };
-    if values.next().is_some() {
-        return false;
-    }
-    value.to_str().is_ok_and(|value| {
-        let mut parts = value.split(';');
-        if !parts
-            .next()
-            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
-        {
-            return false;
-        }
-        let Some(parameter) = parts.next() else {
-            return true;
-        };
-        parts.next().is_none()
-            && parameter
-                .trim()
-                .split_once('=')
-                .is_some_and(|(name, value)| {
-                    name.trim().eq_ignore_ascii_case("charset")
-                        && value.trim().eq_ignore_ascii_case("utf-8")
-                })
-    })
-}
-
 fn one_path_id(path: Result<Path<String>, PathRejection>) -> Result<String, ApiError> {
     path.map(|Path(value)| value)
         .map_err(|_| ApiError::InvalidRequest)
@@ -892,29 +864,6 @@ impl IntoResponse for ApiError {
                 .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
         }
         response
-    }
-}
-
-fn json_response<T: Serialize>(status: StatusCode, document: &T) -> Response {
-    match serde_json::to_vec(document) {
-        Ok(body) => (
-            status,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            body,
-        )
-            .into_response(),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            br#"{"error":"internal_error"}"#.as_slice(),
-        )
-            .into_response(),
     }
 }
 

--- a/crates/automata-ci/src/app/mod.rs
+++ b/crates/automata-ci/src/app/mod.rs
@@ -1,4 +1,5 @@
 mod api_security;
+mod api_support;
 pub(crate) mod conformance_api;
 pub(crate) mod delegated_actor_api;
 mod form;

--- a/crates/automata-ci/src/app/protected_environment_review_api.rs
+++ b/crates/automata-ci/src/app/protected_environment_review_api.rs
@@ -15,13 +15,14 @@ use axum::{
     Router,
     body::to_bytes,
     extract::{Path, Request, State, rejection::PathRejection},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{StatusCode, header},
     middleware,
     response::{IntoResponse, Response},
     routing::post,
 };
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+
+use super::api_support::{ApiError, canonical_uuid, is_json_content_type, json_response};
 
 const MAX_REQUEST_BYTES: usize = 1_024;
 
@@ -138,14 +139,6 @@ async fn prepare_request(
     })
 }
 
-fn canonical_uuid(value: &str) -> Result<Uuid, ApiError> {
-    let parsed = Uuid::parse_str(value).map_err(|_| ApiError::InvalidRequest)?;
-    if parsed.is_nil() || parsed.hyphenated().to_string() != value {
-        return Err(ApiError::InvalidRequest);
-    }
-    Ok(parsed)
-}
-
 fn actor_from_request(
     state: &ProtectedEnvironmentReviewApiState,
     request: &Request,
@@ -182,36 +175,6 @@ async fn json_document(request: Request) -> Result<ReviewDocument, ApiError> {
         .await
         .map_err(|_| ApiError::TooLarge)?;
     serde_json::from_slice(&body).map_err(|_| ApiError::InvalidRequest)
-}
-
-fn is_json_content_type(headers: &HeaderMap) -> bool {
-    let mut values = headers.get_all(header::CONTENT_TYPE).iter();
-    let Some(value) = values.next() else {
-        return false;
-    };
-    if values.next().is_some() {
-        return false;
-    }
-    value.to_str().is_ok_and(|value| {
-        let mut parts = value.split(';');
-        if !parts
-            .next()
-            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
-        {
-            return false;
-        }
-        let Some(parameter) = parts.next() else {
-            return true;
-        };
-        parts.next().is_none()
-            && parameter
-                .trim()
-                .split_once('=')
-                .is_some_and(|(name, value)| {
-                    name.trim().eq_ignore_ascii_case("charset")
-                        && value.trim().eq_ignore_ascii_case("utf-8")
-                })
-    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -261,24 +224,6 @@ struct ReviewResponseDocument {
     state: &'static str,
 }
 
-#[derive(Debug, Serialize)]
-struct ErrorDocument {
-    error: &'static str,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ApiError {
-    Unauthorized,
-    Forbidden,
-    NotFound,
-    InvalidRequest,
-    UnsupportedMediaType,
-    TooLarge,
-    Conflict,
-    Unavailable,
-    Internal,
-}
-
 impl From<ProtectedEnvironmentReviewApiBackendError> for ApiError {
     fn from(value: ProtectedEnvironmentReviewApiBackendError) -> Self {
         match value {
@@ -288,77 +233,6 @@ impl From<ProtectedEnvironmentReviewApiBackendError> for ApiError {
             ProtectedEnvironmentReviewApiBackendError::Unavailable => Self::Unavailable,
             ProtectedEnvironmentReviewApiBackendError::Invariant => Self::Internal,
         }
-    }
-}
-
-impl ApiError {
-    const fn status(self) -> StatusCode {
-        match self {
-            Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::Forbidden => StatusCode::FORBIDDEN,
-            Self::NotFound => StatusCode::NOT_FOUND,
-            Self::InvalidRequest => StatusCode::BAD_REQUEST,
-            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Self::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-            Self::Conflict => StatusCode::CONFLICT,
-            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-
-    const fn code(self) -> &'static str {
-        match self {
-            Self::Unauthorized => "unauthorized",
-            Self::Forbidden => "forbidden",
-            Self::NotFound => "not_found",
-            Self::InvalidRequest => "invalid_request",
-            Self::UnsupportedMediaType => "unsupported_media_type",
-            Self::TooLarge => "request_too_large",
-            Self::Conflict => "conflict",
-            Self::Unavailable => "dependency_unavailable",
-            Self::Internal => "internal_error",
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let mut response = json_response(self.status(), &ErrorDocument { error: self.code() });
-        if self == Self::Unauthorized {
-            response.headers_mut().insert(
-                header::WWW_AUTHENTICATE,
-                HeaderValue::from_static("Bearer realm=\"automata\""),
-            );
-        }
-        if self == Self::Unavailable {
-            response
-                .headers_mut()
-                .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
-        }
-        response
-    }
-}
-
-fn json_response<T: Serialize>(status: StatusCode, document: &T) -> Response {
-    match serde_json::to_vec(document) {
-        Ok(body) => (
-            status,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            body,
-        )
-            .into_response(),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            br#"{"error":"internal_error"}"#.as_slice(),
-        )
-            .into_response(),
     }
 }
 

--- a/crates/automata-ci/src/app/workflow_dispatch_api.rs
+++ b/crates/automata-ci/src/app/workflow_dispatch_api.rs
@@ -18,7 +18,7 @@ use axum::{
     Router,
     body::to_bytes,
     extract::{Path, Request, State, rejection::PathRejection},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::StatusCode,
     middleware,
     response::{IntoResponse, Response},
     routing::post,
@@ -28,6 +28,8 @@ use serde::{
     de::{Error as _, MapAccess, Visitor},
 };
 use uuid::Uuid;
+
+use super::api_support::{ApiError, canonical_uuid, is_json_content_type, json_response};
 
 const MAX_REQUEST_BYTES: usize = 131_072;
 const MAX_TARGET_TEXT_BYTES: usize = 1_024;
@@ -321,14 +323,6 @@ fn exact_target(
     ))
 }
 
-fn canonical_uuid(value: &str) -> Result<Uuid, ApiError> {
-    let parsed = Uuid::parse_str(value).map_err(|_| ApiError::InvalidRequest)?;
-    if parsed.is_nil() || parsed.hyphenated().to_string() != value {
-        return Err(ApiError::InvalidRequest);
-    }
-    Ok(parsed)
-}
-
 fn actor_from_request(
     state: &WorkflowDispatchApiState,
     request: &Request,
@@ -365,36 +359,6 @@ async fn json_document(request: Request) -> Result<DispatchDocument, ApiError> {
         return Err(ApiError::TooLarge);
     }
     serde_json::from_slice(&body).map_err(|_| ApiError::InvalidRequest)
-}
-
-fn is_json_content_type(headers: &HeaderMap) -> bool {
-    let mut values = headers.get_all(header::CONTENT_TYPE).iter();
-    let Some(value) = values.next() else {
-        return false;
-    };
-    if values.next().is_some() {
-        return false;
-    }
-    value.to_str().is_ok_and(|value| {
-        let mut parts = value.split(';');
-        if !parts
-            .next()
-            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
-        {
-            return false;
-        }
-        let Some(parameter) = parts.next() else {
-            return true;
-        };
-        parts.next().is_none()
-            && parameter
-                .trim()
-                .split_once('=')
-                .is_some_and(|(name, value)| {
-                    name.trim().eq_ignore_ascii_case("charset")
-                        && value.trim().eq_ignore_ascii_case("utf-8")
-                })
-    })
 }
 
 fn valid_git_ref(value: &str) -> bool {
@@ -499,24 +463,6 @@ struct DispatchResponseDocument {
     replay: bool,
 }
 
-#[derive(Debug, Serialize)]
-struct ErrorDocument {
-    error: &'static str,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ApiError {
-    Unauthorized,
-    Forbidden,
-    NotFound,
-    InvalidRequest,
-    UnsupportedMediaType,
-    TooLarge,
-    Conflict,
-    Unavailable,
-    Internal,
-}
-
 impl From<WorkflowDispatchApiBackendError> for ApiError {
     fn from(value: WorkflowDispatchApiBackendError) -> Self {
         match value {
@@ -527,77 +473,6 @@ impl From<WorkflowDispatchApiBackendError> for ApiError {
             WorkflowDispatchApiBackendError::Unavailable => Self::Unavailable,
             WorkflowDispatchApiBackendError::Invariant => Self::Internal,
         }
-    }
-}
-
-impl ApiError {
-    const fn status(self) -> StatusCode {
-        match self {
-            Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::Forbidden => StatusCode::FORBIDDEN,
-            Self::NotFound => StatusCode::NOT_FOUND,
-            Self::InvalidRequest => StatusCode::BAD_REQUEST,
-            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Self::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-            Self::Conflict => StatusCode::CONFLICT,
-            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-
-    const fn code(self) -> &'static str {
-        match self {
-            Self::Unauthorized => "unauthorized",
-            Self::Forbidden => "forbidden",
-            Self::NotFound => "not_found",
-            Self::InvalidRequest => "invalid_request",
-            Self::UnsupportedMediaType => "unsupported_media_type",
-            Self::TooLarge => "request_too_large",
-            Self::Conflict => "conflict",
-            Self::Unavailable => "dependency_unavailable",
-            Self::Internal => "internal_error",
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let mut response = json_response(self.status(), &ErrorDocument { error: self.code() });
-        if self == Self::Unauthorized {
-            response.headers_mut().insert(
-                header::WWW_AUTHENTICATE,
-                HeaderValue::from_static("Bearer realm=\"automata\""),
-            );
-        }
-        if self == Self::Unavailable {
-            response
-                .headers_mut()
-                .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
-        }
-        response
-    }
-}
-
-fn json_response<T: Serialize>(status: StatusCode, document: &T) -> Response {
-    match serde_json::to_vec(document) {
-        Ok(body) => (
-            status,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            body,
-        )
-            .into_response(),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            br#"{"error":"internal_error"}"#.as_slice(),
-        )
-            .into_response(),
     }
 }
 

--- a/crates/automata-ci/src/app/workflow_rerun_api.rs
+++ b/crates/automata-ci/src/app/workflow_rerun_api.rs
@@ -15,7 +15,7 @@ use axum::{
     Router,
     body::to_bytes,
     extract::{Path, Request, State, rejection::PathRejection},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{StatusCode, header},
     middleware,
     response::{IntoResponse, Response},
     routing::post,
@@ -25,6 +25,8 @@ use serde::{
     de::{Error as _, MapAccess, Visitor},
 };
 use uuid::Uuid;
+
+use super::api_support::{ApiError, canonical_uuid, is_json_content_type, json_response};
 
 const MAX_REQUEST_BYTES: usize = 8 * 1_024;
 const MAX_REPOSITORY_SEGMENT_BYTES: usize = 100;
@@ -249,14 +251,6 @@ fn repository_segment(value: String) -> Result<String, ApiError> {
     Ok(value)
 }
 
-fn canonical_uuid(value: &str) -> Result<Uuid, ApiError> {
-    let parsed = Uuid::parse_str(value).map_err(|_| ApiError::InvalidRequest)?;
-    if parsed.is_nil() || parsed.hyphenated().to_string() != value {
-        return Err(ApiError::InvalidRequest);
-    }
-    Ok(parsed)
-}
-
 fn actor_from_request(
     state: &WorkflowRerunApiState,
     request: &Request,
@@ -297,36 +291,6 @@ async fn json_document(request: Request) -> Result<RerunDocument, ApiError> {
         .await
         .map_err(|_| ApiError::TooLarge)?;
     serde_json::from_slice(&body).map_err(|_| ApiError::InvalidRequest)
-}
-
-fn is_json_content_type(headers: &HeaderMap) -> bool {
-    let mut values = headers.get_all(header::CONTENT_TYPE).iter();
-    let Some(value) = values.next() else {
-        return false;
-    };
-    if values.next().is_some() {
-        return false;
-    }
-    value.to_str().is_ok_and(|value| {
-        let mut parts = value.split(';');
-        if !parts
-            .next()
-            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
-        {
-            return false;
-        }
-        let Some(parameter) = parts.next() else {
-            return true;
-        };
-        parts.next().is_none()
-            && parameter
-                .trim()
-                .split_once('=')
-                .is_some_and(|(name, value)| {
-                    name.trim().eq_ignore_ascii_case("charset")
-                        && value.trim().eq_ignore_ascii_case("utf-8")
-                })
-    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -448,24 +412,6 @@ struct RerunResponseDocument {
     replay: bool,
 }
 
-#[derive(Debug, Serialize)]
-struct ErrorDocument {
-    error: &'static str,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ApiError {
-    Unauthorized,
-    Forbidden,
-    NotFound,
-    InvalidRequest,
-    UnsupportedMediaType,
-    TooLarge,
-    Conflict,
-    Unavailable,
-    Internal,
-}
-
 impl From<WorkflowRerunApiBackendError> for ApiError {
     fn from(value: WorkflowRerunApiBackendError) -> Self {
         match value {
@@ -475,77 +421,6 @@ impl From<WorkflowRerunApiBackendError> for ApiError {
             WorkflowRerunApiBackendError::Unavailable => Self::Unavailable,
             WorkflowRerunApiBackendError::Invariant => Self::Internal,
         }
-    }
-}
-
-impl ApiError {
-    const fn status(self) -> StatusCode {
-        match self {
-            Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::Forbidden => StatusCode::FORBIDDEN,
-            Self::NotFound => StatusCode::NOT_FOUND,
-            Self::InvalidRequest => StatusCode::BAD_REQUEST,
-            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Self::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-            Self::Conflict => StatusCode::CONFLICT,
-            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-
-    const fn code(self) -> &'static str {
-        match self {
-            Self::Unauthorized => "unauthorized",
-            Self::Forbidden => "forbidden",
-            Self::NotFound => "not_found",
-            Self::InvalidRequest => "invalid_request",
-            Self::UnsupportedMediaType => "unsupported_media_type",
-            Self::TooLarge => "request_too_large",
-            Self::Conflict => "conflict",
-            Self::Unavailable => "dependency_unavailable",
-            Self::Internal => "internal_error",
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let mut response = json_response(self.status(), &ErrorDocument { error: self.code() });
-        if self == Self::Unauthorized {
-            response.headers_mut().insert(
-                header::WWW_AUTHENTICATE,
-                HeaderValue::from_static("Bearer realm=\"automata\""),
-            );
-        }
-        if self == Self::Unavailable {
-            response
-                .headers_mut()
-                .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
-        }
-        response
-    }
-}
-
-fn json_response<T: Serialize>(status: StatusCode, document: &T) -> Response {
-    match serde_json::to_vec(document) {
-        Ok(body) => (
-            status,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            body,
-        )
-            .into_response(),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            [
-                (header::CONTENT_TYPE, "application/json"),
-                (header::CACHE_CONTROL, "no-store"),
-            ],
-            br#"{"error":"internal_error"}"#.as_slice(),
-        )
-            .into_response(),
     }
 }
 
@@ -562,7 +437,7 @@ mod tests {
     };
     use axum::{
         body::{Body, to_bytes},
-        http::{Method, Request, StatusCode, header},
+        http::{HeaderValue, Method, Request, StatusCode, header},
     };
     use serde_json::{Value, json};
     use tower::ServiceExt as _;


### PR DESCRIPTION
## Summary

- add one private `app::api_support` owner for the byte-identical JSON media-type, response, canonical path-UUID, and common API-error contracts
- keep management's richer revision-aware error model and every backend conversion, body policy, actor policy, and route local
- add focused tests for media types, UUID canonicalization, every shared error response/header, compact JSON, and serialization fallback

## Scope and behavior

The four API modules contained 417 byte-identical implementation lines. This collapses them to 122 shared lines, eliminating exactly 295 duplicate implementation lines. Including the new characterization tests, the full six-file diff is `+329/-439` (net `-110`).

The extraction preserves exactly:

- `Content-Type: application/json` and `Cache-Control: no-store`
- compact JSON bodies and the internal-error serialization fallback
- bearer challenge on `401` and `Retry-After: 1` on `503`
- lowercase hyphenated non-nil path UUID validation
- all nine common error status/code mappings

It deliberately does **not** share request-body readers, actor construction, backend `From` mappings, or management errors. The existing limits, `Content-Encoding` rules, dispatch body UUID behavior, CLI/browser authority, non-enumeration, and revision-conflict payloads remain local and unchanged.

`api_support` is private and its sibling-facing items are only `pub(super)`. There is no public Rust API, route, dependency, lockfile, schema, migration, or release behavior change.

## Validation

- 5/5 new support contract tests
- 42/42 existing directly affected endpoint tests
- 485/485 full `automata-ci` library tests
- all-target/all-feature check and strict Clippy with warnings denied
- rustdoc with warnings denied
- workspace integration-target topology verifier
- publish planner 17/17 and release-handoff 9/9
- package inventory includes the new private module
- rustfmt and cached diff checks

Independent review verified that every moved production body remains byte-identical to `main` after accounting only for required `pub(super)` visibility.

Fixes #155
