### PR TITLE
refactor(store): retire keyed GitHub service maintenance APIs

### DIFF
--- a/crates/automata-ci-postgres/tests/store/provider/github_service_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_service_authority.rs
@@ -5,11 +5,9 @@ use automata_ci_key_management::{EncryptedEnvelope, KeyId, WrappedDataKey};
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AcquireGithubServerServiceHandoff,
     AdmissionObject, BeginGithubServerServiceMint, BindGithubCheckSuite,
-    ClaimGithubCheckProjection, ClaimGithubServerServiceMint, ClaimGithubServerServiceRevocation,
-    ClaimNextGithubServerServiceMaintenance, ClaimProviderDelivery,
-    EnsureGithubServerServiceAuthority, EraseExpiredGithubServerServiceIssuance,
-    FinishGithubServerServiceMint, FinishGithubServerServiceRevocation,
-    GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS, GITHUB_SERVICE_GENERATION_FAILURE_BACKOFF_MILLIS,
+    ClaimGithubCheckProjection, ClaimNextGithubServerServiceMaintenance, ClaimProviderDelivery,
+    EnsureGithubServerServiceAuthority, FinishGithubServerServiceMint,
+    FinishGithubServerServiceRevocation, GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS,
     GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
     GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId, GithubCheckSuiteId,
     GithubProviderManifest, GithubProviderManifestLimits, GithubProviderManifestRepository as _,
@@ -24,13 +22,12 @@ use automata_ci_store::{
     GithubServerServiceIssuanceState, GithubServerServiceJwtIssuer,
     GithubServerServiceMaintenanceOutcome, GithubServerServiceRevision, GithubServerServiceScope,
     GithubServerServiceStoreError, GithubServerServiceWorkerId,
-    GithubSubjectEvidenceRepository as _, ObjectKey, ProtectedGithubServerServiceCredential,
-    ProviderConnectionId, ProviderDeliveryClaimOwnerId,
+    GithubSubjectEvidenceRepository as _, MAX_GITHUB_SERVICE_REVOKE_CLAIM_MILLIS, ObjectKey,
+    ProtectedGithubServerServiceCredential, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
     ProviderDeliveryClaimRenewalRepository as _, ProviderDeliveryIdentity,
     ProviderDeliveryRenewalTiming, ProviderDeliveryRepository as _, ProviderInstallationId,
     ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
     ProviderRepositoryVisibility, QuarantineGithubServerServiceCredential,
-    ReclaimGithubServerServiceMint, ReconcileExpiredGithubServerServiceMint,
     ReleaseGithubServerServiceHandoff, RenewProviderDeliveryClaim, RepositoryId,
     RetireGithubServerServiceAuthority, TenantScope,
 };
@@ -311,6 +308,104 @@ async fn maintenance_bootstraps_and_recovers_generation_after_lost_claim() -> Te
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn production_sized_mint_retry_waits_for_deadline_reduction() -> TestResult {
+    run_with_database(|database| async move {
+        let fixture = seed_fixture(&database, "maintenance-mint-retry", 10).await?;
+        let identity = ensure_authority(
+            &database,
+            &fixture,
+            GithubServerServiceScope::ChecksWrite,
+            Uuid::new_v4(),
+            100,
+        )
+        .await?;
+        let requested_at = 1_000;
+        let request_deadline = requested_at + MAX_GITHUB_SERVICE_REVOKE_CLAIM_MILLIS;
+        let key = GithubServerServiceIssuanceKey::new(
+            identity.authority_id(),
+            GithubServerServiceGeneration::new(1)?,
+        );
+        let claimed = claim_next_mint(
+            &database,
+            &identity,
+            key.generation(),
+            requested_at,
+            request_deadline,
+        )
+        .await?;
+
+        set_database_test_clock(&database, 1_050).await?;
+        database
+            .store()
+            .begin_github_server_service_mint(BeginGithubServerServiceMint::new(
+                &claimed,
+                UnixMillis::new(1_050),
+            )?)
+            .await?;
+        let retry_at = 1_200;
+        set_database_test_clock(&database, 1_100).await?;
+        let pending = database
+            .store()
+            .finish_github_server_service_mint(&FinishGithubServerServiceMint::retry(
+                claimed.claim().clone(),
+                GithubServerServiceFailureKind::new("provider_unavailable")?,
+                UnixMillis::new(1_100),
+                UnixMillis::new(retry_at),
+            )?)
+            .await?;
+        assert_eq!(pending.key(), key);
+        assert_eq!(
+            pending.state(),
+            GithubServerServiceIssuanceState::MintRetryPending
+        );
+        assert_eq!(
+            pending.request_deadline(),
+            UnixMillis::new(request_deadline)
+        );
+        assert_eq!(pending.mint_attempts(), 1);
+
+        let retry = claim_next_maintenance(
+            &database,
+            identity.tenant(),
+            retry_at,
+            retry_at + MAX_GITHUB_SERVICE_REVOKE_CLAIM_MILLIS,
+        )
+        .await?;
+        assert!(
+            retry.is_none(),
+            "a second production-sized claim cannot fit the original request deadline"
+        );
+        assert_issuance_state(&database, key, "mint_retry").await?;
+
+        let reduced = claim_next_reduced(
+            &database,
+            &identity,
+            key,
+            request_deadline,
+            request_deadline + 100,
+            GithubServerServiceIssuanceState::Rejected,
+        )
+        .await?;
+        assert_eq!(reduced.mint_attempts(), 1);
+        let already_reduced = claim_next_maintenance(
+            &database,
+            identity.tenant(),
+            request_deadline + 1,
+            request_deadline + 101,
+        )
+        .await?;
+        assert!(
+            already_reduced.is_none(),
+            "the terminal retry reduction must not be replayed as maintenance"
+        );
+        assert_issuance_state(&database, key, "rejected").await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn maintenance_skip_locked_makes_progress_on_the_next_authority() -> TestResult {
     run_with_database(|database| async move {
         let fixture = seed_fixture(&database, "maintenance-skip-locked", 10).await?;
@@ -513,6 +608,7 @@ async fn maintenance_uses_the_bounded_head_after_more_than_sixty_four_retired_ro
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)] // One constrained fixture proves saturated-current quarantine atomically.
 async fn saturated_failure_budget_still_quarantines_current() -> TestResult {
     run_with_database(|database| async move {
         let current_fixture = seed_fixture(&database, "failure-breaker-current", 10).await?;
@@ -525,12 +621,56 @@ async fn saturated_failure_budget_still_quarantines_current() -> TestResult {
         )
         .await?;
         mint_ready(&database, &current_identity, 1, 100, 200, 150).await?;
-        let mut refresh_at = 1_920_100;
-        for generation in 2..=33 {
-            refresh_at =
-                reject_claimed_generation(&database, &current_identity, generation, refresh_at)
-                    .await?;
-        }
+
+        // A production-sized refresh window reaches the current credential's
+        // safe-erasure boundary before 32 one-minute failure gates can elapse.
+        // The adjacent rearm test exercises those 32 failures organically; this
+        // fixture starts at the resulting constraint-valid saturated state so
+        // this test can isolate quarantine of a still-current credential.
+        let next_mint_not_before = 200;
+        let mint_gate_generation = 1_u64;
+        let failure_budget_rearm_at =
+            next_mint_not_before + GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS;
+        let mut saturated_setup = database.pool().begin().await?;
+        sqlx::query(
+            "ALTER TABLE github_server_service_authorities \
+             DISABLE TRIGGER github_server_service_authorities_update_guard",
+        )
+        .execute(&mut *saturated_setup)
+        .await?;
+        let saturated = sqlx::query(
+            r"
+            UPDATE github_server_service_authorities
+            SET consecutive_generation_failures = 32,
+                next_mint_not_before_ms = $2,
+                mint_gate_generation = $3,
+                failure_budget_rearm_at_ms = $4,
+                state_updated_at_ms = $2
+            WHERE id = $1
+              AND state = 'active'
+              AND current_issuance_generation = 1
+              AND refresh_issuance_generation IS NULL
+              AND next_issuance_generation = 2
+            ",
+        )
+        .bind(current_identity.authority_id().as_uuid())
+        .bind(next_mint_not_before)
+        .bind(i64::try_from(mint_gate_generation)?)
+        .bind(failure_budget_rearm_at)
+        .execute(&mut *saturated_setup)
+        .await?;
+        sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+            .execute(&mut *saturated_setup)
+            .await?;
+        sqlx::query(
+            "ALTER TABLE github_server_service_authorities \
+             ENABLE TRIGGER github_server_service_authorities_update_guard",
+        )
+        .execute(&mut *saturated_setup)
+        .await?;
+        saturated_setup.commit().await?;
+        assert_eq!(saturated.rows_affected(), 1);
+
         let before_quarantine = database
             .store()
             .inspect_github_server_service_authority(
@@ -543,6 +683,23 @@ async fn saturated_failure_budget_still_quarantines_current() -> TestResult {
             before_quarantine.current_generation(),
             Some(GithubServerServiceGeneration::new(1)?)
         );
+        assert_eq!(
+            before_quarantine.next_generation(),
+            GithubServerServiceGeneration::new(2)?
+        );
+        assert_eq!(before_quarantine.refresh_generation(), None);
+        assert_eq!(
+            before_quarantine.next_mint_not_before(),
+            Some(UnixMillis::new(next_mint_not_before))
+        );
+        assert_eq!(
+            before_quarantine.mint_gate_generation(),
+            Some(GithubServerServiceGeneration::new(mint_gate_generation)?)
+        );
+        assert_eq!(
+            before_quarantine.failure_budget_rearm_at(),
+            Some(UnixMillis::new(failure_budget_rearm_at))
+        );
         let current_metadata = GithubServerServiceEnvelopeMetadata::new(
             current_identity.clone(),
             GithubServerServiceGeneration::new(1)?,
@@ -552,7 +709,8 @@ async fn saturated_failure_budget_still_quarantines_current() -> TestResult {
             32,
             Sha256Digest::from_bytes([21; 32]),
         )?;
-        set_database_test_clock(&database, refresh_at).await?;
+        let quarantined_at = 1_000;
+        set_database_test_clock(&database, quarantined_at).await?;
         let quarantined = database
             .store()
             .quarantine_github_server_service_credential(
@@ -564,7 +722,7 @@ async fn saturated_failure_budget_still_quarantines_current() -> TestResult {
                     ),
                     current_metadata.aad_digest(),
                     GithubServerServiceFailureKind::new("aad_corrupt")?,
-                    UnixMillis::new(refresh_at),
+                    UnixMillis::new(quarantined_at),
                 )?,
             )
             .await?;
@@ -604,31 +762,24 @@ async fn saturated_failure_budget_rearms_one_probationary_generation() -> TestRe
         let mut last_failure_at = 0;
         for generation in 1..=32 {
             let generation = GithubServerServiceGeneration::new(generation)?;
-            set_database_test_clock(&database, requested_at).await?;
-            let claimed = database
-                .store()
-                .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-                    authority_selector(&identity),
-                    generation,
-                    GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-                    UnixMillis::new(requested_at),
-                    UnixMillis::new(requested_at + 1_000),
-                    UnixMillis::new(requested_at + 500),
-                )?)
-                .await?;
+            let claimed = claim_next_mint(
+                &database,
+                &identity,
+                generation,
+                requested_at,
+                requested_at + 500,
+            )
+            .await?;
             last_failure_at = requested_at + 500;
-            set_database_test_clock(&database, last_failure_at).await?;
-            let receipt = database
-                .store()
-                .reconcile_expired_github_server_service_mint(
-                    ReconcileExpiredGithubServerServiceMint::new(
-                        authority_selector(&identity),
-                        claimed.claim().key(),
-                        UnixMillis::new(last_failure_at),
-                    )?,
-                )
-                .await?;
-            assert_eq!(receipt.state(), GithubServerServiceIssuanceState::Rejected);
+            claim_next_reduced(
+                &database,
+                &identity,
+                claimed.claim().key(),
+                last_failure_at,
+                last_failure_at + 100,
+                GithubServerServiceIssuanceState::Rejected,
+            )
+            .await?;
             requested_at = last_failure_at + 60_000;
         }
 
@@ -696,9 +847,9 @@ async fn current_refresh_handoff_revocation_and_retirement_are_fenced() -> TestR
     run_with_database(|database| async move {
         let scenario = prepare_lifecycle_scenario(&database).await?;
 
-        let revoke_worker_uuid = rotate_lifecycle_authority(&database, &scenario).await?;
+        rotate_lifecycle_authority(&database, &scenario).await?;
 
-        release_and_revoke_previous(&database, &scenario, revoke_worker_uuid).await?;
+        release_and_revoke_previous(&database, &scenario).await?;
 
         retire_lifecycle_authority(&database, &scenario.authority).await?;
 
@@ -830,7 +981,7 @@ async fn prepare_lifecycle_scenario(database: &TestDatabase) -> TestResult<Lifec
 async fn rotate_lifecycle_authority(
     database: &TestDatabase,
     scenario: &LifecycleScenario,
-) -> TestResult<Uuid> {
+) -> TestResult {
     // Committing generation two atomically makes it current and moves the
     // prior current generation into revoke-only custody.
     mint_ready(
@@ -866,30 +1017,19 @@ async fn rotate_lifecycle_authority(
         scenario.authority.authority_id(),
         GithubServerServiceGeneration::new(1)?,
     );
-    let revoke_worker_uuid = Uuid::new_v4();
-    set_database_test_clock(database, 2_222_000).await?;
-    let live_error = database
-        .store()
-        .claim_github_server_service_revocation(ClaimGithubServerServiceRevocation::new(
-            authority_selector(&scenario.authority),
-            old_key,
-            GithubServerServiceWorkerId::from_uuid(revoke_worker_uuid)?,
-            UnixMillis::new(2_222_000),
-            UnixMillis::new(2_223_000),
-        )?)
-        .await
-        .expect_err("live handoff must block revocation");
-    assert!(matches!(
-        live_error,
-        GithubServerServiceStoreError::HandoffStillLive
-    ));
-    Ok(revoke_worker_uuid)
+    let live =
+        claim_next_maintenance(database, scenario.authority.tenant(), 2_222_000, 2_223_000).await?;
+    assert!(
+        live.is_none(),
+        "a live handoff must exclude its exact revocation from maintenance"
+    );
+    assert_issuance_state(database, old_key, "revoke_pending").await?;
+    Ok(())
 }
 
 async fn release_and_revoke_previous(
     database: &TestDatabase,
     scenario: &LifecycleScenario,
-    revoke_worker_uuid: Uuid,
 ) -> TestResult {
     set_database_test_clock(database, 2_223_000).await?;
     database
@@ -906,18 +1046,10 @@ async fn release_and_revoke_previous(
         scenario.authority.authority_id(),
         GithubServerServiceGeneration::new(1)?,
     );
-    set_database_test_clock(database, 2_224_000).await?;
-    let revoke = database
-        .store()
-        .claim_github_server_service_revocation(ClaimGithubServerServiceRevocation::new(
-            authority_selector(&scenario.authority),
-            old_key,
-            GithubServerServiceWorkerId::from_uuid(revoke_worker_uuid)?,
-            UnixMillis::new(2_224_000),
-            UnixMillis::new(2_225_000),
-        )?)
-        .await
-        .map_err(|error| format!("claim prior-generation revocation: {error}"))?;
+    let revoke =
+        claim_next_revocation(database, &scenario.authority, old_key, 2_224_000, 2_225_000)
+            .await
+            .map_err(|error| format!("claim prior-generation revocation: {error}"))?;
     set_database_test_clock(database, 2_224_500).await?;
     let revoked = database
         .store()
@@ -952,18 +1084,10 @@ async fn retire_lifecycle_authority(
         authority.authority_id(),
         GithubServerServiceGeneration::new(2)?,
     );
-    set_database_test_clock(database, 2_231_000).await?;
-    let current_revoke = database
-        .store()
-        .claim_github_server_service_revocation(ClaimGithubServerServiceRevocation::new(
-            authority_selector(authority),
-            current_key,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(2_231_000),
-            UnixMillis::new(2_232_000),
-        )?)
-        .await
-        .map_err(|error| format!("claim current-generation revocation: {error}"))?;
+    let current_revoke =
+        claim_next_revocation(database, authority, current_key, 2_231_000, 2_232_000)
+            .await
+            .map_err(|error| format!("claim current-generation revocation: {error}"))?;
     set_database_test_clock(database, 2_231_500).await?;
     database
         .store()
@@ -1272,18 +1396,14 @@ async fn prepare_expired_mint(
         100,
     )
     .await?;
-    set_database_test_clock(database, 1_000).await?;
-    let claimed = database
-        .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            authority_selector(&identity),
-            GithubServerServiceGeneration::new(1)?,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(1_000),
-            UnixMillis::new(2_000),
-            UnixMillis::new(1_500),
-        )?)
-        .await?;
+    let claimed = claim_next_mint(
+        database,
+        &identity,
+        GithubServerServiceGeneration::new(1)?,
+        1_000,
+        2_000,
+    )
+    .await?;
     set_database_test_clock(database, 1_100).await?;
     database
         .store()
@@ -1339,44 +1459,25 @@ async fn reconcile_expired_mint(
     claimed: &automata_ci_store::ClaimedGithubServerServiceMint,
 ) -> TestResult<GithubServerServiceIssuanceKey> {
     let key = claimed.claim().key();
-    set_database_test_clock(database, 1_499).await?;
-    let early = database
-        .store()
-        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
-            authority_selector(identity),
-            key,
-            UnixMillis::new(1_499),
-        )?)
-        .await
-        .expect_err("a live mint claim must not be reconciled");
-    assert!(matches!(
-        early,
-        GithubServerServiceStoreError::ClaimRejected
-    ));
+    let early = claim_next_maintenance(database, identity.tenant(), 1_999, 2_099).await?;
+    assert!(early.is_none(), "a live mint claim must not be reduced");
+    assert_issuance_state(database, key, "minting").await?;
 
-    set_database_test_clock(database, 1_500).await?;
-    let indeterminate = database
-        .store()
-        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
-            authority_selector(identity),
-            key,
-            UnixMillis::new(1_500),
-        )?)
-        .await?;
-    assert_eq!(
-        indeterminate.state(),
-        GithubServerServiceIssuanceState::Indeterminate
+    claim_next_reduced(
+        database,
+        identity,
+        key,
+        2_000,
+        2_100,
+        GithubServerServiceIssuanceState::Indeterminate,
+    )
+    .await?;
+    let replay = claim_next_maintenance(database, identity.tenant(), 2_100, 2_200).await?;
+    assert!(
+        replay.is_none(),
+        "an already reduced generation must not be rediscovered"
     );
-    set_database_test_clock(database, 1_600).await?;
-    let replay = database
-        .store()
-        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
-            authority_selector(identity),
-            key,
-            UnixMillis::new(1_600),
-        )?)
-        .await?;
-    assert_eq!(replay, indeterminate);
+    assert_issuance_state(database, key, "indeterminate").await?;
     Ok(key)
 }
 
@@ -1385,22 +1486,12 @@ async fn assert_indeterminate_mint_gate(
     identity: &GithubServerServiceAuthorityIdentity,
     key: GithubServerServiceIssuanceKey,
 ) -> TestResult<GithubServerServiceGeneration> {
-    set_database_test_clock(database, 1_700).await?;
-    let remint = database
-        .store()
-        .reclaim_github_server_service_mint(ReclaimGithubServerServiceMint::new(
-            authority_selector(identity),
-            key,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(1_700),
-            UnixMillis::new(1_800),
-        )?)
-        .await
-        .expect_err("an ambiguous generation must never be reminted");
-    assert!(matches!(
-        remint,
-        GithubServerServiceStoreError::ClaimRejected
-    ));
+    let remint = claim_next_maintenance(database, identity.tenant(), 2_200, 2_300).await?;
+    assert!(
+        remint.is_none(),
+        "an ambiguous generation must never be reminted"
+    );
+    assert_issuance_state(database, key, "indeterminate").await?;
     let descriptor = database
         .store()
         .inspect_github_server_service_authority(identity.tenant(), identity.authority_id())
@@ -1408,23 +1499,11 @@ async fn assert_indeterminate_mint_gate(
     assert_eq!(descriptor.refresh_generation(), None);
 
     let next_generation = GithubServerServiceGeneration::new(2)?;
-    set_database_test_clock(database, 2_100).await?;
-    let gated = database
-        .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            authority_selector(identity),
-            next_generation,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(2_100),
-            UnixMillis::new(3_000),
-            UnixMillis::new(2_500),
-        )?)
-        .await
-        .expect_err("indeterminate authority must gate a successor until safe erasure");
-    assert!(matches!(
-        gated,
-        GithubServerServiceStoreError::ClaimRejected
-    ));
+    let gated = claim_next_maintenance(database, identity.tenant(), 2_300, 2_400).await?;
+    assert!(
+        gated.is_none(),
+        "indeterminate authority must gate a successor until safe erasure"
+    );
     Ok(next_generation)
 }
 
@@ -1434,54 +1513,35 @@ async fn erase_and_advance_indeterminate_mint(
     key: GithubServerServiceIssuanceKey,
     next_generation: GithubServerServiceGeneration,
 ) -> TestResult {
-    set_database_test_clock(database, 3_781_999).await?;
-    let early = database
-        .store()
-        .erase_expired_github_server_service_issuance(EraseExpiredGithubServerServiceIssuance::new(
-            authority_selector(identity),
-            key,
-            UnixMillis::new(3_781_999),
-        )?)
-        .await
-        .expect_err("ambiguous custody must remain until conservative expiry");
-    assert!(matches!(
-        early,
-        GithubServerServiceStoreError::ClaimRejected
-    ));
-    set_database_test_clock(database, 3_782_000).await?;
-    let erased = database
-        .store()
-        .erase_expired_github_server_service_issuance(EraseExpiredGithubServerServiceIssuance::new(
-            authority_selector(identity),
-            key,
-            UnixMillis::new(3_782_000),
-        )?)
-        .await?;
-    assert_eq!(erased.state(), GithubServerServiceIssuanceState::Revoked);
-
-    set_database_test_clock(database, 3_782_000).await?;
-    database
-        .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            authority_selector(identity),
-            next_generation,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(3_782_000),
-            UnixMillis::new(3_783_000),
-            UnixMillis::new(3_782_500),
-        )?)
-        .await?;
+    let early = claim_next_maintenance(database, identity.tenant(), 3_781_999, 3_782_099).await?;
+    assert!(
+        early.is_none(),
+        "ambiguous custody must remain until conservative expiry"
+    );
+    assert_issuance_state(database, key, "indeterminate").await?;
+    let claimed =
+        claim_next_mint(database, identity, next_generation, 3_782_000, 3_782_500).await?;
     let pre_io_key = GithubServerServiceIssuanceKey::new(identity.authority_id(), next_generation);
-    set_database_test_clock(database, 3_782_500).await?;
-    let rejected = database
-        .store()
-        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
-            authority_selector(identity),
-            pre_io_key,
-            UnixMillis::new(3_782_500),
-        )?)
-        .await?;
-    assert_eq!(rejected.state(), GithubServerServiceIssuanceState::Rejected);
+    assert_eq!(claimed.claim().key(), pre_io_key);
+    assert_issuance_state(database, key, "indeterminate").await?;
+    claim_next_reduced(
+        database,
+        identity,
+        key,
+        3_782_000,
+        3_782_100,
+        GithubServerServiceIssuanceState::Revoked,
+    )
+    .await?;
+    claim_next_reduced(
+        database,
+        identity,
+        pre_io_key,
+        3_782_500,
+        3_782_600,
+        GithubServerServiceIssuanceState::Rejected,
+    )
+    .await?;
     Ok(())
 }
 
