### PR TITLE
fix(control): finalize undeliverable lease claims

### DIFF
--- a/crates/automata-ci-control/src/lease/observer.rs
+++ b/crates/automata-ci-control/src/lease/observer.rs
@@ -22,6 +22,10 @@ pub enum LeasePollObservation {
 /// Privacy-safe durable claim rejection categories.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LeaseClaimRejection {
+    /// An unpublished claim reached its lease deadline and became terminal.
+    ClaimExpired,
+    /// An unpublished claim lost its exact attempt fence and became terminal.
+    ClaimSuperseded,
     /// The selected attempt no longer exists at transactional recheck.
     AttemptNotFound,
     /// The selected attempt is no longer in the queued lifecycle state.

--- a/crates/automata-ci-control/src/lease/operation.rs
+++ b/crates/automata-ci-control/src/lease/operation.rs
@@ -735,6 +735,12 @@ impl ClaimedAttempt {
 /// Durable negative claim decision. Retrying the same operation replays it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ClaimRejection {
+    /// A claim that never produced a replayable runner response reached its
+    /// lease deadline and can no longer be delivered.
+    ClaimExpired,
+    /// The exact attempt fence stopped being current before the claimed lease
+    /// could be delivered.
+    ClaimSuperseded,
     /// The selected attempt no longer exists.
     AttemptNotFound,
     /// The selected attempt is no longer queued.

--- a/crates/automata-ci-control/src/lease/service.rs
+++ b/crates/automata-ci-control/src/lease/service.rs
@@ -495,6 +495,8 @@ const fn observe_outcome(outcome: &LeasePollOutcome) -> LeasePollObservation {
 
 const fn observe_rejection(reason: ClaimRejection) -> super::LeaseClaimRejection {
     match reason {
+        ClaimRejection::ClaimExpired => super::LeaseClaimRejection::ClaimExpired,
+        ClaimRejection::ClaimSuperseded => super::LeaseClaimRejection::ClaimSuperseded,
         ClaimRejection::AttemptNotFound => super::LeaseClaimRejection::AttemptNotFound,
         ClaimRejection::AttemptNotQueued(_) => super::LeaseClaimRejection::AttemptNotQueued,
         ClaimRejection::NoLongerRunnable => super::LeaseClaimRejection::NoLongerRunnable,

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -7,8 +7,9 @@ use automata_ci_control::{
         CancellationActor, CancellationReason, CancellationRepository as _, RequestCancellation,
     },
     lease::{
-        BeginLeaseRequest, CompleteLeaseRequest, LeaseRequestKey, NoWorkLeaseRequest,
-        RunnableScanLimit, RunnableScanRequest, TryClaimAttempt, TryClaimOutcome,
+        BeginLeaseRequest, ClaimRejection, CompleteLeaseRequest, LeaseRequestKey,
+        NoWorkLeaseRequest, RunnableScanLimit, RunnableScanRequest, TryClaimAttempt,
+        TryClaimOutcome,
         repository::{
             RunnableAttemptRepository as _, RunnerClaimRepository as _,
             RunnerLeaseRequestRepository as _,
@@ -54,6 +55,151 @@ const LEASE_REQUEST_KIND: &str = "automata.runner.lease-request.v1";
 const LEASE_OFFER_KIND: &str = "automata.runner.lease-offer.v1";
 const ACTIVE_LEASE_DURATION_MILLIS: i64 = 300_000;
 const EXPIRING_LEASE_DURATION_MILLIS: i64 = 2_000;
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn expired_unpublished_claim_becomes_one_terminal_replay_without_maintenance() -> TestResult {
+    run_with_database(|database| async move {
+        let clock = TestClock::freeze_at_database_now(database.pool()).await?;
+        let (seed, lease, _metadata, slot, operation_id, _request_digest) =
+            active_lease_with_duration(&database, EXPIRING_LEASE_DURATION_MILLIS).await?;
+        let request = LeaseRequestKey::first(seed.session_fences[0], operation_id, slot);
+
+        wait_until_database_time(&clock, lease.expires_at()).await?;
+
+        let first = database
+            .store()
+            .lookup_lease_request(request)
+            .await?
+            .expect("the admitted request retains one terminal receipt");
+        assert!(matches!(
+            first.outcome(),
+            TryClaimOutcome::Rejected(ClaimRejection::ClaimExpired)
+        ));
+        assert!(first.was_replayed());
+
+        let second = database
+            .store()
+            .lookup_lease_request(request)
+            .await?
+            .expect("the terminal receipt replays exactly");
+        assert_eq!(second.outcome(), first.outcome());
+        assert!(second.was_replayed());
+
+        let stored: (String, Option<i64>, Option<uuid::Uuid>, Option<i32>) = sqlx::query_as(
+            r"
+            SELECT outcome, claimed_fencing_token, claimed_job_id,
+                   claimed_job_ir_schema
+            FROM runner_operation_receipts
+            WHERE runner_session_id = $1 AND operation_id = $2
+            ",
+        )
+        .bind(seed.session_fences[0].session_id().as_uuid())
+        .bind(operation_id.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(stored, ("claim_expired".to_owned(), None, None, None));
+
+        let lifecycle: String =
+            sqlx::query_scalar("SELECT lifecycle FROM job_attempts WHERE id = $1")
+                .bind(lease.attempt_id().as_uuid())
+                .fetch_one(database.pool())
+                .await?;
+        assert_eq!(
+            lifecycle, "leased",
+            "request finalization is independent from bounded attempt maintenance"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn superseded_unpublished_claim_becomes_one_terminal_replay() -> TestResult {
+    run_with_database(|database| async move {
+        let (seed, lease, _metadata, slot, operation_id, _request_digest) =
+            active_lease_with_duration(&database, ACTIVE_LEASE_DURATION_MILLIS).await?;
+        let fence = seed.session_fences[0];
+        let request = LeaseRequestKey::first(fence, operation_id, slot);
+        let requested_at = database_now(&database).await?;
+        let cancellation_operation = OperationId::new();
+        let reason = CancellationReason::new("supersede unpublished claim")?;
+        let cancellation_payload = CancelJobCommandPayload::new(
+            lease.attempt_id(),
+            lease.guard(),
+            RunnerProtocolVersion::new(1)?,
+            reason.as_str(),
+            requested_at,
+        )?
+        .encode_json()?;
+        database
+            .store()
+            .request_cancellation(
+                RequestCancellation::new(
+                    cancellation_operation,
+                    lease.attempt_id(),
+                    CancellationActor::new("test scheduler")?,
+                    Some(reason),
+                    requested_at,
+                )
+                .with_delivery(EnqueueRunnerCommand::new(
+                    fence,
+                    cancellation_operation,
+                    RunnerOperationKind::new(CANCEL_JOB_COMMAND_KIND)?,
+                    RunnerCommandPayload::new(
+                        DocumentSchema::new(CANCEL_JOB_COMMAND_SCHEMA)?,
+                        cancellation_payload,
+                    )?,
+                    requested_at,
+                )),
+            )
+            .await?;
+        let completed_at = database_now(&database).await?;
+        database
+            .store()
+            .commit_runner_terminal_result(CommitRunnerTerminalResult::new(
+                operation_request(
+                    fence,
+                    OperationId::new(),
+                    "automata.runner.job-result.v1",
+                    [91; 32],
+                )?,
+                lease.attempt_id(),
+                lease.guard(),
+                DocumentSchema::new(1)?,
+                80,
+                Sha256Digest::from_bytes([92; 32]),
+                ObjectKey::new("results/superseded-claim.json")?,
+                JobConclusion::Success,
+                completed_at,
+                completed_at,
+                response(b"terminal result committed")?,
+            )?)
+            .await?;
+
+        let first = database
+            .store()
+            .lookup_lease_request(request)
+            .await?
+            .expect("the admitted request retains one terminal receipt");
+        assert!(matches!(
+            first.outcome(),
+            TryClaimOutcome::Rejected(ClaimRejection::ClaimSuperseded)
+        ));
+        assert!(first.was_replayed());
+
+        let second = database
+            .store()
+            .lookup_lease_request(request)
+            .await?
+            .expect("the terminal receipt replays exactly");
+        assert_eq!(second.outcome(), first.outcome());
+        assert!(second.was_replayed());
+        Ok(())
+    })
+    .await
+}
 #[tokio::test]
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
 async fn lease_request_chains_bound_retry_state_per_live_slot() -> TestResult {

--- a/crates/automata-ci-store-postgres/migrations/0030_finalize_expired_lease_claims.sql
+++ b/crates/automata-ci-store-postgres/migrations/0030_finalize_expired_lease_claims.sql
@@ -1,0 +1,70 @@
+ALTER TABLE runner_operation_receipts
+    DROP CONSTRAINT runner_operation_receipts_outcome,
+    DROP CONSTRAINT runner_operation_receipts_result_shape;
+
+ALTER TABLE runner_operation_receipts
+    ADD CONSTRAINT runner_operation_receipts_outcome CHECK (
+        outcome = ANY (ARRAY[
+            'pending', 'claimed', 'claim_expired', 'claim_superseded', 'no_work',
+            'attempt_not_found', 'not_queued', 'not_routable',
+            'not_runnable', 'slot_out_of_range', 'slot_occupied',
+            'scan_superseded', 'authority_rejected'
+        ])
+    ),
+    ADD CONSTRAINT runner_operation_receipts_result_shape CHECK (
+        (outcome = 'pending'
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NULL
+            AND completed_at_ms IS NULL)
+        OR (outcome = 'no_work'
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = 'claimed'
+            AND claimed_fencing_token IS NOT NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = ANY (ARRAY['claim_expired', 'claim_superseded'])
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = 'not_queued'
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NOT NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = 'slot_occupied'
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NOT NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = ANY (ARRAY[
+                'attempt_not_found', 'not_routable', 'not_runnable',
+                'slot_out_of_range'
+            ])
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NOT NULL
+            AND completed_at_ms IS NOT NULL)
+        OR (outcome = ANY (ARRAY['scan_superseded', 'authority_rejected'])
+            AND claimed_fencing_token IS NULL
+            AND rejection_lifecycle IS NULL
+            AND occupied_attempt_id IS NULL
+            AND committed_cursor_version IS NULL
+            AND completed_at_ms IS NOT NULL)
+    );
+
+COMMENT ON CONSTRAINT runner_operation_receipts_result_shape
+    ON runner_operation_receipts IS
+    'An admitted lease selection is either replayably live or durably terminal; an undeliverable claim cannot remain replayable as claimed.';

--- a/crates/automata-ci-store-postgres/src/g1.rs
+++ b/crates/automata-ci-store-postgres/src/g1.rs
@@ -5704,8 +5704,7 @@ impl RunnerClaimRepository for PostgresStore {
         let row = claim_receipt_row(&mut transaction, request).await?;
         let receipt = if let Some(row) = row.as_ref() {
             let receipt = decode_claim_receipt(row, request, true)?;
-            require_live_claim_receipt(&mut transaction, &receipt).await?;
-            Some(receipt)
+            Some(resolve_claim_receipt(&mut transaction, receipt).await?)
         } else {
             None
         };
@@ -7730,6 +7729,16 @@ async fn complete_claim_receipt(
         TryClaimOutcome::Rejected(ClaimRejection::AttemptNotFound) => {
             ("attempt_not_found", None, None, None)
         }
+        TryClaimOutcome::Rejected(ClaimRejection::ClaimExpired) => {
+            return Err(invalid_operation_receipt(
+                "a fresh claim cannot complete as an expired claim",
+            ));
+        }
+        TryClaimOutcome::Rejected(ClaimRejection::ClaimSuperseded) => {
+            return Err(invalid_operation_receipt(
+                "a fresh claim cannot complete as a superseded claim",
+            ));
+        }
         TryClaimOutcome::Rejected(ClaimRejection::AttemptNotQueued(lifecycle)) => {
             ("not_queued", None, Some(lifecycle_name(*lifecycle)), None)
         }
@@ -7873,68 +7882,113 @@ async fn replay_claim(
         .await?
         .ok_or_else(|| invalid_operation_receipt("conflicting receipt disappeared"))?;
     let receipt = decode_claim_receipt(&row, request, true)?;
-    require_live_claim_receipt(transaction, &receipt).await?;
-    Ok(receipt)
+    resolve_claim_receipt(transaction, receipt).await
 }
 
-async fn require_live_claim_receipt(
+/// Resolves the provisional claim phase of an admitted lease request.
+///
+/// A successful claim is replayable only while its exact attempt fence and
+/// lease remain live. An expired or superseded unpublished selection is
+/// atomically finalized as a durable negative outcome. The control layer can
+/// then complete one canonical no-work response, so an exact retry can never
+/// become trapped behind an undeliverable claim.
+async fn resolve_claim_receipt(
     transaction: &mut Transaction<'_, Postgres>,
-    receipt: &TryClaimReceipt,
-) -> Result<(), StoreError> {
+    receipt: TryClaimReceipt,
+) -> Result<TryClaimReceipt, StoreError> {
     let TryClaimOutcome::Claimed(claimed) = receipt.outcome() else {
-        return Ok(());
+        return Ok(receipt);
     };
     let lease = claimed.lease();
-    let assignment = claimed.assignment();
-    let session = assignment.session();
-    let row = sqlx::query(
+    let database_now = super::runner_attempt_database_now(transaction).await?;
+    let rejection = if database_now >= lease.expires_at() {
+        Some(ClaimRejection::ClaimExpired)
+    } else {
+        let assignment = claimed.assignment();
+        let session = assignment.session();
+        let live: bool = sqlx::query_scalar(
+            r"
+            SELECT EXISTS (
+                SELECT 1
+                FROM job_attempts
+                WHERE id = $1
+                  AND lifecycle IN ('leased', 'preparing', 'running', 'cancelling', 'finalizing')
+                  AND lease_id = $2
+                  AND fencing_token = $3
+                  AND runner_id = $4
+                  AND runner_session_id = $5
+                  AND runner_session_epoch = $6
+                  AND runner_generation = $7
+                  AND runner_slot = $8
+                  AND lease_issued_at_ms = $9
+                  AND lease_expires_at_ms >= $10
+            )
+            ",
+        )
+        .bind(lease.attempt_id().as_uuid())
+        .bind(lease.lease_id().as_uuid())
+        .bind(fencing_i64(lease.fencing_token())?)
+        .bind(session.runner_id().as_uuid())
+        .bind(session.session_id().as_uuid())
+        .bind(epoch_i64(session.session_epoch())?)
+        .bind(generation_i64(session.runner_generation())?)
+        .bind(i32::from(assignment.slot().ordinal()))
+        .bind(lease.issued_at().get())
+        .bind(lease.expires_at().get())
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(operation_error)?;
+        (!live).then_some(ClaimRejection::ClaimSuperseded)
+    };
+    let Some(rejection) = rejection else {
+        return Ok(receipt);
+    };
+    let outcome = match rejection {
+        ClaimRejection::ClaimExpired => "claim_expired",
+        ClaimRejection::ClaimSuperseded => "claim_superseded",
+        _ => {
+            return Err(invalid_operation_receipt(
+                "live claim resolved to an invalid terminal reason",
+            ));
+        }
+    };
+
+    let updated = sqlx::query(
         r"
-        SELECT lifecycle IN ('leased', 'preparing', 'running', 'cancelling', 'finalizing')
-                   AS lifecycle_is_active,
-               COALESCE(lease_id = $2
-                   AND fencing_token = $3
-                   AND runner_id = $4
-                   AND runner_session_id = $5
-                   AND runner_session_epoch = $6
-                   AND runner_generation = $7
-                   AND runner_slot = $8
-                   AND lease_issued_at_ms = $9
-                   AND lease_expires_at_ms >= $10, FALSE) AS exact_live_fence
-        FROM job_attempts
-        WHERE id = $1
-        FOR UPDATE
+        UPDATE runner_operation_receipts
+        SET outcome = $3,
+            claimed_fencing_token = NULL,
+            rejection_lifecycle = NULL,
+            occupied_attempt_id = NULL,
+            claimed_job_id = NULL,
+            claimed_run_id = NULL,
+            claimed_job_ir_schema = NULL,
+            claimed_job_ir_size_bytes = NULL,
+            claimed_job_ir_digest = NULL,
+            claimed_job_ir_object_key = NULL,
+            completed_at_ms = $4
+        WHERE runner_session_id = $1
+          AND operation_id = $2
+          AND outcome = 'claimed'
         ",
     )
-    .bind(lease.attempt_id().as_uuid())
-    .bind(lease.lease_id().as_uuid())
-    .bind(fencing_i64(lease.fencing_token())?)
-    .bind(session.runner_id().as_uuid())
-    .bind(session.session_id().as_uuid())
-    .bind(epoch_i64(session.session_epoch())?)
-    .bind(generation_i64(session.runner_generation())?)
-    .bind(i32::from(assignment.slot().ordinal()))
-    .bind(lease.issued_at().get())
-    .bind(lease.expires_at().get())
-    .fetch_optional(&mut **transaction)
+    .bind(receipt.session_id().as_uuid())
+    .bind(receipt.operation_id().as_uuid())
+    .bind(outcome)
+    .bind(database_now.get())
+    .execute(&mut **transaction)
     .await
     .map_err(operation_error)?;
-    let Some(row) = row else {
-        return Err(StoreError::AttemptFenceRejected(lease.attempt_id()));
-    };
-    let lifecycle_is_active: bool = row
-        .try_get("lifecycle_is_active")
-        .map_err(operation_error)?;
-    let exact_live_fence: bool = row.try_get("exact_live_fence").map_err(operation_error)?;
-    if !lifecycle_is_active || !exact_live_fence {
-        return Err(StoreError::AttemptFenceRejected(lease.attempt_id()));
+    if updated.rows_affected() != 1 {
+        return Err(invalid_operation_receipt(
+            "terminal claim did not finalize exactly once",
+        ));
     }
-    let database_now = super::runner_attempt_database_now(transaction).await?;
-    if database_now >= lease.expires_at() {
-        return Err(StoreError::Attempt(AttemptStoreError::LeaseExpired(
-            lease.attempt_id(),
-        )));
-    }
-    Ok(())
+    Ok(TryClaimReceipt::new(
+        receipt.request_key(),
+        TryClaimOutcome::Rejected(rejection),
+        true,
+    ))
 }
 
 async fn claim_receipt_row(
@@ -7987,6 +8041,8 @@ fn decode_claim_receipt(
     }
     let name: &str = row.try_get("outcome").map_err(operation_error)?;
     let outcome = match name {
+        "claim_expired" => TryClaimOutcome::Rejected(ClaimRejection::ClaimExpired),
+        "claim_superseded" => TryClaimOutcome::Rejected(ClaimRejection::ClaimSuperseded),
         "claimed" => {
             let attempt_id = receipt_attempt_id(row)?;
             let lease_id = receipt_lease_id(row)?;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -121,6 +121,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0029_align_artifact_protocol_version.sql",
         "00d51644b2bed927c55fbd7bfa6ba84efe66526d59adb0accd3ab2b4b27d11fec73a62e6d4ae7af159a0b2c522e2eea2",
     ),
+    (
+        "0030_finalize_expired_lease_claims.sql",
+        "68a3755eb8e238649342c7e19a99c467351a6f735cd01a55846e3451e6eabf812ddd922192a3c2a4b9f6fcb3c65cb8a5",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci/src/server/metrics.rs
+++ b/crates/automata-ci/src/server/metrics.rs
@@ -2093,12 +2093,14 @@ const fn results_http_outcome(status: ResultsHttpStatusClass) -> &'static str {
     }
 }
 
-const fn lease_poll_label_values() -> [(&'static str, &'static str, &'static str); 21] {
+const fn lease_poll_label_values() -> [(&'static str, &'static str, &'static str); 25] {
     [
         ("claimed", "new", "none"),
         ("claimed", "replay", "none"),
         ("no_work", "new", "none"),
         ("no_work", "replay", "none"),
+        ("rejected", "new", "claim_expired"),
+        ("rejected", "new", "claim_superseded"),
         ("rejected", "new", "attempt_not_found"),
         ("rejected", "new", "attempt_not_queued"),
         ("rejected", "new", "no_longer_runnable"),
@@ -2106,6 +2108,8 @@ const fn lease_poll_label_values() -> [(&'static str, &'static str, &'static str
         ("rejected", "new", "slot_out_of_range"),
         ("rejected", "new", "slot_occupied"),
         ("rejected", "new", "scan_superseded"),
+        ("rejected", "replay", "claim_expired"),
+        ("rejected", "replay", "claim_superseded"),
         ("rejected", "replay", "attempt_not_found"),
         ("rejected", "replay", "attempt_not_queued"),
         ("rejected", "replay", "no_longer_runnable"),
@@ -2199,6 +2203,8 @@ const fn lease_poll_labels(
 
 const fn lease_rejection(reason: LeaseClaimRejection) -> &'static str {
     match reason {
+        LeaseClaimRejection::ClaimExpired => "claim_expired",
+        LeaseClaimRejection::ClaimSuperseded => "claim_superseded",
         LeaseClaimRejection::AttemptNotFound => "attempt_not_found",
         LeaseClaimRejection::AttemptNotQueued => "attempt_not_queued",
         LeaseClaimRejection::NoLongerRunnable => "no_longer_runnable",


### PR DESCRIPTION
## Summary

- make every admitted lease selection resolve to exactly one durable state: live, expired, or superseded
- terminalize undeliverable claim receipts instead of returning retryable store conflicts
- remove attempt-row locking from claim replay resolution, eliminating the inverse receipt/attempt lock order
- expose closed expired/superseded metrics and freeze the PostgreSQL migration lineage

## Validation

- real PostgreSQL tests for expiry without maintenance and supersession before expiry
- `cargo test -p automata-ci-control --all-targets --all-features --locked --no-fail-fast`
- `cargo test -p automata-ci-store-postgres --all-targets --all-features --locked --no-fail-fast`
- affected-package Clippy with `-D warnings`
