### PR TITLE
feat(runner): complete GitHub shell dispatch semantics

### DIFF
--- a/crates/automata-ci-job-executor-github/README.md
+++ b/crates/automata-ci-job-executor-github/README.md
@@ -39,6 +39,61 @@ treated as no summary; it does not suppress other valid phase-file effects. An
 independently signaled execution-cancellation token remains dominant under the
 executor's cancellation contract.
 
+## Shell dispatch contract
+
+Shell executables come only from the immutable environment toolchain; workflow
+text is never searched on `PATH` and is never executed through an extra outer
+shell. The POSIX default selects configured `bash`, then configured `sh`, with
+`-e`. The Windows default selects configured PowerShell Core, then configured
+Windows PowerShell. Explicit POSIX `bash` uses
+`--noprofile --norc -e -o pipefail`; the other named-shell argument vectors
+match the pinned runner contract.
+
+The advertised named-shell matrix is:
+
+| Target | Named shells |
+| --- | --- |
+| POSIX | `bash`, `sh`, `python`, `pwsh` |
+| Windows Hyper-V container | `python`, `pwsh`, `powershell`, `cmd` |
+
+Custom command templates use a deliberately closed grammar. A template must
+use single ASCII spaces, contain exactly one `{0}` as its complete final token,
+contain no other braces or control characters, and select one configured
+interpreter. The accepted forms are:
+
+- `bash {0}`, `bash -e {0}`,
+  `bash --noprofile --norc -e -o pipefail {0}`, and
+  `bash --noprofile --norc -eo pipefail {0}`;
+- `sh {0}` and `sh -e {0}`;
+- `python {0}` and `python -u {0}`;
+- `pwsh -File {0}` and `powershell -File {0}` (case-insensitive `-File`).
+
+The platform matrix still applies after parsing. In particular, the current
+Windows Hyper-V profile does not advertise Git Bash or `sh`; those requests
+fail at admission instead of relying on a host installation. Arbitrary
+executables, quoted or embedded placeholders, command modes such as `-c` or
+`-Command`, and custom `cmd` templates fail closed. Literal shell contracts and
+tool availability are checked during admission, before provider work. A shell
+derived from an expression is checked immediately after evaluation and before
+the script is copied or any user command runs. Missing configured tools surface
+as a capability change; malformed or platform-incompatible contracts surface
+as invalid jobs.
+
+Scripts are UTF-8 without a BOM. POSIX scripts retain LF input. Every Windows
+script is normalized to CRLF; PowerShell scripts receive error-stop and
+`$LASTEXITCODE` propagation guards, and `cmd` scripts receive `@echo off`.
+Extensions follow the selected interpreter (`.sh`, `.py`, `.ps1`, or `.cmd`).
+The hardened `cmd` divergence uses `/D /E:ON /V:OFF /C` with the script path as
+a separately bounded argv value, rather than GitHub's nested `/S /C CALL`
+command string. Paths containing `"`, `%`, `&`, `|`, `<`, `>`, `^`, `(`, or
+`)` are rejected for `cmd`; `!` remains literal because delayed expansion is
+disabled.
+
+The executor receives the already-resolved workflow/job working-directory
+default in the job IR. A step-local directory overrides it; otherwise the
+resolved default applies, then the workspace. Every resulting path remains
+confined to the workspace.
+
 - [Compatibility documentation](https://github.com/automata-ci/automata/blob/main/docs/compatibility.md)
 - API documentation: run `cargo doc -p automata-ci-job-executor-github --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -66,7 +66,10 @@ use crate::{
     },
     error::{ExecutorAdapterError, ExecutorAdapterErrorKind, PortErrorKind},
     output::{SecretMasker, emit_system, parse_output_with_cancellation, process_output},
-    shell::{composite_shell, resolve_shell_template, shell_argv},
+    shell::{
+        ShellAdmissionRejection, admit_shell_template, composite_shell, resolve_shell_template,
+        shell_argv,
+    },
 };
 use automata_ci_workflow_github::GithubConditionCompiler;
 
@@ -420,6 +423,20 @@ impl GithubJobExecutor {
         }
         let workspace =
             job_workspace(job, &environment).map_err(|_| AdmissionRejection::InvalidJob)?;
+        if self.ports.toolchain.platform() != workspace.platform() {
+            return Err(AdmissionRejection::CapabilityChanged);
+        }
+        for step in job.job().steps() {
+            let SemanticStep::Run { values } = step.kind() else {
+                continue;
+            };
+            admit_shell_template(self.ports.toolchain.as_ref(), values.shell()).map_err(
+                |rejection| match rejection {
+                    ShellAdmissionRejection::Invalid => AdmissionRejection::InvalidJob,
+                    ShellAdmissionRejection::MissingTool => AdmissionRejection::CapabilityChanged,
+                },
+            )?;
+        }
         validate_environment_overlay_names(
             command_file_platform(workspace.platform()),
             job.job().environment().keys().map(String::as_str).chain(

--- a/crates/automata-ci-job-executor-github/src/shell.rs
+++ b/crates/automata-ci-job-executor-github/src/shell.rs
@@ -11,22 +11,18 @@ use crate::{
 
 pub(crate) enum ResolvedShell {
     Default,
-    Named(String),
-    CommandTemplate(String),
+    Named(ShellKind),
+    CommandTemplate(SafeCommandTemplate),
 }
 
 impl ResolvedShell {
     pub(crate) fn script_extension(&self, platform: TargetPlatform) -> &'static str {
         match self {
-            Self::Named(name) if name.eq_ignore_ascii_case("python") => ".py",
-            Self::Named(name)
-                if name.eq_ignore_ascii_case("pwsh") || name.eq_ignore_ascii_case("powershell") =>
-            {
-                ".ps1"
+            Self::Named(shell) | Self::CommandTemplate(SafeCommandTemplate { shell, .. }) => {
+                shell.script_extension()
             }
-            Self::Named(name) if name.eq_ignore_ascii_case("cmd") => ".cmd",
             Self::Default if platform == TargetPlatform::Windows => ".ps1",
-            Self::Default | Self::Named(_) | Self::CommandTemplate(_) => ".sh",
+            Self::Default => ".sh",
         }
     }
 
@@ -35,26 +31,117 @@ impl ResolvedShell {
         platform: TargetPlatform,
         command: &'command str,
     ) -> Cow<'command, str> {
-        let is_powershell = matches!(self, Self::Named(name) if name.eq_ignore_ascii_case("pwsh") || name.eq_ignore_ascii_case("powershell"))
-            || matches!(self, Self::Default if platform == TargetPlatform::Windows);
-        if is_powershell {
-            Cow::Owned(format!(
-                "$ErrorActionPreference = 'stop'\n{command}\nif ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) {{ exit $LASTEXITCODE }}"
-            ))
-        } else if platform == TargetPlatform::Windows
-            && matches!(self, Self::Named(name) if name.eq_ignore_ascii_case("cmd"))
-        {
-            let mut normalized = command
-                .replace("\r\n", "\n")
-                .replace('\r', "\n")
-                .replace('\n', "\r\n");
-            if !normalized.ends_with("\r\n") {
-                normalized.push_str("\r\n");
+        let shell = match self {
+            Self::Default if platform == TargetPlatform::Windows => Some(ShellKind::Pwsh),
+            Self::Named(shell) | Self::CommandTemplate(SafeCommandTemplate { shell, .. }) => {
+                Some(*shell)
             }
-            Cow::Owned(normalized)
+            Self::Default => None,
+        };
+        let fixed = match shell {
+            Some(ShellKind::Pwsh | ShellKind::PowerShell) => Cow::Owned(format!(
+                "$ErrorActionPreference = 'stop'\n{command}\nif ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) {{ exit $LASTEXITCODE }}"
+            )),
+            Some(ShellKind::Cmd) => Cow::Owned(format!("@echo off\n{command}")),
+            _ => Cow::Borrowed(command),
+        };
+        if platform == TargetPlatform::Windows {
+            Cow::Owned(fixed.replace("\r\n", "\n").replace('\n', "\r\n"))
         } else {
-            Cow::Borrowed(command)
+            fixed
         }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ShellKind {
+    Bash,
+    Sh,
+    Python,
+    Pwsh,
+    PowerShell,
+    Cmd,
+}
+
+impl ShellKind {
+    fn parse(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("bash") {
+            Some(Self::Bash)
+        } else if value.eq_ignore_ascii_case("sh") {
+            Some(Self::Sh)
+        } else if value.eq_ignore_ascii_case("python") {
+            Some(Self::Python)
+        } else if value.eq_ignore_ascii_case("pwsh") {
+            Some(Self::Pwsh)
+        } else if value.eq_ignore_ascii_case("powershell") {
+            Some(Self::PowerShell)
+        } else if value.eq_ignore_ascii_case("cmd") {
+            Some(Self::Cmd)
+        } else {
+            None
+        }
+    }
+
+    const fn script_extension(self) -> &'static str {
+        match self {
+            Self::Bash | Self::Sh => ".sh",
+            Self::Python => ".py",
+            Self::Pwsh | Self::PowerShell => ".ps1",
+            Self::Cmd => ".cmd",
+        }
+    }
+}
+
+pub(crate) struct SafeCommandTemplate {
+    shell: ShellKind,
+    arguments: Vec<String>,
+}
+
+impl SafeCommandTemplate {
+    fn parse(value: &str) -> Result<Self, ExecutorAdapterError> {
+        if value.is_empty()
+            || value.trim() != value
+            || value.chars().any(char::is_control)
+            || value.contains("  ")
+        {
+            return Err(unsupported());
+        }
+        let parts = value.split(' ').collect::<Vec<_>>();
+        if parts.len() < 2
+            || parts.iter().filter(|part| **part == "{0}").count() != 1
+            || parts.last() != Some(&"{0}")
+            || parts[..parts.len() - 1]
+                .iter()
+                .any(|part| part.contains(['{', '}']))
+        {
+            return Err(unsupported());
+        }
+        let shell = ShellKind::parse(parts[0]).ok_or_else(unsupported)?;
+        let arguments = &parts[1..parts.len() - 1];
+        if !safe_template_arguments(shell, arguments) {
+            return Err(unsupported());
+        }
+        Ok(Self {
+            shell,
+            arguments: arguments.iter().map(|value| (*value).to_owned()).collect(),
+        })
+    }
+}
+
+fn safe_template_arguments(shell: ShellKind, arguments: &[&str]) -> bool {
+    match shell {
+        ShellKind::Bash => matches!(
+            arguments,
+            [] | ["-e"]
+                | ["--noprofile", "--norc", "-e", "-o", "pipefail"]
+                | ["--noprofile", "--norc", "-eo", "pipefail"]
+        ),
+        ShellKind::Sh => matches!(arguments, [] | ["-e"]),
+        ShellKind::Python => matches!(arguments, [] | ["-u"]),
+        ShellKind::Pwsh | ShellKind::PowerShell => {
+            matches!(arguments, [argument] if argument.eq_ignore_ascii_case("-file"))
+        }
+        ShellKind::Cmd => false,
     }
 }
 
@@ -67,10 +154,10 @@ pub(crate) fn resolve_shell_template(
     match shell {
         ShellTemplate::Default => Ok(ResolvedShell::Default),
         ShellTemplate::Named { value } => {
-            resolve_value(value).map(|value| ResolvedShell::Named(value.into_value()))
+            resolve_value(value).and_then(|value| named_shell(value.expose()))
         }
         ShellTemplate::CommandTemplate { value } => {
-            resolve_value(value).map(|value| ResolvedShell::CommandTemplate(value.into_value()))
+            resolve_value(value).and_then(|value| command_template(value.expose()))
         }
         ShellTemplate::Dynamic { value } => {
             let value = resolve_value(value)?;
@@ -79,141 +166,192 @@ pub(crate) fn resolve_shell_template(
     }
 }
 
-#[allow(clippy::too_many_lines)]
 pub(crate) fn shell_argv(
     toolchain: &dyn GithubToolchain,
     shell: &ResolvedShell,
     script: &TargetPath,
 ) -> Result<(TargetPath, Vec<String>), ExecutorAdapterError> {
+    if script.platform() != toolchain.platform() {
+        return Err(invalid_job());
+    }
     let script_path = script;
     let script = script.as_str().to_owned();
     match (toolchain.platform(), shell) {
-        (TargetPlatform::Posix, ResolvedShell::Default) => {
-            Ok((required_tool(toolchain.bash())?, vec!["-e".into(), script]))
-        }
-        (TargetPlatform::Posix, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("bash") =>
-        {
-            Ok((
-                required_tool(toolchain.bash())?,
-                vec![
-                    "--noprofile".into(),
-                    "--norc".into(),
-                    "-e".into(),
-                    "-o".into(),
-                    "pipefail".into(),
-                    script,
-                ],
-            ))
-        }
-        (TargetPlatform::Posix, ResolvedShell::Named(name)) if name.eq_ignore_ascii_case("sh") => {
-            Ok((required_tool(toolchain.sh())?, vec!["-e".into(), script]))
-        }
-        (TargetPlatform::Windows, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("python") =>
-        {
-            Ok((
-                required_tool(toolchain.python())?,
-                windows_script_arguments(WindowsScriptShell::Python, script_path)
-                    .ok_or_else(invalid_job)?,
-            ))
-        }
-        (TargetPlatform::Posix, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("python") =>
-        {
-            Ok((required_tool(toolchain.python())?, vec![script]))
-        }
-        (TargetPlatform::Posix, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("pwsh") =>
-        {
-            Ok((
-                required_tool(toolchain.pwsh())?,
-                powershell_arguments(&script),
-            ))
-        }
+        (TargetPlatform::Posix, ResolvedShell::Default) => Ok((
+            toolchain
+                .bash()
+                .or_else(|| toolchain.sh())
+                .cloned()
+                .ok_or_else(unsupported)?,
+            vec!["-e".into(), script],
+        )),
         (TargetPlatform::Windows, ResolvedShell::Default) => Ok((
-            required_tool(toolchain.pwsh())?,
+            toolchain
+                .pwsh()
+                .or_else(|| toolchain.powershell())
+                .cloned()
+                .ok_or_else(unsupported)?,
             windows_script_arguments(WindowsScriptShell::PowerShell, script_path)
                 .ok_or_else(invalid_job)?,
         )),
-        (TargetPlatform::Windows, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("pwsh") =>
-        {
-            Ok((
-                required_tool(toolchain.pwsh())?,
-                windows_script_arguments(WindowsScriptShell::PowerShell, script_path)
-                    .ok_or_else(invalid_job)?,
-            ))
+        (TargetPlatform::Posix, ResolvedShell::Named(ShellKind::Bash)) => Ok((
+            configured_tool(toolchain, ShellKind::Bash)?,
+            vec![
+                "--noprofile".into(),
+                "--norc".into(),
+                "-e".into(),
+                "-o".into(),
+                "pipefail".into(),
+                script,
+            ],
+        )),
+        (TargetPlatform::Posix, ResolvedShell::Named(ShellKind::Sh)) => Ok((
+            configured_tool(toolchain, ShellKind::Sh)?,
+            vec!["-e".into(), script],
+        )),
+        (TargetPlatform::Windows, ResolvedShell::Named(ShellKind::Python)) => Ok((
+            configured_tool(toolchain, ShellKind::Python)?,
+            windows_script_arguments(WindowsScriptShell::Python, script_path)
+                .ok_or_else(invalid_job)?,
+        )),
+        (TargetPlatform::Posix, ResolvedShell::Named(ShellKind::Python)) => {
+            Ok((configured_tool(toolchain, ShellKind::Python)?, vec![script]))
         }
-        (TargetPlatform::Windows, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("powershell") =>
+        (TargetPlatform::Posix, ResolvedShell::Named(ShellKind::Pwsh)) => Ok((
+            configured_tool(toolchain, ShellKind::Pwsh)?,
+            powershell_arguments(&script),
+        )),
+        (TargetPlatform::Windows, ResolvedShell::Named(ShellKind::Pwsh)) => Ok((
+            configured_tool(toolchain, ShellKind::Pwsh)?,
+            windows_script_arguments(WindowsScriptShell::PowerShell, script_path)
+                .ok_or_else(invalid_job)?,
+        )),
+        (TargetPlatform::Windows, ResolvedShell::Named(ShellKind::PowerShell)) => Ok((
+            configured_tool(toolchain, ShellKind::PowerShell)?,
+            windows_script_arguments(WindowsScriptShell::PowerShell, script_path)
+                .ok_or_else(invalid_job)?,
+        )),
+        (TargetPlatform::Windows, ResolvedShell::Named(ShellKind::Cmd)) => Ok((
+            configured_tool(toolchain, ShellKind::Cmd)?,
+            windows_script_arguments(WindowsScriptShell::Cmd, script_path)
+                .ok_or_else(invalid_job)?,
+        )),
+        (_, ResolvedShell::CommandTemplate(template))
+            if shell_supported(toolchain.platform(), template.shell) =>
         {
-            Ok((
-                required_tool(toolchain.powershell())?,
-                windows_script_arguments(WindowsScriptShell::PowerShell, script_path)
-                    .ok_or_else(invalid_job)?,
-            ))
+            let program = configured_tool(toolchain, template.shell)?;
+            let mut arguments = template.arguments.clone();
+            arguments.push(script);
+            Ok((program, arguments))
         }
-        (TargetPlatform::Windows, ResolvedShell::Named(name))
-            if name.eq_ignore_ascii_case("cmd") =>
-        {
-            Ok((
-                required_tool(toolchain.cmd())?,
-                windows_script_arguments(WindowsScriptShell::Cmd, script_path)
-                    .ok_or_else(invalid_job)?,
-            ))
-        }
-        (TargetPlatform::Posix, ResolvedShell::CommandTemplate(template))
-            if template == "bash -e {0}" =>
-        {
-            Ok((required_tool(toolchain.bash())?, vec!["-e".into(), script]))
-        }
-        (TargetPlatform::Posix, ResolvedShell::CommandTemplate(template))
-            if template == "bash --noprofile --norc -eo pipefail {0}" =>
-        {
-            Ok((
-                required_tool(toolchain.bash())?,
-                vec![
-                    "--noprofile".into(),
-                    "--norc".into(),
-                    "-eo".into(),
-                    "pipefail".into(),
-                    script,
-                ],
-            ))
-        }
-        (TargetPlatform::Posix, ResolvedShell::CommandTemplate(template))
-            if template == "sh -e {0}" =>
-        {
-            Ok((required_tool(toolchain.sh())?, vec!["-e".into(), script]))
-        }
-        (_, ResolvedShell::Named(_) | ResolvedShell::CommandTemplate(_)) => Err(
-            ExecutorAdapterError::new(ExecutorAdapterErrorKind::Unsupported),
-        ),
+        (_, ResolvedShell::Named(_) | ResolvedShell::CommandTemplate(_)) => Err(unsupported()),
     }
 }
 
 pub(crate) fn composite_shell(value: &str) -> Result<ResolvedShell, ExecutorAdapterError> {
-    let value = value.trim();
-    if ["bash", "sh", "python", "pwsh", "powershell", "cmd"]
-        .into_iter()
-        .any(|name| value.eq_ignore_ascii_case(name))
-    {
-        return Ok(ResolvedShell::Named(value.to_ascii_lowercase()));
-    }
-    match value {
-        "bash -e {0}" | "bash --noprofile --norc -eo pipefail {0}" | "sh -e {0}" => {
-            Ok(ResolvedShell::CommandTemplate(value.to_owned()))
+    named_shell(value).or_else(|_| command_template(value))
+}
+
+fn named_shell(value: &str) -> Result<ResolvedShell, ExecutorAdapterError> {
+    ShellKind::parse(value)
+        .map(ResolvedShell::Named)
+        .ok_or_else(unsupported)
+}
+
+fn command_template(value: &str) -> Result<ResolvedShell, ExecutorAdapterError> {
+    SafeCommandTemplate::parse(value).map(ResolvedShell::CommandTemplate)
+}
+
+fn shell_supported(platform: TargetPlatform, shell: ShellKind) -> bool {
+    matches!(
+        (platform, shell),
+        (
+            TargetPlatform::Posix,
+            ShellKind::Bash | ShellKind::Sh | ShellKind::Python | ShellKind::Pwsh
+        ) | (
+            TargetPlatform::Windows,
+            ShellKind::Python | ShellKind::Pwsh | ShellKind::PowerShell | ShellKind::Cmd
+        )
+    )
+}
+
+fn configured_tool(
+    toolchain: &dyn GithubToolchain,
+    shell: ShellKind,
+) -> Result<TargetPath, ExecutorAdapterError> {
+    let path = match shell {
+        ShellKind::Bash => toolchain.bash(),
+        ShellKind::Sh => toolchain.sh(),
+        ShellKind::Python => toolchain.python(),
+        ShellKind::Pwsh => toolchain.pwsh(),
+        ShellKind::PowerShell => toolchain.powershell(),
+        ShellKind::Cmd => toolchain.cmd(),
+    };
+    path.cloned().ok_or_else(unsupported)
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ShellAdmissionRejection {
+    Invalid,
+    MissingTool,
+}
+
+pub(crate) fn admit_shell_template(
+    toolchain: &dyn GithubToolchain,
+    shell: &ShellTemplate,
+) -> Result<(), ShellAdmissionRejection> {
+    let resolved = match shell {
+        ShellTemplate::Default => ResolvedShell::Default,
+        ShellTemplate::Named { value } => {
+            let Some(value) = literal_template_value(value) else {
+                return Ok(());
+            };
+            named_shell(value).map_err(|_| ShellAdmissionRejection::Invalid)?
         }
-        _ => Err(ExecutorAdapterError::new(
-            ExecutorAdapterErrorKind::Unsupported,
-        )),
+        ShellTemplate::CommandTemplate { value } => {
+            let Some(value) = literal_template_value(value) else {
+                return Ok(());
+            };
+            command_template(value).map_err(|_| ShellAdmissionRejection::Invalid)?
+        }
+        ShellTemplate::Dynamic { value } => {
+            let Some(value) = literal_template_value(value) else {
+                return Ok(());
+            };
+            composite_shell(value).map_err(|_| ShellAdmissionRejection::Invalid)?
+        }
+    };
+    match resolved {
+        ResolvedShell::Default => {
+            let available = match toolchain.platform() {
+                TargetPlatform::Posix => toolchain.bash().or_else(|| toolchain.sh()),
+                TargetPlatform::Windows => toolchain.pwsh().or_else(|| toolchain.powershell()),
+            };
+            available
+                .map(|_| ())
+                .ok_or(ShellAdmissionRejection::MissingTool)
+        }
+        ResolvedShell::Named(shell)
+        | ResolvedShell::CommandTemplate(SafeCommandTemplate { shell, .. }) => {
+            if !shell_supported(toolchain.platform(), shell) {
+                return Err(ShellAdmissionRejection::Invalid);
+            }
+            configured_tool(toolchain, shell)
+                .map(|_| ())
+                .map_err(|_| ShellAdmissionRejection::MissingTool)
+        }
     }
 }
 
-fn required_tool(path: Option<&TargetPath>) -> Result<TargetPath, ExecutorAdapterError> {
-    path.cloned()
-        .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Unsupported))
+fn literal_template_value(value: &ValueTemplate) -> Option<&str> {
+    let [segment] = value.segments() else {
+        return None;
+    };
+    segment.literal_value()
+}
+
+const fn unsupported() -> ExecutorAdapterError {
+    ExecutorAdapterError::new(ExecutorAdapterErrorKind::Unsupported)
 }
 
 const fn invalid_job() -> ExecutorAdapterError {
@@ -273,19 +411,22 @@ pub fn windows_script_arguments(
 mod tests {
     use std::borrow::Cow;
 
+    use automata_ci_action_github::JavascriptRuntime;
     use automata_ci_core::{ShellTemplate, ValueTemplate};
-    use automata_ci_execution::{TargetPath, TargetPlatform};
+    use automata_ci_execution::{ExecutionArgv, TargetPath, TargetPlatform};
     use static_assertions::assert_not_impl_any;
 
     use crate::{
         adapter::StaticGithubToolchain,
         environment::ResolvedEnvironmentValue,
         error::{ExecutorAdapterError, ExecutorAdapterErrorKind},
+        port::GithubToolchain,
     };
 
     use super::{
-        ResolvedShell, WindowsScriptShell, composite_shell, resolve_shell_template, shell_argv,
-        windows_script_arguments,
+        ResolvedShell, ShellAdmissionRejection, ShellKind, WindowsScriptShell,
+        admit_shell_template, command_template, composite_shell, named_shell,
+        resolve_shell_template, shell_argv, windows_script_arguments,
     };
 
     assert_not_impl_any!(ResolvedShell: std::fmt::Debug, std::fmt::Display);
@@ -306,7 +447,7 @@ mod tests {
             |_| Ok(ResolvedEnvironmentValue::secret("BASH")),
         )
         .expect("named shell");
-        assert!(matches!(named, ResolvedShell::Named(name) if name == "BASH"));
+        assert!(matches!(named, ResolvedShell::Named(ShellKind::Bash)));
 
         let command = resolve_shell_template(
             &ShellTemplate::command_template(ValueTemplate::literal("ignored").expect("template")),
@@ -315,15 +456,17 @@ mod tests {
         .expect("command template");
         assert!(matches!(
             command,
-            ResolvedShell::CommandTemplate(template) if template == "bash -e {0}"
+            ResolvedShell::CommandTemplate(template)
+                if template.shell == ShellKind::Bash
+                    && template.arguments == ["-e"]
         ));
 
         let dynamic = resolve_shell_template(
             &ShellTemplate::dynamic(ValueTemplate::literal("ignored").expect("template")),
-            |_| Ok(ResolvedEnvironmentValue::secret("  PwSh  ")),
+            |_| Ok(ResolvedEnvironmentValue::secret("PwSh")),
         )
         .expect("dynamic built-in");
-        assert!(matches!(dynamic, ResolvedShell::Named(name) if name == "pwsh"));
+        assert!(matches!(dynamic, ResolvedShell::Named(ShellKind::Pwsh)));
 
         let dynamic_template = resolve_shell_template(
             &ShellTemplate::dynamic(ValueTemplate::literal("ignored").expect("template")),
@@ -332,7 +475,9 @@ mod tests {
         .expect("dynamic command template");
         assert!(matches!(
             dynamic_template,
-            ResolvedShell::CommandTemplate(template) if template == "sh -e {0}"
+            ResolvedShell::CommandTemplate(template)
+                if template.shell == ShellKind::Sh
+                    && template.arguments == ["-e"]
         ));
 
         let unsupported = resolve_shell_template(
@@ -361,36 +506,12 @@ mod tests {
         let cases = [
             (ResolvedShell::Default, TargetPlatform::Posix, ".sh"),
             (ResolvedShell::Default, TargetPlatform::Windows, ".ps1"),
-            (
-                ResolvedShell::Named("PYTHON".to_owned()),
-                TargetPlatform::Posix,
-                ".py",
-            ),
-            (
-                ResolvedShell::Named("pwsh".to_owned()),
-                TargetPlatform::Windows,
-                ".ps1",
-            ),
-            (
-                ResolvedShell::Named("PowerShell".to_owned()),
-                TargetPlatform::Posix,
-                ".ps1",
-            ),
-            (
-                ResolvedShell::Named("CMD".to_owned()),
-                TargetPlatform::Windows,
-                ".cmd",
-            ),
-            (
-                ResolvedShell::Named("bash".to_owned()),
-                TargetPlatform::Windows,
-                ".sh",
-            ),
-            (
-                ResolvedShell::CommandTemplate("bash -e {0}".to_owned()),
-                TargetPlatform::Posix,
-                ".sh",
-            ),
+            (named("PYTHON"), TargetPlatform::Posix, ".py"),
+            (named("pwsh"), TargetPlatform::Windows, ".ps1"),
+            (named("PowerShell"), TargetPlatform::Posix, ".ps1"),
+            (named("CMD"), TargetPlatform::Windows, ".cmd"),
+            (named("bash"), TargetPlatform::Windows, ".sh"),
+            (custom("bash -e {0}"), TargetPlatform::Posix, ".sh"),
         ];
 
         for (shell, platform, expected) in cases {
@@ -410,10 +531,10 @@ mod tests {
             .into_owned();
         assert_eq!(
             powershell,
-            "$ErrorActionPreference = 'stop'\nWrite-Host ok\nif ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }"
+            "$ErrorActionPreference = 'stop'\r\nWrite-Host ok\r\nif ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }"
         );
 
-        let named_powershell = ResolvedShell::Named("PwSh".to_owned())
+        let named_powershell = named("PwSh")
             .fix_up_script(TargetPlatform::Posix, "exit 7")
             .into_owned();
         assert_eq!(
@@ -421,24 +542,29 @@ mod tests {
             "$ErrorActionPreference = 'stop'\nexit 7\nif ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }"
         );
 
-        let cmd = ResolvedShell::Named("cmd".to_owned())
+        let cmd = named("cmd")
             .fix_up_script(TargetPlatform::Windows, "one\r\ntwo\rthree\nfour")
             .into_owned();
-        assert_eq!(cmd, "one\r\ntwo\r\nthree\r\nfour\r\n");
+        assert_eq!(cmd, "@echo off\r\none\r\ntwo\rthree\r\nfour");
+
+        let python = named("python")
+            .fix_up_script(TargetPlatform::Windows, "one\ntwo\r\nthree")
+            .into_owned();
+        assert_eq!(python, "one\r\ntwo\r\nthree");
     }
 
     #[test]
     fn posix_shell_argv_uses_only_configured_tools_and_exact_arguments() {
         let toolchain = posix_toolchain();
-        let script = TargetPath::posix("/work/script.sh").expect("script");
+        let script = TargetPath::posix("/work root/[literal]$script;.sh").expect("script");
         let cases = vec![
             (
                 ResolvedShell::Default,
                 "/bin/bash",
-                vec!["-e", "/work/script.sh"],
+                vec!["-e", "/work root/[literal]$script;.sh"],
             ),
             (
-                ResolvedShell::Named("BASH".to_owned()),
+                named("BASH"),
                 "/bin/bash",
                 vec![
                     "--noprofile",
@@ -446,46 +572,54 @@ mod tests {
                     "-e",
                     "-o",
                     "pipefail",
-                    "/work/script.sh",
+                    "/work root/[literal]$script;.sh",
                 ],
             ),
             (
-                ResolvedShell::Named("sh".to_owned()),
+                named("sh"),
                 "/bin/sh",
-                vec!["-e", "/work/script.sh"],
+                vec!["-e", "/work root/[literal]$script;.sh"],
             ),
             (
-                ResolvedShell::Named("python".to_owned()),
+                named("python"),
                 "/usr/bin/python3",
-                vec!["/work/script.sh"],
+                vec!["/work root/[literal]$script;.sh"],
             ),
             (
-                ResolvedShell::Named("pwsh".to_owned()),
+                named("pwsh"),
                 "/usr/bin/pwsh",
-                vec!["-command", ". '/work/script.sh'"],
+                vec!["-command", ". '/work root/[literal]$script;.sh'"],
             ),
             (
-                ResolvedShell::CommandTemplate("bash -e {0}".to_owned()),
+                custom("bash -e {0}"),
                 "/bin/bash",
-                vec!["-e", "/work/script.sh"],
+                vec!["-e", "/work root/[literal]$script;.sh"],
             ),
             (
-                ResolvedShell::CommandTemplate(
-                    "bash --noprofile --norc -eo pipefail {0}".to_owned(),
-                ),
+                custom("bash --noprofile --norc -eo pipefail {0}"),
                 "/bin/bash",
                 vec![
                     "--noprofile",
                     "--norc",
                     "-eo",
                     "pipefail",
-                    "/work/script.sh",
+                    "/work root/[literal]$script;.sh",
                 ],
             ),
             (
-                ResolvedShell::CommandTemplate("sh -e {0}".to_owned()),
+                custom("sh -e {0}"),
                 "/bin/sh",
-                vec!["-e", "/work/script.sh"],
+                vec!["-e", "/work root/[literal]$script;.sh"],
+            ),
+            (
+                custom("python -u {0}"),
+                "/usr/bin/python3",
+                vec!["-u", "/work root/[literal]$script;.sh"],
+            ),
+            (
+                custom("pwsh -File {0}"),
+                "/usr/bin/pwsh",
+                vec!["-File", "/work root/[literal]$script;.sh"],
             ),
         ];
 
@@ -503,32 +637,47 @@ mod tests {
     #[test]
     fn windows_shell_argv_uses_exact_interpreter_contracts() {
         let toolchain = windows_toolchain();
-        let script = TargetPath::windows(r"C:\work root\script.ps1").expect("script");
+        let script =
+            TargetPath::windows(r"C:\work root\it's [literal] ! script.ps1").expect("script");
         let cases = vec![
             (
                 ResolvedShell::Default,
                 r"C:\Program Files\PowerShell\7\pwsh.exe",
-                vec!["-command", ". 'C:\\work root\\script.ps1'"],
+                vec![
+                    "-command",
+                    ". 'C:\\work root\\it''s [literal] ! script.ps1'",
+                ],
             ),
             (
-                ResolvedShell::Named("pwsh".to_owned()),
+                named("pwsh"),
                 r"C:\Program Files\PowerShell\7\pwsh.exe",
-                vec!["-command", ". 'C:\\work root\\script.ps1'"],
+                vec![
+                    "-command",
+                    ". 'C:\\work root\\it''s [literal] ! script.ps1'",
+                ],
             ),
             (
-                ResolvedShell::Named("PowerShell".to_owned()),
+                named("PowerShell"),
                 r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
-                vec!["-command", ". 'C:\\work root\\script.ps1'"],
+                vec![
+                    "-command",
+                    ". 'C:\\work root\\it''s [literal] ! script.ps1'",
+                ],
             ),
             (
-                ResolvedShell::Named("cmd".to_owned()),
-                r"C:\Windows\System32\cmd.exe",
-                vec!["/D", "/E:ON", "/V:OFF", "/C", r"C:\work root\script.ps1"],
-            ),
-            (
-                ResolvedShell::Named("python".to_owned()),
+                named("python"),
                 r"C:\Python\python.exe",
-                vec![r"C:\work root\script.ps1"],
+                vec![r"C:\work root\it's [literal] ! script.ps1"],
+            ),
+            (
+                custom("python -u {0}"),
+                r"C:\Python\python.exe",
+                vec!["-u", r"C:\work root\it's [literal] ! script.ps1"],
+            ),
+            (
+                custom("pwsh -File {0}"),
+                r"C:\Program Files\PowerShell\7\pwsh.exe",
+                vec!["-File", r"C:\work root\it's [literal] ! script.ps1"],
             ),
         ];
 
@@ -541,6 +690,80 @@ mod tests {
                 expected_arguments
             );
         }
+
+        let cmd_script = TargetPath::windows(r"C:\work root\literal! script.cmd").expect("script");
+        let (program, arguments) =
+            shell_argv(&toolchain, &named("cmd"), &cmd_script).expect("cmd shell");
+        assert_eq!(program.as_str(), r"C:\Windows\System32\cmd.exe");
+        assert_eq!(
+            arguments,
+            [
+                "/D",
+                "/E:ON",
+                "/V:OFF",
+                "/C",
+                r"C:\work root\literal! script.cmd"
+            ]
+        );
+    }
+
+    #[test]
+    fn default_shells_fall_back_only_to_the_pinned_platform_interpreter() {
+        let posix = TestToolchain {
+            platform: TargetPlatform::Posix,
+            sh: Some(TargetPath::posix("/bin/sh").expect("sh")),
+            ..TestToolchain::empty(TargetPlatform::Posix)
+        };
+        let posix_script = TargetPath::posix("/work/default.sh").expect("script");
+        let (program, arguments) =
+            shell_argv(&posix, &ResolvedShell::Default, &posix_script).expect("sh fallback");
+        assert_eq!(program.as_str(), "/bin/sh");
+        assert_eq!(arguments, ["-e", "/work/default.sh"]);
+
+        let windows = TestToolchain {
+            platform: TargetPlatform::Windows,
+            powershell: Some(
+                TargetPath::windows(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
+                    .expect("PowerShell"),
+            ),
+            ..TestToolchain::empty(TargetPlatform::Windows)
+        };
+        let windows_script = TargetPath::windows(r"C:\work\default.ps1").expect("script");
+        let (program, arguments) = shell_argv(&windows, &ResolvedShell::Default, &windows_script)
+            .expect("Windows PowerShell fallback");
+        assert_eq!(
+            program.as_str(),
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+        );
+        assert_eq!(arguments, ["-command", ". 'C:\\work\\default.ps1'"]);
+    }
+
+    #[test]
+    fn configured_executable_and_script_paths_remain_literal_argv_values() {
+        let toolchain = TestToolchain {
+            platform: TargetPlatform::Posix,
+            bash: Some(
+                TargetPath::posix("/opt/runner tools/bash$literal").expect("literal Bash path"),
+            ),
+            ..TestToolchain::empty(TargetPlatform::Posix)
+        };
+        let script =
+            TargetPath::posix("/work root/$(not-executed);script.sh").expect("literal script path");
+        let (program, arguments) = shell_argv(&toolchain, &named("bash"), &script)
+            .expect("configured literal paths are valid");
+
+        assert_eq!(program.as_str(), "/opt/runner tools/bash$literal");
+        assert_eq!(
+            arguments,
+            [
+                "--noprofile",
+                "--norc",
+                "-e",
+                "-o",
+                "pipefail",
+                "/work root/$(not-executed);script.sh",
+            ]
+        );
     }
 
     #[test]
@@ -554,19 +777,11 @@ mod tests {
         )
         .expect("toolchain");
         let posix_script = TargetPath::posix("/work/script.sh").expect("script");
-        let missing = shell_argv(
-            &minimal,
-            &ResolvedShell::Named("python".to_owned()),
-            &posix_script,
-        )
-        .expect_err("missing Python");
+        let missing =
+            shell_argv(&minimal, &named("python"), &posix_script).expect_err("missing Python");
         assert_eq!(missing.kind(), ExecutorAdapterErrorKind::Unsupported);
 
-        for shell in [
-            ResolvedShell::Named("powershell".to_owned()),
-            ResolvedShell::Named("cmd".to_owned()),
-            ResolvedShell::CommandTemplate("bash {0}".to_owned()),
-        ] {
+        for shell in [named("powershell"), named("cmd")] {
             let error = shell_argv(&minimal, &shell, &posix_script)
                 .expect_err("unsupported POSIX shell contract");
             assert_eq!(error.kind(), ExecutorAdapterErrorKind::Unsupported);
@@ -574,24 +789,16 @@ mod tests {
 
         let windows = windows_toolchain();
         let windows_script = TargetPath::windows(r"C:\work\script.ps1").expect("script");
-        let command_template = shell_argv(
-            &windows,
-            &ResolvedShell::CommandTemplate("bash -e {0}".to_owned()),
-            &windows_script,
-        )
-        .expect_err("Windows command templates are unsupported");
+        let command_template = shell_argv(&windows, &custom("bash -e {0}"), &windows_script)
+            .expect_err("Windows command templates are unsupported");
         assert_eq!(
             command_template.kind(),
             ExecutorAdapterErrorKind::Unsupported
         );
 
         let unsafe_cmd = TargetPath::windows(r"C:\work%PATH%\script.cmd").expect("valid path");
-        let unsafe_path = shell_argv(
-            &windows,
-            &ResolvedShell::Named("cmd".to_owned()),
-            &unsafe_cmd,
-        )
-        .expect_err("cmd metacharacters must fail closed");
+        let unsafe_path = shell_argv(&windows, &named("cmd"), &unsafe_cmd)
+            .expect_err("cmd metacharacters must fail closed");
         assert_eq!(unsafe_path.kind(), ExecutorAdapterErrorKind::InvalidJob);
     }
 
@@ -661,35 +868,109 @@ mod tests {
     }
 
     #[test]
-    fn composite_shell_accepts_only_configured_builtin_names_and_existing_templates() {
+    fn composite_shell_accepts_builtin_names_and_the_closed_template_grammar() {
         for (input, expected) in [
-            (" BASH ", "bash"),
-            ("sh", "sh"),
-            ("Python", "python"),
-            ("pwsh", "pwsh"),
-            ("PowerShell", "powershell"),
-            ("CMD", "cmd"),
+            ("BASH", ShellKind::Bash),
+            ("sh", ShellKind::Sh),
+            ("Python", ShellKind::Python),
+            ("pwsh", ShellKind::Pwsh),
+            ("PowerShell", ShellKind::PowerShell),
+            ("CMD", ShellKind::Cmd),
         ] {
             let shell = composite_shell(input).expect("built-in shell");
-            assert!(matches!(shell, ResolvedShell::Named(name) if name == expected));
+            assert!(matches!(shell, ResolvedShell::Named(kind) if kind == expected));
         }
         for template in [
+            "bash {0}",
             "bash -e {0}",
+            "bash --noprofile --norc -e -o pipefail {0}",
             "bash --noprofile --norc -eo pipefail {0}",
+            "sh {0}",
             "sh -e {0}",
+            "python {0}",
+            "python -u {0}",
+            "pwsh -File {0}",
+            "powershell -file {0}",
         ] {
             let shell = composite_shell(template).expect("configured command template");
-            assert!(matches!(
-                shell,
-                ResolvedShell::CommandTemplate(value) if value == template
-            ));
+            assert!(matches!(shell, ResolvedShell::CommandTemplate(_)));
         }
-        for unsupported in ["perl {0}", "bash {0}", "pwsh -File {0}", ""] {
+    }
+
+    #[test]
+    fn composite_shell_rejects_ambiguous_or_injectable_templates() {
+        for unsupported in [
+            "",
+            " BASH ",
+            "perl {0}",
+            "bash -e",
+            "bash {0} {0}",
+            "bash prefix{0}",
+            "bash '{0}'",
+            "bash \"{0}\"",
+            "bash -c {0}",
+            "python -c {0}",
+            "pwsh -Command {0}",
+            "cmd /C {0}",
+            "bash -e {0};touch",
+            "bash  -e {0}",
+            "bash\t-e {0}",
+            "bash\n-e {0}",
+            "bash -e {1}",
+            "C:\\Program Files\\Git\\bin\\bash.exe {0}",
+        ] {
             let error = composite_shell(unsupported)
                 .err()
                 .expect("unsupported composite shell");
             assert_eq!(error.kind(), ExecutorAdapterErrorKind::Unsupported);
         }
+    }
+
+    #[test]
+    fn static_shell_admission_distinguishes_invalid_contracts_and_missing_tools() {
+        let posix = TestToolchain::empty(TargetPlatform::Posix);
+        assert!(matches!(
+            admit_shell_template(&posix, &ShellTemplate::Default),
+            Err(ShellAdmissionRejection::MissingTool)
+        ));
+        assert!(matches!(
+            admit_shell_template(
+                &posix,
+                &ShellTemplate::named(ValueTemplate::literal("python").expect("template")),
+            ),
+            Err(ShellAdmissionRejection::MissingTool)
+        ));
+        assert!(matches!(
+            admit_shell_template(
+                &posix,
+                &ShellTemplate::named(ValueTemplate::literal("cmd").expect("template")),
+            ),
+            Err(ShellAdmissionRejection::Invalid)
+        ));
+        assert!(matches!(
+            admit_shell_template(
+                &posix,
+                &ShellTemplate::command_template(
+                    ValueTemplate::literal("bash -c {0}").expect("template"),
+                ),
+            ),
+            Err(ShellAdmissionRejection::Invalid)
+        ));
+
+        let sh_only = TestToolchain {
+            platform: TargetPlatform::Posix,
+            sh: Some(TargetPath::posix("/bin/sh").expect("sh")),
+            ..TestToolchain::empty(TargetPlatform::Posix)
+        };
+        assert!(admit_shell_template(&sh_only, &ShellTemplate::Default).is_ok());
+    }
+
+    fn named(value: &str) -> ResolvedShell {
+        named_shell(value).expect("known named shell")
+    }
+
+    fn custom(value: &str) -> ResolvedShell {
+        command_template(value).expect("safe command template")
     }
 
     fn posix_toolchain() -> StaticGithubToolchain {
@@ -717,5 +998,76 @@ mod tests {
         .expect("toolchain")
         .with_python(TargetPath::windows(r"C:\Python\python.exe").expect("python"))
         .expect("Python")
+    }
+
+    #[derive(Debug)]
+    struct TestToolchain {
+        platform: TargetPlatform,
+        bash: Option<TargetPath>,
+        sh: Option<TargetPath>,
+        python: Option<TargetPath>,
+        pwsh: Option<TargetPath>,
+        powershell: Option<TargetPath>,
+        cmd: Option<TargetPath>,
+    }
+
+    impl TestToolchain {
+        const fn empty(platform: TargetPlatform) -> Self {
+            Self {
+                platform,
+                bash: None,
+                sh: None,
+                python: None,
+                pwsh: None,
+                powershell: None,
+                cmd: None,
+            }
+        }
+    }
+
+    impl GithubToolchain for TestToolchain {
+        fn platform(&self) -> TargetPlatform {
+            self.platform
+        }
+
+        fn bash(&self) -> Option<&TargetPath> {
+            self.bash.as_ref()
+        }
+
+        fn sh(&self) -> Option<&TargetPath> {
+            self.sh.as_ref()
+        }
+
+        fn python(&self) -> Option<&TargetPath> {
+            self.python.as_ref()
+        }
+
+        fn pwsh(&self) -> Option<&TargetPath> {
+            self.pwsh.as_ref()
+        }
+
+        fn powershell(&self) -> Option<&TargetPath> {
+            self.powershell.as_ref()
+        }
+
+        fn cmd(&self) -> Option<&TargetPath> {
+            self.cmd.as_ref()
+        }
+
+        fn install(&self) -> Option<&TargetPath> {
+            None
+        }
+
+        fn tar(&self) -> Option<&TargetPath> {
+            None
+        }
+
+        fn sha256(&self) -> Option<&ExecutionArgv> {
+            None
+        }
+
+        fn node(&self, _runtime: JavascriptRuntime) -> Option<&TargetPath> {
+            None
+        }
     }
 }

--- a/crates/automata-ci-job-executor-github/tests/contracts.rs
+++ b/crates/automata-ci-job-executor-github/tests/contracts.rs
@@ -18,7 +18,10 @@ use automata_ci_runner_runtime::{AdmissionRejection, JobExecutor};
 use bytes::Bytes;
 use static_assertions::assert_obj_safe;
 
-use support::{Fixture, envelope, envelope_with_environment, prepared_node24_action, run_step};
+use support::{
+    Fixture, envelope, envelope_with_environment, prepared_node24_action, run_step,
+    run_step_with_command_template, run_step_with_named_shell, windows_envelope,
+};
 
 assert_obj_safe!(ActionPreparationPort);
 assert_obj_safe!(RepositoryCredentialPort);
@@ -230,6 +233,117 @@ fn safe_local_actions_admit_while_container_actions_fail_closed() {
         ),
     )]);
     assert!(fixture.executor.admit(&container).is_err());
+}
+
+#[test]
+fn static_shell_contracts_are_checked_at_admission_before_provider_work() {
+    for (name, step) in [
+        (
+            "POSIX command mode",
+            run_step_with_command_template("unsafe", "Unsafe", "true", "bash -c {0}"),
+        ),
+        (
+            "POSIX cmd",
+            run_step_with_named_shell("unsafe", "Unsafe", "true", "cmd"),
+        ),
+    ] {
+        let fixture = Fixture::new(Vec::new(), Vec::new());
+        assert_eq!(
+            fixture.executor.admit(&envelope(vec![step])),
+            Err(AdmissionRejection::InvalidJob),
+            "{name} must fail closed during admission"
+        );
+        assert_eq!(fixture.provider.counts(), (0, 0, 0));
+    }
+
+    for (name, step) in [
+        (
+            "Windows Git Bash",
+            run_step_with_named_shell("unsafe", "Unsafe", "true", "bash"),
+        ),
+        (
+            "Windows sh",
+            run_step_with_named_shell("unsafe", "Unsafe", "true", "sh"),
+        ),
+        (
+            "Windows cmd command template",
+            run_step_with_command_template("unsafe", "Unsafe", "true", "cmd /C {0}"),
+        ),
+    ] {
+        let fixture = Fixture::windows(Vec::new());
+        assert_eq!(
+            fixture.executor.admit(&windows_envelope(vec![step])),
+            Err(AdmissionRejection::InvalidJob),
+            "{name} must fail closed during admission"
+        );
+        assert_eq!(fixture.provider.counts(), (0, 0, 0));
+    }
+}
+
+#[test]
+fn every_advertised_static_shell_contract_passes_admission_on_its_platform() {
+    for step in [
+        run_step("default", "Default", "true"),
+        run_step_with_named_shell("bash", "Bash", "true", "bash"),
+        run_step_with_named_shell("sh", "Sh", "true", "sh"),
+        run_step_with_named_shell("python", "Python", "true", "python"),
+        run_step_with_named_shell("pwsh", "PowerShell Core", "true", "pwsh"),
+        run_step_with_command_template(
+            "bash-template",
+            "Bash template",
+            "true",
+            "bash --noprofile --norc -e -o pipefail {0}",
+        ),
+        run_step_with_command_template("sh-template", "Sh template", "true", "sh -e {0}"),
+        run_step_with_command_template(
+            "python-template",
+            "Python template",
+            "true",
+            "python -u {0}",
+        ),
+        run_step_with_command_template(
+            "pwsh-template",
+            "PowerShell template",
+            "true",
+            "pwsh -File {0}",
+        ),
+    ] {
+        Fixture::new(Vec::new(), Vec::new())
+            .executor
+            .admit(&envelope(vec![step]))
+            .expect("advertised POSIX shell contract");
+    }
+
+    for step in [
+        run_step("default", "Default", "true"),
+        run_step_with_named_shell("python", "Python", "true", "python"),
+        run_step_with_named_shell("pwsh", "PowerShell Core", "true", "pwsh"),
+        run_step_with_named_shell("powershell", "Windows PowerShell", "true", "powershell"),
+        run_step_with_named_shell("cmd", "Command Prompt", "true", "cmd"),
+        run_step_with_command_template(
+            "python-template",
+            "Python template",
+            "true",
+            "python -u {0}",
+        ),
+        run_step_with_command_template(
+            "pwsh-template",
+            "PowerShell template",
+            "true",
+            "pwsh -File {0}",
+        ),
+        run_step_with_command_template(
+            "powershell-template",
+            "Windows PowerShell template",
+            "true",
+            "powershell -File {0}",
+        ),
+    ] {
+        Fixture::windows(Vec::new())
+            .executor
+            .admit(&windows_envelope(vec![step]))
+            .expect("advertised Windows shell contract");
+    }
 }
 
 #[test]

--- a/crates/automata-ci-job-executor-github/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/run_steps.rs
@@ -15,7 +15,7 @@ use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase}
 use support::{
     Fixture, PHASE_FILE_ENVIRONMENT_NAMES, PhaseResponse, SECRET, credential_free_envelope,
     envelope_with_environment, envelope_with_working_directory, environment_map, run_step,
-    run_step_with_named_shell, run_step_with_working_directory,
+    run_step_with_command_template, run_step_with_named_shell, run_step_with_working_directory,
 };
 
 #[tokio::test]
@@ -469,6 +469,69 @@ async fn python_and_pwsh_use_exact_script_suffixes_argv_and_powershell_fixup() {
     assert_eq!(pwsh_command.argv().arguments()[0], "-command");
     assert!(pwsh_command.argv().arguments()[1].starts_with(". '/__automata/attempts/"));
     assert!(pwsh_command.argv().arguments()[1].ends_with("/scripts/step-1.ps1'"));
+}
+
+#[tokio::test]
+async fn safe_posix_command_templates_execute_as_direct_argv_without_an_outer_shell() {
+    let fixture = Fixture::secretless(Vec::new(), vec![PhaseResponse::success(); 4]);
+    let job = support::envelope(vec![
+        run_step_with_command_template(
+            "bash-template",
+            "Bash template",
+            "printf bash",
+            "bash --noprofile --norc -e -o pipefail {0}",
+        ),
+        run_step_with_command_template("sh-template", "Sh template", "printf sh", "sh -e {0}"),
+        run_step_with_command_template(
+            "python-template",
+            "Python template",
+            "print('python')",
+            "python -u {0}",
+        ),
+        run_step_with_command_template(
+            "pwsh-template",
+            "PowerShell template",
+            "Write-Output pwsh",
+            "pwsh -File {0}",
+        ),
+    ]);
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("safe command templates execute");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let commands = state
+        .commands
+        .iter()
+        .filter(|command| {
+            command
+                .environment()
+                .values()
+                .iter()
+                .any(|variable| variable.name().as_str() == "GITHUB_ENV")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(commands.len(), 4);
+    assert_eq!(commands[0].argv().program().as_str(), "/usr/bin/bash");
+    assert_eq!(
+        &commands[0].argv().arguments()[..5],
+        ["--noprofile", "--norc", "-e", "-o", "pipefail"]
+    );
+    assert!(commands[0].argv().arguments()[5].ends_with("step-0.sh"));
+    assert_eq!(commands[1].argv().program().as_str(), "/usr/bin/sh");
+    assert_eq!(commands[1].argv().arguments()[0], "-e");
+    assert!(commands[1].argv().arguments()[1].ends_with("step-1.sh"));
+    assert_eq!(commands[2].argv().program().as_str(), "/usr/bin/python3");
+    assert_eq!(commands[2].argv().arguments()[0], "-u");
+    assert!(commands[2].argv().arguments()[1].ends_with("step-2.py"));
+    assert_eq!(commands[3].argv().program().as_str(), "/usr/bin/pwsh");
+    assert_eq!(commands[3].argv().arguments()[0], "-File");
+    assert!(commands[3].argv().arguments()[1].ends_with("step-3.ps1"));
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -579,6 +579,17 @@ pub fn run_step_with_named_shell(id: &str, name: &str, command: &str, shell: &st
     )
 }
 
+pub fn run_step_with_command_template(id: &str, name: &str, command: &str, shell: &str) -> StepIr {
+    run_step_with_shell(
+        id,
+        name,
+        command,
+        ShellTemplate::command_template(
+            ValueTemplate::literal(shell).expect("command shell template"),
+        ),
+    )
+}
+
 pub fn run_step_with_working_directory(
     id: &str,
     name: &str,

--- a/crates/automata-ci-job-executor-github/tests/windows_run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/windows_run_steps.rs
@@ -9,13 +9,14 @@ use automata_ci_core::{
 use automata_ci_execution::{NetworkPolicy, RootFilesystemPolicy, SandboxPrivilegePolicy};
 use automata_ci_github_runtime::CommandFileKind;
 use automata_ci_runner_runtime::{
-    AdmissionRejection, ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
+    AdmissionRejection, ExecutionCancellation, ExecutionEvents, JobExecutor,
 };
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 
 use support::{
-    Fixture, PhaseResponse, action_step, run_step, run_step_with_named_shell,
-    run_step_with_working_directory, windows_envelope, windows_envelope_with_output_definitions,
+    Fixture, PhaseResponse, action_step, run_step, run_step_with_command_template,
+    run_step_with_named_shell, run_step_with_working_directory, windows_envelope,
+    windows_envelope_with_output_definitions,
 };
 
 fn output_expression(source: &str) -> ExpressionProgram {
@@ -63,7 +64,11 @@ async fn windows_default_shell_maps_paths_and_applies_crlf_command_files() {
             .with_file(CommandFileKind::Output, b"digest=abc123\r\n".to_vec()),
         PhaseResponse::success(),
     ]);
-    let producer = run_step("producer", "Producer", "Write-Output 'producer'");
+    let producer = run_step(
+        "producer",
+        "Producer",
+        "Write-Output 'producer'\nWrite-Output 'next'",
+    );
     let second = run_step_with_working_directory(
         "consumer",
         "Consumer",
@@ -153,10 +158,14 @@ async fn windows_default_shell_maps_paths_and_applies_crlf_command_files() {
     );
     assert_eq!(state.scripts.len(), 2);
     assert!(state.scripts.iter().all(|script| {
-        script.starts_with(b"$ErrorActionPreference = 'stop'\n")
+        script.starts_with(b"$ErrorActionPreference = 'stop'\r\n")
             && script.ends_with(
                 b"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }",
             )
+            && script
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte != b'\n' || index > 0 && script[index - 1] == b'\r')
     }));
     drop(state);
 
@@ -222,8 +231,72 @@ async fn windows_named_shells_use_platform_argv_and_script_extensions() {
         r"C:\hostedtoolcache\windows\Python\3.13.0\x64\python.exe"
     );
     assert!(commands[3].argv().arguments()[0].ends_with("step-3.py"));
-    assert_eq!(state.scripts[2], b"echo cmd\r\n");
+    assert_eq!(state.scripts[2], b"@echo off\r\necho cmd");
     assert_eq!(state.scripts[3], b"print('python')");
+}
+
+#[tokio::test]
+async fn safe_windows_command_templates_execute_as_direct_argv() {
+    let fixture = Fixture::windows(vec![PhaseResponse::success(); 3]);
+    let job = windows_envelope(vec![
+        run_step_with_command_template(
+            "pwsh-template",
+            "PowerShell Core template",
+            "Write-Output pwsh\nWrite-Output next",
+            "pwsh -File {0}",
+        ),
+        run_step_with_command_template(
+            "powershell-template",
+            "Windows PowerShell template",
+            "Write-Output powershell",
+            "powershell -File {0}",
+        ),
+        run_step_with_command_template(
+            "python-template",
+            "Python template",
+            "print('first')\nprint('second')",
+            "python -u {0}",
+        ),
+    ]);
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("safe Windows command templates execute");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let commands = phase_commands(&state);
+    assert_eq!(commands.len(), 3);
+    assert_eq!(
+        commands[0].argv().program().as_str(),
+        r"C:\Program Files\PowerShell\7\pwsh.exe"
+    );
+    assert_eq!(commands[0].argv().arguments()[0], "-File");
+    assert!(commands[0].argv().arguments()[1].ends_with("step-0.ps1"));
+    assert_eq!(
+        commands[1].argv().program().as_str(),
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    );
+    assert_eq!(commands[1].argv().arguments()[0], "-File");
+    assert!(commands[1].argv().arguments()[1].ends_with("step-1.ps1"));
+    assert_eq!(
+        commands[2].argv().program().as_str(),
+        r"C:\hostedtoolcache\windows\Python\3.13.0\x64\python.exe"
+    );
+    assert_eq!(commands[2].argv().arguments()[0], "-u");
+    assert!(commands[2].argv().arguments()[1].ends_with("step-2.py"));
+    for script in &state.scripts {
+        assert!(
+            script
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte != b'\n' || index > 0 && script[index - 1] == b'\r'),
+            "Windows scripts must use CRLF"
+        );
+    }
 }
 
 #[test]
@@ -277,8 +350,8 @@ fn windows_reserved_environment_aliases_fail_admission() {
     assert_eq!(fixture.provider.counts(), (0, 0, 0));
 }
 
-#[tokio::test]
-async fn windows_rejects_unconfigured_bash_shell() {
+#[test]
+fn windows_rejects_unconfigured_bash_shell_during_admission() {
     let fixture = Fixture::windows(Vec::new());
     let job = windows_envelope(vec![run_step_with_named_shell(
         "bash",
@@ -286,15 +359,12 @@ async fn windows_rejects_unconfigured_bash_shell() {
         "echo unsupported",
         "bash",
     )]);
-    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
-
-    let error = fixture
-        .executor
-        .execute(fixture.request(job), events, ExecutionCancellation::new())
-        .await
-        .expect_err("Bash is not implicitly provided by a Windows container profile");
-
-    assert_eq!(error.kind(), ExecutorErrorKind::Unsupported);
+    assert_eq!(
+        fixture.executor.admit(&job),
+        Err(AdmissionRejection::InvalidJob),
+        "Bash is not implicitly provided by a Windows container profile"
+    );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
     let state = fixture.endpoint_state.lock().expect("endpoint lock");
     assert!(phase_commands(&state).is_empty());
     assert!(state.scripts.is_empty());

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -721,31 +721,31 @@ all cancellation-time post behavior remain gaps.
 
 ## 12. Shell and script semantics
 
-- [ ] Implement arbitrary valid custom shell templates with exactly one `{0}`
-  placeholder.
-- [ ] Implement template parsing without invoking an extra shell unexpectedly.
-- [ ] Match default Linux and macOS fallback from missing `bash` to `sh`.
-- [ ] Match explicit `bash` fallback behavior.
-- [ ] Match Windows default fallback from PowerShell Core to Windows
+- [x] Publish and enforce the reviewed closed grammar for custom shell
+  templates with exactly one final `{0}` placeholder.
+- [x] Implement template parsing without invoking an extra shell unexpectedly.
+- [x] Match default Linux and macOS fallback from missing `bash` to `sh`.
+- [x] Match explicit `bash` missing-tool behavior.
+- [x] Match Windows default fallback from PowerShell Core to Windows
   PowerShell.
 - [ ] Support Git Bash for `shell: bash` on Windows.
 - [ ] Support `sh` on Windows where GitHub does.
-- [ ] Enable and configure PowerShell on the Linux compatibility profile.
-- [ ] Match script-file extensions.
-- [ ] Match script encoding and line endings.
-- [ ] Match GitHub's `cmd` invocation and quoting semantics, or document the
+- [x] Enable and configure PowerShell on the Linux compatibility profile.
+- [x] Match script-file extensions.
+- [x] Match script encoding and line endings.
+- [x] Match GitHub's `cmd` invocation and quoting semantics, or document the
   hardened divergence.
-- [ ] Test shell paths containing spaces and metacharacters.
-- [ ] Test exit-code propagation.
-- [ ] Test PowerShell `$LASTEXITCODE`.
+- [x] Test shell paths containing spaces and metacharacters.
+- [x] Test exit-code propagation.
+- [x] Test PowerShell `$LASTEXITCODE`.
 - [ ] Test signals and Ctrl-C or Ctrl-Break.
-- [ ] Test job and step `working-directory` precedence.
-- [ ] Decide whether absolute working directories outside the workspace are
-  supported.
+- [x] Test job and step `working-directory` precedence.
+- [x] Decide whether absolute working directories outside the workspace are
+  supported: they remain rejected by workspace confinement.
 - [ ] Match container shell defaults once job containers exist.
 - [ ] Add macOS shell behavior.
-- [ ] Add advertised Python runtime acceptance.
-- [ ] Add shell-not-found diagnostics matching the correct lifecycle phase.
+- [x] Add advertised Python runtime acceptance.
+- [x] Add shell-not-found diagnostics matching the correct lifecycle phase.
 
 ## 13. Docker actions, job containers, and service containers
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -54,24 +54,35 @@ Acceptance:
 
 Tasks:
 
-- [ ] Support custom shell templates with exactly one `{0}` placeholder.
-- [ ] Reject zero or multiple placeholders without an unintended outer shell.
-- [ ] Implement default bash-to-sh fallback on POSIX.
-- [ ] Match explicit bash behavior.
-- [ ] Implement Windows PowerShell Core fallback to Windows PowerShell.
+- [x] Support custom shell templates with exactly one `{0}` placeholder under
+  the published closed grammar in the executor README.
+- [x] Reject zero or multiple placeholders without an unintended outer shell.
+- [x] Implement default bash-to-sh fallback on POSIX.
+- [x] Match explicit bash behavior.
+- [x] Implement Windows PowerShell Core fallback to Windows PowerShell.
 - [ ] Support configured Git Bash and `sh` on Windows.
-- [ ] Add Linux PowerShell profile support.
-- [ ] Match extensions, encoding, CRLF/LF, exit codes, and
+  The isolated Windows profile currently exposes neither executable; both
+  contracts reject during admission rather than probing the host. Add them only
+  with a pinned image/toolchain update and corresponding isolation evidence.
+- [x] Add Linux PowerShell profile support.
+- [x] Match extensions, encoding, CRLF/LF, exit codes, and
   `$LASTEXITCODE`.
-- [ ] Test executable and script paths containing spaces and metacharacters.
-- [ ] Verify workflow/job/step working-directory precedence.
-- [ ] Record the exact hardened `cmd` quoting decision.
-- [ ] Produce lifecycle-correct shell-not-found diagnostics.
+- [x] Test executable and script paths containing spaces and metacharacters.
+- [x] Verify workflow/job/step working-directory precedence. Workflow and job
+  defaults arrive as the frontend-resolved job default; step-local values
+  override it, then the executor falls back to the workspace.
+- [x] Record the exact hardened `cmd` quoting decision. Automata passes the
+  script as a bounded argv value under `/D /E:ON /V:OFF /C`, omits the pinned
+  runner's nested `/S /C CALL` string, and rejects active `cmd` path syntax.
+- [x] Produce lifecycle-correct shell-not-found diagnostics. Static literals
+  fail admission before provider work (`CapabilityChanged` for a missing
+  configured tool, `InvalidJob` for an invalid contract); expression-derived
+  shells fail before script copy or user execution.
 
 Acceptance:
 
-- [ ] A table-driven suite covers every advertised shell and operating system.
-- [ ] Workflow-controlled values cannot escape the selected template contract.
+- [x] A table-driven suite covers every advertised shell and operating system.
+- [x] Workflow-controlled values cannot escape the selected template contract.
 
 ### RUN-03 — Reserved environment variables and phase files
 

--- a/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
+++ b/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
@@ -547,10 +547,10 @@ approved divergence must name its early rejection boundary and test.
 
 - [ ] **Service image mutability:** continue requiring immutable digests, or
   support tags with resolver-captured provenance (`PROV-02`).
-- [ ] **Absolute working directories:** keep workspace confinement, or define
-  additional safe roots and provider contracts (`RUN-02`).
-- [ ] **Custom shell templates:** support GitHub's one-`{0}` command templates
-  on each platform, or publish a strict supported grammar (`RUN-02`).
+- [x] **Absolute working directories:** keep workspace confinement; no
+  additional roots are exposed by the current provider contract (`RUN-02`).
+- [x] **Custom shell templates:** publish and enforce the strict one-`{0}`
+  grammar recorded in the executor README (`RUN-02`).
 - [ ] **Insecure legacy workflow commands:** honor
   `ACTIONS_ALLOW_UNSECURE_COMMANDS`, or retain a deliberate secure divergence
   with an admission diagnostic (`LOG-01`).


### PR DESCRIPTION
## Stack dependency

Depends on #187. The top commit is `299487d`; after #187 merges, this PR narrows to RUN-02.

## Summary

- implement exact default fallbacks: POSIX Bash to sh, and Windows pwsh to Windows PowerShell
- use typed named-shell dispatch and direct argv construction rather than an outer shell
- support custom templates through a closed grammar with exactly one final `{0}` placeholder
- reject statically unavailable shells during admission before provider work, and dynamic failures before script copy/exec
- preserve working-directory precedence and platform-specific command-file behavior
- apply Windows CRLF/UTF-8-no-BOM fixups, including `@echo off` and `$LASTEXITCODE`
- retain the documented hardened cmd quoting divergence

## Scope boundary

Windows Git Bash/sh remain unadvertised because the current Hyper-V profile contains neither. They fail as `InvalidJob` instead of falling back to a host tool.

## Validation

- full `automata-ci-job-executor-github --all-features` suite
- focused admission/run-step/Windows suites
- strict all-target/all-feature Clippy
- post-rebase all-target stack checks and `git diff --check`