@@ -1500,18 +1560,7 @@ async fn late_known_token_narrows_indeterminate_failure_gate_to_authenticated_ex
         )
         .await?;
         let generation = GithubServerServiceGeneration::new(1)?;
-        set_database_test_clock(&database, 1_000).await?;
-        let claimed = database
-            .store()
-            .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-                authority_selector(&identity),
-                generation,
-                GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-                UnixMillis::new(1_000),
-                UnixMillis::new(2_000),
-                UnixMillis::new(1_500),
-            )?)
-            .await?;
+        let claimed = claim_next_mint(&database, &identity, generation, 1_000, 2_000).await?;
         set_database_test_clock(&database, 1_100).await?;
         database
             .store()
@@ -1521,17 +1570,15 @@ async fn late_known_token_narrows_indeterminate_failure_gate_to_authenticated_ex
             )?)
             .await?;
         let key = claimed.claim().key();
-        set_database_test_clock(&database, 1_500).await?;
-        database
-            .store()
-            .reconcile_expired_github_server_service_mint(
-                ReconcileExpiredGithubServerServiceMint::new(
-                    authority_selector(&identity),
-                    key,
-                    UnixMillis::new(1_500),
-                )?,
-            )
-            .await?;
+        claim_next_reduced(
+            &database,
+            &identity,
+            key,
+            2_000,
+            2_100,
+            GithubServerServiceIssuanceState::Indeterminate,
+        )
+        .await?;
         let ambiguous = database
             .store()
             .inspect_github_server_service_authority(identity.tenant(), identity.authority_id())
@@ -1552,34 +1599,12 @@ async fn late_known_token_narrows_indeterminate_failure_gate_to_authenticated_ex
         );
 
         let successor = GithubServerServiceGeneration::new(2)?;
-        set_database_test_clock(&database, 219_999).await?;
-        let early = database
-            .store()
-            .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-                authority_selector(&identity),
-                successor,
-                GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-                UnixMillis::new(219_999),
-                UnixMillis::new(220_099),
-                UnixMillis::new(220_098),
-            )?)
-            .await;
-        assert!(matches!(
-            early,
-            Err(GithubServerServiceStoreError::ClaimRejected)
-        ));
-        set_database_test_clock(&database, 220_000).await?;
-        database
-            .store()
-            .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-                authority_selector(&identity),
-                successor,
-                GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-                UnixMillis::new(220_000),
-                UnixMillis::new(220_100),
-                UnixMillis::new(220_099),
-            )?)
-            .await?;
+        let early = claim_next_maintenance(&database, identity.tenant(), 219_999, 220_099).await?;
+        assert!(
+            early.is_none(),
+            "the authenticated expiry gate is exclusive"
+        );
+        claim_next_mint(&database, &identity, successor, 220_000, 220_100).await?;
         Ok(())
     })
     .await
@@ -1611,9 +1636,9 @@ async fn finish_late_known_token(
     let revoke_only = FinishGithubServerServiceMint::issued_revoke_only(
         claimed.claim().clone(),
         protected,
-        UnixMillis::new(1_600),
+        UnixMillis::new(2_100),
     )?;
-    set_database_test_clock(database, 1_600).await?;
+    set_database_test_clock(database, 2_100).await?;
     let retained = database
         .store()
         .finish_github_server_service_mint(&revoke_only)
@@ -2238,36 +2263,81 @@ async fn claim_next_maintenance(
         .await?)
 }
 
