### PR TITLE
fix(checks): align native rerun action contract

### DIFF
--- a/crates/automata-ci-github-delivery/src/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/src/checks_publisher.rs
@@ -1564,7 +1564,7 @@ fn requested_actions(
         actions.push(
             GithubCheckRequestedAction::new(
                 "Re-run this job",
-                "Run this job and its dependencies",
+                "Run this job and its dependents",
                 "rerun_job",
             )
             .map_err(|_| GithubChecksPublisherError::InvariantViolation)?,
@@ -1573,7 +1573,7 @@ fn requested_actions(
     actions.push(
         GithubCheckRequestedAction::new(
             "Re-run failed jobs",
-            "Run failed jobs and dependencies",
+            "Run failed jobs and their dependents",
             "rerun_failed",
         )
         .map_err(|_| GithubChecksPublisherError::InvariantViolation)?,

--- a/crates/automata-ci-github-delivery/tests/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/tests/checks_publisher.rs
@@ -1286,6 +1286,21 @@ async fn create_cutoff_and_state_publication_follow_exact_durable_actions() {
     assert!(requests[3].raw.contains(r#""status":"in_progress""#));
     assert!(requests[5].raw.contains(r#""status":"completed""#));
     assert!(requests[5].raw.contains(r#""conclusion":"success""#));
+    assert_eq!(
+        request_json(&requests[5])["actions"],
+        serde_json::json!([
+            {
+                "label": "Re-run failed jobs",
+                "description": "Run failed jobs and their dependents",
+                "identifier": "rerun_failed"
+            },
+            {
+                "label": "Re-run all jobs",
+                "description": "Run every job in this workflow",
+                "identifier": "rerun_all"
+            }
+        ])
+    );
     let events = harness.events();
     assert!(
         position(&events, "store:begin_run_create")
@@ -1417,6 +1432,26 @@ async fn terminal_job_publishes_verified_step_markdown_and_exact_details_link() 
     assert!(text.contains("| `checkout` | passed | passed | 0s |"));
     assert!(text.contains("| `test` | failed | failed | 0s |"));
     assert!(text.contains("The failing assertion was safely masked."));
+    assert_eq!(
+        body["actions"],
+        serde_json::json!([
+            {
+                "label": "Re-run this job",
+                "description": "Run this job and its dependents",
+                "identifier": "rerun_job"
+            },
+            {
+                "label": "Re-run failed jobs",
+                "description": "Run failed jobs and their dependents",
+                "identifier": "rerun_failed"
+            },
+            {
+                "label": "Re-run all jobs",
+                "description": "Run every job in this workflow",
+                "identifier": "rerun_all"
+            }
+        ])
+    );
 }
 
 #[tokio::test]

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -127,6 +127,15 @@ and links directly to that job in the Automata dashboard. Initial attempts and
 later retries use the same transactional insertion path. Automata does not
 pretend these are native GitHub Actions run records.
 
+The Wave 1 contract slice is component-complete: claims freeze exact identity,
+lifecycle timestamps, authority, presentation evidence, and annotation
+progress; provider mutations use bounded reconciliation and durable issue
+cutoffs; and requested actions map to the existing reauthorized, idempotent
+rerun selections. This does not complete `CHECK-01` product acceptance. The
+remaining package work still depends on the complete `RES-02` result surface,
+the final `AUTH-03` credential path, broader workflow fixtures, and retained
+live-GitHub evidence.
+
 Tasks:
 
 - [x] Preserve one fenced aggregate Check subject and durable outbox lifecycle
@@ -135,21 +144,21 @@ Tasks:
   distinct workflow subject for each physical rerun.
 - [x] Project queued, in-progress, completed, skipped, cancelled, failed, and
   timed-out states and conclusions from the durable attempt lifecycle.
-- [ ] Publish accurate start and completion timestamps.
+- [x] Publish accurate start and completion timestamps.
 - [x] Publish a bounded job name and an exact HTTPS dashboard `details_url`.
-- [ ] Publish bounded title, summary, text, and annotations.
-- [ ] Batch annotations within GitHub API limits and preserve deterministic
+- [x] Publish bounded title, summary, text, and annotations.
+- [x] Batch annotations within GitHub API limits and preserve deterministic
   ordering.
-- [ ] Add requested-action support only after its authority and idempotency
+- [x] Add requested-action support only after its authority and idempotency
   model is explicit; otherwise omit the field.
 - [ ] Publish status badges from durable workflow/ref state with bounded cache
   behavior and no credential-bearing redirect.
-- [ ] Decide whether optional commit-status projection is needed alongside
+- [x] Decide whether optional commit-status projection is needed alongside
   Checks; implement an idempotent projector or record an explicit divergence.
 - [ ] Extend reconciliation across delivery retries, out-of-order updates,
   force-push replacement, per-job attempts, and deleted refs without collapsing
   the existing rerun-specific workflow subjects.
-- [ ] Bound API retries and handle rate limiting without blocking scheduler
+- [x] Bound API retries and handle rate limiting without blocking scheduler
   progress.
 - [ ] Add product fixtures for multi-job, matrix, reusable, cancelled, and
   partially failed workflows.


### PR DESCRIPTION
## Summary

- make native GitHub Check rerun actions describe the durable operation they actually request
- replace the incorrect “rerun dependencies” wording with downstream-dependent semantics for both job and workflow Check payloads
- add exact provider-payload assertions so UI labels cannot drift from the fenced rerun contract
- document which CHECK-01 pieces are Wave 1 component-complete and which remain full-product acceptance work

## Scope boundary

The local Wave 1 CHECK-01 contract is complete after this fix. Full acceptance still depends on RES-02/final AUTH-03, force-push and deleted-ref reconciliation, badges, broader product fixtures, and retained live-GitHub evidence.

## Validation

- full GitHub-delivery suite, including annotation replay/fencing coverage
- full GitHub and Store suites
- Store PostgreSQL all-target check
- strict GitHub-delivery Clippy
- formatting and `git diff --check`

Live PostgreSQL race tests were not executed locally because `AUTOMATA_TEST_DATABASE_URL` is unavailable.