### PR TITLE
refactor(auth): remove standalone session creation

### DIFF
--- a/crates/automata-ci-auth-postgres/src/installation.rs
+++ b/crates/automata-ci-auth-postgres/src/installation.rs
@@ -14,10 +14,7 @@ use automata_ci_auth::{
         InstallationState,
     },
     login::LoginTransactionId,
-    session::{
-        CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-        SessionRepositoryError,
-    },
+    session::{DurableSession, DurableSessionIdentity, SessionRepositoryError},
     sign_in::PendingSessionConflict,
     vault::{ProviderTokenKey, ProviderTokenVaultError},
 };
@@ -27,7 +24,9 @@ use uuid::Uuid;
 
 use super::{
     PostgresGithubMembershipRepository, PostgresHumanSessionRepository, PostgresProviderTokenVault,
-    session::{database_time_milliseconds, validate_caller_time},
+    session::{
+        CreateSession, CreateSessionOutcome, database_time_milliseconds, validate_caller_time,
+    },
     support::{canonical_uuid, constraint, timestamp_from_milliseconds, timestamp_to_milliseconds},
 };
 

--- a/crates/automata-ci-auth-postgres/src/session.rs
+++ b/crates/automata-ci-auth-postgres/src/session.rs
@@ -5,11 +5,11 @@ use automata_ci_auth::{
     human::{PrincipalId, ProviderId, ProviderSubject, TenantId},
     session::{
         ActivateCliSession, ActivateCliSessionOutcome, CLI_SESSION_ACTIVATION_LIFETIME_SECONDS,
-        CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-        HumanSessionRepository, ResolveSession, ResolveSessionOutcome, RevokeOwnSession,
-        RevokeOwnSessionOutcome, RevokePrincipalSessions, RevokePrincipalSessionsOutcome,
-        SessionId, SessionKind, SessionRepositoryError, SessionRepositoryFuture,
-        SessionResolutionStatus, SessionTokenLookup, TouchSession, TouchSessionOutcome,
+        DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+        ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
+        RevokePrincipalSessionsOutcome, SessionId, SessionKind, SessionRepositoryError,
+        SessionRepositoryFuture, SessionResolutionStatus, SessionTokenLookup, TouchSession,
+        TouchSessionOutcome,
     },
 };
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
@@ -19,6 +19,29 @@ use super::support::{
     canonical_uuid, constraint, is_integrity_violation, timestamp_from_milliseconds,
     timestamp_to_milliseconds,
 };
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CreateSession {
+    lookup: SessionTokenLookup,
+    session: DurableSession,
+}
+
+impl CreateSession {
+    pub(super) const fn new(lookup: SessionTokenLookup, session: DurableSession) -> Self {
+        Self { lookup, session }
+    }
+
+    fn into_parts(self) -> (SessionTokenLookup, DurableSession) {
+        (self.lookup, self.session)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CreateSessionOutcome {
+    Created,
+    SessionIdConflict,
+    TokenDigestConflict,
+}
 
 /// `PostgreSQL` implementation of the durable human-session boundary.
 #[derive(Clone)]
@@ -33,7 +56,7 @@ impl PostgresHumanSessionRepository {
         Self { pool }
     }
 
-    pub(crate) async fn create_in_transaction(
+    pub(super) async fn create_in_transaction(
         transaction: &mut Transaction<'_, Postgres>,
         request: CreateSession,
     ) -> Result<(CreateSessionOutcome, Option<DurableSession>), SessionRepositoryError> {
@@ -698,24 +721,6 @@ async fn activate_pending_cli_row(
 }
 
 impl HumanSessionRepository for PostgresHumanSessionRepository {
-    fn create(&self, request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-        Box::pin(async move {
-            let mut transaction = self
-                .pool
-                .begin()
-                .await
-                .map_err(|_| SessionRepositoryError::Unavailable)?;
-            let (outcome, _) = create_session(&mut transaction, request).await?;
-            if outcome == CreateSessionOutcome::Created {
-                transaction
-                    .commit()
-                    .await
-                    .map_err(|_| SessionRepositoryError::Unavailable)?;
-            }
-            Ok(outcome)
-        })
-    }
-
     fn resolve<'a>(
         &'a self,
         request: &'a ResolveSession,

--- a/crates/automata-ci-auth-postgres/src/sign_in.rs
+++ b/crates/automata-ci-auth-postgres/src/sign_in.rs
@@ -7,10 +7,7 @@ use automata_ci_auth::{
     },
     human::{PrincipalId, ProviderIdentityAssertion, TenantId},
     login::LoginTransactionVersion,
-    session::{
-        CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-        SessionRepositoryError,
-    },
+    session::{DurableSession, DurableSessionIdentity, SessionRepositoryError},
     sign_in::{
         FinalizeSignIn, FinalizeSignInOutcome, HumanSignInFinalizer, PendingSessionCandidate,
         PendingSessionConflict, SignInFinalizerError, SignInFinalizerFuture,
@@ -24,7 +21,9 @@ use uuid::Uuid;
 use super::{
     PostgresGithubMembershipRepository, PostgresHumanSessionRepository, PostgresProviderTokenVault,
     login::{LockSignInOutcome, lock_sign_in_for_finalization},
-    session::{database_time_milliseconds, validate_caller_time},
+    session::{
+        CreateSession, CreateSessionOutcome, database_time_milliseconds, validate_caller_time,
+    },
     support::{
         canonical_uuid, is_integrity_violation, timestamp_from_milliseconds,
         timestamp_to_milliseconds,

--- a/crates/automata-ci-auth/src/session.rs
+++ b/crates/automata-ci-auth/src/session.rs
@@ -525,41 +525,6 @@ pub enum SessionResolutionStatus {
     },
 }
 
-/// Raw-free persistence request for creating one durable session.
-///
-/// The keyed lookup and safe session metadata must be inserted atomically so
-/// neither a token digest nor a session identity can be reused independently.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CreateSession {
-    lookup: SessionTokenLookup,
-    session: DurableSession,
-}
-
-impl CreateSession {
-    /// Binds an opaque-token lookup to its durable safe metadata.
-    #[must_use]
-    pub const fn new(lookup: SessionTokenLookup, session: DurableSession) -> Self {
-        Self { lookup, session }
-    }
-
-    /// Returns the keyed lookup used to authenticate the bearer.
-    #[must_use]
-    pub const fn lookup(&self) -> &SessionTokenLookup {
-        &self.lookup
-    }
-
-    /// Returns the safe durable session metadata to create.
-    #[must_use]
-    pub const fn session(&self) -> &DurableSession {
-        &self.session
-    }
-
-    /// Consumes the request into its keyed lookup and session metadata.
-    pub fn into_parts(self) -> (SessionTokenLookup, DurableSession) {
-        (self.lookup, self.session)
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Raw-free request to resolve one bearer lookup for an exact session kind.
 ///
@@ -788,17 +753,6 @@ impl RevokePrincipalSessions {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-/// Closed result of atomically creating a durable session and token lookup.
-pub enum CreateSessionOutcome {
-    /// Both the session record and token lookup were created.
-    Created,
-    /// The durable session identifier is already assigned.
-    SessionIdConflict,
-    /// The keyed token digest is already assigned to another session.
-    TokenDigestConflict,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Closed result of resolving a durable browser or CLI session.
 pub enum ResolveSessionOutcome {
@@ -929,9 +883,6 @@ pub type SessionRepositoryFuture<'a, T> =
 /// `resolve` and `touch` must compare the session's authorization revision with
 /// the current durable tenant/principal revision in the same database operation.
 pub trait HumanSessionRepository: fmt::Debug + Send + Sync {
-    /// Atomically creates safe session metadata and its keyed token lookup.
-    fn create(&self, request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome>;
-
     /// Resolves one lookup and current tenant authority without exposing the bearer.
     fn resolve<'a>(
         &'a self,

--- a/crates/automata-ci-auth/tests/github_login_service.rs
+++ b/crates/automata-ci-auth/tests/github_login_service.rs
@@ -34,11 +34,10 @@ use automata_ci_auth::{
     },
     secret::{SecretBytes, SecretString},
     session::{
-        CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-        HumanSessionRepository, ResolveSession, ResolveSessionOutcome, RevokeOwnSession,
-        RevokeOwnSessionOutcome, RevokePrincipalSessions, RevokePrincipalSessionsOutcome,
-        SessionId, SessionKind, SessionRepositoryFuture, SessionTokenLookup, TouchSession,
-        TouchSessionOutcome,
+        DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+        ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
+        RevokePrincipalSessionsOutcome, SessionId, SessionKind, SessionRepositoryFuture,
+        SessionTokenLookup, TouchSession, TouchSessionOutcome,
     },
     session_credential::{
         SessionCredentialKey, SessionCredentialKeyring, SessionCredentialService,
@@ -333,10 +332,6 @@ fn next_version(version: LoginTransactionVersion) -> LoginTransactionVersion {
 struct UnusedSessionRepository;
 
 impl HumanSessionRepository for UnusedSessionRepository {
-    fn create(&self, _request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-        panic!("coordinator preparation must not create outside the finalizer")
-    }
-
     fn resolve<'a>(
         &'a self,
         _request: &'a ResolveSession,

--- a/crates/automata-ci-auth/tests/installation_contract.rs
+++ b/crates/automata-ci-auth/tests/installation_contract.rs
@@ -17,11 +17,10 @@ use automata_ci_auth::{
     login::LoginTransactionId,
     secret::{SecretBytes, SecretString},
     session::{
-        CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-        HumanSessionRepository, ResolveSession, ResolveSessionOutcome, RevokeOwnSession,
-        RevokeOwnSessionOutcome, RevokePrincipalSessions, RevokePrincipalSessionsOutcome,
-        SessionId, SessionKind, SessionRepositoryFuture, SessionTokenDigestKeyId, TouchSession,
-        TouchSessionOutcome,
+        DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+        ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
+        RevokePrincipalSessionsOutcome, SessionId, SessionKind, SessionRepositoryFuture,
+        SessionTokenDigestKeyId, TouchSession, TouchSessionOutcome,
     },
     session_credential::{
         SessionCredentialKey, SessionCredentialKeyring, SessionCredentialService,
@@ -40,10 +39,6 @@ use support::{DeterministicRandom, FixedClock};
 struct UnusedSessionRepository;
 
 impl HumanSessionRepository for UnusedSessionRepository {
-    fn create(&self, _request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-        panic!("preparing an installation session must not persist it")
-    }
-
     fn resolve<'a>(
         &'a self,
         _request: &'a ResolveSession,

--- a/crates/automata-ci-auth/tests/session_credential.rs
+++ b/crates/automata-ci-auth/tests/session_credential.rs
@@ -10,11 +10,11 @@ use automata_ci_auth::{
     human::{AuthenticatedHuman, PrincipalId, ProviderId, ProviderSubject, TenantId},
     secret::{CsrfToken, RandomnessError, SecretBytes, SecureRandom},
     session::{
-        ActivateCliSession, ActivateCliSessionOutcome, CreateSession, CreateSessionOutcome,
-        DurableSession, HumanSessionRepository, ResolveSession, ResolveSessionOutcome,
-        RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
-        RevokePrincipalSessionsOutcome, SessionKind, SessionRepositoryError,
-        SessionRepositoryFuture, SessionTokenDigestKeyId, TouchSession, TouchSessionOutcome,
+        ActivateCliSession, ActivateCliSessionOutcome, DurableSession, HumanSessionRepository,
+        ResolveSession, ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome,
+        RevokePrincipalSessions, RevokePrincipalSessionsOutcome, SessionKind,
+        SessionRepositoryError, SessionRepositoryFuture, SessionTokenDigestKeyId, TouchSession,
+        TouchSessionOutcome,
     },
     session_credential::{
         InvalidSessionCredential, MAX_SESSION_CREDENTIAL_KEYS, PreparedSessionCredential,
@@ -47,7 +47,6 @@ struct RepositoryState {
     activation_results: VecDeque<Result<ActivateCliSessionOutcome, SessionRepositoryError>>,
     touch_results: VecDeque<Result<TouchSessionOutcome, SessionRepositoryError>>,
     revoke_results: VecDeque<Result<RevokeOwnSessionOutcome, SessionRepositoryError>>,
-    create_requests: usize,
     resolve_requests: Vec<ResolveSession>,
     activation_requests: Vec<ActivateCliSession>,
     touch_requests: Vec<TouchSession>,
@@ -94,11 +93,6 @@ impl RecordingRepository {
 }
 
 impl HumanSessionRepository for RecordingRepository {
-    fn create(&self, _request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-        self.state.lock().expect("repository state").create_requests += 1;
-        Box::pin(async { Ok(CreateSessionOutcome::Created) })
-    }
-
     fn resolve<'a>(
         &'a self,
         request: &'a ResolveSession,
@@ -355,15 +349,6 @@ fn nonpersisting_preparation_linearly_binds_raw_credential_to_safe_candidate() {
     let rendered = format!("{prepared:?}");
     assert!(rendered.contains("[REDACTED]"));
     assert!(!rendered.contains(raw));
-    assert_eq!(
-        repository
-            .state
-            .lock()
-            .expect("repository state")
-            .create_requests,
-        0
-    );
-
     let (credential, candidate) = prepared.into_parts();
     let derived_lookup = service
         .derive_lookup_raw(credential.expose_secret(), SessionKind::Browser)
@@ -558,14 +543,6 @@ fn preparation_lifetime_and_overflow_fail_closed_before_storage() {
             .expect_err("preparation overflow"),
         SessionCredentialServiceError::LifetimeOverflow
     );
-    assert_eq!(
-        repository
-            .state
-            .lock()
-            .expect("repository state")
-            .create_requests,
-        0
-    );
     let raw = raw_credential("active", 9);
     assert_eq!(
         block_on(service.touch_raw(&raw, SessionKind::Browser, Duration::from_secs(10),))
@@ -597,14 +574,6 @@ fn randomness_failure_never_reaches_session_storage() {
             )
             .expect_err("random failure"),
         SessionCredentialServiceError::RandomnessUnavailable
-    );
-    assert_eq!(
-        random_repository
-            .state
-            .lock()
-            .expect("repository state")
-            .create_requests,
-        0
     );
 }
 

--- a/crates/automata-ci-auth/tests/sign_in_contract.rs
+++ b/crates/automata-ci-auth/tests/sign_in_contract.rs
@@ -12,10 +12,9 @@ use automata_ci_auth::{
     },
     secret::{SecretBytes, SecretString},
     session::{
-        CreateSession, CreateSessionOutcome, HumanSessionRepository, ResolveSession,
-        ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
-        RevokePrincipalSessionsOutcome, SessionKind, SessionRepositoryFuture, TouchSession,
-        TouchSessionOutcome,
+        HumanSessionRepository, ResolveSession, ResolveSessionOutcome, RevokeOwnSession,
+        RevokeOwnSessionOutcome, RevokePrincipalSessions, RevokePrincipalSessionsOutcome,
+        SessionKind, SessionRepositoryFuture, TouchSession, TouchSessionOutcome,
     },
     session_credential::{
         SessionCredentialKey, SessionCredentialKeyring, SessionCredentialService,
@@ -45,10 +44,6 @@ const LOGIN_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 struct UnusedSessionRepository;
 
 impl HumanSessionRepository for UnusedSessionRepository {
-    fn create(&self, _request: CreateSession) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-        panic!("preparing a sign-in credential must not persist a session")
-    }
-
     fn resolve<'a>(
         &'a self,
         _request: &'a ResolveSession,

--- a/crates/automata-ci-postgres/tests/auth/cli_session_activation.rs
+++ b/crates/automata-ci-postgres/tests/auth/cli_session_activation.rs
@@ -1,14 +1,13 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use automata_ci_auth::{
-    human::{PrincipalId, ProviderId, ProviderSubject, TenantId},
+    human::{PrincipalId, TenantId},
     request_auth::{
         RequestAuthenticationResolver, ResolveAuthenticatedRequest,
         ResolveAuthenticatedRequestOutcome,
     },
     session::{
-        ActivateCliSession, ActivateCliSessionOutcome, CreateSession, CreateSessionOutcome,
-        DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+        ActivateCliSession, ActivateCliSessionOutcome, HumanSessionRepository, ResolveSession,
         ResolveSessionOutcome, RevokeOwnSession, SessionId, SessionKind, SessionTokenDigest,
         SessionTokenDigestKeyId, SessionTokenLookup, TouchSession, TouchSessionOutcome,
     },
@@ -40,33 +39,6 @@ fn lookup(byte: u8) -> SessionTokenLookup {
         SessionTokenDigestKeyId::new("cli-activation-hmac-v1").expect("lookup key"),
         SessionTokenDigest::new([byte; 32]),
     )
-}
-
-fn session(
-    id: Uuid,
-    principal: Uuid,
-    kind: SessionKind,
-    authorization_revision: u64,
-) -> DurableSession {
-    let issued_at = now();
-    DurableSession::new(
-        DurableSessionIdentity::new(
-            SessionId::new(id.hyphenated().to_string()).expect("session ID"),
-            TenantId::new(TENANT).expect("tenant"),
-            PrincipalId::new(principal.hyphenated().to_string()).expect("principal"),
-            ProviderId::new("github").expect("provider"),
-            ProviderSubject::new(SUBJECT).expect("subject"),
-            kind,
-        )
-        .expect("durable identity"),
-        authorization_revision,
-        issued_at,
-        issued_at,
-        issued_at.checked_add(800).expect("idle expiry"),
-        issued_at.checked_add(900).expect("absolute expiry"),
-        None,
-    )
-    .expect("durable session")
 }
 
 async fn seed_actor(pool: &PgPool) -> TestResult<Uuid> {
@@ -112,23 +84,66 @@ async fn seed_actor(pool: &PgPool) -> TestResult<Uuid> {
     Ok(principal)
 }
 
-async fn create(
-    repository: &PostgresHumanSessionRepository,
+// These fixtures intentionally seed pre-existing rows without recreating the
+// production session-issuance API.
+async fn seed_session(
+    pool: &PgPool,
     principal: Uuid,
     id: Uuid,
     kind: SessionKind,
-    lookup: SessionTokenLookup,
-    revision: u64,
+    lookup: &SessionTokenLookup,
+    authorization_revision: u64,
 ) -> TestResult {
-    assert_eq!(
-        repository
-            .create(CreateSession::new(
-                lookup,
-                session(id, principal, kind, revision),
-            ))
-            .await?,
-        CreateSessionOutcome::Created
-    );
+    let database_time_ms: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT * 1000")
+            .fetch_one(pool)
+            .await?;
+    let (session_kind, audience, lifecycle_status, activation_deadline_ms) = match kind {
+        SessionKind::Browser => ("browser", "automata.web", "active", None),
+        SessionKind::Cli => (
+            "cli",
+            "automata.cli",
+            "pending_activation",
+            Some(
+                database_time_ms
+                    .checked_add(300_000)
+                    .expect("activation deadline"),
+            ),
+        ),
+    };
+    sqlx::query(
+        r"
+        INSERT INTO human_sessions (
+            id,tenant_id,principal_id,provider_id,provider_subject,
+            session_kind,audience,token_hash,token_hash_key_id,
+            authorization_revision,predecessor_session_id,issued_at_ms,
+            last_seen_at_ms,idle_expires_at_ms,expires_at_ms,revoked_at_ms,
+            revocation_reason,revision,lifecycle_status,activation_deadline_ms,
+            activated_at_ms
+        ) VALUES ($1,$2,$3,'github',$4,$5,$6,$7,$8,$9,NULL,$10,$10,$11,$12,
+                  NULL,NULL,1,$13,$14,NULL)
+        ",
+    )
+    .bind(id)
+    .bind(TENANT)
+    .bind(principal)
+    .bind(SUBJECT)
+    .bind(session_kind)
+    .bind(audience)
+    .bind(lookup.digest().as_bytes().as_slice())
+    .bind(lookup.key_id().as_str())
+    .bind(i64::try_from(authorization_revision)?)
+    .bind(database_time_ms)
+    .bind(database_time_ms.checked_add(800_000).expect("idle expiry"))
+    .bind(
+        database_time_ms
+            .checked_add(900_000)
+            .expect("absolute expiry"),
+    )
+    .bind(lifecycle_status)
+    .bind(activation_deadline_ms)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
@@ -320,12 +335,12 @@ async fn pending_cli_is_unusable_until_one_concurrent_activation_wins() -> TestR
         let resolver = PostgresRequestAuthenticationResolver::new(pool.clone());
         let session_id = Uuid::new_v4();
         let cli_lookup = lookup(1);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             session_id,
             SessionKind::Cli,
-            cli_lookup.clone(),
+            &cli_lookup,
             1,
         )
         .await?;
@@ -482,12 +497,12 @@ async fn activation_closes_every_noncurrent_or_non_cli_state() -> TestResult {
         );
 
         let browser_lookup = lookup(2);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             Uuid::new_v4(),
             SessionKind::Browser,
-            browser_lookup.clone(),
+            &browser_lookup,
             1,
         )
         .await?;
@@ -542,12 +557,12 @@ async fn activation_closes_every_noncurrent_or_non_cli_state() -> TestResult {
 
         let revoked_id = Uuid::new_v4();
         let revoked_lookup = lookup(4);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             revoked_id,
             SessionKind::Cli,
-            revoked_lookup.clone(),
+            &revoked_lookup,
             1,
         )
         .await?;
@@ -570,12 +585,12 @@ async fn activation_closes_every_noncurrent_or_non_cli_state() -> TestResult {
         );
 
         let disabled_lookup = lookup(5);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             Uuid::new_v4(),
             SessionKind::Cli,
-            disabled_lookup.clone(),
+            &disabled_lookup,
             1,
         )
         .await?;
@@ -602,12 +617,12 @@ async fn activation_closes_every_noncurrent_or_non_cli_state() -> TestResult {
         .await?;
 
         let suspended_lookup = lookup(6);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             Uuid::new_v4(),
             SessionKind::Cli,
-            suspended_lookup.clone(),
+            &suspended_lookup,
             1,
         )
         .await?;
@@ -642,12 +657,12 @@ async fn activation_closes_every_noncurrent_or_non_cli_state() -> TestResult {
         .fetch_one(pool)
         .await?;
         let stale_lookup = lookup(7);
-        create(
-            &repository,
+        seed_session(
+            pool,
             principal,
             Uuid::new_v4(),
             SessionKind::Cli,
-            stale_lookup.clone(),
+            &stale_lookup,
             u64::try_from(current_revision)?,
         )
         .await?;

--- a/crates/automata-ci-postgres/tests/auth/human_auth.rs
+++ b/crates/automata-ci-postgres/tests/auth/human_auth.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use automata_ci_auth::{
-    human::{PrincipalId, ProviderId, ProviderSubject, TenantId},
+    human::{PrincipalId, ProviderId, TenantId},
     login::{
         ConsumeLoginTransaction, ConsumeLoginTransactionOutcome, CreateLoginTransactionOutcome,
         LoadLoginTransactionOutcome, LoginBindingDigest, LoginBindingDigestKeyId, LoginTransaction,
@@ -14,8 +14,7 @@ use automata_ci_auth::{
     },
     secret::{SecretBytes as AuthSecretBytes, SecretString},
     session::{
-        ActivateCliSession, ActivateCliSessionOutcome, CreateSession, CreateSessionOutcome,
-        DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+        ActivateCliSession, ActivateCliSessionOutcome, HumanSessionRepository, ResolveSession,
         ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome, RevokePrincipalSessions,
         SessionId, SessionKind, SessionTokenDigest, SessionTokenDigestKeyId, SessionTokenLookup,
         TouchSession, TouchSessionOutcome,
@@ -458,35 +457,70 @@ fn session_lookup(key: &str, byte: u8) -> SessionTokenLookup {
     )
 }
 
-fn durable_session(
-    id: &str,
-    tenant: &str,
+struct SessionSeed<'a> {
+    id: &'a str,
+    tenant: &'a str,
     principal: Uuid,
     kind: SessionKind,
-    revision: u64,
-    idle_expires_at: u64,
-) -> DurableSession {
-    let issued_at = now();
-    DurableSession::new(
-        DurableSessionIdentity::new(
-            SessionId::new(id).expect("session ID"),
-            TenantId::new(tenant).expect("tenant ID"),
-            PrincipalId::new(principal.hyphenated().to_string()).expect("principal ID"),
-            ProviderId::new("github").expect("provider ID"),
-            ProviderSubject::new("42").expect("provider subject"),
-            kind,
-        )
-        .expect("identity"),
-        revision,
-        issued_at,
-        issued_at,
-        issued_at
-            .checked_add(idle_expires_at.checked_sub(100).expect("idle lifetime"))
-            .expect("idle expiry"),
-        issued_at.checked_add(300).expect("absolute expiry"),
-        None,
+    lookup: &'a SessionTokenLookup,
+    authorization_revision: u64,
+    idle_lifetime_seconds: u64,
+}
+
+// These fixtures intentionally seed pre-existing rows without recreating the
+// production session-issuance API.
+async fn seed_session(pool: &PgPool, seed: SessionSeed<'_>) -> TestResult {
+    let database_time_ms: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT * 1000")
+            .fetch_one(pool)
+            .await?;
+    let idle_lifetime_ms = i64::try_from(seed.idle_lifetime_seconds)?
+        .checked_mul(1_000)
+        .expect("idle lifetime milliseconds");
+    let idle_expires_at_ms = database_time_ms
+        .checked_add(idle_lifetime_ms)
+        .expect("idle expiry");
+    let expires_at_ms = database_time_ms
+        .checked_add(300_000)
+        .expect("absolute expiry");
+    let (session_kind, audience, lifecycle_status, activation_deadline_ms) = match seed.kind {
+        SessionKind::Browser => ("browser", "automata.web", "active", None),
+        SessionKind::Cli => (
+            "cli",
+            "automata.cli",
+            "pending_activation",
+            Some(expires_at_ms),
+        ),
+    };
+    sqlx::query(
+        r"
+        INSERT INTO human_sessions (
+            id,tenant_id,principal_id,provider_id,provider_subject,
+            session_kind,audience,token_hash,token_hash_key_id,
+            authorization_revision,predecessor_session_id,issued_at_ms,
+            last_seen_at_ms,idle_expires_at_ms,expires_at_ms,revoked_at_ms,
+            revocation_reason,revision,lifecycle_status,activation_deadline_ms,
+            activated_at_ms
+        ) VALUES ($1,$2,$3,'github','42',$4,$5,$6,$7,$8,NULL,$9,$9,$10,$11,
+                  NULL,NULL,1,$12,$13,NULL)
+        ",
     )
-    .expect("session")
+    .bind(Uuid::parse_str(seed.id)?)
+    .bind(seed.tenant)
+    .bind(seed.principal)
+    .bind(session_kind)
+    .bind(audience)
+    .bind(seed.lookup.digest().as_bytes().as_slice())
+    .bind(seed.lookup.key_id().as_str())
+    .bind(i64::try_from(seed.authorization_revision)?)
+    .bind(database_time_ms)
+    .bind(idle_expires_at_ms)
+    .bind(expires_at_ms)
+    .bind(lifecycle_status)
+    .bind(activation_deadline_ms)
+    .execute(pool)
+    .await?;
+    Ok(())
 }
 
 #[tokio::test]
@@ -500,22 +534,19 @@ async fn touch_final_write_cannot_extend_a_session_expired_during_statement_dela
         let repository = PostgresHumanSessionRepository::new(pool.clone());
         let session_id = "abababab-abab-4bab-8bab-abababababab";
         let lookup = session_lookup("touch-delay-hmac-v1", 0x5a);
-        assert_eq!(
-            repository
-                .create(CreateSession::new(
-                    lookup.clone(),
-                    durable_session(
-                        session_id,
-                        "tenant-a",
-                        principal,
-                        SessionKind::Browser,
-                        1,
-                        102,
-                    ),
-                ))
-                .await?,
-            CreateSessionOutcome::Created
-        );
+        seed_session(
+            pool,
+            SessionSeed {
+                id: session_id,
+                tenant: "tenant-a",
+                principal,
+                kind: SessionKind::Browser,
+                lookup: &lookup,
+                authorization_revision: 1,
+                idle_lifetime_seconds: 2,
+            },
+        )
+        .await?;
         let before: (i64, i64) =
             sqlx::query_as("SELECT last_seen_at_ms,revision FROM human_sessions WHERE id=$1")
                 .bind(Uuid::parse_str(session_id)?)
@@ -593,15 +624,19 @@ async fn sessions_enforce_audience_idle_revision_and_tenant_scoped_revocation() 
 
         let first_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
         let first_lookup = session_lookup("session-hmac-v1", 5);
-        assert_eq!(
-            repository
-                .create(CreateSession::new(
-                    first_lookup.clone(),
-                    durable_session(first_id, "tenant-a", principal, SessionKind::Browser, 1, 200),
-                ))
-                .await?,
-            CreateSessionOutcome::Created
-        );
+        seed_session(
+            database.pool(),
+            SessionSeed {
+                id: first_id,
+                tenant: "tenant-a",
+                principal,
+                kind: SessionKind::Browser,
+                lookup: &first_lookup,
+                authorization_revision: 1,
+                idle_lifetime_seconds: 100,
+            },
+        )
+        .await?;
         assert!(matches!(
             repository
                 .resolve(&ResolveSession::new(
@@ -670,12 +705,19 @@ async fn sessions_enforce_audience_idle_revision_and_tenant_scoped_revocation() 
 
         let second_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
         let second_lookup = session_lookup("session-hmac-v1", 6);
-        repository
-            .create(CreateSession::new(
-                second_lookup.clone(),
-                durable_session(second_id, "tenant-a", principal, SessionKind::Browser, 2, 220),
-            ))
-            .await?;
+        seed_session(
+            database.pool(),
+            SessionSeed {
+                id: second_id,
+                tenant: "tenant-a",
+                principal,
+                kind: SessionKind::Browser,
+                lookup: &second_lookup,
+                authorization_revision: 2,
+                idle_lifetime_seconds: 120,
+            },
+        )
+        .await?;
         clock.advance(1_100).await?;
         assert!(matches!(
             repository
@@ -725,12 +767,19 @@ async fn sessions_enforce_audience_idle_revision_and_tenant_scoped_revocation() 
 
         let tenant_b_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
         let tenant_b_lookup = session_lookup("session-hmac-v1", 7);
-        repository
-            .create(CreateSession::new(
-                tenant_b_lookup.clone(),
-                durable_session(tenant_b_id, "tenant-b", principal, SessionKind::Cli, 1, 250),
-            ))
-            .await?;
+        seed_session(
+            database.pool(),
+            SessionSeed {
+                id: tenant_b_id,
+                tenant: "tenant-b",
+                principal,
+                kind: SessionKind::Cli,
+                lookup: &tenant_b_lookup,
+                authorization_revision: 1,
+                idle_lifetime_seconds: 150,
+            },
+        )
+        .await?;
         assert!(matches!(
             repository
                 .resolve(&ResolveSession::new(
@@ -797,19 +846,20 @@ async fn principal_revocation_fails_closed_instead_of_leaving_future_issued_sess
         let principal = seed_human(pool, "tenant-a").await?;
         let repository = PostgresHumanSessionRepository::new(pool.clone());
         let current_id = "12121212-1212-4212-8212-121212121212";
-        repository
-            .create(CreateSession::new(
-                session_lookup("session-hmac-v1", 0x31),
-                durable_session(
-                    current_id,
-                    "tenant-a",
-                    principal,
-                    SessionKind::Browser,
-                    1,
-                    200,
-                ),
-            ))
-            .await?;
+        let current_lookup = session_lookup("session-hmac-v1", 0x31);
+        seed_session(
+            pool,
+            SessionSeed {
+                id: current_id,
+                tenant: "tenant-a",
+                principal,
+                kind: SessionKind::Browser,
+                lookup: &current_lookup,
+                authorization_revision: 1,
+                idle_lifetime_seconds: 100,
+            },
+        )
+        .await?;
         let future_id = Uuid::parse_str("34343434-3434-4434-8434-343434343434")?;
         sqlx::query(
             r"

--- a/crates/automata-ci/src/app/human_auth_middleware.rs
+++ b/crates/automata-ci/src/app/human_auth_middleware.rs
@@ -739,10 +739,10 @@ mod tests {
         request_auth::{RequestAuthenticationFuture, ViewerDisplayMetadata},
         secret::{SecretBytes, SystemSecureRandom},
         session::{
-            CreateSession, CreateSessionOutcome, DurableSession, DurableSessionIdentity,
-            HumanSessionRepository, ResolveSession, ResolveSessionOutcome, RevokeOwnSession,
-            RevokeOwnSessionOutcome, RevokePrincipalSessions, RevokePrincipalSessionsOutcome,
-            SessionRepositoryError, SessionRepositoryFuture, SessionTokenDigestKeyId, TouchSession,
+            DurableSession, DurableSessionIdentity, HumanSessionRepository, ResolveSession,
+            ResolveSessionOutcome, RevokeOwnSession, RevokeOwnSessionOutcome,
+            RevokePrincipalSessions, RevokePrincipalSessionsOutcome, SessionRepositoryError,
+            SessionRepositoryFuture, SessionTokenDigestKeyId, TouchSession,
         },
         session_credential::{SessionCredentialKey, SessionCredentialKeyring},
         time::UnixTimestamp,
@@ -785,13 +785,6 @@ mod tests {
     }
 
     impl HumanSessionRepository for TouchingSessionRepository {
-        fn create(
-            &self,
-            _request: CreateSession,
-        ) -> SessionRepositoryFuture<'_, CreateSessionOutcome> {
-            Box::pin(async { Err(SessionRepositoryError::InvalidRequest) })
-        }
-
         fn resolve<'a>(
             &'a self,
             _request: &'a ResolveSession,


### PR DESCRIPTION
## Outcome

Removes the now-unused standalone `HumanSessionRepository::create` boundary and its public request/result vocabulary. Production session creation now has one explicit architecture: prepare a credential candidate, then create the durable session inside the atomic sign-in or installation finalizer transaction.

The PostgreSQL transaction engine remains private and byte-identical. Five fake repository stubs are gone, and the eleven lifecycle-test seeds now use explicit test-local SQL rather than recreating a production issuance API.

The diff is 11 Rust files, +262/-296 (net -34).

## Related issue

Fixes #168.

## Trust and compatibility impact

The removed public auth API is:

- `CreateSession`
- `CreateSessionOutcome`
- `HumanSessionRepository::create`

There were no production callers after #166. This is an intentional pre-release source contraction in the unpublished `automata-ci-auth` 0.1 crate, not a drop-in compatibility claim.

The retained PostgreSQL engine is now adapter-private. Its principal → provider identity → membership lock order, current authorization-revision validation, database-clock rebasing, browser/CLI lifecycle shaping, session-ID versus token-digest collision classification, returned rebased session, and outer finalizer transaction behavior are unchanged.

The fixture SQL samples database time once and preserves the previous rebased identity, digest/key, authorization and row revisions, audience/kind, active versus pending lifecycle, idle/absolute lifetime, activation deadline, and null predecessor/revocation fields. It is test-local only; no public, production, or `cfg(test)` seeding API was added.

There is no Cargo dependency, lockfile, schema, migration, durable-row, wire/Serde, generated-file, or release-metadata change.

## Verification

Passed on `9456dc85` (`main` at submission):

- `cargo fmt --all -- --check`
- `git diff --check`
- full auth and auth-postgres test suites
- focused fake tests: 46/46 passed (28 auth, 18 product middleware)
- `cargo test --locked -p automata-ci --all-targets --all-features`: 632 passed, 1 PostgreSQL-only matrix ignored
- all-target/all-feature checks for auth, auth-postgres, PostgreSQL integration, and product packages
- strict Clippy for all four affected packages, `--no-deps -- -D warnings`
- strict rustdoc for auth and auth-postgres
- integration-target ownership guard: 28 aggregate packages / 343 Rust sources / 33 targets
- publish policy tests: 17/17
- release handoff tests: 9/9
- exhaustive public-path scan: `CreateSession` and `CreateSessionOutcome` remain only as `pub(super)` adapter-local vocabulary

PostgreSQL 18.4 live validation passed 13/13 contracts covering:

- CLI activation timing, single-winner behavior, lifecycle rejection, and database-time resampling
- browser/CLI audience, idle, revision, revocation, and final-write expiry behavior
- browser and device sign-in finalization
- both collision classes and rollback
- unavailable KMS rollback
- installation bootstrap atomicity and unavailable-encryption retry

The disposable PostgreSQL namespace and container were removed after validation.

## AI assistance

OpenAI Codex helped audit post-#166 reachability, implement the private adapter boundary and fixture migration, run PostgreSQL 18 validation, and perform an independent semantic/diff review. All reported commands and behavior claims were verified against the repository and local test results.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
