### PR TITLE
fix(test): route YAML alias contracts through aggregate

### DIFF
--- a/crates/automata-ci-workflow-github/tests/workflow_github.rs
+++ b/crates/automata-ci-workflow-github/tests/workflow_github.rs
@@ -18,4 +18,5 @@ mod schedule_contract;
 mod support;
 mod trigger_selection;
 mod workflow_dispatch_inputs;
+mod yaml_aliases;
 mod yaml_semantics;

--- a/crates/automata-ci-workflow-github/tests/yaml_aliases.rs
+++ b/crates/automata-ci-workflow-github/tests/yaml_aliases.rs
@@ -1,4 +1,4 @@
-mod support;
+use crate::support;
 
 use automata_ci_core::{WorkflowEventProvenance, WorkflowPlan};
 use automata_ci_workflow_github::{


### PR DESCRIPTION
## Outcome

Routes the 11 YAML anchor/alias contracts added by #183 through the existing `workflow_github` aggregate target.

The workspace has `autotests = false` for this crate, so `tests/yaml_aliases.rs` was not compiled and the fail-closed topology verifier correctly rejected it as unowned. The patch adds the module to the aggregate root and reuses the aggregate's existing `support` module.

Diff: 2 files, +2/-1.

## Verification

- topology verifier: 28 aggregate packages, 344 Rust sources, 33 targets
- aggregate inventory: 144 → 155 tests
- exact YAML-alias inventory: 11/11 names preserved with no duplicate or missing test
- lines 2–373 of `yaml_aliases.rs` remain byte-identical
- workflow-github tests: 21 unit + 155 integration, all passing
- strict all-target/all-feature Clippy
- formatting and diff checks
- fail-closed mutations reject a missing route, duplicate route, synthetic orphan, and reverted local support declaration
- no open PR touches either changed file

## AI assistance

OpenAI Codex helped diagnose the aggregate ownership regression and independently verify source/test-name equivalence and fail-closed mutations. All submitted claims were verified against the repository.
