### PR TITLE
feat(local): pin Docker engine and anchor installation identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   sensitivity.
 - Read-only `automata local doctor` preflight for the initial x86-64 Linux,
   Apple Silicon macOS, and x86-64 Windows host tuples, a local Linux Docker
-  Engine, and Docker Compose plugin 2.20.0 or newer.
+  Engine, and Docker Compose plugin 2.20.0 or newer. Docker daemon probes are
+  pinned to the exact endpoint resolved from the context selected first;
+  stable JSON schema 3 and human output report its bounded name. The internal
+  adapter can strictly inspect or create-and-adopt a repository-agnostic
+  installation identity anchor without exposing a product mutation command.
 
 ### Known limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,11 +569,17 @@ dependencies = [
 name = "automata-ci-local"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "automata-ci-core",
+ "bollard",
  "processkit",
  "rustix",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1511,6 +1517,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.5.0",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
 ]
 
 [[package]]
@@ -2608,6 +2657,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2723,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4341,6 +4420,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5735,6 +5825,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,6 +5848,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ anyhow = "1.0.99"
 async-trait = "0.1.91"
 aws-sdk-s3 = { version = "=1.141.0", default-features = false, features = ["behavior-version-latest", "http-1x", "rt-tokio"] }
 aws-smithy-http-client = { version = "=1.2.0", default-features = false, features = ["rustls-ring"] }
+bollard = { version = "=0.21.0", default-features = false, features = ["pipe"] }
 automata-ci-auth = { path = "crates/automata-ci-auth", version = "0.1.0" }
 automata-ci-action = { path = "crates/automata-ci-action", version = "0.1.0" }
 automata-ci-action-github = { path = "crates/automata-ci-action-github", version = "0.1.0" }

--- a/crates/automata-ci-local/Cargo.toml
+++ b/crates/automata-ci-local/Cargo.toml
@@ -14,9 +14,15 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+async-trait.workspace = true
+automata-ci-core.workspace = true
+bollard.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+uuid.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rustix.workspace = true

--- a/crates/automata-ci-local/README.md
+++ b/crates/automata-ci-local/README.md
@@ -7,15 +7,29 @@ API compatibility; and Compose plugin version 2.20.0 or newer. It will supervise
 the local Compose project without adding container-engine behavior to the
 control-plane crate.
 
-The user-visible slice remains a read-only host preflight. It deliberately does
-not create a host installation manifest, resource inventory, lifecycle state
-machine, Docker-version pin, or secret value. Engine identity and ownership
-contracts land with the first Docker adapter that consumes and
-integration-tests them; they are not published as unused speculative APIs.
+The user-visible slice remains a read-only host preflight. Context discovery is
+completed first, subsequent daemon probes are pinned to that exact local
+Unix-socket or Windows-named-pipe endpoint, and JSON schema 3 reports the
+bounded context name. The private endpoint URI is retained only so the library
+adapter can connect to the same daemon and reverify its identity.
 
-No product command creates, adopts, or deletes an engine resource yet. The
-Docker adapter, checked-in Compose topology, workers, workflow execution, and
-GitHub connection are added only with their own tested contracts.
+The first engine adapter can inspect or create-and-adopt one immutable external
+identity volume for a named installation. It always post-inspects Docker's
+deterministic volume name, exact Automata-managed labels, local driver/scope,
+empty driver options, and container attachments. It exposes no generic Docker
+mutation, delete, prune, image-pull, helper-container, or Compose API.
+
+An installation is one reusable control-plane and runner-capacity domain, not
+one repository. Repositories sharing an installation are one trusted set and
+retain their own admission, authorization, secret, cache, and history scope in
+the existing control plane. A separate `--installation` name is the explicit
+way to request another deployment/capacity domain.
+
+No product command creates, adopts, or deletes an engine resource yet. Desired
+specification persistence, the checked-in Compose topology, workers, workflow
+execution, and GitHub connection are added only with their own tested
+contracts. There is still no host installation manifest, mirrored resource
+inventory, lifecycle state machine, or secret value in this crate.
 
 This crate has no command-line parser. The `automata` product maps its public
 CLI into the typed requests exposed here.

