### PR TITLE
fix(docs): align runner schema version guidance

### DIFF
--- a/crates/automata-ci-protocol-protobuf/proto/automata/runner/v1/runner.proto
+++ b/crates/automata-ci-protocol-protobuf/proto/automata/runner/v1/runner.proto
@@ -46,7 +46,7 @@ message ProtocolRange {
 }
 
 message JobIrVersionRange {
-  // Current-only contract: both endpoints MUST equal 5.
+  // Current-only contract: both endpoints MUST equal 1.
   uint32 minimum = 1;
   uint32 maximum = 2;
 }
@@ -817,7 +817,7 @@ message RuntimeAuthorityAck {
 }
 
 message JobIrEnvelope {
-  // MUST equal 5; no earlier or later JobIR wire schema is accepted.
+  // MUST equal 1; no earlier or later JobIR wire schema is accepted.
   uint32 schema_version = 1;
   bytes workflow_id = 2;
   JobSource source = 3;

--- a/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
+++ b/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
@@ -3,10 +3,7 @@
 pub struct Unit {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunnerFrame {
-    #[prost(
-        oneof = "runner_frame::Payload",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
-    )]
+    #[prost(oneof = "runner_frame::Payload", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub payload: ::core::option::Option<runner_frame::Payload>,
 }
 /// Nested message and enum types in `RunnerFrame`.
@@ -37,10 +34,7 @@ pub mod runner_frame {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServerFrame {
-    #[prost(
-        oneof = "server_frame::Payload",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
-    )]
+    #[prost(oneof = "server_frame::Payload", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub payload: ::core::option::Option<server_frame::Payload>,
 }
 /// Nested message and enum types in `ServerFrame`.
@@ -628,10 +622,7 @@ pub struct ExpressionCallInstruction {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExpressionInstruction {
-    #[prost(
-        oneof = "expression_instruction::Value",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8"
-    )]
+    #[prost(oneof = "expression_instruction::Value", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
     pub value: ::core::option::Option<expression_instruction::Value>,
 }
 /// Nested message and enum types in `ExpressionInstruction`.
@@ -1408,11 +1399,15 @@ impl HandshakeErrorCode {
         match value {
             "HANDSHAKE_ERROR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
             "HANDSHAKE_ERROR_CODE_INVALID_HELLO" => Some(Self::InvalidHello),
-            "HANDSHAKE_ERROR_CODE_UNSUPPORTED_PROTOCOL" => Some(Self::UnsupportedProtocol),
+            "HANDSHAKE_ERROR_CODE_UNSUPPORTED_PROTOCOL" => {
+                Some(Self::UnsupportedProtocol)
+            }
             "HANDSHAKE_ERROR_CODE_UNSUPPORTED_JOB_IR" => Some(Self::UnsupportedJobIr),
             "HANDSHAKE_ERROR_CODE_UNAUTHENTICATED" => Some(Self::Unauthenticated),
             "HANDSHAKE_ERROR_CODE_UNAUTHORIZED" => Some(Self::Unauthorized),
-            "HANDSHAKE_ERROR_CODE_SESSION_NOT_RESUMABLE" => Some(Self::SessionNotResumable),
+            "HANDSHAKE_ERROR_CODE_SESSION_NOT_RESUMABLE" => {
+                Some(Self::SessionNotResumable)
+            }
             _ => None,
         }
     }
@@ -1501,7 +1496,9 @@ impl RuntimeAuthorityEndpointSecurity {
         match self {
             Self::Unspecified => "RUNTIME_AUTHORITY_ENDPOINT_SECURITY_UNSPECIFIED",
             Self::Tls => "RUNTIME_AUTHORITY_ENDPOINT_SECURITY_TLS",
-            Self::LoopbackDevelopment => "RUNTIME_AUTHORITY_ENDPOINT_SECURITY_LOOPBACK_DEVELOPMENT",
+            Self::LoopbackDevelopment => {
+                "RUNTIME_AUTHORITY_ENDPOINT_SECURITY_LOOPBACK_DEVELOPMENT"
+            }
             Self::TrustedPrivateDevelopment => {
                 "RUNTIME_AUTHORITY_ENDPOINT_SECURITY_TRUSTED_PRIVATE_DEVELOPMENT"
             }
@@ -1603,7 +1600,9 @@ impl ExpressionComparisonOperator {
             Self::Equal => "EXPRESSION_COMPARISON_OPERATOR_EQUAL",
             Self::NotEqual => "EXPRESSION_COMPARISON_OPERATOR_NOT_EQUAL",
             Self::GreaterThan => "EXPRESSION_COMPARISON_OPERATOR_GREATER_THAN",
-            Self::GreaterThanOrEqual => "EXPRESSION_COMPARISON_OPERATOR_GREATER_THAN_OR_EQUAL",
+            Self::GreaterThanOrEqual => {
+                "EXPRESSION_COMPARISON_OPERATOR_GREATER_THAN_OR_EQUAL"
+            }
             Self::LessThan => "EXPRESSION_COMPARISON_OPERATOR_LESS_THAN",
             Self::LessThanOrEqual => "EXPRESSION_COMPARISON_OPERATOR_LESS_THAN_OR_EQUAL",
         }
@@ -1619,7 +1618,9 @@ impl ExpressionComparisonOperator {
                 Some(Self::GreaterThanOrEqual)
             }
             "EXPRESSION_COMPARISON_OPERATOR_LESS_THAN" => Some(Self::LessThan),
-            "EXPRESSION_COMPARISON_OPERATOR_LESS_THAN_OR_EQUAL" => Some(Self::LessThanOrEqual),
+            "EXPRESSION_COMPARISON_OPERATOR_LESS_THAN_OR_EQUAL" => {
+                Some(Self::LessThanOrEqual)
+            }
             _ => None,
         }
     }
