### PR TITLE
fix(store-postgres): persist provider delivery envelopes

### DIFF
--- a/crates/automata-ci-postgres/tests/store/provider/provider_delivery.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/provider_delivery.rs
@@ -14,7 +14,6 @@ use automata_ci_store::{
     ProviderRepositoryId, ProviderRepositoryVisibility, RejectProviderDelivery,
     RenewProviderDeliveryClaim, RetryProviderDelivery, TenantScope,
 };
-use sqlx::Row as _;
 use uuid::Uuid;
 
 use crate::support::{
@@ -398,40 +397,98 @@ fn assert_database_constraint(error: &sqlx::Error, expected: &str) {
     assert_eq!(constraint, Some(expected));
 }
 
-async fn assert_legacy_delivery_is_quarantined(
+async fn assert_partial_event_envelope_is_rejected(
     database: &TestDatabase,
-    delivery_id: Uuid,
-    claim_owner: ProviderDeliveryClaimOwnerId,
+    connection: &ProviderConnectionId,
 ) -> TestResult {
-    let row = sqlx::query(
+    let partial = sqlx::query(
         r"
-        SELECT state, attempt_count, claim_fence, claim_owner_id,
-               last_failure_kind, terminal_claim_owner_id, terminal_claim_fence
-        FROM provider_delivery_inbox
-        WHERE id = $1
+        INSERT INTO provider_delivery_inbox (
+            id, tenant_id, provider, connection_id, installation_id,
+            provider_repository_id, repository_visibility,
+            repository_identity, delivery_id,
+            request_digest, raw_event_digest, raw_event_object_key,
+            raw_event_size_bytes, raw_event_media_type,
+            event_envelope_schema,
+            accepted_at_ms, state_updated_at_ms
+        )
+        VALUES (
+            $1, 'delivery-envelope-legacy', 'synthetic', $2, 101,
+            202, 'private', 'automata-ci/automata', 'delivery-partial-envelope',
+            $3, $4, 'provider-events/delivery-partial-envelope/1',
+            256, 'application/json', 1, 100, 100
+        )
         ",
     )
-    .bind(delivery_id)
+    .bind(Uuid::new_v4())
+    .bind(connection.as_uuid())
+    .bind([41_u8; 32].as_slice())
+    .bind([42_u8; 32].as_slice())
+    .execute(database.pool())
+    .await
+    .expect_err("partially populated event envelopes must fail closed");
+    assert_database_constraint(&partial, "provider_delivery_inbox_event_envelope_complete");
+    Ok(())
+}
+
+async fn seed_legacy_unsealed_deliveries(
+    database: &TestDatabase,
+    connection: &ProviderConnectionId,
+) -> TestResult {
+    sqlx::query(
+        r"
+        INSERT INTO provider_delivery_inbox (
+            id, tenant_id, provider, connection_id, installation_id,
+            provider_repository_id, repository_visibility,
+            repository_identity, delivery_id,
+            request_digest, raw_event_digest, raw_event_object_key,
+            raw_event_size_bytes, raw_event_media_type,
+            accepted_at_ms, state_updated_at_ms
+        )
+        SELECT
+            md5('delivery-envelope-legacy-' || legacy.ordinal::text)::uuid,
+            'delivery-envelope-legacy', 'synthetic', $1, 101,
+            202, 'private', 'automata-ci/automata',
+            'delivery-legacy-unsealed-' || legacy.ordinal::text,
+            decode(repeat('2b', 32), 'hex'),
+            decode(repeat('2c', 32), 'hex'),
+            'provider-events/delivery-legacy-unsealed/' || legacy.ordinal::text,
+            256, 'application/json', 100, 100
+        FROM generate_series(1, 65) AS legacy(ordinal)
+        ",
+    )
+    .bind(connection.as_uuid())
+    .execute(database.pool())
+    .await?;
+    Ok(())
+}
+
+async fn legacy_delivery_state_counts(
+    database: &TestDatabase,
+    claim_owner: ProviderDeliveryClaimOwnerId,
+) -> TestResult<(i64, i64, i64)> {
+    let counts = sqlx::query_as(
+        r"
+        SELECT
+            count(*) FILTER (WHERE state = 'rejected'),
+            count(*) FILTER (WHERE state = 'pending'),
+            count(*) FILTER (
+                WHERE state = 'rejected'
+                  AND attempt_count = 1
+                  AND claim_fence = 1
+                  AND claim_owner_id IS NULL
+                  AND last_failure_kind = 'provider_delivery.legacy_unsealed'
+                  AND terminal_claim_owner_id = $1
+                  AND terminal_claim_fence = 1
+            )
+        FROM provider_delivery_inbox
+        WHERE delivery_id LIKE 'delivery-legacy-unsealed-%'
+        ",
+    )
+    .bind(claim_owner.as_uuid())
     .fetch_one(database.pool())
     .await?;
-    assert_eq!(row.try_get::<String, _>("state")?, "rejected");
-    assert_eq!(row.try_get::<i16, _>("attempt_count")?, 1);
-    assert_eq!(row.try_get::<i64, _>("claim_fence")?, 1);
-    assert_eq!(row.try_get::<Option<Uuid>, _>("claim_owner_id")?, None);
-    assert_eq!(
-        row.try_get::<Option<String>, _>("last_failure_kind")?
-            .as_deref(),
-        Some("provider_delivery.legacy_unsealed")
-    );
-    assert_eq!(
-        row.try_get::<Option<Uuid>, _>("terminal_claim_owner_id")?,
-        Some(claim_owner.as_uuid())
-    );
-    assert_eq!(
-        row.try_get::<Option<i64>, _>("terminal_claim_fence")?,
-        Some(1)
-    );
-    Ok(())
+    Ok(counts)
 }
 
 fn failure(value: &str) -> ProviderDeliveryFailureKind {
@@ -835,14 +892,24 @@ async fn claim_rehydrates_the_exact_persisted_event_envelope() -> TestResult {
     run_with_database(|database| async move {
         seed_tenant(&database, "delivery-envelope-claim").await?;
         let connection = ProviderConnectionId::from_uuid(Uuid::new_v4())?;
-        let accepted = acceptance(
+        let shortest_media_type_envelope = ProviderDeliveryEventEnvelope::new(
+            1,
+            1,
+            Sha256Digest::from_bytes([33; 32]),
+            br"{}".to_vec(),
+            "/",
+        )?;
+        let accepted = acceptance_with_visibility_and_envelope(
             "delivery-envelope-claim",
             connection,
             "delivery-envelope-1",
             31,
             100,
+            ProviderRepositoryVisibility::Private,
+            shortest_media_type_envelope,
         );
         let expected_envelope = accepted.event_envelope().clone();
+        assert_eq!(expected_envelope.media_type(), "/");
         let receipt = database.store().accept_provider_delivery(accepted).await?;
 
         let durable: (i16, i16, Vec<u8>, Vec<u8>, String) = sqlx::query_as(
@@ -884,60 +951,8 @@ async fn claim_quarantines_legacy_unsealed_rows_without_poisoning_sealed_work() 
     run_with_database(|database| async move {
         seed_tenant(&database, "delivery-envelope-legacy").await?;
         let connection = ProviderConnectionId::from_uuid(Uuid::new_v4())?;
-
-        let partial = sqlx::query(
-            r"
-            INSERT INTO provider_delivery_inbox (
-                id, tenant_id, provider, connection_id, installation_id,
-                provider_repository_id, repository_visibility,
-                repository_identity, delivery_id,
-                request_digest, raw_event_digest, raw_event_object_key,
-                raw_event_size_bytes, raw_event_media_type,
-                event_envelope_schema,
-                accepted_at_ms, state_updated_at_ms
-            )
-            VALUES (
-                $1, 'delivery-envelope-legacy', 'synthetic', $2, 101,
-                202, 'private', 'automata-ci/automata', 'delivery-partial-envelope',
-                $3, $4, 'provider-events/delivery-partial-envelope/1',
-                256, 'application/json', 1, 100, 100
-            )
-            ",
-        )
-        .bind(Uuid::new_v4())
-        .bind(connection.as_uuid())
-        .bind([41_u8; 32].as_slice())
-        .bind([42_u8; 32].as_slice())
-        .execute(database.pool())
-        .await
-        .expect_err("partially populated event envelopes must fail closed");
-        assert_database_constraint(&partial, "provider_delivery_inbox_event_envelope_complete");
-
-        let legacy_id = Uuid::new_v4();
-        sqlx::query(
-            r"
-            INSERT INTO provider_delivery_inbox (
-                id, tenant_id, provider, connection_id, installation_id,
-                provider_repository_id, repository_visibility,
-                repository_identity, delivery_id,
-                request_digest, raw_event_digest, raw_event_object_key,
-                raw_event_size_bytes, raw_event_media_type,
-                accepted_at_ms, state_updated_at_ms
-            )
-            VALUES (
-                $1, 'delivery-envelope-legacy', 'synthetic', $2, 101,
-                202, 'private', 'automata-ci/automata', 'delivery-legacy-unsealed',
-                $3, $4, 'provider-events/delivery-legacy-unsealed/1',
-                256, 'application/json', 100, 100
-            )
-            ",
-        )
-        .bind(legacy_id)
-        .bind(connection.as_uuid())
-        .bind([43_u8; 32].as_slice())
-        .bind([44_u8; 32].as_slice())
-        .execute(database.pool())
-        .await?;
+        assert_partial_event_envelope_is_rejected(&database, &connection).await?;
+        seed_legacy_unsealed_deliveries(&database, &connection).await?;
 
         let sealed = database
             .store()
@@ -950,14 +965,45 @@ async fn claim_quarantines_legacy_unsealed_rows_without_poisoning_sealed_work() 
             ))
             .await?;
         let claim_owner = owner();
+        let first_observed_at = database_now(&database).await?;
         let claimed = database
             .store()
-            .claim_provider_delivery(claim(claim_owner, 110))
+            .claim_provider_delivery(ClaimProviderDelivery::new(
+                claim_owner,
+                UnixMillis::new(first_observed_at),
+                UnixMillis::new(first_observed_at + 60_000),
+            )?)
             .await?
             .expect("sealed work remains claimable");
         assert_eq!(claimed.receipt().id(), sealed.id());
+        assert_eq!(
+            legacy_delivery_state_counts(&database, claim_owner).await?,
+            (64, 1, 64),
+            "the first claim commits one bounded quarantine batch"
+        );
 
-        assert_legacy_delivery_is_quarantined(&database, legacy_id, claim_owner).await?;
+        let final_claim_owner = owner();
+        let final_observed_at = database_now(&database).await?;
+        assert!(
+            database
+                .store()
+                .claim_provider_delivery(ClaimProviderDelivery::new(
+                    final_claim_owner,
+                    UnixMillis::new(final_observed_at),
+                    UnixMillis::new(final_observed_at + 60_000),
+                )?)
+                .await?
+                .is_none(),
+            "the next claim drains remaining legacy work without decoding it"
+        );
+        assert_eq!(
+            legacy_delivery_state_counts(&database, claim_owner).await?,
+            (65, 0, 64)
+        );
+        assert_eq!(
+            legacy_delivery_state_counts(&database, final_claim_owner).await?,
+            (65, 0, 1)
+        );
         Ok(())
     })
     .await

--- a/crates/automata-ci-store-postgres/migrations/0040_provider_delivery_event_envelope.sql
+++ b/crates/automata-ci-store-postgres/migrations/0040_provider_delivery_event_envelope.sql
@@ -1,0 +1,196 @@
+-- EVT-01: persist the canonical event envelope accepted with each provider delivery.
+--
+-- Rows accepted before sealed envelopes became mandatory remain all-null so the
+-- bounded legacy quarantine can terminally isolate them without inventing trust
+-- evidence from raw provider JSON. New rows must carry one complete, bounded
+-- envelope.
+
+ALTER TABLE provider_delivery_inbox
+    ADD COLUMN event_envelope_schema SMALLINT,
+    ADD COLUMN event_registry_schema SMALLINT,
+    ADD COLUMN event_envelope_digest BYTEA,
+    ADD COLUMN event_envelope_bytes BYTEA,
+    ADD COLUMN event_envelope_media_type TEXT COLLATE "C";
+
+ALTER TABLE provider_delivery_inbox
+    ADD CONSTRAINT provider_delivery_inbox_event_envelope_complete CHECK (
+        (
+            event_envelope_schema IS NULL
+            AND event_registry_schema IS NULL
+            AND event_envelope_digest IS NULL
+            AND event_envelope_bytes IS NULL
+            AND event_envelope_media_type IS NULL
+        )
+        OR (
+            event_envelope_schema IS NOT NULL
+            AND event_registry_schema IS NOT NULL
+            AND event_envelope_digest IS NOT NULL
+            AND event_envelope_bytes IS NOT NULL
+            AND event_envelope_media_type IS NOT NULL
+            AND event_envelope_schema > 0
+            AND event_registry_schema > 0
+            AND octet_length(event_envelope_digest) = 32
+            AND octet_length(event_envelope_bytes) BETWEEN 1 AND 32768
+            AND octet_length(event_envelope_media_type) BETWEEN 1 AND 128
+            AND event_envelope_media_type LIKE '%/%'
+            AND event_envelope_media_type ~ '^[!-~]+$'
+            AND event_envelope_media_type !~ '[[:space:][:cntrl:];]'
+        )
+    ) NOT VALID;
+
+ALTER TABLE provider_delivery_inbox
+    VALIDATE CONSTRAINT provider_delivery_inbox_event_envelope_complete;
+
+-- Envelope evidence is immutable after acceptance. The only new lifecycle edge
+-- is the bounded quarantine of an eligible all-null legacy row; sealed rows
+-- retain the original state machine unchanged.
+CREATE OR REPLACE FUNCTION automata_enforce_provider_delivery_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id
+        OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+        OR NEW.provider IS DISTINCT FROM OLD.provider
+        OR NEW.connection_id IS DISTINCT FROM OLD.connection_id
+        OR NEW.installation_id IS DISTINCT FROM OLD.installation_id
+        OR NEW.provider_repository_id IS DISTINCT FROM OLD.provider_repository_id
+        OR NEW.repository_visibility IS DISTINCT FROM OLD.repository_visibility
+        OR NEW.repository_identity IS DISTINCT FROM OLD.repository_identity
+        OR NEW.delivery_id IS DISTINCT FROM OLD.delivery_id
+        OR NEW.request_digest IS DISTINCT FROM OLD.request_digest
+        OR NEW.raw_event_digest IS DISTINCT FROM OLD.raw_event_digest
+        OR NEW.raw_event_object_key IS DISTINCT FROM OLD.raw_event_object_key
+        OR NEW.raw_event_size_bytes IS DISTINCT FROM OLD.raw_event_size_bytes
+        OR NEW.raw_event_media_type IS DISTINCT FROM OLD.raw_event_media_type
+        OR NEW.event_envelope_schema IS DISTINCT FROM OLD.event_envelope_schema
+        OR NEW.event_registry_schema IS DISTINCT FROM OLD.event_registry_schema
+        OR NEW.event_envelope_digest IS DISTINCT FROM OLD.event_envelope_digest
+        OR NEW.event_envelope_bytes IS DISTINCT FROM OLD.event_envelope_bytes
+        OR NEW.event_envelope_media_type IS DISTINCT FROM OLD.event_envelope_media_type
+        OR NEW.accepted_at_ms IS DISTINCT FROM OLD.accepted_at_ms
+    THEN
+        RAISE EXCEPTION 'provider delivery immutable evidence cannot change'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'provider_delivery_inbox_evidence_immutable';
+    END IF;
+
+    IF NEW.state_updated_at_ms < OLD.state_updated_at_ms THEN
+        RAISE EXCEPTION 'provider delivery state time cannot regress'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'provider_delivery_inbox_time_regression';
+    END IF;
+
+    IF OLD.event_envelope_schema IS NULL
+        AND OLD.state IN ('pending', 'retry', 'claimed')
+        AND NEW.state = 'rejected'
+    THEN
+        IF NEW.claim_fence <> OLD.claim_fence + 1
+            OR NEW.attempt_count <> GREATEST(OLD.attempt_count, 1)
+            OR NEW.last_failure_kind
+                IS DISTINCT FROM 'provider_delivery.legacy_unsealed'
+            OR (
+                OLD.state = 'retry'
+                AND NEW.state_updated_at_ms < OLD.next_attempt_at_ms
+            )
+            OR (
+                OLD.state = 'claimed'
+                AND NEW.state_updated_at_ms < OLD.claim_expires_at_ms
+            )
+        THEN
+            RAISE EXCEPTION 'legacy provider delivery quarantine must close exact eligible state'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_legacy_unsealed_transition';
+        END IF;
+    ELSIF OLD.state IN ('pending', 'retry') AND NEW.state = 'claimed' THEN
+        IF NEW.claim_fence <> OLD.claim_fence + 1
+            OR NEW.attempt_count <> OLD.attempt_count + 1
+            OR NEW.claimed_at_ms < OLD.state_updated_at_ms
+            OR NEW.state_updated_at_ms IS DISTINCT FROM NEW.claimed_at_ms
+            OR NEW.renewal_predecessor_expires_at_ms IS NOT NULL
+            OR (
+                OLD.state = 'retry'
+                AND NEW.claimed_at_ms < OLD.next_attempt_at_ms
+            )
+            OR NEW.last_failure_kind IS DISTINCT FROM OLD.last_failure_kind
+        THEN
+            RAISE EXCEPTION 'provider delivery claim must advance exact retry state'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_claim_transition';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'claimed' THEN
+        IF NEW.claim_fence = OLD.claim_fence + 1
+            AND NEW.claimed_at_ms IS NOT DISTINCT FROM OLD.claimed_at_ms
+        THEN
+            IF NEW.attempt_count IS DISTINCT FROM OLD.attempt_count
+                OR NEW.claim_owner_id IS DISTINCT FROM OLD.claim_owner_id
+                OR NEW.last_failure_kind IS DISTINCT FROM OLD.last_failure_kind
+                OR NEW.claim_expires_at_ms <= OLD.claim_expires_at_ms
+                OR NEW.state_updated_at_ms <= OLD.state_updated_at_ms
+                OR NEW.state_updated_at_ms >= OLD.claim_expires_at_ms
+                OR NEW.renewal_predecessor_expires_at_ms
+                    IS DISTINCT FROM OLD.claim_expires_at_ms
+            THEN
+                RAISE EXCEPTION 'provider delivery renewal must rotate and strictly extend the live exact claim'
+                    USING ERRCODE = 'check_violation',
+                          CONSTRAINT = 'provider_delivery_inbox_renewal_transition';
+            END IF;
+        ELSIF NEW.claim_fence = OLD.claim_fence + 1 THEN
+            IF NEW.attempt_count IS DISTINCT FROM OLD.attempt_count
+                OR NEW.claimed_at_ms < OLD.claim_expires_at_ms
+                OR NEW.state_updated_at_ms IS DISTINCT FROM NEW.claimed_at_ms
+                OR NEW.renewal_predecessor_expires_at_ms IS NOT NULL
+                OR NEW.last_failure_kind IS DISTINCT FROM OLD.last_failure_kind
+            THEN
+                RAISE EXCEPTION 'provider delivery crash reclaim must advance only its fence'
+                    USING ERRCODE = 'check_violation',
+                          CONSTRAINT = 'provider_delivery_inbox_reclaim_transition';
+            END IF;
+        ELSE
+            RAISE EXCEPTION 'provider delivery claimed-state transition has an invalid fence'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_claimed_fence_transition';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'retry' THEN
+        IF NEW.claim_fence <> OLD.claim_fence
+            OR NEW.attempt_count <> OLD.attempt_count
+            OR NEW.state_updated_at_ms < OLD.claimed_at_ms
+            OR NEW.renewal_predecessor_expires_at_ms IS NOT NULL
+        THEN
+            RAISE EXCEPTION 'provider delivery retry must close the exact claim'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_retry_transition';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'completed' THEN
+        IF NEW.claim_fence <> OLD.claim_fence
+            OR NEW.attempt_count <> OLD.attempt_count
+            OR NEW.state_updated_at_ms < OLD.claimed_at_ms
+            OR NEW.last_failure_kind IS DISTINCT FROM OLD.last_failure_kind
+            OR NEW.renewal_predecessor_expires_at_ms IS NOT NULL
+            OR NEW.terminal_claim_owner_id IS DISTINCT FROM OLD.claim_owner_id
+            OR NEW.terminal_claim_fence IS DISTINCT FROM OLD.claim_fence
+        THEN
+            RAISE EXCEPTION 'provider delivery completion must close the exact claim'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_completion_transition';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'rejected' THEN
+        IF NEW.claim_fence <> OLD.claim_fence
+            OR NEW.attempt_count <> OLD.attempt_count
+            OR NEW.state_updated_at_ms < OLD.claimed_at_ms
+            OR NEW.renewal_predecessor_expires_at_ms IS NOT NULL
+            OR NEW.terminal_claim_owner_id IS DISTINCT FROM OLD.claim_owner_id
+            OR NEW.terminal_claim_fence IS DISTINCT FROM OLD.claim_fence
+        THEN
+            RAISE EXCEPTION 'provider delivery rejection must close the exact claim'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'provider_delivery_inbox_rejection_transition';
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'provider delivery lifecycle transition is not permitted'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'provider_delivery_inbox_lifecycle_transition';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -161,6 +161,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0039_qualify_workflow_permission_guard.sql",
         "2dc845db52210db4a44a41232845bb7e5ddff10663b8977ce087f6699b80376e5643f7b09b880446abc6a4beced44d80",
     ),
+    (
+        "0040_provider_delivery_event_envelope.sql",
+        "939ba465bb389fbe4c3ed2066e4e86cd46102664e35451ea182af3f49d10e142fcdc046c1f957c28d9eb1747309793e0",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -361,6 +365,64 @@ fn runtime_authority_delivery_is_post_accept_exact_and_value_free() {
             "runtime-authority migration must not persist grant material: {forbidden}"
         );
     }
+}
+
+#[test]
+fn provider_delivery_event_envelope_is_complete_bounded_and_legacy_nullable() {
+    let source = include_str!("../migrations/0040_provider_delivery_event_envelope.sql");
+
+    for required in [
+        "ADD COLUMN event_envelope_schema SMALLINT",
+        "ADD COLUMN event_registry_schema SMALLINT",
+        "ADD COLUMN event_envelope_digest BYTEA",
+        "ADD COLUMN event_envelope_bytes BYTEA",
+        "ADD COLUMN event_envelope_media_type TEXT COLLATE \"C\"",
+        "CONSTRAINT provider_delivery_inbox_event_envelope_complete CHECK",
+        "event_envelope_schema IS NULL",
+        "event_registry_schema IS NULL",
+        "event_envelope_digest IS NULL",
+        "event_envelope_bytes IS NULL",
+        "event_envelope_media_type IS NULL",
+        "event_envelope_schema IS NOT NULL",
+        "event_registry_schema IS NOT NULL",
+        "event_envelope_digest IS NOT NULL",
+        "event_envelope_bytes IS NOT NULL",
+        "event_envelope_media_type IS NOT NULL",
+        "event_envelope_schema > 0",
+        "event_registry_schema > 0",
+        "octet_length(event_envelope_digest) = 32",
+        "octet_length(event_envelope_bytes) BETWEEN 1 AND 32768",
+        "octet_length(event_envelope_media_type) BETWEEN 1 AND 128",
+        "event_envelope_media_type LIKE '%/%'",
+        "event_envelope_media_type ~ '^[!-~]+$'",
+        "event_envelope_media_type !~ '[[:space:][:cntrl:];]'",
+        ") NOT VALID",
+        "VALIDATE CONSTRAINT provider_delivery_inbox_event_envelope_complete",
+        "CREATE OR REPLACE FUNCTION automata_enforce_provider_delivery_lifecycle()",
+        "NEW.event_envelope_schema IS DISTINCT FROM OLD.event_envelope_schema",
+        "NEW.event_registry_schema IS DISTINCT FROM OLD.event_registry_schema",
+        "NEW.event_envelope_digest IS DISTINCT FROM OLD.event_envelope_digest",
+        "NEW.event_envelope_bytes IS DISTINCT FROM OLD.event_envelope_bytes",
+        "NEW.event_envelope_media_type IS DISTINCT FROM OLD.event_envelope_media_type",
+        "OLD.event_envelope_schema IS NULL",
+        "OLD.state IN ('pending', 'retry', 'claimed')",
+        "NEW.state = 'rejected'",
+        "NEW.claim_fence <> OLD.claim_fence + 1",
+        "NEW.attempt_count <> GREATEST(OLD.attempt_count, 1)",
+        "IS DISTINCT FROM 'provider_delivery.legacy_unsealed'",
+        "CONSTRAINT = 'provider_delivery_inbox_legacy_unsealed_transition'",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider-delivery envelope migration lost required contract: {required}"
+        );
+    }
+
+    assert_eq!(
+        automata_ci_store::MAX_PROVIDER_DELIVERY_EVENT_ENVELOPE_BYTES,
+        32_768,
+        "product and durable provider-envelope byte limits diverged"
+    );
 }
 
 fn migration_paths() -> Vec<PathBuf> {

--- a/crates/automata-ci-store-postgres/src/provider_delivery.rs
+++ b/crates/automata-ci-store-postgres/src/provider_delivery.rs
@@ -162,7 +162,8 @@ impl ProviderDeliveryRepository for PostgresStore {
             SELECT inbox.id, database_time.now_ms
             FROM provider_delivery_inbox AS inbox
             CROSS JOIN database_time
-            WHERE inbox.state_updated_at_ms <= database_time.now_ms
+            WHERE inbox.event_envelope_schema IS NOT NULL
+              AND inbox.state_updated_at_ms <= database_time.now_ms
               AND inbox.claim_fence < 9223372036854775807
               AND (
                 inbox.state = 'pending'
@@ -236,6 +237,7 @@ impl ProviderDeliveryRepository for PostgresStore {
                 rejected_at_ms = NULL,
                 state_updated_at_ms = $3
             WHERE inbox.id = $1
+              AND inbox.event_envelope_schema IS NOT NULL
               AND inbox.state_updated_at_ms <= $3
               AND inbox.claim_fence < 9223372036854775807
               AND (
@@ -820,7 +822,8 @@ async fn eligible_exhausted_fence(
         SELECT EXISTS (
             SELECT 1
             FROM provider_delivery_inbox
-            WHERE state_updated_at_ms <= $1
+            WHERE event_envelope_schema IS NOT NULL
+              AND state_updated_at_ms <= $1
               AND claim_fence = 9223372036854775807
               AND (
                 state = 'pending'


### PR DESCRIPTION
Closes #222.

## Summary

- append migration 0040 for the five sealed provider-delivery event-envelope values
- enforce all-null or exact all-present bounded envelope shape, including the Rust-valid one-byte media type boundary
- freeze envelope evidence after acceptance while preserving the exact legacy-unsealed quarantine transition
- exclude all-null legacy rows from normal claim selection, guarded claim update, and exhausted-fence detection
- prove bounded progress with 65 legacy rows: 64 quarantines commit without poisoning sealed work, then the final row drains on the next pass

No existing delivery row is rewritten and raw event JSON is never synthesized into authority evidence.

## Validation

- changed-file rustfmt and `git diff --check`
- migration SHA-384 `939ba465bb389fbe4c3ed2066e4e86cd46102664e35451ea182af3f49d10e142fcdc046c1f957c28d9eb1747309793e0`
- Store-PostgreSQL migration layout: 6/6
- PostgreSQL aggregate all-feature no-run compile
- Store-PostgreSQL all-target/all-feature strict Clippy
- aggregate PostgreSQL test-target Clippy with only the established untouched `large_futures` / `too_many_lines` baseline allowances
- fresh PostgreSQL 18.4 provider-delivery module: 25/25 serial
- isolated namespace pre-clean and post-clean verified; template removed
- adapter and integration-test source blobs are byte-identical to the independently reviewed implementation; current-main rebase changed only migration numbering and inventory integration

## Scope

Four files, +393/-86. No Cargo, dependency, protocol, or wire change.