### PR TITLE
feat(logs): add origin-bound SSE live tail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror",
  "tokio",
+ "url",
  "uuid",
  "zeroize",
 ]

--- a/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
@@ -4,17 +4,24 @@ use automata_ci_auth::authorization::{
     repository_read_permissions,
 };
 use automata_ci_auth::human::{PrincipalId, TenantId};
-use automata_ci_core::{JobId, LogSequence, LogStreamId, RunId, RunnerRequirements, WorkflowId};
+use automata_ci_core::{
+    AttemptId, JobId, LogSequence, LogStreamId, RunId, RunnerRequirements, WorkflowId,
+};
 use automata_ci_store::{
     HumanArtifactId, HumanArtifactScope, HumanAuthorizationTarget, HumanGitRef, HumanJobScope,
+    HumanLiveLogBrowserOrigin, HumanLiveLogScope, HumanLiveLogTicketRepository as _,
     HumanLogSegmentPageSize, HumanLogSegmentQuery, HumanPageSize, HumanRepositoryListQuery,
     HumanRunListQuery, HumanRunPageDirection, HumanRunScope, HumanRunStatusFilter,
-    HumanWorkflowListQuery, HumanWorkflowReadRepository as _, RepositoryCoordinate, RepositoryId,
+    HumanWorkflowListQuery, HumanWorkflowReadRepository as _, IssueHumanLiveLogTicket,
+    IssueHumanLiveLogTicketOutcome, RedeemHumanLiveLogTicket, RepositoryCoordinate, RepositoryId,
     StoreError, TenantScope,
 };
+use std::time::Duration;
 use uuid::Uuid;
 
 use crate::support::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+
+use automata_ci_postgres::store::PostgresLiveLogTicketRepository;
 
 #[derive(Clone, Copy, Debug)]
 #[allow(clippy::struct_field_names)]
