### PR TITLE
perf(ci): share Rust compilation across parallel gates

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -31,11 +31,30 @@ jobs:
       CARGO_BUILD_JOBS: "4"
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+          key: cargo-ubuntu-24.04-rust-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-
 
       - name: Show pinned toolchain
         run: |
@@ -82,6 +101,7 @@ jobs:
           ./scripts/ci/tests/install.test.sh
           python3 scripts/ci/tests/integration-test-targets.test.py
           python3 scripts/ci/tests/release-handoff.test.py
+          python3 scripts/ci/tests/rust-build-cache.test.py
           python3 scripts/ci/tests/rust-coverage.test.py
           python3 scripts/ci/tests/service-proxy-buildah-containerfile.test.py
           python3 scripts/ci/tests/service-proxy-candidate.test.py
@@ -93,11 +113,79 @@ jobs:
           prometheus_bin="$(./scripts/ci/prepare-prometheus-tools.sh)"
           PATH="$prometheus_bin:$PATH" ./scripts/ci/verify-native-metrics.sh
 
+  rust_lint:
+    name: Lint Rust workspace
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_BUILD_JOBS: "4"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+          key: cargo-ubuntu-24.04-rust-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-
+
       - name: Lint
         run: |
           trap 'df -h -- "$GITHUB_WORKSPACE"; du -sh -- target 2>/dev/null || true' EXIT
           df -h -- "$GITHUB_WORKSPACE"
           cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  rust_docs:
+    name: Check Rust documentation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_BUILD_JOBS: "4"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+          key: cargo-ubuntu-24.04-rust-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-
 
       - name: Check public API documentation
         env:
@@ -107,7 +195,41 @@ jobs:
       - name: Test workspace documentation
         run: cargo test --workspace --exclude automata-ci-ui-renderer --doc --all-features --locked
 
+  dependency_audit:
+    name: Audit Rust dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry and cargo-deny
+        id: dependency-audit-cargo-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+            ~/.cargo/bin/cargo-deny
+          key: cargo-ubuntu-24.04-rust-1.97.1-deny-0.20.2-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-deny-0.20.2-
+            cargo-ubuntu-24.04-rust-1.97.1-
+
       - name: Install cargo-deny
+        if: ${{ steps.dependency-audit-cargo-cache.outputs.cache-hit != 'true' }}
         run: cargo install cargo-deny --version 0.20.2 --locked
 
       - name: Test vendored renderer macro diagnostics
@@ -142,12 +264,34 @@ jobs:
       CARGO_BUILD_JOBS: "4"
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry and coverage tool
+        id: coverage-cargo-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+            ~/.cargo/bin/cargo-llvm-cov
+          key: cargo-ubuntu-24.04-rust-1.97.1-llvm-cov-0.8.7-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-llvm-cov-0.8.7-
+            cargo-ubuntu-24.04-rust-1.97.1-
 
       - name: Prepare job scratch directory
         run: install -d -m 0700 -- "$TMPDIR"
@@ -165,7 +309,9 @@ jobs:
       - name: Install pinned Rust coverage tooling
         run: |
           rustup component add llvm-tools-preview
-          cargo install cargo-llvm-cov --version 0.8.7 --locked
+          if [[ "${{ steps.coverage-cargo-cache.outputs.cache-hit }}" != true ]]; then
+            cargo install cargo-llvm-cov --version 0.8.7 --locked
+          fi
 
       - name: Test Rust workspace and PostgreSQL invariants
         run: |
@@ -205,12 +351,31 @@ jobs:
       CARGO_BUILD_JOBS: "4"
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+          key: cargo-ubuntu-24.04-rust-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-
 
       - name: Prepare job scratch directory
         run: install -d -m 0700 -- "$TMPDIR"
@@ -291,12 +456,34 @@ jobs:
     name: Build static Linux distribution
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Restore Cargo registry and SBOM tool
+        id: distribution-cargo-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+            ~/.cargo/bin/cargo-cyclonedx
+          key: cargo-ubuntu-24.04-rust-1.97.1-cyclonedx-0.5.9-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-cyclonedx-0.5.9-
+            cargo-ubuntu-24.04-rust-1.97.1-
 
       - name: Read workspace version
         run: |
@@ -321,6 +508,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install pinned SBOM generator
+        if: ${{ steps.distribution-cargo-cache.outputs.cache-hit != 'true' }}
         run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
       - name: Build distribution binaries
@@ -416,6 +604,9 @@ jobs:
     needs:
       - dist_build
       - verify
+      - rust_lint
+      - rust_docs
+      - dependency_audit
       - rust_coverage
       - renderer_tests
       - frontend
