### PR TITLE
feat(ui): add provider repository composition

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -224,11 +224,13 @@ variants fail rather than falling back to an empty client shell.
 `npm run build` also assembles the private, registry-neutral `@automata/ui`
 package beneath `dist/package`. Its deliberately small public surface contains
 the existing Core page renderer, the shared application shell, the theme
-control and bootstrap script, the page-model types, the resumable live-log
-controller, and a stable compiled stylesheet at `@automata/ui/styles.css`. A
-separate host can render its own page content inside `Shell` and supply its own
-authenticated live-log ticket provider. The package does not contain an
-identity provider, Cloud API knowledge, Cloud-only pages, or a plugin system.
+control and bootstrap script, host-neutral provider connection and repository
+selection components, the page-model types, the resumable live-log controller,
+and a stable compiled stylesheet at `@automata/ui/styles.css`. A separate host
+can render its own page content inside `Shell`, compose provider controls around
+the shared presentation, and supply its own authenticated live-log ticket
+provider. The package does not contain an identity provider, Cloud API
+knowledge, Cloud-only pages, or a plugin system.
 
 `npm run verify:package` renders consumer-owned content through the packaged
 shell, checks the compiled stylesheet, creates the npm archive twice, and

--- a/ui/scripts/verify-package.mjs
+++ b/ui/scripts/verify-package.mjs
@@ -19,6 +19,8 @@ const expectedExports = [
   "LiveLogController",
   "LiveLogProtocolError",
   "LiveLogRequestError",
+  "ProviderConnectionPanel",
+  "RepositorySelectionList",
   "Shell",
   "THEME_BOOTSTRAP_SCRIPT",
   "ThemeToggle",

--- a/ui/src/components/ProviderConnectionPanel.tsx
+++ b/ui/src/components/ProviderConnectionPanel.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+
+export type ProviderConnectionLifecycle =
+  | "pending"
+  | "active"
+  | "suspended"
+  | "removed";
+
+export interface ProviderConnectionPanelProps {
+  readonly accountLabel: string | null;
+  readonly children?: ReactNode;
+  readonly controls?: ReactNode;
+  readonly headingId: string;
+  readonly lifecycle: ProviderConnectionLifecycle;
+  readonly providerLabel: string;
+}
+
+/**
+ * Host-neutral framing for an installed source-control provider.
+ *
+ * The host owns authorization and mutations and supplies those controls as
+ * children. Keeping transport out of this component lets the embedded Rust
+ * host and the Cloud SSR host reuse the same presentation without sharing
+ * private APIs.
+ */
+export function ProviderConnectionPanel({
+  accountLabel,
+  children,
+  controls,
+  headingId,
+  lifecycle,
+  providerLabel,
+}: ProviderConnectionPanelProps) {
+  return (
+    <section className="panel provider-connection" aria-labelledby={headingId}>
+      <div className="panel__heading provider-connection__heading">
+        <h2 id={headingId}>{providerLabel}</h2>
+        <span data-provider-connection-state={lifecycle}>
+          {lifecycleLabel(lifecycle)}
+        </span>
+      </div>
+      <div className="provider-connection__summary">
+        <div>
+          <strong>{accountLabel ?? "Installation pending"}</strong>
+          <span>{lifecycleDescription(lifecycle, providerLabel)}</span>
+        </div>
+        {controls}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function lifecycleLabel(lifecycle: ProviderConnectionLifecycle): string {
+  switch (lifecycle) {
+    case "pending":
+      return "Pending";
+    case "active":
+      return "Connected";
+    case "suspended":
+      return "Suspended";
+    case "removed":
+      return "Removed";
+  }
+}
+
+function lifecycleDescription(
+  lifecycle: ProviderConnectionLifecycle,
+  providerLabel: string,
+): string {
+  switch (lifecycle) {
+    case "pending":
+      return `Waiting for ${providerLabel} to confirm this installation.`;
+    case "active":
+      return `Choose which ${providerLabel} repositories this workspace can use.`;
+    case "suspended":
+      return `This ${providerLabel} installation is suspended. Existing selections are read-only.`;
+    case "removed":
+      return `This ${providerLabel} installation was removed. Its repositories are no longer available.`;
+  }
+}

--- a/ui/src/components/RepositorySelectionList.tsx
+++ b/ui/src/components/RepositorySelectionList.tsx
@@ -1,0 +1,59 @@
+export interface SelectableProviderRepository {
+  readonly defaultBranch: string;
+  readonly id: string;
+  readonly name: string;
+  readonly owner: string;
+  readonly private: boolean;
+  readonly selected: boolean;
+}
+
+export interface RepositorySelectionListProps {
+  readonly disabled?: boolean;
+  readonly inputName?: string;
+  readonly repositories: readonly SelectableProviderRepository[];
+}
+
+/** A transport-independent repository checklist for provider setup pages. */
+export function RepositorySelectionList({
+  disabled = false,
+  inputName = "repository_ids",
+  repositories,
+}: RepositorySelectionListProps) {
+  if (repositories.length === 0) {
+    return (
+      <p className="provider-repositories__empty">
+        No repositories are available to this installation.
+      </p>
+    );
+  }
+
+  return (
+    <fieldset className="provider-repositories" disabled={disabled}>
+      <legend className="sr-only">Repositories</legend>
+      <ul className="provider-repositories__list">
+        {repositories.map((repository) => (
+          <li className="provider-repositories__item" key={repository.id}>
+            <label>
+              <input
+                defaultChecked={repository.selected}
+                name={inputName}
+                type="checkbox"
+                value={repository.id}
+              />
+              <span className="provider-repositories__identity">
+                <span>
+                  {repository.owner}/{repository.name}
+                </span>
+                <small>
+                  {repository.private ? "Private" : "Public"}
+                  {" · default branch "}
+                  {repository.defaultBranch}
+                </small>
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </fieldset>
+  );
+}

--- a/ui/src/public.ts
+++ b/ui/src/public.ts
@@ -1,5 +1,15 @@
 export { App, type AppProps } from "./App";
 export { Shell, type ShellProps } from "./components/Shell";
+export {
+  ProviderConnectionPanel,
+  type ProviderConnectionLifecycle,
+  type ProviderConnectionPanelProps,
+} from "./components/ProviderConnectionPanel";
+export {
+  RepositorySelectionList,
+  type RepositorySelectionListProps,
+  type SelectableProviderRepository,
+} from "./components/RepositorySelectionList";
 export { ThemeToggle } from "./components/ThemeToggle";
 export { THEME_BOOTSTRAP_SCRIPT } from "./components/useThemePreference";
 export * from "./liveLogs";

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -9,6 +9,7 @@
 @import "./styles/layout/navigation.css" layer(layout);
 @import "./styles/components/shell.css" layer(components);
 @import "./styles/components/navigation.css" layer(components);
+@import "./styles/components/provider-connection.css" layer(components);
 @import "./styles/components/repository-settings-navigation.css" layer(components);
 @import "./styles/components/controls.css" layer(components);
 @import "./styles/components/surfaces.css" layer(components);

--- a/ui/src/styles/components/provider-connection.css
+++ b/ui/src/styles/components/provider-connection.css
@@ -1,0 +1,95 @@
+.provider-connection__heading [data-provider-connection-state="active"] {
+  color: var(--success-fg);
+}
+
+.provider-connection__heading [data-provider-connection-state="suspended"],
+.provider-connection__heading [data-provider-connection-state="removed"] {
+  color: var(--danger-fg);
+}
+
+.provider-connection__summary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.provider-connection__summary > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.provider-connection__summary strong,
+.provider-connection__summary span {
+  overflow-wrap: anywhere;
+}
+
+.provider-connection__summary span {
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.provider-repositories {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.provider-repositories__list {
+  max-height: 420px;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.provider-repositories__item + .provider-repositories__item {
+  border-top: 1px solid var(--border-muted);
+}
+
+.provider-repositories__item label {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  cursor: pointer;
+}
+
+.provider-repositories__item label:hover {
+  background: var(--canvas-subtle);
+}
+
+.provider-repositories__item input {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin: 2px 0 0;
+}
+
+.provider-repositories__identity {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  overflow-wrap: anywhere;
+}
+
+.provider-repositories__identity > span {
+  font-weight: 600;
+}
+
+.provider-repositories__identity small {
+  color: var(--fg-muted);
+}
+
+.provider-repositories__empty {
+  margin: 0;
+  padding: 24px 16px;
+  color: var(--fg-muted);
+  text-align: center;
+}

--- a/ui/tests/integration/provider-connection-components.test.tsx
+++ b/ui/tests/integration/provider-connection-components.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  ProviderConnectionPanel,
+  RepositorySelectionList,
+} from "../../src/public";
+
+describe("provider connection package components", () => {
+  it("renders host-owned controls and escaped repository metadata", () => {
+    const html = renderToStaticMarkup(
+      <ProviderConnectionPanel
+        accountLabel="analytical-engines"
+        controls={<button type="button">Host action</button>}
+        headingId="provider-example"
+        lifecycle="active"
+        providerLabel="GitHub"
+      >
+        <RepositorySelectionList
+          repositories={[
+            {
+              defaultBranch: "main",
+              id: "123",
+              name: "<script>alert(1)</script>",
+              owner: "automata-ci",
+              private: true,
+              selected: true,
+            },
+          ]}
+        />
+      </ProviderConnectionPanel>,
+    );
+
+    expect(html).toContain('data-provider-connection-state="active"');
+    expect(html).toContain("Connected");
+    expect(html).toContain("Host action");
+    expect(html).toContain('name="repository_ids"');
+    expect(html).toContain('value="123"');
+    expect(html).toContain("Private · default branch main");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("renders read-only lifecycle and empty repository states", () => {
+    const html = renderToStaticMarkup(
+      <ProviderConnectionPanel
+        accountLabel={null}
+        headingId="provider-pending"
+        lifecycle="suspended"
+        providerLabel="Source provider"
+      >
+        <RepositorySelectionList disabled repositories={[]} />
+      </ProviderConnectionPanel>,
+    );
+
+    expect(html).toContain("Installation pending");
+    expect(html).toContain("Suspended");
+    expect(html).toContain("No repositories are available");
+  });
+});

--- a/ui/tests/public.test.ts
+++ b/ui/tests/public.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   App,
+  ProviderConnectionPanel,
+  RepositorySelectionList,
   Shell,
   THEME_BOOTSTRAP_SCRIPT,
   ThemeToggle,
@@ -9,6 +11,8 @@ import {
 describe("public package entrypoint", () => {
   it("exports the supported runtime surface", () => {
     expect(App).toBeTypeOf("function");
+    expect(ProviderConnectionPanel).toBeTypeOf("function");
+    expect(RepositorySelectionList).toBeTypeOf("function");
     expect(Shell).toBeTypeOf("function");
     expect(ThemeToggle).toBeTypeOf("function");
     expect(THEME_BOOTSTRAP_SCRIPT).toBeTypeOf("string");


### PR DESCRIPTION
## Summary

- export host-neutral provider connection and repository-selection components from the public UI package
- keep authorization and mutation controls owned by the consuming Rust or Cloud host
- include shared presentation, public package verification, and SSR escaping tests

## Verification

- npm run check from the ui directory (509 tests plus client, SSR, package, and deterministic archive verification)