### PR TITLE
refactor(store): remove standalone GitHub Check lifecycle

### DIFF
--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -10,8 +10,7 @@ use automata_ci_store::{
     EnsureGithubServerServiceAuthority, GithubAuthenticatedEvent, GithubAuthenticatedEventKind,
     GithubCheckDesiredProjection, GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName,
     GithubCheckProjectionAction, GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId,
-    GithubCheckRunBindingFence, GithubCheckRunId, GithubCheckSubjectId,
-    GithubCheckSubjectRepository as _, GithubCheckSubjectTarget, GithubCheckSuiteId,
+    GithubCheckRunBindingFence, GithubCheckRunId, GithubCheckSubjectId, GithubCheckSuiteId,
     GithubCheckTerminalCause, GithubProviderManifest, GithubProviderManifestLimits,
     GithubProviderManifestRepository as _, GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubProviderWorkflowSelection,
@@ -32,8 +31,8 @@ use automata_ci_store::{
     ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
     ProviderRepositoryVisibility, RecordProviderDeliveryWorkflowProgress,
     RegisterProviderDeliveryWorkflowInventory, RejectProviderDelivery,
-    ResolveGithubRepositoryDispatch, StartGithubCheckProjection, StoreError, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    ResolveGithubRepositoryDispatch, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowSnapshotId,
 };
 use uuid::Uuid;
 
@@ -618,13 +617,26 @@ async fn noncanonical_check_state_rolls_back_delivery_completion() -> TestResult
             ))
             .await?;
         let claim = claim_delivery(&database, accepted.delivery_id(), 0x239, 60_000).await?;
-        database
-            .store()
-            .start_github_check_projection(StartGithubCheckProjection::new(
-                GithubCheckSubjectTarget::new(fixture.tenant.clone(), accepted.check_subject_id()),
-                claim.claimed_at(),
-            )?)
-            .await?;
+        // Deliberately bypass source-specific atomic admission to seed the noncanonical state.
+        let updated = sqlx::query(
+            r"
+            UPDATE github_check_subjects
+            SET desired_state = 'in_progress',
+                desired_revision = desired_revision + 1,
+                desired_updated_at_ms = $3
+            WHERE id = $1
+              AND tenant_id = $2
+              AND desired_state = 'queued'
+              AND desired_updated_at_ms <= $3
+              AND desired_revision < 9223372036854775807
+            ",
+        )
+        .bind(accepted.check_subject_id().as_uuid())
+        .bind(fixture.tenant.as_str())
+        .bind(claim.claimed_at().get())
+        .execute(database.pool())
+        .await?;
+        assert_eq!(updated.rows_affected(), 1);
         let check_before =
             load_check_projection(&database, accepted.check_subject_id().as_uuid()).await?;
         let completion =

--- a/crates/automata-ci-store-postgres/src/github_checks.rs
+++ b/crates/automata-ci-store-postgres/src/github_checks.rs
@@ -16,16 +16,14 @@ use automata_ci_store::{
     GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
     GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
     GithubCheckSubjectIdentity, GithubCheckSubjectKey, GithubCheckSubjectOrigin,
-    GithubCheckSubjectReceipt, GithubCheckSubjectRepository, GithubCheckSubjectTarget,
-    GithubCheckSuiteId, GithubCheckTerminalCause, GithubCheckTerminalizationRepository,
-    GithubRepositoryName, GithubScheduleFireId, GithubServerServiceAuthorityId,
-    GithubServerServiceAuthoritySelector, GithubServerServiceRevision, HUMAN_JOB_RESULT_MEDIA_TYPE,
-    InitializeGithubCheckPresentation, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
-    MAX_TERMINAL_RESULT_BYTES, ProviderConnectionId, ProviderDeliveryId, ProviderInstallationId,
-    ProviderRepositoryId, RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckAnnotationBatch,
-    ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
-    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection,
-    StoreError, TenantScope, TerminalizeGithubCheck,
+    GithubCheckSubjectReceipt, GithubCheckSuiteId, GithubCheckTerminalCause, GithubRepositoryName,
+    GithubScheduleFireId, GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
+    GithubServerServiceRevision, HUMAN_JOB_RESULT_MEDIA_TYPE, InitializeGithubCheckPresentation,
+    MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS, MAX_TERMINAL_RESULT_BYTES, ProviderConnectionId,
+    ProviderDeliveryId, ProviderInstallationId, ProviderRepositoryId,
+    ReleaseUnissuedGithubCheckAnnotationBatch, ReleaseUnissuedGithubCheckRunCreate, RepositoryId,
+    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations,
+    StoreError, TenantScope,
 };
 
 use super::{PostgresStore, pg_bigint};