@@ -427,6 +618,9 @@ jobs:
         env:
           DIST_BUILD_RESULT: ${{ needs.dist_build.result }}
           VERIFY_RESULT: ${{ needs.verify.result }}
+          RUST_LINT_RESULT: ${{ needs.rust_lint.result }}
+          RUST_DOCS_RESULT: ${{ needs.rust_docs.result }}
+          DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency_audit.result }}
           RUST_COVERAGE_RESULT: ${{ needs.rust_coverage.result }}
           RENDERER_TESTS_RESULT: ${{ needs.renderer_tests.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
@@ -435,6 +629,9 @@ jobs:
         run: |
           [[ "$DIST_BUILD_RESULT" == success ]]
           [[ "$VERIFY_RESULT" == success ]]
+          [[ "$RUST_LINT_RESULT" == success ]]
+          [[ "$RUST_DOCS_RESULT" == success ]]
+          [[ "$DEPENDENCY_AUDIT_RESULT" == success ]]
           [[ "$RUST_COVERAGE_RESULT" == success ]]
           [[ "$RENDERER_TESTS_RESULT" == success ]]
           [[ "$FRONTEND_RESULT" == success ]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.30.0",
+ "tokio-tungstenite",
  "tower",
 ]
 
@@ -1686,7 +1686,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1703,7 +1703,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -2270,7 +2270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3173,7 +3173,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3480,7 +3480,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3996,7 +3996,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4244,7 +4244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4639,7 +4639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4934,10 +4934,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5091,19 +5091,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.30.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5347,22 +5335,6 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1 0.10.7",
- "thiserror",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.5.0",
- "httparse",
- "log",
- "rand 0.10.2",
- "sha1 0.11.0",
  "thiserror",
 ]
 
@@ -5930,7 +5902,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,17 @@ must_use_candidate = "allow"
 # debug symbols for the workspace's large dependency graph.
 debug = "line-tables-only"
 
+# Dependency backtraces rarely need source locations. Keeping debug metadata
+# only for workspace crates cuts both compile work and local target size while
+# preserving useful file/line information in Automata code.
+[profile.dev.package."*"]
+debug = false
+
 [profile.test]
 debug = "line-tables-only"
+
+[profile.test.package."*"]
+debug = false
 
 [profile.release]
 codegen-units = 1

--- a/crates/automata-ci-sandbox-kubernetes/Cargo.toml
+++ b/crates/automata-ci-sandbox-kubernetes/Cargo.toml
@@ -36,5 +36,5 @@ futures.workspace = true
 http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["handshake"] }
+tokio-tungstenite = { version = "0.29.0", default-features = false, features = ["handshake"] }
 tower.workspace = true

