### PR TITLE
feat(workflow): complete WF-02 YAML semantics

### DIFF
--- a/crates/automata-ci-github-delivery/src/processor.rs
+++ b/crates/automata-ci-github-delivery/src/processor.rs
@@ -1301,6 +1301,7 @@ fn admission_error(error: &WorkflowAdmissionError) -> GithubDeliveryWorkflowProc
         | WorkflowAdmissionError::AdmissionValue(_)
         | WorkflowAdmissionError::LogicalValue(_)
         | WorkflowAdmissionError::ConcurrencyEvaluation
+        | WorkflowAdmissionError::RunNameEvaluation
         | WorkflowAdmissionError::WorkflowDispatchEvidence
         | WorkflowAdmissionError::Serialization
         | WorkflowAdmissionError::Internal => {
@@ -1319,6 +1320,7 @@ fn admission_error_stage(error: &WorkflowAdmissionError) -> &'static str {
         WorkflowAdmissionError::AdmissionValue(_) => "admission_value",
         WorkflowAdmissionError::LogicalValue(_) => "admission_logical_value",
         WorkflowAdmissionError::ConcurrencyEvaluation => "admission_concurrency_evaluation",
+        WorkflowAdmissionError::RunNameEvaluation => "admission_run_name_evaluation",
         WorkflowAdmissionError::WorkflowDispatchEvidence => "admission_dispatch_evidence",
         WorkflowAdmissionError::Serialization => "admission_serialization",
         WorkflowAdmissionError::Internal => "admission_internal",
@@ -1387,7 +1389,7 @@ mod renewal_tests {
     use super::{
         GithubDeliveryWorkflowAdmissionProcessor, GithubPushChangedFilesAuthority,
         GithubPushChangedFilesError, GithubPushChangedFilesProvider, GithubPushChangedFilesRequest,
-        admission_error,
+        admission_error, admission_error_stage,
     };
     use crate::{
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubDeliveryClock,
@@ -1416,6 +1418,14 @@ mod renewal_tests {
         assert_eq!(
             admission_error(&WorkflowAdmissionError::WorkflowDispatchEvidence),
             crate::GithubDeliveryWorkflowProcessorError::InvariantViolation
+        );
+    }
+
+    #[test]
+    fn run_name_evaluation_has_a_stable_sanitized_admission_stage() {
+        assert_eq!(
+            admission_error_stage(&WorkflowAdmissionError::RunNameEvaluation),
+            "admission_run_name_evaluation"
         );
     }
 

--- a/crates/automata-ci-postgres/tests/store/provider/github_provider_manifest.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_provider_manifest.rs
@@ -705,7 +705,7 @@ async fn sql_canonical_functions_match_rust_golden_and_reject_direct_forgery() -
         assert_eq!(sql_digest, desired.digest().as_bytes().as_slice());
         assert_eq!(
             desired.digest().to_string(),
-            "040637cf95b3f4e6d0aee57ef796f6b9c2fdea3f46153c8a183a7a77f128ca0a"
+        "20f16f866564dd2c9ab17776c2f8acabc5c619fa305066b0f86c1ec9b82c1b64"
         );
 
         let forged_repository = sqlx::query(

--- a/crates/automata-ci-store/src/github_provider_manifest.rs
+++ b/crates/automata-ci-store/src/github_provider_manifest.rs
@@ -83,8 +83,11 @@ pub const GITHUB_PROVIDER_ARCHIVE_MAX_EXPANDED_BYTES: u64 = 1_024 * 1_024 * 1_02
 pub const GITHUB_PROVIDER_ARCHIVE_MAX_ENTRY_PATH_BYTES: u64 = 4 * 1_024;
 /// Exact direct workflow-file count ceiling supported by discovery.
 pub const GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS: u64 = 256;
-/// Exact per-workflow source ceiling supported by discovery.
-pub const GITHUB_PROVIDER_WORKFLOW_MAX_BYTES: u64 = 1_024 * 1_024;
+/// Exact raw UTF-8 per-workflow source ceiling supported by discovery.
+///
+/// This duplicates the provider frontend's 500 KiB boundary deliberately so
+/// the persistence layer does not acquire a dependency on the frontend.
+pub const GITHUB_PROVIDER_WORKFLOW_MAX_BYTES: u64 = 500 * 1_024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GithubProviderManifestLimitRejection {

--- a/crates/automata-ci-store/tests/github_provider_manifest_api.rs
+++ b/crates/automata-ci-store/tests/github_provider_manifest_api.rs
@@ -297,7 +297,7 @@ fn digest_binds_every_mutable_evidence_and_server_derived_repository() {
     );
     assert_eq!(
         original.digest().to_string(),
-        "040637cf95b3f4e6d0aee57ef796f6b9c2fdea3f46153c8a183a7a77f128ca0a"
+        "20f16f866564dd2c9ab17776c2f8acabc5c619fa305066b0f86c1ec9b82c1b64"
     );
     assert_eq!(
         credential_free.authority_profile(),
@@ -340,7 +340,7 @@ fn owner_binding_uses_an_independent_domain_and_preserves_the_base_digest() {
     assert_ne!(owner.digest(), other_owner.digest());
     assert_eq!(
         base.digest().to_string(),
-        "040637cf95b3f4e6d0aee57ef796f6b9c2fdea3f46153c8a183a7a77f128ca0a"
+        "20f16f866564dd2c9ab17776c2f8acabc5c619fa305066b0f86c1ec9b82c1b64"
     );
 }
 

--- a/crates/automata-ci-workflow-github/src/compiler/logical.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/logical.rs
@@ -43,7 +43,9 @@ use super::{
     safety::scan_lossy_yaml,
 };
 
-const RUN_NAME_CONTEXTS: &[ExpressionContext] = &[
+const RUN_NAME_CONTEXTS: &[ExpressionContext] =
+    &[ExpressionContext::Github, ExpressionContext::Inputs];
+const WORKFLOW_CONCURRENCY_CONTEXTS: &[ExpressionContext] = &[
     ExpressionContext::Github,
     ExpressionContext::Inputs,
     ExpressionContext::Vars,
@@ -128,7 +130,7 @@ const WORKFLOW_ENV_POLICY: ValueExpressionPolicy = ValueExpressionPolicy::new(
 const WORKFLOW_CONCURRENCY_POLICY: ValueExpressionPolicy = ValueExpressionPolicy::new(
     "workflow concurrency",
     PlanEvaluationPhase::Admission,
-    RUN_NAME_CONTEXTS,
+    WORKFLOW_CONCURRENCY_CONTEXTS,
     false,
 );
 const STRATEGY_POLICY: ValueExpressionPolicy = ValueExpressionPolicy::new(

--- a/crates/automata-ci-workflow-github/src/compiler/safety.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/safety.rs
@@ -71,6 +71,12 @@ fn scan_mapping_safety(node: &YamlNode, context: &mut CompileContext<'_>) {
                             .with_related("first definition is here", previous.clone()),
                         );
                     }
+                } else {
+                    context.unsupported(
+                        "github.compile.yaml_complex_mapping_key",
+                        "YAML mappings with non-scalar keys cannot be compiled without loss",
+                        entry.key().span().clone(),
+                    );
                 }
                 scan_mapping_safety(entry.key(), context);
                 scan_mapping_safety(entry.value(), context);

--- a/crates/automata-ci-workflow-github/src/compiler/trigger.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/trigger.rs
@@ -222,6 +222,7 @@ fn validate_repository_dispatch_filter(
     trigger_span: &SourceSpan,
     context: &mut CompileContext<'_>,
 ) {
+    context.reject_extensions(filter.extensions());
     if filter.types_configured() && filter.types().is_empty() {
         context.semantic(
             "github.compile.empty_event_filter",
@@ -314,6 +315,7 @@ fn validate_merge_group_filter(
     trigger_span: &SourceSpan,
     context: &mut CompileContext<'_>,
 ) {
+    context.reject_extensions(filter.extensions());
     if filter.types_configured() && filter.types().is_empty() {
         context.semantic(
             "github.compile.empty_event_filter",
@@ -1134,6 +1136,7 @@ fn validate_filter(
     trigger_span: &SourceSpan,
     context: &mut CompileContext<'_>,
 ) {
+    context.reject_extensions(filter.extensions());
     validate_mutually_exclusive_filters(
         "branches",
         filter.branches_configured(),

--- a/crates/automata-ci-workflow-github/src/lib.rs
+++ b/crates/automata-ci-workflow-github/src/lib.rs
@@ -66,8 +66,8 @@ pub use source::{
     SourceFile, SourceId, SourceLocation, SourceModelError, SourceOrigin, SourceProvenance,
     SourceSpan, Spanned,
 };
-pub use syntax::ParseLimits as WorkflowParseLimits;
 pub use syntax::{
     AnchorId, ScalarResolution, ScalarStyle, YamlAlias, YamlAliasExpansion, YamlDocument,
     YamlMappingEntry, YamlNode, YamlNodeKind, YamlScalar, YamlTag,
 };
+pub use syntax::{MAX_GITHUB_WORKFLOW_SOURCE_BYTES, ParseLimits as WorkflowParseLimits};

--- a/crates/automata-ci-workflow-github/src/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/src/repository_archive.rs
@@ -21,6 +21,8 @@ const MAX_WORKFLOW_BYTES: u64 = 16_777_216;
 const MAX_GLOBAL_PAX_BYTES: u64 = 65_536;
 const OBSERVED_STREAM_TAIL_BYTES: usize = 2 * 1_024;
 
+use crate::MAX_GITHUB_WORKFLOW_SOURCE_BYTES;
+
 /// Maximum byte length of a workflow path returned by repository discovery.
 ///
 /// This must remain exactly aligned with the durable provider-delivery
@@ -201,7 +203,7 @@ impl Default for RepositoryWorkflowDiscoveryLimits {
             expanded_bytes: 1024 * 1_024 * 1_024,
             entry_path_bytes: 4 * 1_024,
             workflows: 256,
-            workflow_bytes: 1_024 * 1_024,
+            workflow_bytes: MAX_GITHUB_WORKFLOW_SOURCE_BYTES as u64,
         }
     }
 }

--- a/crates/automata-ci-workflow-github/src/syntax/mod.rs
+++ b/crates/automata-ci-workflow-github/src/syntax/mod.rs
@@ -8,5 +8,5 @@ pub use ast::{
     YamlMappingEntry, YamlNode, YamlNodeKind, YamlScalar, YamlTag,
 };
 pub(crate) use expansion::expand_aliases;
-pub use parser::ParseLimits;
 pub(crate) use parser::parse_yaml;
+pub use parser::{MAX_GITHUB_WORKFLOW_SOURCE_BYTES, ParseLimits};

--- a/crates/automata-ci-workflow-github/src/syntax/parser.rs
+++ b/crates/automata-ci-workflow-github/src/syntax/parser.rs
@@ -13,6 +13,14 @@ use crate::{
     },
 };
 
+/// Automata's pinned maximum raw UTF-8 byte length for one GitHub workflow.
+///
+/// GitHub documents the accepted workflow extensions but does not publish an
+/// exact byte-accounting contract. Automata therefore interprets the parity
+/// plan's 500 KB ceiling as 500 KiB and applies it to the original bytes,
+/// before YAML parsing or newline/BOM normalization.
+pub const MAX_GITHUB_WORKFLOW_SOURCE_BYTES: usize = 500 * 1_024;
+
 /// Independent bounds applied while parsing loss-aware YAML syntax.
 ///
 /// These limits bound retained input, nesting, node allocation, alias uses,
@@ -35,7 +43,7 @@ pub struct ParseLimits {
 impl Default for ParseLimits {
     fn default() -> Self {
         Self {
-            max_source_bytes: 2 * 1024 * 1024,
+            max_source_bytes: MAX_GITHUB_WORKFLOW_SOURCE_BYTES,
             max_depth: 64,
             max_nodes: 100_000,
             max_aliases: 1_024,
@@ -193,8 +201,12 @@ pub(crate) fn parse_yaml(source: &SourceFile, limits: ParseLimits) -> SyntaxRepo
         };
     }
 
-    let mut receiver = AstReceiver::new(source, limits);
-    let result = Parser::new_from_str(source.text()).load(&mut receiver, true);
+    let (parser_source, ignored_leading_characters) = source
+        .text()
+        .strip_prefix('\u{feff}')
+        .map_or((source.text(), 0), |without_bom| (without_bom, 1));
+    let mut receiver = AstReceiver::new(source, limits, ignored_leading_characters);
+    let result = Parser::new_from_str(parser_source).load(&mut receiver, true);
     if let Err(error) = result {
         let marker = *error.marker();
         let marker_offset = receiver.coordinates.byte_offset(marker.index());
@@ -259,10 +271,14 @@ struct AstReceiver<'source> {
 }
 
 impl<'source> AstReceiver<'source> {
-    fn new(source: &'source SourceFile, limits: ParseLimits) -> Self {
+    fn new(
+        source: &'source SourceFile,
+        limits: ParseLimits,
+        ignored_leading_characters: usize,
+    ) -> Self {
         Self {
             source,
-            coordinates: SourceCoordinates::new(source.text()),
+            coordinates: SourceCoordinates::new(source.text(), ignored_leading_characters),
             limits,
             documents: Vec::new(),
             document: None,
@@ -658,10 +674,11 @@ struct SourceCoordinates {
 }
 
 impl SourceCoordinates {
-    fn new(source: &str) -> Self {
+    fn new(source: &str, ignored_leading_characters: usize) -> Self {
         let mut character_to_byte = source
             .char_indices()
             .map(|(byte_offset, _)| byte_offset)
+            .skip(ignored_leading_characters)
             .collect::<Vec<_>>();
         character_to_byte.push(source.len());
         Self { character_to_byte }

--- a/crates/automata-ci-workflow-github/tests/compiler.rs
+++ b/crates/automata-ci-workflow-github/tests/compiler.rs
@@ -78,6 +78,51 @@ fn compiler_rejects_duplicate_keys_retained_by_the_loss_aware_frontend() {
 }
 
 #[test]
+fn compiler_defensively_rejects_complex_mapping_keys_that_decoding_skipped() {
+    let source = "on: workflow_dispatch\nenv:\n  ? [lossy, key]\n  : value\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n";
+    let report = compile(source, "workflow_dispatch");
+    assert!(report.plan().is_none());
+    let diagnostic = report
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| diagnostic.code() == "github.compile.yaml_complex_mapping_key")
+        .expect("complex-key compiler diagnostic");
+    assert_eq!(diagnostic.kind(), DiagnosticKind::Unsupported);
+    assert_eq!(
+        source.get(
+            diagnostic.primary_span().start().byte_offset()
+                ..diagnostic.primary_span().end().byte_offset()
+        ),
+        Some("[lossy, key]")
+    );
+}
+
+#[test]
+fn compiler_rejects_unknown_event_filter_fields_retained_by_decoding() {
+    for (source, event_name) in [
+        (
+            "on:\n  push:\n    mystery: true\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n",
+            "push",
+        ),
+        (
+            "on:\n  merge_group:\n    mystery: true\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n",
+            "merge_group",
+        ),
+        (
+            "on:\n  repository_dispatch:\n    mystery: true\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n",
+            "repository_dispatch",
+        ),
+    ] {
+        let report = compile(source, event_name);
+        assert!(report.plan().is_none(), "{:#?}", report.diagnostics());
+        assert!(report.diagnostics().iter().any(|diagnostic| {
+            diagnostic.kind() == DiagnosticKind::Unsupported
+                && diagnostic.code() == "github.compile.unsupported_field"
+        }));
+    }
+}
+
+#[test]
 fn compiler_rejects_invalid_event_filters() {
     let cases = [
         (

--- a/crates/automata-ci-workflow-github/tests/diagnostics.rs
+++ b/crates/automata-ci-workflow-github/tests/diagnostics.rs
@@ -126,3 +126,75 @@ fn semantic_step_errors_are_distinct_from_unsupported_fields() {
             .all(|diagnostic| diagnostic.kind() == DiagnosticKind::Semantic)
     );
 }
+
+#[test]
+fn duplicate_keys_have_one_taxonomy_at_every_mapping_level() {
+    let sources = [
+        "on: push\non: pull_request\njobs: {}\n",
+        "on:\n  push:\n    branches: [main]\n    branches: [release]\njobs: {}\n",
+        "on: push\ndefaults:\n  run:\n    shell: bash\n    shell: pwsh\njobs: {}\n",
+        "on: push\njobs:\n  build:\n    runs-on: linux\n    runs-on: windows\n    steps: []\n",
+        "on: push\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo one\n        run: echo two\n",
+    ];
+    for source in sources {
+        let report = support::parse(source);
+        let duplicate = report
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code() == "github.duplicate_mapping_key")
+            .unwrap_or_else(|| panic!("missing duplicate diagnostic: {:#?}", report.diagnostics()));
+        assert_eq!(duplicate.kind(), DiagnosticKind::Semantic);
+        assert_eq!(duplicate.related().len(), 1);
+    }
+}
+
+#[test]
+fn unknown_fields_are_unsupported_at_nested_mapping_levels() {
+    let source = "on:\n  push:\n    event-mystery: true\ndefaults:\n  defaults-mystery: true\n  run:\n    run-mystery: true\njobs:\n  build:\n    runs-on: linux\n    strategy:\n      strategy-mystery: true\n    steps:\n      - run: echo ok\n        step-mystery: true\n";
+    let report = support::parse(source);
+    let messages = report
+        .diagnostics_of_kind(DiagnosticKind::Unsupported)
+        .filter(|diagnostic| diagnostic.code() == "github.unsupported_field")
+        .map(automata_ci_workflow_github::Diagnostic::message)
+        .collect::<Vec<_>>();
+    for path in [
+        "on.push.event-mystery",
+        "defaults.defaults-mystery",
+        "defaults.run.run-mystery",
+        "jobs.build.strategy.strategy-mystery",
+        "jobs.build.steps[0].step-mystery",
+    ] {
+        assert!(
+            messages.iter().any(|message| message.contains(path)),
+            "missing {path}: {messages:#?}"
+        );
+    }
+}
+
+#[test]
+fn type_errors_remain_semantic_and_field_specific_across_mapping_levels() {
+    let cases = [
+        ("[]", "github.expected_mapping"),
+        (
+            "on: push\ndefaults: []\njobs: {}\n",
+            "github.expected_mapping",
+        ),
+        (
+            "on: push\njobs:\n  build: invalid\n",
+            "github.expected_mapping",
+        ),
+        (
+            "on: push\njobs:\n  build:\n    runs-on: linux\n    steps: invalid\n",
+            "github.expected_sequence",
+        ),
+    ];
+    for (source, code) in cases {
+        let report = support::parse(source);
+        let diagnostic = report
+            .diagnostics()
+            .iter()
+            .find(|diagnostic| diagnostic.code() == code)
+            .unwrap_or_else(|| panic!("missing {code}: {:#?}", report.diagnostics()));
+        assert_eq!(diagnostic.kind(), DiagnosticKind::Semantic);
+    }
+}

--- a/crates/automata-ci-workflow-github/tests/limits.rs
+++ b/crates/automata-ci-workflow-github/tests/limits.rs
@@ -1,7 +1,48 @@
 use automata_ci_workflow_github::{
-    DiagnosticKind, GithubFrontendReport, GithubWorkflowFrontend, ParseWorkflowRequest,
-    SourceProvenance, WorkflowFrontend, WorkflowParseLimits,
+    DiagnosticKind, GithubFrontendReport, GithubWorkflowFrontend, MAX_GITHUB_WORKFLOW_SOURCE_BYTES,
+    ParseWorkflowRequest, SourceProvenance, WorkflowFrontend, WorkflowParseLimits,
 };
+
+#[test]
+fn default_source_ceiling_has_exact_raw_byte_boundaries() {
+    for size in [
+        MAX_GITHUB_WORKFLOW_SOURCE_BYTES - 1,
+        MAX_GITHUB_WORKFLOW_SOURCE_BYTES,
+    ] {
+        let source = workflow_with_exact_bytes(size);
+        let report = GithubWorkflowFrontend::default().parse(request(&source));
+        assert!(
+            report.plan().is_some(),
+            "size {size}: {:#?}",
+            report.diagnostics()
+        );
+        assert!(
+            !report
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code() == "yaml.source_too_large")
+        );
+    }
+
+    let source = workflow_with_exact_bytes(MAX_GITHUB_WORKFLOW_SOURCE_BYTES + 1);
+    let report = GithubWorkflowFrontend::default().parse(request(&source));
+    assert!(report.plan().is_none());
+    assert_eq!(report.diagnostics().len(), 1);
+    assert_eq!(report.diagnostics()[0].code(), "yaml.source_too_large");
+
+    for prefix in [
+        "\u{feff}on: push\njobs: {}\n#",
+        "on: push\r\njobs: {}\r\n#",
+    ] {
+        let source = workflow_variant_with_exact_bytes(prefix, MAX_GITHUB_WORKFLOW_SOURCE_BYTES);
+        let report = GithubWorkflowFrontend::default().parse(request(&source));
+        assert!(
+            report.plan().is_some(),
+            "raw-byte variant: {:#?}",
+            report.diagnostics()
+        );
+    }
+}
 
 #[test]
 fn source_size_is_checked_before_yaml_construction() {
@@ -142,4 +183,18 @@ fn assert_report_has_one_derived_text_limit(report: &GithubFrontendReport) {
 
 fn request(source: &str) -> ParseWorkflowRequest<'_> {
     ParseWorkflowRequest::new(SourceProvenance::memory("limits.yml"), source)
+}
+
+fn workflow_with_exact_bytes(size: usize) -> String {
+    const PREFIX: &str = "on: push\njobs: {}\n#";
+    workflow_variant_with_exact_bytes(PREFIX, size)
+}
+
+fn workflow_variant_with_exact_bytes(prefix: &str, size: usize) -> String {
+    assert!(size >= prefix.len());
+    let mut source = String::with_capacity(size);
+    source.push_str(prefix);
+    source.extend(std::iter::repeat_n('x', size - prefix.len()));
+    assert_eq!(source.len(), size);
+    source
 }

--- a/crates/automata-ci-workflow-github/tests/logical_compiler.rs
+++ b/crates/automata-ci-workflow-github/tests/logical_compiler.rs
@@ -44,6 +44,19 @@ fn assert_rejected(source: &str, code: &str) {
 }
 
 #[test]
+fn run_name_is_limited_to_github_and_inputs_contexts() {
+    let accepted = compile(
+        "run-name: Deploy ${{ inputs.target }} from ${{ github.ref }}\non: workflow_dispatch\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n",
+        "workflow_dispatch",
+    );
+    assert!(accepted.is_accepted(), "{:#?}", accepted.diagnostics());
+    assert_rejected(
+        "run-name: Deploy ${{ vars.target }}\non: workflow_dispatch\njobs:\n  build:\n    runs-on: linux\n    steps: [{run: echo ok}]\n",
+        "github.expression.unrecognized_context",
+    );
+}
+
+#[test]
 #[allow(clippy::too_many_lines)]
 fn default_compiler_retains_dynamic_activation_execution_and_finalization_templates() {
     let source = r#"name: Synthetic matrix

--- a/crates/automata-ci-workflow-github/tests/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/tests/repository_archive.rs
@@ -35,6 +35,28 @@ fn discovers_exact_direct_workflows_in_deterministic_path_order() {
 }
 
 #[test]
+fn discovery_accepts_only_exact_lowercase_yml_and_yaml_extensions() {
+    let archive = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/.ci/workflows/a.yml", b"a"),
+        regular(b"repository-deadbeef/.ci/workflows/b.yaml", b"b"),
+        regular(b"repository-deadbeef/.ci/workflows/c.YML", b"c"),
+        regular(b"repository-deadbeef/.ci/workflows/d.Yaml", b"d"),
+        regular(b"repository-deadbeef/.ci/workflows/e.yaml.bak", b"e"),
+        regular(b"repository-deadbeef/.ci/workflows/f", b"f"),
+    ]);
+
+    let discovered = discover_repository_workflows(&archive, limits()).expect("valid archive");
+    assert_eq!(
+        discovered
+            .iter()
+            .map(RepositoryWorkflowDiscoveryOutcome::path)
+            .collect::<Vec<_>>(),
+        vec![".ci/workflows/a.yml", ".ci/workflows/b.yaml"]
+    );
+}
+
+#[test]
 fn rejects_the_github_actions_workflow_directory_as_a_second_runtime_authority() {
     for entries in [
         vec![

--- a/crates/automata-ci-workflow-github/tests/yaml_semantics.rs
+++ b/crates/automata-ci-workflow-github/tests/yaml_semantics.rs
@@ -2,6 +2,80 @@ use crate::support;
 
 use automata_ci_workflow_github::{ScalarResolution, YamlNode};
 
+const WORKFLOW_LF: &str =
+    "on: push\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo test\n";
+
+#[test]
+fn bom_and_newline_style_are_retained_but_do_not_change_semantics() {
+    let bom = format!("\u{feff}{WORKFLOW_LF}");
+    let crlf = WORKFLOW_LF.replace('\n', "\r\n");
+    let plain = support::parse(WORKFLOW_LF);
+    let with_bom = support::parse(&bom);
+    let with_crlf = support::parse(&crlf);
+    for report in [&plain, &with_bom, &with_crlf] {
+        assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    }
+    assert_eq!(with_bom.plan().expect("BOM plan").source().text(), bom);
+    assert_eq!(with_crlf.plan().expect("CRLF plan").source().text(), crlf);
+    assert_eq!(workflow_shape(&plain), workflow_shape(&with_bom));
+    assert_eq!(workflow_shape(&plain), workflow_shape(&with_crlf));
+    let bom_root = with_bom
+        .plan()
+        .expect("BOM plan")
+        .document()
+        .root()
+        .as_mapping()
+        .expect("root mapping");
+    assert_eq!(bom_root[0].key().span().start().byte_offset(), 3);
+    assert_eq!(
+        with_bom
+            .plan()
+            .expect("BOM plan")
+            .source()
+            .slice(bom_root[0].key().span()),
+        Some("on")
+    );
+}
+
+#[test]
+fn empty_and_trailing_documents_are_rejected_as_document_count_errors() {
+    let empty = support::parse("");
+    assert!(empty.plan().is_none());
+    assert!(
+        empty
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code() == "github.document_count")
+    );
+
+    let explicit_empty = support::parse("---\n");
+    assert!(explicit_empty.plan().is_none());
+    assert!(
+        explicit_empty
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code() == "github.expected_mapping")
+    );
+
+    let trailing = support::parse("on: push\njobs: {}\n---\n");
+    assert!(trailing.plan().is_none());
+    assert!(
+        trailing
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code() == "github.document_count")
+    );
+}
+
+#[test]
+fn quoted_and_unquoted_on_keys_decode_identically() {
+    let unquoted = support::parse(WORKFLOW_LF);
+    let quoted = support::parse(&WORKFLOW_LF.replacen("on:", "'on':", 1));
+    assert!(unquoted.is_accepted(), "{:#?}", unquoted.diagnostics());
+    assert!(quoted.is_accepted(), "{:#?}", quoted.diagnostics());
+    assert_eq!(workflow_shape(&unquoted), workflow_shape(&quoted));
+}
+
 #[test]
 fn yaml_1_2_does_not_resolve_on_off_yes_or_no_as_booleans() {
     let source = "on: push\nenv:\n  ON_VALUE: on\n  OFF_VALUE: off\n  YES_VALUE: yes\n  NO_VALUE: no\n  TRUE_VALUE: true\n  QUOTED_TRUE: 'true'\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo test\n";
@@ -112,4 +186,23 @@ fn mapping_value<'node>(node: &'node YamlNode, key: &str) -> &'node YamlNode {
         })
         .expect("key")
         .value()
+}
+
+fn workflow_shape(
+    report: &automata_ci_workflow_github::GithubFrontendReport,
+) -> (Vec<String>, Vec<String>) {
+    let workflow = report.plan().expect("plan").workflow();
+    let events = workflow
+        .triggers()
+        .expect("triggers")
+        .events()
+        .iter()
+        .map(|event| format!("{:?}", event.name().value()))
+        .collect();
+    let jobs = workflow
+        .jobs()
+        .iter()
+        .map(|job| job.id().as_str().to_owned())
+        .collect();
+    (events, jobs)
 }

--- a/crates/automata-ci-workflow-service/src/service.rs
+++ b/crates/automata-ci-workflow-service/src/service.rs
@@ -49,13 +49,13 @@ use crate::{
     },
 };
 
-const REQUEST_DIGEST_DOMAIN_V4: &[u8] = b"automata.workflow-admission.request.v4\0";
-const AUTHENTICATED_GITHUB_REQUEST_DIGEST_DOMAIN_V5: &[u8] =
-    b"automata.workflow-admission.request.v5\0";
-const AUTHENTICATED_WORKFLOW_DISPATCH_REQUEST_DIGEST_DOMAIN_V6: &[u8] =
-    b"automata.workflow-admission.request.v6.control-plane-dispatch\0";
-const SCHEDULED_GITHUB_REQUEST_DIGEST_DOMAIN_V7: &[u8] =
-    b"automata.workflow-admission.request.v7.scheduled-github\0";
+const REQUEST_DIGEST_DOMAIN_V8: &[u8] = b"automata.workflow-admission.request.v8.run-name\0";
+const AUTHENTICATED_GITHUB_REQUEST_DIGEST_DOMAIN_V8: &[u8] =
+    b"automata.workflow-admission.request.v8.run-name.authenticated-github\0";
+const AUTHENTICATED_WORKFLOW_DISPATCH_REQUEST_DIGEST_DOMAIN_V8: &[u8] =
+    b"automata.workflow-admission.request.v8.run-name.control-plane-dispatch\0";
+const SCHEDULED_GITHUB_REQUEST_DIGEST_DOMAIN_V8: &[u8] =
+    b"automata.workflow-admission.request.v8.run-name.scheduled-github\0";
 const PROVIDER_DELIVERY_NAMESPACE_DOMAIN: &[u8] =
     b"automata.workflow-admission.provider-delivery\0";
 const ADMISSION_GITHUB_PROPERTIES: &[&str] = &[
@@ -75,6 +75,7 @@ const ADMISSION_GITHUB_PROPERTIES: &[&str] = &[
     "workflow_ref",
     "workflow_sha",
 ];
+const MAX_RUN_DISPLAY_TITLE_BYTES: usize = 1_024;
 
 enum AdmissionAuthority {
     ProviderNeutral,
@@ -425,6 +426,7 @@ impl WorkflowAdmissionService {
 
         let command = self.observe_sync_stage(WorkflowAdmissionStage::Encode, || {
             let concurrency = resolve_workflow_concurrency(&request)?;
+            let display_title = resolve_run_display_title(&request)?;
             let request_digest = canonical_request_digest(
                 &request,
                 delivery_id,
@@ -434,6 +436,7 @@ impl WorkflowAdmissionService {
                 &event_blob,
                 &plan_blob,
                 &base_context_blob,
+                display_title.as_deref(),
                 concurrency.as_ref(),
                 reusable.as_ref().map(|prepared| &prepared.graph),
             );
@@ -451,6 +454,7 @@ impl WorkflowAdmissionService {
                 &event_blob,
                 &plan_blob,
                 &base_context_blob,
+                display_title.as_deref(),
                 concurrency,
                 reusable.as_ref().map(|prepared| prepared.graph.clone()),
             )
@@ -499,6 +503,7 @@ impl WorkflowAdmissionService {
                     &event_blob,
                     &plan_blob,
                     &base_context_blob,
+                    command.display_title(),
                     command.concurrency().cloned(),
                     command.reusable_workflows().cloned(),
                 )?;
@@ -522,6 +527,7 @@ impl WorkflowAdmissionService {
                     &event_blob,
                     &plan_blob,
                     &base_context_blob,
+                    command.display_title(),
                     command.concurrency().cloned(),
                     command.reusable_workflows().cloned(),
                 )?;
@@ -548,6 +554,7 @@ impl WorkflowAdmissionService {
                     &event_blob,
                     &plan_blob,
                     &base_context_blob,
+                    command.display_title(),
                     command.concurrency().cloned(),
                     command.reusable_workflows().cloned(),
                 )?;
@@ -628,6 +635,7 @@ fn build_command(
     event: &PreparedBlob,
     plan: &PreparedBlob,
     base_context: &PreparedBlob,
+    display_title: Option<&str>,
     concurrency: Option<WorkflowConcurrency>,
     reusable_workflows: Option<AdmittedReusableWorkflowExpansion>,
 ) -> Result<AdmitLogicalWorkflowRun, WorkflowAdmissionError> {
@@ -707,7 +715,7 @@ fn build_command(
     if let Some(actor) = request.actor() {
         command = command.actor(actor);
     }
-    if let Some(display_title) = request.display_title() {
+    if let Some(display_title) = display_title {
         command = command.display_title(display_title);
     }
     if let Some(commit_subject) = request.commit_subject() {
@@ -1332,6 +1340,53 @@ fn resolve_workflow_concurrency(
         .map_err(WorkflowAdmissionError::AdmissionValue)
 }
 
+fn resolve_run_display_title(
+    request: &WorkflowAdmissionRequest,
+) -> Result<Option<String>, WorkflowAdmissionError> {
+    let explicit = request.plan().logical().run_name().map(|run_name| {
+        let rendered = match run_name.value() {
+            CompiledValueTemplate::Literal(value) => Ok(value.clone()),
+            CompiledValueTemplate::Expression(expression) => {
+                if request.repository().provider() != "github" {
+                    return Err(WorkflowAdmissionError::RunNameEvaluation);
+                }
+                let context = admission_expression_context(request)
+                    .map_err(|_| WorkflowAdmissionError::RunNameEvaluation)?;
+                evaluate_admission_string(
+                    expression,
+                    &GithubExpressionEvaluator::default(),
+                    &context,
+                )
+                .map_err(|_| WorkflowAdmissionError::RunNameEvaluation)
+            }
+        }?;
+        validate_run_display_title(rendered)
+    });
+    if let Some(title) = explicit
+        .transpose()?
+        .filter(|title| !title.trim().is_empty())
+    {
+        return Ok(Some(title));
+    }
+    request
+        .display_title()
+        .filter(|title| !title.trim().is_empty())
+        .or_else(|| {
+            request
+                .commit_subject()
+                .filter(|subject| !subject.trim().is_empty())
+        })
+        .map(|title| validate_run_display_title(title.to_owned()))
+        .transpose()
+}
+
+fn validate_run_display_title(title: String) -> Result<String, WorkflowAdmissionError> {
+    if title.len() > MAX_RUN_DISPLAY_TITLE_BYTES || title.chars().any(char::is_control) {
+        return Err(WorkflowAdmissionError::RunNameEvaluation);
+    }
+    Ok(title)
+}
+
 fn admission_expression_context(
     request: &WorkflowAdmissionRequest,
 ) -> Result<MapContext, WorkflowAdmissionError> {
@@ -1643,18 +1698,19 @@ fn canonical_request_digest(
     event: &PreparedBlob,
     plan: &PreparedBlob,
     base_context: &PreparedBlob,
+    resolved_display_title: Option<&str>,
     concurrency: Option<&WorkflowConcurrency>,
     reusable_workflows: Option<&AdmittedReusableWorkflowExpansion>,
 ) -> Sha256Digest {
     let mut digest = Sha256::new();
     digest.update(if schedule_fire_id.is_some() {
-        SCHEDULED_GITHUB_REQUEST_DIGEST_DOMAIN_V7
+        SCHEDULED_GITHUB_REQUEST_DIGEST_DOMAIN_V8
     } else if dispatch_claim.is_some() {
-        AUTHENTICATED_WORKFLOW_DISPATCH_REQUEST_DIGEST_DOMAIN_V6
+        AUTHENTICATED_WORKFLOW_DISPATCH_REQUEST_DIGEST_DOMAIN_V8
     } else if delivery_id.is_some() {
-        AUTHENTICATED_GITHUB_REQUEST_DIGEST_DOMAIN_V5
+        AUTHENTICATED_GITHUB_REQUEST_DIGEST_DOMAIN_V8
     } else {
-        REQUEST_DIGEST_DOMAIN_V4
+        REQUEST_DIGEST_DOMAIN_V8
     });
     for value in [
         request.tenant().as_str(),
@@ -1673,6 +1729,7 @@ fn canonical_request_digest(
     digest_optional_field(&mut digest, request.actor());
     digest_optional_field(&mut digest, request.display_title());
     digest_optional_field(&mut digest, request.commit_subject());
+    digest_optional_field(&mut digest, resolved_display_title);
     digest_field(
         &mut digest,
         &request.run_attempt().unwrap_or(1).to_be_bytes(),
@@ -1794,6 +1851,9 @@ pub enum WorkflowAdmissionError {
     /// Workflow-level concurrency could not be resolved from admission-safe context.
     #[error("workflow concurrency could not be resolved at admission")]
     ConcurrencyEvaluation,
+    /// Workflow `run-name` could not be resolved into a bounded durable title.
+    #[error("workflow run-name could not be resolved at admission")]
+    RunNameEvaluation,
     /// Canonical manual-dispatch evidence did not match the authenticated target.
     #[error("authenticated workflow dispatch evidence did not match admission")]
     WorkflowDispatchEvidence,
@@ -1814,6 +1874,7 @@ const fn observe_failure(error: &WorkflowAdmissionError) -> WorkflowAdmissionFai
         | WorkflowAdmissionError::CredentialDiscovery(_)
         | WorkflowAdmissionError::Serialization
         | WorkflowAdmissionError::ConcurrencyEvaluation
+        | WorkflowAdmissionError::RunNameEvaluation
         | WorkflowAdmissionError::WorkflowDispatchEvidence
         | WorkflowAdmissionError::Internal => WorkflowAdmissionFailure::InvalidState,
     }

--- a/crates/automata-ci-workflow-service/tests/logical_projection.rs
+++ b/crates/automata-ci-workflow-service/tests/logical_projection.rs
@@ -294,6 +294,122 @@ fn project_envelope_with_profiles(
 }
 
 #[test]
+fn env_shell_and_working_directory_follow_workflow_job_step_precedence() {
+    let source = r"name: Synthetic CI
+on: workflow_dispatch
+env:
+  SHARED: workflow
+  WORKFLOW_ONLY: workflow-only
+defaults:
+  run:
+    shell: bash
+    working-directory: workflow-dir
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SHARED: job
+      JOB_ONLY: job-only
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: job-dir
+    steps:
+      - run: echo inherited
+        env:
+          SHARED: step
+          STEP_ONLY: step-only
+      - run: echo explicit
+        shell: python {0}
+        working-directory: step-dir
+";
+    let envelope = project_envelope(source);
+    let job = envelope.job();
+    assert_literal_source(job.environment().get("SHARED"), "job");
+    assert_literal_source(job.environment().get("WORKFLOW_ONLY"), "workflow-only");
+    assert_literal_source(job.environment().get("JOB_ONLY"), "job-only");
+    assert_eq!(
+        literal_template(
+            job.working_directory_template()
+                .expect("job working-directory")
+        ),
+        "job-dir"
+    );
+
+    let [inherited, explicit] = job.steps() else {
+        panic!("two projected steps expected")
+    };
+    assert_literal_source(inherited.environment().get("SHARED"), "step");
+    assert_literal_source(inherited.environment().get("STEP_ONLY"), "step-only");
+    assert!(inherited.environment().get("WORKFLOW_ONLY").is_none());
+    let SemanticStep::Run { values } = inherited.kind() else {
+        panic!("inherited run step")
+    };
+    assert!(
+        matches!(values.shell(), ShellTemplate::Named { value } if literal_template(value) == "pwsh")
+    );
+    assert!(values.working_directory().is_none());
+
+    let SemanticStep::Run { values } = explicit.kind() else {
+        panic!("explicit run step")
+    };
+    assert!(
+        matches!(values.shell(), ShellTemplate::CommandTemplate { value } if literal_template(value) == "python {0}")
+    );
+    assert_eq!(
+        literal_template(
+            values
+                .working_directory()
+                .expect("step working-directory override")
+        ),
+        "step-dir"
+    );
+}
+
+#[test]
+fn workflow_run_defaults_apply_when_the_job_has_no_override() {
+    let source = r"name: Synthetic CI
+on: workflow_dispatch
+defaults:
+  run:
+    shell: bash
+    working-directory: workflow-dir
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo inherited
+";
+    let envelope = project_envelope(source);
+    assert_eq!(
+        literal_template(
+            envelope
+                .job()
+                .working_directory_template()
+                .expect("workflow working-directory")
+        ),
+        "workflow-dir"
+    );
+    let SemanticStep::Run { values } = envelope.job().steps()[0].kind() else {
+        panic!("run step")
+    };
+    assert!(
+        matches!(values.shell(), ShellTemplate::Named { value } if literal_template(value) == "bash")
+    );
+}
+
+fn assert_literal_source(source: Option<&ValueSource>, expected: &str) {
+    assert!(matches!(source, Some(ValueSource::Literal(value)) if value == expected));
+}
+
+fn literal_template(template: &automata_ci_core::ValueTemplate) -> &str {
+    let [segment] = template.segments() else {
+        panic!("one literal segment expected")
+    };
+    segment.literal_value().expect("literal template")
+}
+
+#[test]
 fn mapped_profile_preserves_multi_label_and_group_routing() {
     let source = r"name: Synthetic CI
 on: workflow_dispatch

--- a/crates/automata-ci-workflow-service/tests/projection.rs
+++ b/crates/automata-ci-workflow-service/tests/projection.rs
@@ -36,6 +36,129 @@ use bytes::Bytes;
 use uuid::Uuid;
 
 #[tokio::test]
+async fn run_name_is_evaluated_once_and_is_identical_on_replay() {
+    let request = run_name_request(
+        "run-name-replay",
+        Some("Deploy ${{ inputs.target }} by @${{ github.actor }}"),
+        Some("provider fallback"),
+        Some("commit fallback"),
+        "production",
+    );
+    let repository = Arc::new(ControllableRepository::default());
+    let service = service(repository.clone());
+
+    let first = service.admit(request.clone()).await.expect("new admission");
+    let first_command = repository.take_command();
+    assert!(!first.receipt().is_replay());
+    assert_eq!(
+        first_command.display_title(),
+        Some("Deploy production by @synthetic-actor")
+    );
+
+    repository.mode.store(1, Ordering::SeqCst);
+    let replay = service.admit(request).await.expect("exact replay");
+    let replay_command = repository.take_command();
+    assert!(replay.receipt().is_replay());
+    assert_eq!(
+        replay_command.display_title(),
+        first_command.display_title()
+    );
+    assert_eq!(
+        replay_command.request_digest(),
+        first_command.request_digest()
+    );
+}
+
+#[tokio::test]
+async fn run_name_fallback_precedence_is_explicit_then_provider_then_commit() {
+    let cases = [
+        (
+            "run-name-explicit",
+            Some("explicit title"),
+            Some("provider title"),
+            Some("commit title"),
+            Some("explicit title"),
+        ),
+        (
+            "run-name-whitespace",
+            Some("'   '"),
+            Some("provider title"),
+            Some("commit title"),
+            Some("provider title"),
+        ),
+        (
+            "run-name-commit",
+            None,
+            Some("   "),
+            Some("commit title"),
+            Some("commit title"),
+        ),
+        ("run-name-none", None, None, None, None),
+    ];
+    for (tenant, run_name, provider, commit, expected) in cases {
+        let repository = Arc::new(ControllableRepository::default());
+        service(repository.clone())
+            .admit(run_name_request(
+                tenant,
+                run_name,
+                provider,
+                commit,
+                "production",
+            ))
+            .await
+            .expect("admission");
+        assert_eq!(repository.take_command().display_title(), expected);
+    }
+}
+
+#[tokio::test]
+async fn run_name_has_exact_durable_byte_and_control_boundaries() {
+    for (length, accepted) in [(1_023, true), (1_024, true), (1_025, false)] {
+        let repository = Arc::new(ControllableRepository::default());
+        let result = service(repository.clone())
+            .admit(run_name_request(
+                &format!("run-name-{length}"),
+                Some(&"a".repeat(length)),
+                None,
+                None,
+                "production",
+            ))
+            .await;
+        if accepted {
+            result.expect("bounded run-name");
+            assert_eq!(
+                repository
+                    .take_command()
+                    .display_title()
+                    .expect("display title")
+                    .len(),
+                length
+            );
+        } else {
+            assert!(matches!(
+                result.expect_err("oversized run-name"),
+                WorkflowAdmissionError::RunNameEvaluation
+            ));
+            assert!(repository.command.lock().expect("command lock").is_none());
+        }
+    }
+
+    let repository = Arc::new(ControllableRepository::default());
+    let error = service(repository.clone())
+        .admit(run_name_request(
+            "run-name-control",
+            Some("\"bad\\nname\""),
+            None,
+            None,
+            "production",
+        ))
+        .await
+        .expect_err("control characters are not durable titles");
+    assert!(matches!(error, WorkflowAdmissionError::RunNameEvaluation));
+    assert!(repository.command.lock().expect("command lock").is_none());
+}
+
+#[tokio::test]
 async fn human_projection_is_bound_into_the_logical_admission() {
     let original = support::ci_request(
         "logical-projection",
@@ -436,6 +559,75 @@ jobs:
     .run_attempt(1)
     .build()
     .expect("admission request")
+}
+
+fn run_name_request(
+    tenant: &str,
+    run_name: Option<&str>,
+    display_title: Option<&str>,
+    commit_subject: Option<&str>,
+    target: &str,
+) -> WorkflowAdmissionRequest {
+    let run_name = run_name.map_or_else(String::new, |value| format!("run-name: {value}\n"));
+    let source = format!(
+        "{run_name}name: Run-name contract\non: push\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: echo synthetic\n"
+    );
+    let provenance = SourceProvenance::new(
+        SourceId::new(".ci/workflows/run-name.yml"),
+        SourceOrigin::Repository {
+            repository: Arc::from(support::REPOSITORY),
+            revision: Arc::from(support::REVISION),
+            path: Arc::from(".ci/workflows/run-name.yml"),
+        },
+    );
+    let parsed =
+        GithubWorkflowFrontend::default().parse(ParseWorkflowRequest::new(provenance, &source));
+    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
+    let compiled = GithubWorkflowCompiler::new().compile(
+        CompileWorkflowRequest::new(
+            parsed.plan().expect("parsed plan"),
+            WorkflowEventProvenance::new("github", "push")
+                .with_delivery_id(support::DELIVERY)
+                .with_commit_sha(support::REVISION)
+                .with_git_ref(support::GIT_REF),
+        )
+        .with_event_metadata(GithubEventMetadata::push(false)),
+    );
+    assert!(compiled.is_accepted(), "{:#?}", compiled.diagnostics());
+    let base_context = JobRuntimeContext::new_base(
+        context_object([("target", ContextValue::string(target))]),
+        ContextValue::empty_object(),
+        BTreeMap::new(),
+    )
+    .expect("base context");
+    let mut builder = WorkflowAdmissionRequest::builder(
+        automata_ci_store::TenantScope::from_authenticated_tenant_id(tenant).expect("tenant"),
+        automata_ci_workflow_service::AdmissionRepositoryCoordinates::new(
+            "github",
+            "repository-run-name",
+            "automata-ci",
+            "automata",
+        )
+        .expect("repository"),
+        ".ci/workflows/run-name.yml",
+        Bytes::from(source),
+        Bytes::from_static(b"{\"deleted\":false}"),
+        compiled.into_parts().0.expect("compiled plan"),
+        base_context,
+        WorkflowAdmissionIdempotency::operation(automata_ci_core::OperationId::new()),
+    )
+    .commit_sha(support::REVISION)
+    .git_ref(support::GIT_REF)
+    .workflow_name("Run-name contract")
+    .actor("synthetic-actor")
+    .run_attempt(1);
+    if let Some(display_title) = display_title {
+        builder = builder.display_title(display_title);
+    }
+    if let Some(commit_subject) = commit_subject {
+        builder = builder.commit_subject(commit_subject);
+    }
+    builder.build().expect("admission request")
 }
 
 fn context_object(entries: impl IntoIterator<Item = (&'static str, ContextValue)>) -> ContextValue {

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -372,20 +372,20 @@ bounded derived tree while retaining the original source AST. See
 - [x] Match GitHub's handling of duplicate anchors.
 - [x] Continue rejecting YAML merge keys if matching current GitHub behavior.
 - [x] Distinguish aliases from unsupported merge-key syntax in diagnostics.
-- [ ] Differential-test YAML 1.2 boolean behavior.
-- [ ] Test `.yml` and `.yaml`.
-- [ ] Test BOM and newline variants.
-- [ ] Test quoted and unquoted `on`.
-- [ ] Test null, empty, and duplicate values.
-- [ ] Test unknown keys at every workflow level.
-- [ ] Reject unsupported keys rather than preserving them as apparent support.
-- [ ] Enforce the current 500 KB workflow-file limit.
-- [ ] Document Automata's depth, scalar, collection, and expansion limits when
+- [x] Differential-test YAML 1.2 boolean behavior.
+- [x] Test `.yml` and `.yaml`.
+- [x] Test BOM and newline variants.
+- [x] Test quoted and unquoted `on`.
+- [x] Test null, empty, and duplicate values.
+- [x] Test unknown keys at every workflow level.
+- [x] Reject unsupported keys rather than preserving them as apparent support.
+- [x] Enforce the current 500 KB workflow-file limit.
+- [x] Document Automata's depth, scalar, collection, and expansion limits when
   stricter than GitHub.
-- [ ] Preserve accurate source spans through anchor expansion.
-- [ ] Test `run-name` evaluation and display.
-- [ ] Test workflow, job, and step `env` precedence.
-- [ ] Test workflow and job `defaults.run` precedence.
+- [x] Preserve accurate source spans through anchor expansion.
+- [x] Test `run-name` evaluation and display.
+- [x] Test workflow, job, and step `env` precedence.
+- [x] Test workflow and job `defaults.run` precedence.
 - [ ] Test every accepted job field through runtime, not merely
   deserialization.
 - [ ] Test every accepted step field through runtime.

--- a/docs/github-actions-parity/github-actions-parity-02-workflow-language.md
+++ b/docs/github-actions-parity/github-actions-parity-02-workflow-language.md
@@ -72,22 +72,58 @@ only if file ownership is partitioned.
 
 Tasks:
 
-- [ ] Change the default workflow source limit from 2 MiB to 500 KB at the
+- [x] Change the default workflow source limit from 2 MiB to 500 KB at the
   verified pre/post-normalization phase.
-- [ ] Test exact size boundaries, UTF-8 BOM, CRLF/LF, empty input, trailing
+- [x] Test exact size boundaries, UTF-8 BOM, CRLF/LF, empty input, trailing
   documents, quoted/unquoted `on`, and YAML 1.2 scalars.
-- [ ] Distinguish duplicate, unknown, unsupported, and type-invalid fields.
-- [ ] Verify `.yml` and `.yaml` discovery.
-- [ ] Complete `run-name`, workflow/job/step `env`, and `defaults.run`
+- [x] Distinguish duplicate, unknown, unsupported, and type-invalid fields.
+- [x] Verify `.yml` and `.yaml` discovery.
+- [x] Complete `run-name`, workflow/job/step `env`, and `defaults.run`
   precedence tests.
-- [ ] Reject decoded-but-unexecutable fields using FND-01 diagnostics.
-- [ ] Document any stricter depth, scalar, collection, and expansion bounds.
+- [x] Reject decoded-but-unexecutable fields using FND-01 diagnostics.
+- [x] Document any stricter depth, scalar, collection, and expansion bounds.
 
 Acceptance:
 
-- [ ] All boundary tests are deterministic.
-- [ ] No field is accepted merely because an unknown-field map retains it.
-- [ ] Diagnostic classes and spans are stable.
+- [x] All boundary tests are deterministic.
+- [x] No field is accepted merely because an unknown-field map retains it.
+- [x] Diagnostic classes and spans are stable.
+
+Component implementation is complete. GitHub's
+[workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+requires the exact lowercase `.yml` or `.yaml` extensions, specifies YAML, and
+limits `run-name` expressions to `github` and `inputs`. The same reference says
+an omitted or whitespace-only `run-name` falls back to event-specific data;
+Automata consumes the trusted provider projection in this order: evaluated
+`run-name`, provider display title, commit subject, then no stored display title
+(so presentation falls back to the workflow name). The evaluated title is
+stored in the admission command and bound into the versioned request digest,
+making replay use the identical value. The
+[defaults reference](https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs)
+defines the most-specific workflow/job/step precedence now covered from source
+through current `JobIR` projection.
+
+The public GitHub documentation does not publish exact workflow byte accounting
+or a maximum run-title length. Automata therefore makes these explicit pinned
+compatibility policies rather than silently guessing:
+
+- `500 KB` is interpreted as 500 KiB (`512,000` raw UTF-8 bytes), inclusive.
+  Archive discovery and the frontend apply the same limit before parsing. BOM
+  and CRLF bytes count; the original document remains immutable evidence. The
+  parser may ignore one leading UTF-8 BOM semantically, but performs no newline
+  or content normalization, so the post-normalization size is identical.
+- Durable run display titles are at most 1,024 UTF-8 bytes and contain no
+  control characters. This is an Automata storage/UI safety bound pending live
+  differential evidence.
+- The retained syntax tree is bounded to depth 64, 100,000 nodes, and 1,024
+  alias uses. Alias expansion independently allows depth 64, 100,000 expanded
+  nodes, 8 MiB of expanded scalar bytes, and 1,000,000 aggregate work units.
+  Semantic decode has a separate 16 MiB derived-text/diagnostic budget.
+
+Live differential evidence is still required for GitHub's unpublished decimal
+versus binary byte accounting, BOM accounting at the boundary, exhaustive
+event-specific fallback titles, and any provider-side title truncation. Those
+are conformance-gate items, not unrecorded implementation assumptions.
 
 ### WF-03 — Expression semantic closure
 


### PR DESCRIPTION
## Summary

- enforce the 500 KiB raw workflow source ceiling at archive, manifest, and frontend boundaries with exact byte/BOM/newline tests
- preserve YAML 1.2 semantics and original byte spans while rejecting multiple/trailing documents, complex keys, duplicate/unknown/unsupported/type-invalid fields without lossy compilation
- evaluate `run-name` from its allowed admission context, bind the resolved title into immutable request/replay identity, and persist the durable display title
- prove workflow/job/step environment, shell, and working-directory precedence through activation and JobIR projection
- add exact `.yml`/`.yaml` discovery and resource-boundary coverage

## Compatibility boundary

The implementation pins a 512,000-byte raw-source ceiling and a bounded, control-free durable run title. Public GitHub documentation does not fully specify BOM accounting, decimal-vs-binary source accounting, or every fallback-title case, so live differential evidence remains explicitly open rather than inferred.

## Validation

- full `automata-ci-workflow-github` suite
- full `automata-ci-workflow-service` suite
- full `automata-ci-github-delivery` suite (serialized to avoid an unrelated shared-clock test race)
- strict Clippy for all affected packages
- rebased onto current `upstream/main` after WF-01 merged