### PR TITLE
refactor(auth): retire unused authorization facades

### DIFF
--- a/crates/automata-ci-auth/src/authorization.rs
+++ b/crates/automata-ci-auth/src/authorization.rs
@@ -141,19 +141,6 @@ impl RbacPolicy {
         Self { grants }
     }
 
-    /// Returns the union of permissions explicitly granted to the supplied roles.
-    pub fn permissions_for<'a>(
-        &'a self,
-        roles: impl IntoIterator<Item = &'a RoleName>,
-    ) -> BTreeSet<Permission> {
-        roles
-            .into_iter()
-            .filter_map(|role| self.grants.get(role))
-            .flatten()
-            .cloned()
-            .collect()
-    }
-
     /// Reports whether any supplied role explicitly grants a permission.
     pub fn allows<'a>(
         &'a self,
@@ -164,19 +151,6 @@ impl RbacPolicy {
             .into_iter()
             .filter_map(|role| self.grants.get(role))
             .any(|permissions| permissions.contains(permission))
-    }
-}
-
-/// Authorization is a separate port from authentication so deployments can replace
-/// RBAC without replacing their identity provider.
-pub trait Authorizer: std::fmt::Debug + Send + Sync {
-    /// Reports whether the supplied roles explicitly grant a permission.
-    fn is_allowed(&self, roles: &BTreeSet<RoleName>, permission: &Permission) -> bool;
-}
-
-impl Authorizer for RbacPolicy {
-    fn is_allowed(&self, roles: &BTreeSet<RoleName>, permission: &Permission) -> bool {
-        self.allows(roles, permission)
     }
 }
 
@@ -745,20 +719,6 @@ impl CompositeAuthorizationPolicy {
         }
     }
 
-    /// Returns the explicit RBAC policy.
-    #[must_use]
-    pub const fn rbac(&self) -> &RbacPolicy {
-        &self.rbac
-    }
-
-    /// Returns publication policies keyed by exact repository identity.
-    #[must_use]
-    pub const fn repository_publications(
-        &self,
-    ) -> &BTreeMap<RepositoryResource, RepositoryPublicationPolicy> {
-        &self.repository_publications
-    }
-
     /// Applies tenant checks, scoped RBAC, and closed output publication policy.
     #[must_use]
     pub fn allows(&self, context: &AuthorizationContext, request: &AuthorizationRequest) -> bool {
@@ -800,25 +760,5 @@ impl CompositeAuthorizationPolicy {
                 OutputVisibility::Authenticated => authenticated,
                 OutputVisibility::Private => false,
             })
-    }
-}
-
-/// Resource-aware authorization port for server and management-plane composition.
-pub trait ResourceAuthorizer: fmt::Debug + Send + Sync {
-    /// Reports whether current identity evidence allows the exact request.
-    fn is_request_allowed(
-        &self,
-        context: &AuthorizationContext,
-        request: &AuthorizationRequest,
-    ) -> bool;
-}
-
-impl ResourceAuthorizer for CompositeAuthorizationPolicy {
-    fn is_request_allowed(
-        &self,
-        context: &AuthorizationContext,
-        request: &AuthorizationRequest,
-    ) -> bool {
-        self.allows(context, request)
     }
 }

--- a/crates/automata-ci-auth/tests/port_contracts.rs
+++ b/crates/automata-ci-auth/tests/port_contracts.rs
@@ -1,19 +1,12 @@
 use automata_ci_auth::{
-    authorization::{Authorizer, ResourceAuthorizer},
-    github::GithubEndpoint,
-    human::AuthenticationProvider,
-    installation::InstallationRepository,
-    login::LoginTransactionRepository,
-    machine::MachineIdentityVerifier,
-    session::HumanSessionRepository,
-    vault::ProviderTokenVault,
+    github::GithubEndpoint, human::AuthenticationProvider, installation::InstallationRepository,
+    login::LoginTransactionRepository, machine::MachineIdentityVerifier,
+    session::HumanSessionRepository, vault::ProviderTokenVault,
 };
 use static_assertions::assert_obj_safe;
 
 assert_obj_safe!(AuthenticationProvider);
 assert_obj_safe!(InstallationRepository);
-assert_obj_safe!(Authorizer);
-assert_obj_safe!(ResourceAuthorizer);
 assert_obj_safe!(MachineIdentityVerifier);
 assert_obj_safe!(HumanSessionRepository);
 assert_obj_safe!(LoginTransactionRepository);


### PR DESCRIPTION
## Outcome

Remove two generic authorization facade traits, their sole forwarding implementations, and three zero-call policy accessors that never acquired a production consumer. Production and test authorization continue through the retained inherent `RbacPolicy::allows` and `CompositeAuthorizationPolicy::allows` paths, whose implementations and constructors are byte-for-byte unchanged.

## Related issue

Closes #206

## Trust and compatibility impact

Authorization behavior, credentials, storage, schema, protocol, and wire formats are unchanged. This intentionally removes an unused public Rust source surface from an unpublished `0.1.0` crate: `Authorizer`, `ResourceAuthorizer`, and three convenience methods. There are no in-tree consumers or implementations beyond the deleted forwarding impls, but hypothetical Git/path consumers would need to call the retained inherent `allows` methods.

## Verification

- `automata-ci-auth` all-target/all-feature tests: 132/132 passed
- strict auth Clippy with warnings denied passed
- auth rustdoc with warnings denied passed
- all 17 direct reverse-dependent packages passed all-target/all-feature checks
- exact removed-symbol and method-call scans are empty
- targeted rustfmt and diff checks passed

Workspace-wide rustfmt still reports two unrelated, parent-identical files already present on main; neither is part of this two-file patch.

## AI assistance

Codex audited reachability and history, implemented the removal, validated all reverse dependents, and performed an independent final review.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.