### PR TITLE
refactor(workflow): retire obsolete compiler compatibility API

### DIFF
--- a/crates/automata-ci-workflow-github/src/compiler.rs
+++ b/crates/automata-ci-workflow-github/src/compiler.rs
@@ -6,8 +6,6 @@ mod lowering;
 mod safety;
 mod trigger;
 
-use std::fmt::Debug;
-
 use automata_ci_core::{
     ContextValue, Located, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan,
     WorkflowEventProvenance, WorkflowPlan, WorkflowSourceProvenance,
@@ -212,23 +210,6 @@ impl CompilationReport {
     }
 }
 
-/// Provider frontend compiler boundary.
-pub trait WorkflowCompiler: Debug + Send + Sync {
-    /// Dialect-owned, source-preserving plan accepted by this compiler.
-    type SourcePlan: Clone + Debug + Send + Sync + 'static;
-
-    /// Compiles a previously parsed source plan for one exact event provenance.
-    ///
-    /// This compatibility boundary lacks provider-specific event metadata;
-    /// GitHub initial admission should prefer [`GithubWorkflowCompiler::compile`]
-    /// with a [`CompileWorkflowRequest`].
-    fn compile(
-        &self,
-        source_plan: &Self::SourcePlan,
-        event: WorkflowEventProvenance,
-    ) -> CompilationReport;
-}
-
 /// GitHub Actions workflow compiler. It performs no action fetching or execution.
 #[derive(Clone, Copy, Debug, Default)]
 #[non_exhaustive]
@@ -248,18 +229,6 @@ impl GithubWorkflowCompiler {
     #[must_use]
     pub fn compile(&self, request: CompileWorkflowRequest<'_>) -> CompilationReport {
         logical::compile(request)
-    }
-}
-
-impl WorkflowCompiler for GithubWorkflowCompiler {
-    type SourcePlan = GithubWorkflowSourcePlan;
-
-    fn compile(
-        &self,
-        source_plan: &Self::SourcePlan,
-        event: WorkflowEventProvenance,
-    ) -> CompilationReport {
-        self.compile(CompileWorkflowRequest::new(source_plan, event))
     }
 }
 

