### PR TITLE
feat(platform): admit exact Linux tool profiles

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           ./scripts/dev/git-http-server.test.sh
           ./scripts/ci/tests/benchmark-postgres-tests.test.sh
           python3 scripts/ci/tests/psql-test-database.test.py
+          ./scripts/ci/tests/profile-image-contract.test.sh
           ./scripts/ci/tests/container-context.test.sh
           ./scripts/ci/tests/install.test.sh
           python3 scripts/ci/tests/integration-test-targets.test.py

--- a/.ci/workflows/profile-image.yml
+++ b/.ci/workflows/profile-image.yml
@@ -98,8 +98,8 @@ jobs:
           manifest = json.loads(manifest_bytes)
           lock = json.loads((directory / "profile-lock.json").read_bytes())
 
-          if manifest.get("schema_version") != 1 or lock.get("schema_version") != 1:
-              fail("only profile manifest and lock schema version 1 are supported")
+          if manifest.get("schema_version") != 2 or lock.get("schema_version") != 2:
+              fail("only profile manifest and lock schema version 2 are supported")
           profile_id = manifest.get("profile_id")
           if not isinstance(profile_id, str) or profile_id != lock.get("profile_id"):
               fail("manifest and lock profile identifiers differ")
@@ -206,8 +206,8 @@ jobs:
           def fail(message: str) -> None:
               raise SystemExit(f"candidate profile validation failed: {message}")
 
-          if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
-              fail("only profile manifest schema version 1 is supported")
+          if not isinstance(manifest, dict) or manifest.get("schema_version") != 2:
+              fail("only profile manifest schema version 2 is supported")
           profile_id = manifest.get("profile_id")
           if profile_id != "automata.dev/github-hosted-ubuntu-24-04-x64-v1":
               fail("profile identifier is not the reviewed compatibility contract")
@@ -272,6 +272,55 @@ jobs:
                   fail(f"WASI SDK field {field!r} is missing")
           if re.fullmatch(r"[0-9a-f]{64}", wasi_sdk.get("archive_sha256", "")) is None:
               fail("WASI SDK archive checksum is invalid")
+
+          inventory = manifest.get("software_inventory")
+          if not isinstance(inventory, dict) or inventory.get("schema") != (
+              "automata.dev/linux-software-inventory-v1"
+          ):
+              fail("software inventory contract is missing")
+          if inventory.get("dpkg_query") != "/usr/bin/dpkg-query":
+              fail("software inventory package query differs from the reviewed path")
+          packages = inventory.get("dpkg_packages")
+          if not isinstance(packages, dict) or not 1 <= len(packages) <= 128:
+              fail("software inventory package map is missing or unbounded")
+          if list(packages) != sorted(packages):
+              fail("software inventory package map is not canonically ordered")
+          for package, version in packages.items():
+              if re.fullmatch(r"[a-z0-9][a-z0-9+.-]{0,127}", package) is None:
+                  fail(f"invalid software inventory package: {package!r}")
+              if not isinstance(version, str) or re.fullmatch(
+                  r"[!-~]{1,128}", version
+              ) is None:
+                  fail(f"invalid software inventory version: {package!r}")
+          tools = inventory.get("tools")
+          required_tools = {
+              "bash", "cargo", "clang", "g++", "gcc", "git", "install", "make",
+              "node24", "python3", "rustc", "sh", "sha256sum", "sudo", "tar",
+              "unzip", "xz", "zip",
+          }
+          if not isinstance(tools, dict) or set(tools) != required_tools:
+              fail("software inventory tool set differs from the reviewed profile")
+          if list(tools) != sorted(tools):
+              fail("software inventory tool map is not canonically ordered")
+          for tool, contract in tools.items():
+              if not isinstance(contract, dict):
+                  fail(f"invalid software inventory tool contract: {tool!r}")
+              if re.fullmatch(
+                  r"/[A-Za-z0-9._+/-]{1,255}", contract.get("path", "")
+              ) is None:
+                  fail(f"invalid software inventory tool path: {tool!r}")
+              source = contract.get("source")
+              version = contract.get("version")
+              if source is not None and source not in packages:
+                  fail(f"software inventory source is not pinned: {tool!r}")
+              if source is None and (not isinstance(version, str) or not version):
+                  fail(f"standalone software inventory version is missing: {tool!r}")
+          if re.fullmatch(
+              r"[0-9a-f]{64}", tools["node24"].get("archive_sha256", "")
+          ) is None:
+              fail("software inventory Node checksum is invalid")
+          if inventory.get("unavailable_tools") != ["pwsh", "zstd"]:
+              fail("software inventory unavailable-tool set differs")
 
           container_engine = manifest.get("job_container_engine")
           if not isinstance(container_engine, dict):

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -84,8 +84,9 @@ A Kubernetes selection has this provider-specific shape:
 limit. A dedicated non-empty node selector is mandatory. Nonzero ephemeral
 storage or GPU inventory is admitted only with its corresponding verified
 enforcement field or resource mapping. The runner creates the authenticated
-client, exercises every configured environment through create/inspect/destroy,
-and registers only after that lifecycle succeeds. These assertions do not
+client, exercises every configured environment through create, inspect,
+attach, configured-tool execution, and destroy, and registers only after that
+evidence succeeds. These assertions do not
 replace cluster-side CNI, node-local traffic, admission-policy, RuntimeClass,
 or kubelet verification.
 
@@ -502,8 +503,13 @@ Failure exits without advertising the runner. After the network gate, startup
 also creates, inspects, and destroys one sandbox for every configured
 environment profile through the exact provider policy. It requires matching
 provider/profile/generation/running evidence and complete cleanup before it
-constructs the advertised inventory. This verifies that the configured
-digest-pinned image launches through that provider path; it is not
+constructs the advertised inventory. Linux admission attaches to that same
+sandbox and proves the configured Bash, `sh`, optional Python/PowerShell,
+install, tar, SHA-256, and Node-major executables. Host network, host
+filesystem, and host identity are never valid tool-probe boundaries; an
+administrator profile additionally requires administrator and user-namespace
+provider evidence. This verifies that the configured digest-pinned image
+launches and exposes the configured runtime through that provider path; it is not
 supply-chain attestation or the complete hosted-image conformance suite.
 
 The runner schema rejects static repository, workflow, and Results token

