### PR TITLE
fix(results): bound exact-client acceptance process

### DIFF
--- a/crates/automata-ci-results-github/tests/exact_client_real_store.rs
+++ b/crates/automata-ci-results-github/tests/exact_client_real_store.rs
@@ -36,6 +36,7 @@ use axum::{
 use bytes::Bytes;
 use http_body_util::BodyExt as _;
 use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+use tokio::process::Command as TokioCommand;
 use tower::ServiceExt as _;
 use url::Url;
 use uuid::Uuid;
@@ -146,8 +147,9 @@ fn require_node_major(expected: u8) -> TestResult {
     Ok(())
 }
 
-fn isolated_node_command() -> Command {
-    let mut command = Command::new("node");
+fn isolated_node_command() -> TokioCommand {
+    let mut command = TokioCommand::new("node");
+    command.kill_on_drop(true);
     command.env_clear();
     for name in [
         "PATH",
@@ -284,7 +286,7 @@ async fn run_exact_clients(
 
     let scratch = test_scratch("exact-client-real-store");
     std::fs::create_dir_all(&scratch)?;
-    let client_result = run_clients(&environment, &scratch, &token, address);
+    let client_result = run_clients(&environment, &scratch, &token, address).await;
     let adversarial_result =
         run_real_store_adversarial_matrix(&adversarial_router, &token, &expired_token, execution)
             .await;
@@ -438,7 +440,7 @@ fn results_authority_and_tokens(
     Ok((authority, token, expired_token))
 }
 
-fn run_clients(
+async fn run_clients(
     environment: &RealStoreEnvironment,
     scratch: &Path,
     token: &str,
@@ -471,7 +473,8 @@ fn run_clients(
             .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.0")
             .env("AUTOMATA_TEST_ARTIFACT_INPUT", &artifact_input)
             .env("AUTOMATA_TEST_ARTIFACT_ROOT", &artifact_root),
-    )?;
+    )
+    .await?;
 
     let download_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/official_artifact_download_client.mjs");
@@ -490,7 +493,8 @@ fn run_clients(
             .env("AUTOMATA_TEST_ACTIONS_ARTIFACT_VERSION", "6.2.1")
             .env("AUTOMATA_TEST_ARTIFACT_INPUT", &artifact_input)
             .env("AUTOMATA_TEST_ARTIFACT_ROOT", &artifact_root),
-    )?;
+    )
+    .await?;
 
     let cache_input = cache_root.join("cache-input.txt");
     let runner_temp = cache_root.join("runner-temp");
@@ -516,6 +520,7 @@ fn run_clients(
             )
             .env("AUTOMATA_TEST_CACHE_INPUT", cache_input),
     )
+    .await
 }
 
 #[allow(clippy::too_many_lines)] // One ordered real-store transcript covers every RES-01 adversarial case.
@@ -711,8 +716,10 @@ fn path_and_query(url: &Url) -> String {
     )
 }
 
-fn run_node(label: &'static str, command: &mut Command) -> TestResult {
-    let output = command.output()?;
+async fn run_node(label: &'static str, command: &mut TokioCommand) -> TestResult {
+    let output = tokio::time::timeout(Duration::from_mins(2), command.output())
+        .await
+        .map_err(|_| format!("exact {label} client exceeded the 120-second timeout"))??;
     require_success(label, &output)
 }
 

--- a/docs/github-actions-parity-execution-plan.md
+++ b/docs/github-actions-parity-execution-plan.md
@@ -235,7 +235,7 @@ Exit criteria:
 - [ ] pull-request path filters are runnable;
 - [x] reserved runner environment names cannot be overwritten;
 - [x] matrix and expression behavior has exact external candidate fixtures;
-- [ ] official artifact/cache clients run against real product adapters;
+- [x] official artifact/cache clients run against real product adapters;
 - [ ] unsupported jobs fail before a lease.
 
 ### Wave 2: durable runtime interfaces

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -40,8 +40,10 @@ with `@actions/cache` 5.0.5. It verifies every declared Node entry and embedded
 lockfile integrity. Ignored offline tests import explicitly supplied local
 client modules and never download packages. The production-composition test
 connects those clients to the real HTTP adapters, PostgreSQL repositories, and
-S3 blob implementation and retains an identifier-free transcript, but remains
-an opt-in acceptance test until its PostgreSQL/S3 environment is available.
+S3 blob implementation and retains an identifier-free transcript. The ordinary
+CI workflow supplies its isolated PostgreSQL, RustFS, Node, and exact-module
+environment; direct local invocation remains opt-in because it requires those
+same services and immutable inputs.
 Runner protocol v1 carries a required, per-attempt Results authority bundle;
 there is no runner- or fleet-wide Results credential.
 
@@ -71,8 +73,8 @@ Acceptance:
 
 - [ ] Exact action wrappers run against the real Results HTTP adapter,
   PostgreSQL repository, and production blob store.
-- [ ] The suite is deterministic and network independent.
-- [ ] Unsupported operations fail with stable protocol responses rather than
+- [x] The suite is deterministic and network independent.
+- [x] Unsupported operations fail with stable protocol responses rather than
   connection resets or generic internal errors.
 
 ### RES-02 — Complete job, step, log, and result contract


### PR DESCRIPTION
## Summary
- keep the exact Node action-client acceptance subprocesses asynchronous so the in-process Results server can continue serving them
- bound each client process to 120 seconds and kill it on cancellation/drop
- record the completed real PostgreSQL + S3 acceptance gate in the Wave 1 Results plan

## Validation
- `cargo test --locked -p automata-ci-results-github --all-features`
- `cargo clippy --locked -p automata-ci-results-github --all-targets --all-features --no-deps -- -D warnings`
- exact Artifact 6.2 upload / 6.2.1 download tests: 2 passed
- exact Cache 5.0.5 protocol test: 1 passed
- immutable RustFS object-store contract: 1 passed
- combined exact clients through real HTTP + PostgreSQL 18.4 + RustFS/S3: passed twice after the fix (5.48s and 4.48s)
- migration layout: 4 passed

The retained sanitized run evidence contained 33 HTTP request records, 14 storage request records, and 14 storage byte records. The acceptance test verifies credentials and identifiers are absent from that evidence.