-async fn reject_claimed_generation(
+async fn claim_next_mint(
     database: &TestDatabase,
     identity: &GithubServerServiceAuthorityIdentity,
-    generation: u64,
-    requested_at: i64,
-) -> TestResult<i64> {
-    set_database_test_clock(database, requested_at).await?;
-    let claimed = database
-        .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            authority_selector(identity),
-            GithubServerServiceGeneration::new(generation)?,
-            GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-            UnixMillis::new(requested_at),
-            UnixMillis::new(requested_at + 100),
-            UnixMillis::new(requested_at + 99),
-        )?)
-        .await?;
-    let rejected_at = requested_at + 99;
-    set_database_test_clock(database, rejected_at).await?;
-    let receipt = database
-        .store()
-        .reconcile_expired_github_server_service_mint(ReconcileExpiredGithubServerServiceMint::new(
-            authority_selector(identity),
-            claimed.claim().key(),
-            UnixMillis::new(rejected_at),
-        )?)
-        .await?;
-    assert_eq!(receipt.state(), GithubServerServiceIssuanceState::Rejected);
-    Ok(rejected_at + GITHUB_SERVICE_GENERATION_FAILURE_BACKOFF_MILLIS)
+    generation: GithubServerServiceGeneration,
+    observed_at: i64,
+    expires_at: i64,
+) -> TestResult<automata_ci_store::ClaimedGithubServerServiceMint> {
+    let outcome = claim_next_maintenance(database, identity.tenant(), observed_at, expires_at)
+        .await?
+        .expect("the exact authority must have one due mint");
+    let GithubServerServiceMaintenanceOutcome::Mint(claimed) = outcome else {
+        panic!("the exact authority must produce a mint outcome");
+    };
+    let expected_key = GithubServerServiceIssuanceKey::new(identity.authority_id(), generation);
+    assert_eq!(claimed.claim().selector(), &authority_selector(identity));
+    assert_eq!(claimed.claim().key(), expected_key);
+    Ok(*claimed)
+}
+
+async fn claim_next_revocation(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+    key: GithubServerServiceIssuanceKey,
+    observed_at: i64,
+    expires_at: i64,
+) -> TestResult<automata_ci_store::ClaimedGithubServerServiceRevocation> {
+    let outcome = claim_next_maintenance(database, identity.tenant(), observed_at, expires_at)
+        .await?
+        .expect("the exact authority must have one due revocation");
+    let GithubServerServiceMaintenanceOutcome::Revocation(claimed) = outcome else {
+        panic!("the exact authority must produce a revocation outcome");
+    };
+    assert_eq!(claimed.claim().selector(), &authority_selector(identity));
+    assert_eq!(claimed.claim().key(), key);
+    Ok(*claimed)
+}
+
+async fn claim_next_reduced(
+    database: &TestDatabase,
+    identity: &GithubServerServiceAuthorityIdentity,
+    key: GithubServerServiceIssuanceKey,
+    observed_at: i64,
+    expires_at: i64,
+    expected_state: GithubServerServiceIssuanceState,
+) -> TestResult<automata_ci_store::GithubServerServiceIssuanceReceipt> {
+    let outcome = claim_next_maintenance(database, identity.tenant(), observed_at, expires_at)
+        .await?
+        .expect("the exact authority must have one due reduction");
+    let GithubServerServiceMaintenanceOutcome::Reduced { selector, receipt } = outcome else {
+        panic!("the exact authority must produce a reduced outcome");
+    };
+    assert_eq!(selector, authority_selector(identity));
+    assert_eq!(receipt.key(), key);
+    assert_eq!(receipt.state(), expected_state);
+    Ok(receipt)
+}
+
+async fn assert_issuance_state(
+    database: &TestDatabase,
+    key: GithubServerServiceIssuanceKey,
+    expected: &str,
+) -> TestResult {
+    let state: String = sqlx::query_scalar(
+        r"
+        SELECT state
+        FROM github_server_service_authority_issuances
+        WHERE authority_id = $1 AND generation = $2
+        ",
+    )
+    .bind(key.authority_id().as_uuid())
+    .bind(i64::try_from(key.generation().get())?)
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(state, expected);
+    Ok(())
 }
 
 async fn mint_ready(
@@ -2280,20 +2350,15 @@ async fn mint_ready(
 ) -> TestResult {
     let generation_number = generation;
     let generation = GithubServerServiceGeneration::new(generation)?;
-    let worker = GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?;
-    set_database_test_clock(database, requested_at).await?;
-    let claimed = database
-        .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            authority_selector(identity),
-            generation,
-            worker,
-            UnixMillis::new(requested_at),
-            UnixMillis::new(claim_expires_at),
-            UnixMillis::new(claim_expires_at - 1),
-        )?)
-        .await
-        .map_err(|error| format!("claim ready generation {generation_number}: {error}"))?;
+    let claimed = claim_next_mint(
+        database,
+        identity,
+        generation,
+        requested_at,
+        claim_expires_at,
+    )
+    .await
+    .map_err(|error| format!("claim ready generation {generation_number}: {error}"))?;
     set_database_test_clock(database, requested_at + 10).await?;
     database
         .store()

--- a/crates/automata-ci-postgres/tests/store/provider/github_service_authority_clock.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_service_authority_clock.rs
@@ -4,17 +4,15 @@ use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_key_management::{EncryptedEnvelope, KeyId, WrappedDataKey};
 use automata_ci_store::{
     BeginGithubServerServiceMint, BeginGithubServerServiceMintOutcome,
-    ClaimGithubServerServiceMint, ClaimGithubServerServiceRevocation,
     ClaimNextGithubServerServiceMaintenance, EnsureGithubServerServiceAuthority,
-    EraseExpiredGithubServerServiceIssuance, FinishGithubServerServiceMint, GithubRepositoryName,
-    GithubServerServiceAppClientId, GithubServerServiceAppId, GithubServerServiceAuthorityId,
-    GithubServerServiceAuthorityIdentity, GithubServerServiceAuthorityRepository as _,
-    GithubServerServiceAuthoritySelector, GithubServerServiceEnvelopeMetadata,
+    FinishGithubServerServiceMint, GithubRepositoryName, GithubServerServiceAppClientId,
+    GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
+    GithubServerServiceAuthorityRepository as _, GithubServerServiceEnvelopeMetadata,
     GithubServerServiceGeneration, GithubServerServiceIssuanceState, GithubServerServiceJwtIssuer,
     GithubServerServiceMaintenanceOutcome, GithubServerServiceRevision, GithubServerServiceScope,
     GithubServerServiceStoreError, GithubServerServiceWorkerId,
     ProtectedGithubServerServiceCredential, ProviderConnectionId, ProviderInstallationId,
-    ProviderRepositoryId, ReconcileExpiredGithubServerServiceMint, RepositoryId, TenantScope,
+    ProviderRepositoryId, RepositoryId, TenantScope,
 };
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -22,7 +20,6 @@ use uuid::Uuid;
 use crate::support::{TestClock, TestDatabase, TestResult, run_with_unmigrated_database};
 
 const CLAIM_DURATION_MILLIS: i64 = 2_000;