--- a/crates/automata-ci-runner/config/runner.local-1.example.json
+++ b/crates/automata-ci-runner/config/runner.local-1.example.json
@@ -49,7 +49,7 @@
     "environment_profiles": [
       {
         "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-        "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648",
+        "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
         "image": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194",
         "keepalive_program": "/bin/sleep",
         "keepalive_arguments": [

--- a/crates/automata-ci-runner/config/runner.local-2.example.json
+++ b/crates/automata-ci-runner/config/runner.local-2.example.json
@@ -49,7 +49,7 @@
     "environment_profiles": [
       {
         "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-        "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648",
+        "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
         "image": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194",
         "keepalive_program": "/bin/sleep",
         "keepalive_arguments": [

--- a/crates/automata-ci-runner/config/runner.local-3.example.json
+++ b/crates/automata-ci-runner/config/runner.local-3.example.json
@@ -49,7 +49,7 @@
     "environment_profiles": [
       {
         "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-        "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648",
+        "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
         "image": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194",
         "keepalive_program": "/bin/sleep",
         "keepalive_arguments": [

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -710,7 +710,36 @@ fn admit_configured_environment_profiles(
                 toolchain.pwsh().cloned(),
             )
             .map_err(|_| RunnerProductError::ProviderConfiguration)?,
-        RunnerProviderConfig::Podman(_) | RunnerProviderConfig::Kubernetes(_) => policy,
+        RunnerProviderConfig::Podman(_) | RunnerProviderConfig::Kubernetes(_) => policy
+            .with_linux_tools(
+                toolchain
+                    .bash()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .sh()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain.python().cloned(),
+                toolchain.pwsh().cloned(),
+                toolchain
+                    .install()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .tar()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .sha256sum()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain.node12().cloned(),
+                toolchain.node16().cloned(),
+                toolchain.node20().cloned(),
+                toolchain.node24().cloned(),
+            )
+            .map_err(|_| RunnerProductError::ProviderConfiguration)?,
     };
     let result = admit_environment_profiles(provider, config.environments(), policy, cancellation);
     match result {

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -23,8 +23,9 @@ const ADMISSION_GENERATION: u64 = 1;
 const OPERATION_DOMAIN: [u8; 16] = *b"automata-profile";
 const SHELL_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 const SHELL_PROBE_OUTPUT_BYTES: usize = 4 * 1024;
+#[cfg(test)]
 const WINDOWS_SHELL_PROBE_COUNT: usize = 3;
-const MAX_SHELL_PROBE_COUNT: usize = WINDOWS_SHELL_PROBE_COUNT + 1;
+const MAX_SHELL_PROBE_COUNT: usize = 11;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ProfileAdmissionPolicy {
@@ -55,6 +56,13 @@ enum ShellKind {
     WindowsPowerShell,
     Cmd,
     Python,
+    Install,
+    Tar,
+    Sha256sum,
+    Node12,
+    Node16,
+    Node20,
+    Node24,
 }
 
 impl ShellProbe {
@@ -62,15 +70,22 @@ impl ShellProbe {
         Self { kind, program }
     }
 
-    const fn script_name(&self) -> &'static str {
-        match self.kind {
+    const fn script_name(&self) -> Option<&'static str> {
+        Some(match self.kind {
             ShellKind::Bash => "profile admission bash.sh",
             ShellKind::Sh => "profile admission sh.sh",
             ShellKind::Pwsh => "profile admission pwsh.ps1",
             ShellKind::WindowsPowerShell => "profile admission powershell.ps1",
             ShellKind::Cmd => "profile admission cmd.cmd",
             ShellKind::Python => "profile admission python.py",
-        }
+            ShellKind::Install
+            | ShellKind::Tar
+            | ShellKind::Sha256sum
+            | ShellKind::Node12
+            | ShellKind::Node16
+            | ShellKind::Node20
+            | ShellKind::Node24 => return None,
+        })
     }
 
     fn marker(&self, operation_id: OperationId) -> String {
@@ -81,13 +96,20 @@ impl ShellProbe {
             ShellKind::WindowsPowerShell => "powershell",
             ShellKind::Cmd => "cmd",
             ShellKind::Python => "python",
+            ShellKind::Install => "install",
+            ShellKind::Tar => "tar",
+            ShellKind::Sha256sum => "sha256sum",
+            ShellKind::Node12 => "node12",
+            ShellKind::Node16 => "node16",
+            ShellKind::Node20 => "node20",
+            ShellKind::Node24 => "node24",
         };
         format!("automata-profile-{kind}-{operation_id}")
     }
 
-    fn script_content(&self, operation_id: OperationId) -> Vec<u8> {
+    fn script_content(&self, operation_id: OperationId) -> Option<Vec<u8>> {
         let marker = self.marker(operation_id);
-        match self.kind {
+        Some(match self.kind {
             ShellKind::Bash | ShellKind::Sh => {
                 format!("set -eu\nprintf '%s' '{marker}'\n").into_bytes()
             }
@@ -102,39 +124,91 @@ impl ShellProbe {
                 format!("import sys\r\nsys.stdout.write(\"{marker}\")\r\nraise SystemExit(0)\r\n")
                     .into_bytes()
             }
-        }
+            ShellKind::Install
+            | ShellKind::Tar
+            | ShellKind::Sha256sum
+            | ShellKind::Node12
+            | ShellKind::Node16
+            | ShellKind::Node20
+            | ShellKind::Node24 => return None,
+        })
     }
 
-    fn argv(&self, script: &TargetPath) -> Result<ExecutionArgv, ProfileAdmissionError> {
-        let arguments = match (self.kind, script.platform()) {
-            (ShellKind::Bash, TargetPlatform::Posix) => vec![
+    fn argv(
+        &self,
+        script: Option<&TargetPath>,
+        operation_id: OperationId,
+    ) -> Result<ExecutionArgv, ProfileAdmissionError> {
+        let script_platform = script.map(TargetPath::platform);
+        let arguments = match (self.kind, script_platform) {
+            (ShellKind::Bash, Some(TargetPlatform::Posix)) => vec![
                 "--noprofile".to_owned(),
                 "--norc".to_owned(),
                 "-e".to_owned(),
-                script.as_str().to_owned(),
+                script.expect("matched script").as_str().to_owned(),
             ],
-            (ShellKind::Sh, TargetPlatform::Posix) => {
-                vec!["-e".to_owned(), script.as_str().to_owned()]
+            (ShellKind::Sh, Some(TargetPlatform::Posix)) => {
+                vec![
+                    "-e".to_owned(),
+                    script.expect("matched script").as_str().to_owned(),
+                ]
             }
-            (ShellKind::Pwsh, TargetPlatform::Posix) => vec![
+            (ShellKind::Pwsh, Some(TargetPlatform::Posix)) => vec![
                 "-command".to_owned(),
-                format!(". '{}'", script.as_str().replace('\'', "''")),
+                format!(
+                    ". '{}'",
+                    script.expect("matched script").as_str().replace('\'', "''")
+                ),
             ],
-            (ShellKind::Python, TargetPlatform::Posix) => {
-                vec![script.as_str().to_owned()]
+            (ShellKind::Python, Some(TargetPlatform::Posix | TargetPlatform::Windows)) => {
+                vec![script.expect("matched script").as_str().to_owned()]
             }
-            (ShellKind::Pwsh | ShellKind::WindowsPowerShell, TargetPlatform::Windows) => {
-                windows_script_arguments(WindowsScriptShell::PowerShell, script)
+            (ShellKind::Pwsh | ShellKind::WindowsPowerShell, Some(TargetPlatform::Windows)) => {
+                windows_script_arguments(
+                    WindowsScriptShell::PowerShell,
+                    script.expect("matched script"),
+                )
+                .ok_or_else(invalid_catalog)?
+            }
+            (ShellKind::Cmd, Some(TargetPlatform::Windows)) => {
+                windows_script_arguments(WindowsScriptShell::Cmd, script.expect("matched script"))
                     .ok_or_else(invalid_catalog)?
             }
-            (ShellKind::Cmd, TargetPlatform::Windows) => {
-                windows_script_arguments(WindowsScriptShell::Cmd, script)
-                    .ok_or_else(invalid_catalog)?
+            (ShellKind::Install | ShellKind::Tar | ShellKind::Sha256sum, None) => {
+                vec!["--version".to_owned()]
             }
-            (ShellKind::Python, TargetPlatform::Windows) => vec![script.as_str().to_owned()],
+            (
+                ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24,
+                None,
+            ) => {
+                let major = match self.kind {
+                    ShellKind::Node12 => 12,
+                    ShellKind::Node16 => 16,
+                    ShellKind::Node20 => 20,
+                    ShellKind::Node24 => 24,
+                    _ => unreachable!(),
+                };
+                let marker = self.marker(operation_id);
+                vec![
+                    "--input-type=commonjs".to_owned(),
+                    "--eval".to_owned(),
+                    format!(
+                        "if (process.versions.node.split('.')[0] !== '{major}') process.exit(64); process.stdout.write('{marker}')"
+                    ),
+                ]
+            }
             _ => return Err(invalid_catalog()),
         };
         ExecutionArgv::new(self.program.clone(), arguments).map_err(|_| invalid_catalog())
+    }
+
+    fn expected_stdout_matches(&self, operation_id: OperationId, stdout: &[u8]) -> bool {
+        match self.kind {
+            ShellKind::Install => stdout.starts_with(b"install (GNU coreutils) "),
+            ShellKind::Tar => stdout.starts_with(b"tar (GNU tar) "),
+            ShellKind::Sha256sum => stdout.starts_with(b"sha256sum (GNU coreutils) "),
+            _ => stdout == self.marker(operation_id).as_bytes(),
+        }
     }
 }
 
@@ -154,6 +228,59 @@ impl ProfileAdmissionPolicy {
             resource_allocation,
             shell_probes: None,
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn with_linux_tools(
+        mut self,
+        bash: TargetPath,
+        sh: TargetPath,
+        python: Option<TargetPath>,
+        pwsh: Option<TargetPath>,
+        install: TargetPath,
+        tar: TargetPath,
+        sha256sum: TargetPath,
+        node12: Option<TargetPath>,
+        node16: Option<TargetPath>,
+        node20: Option<TargetPath>,
+        node24: Option<TargetPath>,
+    ) -> Result<Self, ProfileAdmissionError> {
+        let mut probes = vec![
+            ShellProbe::new(ShellKind::Bash, bash),
+            ShellProbe::new(ShellKind::Sh, sh),
+        ];
+        if let Some(python) = python {
+            probes.push(ShellProbe::new(ShellKind::Python, python));
+        }
+        if let Some(pwsh) = pwsh {
+            probes.push(ShellProbe::new(ShellKind::Pwsh, pwsh));
+        }
+        probes.extend([
+            ShellProbe::new(ShellKind::Install, install),
+            ShellProbe::new(ShellKind::Tar, tar),
+            ShellProbe::new(ShellKind::Sha256sum, sha256sum),
+        ]);
+        for (kind, program) in [
+            (ShellKind::Node12, node12),
+            (ShellKind::Node16, node16),
+            (ShellKind::Node20, node20),
+            (ShellKind::Node24, node24),
+        ] {
+            if let Some(program) = program {
+                probes.push(ShellProbe::new(kind, program));
+            }
+        }
+        if self.shell_probes.is_some()
+            || probes.len() > MAX_SHELL_PROBE_COUNT
+            || probes.iter().any(|probe| !valid_linux_probe(probe))
+        {
+            return Err(invalid_catalog());
+        }
+        self.shell_probes = Some(ShellProbePolicy {
+            scratch_root: None,
+            probes,
+        });
+        Ok(self)
     }
 
     pub(super) fn with_windows_hyperv_shells(
@@ -224,6 +351,35 @@ impl ProfileAdmissionPolicy {
             probes: shell_probes,
         });
         Ok(self)
+    }
+}
+
+fn valid_linux_probe(probe: &ShellProbe) -> bool {
+    if probe.program.platform() != TargetPlatform::Posix || !probe.program.as_str().starts_with('/')
+    {
+        return false;
+    }
+    let Some(basename) = probe.program.as_str().rsplit('/').next() else {
+        return false;
+    };
+    match probe.kind {
+        ShellKind::Bash => basename == "bash",
+        ShellKind::Sh => basename == "sh",
+        ShellKind::Pwsh => basename == "pwsh",
+        ShellKind::Python => {
+            basename == "python"
+                || basename == "python3"
+                || basename.strip_prefix("python3.").is_some_and(|version| {
+                    !version.is_empty() && version.bytes().all(|byte| byte.is_ascii_digit())
+                })
+        }
+        ShellKind::Install => basename == "install",
+        ShellKind::Tar => basename == "tar",
+        ShellKind::Sha256sum => basename == "sha256sum",
+        ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24 => {
+            basename == "node"
+        }
+        ShellKind::WindowsPowerShell | ShellKind::Cmd => false,
     }
 }
 
@@ -432,7 +588,12 @@ impl ProfileAdmissionContext<'_> {
                 policy
                     .probes
                     .iter()
-                    .map(|probe| target_child(script_root, probe.script_name()))
+                    .map(|probe| {
+                        probe
+                            .script_name()
+                            .map(|name| target_child(script_root, name))
+                            .transpose()
+                    })
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()?;
@@ -462,7 +623,7 @@ impl ProfileAdmissionContext<'_> {
                 &workspace,
                 shell_probes,
                 script_paths,
-                operation_ids,
+                &operation_ids,
             )?;
         }
         self.destroy(&record, operation_ids.destroy)
@@ -604,8 +765,8 @@ impl ProfileAdmissionContext<'_> {
         record: &automata_ci_execution::SandboxRecord,
         workspace: &TargetPath,
         shell_probes: &ShellProbePolicy,
-        script_paths: &[TargetPath],
-        operation_ids: AdmissionOperationIds,
+        script_paths: &[Option<TargetPath>],
+        operation_ids: &AdmissionOperationIds,
     ) -> Result<(), ProfileAdmissionError> {
         let endpoint = match self
             .provider
@@ -658,11 +819,27 @@ impl ProfileAdmissionContext<'_> {
             .zip(operation_ids.copy)
             .zip(operation_ids.exec)
         {
-            let Ok(request) = CopyToRequest::new(
-                operation_id,
-                script.clone(),
+            let (Some(script), Some(content)) = (
+                script.as_ref(),
                 probe.script_content(execution_operation_id),
             ) else {
+                if script.is_some() || probe.script_name().is_some() {
+                    let (cleanup, cleanup_error) = cleanup_handle(
+                        self.provider,
+                        record.handle(),
+                        self.generation,
+                        operation_ids.destroy,
+                        &self.cleanup_cancellation,
+                    );
+                    return Err(ProfileAdmissionError::evidence(
+                        ProfileAdmissionErrorKind::InvalidCopyEvidence,
+                        cleanup,
+                        cleanup_error,
+                    ));
+                }
+                continue;
+            };
+            let Ok(request) = CopyToRequest::new(operation_id, script.clone(), content) else {
                 let (cleanup, cleanup_error) = cleanup_handle(
                     self.provider,
                     record.handle(),
@@ -699,8 +876,7 @@ impl ProfileAdmissionContext<'_> {
             .zip(script_paths)
             .zip(operation_ids.exec)
         {
-            let expected_stdout = probe.marker(operation_id);
-            let Ok(argv) = probe.argv(script) else {
+            let Ok(argv) = probe.argv(script.as_ref(), operation_id) else {
                 let (cleanup, cleanup_error) = cleanup_handle(
                     self.provider,
                     record.handle(),
@@ -755,7 +931,7 @@ impl ProfileAdmissionContext<'_> {
             };
             if output.termination() != ExecutionTermination::Exited(0)
                 || output.was_truncated()
-                || output.stdout() != expected_stdout.as_bytes()
+                || !probe.expected_stdout_matches(operation_id, output.stdout())
                 || !output.stderr().is_empty()
             {
                 let (cleanup, cleanup_error) = cleanup_handle(
@@ -841,6 +1017,7 @@ fn validate_provider_policy(
     policy: &ProfileAdmissionPolicy,
 ) -> Result<(), ProfileAdmissionError> {
     if policy.shell_probes.is_some() {
+        let capabilities = provider.capabilities();
         let common_capabilities = [
             SandboxCapability::WholeJob,
             SandboxCapability::Attach,
@@ -853,16 +1030,30 @@ fn validate_provider_policy(
         ];
         let common_valid = common_capabilities
             .into_iter()
-            .all(|capability| provider.capabilities().supports(capability));
-        let boundary_valid = policy.network == NetworkPolicy::Disabled
-            && policy.root_filesystem == RootFilesystemPolicy::Writable
-            && policy.privilege == SandboxPrivilegePolicy::Unprivileged
-            && provider
-                .capabilities()
-                .supports(SandboxCapability::WritableRootFilesystem)
-            && provider
-                .capabilities()
-                .supports(SandboxCapability::NetworkDisabled);
+            .all(|capability| capabilities.supports(capability));
+        let network_valid = match policy.network {
+            NetworkPolicy::Disabled => capabilities.supports(SandboxCapability::NetworkDisabled),
+            NetworkPolicy::PrivateEgress => capabilities.supports(SandboxCapability::PrivateEgress),
+            NetworkPolicy::Host => false,
+        };
+        let root_valid = match policy.root_filesystem {
+            RootFilesystemPolicy::ReadOnly => {
+                capabilities.supports(SandboxCapability::ReadOnlyRootFilesystem)
+            }
+            RootFilesystemPolicy::Writable => {
+                capabilities.supports(SandboxCapability::WritableRootFilesystem)
+            }
+            RootFilesystemPolicy::Host => false,
+        };
+        let privilege_valid = match policy.privilege {
+            SandboxPrivilegePolicy::Unprivileged => true,
+            SandboxPrivilegePolicy::Administrator => {
+                capabilities.supports(SandboxCapability::Administrator)
+                    && capabilities.supports(SandboxCapability::UserNamespace)
+            }
+            SandboxPrivilegePolicy::Host => false,
+        };
+        let boundary_valid = network_valid && root_valid && privilege_valid;
         if !common_valid || !boundary_valid {
             return Err(ProfileAdmissionError::evidence(
                 ProfileAdmissionErrorKind::InvalidProviderEvidence,
@@ -973,34 +1164,23 @@ impl AdmissionOperationIds {
         Self {
             create: operation_id(profile, probe_attempt, 0x43),
             destroy: operation_id(profile, probe_attempt, 0x44),
-            copy: [
-                operation_id(profile, probe_attempt, 0x60),
-                operation_id(profile, probe_attempt, 0x61),
-                operation_id(profile, probe_attempt, 0x62),
-                operation_id(profile, probe_attempt, 0x63),
-            ],
-            exec: [
-                operation_id(profile, probe_attempt, 0x50),
-                operation_id(profile, probe_attempt, 0x51),
-                operation_id(profile, probe_attempt, 0x52),
-                operation_id(profile, probe_attempt, 0x53),
-            ],
+            copy: std::array::from_fn(|index| {
+                let index = u8::try_from(index).expect("profile probe count fits in u8");
+                operation_id(profile, probe_attempt, 0x60 + index)
+            }),
+            exec: std::array::from_fn(|index| {
+                let index = u8::try_from(index).expect("profile probe count fits in u8");
+                operation_id(profile, probe_attempt, 0x50 + index)
+            }),
         }
     }
 
-    const fn values(self) -> [OperationId; 2 + MAX_SHELL_PROBE_COUNT * 2] {
-        [
-            self.create,
-            self.destroy,
-            self.copy[0],
-            self.copy[1],
-            self.copy[2],
-            self.copy[3],
-            self.exec[0],
-            self.exec[1],
-            self.exec[2],
-            self.exec[3],
-        ]
+    fn values(self) -> Vec<OperationId> {
+        let mut values = Vec::with_capacity(2 + MAX_SHELL_PROBE_COUNT * 2);
+        values.extend([self.create, self.destroy]);
+        values.extend(self.copy);
+        values.extend(self.exec);
+        values
     }
 }
 
@@ -1123,7 +1303,11 @@ mod tests {
                     SandboxCapability::HostFilesystem,
                     SandboxCapability::HostIdentity,
                     SandboxCapability::NetworkDisabled,
+                    SandboxCapability::PrivateEgress,
+                    SandboxCapability::ReadOnlyRootFilesystem,
                     SandboxCapability::WritableRootFilesystem,
+                    SandboxCapability::Administrator,
+                    SandboxCapability::UserNamespace,
                     SandboxCapability::ResourceLimits,
                     SandboxCapability::ProcessLimits,
                 ])
@@ -1309,7 +1493,8 @@ mod tests {
         behavior: FakeBehavior,
     }
 
-    fn fake_shell_kind(program: &TargetPath) -> Option<ShellKind> {
+    fn fake_shell_kind(request: &ExecutionCommand) -> Option<ShellKind> {
+        let program = request.argv().program();
         let basename = program.as_str().rsplit(['/', '\\']).next()?;
         if basename.eq_ignore_ascii_case("bash") {
             Some(ShellKind::Bash)
@@ -1327,6 +1512,22 @@ mod tests {
             || basename.eq_ignore_ascii_case("python.exe")
         {
             Some(ShellKind::Python)
+        } else if basename == "install" {
+            Some(ShellKind::Install)
+        } else if basename == "tar" {
+            Some(ShellKind::Tar)
+        } else if basename == "sha256sum" {
+            Some(ShellKind::Sha256sum)
+        } else if basename == "node" {
+            let evaluation = request.argv().arguments().last()?;
+            [
+                ("!== '12'", ShellKind::Node12),
+                ("!== '16'", ShellKind::Node16),
+                ("!== '20'", ShellKind::Node20),
+                ("!== '24'", ShellKind::Node24),
+            ]
+            .into_iter()
+            .find_map(|(needle, kind)| evaluation.contains(needle).then_some(kind))
         } else {
             None
         }
@@ -1362,15 +1563,20 @@ mod tests {
             } else {
                 ExecutionTermination::Exited(0)
             };
-            let kind = fake_shell_kind(request.argv().program()).ok_or_else(|| {
+            let kind = fake_shell_kind(request).ok_or_else(|| {
                 ExecutionError::new(ExecutionErrorKind::InvalidEnvironment, ExecutionStage::Exec)
             })?;
             let stdout = if self.behavior == FakeBehavior::ExecWrongOutput {
                 b"wrong-shell-probe-output".to_vec()
             } else {
-                ShellProbe::new(kind, request.argv().program().clone())
-                    .marker(request.operation_id())
-                    .into_bytes()
+                match kind {
+                    ShellKind::Install => b"install (GNU coreutils) 9.4\n".to_vec(),
+                    ShellKind::Tar => b"tar (GNU tar) 1.35\n".to_vec(),
+                    ShellKind::Sha256sum => b"sha256sum (GNU coreutils) 9.4\n".to_vec(),
+                    _ => ShellProbe::new(kind, request.argv().program().clone())
+                        .marker(request.operation_id())
+                        .into_bytes(),
+                }
             };
             let stdout = ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, stdout)
                 .map_err(|_| {
@@ -1571,6 +1777,177 @@ mod tests {
         (BTreeMap::from([(attestation, environment)]), policy)
     }
 
+    fn linux_tool_policy() -> ProfileAdmissionPolicy {
+        let resources = ResourceLimits::new(512 * 1024 * 1024, 2_000, 128).expect("resources");
+        ProfileAdmissionPolicy::new(
+            NetworkPolicy::PrivateEgress,
+            RootFilesystemPolicy::Writable,
+            SandboxPrivilegePolicy::Administrator,
+            resources,
+            resource_allocation(resources),
+        )
+        .with_linux_tools(
+            TargetPath::posix("/usr/bin/bash").expect("bash path"),
+            TargetPath::posix("/usr/bin/sh").expect("sh path"),
+            Some(TargetPath::posix("/usr/bin/python3").expect("python path")),
+            None,
+            TargetPath::posix("/usr/bin/install").expect("install path"),
+            TargetPath::posix("/usr/bin/tar").expect("tar path"),
+            TargetPath::posix("/usr/bin/sha256sum").expect("sha256sum path"),
+            None,
+            None,
+            None,
+            Some(TargetPath::posix("/opt/externals/node24/bin/node").expect("node path")),
+        )
+        .expect("Linux tool admission policy")
+    }
+
+    #[test]
+    fn linux_profile_admission_proves_every_configured_tool_in_the_exact_sandbox() {
+        let signals = ProbeCancellation::default();
+        let provider = FakeProvider::new(FakeBehavior::Happy, signals.clone());
+        let (attestation, environment) = environment("linux-toolchain", profile_digest(0x35), 0x46);
+        let expected_environment = environment.default_environment().clone();
+        let profiles = BTreeMap::from([(attestation, environment)]);
+
+        assert_eq!(
+            admit_environment_profiles(&provider, &profiles, linux_tool_policy(), &signals),
+            Ok(ProfileAdmissionOutcome::Admitted)
+        );
+        let calls = provider.calls();
+        let Call::Create(spec) = &calls[0] else {
+            panic!("Linux tool admission must begin with create")
+        };
+        assert_eq!(spec.network(), NetworkPolicy::PrivateEgress);
+        assert_eq!(spec.root_filesystem(), RootFilesystemPolicy::Writable);
+        assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Administrator);
+        assert!(spec.scratch().is_none());
+        assert!(
+            spec.workspace()
+                .as_str()
+                .starts_with("/work/linux-toolchain/profile-admission-")
+        );
+        assert!(matches!(calls[1], Call::Inspect(_)));
+        assert!(matches!(calls[2], Call::Attach(_)));
+
+        let copied = calls[3..6]
+            .iter()
+            .map(|call| match call {
+                Call::CopyTo(request) => request.target().as_str(),
+                _ => panic!("only script probes copy input"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            copied,
+            [
+                format!("{}/profile admission bash.sh", spec.workspace().as_str()),
+                format!("{}/profile admission sh.sh", spec.workspace().as_str()),
+                format!("{}/profile admission python.py", spec.workspace().as_str()),
+            ]
+        );
+
+        let expected_programs = [
+            "/usr/bin/bash",
+            "/usr/bin/sh",
+            "/usr/bin/python3",
+            "/usr/bin/install",
+            "/usr/bin/tar",
+            "/usr/bin/sha256sum",
+            "/opt/externals/node24/bin/node",
+        ];
+        let executions = &calls[6..13];
+        for (call, expected_program) in executions.iter().zip(expected_programs) {
+            let Call::Exec(command) = call else {
+                panic!("every configured Linux tool must execute")
+            };
+            assert_eq!(command.argv().program().as_str(), expected_program);
+            assert_eq!(command.working_directory(), spec.workspace());
+            assert_eq!(command.environment(), &expected_environment);
+            assert_eq!(command.timeout(), SHELL_PROBE_TIMEOUT);
+            assert_eq!(command.output_limit(), SHELL_PROBE_OUTPUT_BYTES);
+        }
+        for call in &executions[3..6] {
+            let Call::Exec(command) = call else {
+                unreachable!()
+            };
+            assert_eq!(command.argv().arguments(), &["--version".to_owned()]);
+        }
+        let Call::Exec(node) = &executions[6] else {
+            unreachable!()
+        };
+        assert_eq!(node.argv().arguments()[0], "--input-type=commonjs");
+        assert!(node.argv().arguments()[2].contains("!== '24'"));
+        assert!(matches!(calls[13], Call::Destroy(_, false)));
+        assert_eq!(provider.resource_count(), 0);
+    }
+
+    #[test]
+    fn linux_profile_tool_policy_rejects_aliased_paths_before_provider_mutation() {
+        let resources = ResourceLimits::new(512 * 1024 * 1024, 2_000, 128).expect("resources");
+        let invalid = ProfileAdmissionPolicy::new(
+            NetworkPolicy::PrivateEgress,
+            RootFilesystemPolicy::Writable,
+            SandboxPrivilegePolicy::Administrator,
+            resources,
+            resource_allocation(resources),
+        )
+        .with_linux_tools(
+            TargetPath::posix("/usr/bin/true").expect("literal path"),
+            TargetPath::posix("/usr/bin/sh").expect("sh path"),
+            None,
+            None,
+            TargetPath::posix("/usr/bin/install").expect("install path"),
+            TargetPath::posix("/usr/bin/tar").expect("tar path"),
+            TargetPath::posix("/usr/bin/sha256sum").expect("sha256sum path"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("a generic successful program cannot stand in for Bash");
+        assert_eq!(invalid.kind(), ProfileAdmissionErrorKind::InvalidCatalog);
+        assert_eq!(
+            invalid.cleanup_status(),
+            ProfileAdmissionCleanupStatus::NotRequired
+        );
+    }
+
+    #[test]
+    fn linux_profile_tool_admission_requires_confined_administrator_evidence() {
+        for missing in [
+            SandboxCapability::PrivateEgress,
+            SandboxCapability::Administrator,
+            SandboxCapability::UserNamespace,
+        ] {
+            let signals = ProbeCancellation::default();
+            let mut provider = FakeProvider::new(FakeBehavior::Happy, signals.clone());
+            provider.capabilities = ProviderCapabilities::new(
+                provider
+                    .capabilities
+                    .values()
+                    .iter()
+                    .copied()
+                    .filter(|capability| *capability != missing),
+            )
+            .expect("capabilities with one Linux boundary omitted");
+            let (profile, sandbox) = environment("linux-tools", profile_digest(0x57), 0x68);
+            let profiles = BTreeMap::from([(profile, sandbox)]);
+
+            let error =
+                admit_environment_profiles(&provider, &profiles, linux_tool_policy(), &signals)
+                    .expect_err("Linux profile tools require the complete sandbox boundary");
+            assert_eq!(
+                error.kind(),
+                ProfileAdmissionErrorKind::InvalidProviderEvidence
+            );
+            assert_eq!(
+                error.cleanup_status(),
+                ProfileAdmissionCleanupStatus::NotRequired
+            );
+            assert!(provider.calls().is_empty(), "missing {missing:?}");
+        }
+    }
+
     #[test]
     fn windows_python_probe_is_present_only_when_the_tool_is_configured() {
         let resources = ResourceLimits::new(256 * 1024 * 1024, 1_000, 16).expect("resources");
@@ -1603,7 +1980,7 @@ mod tests {
             .as_ref()
             .expect("shell probe policy")
             .probes;
-        assert_eq!(probes.len(), MAX_SHELL_PROBE_COUNT);
+        assert_eq!(probes.len(), WINDOWS_SHELL_PROBE_COUNT + 1);
         assert_eq!(
             probes.last().map(|probe| probe.kind),
             Some(ShellKind::Python)
@@ -1799,6 +2176,7 @@ mod tests {
                 copy.content(),
                 ShellProbe::new(expected_kinds[index], (*expected_program).clone())
                     .script_content(command.operation_id())
+                    .expect("shell probe payload")
             );
             assert_eq!(command.argv().program(), expected_program);
             assert_eq!(command.working_directory(), spec.workspace());

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -18,7 +18,7 @@ use automata_ci_runner::product::{RunnerProductError, load_spool_keyring};
 const RUNNER_ID: &str = "6e561f8b-9098-418d-b573-d82f5c73006e";
 const MAX_DECRYPT_ONLY_CONTENT_KEYS: usize = 8;
 const PROFILE_ID: &str = "automata.dev/github-hosted-ubuntu-24-04-x64-v1";
-const PROFILE_DIGEST: &str = "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648";
+const PROFILE_DIGEST: &str = "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21";
 const IMAGE: &str = "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194";
 const SERVICE_PROXY_IMAGE: &str = "registry.example.test/automata/service-proxy@sha256:4d7a838e047d65bbf708d4fc315db9b3b91ae73c0d50459b519089c0713ff34b";
 const BUILDKIT_RUNTIME_IMAGE: &str = "registry.example.test/buildkit/runtime@sha256:7777777777777777777777777777777777777777777777777777777777777777";

--- a/crates/automata-ci-workflow-service/tests/fixtures/github-hosted-ubuntu-24.04-x64/profile-lock.json
+++ b/crates/automata-ci-workflow-service/tests/fixtures/github-hosted-ubuntu-24.04-x64/profile-lock.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "profile_id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-  "profile_manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648",
+  "profile_manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
   "containerfile_sha256": "bbb885b079a1d26cd6c04bf2cf9019715cf21daf0179600c58002f8d6b4b83cd",
   "image": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194"
 }

--- a/crates/automata-ci-workflow-service/tests/fixtures/github-hosted-ubuntu-24.04-x64/profile-manifest.json
+++ b/crates/automata-ci-workflow-service/tests/fixtures/github-hosted-ubuntu-24.04-x64/profile-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "profile_id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
   "platform": {
     "os": "linux",
@@ -35,6 +35,65 @@
     "cargo_home": "/opt/cargo",
     "rustup_home": "/opt/rustup",
     "runner_tool_cache": "/opt/hostedtoolcache"
+  },
+  "software_inventory": {
+    "schema": "automata.dev/linux-software-inventory-v1",
+    "dpkg_query": "/usr/bin/dpkg-query",
+    "dpkg_packages": {
+      "bash": "5.2.21-2ubuntu4",
+      "binutils": "2.42-4ubuntu2.10",
+      "build-essential": "12.10ubuntu1",
+      "ca-certificates": "20260601~24.04.1",
+      "clang-18": "1:18.1.3-1ubuntu1",
+      "coreutils": "9.4-3ubuntu6.2",
+      "curl": "8.5.0-2ubuntu10.11",
+      "dash": "0.5.12-6ubuntu5",
+      "file": "1:5.45-3build1",
+      "g++": "4:13.2.0-7ubuntu1",
+      "gcc": "4:13.2.0-7ubuntu1",
+      "git": "1:2.43.0-1ubuntu7.3",
+      "gnupg": "2.4.4-2ubuntu17.4",
+      "iproute2": "6.1.0-1ubuntu6.4",
+      "libclang1-18": "1:18.1.3-1ubuntu1",
+      "make": "4.3-4.1build2",
+      "musl-tools": "1.2.4-2",
+      "pkg-config": "1.8.1-2build1",
+      "procps": "2:4.0.4-4ubuntu3.2",
+      "python3": "3.12.3-0ubuntu2.1",
+      "python3-pip": "24.0+dfsg-1ubuntu1.3",
+      "python3.12": "3.12.3-1ubuntu0.15",
+      "sudo": "1.9.15p5-3ubuntu5.24.04.2",
+      "tar": "1.35+dfsg-3ubuntu0.4",
+      "unzip": "6.0-28ubuntu4.1",
+      "util-linux": "2.39.3-9ubuntu6.5",
+      "xz-utils": "5.6.1+really5.4.5-1ubuntu0.3",
+      "zip": "3.0-13ubuntu0.2"
+    },
+    "tools": {
+      "bash": { "path": "/usr/bin/bash", "source": "bash" },
+      "cargo": { "path": "/opt/cargo/bin/cargo", "version": "1.97.1" },
+      "clang": { "path": "/usr/bin/clang-18", "source": "clang-18" },
+      "g++": { "path": "/usr/bin/g++", "source": "g++" },
+      "gcc": { "path": "/usr/bin/gcc", "source": "gcc" },
+      "git": { "path": "/usr/bin/git", "source": "git" },
+      "install": { "path": "/usr/bin/install", "source": "coreutils" },
+      "make": { "path": "/usr/bin/make", "source": "make" },
+      "node24": {
+        "path": "/opt/automata/externals/node24/bin/node",
+        "version": "24.19.0",
+        "archive_sha256": "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647"
+      },
+      "python3": { "path": "/usr/bin/python3", "source": "python3" },
+      "rustc": { "path": "/opt/cargo/bin/rustc", "version": "1.97.1" },
+      "sh": { "path": "/usr/bin/sh", "source": "dash" },
+      "sha256sum": { "path": "/usr/bin/sha256sum", "source": "coreutils" },
+      "sudo": { "path": "/usr/bin/sudo", "source": "sudo" },
+      "tar": { "path": "/usr/bin/tar", "source": "tar" },
+      "unzip": { "path": "/usr/bin/unzip", "source": "unzip" },
+      "xz": { "path": "/usr/bin/xz", "source": "xz-utils" },
+      "zip": { "path": "/usr/bin/zip", "source": "zip" }
+    },
+    "unavailable_tools": ["pwsh", "zstd"]
   },
   "job_container_engine": {
     "capability": "automata.core/docker-compatible-api@v1",

--- a/crates/automata-ci/config/github-provider.example.json
+++ b/crates/automata-ci/config/github-provider.example.json
@@ -44,7 +44,7 @@
             "selector": "ubuntu-24.04",
             "environment_profile": {
               "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-              "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648"
+              "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21"
             },
             "operating_system": "linux",
             "architecture": "x86_64",
@@ -152,7 +152,7 @@
             "selector": "ubuntu-24.04",
             "environment_profile": {
               "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-              "manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648"
+              "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21"
             },
             "operating_system": "linux",
             "architecture": "x86_64",

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -151,6 +151,13 @@ Current component foundation:
   and optional GPU requests and limits through scheduler matching, executor
   admission, and `SandboxSpec`; the Kubernetes adapter renders exact resource
   quantities and mapped devices.
+- [x] Profile-manifest schema v2 records an exact package/tool inventory and
+  the local verifier rejects package, executable-path, standalone-version, or
+  unavailable-tool drift against a digest-qualified image.
+- [x] Linux runner startup probes every configured shell, Node major, Python,
+  PowerShell, install, tar, and SHA utility inside a fresh exact-image sandbox
+  before advertising inventory; host boundaries are rejected and sandbox
+  administrator probes require user-namespace evidence.
 
 Remaining tasks:
 

--- a/images/github-hosted-ubuntu-24.04-x64/README.md
+++ b/images/github-hosted-ubuntu-24.04-x64/README.md
@@ -19,6 +19,30 @@ shared-kernel containers remain a distinct isolation tier.
 `profile-manifest.json` is canonical checked-in launch provenance. Its SHA-256
 is the environment attestation carried by scheduling and `JobIR`; the OCI image
 digest is independently pinned in `profile-lock.json` after a reviewed build.
+Manifest schema v2 also records a closed software inventory: exact `dpkg`
+versions, absolute executable paths, checksums for standalone archives, and
+tools deliberately absent from the profile. The verifier queries every pinned
+package inside the exact image, requires every recorded executable to be a
+regular executable file, and runs independent version probes for Rust, Cargo,
+and Node. A stale package, missing path, mutable image reference, or malformed
+inventory rejects the candidate.
+
+Runner startup provides a separate product-admission layer. For every
+configured Linux profile, the runner creates and inspects a fresh sandbox from
+the digest-qualified image, attaches only after provider evidence matches, and
+executes the configured Bash, `sh`, optional Python/PowerShell, GNU
+install/tar/SHA, and Node-major probes before advertising inventory. Probe
+profiles cannot use host networking, the host filesystem, or the host identity.
+An administrator-inside-sandbox profile is admitted only when the provider
+advertises both administrator confinement and a user namespace.
+
+The checked-in OCI digest remains a development identity, not a promoted
+PLAT-01 image. Its registry manifest predates the current single-squashed-layer
+contract and therefore fails the current image verifier before software probes.
+The inventory describes that exact immutable identity, but does not manufacture
+a signature, accepted publisher provenance, or reproducible rebuild evidence.
+Those gates require a new candidate from the accepted Automata issuer.
+
 The image carries Node.js 24.19.0 and the exact renderer tools used by CI:
 `wasm-rquickjs-cli` 0.4.1, `cargo-cyclonedx` 0.5.9, and `cargo-deny` 0.20.2.
 Node 24.19.0 is the reviewed patch-level delta from the actions/runner v2.336.0

--- a/images/github-hosted-ubuntu-24.04-x64/profile-lock.json
+++ b/images/github-hosted-ubuntu-24.04-x64/profile-lock.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "profile_id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
-  "profile_manifest_sha256": "d34437d037410cd10564d232df12591a40e132735fbe415420f605faf3f5d648",
+  "profile_manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
   "containerfile_sha256": "bbb885b079a1d26cd6c04bf2cf9019715cf21daf0179600c58002f8d6b4b83cd",
   "image": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194"
 }

--- a/images/github-hosted-ubuntu-24.04-x64/profile-manifest.json
+++ b/images/github-hosted-ubuntu-24.04-x64/profile-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "profile_id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
   "platform": {
     "os": "linux",
@@ -35,6 +35,65 @@
     "cargo_home": "/opt/cargo",
     "rustup_home": "/opt/rustup",
     "runner_tool_cache": "/opt/hostedtoolcache"
+  },
+  "software_inventory": {
+    "schema": "automata.dev/linux-software-inventory-v1",
+    "dpkg_query": "/usr/bin/dpkg-query",
+    "dpkg_packages": {
+      "bash": "5.2.21-2ubuntu4",
+      "binutils": "2.42-4ubuntu2.10",
+      "build-essential": "12.10ubuntu1",
+      "ca-certificates": "20260601~24.04.1",
+      "clang-18": "1:18.1.3-1ubuntu1",
+      "coreutils": "9.4-3ubuntu6.2",
+      "curl": "8.5.0-2ubuntu10.11",
+      "dash": "0.5.12-6ubuntu5",
+      "file": "1:5.45-3build1",
+      "g++": "4:13.2.0-7ubuntu1",
+      "gcc": "4:13.2.0-7ubuntu1",
+      "git": "1:2.43.0-1ubuntu7.3",
+      "gnupg": "2.4.4-2ubuntu17.4",
+      "iproute2": "6.1.0-1ubuntu6.4",
+      "libclang1-18": "1:18.1.3-1ubuntu1",
+      "make": "4.3-4.1build2",
+      "musl-tools": "1.2.4-2",
+      "pkg-config": "1.8.1-2build1",
+      "procps": "2:4.0.4-4ubuntu3.2",
+      "python3": "3.12.3-0ubuntu2.1",
+      "python3-pip": "24.0+dfsg-1ubuntu1.3",
+      "python3.12": "3.12.3-1ubuntu0.15",
+      "sudo": "1.9.15p5-3ubuntu5.24.04.2",
+      "tar": "1.35+dfsg-3ubuntu0.4",
+      "unzip": "6.0-28ubuntu4.1",
+      "util-linux": "2.39.3-9ubuntu6.5",
+      "xz-utils": "5.6.1+really5.4.5-1ubuntu0.3",
+      "zip": "3.0-13ubuntu0.2"
+    },
+    "tools": {
+      "bash": { "path": "/usr/bin/bash", "source": "bash" },
+      "cargo": { "path": "/opt/cargo/bin/cargo", "version": "1.97.1" },
+      "clang": { "path": "/usr/bin/clang-18", "source": "clang-18" },
+      "g++": { "path": "/usr/bin/g++", "source": "g++" },
+      "gcc": { "path": "/usr/bin/gcc", "source": "gcc" },
+      "git": { "path": "/usr/bin/git", "source": "git" },
+      "install": { "path": "/usr/bin/install", "source": "coreutils" },
+      "make": { "path": "/usr/bin/make", "source": "make" },
+      "node24": {
+        "path": "/opt/automata/externals/node24/bin/node",
+        "version": "24.19.0",
+        "archive_sha256": "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647"
+      },
+      "python3": { "path": "/usr/bin/python3", "source": "python3" },
+      "rustc": { "path": "/opt/cargo/bin/rustc", "version": "1.97.1" },
+      "sh": { "path": "/usr/bin/sh", "source": "dash" },
+      "sha256sum": { "path": "/usr/bin/sha256sum", "source": "coreutils" },
+      "sudo": { "path": "/usr/bin/sudo", "source": "sudo" },
+      "tar": { "path": "/usr/bin/tar", "source": "tar" },
+      "unzip": { "path": "/usr/bin/unzip", "source": "unzip" },
+      "xz": { "path": "/usr/bin/xz", "source": "xz-utils" },
+      "zip": { "path": "/usr/bin/zip", "source": "zip" }
+    },
+    "unavailable_tools": ["pwsh", "zstd"]
   },
   "job_container_engine": {
     "capability": "automata.core/docker-compatible-api@v1",

--- a/images/github-hosted-ubuntu-24.04-x64/verify-profile-image.sh
+++ b/images/github-hosted-ubuntu-24.04-x64/verify-profile-image.sh
@@ -36,6 +36,7 @@ podman image inspect "${image_reference}" > "${inspect_path}"
 
 mapfile -t profile_contract < <(
     python3 - "${manifest_path}" "${inspect_path}" "${expected_revision}" <<'PY'
+import base64
 import json
 import pathlib
 import re
@@ -47,6 +48,9 @@ expected_revision = sys.argv[3]
 
 def fail(message: str) -> None:
     raise SystemExit(f"profile image contract failed: {message}")
+
+if manifest.get("schema_version") != 2:
+    fail("only profile manifest schema version 2 is supported")
 
 if not isinstance(inspected, list) or len(inspected) != 1:
     fail("Podman did not return exactly one inspected image")
@@ -60,6 +64,7 @@ execution = manifest.get("execution") or {}
 toolchain = manifest.get("toolchain") or {}
 wasi_sdk = toolchain.get("wasi_sdk") or {}
 container_engine = manifest.get("job_container_engine") or {}
+software_inventory = manifest.get("software_inventory") or {}
 docker_client = container_engine.get("client")
 if not isinstance(docker_client, str) or not docker_client.startswith("docker-cli-"):
     fail("profile manifest Docker client identity is invalid")
@@ -124,10 +129,67 @@ runtime_values = [
 ]
 if not all(isinstance(value, str) and value for value in runtime_values):
     fail("profile manifest omits a required runtime identity")
-print(*runtime_values, sep="\n")
+
+if software_inventory.get("schema") != "automata.dev/linux-software-inventory-v1":
+    fail("software inventory schema is invalid")
+dpkg_query = software_inventory.get("dpkg_query")
+packages = software_inventory.get("dpkg_packages")
+tools = software_inventory.get("tools")
+unavailable = software_inventory.get("unavailable_tools")
+if dpkg_query != "/usr/bin/dpkg-query":
+    fail("software inventory package query is not the reviewed absolute path")
+if not isinstance(packages, dict) or not 1 <= len(packages) <= 128:
+    fail("software inventory package map is missing or unbounded")
+if list(packages) != sorted(packages):
+    fail("software inventory package map is not canonically ordered")
+for package, version in packages.items():
+    if re.fullmatch(r"[a-z0-9][a-z0-9+.-]{0,127}", package) is None:
+        fail(f"software inventory package name is invalid: {package!r}")
+    if not isinstance(version, str) or re.fullmatch(r"[!-~]{1,128}", version) is None:
+        fail(f"software inventory package version is invalid: {package!r}")
+if not isinstance(tools, dict) or not 1 <= len(tools) <= 64:
+    fail("software inventory tool map is missing or unbounded")
+if list(tools) != sorted(tools):
+    fail("software inventory tool map is not canonically ordered")
+required_tools = {
+    "bash", "cargo", "clang", "g++", "gcc", "git", "install", "make",
+    "node24", "python3", "rustc", "sh", "sha256sum", "sudo", "tar",
+    "unzip", "xz", "zip",
+}
+if set(tools) != required_tools:
+    fail("software inventory tool set differs from the reviewed profile")
+for tool, contract in tools.items():
+    if not isinstance(contract, dict):
+        fail(f"software inventory tool contract is invalid: {tool!r}")
+    path = contract.get("path")
+    if not isinstance(path, str) or re.fullmatch(r"/[A-Za-z0-9._+/-]{1,255}", path) is None:
+        fail(f"software inventory tool path is invalid: {tool!r}")
+    source = contract.get("source")
+    version = contract.get("version")
+    if source is not None and source not in packages:
+        fail(f"software inventory tool source is not pinned: {tool!r}")
+    if source is None and (not isinstance(version, str) or not version):
+        fail(f"software inventory standalone tool version is missing: {tool!r}")
+if re.fullmatch(r"[0-9a-f]{64}", tools["node24"].get("archive_sha256", "")) is None:
+    fail("software inventory Node archive checksum is invalid")
+if unavailable != ["pwsh", "zstd"]:
+    fail("software inventory unavailable-tool set differs from the reviewed profile")
+
+encoded_inventory = base64.urlsafe_b64encode(
+    json.dumps(
+        {
+            "dpkg_query": dpkg_query,
+            "packages": packages,
+            "tools": tools,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+).decode("ascii")
+print(*runtime_values, encoded_inventory, sep="\n")
 PY
 )
-(( ${#profile_contract[@]} == 9 )) || die "profile manifest runtime contract is incomplete"
+(( ${#profile_contract[@]} == 10 )) || die "profile manifest runtime contract is incomplete"
 
 readonly expected_profile_id="${profile_contract[0]}"
 readonly expected_rust="${profile_contract[1]}"
@@ -138,6 +200,7 @@ readonly expected_cargo_deny="${profile_contract[5]}"
 readonly expected_clang_package="${profile_contract[6]}"
 readonly expected_wasi_root="${profile_contract[7]}"
 readonly expected_docker_cli="${profile_contract[8]}"
+readonly expected_software_inventory="${profile_contract[9]}"
 
 podman run --rm \
     --env "EXPECTED_CARGO_CYCLONEDX=${expected_cargo_cyclonedx}" \
@@ -147,6 +210,7 @@ podman run --rm \
     --env "EXPECTED_NODE=${expected_node}" \
     --env "EXPECTED_PROFILE_ID=${expected_profile_id}" \
     --env "EXPECTED_RUST=${expected_rust}" \
+    --env "EXPECTED_SOFTWARE_INVENTORY=${expected_software_inventory}" \
     --env "EXPECTED_WASI_ROOT=${expected_wasi_root}" \
     --env "EXPECTED_WASM_RQUICKJS=${expected_wasm_rquickjs}" \
     --entrypoint /bin/bash \
@@ -165,6 +229,64 @@ podman run --rm \
             "$EXPECTED_CLANG_PACKAGE"
         test -x "${EXPECTED_WASI_ROOT}/bin/clang"
         docker --version | grep -F "Docker version ${EXPECTED_DOCKER_CLI}," >/dev/null
+        python3 - "$EXPECTED_SOFTWARE_INVENTORY" <<'"'"'PY'"'"'
+import base64
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+
+inventory = json.loads(base64.urlsafe_b64decode(sys.argv[1]))
+query = inventory["dpkg_query"]
+probe_environment = {
+    "CARGO_HOME": os.environ["CARGO_HOME"],
+    "PATH": "/opt/cargo/bin:/usr/bin:/bin",
+    "RUSTUP_HOME": os.environ["RUSTUP_HOME"],
+}
+for package, expected in inventory["packages"].items():
+    result = subprocess.run(
+        [query, "--show", "--showformat=${Version}", package],
+        check=False,
+        capture_output=True,
+        env=probe_environment,
+        timeout=5,
+    )
+    if result.returncode != 0 or result.stderr or result.stdout.decode() != expected:
+        raise SystemExit(f"installed package differs from inventory: {package}")
+
+for tool, contract in inventory["tools"].items():
+    path = pathlib.Path(contract["path"])
+    mode = path.stat().st_mode
+    if not stat.S_ISREG(mode) or not os.access(path, os.X_OK):
+        raise SystemExit(f"inventory tool is not an executable file: {tool}")
+
+version_probes = {
+    "cargo": ["--version"],
+    "node24": ["--version"],
+    "rustc": ["--version"],
+}
+for tool, arguments in version_probes.items():
+    contract = inventory["tools"][tool]
+    result = subprocess.run(
+        [contract["path"], *arguments],
+        check=False,
+        capture_output=True,
+        env=probe_environment,
+        timeout=5,
+    )
+    expected = contract["version"]
+    output = result.stdout.decode()
+    if result.returncode != 0 or result.stderr:
+        raise SystemExit(f"standalone inventory tool probe failed: {tool}")
+    if tool == "node24":
+        matches = output.strip() == f"v{expected}"
+    else:
+        matches = output.startswith(f"{tool} {expected} ")
+    if not matches:
+        raise SystemExit(f"standalone inventory tool version differs: {tool}")
+PY
     '
 
 printf 'verified profile image contract: %s\n' "${image_reference}"

--- a/scripts/ci/tests/profile-image-contract.test.sh
+++ b/scripts/ci/tests/profile-image-contract.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+if [[ "${0##*/}" == podman ]]; then
+    : "${FAKE_PODMAN_LOG:?}"
+    case "${1:-} ${2:-}" in
+        'image inspect')
+            printf 'inspect\n' >> "${FAKE_PODMAN_LOG}"
+            cat <<'JSON'
+[{"Os":"linux","Architecture":"amd64","Config":{"User":"0:0","WorkingDir":"/__w","Cmd":["/bin/sleep","infinity"],"Labels":{"org.opencontainers.image.title":"Automata GitHub-hosted Ubuntu 24.04 x64 compatibility profile","org.opencontainers.image.source":"https://github.com/automata-ci/automata","org.opencontainers.image.licenses":"MIT","org.opencontainers.image.revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","org.opencontainers.image.version":"automata.dev/github-hosted-ubuntu-24-04-x64-v1","io.automata.environment-profile":"automata.dev/github-hosted-ubuntu-24-04-x64-v1"},"Env":["AUTOMATA_ENVIRONMENT_PROFILE_ID=automata.dev/github-hosted-ubuntu-24-04-x64-v1","CARGO_HOME=/opt/cargo","RUSTUP_HOME=/opt/rustup","RUNNER_TOOL_CACHE=/opt/hostedtoolcache"]},"RootFS":{"Layers":["sha256:1111111111111111111111111111111111111111111111111111111111111111"]}}]
+JSON
+            ;;
+        'run --rm')
+            printf 'run\n' >> "${FAKE_PODMAN_LOG}"
+            ;;
+        *)
+            fail "unexpected fake Podman request: $*"
+            ;;
+    esac
+    exit 0
+fi
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly script_directory
+repository_root="$(CDPATH='' cd -- "${script_directory}/../../.." && pwd -P)"
+readonly repository_root
+# shellcheck source=scripts/ci/lib/target-paths.sh
+source "${repository_root}/scripts/ci/lib/target-paths.sh"
+
+automata_init_target_root "${repository_root}"
+scratch_root="$(
+    automata_canonical_exact_target_child \
+        "${repository_root}/target/task-tmp/profile-image-contract-test" \
+        "profile image contract test root"
+)"
+readonly scratch_root
+install -d -m 0700 -- "${scratch_root}"
+scratch_directory="$(mktemp -d "${scratch_root}/case.XXXXXXXX")"
+readonly scratch_directory
+cleanup() {
+    rm -rf -- "${scratch_directory}"
+}
+trap cleanup EXIT
+
+fake_bin="${scratch_directory}/bin"
+fake_log="${scratch_directory}/podman.log"
+profile_directory="${repository_root}/images/github-hosted-ubuntu-24.04-x64"
+readonly fake_bin fake_log profile_directory
+install -d -m 0700 -- "${fake_bin}"
+install -m 0755 -- "${BASH_SOURCE[0]}" "${fake_bin}/podman"
+
+run_verifier() {
+    env \
+        PATH="${fake_bin}:${PATH}" \
+        FAKE_PODMAN_LOG="${fake_log}" \
+        "${profile_directory}/verify-profile-image.sh" "$@"
+}
+
+: > "${fake_log}"
+run_verifier 'registry.example/profile@sha256:1111111111111111111111111111111111111111111111111111111111111111' \
+    >/dev/null
+[[ "$(<"${fake_log}")" == $'inspect\nrun' ]] || \
+    fail 'valid schema-v2 profile did not reach the isolated image probe'
+
+invalid_manifest="${scratch_directory}/invalid-profile-manifest.json"
+readonly invalid_manifest
+python3 - "${profile_directory}/profile-manifest.json" "${invalid_manifest}" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+del manifest["software_inventory"]["tools"]["node24"]
+pathlib.Path(sys.argv[2]).write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+: > "${fake_log}"
+if run_verifier \
+    'registry.example/profile@sha256:1111111111111111111111111111111111111111111111111111111111111111' \
+    "${invalid_manifest}" \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+    >"${scratch_directory}/invalid.stdout" \
+    2>"${scratch_directory}/invalid.stderr"; then
+    fail 'profile verifier accepted a missing required tool'
+fi
+grep -Fq -- \
+    'software inventory tool set differs from the reviewed profile' \
+    "${scratch_directory}/invalid.stderr" || \
+    fail 'profile verifier did not retain the stable inventory failure reason'
+[[ "$(<"${fake_log}")" == inspect ]] || \
+    fail 'invalid inventory reached the image execution probe'
+
+printf '%s\n' 'profile image schema-v2 inventory contract passed'

--- a/scripts/ui/reproduce-renderer-in-profile.sh
+++ b/scripts/ui/reproduce-renderer-in-profile.sh
@@ -42,7 +42,7 @@ lock = json.loads(lock_path.read_bytes())
 def fail(message: str) -> None:
     raise SystemExit(f"renderer profile lock validation failed: {message}")
 
-if manifest.get("schema_version") != 1 or lock.get("schema_version") != 1:
+if manifest.get("schema_version") != 2 or lock.get("schema_version") != 2:
     fail("unsupported schema")
 if manifest.get("profile_id") != expected_profile_id:
     fail("unexpected manifest profile ID")


### PR DESCRIPTION
## Summary

- version the Linux profile manifest/lock as a digest-bound package and tool inventory
- validate the committed profile, promotion workflow, image layer shape, package set, tool paths, and Node-major inventory as one contract
- make Podman and Kubernetes runner startup create, inspect, attach to, and execute the configured tools before advertising the profile
- reject host execution boundaries and require administrator plus user-namespace evidence
- keep profile advertisements derived from the inspected immutable toolchain instead of assumed image contents

## Security and compatibility boundary

This is the Wave 1 PLAT-01 component slice; it does not advertise a newly accepted production image. The currently checked-in GHCR digest is a legacy multi-layer development image and intentionally fails the new single-squashed-layer promotion rule. Signed promotion/software-inventory provenance still requires an accepted issuer, and physical host acceptance remains a separate gate.

No host/native fallback is introduced. Windows Hyper-V placement and trust are handled separately.

## Validation

- profile admission suite: 18/18
- runner integration suite: 45/45
- workflow-service suite: 189/189 (one explicitly configured live-S3 test ignored)
- strict affected-package Clippy
- schema-v2 JSON/hash parity
- Ubuntu shell/YAML/profile-image contract checks
- post-rebase all-target Cargo check and `git diff --check`