### PR TITLE
fix(store-postgres): align provider manifest workflow limits

### DIFF
--- a/crates/automata-ci-postgres/tests/store/provider/github_provider_manifest.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_provider_manifest.rs
@@ -10,11 +10,15 @@ use automata_ci_store::{
     GithubRepositoryName, GithubServerServiceAppClientId, GithubServerServiceAppId,
     GithubServerServiceJwtIssuer, GithubServerServiceRevision, ProviderConnectionId,
     ProviderDeliveryIdentity, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryVisibility, TenantScope, github_provider_repository_id,
+    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility, TenantScope,
+    github_provider_repository_id,
 };
 use uuid::Uuid;
 
-use crate::support::{TestResult, run_with_database};
+use crate::support::{TestResult, run_with_database, run_with_unmigrated_database};
+
+static PROVIDER_MANIFEST_MIGRATOR: sqlx::migrate::Migrator =
+    sqlx::migrate!("../automata-ci-store-postgres/migrations");
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
@@ -155,6 +159,190 @@ async fn exact_bootstrap_creates_repository_and_replays_original_evidence() -> T
                 .as_database_error()
                 .and_then(sqlx::error::DatabaseError::constraint),
             Some("github_provider_manifest_current_removal_forbidden")
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)]
+async fn historical_workflow_limit_survives_populated_forward_migration() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        PROVIDER_MANIFEST_MIGRATOR
+            .run_to(32, database.pool())
+            .await?;
+        let tenant = tenant("manifest-workflow-limit-migration");
+        let connection = connection(0x133);
+        let owner_id = ProviderRepositoryOwnerId::new(404)?;
+        let historical = historical_manifest(tenant.clone(), connection, owner_id);
+        assert_eq!(historical.limits().workflow_max_bytes(), 1_048_576);
+        allow_current_manifest_in_predecessor_fixture(database.pool()).await?;
+        let current_seed = manifest(
+            tenant.clone(),
+            connection,
+            RevisionSet::new(1, 1, 1),
+            [7; 32],
+            "Automata CI",
+        )
+        .with_repository_owner_id(owner_id);
+
+        let created = database
+            .store()
+            .bootstrap_github_provider_repository(request(current_seed.clone(), 100))
+            .await?;
+        assert_eq!(created.manifest().current().manifest(), &current_seed);
+        rewrite_current_manifest_as_predecessor_history(database.pool(), connection).await?;
+
+        let predecessor_loaded = database
+            .store()
+            .load_current_github_provider_manifest(&tenant, connection)
+            .await?;
+        assert_eq!(predecessor_loaded.manifest(), &historical);
+
+        let claimed_at = database_now(database.pool()).await?.get();
+        let discovery_id = Uuid::from_u128(0x0001_3301);
+        sqlx::query(
+            r"
+            INSERT INTO github_schedule_discovery_claims (
+                discovery_id, tenant_id, repository_id,
+                provider_connection_id, manifest_revision, manifest_digest,
+                github_repository_owner_id, source_authority_kind,
+                private_source_authority_id,
+                private_source_authority_identity_digest,
+                private_source_authority_app_configuration_revision,
+                private_source_authority_policy_revision,
+                claim_owner_id, claim_fence, state, claimed_at_ms,
+                claim_expires_at_ms, completed_registry_id,
+                created_at_ms, updated_at_ms
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, 'public_anonymous',
+                NULL, NULL, NULL, NULL, $8, 1, 'claimed', $9, $10, NULL, $9, $9
+            )
+            ",
+        )
+        .bind(discovery_id)
+        .bind(tenant.as_str())
+        .bind(historical.repository_id().as_uuid())
+        .bind(connection.as_uuid())
+        .bind(i64::try_from(historical.revision().get())?)
+        .bind(historical.digest().as_bytes().as_slice())
+        .bind(i64::try_from(owner_id.get())?)
+        .bind(Uuid::from_u128(0x0001_3302))
+        .bind(claimed_at)
+        .bind(claimed_at + 30_000)
+        .execute(database.pool())
+        .await?;
+
+        let pointer_before: (String, Uuid, Uuid, i64, Vec<u8>, i64) = sqlx::query_as(
+            r"
+            SELECT tenant_id, repository_id, provider_connection_id,
+                   manifest_revision, manifest_digest, activated_at_ms
+            FROM github_provider_manifest_current
+            WHERE provider_connection_id = $1
+            ",
+        )
+        .bind(connection.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        let evidence_before: (i64, Vec<u8>) = sqlx::query_as(
+            "SELECT manifest_revision, manifest_digest \
+             FROM github_schedule_discovery_claims WHERE discovery_id = $1",
+        )
+        .bind(discovery_id)
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(evidence_before.1, historical.digest().as_bytes());
+
+        database.store().migrate().await?;
+        assert!(
+            sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS (SELECT 1 FROM _sqlx_migrations WHERE version = 33)",
+            )
+            .fetch_one(database.pool())
+            .await?
+        );
+
+        let pointer_after: (String, Uuid, Uuid, i64, Vec<u8>, i64) = sqlx::query_as(
+            r"
+            SELECT tenant_id, repository_id, provider_connection_id,
+                   manifest_revision, manifest_digest, activated_at_ms
+            FROM github_provider_manifest_current
+            WHERE provider_connection_id = $1
+            ",
+        )
+        .bind(connection.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        let evidence_after: (i64, Vec<u8>) = sqlx::query_as(
+            "SELECT manifest_revision, manifest_digest \
+             FROM github_schedule_discovery_claims WHERE discovery_id = $1",
+        )
+        .bind(discovery_id)
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(pointer_after, pointer_before);
+        assert_eq!(evidence_after, evidence_before);
+
+        let loaded = database
+            .store()
+            .load_current_github_provider_manifest(&tenant, connection)
+            .await?;
+        assert_eq!(loaded.manifest(), &historical);
+        assert_eq!(loaded.manifest().digest(), historical.digest());
+        assert_eq!(loaded.manifest().limits().workflow_max_bytes(), 1_048_576);
+        assert!(matches!(
+            database
+                .store()
+                .bootstrap_github_provider_repository(request(historical.clone(), 150))
+                .await,
+            Err(GithubProviderManifestStoreError::ConfigurationDrift)
+        ));
+        super::github_subject_evidence::assert_historical_workflow_limit_evidence_round_trip(
+            &database,
+            &historical,
+        )
+        .await?;
+
+        let replacement = manifest(
+            tenant.clone(),
+            connection,
+            RevisionSet::new(2, 1, 2),
+            [7; 32],
+            "Automata CI",
+        )
+        .with_repository_owner_id(owner_id);
+        let promoted = database
+            .store()
+            .bootstrap_github_provider_repository(request(replacement.clone(), 200))
+            .await?;
+        assert!(!promoted.manifest().is_replay());
+        assert_eq!(promoted.manifest().current().manifest(), &replacement);
+        let replay = database
+            .store()
+            .bootstrap_github_provider_repository(request(replacement.clone(), 300))
+            .await?;
+        assert!(replay.manifest().is_replay());
+        let historical_after_successor = database
+            .store()
+            .load_github_provider_manifest_revision(
+                &tenant,
+                connection,
+                GithubProviderManifestRevision::new(1)?,
+            )
+            .await?;
+        assert_eq!(historical_after_successor.manifest(), &historical);
+        assert_eq!(
+            historical_after_successor.manifest().digest(),
+            historical.digest()
+        );
+        assert_eq!(
+            historical_after_successor
+                .manifest()
+                .limits()
+                .workflow_max_bytes(),
+            1_048_576
         );
         Ok(())
     })
