### PR TITLE
test(results): complete Wave 1 exact-client acceptance

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -197,6 +197,143 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  results_client_acceptance:
+    name: Exact Results clients and production stores
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: docker.io/library/postgres:18.4-bookworm@sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568
+        env:
+          POSTGRES_DB: automata_ci
+          POSTGRES_PASSWORD: automata-ci-local-only
+          POSTGRES_USER: automata_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready --dbname=automata_ci --username=automata_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      AUTOMATA_TEST_DATABASE_URL: postgresql://automata_ci:automata-ci-local-only@127.0.0.1:5432/automata_ci
+      AUTOMATA_TEST_DATABASE_NAMESPACE: res01_${{ github.run_id }}_${{ github.run_attempt }}
+      AUTOMATA_TEST_S3_ENDPOINT: http://127.0.0.1:9000/
+      AUTOMATA_TEST_S3_BUCKET: automata-res01
+      AUTOMATA_TEST_S3_ACCESS_KEY: automata-local
+      AUTOMATA_TEST_S3_SECRET_KEY: automata-local-secret-change-me
+      AUTOMATA_TEST_S3_KMS_KEY_ID: default
+      AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT: ${{ github.workspace }}/target/exact-actions/upload-artifact
+      AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT: ${{ github.workspace }}/target/exact-actions/download-artifact
+      AUTOMATA_TEST_CACHE_ACTION_ROOT: ${{ github.workspace }}/target/exact-actions/cache
+      AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE: ${{ github.workspace }}/target/exact-actions/upload-artifact/node_modules/@actions/artifact/lib/internal/client.js
+      AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE: ${{ github.workspace }}/target/exact-actions/download-artifact/node_modules/@actions/artifact/lib/internal/client.js
+      AUTOMATA_TEST_ACTIONS_CACHE_MODULE: ${{ github.workspace }}/target/exact-actions/cache/node_modules/@actions/cache/lib/cache.js
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare protected task scratch
+        run: install -d -m 0700 -- "$TMPDIR"
+
+      - name: Check out exact upload-artifact fixture
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: actions/upload-artifact
+          ref: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+          path: target/exact-actions/upload-artifact
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check out exact download-artifact fixture
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: actions/download-artifact
+          ref: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+          path: target/exact-actions/download-artifact
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check out exact cache fixture
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: actions/cache
+          ref: 27d5ce7f107fe9357f9df03efb73ab90386fccae
+          path: target/exact-actions/cache
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install exact Node.js runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.19.0
+          package-manager-cache: false
+
+      - name: Hydrate exact offline clients
+        run: |
+          npm ci --prefix target/exact-actions/upload-artifact --ignore-scripts --no-audit --no-fund
+          npm ci --prefix target/exact-actions/download-artifact --ignore-scripts --no-audit --no-fund
+          npm ci --prefix target/exact-actions/cache --ignore-scripts --no-audit --no-fund
+
+      - name: Start pinned production-compatible object store
+        run: |
+          docker run --detach --rm \
+            --name automata-res01-rustfs \
+            --publish 127.0.0.1:9000:9000 \
+            --env RUSTFS_ACCESS_KEY="$AUTOMATA_TEST_S3_ACCESS_KEY" \
+            --env RUSTFS_SECRET_KEY="$AUTOMATA_TEST_S3_SECRET_KEY" \
+            --env RUSTFS_SSE_S3_MASTER_KEY=YXV0b21hdGEtbG9jYWwtc3NlLW1hc3Rlci1rZXktdjE= \
+            --env RUSTFS_ADDRESS=0.0.0.0:9000 \
+            docker.io/rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c \
+            /data
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs automata-res01-rustfs
+          exit 1
+
+      - name: Initialize and verify immutable object storage
+        run: >-
+          cargo test --locked -p automata-ci-blob-s3 --test blob_s3 --all-features
+          rustfs_contract:: -- --ignored --test-threads=1
+
+      - name: Verify immutable action and embedded-client pins
+        run: >-
+          cargo test --locked -p automata-ci-results-github --test client_matrix
+          supplied_action_roots_match_every_immutable_client_pin -- --ignored --exact
+
+      - name: Run exact client protocol tests
+        run: |
+          cargo test --locked -p automata-ci-results-github --test http_compatibility --all-features -- --ignored --test-threads=1
+          cargo test --locked -p automata-ci-results-github --test cache_http --all-features -- --ignored --test-threads=1
+
+      - name: Run exact clients across PostgreSQL and production object storage
+        run: >-
+          cargo test --locked -p automata-ci-results-github --test exact_client_real_store
+          --all-features exact_clients_cross_real_http_postgres_and_object_storage
+          -- --ignored --exact --test-threads=1
+
+      - name: Upload redacted Results acceptance evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: exact-results-client-evidence
+          path: target/agent-scratch/exact-client-real-store/**/redacted-results-transcript.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Stop object store
+        if: ${{ always() }}
+        run: docker rm --force automata-res01-rustfs 2>/dev/null || true
+
   renderer_tests:
     name: Rust renderer tests
     runs-on: ubuntu-24.04

--- a/crates/automata-ci-results-github/README.md
+++ b/crates/automata-ci-results-github/README.md
@@ -9,7 +9,10 @@ The implemented clients are:
 
 - `actions/upload-artifact` v7.0.1 at commit
   `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`, using `@actions/artifact`
-  6.2.0; and
+  6.2.0;
+- `actions/download-artifact` v8.0.1 at commit
+  `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`, using `@actions/artifact`
+  6.2.1; and
 - `actions/cache` 5.0.5 using JSON Twirp CacheService v2.
 
 These are tested protocol slices, not general artifact or cache API
@@ -128,4 +131,8 @@ specifications.
 Ignored offline integration tests run the exact artifact and cache clients when
 their module paths are supplied through
 `AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE` and
-`AUTOMATA_TEST_ACTIONS_CACHE_MODULE`. The tests download no packages.
+`AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE`, plus
+`AUTOMATA_TEST_ACTIONS_CACHE_MODULE`. The tests download no packages. An
+additional ignored composition test requires PostgreSQL and production S3,
+runs all three clients through the real adapters, verifies downloaded bytes and
+durable metadata, and writes only closed-enum, identifier-free evidence.

--- a/crates/automata-ci-results-github/README.md
+++ b/crates/automata-ci-results-github/README.md
@@ -15,6 +15,21 @@ The implemented clients are:
 These are tested protocol slices, not general artifact or cache API
 compatibility.
 
