### PR TITLE
feat(platform): require exact Windows Hyper-V placement

### DIFF
--- a/crates/automata-ci-control/tests/scheduling_policy.rs
+++ b/crates/automata-ci-control/tests/scheduling_policy.rs
@@ -6,7 +6,8 @@ use automata_ci_control::scheduling::{
 use automata_ci_core::{RequirementMismatch, UnixMillis};
 
 use super::scheduling_support::{
-    attempt_id, candidate, effective_runner, job_id, label, routing, runner_id,
+    attempt_id, candidate, effective_runner, job_id, label, routing, runner_id, windows_candidate,
+    windows_effective_runner,
 };
 
 #[test]
@@ -99,6 +100,35 @@ fn incompatibility_preserves_complete_core_matching_diagnostics() {
         runner_declines[0].mismatches(),
         &[RequirementMismatch::MissingLabel(label("gpu"))]
     );
+}
+
+#[test]
+fn windows_hyperv_launch_kind_is_enforced_before_placement() {
+    let candidates = [windows_candidate(1, 100)];
+    let generic_vm_runners = [windows_effective_runner(1, false, &[1])];
+    let decision = DeterministicScheduler.decide(
+        SchedulingInput::new(&candidates, &generic_vm_runners).expect("scheduling snapshot"),
+    );
+    let PlacementDecision::Decline(PlacementDecline::Candidates(declines)) = decision else {
+        panic!("a generic Windows VM must be declined before placement")
+    };
+    let CandidateDeclineReason::NoCompatibleRunner(runner_declines) = declines[0].reason() else {
+        panic!("an exact capability decline was expected")
+    };
+    assert_eq!(
+        runner_declines[0].mismatches(),
+        &[RequirementMismatch::MissingSandboxFeature(
+            automata_ci_core::SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+        )]
+    );
+
+    let exact_runners = [windows_effective_runner(1, true, &[1])];
+    assert!(matches!(
+        DeterministicScheduler.decide(
+            SchedulingInput::new(&candidates, &exact_runners).expect("scheduling snapshot")
+        ),
+        PlacementDecision::Place(_)
+    ));
 }
 
 #[test]

--- a/crates/automata-ci-control/tests/scheduling_support.rs
+++ b/crates/automata-ci-control/tests/scheduling_support.rs
@@ -7,10 +7,10 @@ use automata_ci_control::scheduling::{
     RunnerEvidence, RunnerSlot, SessionGuard,
 };
 use automata_ci_core::{
-    Architecture, AttemptId, ContainerCapabilities, ContainerFeature, JobId, OperatingSystem,
-    ResourceCapacity, RunnerCapabilities, RunnerFeature, RunnerGroup, RunnerId, RunnerLabel,
-    RunnerPlatform, RunnerRequirements, RunnerSessionId, SandboxCapabilities, SandboxFeature,
-    UnixMillis,
+    Architecture, AttemptId, ContainerCapabilities, ContainerFeature, IsolationLevel, JobId,
+    OperatingSystem, ResourceCapacity, RunnerCapabilities, RunnerFeature, RunnerGroup, RunnerId,
+    RunnerLabel, RunnerPlatform, RunnerRequirements, RunnerSessionId, SandboxCapabilities,
+    SandboxFeature, UnixMillis,
 };
 
 pub fn typed_id<T>(tail: u64) -> T
