### PR TITLE
fix(results): align artifact protocol schema

### DIFF
--- a/crates/automata-ci-results-github/tests/postgres_artifacts.rs
+++ b/crates/automata-ci-results-github/tests/postgres_artifacts.rs
@@ -430,7 +430,7 @@ async fn artifact_create_replay_rejects_schema_valid_safety_tampering() -> TestR
                     requested_visibility, effective_visibility,
                     publication_safety_reason, publication_safety_schema
                 ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, 1, 'application/zip',
+                    $1, $2, $3, $4, $5, $6, $7, $8, 7, 'application/zip',
                     1000, 'secretless', 'public', $9, $10, 1
                 )
                 ",
@@ -479,6 +479,11 @@ async fn artifact_create_replay_rejects_noncurrent_publication_safety_schema() -
         )
         .execute(database.pool())
         .await?;
+        sqlx::query(
+            "ALTER TABLE workflow_artifacts DISABLE TRIGGER workflow_artifacts_output_safety_immutable",
+        )
+        .execute(database.pool())
+        .await?;
 
         for schema in [0_i32, 2_i32] {
             sqlx::query(
@@ -497,6 +502,11 @@ async fn artifact_create_replay_rejects_noncurrent_publication_safety_schema() -
                 .expect_err("noncurrent publication-safety schema must fail closed");
             assert_eq!(error.kind(), ArtifactRepositoryErrorKind::CorruptData);
         }
+        sqlx::query(
+            "ALTER TABLE workflow_artifacts ENABLE TRIGGER workflow_artifacts_output_safety_immutable",
+        )
+        .execute(database.pool())
+        .await?;
         Ok(())
     })
     .await
@@ -1516,7 +1526,9 @@ fn create_named_request(
         authority,
         upload_id,
         name: ArtifactName::new(name, 255).expect("artifact name"),
-        version: 1,
+        // Keep the PostgreSQL adapter fixture on the exact protocol accepted by
+        // the production artifact service. This catches schema/service drift.
+        version: 7,
         mime_type: "application/zip".to_owned(),
         expires_at_seconds: None,
         observed_at_seconds: 1_000,

--- a/crates/automata-ci-store-postgres/migrations/0029_align_artifact_protocol_version.sql
+++ b/crates/automata-ci-store-postgres/migrations/0029_align_artifact_protocol_version.sql
@@ -1,0 +1,7 @@
+ALTER TABLE workflow_artifacts
+    DROP CONSTRAINT workflow_artifacts_protocol_version,
+    ADD CONSTRAINT workflow_artifacts_protocol_version
+        CHECK (protocol_version = 7);
+
+COMMENT ON CONSTRAINT workflow_artifacts_protocol_version ON workflow_artifacts IS
+    'Accepts the single GitHub Actions artifact protocol version implemented by the results service.';

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -117,6 +117,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0028_allow_queued_cancellation_after_lease_retry.sql",
         "4841124d150802cd51308c78f1f9607e9ca04c4b077e08eb89936ed5aa7ab527fc1add96b34bb95b0825286191a17d0e",
     ),
+    (
+        "0029_align_artifact_protocol_version.sql",
+        "00d51644b2bed927c55fbd7bfa6ba84efe66526d59adb0accd3ab2b4b27d11fec73a62e6d4ae7af159a0b2c522e2eea2",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;


### PR DESCRIPTION
The production GitHub Results service accepts artifact protocol version 7, while the PostgreSQL constraint still accepted only version 1. That caused every `actions/upload-artifact` CreateArtifact call to roll back and surface as HTTP 503.

This adds the forward-only migration for the single supported protocol and moves PostgreSQL artifact fixtures to the production version. It also makes the historical-corruption fixture explicitly disable the immutability trigger while seeding impossible state.

Verified:
- migration lineage and bounds contract tests
- all 13 PostgreSQL artifact integration tests against an isolated PostgreSQL 18 database
- `cargo fmt --all --check`
- `git diff --check`
