### PR TITLE
refactor(server): share secret loop timing support

### DIFF
--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -20,6 +20,7 @@ mod provisioning_workload_auth;
 mod readiness;
 mod secret_cleanup;
 mod secret_custody;
+mod secret_loop_support;
 mod secret_management;
 mod secret_mutation_recovery;
 mod state_metrics;

--- a/crates/automata-ci/src/server/secret_cleanup.rs
+++ b/crates/automata-ci/src/server/secret_cleanup.rs
@@ -2,7 +2,6 @@
 
 use std::{
     fmt,
-    future::Future,
     sync::{
         Arc,
         atomic::{AtomicI64, Ordering},
@@ -29,6 +28,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     secret_custody::SecretCustodyVerifier,
+    secret_loop_support::{LoopAction, OperationWait, exact_millis, wait_for_operation},
     secret_management::{exact_provider, valid_builtin_registry},
 };
 
@@ -474,39 +474,6 @@ pub(crate) enum SecretCleanupLoopConfigError {
     /// The adapter is not the encrypted built-in exact-version provider.
     #[error("secret cleanup provider contract is invalid")]
     InvalidProvider,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LoopAction {
-    Stop,
-    Drain,
-    Poll,
-}
-
-enum OperationWait<T> {
-    Completed(T),
-    Cancelled,
-    TimedOut,
-}
-
-async fn wait_for_operation<T>(
-    cancellation: &CancellationToken,
-    timeout: Duration,
-    operation: impl Future<Output = T>,
-) -> OperationWait<T> {
-    tokio::select! {
-        biased;
-        () = cancellation.cancelled() => OperationWait::Cancelled,
-        outcome = tokio::time::timeout(timeout, operation) => match outcome {
-            Ok(value) => OperationWait::Completed(value),
-            Err(_) => OperationWait::TimedOut,
-        },
-    }
-}
-
-fn exact_millis(duration: Duration) -> Option<u64> {
-    let millis = u64::try_from(duration.as_millis()).ok()?;
-    (millis != 0 && Duration::from_millis(millis) == duration).then_some(millis)
 }
 
 fn destroy_request(task: &BuiltinSecretCleanupTask) -> Result<DestroySecretVersionRequest, ()> {

--- a/crates/automata-ci/src/server/secret_loop_support.rs
+++ b/crates/automata-ci/src/server/secret_loop_support.rs
@@ -1,0 +1,78 @@
+//! Shared cancellation and exact-timing primitives for durable secret loops.
+
+use std::{future::Future, time::Duration};
+
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LoopAction {
+    Stop,
+    Drain,
+    Poll,
+}
+
+pub(super) enum OperationWait<T> {
+    Completed(T),
+    Cancelled,
+    TimedOut,
+}
+
+pub(super) async fn wait_for_operation<T>(
+    cancellation: &CancellationToken,
+    timeout: Duration,
+    operation: impl Future<Output = T>,
+) -> OperationWait<T> {
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => OperationWait::Cancelled,
+        outcome = tokio::time::timeout(timeout, operation) => match outcome {
+            Ok(value) => OperationWait::Completed(value),
+            Err(_) => OperationWait::TimedOut,
+        },
+    }
+}
+
+pub(super) fn exact_millis(duration: Duration) -> Option<u64> {
+    let millis = u64::try_from(duration.as_millis()).ok()?;
+    (millis != 0 && Duration::from_millis(millis) == duration).then_some(millis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pre_cancelled_token_wins_over_immediately_ready_operation() {
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        let outcome = wait_for_operation(&cancellation, Duration::from_secs(1), async { 17 }).await;
+
+        assert!(matches!(outcome, OperationWait::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn immediately_ready_operation_completes_without_cancellation() {
+        let cancellation = CancellationToken::new();
+
+        let outcome = wait_for_operation(&cancellation, Duration::from_secs(1), async { 17 }).await;
+
+        assert!(matches!(outcome, OperationWait::Completed(17)));
+    }
+
+    #[test]
+    fn exact_millis_accepts_only_positive_exact_representable_values() {
+        assert_eq!(exact_millis(Duration::from_millis(1)), Some(1));
+        assert_eq!(
+            exact_millis(Duration::from_millis(u64::MAX)),
+            Some(u64::MAX)
+        );
+        assert_eq!(exact_millis(Duration::ZERO), None);
+        assert_eq!(exact_millis(Duration::from_nanos(999_999)), None);
+        assert_eq!(
+            exact_millis(Duration::from_millis(1) + Duration::from_nanos(1)),
+            None
+        );
+        assert_eq!(exact_millis(Duration::MAX), None);
+    }
+}

--- a/crates/automata-ci/src/server/secret_mutation_recovery.rs
+++ b/crates/automata-ci/src/server/secret_mutation_recovery.rs
@@ -1,6 +1,6 @@
 //! Bounded cancellation-only recovery for abandoned repository-secret mutations.
 
-use std::{fmt, future::Future, sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use automata_ci_core::UnixMillis;
 use automata_ci_secret::{
@@ -19,6 +19,7 @@ use tokio_util::sync::CancellationToken;
 use super::{
     secret_cleanup::SecretCleanupClock,
     secret_custody::SecretCustodyVerifier,
+    secret_loop_support::{LoopAction, OperationWait, exact_millis, wait_for_operation},
     secret_management::{
         ProviderCreateIntent, created_builtin_target, exact_provider, valid_builtin_registry,
     },
@@ -390,39 +391,6 @@ pub(crate) enum SecretMutationRecoveryLoopConfigError {
     /// An operation could remain in flight until stale takeover becomes legal.
     #[error("secret mutation recovery operation timeout reaches its stale timeout")]
     OperationTimeoutReachesStaleTimeout,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LoopAction {
-    Stop,
-    Drain,
-    Poll,
-}
-
-enum OperationWait<T> {
-    Completed(T),
-    Cancelled,
-    TimedOut,
-}
-
-async fn wait_for_operation<T>(
-    cancellation: &CancellationToken,
-    timeout: Duration,
-    operation: impl Future<Output = T>,
-) -> OperationWait<T> {
-    tokio::select! {
-        biased;
-        () = cancellation.cancelled() => OperationWait::Cancelled,
-        outcome = tokio::time::timeout(timeout, operation) => match outcome {
-            Ok(value) => OperationWait::Completed(value),
-            Err(_) => OperationWait::TimedOut,
-        },
-    }
-}
-
-fn exact_millis(duration: Duration) -> Option<u64> {
-    let millis = u64::try_from(duration.as_millis()).ok()?;
-    (millis != 0 && Duration::from_millis(millis) == duration).then_some(millis)
 }
 
 fn log_repository_failure(operation: &'static str, error: SecretManagementRepositoryError) {


### PR DESCRIPTION
## Outcome

Extracts the byte-identical cancellation and timing kernel used by secret cleanup and secret-mutation recovery into one private server module. The two durable loops retain their own provider, custody, retry, logging, and repository policies.

The diff is 4 Rust files, +82/-68 (net +14, including three focused regression tests).

## Related issue

Fixes #167.

## Trust and compatibility impact

The shared implementation preserves the exact trust-sensitive behavior of both original copies:

- `tokio::select!` remains biased with cancellation first;
- the operation remains awaited inline under `tokio::time::timeout`, so cancellation or timeout immediately drops the in-flight future;
- completed values remain unmodified;
- duration conversion still requires a positive, exactly representable whole-millisecond value.

The new module is private and its items are visible only to sibling server modules. There is no public API, dependency, configuration, schema, migration, protocol, generated-file, or release-metadata change.

## Verification

Passed on `faa0983e` (`main` at submission):

- `cargo fmt --all -- --check`
- `git diff --check`
- focused shared-helper tests: 3/3 passed
- `cargo test --locked -p automata-ci --lib`: 488/488 passed
- full package integration tests: 143 passed, 1 PostgreSQL-only matrix ignored
- `cargo check --locked -p automata-ci --all-targets --all-features`
- strict Clippy for `automata-ci`, all targets/features, `--no-deps -- -D warnings`
- rustdoc for `automata-ci` with `-D warnings`
- independent normalized-source comparison: the consolidated body is identical after removing only the required `pub(super)` visibility

The ignored PostgreSQL matrix was not run because `AUTOMATA_TEST_DATABASE_URL` is unavailable. This PR does not change PostgreSQL code, schemas, migrations, or tests.

## AI assistance

OpenAI Codex helped identify the exact duplicate, implement the private extraction and regression tests, and perform an independent semantic and diff review. All reported commands and behavior claims were verified against the repository and local test results.

## Checklist

- [x] Tests cover the owning boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