@@ -82,13 +82,23 @@ pub fn effective_runner(
 ) -> EffectiveRunner {
     let runner_id = runner_id(tail);
     let observed = observed_capabilities(runner_id, 4);
+    authorize_effective_runner(tail, labels, groups, available_ordinals, observed)
+}
+
+fn authorize_effective_runner(
+    tail: u64,
+    labels: &[&str],
+    groups: &[&str],
+    available_ordinals: &[u16],
+    observed: RunnerCapabilities,
+) -> EffectiveRunner {
+    let runner_id = observed.runner_id();
     let evidence = RunnerEvidence::new(
         SessionGuard::new(runner_id, session_id(tail)),
-        observed,
+        observed.clone(),
         UnixMillis::new(1_000),
     )
     .expect("test evidence must be valid");
-    let effective = observed_capabilities(runner_id, 4);
     let routing = AuthorizedRunnerRouting::new(
         labels.iter().map(|value| label(value)),
         groups.iter().map(|value| group(value)),
@@ -96,8 +106,34 @@ pub fn effective_runner(
     let slots = available_ordinals.iter().map(|ordinal| {
         RunnerSlot::new(runner_id, *ordinal).expect("test slot ordinal must be valid")
     });
-    EffectiveRunner::authorize(&evidence, routing, effective, slots)
+    EffectiveRunner::authorize(&evidence, routing, observed, slots)
         .expect("test effective runner must be valid")
+}
+
+pub fn windows_effective_runner(
+    tail: u64,
+    advertises_hyperv_container: bool,
+    available_ordinals: &[u16],
+) -> EffectiveRunner {
+    let runner_id = runner_id(tail);
+    let mut sandbox_features = vec![
+        SandboxFeature::CLEAN_WORKSPACE,
+        SandboxFeature::NETWORK_ISOLATION,
+    ];
+    if advertises_hyperv_container {
+        sandbox_features.push(SandboxFeature::WINDOWS_HYPERV_CONTAINER);
+    }
+    let observed = RunnerCapabilities::new(
+        runner_id,
+        RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+    )
+    .with_max_parallel_jobs(1)
+    .expect("Windows test runner must advertise one slot")
+    .with_sandbox(SandboxCapabilities::new(
+        IsolationLevel::VirtualMachine,
+        sandbox_features,
+    ));
+    authorize_effective_runner(tail, &["windows"], &[], available_ordinals, observed)
 }
 
 pub fn routing(labels: &[&str]) -> RoutingRequirements {
@@ -116,5 +152,20 @@ pub fn candidate(tail: u64, queued_at: i64, labels: &[&str]) -> RunnableCandidat
         job_id(tail),
         UnixMillis::new(queued_at),
         routing(labels),
+    )
+}
+
+pub fn windows_candidate(tail: u64, queued_at: i64) -> RunnableCandidate {
+    RunnableCandidate::new(
+        attempt_id(tail),
+        job_id(tail),
+        UnixMillis::new(queued_at),
+        RoutingRequirements::new(
+            RunnerRequirements::default()
+                .with_labels([label("windows")])
+                .with_windows_hyperv_container()
+                .with_architecture(Architecture::X86_64),
+        )
+        .expect("Windows Hyper-V routing requirements must be valid"),
     )
 }

--- a/crates/automata-ci-core/src/capability/feature.rs
+++ b/crates/automata-ci-core/src/capability/feature.rs
@@ -285,6 +285,9 @@ capability_id_type! {
         PRIVILEGED_USER = "automata.core/privileged-user@v1",
         /// Explicit host paths can be mounted into the sandbox.
         HOST_PATH_MOUNTS = "automata.core/host-path-mounts@v1",
+        /// Jobs launch only through the explicit Hyper-V-isolated Windows
+        /// container mechanism, without process-container or full-VM fallback.
+        WINDOWS_HYPERV_CONTAINER = "automata.core/windows-hyperv-container@v1",
     }
 }
 

--- a/crates/automata-ci-core/src/capability/requirement.rs
+++ b/crates/automata-ci-core/src/capability/requirement.rs
@@ -77,6 +77,15 @@ impl<'de> Deserialize<'de> for RunnerRequirements {
                 value.schema_version, RUNNER_REQUIREMENTS_SCHEMA_VERSION
             )));
         }