--- a/crates/automata-ci-local/src/engine.rs
+++ b/crates/automata-ci-local/src/engine.rs
@@ -1,0 +1,551 @@
+//! Exact-endpoint Docker Engine adapter for immutable installation identity.
+
+use std::{collections::BTreeMap, fmt, future::Future, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use bollard::{
+    ClientVersion, Docker, errors::Error as BollardError, models::VolumeCreateRequest,
+    query_parameters::ListContainersOptionsBuilder,
+};
+use thiserror::Error;
+
+use crate::{
+    ApiVersion, DoctorReport, EngineEndpoint, EngineSelection, Installation, InstallationId,
+    InstallationName, capped_adapter_api, normalize_architecture,
+};
+
+const ENGINE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const MANAGED_LABEL_PREFIX: &str = "io.automata.local.";
+const LABEL_MANAGED: &str = "io.automata.local.managed";
+const LABEL_IDENTITY_SCHEMA: &str = "io.automata.local.identity-schema";
+const LABEL_INSTALLATION_ID: &str = "io.automata.local.installation-id";
+const LABEL_INSTALLATION_KEY: &str = "io.automata.local.installation-key";
+const LABEL_COMPOSE_PROJECT: &str = "io.automata.local.compose-project";
+const LABEL_RESOURCE_KIND: &str = "io.automata.local.resource-kind";
+const MANAGED_VALUE: &str = "true";
+const IDENTITY_SCHEMA: &str = "1";
+const IDENTITY_ANCHOR_KIND: &str = "identity-anchor";
+
+/// Stable reason for a local Docker Engine adapter failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LocalEngineErrorCode {
+    /// The supplied doctor report did not pass every mandatory preflight gate.
+    PreflightRequired,
+    /// The exact validated local endpoint could not be opened.
+    ConnectionUnavailable,
+    /// An Engine API request failed or timed out.
+    EngineRequestFailed,
+    /// The endpoint no longer identifies the engine selected by preflight.
+    EngineIdentityChanged,
+    /// Docker returned an incomplete or internally inconsistent response.
+    InvalidEngineResponse,
+    /// The deterministic anchor name is occupied by a foreign resource.
+    IdentityCollision,
+    /// An owned-looking anchor does not satisfy the immutable contract.
+    InvalidIdentityAnchor,
+    /// A container is attached to the identity anchor.
+    IdentityAnchorAttached,
+    /// A mutating request may have succeeded but its final state is indeterminate.
+    MutationOutcomeUncertain,
+}
+
+impl LocalEngineErrorCode {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::PreflightRequired => {
+                "local Docker preflight must be ready before engine mutation"
+            }
+            Self::ConnectionUnavailable => {
+                "the exact Docker endpoint selected by preflight is unavailable"
+            }
+            Self::EngineRequestFailed => "the Docker Engine request failed",
+            Self::EngineIdentityChanged => {
+                "the Docker Engine identity changed after preflight; run local doctor again"
+            }
+            Self::InvalidEngineResponse => {
+                "the Docker Engine returned an incomplete or inconsistent response"
+            }
+            Self::IdentityCollision => {
+                "the deterministic installation anchor name is occupied by a foreign resource"
+            }
+            Self::InvalidIdentityAnchor => {
+                "the installation anchor does not satisfy its immutable ownership contract"
+            }
+            Self::IdentityAnchorAttached => {
+                "the installation identity anchor is unexpectedly attached to a container"
+            }
+            Self::MutationOutcomeUncertain => {
+                "the Docker mutation outcome is uncertain; inspect the installation before retrying"
+            }
+        }
+    }
+}
+
+/// Redacted failure returned by the local Docker Engine adapter.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("{message}")]
+pub struct LocalEngineError {
+    code: LocalEngineErrorCode,
+    message: &'static str,
+}
+
+impl LocalEngineError {
+    const fn new(code: LocalEngineErrorCode) -> Self {
+        Self {
+            code,
+            message: code.message(),
+        }
+    }
+
+    /// Returns the stable machine-readable reason.
+    pub const fn code(self) -> LocalEngineErrorCode {
+        self.code
+    }
+
+    /// Returns a non-sensitive operator-facing explanation.
+    pub const fn message(self) -> &'static str {
+        self.message
+    }
+}
+
+/// Docker Engine adapter restricted to local-installation identity operations.
+///
+/// It deliberately exposes no generic volume mutation, deletion, pruning,
+/// image pulling, container lifecycle, or Compose API.
+pub struct DockerInstallationAdapter {
+    engine: Arc<dyn EngineApi>,
+    selection: EngineSelection,
+}
+
+impl fmt::Debug for DockerInstallationAdapter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DockerInstallationAdapter")
+            .field("selection", &self.selection)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DockerInstallationAdapter {
+    /// Connects only to the exact local endpoint retained by a successful
+    /// [`crate::inspect`] result and verifies that the daemon identity still
+    /// agrees with preflight.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalEngineError`] when the exact endpoint cannot be opened or
+    /// no longer reports the selected engine facts.
+    pub async fn connect(report: &DoctorReport) -> Result<Self, LocalEngineError> {
+        if !report.ready() {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::PreflightRequired,
+            ));
+        }
+        let selection = report
+            .selected_engine()
+            .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::PreflightRequired))?;
+        let engine = Arc::new(BollardEngine::connect(selection)?);
+        let adapter = Self {
+            engine,
+            selection: selection.clone(),
+        };
+        adapter.verify_engine().await?;
+        Ok(adapter)
+    }
+
+    /// Inspects and verifies the deterministic identity anchor without
+    /// creating or changing any engine resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalEngineError`] for engine drift, failed requests, foreign
+    /// collisions, malformed ownership labels, unsafe volume configuration, or
+    /// any container attachment.
+    pub async fn inspect_identity(
+        &self,
+        name: &InstallationName,
+    ) -> Result<Option<Installation>, LocalEngineError> {
+        self.verify_engine().await?;
+        let installation = self.inspect_verified_identity(name).await?;
+        self.verify_engine().await?;
+        Ok(installation)
+    }
+
+    /// Creates an absent identity anchor or adopts an exact matching anchor.
+    ///
+    /// Docker's volume-create response is never trusted. The deterministic name
+    /// is freshly inspected after the request, including when the request
+    /// reports a transport failure or loses a concurrent create race.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalEngineError`] when engine identity changes, a foreign
+    /// collision is found, the resulting anchor is unsafe, or a mutation's
+    /// final outcome cannot be proven. This method never attempts rollback.
+    pub async fn create_or_adopt_identity(
+        &self,
+        name: &InstallationName,
+    ) -> Result<Installation, LocalEngineError> {
+        self.verify_engine().await?;
+        if let Some(installation) = self.inspect_verified_identity(name).await? {
+            self.verify_engine().await?;
+            return Ok(installation);
+        }
+
+        let requested = Installation::verified(name.clone(), InstallationId::new());
+        let _create_outcome = self
+            .engine
+            .create_volume(CreateVolume {
+                name: requested.anchor_volume_name().to_owned(),
+                labels: identity_labels(&requested),
+            })
+            .await;
+
+        let inspected = self.inspect_verified_identity(name).await;
+        let Ok(Some(installation)) = inspected else {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::MutationOutcomeUncertain,
+            ));
+        };
+        if self.verify_engine().await.is_err() {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::MutationOutcomeUncertain,
+            ));
+        }
+        Ok(installation)
+    }
+
+    async fn verify_engine(&self) -> Result<(), LocalEngineError> {
+        let facts = self.engine.engine_facts().await.map_err(map_engine_call)?;
+        let expected_api = adapter_api_version(self.selection.api_version())?;
+        let minimum_api = ApiVersion::parse(&facts.minimum_api_version)
+            .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse))?;
+        let maximum_api = ApiVersion::parse(&facts.maximum_api_version)
+            .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse))?;
+        let architecture = normalize_architecture(&facts.architecture)
+            .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse))?;
+        if facts.engine_id != self.selection.engine_id()
+            || facts.server_version != self.selection.server_version()
+            || facts.operating_system != "linux"
+            || architecture != self.selection.architecture()
+            || minimum_api > expected_api
+            || maximum_api < expected_api
+        {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::EngineIdentityChanged,
+            ));
+        }
+        Ok(())
+    }
+
+    async fn inspect_verified_identity(
+        &self,
+        name: &InstallationName,
+    ) -> Result<Option<Installation>, LocalEngineError> {
+        let expected = Installation::expected(name);
+        let Some(volume) = self
+            .engine
+            .inspect_volume(&expected.anchor_volume_name)
+            .await
+            .map_err(map_engine_call)?
+        else {
+            return Ok(None);
+        };
+        if volume.name != expected.anchor_volume_name {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::IdentityCollision,
+            ));
+        }
+        if volume.driver != "local" || volume.scope != "local" || !volume.options.is_empty() {
+            return Err(LocalEngineError::new(
+                LocalEngineErrorCode::IdentityCollision,
+            ));
+        }
+        let id = validate_identity_labels(&volume.labels, &expected)?;
+        if self
+            .engine
+            .volume_attachments(&expected.anchor_volume_name)
+            .await
+            .map_err(map_engine_call)?
+            .is_empty()
+        {
+            Ok(Some(Installation::verified(name.clone(), id)))
+        } else {
+            Err(LocalEngineError::new(
+                LocalEngineErrorCode::IdentityAnchorAttached,
+            ))
+        }
+    }
+
+    #[cfg(test)]
+    fn with_test_engine(selection: EngineSelection, engine: Arc<dyn EngineApi>) -> Self {
+        Self { engine, selection }
+    }
+}
+
+fn identity_labels(installation: &Installation) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (LABEL_MANAGED.to_owned(), MANAGED_VALUE.to_owned()),
+        (LABEL_IDENTITY_SCHEMA.to_owned(), IDENTITY_SCHEMA.to_owned()),
+        (
+            LABEL_INSTALLATION_ID.to_owned(),
+            installation.id().to_string(),
+        ),
+        (
+            LABEL_INSTALLATION_KEY.to_owned(),
+            installation.selector_key().to_string(),
+        ),
+        (
+            LABEL_COMPOSE_PROJECT.to_owned(),
+            installation.compose_project().to_string(),
+        ),
+        (
+            LABEL_RESOURCE_KIND.to_owned(),
+            IDENTITY_ANCHOR_KIND.to_owned(),
+        ),
+    ])
+}
+
+fn validate_identity_labels(
+    labels: &BTreeMap<String, String>,
+    expected: &crate::installation::ExpectedInstallation,
+) -> Result<InstallationId, LocalEngineError> {
+    let managed: BTreeMap<&str, &str> = labels
+        .iter()
+        .filter(|(key, _value)| key.starts_with(MANAGED_LABEL_PREFIX))
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    let Some(id) = managed
+        .get(LABEL_INSTALLATION_ID)
+        .and_then(|value| InstallationId::parse_canonical(value))
+    else {
+        return Err(classify_label_failure(&managed));
+    };
+    let selector_key = expected.selector_key.to_string();
+    if managed.len() != 6
+        || managed.get(LABEL_MANAGED).copied() != Some(MANAGED_VALUE)
+        || managed.get(LABEL_IDENTITY_SCHEMA).copied() != Some(IDENTITY_SCHEMA)
+        || managed.get(LABEL_INSTALLATION_KEY).copied() != Some(selector_key.as_str())
+        || managed.get(LABEL_COMPOSE_PROJECT).copied() != Some(expected.compose_project.as_str())
+        || managed.get(LABEL_RESOURCE_KIND).copied() != Some(IDENTITY_ANCHOR_KIND)
+    {
+        return Err(classify_label_failure(&managed));
+    }
+    Ok(id)
+}
+
+fn classify_label_failure(managed: &BTreeMap<&str, &str>) -> LocalEngineError {
+    let owned = managed.get(LABEL_MANAGED).copied() == Some(MANAGED_VALUE)
+        && managed.get(LABEL_RESOURCE_KIND).copied() == Some(IDENTITY_ANCHOR_KIND);
+    LocalEngineError::new(if owned {
+        LocalEngineErrorCode::InvalidIdentityAnchor
+    } else {
+        LocalEngineErrorCode::IdentityCollision
+    })
+}
+
+fn map_engine_call(error: EngineApiError) -> LocalEngineError {
+    match error {
+        EngineApiError::RequestFailed => {
+            LocalEngineError::new(LocalEngineErrorCode::EngineRequestFailed)
+        }
+        EngineApiError::InvalidResponse => {
+            LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EngineFacts {
+    engine_id: String,
+    server_version: String,
+    minimum_api_version: String,
+    maximum_api_version: String,
+    operating_system: String,
+    architecture: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InspectedVolume {
+    name: String,
+    driver: String,
+    scope: String,
+    options: BTreeMap<String, String>,
+    labels: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CreateVolume {
+    name: String,
+    labels: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EngineApiError {
+    RequestFailed,
+    InvalidResponse,
+}
+
+#[async_trait]
+trait EngineApi: Send + Sync {
+    async fn engine_facts(&self) -> Result<EngineFacts, EngineApiError>;
+
+    async fn inspect_volume(&self, name: &str) -> Result<Option<InspectedVolume>, EngineApiError>;
+
+    async fn create_volume(&self, request: CreateVolume) -> Result<(), EngineApiError>;
+
+    async fn volume_attachments(&self, name: &str) -> Result<Vec<String>, EngineApiError>;
+}
+
+struct BollardEngine {
+    docker: Docker,
+}
+
+impl BollardEngine {
+    fn connect(selection: &EngineSelection) -> Result<Self, LocalEngineError> {
+        let api = adapter_api_version(selection.api_version())?;
+        let version = ClientVersion {
+            major_version: usize::from(api.major),
+            minor_version: usize::from(api.minor),
+        };
+        let connection = selection.connection();
+        let docker = connect_exact_endpoint(connection.endpoint(), connection.host(), &version)
+            .map_err(|_error| LocalEngineError::new(LocalEngineErrorCode::ConnectionUnavailable))?;
+        Ok(Self { docker })
+    }
+}
+
+#[cfg(unix)]
+fn connect_exact_endpoint(
+    endpoint: EngineEndpoint,
+    host: &str,
+    version: &ClientVersion,
+) -> Result<Docker, BollardError> {
+    if endpoint != EngineEndpoint::UnixSocket {
+        return Err(BollardError::SocketNotFoundError(host.to_owned()));
+    }
+    Docker::connect_with_unix(host, ENGINE_REQUEST_TIMEOUT.as_secs(), version)
+}
+
+#[cfg(windows)]
+fn connect_exact_endpoint(
+    endpoint: EngineEndpoint,
+    host: &str,
+    version: &ClientVersion,
+) -> Result<Docker, BollardError> {
+    if endpoint != EngineEndpoint::WindowsNamedPipe {
+        return Err(BollardError::SocketNotFoundError(host.to_owned()));
+    }
+    Docker::connect_with_named_pipe(host, ENGINE_REQUEST_TIMEOUT.as_secs(), version)
+}
+
+fn adapter_api_version(selected: &str) -> Result<ApiVersion, LocalEngineError> {
+    let selected = ApiVersion::parse(selected)
+        .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse))?;
+    capped_adapter_api(selected)
+        .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse))
+}
+
+#[derive(Debug)]
+enum CompleteRequestError {
+    Docker(BollardError),
+    TimedOut,
+}
+
+async fn complete_request<T>(
+    request: impl Future<Output = Result<T, BollardError>>,
+    deadline: Duration,
+) -> Result<T, CompleteRequestError> {
+    tokio::time::timeout(deadline, request)
+        .await
+        .map_err(|_elapsed| CompleteRequestError::TimedOut)?
+        .map_err(CompleteRequestError::Docker)
+}
+
+#[async_trait]
+impl EngineApi for BollardEngine {
+    async fn engine_facts(&self) -> Result<EngineFacts, EngineApiError> {
+        let (info, version) = complete_request(
+            async { tokio::try_join!(self.docker.info(), self.docker.version()) },
+            ENGINE_REQUEST_TIMEOUT,
+        )
+        .await
+        .map_err(|_error| EngineApiError::RequestFailed)?;
+        let info_version = info.server_version.ok_or(EngineApiError::InvalidResponse)?;
+        let server_version = version.version.ok_or(EngineApiError::InvalidResponse)?;
+        let info_architecture = info.architecture.ok_or(EngineApiError::InvalidResponse)?;
+        let server_architecture = version.arch.ok_or(EngineApiError::InvalidResponse)?;
+        let info_operating_system = info.os_type.ok_or(EngineApiError::InvalidResponse)?;
+        let server_operating_system = version.os.ok_or(EngineApiError::InvalidResponse)?;
+        if info_version != server_version
+            || normalize_architecture(&info_architecture)
+                != normalize_architecture(&server_architecture)
+            || info_operating_system != server_operating_system
+        {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        Ok(EngineFacts {
+            engine_id: info.id.ok_or(EngineApiError::InvalidResponse)?,
+            server_version,
+            minimum_api_version: version
+                .min_api_version
+                .ok_or(EngineApiError::InvalidResponse)?,
+            maximum_api_version: version.api_version.ok_or(EngineApiError::InvalidResponse)?,
+            operating_system: server_operating_system,
+            architecture: server_architecture,
+        })
+    }
+
+    async fn inspect_volume(&self, name: &str) -> Result<Option<InspectedVolume>, EngineApiError> {
+        match complete_request(self.docker.inspect_volume(name), ENGINE_REQUEST_TIMEOUT).await {
+            Ok(volume) => Ok(Some(InspectedVolume {
+                name: volume.name,
+                driver: volume.driver,
+                scope: volume
+                    .scope
+                    .map_or_else(String::new, |scope| scope.to_string()),
+                options: volume.options.into_iter().collect(),
+                labels: volume.labels.into_iter().collect(),
+            })),
+            Err(CompleteRequestError::Docker(BollardError::DockerResponseServerError {
+                status_code: 404,
+                ..
+            })) => Ok(None),
+            Err(_error) => Err(EngineApiError::RequestFailed),
+        }
+    }
+
+    async fn create_volume(&self, request: CreateVolume) -> Result<(), EngineApiError> {
+        let request = VolumeCreateRequest {
+            name: Some(request.name),
+            driver: Some("local".to_owned()),
+            driver_opts: Some(std::collections::HashMap::new()),
+            labels: Some(request.labels.into_iter().collect()),
+            cluster_volume_spec: None,
+        };
+        complete_request(self.docker.create_volume(request), ENGINE_REQUEST_TIMEOUT)
+            .await
+            .map(|_untrusted_response| ())
+            .map_err(|_error| EngineApiError::RequestFailed)
+    }
+
+    async fn volume_attachments(&self, name: &str) -> Result<Vec<String>, EngineApiError> {
+        let filters = std::collections::HashMap::from([("volume", vec![name])]);
+        let options = ListContainersOptionsBuilder::new()
+            .all(true)
+            .filters(&filters)
+            .build();
+        complete_request(
+            self.docker.list_containers(Some(options)),
+            ENGINE_REQUEST_TIMEOUT,
+        )
+        .await
+        .map_err(|_error| EngineApiError::RequestFailed)?
+        .into_iter()
+        .map(|container| container.id.ok_or(EngineApiError::InvalidResponse))
+        .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/automata-ci-local/src/engine/tests.rs
+++ b/crates/automata-ci-local/src/engine/tests.rs
@@ -1,0 +1,558 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+
+use super::{
+    CompleteRequestError, CreateVolume, DockerInstallationAdapter, EngineApi, EngineApiError,
+    EngineFacts, IDENTITY_ANCHOR_KIND, IDENTITY_SCHEMA, InspectedVolume, LABEL_COMPOSE_PROJECT,
+    LABEL_IDENTITY_SCHEMA, LABEL_INSTALLATION_ID, LABEL_INSTALLATION_KEY, LABEL_MANAGED,
+    LABEL_RESOURCE_KIND, LocalEngineErrorCode, MANAGED_VALUE, adapter_api_version,
+    complete_request, identity_labels,
+};
+use crate::{
+    ComposeFrontend, DockerConnection, Engine, EngineArchitecture, EngineEndpoint, EngineSelection,
+    Installation, InstallationId, InstallationName,
+};
+
+type VolumeMutation = Box<dyn Fn(&mut InspectedVolume) + Send + Sync>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Call {
+    EngineFacts,
+    Inspect(String),
+    Create(String),
+    Attachments(String),
+}
+
+#[derive(Clone, Debug)]
+enum CreateBehavior {
+    Apply,
+    ApplyThenFail,
+    SucceedWithoutCreating,
+    ConcurrentWinner(InspectedVolume),
+}
+
+struct FakeState {
+    facts: EngineFacts,
+    queued_facts: VecDeque<Result<EngineFacts, EngineApiError>>,
+    volumes: BTreeMap<String, InspectedVolume>,
+    attachments: BTreeMap<String, Vec<String>>,
+    behavior: CreateBehavior,
+    calls: Vec<Call>,
+}
+
+struct FakeEngine {
+    state: Mutex<FakeState>,
+}
+
+impl FakeEngine {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeState {
+                facts: healthy_facts(),
+                queued_facts: VecDeque::new(),
+                volumes: BTreeMap::new(),
+                attachments: BTreeMap::new(),
+                behavior: CreateBehavior::Apply,
+                calls: Vec::new(),
+            }),
+        }
+    }
+
+    fn mutate(&self, update: impl FnOnce(&mut FakeState)) {
+        update(&mut self.state.lock().expect("fake engine lock"));
+    }
+
+    fn calls(&self) -> Vec<Call> {
+        self.state.lock().expect("fake engine lock").calls.clone()
+    }
+}
+
+#[async_trait]
+impl EngineApi for FakeEngine {
+    async fn engine_facts(&self) -> Result<EngineFacts, EngineApiError> {
+        let mut state = self.state.lock().expect("fake engine lock");
+        state.calls.push(Call::EngineFacts);
+        if let Some(facts) = state.queued_facts.pop_front() {
+            facts
+        } else {
+            Ok(state.facts.clone())
+        }
+    }
+
+    async fn inspect_volume(&self, name: &str) -> Result<Option<InspectedVolume>, EngineApiError> {
+        let mut state = self.state.lock().expect("fake engine lock");
+        state.calls.push(Call::Inspect(name.to_owned()));
+        Ok(state.volumes.get(name).cloned())
+    }
+
+    async fn create_volume(&self, request: CreateVolume) -> Result<(), EngineApiError> {
+        let mut state = self.state.lock().expect("fake engine lock");
+        state.calls.push(Call::Create(request.name.clone()));
+        let requested = InspectedVolume {
+            name: request.name.clone(),
+            driver: "local".to_owned(),
+            scope: "local".to_owned(),
+            options: BTreeMap::new(),
+            labels: request.labels,
+        };
+        match state.behavior.clone() {
+            CreateBehavior::Apply => {
+                state.volumes.entry(request.name).or_insert(requested);
+                Ok(())
+            }
+            CreateBehavior::ApplyThenFail => {
+                state.volumes.entry(request.name).or_insert(requested);
+                Err(EngineApiError::RequestFailed)
+            }
+            CreateBehavior::SucceedWithoutCreating => Ok(()),
+            CreateBehavior::ConcurrentWinner(volume) => {
+                state.volumes.insert(request.name, volume);
+                Ok(())
+            }
+        }
+    }
+
+    async fn volume_attachments(&self, name: &str) -> Result<Vec<String>, EngineApiError> {
+        let mut state = self.state.lock().expect("fake engine lock");
+        state.calls.push(Call::Attachments(name.to_owned()));
+        Ok(state.attachments.get(name).cloned().unwrap_or_default())
+    }
+}
+
+fn healthy_facts() -> EngineFacts {
+    EngineFacts {
+        engine_id: "engine-identity".to_owned(),
+        server_version: "29.7.2".to_owned(),
+        minimum_api_version: "1.40".to_owned(),
+        maximum_api_version: "1.55".to_owned(),
+        operating_system: "linux".to_owned(),
+        architecture: "amd64".to_owned(),
+    }
+}
+
+fn selection() -> EngineSelection {
+    EngineSelection {
+        engine: Engine::Docker,
+        compose: ComposeFrontend::DockerPlugin,
+        context_name: "default".to_owned(),
+        endpoint: EngineEndpoint::UnixSocket,
+        engine_id: "engine-identity".to_owned(),
+        server_version: "29.7.2".to_owned(),
+        api_version: "1.55".to_owned(),
+        architecture: EngineArchitecture::Amd64,
+        compose_version: "5.4.0".to_owned(),
+        connection: DockerConnection {
+            context_name: "default".to_owned(),
+            host: "unix:///var/run/docker.sock".to_owned(),
+            endpoint: EngineEndpoint::UnixSocket,
+        },
+    }
+}
+
+fn test_adapter() -> (DockerInstallationAdapter, Arc<FakeEngine>) {
+    let fake = Arc::new(FakeEngine::new());
+    (
+        DockerInstallationAdapter::with_test_engine(selection(), fake.clone()),
+        fake,
+    )
+}
+
+#[test]
+fn adapter_api_is_capped_to_the_bollard_model_ceiling() {
+    let capped = adapter_api_version("1.55").expect("supported selected API");
+    assert_eq!((capped.major, capped.minor), (1, 53));
+
+    let older = adapter_api_version("1.44").expect("older supported API");
+    assert_eq!((older.major, older.minor), (1, 44));
+}
+
+#[tokio::test]
+async fn complete_request_deadline_covers_the_entire_response_future() {
+    let result = complete_request(
+        future::pending::<Result<(), bollard::errors::Error>>(),
+        Duration::ZERO,
+    )
+    .await;
+    assert!(matches!(result, Err(CompleteRequestError::TimedOut)));
+}
+
+#[tokio::test]
+async fn engine_verification_uses_the_capped_adapter_api() {
+    let (adapter, fake) = test_adapter();
+    fake.mutate(|state| state.facts.maximum_api_version = "1.53".to_owned());
+    assert_eq!(
+        adapter
+            .inspect_identity(&InstallationName::default())
+            .await
+            .expect("Bollard-supported API remains in the daemon range"),
+        None
+    );
+
+    fake.mutate(|state| state.facts.minimum_api_version = "1.54".to_owned());
+    assert_eq!(
+        adapter
+            .inspect_identity(&InstallationName::default())
+            .await
+            .expect_err("daemon minimum above the adapter ceiling must fail")
+            .code(),
+        LocalEngineErrorCode::EngineIdentityChanged
+    );
+}
+
+fn anchor(name: &InstallationName, id: InstallationId) -> InspectedVolume {
+    let installation = Installation::verified(name.clone(), id);
+    InspectedVolume {
+        name: installation.anchor_volume_name().to_owned(),
+        driver: "local".to_owned(),
+        scope: "local".to_owned(),
+        options: BTreeMap::new(),
+        labels: identity_labels(&installation),
+    }
+}
+
+#[tokio::test]
+async fn absent_anchor_is_created_post_inspected_and_then_adopted() {
+    let (adapter, fake) = test_adapter();
+    let name = InstallationName::default();
+    let expected_name = Installation::expected(&name).anchor_volume_name;
+
+    let created = adapter
+        .create_or_adopt_identity(&name)
+        .await
+        .expect("create identity anchor");
+    assert_eq!(created.anchor_volume_name(), expected_name);
+    assert_eq!(
+        fake.calls(),
+        vec![
+            Call::EngineFacts,
+            Call::Inspect(expected_name.clone()),
+            Call::Create(expected_name.clone()),
+            Call::Inspect(expected_name.clone()),
+            Call::Attachments(expected_name.clone()),
+            Call::EngineFacts,
+        ]
+    );
+
+    fake.mutate(|state| state.calls.clear());
+    let adopted = adapter
+        .create_or_adopt_identity(&name)
+        .await
+        .expect("adopt identity anchor");
+    assert_eq!(adopted.id(), created.id());
+    assert_eq!(
+        fake.calls(),
+        vec![
+            Call::EngineFacts,
+            Call::Inspect(expected_name.clone()),
+            Call::Attachments(expected_name),
+            Call::EngineFacts,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn post_inspection_not_the_create_response_decides_success() {
+    let (adapter, fake) = test_adapter();
+    let name = InstallationName::new("uncertain").expect("installation name");
+    fake.mutate(|state| state.behavior = CreateBehavior::ApplyThenFail);
+
+    let created = adapter
+        .create_or_adopt_identity(&name)
+        .await
+        .expect("fresh inspection proves the create completed");
+    assert_eq!(created.name(), &name);
+
+    let (adapter, fake) = test_adapter();
+    fake.mutate(|state| state.behavior = CreateBehavior::SucceedWithoutCreating);
+    assert_eq!(
+        adapter
+            .create_or_adopt_identity(&name)
+            .await
+            .expect_err("missing post-create anchor must fail")
+            .code(),
+        LocalEngineErrorCode::MutationOutcomeUncertain
+    );
+}
+
+#[tokio::test]
+async fn a_concurrent_matching_winner_is_adopted() {
+    let (adapter, fake) = test_adapter();
+    let name = InstallationName::new("race").expect("installation name");
+    let winner = anchor(&name, InstallationId::new());
+    let winner_id =
+        InstallationId::parse_canonical(winner.labels[super::LABEL_INSTALLATION_ID].as_str())
+            .expect("winner installation ID");
+    fake.mutate(|state| state.behavior = CreateBehavior::ConcurrentWinner(winner));
+
+    assert_eq!(
+        adapter
+            .create_or_adopt_identity(&name)
+            .await
+            .expect("adopt concurrent winner")
+            .id(),
+        winner_id
+    );
+}
+
+#[tokio::test]
+async fn foreign_volume_shape_fails_without_mutation() {
+    let name = InstallationName::new("foreign-shape").expect("installation name");
+    for mutate in [
+        |volume: &mut InspectedVolume| volume.driver = "nfs".to_owned(),
+        |volume: &mut InspectedVolume| volume.scope = "global".to_owned(),
+        |volume: &mut InspectedVolume| {
+            volume
+                .options
+                .insert("device".to_owned(), "/host/path".to_owned());
+        },
+    ] {
+        let (adapter, fake) = test_adapter();
+        let mut volume = anchor(&name, InstallationId::new());
+        mutate(&mut volume);
+        fake.mutate(|state| {
+            state.volumes.insert(volume.name.clone(), volume);
+        });
+        assert_eq!(
+            adapter
+                .create_or_adopt_identity(&name)
+                .await
+                .expect_err("foreign volume shape")
+                .code(),
+            LocalEngineErrorCode::IdentityCollision
+        );
+        assert!(
+            !fake
+                .calls()
+                .iter()
+                .any(|call| matches!(call, Call::Create(_)))
+        );
+    }
+}
+
+#[tokio::test]
+async fn managed_label_contract_is_exact_but_foreign_labels_are_tolerated() {
+    let name = InstallationName::new("labels").expect("installation name");
+    let mutations: Vec<(&str, VolumeMutation)> = vec![
+        (
+            "missing owner",
+            Box::new(|volume| {
+                volume.labels.remove(LABEL_MANAGED);
+            }),
+        ),
+        (
+            "wrong schema",
+            Box::new(|volume| {
+                volume
+                    .labels
+                    .insert(LABEL_IDENTITY_SCHEMA.to_owned(), "2".to_owned());
+            }),
+        ),
+        (
+            "wrong key",
+            Box::new(|volume| {
+                volume
+                    .labels
+                    .insert(LABEL_INSTALLATION_KEY.to_owned(), "0".repeat(64));
+            }),
+        ),
+        (
+            "wrong project",
+            Box::new(|volume| {
+                volume.labels.insert(
+                    LABEL_COMPOSE_PROJECT.to_owned(),
+                    "automata-local-other".to_owned(),
+                );
+            }),
+        ),
+        (
+            "wrong role",
+            Box::new(|volume| {
+                volume
+                    .labels
+                    .insert(LABEL_RESOURCE_KIND.to_owned(), "other".to_owned());
+            }),
+        ),
+        (
+            "unknown managed label",
+            Box::new(|volume| {
+                volume
+                    .labels
+                    .insert("io.automata.local.future".to_owned(), "value".to_owned());
+            }),
+        ),
+        (
+            "malformed uuid",
+            Box::new(|volume| {
+                volume
+                    .labels
+                    .insert(LABEL_INSTALLATION_ID.to_owned(), "not-a-uuid".to_owned());
+            }),
+        ),
+    ];
+    for (description, mutate) in mutations {
+        let (adapter, fake) = test_adapter();
+        let mut volume = anchor(&name, InstallationId::new());
+        mutate(&mut volume);
+        fake.mutate(|state| {
+            state.volumes.insert(volume.name.clone(), volume);
+        });
+        let error = adapter
+            .inspect_identity(&name)
+            .await
+            .expect_err(description);
+        assert!(matches!(
+            error.code(),
+            LocalEngineErrorCode::IdentityCollision | LocalEngineErrorCode::InvalidIdentityAnchor
+        ));
+    }
+
+    let (adapter, fake) = test_adapter();
+    let mut volume = anchor(&name, InstallationId::new());
+    volume
+        .labels
+        .insert("com.example.note".to_owned(), "allowed".to_owned());
+    fake.mutate(|state| {
+        state.volumes.insert(volume.name.clone(), volume);
+    });
+    assert!(
+        adapter
+            .inspect_identity(&name)
+            .await
+            .expect("foreign namespace is ignored")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn running_or_stopped_attachment_blocks_adoption() {
+    let (adapter, fake) = test_adapter();
+    let name = InstallationName::new("attached").expect("installation name");
+    let volume = anchor(&name, InstallationId::new());
+    fake.mutate(|state| {
+        state
+            .attachments
+            .insert(volume.name.clone(), vec!["stopped-container-id".to_owned()]);
+        state.volumes.insert(volume.name.clone(), volume);
+    });
+    assert_eq!(
+        adapter
+            .inspect_identity(&name)
+            .await
+            .expect_err("any attachment must fail")
+            .code(),
+        LocalEngineErrorCode::IdentityAnchorAttached
+    );
+}
+
+#[tokio::test]
+async fn engine_drift_before_mutation_creates_nothing() {
+    let (adapter, fake) = test_adapter();
+    fake.mutate(|state| state.facts.engine_id = "replacement-engine".to_owned());
+    assert_eq!(
+        adapter
+            .create_or_adopt_identity(&InstallationName::default())
+            .await
+            .expect_err("changed engine must fail")
+            .code(),
+        LocalEngineErrorCode::EngineIdentityChanged
+    );
+    assert_eq!(fake.calls(), vec![Call::EngineFacts]);
+}
+
+#[tokio::test]
+async fn engine_drift_after_create_reports_uncertain_without_cleanup() {
+    let (adapter, fake) = test_adapter();
+    let mut changed = healthy_facts();
+    changed.engine_id = "replacement-engine".to_owned();
+    fake.mutate(|state| {
+        state.queued_facts = VecDeque::from([Ok(healthy_facts()), Ok(changed)]);
+    });
+    assert_eq!(
+        adapter
+            .create_or_adopt_identity(&InstallationName::default())
+            .await
+            .expect_err("post-create engine drift")
+            .code(),
+        LocalEngineErrorCode::MutationOutcomeUncertain
+    );
+    assert_eq!(
+        fake.calls()
+            .iter()
+            .filter(|call| matches!(call, Call::Create(_)))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn identity_label_constants_are_not_accidentally_changed() {
+    assert_eq!(MANAGED_VALUE, "true");
+    assert_eq!(IDENTITY_SCHEMA, "1");
+    assert_eq!(IDENTITY_ANCHOR_KIND, "identity-anchor");
+}
+
+#[tokio::test]
+#[ignore = "requires an explicitly selected live local Docker Engine and removes its exact fixture"]
+async fn live_docker_public_adapter_creates_and_re_adopts_one_exact_anchor() {
+    use bollard::query_parameters::RemoveVolumeOptionsBuilder;
+
+    assert_eq!(
+        std::env::var("AUTOMATA_TEST_LOCAL_DOCKER").as_deref(),
+        Ok("1"),
+        "set AUTOMATA_TEST_LOCAL_DOCKER=1 to authorize the live fixture"
+    );
+    let report = Box::pin(crate::inspect(crate::DoctorRequest::new(
+        crate::EngineRequest::Docker,
+    )))
+    .await;
+    assert!(
+        report.ready(),
+        "live Docker preflight: {:?}",
+        report.issues()
+    );
+    let adapter = DockerInstallationAdapter::connect(&report)
+        .await
+        .expect("connect exact Docker endpoint");
+    let name = InstallationName::new(format!("live-{}", uuid::Uuid::new_v4().simple()))
+        .expect("unique live installation name");
+
+    let first = adapter
+        .create_or_adopt_identity(&name)
+        .await
+        .expect("create live identity anchor");
+    let second = adapter
+        .create_or_adopt_identity(&name)
+        .await
+        .expect("adopt live identity anchor");
+    assert_eq!(second.id(), first.id());
+
+    let selection = report.selected_engine().expect("ready engine selection");
+    let cleanup_engine = super::BollardEngine::connect(selection).expect("cleanup connection");
+    let verified = adapter
+        .inspect_identity(&name)
+        .await
+        .expect("reinspect before cleanup")
+        .expect("live anchor exists before cleanup");
+    assert_eq!(verified, first);
+    cleanup_engine
+        .docker
+        .remove_volume(
+            verified.anchor_volume_name(),
+            Some(RemoveVolumeOptionsBuilder::new().force(false).build()),
+        )
+        .await
+        .expect("remove the exact unattached live fixture");
+    assert_eq!(
+        adapter
+            .inspect_identity(&name)
+            .await
+            .expect("inspect after exact cleanup"),
+        None
+    );
+}

--- a/crates/automata-ci-local/src/installation.rs
+++ b/crates/automata-ci-local/src/installation.rs
@@ -1,0 +1,303 @@
+//! Stable local-installation identity derived from an explicit selector.
+
+use std::{fmt, str::FromStr};
+
+use automata_ci_core::Sha256Digest;
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use uuid::{Uuid, Version};
+
+const DEFAULT_INSTALLATION_NAME: &str = "default";
+const MAX_INSTALLATION_NAME_BYTES: usize = 64;
+const SELECTOR_KEY_DOMAIN: &[u8] = b"automata/local/installation-selector/v1\0";
+const ENGINE_NAME_KEY_HEX_LENGTH: usize = 32;
+const ENGINE_NAME_PREFIX: &str = "automata-local-";
+
+/// Canonical user-facing selector for one local control-plane installation.
+///
+/// An installation is a deployment and runner-capacity domain. It is not bound
+/// to one source repository; repository identity belongs to workflow admission.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct InstallationName(String);
+
+impl InstallationName {
+    /// Validates a canonical installation selector.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallationNameError`] when `value` is empty, exceeds 64
+    /// bytes, or is not lower-case ASCII alphanumeric text separated by single
+    /// hyphens.
+    pub fn new(value: impl Into<String>) -> Result<Self, InstallationNameError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(InstallationNameError::Empty);
+        }
+        if value.len() > MAX_INSTALLATION_NAME_BYTES {
+            return Err(InstallationNameError::TooLong);
+        }
+        let bytes = value.as_bytes();
+        if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
+            return Err(InstallationNameError::InvalidSyntax);
+        }
+        if !bytes[bytes.len() - 1].is_ascii_lowercase() && !bytes[bytes.len() - 1].is_ascii_digit()
+        {
+            return Err(InstallationNameError::InvalidSyntax);
+        }
+        if bytes
+            .iter()
+            .any(|byte| !byte.is_ascii_lowercase() && !byte.is_ascii_digit() && *byte != b'-')
+            || bytes.windows(2).any(|pair| pair == b"--")
+        {
+            return Err(InstallationNameError::InvalidSyntax);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical selector text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for InstallationName {
+    fn default() -> Self {
+        Self(DEFAULT_INSTALLATION_NAME.to_owned())
+    }
+}
+
+impl fmt::Display for InstallationName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl FromStr for InstallationName {
+    type Err = InstallationNameError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+/// Rejected local-installation selector.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum InstallationNameError {
+    /// The selector was empty.
+    #[error("installation name cannot be empty")]
+    Empty,
+    /// The selector exceeded the bounded input length.
+    #[error("installation name cannot exceed 64 bytes")]
+    TooLong,
+    /// The selector was not canonical lower-case ASCII text.
+    #[error(
+        "installation name must use lowercase ASCII letters, digits, and single interior hyphens"
+    )]
+    InvalidSyntax,
+}
+
+/// Full domain-separated digest identifying an installation selector.
+///
+/// Version 1 is SHA-256 over the literal bytes
+/// `automata/local/installation-selector/v1\0`, the canonical selector byte
+/// length as one unsigned big-endian 16-bit integer, and the selector's ASCII
+/// bytes, in that order. Docker names use the leading 128 bits; every adoption
+/// also compares this full 256-bit value from the managed label.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct InstallationSelectorKey(Sha256Digest);
+
+impl InstallationSelectorKey {
+    pub(crate) fn for_name(name: &InstallationName) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(SELECTOR_KEY_DOMAIN);
+        hasher.update(
+            u16::try_from(name.as_str().len())
+                .expect("validated installation names fit in u16")
+                .to_be_bytes(),
+        );
+        hasher.update(name.as_str().as_bytes());
+        Self(Sha256Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Returns the full 256-bit selector digest.
+    pub const fn digest(self) -> Sha256Digest {
+        self.0
+    }
+
+    fn engine_name_component(self) -> String {
+        self.to_string()[..ENGINE_NAME_KEY_HEX_LENGTH].to_owned()
+    }
+}
+
+impl fmt::Display for InstallationSelectorKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Deterministic Docker Compose project name for one installation selector.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComposeProjectName(String);
+
+impl ComposeProjectName {
+    fn for_key(key: InstallationSelectorKey) -> Self {
+        Self(format!(
+            "{ENGINE_NAME_PREFIX}{}",
+            key.engine_name_component()
+        ))
+    }
+
+    /// Returns the engine-safe project name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ComposeProjectName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Random immutable identity stored on one installation anchor.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct InstallationId(Uuid);
+
+impl InstallationId {
+    pub(crate) fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub(crate) fn parse_canonical(value: &str) -> Option<Self> {
+        let parsed = Uuid::parse_str(value).ok()?;
+        (parsed.to_string() == value && parsed.get_version() == Some(Version::Random))
+            .then_some(Self(parsed))
+    }
+
+    /// Returns the immutable UUID.
+    pub const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for InstallationId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Verified identity of one engine-owned local installation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Installation {
+    name: InstallationName,
+    id: InstallationId,
+    selector_key: InstallationSelectorKey,
+    compose_project: ComposeProjectName,
+    anchor_volume_name: String,
+}
+
+impl Installation {
+    pub(crate) fn verified(name: InstallationName, id: InstallationId) -> Self {
+        let selector_key = InstallationSelectorKey::for_name(&name);
+        let compose_project = ComposeProjectName::for_key(selector_key);
+        let anchor_volume_name = format!("{compose_project}-identity");
+        Self {
+            name,
+            id,
+            selector_key,
+            compose_project,
+            anchor_volume_name,
+        }
+    }
+
+    pub(crate) fn expected(name: &InstallationName) -> ExpectedInstallation {
+        let selector_key = InstallationSelectorKey::for_name(name);
+        let compose_project = ComposeProjectName::for_key(selector_key);
+        let anchor_volume_name = format!("{compose_project}-identity");
+        ExpectedInstallation {
+            selector_key,
+            compose_project,
+            anchor_volume_name,
+        }
+    }
+
+    /// Returns the user-facing installation selector.
+    pub const fn name(&self) -> &InstallationName {
+        &self.name
+    }
+
+    /// Returns the immutable installation UUID.
+    pub const fn id(&self) -> InstallationId {
+        self.id
+    }
+
+    /// Returns the full selector key verified from the anchor labels.
+    pub const fn selector_key(&self) -> InstallationSelectorKey {
+        self.selector_key
+    }
+
+    /// Returns the deterministic Compose project name.
+    pub const fn compose_project(&self) -> &ComposeProjectName {
+        &self.compose_project
+    }
+
+    /// Returns the deterministic external identity-volume name.
+    pub fn anchor_volume_name(&self) -> &str {
+        &self.anchor_volume_name
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExpectedInstallation {
+    pub(crate) selector_key: InstallationSelectorKey,
+    pub(crate) compose_project: ComposeProjectName,
+    pub(crate) anchor_volume_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ComposeProjectName, Installation, InstallationName, InstallationNameError,
+        InstallationSelectorKey,
+    };
+
+    #[test]
+    fn installation_names_are_canonical_and_bounded() {
+        for valid in ["default", "team-2", "0", &"a".repeat(64)] {
+            assert_eq!(
+                InstallationName::new(valid).expect("valid installation name"),
+                valid.parse().expect("same parsed installation name")
+            );
+        }
+        for (invalid, expected) in [
+            ("", InstallationNameError::Empty),
+            (&"a".repeat(65), InstallationNameError::TooLong),
+            ("Team", InstallationNameError::InvalidSyntax),
+            ("team_1", InstallationNameError::InvalidSyntax),
+            ("-team", InstallationNameError::InvalidSyntax),
+            ("team-", InstallationNameError::InvalidSyntax),
+            ("team--1", InstallationNameError::InvalidSyntax),
+        ] {
+            assert_eq!(InstallationName::new(invalid), Err(expected));
+        }
+    }
+
+    #[test]
+    fn selector_preimage_and_engine_names_are_stable() {
+        let name = InstallationName::default();
+        let key = InstallationSelectorKey::for_name(&name);
+        assert_eq!(
+            key.to_string(),
+            "df06ebed0fcba9b2d00b0476426924f354f73d0d7c6cd4ed2844b52787ccd120"
+        );
+        assert_eq!(
+            ComposeProjectName::for_key(key).as_str(),
+            "automata-local-df06ebed0fcba9b2d00b0476426924f3"
+        );
+        let expected = Installation::expected(&name);
+        assert_eq!(
+            expected.anchor_volume_name,
+            "automata-local-df06ebed0fcba9b2d00b0476426924f3-identity"
+        );
+    }
+}

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -7,7 +7,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::{collections::BTreeMap, io, process::Stdio, time::Duration};
+use std::{collections::BTreeMap, fmt, io, process::Stdio, time::Duration};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::{
@@ -16,9 +16,20 @@ use tokio::{
     time::timeout,
 };
 
+mod engine;
+mod installation;
+
+pub use engine::{DockerInstallationAdapter, LocalEngineError, LocalEngineErrorCode};
+pub use installation::{
+    ComposeProjectName, Installation, InstallationId, InstallationName, InstallationNameError,
+    InstallationSelectorKey,
+};
+
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const COMMAND_TERMINATION_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_COMMAND_STREAM_BYTES: usize = 64 * 1024;
+const MAX_DOCKER_CONTEXT_NAME_BYTES: usize = 128;
+const MAX_DOCKER_ENDPOINT_BYTES: usize = 4096;
 const MIN_DOCKER_API: ApiVersion = ApiVersion {
     major: 1,
     minor: 44,
@@ -51,18 +62,31 @@ impl DoctorRequest {
 
 /// Inspects the local host without creating state or containers.
 pub async fn inspect(request: DoctorRequest) -> DoctorReport {
-    let (context, version, info, compose) = tokio::join!(
-        capture_docker(
-            DoctorProbe::DockerContext,
-            &["context", "inspect", "--format", "{{json .}}"]
-        ),
-        capture_docker(DoctorProbe::DockerVersion, &["version", "--format", "json"]),
-        capture_docker(DoctorProbe::DockerInfo, &["info", "--format", "json"]),
-        capture_docker(
-            DoctorProbe::DockerCompose,
-            &["compose", "version", "--format", "json"]
-        ),
-    );
+    let context = capture_docker(
+        DoctorProbe::DockerContext,
+        &["context", "inspect", "--format", "{{json .}}"],
+    )
+    .await;
+    let endpoint = validated_context_output(&context, std::env::consts::OS);
+    let compose_arguments = ["compose", "version", "--format", "json"];
+    let (version, info, compose) = if let Some(endpoint) = endpoint.as_ref() {
+        let version_arguments = [
+            "--host",
+            endpoint.host.as_str(),
+            "version",
+            "--format",
+            "json",
+        ];
+        let info_arguments = ["--host", endpoint.host.as_str(), "info", "--format", "json"];
+        tokio::join!(
+            capture_docker(DoctorProbe::DockerVersion, &version_arguments),
+            capture_docker(DoctorProbe::DockerInfo, &info_arguments),
+            capture_docker(DoctorProbe::DockerCompose, &compose_arguments),
+        )
+    } else {
+        let compose = capture_docker(DoctorProbe::DockerCompose, &compose_arguments).await;
+        (ProbeOutput::Skipped, ProbeOutput::Skipped, compose)
+    };
     let probes = ProbeSet {
         context,
         version,
@@ -297,6 +321,34 @@ pub enum EngineEndpoint {
     WindowsNamedPipe,
 }
 
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct DockerConnection {
+    context_name: String,
+    host: String,
+    endpoint: EngineEndpoint,
+}
+
+impl fmt::Debug for DockerConnection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DockerConnection")
+            .field("context_name", &self.context_name)
+            .field("endpoint", &self.endpoint)
+            .field("host", &"<validated-local-endpoint>")
+            .finish()
+    }
+}
+
+impl DockerConnection {
+    pub(crate) fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub(crate) const fn endpoint(&self) -> EngineEndpoint {
+        self.endpoint
+    }
+}
+
 /// Supported Linux engine architecture.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -312,12 +364,15 @@ pub enum EngineArchitecture {
 pub struct EngineSelection {
     engine: Engine,
     compose: ComposeFrontend,
+    context_name: String,
     endpoint: EngineEndpoint,
     engine_id: String,
     server_version: String,
     api_version: String,
     architecture: EngineArchitecture,
     compose_version: String,
+    #[serde(skip)]
+    connection: DockerConnection,
 }
 
 impl EngineSelection {
@@ -329,6 +384,11 @@ impl EngineSelection {
     /// Returns the selected Compose frontend.
     pub const fn compose(&self) -> ComposeFrontend {
         self.compose
+    }
+
+    /// Returns the exact Docker context name observed during preflight.
+    pub fn context_name(&self) -> &str {
+        &self.context_name
     }
 
     /// Returns the validated local endpoint class.
@@ -346,7 +406,7 @@ impl EngineSelection {
         &self.server_version
     }
 
-    /// Returns the negotiated Docker API version reported by the client.
+    /// Returns the exact Docker API version selected for adapter requests.
     pub fn api_version(&self) -> &str {
         &self.api_version
     }
@@ -359,6 +419,10 @@ impl EngineSelection {
     /// Returns the exact Docker Compose plugin version.
     pub fn compose_version(&self) -> &str {
         &self.compose_version
+    }
+
+    pub(crate) const fn connection(&self) -> &DockerConnection {
+        &self.connection
     }
 }
 
@@ -398,7 +462,7 @@ fn build_report(
     let selected_engine = evaluate_engine(operating_system, host_architecture, probes, &mut issues);
     issues.sort_by_key(|issue| issue.probe.sort_key());
     DoctorReport {
-        schema: 2,
+        schema: 3,
         ready: selected_engine.is_some() && issues.is_empty(),
         platform: Platform {
             operating_system: operating_system.to_owned(),
@@ -430,6 +494,7 @@ struct ProbeSet {
 enum ProbeOutput {
     Success(Vec<u8>),
     Failure(CommandFailure),
+    Skipped,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -665,7 +730,7 @@ fn evaluate_engine(
     let compose: Option<DockerComposeDocument> =
         parse_probe(DoctorProbe::DockerCompose, &probes.compose, issues);
 
-    let endpoint = context.as_ref().and_then(|context| {
+    let connection = context.as_ref().and_then(|context| {
         record_validation(
             DoctorProbe::DockerContext,
             validate_context(context, operating_system),
@@ -698,12 +763,14 @@ fn evaluate_engine(
     Some(EngineSelection {
         engine: Engine::Docker,
         compose: ComposeFrontend::DockerPlugin,
-        endpoint: endpoint?,
+        context_name: connection.as_ref()?.context_name.clone(),
+        endpoint: connection.as_ref()?.endpoint,
         engine_id: engine_id?,
         server_version: version.as_ref()?.server_version.clone(),
         api_version: version.as_ref()?.api_version.clone(),
         architecture: version.as_ref()?.architecture,
         compose_version: compose_version?,
+        connection: connection?,
     })
 }
 
@@ -718,6 +785,7 @@ fn parse_probe<T: DeserializeOwned>(
             issues.push(DoctorIssue::new(probe, failure.issue_code()));
             return None;
         }
+        ProbeOutput::Skipped => return None,
     };
     if let Ok(document) = serde_json::from_slice(bytes) {
         Some(document)
@@ -780,15 +848,42 @@ struct DockerContextEndpoint {
     skip_tls_verify: bool,
 }
 
+fn validated_context_output(
+    output: &ProbeOutput,
+    operating_system: &str,
+) -> Option<DockerConnection> {
+    let ProbeOutput::Success(bytes) = output else {
+        return None;
+    };
+    let document: DockerContextDocument = serde_json::from_slice(bytes).ok()?;
+    validate_context(&document, operating_system).ok()
+}
+
 fn validate_context(
     context: &DockerContextDocument,
     operating_system: &str,
-) -> Result<EngineEndpoint, DoctorIssueCode> {
-    if context.name.is_empty() || context.endpoints.docker.skip_tls_verify {
+) -> Result<DockerConnection, DoctorIssueCode> {
+    if !valid_context_name(&context.name)
+        || context.endpoints.docker.host.len() > MAX_DOCKER_ENDPOINT_BYTES
+        || context.endpoints.docker.skip_tls_verify
+    {
         return Err(DoctorIssueCode::UntrustedDockerEndpoint);
     }
-    local_endpoint(&context.endpoints.docker.host, operating_system)
-        .ok_or(DoctorIssueCode::UntrustedDockerEndpoint)
+    let endpoint = local_endpoint(&context.endpoints.docker.host, operating_system)
+        .ok_or(DoctorIssueCode::UntrustedDockerEndpoint)?;
+    Ok(DockerConnection {
+        context_name: context.name.clone(),
+        host: context.endpoints.docker.host.clone(),
+        endpoint,
+    })
+}
+
+fn valid_context_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_DOCKER_CONTEXT_NAME_BYTES
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn local_endpoint(host: &str, operating_system: &str) -> Option<EngineEndpoint> {
@@ -940,9 +1035,12 @@ fn validate_version(
         .get("MinAPIVersion")
         .and_then(|value| ApiVersion::parse(value))
         .ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
+    let adapter_api =
+        capped_adapter_api(client_api).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
     if client_api < MIN_DOCKER_API
+        || adapter_api < MIN_DOCKER_API
         || server_api < client_api
-        || minimum_api > client_api
+        || minimum_api > adapter_api
         || component_api != server_api
         || component_minimum_api != minimum_api
     {
@@ -950,7 +1048,7 @@ fn validate_version(
     }
     Ok(ValidatedVersion {
         server_version: server.version.clone(),
-        api_version: client.api_version.clone(),
+        api_version: format!("{}.{}", adapter_api.major, adapter_api.minor),
         architecture,
     })
 }
@@ -976,6 +1074,14 @@ impl ApiVersion {
             minor: minor.parse().ok()?,
         })
     }
+}
+
+fn capped_adapter_api(selected: ApiVersion) -> Option<ApiVersion> {
+    let supported = ApiVersion {
+        major: u16::try_from(bollard::API_DEFAULT_VERSION.major_version).ok()?,
+        minor: u16::try_from(bollard::API_DEFAULT_VERSION.minor_version).ok()?,
+    };
+    Some(selected.min(supported))
 }
 
 const fn normalize_architecture(value: &str) -> Option<EngineArchitecture> {
@@ -1191,10 +1297,11 @@ mod tests {
         assert!(report.issues().is_empty());
         let engine = report.selected_engine().expect("validated engine");
         assert_eq!(engine.endpoint(), EngineEndpoint::UnixSocket);
+        assert_eq!(engine.context_name(), "default");
         assert_eq!(engine.architecture(), EngineArchitecture::Amd64);
         assert_eq!(engine.compose(), ComposeFrontend::DockerPlugin);
         assert_eq!(engine.engine_id(), "engine-identity");
-        assert_eq!(engine.api_version(), "1.55");
+        assert_eq!(engine.api_version(), "1.53");
         assert_eq!(engine.compose_version(), "5.4.0");
     }
 
@@ -1240,6 +1347,8 @@ mod tests {
         for context in [
             CONTEXT_UNIX.replace("unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"),
             CONTEXT_UNIX.replace("\"SkipTLSVerify\":false", "\"SkipTLSVerify\":true"),
+            CONTEXT_UNIX.replace("\"default\"", "\"context with spaces\""),
+            CONTEXT_UNIX.replace("\"default\"", &format!("\"{}\"", "a".repeat(129))),
         ] {
             let report = report("linux", "x86_64", &healthy_probes(&context));
             assert_eq!(
@@ -1307,7 +1416,21 @@ mod tests {
     }
 
     #[test]
-    fn reports_the_negotiated_client_api_not_the_server_ceiling() {
+    fn rejects_a_daemon_minimum_above_the_adapter_model_ceiling() {
+        let mut probes = healthy_probes(CONTEXT_UNIX);
+        probes.version = success(
+            VERSION_AMD64
+                .replace("\"MinAPIVersion\":\"1.40\"", "\"MinAPIVersion\":\"1.54\"")
+                .into_bytes(),
+        );
+        assert_eq!(
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::UnsupportedDockerApi]
+        );
+    }
+
+    #[test]
+    fn retains_an_older_negotiated_api_below_the_adapter_ceiling() {
         let mut probes = healthy_probes(CONTEXT_UNIX);
         probes.version = success(
             VERSION_AMD64
@@ -1579,7 +1702,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(report).expect("doctor report must serialize"),
             json!({
-                "schema": 2,
+                "schema": 3,
                 "ready": true,
                 "platform": {
                     "operating_system": "linux",
@@ -1589,10 +1712,11 @@ mod tests {
                 "selected_engine": {
                     "engine": "docker",
                     "compose": "docker_plugin",
+                    "context_name": "default",
                     "endpoint": "unix_socket",
                     "engine_id": "engine-identity",
                     "server_version": "29.7.2",
-                    "api_version": "1.55",
+                    "api_version": "1.53",
                     "architecture": "amd64",
                     "compose_version": "5.4.0"
                 },

--- a/crates/automata-ci/src/local/mod.rs
+++ b/crates/automata-ci/src/local/mod.rs
@@ -63,6 +63,7 @@ fn print_human_report(report: &DoctorReport) {
         None => println!("Container engine: unavailable"),
     }
     if let Some(selection) = report.selected_engine() {
+        println!("Docker context: {}", selection.context_name());
         println!("Engine endpoint: {}", endpoint_name(selection.endpoint()));
         println!("Engine identity: {}", selection.engine_id());
         println!(

--- a/crates/automata-ci/tests/local_doctor_process.rs
+++ b/crates/automata-ci/tests/local_doctor_process.rs
@@ -36,7 +36,7 @@ fn failed_local_doctor_is_typed_actionable_json_and_is_read_only() {
     assert!(!output.status.success());
     let report: Value =
         serde_json::from_slice(&output.stdout).expect("stdout must contain one JSON document");
-    assert_eq!(report["schema"], 2);
+    assert_eq!(report["schema"], 3);
     assert_eq!(report["ready"], false);
     assert!(report["selected_engine"].is_null());
     assert!(report.get("state_directory").is_none());
@@ -88,7 +88,7 @@ fn failed_local_doctor_is_typed_actionable_json_and_is_read_only() {
 }
 
 #[test]
-fn interrupted_local_doctor_terminates_every_probe_process_tree() {
+fn interrupted_local_doctor_terminates_the_context_probe_process_tree() {
     let fixture = Fixture::new();
     let fake_bin = fixture.path().join("bin");
     let process_directory = fixture.path().join("processes");
@@ -107,7 +107,49 @@ fn interrupted_local_doctor_terminates_every_probe_process_tree() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     let process = ChildGuard::spawn(&mut command);
-    let probe_processes = wait_for_probe_processes(&process_directory);
+    let probe_processes = wait_for_probe_processes(&process_directory, 2, "context probe");
+    let mut cleanup = ProcessCleanup::new(probe_processes.clone());
+
+    kill_process(process.pid(), Signal::INT).expect("interrupt local doctor");
+    let output = process.wait_for_output(Duration::from_secs(5));
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "an interrupted doctor emits no partial JSON: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8(output.stderr).expect("doctor diagnostics must be UTF-8");
+    assert!(
+        stderr.contains("local preflight interrupted by a process shutdown signal"),
+        "unexpected interrupted-doctor diagnostics: {stderr}"
+    );
+
+    wait_for_processes_to_exit(&probe_processes);
+    cleanup.disarm();
+}
+
+#[test]
+fn interrupted_local_doctor_terminates_all_post_context_probe_trees() {
+    let fixture = Fixture::new();
+    let fake_bin = fixture.path().join("bin");
+    let process_directory = fixture.path().join("processes");
+    fs::create_dir(&fake_bin).expect("create isolated executable directory");
+    fs::create_dir(&process_directory).expect("create process evidence directory");
+    install_post_context_hanging_fake_docker(&fake_bin.join("docker"));
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_automata"));
+    command
+        .args(["local", "doctor", "--json"])
+        .env_clear()
+        .env("PATH", &fake_bin)
+        .env("HOME", fixture.path())
+        .env("FAKE_DOCKER_PROCESS_DIRECTORY", &process_directory)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let process = ChildGuard::spawn(&mut command);
+    let probe_processes =
+        wait_for_probe_processes(&process_directory, 6, "version, info, and Compose probes");
     let mut cleanup = ProcessCleanup::new(probe_processes.clone());
 
     kill_process(process.pid(), Signal::INT).expect("interrupt local doctor");
@@ -147,7 +189,8 @@ case "${{1-}}" in
   context)
     printf '%s\n' '{{"Name":"default","Endpoints":{{"docker":{{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}}}}}}'
     ;;
-  version|info)
+  --host)
+    test "${{2-}}" = 'unix:///var/run/docker.sock'
     printf '%s\n' '{FAILURE_SENTINEL}' >&2
     exit 1
     ;;
@@ -183,18 +226,40 @@ wait
         .expect("make hanging fake docker executable owner-only");
 }
 
-fn wait_for_probe_processes(directory: &Path) -> Vec<Pid> {
+fn install_post_context_hanging_fake_docker(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+if [ "${1-}" = 'context' ]; then
+  printf '%s\n' '{"Name":"default","Endpoints":{"docker":{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}}}'
+  exit 0
+fi
+/bin/sleep 30 &
+descendant=$!
+printf '%s %s\n' "$$" "$descendant" > "${FAKE_DOCKER_PROCESS_DIRECTORY}/$$"
+wait
+"#,
+    )
+    .expect("write post-context hanging fake docker executable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .expect("make post-context fake docker executable owner-only");
+}
+
+fn wait_for_probe_processes(directory: &Path, expected: usize, description: &str) -> Vec<Pid> {
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {
         let processes = recorded_probe_processes(directory);
-        if processes.len() == 8 {
+        if processes.len() == expected {
             return processes;
         }
         if Instant::now() >= deadline {
             for process in &processes {
                 let _ignored = kill_process(*process, Signal::KILL);
             }
-            panic!("expected four probe leaders and descendants, found {processes:?}");
+            panic!(
+                "expected {description} process trees ({expected} processes), found {processes:?}"
+            );
         }
         thread::sleep(Duration::from_millis(10));
     }

--- a/docs/development.md
+++ b/docs/development.md
@@ -274,10 +274,23 @@ cargo run --locked -p automata-ci -- local doctor
 cargo run --locked -p automata-ci -- local doctor --json
 ```
 
-The command does not create host state or any container resources.
-`local up` and the worker composition remain planned; follow the
+The command does not create host state or any container resources. It reports
+the selected Docker context and pins all daemon probes to that context's exact
+validated local endpoint. The library's anchor adapter is exercised by fake
+Engine tests, but no product command invokes its mutation API yet. `local up`
+and the worker composition remain planned; follow the
 [local installation and deployment roadmap](maintainers/roadmaps/local-installation.md) for
 their merge and host-qualification gates.
+
+The opt-in live adapter contract creates one randomly named identity volume,
+adopts the same UUID through the public adapter, then re-inspects and removes
+only that exact unattached fixture:
+
+```console
+AUTOMATA_TEST_LOCAL_DOCKER=1 cargo test --locked -p automata-ci-local \
+  'engine::tests::live_docker_public_adapter_creates_and_re_adopts_one_exact_anchor' \
+  -- --ignored --exact
+```
 
 ## Local PostgreSQL and RustFS
 

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -2,12 +2,13 @@
 
 - Roadmap status: Active
 - Available slice: read-only `automata local doctor` from a reviewed source checkout
-- Current implementation checkpoint: 2A, host-state retirement and reuse contract
+- Current implementation checkpoint: 2B.1, pinned Docker context and immutable identity anchor
 - Date: 2026-08-15
 
 This roadmap owns the work required to make Automata easy to evaluate on one
-machine, optionally connect that installation to one GitHub repository, and then
-grow the tested deployment choices. Capability claims remain in
+machine, run repository-scoped work through a repository-agnostic local
+installation, optionally connect that installation to GitHub, and then grow the
+tested deployment choices. Capability claims remain in
 [Compatibility](../../compatibility.md); this page records product decisions,
 reuse boundaries, merge checkpoints, and the evidence required to change those
 claims.
@@ -153,6 +154,15 @@ Every command that addresses an installation accepts the same
 `--installation NAME` selector. Host-only `doctor` and source-only `check` do
 not invent or select an installation. Any native cache location is an internal
 platform choice, not installation identity or a public lifecycle selector.
+An installation is a repository-agnostic deployment and runner-capacity domain:
+the same selected installation may admit snapshots from different repositories,
+and repository identity never enters its selector key, engine labels, Compose
+project, or desired specification. Repository identity is derived and retained
+with `LocalSnapshot` admission instead. Repositories sharing one installation
+form one trusted set and share its runner capacity; separate installation names
+are useful for distinct trust sets or destructive test environments, but names
+on the same administrator-controlled daemon are not a hostile-code isolation
+boundary.
 JSON reserves stdout for one stable document and never prompts.
 Non-interactive execution never reads values from implicit environment
 variables or command arguments. Secret setters use hidden TTY input when no
@@ -171,7 +181,8 @@ onboarding path:
 
 | Existing path | Reusable capability | Remaining local gap |
 | --- | --- | --- |
-| `automata local doctor` | Cross-platform host, Docker, Compose, and architecture preflight | It is deliberately read-only; checkpoint 2A retires checkpoint 1's proposed native state-root input because installation identity will be engine-owned |
+| `automata local doctor` | Cross-platform host, Docker, Compose, and architecture preflight | It is deliberately read-only; checkpoint 2A retired checkpoint 1's proposed native state-root input, and checkpoint 2B.1 makes installation identity engine-owned |
+| `automata-ci-local` Engine adapter | Exact-endpoint Docker connection plus strict identity-anchor inspect/create/adopt with fake and opt-in live tests | No product command calls the mutation API until desired intent and convergent lifecycle contracts land |
 | `deploy/dev/compose.yaml` | Pinned PostgreSQL and object-storage development dependencies with health checks | It does not compose the product control plane and runner |
 | Control-plane deployment guide and container build | Complete server configuration and product images | Configuration and bootstrap are manual and Unix-oriented |
 | GitHub workflow crates | Frontend, compiler, typed workflow contracts, reusable-workflow handling | They need a separately authorized local snapshot source |
@@ -277,10 +288,12 @@ any of them.
 A deterministic external named Docker volume is created once as the
 installation anchor. Its exact Automata-managed label allowlist contains the
 managed marker, identity schema, installation UUID, installation selector key,
-canonical repository binding, deterministic Compose project, and the anchor
-resource-kind discriminator. The selector key is an identifier, not
-cryptographic key material. Changing an identity field requires confirmed reset
-or an explicit migration; it is never an in-place update.
+deterministic Compose project, and the anchor resource-kind discriminator. The
+selector key is derived only from the canonical installation selector under an
+exact versioned byte preimage; it is an identifier, not cryptographic key
+material. No repository, checkout, worktree, or source identity participates in
+that preimage. Changing an identity field requires confirmed reset or an
+explicit migration; it is never an in-place update.
 
 Create and adoption require `Driver=local`, `Scope=local`, empty driver options,
 no host-bind option, and no container attachment. The supervisor always
@@ -317,10 +330,9 @@ complete document or the next complete document, never a partial desired spec.
 Every persistent service volume carries only immutable Automata
 contract/identity/role labels: managed marker, contract and resource kind,
 installation UUID, selector key, project, and exact role. The identity anchor
-has the additional immutable schema and repository-binding labels described
-above. Persistent volume labels never carry a plan digest, so a plan update
-cannot make durable PostgreSQL, object, runner, or desired-spec data look
-foreign.
+has the additional immutable identity-schema label described above. Persistent
+volume labels never carry a plan digest, so a plan update cannot make durable
+PostgreSQL, object, runner, or desired-spec data look foreign.
 
 #### Replaceable topology and `down`
 
@@ -378,6 +390,10 @@ time alone never authorizes lock deletion.
 #### Exact reset
 
 Reset runs under that lock and uses this ordered transaction:
+
+Before confirmation, the command lists the installation-wide repositories,
+history, repository-scoped secrets, and GitHub connections that will be lost;
+reset is never presented as a checkout-local operation.
 
 1. discover the union of deterministic names, exact Compose-project resources,
    all resources with the installation's managed labels, volume/network
@@ -441,8 +457,13 @@ The new source boundary builds a deterministic, bounded archive from Git's
 tracked and non-ignored worktree inventory. It rejects unsafe file types,
 escaping symlinks, submodule ambiguity, case collisions, and concurrent
 mutation. The archive digest—not a possibly dirty HEAD—is the execution source
-identity. HEAD, dirty state, repository identity, selected workflow, inputs,
-and architecture decisions remain explicit provenance.
+identity. The source adapter also derives the canonical repository identity
+used by local admission. Before assigning that provenance contract version 1,
+its exact versioned byte preimage must define Git worktrees, symlinks,
+non-Unicode paths, case behavior, checkout moves, and clones on Linux, macOS,
+and Windows. HEAD, dirty state, repository identity, selected workflow, inputs,
+and architecture decisions remain explicit run provenance; none becomes local
+installation identity.
 
 `LocalSnapshot` is a distinct admission authority accepted only in the local
 deployment context. It parameterizes source location and archive policy around
@@ -610,9 +631,9 @@ engines fail actionably; and preflight creates no file, credential, or engine
 resource.
 
 Status: available. Host, Docker, Compose, and architecture behavior remains
-useful and is retained. Checkpoint 2A removes public state-root resolution and
-its readiness gate because installation identity will be engine-owned and any
-optional native cache will be internal and discardable.
+useful and is retained. Checkpoint 2A removed public state-root resolution and
+its readiness gate because checkpoint 2B.1 makes installation identity
+engine-owned and any optional native cache remains internal and discardable.
 
 ### 2A. Retire host lifecycle state and freeze the reuse boundary
 
@@ -620,56 +641,106 @@ Remove checkpoint 1's unused public state-root option and JSON field before any
 mutating local command depends on them. Record the reuse-first architecture and
 delete the draft host installation manifest, mirrored resource inventory,
 local-specific operation ID, broad lifecycle state machine, and duplicated
-platform filesystem framework. Do not publish an engine label schema or
-repository-binding algorithm until a real adapter consumes and
-integration-tests it. Do not extract the runner journal into a premature
-generic state library: journal, spool, CLI receipt, provider, and installation
-identity have different custody and recovery contracts.
+platform filesystem framework. Do not publish an engine label schema until a
+real engine adapter consumes and integration-tests it. Do not publish a
+repository-identity algorithm until the `LocalSnapshot` admission adapter
+consumes and integration-tests it. Do not extract the runner journal into a
+premature generic state library: journal, spool, CLI receipt, provider, and
+installation identity have different custody and recovery contracts.
 
 This checkpoint changes only the read-only preflight and the accepted design
 direction. It does not create, inspect, adopt, or delete engine resources and
 does not claim that `local up` is available.
 
-Gate: `local doctor` rejects the removed `--state-dir` option, JSON schema 2 has
-no state path or state-path issue codes, preflight creates no host or engine
-state, all reader-facing docs agree, and the focused native and package-scoped
-cross-target checks pass. The diff contains no unconsumed engine identity API,
-host lifecycle journal, or new platform filesystem substrate.
+Gate for the checkpoint 2A diff: `local doctor` rejects the removed
+`--state-dir` option, JSON schema 2 has no state path or state-path issue codes,
+preflight creates no host or engine state, all reader-facing docs agree, and the
+focused native and package-scoped cross-target checks pass. The diff contains
+no unconsumed engine identity API, host lifecycle journal, or new platform
+filesystem substrate.
 
 ### 2B. Engine identity and desired-spec adapter
 
-Add the first Docker Engine adapter together with the contracts it consumes.
-Define deterministic Compose project identity; a strictly inspected external
-identity anchor; exact role-specific managed-label allowlists; and the atomic,
-digest-bound desired-spec document in an engine config volume. Persistent
-volumes carry immutable identity-only labels while replaceable resources carry
-the rendered plan digest. Compose and fresh engine inspection are resource
-truth; no host manifest mirrors them.
+Land the first Docker Engine adapter and the engine-owned identity and desired
+intent contracts in two independently reviewable, strictly ordered slices.
+Installation identity is a repository-agnostic deployment/capacity boundary;
+repository and snapshot identity remain owned by later `LocalSnapshot`
+admission. Compose and fresh engine inspection are resource truth throughout,
+and no host manifest mirrors them.
 
-Before assigning contract version 1 or creating a volume, define the exact
-versioned byte preimage for repository identity, including Git worktrees,
-symlinks, non-Unicode paths, case behavior, checkout moves, and clones on Linux,
-macOS, and Windows. The adapter, not an arbitrary digest wrapper, constructs
-that binding. Likewise, parsing a resource requires the exact expected role
-from the checked-in rendered plan; a merely well-formed unknown role is not
-owned.
+#### 2B.1. Pinned Docker context and immutable identity anchor
 
-Gate: create and adoption always post-inspect local driver/scope, empty options,
-no bind, exact managed-label allowlist, and no attachments; foreign name/key,
-repository, role, project, or truncated-name collisions fail without mutation;
-the helper atomically commits and verifies a bounded value-free desired
-document; `N`, profile, and render inputs reconstruct the same digest after an
-adapter restart with no realized topology; and fake-daemon plus ignored
-live-Docker tests exercise the public adapter rather than value objects in
-isolation.
+Snapshot the selected Docker context before daemon probes, retain its exact
+validated local Unix-socket or Windows-named-pipe endpoint, pin subsequent
+daemon probes with that exact `--host` value, and connect the direct Engine API
+adapter only to that endpoint. Reverify the expected engine identity before
+mutation. Define the
+exact versioned byte preimage from the canonical installation selector to the
+full selector key, deterministic Compose project, and deterministic anchor
+name. Create only the external immutable identity-anchor volume in this slice;
+do not create, label, mount, or otherwise anticipate the desired-spec volume or
+any realized topology.
+
+The anchor's exact managed-label allowlist contains only its managed marker,
+identity schema, installation UUID, full selector key, Compose project, and
+anchor resource kind. The selector preimage contains no repository, checkout,
+worktree, or source input. The adapter exposes only the high-level inspection
+and create-or-adopt operations consumed here; generic volume mutation, pull,
+remove, reset, and lifecycle APIs do not land speculatively.
+
+Gate: create and adoption always re-inspect the deterministic anchor name after
+`volume create` and require local driver/scope, empty options, no bind, the
+exact anchor managed-label allowlist, and no container attachment. Foreign
+name, full-key, project, resource-kind, or truncated-name collisions fail
+without a second mutation. Changing the active context cannot redirect an
+already pinned adapter; a changed engine identity at the retained endpoint
+fails closed.
+Stateful fake-daemon and ignored live-Docker tests exercise the public adapter,
+including a create response that cannot be trusted, rather than testing value
+objects in isolation. The slice creates no desired-spec volume, helper
+container, Compose topology, host manifest, or repository binding.
+Doctor JSON schema 3 reports the bounded selected context name without exposing
+the retained endpoint URI, and CLI process tests prove daemon probes receive the
+exact validated `--host` value.
+
+#### 2B.2. Desired-spec config volume and atomic helper
+
+Extend the adapter with the separate persistent desired-spec config volume and
+the exact `desired-spec` persistent-volume role. Its immutable labels bind only
+the installation UUID, full selector key, Compose project, persistent-volume
+contract/resource kind, and exact role; they contain neither repository
+identity nor a mutable plan digest. Create and adoption use the same fresh
+post-inspection, local driver/scope, empty-option, no-bind, exact-label, and
+attachment checks as the anchor before any helper is started.
+
+Define the bounded, canonical, credential-value-free desired-spec document. It
+contains only the installation binding, requested `max_parallel_jobs`, exact
+local profile and architecture decision, closed image/render inputs, renderer
+version, and canonical plan digest needed to reconstruct the same stack after
+`down`. Reuse the existing digest-pinned sandbox guest as the one-shot helper;
+strengthen its bounded file write to use a same-directory exclusive temporary
+file, file synchronization, atomic rename, and directory synchronization. The
+adapter post-inspects each exact helper container ID before start, performs a
+fresh helper readback after commit, and accepts the document only when canonical
+decode, installation binding, and recomputed digest agree. It never pulls the
+helper implicitly.
+
+Gate: foreign config-volume name, key, project, role, label, driver, option, or
+attachment evidence fails before helper mutation; interruption leaves either
+the prior complete desired document or the next complete document; and `N`,
+profile, architecture decision, and closed render inputs reconstruct the same
+digest after an adapter restart with no realized topology. Stateful fake-daemon
+and ignored live-Docker tests cover the public read/commit adapter, exact helper
+post-inspection, bounded protocol, fresh readback, and zero topology. This slice
+completes checkpoint 2B but still exposes no user lifecycle command.
 
 ### 2C. Convergent Compose lifecycle and exact reset
 
-Add checked-in value-free rendering, persistent identity-only volume labels,
-digest-labeled replaceable topology, the inert ID-held engine lock, union
-discovery, `up`, `status`, `down`, and exact reset. The command layer remains
-private until these operations are convergent and their destructive boundary is
-proven.
+Build on the completed 2B.2 adapter. Add checked-in value-free rendering,
+persistent identity-only volume labels, digest-labeled replaceable topology,
+the inert ID-held engine lock, union discovery, `up`, `status`, `down`, and exact
+reset. The command layer remains private until these operations are convergent
+and their destructive boundary is proven.
 
 Gate: persistent volumes never carry a mutable plan digest; every replaceable
 resource carries the current digest; unknown managed keys, unexpected roles,
@@ -701,14 +772,18 @@ Add bounded Git worktree snapshotting and a provider-distinct local source
 authority. Parameterize source location/archive loading around the existing
 GitHub Actions frontend and compiler. Feed compiled requests into the existing
 workflow service, admission transaction, scheduler, cancellation, logs, and
-history. Add `automata local check` as a read-only view of that path.
+history. Define and retain the exact canonical repository identity as admitted
+source provenance here, not as an engine installation binding. Add
+`automata local check` as a read-only view of that path.
 
 Gate: clean and dirty worktrees produce deterministic digests; ignored files,
 `.git`, sockets, devices, escaping symlinks, submodule ambiguity, concurrent
 mutation, oversized archives, and case collisions fail closed; direct
 `.github/workflows` and `.ci/workflows` files and admitted same-tree reusable
-workflows use the existing compiler; no source operation mutates Git; and no
-local subject can enter signed-GitHub admission or create a GitHub Check.
+workflows use the existing compiler; the versioned repository-identity preimage
+has cross-platform worktree, symlink, non-Unicode, case, move, and clone
+fixtures; no source operation mutates Git; and no local subject can enter
+signed-GitHub admission or create a GitHub Check.
 
 ### 3C. Arch secretless vertical slice
 


### PR DESCRIPTION
## Summary

- resolve and validate the Docker context before daemon probes, then pin version/info and direct API calls to its exact local Unix socket or Windows named pipe
- publish Doctor JSON schema 3 with the bounded context name and the exact API version supported by both the daemon and the pinned Bollard model
- add a deliberately narrow Docker adapter that can only inspect or create-and-adopt one immutable, repository-agnostic installation identity anchor
- verify local driver/scope, empty options, exact managed labels, full selector key, deterministic Compose project, no attachments, engine identity, and post-create state
- split roadmap checkpoint 2B into independently reviewable identity-anchor and desired-spec slices while retaining the existing pipeline as the implementation target

## Scope boundaries

This is checkpoint 2B.1 only. It adds no product mutation command, desired-spec volume, helper container, Compose topology, `local up`, `local run`, reset/delete API, repository binding, or secret handling. `automata local doctor` remains read-only.

A named installation is a reusable control-plane and runner-capacity domain. Repository identity remains owned by the future `LocalSnapshot` admission boundary and existing repository-scoped control-plane state.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p automata-ci-local --all-targets --all-features --locked` (32 passed, 1 live test ignored)
- `cargo test -p automata-ci --test cli --test local_doctor_process --all-features --locked` (31 CLI and 3 process tests passed)
- warnings-denied Clippy for `automata-ci-local` natively and for `aarch64-apple-darwin`, `x86_64-pc-windows-gnu`, and `x86_64-pc-windows-msvc`
- warnings-denied focused product Clippy
- warnings-denied local-crate rustdoc
- `cargo deny check`
- live Arch Linux Doctor against Docker Engine 29.7.2 / API 1.53 / Compose 5.4.0
- opt-in live Docker anchor create, repeat adoption, exact reinspection, and cleanup; no managed fixture remained

macOS and Windows evidence in this checkpoint is compile/lint coverage. Native clean-host runtime qualification remains in the platform checkpoints before those hosts are advertised for mutation.