@@ -633,170 +631,6 @@ const CLAIM_LOCKED_RERUN_PROJECTION_SQL: &str = r"
         evidence.checks_authority_app_configuration_revision,
         evidence.checks_authority_policy_revision
 ";
-
-#[async_trait]
-impl GithubCheckSubjectRepository for PostgresStore {
-    async fn register_github_check_subject(
-        &self,
-        request: RegisterGithubCheckSubject,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
-        let delivery_id = request
-            .identity()
-            .delivery_id()
-            .ok_or(GithubCheckStoreError::AuthorityRejected)?;
-        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
-        let proposed_id = Uuid::new_v4();
-        let external_id = format!("automata-check:{proposed_id}");
-        let query = format!(
-            r"
-            INSERT INTO github_check_subjects AS subject (
-                id, tenant_id, repository_id, provider_delivery_id, subject_key,
-                provider_connection_id, provider_installation_id,
-                github_repository_id, github_app_id, head_sha, check_name,
-                external_id, created_at_ms, desired_updated_at_ms
-            )
-            SELECT
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $13
-            FROM provider_delivery_inbox AS delivery
-            JOIN repositories AS repository
-              ON repository.id = $3
-             AND repository.tenant_id = $2
-             AND repository.scm_provider = 'github'
-             AND repository.provider_repository_id = $8::TEXT
-            WHERE delivery.id = $4
-              AND delivery.tenant_id = $2
-              AND delivery.provider = 'github'
-              AND delivery.connection_id = $6
-              AND delivery.installation_id = $7
-              AND delivery.provider_repository_id = $8
-              AND delivery.repository_identity = $14
-              AND repository.owner || '/' || repository.name = $14
-            ON CONFLICT (provider_delivery_id, subject_key) DO NOTHING
-            RETURNING {SUBJECT_COLUMNS}
-            "
-        );
-        let inserted = sqlx::query(AssertSqlSafe(query))
-            .bind(proposed_id)
-            .bind(request.identity().tenant().as_str())
-            .bind(request.identity().repository_id().as_uuid())
-            .bind(delivery_id.as_uuid())
-            .bind(request.identity().subject_key().as_str())
-            .bind(request.identity().connection_id().as_uuid())
-            .bind(pg_bigint(request.identity().installation_id().get()))
-            .bind(pg_bigint(request.identity().github_repository_id().get()))
-            .bind(pg_bigint(request.identity().app_id().get()))
-            .bind(request.identity().head_sha().as_bytes().as_slice())
-            .bind(request.identity().name().as_str())
-            .bind(&external_id)
-            .bind(request.created_at().get())
-            .bind(request.identity().github_repository_name().as_str())
-            .fetch_optional(&mut *transaction)
-            .await
-            .map_err(operation_error)?;
-
-        if let Some(row) = inserted {
-            let durable = decode_subject(&row)?;
-            transaction.commit().await.map_err(operation_error)?;
-            return Ok(durable.receipt);
-        }
-
-        let existing = load_subject_by_replay_key(
-            &mut transaction,
-            delivery_id,
-            request.identity().subject_key(),
-        )
-        .await?;
-        let Some(existing) = existing else {
-            return Err(GithubCheckStoreError::AuthorityRejected);
-        };
-        if existing.identity != *request.identity() || existing.created_at != request.created_at() {
-            return Err(GithubCheckStoreError::ReplayConflict);
-        }
-        transaction.commit().await.map_err(operation_error)?;
-        Ok(existing.receipt)
-    }
-
-    async fn start_github_check_projection(
-        &self,
-        request: StartGithubCheckProjection,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
-        let query = format!(
-            r"
-            UPDATE github_check_subjects AS subject
-            SET desired_state = 'in_progress',
-                desired_revision = desired_revision + 1,
-                desired_updated_at_ms = $3
-            WHERE id = $1
-              AND tenant_id = $2
-              AND desired_state = 'queued'
-              AND desired_updated_at_ms <= $3
-              AND desired_revision < 9223372036854775807
-            RETURNING {SUBJECT_COLUMNS}
-            "
-        );
-        let row = sqlx::query(AssertSqlSafe(query))
-            .bind(request.target().subject_id().as_uuid())
-            .bind(request.target().tenant().as_str())
-            .bind(request.started_at().get())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(operation_error)?;
-        if let Some(row) = row {
-            return Ok(decode_subject(&row)?.receipt);
-        }
-        exact_desired_replay(
-            &self.pool,
-            request.target(),
-            GithubCheckDesiredProjection::InProgress,
-            request.started_at(),
-        )
-        .await
-    }
-}
-
-#[async_trait]
-impl GithubCheckTerminalizationRepository for PostgresStore {
-    async fn terminalize_github_check(
-        &self,
-        request: TerminalizeGithubCheck,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
-        let query = format!(
-            r"
-            UPDATE github_check_subjects AS subject
-            SET desired_state = 'completed',
-                desired_conclusion = $3,
-                terminal_cause = $4,
-                desired_revision = desired_revision + 1,
-                desired_updated_at_ms = $5
-            WHERE id = $1
-              AND tenant_id = $2
-              AND desired_state IN ('queued', 'in_progress')
-              AND desired_updated_at_ms <= $5
-              AND desired_revision < 9223372036854775807
-            RETURNING {SUBJECT_COLUMNS}
-            "
-        );
-        let row = sqlx::query(AssertSqlSafe(query))
-            .bind(request.target().subject_id().as_uuid())
-            .bind(request.target().tenant().as_str())
-            .bind(github_check_conclusion_name(request.conclusion()))
-            .bind(github_check_terminal_cause_name(request.cause()))
-            .bind(request.terminal_at().get())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(operation_error)?;
-        if let Some(row) = row {
-            return Ok(decode_subject(&row)?.receipt);
-        }
-        exact_desired_replay(
-            &self.pool,
-            request.target(),
-            GithubCheckDesiredProjection::terminal(request.cause()),
-            request.terminal_at(),
-        )
-        .await
-    }
-}
 
 #[async_trait]
 impl GithubCheckProjectionOutbox for PostgresStore {
@@ -2011,60 +1845,6 @@ fn projection_columns(
             "completed",
             Some(github_check_conclusion_name(cause.conclusion())),
         ),
-    }
-}
-
-async fn load_subject(
-    pool: &sqlx::PgPool,
-    target: &GithubCheckSubjectTarget,
-) -> Result<Option<DecodedSubject>, GithubCheckStoreError> {
-    let query = format!(
-        "SELECT {SUBJECT_COLUMNS} FROM github_check_subjects AS subject WHERE subject.id = $1 AND subject.tenant_id = $2"
-    );
-    sqlx::query(AssertSqlSafe(query))
-        .bind(target.subject_id().as_uuid())
-        .bind(target.tenant().as_str())
-        .fetch_optional(pool)
-        .await
-        .map_err(operation_error)?
-        .map(|row| decode_subject(&row))
-        .transpose()
-}
-
-async fn load_subject_by_replay_key(
-    transaction: &mut Transaction<'_, Postgres>,
-    delivery_id: ProviderDeliveryId,
-    subject_key: &GithubCheckSubjectKey,
-) -> Result<Option<DecodedSubject>, GithubCheckStoreError> {
-    let query = format!(
-        "SELECT {SUBJECT_COLUMNS} FROM github_check_subjects AS subject WHERE subject.provider_delivery_id = $1 AND subject.subject_key = $2 FOR UPDATE"
-    );
-    sqlx::query(AssertSqlSafe(query))
-        .bind(delivery_id.as_uuid())
-        .bind(subject_key.as_str())
-        .fetch_optional(&mut **transaction)
-        .await
-        .map_err(operation_error)?
-        .map(|row| decode_subject(&row))
-        .transpose()
-}
-
-async fn exact_desired_replay(
-    pool: &sqlx::PgPool,
-    target: &GithubCheckSubjectTarget,
-    expected: GithubCheckDesiredProjection,
-    expected_at: UnixMillis,
-) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError> {
-    let existing = load_subject(pool, target).await?;
-    match existing {
-        Some(existing)
-            if existing.receipt.desired() == expected
-                && existing.desired_updated_at == expected_at =>
-        {
-            Ok(existing.receipt)
-        }
-        Some(_) => Err(GithubCheckStoreError::TransitionConflict),
-        None => Err(GithubCheckStoreError::NotFound),
     }
 }
 

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -532,150 +532,6 @@ impl GithubCheckDesiredProjection {
     }
 }
 
