### PR TITLE
Fix fresh-database GitHub manifest digest startup

### DIFF
--- a/crates/automata-ci-store-postgres/migrations/0038_restore_github_manifest_digest_part.sql
+++ b/crates/automata-ci-store-postgres/migrations/0038_restore_github_manifest_digest_part.sql
@@ -1,0 +1,17 @@
+-- The frozen event-trust migration made the manifest digest depend on this
+-- domain-specific length-prefix primitive but omitted its definition.  Keep
+-- the canonical digest implementation singular and make the dependency
+-- explicit in the forward-only migration lineage.
+
+CREATE FUNCTION automata_github_provider_manifest_digest_part(bytea) RETURNS bytea
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    RETURN pg_catalog.int8send(pg_catalog.octet_length($1)::BIGINT) || $1;
+
+-- Resolve and execute the exact dependency while this migration is applied.
+-- This prevents a clean database from accepting another lazily unresolved
+-- manifest-digest function body.
+DO $$
+BEGIN
+    PERFORM automata_github_provider_manifest_digest_part(''::BYTEA);
+END;
+$$;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -153,6 +153,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0037_runtime_authority_deliveries.sql",
         "bf752f9a883c773e4f1ea10f9290f2b41a0ab44db50f7b7d68874014f88c0343fc223ac9948ed11c64b7748deb3a26a0",
     ),
+    (
+        "0038_restore_github_manifest_digest_part.sql",
+        "02fda663c53f99897dfc8671541df9120fd5e9d196f0536c6e1d5dad5515935d8afd8ff196f7f8947f5c3d8be8ef97fa",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;


### PR DESCRIPTION
## Summary

- append migration 0038 defining the manifest-specific digest primitive referenced by frozen migration 0034
- execute the primitive during migration application so clean databases fail immediately on unresolved dependencies
- pin the new forward-only migration in the immutable lineage inventory

## Production evidence

A disposable fresh production database reached GitHub successfully, then failed canonical manifest activation because PostgreSQL could not resolve `automata_github_provider_manifest_digest_part(bytea)`. The repository workflow defaults and installation-token call both return the expected values.

## Validation

- `cargo test -q -p automata-ci-store-postgres migration_layout_tests`
- exact function syntax and output validated on PostgreSQL 18 in a rolled-back transaction
- `git diff --check`