+        if !windows_hyperv_requirement_is_valid(
+            value.operating_system.as_ref(),
+            value.minimum_isolation,
+            &value.sandbox_features,
+        ) {
+            return Err(D::Error::custom(
+                "Windows runner requirements must bind VM isolation and the exact Hyper-V-container launch capability",
+            ));
+        }
         Ok(Self {
             schema_version: value.schema_version,
             labels: value.labels,
@@ -186,7 +195,26 @@ impl RunnerRequirements {
     /// Requires one operating-system family.
     #[must_use]
     pub fn with_operating_system(mut self, operating_system: OperatingSystem) -> Self {
+        if operating_system == OperatingSystem::Windows {
+            return self.with_windows_hyperv_container();
+        }
+        self.sandbox_features
+            .remove(&SandboxFeature::WINDOWS_HYPERV_CONTAINER);
         self.operating_system = Some(operating_system);
+        self
+    }
+
+    /// Requires the only accepted Windows launch shape: a Hyper-V-isolated
+    /// container with a dedicated guest-kernel boundary.
+    ///
+    /// This is intentionally stronger than a generic virtual-machine minimum:
+    /// another VM-backed provider cannot satisfy the exact launch requirement.
+    #[must_use]
+    pub fn with_windows_hyperv_container(mut self) -> Self {
+        self.operating_system = Some(OperatingSystem::Windows);
+        self.minimum_isolation = self.minimum_isolation.max(IsolationLevel::VirtualMachine);
+        self.sandbox_features
+            .insert(SandboxFeature::WINDOWS_HYPERV_CONTAINER);
         self
     }
 
@@ -218,7 +246,12 @@ impl RunnerRequirements {
     /// Replaces the weakest acceptable isolation boundary.
     #[must_use]
     pub const fn with_minimum_isolation(mut self, isolation: IsolationLevel) -> Self {
-        self.minimum_isolation = isolation;
+        self.minimum_isolation = if matches!(&self.operating_system, Some(OperatingSystem::Windows))
+        {
+            IsolationLevel::VirtualMachine
+        } else {
+            isolation
+        };
         self
     }
 
@@ -229,6 +262,16 @@ impl RunnerRequirements {
         features: impl IntoIterator<Item = SandboxFeature>,
     ) -> Self {
         self.sandbox_features = features.into_iter().collect();
+        if self
+            .sandbox_features
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+        {
+            return self.with_windows_hyperv_container();
+        }
+        if self.operating_system == Some(OperatingSystem::Windows) {
+            self.sandbox_features
+                .insert(SandboxFeature::WINDOWS_HYPERV_CONTAINER);
+        }
         self
     }
 
@@ -254,6 +297,21 @@ impl RunnerRequirements {
     pub fn with_environment_profile(mut self, profile: EnvironmentProfile) -> Self {
         self.environment_profile = Some(profile);
         self
+    }
+}
+
+fn windows_hyperv_requirement_is_valid(
+    operating_system: Option<&OperatingSystem>,
+    minimum_isolation: IsolationLevel,
+    sandbox_features: &BTreeSet<SandboxFeature>,
+) -> bool {
+    let requires_hyperv = sandbox_features.contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER);
+    match operating_system {
+        Some(OperatingSystem::Windows) => {
+            minimum_isolation >= IsolationLevel::VirtualMachine && requires_hyperv
+        }
+        Some(OperatingSystem::Linux | OperatingSystem::Macos | OperatingSystem::Other(_))
+        | None => !requires_hyperv,
     }
 }
 

--- a/crates/automata-ci-core/tests/capability_identifiers.rs
+++ b/crates/automata-ci-core/tests/capability_identifiers.rs
@@ -9,6 +9,10 @@ fn known_identifiers_have_stable_namespaced_wire_values() {
         "automata.core/network-isolation@v1",
     );
     assert_eq!(
+        SandboxFeature::WINDOWS_HYPERV_CONTAINER.as_str(),
+        "automata.core/windows-hyperv-container@v1",
+    );
+    assert_eq!(
         ContainerFeature::SERVICE_CONTAINERS.as_str(),
         "automata.core/service-containers@v1",
     );

--- a/crates/automata-ci-core/tests/capability_matching.rs
+++ b/crates/automata-ci-core/tests/capability_matching.rs
@@ -136,6 +136,88 @@ fn typed_requirement_matching_checks_groups_resources_and_features() {
 }
 
 #[test]
+fn windows_requirements_cannot_fall_back_to_a_generic_vm_runner() {
+    let requirements = RunnerRequirements::default()
+        .with_windows_hyperv_container()
+        .with_minimum_isolation(IsolationLevel::Process)
+        .with_sandbox_features([SandboxFeature::NETWORK_ISOLATION]);
+    assert_eq!(
+        requirements.operating_system(),
+        Some(&OperatingSystem::Windows)
+    );
+    assert_eq!(
+        requirements.minimum_isolation(),
+        IsolationLevel::VirtualMachine
+    );
+    assert!(
+        requirements
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
+
+    let generic_vm = RunnerCapabilities::new(
+        RunnerId::new(),
+        RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+    )
+    .with_sandbox(SandboxCapabilities::new(
+        IsolationLevel::VirtualMachine,
+        [SandboxFeature::NETWORK_ISOLATION],
+    ));
+    let mismatch = generic_vm
+        .satisfies(&requirements)
+        .expect_err("generic VM isolation cannot impersonate a Hyper-V container");
+    assert_eq!(
+        mismatch.as_slice(),
+        &[RequirementMismatch::MissingSandboxFeature(
+            SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+        )]
+    );
+
+    let exact = generic_vm.with_sandbox(SandboxCapabilities::new(
+        IsolationLevel::VirtualMachine,
+        [
+            SandboxFeature::NETWORK_ISOLATION,
+            SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+        ],
+    ));
+    assert_eq!(exact.satisfies(&requirements), Ok(()));
+}
+
+#[test]
+fn windows_hyperv_requirement_serde_rejects_weakened_or_cross_platform_shapes() {
+    let exact = RunnerRequirements::default().with_windows_hyperv_container();
+    let mut missing_launch = serde_json::to_value(&exact).expect("serialize requirements");
+    missing_launch["sandbox_features"] = serde_json::json!([]);
+    assert!(serde_json::from_value::<RunnerRequirements>(missing_launch).is_err());
+
+    let mut weak_isolation = serde_json::to_value(&exact).expect("serialize requirements");
+    weak_isolation["minimum_isolation"] = serde_json::json!("shared_kernel");
+    assert!(serde_json::from_value::<RunnerRequirements>(weak_isolation).is_err());
+
+    let mut wrong_platform = serde_json::to_value(&exact).expect("serialize requirements");
+    wrong_platform["operating_system"] = serde_json::json!("linux");
+    assert!(serde_json::from_value::<RunnerRequirements>(wrong_platform).is_err());
+
+    let linux = RunnerRequirements::default()
+        .with_operating_system(OperatingSystem::Linux)
+        .with_minimum_isolation(IsolationLevel::SharedKernel)
+        .with_sandbox_features([SandboxFeature::NETWORK_ISOLATION]);
+    assert_eq!(linux.minimum_isolation(), IsolationLevel::SharedKernel);
+    assert!(
+        !linux
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
+    assert_eq!(
+        serde_json::from_value::<RunnerRequirements>(
+            serde_json::to_value(&linux).expect("serialize Linux requirements")
+        )
+        .expect("Linux requirements retain their existing shape"),
+        linux
+    );
+}
+
+#[test]
 fn allocation_requests_are_placement_evidence_but_limits_require_enforcement_capacity() {
     let allocation = JobResourceAllocation::new(
         ResourceCapacity::new(500, 512 * 1024 * 1024, 0, 0),

--- a/crates/automata-ci-protocol-protobuf/src/decode.rs
+++ b/crates/automata-ci-protocol-protobuf/src/decode.rs
@@ -686,6 +686,14 @@ fn runner_requirements(
 
     let labels = decode_labels(value.labels, "runner_requirements.labels")?;
     let groups = decode_groups(value.eligible_groups, "runner_requirements.eligible_groups")?;
+    let operating_system = value
+        .operating_system
+        .map(self::operating_system)
+        .transpose()?;
+    let minimum_isolation = isolation_level(
+        value.minimum_isolation,
+        "runner_requirements.minimum_isolation",
+    )?;
     let sandbox_features = value
         .sandbox_features
         .into_iter()
@@ -714,6 +722,12 @@ fn runner_requirements(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    validate_windows_hyperv_requirement(
+        operating_system.as_ref(),
+        minimum_isolation,
+        &sandbox_features,
+    )?;
+
     let mut requirements = core::RunnerRequirements::default()
         .with_labels(labels)
         .with_eligible_groups(groups)
@@ -724,16 +738,12 @@ fn runner_requirements(
             )?,
             "runner_requirements.minimum_resources.gpu_count",
         )?)
-        .with_minimum_isolation(isolation_level(
-            value.minimum_isolation,
-            "runner_requirements.minimum_isolation",
-        )?)
+        .with_minimum_isolation(minimum_isolation)
         .with_sandbox_features(sandbox_features)
         .with_container_features(container_features)
         .with_features(features);
-    if let Some(operating_system) = value.operating_system {
-        requirements =
-            requirements.with_operating_system(self::operating_system(operating_system)?);
+    if let Some(operating_system) = operating_system {
+        requirements = requirements.with_operating_system(operating_system);
     }
     if let Some(architecture) = value.architecture {
         requirements = requirements.with_architecture(self::architecture(architecture)?);
@@ -751,6 +761,31 @@ fn runner_requirements(
         requirements = requirements.with_resource_allocation(allocation);
     }
     Ok(requirements)
+}
+
+fn validate_windows_hyperv_requirement(
+    operating_system: Option<&core::OperatingSystem>,
+    minimum_isolation: core::IsolationLevel,
+    sandbox_features: &[core::SandboxFeature],
+) -> Result<(), DecodeError> {
+    let exact_launch = sandbox_features.contains(&core::SandboxFeature::WINDOWS_HYPERV_CONTAINER);
+    if matches!(operating_system, Some(core::OperatingSystem::Windows)) {
+        if minimum_isolation < core::IsolationLevel::VirtualMachine {
+            return Err(DecodeError::InvalidValue {
+                field: "runner_requirements.minimum_isolation",
+            });
+        }
+        if !exact_launch {
+            return Err(DecodeError::InvalidValue {
+                field: "runner_requirements.sandbox_features",
+            });
+        }
+    } else if exact_launch {
+        return Err(DecodeError::InvalidValue {
+            field: "runner_requirements.sandbox_features",
+        });
+    }
+    Ok(())
 }
 
 fn validate_runner_requirement_collections(

--- a/crates/automata-ci-protocol-protobuf/tests/boundary.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/boundary.rs
@@ -180,6 +180,18 @@ fn fixture_job_ir() -> fixture_wire::JobIrEnvelope {
     fixture_wire::JobIrEnvelope::decode(encoded.as_slice()).expect("decode private test DTO")
 }
 
+fn job_ir_runner_requirements(
+    envelope: &mut fixture_wire::JobIrEnvelope,
+) -> &mut fixture_wire::RunnerRequirements {
+    envelope
+        .job
+        .as_mut()
+        .expect("job")
+        .requirements
+        .as_mut()
+        .expect("runner requirements")
+}
+
 #[test]
 fn standalone_job_ir_rejects_schema_and_expression_program_skew() {
     for version in [2, u32::from(JobIrVersion::current().get()) + 1] {
@@ -212,6 +224,52 @@ fn standalone_job_ir_rejects_schema_and_expression_program_skew() {
         Err(DecodeError::UnsupportedSchema {
             field: "expression_program.schema_version",
             ..
+        })
+    ));
+}
+
+#[test]
+fn windows_hyperv_requirement_wire_shape_fails_closed() {
+    let exact = common::rich_job_with_requirements(
+        automata_ci_core::RunnerRequirements::default().with_windows_hyperv_container(),
+    );
+    let encoded = encode_job_ir(&exact, &ProtocolLimits::default()).expect("encode exact shape");
+    let fixture = fixture_wire::JobIrEnvelope::decode(encoded.as_slice())
+        .expect("decode private exact-shape DTO");
+    decode_job_ir(&encode(&fixture), &ProtocolLimits::default()).expect("decode exact shape");
+
+    let mut missing_launch = fixture.clone();
+    job_ir_runner_requirements(&mut missing_launch)
+        .sandbox_features
+        .clear();
+    assert!(matches!(
+        decode_job_ir(&encode(&missing_launch), &ProtocolLimits::default()),
+        Err(DecodeError::InvalidValue {
+            field: "runner_requirements.sandbox_features"
+        })
+    ));
+
+    let mut weak_isolation = fixture.clone();
+    job_ir_runner_requirements(&mut weak_isolation).minimum_isolation =
+        fixture_wire::IsolationLevel::SharedKernel as i32;
+    assert!(matches!(
+        decode_job_ir(&encode(&weak_isolation), &ProtocolLimits::default()),
+        Err(DecodeError::InvalidValue {
+            field: "runner_requirements.minimum_isolation"
+        })
+    ));
+
+    let mut wrong_platform = fixture;
+    job_ir_runner_requirements(&mut wrong_platform).operating_system =
+        Some(fixture_wire::OperatingSystem {
+            value: Some(fixture_wire::operating_system::Value::Linux(
+                fixture_wire::Unit {},
+            )),
+        });
+    assert!(matches!(
+        decode_job_ir(&encode(&wrong_platform), &ProtocolLimits::default()),
+        Err(DecodeError::InvalidValue {
+            field: "runner_requirements.sandbox_features"
         })
     ));
 }

--- a/crates/automata-ci-protocol-protobuf/tests/roundtrip.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/roundtrip.rs
@@ -1,11 +1,15 @@
 use crate::common;
 
-use automata_ci_core::{JobResourceAllocation, OperationId, ResourceCapacity, RunnerRequirements};
+use automata_ci_core::{
+    IsolationLevel, JobResourceAllocation, OperatingSystem, OperationId, ResourceCapacity,
+    RunnerRequirements, SandboxFeature,
+};
 use automata_ci_protocol::{LeaseRequest, ProtocolLimits, RunnerToServer, ServerToRunner};
 use automata_ci_protocol_protobuf::{
-    PROTOBUF_PACKAGE, decode_runner_frame, decode_server_frame, encode_runner_frame,
-    encode_server_frame,
+    PROTOBUF_PACKAGE, decode_job_ir, decode_runner_frame, decode_server_frame, encode_job_ir,
+    encode_runner_frame, encode_server_frame,
 };
+use sha2::{Digest as _, Sha256};
 
 #[test]
 fn every_runner_envelope_variant_round_trips_losslessly() {
@@ -78,6 +82,40 @@ fn resource_allocation_round_trips_with_exact_requests_and_limits() {
         offer.job().job().requirements().resource_allocation(),
         Some(allocation)
     );
+}
+
+#[test]
+fn windows_hyperv_placement_round_trips_and_binds_the_job_digest() {
+    let limits = ProtocolLimits::default();
+    let exact = common::rich_job_with_requirements(
+        RunnerRequirements::default().with_windows_hyperv_container(),
+    );
+    let encoded = encode_job_ir(&exact, &limits).expect("encode exact Windows placement");
+    let digest = Sha256::digest(&encoded);
+    let decoded = decode_job_ir(&encoded, &limits).expect("decode exact Windows placement");
+    let requirements = decoded.job().requirements();
+    assert_eq!(
+        requirements.operating_system(),
+        Some(&OperatingSystem::Windows)
+    );
+    assert_eq!(
+        requirements.minimum_isolation(),
+        IsolationLevel::VirtualMachine
+    );
+    assert!(
+        requirements
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
+    let replay = encode_job_ir(&decoded, &limits).expect("re-encode exact Windows placement");
+    assert_eq!(replay, encoded);
+    assert_eq!(Sha256::digest(&replay), digest);
+
+    let generic_vm = common::rich_job_with_requirements(
+        RunnerRequirements::default().with_minimum_isolation(IsolationLevel::VirtualMachine),
+    );
+    let generic_bytes = encode_job_ir(&generic_vm, &limits).expect("encode generic VM placement");
+    assert_ne!(Sha256::digest(generic_bytes), digest);
 }
 
 #[test]

--- a/crates/automata-ci-protocol/tests/capability_version_skew.rs
+++ b/crates/automata-ci-protocol/tests/capability_version_skew.rs
@@ -1,10 +1,10 @@
 use automata_ci_core::{
-    Architecture, AttemptId, EnvironmentProfile, EnvironmentProfileId, FencingToken, JobId,
-    JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersionRange, JobSource, Lease, LeaseId,
-    OperatingSystem, OperationId, RequirementMismatch, RunId, RunValueTemplates,
+    Architecture, AttemptId, EnvironmentProfile, EnvironmentProfileId, FencingToken,
+    IsolationLevel, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersionRange, JobSource,
+    Lease, LeaseId, OperatingSystem, OperationId, RequirementMismatch, RunId, RunValueTemplates,
     RunnerCapabilities, RunnerFeature, RunnerId, RunnerPlatform, RunnerRequirements,
-    RuntimeBoolean, Sha256Digest, ShellTemplate, StepId, StepIr, UnixMillis, ValueTemplate,
-    WorkflowId,
+    RuntimeBoolean, SandboxCapabilities, SandboxFeature, Sha256Digest, ShellTemplate, StepId,
+    StepIr, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
     CommandSequence, JobRuntimeAuthorities, JobRuntimeAuthority, LeaseOffer,
@@ -178,6 +178,45 @@ fn validated_lease_preserves_exact_environment_profile_attestation() {
         mismatches.as_slice(),
         [RequirementMismatch::EnvironmentProfile { required: actual, .. }] if actual == &required
     ));
+}
+
+#[test]
+fn validated_lease_preserves_exact_windows_hyperv_placement() {
+    let message = lease_offer(RunnerRequirements::default().with_windows_hyperv_container());
+    let validated = ValidatedServerToRunner::new(message, &ProtocolLimits::default())
+        .expect("validate Windows Hyper-V lease offer");
+    let ServerToRunner::LeaseOffer(offer) = validated.into_message() else {
+        panic!("validated a different server message")
+    };
+    let requirements = offer.job().job().requirements();
+    assert_eq!(
+        requirements.operating_system(),
+        Some(&OperatingSystem::Windows)
+    );
+    assert_eq!(
+        requirements.minimum_isolation(),
+        IsolationLevel::VirtualMachine
+    );
+    assert!(
+        requirements
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
+
+    let generic_vm = RunnerCapabilities::new(
+        RunnerId::new(),
+        RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+    )
+    .with_sandbox(SandboxCapabilities::new(IsolationLevel::VirtualMachine, []));
+    let mismatches = generic_vm
+        .satisfies(requirements)
+        .expect_err("generic VM capability cannot accept a Hyper-V-container lease");
+    assert_eq!(
+        mismatches.as_slice(),
+        &[RequirementMismatch::MissingSandboxFeature(
+            SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+        )]
+    );
 }
 
 #[test]

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -113,6 +113,14 @@ and `ContainerUser` identity. Configuration rejects every host-network,
 host-filesystem, administrator, native-process, process-isolated-container, or
 mutable-image alternative.
 
+The resulting inventory advertises
+`automata.core/windows-hyperv-container@v1` only for `windows_hyperv`. GitHub
+Windows projection requires that exact launch capability together with
+`IsolationLevel::VirtualMachine`; a generic VM advertisement, including the
+macOS VM provider, cannot match. Registered and live-observed capabilities are
+intersected before scheduler matching, and the match is repeated before a
+placement can become a lease.
+
 It advertises only PowerShell and `cmd.exe` shell steps plus command files, with
 optional support for one absolute standalone Python interpreter. Every
 configured interpreter is exercised through a copied script in a disposable
@@ -127,7 +135,9 @@ The checked-in runtime and image digests are placeholders, not promoted
 artifacts. Unit and injected-runtime tests do not prove a physical Windows host,
 HCS/HCN behavior, image contents, patch compatibility, or nested Job Object
 enforcement. Keep this runner out of production until a reviewed image and the
-physical-host acceptance gate are published.
+physical-host acceptance gate are published. The exact launch requirement also
+does not create the AUTH-02 one-use trust grant; Windows remains unavailable
+until authenticated placement evidence is implemented and accepted.
 
 Copy [`runner.windows.example.json`](runner.windows.example.json) to an ignored
 host-specific path, replace every placeholder digest, and follow the

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -1664,7 +1664,19 @@ fn provider_capabilities(
                 ]),
             )
         }
-        ProviderKind::WindowsHyperV | ProviderKind::MacosVirtualization => (
+        ProviderKind::WindowsHyperV => (
+            SandboxCapabilities::new(
+                IsolationLevel::VirtualMachine,
+                [
+                    SandboxFeature::CLEAN_WORKSPACE,
+                    SandboxFeature::NETWORK_ISOLATION,
+                    SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+                ],
+            ),
+            BTreeSet::new(),
+            BTreeSet::from([RunnerFeature::SHELL_STEPS, RunnerFeature::COMMAND_FILES]),
+        ),
+        ProviderKind::MacosVirtualization => (
             SandboxCapabilities::new(
                 IsolationLevel::VirtualMachine,
                 [

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -205,6 +205,13 @@ fn validated_config_preserves_exact_runner_and_profile_inventory() {
             .features()
             .contains(&SandboxFeature::READ_ONLY_ROOT)
     );
+    assert!(
+        !config
+            .inventory()
+            .sandbox()
+            .features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
     assert!(config.object_store().force_path_style());
     assert!(
         config

--- a/crates/automata-ci-runner/tests/runner_product_config_macos.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_macos.rs
@@ -1,5 +1,6 @@
 #![cfg(all(target_os = "macos", target_arch = "aarch64"))]
 
+use automata_ci_core::SandboxFeature;
 use automata_ci_runner::product::{RunnerProductConfig, RunnerProductConfigError};
 
 fn baseline() -> serde_json::Value {
@@ -29,6 +30,18 @@ fn legacy_schema_and_native_provider_are_rejected() {
         .remove("macos_virtualization");
     native["macos_native"] = serde_json::json!({});
     assert!(parse(&native).is_err(), "macos_native must be unknown");
+}
+
+#[test]
+fn macos_vm_does_not_advertise_the_windows_hyperv_container_launch_kind() {
+    let config = parse(&baseline()).expect("checked-in macOS runner configuration");
+    assert!(
+        !config
+            .inventory()
+            .sandbox()
+            .features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
 }
 
 #[test]

--- a/crates/automata-ci-runner/tests/runner_product_config_windows.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_windows.rs
@@ -67,6 +67,7 @@ fn checked_in_windows_configuration_selects_only_hyperv_containers() {
         &BTreeSet::from([
             SandboxFeature::CLEAN_WORKSPACE,
             SandboxFeature::NETWORK_ISOLATION,
+            SandboxFeature::WINDOWS_HYPERV_CONTAINER,
         ])
     );
     for feature in [RunnerFeature::SHELL_STEPS, RunnerFeature::COMMAND_FILES] {

--- a/crates/automata-ci-workflow-service/src/logical_projection.rs
+++ b/crates/automata-ci-workflow-service/src/logical_projection.rs
@@ -488,7 +488,10 @@ fn runner_requirements(
             .with_container_features(mapping.container_features().iter().cloned());
     }
     if let MergedSelector::Value(value) = operating_system {
-        requirements = requirements.with_operating_system(value);
+        requirements = match value {
+            OperatingSystem::Windows => requirements.with_windows_hyperv_container(),
+            operating_system => requirements.with_operating_system(operating_system),
+        };
     }
     if let MergedSelector::Value(value) = architecture {
         requirements = requirements.with_architecture(value);

--- a/crates/automata-ci-workflow-service/tests/logical_projection.rs
+++ b/crates/automata-ci-workflow-service/tests/logical_projection.rs
@@ -2,12 +2,12 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use automata_ci_core::{
     Architecture, ContainerFeature, ContextValue, EnvironmentProfile, EnvironmentProfileId,
-    JobAuthorityProfile, JobContentReference, JobExecutionContext, JobId, JobIrEnvelope,
-    JobPermissionGrant, JobPermissionRequest, JobResourceAllocation, JobResourcePolicy,
-    JobValidationError, OperatingSystem, OutputSensitivity, PermissionLevel, ResourceCapacity,
-    RunnerFeature, RuntimePositiveInteger, RuntimeTimeoutUnit, SemanticStep, Sha256Digest,
-    ShellTemplate, TransportProtocol, ValueSource, ValueTemplateSegment, WorkflowEventProvenance,
-    WorkflowId, WorkflowJobKey, WorkflowPlan,
+    IsolationLevel, JobAuthorityProfile, JobContentReference, JobExecutionContext, JobId,
+    JobIrEnvelope, JobPermissionGrant, JobPermissionRequest, JobResourceAllocation,
+    JobResourcePolicy, JobValidationError, OperatingSystem, OutputSensitivity, PermissionLevel,
+    ResourceCapacity, RunnerFeature, RuntimePositiveInteger, RuntimeTimeoutUnit, SandboxFeature,
+    SemanticStep, Sha256Digest, ShellTemplate, TransportProtocol, ValueSource,
+    ValueTemplateSegment, WorkflowEventProvenance, WorkflowId, WorkflowJobKey, WorkflowPlan,
 };
 use automata_ci_expression_github::{GithubObject, GithubValue};
 use automata_ci_protocol::ProtocolLimits;
@@ -225,10 +225,17 @@ fn runtime_reference(
 }
 
 fn execution(instance: &automata_ci_workflow_service::ActivatedJobInstance) -> JobExecutionContext {
+    execution_with_workspace(instance, "/workspace/synthetic")
+}
+
+fn execution_with_workspace(
+    instance: &automata_ci_workflow_service::ActivatedJobInstance,
+    workspace: &str,
+) -> JobExecutionContext {
     JobExecutionContext::new(
         "Synthetic CI",
         GIT_REF,
-        "/workspace/synthetic",
+        workspace,
         JobContentReference::new(
             "runs/synthetic/event.json",
             Sha256Digest::from_bytes([7; 32]),
@@ -268,6 +275,14 @@ fn project_envelope_with_profiles(
     source: &str,
     profiles: &GithubRunnerProfileCatalog,
 ) -> JobIrEnvelope {
+    project_envelope_with_profiles_and_workspace(source, profiles, "/workspace/synthetic")
+}
+
+fn project_envelope_with_profiles_and_workspace(
+    source: &str,
+    profiles: &GithubRunnerProfileCatalog,
+    workspace: &str,
+) -> JobIrEnvelope {
     let plan = plan(source);
     let activation = activate(&plan);
     let instance = &activation.instances()[0];
@@ -282,7 +297,7 @@ fn project_envelope_with_profiles(
             fixed_id(31, WorkflowId::from_uuid),
             fixed_id(32, automata_ci_core::RunId::from_uuid),
             fixed_id(33, JobId::from_uuid),
-            execution(instance),
+            execution_with_workspace(instance, workspace),
             profiles,
             JobAuthorityProfile::Standard,
             &permission_policy(),
@@ -462,6 +477,53 @@ jobs:
         requirements
             .container_features()
             .contains(&ContainerFeature::DOCKER_COMPATIBLE_API)
+    );
+    assert_eq!(requirements.minimum_isolation(), IsolationLevel::Process);
+    assert!(
+        !requirements
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+    );
+}
+
+#[test]
+fn windows_profile_projection_requires_the_exact_hyperv_container_boundary() {
+    let source = r"name: Synthetic CI
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: windows-2025
+    steps: [{run: Write-Output ok}]
+";
+    let profile = EnvironmentProfile::new(
+        EnvironmentProfileId::new("automata.test/windows-2025").expect("profile id"),
+        Sha256Digest::from_bytes([0x25; 32]),
+    );
+    let profiles = GithubRunnerProfileCatalog::new([GithubRunnerProfileMapping::new(
+        "windows-2025",
+        profile.clone(),
+        OperatingSystem::Windows,
+        Architecture::X86_64,
+    )
+    .expect("Windows profile mapping")])
+    .expect("profile catalog");
+
+    let envelope =
+        project_envelope_with_profiles_and_workspace(source, &profiles, "/__w/synthetic");
+    let requirements = envelope.job().requirements();
+    assert_eq!(requirements.environment_profile(), Some(&profile));
+    assert_eq!(
+        requirements.operating_system(),
+        Some(&OperatingSystem::Windows)
+    );
+    assert_eq!(
+        requirements.minimum_isolation(),
+        IsolationLevel::VirtualMachine
+    );
+    assert!(
+        requirements
+            .sandbox_features()
+            .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
     );
 }
 

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -48,6 +48,14 @@ blocking trust order is `EVT-01` -> `AUTH-02` -> `WIN-ISO-01`; component
 provider work may proceed offline but cannot advertise support before that
 route and the management/recovery gates pass.
 
+Current component placement foundation binds GitHub-projected Windows jobs to
+both VM-grade isolation and the exact
+`automata.core/windows-hyperv-container@v1` launch capability. Only the
+`windows_hyperv` runner composition advertises it; Linux and macOS do not.
+Capability intersection and scheduler matching reject a generic VM before a
+placement becomes a lease. This is not the AUTH-02 trust grant and does not
+make Windows schedulable in production.
+
 ## Work packages
 
 ### WIN-ISO — Disposable Hyper-V-isolated Windows containers

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -83,6 +83,10 @@ implemented scope is intentionally smaller than production acceptance:
 - [x] On provider open, replay the bounded lifecycle journal, destructively
       reconcile journal-owned containers, enumerate Automata-labelled
       leftovers, and refuse registration if any unexplained resource remains.
+- [x] Bind every GitHub-projected Windows requirement to VM-grade isolation and
+      the exact `automata.core/windows-hyperv-container@v1` capability; advertise
+      that capability only from `windows_hyperv` and enforce matching before
+      placement.
 - [x] Keep JavaScript/composite actions, services, nested job containers,
       egress, GPUs, ephemeral-disk claims, and parallel capacity unavailable
       unless their later packages pass.
@@ -90,7 +94,7 @@ implemented scope is intentionally smaller than production acceptance:
 This pull request does **not** prove or complete:
 
 - [ ] authenticated workload trust classification;
-- [ ] fail-closed trust-to-provider routing;
+- [ ] the AUTH-02 one-use trust decision and trust-to-provider admission grant;
 - [ ] a least-privilege broker between a compromised runner and the container
       management endpoint;
 - [ ] an independent watchdog and broker-mediated recovery while the runner is
@@ -662,8 +666,11 @@ implicit default.
 - [ ] Carry authenticated event identity, repository/ref provenance, actor,
       fork/Dependabot status, policy version, requested secrets, and trust
       classification into scheduling.
-- [ ] Define the exact `WindowsHyperVContainer` requirement and reject
-      unknown, missing, stale, or unsigned placement evidence.
+- [x] Define the exact `WindowsHyperVContainer` requirement, pair it with
+      `IsolationLevel::VirtualMachine`, carry it through JobIR/protobuf replay,
+      and reject generic VM or alternate-provider capabilities before lease.
+- [ ] Reject unknown, missing, stale, or unsigned authenticated placement
+      evidence through the AUTH-02 one-use grant.
 - [ ] Ensure no scheduler, rerun, recovery, administrative API, or capacity
       fallback can select an alternate Windows boundary.
 - [ ] Bind a one-use admission grant to attempt, operation, generation,


### PR DESCRIPTION
## Stack dependency

Depends on #188. The top commit is `ffb1cab`; after #188 merges, this PR narrows automatically to the Windows placement contract.

## Summary

- add the canonical `automata.core/windows-hyperv-container@v1` runner feature
- require Windows jobs to carry VM-grade isolation plus the exact Hyper-V-container launch feature
- advertise that capability only from the `WindowsHyperVContainer` provider, never a generic Windows VM or other platform
- preserve the exact requirement through JobIR protobuf encode/decode, digest identity, re-encode, and validated lease selection
- fail malformed serde/protobuf feature shapes and capability downgrades before placement
- prove Linux and macOS profiles do not acquire the Windows launch capability

## Security boundary

This freezes the Wave 1 pre-lease placement contract; it does not claim production Windows acceptance. The one-use signed/stale trust grant remains in the AUTH-02 chain. Physical HCS/HCN, least-privilege broker/watchdog, reviewed image, recovery, and hostile-host evidence remain explicit external gates. No native or generic-VM fallback is introduced.

## Validation

- core: 112/112
- control: 126/126
- protocol: 50/50
- workflow: 139/139
- runner consolidated target: 45/45
- protobuf: 60/60, excluding the existing Unix shell-wrapper codegen check on Win32
- strict affected-package Clippy and focused Windows/protobuf tests
- rustfmt and `git diff --check`