### PR TITLE
fix(runner): isolate GitHub phase-file lifecycles

### DIFF
--- a/crates/automata-ci-github-runtime/README.md
+++ b/crates/automata-ci-github-runtime/README.md
@@ -46,6 +46,20 @@ and PATH changes therefore become input to later steps, outputs belong only to
 the completed step, and `GITHUB_STATE` is keyed by the exact action invocation
 for its paired post action. A run step cannot publish post-action state.
 
+The command-file decoder consumes one leading UTF-8 BOM, selects the pinned
+runner's Unix or Windows line reader explicitly, and requires heredoc
+delimiters to match a complete line. Duplicate records remain in source order
+so the phase applicator produces the runner's last-write-wins environment,
+output, and state behavior. Empty names, empty heredoc delimiters, missing
+delimiters, and otherwise malformed records fail closed without including
+workflow-controlled contents in diagnostics.
+
+The pinned runner skips a step-summary file larger than 1 MiB after emitting a
+diagnostic; it does not truncate that file. Automata currently enforces the
+same byte ceiling as a fail-closed decoder limit. Preserving the runner's
+diagnostic-and-skip behavior across the bounded executor copy interface is a
+narrow compatibility follow-up; no truncation behavior is inferred here.
+
 The parser supports both current `::command::data` syntax and the runner's
 legacy `##[command]data` syntax. Deprecated `set-output` and `save-state` are
 represented as typed mutations. Insecure `set-env` and `add-path` stdout