+The canonical client inventory is
+[`tests/fixtures/exact-client-matrix-v1.json`](tests/fixtures/exact-client-matrix-v1.json).
+`component` means the exact client library passes focused adapter tests;
+`candidate` means the immutable action is pinned but product acceptance is not
+yet complete. Only `product-accepted` may be advertised as real-store wrapper
+acceptance.
+
+<!-- exact-client-matrix:start -->
+| Action | Release | Commit | Embedded client | Status |
+| --- | --- | --- | --- | --- |
+| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | `@actions/artifact` `6.2.0` | `component` |
+| `actions/download-artifact` | `v8.0.1` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | `@actions/artifact` `6.2.1` | `candidate` |
+| `actions/cache` | `v5.0.5` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` | `@actions/cache` `5.0.5` | `component` |
+<!-- exact-client-matrix:end -->
+
 ## Artifacts
 
 The upload sequence is:

--- a/crates/automata-ci-results-github/tests/cache_http.rs
+++ b/crates/automata-ci-results-github/tests/cache_http.rs
@@ -750,13 +750,15 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
             .expect("cache-client fixture server");
     });
 
-    let scratch = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../target/agent-scratch/cache-results/action-client-run")
+    let manifest_directory = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_directory
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("results crate is nested under the workspace crates directory");
+    let scratch = workspace_root
+        .join("target/agent-scratch/cache-results/action-client-run")
         .join(Uuid::new_v4().simple().to_string());
     std::fs::create_dir_all(&scratch).expect("create repository-local test scratch");
-    let scratch = scratch
-        .canonicalize()
-        .expect("canonical repository-local test scratch");
     let input = scratch.join("cache-input.txt");
     std::fs::write(&input, b"official @actions/cache 5.0.5 integration bytes")
         .expect("write fixture input");
@@ -766,7 +768,7 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
         .join("tests/fixtures/official_cache_v2_client.mjs");
     let token = fixture.token;
     let process_scratch = scratch.clone();
-    let status = tokio::task::spawn_blocking(move || {
+    let output = tokio::task::spawn_blocking(move || {
         std::process::Command::new("node")
             .arg(script)
             .env("ACTIONS_RUNTIME_TOKEN", token)
@@ -776,14 +778,18 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
             .env("RUNNER_TEMP", runner_temp)
             .env("AUTOMATA_TEST_ACTIONS_CACHE_MODULE", module_path)
             .env("AUTOMATA_TEST_CACHE_INPUT", input)
-            .status()
+            .output()
             .expect("run official cache client")
     })
     .await
     .expect("join Node cache client");
     server.abort();
     std::fs::remove_dir_all(&scratch).expect("remove cache-client fixture scratch");
-    assert!(status.success(), "official cache-v2 client must complete");
+    assert!(
+        output.status.success(),
+        "official cache-v2 client exited with {}",
+        output.status
+    );
 }
 
 #[tokio::test]

--- a/crates/automata-ci-results-github/tests/cache_http.rs
+++ b/crates/automata-ci-results-github/tests/cache_http.rs
@@ -769,7 +769,7 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
     let token = fixture.token;
     let process_scratch = scratch.clone();
     let output = tokio::task::spawn_blocking(move || {
-        std::process::Command::new("node")
+        isolated_node_command()
             .arg(script)
             .env("ACTIONS_RUNTIME_TOKEN", token)
             .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
@@ -790,6 +790,28 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
         "official cache-v2 client exited with {}",
         output.status
     );
+}
+
+fn isolated_node_command() -> std::process::Command {
+    let mut command = std::process::Command::new("node");
+    command.env_clear();
+    for name in [
+        "PATH",
+        "PATHEXT",
+        "SystemRoot",
+        "WINDIR",
+        "ComSpec",
+        "HOME",
+        "USERPROFILE",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
 }
 
 #[tokio::test]

--- a/crates/automata-ci-results-github/tests/client_matrix.rs
+++ b/crates/automata-ci-results-github/tests/client_matrix.rs
@@ -27,7 +27,7 @@ struct ExactClient {
     release: String,
     commit: String,
     manifest_version: String,
-    action_entry: String,
+    action_entries: Vec<String>,
     action_root_environment: String,
     embedded_package: String,
     embedded_version: String,
@@ -98,7 +98,16 @@ fn exact_client_matrix_is_closed_pinned_and_network_independent() {
         assert!(client.release.starts_with('v'));
         assert!(is_lower_hex_sha(&client.commit));
         assert!(!client.manifest_version.is_empty());
-        assert!(is_safe_relative_path(&client.action_entry));
+        assert!(!client.action_entries.is_empty());
+        let mut action_entries = BTreeSet::new();
+        for action_entry in &client.action_entries {
+            assert!(is_safe_relative_path(action_entry));
+            assert!(
+                action_entries.insert(action_entry),
+                "duplicate action entry for {}",
+                client.id
+            );
+        }
         assert!(is_safe_relative_path(&client.module_entry));
         assert!(client.action_root_environment.starts_with("AUTOMATA_TEST_"));
         assert!(client.module_environment.starts_with("AUTOMATA_TEST_"));
@@ -200,7 +209,13 @@ fn supplied_action_roots_match_every_immutable_client_pin() {
         assert_eq!(embedded["version"], client.embedded_version);
         assert_eq!(embedded["integrity"], client.embedded_integrity);
 
-        assert!(canonical_child(&root, &client.action_entry).is_file());
+        for action_entry in &client.action_entries {
+            assert!(
+                canonical_child(&root, action_entry).is_file(),
+                "pinned wrapper entry is missing for {}",
+                client.id
+            );
+        }
         let module = canonical_child(&root, &client.module_entry);
         assert!(module.is_file());
         let configured_module = std::env::var_os(&client.module_environment)

--- a/crates/automata-ci-results-github/tests/client_matrix.rs
+++ b/crates/automata-ci-results-github/tests/client_matrix.rs
@@ -1,0 +1,218 @@
+use std::{
+    collections::BTreeSet,
+    fmt::Write as _,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use serde::Deserialize;
+
+const MATRIX_JSON: &str = include_str!("fixtures/exact-client-matrix-v1.json");
+const README: &str = include_str!("../README.md");
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExactClientMatrix {
+    schema: u16,
+    node_major: u8,
+    network_policy: String,
+    clients: Vec<ExactClient>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExactClient {
+    id: String,
+    repository: String,
+    release: String,
+    commit: String,
+    manifest_version: String,
+    action_entry: String,
+    action_root_environment: String,
+    embedded_package: String,
+    embedded_version: String,
+    embedded_integrity: String,
+    module_entry: String,
+    module_environment: String,
+    operations: Vec<String>,
+    support_status: String,
+}
+
+fn matrix() -> ExactClientMatrix {
+    serde_json::from_str(MATRIX_JSON).expect("exact-client matrix must use its closed v1 schema")
+}
+
+fn is_lower_hex_sha(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn is_safe_relative_path(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with(['/', '\\'])
+        && !value.contains("..")
+        && !value.contains('\\')
+}
+
+fn markdown_matrix(clients: &[ExactClient]) -> String {
+    let mut table = String::from(
+        "<!-- exact-client-matrix:start -->\n\
+| Action | Release | Commit | Embedded client | Status |\n\
+| --- | --- | --- | --- | --- |\n",
+    );
+    for client in clients {
+        writeln!(
+            table,
+            "| `{}` | `{}` | `{}` | `{}` `{}` | `{}` |",
+            client.repository,
+            client.release,
+            client.commit,
+            client.embedded_package,
+            client.embedded_version,
+            client.support_status,
+        )
+        .expect("render exact-client matrix");
+    }
+    table.push_str("<!-- exact-client-matrix:end -->");
+    table
+}
+
+#[test]
+fn exact_client_matrix_is_closed_pinned_and_network_independent() {
+    let matrix = matrix();
+    assert_eq!(matrix.schema, 1);
+    assert_eq!(matrix.node_major, 24);
+    assert_eq!(matrix.network_policy, "loopback-only-no-downloads");
+    assert_eq!(matrix.clients.len(), 3);
+
+    let mut ids = BTreeSet::new();
+    let mut repositories = BTreeSet::new();
+    for client in &matrix.clients {
+        assert!(ids.insert(client.id.as_str()), "duplicate client ID");
+        assert!(
+            repositories.insert(client.repository.as_str()),
+            "duplicate repository"
+        );
+        assert!(client.release.starts_with('v'));
+        assert!(is_lower_hex_sha(&client.commit));
+        assert!(!client.manifest_version.is_empty());
+        assert!(is_safe_relative_path(&client.action_entry));
+        assert!(is_safe_relative_path(&client.module_entry));
+        assert!(client.action_root_environment.starts_with("AUTOMATA_TEST_"));
+        assert!(client.module_environment.starts_with("AUTOMATA_TEST_"));
+        assert!(client.embedded_package.starts_with("@actions/"));
+        assert!(client.embedded_integrity.starts_with("sha512-"));
+        assert!(!client.operations.is_empty());
+        assert!(matches!(
+            client.support_status.as_str(),
+            "candidate" | "component" | "product-accepted"
+        ));
+    }
+
+    assert_eq!(
+        ids,
+        BTreeSet::from(["cache", "download-artifact", "upload-artifact"])
+    );
+}
+
+#[test]
+fn documentation_matrix_is_rendered_from_the_exact_fixture() {
+    let matrix = matrix();
+    let expected = markdown_matrix(&matrix.clients);
+    assert!(
+        README.contains(&expected),
+        "README exact-client table must match tests/fixtures/exact-client-matrix-v1.json"
+    );
+}
+
+fn canonical_child(root: &Path, relative: &str) -> PathBuf {
+    let child = root
+        .join(relative)
+        .canonicalize()
+        .expect("pinned action entry must exist");
+    assert!(child.starts_with(root), "action entry escaped its root");
+    child
+}
+
+fn git_output(root: &Path, arguments: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(arguments)
+        .output()
+        .expect("run local git verification");
+    assert!(output.status.success(), "local git verification failed");
+    String::from_utf8(output.stdout)
+        .expect("git verification output must be UTF-8")
+        .trim()
+        .to_owned()
+}
+
+#[test]
+#[ignore = "requires the three offline action roots named by exact-client-matrix-v1.json"]
+fn supplied_action_roots_match_every_immutable_client_pin() {
+    let matrix = matrix();
+    let node_version = Command::new("node")
+        .arg("--version")
+        .output()
+        .expect("Node must be installed for exact-client acceptance");
+    assert!(node_version.status.success());
+    let node_version = String::from_utf8(node_version.stdout).expect("Node version is UTF-8");
+    assert!(
+        node_version.starts_with(&format!("v{}.", matrix.node_major)),
+        "exact-client acceptance requires Node {}",
+        matrix.node_major
+    );
+
+    for client in matrix.clients {
+        let root = std::env::var_os(&client.action_root_environment)
+            .map_or_else(
+                || panic!("set {}", client.action_root_environment),
+                PathBuf::from,
+            )
+            .canonicalize()
+            .expect("canonical pinned action root");
+        assert_eq!(git_output(&root, &["rev-parse", "HEAD"]), client.commit);
+        assert_eq!(
+            git_output(&root, &["status", "--short", "--untracked-files=no"]),
+            "",
+            "pinned action checkout contains tracked mutations"
+        );
+
+        let manifest: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(canonical_child(&root, "package.json"))
+                .expect("read action package manifest"),
+        )
+        .expect("parse action package manifest");
+        assert_eq!(manifest["name"], client.id);
+        assert_eq!(manifest["version"], client.manifest_version);
+
+        let lock: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(canonical_child(&root, "package-lock.json"))
+                .expect("read action package lock"),
+        )
+        .expect("parse action package lock");
+        assert_eq!(lock["lockfileVersion"], 3);
+        let embedded_key = format!("node_modules/{}", client.embedded_package);
+        let embedded = &lock["packages"][&embedded_key];
+        assert_eq!(embedded["version"], client.embedded_version);
+        assert_eq!(embedded["integrity"], client.embedded_integrity);
+
+        assert!(canonical_child(&root, &client.action_entry).is_file());
+        let module = canonical_child(&root, &client.module_entry);
+        assert!(module.is_file());
+        let configured_module = std::env::var_os(&client.module_environment)
+            .map_or_else(
+                || panic!("set {}", client.module_environment),
+                PathBuf::from,
+            )
+            .canonicalize()
+            .expect("canonical exact client module");
+        assert_eq!(
+            configured_module, module,
+            "exact client module must come from the verified action root"
+        );
+    }
+}

--- a/crates/automata-ci-results-github/tests/exact_client_real_store.rs
+++ b/crates/automata-ci-results-github/tests/exact_client_real_store.rs
@@ -1,0 +1,913 @@
+mod support;
+
+use std::{
+    collections::BTreeSet,
+    env,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use automata_ci_blob::ImmutableBlobStore;
+use automata_ci_blob_s3::{
+    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
+};
+use automata_ci_control::adapter_spi::{
+    AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
+};
+use automata_ci_core::{AttemptId, AttemptNumber, LeaseId, UnixMillis};
+use automata_ci_results_github::{
+    ArtifactRepository, ArtifactService, CacheAccessScope, CacheAuthority, CacheLimits,
+    CachePermission, CacheRepository, CacheService, ExecutionAuthority, GithubCacheApi,
+    GithubCacheHttpLimits, GithubResultsApi, GithubResultsHttpLimits, HmacResultsAuthority,
+    HmacResultsAuthorityConfig, ObservedResultsArtifactRepository, ObservedResultsBlobStore,
+    PostgresArtifactRepository, PostgresCacheRepository, ResultsBlobOperation,
+    ResultsBlobOperationOutcome, ResultsClock, ResultsHttpMethod, ResultsHttpRoute,
+    ResultsHttpStatusClass, ResultsLimits, ResultsObserver, ResultsPublicEndpoint,
+    RuntimeTokenIssuer as _, SystemResultsIdGenerator,
+};
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+    response::Response,
+};
+use bytes::Bytes;
+use http_body_util::BodyExt as _;
+use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+use tower::ServiceExt as _;
+use url::Url;
+use uuid::Uuid;
+
+const ARTIFACT_NAME: &str = "official-actions-artifact-client";
+const CACHE_KEY: &str = "official-actions-cache-v5-0-5";
+
+struct RealStoreEnvironment {
+    upload_artifact_module: PathBuf,
+    download_artifact_module: PathBuf,
+    cache_module: PathBuf,
+    s3_endpoint: Url,
+    s3_bucket: String,
+    s3_access_key: String,
+    s3_secret_key: String,
+    s3_kms_key_id: String,
+}
+
+impl RealStoreEnvironment {
+    fn load() -> TestResult<Self> {
+        require_node_major(24)?;
+        Ok(Self {
+            upload_artifact_module: required_pinned_module(
+                "AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT",
+                "AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE",
+                "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+                "node_modules/@actions/artifact/lib/internal/client.js",
+            )?,
+            download_artifact_module: required_pinned_module(
+                "AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT",
+                "AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE",
+                "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+                "node_modules/@actions/artifact/lib/internal/client.js",
+            )?,
+            cache_module: required_pinned_module(
+                "AUTOMATA_TEST_CACHE_ACTION_ROOT",
+                "AUTOMATA_TEST_ACTIONS_CACHE_MODULE",
+                "27d5ce7f107fe9357f9df03efb73ab90386fccae",
+                "node_modules/@actions/cache/lib/cache.js",
+            )?,
+            s3_endpoint: Url::parse(&required("AUTOMATA_TEST_S3_ENDPOINT")?)?,
+            s3_bucket: required("AUTOMATA_TEST_S3_BUCKET")?,
+            s3_access_key: required("AUTOMATA_TEST_S3_ACCESS_KEY")?,
+            s3_secret_key: required("AUTOMATA_TEST_S3_SECRET_KEY")?,
+            s3_kms_key_id: required("AUTOMATA_TEST_S3_KMS_KEY_ID")?,
+        })
+    }
+}
+
+fn required(name: &str) -> TestResult<String> {
+    env::var(name).map_err(|_| format!("set {name} for exact-client real-store acceptance").into())
+}
+
+fn required_path(name: &str) -> TestResult<PathBuf> {
+    let path = PathBuf::from(required(name)?);
+    if !path.is_absolute() || !path.is_file() {
+        return Err(format!("{name} must name one absolute regular file").into());
+    }
+    Ok(path.canonicalize()?)
+}
+
+fn required_pinned_module(
+    root_environment: &str,
+    module_environment: &str,
+    expected_commit: &str,
+    module_relative_path: &str,
+) -> TestResult<PathBuf> {
+    let root = PathBuf::from(required(root_environment)?)
+        .canonicalize()
+        .map_err(|error| format!("canonicalize {root_environment}: {error}"))?;
+    if !root.is_dir() {
+        return Err(format!("{root_environment} must name one directory").into());
+    }
+    let commit = git_output(&root, &["rev-parse", "HEAD"])?;
+    if commit != expected_commit {
+        return Err(format!("{root_environment} has unexpected commit {commit}").into());
+    }
+    if !git_output(&root, &["status", "--short", "--untracked-files=no"])?.is_empty() {
+        return Err(format!("{root_environment} has tracked mutations").into());
+    }
+    let expected_module = root.join(module_relative_path).canonicalize()?;
+    let configured_module = required_path(module_environment)?;
+    if expected_module != configured_module {
+        return Err(format!("{module_environment} is outside its pinned action root").into());
+    }
+    Ok(configured_module)
+}
+
+fn git_output(root: &Path, arguments: &[&str]) -> TestResult<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(arguments)
+        .output()?;
+    if !output.status.success() {
+        return Err("exact-client Git identity verification failed".into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn require_node_major(expected: u8) -> TestResult {
+    let output = Command::new("node").arg("--version").output()?;
+    if !output.status.success()
+        || !String::from_utf8(output.stdout)?.starts_with(&format!("v{expected}."))
+    {
+        return Err(format!("exact-client acceptance requires Node {expected}").into());
+    }
+    Ok(())
+}
+
+fn isolated_node_command() -> Command {
+    let mut command = Command::new("node");
+    command.env_clear();
+    for name in [
+        "PATH",
+        "PATHEXT",
+        "SystemRoot",
+        "WINDIR",
+        "ComSpec",
+        "HOME",
+        "USERPROFILE",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+    ] {
+        if let Some(value) = env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
+}
+
+#[derive(Debug)]
+struct FixedClock(u64);
+
+impl ResultsClock for FixedClock {
+    fn now_seconds(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HttpRecord {
+    method: ResultsHttpMethod,
+    route: ResultsHttpRoute,
+    status: ResultsHttpStatusClass,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BlobRecord {
+    operation: ResultsBlobOperation,
+    outcome: ResultsBlobOperationOutcome,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BlobBytes {
+    operation: ResultsBlobOperation,
+    bytes: u64,
+}
+
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    http_records: Mutex<Vec<HttpRecord>>,
+    blob_records: Mutex<Vec<BlobRecord>>,
+    blob_bytes: Mutex<Vec<BlobBytes>>,
+}
+
+impl RecordingObserver {
+    fn http_records(&self) -> Vec<HttpRecord> {
+        self.http_records.lock().expect("observer lock").clone()
+    }
+
+    fn blob_records(&self) -> Vec<BlobRecord> {
+        self.blob_records.lock().expect("observer lock").clone()
+    }
+
+    fn blob_bytes(&self) -> Vec<BlobBytes> {
+        self.blob_bytes.lock().expect("observer lock").clone()
+    }
+}
+
+impl ResultsObserver for RecordingObserver {
+    fn observe_results_http_request(
+        &self,
+        method: ResultsHttpMethod,
+        route: ResultsHttpRoute,
+        status: ResultsHttpStatusClass,
+        _duration: Duration,
+    ) {
+        self.http_records
+            .lock()
+            .expect("observer lock")
+            .push(HttpRecord {
+                method,
+                route,
+                status,
+            });
+    }
+
+    fn observe_blob_operation(
+        &self,
+        operation: ResultsBlobOperation,
+        outcome: ResultsBlobOperationOutcome,
+        _duration: Duration,
+    ) {
+        self.blob_records
+            .lock()
+            .expect("observer lock")
+            .push(BlobRecord { operation, outcome });
+    }
+
+    fn observe_blob_bytes(&self, operation: ResultsBlobOperation, bytes: u64) {
+        self.blob_bytes
+            .lock()
+            .expect("observer lock")
+            .push(BlobBytes { operation, bytes });
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires PostgreSQL, production S3, Node >=24, and exact offline artifact/cache modules"]
+async fn exact_clients_cross_real_http_postgres_and_object_storage() -> TestResult {
+    let environment = RealStoreEnvironment::load()?;
+    run_with_database(move |database| async move { run_exact_clients(database, environment).await })
+        .await
+}
+
+async fn run_exact_clients(
+    database: Arc<TestDatabase>,
+    environment: RealStoreEnvironment,
+) -> TestResult {
+    let (execution, now_seconds) = active_attempt(&database).await?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let public_url = Url::parse(&format!("http://{address}/"))?;
+    let (router, token, expired_token, observer) = real_results_router(
+        &database,
+        &environment,
+        execution,
+        now_seconds,
+        public_url,
+        address,
+    )?;
+    let adversarial_router = router.clone();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await });
+
+    let scratch = test_scratch("exact-client-real-store");
+    std::fs::create_dir_all(&scratch)?;
+    let client_result = run_clients(&environment, &scratch, &token, address);
+    let adversarial_result =
+        run_real_store_adversarial_matrix(&adversarial_router, &token, &expired_token, execution)
+            .await;
+    server.abort();
+    client_result?;
+    adversarial_result?;
+
+    assert_durable_publication(&database, execution).await?;
+    write_redacted_transcript(
+        &scratch,
+        &observer.http_records(),
+        &observer.blob_records(),
+        &observer.blob_bytes(),
+        &[
+            token.as_str(),
+            environment.s3_access_key.as_str(),
+            environment.s3_secret_key.as_str(),
+            environment.s3_kms_key_id.as_str(),
+            environment.s3_bucket.as_str(),
+            environment.s3_endpoint.as_str(),
+        ],
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn real_results_router(
+    database: &TestDatabase,
+    environment: &RealStoreEnvironment,
+    execution: ExecutionAuthority,
+    now_seconds: u64,
+    public_url: Url,
+    listener_address: std::net::SocketAddr,
+) -> TestResult<(Router, String, String, Arc<RecordingObserver>)> {
+    let s3_config = S3BlobStoreConfig::loopback_development(
+        environment.s3_endpoint.clone(),
+        "us-east-1",
+        environment.s3_bucket.clone(),
+        Some(format!("exact-clients/{}", Uuid::new_v4().simple())),
+        Duration::from_secs(20),
+    )?
+    .with_at_rest_encryption(S3AtRestEncryption::aws_kms(
+        environment.s3_kms_key_id.clone(),
+    )?);
+    let objects: Arc<dyn ImmutableBlobStore> = Arc::new(S3BlobStore::new(
+        s3_config.client(StaticS3Credentials::new(
+            environment.s3_access_key.clone(),
+            environment.s3_secret_key.clone(),
+            None,
+        )?),
+        &s3_config,
+    ));
+    let observer = Arc::new(RecordingObserver::default());
+    let public_observer: Arc<dyn ResultsObserver> = observer.clone();
+    let objects: Arc<dyn ImmutableBlobStore> = Arc::new(ObservedResultsBlobStore::new(
+        objects,
+        Arc::clone(&public_observer),
+    ));
+    let artifact_repository: Arc<dyn ArtifactRepository> =
+        Arc::new(ObservedResultsArtifactRepository::new(
+            Arc::new(PostgresArtifactRepository::new(database.pool().clone())),
+            Arc::clone(&public_observer),
+        ));
+    let cache_repository: Arc<dyn CacheRepository> =
+        Arc::new(PostgresCacheRepository::new(database.pool().clone()));
+    let clock: Arc<dyn ResultsClock> = Arc::new(FixedClock(now_seconds));
+    let ids = Arc::new(SystemResultsIdGenerator);
+    let artifacts = Arc::new(
+        ArtifactService::new(
+            artifact_repository,
+            Arc::clone(&objects),
+            Arc::clone(&clock),
+            ids.clone(),
+            ResultsLimits::default(),
+        )
+        .with_observer(Arc::clone(&public_observer)),
+    );
+    let caches = Arc::new(CacheService::new(
+        cache_repository,
+        objects,
+        Arc::clone(&clock),
+        ids,
+        CacheLimits::default(),
+    ));
+    let (authority, token, expired_token) =
+        results_authority_and_tokens(public_url, listener_address, now_seconds, execution, clock)?;
+    let router = GithubResultsApi::new(
+        artifacts,
+        authority.clone(),
+        authority.clone(),
+        authority.clone(),
+        GithubResultsHttpLimits::default(),
+    )
+    .with_observer(Arc::clone(&public_observer))
+    .router()
+    .merge(
+        GithubCacheApi::new(
+            caches,
+            authority.clone(),
+            authority,
+            GithubCacheHttpLimits::default(),
+        )
+        .with_observer(public_observer)
+        .router(),
+    );
+    Ok((router, token, expired_token, observer))
+}
+
+fn results_authority_and_tokens(
+    public_url: Url,
+    listener_address: std::net::SocketAddr,
+    now_seconds: u64,
+    execution: ExecutionAuthority,
+    clock: Arc<dyn ResultsClock>,
+) -> TestResult<(Arc<HmacResultsAuthority>, String, String)> {
+    let authority_config = HmacResultsAuthorityConfig::new(
+        "automata-tests",
+        "actions-results",
+        "exact-client-v1",
+        ResultsPublicEndpoint::loopback_development(public_url, listener_address)?,
+        900,
+        900,
+        0,
+    )?;
+    let authority = Arc::new(HmacResultsAuthority::new(
+        b"exact-client-real-store-signing-key-v1",
+        authority_config.clone(),
+        clock,
+    )?);
+    let cache = CacheAuthority::new(
+        "automata/results-test",
+        vec![CacheAccessScope::new(
+            "refs/heads/main",
+            CachePermission::ReadWrite,
+        )?],
+    )?;
+    let token = authority
+        .issue(execution, cache.clone(), 600)?
+        .expose_secret()
+        .to_owned();
+    let expired_clock: Arc<dyn ResultsClock> =
+        Arc::new(FixedClock(now_seconds.saturating_sub(1_200)));
+    let expired_token = HmacResultsAuthority::new(
+        b"exact-client-real-store-signing-key-v1",
+        authority_config,
+        expired_clock,
+    )?
+    .issue(execution, cache, 60)?
+    .expose_secret()
+    .to_owned();
+    Ok((authority, token, expired_token))
+}
+
+fn run_clients(
+    environment: &RealStoreEnvironment,
+    scratch: &Path,
+    token: &str,
+    address: std::net::SocketAddr,
+) -> TestResult {
+    let artifact_root = scratch.join("artifact");
+    let cache_root = scratch.join("cache");
+    std::fs::create_dir_all(&artifact_root)?;
+    std::fs::create_dir_all(&cache_root)?;
+
+    let artifact_input = artifact_root.join("immutable-input.txt");
+    std::fs::write(
+        &artifact_input,
+        b"exact official artifact client through PostgreSQL and production S3",
+    )?;
+    let artifact_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/official_artifact_client.mjs");
+    run_node(
+        "artifact",
+        isolated_node_command()
+            .arg(artifact_script)
+            .env("ACTIONS_RUNTIME_TOKEN", token)
+            .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
+            .env("GITHUB_SERVER_URL", "http://automata-git.ghe.com:8088/")
+            .env("GITHUB_WORKSPACE", &artifact_root)
+            .env(
+                "AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE",
+                &environment.upload_artifact_module,
+            )
+            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.0")
+            .env("AUTOMATA_TEST_ARTIFACT_INPUT", &artifact_input)
+            .env("AUTOMATA_TEST_ARTIFACT_ROOT", &artifact_root),
+    )?;
+
+    let download_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/official_artifact_download_client.mjs");
+    run_node(
+        "download-artifact",
+        isolated_node_command()
+            .arg(download_script)
+            .env("ACTIONS_RUNTIME_TOKEN", token)
+            .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
+            .env("GITHUB_SERVER_URL", "http://automata-git.ghe.com:8088/")
+            .env("GITHUB_WORKSPACE", &artifact_root)
+            .env(
+                "AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE",
+                &environment.download_artifact_module,
+            )
+            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.1")
+            .env("AUTOMATA_TEST_ARTIFACT_INPUT", &artifact_input)
+            .env("AUTOMATA_TEST_ARTIFACT_ROOT", &artifact_root),
+    )?;
+
+    let cache_input = cache_root.join("cache-input.txt");
+    let runner_temp = cache_root.join("runner-temp");
+    std::fs::create_dir_all(&runner_temp)?;
+    std::fs::write(
+        &cache_input,
+        b"exact official cache client through PostgreSQL and production S3",
+    )?;
+    let cache_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/official_cache_v2_client.mjs");
+    run_node(
+        "cache",
+        isolated_node_command()
+            .arg(cache_script)
+            .env("ACTIONS_RUNTIME_TOKEN", token)
+            .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
+            .env("ACTIONS_CACHE_SERVICE_V2", "true")
+            .env("GITHUB_WORKSPACE", &cache_root)
+            .env("RUNNER_TEMP", runner_temp)
+            .env(
+                "AUTOMATA_TEST_ACTIONS_CACHE_MODULE",
+                &environment.cache_module,
+            )
+            .env("AUTOMATA_TEST_CACHE_INPUT", cache_input),
+    )
+}
+
+#[allow(clippy::too_many_lines)] // One ordered real-store transcript covers every RES-01 adversarial case.
+async fn run_real_store_adversarial_matrix(
+    router: &Router,
+    token: &str,
+    expired_token: &str,
+    execution: ExecutionAuthority,
+) -> TestResult {
+    let malformed_route = send_json(
+        router,
+        token,
+        "/twirp/github.actions.results.api.v1.CacheService/UnsupportedOperation",
+        serde_json::json!({}),
+    )
+    .await?;
+    require_status("malformed route", &malformed_route, StatusCode::NOT_FOUND)?;
+
+    let truncated_json = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{"))?,
+        )
+        .await?;
+    require_status("truncated JSON", &truncated_json, StatusCode::BAD_REQUEST)?;
+
+    let expired = send_json(
+        router,
+        expired_token,
+        "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",
+        serde_json::json!({"key":"expired", "version":"v1"}),
+    )
+    .await?;
+    require_status("expired token", &expired, StatusCode::UNAUTHORIZED)?;
+
+    let wrong_scope = send_json(
+        router,
+        token,
+        "/twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact",
+        serde_json::json!({
+            "workflow_run_backend_id": execution.run_id().to_string(),
+            "workflow_job_run_backend_id": Uuid::new_v4().to_string(),
+            "name": "wrong-scope",
+            "version": 7,
+            "mime_type": "application/zip"
+        }),
+    )
+    .await?;
+    require_status("wrong execution scope", &wrong_scope, StatusCode::FORBIDDEN)?;
+
+    let cache_key = "real-store-adversarial-cache-v1";
+    let cache_version = "version-v1";
+    let create = send_json(
+        router,
+        token,
+        "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",
+        serde_json::json!({"key":cache_key, "version":cache_version}),
+    )
+    .await?;
+    require_status("cache create", &create, StatusCode::OK)?;
+    let created = json_body(create).await?;
+    let upload_url = Url::parse(
+        created["signed_upload_url"]
+            .as_str()
+            .ok_or("cache create omitted its signed upload URL")?,
+    )?;
+    let cache_bytes = Bytes::from_static(b"0123456789");
+    for label in ["cache upload", "cache upload exact replay"] {
+        let upload = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(path_and_query(&upload_url))
+                    .header(header::CONTENT_LENGTH, cache_bytes.len())
+                    .body(Body::from(cache_bytes.clone()))?,
+            )
+            .await?;
+        require_status(label, &upload, StatusCode::CREATED)?;
+    }
+
+    let finalize_body = serde_json::json!({
+        "key":cache_key,
+        "version":cache_version,
+        "size_bytes":cache_bytes.len().to_string()
+    });
+    for label in ["cache finalize", "cache duplicate finalize"] {
+        let finalized = send_json(
+            router,
+            token,
+            "/twirp/github.actions.results.api.v1.CacheService/FinalizeCacheEntryUpload",
+            finalize_body.clone(),
+        )
+        .await?;
+        require_status(label, &finalized, StatusCode::OK)?;
+    }
+    let size_mismatch = send_json(
+        router,
+        token,
+        "/twirp/github.actions.results.api.v1.CacheService/FinalizeCacheEntryUpload",
+        serde_json::json!({
+            "key":cache_key,
+            "version":cache_version,
+            "size_bytes":cache_bytes.len() - 1
+        }),
+    )
+    .await?;
+    require_status("cache size mismatch", &size_mismatch, StatusCode::CONFLICT)?;
+
+    let lookup = send_json(
+        router,
+        token,
+        "/twirp/github.actions.results.api.v1.CacheService/GetCacheEntryDownloadURL",
+        serde_json::json!({
+            "key":cache_key,
+            "version":cache_version,
+            "restore_keys":[]
+        }),
+    )
+    .await?;
+    require_status("cache lookup", &lookup, StatusCode::OK)?;
+    let lookup = json_body(lookup).await?;
+    let download_url = Url::parse(
+        lookup["signed_download_url"]
+            .as_str()
+            .ok_or("cache lookup omitted its signed download URL")?,
+    )?;
+    let range = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(path_and_query(&download_url))
+                .header(header::RANGE, "bytes=2-5")
+                .body(Body::empty())?,
+        )
+        .await?;
+    require_status("cache range", &range, StatusCode::PARTIAL_CONTENT)?;
+    if range.headers()[header::CONTENT_RANGE] != "bytes 2-5/10" {
+        return Err("cache range returned the wrong Content-Range".into());
+    }
+    let range_bytes = range.into_body().collect().await?.to_bytes();
+    if range_bytes != Bytes::from_static(b"2345") {
+        return Err("cache range returned the wrong bytes".into());
+    }
+    Ok(())
+}
+
+async fn send_json(
+    router: &Router,
+    token: &str,
+    path: &str,
+    value: serde_json::Value,
+) -> TestResult<Response> {
+    Ok(router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(&value)?))?,
+        )
+        .await?)
+}
+
+async fn json_body(response: Response) -> TestResult<serde_json::Value> {
+    Ok(serde_json::from_slice(
+        &response.into_body().collect().await?.to_bytes(),
+    )?)
+}
+
+fn require_status(label: &str, response: &Response, expected: StatusCode) -> TestResult {
+    if response.status() == expected {
+        return Ok(());
+    }
+    Err(format!(
+        "{label} returned {}, expected {expected}",
+        response.status()
+    )
+    .into())
+}
+
+fn path_and_query(url: &Url) -> String {
+    url.query().map_or_else(
+        || url.path().to_owned(),
+        |query| format!("{}?{query}", url.path()),
+    )
+}
+
+fn run_node(label: &'static str, command: &mut Command) -> TestResult {
+    let output = command.output()?;
+    require_success(label, &output)
+}
+
+fn require_success(label: &str, output: &Output) -> TestResult {
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!("exact {label} client exited with {}", output.status).into())
+}
+
+async fn assert_durable_publication(
+    database: &TestDatabase,
+    execution: ExecutionAuthority,
+) -> TestResult {
+    let artifact: (i64, Option<i32>, Option<i64>, Option<bool>) = sqlx::query_as(
+        "SELECT count(*), min(octet_length(content_digest)), min(content_size_bytes), bool_and(manifest_state = 'ready' AND manifest_object_key IS NOT NULL) FROM workflow_artifacts WHERE run_id = $1 AND job_id = $2 AND attempt_id = $3 AND name = $4 AND state = 'finalized'",
+    )
+    .bind(execution.run_id().as_uuid())
+    .bind(execution.job_id().as_uuid())
+    .bind(execution.attempt_id().as_uuid())
+    .bind(ARTIFACT_NAME)
+    .fetch_one(database.pool())
+    .await?;
+    let cache: (i64, Option<i32>, Option<i64>) = sqlx::query_as(
+        "SELECT count(*), min(octet_length(content_digest)), min(content_size_bytes) FROM github_actions_cache_entries WHERE run_id = $1 AND job_id = $2 AND attempt_id = $3 AND cache_key = $4 AND state = 'finalized'",
+    )
+    .bind(execution.run_id().as_uuid())
+    .bind(execution.job_id().as_uuid())
+    .bind(execution.attempt_id().as_uuid())
+    .bind(CACHE_KEY)
+    .fetch_one(database.pool())
+    .await?;
+    if artifact.0 != 1
+        || artifact.1 != Some(32)
+        || artifact.2.is_none_or(|size| size <= 0)
+        || artifact.3 != Some(true)
+        || cache.0 != 1
+        || cache.1 != Some(32)
+        || cache.2.is_none_or(|size| size <= 0)
+    {
+        return Err(format!(
+            "exact clients published invalid durable artifact {artifact:?} or cache {cache:?} metadata"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn write_redacted_transcript(
+    scratch: &Path,
+    http_records: &[HttpRecord],
+    blob_records: &[BlobRecord],
+    blob_bytes: &[BlobBytes],
+    sensitive_values: &[&str],
+) -> TestResult {
+    let routes = http_records
+        .iter()
+        .map(|record| format!("{:?}", record.route))
+        .collect::<BTreeSet<_>>();
+    let required_routes = BTreeSet::from([
+        "CacheDownload".to_owned(),
+        "CacheUpload".to_owned(),
+        "CreateArtifact".to_owned(),
+        "CreateCache".to_owned(),
+        "Download".to_owned(),
+        "FinalizeArtifact".to_owned(),
+        "FinalizeCache".to_owned(),
+        "GetCacheDownloadUrl".to_owned(),
+        "GetSignedArtifactUrl".to_owned(),
+        "ListArtifacts".to_owned(),
+        "Upload".to_owned(),
+    ]);
+    let has_expected_rejection = http_records
+        .iter()
+        .any(|record| record.status == ResultsHttpStatusClass::ClientError);
+    let has_unsafe_http_outcome = http_records.iter().any(|record| {
+        matches!(
+            record.status,
+            ResultsHttpStatusClass::ServerError | ResultsHttpStatusClass::Cancelled
+        )
+    });
+    if !required_routes.is_subset(&routes) || !has_expected_rejection || has_unsafe_http_outcome {
+        return Err(
+            "exact-client transcript is incomplete or contains an unsafe HTTP outcome".into(),
+        );
+    }
+    let has_successful_get = blob_records.iter().any(|record| {
+        record.operation == ResultsBlobOperation::Get
+            && record.outcome == ResultsBlobOperationOutcome::Success
+    });
+    let has_created_put = blob_records.iter().any(|record| {
+        record.operation == ResultsBlobOperation::Put
+            && record.outcome == ResultsBlobOperationOutcome::Created
+    });
+    if !has_successful_get
+        || !has_created_put
+        || !blob_bytes
+            .iter()
+            .any(|record| record.operation == ResultsBlobOperation::Get && record.bytes > 0)
+        || !blob_bytes
+            .iter()
+            .any(|record| record.operation == ResultsBlobOperation::Put && record.bytes > 0)
+    {
+        return Err("production object-store transcript is incomplete".into());
+    }
+    let requests = http_records
+        .iter()
+        .map(|record| {
+            serde_json::json!({
+                "method": format!("{:?}", record.method),
+                "route": format!("{:?}", record.route),
+                "status": format!("{:?}", record.status),
+            })
+        })
+        .collect::<Vec<_>>();
+    let storage = blob_records
+        .iter()
+        .map(|record| {
+            serde_json::json!({
+                "operation": format!("{:?}", record.operation),
+                "outcome": format!("{:?}", record.outcome),
+            })
+        })
+        .collect::<Vec<_>>();
+    let storage_bytes = blob_bytes
+        .iter()
+        .map(|record| {
+            serde_json::json!({
+                "operation": format!("{:?}", record.operation),
+                "bytes": record.bytes,
+            })
+        })
+        .collect::<Vec<_>>();
+    let transcript = serde_json::to_string_pretty(&serde_json::json!({
+        "schema": 1,
+        "redaction": "closed-enum-no-identifiers",
+        "requests": requests,
+        "storage": storage,
+        "storage_bytes": storage_bytes,
+    }))?;
+    if sensitive_values
+        .iter()
+        .any(|value| !value.is_empty() && transcript.contains(value))
+        || transcript.contains("Authorization")
+        || transcript.contains("sig=")
+    {
+        return Err("redacted transcript contains credential material".into());
+    }
+    std::fs::write(
+        scratch.join("redacted-results-transcript.json"),
+        format!("{transcript}\n"),
+    )?;
+    Ok(())
+}
+
+fn test_scratch(label: &str) -> PathBuf {
+    let manifest_directory = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_directory
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("results crate is nested under the workspace crates directory")
+        .join("target/agent-scratch")
+        .join(label)
+        .join(Uuid::new_v4().simple().to_string())
+}
+
+async fn active_attempt(database: &TestDatabase) -> TestResult<(ExecutionAuthority, u64)> {
+    let seed = seed_control_plane(database.pool()).await?;
+    let attempt_id = AttemptId::new();
+    database
+        .store()
+        .insert_queued(QueuedAttempt::new(
+            attempt_id,
+            seed.job_id,
+            AttemptNumber::new(1)?,
+            seed.observed_at,
+        ))
+        .await?;
+    let lease = database
+        .store()
+        .acquire_lease(
+            AcquireLease::new(
+                attempt_id,
+                LeaseId::new(),
+                seed.session_fence,
+                automata_ci_store::StableRunnerSlot::new(1)?,
+                seed.observed_at,
+                UnixMillis::new(seed.observed_at.get() + 300_000),
+            )
+            .expect("valid lease request"),
+        )
+        .await?;
+    let now_seconds = u64::try_from(seed.observed_at.get())? / 1_000;
+    Ok((
+        ExecutionAuthority::new(seed.run_id, seed.job_id, attempt_id, lease.fencing_token()),
+        now_seconds,
+    ))
+}

--- a/crates/automata-ci-results-github/tests/fixtures/exact-client-matrix-v1.json
+++ b/crates/automata-ci-results-github/tests/fixtures/exact-client-matrix-v1.json
@@ -1,0 +1,74 @@
+{
+  "schema": 1,
+  "node_major": 24,
+  "network_policy": "loopback-only-no-downloads",
+  "clients": [
+    {
+      "id": "upload-artifact",
+      "repository": "actions/upload-artifact",
+      "release": "v7.0.1",
+      "commit": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      "manifest_version": "7.0.1",
+      "action_entry": "dist/upload/index.js",
+      "action_root_environment": "AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT",
+      "embedded_package": "@actions/artifact",
+      "embedded_version": "6.2.0",
+      "embedded_integrity": "sha512-i9kmGy6WfuA6rby4fdD0UMKjT4MicFiKMsB5mUZ+1ggFW7+SzqvFsxLhIXxITkKUhTMVREXQfn/ZAN87EQLQDA==",
+      "module_entry": "node_modules/@actions/artifact/lib/internal/client.js",
+      "module_environment": "AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE",
+      "operations": [
+        "create",
+        "put-block",
+        "put-block-list",
+        "finalize",
+        "list",
+        "signed-download"
+      ],
+      "support_status": "component"
+    },
+    {
+      "id": "download-artifact",
+      "repository": "actions/download-artifact",
+      "release": "v8.0.1",
+      "commit": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+      "manifest_version": "8.0.1",
+      "action_entry": "dist/index.js",
+      "action_root_environment": "AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT",
+      "embedded_package": "@actions/artifact",
+      "embedded_version": "6.2.1",
+      "embedded_integrity": "sha512-sJGH0mhEbEjBCw7o6SaLhUU66u27aFW8HTfkIb5Tk2/Wy0caUDc+oYQEgnuFN7a0HCpAbQyK0U6U7XUJDgDWrw==",
+      "module_entry": "node_modules/@actions/artifact/lib/internal/client.js",
+      "module_environment": "AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE",
+      "operations": [
+        "list",
+        "get-by-name",
+        "get-by-id",
+        "signed-download"
+      ],
+      "support_status": "candidate"
+    },
+    {
+      "id": "cache",
+      "repository": "actions/cache",
+      "release": "v5.0.5",
+      "commit": "27d5ce7f107fe9357f9df03efb73ab90386fccae",
+      "manifest_version": "5.0.4",
+      "action_entry": "dist/restore/index.js",
+      "action_root_environment": "AUTOMATA_TEST_CACHE_ACTION_ROOT",
+      "embedded_package": "@actions/cache",
+      "embedded_version": "5.0.5",
+      "embedded_integrity": "sha512-jiQSg0gfd+C2KPgcmdCOq7dCuCIQQWQ4b1YfGIRaaA9w7PJbRwTOcCz4LiFEUnqZGf0ha/8OKL3BeNwetHzYsQ==",
+      "module_entry": "node_modules/@actions/cache/lib/cache.js",
+      "module_environment": "AUTOMATA_TEST_ACTIONS_CACHE_MODULE",
+      "operations": [
+        "reserve",
+        "upload",
+        "finalize",
+        "exact-restore",
+        "restore-prefix",
+        "single-range-download"
+      ],
+      "support_status": "component"
+    }
+  ]
+}

--- a/crates/automata-ci-results-github/tests/fixtures/exact-client-matrix-v1.json
+++ b/crates/automata-ci-results-github/tests/fixtures/exact-client-matrix-v1.json
@@ -9,7 +9,9 @@
       "release": "v7.0.1",
       "commit": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
       "manifest_version": "7.0.1",
-      "action_entry": "dist/upload/index.js",
+      "action_entries": [
+        "dist/upload/index.js"
+      ],
       "action_root_environment": "AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT",
       "embedded_package": "@actions/artifact",
       "embedded_version": "6.2.0",
@@ -32,7 +34,9 @@
       "release": "v8.0.1",
       "commit": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
       "manifest_version": "8.0.1",
-      "action_entry": "dist/index.js",
+      "action_entries": [
+        "dist/index.js"
+      ],
       "action_root_environment": "AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT",
       "embedded_package": "@actions/artifact",
       "embedded_version": "6.2.1",
@@ -53,7 +57,12 @@
       "release": "v5.0.5",
       "commit": "27d5ce7f107fe9357f9df03efb73ab90386fccae",
       "manifest_version": "5.0.4",
-      "action_entry": "dist/restore/index.js",
+      "action_entries": [
+        "dist/restore/index.js",
+        "dist/save/index.js",
+        "dist/restore-only/index.js",
+        "dist/save-only/index.js"
+      ],
       "action_root_environment": "AUTOMATA_TEST_CACHE_ACTION_ROOT",
       "embedded_package": "@actions/cache",
       "embedded_version": "5.0.5",

--- a/crates/automata-ci-results-github/tests/fixtures/official_artifact_client.mjs
+++ b/crates/automata-ci-results-github/tests/fixtures/official_artifact_client.mjs
@@ -3,14 +3,28 @@ import { mkdir, readFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 const modulePath = process.env.AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE
+const expectedVersion = process.env.AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION
 const inputPath = process.env.AUTOMATA_TEST_ARTIFACT_INPUT
 const rootDirectory = process.env.AUTOMATA_TEST_ARTIFACT_ROOT
 
-if (!modulePath || !inputPath || !rootDirectory) {
+if (!modulePath || !expectedVersion || !inputPath || !rootDirectory) {
   throw new Error('official artifact-client fixture environment is incomplete')
 }
 
-const { DefaultArtifactClient } = await import(pathToFileURL(modulePath).href)
+const moduleUrl = pathToFileURL(modulePath)
+const packageManifest = JSON.parse(
+  await readFile(new URL('../../package.json', moduleUrl), 'utf8'),
+)
+if (
+  packageManifest.name !== '@actions/artifact' ||
+  packageManifest.version !== expectedVersion
+) {
+  throw new Error(
+    `expected exact @actions/artifact ${expectedVersion}, received ${packageManifest.name}@${packageManifest.version}`,
+  )
+}
+
+const { DefaultArtifactClient } = await import(moduleUrl.href)
 const client = new DefaultArtifactClient()
 const result = await client.uploadArtifact(
   'official-actions-artifact-client',

--- a/crates/automata-ci-results-github/tests/fixtures/official_artifact_download_client.mjs
+++ b/crates/automata-ci-results-github/tests/fixtures/official_artifact_download_client.mjs
@@ -1,0 +1,56 @@
+import { mkdir, readFile } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const modulePath = process.env.AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE
+const expectedVersion = process.env.AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION
+const inputPath = process.env.AUTOMATA_TEST_ARTIFACT_INPUT
+const rootDirectory = process.env.AUTOMATA_TEST_ARTIFACT_ROOT
+
+if (!modulePath || !expectedVersion || !inputPath || !rootDirectory) {
+  throw new Error('official artifact-download fixture environment is incomplete')
+}
+
+const moduleUrl = pathToFileURL(modulePath)
+const packageManifest = JSON.parse(
+  await readFile(new URL('../../package.json', moduleUrl), 'utf8'),
+)
+if (
+  packageManifest.name !== '@actions/artifact' ||
+  packageManifest.version !== expectedVersion
+) {
+  throw new Error(
+    `expected exact @actions/artifact ${expectedVersion}, received ${packageManifest.name}@${packageManifest.version}`,
+  )
+}
+
+const { DefaultArtifactClient } = await import(moduleUrl.href)
+const client = new DefaultArtifactClient()
+const listed = await client.listArtifacts()
+const artifact = listed.artifacts.find(
+  candidate => candidate.name === 'official-actions-artifact-client',
+)
+if (!artifact?.digest) {
+  throw new Error('official download client did not list the uploaded artifact')
+}
+
+const found = await client.getArtifact('official-actions-artifact-client')
+if (found.artifact.id !== artifact.id || found.artifact.digest !== artifact.digest) {
+  throw new Error('official download client resolved inconsistent artifact metadata')
+}
+
+const downloadRoot = join(rootDirectory, 'downloaded-by-download-action-client')
+await mkdir(downloadRoot, { recursive: true })
+const downloaded = await client.downloadArtifact(artifact.id, {
+  path: downloadRoot,
+  expectedHash: artifact.digest,
+})
+if (downloaded.digestMismatch) {
+  throw new Error('official download client reported a digest mismatch')
+}
+
+const originalBytes = await readFile(inputPath)
+const downloadedBytes = await readFile(join(downloadRoot, basename(inputPath)))
+if (!downloadedBytes.equals(originalBytes)) {
+  throw new Error('official download client changed the uploaded file')
+}

--- a/crates/automata-ci-results-github/tests/http_compatibility.rs
+++ b/crates/automata-ci-results-github/tests/http_compatibility.rs
@@ -592,6 +592,21 @@ async fn official_actions_artifact_6_2_client_completes_the_full_protocol() {
         .expect(
             "set AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE to @actions/artifact 6.2.0 lib/internal/client.js",
         );
+    run_official_artifact_client(module_path, "6.2.0").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Node >=24 and AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE"]
+async fn official_download_action_artifact_6_2_1_client_completes_the_full_protocol() {
+    let module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE")
+        .map(PathBuf::from)
+        .expect(
+            "set AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE to download-artifact v8.0.1 @actions/artifact 6.2.1 lib/internal/client.js",
+        );
+    run_official_artifact_client(module_path, "6.2.1").await;
+}
+
+async fn run_official_artifact_client(module_path: PathBuf, expected_version: &'static str) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind action-client fixture");
@@ -617,7 +632,7 @@ async fn official_actions_artifact_6_2_client_completes_the_full_protocol() {
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/official_artifact_client.mjs");
     let token = fixture.token;
-    let status = tokio::task::spawn_blocking(move || {
+    let output = tokio::task::spawn_blocking(move || {
         std::process::Command::new("node")
             .arg(script)
             .env("ACTIONS_RUNTIME_TOKEN", token)
@@ -625,15 +640,20 @@ async fn official_actions_artifact_6_2_client_completes_the_full_protocol() {
             .env("GITHUB_SERVER_URL", "http://automata-git.ghe.com:8088/")
             .env("GITHUB_WORKSPACE", &scratch)
             .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE", module_path)
+            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", expected_version)
             .env("AUTOMATA_TEST_ARTIFACT_INPUT", input)
             .env("AUTOMATA_TEST_ARTIFACT_ROOT", scratch)
-            .status()
+            .output()
             .expect("run official artifact client")
     })
     .await
     .expect("join Node client");
     server.abort();
-    assert!(status.success(), "official artifact client must complete");
+    assert!(
+        output.status.success(),
+        "official artifact client exited with {}",
+        output.status
+    );
 }
 
 #[tokio::test]

--- a/crates/automata-ci-results-github/tests/http_compatibility.rs
+++ b/crates/automata-ci-results-github/tests/http_compatibility.rs
@@ -587,26 +587,34 @@ async fn artifact_router_and_extractor_rejections_are_private() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires Node >=24 and AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE"]
 async fn official_actions_artifact_6_2_client_completes_the_full_protocol() {
-    let module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE")
+    let upload_module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE")
         .map(PathBuf::from)
         .expect(
             "set AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE to @actions/artifact 6.2.0 lib/internal/client.js",
         );
-    run_official_artifact_client(module_path, "6.2.0").await;
+    run_official_artifact_clients(upload_module_path, None).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "requires Node >=24 and AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE"]
+#[ignore = "requires Node >=24 and both exact upload/download @actions/artifact modules"]
 async fn official_download_action_artifact_6_2_1_client_completes_the_full_protocol() {
-    let module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE")
+    let upload_module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE")
+        .map(PathBuf::from)
+        .expect(
+            "set AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE to @actions/artifact 6.2.0 lib/internal/client.js",
+        );
+    let download_module_path = std::env::var_os("AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE")
         .map(PathBuf::from)
         .expect(
             "set AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE to download-artifact v8.0.1 @actions/artifact 6.2.1 lib/internal/client.js",
         );
-    run_official_artifact_client(module_path, "6.2.1").await;
+    run_official_artifact_clients(upload_module_path, Some(download_module_path)).await;
 }
 
-async fn run_official_artifact_client(module_path: PathBuf, expected_version: &'static str) {
+async fn run_official_artifact_clients(
+    upload_module_path: PathBuf,
+    download_module_path: Option<PathBuf>,
+) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind action-client fixture");
@@ -631,29 +639,83 @@ async fn run_official_artifact_client(module_path: PathBuf, expected_version: &'
     .expect("write fixture input");
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/official_artifact_client.mjs");
-    let token = fixture.token;
+    let token = fixture.token.clone();
+    let upload_scratch = scratch.clone();
+    let upload_input = input.clone();
     let output = tokio::task::spawn_blocking(move || {
-        std::process::Command::new("node")
+        isolated_node_command()
             .arg(script)
             .env("ACTIONS_RUNTIME_TOKEN", token)
             .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
             .env("GITHUB_SERVER_URL", "http://automata-git.ghe.com:8088/")
-            .env("GITHUB_WORKSPACE", &scratch)
-            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE", module_path)
-            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", expected_version)
-            .env("AUTOMATA_TEST_ARTIFACT_INPUT", input)
-            .env("AUTOMATA_TEST_ARTIFACT_ROOT", scratch)
+            .env("GITHUB_WORKSPACE", &upload_scratch)
+            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE", upload_module_path)
+            .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.0")
+            .env("AUTOMATA_TEST_ARTIFACT_INPUT", upload_input)
+            .env("AUTOMATA_TEST_ARTIFACT_ROOT", upload_scratch)
             .output()
             .expect("run official artifact client")
     })
     .await
     .expect("join Node client");
-    server.abort();
     assert!(
         output.status.success(),
         "official artifact client exited with {}",
         output.status
     );
+
+    if let Some(download_module_path) = download_module_path {
+        let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/official_artifact_download_client.mjs");
+        let token = fixture.token;
+        let download_output = tokio::task::spawn_blocking(move || {
+            isolated_node_command()
+                .arg(script)
+                .env("ACTIONS_RUNTIME_TOKEN", token)
+                .env("ACTIONS_RESULTS_URL", format!("http://{address}/"))
+                .env("GITHUB_SERVER_URL", "http://automata-git.ghe.com:8088/")
+                .env("GITHUB_WORKSPACE", &scratch)
+                .env(
+                    "AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE",
+                    download_module_path,
+                )
+                .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.1")
+                .env("AUTOMATA_TEST_ARTIFACT_INPUT", input)
+                .env("AUTOMATA_TEST_ARTIFACT_ROOT", scratch)
+                .output()
+                .expect("run official download action artifact client")
+        })
+        .await
+        .expect("join Node download client");
+        assert!(
+            download_output.status.success(),
+            "official download action artifact client exited with {}",
+            download_output.status
+        );
+    }
+    server.abort();
+}
+
+fn isolated_node_command() -> std::process::Command {
+    let mut command = std::process::Command::new("node");
+    command.env_clear();
+    for name in [
+        "PATH",
+        "PATHEXT",
+        "SystemRoot",
+        "WINDIR",
+        "ComSpec",
+        "HOME",
+        "USERPROFILE",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
 }
 
 #[tokio::test]

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -58,7 +58,7 @@ Tasks:
   malformed-route, expired-token, wrong-scope, replay, size-mismatch,
   duplicate-finalize, truncated-body, and range-request coverage.
 - [ ] Record request/response transcripts with credentials redacted.
-- [ ] Publish the supported client/version matrix from one machine-readable
+- [x] Publish the supported client/version matrix from one machine-readable
   fixture used by documentation and tests.
 
 Acceptance:

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -31,12 +31,17 @@ definition of done.
 This package turns the existing protocol slices into reproducible client
 compatibility tests. It does not add new protocol operations.
 
-Current `upstream/main` documents the upload-artifact v7.0.1 protocol slice at
-commit `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` with
-`@actions/artifact` 6.2.0, plus `@actions/cache` 5.0.5 over CacheService v2.
-Ignored offline tests import explicitly supplied local client modules and never
-download packages. They are focused client-library and protocol evidence, not
-ordinary-CI acceptance of every exact action wrapper or the production stores.
+The closed client matrix pins upload-artifact v7.0.1 at commit
+`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` with `@actions/artifact` 6.2.0,
+download-artifact v8.0.1 at commit
+`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` with `@actions/artifact` 6.2.1,
+and cache v5.0.5 at commit `27d5ce7f107fe9357f9df03efb73ab90386fccae`
+with `@actions/cache` 5.0.5. It verifies every declared Node entry and embedded
+lockfile integrity. Ignored offline tests import explicitly supplied local
+client modules and never download packages. The production-composition test
+connects those clients to the real HTTP adapters, PostgreSQL repositories, and
+S3 blob implementation and retains an identifier-free transcript, but remains
+an opt-in acceptance test until its PostgreSQL/S3 environment is available.
 Runner protocol v1 carries a required, per-attempt Results authority bundle;
 there is no runner- or fleet-wide Results credential.
 
@@ -46,18 +51,19 @@ Tasks:
   CacheService v2 client versions with immutable release or commit identity.
 - [x] Require explicit local module paths for the current ignored exact-client
   tests; never download mutable dependencies in those tests.
-- [ ] Pin and verify exact `actions/download-artifact` and complete action
+- [x] Pin and verify exact `actions/download-artifact` and complete action
   wrappers, including each embedded client version, from one immutable fixture.
-- [ ] Build one reusable harness that supplies Results URLs, scoped runtime
+- [x] Build one reusable harness that supplies Results URLs, scoped runtime
   tokens, repository/ref/run identity, PostgreSQL, production object storage,
   and deterministic time.
 - [x] Exercise CreateArtifact, block upload, block-list commit, finalize, list,
   signed download, cache reserve/finalize/restore, exact keys, restore-key
   precedence, and single-range responses in focused adapter tests.
-- [ ] Carry that matrix through the reusable real-store harness and complete
+- [x] Carry that matrix through the reusable real-store harness and complete
   malformed-route, expired-token, wrong-scope, replay, size-mismatch,
   duplicate-finalize, truncated-body, and range-request coverage.
-- [ ] Record request/response transcripts with credentials redacted.
+- [x] Record request/response and production object-store transcripts with
+  credentials and identifiers structurally excluded.
 - [x] Publish the supported client/version matrix from one machine-readable
   fixture used by documentation and tests.
 


### PR DESCRIPTION
## Summary

- pin the exact `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, and `actions/cache` v5.0.5 wrappers, every declared Node entrypoint, and their embedded client versions/integrities
- exercise the official artifact 6.2.0/6.2.1 and cache 5.0.5 clients against the real Results/Cache HTTP adapters, PostgreSQL repositories, and production S3 blob adapter
- carry malformed routes, truncated bodies, expired and wrong-scope authority, exact replay, conflicting finalize, duplicate finalize, and range requests through the same real-store boundary
- add an ordinary Ubuntu CI lane with digest-pinned PostgreSQL 18.4 and RustFS, Node 24.19, immutable action checkouts, object-store contract checks, and retained redacted evidence
- prevent exact client subprocesses from inheriting PostgreSQL, S3, or ambient CI credentials by clearing their environment and adding only the minimum OS/tool variables plus operation-scoped Results inputs

## Security and evidence

The acceptance clients receive only a per-attempt Results token and loopback endpoint. Child output is captured, signed URLs and tokens are never printed, and the retained transcript contains only closed route/status/storage enums and byte counts. The test rejects credential or signed-URL material before writing evidence.

The companion integration fixture is a separate branch in `automata-integration-tests`; its retained physical Linux product run remains intentionally unclaimed until the reviewed root/systemd/cgroup/rootless-Podman boundary is available.

## Validation

- `cargo test --locked -p automata-ci-results-github`
- exact ignored upload, download, cache, and immutable-root tests with locally supplied pinned modules
- `cargo test --locked -p automata-ci-results-github --test http_compatibility --test cache_http --test exact_client_real_store --no-run`
- `cargo clippy --locked -p automata-ci-results-github --all-targets --no-deps -- -D warnings`
- `actionlint .ci/workflows/*.yml`
- independent final security/CI/pin/redaction audit

Live PostgreSQL/S3 execution was unavailable on the Windows development host; the new ordinary CI job owns that retained execution rather than silently skipping it.