@@ -23,6 +30,69 @@ struct PublicFixture {
     job_id: JobId,
     stream_id: LogStreamId,
     artifact_id: HumanArtifactId,
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn live_log_tickets_are_origin_bound_and_consumed_once_across_replicas() -> TestResult {
+    run_with_database(|database| async move {
+        let seed = seed_control_plane(database.pool(), 1).await?;
+        make_repository_navigation_public(&database, &seed.tenant_id, seed.repository_id).await?;
+        let fixture = seed_public_completed_run(&database, &seed).await?;
+        let attempt_id: Uuid =
+            sqlx::query_scalar("SELECT attempt_id FROM attempt_log_streams WHERE id = $1")
+                .bind(fixture.stream_id.as_uuid())
+                .fetch_one(database.pool())
+                .await?;
+        let scope = HumanLiveLogScope::new(
+            TenantScope::from_authenticated_tenant_id(seed.tenant_id.clone())?,
+            RepositoryId::from_uuid(seed.repository_id),
+            fixture.run_id,
+            fixture.job_id,
+            AttemptId::from_uuid(attempt_id),
+            fixture.stream_id,
+        )?;
+        let expected_origin = HumanLiveLogBrowserOrigin::new("https://cloud.automata.example")?;
+        let wrong_origin = HumanLiveLogBrowserOrigin::new("https://other.automata.example")?;
+        let issue = IssueHumanLiveLogTicket::new(
+            [7_u8; 32],
+            scope.clone(),
+            expected_origin.clone(),
+            Duration::from_mins(1),
+        )?;
+        let first = PostgresLiveLogTicketRepository::new(database.pool().clone());
+        let second = PostgresLiveLogTicketRepository::new(database.connect_pool(2).await?);
+        assert!(matches!(
+            first.issue(&issue).await?,
+            IssueHumanLiveLogTicketOutcome::Issued(_)
+        ));
+        assert_eq!(
+            second.issue(&issue).await?,
+            IssueHumanLiveLogTicketOutcome::DigestCollision
+        );
+        assert!(
+            second
+                .redeem(&RedeemHumanLiveLogTicket::new([7_u8; 32], wrong_origin))
+                .await?
+                .is_none()
+        );
+        let redeemed = second
+            .redeem(&RedeemHumanLiveLogTicket::new(
+                [7_u8; 32],
+                expected_origin.clone(),
+            ))
+            .await?
+            .expect("the correctly bound replica consumes the ticket");
+        assert_eq!(redeemed.scope(), &scope);
+        assert!(
+            first
+                .redeem(&RedeemHumanLiveLogTicket::new([7_u8; 32], expected_origin,))
+                .await?
+                .is_none()
+        );
+        Ok(())
+    })
+    .await
 }
 
 #[tokio::test]
@@ -1404,7 +1474,7 @@ async fn seed_public_completed_run(
             secret_exposure_class, requested_visibility, effective_visibility,
             publication_safety_reason, publication_safety_schema
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, 1, 'coverage', 1,
+            $1, $2, $3, $4, $5, $6, 1, 'coverage', 7,
             'application/octet-stream', 1000, 'finalized', $7, 3,
             'web/artifacts/manifest', $8, 1, 'application/json', 1, 2,
             'ready', 1, 1, 3, $7, 2, $9,

--- a/crates/automata-ci-store-postgres/migrations/0031_human_live_log_tickets.sql
+++ b/crates/automata-ci-store-postgres/migrations/0031_human_live_log_tickets.sql
@@ -1,0 +1,53 @@
+CREATE TABLE human_live_log_tickets (
+    token_sha256 bytea PRIMARY KEY,
+    tenant_id text NOT NULL,
+    repository_id uuid NOT NULL,
+    run_id uuid NOT NULL,
+    job_id uuid NOT NULL,
+    attempt_id uuid NOT NULL,
+    stream_id uuid NOT NULL,
+    browser_origin text NOT NULL,
+    protocol_version smallint NOT NULL,
+    issued_at_ms bigint NOT NULL,
+    expires_at_ms bigint NOT NULL,
+    consumed_at_ms bigint,
+    CONSTRAINT human_live_log_tickets_digest_shape
+        CHECK (octet_length(token_sha256) = 32),
+    CONSTRAINT human_live_log_tickets_ids_non_nil
+        CHECK (
+            repository_id <> '00000000-0000-0000-0000-000000000000'::uuid
+            AND run_id <> '00000000-0000-0000-0000-000000000000'::uuid
+            AND job_id <> '00000000-0000-0000-0000-000000000000'::uuid
+            AND attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid
+            AND stream_id <> '00000000-0000-0000-0000-000000000000'::uuid
+        ),
+    CONSTRAINT human_live_log_tickets_origin_shape
+        CHECK (
+            octet_length(browser_origin) BETWEEN 1 AND 2048
+            AND browser_origin !~ '[[:cntrl:]]'
+        ),
+    CONSTRAINT human_live_log_tickets_protocol_current
+        CHECK (protocol_version = 1),
+    CONSTRAINT human_live_log_tickets_lifetime_bounded
+        CHECK (
+            issued_at_ms >= 0
+            AND expires_at_ms > issued_at_ms
+            AND expires_at_ms - issued_at_ms <= 60000
+        ),
+    CONSTRAINT human_live_log_tickets_consumption_shape
+        CHECK (
+            consumed_at_ms IS NULL
+            OR (consumed_at_ms >= issued_at_ms AND consumed_at_ms < expires_at_ms)
+        ),
+    CONSTRAINT human_live_log_tickets_tenant_repository_fkey
+        FOREIGN KEY (tenant_id, repository_id)
+        REFERENCES repositories(tenant_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT human_live_log_tickets_stream_fkey
+        FOREIGN KEY (attempt_id, stream_id)
+        REFERENCES attempt_log_streams(attempt_id, id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX human_live_log_tickets_expiry
+    ON human_live_log_tickets (expires_at_ms, token_sha256);

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -48,6 +48,7 @@ mod github_provider_manifest;
 mod github_schedule;
 mod github_service_authority;
 mod github_subject_evidence;
+mod live_log_ticket;
 mod log_notifications;
 mod logical_activation;
 mod logical_activation_preparation;
@@ -77,6 +78,7 @@ mod workflow_runtime_policy;
 pub use github_oidc::{
     PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository,
 };
+pub use live_log_ticket::PostgresLiveLogTicketRepository;
 pub use log_notifications::PostgresLogCommitListener;
 pub use secret_custody::PostgresSecretCustodyRepository;
 pub use secret_management::PostgresSecretManagementRepository;

--- a/crates/automata-ci-store-postgres/src/live_log_ticket.rs
+++ b/crates/automata-ci-store-postgres/src/live_log_ticket.rs
@@ -1,0 +1,167 @@
+use async_trait::async_trait;
+use automata_ci_core::{AttemptId, JobId, LogStreamId, RunId, UnixMillis};
+use automata_ci_store::{
+    HumanLiveLogScope, HumanLiveLogTicketRepository, IssueHumanLiveLogTicket,
+    IssueHumanLiveLogTicketOutcome, IssuedHumanLiveLogTicket, RedeemHumanLiveLogTicket,
+    RedeemedHumanLiveLogTicket, RepositoryId, StoreError, TenantScope,
+};
+use sqlx::{PgPool, Row as _};
+
+const EXPIRED_TICKET_DELETE_BATCH: i64 = 64;
+
+/// PostgreSQL-backed, cross-replica one-time live-log ticket repository.
+#[derive(Clone, Debug)]
+pub struct PostgresLiveLogTicketRepository {
+    pool: PgPool,
+}
+
+impl PostgresLiveLogTicketRepository {
+    /// Creates a repository over the shard's shared `PostgreSQL` pool.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl HumanLiveLogTicketRepository for PostgresLiveLogTicketRepository {
+    async fn issue(
+        &self,
+        request: &IssueHumanLiveLogTicket,
+    ) -> Result<IssueHumanLiveLogTicketOutcome, StoreError> {
+        let lifetime_ms = i64::try_from(request.lifetime().as_millis())
+            .map_err(|_| StoreError::corrupt_data("live-log ticket lifetime exceeds bigint"))?;
+        let row =
+            sqlx::query(
+                r"
+            WITH database_clock AS (
+                SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint AS now_ms
+            ), expired AS (
+                SELECT ticket.token_sha256
+                FROM human_live_log_tickets AS ticket, database_clock
+                WHERE ticket.expires_at_ms <= database_clock.now_ms
+                ORDER BY ticket.expires_at_ms, ticket.token_sha256
+                LIMIT $11
+                FOR UPDATE SKIP LOCKED
+            ), deleted AS (
+                DELETE FROM human_live_log_tickets AS ticket
+                USING expired
+                WHERE ticket.token_sha256 = expired.token_sha256
+            )
+            INSERT INTO human_live_log_tickets (
+                token_sha256, tenant_id, repository_id, run_id, job_id,
+                attempt_id, stream_id, browser_origin, protocol_version,
+                issued_at_ms, expires_at_ms
+            )
+            SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9,
+                   database_clock.now_ms, database_clock.now_ms + $10
+            FROM database_clock
+            ON CONFLICT (token_sha256) DO NOTHING
+            RETURNING issued_at_ms, expires_at_ms
+            ",
+            )
+            .bind(request.token_sha256().as_slice())
+            .bind(request.scope().tenant().as_str())
+            .bind(request.scope().repository_id().as_uuid())
+            .bind(request.scope().run_id().as_uuid())
+            .bind(request.scope().job_id().as_uuid())
+            .bind(request.scope().attempt_id().as_uuid())
+            .bind(request.scope().stream_id().as_uuid())
+            .bind(request.browser_origin().as_str())
+            .bind(i16::try_from(request.protocol_version()).map_err(|_| {
+                StoreError::corrupt_data("live-log ticket protocol exceeds smallint")
+            })?)
+            .bind(lifetime_ms)
+            .bind(EXPIRED_TICKET_DELETE_BATCH)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::operation)?;
+        let Some(row) = row else {
+            return Ok(IssueHumanLiveLogTicketOutcome::DigestCollision);
+        };
+        let issued_at =
+            UnixMillis::new(row.try_get("issued_at_ms").map_err(StoreError::operation)?);
+        let expires_at = UnixMillis::new(
+            row.try_get("expires_at_ms")
+                .map_err(StoreError::operation)?,
+        );
+        if expires_at.get() <= issued_at.get() || expires_at.get() - issued_at.get() != lifetime_ms
+        {
+            return Err(StoreError::corrupt_data(
+                "live-log ticket timestamps violate the requested lifetime",
+            ));
+        }
+        Ok(IssueHumanLiveLogTicketOutcome::Issued(
+            IssuedHumanLiveLogTicket::new(issued_at, expires_at),
+        ))
+    }
+
+    async fn redeem(
+        &self,
+        request: &RedeemHumanLiveLogTicket,
+    ) -> Result<Option<RedeemedHumanLiveLogTicket>, StoreError> {
+        let row =
+            sqlx::query(
+                r"
+            WITH database_clock AS (
+                SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint AS now_ms
+            )
+            UPDATE human_live_log_tickets AS ticket
+            SET consumed_at_ms = database_clock.now_ms
+            FROM database_clock
+            WHERE ticket.token_sha256 = $1
+              AND ticket.browser_origin = $2
+              AND ticket.protocol_version = $3
+              AND ticket.consumed_at_ms IS NULL
+              AND ticket.expires_at_ms > database_clock.now_ms
+            RETURNING ticket.tenant_id, ticket.repository_id, ticket.run_id,
+                      ticket.job_id, ticket.attempt_id, ticket.stream_id,
+                      ticket.consumed_at_ms, ticket.expires_at_ms
+            ",
+            )
+            .bind(request.token_sha256().as_slice())
+            .bind(request.browser_origin().as_str())
+            .bind(i16::try_from(request.protocol_version()).map_err(|_| {
+                StoreError::corrupt_data("live-log ticket protocol exceeds smallint")
+            })?)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::operation)?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let tenant_id: String = row.try_get("tenant_id").map_err(StoreError::operation)?;
+        let tenant = TenantScope::from_authenticated_tenant_id(tenant_id)
+            .map_err(|_| StoreError::corrupt_data("live-log ticket tenant is invalid"))?;
+        let scope = HumanLiveLogScope::new(
+            tenant,
+            RepositoryId::from_uuid(
+                row.try_get("repository_id")
+                    .map_err(StoreError::operation)?,
+            ),
+            RunId::from_uuid(row.try_get("run_id").map_err(StoreError::operation)?),
+            JobId::from_uuid(row.try_get("job_id").map_err(StoreError::operation)?),
+            AttemptId::from_uuid(row.try_get("attempt_id").map_err(StoreError::operation)?),
+            LogStreamId::from_uuid(row.try_get("stream_id").map_err(StoreError::operation)?),
+        )
+        .map_err(|_| StoreError::corrupt_data("live-log ticket scope is invalid"))?;
+        let consumed_at = UnixMillis::new(
+            row.try_get("consumed_at_ms")
+                .map_err(StoreError::operation)?,
+        );
+        let expires_at = UnixMillis::new(
+            row.try_get("expires_at_ms")
+                .map_err(StoreError::operation)?,
+        );
+        if consumed_at.get() >= expires_at.get() {
+            return Err(StoreError::corrupt_data(
+                "consumed live-log ticket is not inside its lifetime",
+            ));
+        }
+        Ok(Some(RedeemedHumanLiveLogTicket::new(
+            scope,
+            consumed_at,
+            expires_at,
+        )))
+    }
+}

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -125,6 +125,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0030_finalize_expired_lease_claims.sql",
         "68a3755eb8e238649342c7e19a99c467351a6f735cd01a55846e3451e6eabf812ddd922192a3c2a4b9f6fcb3c65cb8a5",
     ),
+    (
+        "0031_human_live_log_tickets.sql",
+        "63fba5e432f071d107bfa0b28859bca6396054890ee2c0f448a4a06b44c323ba1ead27056e1d7d4e60306a54920bc968",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store/Cargo.toml
+++ b/crates/automata-ci-store/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+url.workspace = true
 uuid.workspace = true
 zeroize.workspace = true
 

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -14,6 +14,7 @@ mod github_repository_dispatch;
 mod github_schedule;
 mod github_service_authority;
 mod github_subject_evidence;
+mod live_log_ticket;
 mod logical_activation;
 mod logical_activation_preparation;
 mod logical_instance_result;
@@ -190,6 +191,12 @@ pub use github_subject_evidence::{
     GithubWorkflowRunSubjectEvidence, ManifestPinnedGithubDeliveryEvidence,
     ManifestPinnedGithubDeliveryReceipt, RecordGithubWorkflowRunSubjectEvidence,
     ValidateGithubWorkflowRunSubjectEvidenceReplay,
+};
+pub use live_log_ticket::{
+    HUMAN_LIVE_LOG_PROTOCOL_VERSION, HumanLiveLogBrowserOrigin, HumanLiveLogScope,
+    HumanLiveLogTicketRepository, HumanLiveLogTicketValueError, IssueHumanLiveLogTicket,
+    IssueHumanLiveLogTicketOutcome, IssuedHumanLiveLogTicket, MAX_HUMAN_LIVE_LOG_TICKET_LIFETIME,
+    RedeemHumanLiveLogTicket, RedeemedHumanLiveLogTicket,
 };
 pub use logical_activation::{
     ActivatedLogicalInstanceDescriptor, ClaimLogicalJobActivation, ClaimedLogicalJobActivation,

--- a/crates/automata-ci-store/src/live_log_ticket.rs
+++ b/crates/automata-ci-store/src/live_log_ticket.rs
@@ -1,0 +1,427 @@
+//! One-time, replica-independent credentials for authorized human log tails.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use automata_ci_core::{AttemptId, JobId, LogStreamId, RunId, UnixMillis};
+use thiserror::Error;
+use url::{Host, Url};
+
+use crate::{RepositoryId, StoreError, TenantScope};
+
+/// Wire version shared by ticket issuance and live-log transports.
+pub const HUMAN_LIVE_LOG_PROTOCOL_VERSION: u16 = 1;
+/// Maximum time in which an issued live-log ticket may be redeemed.
+pub const MAX_HUMAN_LIVE_LOG_TICKET_LIFETIME: Duration = Duration::from_mins(1);
+
+const MAX_BROWSER_ORIGIN_BYTES: usize = 2_048;
+
+/// Exact durable resource authorized for one live-log connection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanLiveLogScope {
+    tenant: TenantScope,
+    repository_id: RepositoryId,
+    run_id: RunId,
+    job_id: JobId,
+    attempt_id: AttemptId,
+    stream_id: LogStreamId,
+}
+
+impl HumanLiveLogScope {
+    /// Creates a completely nested, non-nil live-log resource scope.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a nil durable identity.
+    pub fn new(
+        tenant: TenantScope,
+        repository_id: RepositoryId,
+        run_id: RunId,
+        job_id: JobId,
+        attempt_id: AttemptId,
+        stream_id: LogStreamId,
+    ) -> Result<Self, HumanLiveLogTicketValueError> {
+        if repository_id.as_uuid().is_nil()
+            || run_id.as_uuid().is_nil()
+            || job_id.as_uuid().is_nil()
+            || attempt_id.as_uuid().is_nil()
+            || stream_id.as_uuid().is_nil()
+        {
+            return Err(HumanLiveLogTicketValueError);
+        }
+        Ok(Self {
+            tenant,
+            repository_id,
+            run_id,
+            job_id,
+            attempt_id,
+            stream_id,
+        })
+    }
+
+    /// Returns the workspace that owns the stream.
+    #[must_use]
+    pub const fn tenant(&self) -> &TenantScope {
+        &self.tenant
+    }
+
+    /// Returns the exact parent repository.
+    #[must_use]
+    pub const fn repository_id(&self) -> RepositoryId {
+        self.repository_id
+    }
+
+    /// Returns the exact parent workflow run.
+    #[must_use]
+    pub const fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    /// Returns the exact parent job.
+    #[must_use]
+    pub const fn job_id(&self) -> JobId {
+        self.job_id
+    }
+
+    /// Returns the exact execution attempt.
+    #[must_use]
+    pub const fn attempt_id(&self) -> AttemptId {
+        self.attempt_id
+    }
+
+    /// Returns the exact durable log stream.
+    #[must_use]
+    pub const fn stream_id(&self) -> LogStreamId {
+        self.stream_id
+    }
+}
+
+/// Canonical browser origin to which a live-log ticket is bound.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HumanLiveLogBrowserOrigin(String);
+
+impl HumanLiveLogBrowserOrigin {
+    /// Validates a canonical HTTPS origin or literal-loopback HTTP origin.
+    ///
+    /// # Errors
+    ///
+    /// Rejects credentials, paths, queries, fragments, noncanonical text, and
+    /// cleartext non-loopback origins.
+    pub fn new(value: impl Into<String>) -> Result<Self, HumanLiveLogTicketValueError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > MAX_BROWSER_ORIGIN_BYTES {
+            return Err(HumanLiveLogTicketValueError);
+        }
+        let parsed = Url::parse(&value).map_err(|_| HumanLiveLogTicketValueError)?;
+        let secure = parsed.scheme() == "https";
+        let loopback = parsed.scheme() == "http"
+            && matches!(
+                parsed.host(),
+                Some(Host::Ipv4(address)) if address.is_loopback()
+            )
+            || parsed.scheme() == "http"
+                && matches!(
+                    parsed.host(),
+                    Some(Host::Ipv6(address)) if address.is_loopback()
+                );
+        if (!secure && !loopback)
+            || parsed.host().is_none()
+            || !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.path() != "/"
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.origin().ascii_serialization() != value
+        {
+            return Err(HumanLiveLogTicketValueError);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical serialized origin without a trailing slash.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Sanitized invalid live-log ticket value.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("live-log ticket value is invalid")]
+pub struct HumanLiveLogTicketValueError;
+
+/// Durable issue request containing only a one-way credential digest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssueHumanLiveLogTicket {
+    token_sha256: [u8; 32],
+    scope: HumanLiveLogScope,
+    browser_origin: HumanLiveLogBrowserOrigin,
+    protocol_version: u16,
+    lifetime: Duration,
+}
+
+impl IssueHumanLiveLogTicket {
+    /// Creates a bounded current-protocol ticket issue request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero, subsecond, or over-limit lifetime.
+    pub fn new(
+        token_sha256: [u8; 32],
+        scope: HumanLiveLogScope,
+        browser_origin: HumanLiveLogBrowserOrigin,
+        lifetime: Duration,
+    ) -> Result<Self, HumanLiveLogTicketValueError> {
+        if lifetime.is_zero()
+            || lifetime > MAX_HUMAN_LIVE_LOG_TICKET_LIFETIME
+            || lifetime.subsec_nanos() != 0
+        {
+            return Err(HumanLiveLogTicketValueError);
+        }
+        Ok(Self {
+            token_sha256,
+            scope,
+            browser_origin,
+            protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+            lifetime,
+        })
+    }
+
+    /// Returns the one-way lookup digest.
+    #[must_use]
+    pub const fn token_sha256(&self) -> &[u8; 32] {
+        &self.token_sha256
+    }
+
+    /// Returns the authorized durable resource.
+    #[must_use]
+    pub const fn scope(&self) -> &HumanLiveLogScope {
+        &self.scope
+    }
+
+    /// Returns the browser origin allowed to redeem the ticket.
+    #[must_use]
+    pub const fn browser_origin(&self) -> &HumanLiveLogBrowserOrigin {
+        &self.browser_origin
+    }
+
+    /// Returns the exact live-log protocol version.
+    #[must_use]
+    pub const fn protocol_version(&self) -> u16 {
+        self.protocol_version
+    }
+
+    /// Returns the bounded redemption window.
+    #[must_use]
+    pub const fn lifetime(&self) -> Duration {
+        self.lifetime
+    }
+}
+
+/// Successful ticket issue metadata. The raw credential remains app-owned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IssuedHumanLiveLogTicket {
+    issued_at: UnixMillis,
+    expires_at: UnixMillis,
+}
+
+impl IssuedHumanLiveLogTicket {
+    /// Creates exact database-clock issue metadata.
+    #[must_use]
+    pub const fn new(issued_at: UnixMillis, expires_at: UnixMillis) -> Self {
+        Self {
+            issued_at,
+            expires_at,
+        }
+    }
+
+    /// Returns the database-clock issue time.
+    #[must_use]
+    pub const fn issued_at(self) -> UnixMillis {
+        self.issued_at
+    }
+
+    /// Returns the exclusive database-clock redemption deadline.
+    #[must_use]
+    pub const fn expires_at(self) -> UnixMillis {
+        self.expires_at
+    }
+}
+
+/// Outcome of inserting a random ticket digest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IssueHumanLiveLogTicketOutcome {
+    /// The digest was inserted and can be returned to the caller.
+    Issued(IssuedHumanLiveLogTicket),
+    /// The random digest already existed; the caller should generate a new credential.
+    DigestCollision,
+}
+
+/// Atomic one-time ticket redemption request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RedeemHumanLiveLogTicket {
+    token_sha256: [u8; 32],
+    browser_origin: HumanLiveLogBrowserOrigin,
+    protocol_version: u16,
+}
+
+impl RedeemHumanLiveLogTicket {
+    /// Creates an exact current-protocol redemption request.
+    #[must_use]
+    pub const fn new(token_sha256: [u8; 32], browser_origin: HumanLiveLogBrowserOrigin) -> Self {
+        Self {
+            token_sha256,
+            browser_origin,
+            protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+        }
+    }
+
+    /// Returns the one-way lookup digest.
+    #[must_use]
+    pub const fn token_sha256(&self) -> &[u8; 32] {
+        &self.token_sha256
+    }
+
+    /// Returns the exact requesting browser origin.
+    #[must_use]
+    pub const fn browser_origin(&self) -> &HumanLiveLogBrowserOrigin {
+        &self.browser_origin
+    }
+
+    /// Returns the exact requested protocol version.
+    #[must_use]
+    pub const fn protocol_version(&self) -> u16 {
+        self.protocol_version
+    }
+}
+
+/// Scope recovered by one successful atomic redemption.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RedeemedHumanLiveLogTicket {
+    scope: HumanLiveLogScope,
+    consumed_at: UnixMillis,
+    expires_at: UnixMillis,
+}
+
+impl RedeemedHumanLiveLogTicket {
+    /// Creates exact database-decoded redemption evidence.
+    #[must_use]
+    pub const fn new(
+        scope: HumanLiveLogScope,
+        consumed_at: UnixMillis,
+        expires_at: UnixMillis,
+    ) -> Self {
+        Self {
+            scope,
+            consumed_at,
+            expires_at,
+        }
+    }
+
+    /// Returns the exact durable stream authority.
+    #[must_use]
+    pub const fn scope(&self) -> &HumanLiveLogScope {
+        &self.scope
+    }
+
+    /// Returns when the database atomically consumed the ticket.
+    #[must_use]
+    pub const fn consumed_at(&self) -> UnixMillis {
+        self.consumed_at
+    }
+
+    /// Returns the original exclusive redemption deadline.
+    #[must_use]
+    pub const fn expires_at(&self) -> UnixMillis {
+        self.expires_at
+    }
+}
+
+/// Shared durable repository for one-time live-log tickets.
+#[async_trait]
+pub trait HumanLiveLogTicketRepository: std::fmt::Debug + Send + Sync {
+    /// Inserts one digest or reports the vanishingly unlikely random collision.
+    async fn issue(
+        &self,
+        request: &IssueHumanLiveLogTicket,
+    ) -> Result<IssueHumanLiveLogTicketOutcome, StoreError>;
+
+    /// Atomically consumes one unexpired, origin-bound ticket.
+    async fn redeem(
+        &self,
+        request: &RedeemHumanLiveLogTicket,
+    ) -> Result<Option<RedeemedHumanLiveLogTicket>, StoreError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn browser_origins_are_canonical_and_never_downgrade_remote_http() {
+        for valid in [
+            "https://ci.example",
+            "http://127.0.0.1:8080",
+            "http://[::1]",
+        ] {
+            assert_eq!(
+                HumanLiveLogBrowserOrigin::new(valid)
+                    .expect("valid origin")
+                    .as_str(),
+                valid
+            );
+        }
+        for invalid in [
+            "http://ci.example",
+            "https://ci.example/",
+            "https://ci.example/path",
+            "https://user@ci.example",
+            "https://ci.example?query",
+        ] {
+            assert!(
+                HumanLiveLogBrowserOrigin::new(invalid).is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn scope_and_lifetime_reject_ambiguous_authority() {
+        let tenant =
+            TenantScope::from_authenticated_tenant_id("workspace".to_owned()).expect("tenant");
+        let scope = HumanLiveLogScope::new(
+            tenant.clone(),
+            RepositoryId::from_uuid(Uuid::from_u128(1)),
+            RunId::from_uuid(Uuid::from_u128(2)),
+            JobId::from_uuid(Uuid::from_u128(3)),
+            AttemptId::from_uuid(Uuid::from_u128(4)),
+            LogStreamId::from_uuid(Uuid::from_u128(5)),
+        )
+        .expect("scope");
+        let origin = HumanLiveLogBrowserOrigin::new("https://ci.example").expect("origin");
+        assert!(
+            IssueHumanLiveLogTicket::new(
+                [1; 32],
+                scope.clone(),
+                origin.clone(),
+                Duration::from_mins(1)
+            )
+            .is_ok()
+        );
+        assert!(
+            IssueHumanLiveLogTicket::new([1; 32], scope, origin, Duration::from_secs(61)).is_err()
+        );
+        assert!(
+            HumanLiveLogScope::new(
+                tenant,
+                RepositoryId::from_uuid(Uuid::nil()),
+                RunId::from_uuid(Uuid::from_u128(2)),
+                JobId::from_uuid(Uuid::from_u128(3)),
+                AttemptId::from_uuid(Uuid::from_u128(4)),
+                LogStreamId::from_uuid(Uuid::from_u128(5)),
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/automata-ci/src/app/delegated_actor_api.rs
+++ b/crates/automata-ci/src/app/delegated_actor_api.rs
@@ -8,8 +8,8 @@ use std::{
 
 use automata_ci_auth::{
     delegated_actor::{
-        DelegatedActorAssertion, DelegatedActorResolver, DelegatedActorResolverError,
-        ResolveDelegatedActorOutcome, ResolveDelegatedActorRequest,
+        DelegatedActorAssertion, DelegatedActorRequestSnapshot, DelegatedActorResolver,
+        DelegatedActorResolverError, ResolveDelegatedActorOutcome, ResolveDelegatedActorRequest,
     },
     human::TenantId,
     time::UnixTimestamp,
@@ -28,11 +28,22 @@ use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse as _, Response},
-    routing::get,
+    routing::{get, post},
 };
+
+use super::{
+    live_log::{
+        LiveLogService, issued_response, parse_job_id, parse_run_id, repository_path,
+        service_error_response,
+    },
+    web::{RequestContext, Viewer},
+};
+use automata_ci_store::HumanLiveLogBrowserOrigin;
 
 /// Protected Core endpoint used by Cloud to resolve the current viewer.
 pub const DELEGATED_ACTOR_VIEWER_PATH: &str = "/internal/v1/workspaces/{workspace_id}/viewer";
+/// Protected Core endpoint used by Cloud to authorize one browser log tail.
+pub const DELEGATED_ACTOR_LIVE_LOG_TICKET_PATH: &str = "/internal/v1/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}/live-ticket";
 
 const MAX_ASSERTION_BYTES: usize = 8 * 1024;
 const MAX_JWT_SEGMENT_BYTES: usize = 6 * 1024;
@@ -350,6 +361,8 @@ pub(crate) enum DelegatedActorVerificationError {
 struct DelegatedActorApiState {
     verifier: Arc<DelegatedActorVerifier>,
     resolver: Arc<dyn DelegatedActorResolver>,
+    live_logs: Arc<LiveLogService>,
+    browser_origin: HumanLiveLogBrowserOrigin,
 }
 
 impl std::fmt::Debug for DelegatedActorApiState {
@@ -358,6 +371,8 @@ impl std::fmt::Debug for DelegatedActorApiState {
             .debug_struct("DelegatedActorApiState")
             .field("verifier", &self.verifier)
             .field("resolver", &self.resolver)
+            .field("live_logs", &self.live_logs)
+            .field("browser_origin", &self.browser_origin)
             .finish()
     }
 }
@@ -375,10 +390,21 @@ struct WorkspaceViewerResponse {
 pub(crate) fn router(
     verifier: Arc<DelegatedActorVerifier>,
     resolver: Arc<dyn DelegatedActorResolver>,
+    live_logs: Arc<LiveLogService>,
+    browser_origin: HumanLiveLogBrowserOrigin,
 ) -> Router {
     Router::new()
         .route(DELEGATED_ACTOR_VIEWER_PATH, get(workspace_viewer))
-        .with_state(DelegatedActorApiState { verifier, resolver })
+        .route(
+            DELEGATED_ACTOR_LIVE_LOG_TICKET_PATH,
+            post(workspace_live_log_ticket),
+        )
+        .with_state(DelegatedActorApiState {
+            verifier,
+            resolver,
+            live_logs,
+            browser_origin,
+        })
 }
 
 async fn workspace_viewer(
@@ -389,34 +415,9 @@ async fn workspace_viewer(
     let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let Some(token) = bearer_token(&headers) else {
-        return unauthorized();
-    };
-    let now = unix_time();
-    let verified = match state.verifier.verify(token, now).await {
-        Ok(value) if value.workspace_id == workspace_uuid => value,
-        Ok(_) | Err(DelegatedActorVerificationError::Rejected) => return unauthorized(),
-        Err(DelegatedActorVerificationError::Unavailable) => {
-            return status_response(StatusCode::SERVICE_UNAVAILABLE);
-        }
-    };
-    let Ok(tenant_id) = TenantId::new(workspace_id.clone()) else {
-        return status_response(StatusCode::NOT_FOUND);
-    };
-    let request = ResolveDelegatedActorRequest::new(verified.assertion, tenant_id);
-    let snapshot = match state.resolver.resolve(&request).await {
-        Ok(ResolveDelegatedActorOutcome::Authenticated(snapshot)) => snapshot,
-        Ok(
-            ResolveDelegatedActorOutcome::NotFound
-            | ResolveDelegatedActorOutcome::PrincipalDisabled
-            | ResolveDelegatedActorOutcome::MembershipSuspended,
-        ) => return status_response(StatusCode::FORBIDDEN),
-        Err(DelegatedActorResolverError::Unavailable) => {
-            return status_response(StatusCode::SERVICE_UNAVAILABLE);
-        }
-        Err(DelegatedActorResolverError::CorruptData) => {
-            return status_response(StatusCode::INTERNAL_SERVER_ERROR);
-        }
+    let snapshot = match resolve_actor(&state, workspace_uuid, &headers).await {
+        Ok(snapshot) => snapshot,
+        Err(response) => return response,
     };
     let authorization = snapshot.authorization();
     let Some(principal_id) = authorization.principal_id() else {
@@ -439,6 +440,96 @@ async fn workspace_viewer(
         }),
     )
         .into_response()
+}
+
+async fn workspace_live_log_ticket(
+    State(state): State<DelegatedActorApiState>,
+    Path((workspace_id, owner, repository, run_id, job_id)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+    headers: HeaderMap,
+) -> Response {
+    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let snapshot = match resolve_actor(&state, workspace_uuid, &headers).await {
+        Ok(snapshot) => snapshot,
+        Err(response) => return response,
+    };
+    let Some(repository) = repository_path(owner, repository) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let (Some(run_id), Some(job_id)) = (parse_run_id(&run_id), parse_job_id(&job_id)) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let Ok(tenant_id) = TenantId::new(workspace_id) else {
+        return status_response(StatusCode::NOT_FOUND);
+    };
+    let Ok(context) = RequestContext::new(
+        tenant_id,
+        snapshot.authorization().clone(),
+        Some(Viewer {
+            display_name: snapshot.viewer().display_name().to_owned(),
+        }),
+        None,
+    ) else {
+        return status_response(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    match state
+        .live_logs
+        .issue(
+            &context,
+            &repository,
+            run_id,
+            job_id,
+            state.browser_origin.clone(),
+        )
+        .await
+    {
+        Ok(Some(issued)) => issued_response(&issued),
+        Ok(None) => status_response(StatusCode::NOT_FOUND),
+        Err(error) => service_error_response(error),
+    }
+}
+
+async fn resolve_actor(
+    state: &DelegatedActorApiState,
+    workspace_uuid: Uuid,
+    headers: &HeaderMap,
+) -> Result<Box<DelegatedActorRequestSnapshot>, Response> {
+    let Some(token) = bearer_token(headers) else {
+        return Err(unauthorized());
+    };
+    let now = unix_time();
+    let verified = match state.verifier.verify(token, now).await {
+        Ok(value) if value.workspace_id == workspace_uuid => value,
+        Ok(_) | Err(DelegatedActorVerificationError::Rejected) => return Err(unauthorized()),
+        Err(DelegatedActorVerificationError::Unavailable) => {
+            return Err(status_response(StatusCode::SERVICE_UNAVAILABLE));
+        }
+    };
+    let Ok(tenant_id) = TenantId::new(workspace_uuid.hyphenated().to_string()) else {
+        return Err(status_response(StatusCode::NOT_FOUND));
+    };
+    let request = ResolveDelegatedActorRequest::new(verified.assertion, tenant_id);
+    match state.resolver.resolve(&request).await {
+        Ok(ResolveDelegatedActorOutcome::Authenticated(snapshot)) => Ok(snapshot),
+        Ok(
+            ResolveDelegatedActorOutcome::NotFound
+            | ResolveDelegatedActorOutcome::PrincipalDisabled
+            | ResolveDelegatedActorOutcome::MembershipSuspended,
+        ) => Err(status_response(StatusCode::FORBIDDEN)),
+        Err(DelegatedActorResolverError::Unavailable) => {
+            Err(status_response(StatusCode::SERVICE_UNAVAILABLE))
+        }
+        Err(DelegatedActorResolverError::CorruptData) => {
+            Err(status_response(StatusCode::INTERNAL_SERVER_ERROR))
+        }
+    }
 }
 
 fn bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/crates/automata-ci/src/app/live_log.rs
+++ b/crates/automata-ci/src/app/live_log.rs
@@ -1,0 +1,897 @@
+//! Origin-bound one-time live-log tickets and the reference SSE transport.
+
+use std::{
+    collections::{BTreeSet, VecDeque},
+    convert::Infallible,
+    fmt,
+    str::FromStr as _,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use automata_ci_auth::secret::SecretString;
+use automata_ci_core::{JobId, RunId, UnixMillis};
+use automata_ci_store::{
+    HUMAN_LIVE_LOG_PROTOCOL_VERSION, HumanLiveLogBrowserOrigin, HumanLiveLogScope,
+    HumanLiveLogTicketRepository, HumanLogCommitNotificationHub, HumanLogCommitSubscription,
+    IssueHumanLiveLogTicket, IssueHumanLiveLogTicketOutcome, MAX_HUMAN_LIVE_LOG_TICKET_LIFETIME,
+    RedeemHumanLiveLogTicket,
+};
+use axum::{
+    Json, Router,
+    body::{Body, Bytes, to_bytes},
+    extract::{Extension, Path, Request, State},
+    http::{
+        HeaderMap, HeaderName, HeaderValue, Method, StatusCode,
+        header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ORIGIN, VARY},
+    },
+    response::{IntoResponse as _, Response},
+    routing::post,
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use futures::stream;
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use tracing::error;
+use zeroize::{Zeroize as _, Zeroizing};
+
+use super::web::{
+    LiveLogBatch, LiveLogRecord, LogChannel, RepositoryPath, RequestContext, WebData, WebDataError,
+};
+
+/// Authenticated browser endpoint that issues a capability for one exact log.
+pub(crate) const BROWSER_LIVE_LOG_TICKET_PATH: &str =
+    "/{owner}/{repository}/actions/runs/{run_id}/jobs/{job_id}/live-ticket";
+/// Credential-only public endpoint used by the reference streaming transport.
+pub(crate) const LIVE_LOG_SSE_PATH: &str = "/live/v1/logs";
+
+const TICKET_PREFIX: &str = "allt_v1_";
+const TICKET_RANDOM_BYTES: usize = 32;
+const TICKET_ENCODED_BYTES: usize = 43;
+const TICKET_LENGTH: usize = TICKET_PREFIX.len() + TICKET_ENCODED_BYTES;
+const MAX_TICKET_GENERATION_ATTEMPTS: usize = 3;
+const MAX_CHECKPOINT_BYTES: usize = 512;
+const MAX_REQUEST_BODY_BYTES: usize = 0;
+const DURABLE_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
+const SSE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const SSE_CONNECTION_LIFETIME: Duration = Duration::from_mins(5);
+const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
+const ACCESS_CONTROL_ALLOW_ORIGIN: HeaderName =
+    HeaderName::from_static("access-control-allow-origin");
+const ACCESS_CONTROL_ALLOW_METHODS: HeaderName =
+    HeaderName::from_static("access-control-allow-methods");
+const ACCESS_CONTROL_ALLOW_HEADERS: HeaderName =
+    HeaderName::from_static("access-control-allow-headers");
+const ACCESS_CONTROL_MAX_AGE: HeaderName = HeaderName::from_static("access-control-max-age");
+const ACCESS_CONTROL_REQUEST_METHOD: HeaderName =
+    HeaderName::from_static("access-control-request-method");
+const ACCESS_CONTROL_REQUEST_HEADERS: HeaderName =
+    HeaderName::from_static("access-control-request-headers");
+const X_ACCEL_BUFFERING: HeaderName = HeaderName::from_static("x-accel-buffering");
+
+/// Shared ticket, authorization, replay, and notification dependencies.
+#[derive(Clone)]
+pub(crate) struct LiveLogService {
+    data: Arc<dyn WebData>,
+    tickets: Arc<dyn HumanLiveLogTicketRepository>,
+    notifications: Arc<HumanLogCommitNotificationHub>,
+}
+
+impl LiveLogService {
+    #[must_use]
+    pub(crate) const fn new(
+        data: Arc<dyn WebData>,
+        tickets: Arc<dyn HumanLiveLogTicketRepository>,
+        notifications: Arc<HumanLogCommitNotificationHub>,
+    ) -> Self {
+        Self {
+            data,
+            tickets,
+            notifications,
+        }
+    }
+
+    /// Reuses Core's exact human log authorization and issues one random ticket.
+    pub(crate) async fn issue(
+        &self,
+        context: &RequestContext,
+        repository: &RepositoryPath,
+        run_id: RunId,
+        job_id: JobId,
+        browser_origin: HumanLiveLogBrowserOrigin,
+    ) -> Result<Option<IssuedLiveLogAccess>, LiveLogServiceError> {
+        let Some(authorized) = self
+            .data
+            .authorize_live_log(context, repository, run_id, job_id)
+            .await
+            .map_err(LiveLogServiceError::Data)?
+        else {
+            return Ok(None);
+        };
+        for _ in 0..MAX_TICKET_GENERATION_ATTEMPTS {
+            let credential = generate_ticket()?;
+            let digest = ticket_digest(credential.expose_secret())?;
+            let request = IssueHumanLiveLogTicket::new(
+                digest,
+                authorized.scope.clone(),
+                browser_origin.clone(),
+                MAX_HUMAN_LIVE_LOG_TICKET_LIFETIME,
+            )
+            .map_err(|_| LiveLogServiceError::Internal)?;
+            match self.tickets.issue(&request).await {
+                Ok(IssueHumanLiveLogTicketOutcome::Issued(receipt)) => {
+                    return Ok(Some(IssuedLiveLogAccess {
+                        credential,
+                        expires_at: receipt.expires_at(),
+                    }));
+                }
+                Ok(IssueHumanLiveLogTicketOutcome::DigestCollision) => {}
+                Err(error) => {
+                    error!(%error, "failed to persist a live-log ticket");
+                    return Err(LiveLogServiceError::Unavailable);
+                }
+            }
+        }
+        Err(LiveLogServiceError::Internal)
+    }
+
+    async fn redeem(
+        &self,
+        raw_ticket: &str,
+        browser_origin: HumanLiveLogBrowserOrigin,
+    ) -> Result<Option<HumanLiveLogScope>, LiveLogServiceError> {
+        let digest = ticket_digest(raw_ticket)?;
+        let request = RedeemHumanLiveLogTicket::new(digest, browser_origin);
+        match self.tickets.redeem(&request).await {
+            Ok(Some(redeemed)) => Ok(Some(redeemed.scope().clone())),
+            Ok(None) => Ok(None),
+            Err(error) => {
+                error!(%error, "failed to redeem a live-log ticket");
+                Err(LiveLogServiceError::Unavailable)
+            }
+        }
+    }
+
+    async fn read(
+        &self,
+        scope: &HumanLiveLogScope,
+        checkpoint: Option<&str>,
+        replay_checkpoint: bool,
+    ) -> Result<Option<LiveLogBatch>, LiveLogServiceError> {
+        self.data
+            .read_live_log(scope, checkpoint, replay_checkpoint)
+            .await
+            .map_err(LiveLogServiceError::Data)
+    }
+
+    fn subscribe(&self, scope: &HumanLiveLogScope) -> HumanLogCommitSubscription {
+        self.notifications.subscribe(scope.stream_id())
+    }
+}
+
+impl fmt::Debug for LiveLogService {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LiveLogService")
+            .field("data", &self.data)
+            .field("tickets", &"[REDACTED]")
+            .field("notifications", &self.notifications)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IssuedLiveLogAccess {
+    credential: SecretString,
+    expires_at: UnixMillis,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LiveLogServiceError {
+    InvalidCredential,
+    Data(WebDataError),
+    Unavailable,
+    Internal,
+}
+
+#[derive(Clone)]
+struct BrowserTicketState {
+    service: Arc<LiveLogService>,
+    origin: HumanLiveLogBrowserOrigin,
+}
+
+impl fmt::Debug for BrowserTicketState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BrowserTicketState")
+            .field("service", &self.service)
+            .field("origin", &self.origin)
+            .finish()
+    }
+}
+
+/// Builds the session- and CSRF-protected browser ticket endpoint.
+pub(crate) fn browser_ticket_router(
+    service: Arc<LiveLogService>,
+    origin: HumanLiveLogBrowserOrigin,
+) -> Router {
+    Router::new()
+        .route(BROWSER_LIVE_LOG_TICKET_PATH, post(issue_browser_ticket))
+        .with_state(BrowserTicketState { service, origin })
+}
+
+async fn issue_browser_ticket(
+    State(state): State<BrowserTicketState>,
+    Extension(context): Extension<RequestContext>,
+    Path((owner, repository, run_id, job_id)): Path<(String, String, String, String)>,
+    request: Request,
+) -> Response {
+    if request.uri().query().is_some()
+        || request_origin(request.headers()) != Some(state.origin.as_str())
+        || !request_body_is_empty(request).await
+    {
+        return json_error(StatusCode::BAD_REQUEST, "invalid_request");
+    }
+    let Some(repository) = repository_path(owner, repository) else {
+        return json_error(StatusCode::BAD_REQUEST, "invalid_request");
+    };
+    let (Some(run_id), Some(job_id)) = (parse_run_id(&run_id), parse_job_id(&job_id)) else {
+        return json_error(StatusCode::BAD_REQUEST, "invalid_request");
+    };
+    match state
+        .service
+        .issue(&context, &repository, run_id, job_id, state.origin)
+        .await
+    {
+        Ok(Some(issued)) => issued_response(&issued),
+        Ok(None) => json_error(StatusCode::NOT_FOUND, "not_found"),
+        Err(error) => service_error_response(error),
+    }
+}
+
+#[derive(Clone)]
+struct StreamState {
+    service: Arc<LiveLogService>,
+    allowed_origins: Arc<BTreeSet<String>>,
+}
+
+impl fmt::Debug for StreamState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StreamState")
+            .field("service", &self.service)
+            .field("allowed_origins", &self.allowed_origins)
+            .finish()
+    }
+}
+
+/// Builds the credential-only SSE endpoint outside ordinary human middleware.
+pub(crate) fn stream_router(
+    service: Arc<LiveLogService>,
+    allowed_origins: BTreeSet<String>,
+) -> Router {
+    Router::new()
+        .route(LIVE_LOG_SSE_PATH, post(stream_sse).options(preflight_sse))
+        .with_state(StreamState {
+            service,
+            allowed_origins: Arc::new(allowed_origins),
+        })
+}
+
+async fn preflight_sse(State(state): State<StreamState>, headers: HeaderMap) -> Response {
+    let Some(origin) = allowed_request_origin(&state, &headers) else {
+        return StatusCode::FORBIDDEN.into_response();
+    };
+    if exact_header(&headers, &ACCESS_CONTROL_REQUEST_METHOD) != Some("POST")
+        || !valid_preflight_headers(exact_header(&headers, &ACCESS_CONTROL_REQUEST_HEADERS))
+    {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    let mut response = StatusCode::NO_CONTENT.into_response();
+    insert_cors_headers(response.headers_mut(), origin);
+    response.headers_mut().insert(
+        ACCESS_CONTROL_ALLOW_METHODS,
+        HeaderValue::from_static("POST"),
+    );
+    response.headers_mut().insert(
+        ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("authorization, last-event-id"),
+    );
+    response
+        .headers_mut()
+        .insert(ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static("300"));
+    response
+}
+
+async fn stream_sse(State(state): State<StreamState>, request: Request) -> Response {
+    if request.method() != Method::POST || request.uri().query().is_some() {
+        return stream_error(StatusCode::BAD_REQUEST, "invalid_request", None);
+    }
+    let Some(origin) = allowed_request_origin(&state, request.headers()) else {
+        return stream_error(StatusCode::FORBIDDEN, "forbidden", None);
+    };
+    let Ok(origin) = HumanLiveLogBrowserOrigin::new(origin.to_owned()) else {
+        return stream_error(StatusCode::FORBIDDEN, "forbidden", None);
+    };
+    let Some(ticket) = authorization_ticket(request.headers()) else {
+        return stream_error(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            Some(origin.as_str()),
+        );
+    };
+    let Ok(ticket) = SecretString::new(ticket.to_owned()) else {
+        return stream_error(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            Some(origin.as_str()),
+        );
+    };
+    let checkpoint = match checkpoint_header(request.headers()) {
+        Ok(checkpoint) => checkpoint.map(str::to_owned),
+        Err(()) => {
+            return stream_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_checkpoint",
+                Some(origin.as_str()),
+            );
+        }
+    };
+    if !request_body_is_empty(request).await {
+        return stream_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some(origin.as_str()),
+        );
+    }
+    let scope = match state
+        .service
+        .redeem(ticket.expose_secret(), origin.clone())
+        .await
+    {
+        Ok(Some(scope)) => scope,
+        Ok(None) | Err(LiveLogServiceError::InvalidCredential) => {
+            return stream_error(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                Some(origin.as_str()),
+            );
+        }
+        Err(error) => {
+            return stream_service_error(error, Some(origin.as_str()));
+        }
+    };
+    let tail = SseTail::new(Arc::clone(&state.service), scope, checkpoint);
+    let body = Body::from_stream(stream::unfold(tail, SseTail::next));
+    let mut response = Response::new(body);
+    let headers = response.headers_mut();
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/event-stream; charset=utf-8"),
+    );
+    headers.insert(X_ACCEL_BUFFERING, HeaderValue::from_static("no"));
+    insert_cors_headers(headers, origin.as_str());
+    response
+}
+
+struct SseTail {
+    service: Arc<LiveLogService>,
+    scope: HumanLiveLogScope,
+    subscription: HumanLogCommitSubscription,
+    checkpoint: Option<String>,
+    replay_checkpoint: bool,
+    pending: VecDeque<Bytes>,
+    deadline: Instant,
+    last_write: Instant,
+    finished: bool,
+}
+
+impl SseTail {
+    fn new(
+        service: Arc<LiveLogService>,
+        scope: HumanLiveLogScope,
+        checkpoint: Option<String>,
+    ) -> Self {
+        let subscription = service.subscribe(&scope);
+        let now = Instant::now();
+        let mut pending = VecDeque::new();
+        pending.push_back(Bytes::from_static(b": connected\nretry: 1000\n\n"));
+        Self {
+            service,
+            scope,
+            subscription,
+            checkpoint,
+            replay_checkpoint: true,
+            pending,
+            deadline: now + SSE_CONNECTION_LIFETIME,
+            last_write: now,
+            finished: false,
+        }
+    }
+
+    async fn next(mut self) -> Option<(Result<Bytes, Infallible>, Self)> {
+        loop {
+            if let Some(bytes) = self.pending.pop_front() {
+                self.last_write = Instant::now();
+                return Some((Ok(bytes), self));
+            }
+            if self.finished {
+                return None;
+            }
+            if Instant::now() >= self.deadline {
+                self.pending.push_back(sse_reconnect_event());
+                self.finished = true;
+                continue;
+            }
+            let batch = match self
+                .service
+                .read(
+                    &self.scope,
+                    self.checkpoint.as_deref(),
+                    self.replay_checkpoint,
+                )
+                .await
+            {
+                Ok(Some(batch)) => batch,
+                Ok(None) => {
+                    self.pending.push_back(sse_error_event("stream_changed"));
+                    self.finished = true;
+                    continue;
+                }
+                Err(error) => {
+                    error!(?error, "live-log durable tail failed");
+                    self.pending.push_back(sse_error_event("unavailable"));
+                    self.finished = true;
+                    continue;
+                }
+            };
+            self.replay_checkpoint = false;
+            self.checkpoint.clone_from(&batch.checkpoint);
+            for record in batch.records {
+                if let Ok(event) = sse_log_event(&self.scope, &record) {
+                    self.pending.push_back(event);
+                } else {
+                    self.pending.push_back(sse_error_event("internal_error"));
+                    self.finished = true;
+                    break;
+                }
+            }
+            if batch.stream_closed && !batch.more_available && !self.finished {
+                self.pending
+                    .push_back(sse_complete_event(self.checkpoint.as_deref()));
+                self.finished = true;
+            }
+            if !self.pending.is_empty() || self.finished {
+                continue;
+            }
+            if batch.more_available {
+                continue;
+            }
+            let wait = self
+                .deadline
+                .saturating_duration_since(Instant::now())
+                .min(DURABLE_RECHECK_INTERVAL);
+            if wait.is_zero() {
+                continue;
+            }
+            let _wake = self.subscription.wait_or_recheck(wait).await;
+            if self.last_write.elapsed() >= SSE_HEARTBEAT_INTERVAL {
+                self.pending
+                    .push_back(Bytes::from_static(b": keepalive\n\n"));
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TicketResponse<'a> {
+    protocol_version: u16,
+    ticket: &'a str,
+    expires_at_ms: i64,
+    transports: [TransportCapability; 1],
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TransportCapability {
+    kind: &'static str,
+    method: &'static str,
+    path: &'static str,
+}
+
+pub(crate) fn issued_response(issued: &IssuedLiveLogAccess) -> Response {
+    let response = TicketResponse {
+        protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+        ticket: issued.credential.expose_secret(),
+        expires_at_ms: issued.expires_at.get(),
+        transports: [TransportCapability {
+            kind: "sse",
+            method: "POST",
+            path: LIVE_LOG_SSE_PATH,
+        }],
+    };
+    ([(CACHE_CONTROL, "no-store")], Json(response)).into_response()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SseLogDocument<'a> {
+    protocol_version: u16,
+    stream_id: String,
+    sequence: u64,
+    fragment: Option<u32>,
+    emitted_at_ms: i64,
+    channel: &'static str,
+    text: &'a str,
+}
+
+fn sse_log_event(scope: &HumanLiveLogScope, record: &LiveLogRecord) -> Result<Bytes, ()> {
+    let channel = match record.line.channel {
+        LogChannel::Stdout => "stdout",
+        LogChannel::Stderr => "stderr",
+        LogChannel::System => "system",
+    };
+    let document = SseLogDocument {
+        protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+        stream_id: scope.stream_id().to_string(),
+        sequence: record.line.sequence,
+        fragment: record.line.fragment,
+        emitted_at_ms: record.line.emitted_at.get(),
+        channel,
+        text: &record.line.text,
+    };
+    let json = serde_json::to_string(&document).map_err(|_| ())?;
+    Ok(Bytes::from(format!(
+        "id: {}\nevent: log\ndata: {json}\n\n",
+        record.checkpoint
+    )))
+}
+
+fn sse_complete_event(checkpoint: Option<&str>) -> Bytes {
+    let id = checkpoint.map_or_else(String::new, |checkpoint| format!("id: {checkpoint}\n"));
+    Bytes::from(format!(
+        "{id}event: complete\ndata: {{\"protocolVersion\":{HUMAN_LIVE_LOG_PROTOCOL_VERSION}}}\n\n"
+    ))
+}
+
+fn sse_reconnect_event() -> Bytes {
+    Bytes::from(format!(
+        "event: reconnect\ndata: {{\"protocolVersion\":{HUMAN_LIVE_LOG_PROTOCOL_VERSION}}}\n\n"
+    ))
+}
+
+fn sse_error_event(error: &'static str) -> Bytes {
+    Bytes::from(format!(
+        "event: error\ndata: {{\"protocolVersion\":{HUMAN_LIVE_LOG_PROTOCOL_VERSION},\"error\":\"{error}\"}}\n\n"
+    ))
+}
+
+fn generate_ticket() -> Result<SecretString, LiveLogServiceError> {
+    let mut entropy = Zeroizing::new([0_u8; TICKET_RANDOM_BYTES]);
+    getrandom::fill(entropy.as_mut()).map_err(|_| LiveLogServiceError::Internal)?;
+    let encoded = URL_SAFE_NO_PAD.encode(entropy.as_ref());
+    SecretString::new(format!("{TICKET_PREFIX}{encoded}"))
+        .map_err(|_| LiveLogServiceError::Internal)
+}
+
+fn ticket_digest(raw: &str) -> Result<[u8; 32], LiveLogServiceError> {
+    if raw.len() != TICKET_LENGTH || !raw.starts_with(TICKET_PREFIX) {
+        return Err(LiveLogServiceError::InvalidCredential);
+    }
+    let encoded = &raw[TICKET_PREFIX.len()..];
+    let mut decoded = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| LiveLogServiceError::InvalidCredential)?;
+    let canonical =
+        decoded.len() == TICKET_RANDOM_BYTES && URL_SAFE_NO_PAD.encode(&decoded) == encoded;
+    decoded.zeroize();
+    if !canonical {
+        return Err(LiveLogServiceError::InvalidCredential);
+    }
+    Ok(Sha256::digest(raw.as_bytes()).into())
+}
+
+fn authorization_ticket(headers: &HeaderMap) -> Option<&str> {
+    let value = exact_header(headers, &AUTHORIZATION)?;
+    let ticket = value.strip_prefix("AutomataLogTicket ")?;
+    (ticket.len() == TICKET_LENGTH && !ticket.bytes().any(|byte| byte.is_ascii_whitespace()))
+        .then_some(ticket)
+}
+
+fn checkpoint_header(headers: &HeaderMap) -> Result<Option<&str>, ()> {
+    let Some(value) = exact_optional_header(headers, &LAST_EVENT_ID)? else {
+        return Ok(None);
+    };
+    if value.is_empty()
+        || value.len() > MAX_CHECKPOINT_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(());
+    }
+    Ok(Some(value))
+}
+
+fn request_origin(headers: &HeaderMap) -> Option<&str> {
+    exact_header(headers, &ORIGIN)
+}
+
+fn allowed_request_origin<'a>(state: &StreamState, headers: &'a HeaderMap) -> Option<&'a str> {
+    let origin = request_origin(headers)?;
+    state.allowed_origins.contains(origin).then_some(origin)
+}
+
+fn exact_header<'a>(headers: &'a HeaderMap, name: &HeaderName) -> Option<&'a str> {
+    exact_optional_header(headers, name).ok().flatten()
+}
+
+fn exact_optional_header<'a>(
+    headers: &'a HeaderMap,
+    name: &HeaderName,
+) -> Result<Option<&'a str>, ()> {
+    let mut values = headers.get_all(name).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(());
+    }
+    value.to_str().map(Some).map_err(|_| ())
+}
+
+fn valid_preflight_headers(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let mut saw_authorization = false;
+    for header in value.split(',').map(str::trim) {
+        if header.eq_ignore_ascii_case("authorization") {
+            if saw_authorization {
+                return false;
+            }
+            saw_authorization = true;
+        } else if !header.eq_ignore_ascii_case("last-event-id") {
+            return false;
+        }
+    }
+    saw_authorization
+}
+
+fn insert_cors_headers(headers: &mut HeaderMap, origin: &str) {
+    if let Ok(origin) = HeaderValue::from_str(origin) {
+        headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    }
+    headers.append(VARY, HeaderValue::from_static("Origin"));
+}
+
+async fn request_body_is_empty(request: Request) -> bool {
+    if request
+        .headers()
+        .get(CONTENT_LENGTH)
+        .is_some_and(|length| length != "0")
+    {
+        return false;
+    }
+    to_bytes(request.into_body(), MAX_REQUEST_BODY_BYTES)
+        .await
+        .is_ok_and(|bytes| bytes.is_empty())
+}
+
+pub(crate) fn repository_path(owner: String, name: String) -> Option<RepositoryPath> {
+    (valid_route_segment(&owner) && valid_route_segment(&name))
+        .then_some(RepositoryPath { owner, name })
+}
+
+fn valid_route_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && !matches!(value, "." | "..")
+        && !value.chars().any(char::is_control)
+}
+
+pub(crate) fn parse_run_id(value: &str) -> Option<RunId> {
+    let id = RunId::from_str(value).ok()?;
+    (!id.as_uuid().is_nil() && id.to_string() == value).then_some(id)
+}
+
+pub(crate) fn parse_job_id(value: &str) -> Option<JobId> {
+    let id = JobId::from_str(value).ok()?;
+    (!id.as_uuid().is_nil() && id.to_string() == value).then_some(id)
+}
+
+pub(crate) fn service_error_response(error: LiveLogServiceError) -> Response {
+    match error {
+        LiveLogServiceError::InvalidCredential => {
+            json_error(StatusCode::UNAUTHORIZED, "unauthorized")
+        }
+        LiveLogServiceError::Data(WebDataError::InvalidRequest) => {
+            json_error(StatusCode::BAD_REQUEST, "invalid_request")
+        }
+        LiveLogServiceError::Data(WebDataError::Unavailable) | LiveLogServiceError::Unavailable => {
+            json_error(StatusCode::SERVICE_UNAVAILABLE, "unavailable")
+        }
+        LiveLogServiceError::Data(WebDataError::Corrupt) | LiveLogServiceError::Internal => {
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
+        }
+    }
+}
+
+fn stream_service_error(error: LiveLogServiceError, origin: Option<&str>) -> Response {
+    match error {
+        LiveLogServiceError::InvalidCredential => {
+            stream_error(StatusCode::UNAUTHORIZED, "unauthorized", origin)
+        }
+        LiveLogServiceError::Data(WebDataError::InvalidRequest) => {
+            stream_error(StatusCode::BAD_REQUEST, "invalid_request", origin)
+        }
+        LiveLogServiceError::Data(WebDataError::Unavailable) | LiveLogServiceError::Unavailable => {
+            stream_error(StatusCode::SERVICE_UNAVAILABLE, "unavailable", origin)
+        }
+        LiveLogServiceError::Data(WebDataError::Corrupt) | LiveLogServiceError::Internal => {
+            stream_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", origin)
+        }
+    }
+}
+
+fn json_error(status: StatusCode, code: &'static str) -> Response {
+    (
+        status,
+        [(CACHE_CONTROL, "no-store")],
+        Json(serde_json::json!({ "error": code })),
+    )
+        .into_response()
+}
+
+fn stream_error(status: StatusCode, code: &'static str, origin: Option<&str>) -> Response {
+    let mut response = json_error(status, code);
+    if let Some(origin) = origin {
+        insert_cors_headers(response.headers_mut(), origin);
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use automata_ci_core::{AttemptId, LogStreamId};
+    use automata_ci_store::{RedeemedHumanLiveLogTicket, RepositoryId, StoreError, TenantScope};
+    use tokio::sync::Mutex;
+    use tower::ServiceExt as _;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::app::web::EmptyWebData;
+
+    #[derive(Debug)]
+    struct OneTicketRepository {
+        entry: Mutex<Option<([u8; 32], HumanLiveLogBrowserOrigin, HumanLiveLogScope)>>,
+    }
+
+    #[async_trait]
+    impl HumanLiveLogTicketRepository for OneTicketRepository {
+        async fn issue(
+            &self,
+            _request: &IssueHumanLiveLogTicket,
+        ) -> Result<IssueHumanLiveLogTicketOutcome, StoreError> {
+            Ok(IssueHumanLiveLogTicketOutcome::DigestCollision)
+        }
+
+        async fn redeem(
+            &self,
+            request: &RedeemHumanLiveLogTicket,
+        ) -> Result<Option<RedeemedHumanLiveLogTicket>, StoreError> {
+            let mut entry = self.entry.lock().await;
+            let Some((digest, origin, _)) = entry.as_ref() else {
+                return Ok(None);
+            };
+            if digest != request.token_sha256() || origin != request.browser_origin() {
+                return Ok(None);
+            }
+            let (_, _, scope) = entry.take().expect("matched ticket remains present");
+            Ok(Some(RedeemedHumanLiveLogTicket::new(
+                scope,
+                UnixMillis::new(1),
+                UnixMillis::new(2),
+            )))
+        }
+    }
+
+    fn fixture_scope() -> HumanLiveLogScope {
+        HumanLiveLogScope::new(
+            TenantScope::from_authenticated_tenant_id("workspace".to_owned()).expect("tenant"),
+            RepositoryId::from_uuid(Uuid::from_u128(1)),
+            RunId::from_uuid(Uuid::from_u128(2)),
+            JobId::from_uuid(Uuid::from_u128(3)),
+            AttemptId::from_uuid(Uuid::from_u128(4)),
+            LogStreamId::from_uuid(Uuid::from_u128(5)),
+        )
+        .expect("live-log scope")
+    }
+
+    fn stream_request(origin: &str, ticket: &str) -> Request {
+        Request::builder()
+            .method(Method::POST)
+            .uri(LIVE_LOG_SSE_PATH)
+            .header(ORIGIN, origin)
+            .header(AUTHORIZATION, format!("AutomataLogTicket {ticket}"))
+            .body(Body::empty())
+            .expect("stream request")
+    }
+
+    #[test]
+    fn generated_ticket_is_strictly_canonical_and_redacted() {
+        let ticket = generate_ticket().expect("random ticket");
+        assert!(ticket.expose_secret().starts_with(TICKET_PREFIX));
+        assert_eq!(ticket.expose_secret().len(), TICKET_LENGTH);
+        assert!(ticket_digest(ticket.expose_secret()).is_ok());
+        assert!(ticket_digest("allt_v1_not-canonical").is_err());
+        assert!(!format!("{ticket:?}").contains(ticket.expose_secret()));
+    }
+
+    #[test]
+    fn preflight_requires_only_the_bounded_supported_headers() {
+        assert!(valid_preflight_headers(Some("authorization")));
+        assert!(valid_preflight_headers(Some(
+            "Authorization, Last-Event-ID"
+        )));
+        assert!(!valid_preflight_headers(Some("last-event-id")));
+        assert!(!valid_preflight_headers(Some("authorization, cookie")));
+    }
+
+    #[tokio::test]
+    async fn sse_ticket_is_origin_bound_one_time_and_never_placed_in_the_url() {
+        let ticket = format!("{TICKET_PREFIX}{}", URL_SAFE_NO_PAD.encode([9_u8; 32]));
+        let digest = ticket_digest(&ticket).expect("ticket digest");
+        let expected_origin =
+            HumanLiveLogBrowserOrigin::new("https://cloud.automata.example").expect("origin");
+        let wrong_origin =
+            HumanLiveLogBrowserOrigin::new("https://other.automata.example").expect("origin");
+        let repository = Arc::new(OneTicketRepository {
+            entry: Mutex::new(Some((digest, expected_origin.clone(), fixture_scope()))),
+        });
+        let service = Arc::new(LiveLogService::new(
+            Arc::new(EmptyWebData),
+            repository,
+            Arc::new(HumanLogCommitNotificationHub::default()),
+        ));
+        let origins = BTreeSet::from([
+            expected_origin.as_str().to_owned(),
+            wrong_origin.as_str().to_owned(),
+        ]);
+        let app = stream_router(service, origins);
+
+        let wrong = app
+            .clone()
+            .oneshot(stream_request(wrong_origin.as_str(), &ticket))
+            .await
+            .expect("wrong-origin response");
+        assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+        let accepted = app
+            .clone()
+            .oneshot(stream_request(expected_origin.as_str(), &ticket))
+            .await
+            .expect("accepted stream");
+        assert_eq!(accepted.status(), StatusCode::OK);
+        assert_eq!(
+            accepted.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&HeaderValue::from_static("https://cloud.automata.example"))
+        );
+        let body = to_bytes(accepted.into_body(), 4 * 1024)
+            .await
+            .expect("bounded stream body");
+        let body = String::from_utf8(body.to_vec()).expect("UTF-8 SSE");
+        assert!(body.contains(": connected"));
+        assert!(body.contains("event: error"));
+        assert!(!body.contains(&ticket));
+
+        let replay = app
+            .oneshot(stream_request(expected_origin.as_str(), &ticket))
+            .await
+            .expect("replay response");
+        assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/automata-ci/src/app/live_log.rs
+++ b/crates/automata-ci/src/app/live_log.rs
@@ -520,7 +520,8 @@ pub(crate) fn issued_response(issued: &IssuedLiveLogAccess) -> Response {
 struct SseLogDocument<'a> {
     protocol_version: u16,
     stream_id: String,
-    sequence: u64,
+    /// Decimal text preserves the complete u64 identity in JavaScript.
+    sequence: String,
     fragment: Option<u32>,
     emitted_at_ms: i64,
     channel: &'static str,
@@ -536,7 +537,7 @@ fn sse_log_event(scope: &HumanLiveLogScope, record: &LiveLogRecord) -> Result<By
     let document = SseLogDocument {
         protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
         stream_id: scope.stream_id().to_string(),
-        sequence: record.line.sequence,
+        sequence: record.line.sequence.to_string(),
         fragment: record.line.fragment,
         emitted_at_ms: record.line.emitted_at.get(),
         channel,
@@ -829,6 +830,24 @@ mod tests {
         assert!(ticket_digest(ticket.expose_secret()).is_ok());
         assert!(ticket_digest("allt_v1_not-canonical").is_err());
         assert!(!format!("{ticket:?}").contains(ticket.expose_secret()));
+    }
+
+    #[test]
+    fn sse_log_sequences_remain_lossless_for_javascript_clients() {
+        let document = SseLogDocument {
+            protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+            stream_id: Uuid::from_u128(5).to_string(),
+            sequence: u64::MAX.to_string(),
+            fragment: None,
+            emitted_at_ms: 1_777_890_010_000,
+            channel: "stdout",
+            text: "complete",
+        };
+
+        let json = serde_json::to_string(&document).expect("SSE JSON");
+
+        assert!(json.contains(r#""sequence":"18446744073709551615""#));
+        assert!(!json.contains(r#""sequence":18446744073709551615"#));
     }
 
     #[test]

--- a/crates/automata-ci/src/app/mod.rs
+++ b/crates/automata-ci/src/app/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod github_auth;
 pub mod http;
 pub(crate) mod human_auth;
 pub(crate) mod human_auth_middleware;
+pub(crate) mod live_log;
 pub(crate) mod management_api;
 pub(crate) mod protected_environment_review_api;
 pub(crate) mod publication_settings;

--- a/crates/automata-ci/src/app/web/data.rs
+++ b/crates/automata-ci/src/app/web/data.rs
@@ -22,6 +22,7 @@ use automata_ci_auth::{
     time::Clock,
 };
 use automata_ci_core::{JobId, RunId, UnixMillis, WorkflowId};
+use automata_ci_store::HumanLiveLogScope;
 use bytes::Bytes;
 use futures::Stream;
 use thiserror::Error;
@@ -1139,6 +1140,28 @@ pub(crate) struct JobLogLive {
     pub(crate) more_available: bool,
 }
 
+/// One exact authorized live-log resource returned without a bearer credential.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AuthorizedLiveLog {
+    pub(crate) scope: HumanLiveLogScope,
+}
+
+/// One transport-neutral log record and its post-record durable checkpoint.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LiveLogRecord {
+    pub(crate) checkpoint: String,
+    pub(crate) line: LogLine,
+}
+
+/// One bounded forward read used by every live-log transport adapter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LiveLogBatch {
+    pub(crate) records: Vec<LiveLogRecord>,
+    pub(crate) checkpoint: Option<String>,
+    pub(crate) stream_closed: bool,
+    pub(crate) more_available: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JobNavigationItem {
     pub(crate) id: JobId,
@@ -1250,6 +1273,27 @@ pub(crate) trait WebData: fmt::Debug + Send + Sync {
         job_id: JobId,
         request: &JobLogRequest,
     ) -> Result<Option<JobLogPage>, WebDataError>;
+
+    /// Authorizes one exact current attempt stream without issuing credentials.
+    async fn authorize_live_log(
+        &self,
+        _context: &RequestContext,
+        _repository: &RepositoryPath,
+        _run_id: RunId,
+        _job_id: JobId,
+    ) -> Result<Option<AuthorizedLiveLog>, WebDataError> {
+        Ok(None)
+    }
+
+    /// Reads one bounded forward batch from previously authorized exact scope.
+    async fn read_live_log(
+        &self,
+        _scope: &HumanLiveLogScope,
+        _checkpoint: Option<&str>,
+        _replay_checkpoint: bool,
+    ) -> Result<Option<LiveLogBatch>, WebDataError> {
+        Ok(None)
+    }
 
     async fn artifact(
         &self,

--- a/crates/automata-ci/src/app/web/live.rs
+++ b/crates/automata-ci/src/app/web/live.rs
@@ -21,7 +21,7 @@ use automata_ci_results_github::{
 use automata_ci_store::{
     HumanArtifactBlock, HumanArtifactDownload as StoredArtifactDownload, HumanArtifactId,
     HumanArtifactScope, HumanArtifactSummary, HumanAuthorizationTarget, HumanGitRef, HumanJob,
-    HumanJobDetail, HumanJobNavigation, HumanJobScope, HumanLogSegmentCursor,
+    HumanJobDetail, HumanJobNavigation, HumanJobScope, HumanLiveLogScope, HumanLogSegmentCursor,
     HumanLogSegmentPageDirection, HumanLogSegmentPageSize, HumanLogSegmentQuery,
     HumanOutputPublication, HumanPageSize, HumanRawLogDisposition, HumanRepository,
     HumanRepositoryCursor, HumanRepositoryListQuery, HumanRepositoryPage, HumanRun,
@@ -37,12 +37,13 @@ use sha2::{Digest as _, Sha256};
 use super::{
     codec::{LogSegmentExpectation, decode_log_segment},
     data::{
-        ArtifactDownload, ArtifactSummary, CollectionVisibility, JobLogLive, JobLogPage,
-        JobLogRequest, JobNavigationItem, JobSummary, LogChannel, LogLine, Repository,
-        RepositoryDirectoryItem, RepositoryDirectoryPage, RepositoryDirectoryRequest,
-        RepositoryPath, RepositorySettingsDestination, RepositorySettingsPage, RequestContext,
-        RunDetailPage, RunDetailRequest, RunListPage, RunListRequest, RunSummary, Status,
-        StatusFilter, VisibleCollection, WebData, WebDataError, Workflow, WorkflowDefinition,
+        ArtifactDownload, ArtifactSummary, AuthorizedLiveLog, CollectionVisibility, JobLogLive,
+        JobLogPage, JobLogRequest, JobNavigationItem, JobSummary, LiveLogBatch, LiveLogRecord,
+        LogChannel, LogLine, Repository, RepositoryDirectoryItem, RepositoryDirectoryPage,
+        RepositoryDirectoryRequest, RepositoryPath, RepositorySettingsDestination,
+        RepositorySettingsPage, RequestContext, RunDetailPage, RunDetailRequest, RunListPage,
+        RunListRequest, RunSummary, Status, StatusFilter, VisibleCollection, WebData, WebDataError,
+        Workflow, WorkflowDefinition,
     },
     text::is_safe_display_text,
 };
@@ -2681,6 +2682,234 @@ impl WebData for LiveWebData {
         .await
     }
 
+    async fn authorize_live_log(
+        &self,
+        context: &RequestContext,
+        repository_path: &RepositoryPath,
+        run_id: RunId,
+        job_id: JobId,
+    ) -> Result<Option<AuthorizedLiveLog>, WebDataError> {
+        let tenant = Self::tenant(context)?;
+        let Some(repository) = self
+            .resolve_repository_exact(&tenant, repository_path)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let job_scope = HumanJobScope::new(tenant.clone(), repository.id, run_id, job_id);
+        let Some(detail) = self
+            .reads
+            .get_job(&job_scope)
+            .await
+            .map_err(map_store_error)?
+        else {
+            return Ok(None);
+        };
+        if detail.run.id != run_id || detail.job.id != job_id {
+            return Err(WebDataError::Corrupt);
+        }
+        let Some(stream) = detail.log_stream.as_ref() else {
+            return Ok(None);
+        };
+        let Some(attempt) = detail.job.latest_attempt.as_ref() else {
+            return Err(WebDataError::Corrupt);
+        };
+        if detail.job.log_publication.as_ref() != Some(&stream.publication)
+            || stream.attempt_id != attempt.id
+            || !log_stream_safety_is_valid(stream)
+        {
+            return Err(WebDataError::Corrupt);
+        }
+        if !self
+            .log_access_allowed(context, &tenant, &repository, Some(&stream.publication))
+            .await?
+        {
+            return Ok(None);
+        }
+        let scope =
+            HumanLiveLogScope::new(tenant, repository.id, run_id, job_id, attempt.id, stream.id)
+                .map_err(|_| WebDataError::Corrupt)?;
+        Ok(Some(AuthorizedLiveLog { scope }))
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the bounded tail keeps checkpoint, segment, blob, and record validation contiguous"
+    )]
+    async fn read_live_log(
+        &self,
+        scope: &HumanLiveLogScope,
+        checkpoint: Option<&str>,
+        replay_checkpoint: bool,
+    ) -> Result<Option<LiveLogBatch>, WebDataError> {
+        let decoded_checkpoint = match checkpoint {
+            None => None,
+            Some(checkpoint) => {
+                let Some(decoded) = decode_log_cursor(
+                    checkpoint,
+                    scope.tenant(),
+                    scope.repository_id(),
+                    scope.run_id(),
+                    scope.job_id(),
+                    scope.stream_id(),
+                ) else {
+                    return Ok(None);
+                };
+                if decoded.direction != HumanLogSegmentPageDirection::Newer {
+                    return Ok(None);
+                }
+                Some(decoded)
+            }
+        };
+        let query = HumanLogSegmentQuery {
+            scope: HumanJobScope::new(
+                scope.tenant().clone(),
+                scope.repository_id(),
+                scope.run_id(),
+                scope.job_id(),
+            ),
+            stream_id: scope.stream_id(),
+            cursor: decoded_checkpoint.map(|cursor| HumanLogSegmentCursor {
+                sequence: cursor.sequence,
+                direction: HumanLogSegmentPageDirection::Newer,
+            }),
+            limit: HumanLogSegmentPageSize::new(LOG_SEGMENT_PAGE_SIZE)
+                .map_err(|_| WebDataError::Corrupt)?,
+        };
+        let Some(page) = self
+            .reads
+            .list_log_segments(&query)
+            .await
+            .map_err(map_store_error)?
+        else {
+            return Ok(None);
+        };
+        if page.stream.id != scope.stream_id()
+            || page.stream.attempt_id != scope.attempt_id()
+            || !log_stream_safety_is_valid(&page.stream)
+        {
+            return Err(WebDataError::Corrupt);
+        }
+
+        let mut records = Vec::new();
+        let mut decoded_bytes = 0_usize;
+        let mut checkpoint_cursor = decoded_checkpoint;
+        let mut saw_boundary = decoded_checkpoint.is_none();
+        let mut hit_limit = false;
+        'segments: for segment in &page.segments {
+            let blob = self
+                .objects
+                .get_verified(&segment.descriptor, segment.descriptor.size())
+                .await
+                .map_err(map_blob_error)?;
+            let expectation = LogSegmentExpectation::new(
+                scope.attempt_id(),
+                scope.stream_id(),
+                segment.first_sequence,
+                segment.last_sequence,
+                segment.uncompressed_size,
+                segment.end_of_stream,
+            );
+            let frames =
+                tokio::task::spawn_blocking(move || decode_log_segment(&blob, expectation))
+                    .await
+                    .map_err(|_| WebDataError::Unavailable)?
+                    .map_err(|_| WebDataError::Corrupt)?;
+            for frame in frames {
+                let candidates = render_frame_lines(&frame)?;
+                if candidates.is_empty() {
+                    checkpoint_cursor = Some(DecodedLogCursor {
+                        sequence: frame.sequence(),
+                        line_ordinal: 0,
+                        direction: HumanLogSegmentPageDirection::Newer,
+                    });
+                }
+                if let Some(boundary) = decoded_checkpoint {
+                    if frame.sequence() < boundary.sequence {
+                        continue;
+                    }
+                    if frame.sequence() > boundary.sequence && !saw_boundary {
+                        return Ok(None);
+                    }
+                    if frame.sequence() == boundary.sequence {
+                        saw_boundary = true;
+                        if usize::try_from(boundary.line_ordinal)
+                            .ok()
+                            .is_none_or(|ordinal| ordinal >= candidates.len())
+                            && !(boundary.line_ordinal == 0 && frame.payload().is_empty())
+                        {
+                            return Ok(None);
+                        }
+                    }
+                }
+                for candidate in candidates {
+                    let candidate_position = (candidate.sequence.get(), candidate.ordinal);
+                    if let Some(boundary) = decoded_checkpoint {
+                        let boundary_position = (boundary.sequence.get(), boundary.line_ordinal);
+                        if candidate_position < boundary_position
+                            || (!replay_checkpoint && candidate_position == boundary_position)
+                        {
+                            continue;
+                        }
+                    }
+                    let next_bytes = decoded_bytes
+                        .checked_add(candidate.text.len())
+                        .ok_or(WebDataError::Corrupt)?;
+                    if records.len() == super::data::LOG_PAGE_SIZE
+                        || next_bytes > super::data::LOG_PAGE_DECODED_BYTES
+                    {
+                        hit_limit = true;
+                        break 'segments;
+                    }
+                    decoded_bytes = next_bytes;
+                    let cursor =
+                        rendered_line_cursor(&candidate, HumanLogSegmentPageDirection::Newer);
+                    let checkpoint = encode_log_cursor(
+                        scope.tenant(),
+                        scope.repository_id(),
+                        scope.run_id(),
+                        scope.job_id(),
+                        scope.stream_id(),
+                        cursor,
+                    );
+                    checkpoint_cursor = Some(cursor);
+                    records.push(LiveLogRecord {
+                        checkpoint,
+                        line: visible_log_line(candidate),
+                    });
+                }
+            }
+        }
+        if !cursor_boundary_is_valid(decoded_checkpoint, saw_boundary, &page) {
+            return Ok(None);
+        }
+        let more_available = hit_limit || page.newer_cursor.is_some();
+        let stream_closed = page.stream.closed_at.is_some() && !more_available;
+        if stream_closed
+            && page
+                .segments
+                .last()
+                .is_some_and(|segment| !segment.end_of_stream)
+        {
+            return Err(WebDataError::Corrupt);
+        }
+        Ok(Some(LiveLogBatch {
+            records,
+            checkpoint: checkpoint_cursor.map(|cursor| {
+                encode_log_cursor(
+                    scope.tenant(),
+                    scope.repository_id(),
+                    scope.run_id(),
+                    scope.job_id(),
+                    scope.stream_id(),
+                    cursor,
+                )
+            }),
+            stream_closed,
+            more_available,
+        }))
+    }
+
     async fn artifact(
         &self,
         context: &RequestContext,
@@ -4247,6 +4476,55 @@ mod tests {
         assert_eq!(
             replay.live.and_then(|live| live.checkpoint).as_deref(),
             Some(checkpoint.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_neutral_tail_authorizes_exact_scope_and_controls_replay() {
+        let (data, context, repository, run_id, job_id) = fake_live_data(true).await;
+        let authorized = WebData::authorize_live_log(&data, &context, &repository, run_id, job_id)
+            .await
+            .expect("authorize live log")
+            .expect("authorized exact stream");
+
+        let first = WebData::read_live_log(&data, &authorized.scope, None, true)
+            .await
+            .expect("initial durable tail")
+            .expect("current stream");
+        assert_eq!(first.records.len(), 1);
+        assert_eq!(first.records[0].line.text, "checkout ok");
+        assert!(first.stream_closed);
+        assert!(!first.more_available);
+        let checkpoint = first.records[0].checkpoint.clone();
+
+        let replay = WebData::read_live_log(&data, &authorized.scope, Some(&checkpoint), true)
+            .await
+            .expect("replay durable tail")
+            .expect("same stream");
+        assert_eq!(replay.records.len(), 1);
+        assert_eq!(replay.records[0].checkpoint, checkpoint);
+
+        let advanced = WebData::read_live_log(&data, &authorized.scope, Some(&checkpoint), false)
+            .await
+            .expect("advance durable tail")
+            .expect("same stream");
+        assert!(advanced.records.is_empty());
+        assert_eq!(advanced.checkpoint, first.checkpoint);
+        assert!(advanced.stream_closed);
+
+        let (denied, denied_context, denied_repository, denied_run, denied_job) =
+            fake_live_data(false).await;
+        assert!(
+            WebData::authorize_live_log(
+                &denied,
+                &denied_context,
+                &denied_repository,
+                denied_run,
+                denied_job,
+            )
+            .await
+            .expect("closed authorization decision")
+            .is_none()
         );
     }
 

--- a/crates/automata-ci/src/app/web/mod.rs
+++ b/crates/automata-ci/src/app/web/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use data::{
     RbacRoleListPage, RbacRoleListRequest, RbacUserDetailPage, RbacUserDetailRequest,
     RbacUserListPage, RbacUserListRequest, RbacWebDataError, RbacWebReadOutcome,
 };
+pub(crate) use data::{LiveLogBatch, LiveLogRecord, LogChannel, RepositoryPath, WebDataError};
 pub(crate) use data::{ManagementRbacWebData, RbacWebData, RequestContext, Viewer, WebData};
 pub(crate) use data::{
     SetupPageAvailability, SetupPageAvailabilityError, SetupPageAvailabilityState,

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, fmt, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use automata_ci_auth::{
@@ -69,7 +69,8 @@ use automata_ci_runner_transport::{
 use automata_ci_secret::{SecretProvider, SecretProviderRegistry};
 use automata_ci_secret_postgres::PostgresSecretProvider;
 use automata_ci_store::{
-    BuiltinSecretCleanupRepository, ConformanceReadRepository, HumanWorkflowReadRepository,
+    BuiltinSecretCleanupRepository, ConformanceReadRepository, HumanLiveLogBrowserOrigin,
+    HumanLiveLogTicketRepository, HumanLogCommitNotificationHub, HumanWorkflowReadRepository,
     LogicalActivationPreparationStore, LogicalActivationRepository, LogicalActivationWorkerId,
     LogicalInstanceResultRepository, LogicalInstanceResultWorkerId, LogicalJobResultRepository,
     LogicalJobResultWorkerId, LogicalMaterializationRepository, LogicalMaterializationWorkerId,
@@ -82,8 +83,8 @@ use automata_ci_store::{
     WorkflowRerunRepository,
 };
 use automata_ci_store_postgres::{
-    PostgresSecretCustodyRepository, PostgresSecretManagementRepository, PostgresStore,
-    PostgresStoreError,
+    PostgresLiveLogTicketRepository, PostgresLogCommitListener, PostgresSecretCustodyRepository,
+    PostgresSecretManagementRepository, PostgresStore, PostgresStoreError,
 };
 use automata_ci_workflow_service::{
     AdmissionClock, AutonomousWorkflowPhaseExecutor, AutonomousWorkflowService,
@@ -124,6 +125,7 @@ use crate::app::{
         setup_router as github_setup_router,
     },
     human_auth_middleware::HumanRequestAuthentication,
+    live_log::{LiveLogService, browser_ticket_router, stream_router as live_log_stream_router},
     management_api::management_api_router,
     protected_environment_review_api::{
         ProtectedEnvironmentReviewApiBackend, protected_environment_review_api_router,
@@ -190,6 +192,9 @@ pub(crate) struct ProductionComponents {
     pub(crate) state_sampler: ControlPlaneStateSampler,
     pub(crate) human_api: Router,
     pub(crate) delegated_actor_api: Option<Router>,
+    pub(crate) live_log_stream_api: Router,
+    pub(crate) log_commit_listener: Option<PostgresLogCommitListener>,
+    pub(crate) log_commit_notifications: Arc<HumanLogCommitNotificationHub>,
     pub(crate) human_request_authentication: Option<HumanRequestAuthentication>,
     pub(crate) rbac_web_data: Option<Arc<dyn RbacWebData>>,
     pub(crate) setup_page_availability: Option<Arc<dyn SetupPageAvailability>>,
@@ -219,6 +224,9 @@ impl fmt::Debug for ProductionComponents {
             .field("state_sampler", &self.state_sampler)
             .field("human_api", &self.human_api)
             .field("delegated_actor_api", &self.delegated_actor_api)
+            .field("live_log_stream_api", &self.live_log_stream_api)
+            .field("log_commit_listener", &self.log_commit_listener)
+            .field("log_commit_notifications", &self.log_commit_notifications)
             .field(
                 "human_request_authentication",
                 &self.human_request_authentication,
@@ -259,26 +267,10 @@ impl ProductionComponents {
         // the migrator on every readiness tick repeatedly acquires migration
         // locks and emits expected duplicate-table diagnostics under SQLx.
         store.migrate().await?;
-        let delegated_actor_api = config
-            .management()
-            .map(|management| -> Result<Router, ServerCompositionError> {
-                let verifier = DelegatedActorVerifier::new(DelegatedActorVerifierConfig {
-                    issuer: management
-                        .authority()
-                        .delegated_actor_issuer()
-                        .as_str()
-                        .to_owned(),
-                    audience: management.authority().shard_id().as_str().to_owned(),
-                    jwks_url: management.delegated_actor_jwks_url().clone(),
-                })
-                .map_err(|_| ServerCompositionError::InvalidManagementConfiguration)?;
-                let resolver: Arc<dyn automata_ci_auth::delegated_actor::DelegatedActorResolver> =
-                    Arc::new(PostgresDelegatedActorResolver::new(
-                        store.postgres_pool().clone(),
-                    ));
-                Ok(delegated_actor_api_router(Arc::new(verifier), resolver))
-            })
-            .transpose()?;
+        let log_commit_notifications = Arc::new(HumanLogCommitNotificationHub::default());
+        let log_commit_listener = PostgresLogCommitListener::connect(store.postgres_pool())
+            .await
+            .map_err(|_| ServerCompositionError::LiveLogStorage)?;
         let management_server =
             build_management_server(config, management_listener, store.as_ref())?;
         let workflow_clock: Arc<dyn AdmissionClock> = Arc::new(SystemAdmissionClock);
@@ -380,6 +372,68 @@ impl ProductionComponents {
                     ));
                 data
             });
+        let live_web_data = LiveWebData::new(Arc::clone(&human_reads), Arc::clone(&blob_store));
+        let live_web_data = if let Some(secrets) = repository_secret_web.as_ref() {
+            live_web_data.with_repository_secrets(Arc::clone(secrets))
+        } else {
+            live_web_data
+        };
+        let web_data: Arc<dyn WebData> = Arc::new(live_web_data);
+        let ticket_repository: Arc<dyn HumanLiveLogTicketRepository> = Arc::new(
+            PostgresLiveLogTicketRepository::new(store.postgres_pool().clone()),
+        );
+        let live_log_service = Arc::new(LiveLogService::new(
+            Arc::clone(&web_data),
+            ticket_repository,
+            Arc::clone(&log_commit_notifications),
+        ));
+        let mut live_log_origins = BTreeSet::new();
+        if let Some(human_auth) = config.human_auth() {
+            let origin = human_auth.external_url().origin().ascii_serialization();
+            HumanLiveLogBrowserOrigin::new(origin.clone())
+                .map_err(|_| ServerCompositionError::InvalidHumanAuthentication)?;
+            live_log_origins.insert(origin);
+        }
+        if let Some(management) = config.management() {
+            let origin = management
+                .authority()
+                .delegated_actor_issuer()
+                .as_str()
+                .to_owned();
+            HumanLiveLogBrowserOrigin::new(origin.clone())
+                .map_err(|_| ServerCompositionError::InvalidManagementConfiguration)?;
+            live_log_origins.insert(origin);
+        }
+        let live_log_stream_api =
+            live_log_stream_router(Arc::clone(&live_log_service), live_log_origins);
+        let delegated_actor_api = config
+            .management()
+            .map(|management| -> Result<Router, ServerCompositionError> {
+                let issuer = management
+                    .authority()
+                    .delegated_actor_issuer()
+                    .as_str()
+                    .to_owned();
+                let verifier = DelegatedActorVerifier::new(DelegatedActorVerifierConfig {
+                    issuer: issuer.clone(),
+                    audience: management.authority().shard_id().as_str().to_owned(),
+                    jwks_url: management.delegated_actor_jwks_url().clone(),
+                })
+                .map_err(|_| ServerCompositionError::InvalidManagementConfiguration)?;
+                let resolver: Arc<dyn automata_ci_auth::delegated_actor::DelegatedActorResolver> =
+                    Arc::new(PostgresDelegatedActorResolver::new(
+                        store.postgres_pool().clone(),
+                    ));
+                let origin = HumanLiveLogBrowserOrigin::new(issuer)
+                    .map_err(|_| ServerCompositionError::InvalidManagementConfiguration)?;
+                Ok(delegated_actor_api_router(
+                    Arc::new(verifier),
+                    resolver,
+                    Arc::clone(&live_log_service),
+                    origin,
+                ))
+            })
+            .transpose()?;
         let mut human = build_human_api(
             config,
             store.clone(),
@@ -389,6 +443,7 @@ impl ProductionComponents {
             repository_secret_web.clone(),
             fallback_tenant,
             capability_readiness,
+            Arc::clone(&live_log_service),
         )
         .await?;
         let github_provider_config = validate_effective_ui_tenant(config, &human.effective_tenant)?;
@@ -435,13 +490,6 @@ impl ProductionComponents {
         )
         .await?;
 
-        let live_web_data = LiveWebData::new(Arc::clone(&human_reads), Arc::clone(&blob_store));
-        let live_web_data = if let Some(secrets) = repository_secret_web.as_ref() {
-            live_web_data.with_repository_secrets(Arc::clone(secrets))
-        } else {
-            live_web_data
-        };
-        let web_data: Arc<dyn WebData> = Arc::new(live_web_data);
         let maintenance_loop = build_maintenance_loop(config, store.clone(), metrics)?;
         let (results_api, results_runtime_authority_issuer) =
             build_results(config, store.as_ref(), blob_store.clone(), metrics)?;
@@ -586,6 +634,9 @@ impl ProductionComponents {
             state_sampler,
             human_api: human.router,
             delegated_actor_api,
+            live_log_stream_api,
+            log_commit_listener: Some(log_commit_listener),
+            log_commit_notifications,
             human_request_authentication: human.request_authentication,
             rbac_web_data: human.rbac_web_data,
             setup_page_availability: human.setup_page_availability,
@@ -1540,6 +1591,7 @@ async fn build_human_api(
     repository_secret_web: Option<Arc<dyn RepositorySecretWebData>>,
     fallback_tenant: TenantId,
     capability_readiness: RunnerCapabilityReadiness,
+    live_log_service: Arc<LiveLogService>,
 ) -> Result<HumanApiComposition, ServerCompositionError> {
     let deployment_token = config.load_conformance_export_token()?;
     let mut router = match deployment_token.as_deref() {
@@ -1593,6 +1645,9 @@ async fn build_human_api(
     };
     let runtime = HumanAuthRuntime::build(config, store.as_ref())
         .map_err(|_| ServerCompositionError::InvalidHumanAuthentication)?;
+    let live_log_origin = HumanLiveLogBrowserOrigin::new(runtime.origin().as_str().to_owned())
+        .map_err(|_| ServerCompositionError::InvalidHumanAuthentication)?;
+    router = router.merge(browser_ticket_router(live_log_service, live_log_origin));
     let installation = runtime
         .installation_repository()
         .load()
@@ -2019,6 +2074,9 @@ pub enum ServerCompositionError {
     /// The private management listener's TLS identity or product wiring was invalid.
     #[error("management listener configuration is invalid")]
     InvalidManagementConfiguration,
+    /// The live-log ticket or notification store could not be initialized.
+    #[error("live-log storage initialization failed")]
+    LiveLogStorage,
     /// The reviewed TLS/transport policy rejected the supplied configuration.
     #[error(transparent)]
     Transport(#[from] TransportConfigurationError),

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -27,16 +27,18 @@ mod state_metrics;
 mod workflow_dispatch;
 mod workflow_rerun;
 
-use std::{future::Future, net::SocketAddr, pin::Pin, time::Duration};
+use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::{Context as _, Result};
 use automata_ci_blob::BlobStoreErrorKind;
 use automata_ci_provisioning_grpc::ManagementGrpcServer;
 use automata_ci_runner_transport::RunnerControlServer;
 use automata_ci_store::{
+    HumanLogCommitNotificationHub, HumanLogCommitNotificationSource,
     LogicalInstanceResultStoreError, LogicalInstanceResultValueError, LogicalJobResultStoreError,
     LogicalJobResultValueError, StoreError,
 };
+use automata_ci_store_postgres::PostgresLogCommitListener;
 use automata_ci_workflow_service::{
     AutonomousWorkflowService, LogicalResultProjectionError, LogicalResultProjectionOutcome,
     LogicalResultProjectionService, LogicalRunFinalizationService, ReusableWorkflowRuntimeService,
@@ -51,7 +53,7 @@ use futures::{StreamExt as _, stream::FuturesUnordered};
 use thiserror::Error;
 use tokio::{net::TcpListener, sync::oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{app::http, build_info::BuildInfo, cli::ServerArgs, shutdown};
 
@@ -214,6 +216,9 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
                 )),
                 None => router,
             };
+            // Live transports authenticate only the one-time, origin-bound
+            // ticket and must remain outside browser/CLI session parsing.
+            let router = router.merge(components.live_log_stream_api.clone());
             let router = match config.management() {
                 Some(management) => {
                     let router = router.merge(crate::app::shard_capabilities::router(
@@ -464,7 +469,13 @@ where
     let mut components = components;
     let github_provider = components.github_provider.take();
     let management_server = components.management_server.take();
+    let mut log_commit_listener = components
+        .log_commit_listener
+        .take()
+        .expect("production composition always installs the log notification listener");
+    let log_commit_notifications = Arc::clone(&components.log_commit_notifications);
     let http_cancellation = cancellation.clone();
+    let log_notification_cancellation = cancellation.child_token();
     let runner_cancellation = cancellation.child_token();
     let results_cancellation = cancellation.child_token();
     let monitor_cancellation = cancellation.child_token();
@@ -477,12 +488,31 @@ where
     let github_provider_cancellation = cancellation.child_token();
 
     let http = async move {
-        axum::serve(http_listener, router)
-            .with_graceful_shutdown(async move {
-                http_cancellation.cancelled().await;
-            })
-            .await
-            .map_err(|_| ManagedServiceError::HumanHttp)
+        let server_cancellation = http_cancellation.clone();
+        let server = async move {
+            axum::serve(http_listener, router)
+                .with_graceful_shutdown(async move {
+                    server_cancellation.cancelled().await;
+                })
+                .await
+        };
+        let notifications = run_log_commit_notifications(
+            &mut log_commit_listener,
+            &log_commit_notifications,
+            log_notification_cancellation,
+        );
+        tokio::pin!(server);
+        tokio::pin!(notifications);
+        tokio::select! {
+            result = &mut server => {
+                http_cancellation.cancel();
+                notifications.await;
+                result.map_err(|_| ManagedServiceError::HumanHttp)
+            }
+            () = &mut notifications => {
+                server.await.map_err(|_| ManagedServiceError::HumanHttp)
+            }
+        }
     };
     let runner = run_machine_listeners(
         components.runner_server,
@@ -566,6 +596,34 @@ where
     )
     .await;
     result.context("control-plane service supervision failed")
+}
+
+async fn run_log_commit_notifications(
+    listener: &mut PostgresLogCommitListener,
+    hub: &HumanLogCommitNotificationHub,
+    cancellation: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            () = cancellation.cancelled() => return,
+            result = listener.receive() => match result {
+                Ok(hint) => {
+                    hub.publish(hint);
+                }
+                Err(error) => {
+                    // Durable readers poll independently, so listener failure
+                    // degrades latency without losing output or correctness.
+                    warn!(%error, "live-log commit notification receive failed; retrying");
+                    tokio::select! {
+                        biased;
+                        () = cancellation.cancelled() => return,
+                        () = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/docs/architecture-decisions/0004-resumable-live-log-delivery.md
+++ b/docs/architecture-decisions/0004-resumable-live-log-delivery.md
@@ -19,13 +19,13 @@ connection can nevertheless terminate on one replica for its lifetime, so
 replica loss, deployment draining, network changes, and suspended browser tabs
 must not lose output or require sticky workspace routing.
 
-WebTransport is available in current major browsers and offers reliable
-multiplexed streams, stream backpressure, and QUIC connection migration. It
-still depends on an HTTP/3 and QUIC-capable edge, may be blocked by enterprise
-networks, and has a less mature Rust server ecosystem than ordinary HTTP.
+WebTransport is newly available across current major browsers and offers
+reliable multiplexed streams, stream backpressure, and QUIC connection
+migration. Its installed base will lag browser support, it depends on an HTTP/3
+and QUIC-capable edge, and enterprise networks may block or degrade UDP.
 Self-hosted installations may also run behind proxies without WebTransport
-support. Server-Sent Events are widely deployable but do not provide the same
-multiplexed binary session.
+support. Server-Sent Events are widely deployable over ordinary HTTP and fit
+the initial ordered, unidirectional text workload directly.
 
 ## Decision
 
@@ -43,13 +43,26 @@ replay the checkpoint record, and clients must deduplicate by durable identity.
 The client advances its checkpoint only after it has decoded and accepted a
 complete record.
 
-One reliable ordered WebTransport stream carries log records. Log bytes do not
-use datagrams. Separate reliable streams may later carry independent jobs or
-run-status events so loss on one stream does not block another. The initial SSE
-adapter carries the same logical records as UTF-8 JSON event data. The browser
-tries WebTransport first with a short establishment deadline, falls back to
-streaming `fetch` over SSE, and finally uses bounded snapshot polling. A
-transport failure never changes the checkpoint.
+Streaming `fetch` over SSE is the primary live transport and carries logical
+records as UTF-8 JSON event data. It is expected to run over HTTP/2 in managed
+production deployments so HTTP/1.1's low per-origin connection limit does not
+constrain parallel jobs. The browser falls back to bounded snapshot polling.
+A transport failure never changes the checkpoint.
+
+WebTransport remains an optional future adapter rather than part of the
+initial delivery. It will be added only if production measurements show that
+multi-job multiplexing, connection limits, or transport latency justify a
+second implementation and its infrastructure matrix. If added, one reliable
+ordered stream carries records; log bytes do not use datagrams. Independent
+streams may carry separate jobs or run-status events.
+
+The shared UI package owns transport selection, strict decoding, durable
+identity deduplication, checkpoint advancement, reconnects, and fallback. Its
+ticket-provider boundary returns one normalized Core access capability, so the
+embedded self-hosted UI can acquire a ticket with its Core session while the
+Cloud SSR UI can acquire one through the private Cloud API. Neither adapter
+handles log bytes. SSE JSON represents the durable `u64` sequence as canonical
+decimal text so JavaScript clients do not lose identity precision.
 
 The authoritative replay path reads committed segment metadata and verified
 objects. A shard-wide notification is only a latency hint that new committed
@@ -66,24 +79,25 @@ to Core. Cloud does not mint Core authority independently and does not proxy log
 payloads. Self-hosted installations use the same Core authorization and tail
 with their configured human identity provider.
 
-WebTransport does not carry browser cookies or ordinary HTTP authentication.
-The browser therefore sends the one-time log ticket on a bounded initial
-control stream after session establishment. Tickets are not placed in URLs.
-Pre-authentication sessions have strict byte, stream-count, and time limits,
-and Core validates the exact browser origin. The SSE adapter uses streaming
-`fetch` so it can carry the same ticket in an authorization header.
+Tickets are never placed in URLs. The SSE adapter uses streaming `fetch` so it
+can carry the one-time ticket in an authorization header. If WebTransport is
+implemented, the browser sends the ticket on a bounded initial control stream
+because WebTransport does not carry browser cookies or ordinary HTTP
+authentication. Such pre-authentication sessions must have strict byte,
+stream-count, and time limits. Core validates the exact browser origin for
+every transport.
 
 When a page becomes hidden or frozen, the UI persists only its non-secret
 checkpoint and may close the live connection after a short grace period. On
 visibility restoration, page restoration, or reload, it obtains a fresh ticket
-and resumes. QUIC connection migration improves continuity across network
-changes but is not treated as protection against browser suspension or page
-discard.
+and resumes. If WebTransport is later implemented, QUIC connection migration
+may improve continuity across network changes but is not treated as protection
+against browser suspension or page discard.
 
-Core advertises transports as capabilities. WebTransport is enabled only when
-the configured listener, TLS identity, load balancer, and server implementation
-have passed conformance checks. SSE remains a supported fallback rather than a
-temporary migration mechanism.
+Core advertises transports as capabilities. SSE is the required baseline.
+WebTransport may be advertised later only when the configured listener, TLS
+identity, load balancer, and server implementation have passed conformance
+checks and measured demand justifies enabling it.
 
 ## Consequences
 
@@ -96,9 +110,10 @@ temporary migration mechanism.
 - The shared public UI can use the same transport controller in the embedded
   self-hosted build and the Cloud SSR build. Cloud supplies ticket acquisition
   and routing rather than a separate log implementation.
-- Production WebTransport requires an end-to-end QUIC listener, TLS termination
-  at Core or a reviewed WebTransport edge, connection-ID-aware load balancing,
-  origin enforcement, draining, and browser interoperability tests.
+- A future production WebTransport adapter would require an end-to-end QUIC
+  listener, TLS termination at Core or a reviewed WebTransport edge,
+  connection-ID-aware load balancing, origin enforcement, draining, and
+  browser interoperability tests.
 - Slow clients require bounded per-session queues. Falling behind drops the
   connection and resumes from durable storage instead of accumulating
   unbounded process memory.
@@ -112,21 +127,22 @@ temporary migration mechanism.
    durable-read fallback.
 3. Implement streaming `fetch` SSE as the reference adapter and retain bounded
    snapshot polling as the final fallback.
-4. Implement a WebTransport adapter behind the same tail interface and validate
-   Chrome, Firefox, and Safari behavior against the selected Rust library.
-5. Validate QUIC routing, pod draining, UDP-blocked fallback, network migration,
-   slow consumers, browser suspension, authorization expiry, and replica loss
-   before preferring WebTransport in Cloud.
+4. Measure HTTP/2 connection use, multi-job viewing, latency, proxy failures,
+   slow consumers, browser suspension, authorization expiry, and replica loss.
+5. Only if measurements justify it, implement WebTransport behind the same tail
+   interface and validate QUIC routing, draining, UDP-blocked fallback, network
+   migration, and Chrome, Firefox, and Safari interoperability.
 
 ## Alternatives considered
 
-WebTransport without a fallback was rejected because browser API availability
-does not guarantee that UDP, HTTP/3, the deployment proxy, or the Rust server
-path is usable. SSE alone remains a sound simpler implementation, but it gives
-up connection migration and an efficient multiplexed foundation for future
-live run data. WebSockets were not selected for this boundary. Routing a
-browser to the replica that owns a runner connection was rejected because it
-would introduce replica affinity and make recovery depend on process-local
-state. A dedicated live-log broker remains an option if durable segment
-notification and replay cannot meet measured latency or scale requirements; it
-is not required by the initial design.
+WebTransport as the initial preferred transport was rejected because browser
+API availability does not guarantee that the installed client, UDP, HTTP/3,
+deployment proxy, or Rust server path is usable. Its advantages are not yet
+material for one ordered server-to-browser text stream, while SSE must remain
+production quality for fallback users regardless. WebSockets were not selected
+for this unidirectional boundary. Routing a browser to the replica that owns a
+runner connection was rejected because it would introduce replica affinity and
+make recovery depend on process-local state. A dedicated live-log broker
+remains an option if durable segment notification and replay cannot meet
+measured latency or scale requirements; it is not required by the initial
+design.

--- a/ui/README.md
+++ b/ui/README.md
@@ -44,6 +44,7 @@ separate:
 ```text
 src/
 ├── components/   reusable landmarks and presentation components
+├── liveLogs/      resumable transport controller and strict SSE adapter
 ├── pages/        page composition and page-local derived view state
 ├── presentation/ shared status, timing, and event copy derivation
 ├── preview/      representative sample data, projections, and demo routing
@@ -223,10 +224,11 @@ variants fail rather than falling back to an empty client shell.
 `npm run build` also assembles the private, registry-neutral `@automata/ui`
 package beneath `dist/package`. Its deliberately small public surface contains
 the existing Core page renderer, the shared application shell, the theme
-control and bootstrap script, the page-model types, and a stable compiled
-stylesheet at `@automata/ui/styles.css`. A separate host can render its own page
-content inside `Shell`; the package does not contain transport, authentication,
-data loading, Cloud-only pages, or a plugin system.
+control and bootstrap script, the page-model types, the resumable live-log
+controller, and a stable compiled stylesheet at `@automata/ui/styles.css`. A
+separate host can render its own page content inside `Shell` and supply its own
+authenticated live-log ticket provider. The package does not contain an
+identity provider, Cloud API knowledge, Cloud-only pages, or a plugin system.
 
 `npm run verify:package` renders consumer-owned content through the packaged
 shell, checks the compiled stylesheet, creates the npm archive twice, and

--- a/ui/scripts/verify-package.mjs
+++ b/ui/scripts/verify-package.mjs
@@ -15,9 +15,15 @@ const packageApi = await import(
 );
 const expectedExports = [
   "App",
+  "LIVE_LOG_PROTOCOL_VERSION",
+  "LiveLogController",
+  "LiveLogProtocolError",
+  "LiveLogRequestError",
   "Shell",
   "THEME_BOOTSTRAP_SCRIPT",
   "ThemeToggle",
+  "createSameOriginLiveLogAccessProvider",
+  "validateLiveLogAccess",
 ];
 
 if (JSON.stringify(Object.keys(packageApi).sort()) !== JSON.stringify(expectedExports)) {

--- a/ui/src/liveLogs/controller.ts
+++ b/ui/src/liveLogs/controller.ts
@@ -1,0 +1,355 @@
+import {
+  LiveLogProtocolError,
+  LiveLogRequestError,
+  liveLogTransportUrl,
+  validateLiveLogAccess,
+  validateLiveLogCheckpoint,
+  type LiveLogAccess,
+  type LiveLogAccessProvider,
+  type LiveLogFetch,
+  type LiveLogTransportCapability,
+} from "./protocol";
+import {
+  LiveLogSseError,
+  connectLiveLogSse,
+  type LiveLogRecord,
+} from "./sse";
+
+const DEFAULT_RETRY_MS = 1_000;
+const MAX_RETRY_MS = 30_000;
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 5;
+
+export interface LiveLogControllerOptions {
+  readonly access: LiveLogAccessProvider;
+  readonly onRecord: (
+    record: LiveLogRecord,
+    checkpoint: string,
+  ) => void | Promise<void>;
+  readonly onComplete?: (checkpoint: string | null) => void | Promise<void>;
+  readonly onFallback?: (failure: LiveLogFailure) => void | Promise<void>;
+  readonly onStateChange?: (state: LiveLogControllerState) => void;
+  readonly initialCheckpoint?: string | null;
+  readonly fetch?: LiveLogFetch;
+  /** Number of failed connection attempts before snapshot fallback. */
+  readonly maxConsecutiveFailures?: number;
+}
+
+export type LiveLogControllerState =
+  | { readonly kind: "connecting"; readonly attempt: number }
+  | { readonly kind: "open" }
+  | {
+      readonly kind: "reconnecting";
+      readonly attempt: number;
+      readonly delayMs: number;
+    }
+  | { readonly kind: "paused" }
+  | { readonly kind: "complete" }
+  | { readonly kind: "fallback"; readonly failure: LiveLogFailure };
+
+export interface LiveLogFailure {
+  readonly code: "ticket" | "transport" | "protocol" | "network" | "client";
+  readonly message: string;
+}
+
+interface RecordIdentity {
+  readonly streamId: string;
+  readonly sequence: string;
+  readonly fragment: number | null;
+}
+
+interface LiveLogTransportDriver {
+  readonly kind: string;
+  readonly method: string;
+  connect(options: LiveLogTransportConnection): Promise<LiveLogTransportResult>;
+}
+
+type LiveLogTransportResult =
+  | { readonly kind: "complete" }
+  | { readonly kind: "reconnect" };
+
+interface LiveLogTransportConnection {
+  readonly access: LiveLogAccess;
+  readonly capability: LiveLogTransportCapability;
+  readonly checkpoint: string | null;
+  readonly signal: AbortSignal;
+  readonly fetch: LiveLogFetch;
+  readonly onOpen: () => void;
+  readonly onRetry: (milliseconds: number) => void;
+  readonly onRecord: (
+    record: LiveLogRecord,
+    checkpoint: string,
+  ) => void | Promise<void>;
+}
+
+const SSE_TRANSPORT: LiveLogTransportDriver = {
+  kind: "sse",
+  method: "POST",
+  connect: (options) =>
+    connectLiveLogSse({
+      url: liveLogTransportUrl(options.access, options.capability),
+      ticket: options.access.ticket,
+      checkpoint: options.checkpoint,
+      signal: options.signal,
+      fetch: options.fetch,
+      onOpen: options.onOpen,
+      onRetry: options.onRetry,
+      onRecord: options.onRecord,
+    }),
+};
+
+/** Ordered by preference; future transports slot in without changing replay. */
+const TRANSPORTS: readonly LiveLogTransportDriver[] = [SSE_TRANSPORT];
+
+/**
+ * Owns resumable live delivery while leaving identity/session policy to the
+ * supplied ticket provider. Pausing retains only the non-secret checkpoint.
+ */
+export class LiveLogController {
+  readonly #options: LiveLogControllerOptions;
+  readonly #fetch: LiveLogFetch;
+  readonly #maximumFailures: number;
+  #checkpoint: string | null;
+  #lastRecord: RecordIdentity | null = null;
+  #abort: AbortController | null = null;
+  #running: Promise<void> | null = null;
+  #disposed = false;
+  #retryMs = DEFAULT_RETRY_MS;
+
+  constructor(options: LiveLogControllerOptions) {
+    this.#options = options;
+    this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.#maximumFailures =
+      options.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
+    if (
+      !Number.isInteger(this.#maximumFailures) ||
+      this.#maximumFailures < 0 ||
+      this.#maximumFailures > 100
+    ) {
+      throw new TypeError("maxConsecutiveFailures must be between 0 and 100");
+    }
+    this.#checkpoint =
+      options.initialCheckpoint === undefined ||
+      options.initialCheckpoint === null
+        ? null
+        : validateLiveLogCheckpoint(options.initialCheckpoint);
+  }
+
+  get checkpoint(): string | null {
+    return this.#checkpoint;
+  }
+
+  get running(): boolean {
+    return this.#running !== null;
+  }
+
+  /** Starts or resumes delivery. Concurrent starts share one run. */
+  start(): Promise<void> {
+    if (this.#disposed) {
+      return Promise.reject(new Error("the live-log controller is disposed"));
+    }
+    if (this.#running !== null) {
+      if (this.#abort?.signal.aborted === true) {
+        return this.#running.then(() => this.start());
+      }
+      return this.#running;
+    }
+    const abort = new AbortController();
+    this.#abort = abort;
+    const run = this.#run(abort.signal);
+    this.#running = run;
+    void run.then(
+      () => {
+        if (this.#running === run) {
+          this.#running = null;
+          this.#abort = null;
+        }
+      },
+      () => {
+        if (this.#running === run) {
+          this.#running = null;
+          this.#abort = null;
+        }
+      },
+    );
+    return run;
+  }
+
+  /** Stops network work while preserving the checkpoint for a later start. */
+  pause(): void {
+    this.#abort?.abort();
+    if (!this.#disposed) {
+      this.#emit({ kind: "paused" });
+    }
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+    this.#abort?.abort();
+  }
+
+  async #run(signal: AbortSignal): Promise<void> {
+    let failures = 0;
+    for (;;) {
+      if (signal.aborted) {
+        return;
+      }
+      this.#emit({ kind: "connecting", attempt: failures + 1 });
+      try {
+        const access = validateLiveLogAccess(await this.#options.access(signal));
+        const selected = selectTransport(access);
+        const result = await selected.driver.connect({
+          access,
+          capability: selected.capability,
+          checkpoint: this.#checkpoint,
+          signal,
+          fetch: this.#fetch,
+          onOpen: () => {
+            this.#emit({ kind: "open" });
+          },
+          onRetry: (milliseconds) => {
+            this.#retryMs = milliseconds;
+          },
+          onRecord: async (record, checkpoint) => {
+            if (await this.#acceptRecord(record, checkpoint)) {
+              failures = 0;
+            }
+          },
+        });
+        if (result.kind === "complete") {
+          await this.#options.onComplete?.(this.#checkpoint);
+          this.#emit({ kind: "complete" });
+          return;
+        }
+        failures = 0;
+        this.#emit({ kind: "reconnecting", attempt: 1, delayMs: 0 });
+        continue;
+      } catch (error) {
+        if (signal.aborted || isAbortError(error)) {
+          return;
+        }
+        failures += 1;
+        const failure = safeFailure(error);
+        if (failures > this.#maximumFailures) {
+          this.#emit({ kind: "fallback", failure });
+          await this.#options.onFallback?.(failure);
+          return;
+        }
+        const delayMs = Math.min(
+          this.#retryMs * 2 ** Math.max(failures - 1, 0),
+          MAX_RETRY_MS,
+        );
+        this.#emit({ kind: "reconnecting", attempt: failures + 1, delayMs });
+        await abortableDelay(delayMs, signal);
+      }
+    }
+  }
+
+  async #acceptRecord(
+    record: LiveLogRecord,
+    checkpoint: string,
+  ): Promise<boolean> {
+    const nextCheckpoint = validateLiveLogCheckpoint(checkpoint);
+    if (this.#lastRecord !== null) {
+      if (record.streamId !== this.#lastRecord.streamId) {
+        throw new LiveLogProtocolError("the live-log stream identity changed");
+      }
+      const order = compareRecord(record, this.#lastRecord);
+      if (order < 0) {
+        throw new LiveLogProtocolError("the live-log sequence moved backwards");
+      }
+      if (order === 0) {
+        this.#checkpoint = nextCheckpoint;
+        return false;
+      }
+    }
+    await this.#options.onRecord(record, nextCheckpoint);
+    this.#lastRecord = {
+      streamId: record.streamId,
+      sequence: record.sequence,
+      fragment: record.fragment,
+    };
+    this.#checkpoint = nextCheckpoint;
+    return true;
+  }
+
+  #emit(state: LiveLogControllerState): void {
+    this.#options.onStateChange?.(state);
+  }
+}
+
+function compareRecord(current: LiveLogRecord, previous: RecordIdentity): number {
+  const sequence = compareDecimal(current.sequence, previous.sequence);
+  if (sequence !== 0) {
+    return sequence;
+  }
+  if (current.fragment === previous.fragment) {
+    return 0;
+  }
+  if (current.fragment === null || previous.fragment === null) {
+    return -1;
+  }
+  return current.fragment < previous.fragment ? -1 : 1;
+}
+
+function selectTransport(access: LiveLogAccess): {
+  readonly driver: LiveLogTransportDriver;
+  readonly capability: LiveLogTransportCapability;
+} {
+  for (const driver of TRANSPORTS) {
+    const capability = access.transports.find(
+      (candidate) =>
+        candidate.kind === driver.kind && candidate.method === driver.method,
+    );
+    if (capability !== undefined) {
+      return { driver, capability };
+    }
+  }
+  throw new LiveLogProtocolError("Core did not advertise a supported transport");
+}
+
+function compareDecimal(left: string, right: string): number {
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function safeFailure(error: unknown): LiveLogFailure {
+  if (error instanceof LiveLogProtocolError) {
+    return { code: "protocol", message: error.message };
+  }
+  if (error instanceof LiveLogRequestError) {
+    return { code: error.code, message: error.message };
+  }
+  if (error instanceof LiveLogSseError) {
+    return {
+      code:
+        error.code === "protocol"
+          ? "protocol"
+          : error.code === "network"
+            ? "network"
+            : "transport",
+      message: error.message,
+    };
+  }
+  return { code: "client", message: "the live-log client failed" };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function abortableDelay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timer = globalThis.setTimeout(finished, milliseconds);
+    signal.addEventListener("abort", finished, { once: true });
+    function finished() {
+      globalThis.clearTimeout(timer);
+      signal.removeEventListener("abort", finished);
+      resolve();
+    }
+  });
+}

--- a/ui/src/liveLogs/index.ts
+++ b/ui/src/liveLogs/index.ts
@@ -1,0 +1,19 @@
+export {
+  LiveLogController,
+  type LiveLogControllerOptions,
+  type LiveLogControllerState,
+  type LiveLogFailure,
+} from "./controller";
+export {
+  LIVE_LOG_PROTOCOL_VERSION,
+  LiveLogProtocolError,
+  LiveLogRequestError,
+  createSameOriginLiveLogAccessProvider,
+  validateLiveLogAccess,
+  type LiveLogAccess,
+  type LiveLogAccessProvider,
+  type LiveLogFetch,
+  type LiveLogTransportCapability,
+  type SameOriginLiveLogAccessProviderOptions,
+} from "./protocol";
+export type { LiveLogChannel, LiveLogRecord } from "./sse";

--- a/ui/src/liveLogs/protocol.ts
+++ b/ui/src/liveLogs/protocol.ts
@@ -1,0 +1,301 @@
+export const LIVE_LOG_PROTOCOL_VERSION = 1 as const;
+
+const TICKET = /^allt_v1_[A-Za-z0-9_-]{43}$/u;
+const CHECKPOINT = /^[A-Za-z0-9_-]{1,512}$/u;
+const TRANSPORT_KIND = /^[a-z][a-z0-9-]{0,31}$/u;
+const MAX_TICKET_RESPONSE_BYTES = 32 * 1024;
+const MAX_TRANSPORTS = 8;
+
+export interface LiveLogTransportCapability {
+  readonly kind: string;
+  readonly method: string;
+  readonly path: string;
+}
+
+/** Normalized result supplied by either Core or Automata Cloud. */
+export interface LiveLogAccess {
+  readonly protocolVersion: typeof LIVE_LOG_PROTOCOL_VERSION;
+  readonly ticket: string;
+  readonly expiresAtMs: number;
+  /** Trusted origin on which the advertised transport paths are served. */
+  readonly logsOrigin: string;
+  readonly transports: readonly LiveLogTransportCapability[];
+}
+
+export type LiveLogAccessProvider = (
+  signal: AbortSignal,
+) => Promise<LiveLogAccess>;
+
+export type LiveLogFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface SameOriginLiveLogAccessProviderOptions {
+  /** Same-origin Core endpoint ending in `/live-ticket`. */
+  readonly endpoint: string;
+  /** Explicit document URL for non-browser consumers and tests. */
+  readonly documentUrl?: string;
+  readonly fetch?: LiveLogFetch;
+}
+
+interface CoreTicketResponse {
+  readonly protocolVersion: typeof LIVE_LOG_PROTOCOL_VERSION;
+  readonly ticket: string;
+  readonly expiresAtMs: number;
+  readonly transports: readonly LiveLogTransportCapability[];
+}
+
+/**
+ * Builds the ticket adapter used by the embedded, self-hosted UI. Cloud uses
+ * the same controller with an adapter for its own authenticated API response.
+ */
+export function createSameOriginLiveLogAccessProvider(
+  options: SameOriginLiveLogAccessProviderOptions,
+): LiveLogAccessProvider {
+  return async (signal) => {
+    const documentUrl =
+      options.documentUrl ?? globalThis.location?.href;
+    if (documentUrl === undefined) {
+      throw new LiveLogProtocolError("a document URL is required");
+    }
+    const document = parseHttpUrl(documentUrl, "document URL");
+    const endpoint = new URL(options.endpoint, document);
+    if (
+      endpoint.origin !== document.origin ||
+      endpoint.username !== "" ||
+      endpoint.password !== "" ||
+      endpoint.search !== "" ||
+      endpoint.hash !== ""
+    ) {
+      throw new LiveLogProtocolError("the ticket endpoint must be same-origin");
+    }
+    const fetcher = options.fetch ?? globalThis.fetch.bind(globalThis);
+    const response = await fetcher(endpoint, {
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+      method: "POST",
+      redirect: "error",
+      referrerPolicy: "same-origin",
+      signal,
+    });
+    if (!response.ok) {
+      throw new LiveLogRequestError(
+        "ticket",
+        `the live-log ticket endpoint returned ${response.status}`,
+      );
+    }
+    const length = response.headers.get("Content-Length");
+    if (length !== null && Number(length) > MAX_TICKET_RESPONSE_BYTES) {
+      throw new LiveLogProtocolError("the ticket response is too large");
+    }
+    const body = await response.text();
+    if (new TextEncoder().encode(body).byteLength > MAX_TICKET_RESPONSE_BYTES) {
+      throw new LiveLogProtocolError("the ticket response is too large");
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(body) as unknown;
+    } catch {
+      throw new LiveLogProtocolError("the ticket response is not valid JSON");
+    }
+    const ticket = parseCoreTicketResponse(decoded);
+    return validateLiveLogAccess({
+      ...ticket,
+      logsOrigin: document.origin,
+    });
+  };
+}
+
+export function validateLiveLogAccess(value: LiveLogAccess): LiveLogAccess {
+  const access = plainRecord(value, "live-log access");
+  exactKeys(access, [
+    "protocolVersion",
+    "ticket",
+    "expiresAtMs",
+    "logsOrigin",
+    "transports",
+  ], "live-log access");
+  if (access.protocolVersion !== LIVE_LOG_PROTOCOL_VERSION) {
+    throw new LiveLogProtocolError("the live-log protocol version is unsupported");
+  }
+  const ticket = boundedString(access.ticket, 51, 51, "ticket");
+  if (!TICKET.test(ticket)) {
+    throw new LiveLogProtocolError("the live-log ticket is not canonical");
+  }
+  const expiresAtMs = safeInteger(access.expiresAtMs, 1, "ticket expiry");
+  const logsOrigin = canonicalOrigin(access.logsOrigin);
+  if (!Array.isArray(access.transports) || access.transports.length === 0) {
+    throw new LiveLogProtocolError("at least one live-log transport is required");
+  }
+  if (access.transports.length > MAX_TRANSPORTS) {
+    throw new LiveLogProtocolError("too many live-log transports were advertised");
+  }
+  const transports = access.transports.map((transport) =>
+    validateTransport(transport),
+  );
+  return {
+    protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+    ticket,
+    expiresAtMs,
+    logsOrigin,
+    transports,
+  };
+}
+
+export function validateLiveLogCheckpoint(value: string): string {
+  if (!CHECKPOINT.test(value)) {
+    throw new LiveLogProtocolError("the live-log checkpoint is not canonical");
+  }
+  return value;
+}
+
+export function liveLogTransportUrl(
+  access: LiveLogAccess,
+  transport: LiveLogTransportCapability,
+): URL {
+  const origin = canonicalOrigin(access.logsOrigin);
+  if (!transport.path.startsWith("/") || transport.path.includes("\\")) {
+    throw new LiveLogProtocolError("the live-log transport path is invalid");
+  }
+  const url = new URL(transport.path, `${origin}/`);
+  if (
+    url.origin !== origin ||
+    url.pathname !== transport.path ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    throw new LiveLogProtocolError("the live-log transport escaped its origin");
+  }
+  return url;
+}
+
+export class LiveLogProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LiveLogProtocolError";
+  }
+}
+
+export class LiveLogRequestError extends Error {
+  readonly code: "ticket" | "transport";
+
+  constructor(code: "ticket" | "transport", message: string) {
+    super(message);
+    this.name = "LiveLogRequestError";
+    this.code = code;
+  }
+}
+
+function parseCoreTicketResponse(value: unknown): CoreTicketResponse {
+  const ticket = plainRecord(value, "ticket response");
+  exactKeys(ticket, [
+    "protocolVersion",
+    "ticket",
+    "expiresAtMs",
+    "transports",
+  ], "ticket response");
+  return {
+    protocolVersion: ticket.protocolVersion as typeof LIVE_LOG_PROTOCOL_VERSION,
+    ticket: ticket.ticket as string,
+    expiresAtMs: ticket.expiresAtMs as number,
+    transports: ticket.transports as readonly LiveLogTransportCapability[],
+  };
+}
+
+function validateTransport(value: unknown): LiveLogTransportCapability {
+  const transport = plainRecord(value, "transport capability");
+  exactKeys(transport, ["kind", "method", "path"], "transport capability");
+  const kind = boundedString(transport.kind, 32, 1, "transport kind");
+  if (!TRANSPORT_KIND.test(kind)) {
+    throw new LiveLogProtocolError("the live-log transport kind is invalid");
+  }
+  const method = boundedString(transport.method, 16, 1, "transport method");
+  if (!/^[A-Z]+$/u.test(method)) {
+    throw new LiveLogProtocolError("the live-log transport method is invalid");
+  }
+  const path = boundedString(transport.path, 1_024, 1, "transport path");
+  return { kind, method, path };
+}
+
+function canonicalOrigin(value: unknown): string {
+  const origin = boundedString(value, 2_048, 1, "logs origin");
+  const parsed = parseHttpUrl(origin, "logs origin");
+  if (
+    parsed.origin !== origin ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    throw new LiveLogProtocolError("the logs origin is not canonical");
+  }
+  return origin;
+}
+
+function parseHttpUrl(value: string, label: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new LiveLogProtocolError(`the ${label} is invalid`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new LiveLogProtocolError(`the ${label} must use HTTP`);
+  }
+  return parsed;
+}
+
+function plainRecord(value: unknown, label: string): Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new LiveLogProtocolError(`the ${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  const expected = new Set(keys);
+  const actual = Object.keys(value);
+  if (
+    actual.length !== keys.length ||
+    actual.some((key) => !expected.has(key))
+  ) {
+    throw new LiveLogProtocolError(`the ${label} has unexpected fields`);
+  }
+}
+
+function boundedString(
+  value: unknown,
+  maximum: number,
+  minimum: number,
+  label: string,
+): string {
+  if (typeof value !== "string") {
+    throw new LiveLogProtocolError(`the ${label} must be a string`);
+  }
+  const size = new TextEncoder().encode(value).byteLength;
+  if (size < minimum || size > maximum) {
+    throw new LiveLogProtocolError(`the ${label} has an invalid size`);
+  }
+  return value;
+}
+
+function safeInteger(value: unknown, minimum: number, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new LiveLogProtocolError(`the ${label} must be a safe integer`);
+  }
+  return value as number;
+}

--- a/ui/src/liveLogs/sse.ts
+++ b/ui/src/liveLogs/sse.ts
@@ -1,0 +1,453 @@
+import {
+  LIVE_LOG_PROTOCOL_VERSION,
+  LiveLogProtocolError,
+  type LiveLogFetch,
+} from "./protocol";
+
+const MAX_SSE_CHUNK_BYTES = 1024 * 1024;
+const MAX_SSE_BUFFER_CODE_UNITS = 1024 * 1024;
+const MAX_SSE_EVENT_CODE_UNITS = 512 * 1024;
+const MAX_LOG_TEXT_BYTES = 65_536;
+const MAX_U64_DECIMAL = "18446744073709551615";
+const MAX_U32 = 4_294_967_295;
+const MIN_TIMESTAMP_MS = -62_167_219_200_000;
+const MAX_TIMESTAMP_MS = 253_402_300_799_999;
+const STREAM_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const DECIMAL = /^(0|[1-9][0-9]{0,19})$/u;
+const CONTROL_CHARACTER_EXCEPT_TAB = /[\u0000-\u0008\u000a-\u001f\u007f-\u009f]/u;
+const BIDI_FORMATTING_CHARACTER =
+  /[\u061c\u200e-\u200f\u202a-\u202e\u2066-\u2069]/u;
+
+export type LiveLogChannel = "stdout" | "stderr" | "system";
+
+export interface LiveLogRecord {
+  readonly streamId: string;
+  /** Canonical decimal text keeps the Core u64 sequence lossless in JS. */
+  readonly sequence: string;
+  readonly fragment: number | null;
+  readonly emittedAtMs: number;
+  readonly channel: LiveLogChannel;
+  readonly text: string;
+}
+
+export interface SseConnectionOptions {
+  readonly url: URL;
+  readonly ticket: string;
+  readonly checkpoint: string | null;
+  readonly signal: AbortSignal;
+  readonly fetch: LiveLogFetch;
+  readonly onRecord: (
+    record: LiveLogRecord,
+    checkpoint: string,
+  ) => void | Promise<void>;
+  readonly onOpen?: () => void;
+  readonly onRetry?: (milliseconds: number) => void;
+}
+
+export type SseConnectionResult =
+  | { readonly kind: "complete" }
+  | { readonly kind: "reconnect" };
+
+interface DecodedSseEvent {
+  readonly event: string | null;
+  readonly data: string | null;
+  readonly id: string | null;
+  readonly retry: number | null;
+}
+
+interface ProtocolEnvelope {
+  readonly protocolVersion: typeof LIVE_LOG_PROTOCOL_VERSION;
+}
+
+interface ErrorEnvelope extends ProtocolEnvelope {
+  readonly error: string;
+}
+
+export async function connectLiveLogSse(
+  options: SseConnectionOptions,
+): Promise<SseConnectionResult> {
+  const headers = new Headers({
+    Accept: "text/event-stream",
+    Authorization: `AutomataLogTicket ${options.ticket}`,
+  });
+  if (options.checkpoint !== null) {
+    headers.set("Last-Event-ID", options.checkpoint);
+  }
+  const response = await options.fetch(options.url, {
+    credentials: "omit",
+    headers,
+    method: "POST",
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+    signal: options.signal,
+  });
+  if (!response.ok) {
+    throw new LiveLogSseError(
+      "http",
+      `the live-log transport returned ${response.status}`,
+    );
+  }
+  const contentType = response.headers.get("Content-Type")?.toLowerCase();
+  if (contentType?.startsWith("text/event-stream") !== true) {
+    throw new LiveLogSseError(
+      "protocol",
+      "the live-log transport did not return an event stream",
+    );
+  }
+  if (response.body === null) {
+    throw new LiveLogSseError(
+      "protocol",
+      "the live-log transport returned no body",
+    );
+  }
+  options.onOpen?.();
+
+  const reader = response.body.getReader();
+  const text = new TextDecoder("utf-8", { fatal: true });
+  const decoder = new SseDecoder();
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        try {
+          text.decode();
+        } catch {
+          throw new LiveLogSseError(
+            "protocol",
+            "the live-log stream ended within a UTF-8 character",
+          );
+        }
+        throw new LiveLogSseError(
+          "network",
+          "the live-log stream ended before completion",
+        );
+      }
+      if (chunk.value.byteLength > MAX_SSE_CHUNK_BYTES) {
+        throw new LiveLogSseError("protocol", "a live-log chunk is too large");
+      }
+      let decoded: string;
+      try {
+        decoded = text.decode(chunk.value, { stream: true });
+      } catch {
+        throw new LiveLogSseError(
+          "protocol",
+          "the live-log stream is not valid UTF-8",
+        );
+      }
+      const events = decoder.push(decoded);
+      for (const event of events) {
+        if (event.retry !== null) {
+          options.onRetry?.(event.retry);
+        }
+        if (event.data === null) {
+          continue;
+        }
+        switch (event.event ?? "message") {
+          case "log": {
+            if (event.id === null) {
+              throw new LiveLogSseError(
+                "protocol",
+                "a live-log record has no checkpoint",
+              );
+            }
+            await options.onRecord(parseLogRecord(event.data), event.id);
+            break;
+          }
+          case "complete":
+            parseProtocolEnvelope(event.data, "completion");
+            return { kind: "complete" };
+          case "reconnect":
+            parseProtocolEnvelope(event.data, "reconnect");
+            return { kind: "reconnect" };
+          case "error": {
+            const error = parseErrorEnvelope(event.data);
+            throw new LiveLogSseError(
+              "server",
+              `Core ended the live-log stream: ${error.error}`,
+            );
+          }
+          default:
+            throw new LiveLogSseError(
+              "protocol",
+              "the live-log stream contains an unsupported event",
+            );
+        }
+      }
+    }
+  } catch (error) {
+    if (error instanceof LiveLogProtocolError) {
+      throw new LiveLogSseError("protocol", error.message);
+    }
+    throw error;
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // The connection may already have failed or been aborted.
+    }
+    reader.releaseLock();
+  }
+}
+
+export class LiveLogSseError extends Error {
+  readonly code: "http" | "network" | "protocol" | "server";
+
+  constructor(
+    code: "http" | "network" | "protocol" | "server",
+    message: string,
+  ) {
+    super(message);
+    this.name = "LiveLogSseError";
+    this.code = code;
+  }
+}
+
+class SseDecoder {
+  #buffer = "";
+  #eventName: string | null = null;
+  #data: string[] = [];
+  #id: string | null = null;
+  #retry: number | null = null;
+  #eventSize = 0;
+
+  push(chunk: string): readonly DecodedSseEvent[] {
+    this.#buffer += chunk;
+    if (this.#buffer.length > MAX_SSE_BUFFER_CODE_UNITS) {
+      throw new LiveLogSseError("protocol", "the live-log buffer is too large");
+    }
+    const events: DecodedSseEvent[] = [];
+    for (;;) {
+      const boundary = lineBoundary(this.#buffer);
+      if (boundary === null) {
+        break;
+      }
+      const line = this.#buffer.slice(0, boundary.index);
+      this.#buffer = this.#buffer.slice(boundary.index + boundary.length);
+      const event = this.#acceptLine(line);
+      if (event !== null) {
+        events.push(event);
+      }
+    }
+    return events;
+  }
+
+  #acceptLine(line: string): DecodedSseEvent | null {
+    this.#eventSize += line.length + 1;
+    if (this.#eventSize > MAX_SSE_EVENT_CODE_UNITS) {
+      throw new LiveLogSseError("protocol", "a live-log event is too large");
+    }
+    if (line === "") {
+      const event =
+        this.#data.length > 0 || this.#retry !== null
+          ? {
+              event: this.#eventName,
+              data: this.#data.length > 0 ? this.#data.join("\n") : null,
+              id: this.#id,
+              retry: this.#retry,
+            }
+          : null;
+      this.#eventName = null;
+      this.#data = [];
+      this.#id = null;
+      this.#retry = null;
+      this.#eventSize = 0;
+      return event;
+    }
+    if (line.startsWith(":")) {
+      return null;
+    }
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    let value = separator === -1 ? "" : line.slice(separator + 1);
+    if (value.startsWith(" ")) {
+      value = value.slice(1);
+    }
+    switch (field) {
+      case "event":
+        if (this.#eventName !== null) {
+          throw new LiveLogSseError("protocol", "a live-log event repeats its type");
+        }
+        this.#eventName = value;
+        break;
+      case "data":
+        this.#data.push(value);
+        break;
+      case "id":
+        if (this.#id !== null || value.includes("\0")) {
+          throw new LiveLogSseError("protocol", "a live-log event has an invalid ID");
+        }
+        this.#id = value;
+        break;
+      case "retry":
+        if (this.#retry !== null) {
+          throw new LiveLogSseError(
+            "protocol",
+            "a live-log event repeats its retry delay",
+          );
+        }
+        if (/^[0-9]+$/u.test(value)) {
+          const parsed = Number(value);
+          if (Number.isSafeInteger(parsed)) {
+            this.#retry = Math.min(Math.max(parsed, 250), 30_000);
+          }
+        }
+        break;
+      default:
+        // Unknown SSE fields are explicitly ignored by the event-stream format.
+        break;
+    }
+    return null;
+  }
+}
+
+function parseLogRecord(data: string): LiveLogRecord {
+  const record = parseJsonRecord(data, "log record");
+  exactKeys(record, [
+    "protocolVersion",
+    "streamId",
+    "sequence",
+    "fragment",
+    "emittedAtMs",
+    "channel",
+    "text",
+  ], "log record");
+  if (record.protocolVersion !== LIVE_LOG_PROTOCOL_VERSION) {
+    throw new LiveLogProtocolError("the log record protocol version is unsupported");
+  }
+  if (typeof record.streamId !== "string" || !STREAM_ID.test(record.streamId)) {
+    throw new LiveLogProtocolError("the log record stream ID is invalid");
+  }
+  if (
+    typeof record.sequence !== "string" ||
+    !DECIMAL.test(record.sequence) ||
+    compareDecimal(record.sequence, MAX_U64_DECIMAL) > 0
+  ) {
+    throw new LiveLogProtocolError("the log record sequence is invalid");
+  }
+  if (
+    record.fragment !== null &&
+    (!Number.isInteger(record.fragment) ||
+      (record.fragment as number) < 1 ||
+      (record.fragment as number) > MAX_U32)
+  ) {
+    throw new LiveLogProtocolError("the log record fragment is invalid");
+  }
+  if (
+    !Number.isSafeInteger(record.emittedAtMs) ||
+    (record.emittedAtMs as number) < MIN_TIMESTAMP_MS ||
+    (record.emittedAtMs as number) > MAX_TIMESTAMP_MS
+  ) {
+    throw new LiveLogProtocolError("the log record timestamp is invalid");
+  }
+  if (
+    record.channel !== "stdout" &&
+    record.channel !== "stderr" &&
+    record.channel !== "system"
+  ) {
+    throw new LiveLogProtocolError("the log record channel is invalid");
+  }
+  if (
+    typeof record.text !== "string" ||
+    new TextEncoder().encode(record.text).byteLength > MAX_LOG_TEXT_BYTES ||
+    CONTROL_CHARACTER_EXCEPT_TAB.test(record.text) ||
+    BIDI_FORMATTING_CHARACTER.test(record.text)
+  ) {
+    throw new LiveLogProtocolError("the log record text is invalid");
+  }
+  return {
+    streamId: record.streamId,
+    sequence: record.sequence,
+    fragment: record.fragment as number | null,
+    emittedAtMs: record.emittedAtMs as number,
+    channel: record.channel,
+    text: record.text,
+  };
+}
+
+function parseProtocolEnvelope(data: string, label: string): ProtocolEnvelope {
+  const envelope = parseJsonRecord(data, label);
+  exactKeys(envelope, ["protocolVersion"], label);
+  if (envelope.protocolVersion !== LIVE_LOG_PROTOCOL_VERSION) {
+    throw new LiveLogProtocolError(`the ${label} protocol version is unsupported`);
+  }
+  return { protocolVersion: LIVE_LOG_PROTOCOL_VERSION };
+}
+
+function parseErrorEnvelope(data: string): ErrorEnvelope {
+  const envelope = parseJsonRecord(data, "error event");
+  exactKeys(envelope, ["protocolVersion", "error"], "error event");
+  if (envelope.protocolVersion !== LIVE_LOG_PROTOCOL_VERSION) {
+    throw new LiveLogProtocolError("the error protocol version is unsupported");
+  }
+  if (
+    typeof envelope.error !== "string" ||
+    !/^[a-z][a-z0-9_]{0,63}$/u.test(envelope.error)
+  ) {
+    throw new LiveLogProtocolError("the live-log error code is invalid");
+  }
+  return {
+    protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+    error: envelope.error,
+  };
+}
+
+function parseJsonRecord(data: string, label: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(data) as unknown;
+  } catch {
+    throw new LiveLogProtocolError(`the ${label} is not valid JSON`);
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new LiveLogProtocolError(`the ${label} is not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  const expected = new Set(keys);
+  const actual = Object.keys(value);
+  if (
+    actual.length !== keys.length ||
+    actual.some((key) => !expected.has(key))
+  ) {
+    throw new LiveLogProtocolError(`the ${label} has unexpected fields`);
+  }
+}
+
+function compareDecimal(left: string, right: string): number {
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function lineBoundary(
+  value: string,
+): { readonly index: number; readonly length: number } | null {
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\n") {
+      return { index, length: 1 };
+    }
+    if (character === "\r") {
+      if (index + 1 === value.length) {
+        return null;
+      }
+      return {
+        index,
+        length: value[index + 1] === "\n" ? 2 : 1,
+      };
+    }
+  }
+  return null;
+}

--- a/ui/src/public.ts
+++ b/ui/src/public.ts
@@ -2,4 +2,5 @@ export { App, type AppProps } from "./App";
 export { Shell, type ShellProps } from "./components/Shell";
 export { ThemeToggle } from "./components/ThemeToggle";
 export { THEME_BOOTSTRAP_SCRIPT } from "./components/useThemePreference";
+export * from "./liveLogs";
 export type * from "./models";

--- a/ui/tests/unit/live-logs.test.ts
+++ b/ui/tests/unit/live-logs.test.ts
@@ -1,0 +1,632 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LIVE_LOG_PROTOCOL_VERSION,
+  LiveLogController,
+  createSameOriginLiveLogAccessProvider,
+  validateLiveLogAccess,
+  type LiveLogAccess,
+  type LiveLogFetch,
+  type LiveLogFailure,
+  type LiveLogRecord,
+} from "../../src/liveLogs";
+
+const STREAM_ID = "00000000-0000-4000-8000-000000000005";
+const TICKET_ONE = `allt_v1_${"A".repeat(43)}`;
+const TICKET_TWO = `allt_v1_${"B".repeat(43)}`;
+
+describe("same-origin live-log ticket acquisition", () => {
+  it("keeps the credential in a validated response and derives Core's origin", async () => {
+    const fetchMock = vi.fn<LiveLogFetch>(async () =>
+      Response.json({
+        protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+        ticket: TICKET_ONE,
+        expiresAtMs: Date.now() + 60_000,
+        transports: [{ kind: "sse", method: "POST", path: "/live/v1/logs" }],
+      }),
+    );
+    const acquire = createSameOriginLiveLogAccessProvider({
+      endpoint: "/octo/repo/actions/runs/run/jobs/job/live-ticket",
+      documentUrl: "https://ci.example/octo/repo/actions/runs/run/jobs/job",
+      fetch: fetchMock,
+    });
+
+    const access = await acquire(new AbortController().signal);
+
+    expect(access).toEqual({
+      protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+      ticket: TICKET_ONE,
+      expiresAtMs: expect.any(Number),
+      logsOrigin: "https://ci.example",
+      transports: [{ kind: "sse", method: "POST", path: "/live/v1/logs" }],
+    });
+    const [input, init] = fetchMock.mock.calls[0] ?? [];
+    expect((input as URL).href).toBe(
+      "https://ci.example/octo/repo/actions/runs/run/jobs/job/live-ticket",
+    );
+    expect(init).toMatchObject({
+      cache: "no-store",
+      credentials: "same-origin",
+      method: "POST",
+      redirect: "error",
+    });
+    expect((input as URL).href).not.toContain(TICKET_ONE);
+  });
+
+  it("rejects a ticket endpoint outside the document origin", async () => {
+    const fetchMock = vi.fn<LiveLogFetch>();
+    const acquire = createSameOriginLiveLogAccessProvider({
+      endpoint: "https://evil.invalid/live-ticket",
+      documentUrl: "https://ci.example/jobs/1",
+      fetch: fetchMock,
+    });
+
+    await expect(acquire(new AbortController().signal)).rejects.toThrow(
+      "same-origin",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["HTTP failure", new Response(null, { status: 503 }), "returned 503"],
+    [
+      "declared oversized response",
+      new Response("{}", { headers: { "Content-Length": "32769" } }),
+      "too large",
+    ],
+    [
+      "actual oversized response",
+      new Response("x".repeat(32 * 1024 + 1)),
+      "too large",
+    ],
+    ["malformed JSON", new Response("{"), "not valid JSON"],
+  ])("rejects a %s", async (_name, response, message) => {
+    const acquire = createSameOriginLiveLogAccessProvider({
+      endpoint: "/jobs/1/live-ticket",
+      documentUrl: "https://ci.example/jobs/1",
+      fetch: async () => response,
+    });
+
+    await expect(acquire(new AbortController().signal)).rejects.toThrow(message);
+  });
+});
+
+describe("live-log capability validation", () => {
+  it.each([
+    [null, "plain object"],
+    [{ ...access(TICKET_ONE), extra: true }, "unexpected fields"],
+    [{ ...access(TICKET_ONE), protocolVersion: 2 }, "version"],
+    [{ ...access(TICKET_ONE), ticket: "not-a-ticket" }, "ticket"],
+    [{ ...access(TICKET_ONE), expiresAtMs: 0 }, "safe integer"],
+    [{ ...access(TICKET_ONE), logsOrigin: "not a URL" }, "invalid"],
+    [{ ...access(TICKET_ONE), logsOrigin: "ftp://logs.example" }, "use HTTP"],
+    [{ ...access(TICKET_ONE), logsOrigin: "https://logs.example/path" }, "canonical"],
+    [{ ...access(TICKET_ONE), transports: [] }, "at least one"],
+    [
+      {
+        ...access(TICKET_ONE),
+        transports: Array.from({ length: 9 }, () => ({
+          kind: "sse",
+          method: "POST",
+          path: "/live/v1/logs",
+        })),
+      },
+      "too many",
+    ],
+    [{ ...access(TICKET_ONE), transports: [null] }, "plain object"],
+    [
+      {
+        ...access(TICKET_ONE),
+        transports: [{ kind: "SSE", method: "POST", path: "/live/v1/logs" }],
+      },
+      "kind",
+    ],
+    [
+      {
+        ...access(TICKET_ONE),
+        transports: [{ kind: "sse", method: "post", path: "/live/v1/logs" }],
+      },
+      "method",
+    ],
+    [
+      {
+        ...access(TICKET_ONE),
+        transports: [{ kind: "sse", method: "POST", path: 42 }],
+      },
+      "must be a string",
+    ],
+  ])("rejects invalid normalized access %#", (value, message) => {
+    expect(() => validateLiveLogAccess(value as LiveLogAccess)).toThrow(message);
+  });
+});
+
+describe("live-log transport controller", () => {
+  it("decodes arbitrarily chunked UTF-8 records and advances after application", async () => {
+    const applied: Array<{ record: LiveLogRecord; checkpoint: string }> = [];
+    const states: string[] = [];
+    const payload = [
+      ": connected\r\nretry: 1250\r\n\r\n",
+      logEvent("checkpoint_1", {
+        sequence: "18446744073709551615",
+        text: "compile café 🚀",
+      }),
+      "event: complete\ndata: {\"protocolVersion\":1}\n\n",
+    ].join("");
+    const fetchMock = vi.fn<LiveLogFetch>(async () =>
+      eventStreamResponse(payload, [1, 5, 37, 43]),
+    );
+    const controller = new LiveLogController({
+      access: async () => access(TICKET_ONE),
+      fetch: fetchMock,
+      onRecord: (record, checkpoint) => {
+        applied.push({ record, checkpoint });
+      },
+      onStateChange: (state) => states.push(state.kind),
+    });
+
+    await controller.start();
+
+    expect(applied).toEqual([
+      {
+        checkpoint: "checkpoint_1",
+        record: {
+          streamId: STREAM_ID,
+          sequence: "18446744073709551615",
+          fragment: null,
+          emittedAtMs: 1_777_890_010_000,
+          channel: "stdout",
+          text: "compile café 🚀",
+        },
+      },
+    ]);
+    expect(controller.checkpoint).toBe("checkpoint_1");
+    expect(states).toEqual(["connecting", "open", "complete"]);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect((url as URL).href).toBe("https://logs.example/live/v1/logs");
+    expect((url as URL).href).not.toContain(TICKET_ONE);
+    expect(init).toMatchObject({
+      credentials: "omit",
+      method: "POST",
+      redirect: "error",
+      referrerPolicy: "no-referrer",
+    });
+    const headers = init?.headers;
+    expect(headers).toBeInstanceOf(Headers);
+    expect((headers as Headers).get("Authorization")).toBe(
+      `AutomataLogTicket ${TICKET_ONE}`,
+    );
+    expect((headers as Headers).get("Last-Event-ID")).toBeNull();
+  });
+
+  it("gets a fresh ticket, resumes its checkpoint, and drops a replayed record", async () => {
+    const records: LiveLogRecord[] = [];
+    const tickets = [TICKET_ONE, TICKET_TWO];
+    const acquire = vi.fn(async () => access(tickets.shift() ?? TICKET_TWO));
+    const responses = [
+      eventStreamResponse(
+        `${logEvent("checkpoint_1", { sequence: "7", text: "first" })}` +
+          "event: reconnect\ndata: {\"protocolVersion\":1}\n\n",
+      ),
+      eventStreamResponse(
+        `${logEvent("checkpoint_1", { sequence: "7", text: "first" })}` +
+          `${logEvent("checkpoint_2", { sequence: "8", text: "second" })}` +
+          "event: complete\ndata: {\"protocolVersion\":1}\n\n",
+      ),
+    ];
+    const fetchMock = vi.fn<LiveLogFetch>(async () => {
+      const response = responses.shift();
+      if (response === undefined) {
+        throw new Error("unexpected live-log request");
+      }
+      return response;
+    });
+    const controller = new LiveLogController({
+      access: acquire,
+      fetch: fetchMock,
+      onRecord: (record) => {
+        records.push(record);
+      },
+    });
+
+    await controller.start();
+
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(records.map((record) => record.text)).toEqual(["first", "second"]);
+    expect(controller.checkpoint).toBe("checkpoint_2");
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    const secondHeaders = fetchMock.mock.calls[1]?.[1]?.headers as Headers;
+    expect(firstHeaders.get("Authorization")).toContain(TICKET_ONE);
+    expect(secondHeaders.get("Authorization")).toContain(TICKET_TWO);
+    expect(secondHeaders.get("Last-Event-ID")).toBe("checkpoint_1");
+  });
+
+  it("does not advance a checkpoint for malformed data and selects fallback", async () => {
+    const fallback = vi.fn();
+    const malformed = logEvent("checkpoint_bad", {
+      sequence: 9,
+      text: "sequence must be lossless decimal text",
+    });
+    const controller = new LiveLogController({
+      access: async () => access(TICKET_ONE),
+      fetch: async () => eventStreamResponse(malformed),
+      maxConsecutiveFailures: 0,
+      onRecord: vi.fn(),
+      onFallback: fallback,
+    });
+
+    await controller.start();
+
+    expect(controller.checkpoint).toBeNull();
+    expect(fallback).toHaveBeenCalledWith({
+      code: "protocol",
+      message: "the log record sequence is invalid",
+    });
+  });
+
+  it("replays a record when the UI has not successfully applied it", async () => {
+    const fallback = vi.fn();
+    const controller = new LiveLogController({
+      access: async () => access(TICKET_ONE),
+      fetch: async () =>
+        eventStreamResponse(
+          logEvent("checkpoint_unapplied", { sequence: "12", text: "retry me" }),
+        ),
+      maxConsecutiveFailures: 0,
+      onRecord: () => {
+        throw new Error("render target unavailable");
+      },
+      onFallback: fallback,
+    });
+
+    await controller.start();
+
+    expect(controller.checkpoint).toBeNull();
+    expect(fallback).toHaveBeenCalledWith({
+      code: "client",
+      message: "the live-log client failed",
+    });
+  });
+
+  it("rejects advertised transport paths that escape the trusted logs origin", async () => {
+    const fallback = vi.fn();
+    const controller = new LiveLogController({
+      access: async () => ({
+        ...access(TICKET_ONE),
+        transports: [
+          {
+            kind: "sse",
+            method: "POST",
+            path: "//evil.invalid/live/v1/logs",
+          },
+        ],
+      }),
+      fetch: vi.fn() as LiveLogFetch,
+      maxConsecutiveFailures: 0,
+      onRecord: vi.fn(),
+      onFallback: fallback,
+    });
+
+    await controller.start();
+
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "protocol" }),
+    );
+  });
+
+  it("pauses, resumes with a fresh ticket, and becomes permanently disposable", async () => {
+    let acquisition = 0;
+    const acquire = vi.fn((signal: AbortSignal): Promise<LiveLogAccess> => {
+      acquisition += 1;
+      if (acquisition === 2) {
+        return Promise.resolve(access(TICKET_TWO));
+      }
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => reject(new DOMException("aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+    const states: string[] = [];
+    const controller = new LiveLogController({
+      access: acquire,
+      fetch: async () =>
+        eventStreamResponse(
+          "event: complete\ndata: {\"protocolVersion\":1}\n\n",
+        ),
+      onRecord: vi.fn(),
+      onStateChange: (state) => states.push(state.kind),
+    });
+
+    expect(controller.running).toBe(false);
+    const first = controller.start();
+    expect(controller.running).toBe(true);
+    expect(controller.start()).toBe(first);
+    controller.pause();
+    const resumed = controller.start();
+    await resumed;
+
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect(states).toContain("paused");
+    expect(controller.running).toBe(false);
+    controller.dispose();
+    await expect(controller.start()).rejects.toThrow("disposed");
+  });
+
+  it("can be paused during bounded retry backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new LiveLogController({
+        access: async () => access(TICKET_ONE),
+        fetch: async () => new Response(null, { status: 503 }),
+        maxConsecutiveFailures: 2,
+        onRecord: vi.fn(),
+      });
+
+      const running = controller.start();
+      await vi.advanceTimersByTimeAsync(0);
+      controller.pause();
+      await running;
+      expect(controller.running).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears a failed run before allowing another start", async () => {
+    const controller = new LiveLogController({
+      access: async () => access(TICKET_ONE),
+      onRecord: vi.fn(),
+      onStateChange: () => {
+        throw new Error("observer failed");
+      },
+    });
+
+    await expect(controller.start()).rejects.toThrow("observer failed");
+    expect(controller.running).toBe(false);
+  });
+});
+
+describe("live-log SSE rejection", () => {
+  it.each([
+    [
+      "HTTP failure",
+      () => new Response(null, { status: 503 }),
+      "transport",
+      "returned 503",
+    ],
+    [
+      "wrong content type",
+      () => new Response("not SSE"),
+      "protocol",
+      "event stream",
+    ],
+    [
+      "missing body",
+      () =>
+        new Response(null, {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      "protocol",
+      "no body",
+    ],
+    [
+      "premature EOF",
+      () => eventStreamResponse(""),
+      "network",
+      "before completion",
+    ],
+    [
+      "invalid UTF-8",
+      () => byteStreamResponse([new Uint8Array([0xff])]),
+      "protocol",
+      "not valid UTF-8",
+    ],
+    [
+      "truncated UTF-8",
+      () => byteStreamResponse([new Uint8Array([0xc3])]),
+      "protocol",
+      "within a UTF-8 character",
+    ],
+    [
+      "oversized chunk",
+      () => byteStreamResponse([new Uint8Array(1024 * 1024 + 1)]),
+      "protocol",
+      "chunk is too large",
+    ],
+    [
+      "oversized buffer",
+      () =>
+        byteStreamResponse([
+          new Uint8Array(600_000).fill(97),
+          new Uint8Array(600_000).fill(97),
+        ]),
+      "protocol",
+      "buffer is too large",
+    ],
+    [
+      "oversized event",
+      () =>
+        eventStreamResponse(
+          `data: ${"a".repeat(300_000)}\ndata: ${"b".repeat(300_000)}\n\n`,
+        ),
+      "protocol",
+      "event is too large",
+    ],
+    [
+      "record without checkpoint",
+      () =>
+        eventStreamResponse(
+          logEvent("checkpoint", {}).replace("id: checkpoint\n", ""),
+        ),
+      "protocol",
+      "no checkpoint",
+    ],
+    [
+      "server error event",
+      () =>
+        eventStreamResponse(
+          "event: error\ndata: {\"protocolVersion\":1,\"error\":\"internal_error\"}\n\n",
+        ),
+      "transport",
+      "internal_error",
+    ],
+    [
+      "unsupported event",
+      () => eventStreamResponse("event: mystery\ndata: {}\n\n"),
+      "protocol",
+      "unsupported event",
+    ],
+    [
+      "duplicate event field",
+      () =>
+        eventStreamResponse(
+          "event: log\nevent: log\ndata: {}\n\n",
+        ),
+      "protocol",
+      "repeats its type",
+    ],
+    [
+      "invalid event ID",
+      () => eventStreamResponse("id: bad\0id\nevent: log\ndata: {}\n\n"),
+      "protocol",
+      "invalid ID",
+    ],
+    [
+      "duplicate retry field",
+      () => eventStreamResponse("retry: 1000\nretry: 1000\n\n"),
+      "protocol",
+      "retry delay",
+    ],
+  ] as const)("rejects %s", async (_name, response, code, message) => {
+    const failure = await failureFor(response());
+
+    expect(failure).toEqual({ code, message: expect.stringContaining(message) });
+  });
+
+  it.each([
+    [{ protocolVersion: 2 }, "protocol version"],
+    [{ streamId: "not-a-uuid" }, "stream ID"],
+    [{ sequence: "18446744073709551616" }, "sequence"],
+    [{ fragment: 0 }, "fragment"],
+    [{ emittedAtMs: 253_402_300_800_000 }, "timestamp"],
+    [{ channel: "debug" }, "channel"],
+    [{ text: "line\nnext" }, "text"],
+    [{ extra: true }, "unexpected fields"],
+  ])("rejects malformed record fields %#", async (overrides, message) => {
+    const failure = await failureFor(eventStreamResponse(logEvent("checkpoint", overrides)));
+
+    expect(failure).toEqual({
+      code: "protocol",
+      message: expect.stringContaining(message),
+    });
+  });
+
+  it.each([
+    ["not JSON", "not valid JSON"],
+    ["[]", "not an object"],
+  ])("rejects a log document that is %s", async (data, message) => {
+    const failure = await failureFor(
+      eventStreamResponse(`id: checkpoint\nevent: log\ndata: ${data}\n\n`),
+    );
+
+    expect(failure.message).toContain(message);
+  });
+
+  it("ignores extension fields in SSE framing itself", async () => {
+    const controller = new LiveLogController({
+      access: async () => access(TICKET_ONE),
+      fetch: async () =>
+        eventStreamResponse(
+          "extension: ignored\nevent: complete\ndata: {\"protocolVersion\":1}\n\n",
+        ),
+      onRecord: vi.fn(),
+    });
+
+    await controller.start();
+  });
+});
+
+function access(ticket: string): LiveLogAccess {
+  return {
+    protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+    ticket,
+    expiresAtMs: Date.now() + 60_000,
+    logsOrigin: "https://logs.example",
+    transports: [{ kind: "sse", method: "POST", path: "/live/v1/logs" }],
+  };
+}
+
+function logEvent(
+  checkpoint: string,
+  overrides: Readonly<Record<string, unknown>> = {},
+): string {
+  const record = {
+    protocolVersion: LIVE_LOG_PROTOCOL_VERSION,
+    streamId: STREAM_ID,
+    sequence: "1",
+    fragment: null,
+    emittedAtMs: 1_777_890_010_000,
+    channel: "stdout",
+    text: "line",
+    ...overrides,
+  };
+  return `id: ${checkpoint}\nevent: log\ndata: ${JSON.stringify(record)}\n\n`;
+}
+
+function eventStreamResponse(
+  value: string,
+  cutPoints: readonly number[] = [],
+): Response {
+  const bytes = new TextEncoder().encode(value);
+  const points = [...cutPoints, bytes.length]
+    .filter((point) => point > 0 && point <= bytes.length)
+    .sort((left, right) => left - right);
+  let offset = 0;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const point of points) {
+        if (point > offset) {
+          controller.enqueue(bytes.slice(offset, point));
+          offset = point;
+        }
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+  });
+}
+
+function byteStreamResponse(chunks: readonly Uint8Array[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+  });
+}
+
+async function failureFor(response: Response): Promise<LiveLogFailure> {
+  let failure: LiveLogFailure | undefined;
+  const controller = new LiveLogController({
+    access: async () => access(TICKET_ONE),
+    fetch: async () => response,
+    maxConsecutiveFailures: 0,
+    onRecord: vi.fn(),
+    onFallback: (selected) => {
+      failure = selected;
+    },
+  });
+
+  await controller.start();
+  if (failure === undefined) {
+    throw new Error("the live-log controller did not select fallback");
+  }
+  return failure;
+}


### PR DESCRIPTION
## Summary

- add a transport-neutral, bounded durable live-log tail over existing verified PostgreSQL/object-storage log segments
- add short-lived one-time tickets bound to the exact workspace, repository, run, job, attempt, stream, protocol version, and browser origin
- issue tickets through both self-hosted human auth and delegated Cloud-to-Core authorization, then stream directly from Core with authenticated fetch-based SSE
- add the shared UI transport controller with strict incremental SSE decoding, fresh-ticket reconnects, replay deduplication, checkpoint-safe application, pause/resume, bounded fallback, and a provider-neutral Cloud/self-hosted ticket boundary
- fan out PostgreSQL commit notifications as latency hints while retaining one-second durable rechecks for correctness
- enforce strict CORS, header-only credentials, lossless u64 sequence identities, bounded batches and client buffers, keepalives, and finite connections

SSE over HTTP/2 is the primary production transport and snapshot polling remains the final fallback. WebTransport is now a measurement-gated future adapter rather than an initial default.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p automata-ci --all-targets --all-features --locked -- -D warnings
- cargo test -p automata-ci app::live_log::tests
- cargo test -p automata-ci-store -p automata-ci-store-postgres -p automata-ci --lib --locked
- cargo test -p automata-ci-postgres --test postgres --all-features --locked live_log_tickets_are_origin_bound_and_consumed_once_across_replicas -- --ignored --test-threads=1 (PostgreSQL 18)
- npm run check (507 frontend tests plus client, SSR, and package builds)
- npm run test:coverage (94.25% statements, 85.34% branches, 97.63% functions, 94.30% lines)
- focused live-log HTTP and transport-neutral replay tests after rebasing onto current main