--- a/crates/automata-ci-github-runtime/tests/file_commands.rs
+++ b/crates/automata-ci-github-runtime/tests/file_commands.rs
@@ -27,17 +27,19 @@ fn render_name_values(file: &ParsedCommandFile) -> String {
 #[test]
 fn env_fixture_matches_reviewed_runner_golden() {
     let parser = GithubCommandFileDecoder::default();
+    let source =
+        String::from_utf8_lossy(include_bytes!("fixtures/command_files.env")).replace("\r\n", "\n");
     let parsed = parser
         .decode(
             CommandFileKind::Environment,
-            include_bytes!("fixtures/command_files.env"),
+            source.as_bytes(),
             CommandFilePlatform::Unix,
         )
         .expect("valid fixture");
 
     assert_eq!(
         render_name_values(&parsed),
-        include_str!("fixtures/command_files.golden")
+        include_str!("fixtures/command_files.golden").replace("\r\n", "\n")
     );
 }
 
@@ -77,6 +79,85 @@ fn heredoc_newlines_follow_the_selected_runner_platform() {
 }
 
 #[test]
+fn ordinary_records_follow_the_selected_runner_platform_line_reader() {
+    let parser = GithubCommandFileDecoder::default();
+    let source = b"FIRST=one\r\nSECOND=two\n";
+
+    let unix = parser
+        .decode(CommandFileKind::Output, source, CommandFilePlatform::Unix)
+        .expect("valid Unix records");
+    let windows = parser
+        .decode(
+            CommandFileKind::Output,
+            source,
+            CommandFilePlatform::Windows,
+        )
+        .expect("valid Windows records");
+
+    assert_eq!(render_name_values(&unix), "FIRST=one\\r\nSECOND=two\n");
+    assert_eq!(render_name_values(&windows), "FIRST=one\nSECOND=two\n");
+}
+
+#[test]
+fn heredoc_delimiters_match_only_an_exact_complete_line() {
+    let parser = GithubCommandFileDecoder::default();
+    let parsed = parser
+        .decode(
+            CommandFileKind::Output,
+            b"VALUE<<EOF\nfirst\nEOF suffix\nprefix EOF\nEOF\nAFTER=next\n",
+            CommandFilePlatform::Unix,
+        )
+        .expect("delimiter substrings remain value bytes");
+
+    assert_eq!(
+        render_name_values(&parsed),
+        "VALUE=first\\nEOF suffix\\nprefix EOF\nAFTER=next\n"
+    );
+}
+
+#[test]
+fn duplicate_records_are_retained_in_source_order_for_later_last_write_wins_application() {
+    let parser = GithubCommandFileDecoder::default();
+    for kind in [
+        CommandFileKind::Environment,
+        CommandFileKind::Output,
+        CommandFileKind::State,
+    ] {
+        let parsed = parser
+            .decode(
+                kind,
+                b"NAME=first\nNAME=second\n",
+                CommandFilePlatform::Unix,
+            )
+            .expect("duplicate records use the runner grammar");
+        assert_eq!(render_name_values(&parsed), "NAME=first\nNAME=second\n");
+    }
+}
+
+#[test]
+fn empty_names_and_delimiters_are_rejected_for_every_name_value_file() {
+    let parser = GithubCommandFileDecoder::default();
+    for kind in [
+        CommandFileKind::Environment,
+        CommandFileKind::Output,
+        CommandFileKind::State,
+    ] {
+        assert_eq!(
+            parser.decode(kind, b"=value\n", CommandFilePlatform::Unix),
+            Err(CommandFileError::EmptyName { kind })
+        );
+        assert_eq!(
+            parser.decode(kind, b"<<EOF\nvalue\nEOF\n", CommandFilePlatform::Unix),
+            Err(CommandFileError::EmptyName { kind })
+        );
+        assert_eq!(
+            parser.decode(kind, b"NAME<<\n", CommandFilePlatform::Unix),
+            Err(CommandFileError::EmptyDelimiter { kind })
+        );
+    }
+}
+
+#[test]
 fn path_file_uses_universal_line_endings_and_preserves_order() {
     let parser = GithubCommandFileDecoder::default();
     let source = include_bytes!("fixtures/path_file.txt");
@@ -87,7 +168,10 @@ fn path_file_uses_universal_line_endings_and_preserves_order() {
         panic!("wrong decoded file kind");
     };
     let rendered = path.paths().collect::<Vec<_>>().join("\n") + "\n";
-    assert_eq!(rendered, include_str!("fixtures/path_file.golden"));
+    assert_eq!(
+        rendered,
+        include_str!("fixtures/path_file.golden").replace("\r\n", "\n")
+    );
 
     let ParsedCommandFile::Path(mixed) = parser
         .decode(
@@ -125,6 +209,18 @@ fn utf8_bom_is_consumed_and_summary_content_is_preserved() {
         panic!("wrong decoded file kind");
     };
     assert_eq!(summary.markdown(), "# title\r\n\r\nbody\n");
+
+    let ParsedCommandFile::StepSummary(summary) = parser
+        .decode(
+            CommandFileKind::StepSummary,
+            b"\xEF\xBB\xBF# title\n",
+            CommandFilePlatform::Unix,
+        )
+        .expect("summary BOM is accepted")
+    else {
+        panic!("wrong decoded file kind");
+    };
+    assert_eq!(summary.markdown(), "# title\n");
 }
 
 #[test]

--- a/crates/automata-ci-github-runtime/tests/phase_application.rs
+++ b/crates/automata-ci-github-runtime/tests/phase_application.rs
@@ -156,6 +156,48 @@ fn completed_step_boundary_delays_environment_and_path_but_scopes_outputs() {
 }
 
 #[test]
+fn duplicate_name_value_records_apply_in_order_with_the_last_value_winning() {
+    let invocation = ActionInvocationId::new("duplicate-action").expect("valid invocation ID");
+    let step_id = StepId::new("duplicate").expect("valid step ID");
+    let applied = GithubCompletedStepApplicator::default()
+        .apply_completed_step(
+            &JobCommandState::new(CommandFilePlatform::Unix),
+            &StepScope::new(step_id.clone(), StepPhase::ActionMain(invocation.clone())),
+            &commands(
+                b"ENVIRONMENT=first\nENVIRONMENT=second\n",
+                b"OUTPUT=first\nOUTPUT=second\n",
+                b"/first\n/second\n/first\n",
+                b"STATE=first\nSTATE=second\n",
+                b"",
+            ),
+        )
+        .expect("bounded duplicate records");
+
+    assert_eq!(
+        value(applied.next_state().environment(), "ENVIRONMENT"),
+        Some("second")
+    );
+    assert_eq!(
+        value(
+            applied.next_state().outputs(&step_id).expect("step output"),
+            "OUTPUT"
+        ),
+        Some("second")
+    );
+    assert_eq!(
+        value(
+            &applied.next_state().post_action_environment(&invocation),
+            "STATE_STATE"
+        ),
+        Some("second")
+    );
+    assert_eq!(
+        applied.next_state().prepend_path().collect::<Vec<_>>(),
+        ["/first", "/second"]
+    );
+}
+
+#[test]
 fn action_state_is_visible_only_to_the_exact_paired_post_action() {
     let invocation = ActionInvocationId::new("checkout-main-42").expect("valid invocation ID");
     let other = ActionInvocationId::new("checkout-main-43").expect("valid invocation ID");

--- a/crates/automata-ci-github-runtime/tests/workflow_commands.rs
+++ b/crates/automata-ci-github-runtime/tests/workflow_commands.rs
@@ -64,7 +64,10 @@ fn reviewed_command_fixture_matches_golden() {
         .collect::<Vec<_>>()
         .join("\n")
         + "\n";
-    assert_eq!(rendered, include_str!("fixtures/workflow_commands.golden"));
+    assert_eq!(
+        rendered,
+        include_str!("fixtures/workflow_commands.golden").replace("\r\n", "\n")
+    );
 }
 
 #[test]

--- a/crates/automata-ci-job-executor-github/README.md
+++ b/crates/automata-ci-job-executor-github/README.md
@@ -21,6 +21,24 @@ regular files inside the sandbox; OCI subjects are normalized; and successful
 subjects become the deterministic list visible to later phases. Parsing and
 job aggregation are atomic and bounded.
 
+Every run, JavaScript pre/main/post, and composite child phase receives a fresh
+set of seven attempt-scoped paths: `GITHUB_ENV`, `GITHUB_OUTPUT`, `GITHUB_PATH`,
+`GITHUB_STATE`, `GITHUB_STEP_SUMMARY`, `GITHUB_ARTIFACTS`, and the read-only
+`GITHUB_ARTIFACTS_LIST`. The first six start empty and the list starts from the
+current canonical job artifact snapshot. Paths are deterministic within one
+attempt and phase for recovery, while different phases and attempts are
+disjoint. Same-attempt recovery reinitializes every file before the path is
+reused, so stale bytes cannot become phase input.
+
+After an execution endpoint returns a terminal output, the executor makes a
+bounded collection attempt for success, nonzero exit, timeout, and
+provider-reported cancellation. Collection or parsing failure cannot replace
+an already-known failure, timeout, or cancellation outcome, and command state
+plus retained attachments commit atomically. A missing or deleted summary is
+treated as no summary; it does not suppress other valid phase-file effects. An
+independently signaled execution-cancellation token remains dominant under the
+executor's cancellation contract.
+
 - [Compatibility documentation](https://github.com/automata-ci/automata/blob/main/docs/compatibility.md)
 - API documentation: run `cargo doc -p automata-ci-job-executor-github --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -4440,9 +4440,10 @@ impl GithubJobExecutor {
         let Some(output) = reconcile_cancelled_operation(output, cancellation)? else {
             return Ok(CommandOutcome::Cancelled);
         };
-        if cancellation.is_cancelled() || output.termination() == ExecutionTermination::Cancelled {
+        if cancellation.is_cancelled() {
             return Ok(CommandOutcome::Cancelled);
         }
+        let outcome = CommandOutcome::from_termination(output.termination());
         if output.was_truncated() {
             if emit_system_while_active(TRUNCATED_OUTPUT_DIAGNOSTIC, masker, events, cancellation)?
                 .is_none()
@@ -4453,53 +4454,67 @@ impl GithubJobExecutor {
                 ExecutorAdapterErrorKind::ResourceExhausted,
             ));
         }
-        let completed = self.collect_completed_phase(
-            endpoint,
-            attempt_id,
-            execution.phase,
-            &command_paths,
-            commands.platform(),
-            &output,
-            masker,
-            events,
-            cancellation,
-        );
-        let Some(completed) = reconcile_cancelled_operation(completed, cancellation)? else {
-            return Ok(CommandOutcome::Cancelled);
-        };
-        if cancellation.is_cancelled() {
-            return Ok(CommandOutcome::Cancelled);
+        let collected = (|| {
+            let completed = self.collect_completed_phase(
+                endpoint,
+                attempt_id,
+                execution.phase,
+                &command_paths,
+                commands.platform(),
+                &output,
+                masker,
+                events,
+                cancellation,
+            )?;
+            if cancellation.is_cancelled() {
+                return Err(cancelled());
+            }
+            let artifacts = self.resolve_artifact_subjects(
+                endpoint,
+                attempt_id,
+                execution.phase,
+                &paths.workspace,
+                command.environment(),
+                &completed.artifacts,
+                artifact_hash_timeout,
+                cancellation,
+            )?;
+            let completed_commands = completed.commands.with_artifacts(artifacts);
+            let runtime_step_id = RuntimeStepId::new(execution.step_id)
+                .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
+            let scope = StepScope::new(runtime_step_id, execution.scope);
+            let applied = self
+                .completed_steps
+                .apply_completed_step(commands, &scope, &completed_commands)
+                .map_err(|error| map_phase_application_error(&error))?;
+            if cancellation.is_cancelled() {
+                return Err(cancelled());
+            }
+            let mut next_attachments = attachments.clone();
+            next_attachments.record_phase(
+                execution.report_step_id,
+                applied.summary().markdown(),
+                &completed.annotations,
+                applied.notices(),
+                masker,
+            )?;
+            Ok((applied.into_next_state(), next_attachments))
+        })();
+
+        match collected {
+            Ok((next_commands, next_attachments)) => {
+                *commands = next_commands;
+                *attachments = next_attachments;
+            }
+            Err(_) if outcome != CommandOutcome::Success => {
+                // The runner processes command files in a finally boundary. A
+                // partial or malformed file may not replace the process's
+                // already-known failure, timeout, or cancellation outcome.
+                return Ok(outcome);
+            }
+            Err(error) => return Err(error),
         }
-        let artifacts = self.resolve_artifact_subjects(
-            endpoint,
-            attempt_id,
-            execution.phase,
-            &paths.workspace,
-            command.environment(),
-            &completed.artifacts,
-            artifact_hash_timeout,
-            cancellation,
-        )?;
-        let completed_commands = completed.commands.with_artifacts(artifacts);
-        let runtime_step_id = RuntimeStepId::new(execution.step_id)
-            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-        let scope = StepScope::new(runtime_step_id, execution.scope);
-        let applied = self
-            .completed_steps
-            .apply_completed_step(commands, &scope, &completed_commands)
-            .map_err(|error| map_phase_application_error(&error));
-        let Some(applied) = reconcile_cancelled_operation(applied, cancellation)? else {
-            return Ok(CommandOutcome::Cancelled);
-        };
-        attachments.record_phase(
-            execution.report_step_id,
-            applied.summary().markdown(),
-            &completed.annotations,
-            applied.notices(),
-            masker,
-        )?;
-        *commands = applied.into_next_state();
-        Ok(CommandOutcome::from_termination(output.termination()))
+        Ok(outcome)
     }
 
     fn build_phase_command(
@@ -4669,9 +4684,16 @@ impl GithubJobExecutor {
                 limit,
             )
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-            let bytes = endpoint
-                .copy_from(&request, &CancellationBridge(cancellation))
-                .map_err(map_execution_error)?;
+            let bytes = match endpoint.copy_from(&request, &CancellationBridge(cancellation)) {
+                Ok(bytes) => bytes,
+                Err(error)
+                    if *kind == CommandFileKind::StepSummary
+                        && error.kind() == ExecutionErrorKind::NotFound =>
+                {
+                    Vec::new()
+                }
+                Err(error) => return Err(map_execution_error(error)),
+            };
             if cancellation.is_cancelled() {
                 return Err(ExecutorAdapterError::new(
                     ExecutorAdapterErrorKind::Cancelled,
@@ -5190,7 +5212,7 @@ struct DecodedCommandFiles {
     artifacts: ArtifactDeclarationCommandFile,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct ExecutionAttachments {
     by_step: BTreeMap<String, RetainedStepAttachments>,
     annotation_count: usize,
@@ -5295,7 +5317,7 @@ impl ExecutionAttachments {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct RetainedStepAttachments {
     summary: String,
     annotations: Vec<StepAnnotation>,
@@ -7124,10 +7146,12 @@ fn provider_failure_outcome(error: &ProviderError) -> ProviderFailureOutcome {
 mod tests {
     use std::{
         cell::Cell,
+        collections::BTreeSet,
         time::{Duration, Instant},
     };
 
-    use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream};
+    use automata_ci_core::AttemptId;
+    use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream, TargetPath};
     use automata_ci_expression_github::GithubValue;
     use automata_ci_github_runtime::{
         CommandFileDecoder, CommandFileKind, CommandFilePlatform, GithubCommandFileDecoder,
@@ -7136,7 +7160,7 @@ mod tests {
     use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionCancellationReason};
 
     use super::{
-        ActionBudgetRejection, ActionExecutionBudget, CleanupCancellation,
+        ActionBudgetRejection, ActionExecutionBudget, AttemptPaths, CleanupCancellation,
         ExecutorAdapterErrorKind, GithubStatus, JobConclusion, MAX_ACTION_INVOCATIONS,
         MAX_ACTION_NESTING_DEPTH, MAX_COMPOSITE_CHILD_STEPS, MAX_COMPOSITE_DERIVED_BYTES,
         MAX_EVENT_DEPTH, SecretMasker, action_invocation_count_rejection,
@@ -7144,6 +7168,44 @@ mod tests {
         event_depth_rejection, github_value_from_json, parse_output_with_cancellation,
         reconcile_cancelled_operation, reconcile_post_operation, resource_exhausted,
     };
+
+    #[test]
+    fn command_file_paths_are_stable_for_recovery_and_isolated_by_phase_and_attempt() {
+        let runner_root = TargetPath::posix("/__automata").expect("runner root");
+        let workspace = TargetPath::posix("/__w/automata/automata").expect("workspace");
+        let attempt_id = AttemptId::new();
+        let first = AttemptPaths::new(&runner_root, attempt_id, &workspace).expect("attempt paths");
+        let recovered =
+            AttemptPaths::new(&runner_root, attempt_id, &workspace).expect("recovered paths");
+        let next_attempt = AttemptPaths::new(&runner_root, AttemptId::new(), &workspace)
+            .expect("next attempt paths");
+
+        let first_phase = phase_file_path_values(&first, 7);
+        let recovered_phase = phase_file_path_values(&recovered, 7);
+        let next_phase = phase_file_path_values(&first, 8);
+        let next_attempt_phase = phase_file_path_values(&next_attempt, 7);
+
+        assert_eq!(first_phase, recovered_phase);
+        assert_eq!(first_phase.iter().collect::<BTreeSet<_>>().len(), 7);
+        assert!(first_phase.iter().all(|path| !next_phase.contains(path)));
+        assert!(
+            first_phase
+                .iter()
+                .all(|path| !next_attempt_phase.contains(path))
+        );
+    }
+
+    fn phase_file_path_values(paths: &AttemptPaths, phase: u32) -> Vec<String> {
+        let files = paths.command_files(phase).expect("command file paths");
+        let mut values = files
+            .values
+            .iter()
+            .map(|(_, path)| path.as_str().to_owned())
+            .collect::<Vec<_>>();
+        values.push(files.artifacts.as_str().to_owned());
+        values.push(files.artifacts_list.as_str().to_owned());
+        values
+    }
 
     #[test]
     fn event_json_conversion_preserves_nested_types() {

--- a/crates/automata-ci-job-executor-github/tests/action_pre_job.rs
+++ b/crates/automata-ci-job-executor-github/tests/action_pre_job.rs
@@ -8,8 +8,9 @@ use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionEvents, JobExec
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 
 use support::{
-    Fixture, PhaseResponse, action_step, envelope, environment_map, local_action_step,
-    prepared_node24_action_with_pre, prepared_node24_action_with_pre_condition, run_step,
+    Fixture, PhaseResponse, action_step, assert_fresh_isolated_phase_files, envelope,
+    environment_map, local_action_step, prepared_node24_action_with_pre,
+    prepared_node24_action_with_pre_condition, run_step,
 };
 
 #[tokio::test]
@@ -19,11 +20,21 @@ async fn repository_action_pre_runs_before_every_main_job_step() {
         vec![
             PhaseResponse::success()
                 .with_file(CommandFileKind::Environment, b"PRE_JOB=ready\n".to_vec())
-                .with_file(CommandFileKind::State, b"from_pre=yes\n".to_vec()),
-            PhaseResponse::success(),
-            PhaseResponse::success(),
-            PhaseResponse::success(),
-            PhaseResponse::success(),
+                .with_file(CommandFileKind::State, b"from_pre=yes\n".to_vec())
+                .with_file(CommandFileKind::StepSummary, b"pre\n".to_vec())
+                .with_artifacts_list_write(b"corrupt pre list".to_vec()),
+            PhaseResponse::success()
+                .with_file(CommandFileKind::StepSummary, b"first run\n".to_vec())
+                .with_artifacts_list_write(b"corrupt first-run list".to_vec()),
+            PhaseResponse::success()
+                .with_file(CommandFileKind::StepSummary, b"main\n".to_vec())
+                .with_artifacts_list_write(b"corrupt main list".to_vec()),
+            PhaseResponse::success()
+                .with_file(CommandFileKind::StepSummary, b"last run\n".to_vec())
+                .with_artifacts_list_write(b"corrupt last-run list".to_vec()),
+            PhaseResponse::success()
+                .with_file(CommandFileKind::StepSummary, b"post\n".to_vec())
+                .with_artifacts_list_write(b"corrupt post list".to_vec()),
         ],
     );
     let request = fixture.request(envelope(vec![
@@ -40,9 +51,25 @@ async fn repository_action_pre_runs_before_every_main_job_step() {
         .expect("action lifecycle executes");
 
     assert_eq!(result.conclusion(), JobConclusion::Success);
+    assert_eq!(result.steps()[0].summary_markdown(), Some("first run\n"));
+    assert_eq!(
+        result.steps()[1].summary_markdown(),
+        Some("pre\nmain\npost\n")
+    );
+    assert_eq!(result.steps()[2].summary_markdown(), Some("last run\n"));
     let state = fixture.endpoint_state.lock().expect("endpoint lock");
-    let phases = state
+    let phase_commands = state
         .commands
+        .iter()
+        .filter(|command| {
+            matches!(
+                command.argv().program().as_str(),
+                "/usr/bin/bash" | "/opt/node24/bin/node"
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_fresh_isolated_phase_files(&state, &phase_commands);
+    let phases = phase_commands
         .iter()
         .filter_map(|command| match command.argv().program().as_str() {
             "/usr/bin/bash" => Some("run".to_owned()),

--- a/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
+++ b/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
@@ -21,7 +21,8 @@ use bytes::Bytes;
 use sha2::{Digest as _, Sha256};
 
 use support::{
-    Fixture, PhaseResponse, SECRET, envelope, environment_map, prepared_node24_action, run_step,
+    Fixture, PhaseResponse, SECRET, assert_fresh_isolated_phase_files, envelope, environment_map,
+    prepared_node24_action, run_step,
 };
 
 const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
@@ -92,6 +93,17 @@ runs:
       run: printf '%s\n' "$INPUT_MESSAGE"
       shell: bash
 "#;
+
+const REPEATED_LOCAL_PARENT: &str = r"
+name: Repeated local parent
+runs:
+  using: composite
+  steps:
+    - id: first
+      uses: ./actions/child
+    - id: second
+      uses: ./actions/child
+";
 
 const POST_PARENT: &str = r"
 name: Post parent
@@ -295,6 +307,63 @@ async fn checked_out_composite_nests_local_and_repository_actions() {
         "/__w/automata/automata/actions/child"
     );
     assert!(repository["GITHUB_ACTION_PATH"].contains("/actions/action-"));
+}
+
+#[tokio::test]
+async fn nested_repeated_composite_occurrences_receive_fresh_phase_file_sets() {
+    let fixture = Fixture::new(
+        Vec::new(),
+        vec![
+            PhaseResponse::success()
+                .with_file(
+                    automata_ci_github_runtime::CommandFileKind::StepSummary,
+                    b"first child\n".to_vec(),
+                )
+                .with_artifacts_list_write(b"corrupt first list".to_vec()),
+            PhaseResponse::success()
+                .with_file(
+                    automata_ci_github_runtime::CommandFileKind::StepSummary,
+                    b"second child\n".to_vec(),
+                )
+                .with_artifacts_list_write(b"corrupt second list".to_vec()),
+        ],
+    );
+    {
+        let mut state = fixture.endpoint_state.lock().expect("endpoint lock");
+        state.files.insert(
+            "/__w/automata/automata/actions/parent/action.yaml".to_owned(),
+            REPEATED_LOCAL_PARENT.as_bytes().to_vec(),
+        );
+        state.files.insert(
+            "/__w/automata/automata/actions/child/action.yml".to_owned(),
+            CHILD_COMPOSITE.as_bytes().to_vec(),
+        );
+    }
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(
+            fixture.request(envelope(vec![local_step("parent", "./actions/parent")])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("repeated nested composite executes");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    assert_eq!(
+        result.steps()[0].summary_markdown(),
+        Some("first child\nsecond child\n")
+    );
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let phases = state
+        .commands
+        .iter()
+        .filter(|command| command.argv().program().as_str() == "/usr/bin/bash")
+        .collect::<Vec<_>>();
+    assert_eq!(phases.len(), 2);
+    assert_fresh_isolated_phase_files(&state, &phases);
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/run_steps.rs
@@ -13,9 +13,9 @@ use automata_ci_runner_runtime::{
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 
 use support::{
-    Fixture, PhaseResponse, SECRET, credential_free_envelope, envelope_with_environment,
-    envelope_with_working_directory, environment_map, run_step, run_step_with_named_shell,
-    run_step_with_working_directory,
+    Fixture, PHASE_FILE_ENVIRONMENT_NAMES, PhaseResponse, SECRET, credential_free_envelope,
+    envelope_with_environment, envelope_with_working_directory, environment_map, run_step,
+    run_step_with_named_shell, run_step_with_working_directory,
 };
 
 #[tokio::test]
@@ -214,6 +214,215 @@ async fn summaries_and_structured_annotations_are_masked_and_retained() {
         !serde_json::to_string(&result)
             .expect("serialize")
             .contains(secret)
+    );
+}
+
+#[tokio::test]
+async fn phase_files_are_collected_after_failure_timeout_and_cancelled_termination() {
+    for (termination, expected, summary) in [
+        (
+            automata_ci_execution::ExecutionTermination::Exited(19),
+            JobConclusion::Failure,
+            "failure summary\n",
+        ),
+        (
+            automata_ci_execution::ExecutionTermination::TimedOut,
+            JobConclusion::TimedOut,
+            "timeout summary\n",
+        ),
+        (
+            automata_ci_execution::ExecutionTermination::Cancelled,
+            JobConclusion::Cancelled,
+            "cancelled summary\n",
+        ),
+    ] {
+        let mut response = PhaseResponse::success()
+            .with_file(CommandFileKind::StepSummary, summary.as_bytes().to_vec());
+        response.termination = termination;
+        let fixture = Fixture::new(Vec::new(), vec![response]);
+        let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+        let result = fixture
+            .executor
+            .execute(
+                fixture.request(support::envelope(vec![run_step("phase", "Phase", "true")])),
+                events,
+                ExecutionCancellation::new(),
+            )
+            .await
+            .expect("primary process outcome remains a terminal job result");
+
+        assert_eq!(result.conclusion(), expected);
+        assert_eq!(result.steps().len(), 1);
+        assert_eq!(result.steps()[0].summary_markdown(), Some(summary));
+        assert_eq!(
+            fixture
+                .endpoint_state
+                .lock()
+                .expect("endpoint lock")
+                .copy_from_calls_since_exec,
+            6,
+            "five standard command files and the artifact declaration file are collected"
+        );
+    }
+}
+
+#[tokio::test]
+async fn malformed_collection_cannot_replace_a_known_primary_process_outcome() {
+    for (termination, expected) in [
+        (
+            automata_ci_execution::ExecutionTermination::Exited(23),
+            JobConclusion::Failure,
+        ),
+        (
+            automata_ci_execution::ExecutionTermination::TimedOut,
+            JobConclusion::TimedOut,
+        ),
+        (
+            automata_ci_execution::ExecutionTermination::Cancelled,
+            JobConclusion::Cancelled,
+        ),
+    ] {
+        let mut response = PhaseResponse::success()
+            .with_file(CommandFileKind::Environment, b"=invalid-name\n".to_vec());
+        response.termination = termination;
+        let fixture = Fixture::new(Vec::new(), vec![response]);
+        let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+        let result = fixture
+            .executor
+            .execute(
+                fixture.request(support::envelope(vec![run_step("phase", "Phase", "true")])),
+                events,
+                ExecutionCancellation::new(),
+            )
+            .await
+            .expect("command-file error must not replace the primary process outcome");
+
+        assert_eq!(result.conclusion(), expected);
+        assert_eq!(result.steps()[0].conclusion(), expected);
+        assert_eq!(
+            fixture
+                .endpoint_state
+                .lock()
+                .expect("endpoint lock")
+                .copy_from_calls_since_exec,
+            1,
+            "collection was attempted before the malformed first command file was rejected"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_deleted_step_summary_is_empty_without_suppressing_other_phase_files() {
+    let fixture = Fixture::new(
+        Vec::new(),
+        vec![
+            PhaseResponse::success()
+                .with_file(CommandFileKind::Environment, b"LATER=retained\n".to_vec())
+                .delete_file(CommandFileKind::StepSummary),
+            PhaseResponse::success(),
+        ],
+    );
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(
+            fixture.request(support::envelope(vec![
+                run_step("delete-summary", "Delete summary", "true"),
+                run_step("observe", "Observe", "true"),
+            ])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("a missing summary is the same as no summary");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    assert_eq!(result.steps()[0].summary_markdown(), None);
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let runs = state
+        .commands
+        .iter()
+        .filter(|command| command.argv().program().as_str() == "/usr/bin/bash")
+        .collect::<Vec<_>>();
+    assert_eq!(runs.len(), 2);
+    assert_eq!(
+        environment_map(runs[1]).get("LATER").map(String::as_str),
+        Some("retained")
+    );
+}
+
+#[tokio::test]
+async fn recovery_reinitializes_all_phase_files_before_reusing_stable_attempt_paths() {
+    let fixture = Fixture::new(
+        Vec::new(),
+        vec![PhaseResponse::success(), PhaseResponse::success()],
+    );
+    let request = fixture.request(support::envelope(vec![run_step("phase", "Phase", "true")]));
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    fixture
+        .executor
+        .execute(
+            request.clone(),
+            events.clone(),
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("initial execution succeeds");
+
+    let original_paths = {
+        let mut state = fixture.endpoint_state.lock().expect("endpoint lock");
+        let command = state
+            .commands
+            .iter()
+            .find(|command| command.argv().program().as_str() == "/usr/bin/bash")
+            .expect("initial phase command");
+        let environment = environment_map(command);
+        let paths = PHASE_FILE_ENVIRONMENT_NAMES.map(|name| environment[name].clone());
+        for path in &paths {
+            state
+                .files
+                .insert(path.clone(), b"stale recovery bytes".to_vec());
+        }
+        paths
+    };
+
+    fixture
+        .executor
+        .execute(request, events, ExecutionCancellation::new())
+        .await
+        .expect("same-attempt recovery succeeds");
+
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let recovered = state
+        .commands
+        .iter()
+        .filter(|command| command.argv().program().as_str() == "/usr/bin/bash")
+        .nth(1)
+        .expect("recovered phase command");
+    let recovered_environment = environment_map(recovered);
+    assert_eq!(
+        original_paths,
+        PHASE_FILE_ENVIRONMENT_NAMES.map(|name| recovered_environment[name].clone())
+    );
+
+    let recovered_initial = state
+        .phase_file_initial_contents
+        .get(1)
+        .expect("recovered phase snapshot");
+    for name in &PHASE_FILE_ENVIRONMENT_NAMES[..6] {
+        assert_eq!(
+            recovered_initial.get(*name).map(Vec::as_slice),
+            Some(&[][..]),
+            "{name} retained stale bytes during recovery"
+        );
+    }
+    assert!(
+        recovered_initial["GITHUB_ARTIFACTS_LIST"].starts_with(br#"{"version":1,"subjects":["#),
+        "recovery did not rebuild the canonical artifact-list input"
     );
 }
 

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -411,6 +411,8 @@ impl Fixture {
         };
         let endpoint_state = Arc::new(Mutex::new(EndpointState {
             files: BTreeMap::new(),
+            missing_files: BTreeSet::new(),
+            phase_file_initial_contents: Vec::new(),
             commands: Vec::new(),
             scripts: Vec::new(),
             copy_from_calls: 0,
@@ -1113,6 +1115,7 @@ pub struct PhaseResponse {
     pub termination: ExecutionTermination,
     pub output: Vec<(ExecutionOutputStream, Vec<u8>)>,
     pub files: Vec<(CommandFileKind, Vec<u8>)>,
+    deleted_files: Vec<CommandFileKind>,
     artifacts_list_write: Option<Vec<u8>>,
     truncated: bool,
     cancellation: Option<ExecutionCancellation>,
@@ -1126,6 +1129,7 @@ impl PhaseResponse {
             termination: ExecutionTermination::Exited(0),
             output: Vec::new(),
             files: Vec::new(),
+            deleted_files: Vec::new(),
             artifacts_list_write: None,
             truncated: false,
             cancellation: None,
@@ -1148,6 +1152,11 @@ impl PhaseResponse {
 
     pub fn with_file(mut self, kind: CommandFileKind, value: impl Into<Vec<u8>>) -> Self {
         self.files.push((kind, value.into()));
+        self
+    }
+
+    pub fn delete_file(mut self, kind: CommandFileKind) -> Self {
+        self.deleted_files.push(kind);
         self
     }
 
@@ -1184,6 +1193,8 @@ impl PhaseResponse {
 
 pub struct EndpointState {
     pub files: BTreeMap<String, Vec<u8>>,
+    missing_files: BTreeSet<String>,
+    pub phase_file_initial_contents: Vec<BTreeMap<String, Vec<u8>>>,
     pub commands: Vec<ExecutionCommand>,
     pub scripts: Vec<Vec<u8>>,
     pub copy_from_calls: usize,
@@ -1204,6 +1215,75 @@ impl fmt::Debug for FakeEndpoint {
         formatter
             .debug_struct("FakeEndpoint")
             .finish_non_exhaustive()
+    }
+}
+
+fn capture_phase_file_initial_contents(
+    request: &ExecutionCommand,
+    state: &EndpointState,
+) -> BTreeMap<String, Vec<u8>> {
+    PHASE_FILE_ENVIRONMENT_NAMES
+        .into_iter()
+        .map(|name| {
+            let path = request
+                .environment()
+                .values()
+                .iter()
+                .find(|value| value.name().as_str() == name)
+                .expect("phase file environment")
+                .value()
+                .expose();
+            (
+                name.to_owned(),
+                state
+                    .files
+                    .get(path)
+                    .cloned()
+                    .expect("initialized phase file"),
+            )
+        })
+        .collect()
+}
+
+fn apply_phase_response_files(
+    request: &ExecutionCommand,
+    state: &mut EndpointState,
+    response: &PhaseResponse,
+) {
+    for (kind, bytes) in &response.files {
+        let path = request
+            .environment()
+            .values()
+            .iter()
+            .find(|value| value.name().as_str() == kind.environment_variable())
+            .expect("command file env")
+            .value()
+            .expose();
+        state.files.insert(path.to_owned(), bytes.clone());
+    }
+    for kind in &response.deleted_files {
+        let path = request
+            .environment()
+            .values()
+            .iter()
+            .find(|value| value.name().as_str() == kind.environment_variable())
+            .expect("command file env")
+            .value()
+            .expose()
+            .to_owned();
+        state.files.remove(&path);
+        state.missing_files.insert(path);
+    }
+    if let Some(bytes) = &response.artifacts_list_write {
+        let path = request
+            .environment()
+            .values()
+            .iter()
+            .find(|value| value.name().as_str() == "GITHUB_ARTIFACTS_LIST")
+            .expect("artifact list env")
+            .value()
+            .expose();
+        state.files.insert(path.to_owned(), bytes.clone());
     }
 }
 
@@ -1275,6 +1355,10 @@ impl ExecutionEndpoint for FakeEndpoint {
         if let Some(output) = artifact_hash_output(request, &state.files) {
             return output;
         }
+        let phase_file_initial_contents = capture_phase_file_initial_contents(request, &state);
+        state
+            .phase_file_initial_contents
+            .push(phase_file_initial_contents);
         let response = state
             .responses
             .pop_front()
@@ -1283,32 +1367,11 @@ impl ExecutionEndpoint for FakeEndpoint {
             cancellation.signal(ExecutionCancellationReason::ServerRequest);
         }
         state.copy_from_calls_since_exec = 0;
-        state.cancellation_before_copy_from = response.cancellation_before_copy_from;
         if !response.delay.is_zero() {
             std::thread::sleep(response.delay);
         }
-        for (kind, bytes) in &response.files {
-            let path = request
-                .environment()
-                .values()
-                .iter()
-                .find(|value| value.name().as_str() == kind.environment_variable())
-                .expect("command file env")
-                .value()
-                .expose();
-            state.files.insert(path.to_owned(), bytes.clone());
-        }
-        if let Some(bytes) = &response.artifacts_list_write {
-            let path = request
-                .environment()
-                .values()
-                .iter()
-                .find(|value| value.name().as_str() == "GITHUB_ARTIFACTS_LIST")
-                .expect("artifact list env")
-                .value()
-                .expose();
-            state.files.insert(path.to_owned(), bytes.clone());
-        }
+        apply_phase_response_files(request, &mut state, &response);
+        state.cancellation_before_copy_from = response.cancellation_before_copy_from;
         execution_output(response.termination, response.output, response.truncated)
             .map_err(|_| execution_error(ExecutionStage::Exec))
     }
@@ -1335,6 +1398,7 @@ impl ExecutionEndpoint for FakeEndpoint {
         _cancellation: &dyn Cancellation,
     ) -> Result<(), ExecutionError> {
         let mut state = self.state.lock().expect("endpoint lock");
+        state.missing_files.remove(request.target().as_str());
         state.files.insert(
             request.target().as_str().to_owned(),
             request.content().to_vec(),
@@ -1365,6 +1429,12 @@ impl ExecutionEndpoint for FakeEndpoint {
         }
         state.copy_from_calls += 1;
         state.copy_from_calls_since_exec += 1;
+        if state.missing_files.contains(request.source().as_str()) {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::NotFound,
+                ExecutionStage::CopyFrom,
+            ));
+        }
         Ok(state
             .files
             .get(request.source().as_str())
@@ -2393,6 +2463,88 @@ pub fn environment_map(command: &ExecutionCommand) -> BTreeMap<String, String> {
             )
         })
         .collect()
+}
+
+pub const PHASE_FILE_ENVIRONMENT_NAMES: [&str; 7] = [
+    "GITHUB_ENV",
+    "GITHUB_OUTPUT",
+    "GITHUB_PATH",
+    "GITHUB_STATE",
+    "GITHUB_STEP_SUMMARY",
+    "GITHUB_ARTIFACTS",
+    "GITHUB_ARTIFACTS_LIST",
+];
+
+pub fn assert_fresh_isolated_phase_files(state: &EndpointState, phases: &[&ExecutionCommand]) {
+    assert_eq!(
+        state.phase_file_initial_contents.len(),
+        phases.len(),
+        "every executed phase must expose one initialized file set"
+    );
+    let mut all_paths = BTreeSet::new();
+    let mut attempt_command_directories = BTreeSet::new();
+
+    for (phase_index, (command, initial)) in phases
+        .iter()
+        .zip(&state.phase_file_initial_contents)
+        .enumerate()
+    {
+        let environment = environment_map(command);
+        let mut ordinal = None;
+        for name in PHASE_FILE_ENVIRONMENT_NAMES {
+            let path = environment
+                .get(name)
+                .unwrap_or_else(|| panic!("phase {phase_index} is missing {name}"));
+            assert!(
+                all_paths.insert(path.clone()),
+                "phase file path was reused: {path}"
+            );
+            let (directory, file_name) = path
+                .rsplit_once(['/', '\\'])
+                .unwrap_or_else(|| panic!("phase file has no command directory: {path}"));
+            attempt_command_directories.insert(directory.to_owned());
+            let phase_ordinal = file_name
+                .strip_prefix("phase-")
+                .and_then(|value| value.split_once('-'))
+                .map_or_else(
+                    || panic!("phase file name is not ordinal-scoped: {path}"),
+                    |(value, _)| value,
+                );
+            match ordinal {
+                Some(expected) => assert_eq!(phase_ordinal, expected),
+                None => ordinal = Some(phase_ordinal),
+            }
+            assert!(
+                state.files.contains_key(path),
+                "initialized phase file is absent after execution: {path}"
+            );
+        }
+
+        for name in &PHASE_FILE_ENVIRONMENT_NAMES[..6] {
+            assert_eq!(
+                initial.get(*name).map(Vec::as_slice),
+                Some(&[][..]),
+                "{name} was not empty before phase {phase_index}"
+            );
+        }
+        let artifacts_list = initial
+            .get("GITHUB_ARTIFACTS_LIST")
+            .expect("initialized artifact-list snapshot");
+        assert!(
+            artifacts_list.starts_with(br#"{"version":1,"subjects":["#),
+            "artifact-list input was not regenerated before phase {phase_index}"
+        );
+    }
+
+    assert_eq!(
+        all_paths.len(),
+        phases.len() * PHASE_FILE_ENVIRONMENT_NAMES.len()
+    );
+    assert_eq!(
+        attempt_command_directories.len(),
+        1,
+        "one execution must keep all phase files below its attempt root"
+    );
 }
 
 pub fn journal_identity() -> SandboxIdentity {

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -85,21 +85,26 @@ Tasks:
   share those prefixes.
 - [x] Preserve the documented `CI` exception.
 - [x] Continue blocking `NODE_OPTIONS` through `GITHUB_ENV`.
-- [ ] Rotate environment, output, path, state, summary, and artifact files for
+- [x] Rotate environment, output, path, state, summary, and artifact files for
   every phase.
-- [ ] Match BOM, CRLF, multiline delimiter, duplicate-key, and invalid-name
+- [x] Match BOM, CRLF, multiline delimiter, duplicate-key, and invalid-name
   behavior.
-- [ ] Test command-file collection after success, failure, timeout, and
+- [x] Test command-file collection after success, failure, timeout, and
   cancellation.
 - [ ] Aggregate step summaries in completed-step order, define deletion and
   empty-file behavior, and preserve a deterministic truncation indicator.
-- [ ] Verify summary isolation across pre, main, post, composite, and repeated
+  - [x] Completed-step ordering plus missing, deleted, and empty summaries are
+    defined and covered.
+  - [ ] Match the pinned runner's diagnostic-and-skip behavior for a summary
+    larger than 1 MiB across the bounded copy interface. The pinned runner does
+    not truncate the file, so no truncation policy is inferred.
+- [x] Verify summary isolation across pre, main, post, composite, and repeated
   action occurrences.
 
 Acceptance:
 
 - [x] A step cannot shadow runner identity or command-file paths.
-- [ ] Phase files never leak between steps or action occurrences.
+- [x] Phase files never leak between steps or action occurrences.
 
 ### ACT-01 — Checked-out local action `pre`
 


### PR DESCRIPTION
## Summary

- give every run, JavaScript lifecycle hook, and composite child phase a fresh attempt-scoped set of GitHub command files
- reinitialize same-attempt recovery paths before reuse so stale bytes cannot cross phase boundaries
- protect the exact GitHub/runner-owned environment-variable catalog with Unix/Windows name semantics while preserving valid custom names such as `GITHUB_TOKEN` and `RUNNER_DIGEST`
- reject protected declarative and composite-action overlays before provider or action code, and retain sanitized notices for blocked workflow-command writes
- make terminal outcome dominance and command-state/attachment collection atomic across failure, timeout, cancellation, deleted summaries, and parse failures

## Compatibility and security

This closes the Wave 1 RUN-03 component contract. It intentionally protects the finite reviewed runtime-variable catalog rather than all `GITHUB_`/`RUNNER_` prefixes. `NODE_OPTIONS` keeps GitHub-compatible command-file blocking semantics, while declarative values remain governed by the runtime profile.

## Validation

- `cargo test --locked -p automata-ci-github-runtime --test phase_application`
- focused legacy workflow-command deferral and emitted-product-context protection tests
- `cargo test --locked -p automata-ci-job-executor-github --all-features`
- strict affected-package Clippy
- full rebased Wave 1 runner/pre-lease stack: workflow-service, control, runner, executor, server all-target checks and strict affected-package Clippy

The two pre-existing Windows checkout failures in the runtime crate's reviewed CRLF golden-file tests are unchanged by this branch; the modified phase/application targets and the full executor suite pass.