### PR TITLE
refactor(errors): retire declaration-only variants

### DIFF
--- a/crates/automata-ci-core/src/workflow/validation.rs
+++ b/crates/automata-ci-core/src/workflow/validation.rs
@@ -234,9 +234,6 @@ pub enum WorkflowPlanError {
         /// Duplicate step identifier.
         step: String,
     },
-    /// A named timeout is explicitly zero.
-    #[error("timeout cannot be zero for `{0}`")]
-    ZeroTimeout(String),
     /// A named positive integer field is zero.
     #[error("{field} must be greater than zero")]
     ZeroPositiveInteger {
@@ -252,9 +249,6 @@ pub enum WorkflowPlanError {
     /// A job runner profile specifies neither a group nor labels.
     #[error("runner profile for job `{0}` has neither a group nor labels")]
     EmptyRunnerProfile(String),
-    /// A value-map layer repeats one canonical key.
-    #[error("key `{0}` appears more than once in one value-map layer")]
-    DuplicateValueKey(String),
     /// A permissions map repeats one canonical permission name.
     #[error("permission `{0}` appears more than once")]
     DuplicatePermission(String),
@@ -354,9 +348,6 @@ pub enum WorkflowPlanError {
         /// Phase declared by the template.
         actual: &'static str,
     },
-    /// A literal template is marked for a non-admission evaluation phase.
-    #[error("literal value templates must use the admission phase")]
-    NonCanonicalLiteralPhase,
     /// A workflow strategy uses a schema this build cannot interpret safely.
     #[error("unsupported workflow-strategy schema {received}; this build supports {supported}")]
     UnsupportedStrategyVersion {

--- a/crates/automata-ci-runner-journal/src/error.rs
+++ b/crates/automata-ci-runner-journal/src/error.rs
@@ -29,14 +29,6 @@ pub enum StateRootError {
 /// A semantic journal mutation would violate a recovery or fencing invariant.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum JournalInvariantError {
-    /// A mutation targeted a journal belonging to a different runner.
-    #[error("journal belongs to runner {expected}; received {received}")]
-    RunnerMismatch {
-        /// Runner identity durably bound to the journal.
-        expected: RunnerId,
-        /// Runner identity supplied by the attempted mutation.
-        received: RunnerId,
-    },
     /// A session-scoped operation was attempted before a session was recorded.
     #[error("no runner session is currently journaled")]
     NoSession,

--- a/crates/automata-ci-runner-runtime/src/error.rs
+++ b/crates/automata-ci-runner-runtime/src/error.rs
@@ -79,9 +79,6 @@ pub enum RunnerRuntimeError {
     /// The server did not permit abandoning every undeliverable old-session item.
     #[error("old-session recovery is missing an explicit delivery permission")]
     OrphanRecoveryPermissionMissing,
-    /// A command addressed the wrong stable poll slot.
-    #[error("lease offer addressed an unexpected runner slot")]
-    SlotCorrelationMismatch,
     /// `JobIR` required environment and executor selection differed exactly.
     #[error("executor environment attestation does not exactly match JobIR requirements")]
     EnvironmentAttestationMismatch,

--- a/crates/automata-ci-sandbox-podman/src/error.rs
+++ b/crates/automata-ci-sandbox-podman/src/error.rs
@@ -24,9 +24,6 @@ pub enum PodmanConfigurationError {
     /// The current operating system cannot provide this adapter's safety contract.
     #[error("Podman adapter has no implementation for this platform")]
     UnsupportedPlatform,
-    /// Private generated state could not be materialized or validated exactly.
-    #[error("Podman local state setup failed")]
-    StateSetup,
     /// The attempt-scoped Docker-compatible proxy could not be bound safely.
     #[error("attempt-scoped Docker API could not be started safely")]
     JobEngineUnavailable,

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -2083,9 +2083,6 @@ pub enum GithubCheckStoreError {
     /// An outbox claim is stale, expired, or has the wrong action.
     #[error("the GitHub Check projection claim is stale or rejected")]
     ClaimRejected,
-    /// The desired-revision attempt limit is exhausted.
-    #[error("the GitHub Check projection attempt limit is exhausted")]
-    AttemptLimitReached,
     /// A different external suite or Check Run was already bound.
     #[error("the GitHub Check external identity conflicts with durable identity")]
     ExternalIdentityConflict,

--- a/crates/automata-ci-store/src/github_service_authority.rs
+++ b/crates/automata-ci-store/src/github_service_authority.rs
@@ -2441,9 +2441,6 @@ pub enum GithubServerServiceValueError {
     /// App JWT client identity is invalid.
     #[error("GitHub App client ID is invalid")]
     InvalidAppClientId,
-    /// Configured App JWT issuer choice is unknown.
-    #[error("GitHub App JWT issuer choice is invalid")]
-    InvalidJwtIssuer,
     /// Issuance generation is invalid.
     #[error("server-service issuance generation is invalid")]
     InvalidGeneration,
@@ -2456,9 +2453,6 @@ pub enum GithubServerServiceValueError {
     /// Service scope is unknown.
     #[error("server-service authority scope is invalid")]
     InvalidScope,
-    /// Consumer action is unknown.
-    #[error("server-service authority action is invalid")]
-    InvalidAction,
     /// Timestamp is before the Unix epoch.
     #[error("server-service authority timestamp is negative")]
     NegativeTimestamp,

--- a/crates/automata-ci-store/src/value.rs
+++ b/crates/automata-ci-store/src/value.rs
@@ -294,8 +294,6 @@ pub(crate) fn sha256_digest(bytes: &[u8]) -> automata_ci_core::Sha256Digest {
 /// Invalid values rejected before they reach a storage adapter.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum DurabilityValueError {
-    #[error("SHA-256 digest has {length} bytes; expected 32")]
-    InvalidDigestLength { length: usize },
     #[error("document schema must be positive")]
     ZeroSchema,
     #[error("runner protocol version must be positive")]


### PR DESCRIPTION
Closes #225.

## Summary

- remove ten declaration-only invariant variants from seven public Rust error enums
- preserve every live same-named variant and all existing error conversions
- make no runtime, storage, migration, protocol, wire, dependency, or configuration change

## Compatibility

This intentionally contracts exhaustive public Rust enums before the first release. The workspace remains version 0.1.0; no repository tag, GitHub release, crate, archive, or image has been published.

## Validation

- changed-file rustfmt and `git diff --check`
- exact qualified stale-symbol scans
- owning all-target/all-feature checks for core, Store, Podman sandbox, runner journal, and runner runtime
- 716 owning tests passed; 7 opt-in live Podman tests remained ignored
- owning strict Clippy with `-D warnings`
- reverse all-target/all-feature checks for `automata-ci` and `automata-ci-runner`
- independent review approved exact 7-file, 34-deletion scope

Workspace-wide formatting remains red only on unrelated current-main files; every authored file passes direct rustfmt.