@@ -1993,7 +1994,9 @@ impl RemoteErrorCode {
             "REMOTE_ERROR_CODE_STALE_SESSION" => Some(Self::StaleSession),
             "REMOTE_ERROR_CODE_INVALID_SLOT" => Some(Self::InvalidSlot),
             "REMOTE_ERROR_CODE_OPERATION_KEY_REUSED" => Some(Self::OperationKeyReused),
-            "REMOTE_ERROR_CODE_COMMAND_CURSOR_CONFLICT" => Some(Self::CommandCursorConflict),
+            "REMOTE_ERROR_CODE_COMMAND_CURSOR_CONFLICT" => {
+                Some(Self::CommandCursorConflict)
+            }
             "REMOTE_ERROR_CODE_LEASE_NOT_FOUND" => Some(Self::LeaseNotFound),
             "REMOTE_ERROR_CODE_STALE_FENCING_TOKEN" => Some(Self::StaleFencingToken),
             "REMOTE_ERROR_CODE_CONFLICT" => Some(Self::Conflict),

--- a/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
+++ b/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
@@ -72,7 +72,7 @@ pub struct ProtocolRange {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct JobIrVersionRange {
-    /// Current-only contract: both endpoints MUST equal 5.
+    /// Current-only contract: both endpoints MUST equal 1.
     #[prost(uint32, tag = "1")]
     pub minimum: u32,
     #[prost(uint32, tag = "2")]
@@ -1166,7 +1166,7 @@ pub struct RuntimeAuthorityAck {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JobIrEnvelope {
-    /// MUST equal 5; no earlier or later JobIR wire schema is accepted.
+    /// MUST equal 1; no earlier or later JobIR wire schema is accepted.
     #[prost(uint32, tag = "1")]
     pub schema_version: u32,
     #[prost(bytes = "vec", tag = "2")]

--- a/docs/github-actions-parity/trust-snapshots.md
+++ b/docs/github-actions-parity/trust-snapshots.md
@@ -108,7 +108,7 @@ authenticated provider/manual/schedule facts
 ```
 
 No downstream consumer reopens webhook JSON, infers actor authority from a
-login, or independently classifies a fork. JobIR schema 5 carries the exact
+login, or independently classifies a fork. JobIR schema 1 carries the exact
 canonical snapshot bytes and SHA-256 digest. The runner protobuf uses fields 16
 and 17 for those values.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -544,7 +544,7 @@ process-observed and the observer never changes journal correctness.
 
 Spool metrics are emitted inside the durable store, after the outcome is known;
 the decorator does not guess about deduplication, adoption, reclaim, protection
-authentication, or uncertain mutation. Runner-journal schema 7 persists the
+authentication, or uncertain mutation. Runner-journal schema 2 persists the
 bounded non-secret enqueue timestamps used by pending-delivery oldest-age
 objectives. Metric counters remain process-local and are never persisted.
 


### PR DESCRIPTION
Closes #234.

Stacked on #236 so the diff contains only the intended documentation corrections. After #236 merges this PR will be retargeted/rebased to `main`.

## Summary

- correct the authoritative runner proto: current JobIR range and envelope schema are 1, not 5
- regenerate the checked-in prost documentation from the source schema
- correct the trust-snapshot guide to JobIR schema 1
- correct the observability guide to runner-journal schema 2, not 7

No field numbers, messages, encoding, negotiation, runtime behavior, or durable format changes.

## Validation

- pinned protobuf codegen verification passed
- protocol-protobuf all-target/all-feature suite: 64/64
- scoped protobuf rustfmt and `git diff --check`
- exact stale-number scans across protobuf, docs, and runner-journal sources
- no active-PR path overlap beyond the intentional #236 stack

## Scope

Four files, six one-line documentation replacements.