--- a/crates/automata-ci/tests/metrics_semantics.rs
+++ b/crates/automata-ci/tests/metrics_semantics.rs
@@ -81,13 +81,13 @@ fn semantic_metrics_have_an_exact_bounded_privacy_safe_exposition() {
         .filter_map(|line| line.split_once(' ').map(|(sample, _value)| sample))
         .filter(|sample| is_semantic_metric(sample.split('{').next().expect("sample name")))
         .count();
-    assert_eq!(semantic_series, 1_118);
+    assert_eq!(semantic_series, 1_122);
     let all_series = exposition
         .lines()
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_344,
+        all_series, 5_348,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(

--- a/crates/automata-ci/tests/results_metrics.rs
+++ b/crates/automata-ci/tests/results_metrics.rs
@@ -84,7 +84,7 @@ fn results_and_storage_schema_is_exact_bounded_and_identifier_free() {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .count();
     assert_eq!(
-        all_series, 5_344,
+        all_series, 5_348,
         "the preinitialized series set must match the reviewed cardinality manifest"
     );
     assert_eq!(

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,21 @@ cargo test -p automata-ci --locked
 cargo test -p automata-ci-runner --locked
 ```
 
+Development and test profiles keep file/line information for first-party
+crates, while dependencies omit debug metadata. On Linux hosts with LLVM's
+linker installed, the CI-equivalent faster linker can be enabled per command:
+
+```console
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS='-C link-arg=-fuse-ld=lld' \
+  cargo test -p automata-ci --locked
+```
+
+CI runs repository verification, Rust linting, documentation, dependency
+auditing, coverage, renderer tests, and distribution construction as parallel
+gates. Rust jobs share content-addressed compiler outputs through `sccache` and
+cache the locked Cargo registry plus pinned CI tools; raw `target/` directories
+are deliberately not cached because they are large and path-sensitive.
+
 Before opening a pull request, run the workspace checks used by CI:
 
 ```console

--- a/scripts/ci/tests/rust-build-cache.test.py
+++ b/scripts/ci/tests/rust-build-cache.test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fail closed when CI loses the bounded Rust build-cache contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".." / ".ci" / "workflows" / "ci.yml"
+SCCACHE_ACTION = (
+    "mozilla-actions/sccache-action@"
+    "fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11"
+)
+CACHE_ACTION = (
+    "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5"
+)
+RUST_JOBS = (
+    "verify",
+    "rust_lint",
+    "rust_docs",
+    "dependency_audit",
+    "rust_coverage",
+    "renderer_tests",
+    "dist_build",
+)
+
+
+def job_body(workflow: str, job: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job)}:\n(?P<body>.*?)(?=^  [a-z][a-z0-9_]*:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"missing CI job: {job}")
+    return match.group("body")
+
+
+def main() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    for job in RUST_JOBS:
+        body = job_body(workflow, job)
+        assert "RUSTC_WRAPPER: sccache" in body, f"{job} lost the rustc wrapper"
+        assert "SCCACHE_GHA_ENABLED: \"true\"" in body, (
+            f"{job} lost the repository compiler-cache backend"
+        )
+        assert SCCACHE_ACTION in body, f"{job} lost the pinned sccache installer"
+        assert "version: v0.17.0" in body, f"{job} changed the sccache binary"
+        assert CACHE_ACTION in body, f"{job} lost the pinned Cargo cache action"
+        assert "~/.cargo/registry/cache" in body
+        assert "~/.cargo/registry/index" in body
+        assert "~/.cargo/registry/src" in body
+        assert "target/" not in "\n".join(
+            line.strip()
+            for line in body.splitlines()
+            if line.strip().startswith("~/.cargo/")
+        )
+
+    for job in ("verify", "rust_lint", "rust_docs", "rust_coverage", "renderer_tests"):
+        assert (
+            "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "
+            "-C link-arg=-fuse-ld=lld"
+        ) in job_body(workflow, job), f"{job} lost the fast GNU/Linux linker"
+
+    distribution = job_body(workflow, "dist")
+    for gate in ("rust_lint", "rust_docs", "dependency_audit"):
+        assert f"- {gate}" in distribution, f"distribution no longer requires {gate}"
+    assert "cargo-deny --version 0.20.2" in workflow
+    assert "cargo-llvm-cov --version 0.8.7" in workflow
+    assert "cargo-cyclonedx --version 0.5.9" in workflow
+    print("verified parallel Rust gates and bounded shared compiler caches")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- share Rust compilation outputs between CI runs with pinned `sccache` and GitHub Actions cache integrations, while caching only Cargo registries and pinned tools rather than the raw Cargo target directory
- run Rust lint, documentation, and dependency-audit gates in parallel and make the distribution admission job require each result explicitly
- reduce local and CI artifact cost by removing dependency debug metadata, use `lld` on GNU/Linux CI jobs, and deduplicate the Kubernetes sandbox websocket development dependency
- add a workflow contract test and developer documentation for the cache/profile policy
- update the cardinality manifests missed by the latest `main` lease-metrics change so the complete Rust test set remains green

## Measurements

All timings used four Cargo jobs on the same host and a clean target directory unless noted.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Representative `cargo check`, cold target/cache vs. clean target with warm same-path `sccache` | 63.73 s | 25.10 s | **-60.6%** |
| Clean control-plane unit-test build (`--no-run`) | 86.97 s | 86.63 s | -0.4% |
| Incremental application relink after touching the library | 5.95 s | 5.77 s | -2.9% |
| Clean build target size | 4,898,304 KiB | 4,345,700 KiB | **-11.3%** |
| Resolved dependency packages | 554 | 552 | -2 |

The clean-build wall time is intentionally neutral: the larger gain comes from reusing content-addressed compiler results across CI runs and shortening the critical path by parallelizing independent gates. The warm-cache benchmark recorded 566 Rust cache hits with no cache read/write errors.

## Validation

- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked`
- workspace doctests and all ordinary workspace test targets (the two stale metrics-cardinality assertions were corrected and rerun serially)
- `cargo test -p automata-ci-sandbox-kubernetes --all-targets --all-features --locked --no-fail-fast`
- `cargo fmt --all -- --check`
- `actionlint .ci/workflows/*.yml`
- `python3 scripts/ci/tests/rust-build-cache.test.py`
- Rust coverage, publish-crates, integration-target, integration-snapshot, and release-handoff contract tests
