### PR TITLE
refactor(auth): remove static GitHub role mapper

### DIFF
--- a/crates/automata-ci-auth/src/github/mod.rs
+++ b/crates/automata-ci-auth/src/github/mod.rs
@@ -1,4 +1,4 @@
-//! GitHub App human authentication protocol and explicit RBAC mapping.
+//! GitHub App human authentication protocol and membership snapshots.
 
 mod flow;
 mod login_service;
@@ -39,9 +39,8 @@ pub use port::{
 };
 pub use role_mapping::{
     GithubMembershipSnapshot, GithubOrganizationId, GithubOrganizationLogin,
-    GithubOrganizationMembership, GithubOrganizationMembershipRole, GithubRoleMapper,
-    GithubRoleMapping, GithubRoleMappingError, GithubRoleSource, GithubTeam, GithubTeamId,
-    GithubTeamSlug,
+    GithubOrganizationMembership, GithubOrganizationMembershipRole, GithubRoleMappingError,
+    GithubTeam, GithubTeamId, GithubTeamSlug,
 };
 pub use transaction_state::{
     GithubDeviceTransactionMetadata, GithubTransactionStateCodec, GithubTransactionStateError,

--- a/crates/automata-ci-auth/src/github/role_mapping.rs
+++ b/crates/automata-ci-auth/src/github/role_mapping.rs
@@ -1,9 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-use crate::authorization::RoleName;
 
 const MAX_GITHUB_DISPLAY_NAME_LENGTH: usize = 255;
 
@@ -286,118 +284,8 @@ impl GithubMembershipSnapshot {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-/// A stable GitHub membership source that may grant configured Automata roles.
-pub enum GithubRoleSource {
-    /// Membership in one GitHub organization.
-    Organization {
-        /// The stable organization identifier.
-        organization_id: GithubOrganizationId,
-    },
-    /// Membership in one team within a GitHub organization.
-    Team {
-        /// The stable identifier of the containing organization.
-        organization_id: GithubOrganizationId,
-        /// The stable team identifier.
-        team_id: GithubTeamId,
-    },
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-/// An explicit mapping from a stable GitHub membership source to Automata roles.
-pub struct GithubRoleMapping {
-    source: GithubRoleSource,
-    roles: BTreeSet<RoleName>,
-}
-
-impl GithubRoleMapping {
-    /// Creates one explicit membership-to-role mapping.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when no role is assigned.
-    pub fn new(
-        source: GithubRoleSource,
-        roles: BTreeSet<RoleName>,
-    ) -> Result<Self, GithubRoleMappingError> {
-        if roles.is_empty() {
-            return Err(GithubRoleMappingError::EmptyRoles);
-        }
-        Ok(Self { source, roles })
-    }
-
-    /// Returns the stable GitHub membership source.
-    pub const fn source(&self) -> &GithubRoleSource {
-        &self.source
-    }
-
-    /// Returns the explicitly granted Automata roles.
-    pub const fn roles(&self) -> &BTreeSet<RoleName> {
-        &self.roles
-    }
-
-    /// Splits the mapping into its source and granted roles.
-    pub fn into_parts(self) -> (GithubRoleSource, BTreeSet<RoleName>) {
-        (self.source, self.roles)
-    }
-}
-
-/// Resolves only configured organization/team mappings. Membership in GitHub, org
-/// ownership, and a role's spelling never grant an implicit Automata role.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct GithubRoleMapper {
-    mappings: BTreeMap<GithubRoleSource, BTreeSet<RoleName>>,
-}
-
-impl GithubRoleMapper {
-    /// Indexes validated explicit role mappings.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when any supplied mapping has no role.
-    pub fn new(
-        mappings: impl IntoIterator<Item = GithubRoleMapping>,
-    ) -> Result<Self, GithubRoleMappingError> {
-        let mut indexed = BTreeMap::<GithubRoleSource, BTreeSet<RoleName>>::new();
-        for mapping in mappings {
-            if mapping.roles.is_empty() {
-                return Err(GithubRoleMappingError::EmptyRoles);
-            }
-            indexed
-                .entry(mapping.source)
-                .or_default()
-                .extend(mapping.roles);
-        }
-        Ok(Self { mappings: indexed })
-    }
-
-    /// Resolves the union of explicitly configured roles for a membership snapshot.
-    pub fn roles_for(&self, memberships: &GithubMembershipSnapshot) -> BTreeSet<RoleName> {
-        let organization_roles = memberships
-            .organizations
-            .keys()
-            .filter_map(|organization_id| {
-                self.mappings.get(&GithubRoleSource::Organization {
-                    organization_id: *organization_id,
-                })
-            });
-        let team_roles = memberships.teams.values().filter_map(|team| {
-            self.mappings.get(&GithubRoleSource::Team {
-                organization_id: team.organization_id,
-                team_id: team.id,
-            })
-        });
-        organization_roles
-            .chain(team_roles)
-            .flatten()
-            .cloned()
-            .collect()
-    }
-}
-
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
-/// A validation failure in GitHub membership metadata or role mapping.
+/// A validation failure in GitHub membership metadata.
 pub enum GithubRoleMappingError {
     /// A GitHub numeric identity is not positive.
     #[error("{label} must be a positive integer")]
@@ -411,9 +299,6 @@ pub enum GithubRoleMappingError {
         /// The kind of display name that failed validation.
         label: &'static str,
     },
-    /// A role mapping grants no Automata roles.
-    #[error("a GitHub role mapping must grant at least one explicit role")]
-    EmptyRoles,
     /// A snapshot contains the same organization ID more than once.
     #[error("a membership snapshot contains a duplicate organization ID")]
     DuplicateOrganizationId,

--- a/crates/automata-ci-auth/tests/authorization_contract.rs
+++ b/crates/automata-ci-auth/tests/authorization_contract.rs
@@ -4,18 +4,13 @@ use automata_ci_auth::{
     authorization::{Permission, RbacPolicy, RoleName},
     github::{
         GithubMembershipSnapshot, GithubOrganizationId, GithubOrganizationLogin,
-        GithubOrganizationMembership, GithubOrganizationMembershipRole, GithubRoleMapper,
-        GithubRoleMapping, GithubRoleMappingError, GithubRoleSource, GithubTeam, GithubTeamId,
-        GithubTeamSlug,
+        GithubOrganizationMembership, GithubOrganizationMembershipRole, GithubRoleMappingError,
+        GithubTeam, GithubTeamId, GithubTeamSlug,
     },
 };
 
 fn role(value: &str) -> RoleName {
     RoleName::new(value).expect("valid role")
-}
-
-fn roles(values: &[&str]) -> BTreeSet<RoleName> {
-    values.iter().map(|value| role(value)).collect()
 }
 
 fn organization(
@@ -40,7 +35,7 @@ fn team(id: i64, organization_id: i64, organization_login: &str, slug: &str) -> 
 }
 
 #[test]
-fn github_membership_grants_only_explicitly_mapped_roles() {
+fn github_membership_snapshot_uses_stable_id_lookups_and_normalized_metadata() {
     let organization_id = GithubOrganizationId::new(44).expect("organization ID");
     let team_id = GithubTeamId::new(91).expect("team ID");
     let memberships = GithubMembershipSnapshot::new(
@@ -57,118 +52,22 @@ fn github_membership_grants_only_explicitly_mapped_roles() {
         )],
     )
     .expect("membership snapshot");
-    let mapper = GithubRoleMapper::new([
-        GithubRoleMapping::new(
-            GithubRoleSource::Team {
-                organization_id,
-                team_id,
-            },
-            roles(&["run-operator"]),
-        )
-        .expect("team mapping"),
-        GithubRoleMapping::new(
-            GithubRoleSource::Organization {
-                organization_id: GithubOrganizationId::new(45).expect("organization ID"),
-            },
-            roles(&["administrator"]),
-        )
-        .expect("unrelated mapping"),
-    ])
-    .expect("role mapper");
 
-    assert_eq!(mapper.roles_for(&memberships), roles(&["run-operator"]));
-    assert_eq!(
-        memberships
-            .organization(organization_id)
-            .expect("organization")
-            .login()
-            .as_str(),
-        "automata-org"
-    );
-}
-
-#[test]
-fn an_unmapped_owner_or_team_has_no_implicit_role() {
-    let memberships = GithubMembershipSnapshot::new(
-        [organization(
-            44,
-            "automata",
-            GithubOrganizationMembershipRole::Admin,
-        )],
-        [],
-    )
-    .expect("membership snapshot");
-    let mapper = GithubRoleMapper::default();
-    assert!(mapper.roles_for(&memberships).is_empty());
+    let organization = memberships
+        .organization(organization_id)
+        .expect("organization");
+    assert_eq!(organization.login().as_str(), "automata-org");
+    assert_eq!(organization.role(), GithubOrganizationMembershipRole::Admin);
+    let team = memberships.team(team_id).expect("team");
+    assert_eq!(team.organization_id(), organization_id);
+    assert_eq!(team.organization_login().as_str(), "automata-org");
+    assert_eq!(team.slug().as_str(), "ci-operators");
 }
 
 #[test]
 fn team_snapshot_requires_the_containing_organization() {
     let result = GithubMembershipSnapshot::new([], [team(91, 44, "automata", "operators")]);
     assert_eq!(result, Err(GithubRoleMappingError::TeamWithoutOrganization));
-}
-
-#[test]
-fn mutable_github_names_never_participate_in_role_authority() {
-    let organization_id = GithubOrganizationId::new(44).expect("organization ID");
-    let team_id = GithubTeamId::new(91).expect("team ID");
-    let mapper = GithubRoleMapper::new([
-        GithubRoleMapping::new(
-            GithubRoleSource::Organization { organization_id },
-            roles(&["organization-reader"]),
-        )
-        .expect("organization mapping"),
-        GithubRoleMapping::new(
-            GithubRoleSource::Team {
-                organization_id,
-                team_id,
-            },
-            roles(&["run-operator"]),
-        )
-        .expect("team mapping"),
-    ])
-    .expect("role mapper");
-
-    let after_renames = GithubMembershipSnapshot::new(
-        [organization(
-            44,
-            "new-organization-login",
-            GithubOrganizationMembershipRole::Member,
-        )],
-        [team(91, 44, "new-organization-login", "renamed-team")],
-    )
-    .expect("renamed membership snapshot");
-
-    assert_eq!(
-        mapper.roles_for(&after_renames),
-        roles(&["organization-reader", "run-operator"])
-    );
-}
-
-#[test]
-fn identical_names_with_different_ids_never_match_a_mapping() {
-    let mapped_organization_id = GithubOrganizationId::new(44).expect("organization ID");
-    let mapped_team_id = GithubTeamId::new(91).expect("team ID");
-    let mapper = GithubRoleMapper::new([GithubRoleMapping::new(
-        GithubRoleSource::Team {
-            organization_id: mapped_organization_id,
-            team_id: mapped_team_id,
-        },
-        roles(&["run-operator"]),
-    )
-    .expect("team mapping")])
-    .expect("role mapper");
-    let impersonating_names = GithubMembershipSnapshot::new(
-        [organization(
-            45,
-            "automata",
-            GithubOrganizationMembershipRole::Admin,
-        )],
-        [team(92, 45, "automata", "operators")],
-    )
-    .expect("membership snapshot");
-
-    assert!(mapper.roles_for(&impersonating_names).is_empty());
 }
 
 #[test]
@@ -241,13 +140,11 @@ fn membership_snapshots_reject_duplicate_and_conflicting_relationships() {
 }
 
 #[test]
-fn github_numeric_ids_must_be_positive_in_constructors_and_settings_json() {
+fn github_numeric_ids_must_be_positive_in_constructors_and_json() {
     assert!(GithubOrganizationId::new(0).is_err());
     assert!(GithubTeamId::new(-1).is_err());
-    assert!(
-        serde_json::from_str::<GithubRoleSource>(r#"{"kind":"organization","organization_id":0}"#)
-            .is_err()
-    );
+    assert!(serde_json::from_str::<GithubOrganizationId>("0").is_err());
+    assert!(serde_json::from_str::<GithubTeamId>("-1").is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- remove the unused in-memory `GithubRoleSource`, `GithubRoleMapping`, and `GithubRoleMapper` authority branch
- remove the now-unreachable `EmptyRoles` error variant and public reexports
- refocus authorization tests on retained stable-ID snapshot lookup, normalized metadata, and direct numeric-ID Serde validation

## Why

The static mapper has no production caller. The live request-authentication path resolves the newest durable GitHub membership snapshot against active tenant-scoped mappings in PostgreSQL using stable numeric organization/team IDs. It also handles snapshot ties, expiry, disabled/foreign mappings, renames, and corrupt joins fail-closed. Durable mapping management remains separately represented by `ManagedGithubMappingSource`.

Keeping a second test-only mapper advertises an authority path production cannot exercise and weakens the architectural signal around current durable mapping state.

This removes only the static branch. Organization/team IDs, normalized display metadata, membership observations, `GithubMembershipSnapshot`, the retained validation error, mapping-management contracts, and all PostgreSQL authority behavior remain unchanged.

This intentionally removes three public Rust types, their methods/Serde shape, and one error variant from an unpublished `0.1.0` crate. It changes no runtime, dependency, schema, migration, persisted value, or live wire contract.

## Validation

- auth: 132/132 tests; exactly three mapper-only tests removed
- retained authorization contract: 6/6 tests
- GitHub membership contracts: 6/6 tests
- PostgreSQL numeric mapping unit passed
- PostgreSQL all-target/all-feature check and workspace all-target check
- strict auth Clippy and rustdoc with warnings denied
- integration-target topology verifier
- package inventory remains 54 files
- exhaustive stale-symbol scan, rustfmt, and cached diff checks

Independent review verified that retained ID/name/membership/snapshot implementations are byte-unchanged and the production numeric mapping path is untouched.

Fixes #161
