### PR TITLE
chore(runner): diagnose GitHub phase failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "uuid",
  "zeroize",
 ]

--- a/crates/automata-ci-github-runtime/tests/file_commands.rs
+++ b/crates/automata-ci-github-runtime/tests/file_commands.rs
@@ -59,6 +59,25 @@ fn all_name_value_files_share_the_exact_grammar() {
 }
 
 #[test]
+fn actions_core_empty_heredoc_exports_match_github_runner_grammar() {
+    let parser = GithubCommandFileDecoder::default();
+    let source = b"SCCACHE_PATH<<ghadelimiter_one\n/opt/hostedtoolcache/sccache/0.17.0/x64/sccache\nghadelimiter_one\nACTIONS_CACHE_SERVICE_V2<<ghadelimiter_two\non\nghadelimiter_two\nACTIONS_RESULTS_URL<<ghadelimiter_three\n\nghadelimiter_three\nACTIONS_RUNTIME_TOKEN<<ghadelimiter_four\n\nghadelimiter_four\n";
+
+    let parsed = parser
+        .decode(
+            CommandFileKind::Environment,
+            source,
+            CommandFilePlatform::Unix,
+        )
+        .expect("@actions/core exportVariable payload must decode");
+
+    assert_eq!(
+        render_name_values(&parsed),
+        "SCCACHE_PATH=/opt/hostedtoolcache/sccache/0.17.0/x64/sccache\nACTIONS_CACHE_SERVICE_V2=on\nACTIONS_RESULTS_URL=\nACTIONS_RUNTIME_TOKEN=\n"
+    );
+}
+
+#[test]
 fn heredoc_newlines_follow_the_selected_runner_platform() {
     let parser = GithubCommandFileDecoder::default();
     let source = b"VALUE<<EOF\r\none\r\nEOF\r\n";

--- a/crates/automata-ci-job-executor-github/Cargo.toml
+++ b/crates/automata-ci-job-executor-github/Cargo.toml
@@ -36,6 +36,7 @@ sha2.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 zeroize.workspace = true
 

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -4421,22 +4421,38 @@ impl GithubJobExecutor {
         }
         let artifact_hash_timeout = execution.timeout.min(ARTIFACT_HASH_TIMEOUT);
         let command_paths = paths.command_files(execution.phase)?;
-        let initialized = self.initialize_command_files(
-            endpoint,
-            attempt_id,
-            execution.phase,
-            &command_paths,
-            commands,
-            cancellation,
-        );
+        let initialized = self
+            .initialize_command_files(
+                endpoint,
+                attempt_id,
+                execution.phase,
+                &command_paths,
+                commands,
+                cancellation,
+            )
+            .map_err(|error| {
+                observe_phase_failure(
+                    error,
+                    attempt_id,
+                    execution.phase,
+                    "initialize_command_files",
+                )
+            });
         let Some(()) = reconcile_cancelled_operation(initialized, cancellation)? else {
             return Ok(CommandOutcome::Cancelled);
         };
         let environment = add_command_file_environment(&execution.environment, &command_paths)?;
-        let command = self.build_phase_command(attempt_id, &execution, environment)?;
+        let command = self
+            .build_phase_command(attempt_id, &execution, environment)
+            .map_err(|error| {
+                observe_phase_failure(error, attempt_id, execution.phase, "build_phase_command")
+            })?;
         let output = endpoint
             .exec(&command, &CancellationBridge(cancellation))
-            .map_err(map_execution_error);
+            .map_err(map_execution_error)
+            .map_err(|error| {
+                observe_phase_failure(error, attempt_id, execution.phase, "execute_phase")
+            });
         let Some(output) = reconcile_cancelled_operation(output, cancellation)? else {
             return Ok(CommandOutcome::Cancelled);
         };
@@ -4455,17 +4471,26 @@ impl GithubJobExecutor {
             ));
         }
         let collected = (|| {
-            let completed = self.collect_completed_phase(
-                endpoint,
-                attempt_id,
-                execution.phase,
-                &command_paths,
-                commands.platform(),
-                &output,
-                masker,
-                events,
-                cancellation,
-            )?;
+            let completed = self
+                .collect_completed_phase(
+                    endpoint,
+                    attempt_id,
+                    execution.phase,
+                    &command_paths,
+                    commands.platform(),
+                    &output,
+                    masker,
+                    events,
+                    cancellation,
+                )
+                .map_err(|error| {
+                    observe_phase_failure(
+                        error,
+                        attempt_id,
+                        execution.phase,
+                        "collect_completed_phase",
+                    )
+                })?;
             if cancellation.is_cancelled() {
                 return Err(cancelled());
             }
@@ -4486,7 +4511,15 @@ impl GithubJobExecutor {
             let applied = self
                 .completed_steps
                 .apply_completed_step(commands, &scope, &completed_commands)
-                .map_err(|error| map_phase_application_error(&error))?;
+                .map_err(|error| map_phase_application_error(&error))
+                .map_err(|error| {
+                    observe_phase_failure(
+                        error,
+                        attempt_id,
+                        execution.phase,
+                        "apply_completed_step",
+                    )
+                })?;
             if cancellation.is_cancelled() {
                 return Err(cancelled());
             }
@@ -4553,8 +4586,11 @@ impl GithubJobExecutor {
         events: &Arc<dyn ExecutionEvents>,
         cancellation: &dyn ExecutorCancellation,
     ) -> Result<CollectedPhase, ExecutorAdapterError> {
-        let completed =
-            self.read_command_files(endpoint, attempt_id, phase, paths, platform, cancellation)?;
+        let completed = self
+            .read_command_files(endpoint, attempt_id, phase, paths, platform, cancellation)
+            .map_err(|error| {
+                observe_phase_failure(error, attempt_id, phase, "read_command_files")
+            })?;
         if cancellation.is_cancelled() {
             return Err(ExecutorAdapterError::new(
                 ExecutorAdapterErrorKind::Cancelled,
@@ -4566,7 +4602,8 @@ impl GithubJobExecutor {
             self.workflow_command_policy,
             masker,
             &|| cancellation.is_cancelled(),
-        )?;
+        )
+        .map_err(|error| observe_phase_failure(error, attempt_id, phase, "parse_output"))?;
         if cancellation.is_cancelled() {
             return Err(ExecutorAdapterError::new(
                 ExecutorAdapterErrorKind::Cancelled,
@@ -4587,7 +4624,8 @@ impl GithubJobExecutor {
                 ExecutorAdapterErrorKind::Cancelled,
             ));
         }
-        processed?;
+        processed
+            .map_err(|error| observe_phase_failure(error, attempt_id, phase, "process_output"))?;
         Ok(CollectedPhase {
             commands: completed.commands.with_legacy_mutations(&legacy),
             artifacts: completed.artifacts,
@@ -4702,7 +4740,16 @@ impl GithubJobExecutor {
             parsed.push(
                 self.command_files
                     .decode(*kind, &bytes, platform)
-                    .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?,
+                    .map_err(|error| {
+                        tracing::warn!(
+                            attempt_id = %attempt_id,
+                            phase,
+                            command_file_kind = ?kind,
+                            decode_error = ?error,
+                            "GitHub command file was rejected"
+                        );
+                        ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob)
+                    })?,
             );
         }
         let [environment, output, path, state, summary] = parsed
@@ -6757,6 +6804,22 @@ fn artifact_file_name(path: &str) -> Result<String, ExecutorAdapterError> {
         .filter(|name| !name.is_empty())
         .map(str::to_owned)
         .ok_or_else(invalid_job)
+}
+
+fn observe_phase_failure(
+    error: ExecutorAdapterError,
+    attempt_id: AttemptId,
+    phase: u32,
+    failure_stage: &'static str,
+) -> ExecutorAdapterError {
+    tracing::warn!(
+        attempt_id = %attempt_id,
+        phase,
+        failure_stage,
+        error_kind = ?error.kind(),
+        "GitHub job phase failed"
+    );
+    error
 }
 
 const fn map_phase_application_error(error: &PhaseApplicationError) -> ExecutorAdapterError {

--- a/crates/automata-ci-job-executor-github/tests/javascript_actions.rs
+++ b/crates/automata-ci-job-executor-github/tests/javascript_actions.rs
@@ -200,6 +200,32 @@ async fn metadata_driven_node24_actions_run_main_then_posts_in_lifo_order() {
 }
 
 #[tokio::test]
+async fn sccache_action_environment_and_path_exports_survive_main_and_post() {
+    let environment = b"SCCACHE_PATH<<ghadelimiter_one\n/opt/hostedtoolcache/sccache/0.17.0/x64/sccache\nghadelimiter_one\nACTIONS_CACHE_SERVICE_V2<<ghadelimiter_two\non\nghadelimiter_two\nACTIONS_RESULTS_URL<<ghadelimiter_three\nhttps://results.example/\nghadelimiter_three\nACTIONS_RUNTIME_TOKEN<<ghadelimiter_four\nruntime-token\nghadelimiter_four\n";
+    let responses = vec![
+        PhaseResponse::success()
+            .with_file(CommandFileKind::Environment, environment.to_vec())
+            .with_file(
+                CommandFileKind::Path,
+                b"/opt/hostedtoolcache/sccache/0.17.0/x64\n".to_vec(),
+            ),
+        PhaseResponse::success(),
+    ];
+    let fixture = Fixture::new(vec![prepared_node24_action()], responses);
+    let action = action_step("sccache", "mozilla-actions/sccache-action");
+    let request = fixture.request(envelope(vec![action]));
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(request, events, ExecutionCancellation::new())
+        .await
+        .expect("sccache-compatible command files execute");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+}
+
+#[tokio::test]
 async fn registered_post_does_not_start_when_execution_is_cancelled_before_posts() {
     let cancellation = ExecutionCancellation::new();
     let fixture = Fixture::new(


### PR DESCRIPTION
Adds secret-free phase-stage diagnostics for GitHub executor failures and regression coverage for the exact @actions/core environment/PATH command-file shape emitted by sccache-action. This is the diagnostic foundation for the live sccache compatibility failure.