### PR TITLE
refactor(time): retire orphan provider system clocks

### DIFF
--- a/crates/automata-ci-credential-github/src/authority_coordinator.rs
+++ b/crates/automata-ci-credential-github/src/authority_coordinator.rs
@@ -378,19 +378,6 @@ pub trait GithubRuntimeAuthorityCoordinatorClock: fmt::Debug + Send + Sync {
     fn now(&self) -> UnixMillis;
 }
 
-/// Operating-system clock used by a production coordinator.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SystemGithubRuntimeAuthorityCoordinatorClock;
-
-impl GithubRuntimeAuthorityCoordinatorClock for SystemGithubRuntimeAuthorityCoordinatorClock {
-    fn now(&self) -> UnixMillis {
-        let milliseconds = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |duration| duration.as_millis());
-        UnixMillis::new(i64::try_from(milliseconds).unwrap_or(i64::MAX))
-    }
-}
-
 /// An exact encrypted commit retained after an ambiguous repository result.
 ///
 /// The value owns no plaintext. It keeps the same timestamp, metadata,

--- a/crates/automata-ci-credential-github/src/lib.rs
+++ b/crates/automata-ci-credential-github/src/lib.rs
@@ -38,8 +38,7 @@ pub use authority_coordinator::{
     GithubRuntimeAuthorityResolutionValueError, PendingGithubRuntimeAuthorityCommit,
     PendingGithubRuntimeAuthorityCommitError, PinnedGithubRuntimeAuthorityMintBroker,
     PinnedGithubRuntimeAuthorityMintBrokerError, ResolvedGithubRuntimeAuthorityRequest,
-    SystemGithubRuntimeAuthorityCoordinatorClock, github_job_runtime_authority_request,
-    github_runtime_authority_workload_identity,
+    github_job_runtime_authority_request, github_runtime_authority_workload_identity,
 };
 pub use authority_issuer::{
     GITHUB_REPOSITORY_AUTHORITY_NAMESPACE, GITHUB_REPOSITORY_RUNTIME_AUTHORITY,
@@ -80,7 +79,6 @@ pub use server_service_authority::{
     MAX_GITHUB_SERVER_SERVICE_INSTALLATION_BROKERS, PendingGithubServerServiceCorruptionCleanup,
     PendingGithubServerServiceHandoffRelease, PendingGithubServerServiceMintCommit,
     PendingGithubServerServiceRevocationCommit, ResolvedGithubServerServiceCredentialRequest,
-    SystemGithubServerServiceCoordinatorClock, github_server_service_credential_request,
-    github_server_service_workload_identity,
+    github_server_service_credential_request, github_server_service_workload_identity,
 };
 pub use signer::GithubAppKeyError;

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -368,19 +368,6 @@ pub trait GithubServerServiceCoordinatorClock: fmt::Debug + Send + Sync {
     fn now(&self) -> UnixMillis;
 }
 
-/// Operating-system clock for a production server-service coordinator.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SystemGithubServerServiceCoordinatorClock;
-
-impl GithubServerServiceCoordinatorClock for SystemGithubServerServiceCoordinatorClock {
-    fn now(&self) -> UnixMillis {
-        let milliseconds = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |duration| duration.as_millis());
-        UnixMillis::new(i64::try_from(milliseconds).unwrap_or(i64::MAX))
-    }
-}
-
 /// Value-free evidence returned by the irreversible Store mint cutoff.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubServerServiceMintCutoffEvidence {

--- a/crates/automata-ci-github-delivery/src/lib.rs
+++ b/crates/automata-ci-github-delivery/src/lib.rs
@@ -65,7 +65,6 @@ pub use schedule::{
     GithubScheduleServiceError, GithubScheduleServicePass, GithubScheduleSourceCredential,
     GithubScheduleSourceCredentialProvider, GithubScheduleSourceCredentialProviderError,
     GithubScheduleSourceCredentialRequest, GithubScheduleSourceCredentialValueError,
-    SystemGithubScheduleClock,
 };
 
 pub use worker::{

--- a/crates/automata-ci-github-delivery/src/schedule.rs
+++ b/crates/automata-ci-github-delivery/src/schedule.rs
@@ -6,12 +6,7 @@
 //! resulting archive inventory. Due work then has a second fire fence whose
 //! Check registration and workflow admission are independently atomic.
 
-use std::{
-    collections::BTreeMap,
-    fmt,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{collections::BTreeMap, fmt, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use automata_ci_auth::secret::SecretString;
@@ -84,21 +79,6 @@ pub trait GithubScheduleClock: fmt::Debug + Send + Sync {
     ///
     /// Returns a sanitized failure when no valid trusted instant is available.
     fn now(&self) -> Result<UnixMillis, GithubScheduleServiceError>;
-}
-
-/// Product clock backed by the host wall clock.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SystemGithubScheduleClock;
-
-impl GithubScheduleClock for SystemGithubScheduleClock {
-    fn now(&self) -> Result<UnixMillis, GithubScheduleServiceError> {
-        let elapsed = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| GithubScheduleServiceError::InvalidTrustedTime)?;
-        let millis = i64::try_from(elapsed.as_millis())
-            .map_err(|_| GithubScheduleServiceError::InvalidTrustedTime)?;
-        Ok(UnixMillis::new(millis))
-    }
 }
 
 /// Bounded runtime policy for scheduled discovery and due-fire handling.

--- a/crates/automata-ci-oidc-github/src/http.rs
+++ b/crates/automata-ci-oidc-github/src/http.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc, time::SystemTime};
+use std::{fmt, sync::Arc};
 
 use axum::{
     Json, Router,
@@ -43,19 +43,6 @@ pub trait OidcClock: fmt::Debug + Send + Sync {
     ///
     /// Fails when the time source is unavailable or predates the epoch.
     fn now_seconds(&self) -> Result<u64, OidcClockError>;
-}
-
-/// Operating-system wall clock used by production HTTP composition.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SystemOidcClock;
-
-impl OidcClock for SystemOidcClock {
-    fn now_seconds(&self) -> Result<u64, OidcClockError> {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|duration| duration.as_secs())
-            .map_err(|_| OidcClockError)
-    }
 }
 
 #[derive(Clone)]

--- a/crates/automata-ci-oidc-github/src/lib.rs
+++ b/crates/automata-ci-oidc-github/src/lib.rs
@@ -29,7 +29,7 @@ pub use bearer::{
 };
 pub use http::{
     GithubOidcApi, OIDC_DISCOVERY_PATH, OIDC_JWKS_CACHE_SECONDS, OIDC_JWKS_PATH, OIDC_TOKEN_PATH,
-    OIDC_TOKEN_REQUEST_PATH_AND_QUERY, OidcClock, OidcClockError, SystemOidcClock,
+    OIDC_TOKEN_REQUEST_PATH_AND_QUERY, OidcClock, OidcClockError,
 };
 pub use keys::{
     JsonWebKeySet, OidcIdToken, Rs256KeyError, Rs256Keyring, Rs256SigningKey, RsaPublicJwk,


### PR DESCRIPTION
## Outcome

Remove four public `System*Clock` convenience adapters that have no workspace consumers:

- `SystemGithubScheduleClock`
- `SystemGithubRuntimeAuthorityCoordinatorClock`
- `SystemGithubServerServiceCoordinatorClock`
- `SystemOidcClock`

The injectable clock traits remain. Production continues to compose the shared non-regressing GitHub provider clock and the private unified GitHub OIDC clock.

## Related issue

Closes #213

## Trust and compatibility impact

This is an intentional pre-release Rust source API contraction in unpublished 0.1.0 workspace crates. It removes only orphan adapter structs and their crate-root reexports; no runtime behavior, trusted-time validation, persistence, protocol, migration, or wire contract changes.

`NonRegressingGithubProviderClock` remains the production implementation for delivery scheduling and both credential authority coordinators. `SystemGithubOidcClock` remains the production implementation for OIDC HTTP/currentness/provisioning.

## Verification

- owning delivery tests: 150/150 passed
- owning OIDC tests: 24/24 passed
- unaffected credential targets: 73/73 passed
- four-package all-target/all-feature locked check passed, including the product composition
- owning strict Clippy with warnings denied passed
- owning rustdoc with warnings denied passed
- exact stale-symbol, changed-file rustfmt, and diff checks passed
- all seven changed paths reviewed independently; production replacement compositions are byte-identical

The unrelated `authority_issuer` fixture failure (`InvalidJobIr`) reproduces identically on untouched main at the same source line; it is not caused by this patch.

## AI assistance

Codex audited reachability and production composition, removed the orphan adapters, ran owning and reverse-dependent validation, and performed an independent semantic review and baseline comparison.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.