### PR TITLE
ci: verify redundant Automata deployment

### DIFF
--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -25,6 +25,7 @@ concurrency:
 # Pages deployment is intentionally omitted until Automata supports GitHub
 # deployment environments end to end; this repository must have one workflow
 # authority and therefore cannot also contain .github/workflows.
+# Live probe: verify the redundant Automata control plane and six-runner fleet.
 jobs:
   build:
     name: Build demo and capture screenshots

--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -34,7 +34,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      pages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -72,7 +72,7 @@ jobs:
         run: npm run screenshots
 
       - name: Upload screenshot review artifact
-        if: ${{ always() && hashFiles('ui/dist/preview/screenshots/*.png') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ui-screenshots

--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -25,7 +25,8 @@ concurrency:
 # Pages deployment is intentionally omitted until Automata supports GitHub
 # deployment environments end to end; this repository must have one workflow
 # authority and therefore cannot also contain .github/workflows.
-# Live probe: verify the redundant Automata control plane and six-runner fleet.
+# Live probe: verify the redundant control plane and six-runner fleet after the
+# runtime-permission correction.
 jobs:
   build:
     name: Build demo and capture screenshots


### PR DESCRIPTION
## Summary

- trigger a fresh Automata CI run against the current production topology
- remove the unnecessary GitHub Pages read permission that prevented runtime-token minting

## Validation

- `cargo test -p automata-ci-workflow-github --tests --locked`
- production verification will be recorded on this PR