--- a/crates/automata-ci-workflow-github/src/lib.rs
+++ b/crates/automata-ci-workflow-github/src/lib.rs
@@ -16,7 +16,7 @@ mod syntax;
 
 pub use compiler::{
     CompilationDisposition, CompilationReport, CompileWorkflowRequest, GithubWorkflowCompiler,
-    WorkflowCompiler, WorkflowNotSelectedReason,
+    WorkflowNotSelectedReason,
 };
 pub use diagnostic::{Diagnostic, DiagnosticKind, DiagnosticSeverity, RelatedDiagnostic};
 pub use expression::{
@@ -29,7 +29,6 @@ pub use frontend::{
     FrontendReport, GithubFrontendReport, GithubWorkflowFrontend, ParseWorkflowRequest,
     WorkflowFrontend,
 };
-#[allow(deprecated)]
 pub use model::{
     ActionStep, BooleanValue, Concurrency, ConcurrencyQueue, ContainerCredentials,
     ContainerEnvironment, ContainerSequence, Defaults, DetailedConcurrency, DetailedContainer,
@@ -45,8 +44,8 @@ pub use model::{
     MergeGroupFilter, Needs, PermissionEntry, PermissionLevel, Permissions, PreservedField,
     PushPullRequestFilter, RepositoryDispatchFilter, ReusableWorkflowCall, ReusableWorkflowInputs,
     ReusableWorkflowSecretMap, ReusableWorkflowSecrets, RunDefaults, RunStep, RunnerSelection,
-    SOURCE_PLAN_SCHEMA_VERSION, ScalarValue, Step, StepExecution, StepId, StrategyMatrix,
-    TriggerConfiguration, TriggerSet, ValueMap, ValueMapEntry, WorkflowJob, WorkflowTriggers,
+    ScalarValue, Step, StepExecution, StepId, StrategyMatrix, TriggerConfiguration, TriggerSet,
+    ValueMap, ValueMapEntry, WorkflowJob, WorkflowTriggers,
 };
 pub use repository_archive::{
     MAX_REPOSITORY_WORKFLOW_PATH_BYTES, RepositoryWorkflowDiscoveryError,

--- a/crates/automata-ci-workflow-github/src/model/mod.rs
+++ b/crates/automata-ci-workflow-github/src/model/mod.rs
@@ -32,8 +32,7 @@ pub use value::{
     EnvironmentVariables, PermissionEntry, PermissionLevel, Permissions, PreservedField,
     RunDefaults, ScalarValue, ValueMap, ValueMapEntry,
 };
-#[allow(deprecated)]
-pub use workflow::{GithubWorkflow, GithubWorkflowSourcePlan, SOURCE_PLAN_SCHEMA_VERSION};
+pub use workflow::{GithubWorkflow, GithubWorkflowSourcePlan};
 pub use workflow_dispatch::{
     GithubWorkflowDispatchContract, GithubWorkflowDispatchInputDefault,
     GithubWorkflowDispatchInputDefinition, GithubWorkflowDispatchInputType,

--- a/crates/automata-ci-workflow-github/src/model/workflow.rs
+++ b/crates/automata-ci-workflow-github/src/model/workflow.rs
@@ -3,12 +3,6 @@ use crate::{
     SourceSpan, Spanned, TriggerSet, WorkflowJob, YamlDocument,
 };
 
-/// Compatibility marker retained for downstream callers of the pre-greenfield
-/// source-plan API. [`GithubWorkflowSourcePlan`] is an in-process model and does
-/// not serialize or negotiate this value.
-#[deprecated(note = "GithubWorkflowSourcePlan is an unversioned in-process model")]
-pub const SOURCE_PLAN_SCHEMA_VERSION: u16 = 1;
-
 /// Complete GitHub workflow model decoded from one exact YAML document.
 ///
 /// Values and expressions remain source-level. This type is not scheduler IR;

--- a/crates/automata-ci-workflow-github/tests/compiler.rs
+++ b/crates/automata-ci-workflow-github/tests/compiler.rs
@@ -3,7 +3,7 @@ use crate::support;
 use automata_ci_core::{WorkflowEventProvenance, WorkflowPlan, WorkflowPlanVersion};
 use automata_ci_workflow_github::{
     CompilationDisposition, CompileWorkflowRequest, DiagnosticKind, GithubEventMetadata,
-    GithubWorkflowCompiler, WorkflowCompiler, WorkflowNotSelectedReason,
+    GithubWorkflowCompiler, WorkflowNotSelectedReason,
 };
 
 fn event(name: &str) -> WorkflowEventProvenance {
@@ -30,7 +30,7 @@ fn compile(source: &str, event_name: &str) -> automata_ci_workflow_github::Compi
 }
 
 #[test]
-fn inherent_and_trait_paths_emit_only_the_current_logical_plan() {
+fn inherent_compiler_emits_only_the_current_logical_plan() {
     let source = r"on: workflow_dispatch
 jobs:
   verify:
@@ -41,27 +41,19 @@ jobs:
     let parsed = support::parse(source);
     assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
     let source_plan = parsed.plan().expect("source plan");
-    let compiler = GithubWorkflowCompiler::new();
-    let inherent = compiler.compile(CompileWorkflowRequest::new(
+    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
         source_plan,
         event("workflow_dispatch"),
     ));
-    let through_trait = <GithubWorkflowCompiler as WorkflowCompiler>::compile(
-        &compiler,
-        source_plan,
-        event("workflow_dispatch"),
-    );
 
-    for report in [inherent, through_trait] {
-        assert!(report.is_accepted(), "{:#?}", report.diagnostics());
-        let plan = report.plan().expect("current plan");
-        assert_eq!(plan.version(), WorkflowPlanVersion::v1());
-        assert_eq!(plan.jobs().len(), 1);
-        plan.validate().expect("valid current plan");
-        let encoded = serde_json::to_string(plan).expect("serialize plan");
-        let decoded: WorkflowPlan = serde_json::from_str(&encoded).expect("deserialize plan");
-        assert_eq!(decoded, *plan);
-    }
+    assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    let plan = report.plan().expect("current plan");
+    assert_eq!(plan.version(), WorkflowPlanVersion::v1());
+    assert_eq!(plan.jobs().len(), 1);
+    plan.validate().expect("valid current plan");
+    let encoded = serde_json::to_string(plan).expect("serialize plan");
+    let decoded: WorkflowPlan = serde_json::from_str(&encoded).expect("deserialize plan");
+    assert_eq!(decoded, *plan);
 }
 
 #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ workflow YAML + event
         |
   source plan
         |
- WorkflowCompiler
+ GithubWorkflowCompiler
         |
  immutable logical WorkflowPlan
         |


### PR DESCRIPTION
## Outcome

Remove the unused generic `WorkflowCompiler` compatibility trait and deprecated `SOURCE_PLAN_SCHEMA_VERSION` constant. Every production caller already uses the retained `GithubWorkflowCompiler::compile(CompileWorkflowRequest)` API, which carries provider metadata the compatibility trait could not express.

The concrete compiler, logical lowering, diagnostics, reports, and production call sites are unchanged. The former parity test now exercises the inherent path once while retaining the same plan validation and JSON round-trip assertions.

## Related issue

Closes #208

## Trust and compatibility impact

No runtime, credential, storage, protocol, serialized schema, or wire-format behavior changes. `GithubWorkflowSourcePlan` remains an unversioned in-process value. This intentionally removes an unused public Rust trait/associated method and deprecated constant from an unpublished workspace `0.1.0` crate; hypothetical Git/path consumers must use the richer retained concrete API.

## Verification

- workflow-github unit tests: 21/21 passed
- workflow-github aggregate integration tests: 168/168 passed
- strict all-target/all-feature Clippy passed
- rustdoc with warnings denied passed
- all-target/all-feature checks passed for all six direct reverse dependents
- removed-symbol scans are empty
- retained inherent compile hash and logical/lowering file identity match main
- targeted rustfmt and diff checks passed
- merge-tree with open PR #191 auto-merges the shared compiler file

Workspace-wide rustfmt still reports two unrelated parent-identical files outside this patch.

## AI assistance

Codex audited reachability and compatibility, implemented the six-file removal, preserved/refocused test coverage, validated every reverse dependent, and performed an independent final review.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.