@@ -940,6 +1128,19 @@ async fn sql_canonical_functions_match_rust_golden_and_reject_direct_forgery() -
             &zero_binding_generation,
             "github_provider_manifest_revisions_positive",
         );
+        let unknown_workflow_limit = insert_canonical_direct_mutation(
+            database.pool(),
+            connection,
+            Uuid::from_u128(0x507),
+            "workflow_max_bytes",
+            "1048575",
+        )
+        .await
+        .expect_err("a digest-correct third workflow limit must fail closed");
+        assert_constraint(
+            &unknown_workflow_limit,
+            "github_provider_manifest_revisions_archive_limits",
+        );
         Ok(())
     })
     .await
@@ -1030,6 +1231,57 @@ fn manifest_at_ref(
         GithubProviderWorkflowSelection::all_direct(),
         git_ref,
     )
+}
+
+fn historical_manifest(
+    tenant: TenantScope,
+    connection: ProviderConnectionId,
+    owner_id: ProviderRepositoryOwnerId,
+) -> GithubProviderManifest {
+    let limits = automata_ci_store::adapter_spi::github_provider_manifest_limits(
+        automata_ci_store::GITHUB_PROVIDER_WEBHOOK_MAX_BODY_BYTES,
+        automata_ci_store::GITHUB_PROVIDER_WEBHOOK_ACCEPT_TIMEOUT_MILLIS,
+        automata_ci_store::GITHUB_PROVIDER_PUSH_WEBHOOK_MAX_COMMITS,
+        automata_ci_store::GITHUB_PROVIDER_PATH_FILTER_MAX_COMMITS,
+        automata_ci_store::GITHUB_PROVIDER_PATH_FILTER_MAX_CHANGED_FILES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_COMPRESSED_BYTES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_DECOMPRESSED_BYTES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_ENTRIES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_EXPANDED_BYTES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_ENTRY_PATH_BYTES,
+        automata_ci_store::GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS,
+        1_048_576,
+    )
+    .expect("historical durable manifest limits");
+    let runtime_policy = github_manifest_fixture::fixture_github_runtime_policy(1);
+    GithubProviderManifest::new_with_workflow_selection_and_git_ref(
+        tenant,
+        connection,
+        ProviderInstallationId::new(101).expect("installation"),
+        ProviderRepositoryId::new(202).expect("repository"),
+        GithubRepositoryName::new("automata-ci/automata").expect("repository name"),
+        ProviderRepositoryVisibility::Public,
+        GithubServerServiceAppId::new(303).expect("App"),
+        GithubServerServiceAppClientId::new("Iv1.8a61f9b3a7aba766").expect("client ID"),
+        GithubServerServiceJwtIssuer::AppClientId,
+        Sha256Digest::from_bytes([7; 32]),
+        GithubServerServiceRevision::new(1).expect("App revision"),
+        GithubProviderWebhookVerifierFingerprint::from_sha256(Sha256Digest::from_bytes([9; 32]))
+            .expect("verifier fingerprint"),
+        GithubServerServiceRevision::new(1).expect("verifier revision"),
+        GithubServerServiceRevision::new(1).expect("policy revision"),
+        automata_ci_core::JobAuthorityProfile::Standard,
+        runtime_policy.runner_policy,
+        runtime_policy.revision,
+        runtime_policy.semantic_digest,
+        GithubProviderWorkflowSelection::all_direct(),
+        GithubProviderGitRef::main(),
+        GithubCheckName::new("Automata CI").expect("Check name"),
+        GithubProviderOrigins::github_dot_com(),
+        limits,
+        GithubProviderManifestRevision::new(1).expect("manifest revision"),
+    )
+    .with_repository_owner_id(owner_id)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1213,6 +1465,136 @@ fn delivery_identity_for_installation(
         "delivery-1",
     )
     .expect("delivery identity")
+}
+
+async fn allow_current_manifest_in_predecessor_fixture(pool: &sqlx::PgPool) -> TestResult {
+    sqlx::raw_sql(
+        r"
+        ALTER TABLE ONLY github_provider_manifest_revisions
+            DROP CONSTRAINT github_provider_manifest_revisions_archive_limits;
+        ALTER TABLE ONLY github_provider_manifest_revisions
+            ADD CONSTRAINT github_provider_manifest_revisions_archive_limits CHECK (
+                archive_max_compressed_bytes = 268435456
+                AND archive_max_decompressed_bytes = 2147483648
+                AND archive_max_entries = 100000
+                AND archive_max_expanded_bytes = 1073741824
+                AND archive_max_entry_path_bytes = 4096
+                AND archive_max_workflows = 256
+                AND workflow_max_bytes IN (512000, 1048576)
+            );
+        ",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn rewrite_current_manifest_as_predecessor_history(
+    pool: &sqlx::PgPool,
+    connection: ProviderConnectionId,
+) -> TestResult {
+    let mut transaction = pool.begin().await?;
+    sqlx::raw_sql(
+        r"
+        ALTER TABLE ONLY github_provider_manifest_current
+            DROP CONSTRAINT github_provider_manifest_current_exact_revision;
+        ALTER TABLE github_provider_manifest_revisions
+            DISABLE TRIGGER github_provider_manifest_revisions_no_update;
+        ALTER TABLE github_provider_manifest_current
+            DISABLE TRIGGER github_provider_manifest_current_guard;
+        ",
+    )
+    .execute(&mut *transaction)
+    .await?;
+
+    let updated = sqlx::query_scalar::<_, Vec<u8>>(
+        r"
+        WITH replacement AS (
+            SELECT
+                revision.provider_connection_id,
+                revision.manifest_revision,
+                automata_github_provider_manifest_digest(
+                    pg_catalog.jsonb_populate_record(
+                        revision,
+                        pg_catalog.jsonb_build_object(
+                            'workflow_max_bytes', 1048576
+                        )
+                    )
+                ) AS manifest_digest
+            FROM github_provider_manifest_revisions AS revision
+            WHERE revision.provider_connection_id = $1
+              AND revision.manifest_revision = 1
+        ), updated_revision AS (
+            UPDATE github_provider_manifest_revisions AS revision
+            SET workflow_max_bytes = 1048576,
+                manifest_digest = replacement.manifest_digest
+            FROM replacement
+            WHERE revision.provider_connection_id = replacement.provider_connection_id
+              AND revision.manifest_revision = replacement.manifest_revision
+            RETURNING revision.provider_connection_id,
+                      revision.manifest_revision,
+                      revision.manifest_digest
+        )
+        UPDATE github_provider_manifest_current AS current_manifest
+        SET manifest_digest = updated_revision.manifest_digest
+        FROM updated_revision
+        WHERE current_manifest.provider_connection_id =
+                  updated_revision.provider_connection_id
+          AND current_manifest.manifest_revision = updated_revision.manifest_revision
+        RETURNING current_manifest.manifest_digest
+        ",
+    )
+    .bind(connection.as_uuid())
+    .fetch_one(&mut *transaction)
+    .await?;
+
+    sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+        .execute(&mut *transaction)
+        .await?;
+
+    sqlx::raw_sql(
+        r"
+        ALTER TABLE github_provider_manifest_revisions
+            ENABLE TRIGGER github_provider_manifest_revisions_no_update;
+        ALTER TABLE github_provider_manifest_current
+            ENABLE TRIGGER github_provider_manifest_current_guard;
+        ALTER TABLE ONLY github_provider_manifest_current
+            ADD CONSTRAINT github_provider_manifest_current_exact_revision
+            FOREIGN KEY (
+                tenant_id, repository_id, provider_connection_id,
+                manifest_revision, manifest_digest
+            ) REFERENCES github_provider_manifest_revisions (
+                tenant_id, repository_id, provider_connection_id,
+                manifest_revision, manifest_digest
+            ) ON DELETE RESTRICT;
+        ALTER TABLE ONLY github_provider_manifest_revisions
+            DROP CONSTRAINT github_provider_manifest_revisions_archive_limits;
+        ALTER TABLE ONLY github_provider_manifest_revisions
+            ADD CONSTRAINT github_provider_manifest_revisions_archive_limits CHECK (
+                archive_max_compressed_bytes = 268435456
+                AND archive_max_decompressed_bytes = 2147483648
+                AND archive_max_entries = 100000
+                AND archive_max_expanded_bytes = 1073741824
+                AND archive_max_entry_path_bytes = 4096
+                AND archive_max_workflows = 256
+                AND workflow_max_bytes = 1048576
+            );
+        ",
+    )
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+
+    let canonical: Vec<u8> = sqlx::query_scalar(
+        "SELECT automata_github_provider_manifest_digest(revision) \
+         FROM github_provider_manifest_revisions AS revision \
+         WHERE provider_connection_id = $1 AND manifest_revision = 1",
+    )
+    .bind(connection.as_uuid())
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(updated, canonical);
+    Ok(())
 }
 
 async fn database_now(pool: &sqlx::PgPool) -> TestResult<UnixMillis> {

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -1346,6 +1346,67 @@ async fn public_api_decodes_historical_manifest_profile_and_runner_policy() -> T
     .await
 }
 
+pub(super) async fn assert_historical_workflow_limit_evidence_round_trip(
+    database: &TestDatabase,
+    manifest: &GithubProviderManifest,
+) -> TestResult {
+    assert_eq!(manifest.limits().workflow_max_bytes(), 1_048_576);
+    let activated_at = database
+        .store()
+        .load_current_github_provider_manifest(manifest.tenant(), manifest.connection_id())
+        .await?
+        .activated_at()
+        .expect("historical manifest is current during evidence acceptance");
+    let fixture = Fixture {
+        tenant: manifest.tenant().clone(),
+        connection: manifest.connection_id(),
+        manifest: manifest.clone(),
+        activated_at,
+        checks_authority: authority(
+            manifest,
+            GithubServerServiceScope::ChecksWrite,
+            Uuid::from_u128(0x0002_0501),
+            [11; 32],
+        )?,
+        private_source_authority: None,
+    };
+    let fixture = ensure_fixture_authorities(database, fixture, activated_at.get()).await?;
+    let request = acceptance(
+        &fixture,
+        "delivery-historical-workflow-limit",
+        OWNER_ID,
+        OWNER_ID,
+        HEAD_SHA,
+        activated_at.get(),
+        0x5a,
+    );
+    let accepted = database
+        .store()
+        .accept_manifest_pinned_github_delivery(request.clone())
+        .await?;
+    assert_eq!(accepted.evidence().manifest(), manifest);
+    assert_eq!(
+        accepted.evidence().manifest().limits().workflow_max_bytes(),
+        1_048_576
+    );
+
+    let loaded = database
+        .store()
+        .load_manifest_pinned_github_delivery_evidence(manifest.tenant(), accepted.delivery_id())
+        .await?;
+    assert_eq!(loaded.manifest(), manifest);
+    assert_eq!(loaded.manifest().digest(), manifest.digest());
+    assert_eq!(loaded.manifest().limits().workflow_max_bytes(), 1_048_576);
+    assert_eq!(
+        database
+            .store()
+            .accept_manifest_pinned_github_delivery(request)
+            .await?,
+        accepted
+    );
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn concurrent_private_acceptance_pins_both_disjoint_authorities_once() -> TestResult {
@@ -1623,6 +1684,17 @@ async fn bootstrap_manifest_only_with_selection(
         [6; 32],
         selection,
     );
+    bootstrap_manifest_fixture(database, manifest, at).await
+}
+
+async fn bootstrap_manifest_fixture(
+    database: &TestDatabase,
+    manifest: GithubProviderManifest,
+    at: i64,
+) -> TestResult<Fixture> {
+    let tenant = manifest.tenant().clone();
+    let connection = manifest.connection_id();
+    let visibility = manifest.repository_visibility();
     let bootstrapped = database
         .store()
         .bootstrap_github_provider_repository(
@@ -1709,6 +1781,29 @@ fn manifest_with_selection(
     verifier: [u8; 32],
     selection: GithubProviderWorkflowSelection,
 ) -> GithubProviderManifest {
+    manifest_with_selection_and_limits(
+        tenant,
+        connection,
+        visibility,
+        revisions,
+        spki,
+        verifier,
+        selection,
+        GithubProviderManifestLimits::github_dot_com_ci(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn manifest_with_selection_and_limits(
+    tenant: TenantScope,
+    connection: ProviderConnectionId,
+    visibility: ProviderRepositoryVisibility,
+    revisions: ManifestRevisions,
+    spki: [u8; 32],
+    verifier: [u8; 32],
+    selection: GithubProviderWorkflowSelection,
+    limits: GithubProviderManifestLimits,
+) -> GithubProviderManifest {
     let runtime_policy = github_manifest_fixture::fixture_github_runtime_policy(revisions.policy);
     GithubProviderManifest::new_with_workflow_selection(
         tenant,
@@ -1733,7 +1828,7 @@ fn manifest_with_selection(
         selection,
         GithubCheckName::new("Automata CI").expect("Check name"),
         GithubProviderOrigins::github_dot_com(),
-        GithubProviderManifestLimits::github_dot_com_ci(),
+        limits,
         GithubProviderManifestRevision::new(revisions.manifest).expect("manifest revision"),
     )
     .with_repository_owner_id(ProviderRepositoryOwnerId::new(OWNER_ID).expect("repository owner"))

--- a/crates/automata-ci-postgres/tests/store/provider/github_workflow_permissions.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_workflow_permissions.rs
@@ -7,12 +7,11 @@ use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_key_management::{EncryptedEnvelope, KeyId, WrappedDataKey};
 use automata_ci_store::{
     AcquireGithubServerServiceHandoff, BeginGithubServerServiceMint,
-    BootstrapGithubProviderRepository, ClaimGithubServerServiceRevocation,
-    ClaimNextGithubServerServiceMaintenance, EnsureGithubServerServiceAuthority,
-    FinalizeGithubWorkflowPermissionObservation, FinishGithubServerServiceMint,
-    FinishGithubServerServiceRevocation, GITHUB_WORKFLOW_PERMISSION_DEFAULT_FRESHNESS_MILLIS,
-    GithubCheckName, GithubProviderManifest, GithubProviderManifestLimits,
-    GithubProviderManifestRevision, GithubProviderOrigins,
+    BootstrapGithubProviderRepository, ClaimNextGithubServerServiceMaintenance,
+    EnsureGithubServerServiceAuthority, FinalizeGithubWorkflowPermissionObservation,
+    FinishGithubServerServiceMint, FinishGithubServerServiceRevocation,
+    GITHUB_WORKFLOW_PERMISSION_DEFAULT_FRESHNESS_MILLIS, GithubCheckName, GithubProviderManifest,
+    GithubProviderManifestLimits, GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubRepositoryName, GithubServerServiceAppClientId,
     GithubServerServiceAppId, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
     GithubServerServiceAuthorityRepository as _, GithubServerServiceAuthoritySelector,
@@ -532,16 +531,22 @@ async fn ambiguous_handoff_reconciliation_survives_authority_retirement() -> Tes
             attempt.generation,
         );
         set_database_test_clock(&database, BASE_TIME + 1_030).await?;
-        let revocation = database
+        let maintenance = database
             .store()
-            .claim_github_server_service_revocation(ClaimGithubServerServiceRevocation::new(
-                selector(&fixture.authority),
-                issuance_key,
-                GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
-                UnixMillis::new(BASE_TIME + 1_030),
-                UnixMillis::new(BASE_TIME + 2_030),
-            )?)
-            .await?;
+            .claim_next_github_server_service_maintenance(
+                ClaimNextGithubServerServiceMaintenance::for_authority(
+                    selector(&fixture.authority),
+                    GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+                    UnixMillis::new(BASE_TIME + 1_030),
+                    UnixMillis::new(BASE_TIME + 2_030),
+                )?,
+            )
+            .await?
+            .expect("the exact retiring authority must have revocation maintenance");
+        let GithubServerServiceMaintenanceOutcome::Revocation(revocation) = maintenance else {
+            panic!("the exact retiring authority must produce a revocation claim");
+        };
+        assert_eq!(revocation.claim().key(), issuance_key);
         set_database_test_clock(&database, BASE_TIME + 1_040).await?;
         database
             .store()

--- a/crates/automata-ci-store-postgres/migrations/0036_align_provider_manifest_workflow_limits.sql
+++ b/crates/automata-ci-store-postgres/migrations/0036_align_provider_manifest_workflow_limits.sql
@@ -1,0 +1,23 @@
+-- Preserve historical provider-manifest evidence while admitting the current
+-- 500-KiB workflow-source policy. Manifest rows and their digest-bound foreign
+-- keys remain immutable; only the closed set accepted by the table changes.
+ALTER TABLE ONLY github_provider_manifest_revisions
+    ADD CONSTRAINT github_provider_manifest_revisions_archive_limits_compat CHECK (
+        archive_max_compressed_bytes = 268435456
+        AND archive_max_decompressed_bytes = 2147483648
+        AND archive_max_entries = 100000
+        AND archive_max_expanded_bytes = 1073741824
+        AND archive_max_entry_path_bytes = 4096
+        AND archive_max_workflows = 256
+        AND workflow_max_bytes IN (512000, 1048576)
+    ) NOT VALID;
+
+ALTER TABLE ONLY github_provider_manifest_revisions
+    VALIDATE CONSTRAINT github_provider_manifest_revisions_archive_limits_compat;
+
+ALTER TABLE ONLY github_provider_manifest_revisions
+    DROP CONSTRAINT github_provider_manifest_revisions_archive_limits;
+
+ALTER TABLE ONLY github_provider_manifest_revisions
+    RENAME CONSTRAINT github_provider_manifest_revisions_archive_limits_compat
+    TO github_provider_manifest_revisions_archive_limits;

--- a/crates/automata-ci-store-postgres/src/github_provider_manifest.rs
+++ b/crates/automata-ci-store-postgres/src/github_provider_manifest.rs
@@ -13,8 +13,8 @@ use super::{
 use automata_ci_store::{
     AdmissionObject, BootstrapGithubProviderRepository, GithubCheckName,
     GithubInstallationBindingGeneration, GithubProviderManifest,
-    GithubProviderManifestBootstrapReceipt, GithubProviderManifestLimits,
-    GithubProviderManifestRecord, GithubProviderManifestRepository, GithubProviderManifestRevision,
+    GithubProviderManifestBootstrapReceipt, GithubProviderManifestRecord,
+    GithubProviderManifestRepository, GithubProviderManifestRevision,
     GithubProviderManifestStoreError, GithubProviderOrigins,
     GithubProviderRepositoryBootstrapReceipt, GithubProviderRunnerPolicyObject,
     GithubProviderWebhookVerifierFingerprint, GithubProviderWorkflowSelection,
@@ -98,6 +98,11 @@ impl GithubProviderManifestRepository for PostgresStore {
         request: BootstrapGithubProviderRepository,
     ) -> Result<GithubProviderRepositoryBootstrapReceipt, GithubProviderManifestStoreError> {
         let desired = request.manifest().manifest().clone();
+        if desired.limits().workflow_max_bytes()
+            != automata_ci_store::GITHUB_PROVIDER_WORKFLOW_MAX_BYTES
+        {
+            return Err(GithubProviderManifestStoreError::ConfigurationDrift);
+        }
         let mut transaction = self.pool.begin().await.map_err(operation_error)?;
         sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
             .execute(&mut *transaction)
@@ -932,7 +937,7 @@ fn decode_manifest_record(
             .map_err(operation_error)?,
     )
     .map_err(|_| GithubProviderManifestStoreError::CorruptData)?;
-    let limits = GithubProviderManifestLimits::new(
+    let limits = automata_ci_store::adapter_spi::github_provider_manifest_limits(
         positive_u64(
             row.try_get("webhook_max_body_bytes")
                 .map_err(operation_error)?,

--- a/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
+++ b/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
@@ -8,15 +8,14 @@ use automata_ci_store::{
     AdmissionObject, AuthenticatedGithubDeliveryClaim, EventControlSubjectId, EventSubjectId,
     EventSubjectOrigin, GithubAuthenticatedEvent, GithubAuthenticatedEventKind, GithubCheckHeadSha,
     GithubCheckName, GithubCheckSubjectId, GithubCheckSubjectKey, GithubProviderManifest,
-    GithubProviderManifestLimits, GithubProviderManifestRevision, GithubProviderOrigins,
-    GithubProviderRunnerPolicyObject, GithubProviderWebhookVerifierFingerprint,
-    GithubProviderWorkflowSelection, GithubRepositoryDispatchEvidenceRepository,
-    GithubRepositoryDispatchResolution, GithubRepositoryDispatchResolutionAuthority,
-    GithubRepositoryName, GithubServerServiceAppClientId, GithubServerServiceAppId,
-    GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
-    GithubServerServiceJwtIssuer, GithubServerServiceRevision, GithubServerServiceScope,
-    GithubSubjectEvidenceRepository, GithubSubjectEvidenceStoreError,
-    GithubWorkflowRunSubjectEvidence, LogicalWorkflowInvocationId,
+    GithubProviderManifestRevision, GithubProviderOrigins, GithubProviderRunnerPolicyObject,
+    GithubProviderWebhookVerifierFingerprint, GithubProviderWorkflowSelection,
+    GithubRepositoryDispatchEvidenceRepository, GithubRepositoryDispatchResolution,
+    GithubRepositoryDispatchResolutionAuthority, GithubRepositoryName,
+    GithubServerServiceAppClientId, GithubServerServiceAppId, GithubServerServiceAuthorityId,
+    GithubServerServiceAuthoritySelector, GithubServerServiceJwtIssuer,
+    GithubServerServiceRevision, GithubServerServiceScope, GithubSubjectEvidenceRepository,
+    GithubSubjectEvidenceStoreError, GithubWorkflowRunSubjectEvidence, LogicalWorkflowInvocationId,
     ManifestPinnedGithubDeliveryEvidence, ManifestPinnedGithubDeliveryReceipt, ObjectKey,
     PendingGithubRepositoryDispatchEvidence, PendingGithubRepositoryDispatchReceipt,
     ProviderConnectionId, ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId,
@@ -2581,7 +2580,7 @@ fn decode_manifest(row: &PgRow) -> Result<GithubProviderManifest, GithubSubjectE
             .map_err(operation_error)?,
     )
     .map_err(|_| GithubSubjectEvidenceStoreError::CorruptData)?;
-    let limits = GithubProviderManifestLimits::new(
+    let limits = automata_ci_store::adapter_spi::github_provider_manifest_limits(
         positive_column(row, "webhook_max_body_bytes")?,
         positive_column(row, "webhook_accept_timeout_ms")?,
         positive_column(row, "push_webhook_max_commits")?,

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -145,6 +145,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0035_workflow_run_trust_snapshots.sql",
         "d089ea8658be480cef856ac775dae5c9612ac9bf2306d0a636938398c6f79bc88f6f11b05e23debd1d165df543fd50d7",
     ),
+    (
+        "0036_align_provider_manifest_workflow_limits.sql",
+        "d9667008f0976f9c060affbb4ec1e978eed89c7cc483d3dfebd5f6beb40eed8e11ab2906b56ff89ba211a82c7dc613ca",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -254,6 +258,42 @@ fn logical_activation_scheduling_policy_is_relationally_exact() {
         assert!(
             source.contains(required),
             "logical scheduling-policy migration lost required contract: {required}"
+        );
+    }
+}
+
+#[test]
+fn provider_manifest_workflow_limits_preserve_closed_history() {
+    let source = include_str!("../migrations/0036_align_provider_manifest_workflow_limits.sql");
+
+    for required in [
+        "ADD CONSTRAINT github_provider_manifest_revisions_archive_limits_compat",
+        "NOT VALID",
+        "VALIDATE CONSTRAINT github_provider_manifest_revisions_archive_limits_compat",
+        "DROP CONSTRAINT github_provider_manifest_revisions_archive_limits",
+        "RENAME CONSTRAINT github_provider_manifest_revisions_archive_limits_compat",
+        "TO github_provider_manifest_revisions_archive_limits",
+        "archive_max_compressed_bytes = 268435456",
+        "archive_max_decompressed_bytes = 2147483648",
+        "archive_max_entries = 100000",
+        "archive_max_expanded_bytes = 1073741824",
+        "archive_max_entry_path_bytes = 4096",
+        "archive_max_workflows = 256",
+        "workflow_max_bytes IN (512000, 1048576)",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider-manifest limit migration lost required contract: {required}"
+        );
+    }
+    for forbidden in [
+        "UPDATE github_provider_manifest_revisions",
+        "UPDATE github_provider_manifest_current",
+        "automata_github_provider_manifest_digest",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "provider-manifest limit migration must not rewrite durable evidence: {forbidden}"
         );
     }
 }

--- a/crates/automata-ci-store/src/adapter_spi.rs
+++ b/crates/automata-ci-store/src/adapter_spi.rs
@@ -121,6 +121,41 @@ pub fn github_provider_manifest(
     )
 }
 
+/// Rehydrates the closed current or historical durable manifest limits.
+///
+/// The historical workflow-source ceiling is accepted only at this adapter
+/// boundary. Public construction remains pinned to the current policy.
+#[allow(clippy::too_many_arguments)]
+pub const fn github_provider_manifest_limits(
+    webhook_max_body_bytes: u64,
+    webhook_accept_timeout_millis: u64,
+    push_webhook_max_commits: u64,
+    path_filter_max_commits: u64,
+    path_filter_max_changed_files: u64,
+    archive_max_compressed_bytes: u64,
+    archive_max_decompressed_bytes: u64,
+    archive_max_entries: u64,
+    archive_max_expanded_bytes: u64,
+    archive_max_entry_path_bytes: u64,
+    archive_max_workflows: u64,
+    workflow_max_bytes: u64,
+) -> Result<crate::GithubProviderManifestLimits, crate::GithubProviderManifestValueError> {
+    crate::GithubProviderManifestLimits::from_durable(
+        webhook_max_body_bytes,
+        webhook_accept_timeout_millis,
+        push_webhook_max_commits,
+        path_filter_max_commits,
+        path_filter_max_changed_files,
+        archive_max_compressed_bytes,
+        archive_max_decompressed_bytes,
+        archive_max_entries,
+        archive_max_expanded_bytes,
+        archive_max_entry_path_bytes,
+        archive_max_workflows,
+        workflow_max_bytes,
+    )
+}
+
 /// Validates durable timing while rehydrating one manifest record.
 pub fn github_provider_manifest_record(
     manifest: crate::GithubProviderManifest,
@@ -1033,6 +1068,46 @@ mod tests {
         assert_eq!(
             secret_custody_canary_schema_version(),
             crate::secret_custody::SECRET_CUSTODY_CANARY_SCHEMA_VERSION
+        );
+    }
+
+    #[test]
+    fn provider_manifest_limit_rehydration_accepts_only_closed_history() {
+        fn limits(
+            workflow_max_bytes: u64,
+        ) -> Result<crate::GithubProviderManifestLimits, crate::GithubProviderManifestValueError>
+        {
+            github_provider_manifest_limits(
+                crate::GITHUB_PROVIDER_WEBHOOK_MAX_BODY_BYTES,
+                crate::GITHUB_PROVIDER_WEBHOOK_ACCEPT_TIMEOUT_MILLIS,
+                crate::GITHUB_PROVIDER_PUSH_WEBHOOK_MAX_COMMITS,
+                crate::GITHUB_PROVIDER_PATH_FILTER_MAX_COMMITS,
+                crate::GITHUB_PROVIDER_PATH_FILTER_MAX_CHANGED_FILES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_COMPRESSED_BYTES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_DECOMPRESSED_BYTES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_ENTRIES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_EXPANDED_BYTES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_ENTRY_PATH_BYTES,
+                crate::GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS,
+                workflow_max_bytes,
+            )
+        }
+
+        assert_eq!(
+            limits(crate::GITHUB_PROVIDER_WORKFLOW_MAX_BYTES)
+                .expect("current durable workflow limit")
+                .workflow_max_bytes(),
+            512_000
+        );
+        assert_eq!(
+            limits(1_048_576)
+                .expect("historical durable workflow limit")
+                .workflow_max_bytes(),
+            1_048_576
+        );
+        assert_eq!(
+            limits(1_048_575),
+            Err(crate::GithubProviderManifestValueError::InvalidLimits)
         );
     }
 

--- a/crates/automata-ci-store/src/github_provider_manifest.rs
+++ b/crates/automata-ci-store/src/github_provider_manifest.rs
@@ -89,6 +89,8 @@ pub const GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS: u64 = 256;
 /// the persistence layer does not acquire a dependency on the frontend.
 pub const GITHUB_PROVIDER_WORKFLOW_MAX_BYTES: u64 = 500 * 1_024;
 
+const GITHUB_PROVIDER_HISTORICAL_WORKFLOW_MAX_BYTES: u64 = 1_024 * 1_024;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GithubProviderManifestLimitRejection {
     RunnerPolicyBytes,
@@ -436,6 +438,42 @@ impl GithubProviderManifestLimits {
         archive_max_workflows: u64,
         workflow_max_bytes: u64,
     ) -> Result<Self, GithubProviderManifestValueError> {
+        Self::from_supported_values(
+            webhook_max_body_bytes,
+            webhook_accept_timeout_millis,
+            push_webhook_max_commits,
+            path_filter_max_commits,
+            path_filter_max_changed_files,
+            archive_max_compressed_bytes,
+            archive_max_decompressed_bytes,
+            archive_max_entries,
+            archive_max_expanded_bytes,
+            archive_max_entry_path_bytes,
+            archive_max_workflows,
+            workflow_max_bytes,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    const fn from_supported_values(
+        webhook_max_body_bytes: u64,
+        webhook_accept_timeout_millis: u64,
+        push_webhook_max_commits: u64,
+        path_filter_max_commits: u64,
+        path_filter_max_changed_files: u64,
+        archive_max_compressed_bytes: u64,
+        archive_max_decompressed_bytes: u64,
+        archive_max_entries: u64,
+        archive_max_expanded_bytes: u64,
+        archive_max_entry_path_bytes: u64,
+        archive_max_workflows: u64,
+        workflow_max_bytes: u64,
+        allow_historical_workflow_limit: bool,
+    ) -> Result<Self, GithubProviderManifestValueError> {
+        let historical_workflow_limit = allow_historical_workflow_limit
+            && workflow_max_bytes == GITHUB_PROVIDER_HISTORICAL_WORKFLOW_MAX_BYTES;
+
         if webhook_max_body_bytes != GITHUB_PROVIDER_WEBHOOK_MAX_BODY_BYTES
             || webhook_accept_timeout_millis != GITHUB_PROVIDER_WEBHOOK_ACCEPT_TIMEOUT_MILLIS
             || push_webhook_max_commits != GITHUB_PROVIDER_PUSH_WEBHOOK_MAX_COMMITS
@@ -447,14 +485,16 @@ impl GithubProviderManifestLimits {
             || archive_expanded_bytes_rejection(archive_max_expanded_bytes).is_some()
             || archive_entry_path_bytes_rejection(archive_max_entry_path_bytes).is_some()
             || archive_workflows_rejection(archive_max_workflows).is_some()
-            || workflow_bytes_rejection(workflow_max_bytes).is_some()
+            || (workflow_bytes_rejection(workflow_max_bytes).is_some()
+                && !historical_workflow_limit)
             || archive_max_compressed_bytes != GITHUB_PROVIDER_ARCHIVE_MAX_COMPRESSED_BYTES
             || archive_max_decompressed_bytes != GITHUB_PROVIDER_ARCHIVE_MAX_DECOMPRESSED_BYTES
             || archive_max_entries != GITHUB_PROVIDER_ARCHIVE_MAX_ENTRIES
             || archive_max_expanded_bytes != GITHUB_PROVIDER_ARCHIVE_MAX_EXPANDED_BYTES
             || archive_max_entry_path_bytes != GITHUB_PROVIDER_ARCHIVE_MAX_ENTRY_PATH_BYTES
             || archive_max_workflows != GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS
-            || workflow_max_bytes != GITHUB_PROVIDER_WORKFLOW_MAX_BYTES
+            || (workflow_max_bytes != GITHUB_PROVIDER_WORKFLOW_MAX_BYTES
+                && !historical_workflow_limit)
         {
             return Err(GithubProviderManifestValueError::InvalidLimits);
         }
@@ -472,6 +512,39 @@ impl GithubProviderManifestLimits {
             archive_max_workflows,
             workflow_max_bytes,
         })
+    }
+
+    #[cfg(feature = "adapter-spi")]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) const fn from_durable(
+        webhook_max_body_bytes: u64,
+        webhook_accept_timeout_millis: u64,
+        push_webhook_max_commits: u64,
+        path_filter_max_commits: u64,
+        path_filter_max_changed_files: u64,
+        archive_max_compressed_bytes: u64,
+        archive_max_decompressed_bytes: u64,
+        archive_max_entries: u64,
+        archive_max_expanded_bytes: u64,
+        archive_max_entry_path_bytes: u64,
+        archive_max_workflows: u64,
+        workflow_max_bytes: u64,
+    ) -> Result<Self, GithubProviderManifestValueError> {
+        Self::from_supported_values(
+            webhook_max_body_bytes,
+            webhook_accept_timeout_millis,
+            push_webhook_max_commits,
+            path_filter_max_commits,
+            path_filter_max_changed_files,
+            archive_max_compressed_bytes,
+            archive_max_decompressed_bytes,
+            archive_max_entries,
+            archive_max_expanded_bytes,
+            archive_max_entry_path_bytes,
+            archive_max_workflows,
+            workflow_max_bytes,
+            true,
+        )
     }
 
     /// Returns the production GitHub.com dogfood limits.

--- a/crates/automata-ci-store/tests/github_provider_manifest_api.rs
+++ b/crates/automata-ci-store/tests/github_provider_manifest_api.rs
@@ -147,6 +147,24 @@ fn resource_policy_accepts_only_the_exact_supported_values() {
     assert_eq!(
         GithubProviderManifestLimits::new(
             GITHUB_PROVIDER_WEBHOOK_MAX_BODY_BYTES,
+            GITHUB_PROVIDER_WEBHOOK_ACCEPT_TIMEOUT_MILLIS,
+            GITHUB_PROVIDER_PUSH_WEBHOOK_MAX_COMMITS,
+            GITHUB_PROVIDER_PATH_FILTER_MAX_COMMITS,
+            GITHUB_PROVIDER_PATH_FILTER_MAX_CHANGED_FILES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_COMPRESSED_BYTES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_DECOMPRESSED_BYTES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_ENTRIES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_EXPANDED_BYTES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_ENTRY_PATH_BYTES,
+            GITHUB_PROVIDER_ARCHIVE_MAX_WORKFLOWS,
+            1_048_576,
+        ),
+        Err(GithubProviderManifestValueError::InvalidLimits)
+    );
+
+    assert_eq!(
+        GithubProviderManifestLimits::new(
+            GITHUB_PROVIDER_WEBHOOK_MAX_BODY_BYTES,
             GITHUB_PROVIDER_WEBHOOK_ACCEPT_TIMEOUT_MILLIS - 1,
             GITHUB_PROVIDER_PUSH_WEBHOOK_MAX_COMMITS,
             GITHUB_PROVIDER_PATH_FILTER_MAX_COMMITS,


### PR DESCRIPTION
## Outcome

Repair the durable GitHub provider-manifest contract after the current workflow-source ceiling changed to 500 KiB. Fresh manifests at 512,000 bytes can now bootstrap and replay, while historical 1 MiB manifest rows remain decodable with their original digest-bound keys, current pointers, and downstream evidence references intact.

The forward migration expands only the closed durable CHECK set. It does not rewrite any manifest row, digest, key, pointer, or foreign-key evidence.

## Related issue

Closes #205

## Trust and compatibility impact

This changes a durable storage constraint and historical row rehydration. Public manifest construction remains closed to the current 512,000-byte policy. The historical 1 MiB value is accepted only through the unstable adapter rehydration boundary, and production bootstrap rejects rehydrated historical limits as new writes.

Migration 0033 preserves both recognized values, rejects every third value, and leaves all nine exact manifest foreign-key relationships untouched. Frozen migrations are not modified.

## Verification

- Store unit and contract suites: 50 + 165 passed
- focused adapter/public manifest-limit contracts passed
- migration layout and populated v32 -> v33 upgrade contracts passed
- three affected packages passed all-target/all-feature checks
- strict Clippy with warnings denied passed
- rustdoc with warnings denied passed
- PostgreSQL 18.4 provider-manifest module: 10/10 passed
- PostgreSQL 18.4 historical subject-evidence decode/replay: 1/1 passed
- exact historical pointer, digest, schedule-claim FK, current successor, and replay assertions passed
- post-rebase locked three-package check passed
- isolated PostgreSQL namespaces were removed

Global rustfmt still reports two unrelated parent formatting findings; all authored hunks pass formatting and diff checks.

## AI assistance

Codex diagnosed the Rust/schema drift, designed and implemented the compatibility migration and adapter-only historical decoder, built populated upgrade/evidence tests, and performed independent migration and PostgreSQL review.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.