-/// Immutable registration request for one pre-admission subject.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RegisterGithubCheckSubject {
-    identity: GithubCheckSubjectIdentity,
-    created_at: UnixMillis,
-}
-
-impl RegisterGithubCheckSubject {
-    /// Constructs a queued subject registration.
-    ///
-    /// # Errors
-    ///
-    /// Rejects timestamps before the Unix epoch.
-    pub fn new(
-        identity: GithubCheckSubjectIdentity,
-        created_at: UnixMillis,
-    ) -> Result<Self, GithubCheckValueError> {
-        validate_timestamp(created_at, "GitHub Check creation time")?;
-        Ok(Self {
-            identity,
-            created_at,
-        })
-    }
-
-    /// Returns the exact immutable identity.
-    #[must_use]
-    pub const fn identity(&self) -> &GithubCheckSubjectIdentity {
-        &self.identity
-    }
-    /// Returns the durable creation time.
-    #[must_use]
-    pub const fn created_at(&self) -> UnixMillis {
-        self.created_at
-    }
-}
-
-/// Tenant-scoped subject target used by all later mutations.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GithubCheckSubjectTarget {
-    tenant: TenantScope,
-    subject_id: GithubCheckSubjectId,
-}
-
-impl GithubCheckSubjectTarget {
-    /// Constructs an exact tenant-scoped target.
-    #[must_use]
-    pub const fn new(tenant: TenantScope, subject_id: GithubCheckSubjectId) -> Self {
-        Self { tenant, subject_id }
-    }
-
-    /// Returns the authenticated tenant scope.
-    #[must_use]
-    pub const fn tenant(&self) -> &TenantScope {
-        &self.tenant
-    }
-    /// Returns the durable subject identity.
-    #[must_use]
-    pub const fn subject_id(&self) -> GithubCheckSubjectId {
-        self.subject_id
-    }
-}
-
-/// Marks a queued desired projection in progress.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StartGithubCheckProjection {
-    target: GithubCheckSubjectTarget,
-    started_at: UnixMillis,
-}
-
-impl StartGithubCheckProjection {
-    /// Constructs a server-owned in-progress transition.
-    ///
-    /// # Errors
-    ///
-    /// Rejects timestamps before the Unix epoch.
-    pub fn new(
-        target: GithubCheckSubjectTarget,
-        started_at: UnixMillis,
-    ) -> Result<Self, GithubCheckValueError> {
-        validate_timestamp(started_at, "GitHub Check start time")?;
-        Ok(Self { target, started_at })
-    }
-
-    /// Returns the exact subject target.
-    #[must_use]
-    pub const fn target(&self) -> &GithubCheckSubjectTarget {
-        &self.target
-    }
-    /// Returns the desired-transition time.
-    #[must_use]
-    pub const fn started_at(&self) -> UnixMillis {
-        self.started_at
-    }
-}
-
-/// Terminalizes a subject through the server-only terminalization port.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TerminalizeGithubCheck {
-    target: GithubCheckSubjectTarget,
-    cause: GithubCheckTerminalCause,
-    terminal_at: UnixMillis,
-}
-
-impl TerminalizeGithubCheck {
-    /// Constructs a terminal transition with a cause-derived conclusion.
-    ///
-    /// # Errors
-    ///
-    /// Rejects timestamps before the Unix epoch.
-    pub fn new(
-        target: GithubCheckSubjectTarget,
-        cause: GithubCheckTerminalCause,
-        terminal_at: UnixMillis,
-    ) -> Result<Self, GithubCheckValueError> {
-        validate_timestamp(terminal_at, "GitHub Check terminal time")?;
-        Ok(Self {
-            target,
-            cause,
-            terminal_at,
-        })
-    }
-
-    /// Returns the exact subject target.
-    #[must_use]
-    pub const fn target(&self) -> &GithubCheckSubjectTarget {
-        &self.target
-    }
-    /// Returns the closed terminal cause.
-    #[must_use]
-    pub const fn cause(&self) -> GithubCheckTerminalCause {
-        self.cause
-    }
-    /// Returns the cause-derived conclusion.
-    #[must_use]
-    pub const fn conclusion(&self) -> GithubCheckConclusion {
-        self.cause.conclusion()
-    }
-    /// Returns the terminal transition time.
-    #[must_use]
-    pub const fn terminal_at(&self) -> UnixMillis {
-        self.terminal_at
-    }
-}
-
 /// Durable current subject state.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubCheckSubjectReceipt {
@@ -2224,18 +2080,6 @@ pub enum GithubCheckStoreError {
     /// Backend operation failed without exposing sensitive details.
     #[error(transparent)]
     Operation(#[from] RepositoryOperationError),
-    /// The requested subject does not exist in the authenticated scope.
-    #[error("the GitHub Check subject is unavailable")]
-    NotFound,
-    /// Registration replay changed immutable evidence.
-    #[error("the GitHub Check subject replay conflicts with durable identity")]
-    ReplayConflict,
-    /// A run link or desired transition conflicts with durable state.
-    #[error("the GitHub Check subject transition conflicts with durable state")]
-    TransitionConflict,
-    /// Provider delivery, repository, or run authority did not match exactly.
-    #[error("the GitHub Check subject authority is not exact")]
-    AuthorityRejected,
     /// An outbox claim is stale, expired, or has the wrong action.
     #[error("the GitHub Check projection claim is stale or rejected")]
     ClaimRejected,
@@ -2262,32 +2106,6 @@ impl GithubCheckStoreError {
     pub fn operation(source: impl std::error::Error + Send + Sync + 'static) -> Self {
         RepositoryOperationError::from_source(source).into()
     }
-}
-
-/// Durable pre-admission Check-subject lifecycle, excluding terminalization.
-#[async_trait]
-pub trait GithubCheckSubjectRepository: Send + Sync {
-    /// Registers a queued subject or returns the exact existing replay receipt.
-    async fn register_github_check_subject(
-        &self,
-        request: RegisterGithubCheckSubject,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
-
-    /// Advances a queued subject to in-progress desired state.
-    async fn start_github_check_projection(
-        &self,
-        request: StartGithubCheckProjection,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
-}
-
-/// Least-authority server-owned port for explicit Check terminalization.
-#[async_trait]
-pub trait GithubCheckTerminalizationRepository: Send + Sync {
-    /// Terminalizes queued or in-progress desired state with a closed cause mapping.
-    async fn terminalize_github_check(
-        &self,
-        request: TerminalizeGithubCheck,
-    ) -> Result<GithubCheckSubjectReceipt, GithubCheckStoreError>;
 }
 
 /// Fenced durable outbox for GitHub Checks provider workers.

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -86,14 +86,12 @@ pub use github_checks::{
     GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
     GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
     GithubCheckSubjectId, GithubCheckSubjectIdentity, GithubCheckSubjectKey,
-    GithubCheckSubjectOrigin, GithubCheckSubjectReceipt, GithubCheckSubjectRepository,
-    GithubCheckSubjectTarget, GithubCheckSuiteId, GithubCheckTerminalCause,
-    GithubCheckTerminalizationRepository, GithubCheckValueError, InitializeGithubCheckPresentation,
+    GithubCheckSubjectOrigin, GithubCheckSubjectReceipt, GithubCheckSuiteId,
+    GithubCheckTerminalCause, GithubCheckValueError, InitializeGithubCheckPresentation,
     MAX_GITHUB_CHECK_CREATE_RECONCILE_GRACE_MILLIS, MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS,
     MAX_GITHUB_CHECK_PROJECTION_CLAIM_MILLIS, MAX_GITHUB_CHECK_PROJECTION_RETRY_MILLIS,
-    RegisterGithubCheckSubject, ReleaseUnissuedGithubCheckAnnotationBatch,
-    ReleaseUnissuedGithubCheckRunCreate, ResolveGithubCheckRunCreate, RetryGithubCheckProjection,
-    RetryUncertainGithubCheckAnnotations, StartGithubCheckProjection, TerminalizeGithubCheck,
+    ReleaseUnissuedGithubCheckAnnotationBatch, ReleaseUnissuedGithubCheckRunCreate,
+    ResolveGithubCheckRunCreate, RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations,
 };
 pub use github_job_runtime_authority::{
     GithubJobRuntimeAuthorityEvidence, GithubJobRuntimeAuthorityExecution,


### PR DESCRIPTION
## Outcome

Removes the unused generic GitHub Check subject lifecycle from Store and PostgreSQL. Check creation, admission/start, and terminalization now have one architecture: each transition remains inside its source-specific delivery, schedule, rerun, admission, finalization, cancellation, or failure transaction with the corresponding authority and immutable evidence.

The lone old caller was a corruption fixture. It now uses explicit test-local SQL to construct the same intentionally noncanonical state without adding a production or `cfg(test)` seeding API.

The diff is 4 Rust files, +35/-427 (net -392).

## Related issue

Fixes #171.

## Trust and compatibility impact

This deletes weaker second paths that could register, start, or terminalize a tenant-scoped Check independently of the owning durable aggregate. All active source-specific transaction implementations are unchanged.

The removed public Store API is:

- `RegisterGithubCheckSubject`
- `GithubCheckSubjectTarget`
- `StartGithubCheckProjection`
- `TerminalizeGithubCheck`
- `GithubCheckSubjectRepository`
- `GithubCheckTerminalizationRepository`
- their three repository methods
- the now-orphaned `GithubCheckStoreError` variants `NotFound`, `ReplayConflict`, `TransitionConflict`, and `AuthorityRejected`

There were no production callers. This is an intentional pre-release source contraction in the unpublished Store 0.1 crate, not a drop-in compatibility claim.

Check identity, receipt, desired projection, terminal causes/conclusions, projection outbox, publishing, annotation, reconciliation, retry, and all active atomic lifecycle paths remain unchanged. There is no Cargo dependency, lockfile, schema, migration, durable-row, wire-format, generated-file, or release-metadata change.

## Verification

Passed on rebased head `79456fa` over `8903c2c7` (`main` at submission):

- `cargo fmt --all -- --check`
- `git diff origin/main...HEAD --check`
- exhaustive repository scan: zero references to all six removed types/traits and three methods
- Store tests: 207/207 passed (42 library + 165 contract tests)
- GitHub Checks publisher tests: 33/33 passed
- all-target/all-feature checks for Store, Store PostgreSQL, and PostgreSQL integration crates
- strict Clippy for those three packages, all targets/features, `--no-deps -- -D warnings`
- rustdoc for Store and Store PostgreSQL with `-D warnings`
- integration-target ownership guard: 28 aggregate packages / 343 Rust sources / 33 targets
- publish policy tests: 17/17
- release handoff tests: 9/9
- Store and Store PostgreSQL package inventories

PostgreSQL 18.4 live validation passed all nine owning contracts:

- migrated noncanonical-state rollback
- manifest-pinned acceptance and exact replay
- repository-dispatch resolution
- pre-admission rejection terminalization
- all-direct fanout
- schedule fencing
- logical admission
- logical finalization/takeover
- preterminal concurrency cancellation

The complete ignored PostgreSQL adapter suite was also attempted: 394/403 passed in one four-thread run. One order-sensitive failure passed immediately in isolation. The other eight failed identically when rerun on untouched base `faa0983e`, with the same constraint, duplicate-key, or deadlock diagnostics; none exercises the removed lifecycle. Both test namespaces and the disposable PostgreSQL container were cleaned up after validation.

## AI assistance

OpenAI Codex helped audit reachability and active transaction replacements, implement the API contraction and fixture migration, run PostgreSQL 18 validation, and perform an independent semantic/diff review. All reported commands and behavior claims were verified against the repository and local test results.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