-const REQUEST_DURATION_MILLIS: i64 = 10_000;
 
 #[derive(Clone)]
 struct Fixture {
@@ -97,18 +94,35 @@ async fn caller_clock_is_admission_only_and_database_issues_full_duration() -> T
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
-async fn delayed_authority_lock_rebases_both_fences_and_replays_exact_duration() -> TestResult {
+#[allow(clippy::too_many_lines)] // One lock wait proves operation-time rebasing and duplicate suppression.
+async fn delayed_refresh_issuance_lock_rebases_atomic_fences_without_duplicate() -> TestResult {
     run_with_unmigrated_database(|database| async move {
         let clock = TestClock::freeze_at_database_now(database.pool()).await?;
         apply_authority_migrations(&database).await?;
         let fixture = seed_authority(&database).await?;
+
+        let current = claim_and_begin(&database, &fixture, CLAIM_DURATION_MILLIS).await?;
+        let committed_at = current.claimed_at().get() + 50;
+        clock.set(committed_at).await?;
+        let ready = database
+            .store()
+            .finish_github_server_service_mint(&FinishGithubServerServiceMint::ready(
+                current.claim().clone(),
+                protected_for_claim(&fixture.identity, &current)?,
+                UnixMillis::new(committed_at),
+            )?)
+            .await?;
+        assert_eq!(ready.state(), GithubServerServiceIssuanceState::Ready);
+
+        // The fixture credential expires 3,600,000ms after its request and
+        // refresh becomes due 1,680,000ms before that expiry.
+        let refresh_due_at = current.receipt().requested_at().get() + 1_920_000;
+        clock.set(refresh_due_at).await?;
         let caller_observed_at = database_now_ms(&database).await?;
-        let request = ClaimGithubServerServiceMint::new(
-            selector(&fixture.identity),
-            GithubServerServiceGeneration::new(1)?,
+        let request = ClaimNextGithubServerServiceMaintenance::new(
+            fixture.tenant.clone(),
             GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
             UnixMillis::new(caller_observed_at),
-            UnixMillis::new(caller_observed_at + REQUEST_DURATION_MILLIS),
             UnixMillis::new(caller_observed_at + CLAIM_DURATION_MILLIS),
         )?;
         let replay_request = request.clone();
@@ -117,22 +131,29 @@ async fn delayed_authority_lock_rebases_both_fences_and_replays_exact_duration()
         let blocking_backend_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
             .fetch_one(&mut *blocker)
             .await?;
-        sqlx::query("SELECT id FROM github_server_service_authorities WHERE id = $1 FOR UPDATE")
-            .bind(fixture.identity.authority_id().as_uuid())
-            .fetch_one(&mut *blocker)
-            .await?;
+        sqlx::query(
+            r"
+            SELECT generation
+            FROM github_server_service_authority_issuances
+            WHERE authority_id = $1 AND generation = 1
+            FOR UPDATE
+            ",
+        )
+        .bind(fixture.identity.authority_id().as_uuid())
+        .fetch_one(&mut *blocker)
+        .await?;
 
         let claimant_database = Arc::clone(&database);
         let claimant = tokio::spawn(async move {
             claimant_database
                 .store()
-                .claim_github_server_service_mint(request)
+                .claim_next_github_server_service_maintenance(request)
                 .await
         });
         wait_for_backend_blocked_by(
             database.pool(),
             blocking_backend_pid,
-            "FROM github_server_service_authorities",
+            "mint_claim_fence, mint_claim_owner_id",
         )
         .await?;
         clock
@@ -145,7 +166,20 @@ async fn delayed_authority_lock_rebases_both_fences_and_replays_exact_duration()
         let release_floor = database_now_ms(&database).await?;
         blocker.commit().await?;
 
-        let claimed = tokio::time::timeout(Duration::from_secs(10), claimant).await???;
+        let outcome = tokio::time::timeout(Duration::from_secs(10), claimant)
+            .await???
+            .expect("the due refresh must remain discoverable after the issuance lock");
+        let GithubServerServiceMaintenanceOutcome::Mint(claimed) = outcome else {
+            panic!("the due refresh must produce a mint claim");
+        };
+        assert_eq!(
+            claimed.claim().key().authority_id(),
+            fixture.identity.authority_id()
+        );
+        assert_eq!(
+            claimed.claim().key().generation(),
+            GithubServerServiceGeneration::new(2)?
+        );
         assert!(claimed.claimed_at().get() >= release_floor);
         assert_eq!(claimed.receipt().requested_at(), claimed.claimed_at());
         assert_eq!(
@@ -154,20 +188,20 @@ async fn delayed_authority_lock_rebases_both_fences_and_replays_exact_duration()
         );
         assert_eq!(
             claimed.receipt().request_deadline().get() - claimed.receipt().requested_at().get(),
-            REQUEST_DURATION_MILLIS
+            CLAIM_DURATION_MILLIS
         );
         assert!(
             claimed.claimed_at().get() >= caller_observed_at + CLAIM_DURATION_MILLIS,
             "the original caller lease had elapsed before the row lock was released"
         );
 
-        let replayed = database
+        let duplicate = database
             .store()
-            .claim_github_server_service_mint(replay_request)
+            .claim_next_github_server_service_maintenance(replay_request)
             .await?;
-        assert_eq!(
-            replayed, claimed,
-            "rebased lost response must replay exactly"
+        assert!(
+            duplicate.is_none(),
+            "a live rebased refresh claim must not be duplicated"
         );
         Ok(())
     })
@@ -180,7 +214,7 @@ async fn fast_clock_cannot_reduce_live_mint_or_erase_ready_custody() -> TestResu
     run_with_unmigrated_database(|database| async move {
         apply_authority_migrations(&database).await?;
         let fixture = seed_authority(&database).await?;
-        let claimed = claim_and_begin(&database, &fixture, 30_000, 120_000).await?;
+        let claimed = claim_and_begin(&database, &fixture, 30_000).await?;
 
         let fast_observed_at = database_now_ms(&database).await? + 45_000;
         let maintenance = database
@@ -199,21 +233,6 @@ async fn fast_clock_cannot_reduce_live_mint_or_erase_ready_custody() -> TestResu
             "database-live mint must not be reduced"
         );
 
-        let reconcile = database
-            .store()
-            .reconcile_expired_github_server_service_mint(
-                ReconcileExpiredGithubServerServiceMint::new(
-                    selector(&fixture.identity),
-                    claimed.claim().key(),
-                    UnixMillis::new(fast_observed_at),
-                )?,
-            )
-            .await;
-        assert!(matches!(
-            reconcile,
-            Err(GithubServerServiceStoreError::ClaimRejected)
-        ));
-
         let committed_at = UnixMillis::new(database_now_ms(&database).await?);
         let protected = protected_for_claim(&fixture.identity, &claimed)?;
         let finish =
@@ -224,20 +243,6 @@ async fn fast_clock_cannot_reduce_live_mint_or_erase_ready_custody() -> TestResu
             .await?;
         assert_eq!(ready.state(), GithubServerServiceIssuanceState::Ready);
 
-        let erase = database
-            .store()
-            .erase_expired_github_server_service_issuance(
-                EraseExpiredGithubServerServiceIssuance::new(
-                    selector(&fixture.identity),
-                    ready.key(),
-                    ready.safe_erase_after(),
-                )?,
-            )
-            .await;
-        assert!(matches!(
-            erase,
-            Err(GithubServerServiceStoreError::ClaimRejected)
-        ));
         let scan = database
             .store()
             .claim_next_github_server_service_maintenance(
@@ -266,7 +271,7 @@ async fn late_ready_result_is_retained_revoke_only_and_replays() -> TestResult {
         let clock = TestClock::freeze_at_database_now(database.pool()).await?;
         apply_authority_migrations(&database).await?;
         let fixture = seed_authority(&database).await?;
-        let claimed = claim_and_begin(&database, &fixture, 2_000, 5_000).await?;
+        let claimed = claim_and_begin(&database, &fixture, 2_000).await?;
         let protected = protected_for_claim(&fixture.identity, &claimed)?;
         let committed_at = UnixMillis::new(claimed.claimed_at().get() + 50);
         let finish =
@@ -300,31 +305,40 @@ async fn late_ready_result_is_retained_revoke_only_and_replays() -> TestResult {
         assert_eq!(replayed, retained);
 
         let revocation_observed_at = database_now_ms(&database).await?;
-        let revocation_request = ClaimGithubServerServiceRevocation::new(
-            selector(&fixture.identity),
-            retained.key(),
+        let revocation_request = ClaimNextGithubServerServiceMaintenance::new(
+            fixture.tenant.clone(),
             GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
             UnixMillis::new(revocation_observed_at),
             UnixMillis::new(revocation_observed_at + 500),
         )?;
-        let revocation_replay_request = revocation_request.clone();
-        let first = database
+        let first_outcome = database
             .store()
-            .claim_github_server_service_revocation(revocation_request.clone())
-            .await?;
-        let replay = database
+            .claim_next_github_server_service_maintenance(revocation_request.clone())
+            .await?
+            .expect("the retained credential must be due for revocation");
+        let GithubServerServiceMaintenanceOutcome::Revocation(first) = first_outcome else {
+            panic!("the retained credential must produce a revocation claim");
+        };
+        assert_eq!(first.claim().key(), retained.key());
+        let live_duplicate = database
             .store()
-            .claim_github_server_service_revocation(revocation_replay_request)
+            .claim_next_github_server_service_maintenance(revocation_request.clone())
             .await?;
-        assert_eq!(replay.claim(), first.claim());
-        assert_eq!(replay.claimed_at(), first.claimed_at());
-        assert_eq!(replay.claim_expires_at(), first.claim_expires_at());
+        assert!(
+            live_duplicate.is_none(),
+            "a live revocation claim must not be duplicated"
+        );
 
         wait_until_database_time(&clock, first.claim_expires_at().get()).await?;
-        let takeover = database
+        let takeover_outcome = database
             .store()
-            .claim_github_server_service_revocation(revocation_request)
-            .await?;
+            .claim_next_github_server_service_maintenance(revocation_request)
+            .await?
+            .expect("the expired revocation claim must be recoverable");
+        let GithubServerServiceMaintenanceOutcome::Revocation(takeover) = takeover_outcome else {
+            panic!("the expired revocation must produce a replacement claim");
+        };
+        assert_eq!(takeover.claim().key(), retained.key());
         assert_eq!(
             takeover.claim().fence().get(),
             first.claim().fence().get() + 1
@@ -406,20 +420,30 @@ async fn claim_and_begin(
     database: &TestDatabase,
     fixture: &Fixture,
     claim_duration: i64,
-    request_duration: i64,
 ) -> TestResult<automata_ci_store::ClaimedGithubServerServiceMint> {
     let observed_at = database_now_ms(database).await?;
-    let claimed = database
+    let outcome = database
         .store()
-        .claim_github_server_service_mint(ClaimGithubServerServiceMint::new(
-            selector(&fixture.identity),
-            GithubServerServiceGeneration::new(1)?,
+        .claim_next_github_server_service_maintenance(ClaimNextGithubServerServiceMaintenance::new(
+            fixture.tenant.clone(),
             GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
             UnixMillis::new(observed_at),
-            UnixMillis::new(observed_at + request_duration),
             UnixMillis::new(observed_at + claim_duration),
         )?)
-        .await?;
+        .await?
+        .expect("the bootstrap authority must produce one mint claim");
+    let GithubServerServiceMaintenanceOutcome::Mint(claimed) = outcome else {
+        panic!("the bootstrap authority must produce a mint outcome");
+    };
+    let claimed = *claimed;
+    assert_eq!(
+        claimed.claim().key().authority_id(),
+        fixture.identity.authority_id()
+    );
+    assert_eq!(
+        claimed.claim().key().generation(),
+        GithubServerServiceGeneration::new(1)?
+    );
     database
         .store()
         .begin_github_server_service_mint(BeginGithubServerServiceMint::new(
@@ -453,12 +477,6 @@ fn protected_for_claim(
             vec![9; 48],
         )?,
     )?)
-}
-
-fn selector(
-    identity: &GithubServerServiceAuthorityIdentity,
-) -> GithubServerServiceAuthoritySelector {
-    GithubServerServiceAuthoritySelector::from_identity(identity)
 }
 
 async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -6,30 +6,26 @@ use uuid::Uuid;
 
 use automata_ci_store::{
     AcquireGithubServerServiceHandoff, BeginGithubServerServiceMint,
-    BeginGithubServerServiceMintOutcome, ClaimGithubServerServiceMint,
-    ClaimGithubServerServiceRevocation, ClaimNextGithubServerServiceMaintenance,
+    BeginGithubServerServiceMintOutcome, ClaimNextGithubServerServiceMaintenance,
     ClaimedGithubServerServiceMint, ClaimedGithubServerServiceRevocation,
-    EnsureGithubServerServiceAuthority, EraseExpiredGithubServerServiceIssuance,
-    FinishGithubServerServiceMint, FinishGithubServerServiceRevocation,
-    GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS, GithubRepositoryName, GithubServerServiceAction,
-    GithubServerServiceAppClientId, GithubServerServiceAppId,
-    GithubServerServiceAuthorityDescriptor, GithubServerServiceAuthorityId,
-    GithubServerServiceAuthorityIdentity, GithubServerServiceAuthorityRepository,
-    GithubServerServiceAuthoritySelector, GithubServerServiceAuthorityState,
-    GithubServerServiceClaim, GithubServerServiceClaimFence, GithubServerServiceConsumerClaim,
-    GithubServerServiceConsumerId, GithubServerServiceCredentialHandoff,
-    GithubServerServiceEnvelopeMetadata, GithubServerServiceGeneration,
-    GithubServerServiceHandoffId, GithubServerServiceIssuanceKey,
+    EnsureGithubServerServiceAuthority, FinishGithubServerServiceMint,
+    FinishGithubServerServiceRevocation, GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS,
+    GithubRepositoryName, GithubServerServiceAction, GithubServerServiceAppClientId,
+    GithubServerServiceAppId, GithubServerServiceAuthorityDescriptor,
+    GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
+    GithubServerServiceAuthorityRepository, GithubServerServiceAuthoritySelector,
+    GithubServerServiceAuthorityState, GithubServerServiceClaim, GithubServerServiceClaimFence,
+    GithubServerServiceConsumerClaim, GithubServerServiceConsumerId,
+    GithubServerServiceCredentialHandoff, GithubServerServiceEnvelopeMetadata,
+    GithubServerServiceGeneration, GithubServerServiceHandoffId, GithubServerServiceIssuanceKey,
     GithubServerServiceIssuanceReceipt, GithubServerServiceIssuanceState,
     GithubServerServiceJwtIssuer, GithubServerServiceMaintenanceOutcome,
     GithubServerServiceRevision, GithubServerServiceScope, GithubServerServiceStoreError,
     GithubServerServiceWorkerId, MAX_GITHUB_SERVICE_CONSECUTIVE_GENERATION_FAILURES,
-    MAX_GITHUB_SERVICE_HANDOFF_MILLIS, MAX_GITHUB_SERVICE_MINT_ATTEMPTS,
-    MAX_GITHUB_SERVICE_REQUEST_MILLIS, MAX_GITHUB_SERVICE_REVOKE_ATTEMPTS,
+    MAX_GITHUB_SERVICE_MINT_ATTEMPTS, MAX_GITHUB_SERVICE_REVOKE_ATTEMPTS,
     MIN_GITHUB_SERVICE_READY_USE_MILLIS, ProtectedGithubServerServiceCredential,
     ProviderConnectionId, ProviderInstallationId, ProviderRepositoryId,
-    QuarantineGithubServerServiceCredential, ReclaimGithubServerServiceMint,
-    ReconcileExpiredGithubServerServiceMint, ReleaseGithubServerServiceHandoff, RepositoryId,
+    QuarantineGithubServerServiceCredential, ReleaseGithubServerServiceHandoff, RepositoryId,
     RetireGithubServerServiceAuthority, Sha256Digest, TenantScope,
 };
 
@@ -202,247 +198,6 @@ impl GithubServerServiceAuthorityRepository for PostgresStore {
         load_authority_from_pool(&self.pool, tenant, authority_id).await
     }
 
-    async fn claim_github_server_service_mint(
-        &self,
-        request: ClaimGithubServerServiceMint,
-    ) -> Result<ClaimedGithubServerServiceMint, GithubServerServiceStoreError> {
-        let claim_duration =
-            requested_duration(request.requested_at(), request.claim_expires_at())?;
-        let request_duration =
-            requested_duration(request.requested_at(), request.request_deadline())?;
-        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
-        pin_read_committed(&mut transaction).await?;
-        let authority_row = select_authority_for_update(&mut transaction, request.selector())
-            .await?
-            .ok_or(GithubServerServiceStoreError::NotFound)?;
-        let mut descriptor = decode_authority(&authority_row)?;
-        let key = GithubServerServiceIssuanceKey::new(request.authority_id(), request.generation());
-
-        if let Some(existing) = select_issuance_for_update(&mut transaction, key).await? {
-            let database_now = database_now_ms(&mut transaction).await?;
-            let exact = exact_mint_claim_replay(
-                &existing,
-                request.worker(),
-                claim_duration,
-                request_duration,
-            )? && live_mint_claim_at(&existing, database_now)?;
-            if !exact {
-                return Err(GithubServerServiceStoreError::RefreshAlreadyActive);
-            }
-            let claimed = decode_claimed_mint(descriptor.identity().clone(), &existing)?;
-            transaction.commit().await.map_err(operation_error)?;
-            return Ok(claimed);
-        }
-        if descriptor.state() != GithubServerServiceAuthorityState::Active {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-        if descriptor.refresh_generation().is_some() {
-            return Err(GithubServerServiceStoreError::RefreshAlreadyActive);
-        }
-        let mut database_now = database_now_ms(&mut transaction).await?;
-        validate_caller_clock(request.requested_at(), database_now)?;
-        if descriptor.consecutive_generation_failures()
-            >= MAX_GITHUB_SERVICE_CONSECUTIVE_GENERATION_FAILURES
-        {
-            if !rearm_github_server_service_failure_budget(
-                &mut transaction,
-                &descriptor,
-                UnixMillis::new(database_now),
-            )
-            .await?
-            {
-                return Err(GithubServerServiceStoreError::RetryLimitReached);
-            }
-            let rearmed = select_authority_for_update(&mut transaction, request.selector())
-                .await?
-                .ok_or(GithubServerServiceStoreError::CorruptData)?;
-            descriptor = decode_authority(&rearmed)?;
-            database_now = database_now_ms(&mut transaction).await?;
-            validate_caller_clock(request.requested_at(), database_now)?;
-        }
-        if descriptor
-            .next_mint_not_before()
-            .is_some_and(|not_before| not_before.get() > database_now)
-        {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-        if descriptor.next_generation() != request.generation() {
-            return Err(GithubServerServiceStoreError::FenceExhausted);
-        }
-        if let Some(current_generation) = descriptor.current_generation() {
-            let current_key =
-                GithubServerServiceIssuanceKey::new(request.authority_id(), current_generation);
-            let current = select_issuance_for_update(&mut transaction, current_key)
-                .await?
-                .ok_or(GithubServerServiceStoreError::CorruptData)?;
-            database_now = database_now_ms(&mut transaction).await?;
-            validate_caller_clock(request.requested_at(), database_now)?;
-            let refresh_due_by = MAX_GITHUB_SERVICE_HANDOFF_MILLIS
-                .checked_add(MAX_GITHUB_SERVICE_REQUEST_MILLIS)
-                .and_then(|lead| database_now.checked_add(lead))
-                .ok_or(GithubServerServiceStoreError::CorruptData)?;
-            if issuance_state(&current)? != GithubServerServiceIssuanceState::Ready
-                || optional_i64(&current, "provider_expires_at_ms")?
-                    .and_then(|expires| expires.checked_sub(60_000))
-                    .is_none_or(|usable_until| usable_until > refresh_due_by)
-            {
-                return Err(GithubServerServiceStoreError::ClaimRejected);
-            }
-        }
-        let claim_expires_at = issue_deadline(database_now, claim_duration)?;
-        let request_deadline = issue_deadline(database_now, request_duration)?;
-        if claim_expires_at > request_deadline {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-        let next_generation = request
-            .generation()
-            .get()
-            .checked_add(1)
-            .filter(|value| i64::try_from(*value).is_ok())
-            .ok_or(GithubServerServiceStoreError::FenceExhausted)?;
-        let conservative_expiry = request_deadline
-            .checked_add(3_780_000)
-            .ok_or(GithubServerServiceStoreError::CorruptData)?;
-        sqlx::query(
-            r"
-            INSERT INTO github_server_service_authority_issuances (
-                tenant_id, authority_id, generation, state,
-                mint_attempt_count, mint_claim_fence, mint_claim_owner_id,
-                mint_claimed_at_ms, mint_claim_expires_at_ms,
-                requested_at_ms, request_deadline_at_ms,
-                conservative_expiry_at_ms, safe_erase_after_ms,
-                created_at_ms, state_updated_at_ms
-            ) VALUES (
-                $1, $2, $3, 'claimed', 1, 1, $4, $5, $6,
-                $5, $7, $8, $8, $5, $5
-            )
-            ",
-        )
-        .bind(descriptor.identity().tenant().as_str())
-        .bind(request.authority_id().as_uuid())
-        .bind(pg_bigint(request.generation().get()))
-        .bind(request.worker().as_uuid())
-        .bind(database_now)
-        .bind(claim_expires_at)
-        .bind(request_deadline)
-        .bind(conservative_expiry)
-        .execute(&mut *transaction)
-        .await
-        .map_err(operation_error)?;
-        let updated = sqlx::query(
-            r"
-            UPDATE github_server_service_authorities
-            SET refresh_issuance_generation = $2,
-                next_issuance_generation = $4,
-                state_updated_at_ms = $3
-            WHERE id = $1
-              AND state = 'active'
-              AND refresh_issuance_generation IS NULL
-              AND state_updated_at_ms <= $3
-            ",
-        )
-        .bind(request.authority_id().as_uuid())
-        .bind(pg_bigint(request.generation().get()))
-        .bind(database_now)
-        .bind(i64_from_u64(next_generation)?)
-        .execute(&mut *transaction)
-        .await
-        .map_err(operation_error)?;
-        if updated.rows_affected() != 1 {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-        let issuance = select_issuance_for_update(&mut transaction, key)
-            .await?
-            .ok_or(GithubServerServiceStoreError::CorruptData)?;
-        let claimed = decode_claimed_mint(descriptor.identity().clone(), &issuance)?;
-        transaction.commit().await.map_err(operation_error)?;
-        Ok(claimed)
-    }
-
-    async fn reclaim_github_server_service_mint(
-        &self,
-        request: ReclaimGithubServerServiceMint,
-    ) -> Result<ClaimedGithubServerServiceMint, GithubServerServiceStoreError> {
-        let claim_duration = requested_duration(request.observed_at(), request.claim_expires_at())?;
-        let mut transaction = self.pool.begin().await.map_err(operation_error)?;
-        pin_read_committed(&mut transaction).await?;
-        let authority_row = select_authority_for_update(&mut transaction, request.selector())
-            .await?
-            .ok_or(GithubServerServiceStoreError::NotFound)?;
-        let descriptor = decode_authority(&authority_row)?;
-        let existing = select_issuance_for_update(&mut transaction, request.key())
-            .await?
-            .ok_or(GithubServerServiceStoreError::NotFound)?;
-        let state = issuance_state(&existing)?;
-        let database_now = database_now_ms(&mut transaction).await?;
-        if state == GithubServerServiceIssuanceState::Claimed
-            && optional_uuid(&existing, "mint_claim_owner_id")? == Some(request.worker().as_uuid())
-            && optional_claim_duration(&existing, "mint_claimed_at_ms", "mint_claim_expires_at_ms")?
-                == Some(claim_duration)
-            && live_mint_claim_at(&existing, database_now)?
-        {
-            let claimed = decode_claimed_mint(descriptor.identity().clone(), &existing)?;
-            transaction.commit().await.map_err(operation_error)?;
-            return Ok(claimed);
-        }
-        validate_caller_clock(request.observed_at(), database_now)?;
-        let request_deadline = i64_column(&existing, "request_deadline_at_ms")?;
-        let claim_expires_at = issue_deadline(database_now, claim_duration)?;
-        if descriptor.state() != GithubServerServiceAuthorityState::Active
-            || descriptor.refresh_generation() != Some(request.key().generation())
-            || state != GithubServerServiceIssuanceState::MintRetryPending
-            || optional_i64(&existing, "next_mint_at_ms")?.is_none_or(|next| next > database_now)
-            || claim_expires_at > request_deadline
-        {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-        let attempts = u16_column(&existing, "mint_attempt_count")?;
-        let fence = positive_u64(&existing, "mint_claim_fence")?;
-        if attempts >= MAX_GITHUB_SERVICE_MINT_ATTEMPTS {
-            return Err(GithubServerServiceStoreError::RetryLimitReached);
-        }
-        let next_fence = fence
-            .checked_add(1)
-            .filter(|value| i64::try_from(*value).is_ok())
-            .ok_or(GithubServerServiceStoreError::FenceExhausted)?;
-        let row = sqlx::query(AssertSqlSafe(format!(
-            r"
-            UPDATE github_server_service_authority_issuances
-            SET state = 'claimed',
-                mint_attempt_count = mint_attempt_count + 1,
-                mint_claim_fence = $3,
-                mint_claim_owner_id = $4,
-                mint_claimed_at_ms = $5,
-                mint_claim_expires_at_ms = $6,
-                mint_started_at_ms = NULL,
-                mint_started_owner_id = NULL,
-                mint_started_claim_fence = NULL,
-                mint_started_claimed_at_ms = NULL,
-                mint_started_claim_expires_at_ms = NULL,
-                next_mint_at_ms = NULL,
-                mint_failure_kind = NULL,
-                state_updated_at_ms = $5
-            WHERE authority_id = $1 AND generation = $2
-              AND state = 'mint_retry'
-              AND next_mint_at_ms <= $5
-            RETURNING {ISSUANCE_COLUMNS}
-            "
-        )))
-        .bind(request.key().authority_id().as_uuid())
-        .bind(pg_bigint(request.key().generation().get()))
-        .bind(i64_from_u64(next_fence)?)
-        .bind(request.worker().as_uuid())
-        .bind(database_now)
-        .bind(claim_expires_at)
-        .fetch_optional(&mut *transaction)
-        .await
-        .map_err(operation_error)?
-        .ok_or(GithubServerServiceStoreError::ClaimRejected)?;
-        let claimed = decode_claimed_mint(descriptor.identity().clone(), &row)?;
-        transaction.commit().await.map_err(operation_error)?;
-        Ok(claimed)
-    }
-
     async fn begin_github_server_service_mint(
         &self,
         request: BeginGithubServerServiceMint,
@@ -588,13 +343,6 @@ impl GithubServerServiceAuthorityRepository for PostgresStore {
         }
     }
 
-    async fn reconcile_expired_github_server_service_mint(
-        &self,
-        request: ReconcileExpiredGithubServerServiceMint,
-    ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError> {
-        reconcile_expired_mint(self, request).await
-    }
-
     async fn acquire_github_server_service_handoff(
         &self,
         request: AcquireGithubServerServiceHandoff,
@@ -623,25 +371,11 @@ impl GithubServerServiceAuthorityRepository for PostgresStore {
         retire_authority(self, request).await
     }
 
-    async fn claim_github_server_service_revocation(
-        &self,
-        request: ClaimGithubServerServiceRevocation,
-    ) -> Result<ClaimedGithubServerServiceRevocation, GithubServerServiceStoreError> {
-        claim_revocation(self, request).await
-    }
-
     async fn finish_github_server_service_revocation(
         &self,
         request: FinishGithubServerServiceRevocation,
     ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError> {
         finish_revocation(self, request).await
-    }
-
-    async fn erase_expired_github_server_service_issuance(
-        &self,
-        request: EraseExpiredGithubServerServiceIssuance,
-    ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError> {
-        erase_expired(self, request).await
     }
 
     async fn claim_next_github_server_service_maintenance(
@@ -650,158 +384,6 @@ impl GithubServerServiceAuthorityRepository for PostgresStore {
     ) -> Result<Option<GithubServerServiceMaintenanceOutcome>, GithubServerServiceStoreError> {
         claim_next_maintenance(self, request).await
     }
-}
-
-#[allow(clippy::too_many_lines)]
-async fn reconcile_expired_mint(
-    store: &PostgresStore,
-    request: ReconcileExpiredGithubServerServiceMint,
-) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError> {
-    const PRE_IO_FAILURE: &str = "mint_request_expired_before_provider_call";
-    const POST_IO_FAILURE: &str = "mint_outcome_unobserved_after_claim_expiry";
-
-    let mut transaction = store.pool.begin().await.map_err(operation_error)?;
-    pin_read_committed(&mut transaction).await?;
-    let authority_row = select_authority_for_update(&mut transaction, request.selector())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    let descriptor = decode_authority(&authority_row)?;
-    let existing = select_issuance_for_update(&mut transaction, request.key())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    let state = issuance_state(&existing)?;
-
-    let replay = match state {
-        GithubServerServiceIssuanceState::Rejected => {
-            optional_string(&existing, "mint_failure_kind")?.is_some()
-                && optional_string(&existing, "terminal_reason")?.as_deref()
-                    == Some("request_expired")
-        }
-        GithubServerServiceIssuanceState::Indeterminate => {
-            optional_string(&existing, "mint_failure_kind")?.as_deref() == Some(POST_IO_FAILURE)
-                && optional_string(&existing, "terminal_reason")?.is_none()
-        }
-        _ => false,
-    };
-    if replay {
-        if descriptor
-            .refresh_generation()
-            .is_some_and(|generation| generation == request.key().generation())
-        {
-            return Err(GithubServerServiceStoreError::CorruptData);
-        }
-        let receipt = decode_issuance_receipt(&existing)?;
-        transaction.commit().await.map_err(operation_error)?;
-        return Ok(receipt);
-    }
-
-    if descriptor.state() != GithubServerServiceAuthorityState::Active
-        || descriptor.refresh_generation() != Some(request.key().generation())
-    {
-        return Err(GithubServerServiceStoreError::ClaimRejected);
-    }
-    let database_now = database_now_ms(&mut transaction).await?;
-    validate_caller_clock(request.observed_at(), database_now)?;
-    let request_deadline = i64_column(&existing, "request_deadline_at_ms")?;
-    let (target_state, failure, terminal_reason, expired) = match state {
-        GithubServerServiceIssuanceState::Claimed => (
-            "rejected",
-            PRE_IO_FAILURE.to_owned(),
-            Some("request_expired"),
-            optional_i64(&existing, "mint_claim_expires_at_ms")?
-                .is_some_and(|claim_expiry| database_now >= claim_expiry)
-                || database_now >= request_deadline,
-        ),
-        GithubServerServiceIssuanceState::Minting => (
-            "indeterminate",
-            POST_IO_FAILURE.to_owned(),
-            None,
-            optional_i64(&existing, "mint_claim_expires_at_ms")?
-                .is_some_and(|claim_expiry| database_now >= claim_expiry)
-                || database_now >= request_deadline,
-        ),
-        GithubServerServiceIssuanceState::MintRetryPending => (
-            "rejected",
-            optional_string(&existing, "mint_failure_kind")?
-                .ok_or(GithubServerServiceStoreError::CorruptData)?,
-            Some("request_expired"),
-            database_now >= request_deadline,
-        ),
-        _ => return Err(GithubServerServiceStoreError::ClaimRejected),
-    };
-    if !expired || database_now < i64_column(&existing, "state_updated_at_ms")? {
-        return Err(GithubServerServiceStoreError::ClaimRejected);
-    }
-
-    let row = sqlx::query(AssertSqlSafe(format!(
-        r"
-        UPDATE github_server_service_authority_issuances
-        SET state = $4,
-            mint_claim_owner_id = NULL,
-            mint_claimed_at_ms = NULL,
-            mint_claim_expires_at_ms = NULL,
-            next_mint_at_ms = NULL,
-            generation_failure_gate_at_ms = CASE
-                WHEN $4 = 'rejected' THEN $7 + 60000
-                ELSE safe_erase_after_ms
-            END,
-            mint_failure_kind = $5,
-            terminal_reason = $6,
-            state_updated_at_ms = $7
-        WHERE authority_id = $1 AND generation = $2
-          AND state = $3
-        RETURNING {ISSUANCE_COLUMNS}
-        "
-    )))
-    .bind(request.key().authority_id().as_uuid())
-    .bind(pg_bigint(request.key().generation().get()))
-    .bind(github_server_service_issuance_state_name(state))
-    .bind(target_state)
-    .bind(&failure)
-    .bind(terminal_reason)
-    .bind(database_now)
-    .fetch_optional(&mut *transaction)
-    .await
-    .map_err(operation_error)?
-    .ok_or(GithubServerServiceStoreError::ClaimRejected)?;
-    let updated = sqlx::query(
-        r"
-        UPDATE github_server_service_authorities
-        SET refresh_issuance_generation = NULL,
-            consecutive_generation_failures = LEAST(
-                consecutive_generation_failures + 1, 32
-            ),
-            failure_budget_rearm_at_ms = CASE
-                WHEN consecutive_generation_failures = 31 THEN $5
-                ELSE failure_budget_rearm_at_ms
-            END,
-            mint_gate_generation = CASE
-                WHEN next_mint_not_before_ms IS NULL
-                    OR $4 > next_mint_not_before_ms THEN $2
-                ELSE mint_gate_generation
-            END,
-            next_mint_not_before_ms = GREATEST(
-                COALESCE(next_mint_not_before_ms, $4), $4
-            ),
-            state_updated_at_ms = $3
-        WHERE id = $1 AND refresh_issuance_generation = $2
-          AND state = 'active' AND state_updated_at_ms <= $3
-        ",
-    )
-    .bind(request.key().authority_id().as_uuid())
-    .bind(pg_bigint(request.key().generation().get()))
-    .bind(database_now)
-    .bind(generation_failure_not_before(&row)?)
-    .bind(failure_budget_rearm_at(UnixMillis::new(database_now))?)
-    .execute(&mut *transaction)
-    .await
-    .map_err(operation_error)?;
-    if updated.rows_affected() != 1 {
-        return Err(GithubServerServiceStoreError::ClaimRejected);
-    }
-    let receipt = decode_issuance_receipt(&row)?;
-    transaction.commit().await.map_err(operation_error)?;
-    Ok(receipt)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2715,123 +2297,6 @@ async fn retire_authority(
     Ok(result)
 }
 
-#[allow(clippy::too_many_lines)]
-async fn claim_revocation(
-    store: &PostgresStore,
-    request: ClaimGithubServerServiceRevocation,
-) -> Result<ClaimedGithubServerServiceRevocation, GithubServerServiceStoreError> {
-    let claim_duration = requested_duration(request.observed_at(), request.claim_expires_at())?;
-    let mut transaction = store.pool.begin().await.map_err(operation_error)?;
-    pin_read_committed(&mut transaction).await?;
-    let authority_row = select_authority_for_update(&mut transaction, request.selector())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    let descriptor = decode_authority(&authority_row)?;
-    let existing = select_issuance_for_update(&mut transaction, request.key())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    let state = issuance_state(&existing)?;
-    let database_now = database_now_ms(&mut transaction).await?;
-    if state == GithubServerServiceIssuanceState::RevokeClaimed
-        && optional_uuid(&existing, "revoke_claim_owner_id")? == Some(request.worker().as_uuid())
-        && optional_claim_duration(
-            &existing,
-            "revoke_claimed_at_ms",
-            "revoke_claim_expires_at_ms",
-        )? == Some(claim_duration)
-        && optional_i64(&existing, "revoke_claimed_at_ms")?
-            .is_some_and(|claimed_at| claimed_at <= database_now)
-        && optional_i64(&existing, "revoke_claim_expires_at_ms")?
-            .is_some_and(|expires_at| database_now < expires_at)
-        && i64_column(&existing, "safe_erase_after_ms")? > database_now
-    {
-        let Some(claimed) = decode_claimed_revocation_or_quarantine(
-            &mut transaction,
-            descriptor.identity().clone(),
-            &existing,
-            UnixMillis::new(database_now),
-        )
-        .await?
-        else {
-            transaction.commit().await.map_err(operation_error)?;
-            return Err(GithubServerServiceStoreError::CorruptData);
-        };
-        transaction.commit().await.map_err(operation_error)?;
-        return Ok(claimed);
-    }
-    validate_caller_clock(request.observed_at(), database_now)?;
-    let eligible = state == GithubServerServiceIssuanceState::RevokePending
-        || state == GithubServerServiceIssuanceState::RevokeRetryPending
-            && optional_i64(&existing, "next_revoke_at_ms")?
-                .is_some_and(|next| next <= database_now)
-        || state == GithubServerServiceIssuanceState::RevokeClaimed
-            && optional_i64(&existing, "revoke_claim_expires_at_ms")?
-                .is_some_and(|expiry| expiry <= database_now);
-    let claim_expires_at = issue_deadline(database_now, claim_duration)?;
-    if !eligible || i64_column(&existing, "safe_erase_after_ms")? <= claim_expires_at {
-        return Err(GithubServerServiceStoreError::ClaimRejected);
-    }
-    let attempts = u16_column(&existing, "revoke_attempt_count")?;
-    let fence = nonnegative_u64(&existing, "revoke_claim_fence")?;
-    if attempts >= MAX_GITHUB_SERVICE_REVOKE_ATTEMPTS {
-        return Err(GithubServerServiceStoreError::RetryLimitReached);
-    }
-    if has_live_handoff(
-        &mut transaction,
-        request.key(),
-        UnixMillis::new(database_now),
-    )
-    .await?
-    {
-        return Err(GithubServerServiceStoreError::HandoffStillLive);
-    }
-    let next_fence = fence
-        .checked_add(1)
-        .filter(|value| i64::try_from(*value).is_ok())
-        .ok_or(GithubServerServiceStoreError::FenceExhausted)?;
-    let row = sqlx::query(AssertSqlSafe(format!(
-        r"
-        UPDATE github_server_service_authority_issuances
-        SET state = 'revoke_claimed',
-            revoke_attempt_count = revoke_attempt_count + 1,
-            revoke_claim_fence = $3, revoke_claim_owner_id = $4,
-            revoke_claimed_at_ms = $5, revoke_claim_expires_at_ms = $6,
-            revoke_result_owner_id = NULL,
-            revoke_result_claim_fence = NULL,
-            revoke_result_claimed_at_ms = NULL,
-            revoke_result_claim_expires_at_ms = NULL,
-            next_revoke_at_ms = NULL, revoke_failure_kind = NULL,
-            state_updated_at_ms = $5
-        WHERE authority_id = $1 AND generation = $2
-          AND state IN ('revoke_pending', 'revoke_retry', 'revoke_claimed')
-        RETURNING {ISSUANCE_COLUMNS}
-        "
-    )))
-    .bind(request.key().authority_id().as_uuid())
-    .bind(pg_bigint(request.key().generation().get()))
-    .bind(i64_from_u64(next_fence)?)
-    .bind(request.worker().as_uuid())
-    .bind(database_now)
-    .bind(claim_expires_at)
-    .fetch_optional(&mut *transaction)
-    .await
-    .map_err(operation_error)?
-    .ok_or(GithubServerServiceStoreError::ClaimRejected)?;
-    let Some(claimed) = decode_claimed_revocation_or_quarantine(
-        &mut transaction,
-        descriptor.identity().clone(),
-        &row,
-        UnixMillis::new(database_now),
-    )
-    .await?
-    else {
-        transaction.commit().await.map_err(operation_error)?;
-        return Err(GithubServerServiceStoreError::CorruptData);
-    };
-    transaction.commit().await.map_err(operation_error)?;
-    Ok(claimed)
-}
-
 async fn has_live_handoff(
     connection: &mut PgConnection,
     key: GithubServerServiceIssuanceKey,
@@ -3101,107 +2566,6 @@ async fn rearm_github_server_service_failure_budget(
     .await
     .map_err(operation_error)?;
     Ok(changed.rows_affected() == 1)
-}
-
-async fn erase_expired(
-    store: &PostgresStore,
-    request: EraseExpiredGithubServerServiceIssuance,
-) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError> {
-    let mut transaction = store.pool.begin().await.map_err(operation_error)?;
-    pin_read_committed(&mut transaction).await?;
-    let authority_row = select_authority_for_update(&mut transaction, request.selector())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    let descriptor = decode_authority(&authority_row)?;
-    let existing = select_issuance_for_update(&mut transaction, request.key())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
-    if issuance_state(&existing)? == GithubServerServiceIssuanceState::Revoked {
-        let receipt = decode_issuance_receipt(&existing)?;
-        transaction.commit().await.map_err(operation_error)?;
-        return Ok(receipt);
-    }
-    let database_now = database_now_ms(&mut transaction).await?;
-    validate_caller_clock(request.observed_at(), database_now)?;
-    let state = issuance_state(&existing)?;
-    if !matches!(
-        state,
-        GithubServerServiceIssuanceState::Ready
-            | GithubServerServiceIssuanceState::Indeterminate
-            | GithubServerServiceIssuanceState::Quarantined
-            | GithubServerServiceIssuanceState::RevokePending
-            | GithubServerServiceIssuanceState::RevokeClaimed
-            | GithubServerServiceIssuanceState::RevokeRetryPending
-    ) || i64_column(&existing, "safe_erase_after_ms")? > database_now
-    {
-        return Err(GithubServerServiceStoreError::ClaimRejected);
-    }
-    let terminal_reason = if optional_i64(&existing, "provider_expires_at_ms")?.is_some() {
-        "provider_expired"
-    } else {
-        "conservative_expiry"
-    };
-    let row = sqlx::query(AssertSqlSafe(format!(
-        r"
-        UPDATE github_server_service_authority_issuances
-        SET state = 'revoked', mint_claim_owner_id = NULL,
-            mint_claimed_at_ms = NULL, mint_claim_expires_at_ms = NULL,
-            next_mint_at_ms = NULL, revoke_claim_owner_id = NULL,
-            revoke_claimed_at_ms = NULL, revoke_claim_expires_at_ms = NULL,
-            next_revoke_at_ms = NULL, revoke_failure_kind = NULL,
-            plaintext_schema = NULL, plaintext_size_bytes = NULL,
-            plaintext_digest = NULL, aad_digest = NULL,
-            envelope_schema = NULL, wrapping_key_id = NULL,
-            wrapped_data_key = NULL, nonce = NULL, ciphertext = NULL,
-            terminal_reason = $3, state_updated_at_ms = $4
-        WHERE authority_id = $1 AND generation = $2
-          AND state IN ('ready', 'indeterminate', 'quarantined', 'revoke_pending',
-                        'revoke_claimed', 'revoke_retry')
-          AND safe_erase_after_ms <= $4
-        RETURNING {ISSUANCE_COLUMNS}
-        "
-    )))
-    .bind(request.key().authority_id().as_uuid())
-    .bind(pg_bigint(request.key().generation().get()))
-    .bind(terminal_reason)
-    .bind(database_now)
-    .fetch_optional(&mut *transaction)
-    .await
-    .map_err(operation_error)?
-    .ok_or(GithubServerServiceStoreError::ClaimRejected)?;
-    if state == GithubServerServiceIssuanceState::Ready {
-        if descriptor.current_generation() != Some(request.key().generation()) {
-            return Err(GithubServerServiceStoreError::CorruptData);
-        }
-        let cleared = sqlx::query(
-            r"
-            UPDATE github_server_service_authorities
-            SET current_issuance_generation = NULL, state_updated_at_ms = $3
-            WHERE tenant_id = $1 AND id = $2 AND state = 'active'
-              AND current_issuance_generation = $4
-              AND state_updated_at_ms <= $3
-            ",
-        )
-        .bind(request.selector().tenant().as_str())
-        .bind(request.key().authority_id().as_uuid())
-        .bind(database_now)
-        .bind(pg_bigint(request.key().generation().get()))
-        .execute(&mut *transaction)
-        .await
-        .map_err(operation_error)?;
-        if cleared.rows_affected() != 1 {
-            return Err(GithubServerServiceStoreError::ClaimRejected);
-        }
-    }
-    maybe_finish_retirement(
-        &mut transaction,
-        request.key().authority_id(),
-        UnixMillis::new(database_now),
-    )
-    .await?;
-    let receipt = decode_issuance_receipt(&row)?;
-    transaction.commit().await.map_err(operation_error)?;
-    Ok(receipt)
 }
 
 async fn maybe_finish_retirement(
@@ -3587,55 +2951,6 @@ fn decode_consumer_claim(
         action,
         revision,
     ))
-}
-
-fn exact_mint_claim_replay(
-    row: &PgRow,
-    worker: GithubServerServiceWorkerId,
-    claim_duration: i64,
-    request_duration: i64,
-) -> Result<bool, GithubServerServiceStoreError> {
-    Ok(
-        issuance_state(row)? == GithubServerServiceIssuanceState::Claimed
-            && u16_column(row, "mint_attempt_count")? == 1
-            && positive_u64(row, "mint_claim_fence")? == 1
-            && optional_uuid(row, "mint_claim_owner_id")? == Some(worker.as_uuid())
-            && optional_i64(row, "mint_claimed_at_ms")?
-                == Some(i64_column(row, "requested_at_ms")?)
-            && i64_column(row, "state_updated_at_ms")? == i64_column(row, "requested_at_ms")?
-            && optional_claim_duration(row, "mint_claimed_at_ms", "mint_claim_expires_at_ms")?
-                == Some(claim_duration)
-            && i64_column(row, "request_deadline_at_ms")?
-                .checked_sub(i64_column(row, "requested_at_ms")?)
-                == Some(request_duration),
-    )
-}
-
-fn live_mint_claim_at(
-    row: &PgRow,
-    database_now: i64,
-) -> Result<bool, GithubServerServiceStoreError> {
-    Ok(optional_i64(row, "mint_claimed_at_ms")?
-        .is_some_and(|claimed_at| claimed_at <= database_now)
-        && optional_i64(row, "mint_claim_expires_at_ms")?
-            .is_some_and(|expires_at| database_now < expires_at)
-        && database_now < i64_column(row, "request_deadline_at_ms")?)
-}
-
-fn optional_claim_duration(
-    row: &PgRow,
-    claimed_at_column: &str,
-    expires_at_column: &str,
-) -> Result<Option<i64>, GithubServerServiceStoreError> {
-    let Some(claimed_at) = optional_i64(row, claimed_at_column)? else {
-        return Ok(None);
-    };
-    let Some(expires_at) = optional_i64(row, expires_at_column)? else {
-        return Ok(None);
-    };
-    Ok(expires_at
-        .checked_sub(claimed_at)
-        .filter(|duration| *duration > 0))
 }
 
 fn require_exact_begin_evidence(

--- a/crates/automata-ci-store/src/github_service_authority.rs
+++ b/crates/automata-ci-store/src/github_service_authority.rs
@@ -1044,152 +1044,6 @@ impl ClaimedGithubServerServiceMint {
     }
 }
 
-/// Starts a new initial or refresh generation under one descriptor.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ClaimGithubServerServiceMint {
-    selector: GithubServerServiceAuthoritySelector,
-    generation: GithubServerServiceGeneration,
-    worker: GithubServerServiceWorkerId,
-    requested_at: UnixMillis,
-    request_deadline: UnixMillis,
-    claim_expires_at: UnixMillis,
-}
-
-impl ClaimGithubServerServiceMint {
-    /// Constructs a bounded new-generation claim.
-    ///
-    /// # Errors
-    ///
-    /// Rejects invalid provider-request or claim intervals.
-    pub fn new(
-        selector: GithubServerServiceAuthoritySelector,
-        generation: GithubServerServiceGeneration,
-        worker: GithubServerServiceWorkerId,
-        requested_at: UnixMillis,
-        request_deadline: UnixMillis,
-        claim_expires_at: UnixMillis,
-    ) -> Result<Self, GithubServerServiceValueError> {
-        validate_claim_interval(
-            requested_at,
-            claim_expires_at,
-            MAX_GITHUB_SERVICE_MINT_CLAIM_MILLIS,
-        )?;
-        validate_request_interval(requested_at, request_deadline)?;
-        if claim_expires_at > request_deadline {
-            return Err(GithubServerServiceValueError::InvalidTimeInterval);
-        }
-        Ok(Self {
-            selector,
-            generation,
-            worker,
-            requested_at,
-            request_deadline,
-            claim_expires_at,
-        })
-    }
-    /// Returns the exact immutable descriptor selector.
-    #[must_use]
-    pub const fn selector(&self) -> &GithubServerServiceAuthoritySelector {
-        &self.selector
-    }
-    /// Returns descriptor ID.
-    #[must_use]
-    pub const fn authority_id(&self) -> GithubServerServiceAuthorityId {
-        self.selector.authority_id()
-    }
-    /// Returns the caller-pinned next generation for exact lost-response replay.
-    #[must_use]
-    pub const fn generation(&self) -> GithubServerServiceGeneration {
-        self.generation
-    }
-    /// Returns claiming worker.
-    #[must_use]
-    pub const fn worker(&self) -> GithubServerServiceWorkerId {
-        self.worker
-    }
-    /// Returns trusted request time.
-    #[must_use]
-    pub const fn requested_at(&self) -> UnixMillis {
-        self.requested_at
-    }
-    /// Returns fixed provider deadline.
-    #[must_use]
-    pub const fn request_deadline(&self) -> UnixMillis {
-        self.request_deadline
-    }
-    /// Returns exclusive claim expiry.
-    #[must_use]
-    pub const fn claim_expires_at(&self) -> UnixMillis {
-        self.claim_expires_at
-    }
-}
-
-/// Reclaims a definitively unissued retry generation.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReclaimGithubServerServiceMint {
-    selector: GithubServerServiceAuthoritySelector,
-    key: GithubServerServiceIssuanceKey,
-    worker: GithubServerServiceWorkerId,
-    observed_at: UnixMillis,
-    claim_expires_at: UnixMillis,
-}
-
-impl ReclaimGithubServerServiceMint {
-    /// Constructs a bounded retry claim.
-    ///
-    /// # Errors
-    ///
-    /// Rejects an invalid claim interval.
-    pub fn new(
-        selector: GithubServerServiceAuthoritySelector,
-        key: GithubServerServiceIssuanceKey,
-        worker: GithubServerServiceWorkerId,
-        observed_at: UnixMillis,
-        claim_expires_at: UnixMillis,
-    ) -> Result<Self, GithubServerServiceValueError> {
-        validate_claim_interval(
-            observed_at,
-            claim_expires_at,
-            MAX_GITHUB_SERVICE_MINT_CLAIM_MILLIS,
-        )?;
-        if selector.authority_id() != key.authority_id() {
-            return Err(GithubServerServiceValueError::InvalidClaim);
-        }
-        Ok(Self {
-            selector,
-            key,
-            worker,
-            observed_at,
-            claim_expires_at,
-        })
-    }
-    /// Returns the exact immutable descriptor selector.
-    #[must_use]
-    pub const fn selector(&self) -> &GithubServerServiceAuthoritySelector {
-        &self.selector
-    }
-    /// Returns issuance key.
-    #[must_use]
-    pub const fn key(&self) -> GithubServerServiceIssuanceKey {
-        self.key
-    }
-    /// Returns claiming worker.
-    #[must_use]
-    pub const fn worker(&self) -> GithubServerServiceWorkerId {
-        self.worker
-    }
-    /// Returns trusted observation.
-    #[must_use]
-    pub const fn observed_at(&self) -> UnixMillis {
-        self.observed_at
-    }
-    /// Returns exclusive claim expiry.
-    #[must_use]
-    pub const fn claim_expires_at(&self) -> UnixMillis {
-        self.claim_expires_at
-    }
-}
-
 /// Irreversible durable mint-start boundary recorded before provider I/O.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BeginGithubServerServiceMint {
@@ -1317,57 +1171,6 @@ pub enum BeginGithubServerServiceMintOutcome {
     Started(GithubServerServiceMintStart),
     /// The cutoff already existed; provider I/O must never be repeated.
     AlreadyStarted(GithubServerServiceMintStart),
-}
-
-/// Reconciles a mint whose durable claim or provider deadline expired.
-///
-/// A pre-provider [`GithubServerServiceIssuanceState::Claimed`] or definitively
-/// unissued [`GithubServerServiceIssuanceState::MintRetryPending`] generation
-/// is rejected. A post-cutoff [`GithubServerServiceIssuanceState::Minting`]
-/// generation becomes indeterminate and can never be reminted.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReconcileExpiredGithubServerServiceMint {
-    selector: GithubServerServiceAuthoritySelector,
-    key: GithubServerServiceIssuanceKey,
-    observed_at: UnixMillis,
-}
-
-impl ReconcileExpiredGithubServerServiceMint {
-    /// Constructs a trusted stale-mint reconciliation request.
-    ///
-    /// # Errors
-    ///
-    /// Rejects a pre-epoch observation.
-    pub fn new(
-        selector: GithubServerServiceAuthoritySelector,
-        key: GithubServerServiceIssuanceKey,
-        observed_at: UnixMillis,
-    ) -> Result<Self, GithubServerServiceValueError> {
-        validate_timestamp(observed_at)?;
-        if selector.authority_id() != key.authority_id() {
-            return Err(GithubServerServiceValueError::InvalidClaim);
-        }
-        Ok(Self {
-            selector,
-            key,
-            observed_at,
-        })
-    }
-    /// Returns the exact immutable descriptor selector.
-    #[must_use]
-    pub const fn selector(&self) -> &GithubServerServiceAuthoritySelector {
-        &self.selector
-    }
-    /// Returns the exact issuance key.
-    #[must_use]
-    pub const fn key(&self) -> GithubServerServiceIssuanceKey {
-        self.key
-    }
-    /// Returns the trusted reconciliation observation.
-    #[must_use]
-    pub const fn observed_at(&self) -> UnixMillis {
-        self.observed_at
-    }
 }
 
 /// Canonical provider or cryptographic failure class with no credential data.
@@ -2227,72 +2030,6 @@ impl RetireGithubServerServiceAuthority {
     }
 }
 
-/// Claims one eligible generation for provider revocation.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ClaimGithubServerServiceRevocation {
-    selector: GithubServerServiceAuthoritySelector,
-    key: GithubServerServiceIssuanceKey,
-    worker: GithubServerServiceWorkerId,
-    observed_at: UnixMillis,
-    claim_expires_at: UnixMillis,
-}
-
-impl ClaimGithubServerServiceRevocation {
-    /// Constructs a bounded revocation claim.
-    ///
-    /// # Errors
-    ///
-    /// Rejects an invalid claim interval.
-    pub fn new(
-        selector: GithubServerServiceAuthoritySelector,
-        key: GithubServerServiceIssuanceKey,
-        worker: GithubServerServiceWorkerId,
-        observed_at: UnixMillis,
-        claim_expires_at: UnixMillis,
-    ) -> Result<Self, GithubServerServiceValueError> {
-        validate_claim_interval(
-            observed_at,
-            claim_expires_at,
-            MAX_GITHUB_SERVICE_REVOKE_CLAIM_MILLIS,
-        )?;
-        if selector.authority_id() != key.authority_id() {
-            return Err(GithubServerServiceValueError::InvalidClaim);
-        }
-        Ok(Self {
-            selector,
-            key,
-            worker,
-            observed_at,
-            claim_expires_at,
-        })
-    }
-    /// Returns the exact immutable descriptor selector.
-    #[must_use]
-    pub const fn selector(&self) -> &GithubServerServiceAuthoritySelector {
-        &self.selector
-    }
-    /// Returns issuance key.
-    #[must_use]
-    pub const fn key(&self) -> GithubServerServiceIssuanceKey {
-        self.key
-    }
-    /// Returns claiming worker.
-    #[must_use]
-    pub const fn worker(&self) -> GithubServerServiceWorkerId {
-        self.worker
-    }
-    /// Returns trusted observation.
-    #[must_use]
-    pub const fn observed_at(&self) -> UnixMillis {
-        self.observed_at
-    }
-    /// Returns exclusive claim expiry.
-    #[must_use]
-    pub const fn claim_expires_at(&self) -> UnixMillis {
-        self.claim_expires_at
-    }
-}
-
 /// Provider-revocation claim with protected credential custody.
 pub struct ClaimedGithubServerServiceRevocation {
     claim: GithubServerServiceClaim,
@@ -2482,52 +2219,6 @@ impl FinishGithubServerServiceRevocation {
     }
 }
 
-/// Safely erases indeterminate or quarantined custody after its fixed horizon.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EraseExpiredGithubServerServiceIssuance {
-    selector: GithubServerServiceAuthoritySelector,
-    key: GithubServerServiceIssuanceKey,
-    observed_at: UnixMillis,
-}
-
-impl EraseExpiredGithubServerServiceIssuance {
-    /// Constructs an expiry-based erasure request.
-    ///
-    /// # Errors
-    ///
-    /// Rejects a pre-epoch observation.
-    pub fn new(
-        selector: GithubServerServiceAuthoritySelector,
-        key: GithubServerServiceIssuanceKey,
-        observed_at: UnixMillis,
-    ) -> Result<Self, GithubServerServiceValueError> {
-        validate_timestamp(observed_at)?;
-        if selector.authority_id() != key.authority_id() {
-            return Err(GithubServerServiceValueError::InvalidClaim);
-        }
-        Ok(Self {
-            selector,
-            key,
-            observed_at,
-        })
-    }
-    /// Returns the exact immutable descriptor selector.
-    #[must_use]
-    pub const fn selector(&self) -> &GithubServerServiceAuthoritySelector {
-        &self.selector
-    }
-    /// Returns issuance key.
-    #[must_use]
-    pub const fn key(&self) -> GithubServerServiceIssuanceKey {
-        self.key
-    }
-    /// Returns trusted erasure observation.
-    #[must_use]
-    pub const fn observed_at(&self) -> UnixMillis {
-        self.observed_at
-    }
-}
-
 /// Closes a corrupt current credential while retaining protected custody.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct QuarantineGithubServerServiceCredential {
@@ -2648,7 +2339,7 @@ impl ClaimNextGithubServerServiceMaintenance {
 /// One atomic, restart-safe maintenance result.
 #[derive(Debug)]
 pub enum GithubServerServiceMaintenanceOutcome {
-    /// A due definitive no-token retry was atomically reclaimed for minting.
+    /// A due initial, refresh, or definitive no-token retry was claimed for minting.
     Mint(Box<ClaimedGithubServerServiceMint>),
     /// A due protected credential was atomically claimed for revocation.
     Revocation(Box<ClaimedGithubServerServiceRevocation>),
@@ -2682,15 +2373,9 @@ pub enum GithubServerServiceStoreError {
     /// A current credential cannot satisfy the exact handoff request.
     #[error("GitHub server-service credential handoff was rejected")]
     HandoffRejected,
-    /// One current plus one refresh generation is already retained.
-    #[error("GitHub server-service authority already has an active refresh")]
-    RefreshAlreadyActive,
     /// A positive durable generation or claim fence is exhausted.
     #[error("GitHub server-service authority generation or fence is exhausted")]
     FenceExhausted,
-    /// Closed provider attempt bound is exhausted.
-    #[error("GitHub server-service authority retry bound is exhausted")]
-    RetryLimitReached,
     /// A live exact handoff still requires the credential.
     #[error("GitHub server-service credential is still borrowed")]
     HandoffStillLive,
@@ -2789,16 +2474,6 @@ pub trait GithubServerServiceAuthorityRepository: Send + Sync {
         tenant: &TenantScope,
         authority_id: GithubServerServiceAuthorityId,
     ) -> Result<GithubServerServiceAuthorityDescriptor, GithubServerServiceStoreError>;
-    /// Creates and claims the sole initial/refresh generation.
-    async fn claim_github_server_service_mint(
-        &self,
-        request: ClaimGithubServerServiceMint,
-    ) -> Result<ClaimedGithubServerServiceMint, GithubServerServiceStoreError>;
-    /// Reclaims a definitively unissued retry generation.
-    async fn reclaim_github_server_service_mint(
-        &self,
-        request: ReclaimGithubServerServiceMint,
-    ) -> Result<ClaimedGithubServerServiceMint, GithubServerServiceStoreError>;
     /// Persists the irreversible provider-call cutoff.
     async fn begin_github_server_service_mint(
         &self,
@@ -2808,11 +2483,6 @@ pub trait GithubServerServiceAuthorityRepository: Send + Sync {
     async fn finish_github_server_service_mint(
         &self,
         request: &FinishGithubServerServiceMint,
-    ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError>;
-    /// Closes an expired pre-I/O mint or quarantines an expired post-I/O mint.
-    async fn reconcile_expired_github_server_service_mint(
-        &self,
-        request: ReconcileExpiredGithubServerServiceMint,
     ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError>;
     /// Acquires protected current custody for one exact value-free consumer claim.
     async fn acquire_github_server_service_handoff(
@@ -2834,20 +2504,10 @@ pub trait GithubServerServiceAuthorityRepository: Send + Sync {
         &self,
         request: RetireGithubServerServiceAuthority,
     ) -> Result<GithubServerServiceAuthorityDescriptor, GithubServerServiceStoreError>;
-    /// Claims an eligible retained credential for provider revocation.
-    async fn claim_github_server_service_revocation(
-        &self,
-        request: ClaimGithubServerServiceRevocation,
-    ) -> Result<ClaimedGithubServerServiceRevocation, GithubServerServiceStoreError>;
     /// Commits one closed provider revocation result.
     async fn finish_github_server_service_revocation(
         &self,
         request: FinishGithubServerServiceRevocation,
-    ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError>;
-    /// Erases indeterminate or quarantined custody only after the fixed horizon.
-    async fn erase_expired_github_server_service_issuance(
-        &self,
-        request: EraseExpiredGithubServerServiceIssuance,
     ) -> Result<GithubServerServiceIssuanceReceipt, GithubServerServiceStoreError>;
     /// Atomically discovers and claims/reduces one due tenant maintenance record.
     async fn claim_next_github_server_service_maintenance(

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -153,15 +153,13 @@ pub use github_schedule::{
 };
 pub use github_service_authority::{
     AcquireGithubServerServiceHandoff, BeginGithubServerServiceMint,
-    BeginGithubServerServiceMintOutcome, ClaimGithubServerServiceMint,
-    ClaimGithubServerServiceRevocation, ClaimNextGithubServerServiceMaintenance,
+    BeginGithubServerServiceMintOutcome, ClaimNextGithubServerServiceMaintenance,
     ClaimedGithubServerServiceMint, ClaimedGithubServerServiceRevocation,
-    EnsureGithubServerServiceAuthority, EraseExpiredGithubServerServiceIssuance,
-    FinishGithubServerServiceMint, FinishGithubServerServiceRevocation,
-    GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS, GITHUB_SERVICE_GENERATION_FAILURE_BACKOFF_MILLIS,
-    GITHUB_SERVICE_PROVIDER_CLOCK_SKEW_MILLIS, GITHUB_SERVICE_SAFE_ERASE_SKEW_MILLIS,
-    GITHUB_SERVICE_TOKEN_LIFETIME_MILLIS, GithubServerServiceAction,
-    GithubServerServiceAppClientId, GithubServerServiceAppId,
+    EnsureGithubServerServiceAuthority, FinishGithubServerServiceMint,
+    FinishGithubServerServiceRevocation, GITHUB_SERVICE_FAILURE_BUDGET_REARM_MILLIS,
+    GITHUB_SERVICE_GENERATION_FAILURE_BACKOFF_MILLIS, GITHUB_SERVICE_PROVIDER_CLOCK_SKEW_MILLIS,
+    GITHUB_SERVICE_SAFE_ERASE_SKEW_MILLIS, GITHUB_SERVICE_TOKEN_LIFETIME_MILLIS,
+    GithubServerServiceAction, GithubServerServiceAppClientId, GithubServerServiceAppId,
     GithubServerServiceAuthorityDescriptor, GithubServerServiceAuthorityId,
     GithubServerServiceAuthorityIdentity, GithubServerServiceAuthorityRepository,
     GithubServerServiceAuthoritySelector, GithubServerServiceAuthorityState,
@@ -180,7 +178,6 @@ pub use github_service_authority::{
     MAX_GITHUB_SERVICE_REVOKE_ATTEMPTS, MAX_GITHUB_SERVICE_REVOKE_CLAIM_MILLIS,
     MAX_GITHUB_SERVICE_REVOKE_RETRY_MILLIS, MIN_GITHUB_SERVICE_READY_USE_MILLIS,
     ProtectedGithubServerServiceCredential, QuarantineGithubServerServiceCredential,
-    ReclaimGithubServerServiceMint, ReconcileExpiredGithubServerServiceMint,
     ReleaseGithubServerServiceHandoff, RetireGithubServerServiceAuthority,
 };
 pub use github_subject_evidence::{

--- a/crates/automata-ci-store/tests/github_service_authority_api.rs
+++ b/crates/automata-ci-store/tests/github_service_authority_api.rs
@@ -1,22 +1,23 @@
 use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_key_management::{EncryptedEnvelope, KeyId, WrappedDataKey};
 use automata_ci_store::{
-    AcquireGithubServerServiceHandoff, ClaimGithubServerServiceMint, FinishGithubServerServiceMint,
-    GithubRepositoryName, GithubServerServiceAction, GithubServerServiceAppClientId,
-    GithubServerServiceAppId, GithubServerServiceAuthorityDescriptor,
-    GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
-    GithubServerServiceAuthorityRepository, GithubServerServiceAuthoritySelector,
-    GithubServerServiceAuthorityState, GithubServerServiceClaim, GithubServerServiceClaimFence,
-    GithubServerServiceConsumerClaim, GithubServerServiceConsumerId,
-    GithubServerServiceCredentialHandoff, GithubServerServiceEnvelopeMetadata,
-    GithubServerServiceGeneration, GithubServerServiceHandoffId, GithubServerServiceIssuanceKey,
+    AcquireGithubServerServiceHandoff, ClaimNextGithubServerServiceMaintenance,
+    FinishGithubServerServiceMint, GithubRepositoryName, GithubServerServiceAction,
+    GithubServerServiceAppClientId, GithubServerServiceAppId,
+    GithubServerServiceAuthorityDescriptor, GithubServerServiceAuthorityId,
+    GithubServerServiceAuthorityIdentity, GithubServerServiceAuthorityRepository,
+    GithubServerServiceAuthoritySelector, GithubServerServiceAuthorityState,
+    GithubServerServiceClaim, GithubServerServiceClaimFence, GithubServerServiceConsumerClaim,
+    GithubServerServiceConsumerId, GithubServerServiceCredentialHandoff,
+    GithubServerServiceEnvelopeMetadata, GithubServerServiceGeneration,
+    GithubServerServiceHandoffId, GithubServerServiceIssuanceKey,
     GithubServerServiceIssuanceReceipt, GithubServerServiceIssuanceState,
     GithubServerServiceJwtIssuer, GithubServerServiceRevision, GithubServerServiceScope,
     GithubServerServiceValueError, GithubServerServiceWorkerId,
     MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, MAX_GITHUB_SERVICE_HANDOFF_MILLIS,
     MAX_GITHUB_SERVICE_PLAINTEXT_BYTES, MIN_GITHUB_SERVICE_READY_USE_MILLIS,
     ProtectedGithubServerServiceCredential, ProviderConnectionId, ProviderInstallationId,
-    ProviderRepositoryId, ReconcileExpiredGithubServerServiceMint, RepositoryId, TenantScope,
+    ProviderRepositoryId, RepositoryId, TenantScope,
 };
 use uuid::Uuid;
 
@@ -132,35 +133,55 @@ fn failure_breaker_descriptor_requires_exact_saturated_rearm_shape() {
 }
 
 #[test]
-fn new_generation_claim_is_bounded_and_caller_pinned() {
-    let identity = identity(
-        GithubServerServiceScope::ChecksWrite,
-        GithubServerServiceJwtIssuer::AppClientId,
-    );
-    let selector = GithubServerServiceAuthoritySelector::from_identity(&identity);
-    let authority = identity.authority_id();
-    let generation = GithubServerServiceGeneration::new(4).expect("generation");
-    let request = ClaimGithubServerServiceMint::new(
-        selector.clone(),
-        generation,
-        worker(),
+fn next_maintenance_claim_is_tenant_scoped_and_bounded() {
+    let tenant = TenantScope::from_authenticated_tenant_id("tenant").expect("tenant");
+    let claim_worker = worker();
+    let request = ClaimNextGithubServerServiceMaintenance::new(
+        tenant.clone(),
+        claim_worker,
         UnixMillis::new(1_000),
-        UnixMillis::new(1_120),
         UnixMillis::new(1_100),
     )
-    .expect("bounded claim");
-    assert_eq!(request.authority_id(), authority);
-    assert_eq!(request.generation(), generation);
+    .expect("bounded maintenance claim");
+    assert_eq!(request.tenant(), &tenant);
+    assert_eq!(request.worker(), claim_worker);
+    assert_eq!(request.observed_at(), UnixMillis::new(1_000));
+    assert_eq!(request.claim_expires_at(), UnixMillis::new(1_100));
     assert!(matches!(
-        ClaimGithubServerServiceMint::new(
-            selector,
-            generation,
+        ClaimNextGithubServerServiceMaintenance::new(
+            tenant.clone(),
             worker(),
             UnixMillis::new(1_000),
             UnixMillis::new(121_001),
-            UnixMillis::new(1_100),
         ),
         Err(GithubServerServiceValueError::InvalidTimeInterval)
+    ));
+    assert!(matches!(
+        ClaimNextGithubServerServiceMaintenance::new(
+            tenant.clone(),
+            worker(),
+            UnixMillis::new(1_000),
+            UnixMillis::new(1_000),
+        ),
+        Err(GithubServerServiceValueError::InvalidTimeInterval)
+    ));
+    assert!(matches!(
+        ClaimNextGithubServerServiceMaintenance::new(
+            tenant.clone(),
+            worker(),
+            UnixMillis::new(1_000),
+            UnixMillis::new(999),
+        ),
+        Err(GithubServerServiceValueError::InvalidTimeInterval)
+    ));
+    assert!(matches!(
+        ClaimNextGithubServerServiceMaintenance::new(
+            tenant,
+            worker(),
+            UnixMillis::new(-1),
+            UnixMillis::new(1_000),
+        ),
+        Err(GithubServerServiceValueError::NegativeTimestamp)
     ));
 }
 
@@ -448,27 +469,6 @@ fn handoff_limits_are_action_specific_and_revoke_only_custody_is_never_deliverab
             protected(identity, generation, 32),
         ),
         Err(GithubServerServiceValueError::InvalidHandoff)
-    ));
-}
-
-#[test]
-fn expired_mint_reconciliation_is_bound_to_one_exact_generation() {
-    let key = GithubServerServiceIssuanceKey::new(
-        authority_id(),
-        GithubServerServiceGeneration::new(7).expect("generation"),
-    );
-    let selector = GithubServerServiceAuthoritySelector::from_identity(&identity(
-        GithubServerServiceScope::ChecksWrite,
-        GithubServerServiceJwtIssuer::AppClientId,
-    ));
-    let request =
-        ReconcileExpiredGithubServerServiceMint::new(selector.clone(), key, UnixMillis::new(4_000))
-            .expect("reconciliation request");
-    assert_eq!(request.key(), key);
-    assert_eq!(request.observed_at(), UnixMillis::new(4_000));
-    assert!(matches!(
-        ReconcileExpiredGithubServerServiceMint::new(selector, key, UnixMillis::new(-1)),
-        Err(GithubServerServiceValueError::NegativeTimestamp)
     ));
 }
 

--- a/crates/automata-ci/src/server/github_provider.rs
+++ b/crates/automata-ci/src/server/github_provider.rs
@@ -805,9 +805,7 @@ fn map_authority_store_error(
         GithubServerServiceStoreError::CorruptData
         | GithubServerServiceStoreError::NotFound
         | GithubServerServiceStoreError::HandoffRejected
-        | GithubServerServiceStoreError::RefreshAlreadyActive
         | GithubServerServiceStoreError::FenceExhausted
-        | GithubServerServiceStoreError::RetryLimitReached
         | GithubServerServiceStoreError::HandoffStillLive => {
             GithubProviderBootstrapError::InconsistentState
         }

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -1052,9 +1052,7 @@ fn map_authority_resolution_store_error(
         | GithubServerServiceStoreError::IdentityConflict
         | GithubServerServiceStoreError::ClaimRejected
         | GithubServerServiceStoreError::HandoffRejected
-        | GithubServerServiceStoreError::RefreshAlreadyActive
         | GithubServerServiceStoreError::FenceExhausted
-        | GithubServerServiceStoreError::RetryLimitReached
         | GithubServerServiceStoreError::HandoffStillLive => {
             GithubProviderCredentialHandoffError::Inconsistent
         }


### PR DESCRIPTION
## Outcome

Retires the five unused exact-key GitHub server-service maintenance commands from Store and PostgreSQL. Production maintenance now exposes only the tenant-wide atomic `claim_next_github_server_service_maintenance` boundary; its implementation and the credential coordinator are unchanged.

Tests now exercise that production boundary and assert the exact selected authority, key, generation, and terminal state.

The diff is 8 Rust files, +547/-1,496 (net -949).

## Related issue

Fixes #182.

## Trust and compatibility impact

The removed public surface comprises:

- `ClaimGithubServerServiceMint`
- `ReclaimGithubServerServiceMint`
- `ReconcileExpiredGithubServerServiceMint`
- `ClaimGithubServerServiceRevocation`
- `EraseExpiredGithubServerServiceIssuance`
- their 28 inherent methods, five repository methods, and root reexports
- the now-unreachable `RefreshAlreadyActive` and `RetryLimitReached` variants

`GithubServerServiceAuthorityRepository` contracts from 15 methods to 10. The seven-method production credential port, `coordinate_next`, begin/finish operations, handoffs, quarantine, and explicit authority retirement remain unchanged. The canonical PostgreSQL claim-next implementation is byte-identical.

Important non-goal: this does not claim production mint-retry parity. A new mint's 120-second request deadline cannot accommodate the coordinator's later 120-second retry lease. The focused regression records that the retry remains pending until deadline reduction rather than silently claiming reachability.

This is an intentional pre-release source contraction in the unpublished Store 0.1 crate, not a drop-in compatibility claim. There is no dependency, lockfile, schema, migration, durable-row, protocol, wire-format, generated-file, package-inventory, or release-metadata change.

## Verification

- formatting and Git diff checks pass
- exhaustive retired-symbol and compatibility-shim scan: zero matches
- Store tests: 212/212
- affected Store, Store PostgreSQL, PostgreSQL composition, and product all-target/all-feature checks pass
- strict Clippy and rustdoc with warnings denied pass for all four affected packages
- PostgreSQL 18.4 authority contracts: 14/14
- PostgreSQL 18.4 authority-clock contracts: 4/4
- remaining bounded PostgreSQL lanes: 31/31
  - fixture self-tests: 10/10
  - GitHub Results artifacts/cache: 20/20
  - provider end-to-end matrix: 1/1
- full adapters/Store PostgreSQL lane: 402/407; all five failures reproduce with the same SQLSTATE, constraint/table, and deadlock location on untouched current `main`
- publish policy: 17/17; planner lists 48 crates
- release handoff: 9/9
- coverage policy, package inventories, metadata, and lockfile equivalence pass
- merge-tree checks against current main and every open PR pass with zero changed-path overlap

The integration-target topology verifier currently fails identically on this branch and untouched main because merged #183 added `automata-ci-workflow-github/tests/yaml_aliases.rs` without registering it. This PR does not touch that package or verifier.

## AI assistance

OpenAI Codex helped audit reachability, migrate invariant coverage to the canonical maintenance boundary, and review API, lock, publication, and mint-retry implications. All submitted claims and validation results were verified against the repository and PostgreSQL 18.4.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
