### PR TITLE
fix(postgres-tests): seed authenticated GitHub evidence

### DIFF
--- a/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
@@ -59,12 +59,10 @@ use automata_ci_store::{
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind,
     MarkGithubRuntimeAuthorityIndeterminate, ObjectKey, OpenRunnerSession,
     ProtectedGithubRuntimeAuthority, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
-    QuarantineGithubRuntimeAuthority, ReconcileGithubRuntimeAuthorities,
-    RegisterProviderDeliveryWorkflowInventory, RejectGithubRuntimeAuthorityMint,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, PublishLogicalJobActivation, QuarantineGithubRuntimeAuthority,
+    ReconcileGithubRuntimeAuthorities, RejectGithubRuntimeAuthorityMint,
     RetryGithubRuntimeAuthorityMint, RetryGithubRuntimeAuthorityRevocation,
     ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerOperationKind,
     RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot,
@@ -140,23 +138,29 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "automata-ci",
+        "automata",
+    )
+    .expect("repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("runtime-authority-{namespace}"))
             .expect("idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         WORKFLOW_PATH,
         "CI",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(
             format!("runtime-authority/{namespace}/source"),
@@ -177,7 +181,7 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
             0x13,
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         database_epoch,
     )
@@ -186,6 +190,7 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     LogicalFixture {
@@ -292,6 +297,7 @@ fn retime_logical_admission(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 
@@ -328,16 +334,16 @@ async fn admit_signed_workflow(
     database_epoch: UnixMillis,
 ) -> TestResult {
     let manifest = &fixture.manifest;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        database_epoch,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                database_epoch,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await
         .map_err(|error| format!("repository bootstrap failed: {error:?}"))?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -430,26 +436,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 async fn select_orchestration(

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
@@ -83,6 +83,7 @@ fn admission_base_context(namespace: u128) -> AdmissionObject {
     runtime_context_object(format!("activation/{namespace}/base-context.pb"), 4)
 }
 
+#[allow(clippy::too_many_lines)] // Builds one complete authenticated logical fixture.
 async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> TestResult<Fixture> {
     let tenant_scope = TenantScope::from_authenticated_tenant_id(tenant)?;
     let connection = ProviderConnectionId::from_uuid(Uuid::from_u128(namespace + 20))?;
@@ -138,19 +139,26 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
         vec![first_job],
     )
     .expect("second job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("sample-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![9; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("activation-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("sample-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Verify",
@@ -167,11 +175,12 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
         invocation_id,
         "push",
         admission_object(format!("activation/{namespace}/event"), 3),
-        vec![9; 20],
+        head_sha,
         vec![first, second],
         UnixMillis::new(database_now_ms(database).await?),
     )
     .base_context(admission_base_context(namespace))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical workflow fixture");
     Ok(Fixture {
@@ -187,15 +196,13 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
 #[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -318,6 +325,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
@@ -1163,15 +1163,15 @@ async fn fixture_with_visibility(
         GithubProviderManifestLimits::github_dot_com_ci(),
         GithubProviderManifestRevision::new(1)?,
     );
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks = GithubServerServiceAuthorityIdentity::new(
         tenant_scope.clone(),
         GithubServerServiceAuthorityId::from_uuid(Uuid::from_u128(namespace + 21))?,
@@ -1265,23 +1265,27 @@ async fn fixture_with_visibility(
         &[2; 64],
         "application/json",
     );
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "automata-ci",
+        "automata",
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![3; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope.clone(),
         WorkflowAdmissionIdempotency::provider_delivery(format!("preparation-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([30; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository,
         workflow,
         ".ci/workflows/ci.yml",
         "Automata CI",
-        "refs/heads/main",
+        git_ref,
         snapshot,
         object(
             format!("preparation/{namespace}/source"),
@@ -1298,10 +1302,11 @@ async fn fixture_with_visibility(
         invocation,
         "push",
         event.clone(),
-        vec![3; 20],
+        head_sha,
         jobs,
         UnixMillis::new(configured_at),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(object(
         format!("preparation/{namespace}/base-context.pb"),
         &[4; 64],
@@ -1323,7 +1328,7 @@ async fn fixture_with_visibility(
                         visibility,
                         "automata-ci/automata",
                     )?,
-                    format!("activation-preparation-{namespace}"),
+                    command.idempotency().key(),
                 )?,
                 Sha256Digest::from_bytes([29; 32]),
                 crate::support::authenticated_github_event_object(&event)?,
@@ -1411,6 +1416,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -45,13 +45,11 @@ use automata_ci_store::{
     LogicalWorkflowAdmissionRepository as _, LogicalWorkflowInvocationId, LogicalWorkflowJobId,
     LogicalWorkflowJobKind, ObjectKey, OpenRunnerSession, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, QuarantineLogicalInstanceResult,
-    RegisterProviderDeliveryWorkflowInventory, ReusableSecretPermission, RoutingDocument,
-    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
+    QuarantineLogicalInstanceResult, ReusableSecretPermission, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, RunnerSessionFence, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -1198,6 +1196,7 @@ async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
     )
 }
 
+#[allow(clippy::too_many_lines)] // Builds one complete authenticated logical fixture.
 fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile) -> Fixture {
     let tenant_scope = TenantScope::from_authenticated_tenant_id(tenant).expect("tenant");
     let repository_visibility = match authority_profile {
@@ -1249,19 +1248,27 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("result-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1278,7 +1285,7 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         invocation_id,
         "push",
         admission_object(format!("instance-result/{namespace}/event"), 0x13),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -1287,6 +1294,7 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     Fixture {
@@ -1307,15 +1315,15 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
     let github_repository = manifest.github_repository_id();
     let repository_visibility = manifest.repository_visibility();
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     ensure_instance_result_server_authorities(database, fixture, configured_at).await?;
     let delivery_observed_at = database_now_ms(database).await?;
     let accepted = database
@@ -1332,7 +1340,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
                         repository_visibility,
                         format!("example/project-{namespace}"),
                     )?,
-                    format!("instance-result-{namespace}"),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -1361,26 +1369,14 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -1473,6 +1469,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
@@ -1307,19 +1307,27 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("logical-result-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1344,7 +1352,7 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -1353,6 +1361,7 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
         &[0x15; 512],
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     Fixture {
@@ -1410,6 +1419,21 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         )
         .expect("build job"),
     ];
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!(
@@ -1417,14 +1441,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         ))
         .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1449,7 +1466,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         logical_jobs,
         UnixMillis::new(1_000),
     )
@@ -1458,6 +1475,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         &[0x15; 512],
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("dependency admission");
     [base_id, prepare_id, build_id].map(|logical_job_id| Fixture {
@@ -1509,15 +1527,15 @@ fn fixture_manifest(tenant: TenantScope, namespace: u128) -> GithubProviderManif
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture) -> TestResult {
     let manifest = &fixture.manifest;
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -1556,7 +1574,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
                         manifest.repository_visibility(),
                         manifest.github_repository_name().as_str(),
                     )?,
-                    format!("logical-job-result-{}", fixture.namespace),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -1639,6 +1657,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -2027,6 +2027,16 @@ async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
     )
 }
 
+fn lower_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
 async fn wait_until_database_after(database: &TestDatabase, target_ms: i64) -> TestResult {
     while database_now_ms(database).await? <= target_ms {
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -2074,23 +2084,27 @@ async fn fixture_with_concurrency(
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository_id.get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("materialize-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository_id.get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(format!("materialization/{namespace}/source"), 0x11),
         admission_object_from_bytes(
@@ -2103,10 +2117,11 @@ async fn fixture_with_concurrency(
         invocation_id,
         "push",
         admission_object(format!("materialization/{namespace}/event"), 0x13),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(clock_origin_ms),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(runtime_context_object(
         format!("materialization/{namespace}/base-context.pb"),
         0x15,
@@ -2522,15 +2537,13 @@ async fn admit_authenticated_fixture(
     publish_publicly: bool,
 ) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
 
     let manifest = &fixture.manifest;
     database
@@ -2590,7 +2603,7 @@ async fn admit_authenticated_fixture(
                         manifest.repository_visibility(),
                         manifest.github_repository_name().as_str(),
                     )?,
-                    format!("materialization-{}", fixture.namespace),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -2626,7 +2639,7 @@ async fn admit_authenticated_fixture(
                 claimed.claim(),
                 ProviderDeliveryWorkflowInventory::new(
                     fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
+                    lower_hex(fixture.command.head_sha()),
                     Sha256Digest::from_bytes([0x90; 32]),
                     vec![
                         ProviderDeliveryWorkflowInventoryEntry::new(
@@ -2704,6 +2717,7 @@ fn logical_command_at(
         builder = builder.base_context(base_context.clone());
     }
     builder = builder.concurrency(command.concurrency().cloned());
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -8,9 +8,7 @@ use automata_ci_auth::{
 };
 use automata_ci_core::{
     JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile, OperationId, RunId, Sha256Digest,
-    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
-    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
-    UnixMillis, WorkflowId, WorkflowJobKey,
+    TrustSnapshot, UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AdmissionObject,
@@ -78,33 +76,6 @@ fn object_with_media(key: String, digest: u8, media_type: &str) -> AdmissionObje
         media_type,
     )
     .expect("admission object")
-}
-
-fn trusted_snapshot(namespace: u128) -> TrustSnapshot {
-    let repository_id = namespace.to_string();
-    TrustPolicy::current()
-        .evaluate(
-            TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
-                .with_original_actor(
-                    TrustActorEvidence::new(
-                        format!("actor-{namespace}"),
-                        TrustActorKind::User,
-                        TrustAutomationKind::None,
-                    )
-                    .expect("actor evidence"),
-                )
-                .with_repositories(
-                    TrustRepositoryEvidence::new(repository_id.as_str(), "owner-1")
-                        .expect("source repository"),
-                    TrustRepositoryEvidence::new(repository_id.as_str(), "owner-1")
-                        .expect("target repository"),
-                )
-                .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
-                .with_revisions("source-sha", "target-sha", "execution-sha")
-                .with_fork(false)
-                .with_token_recursion(TrustTokenRecursion::Suppressed),
-        )
-        .expect("trusted snapshot")
 }
 
 async fn prepare_job(
@@ -206,8 +177,10 @@ fn fixture_manifest_binding(
         GithubServerServiceAppClientId::new(format!("Iv1.logical-orchestration-{namespace}"))
             .expect("app client ID"),
         GithubServerServiceJwtIssuer::AppClientId,
-        Sha256Digest::from_bytes([0x71; 32]),
-        GithubServerServiceRevision::new(1).expect("configuration revision"),
+        Sha256Digest::from_bytes(
+            [u8::try_from(0x70 + manifest_revision).expect("small manifest revision"); 32],
+        ),
+        GithubServerServiceRevision::new(manifest_revision).expect("configuration revision"),
         GithubProviderWebhookVerifierFingerprint::from_sha256(Sha256Digest::from_bytes([0x72; 32]))
             .expect("webhook fingerprint"),
         GithubServerServiceRevision::new(1).expect("webhook revision"),
@@ -234,15 +207,15 @@ async fn stage_authenticated_admission(
 ) -> TestResult<(AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim)> {
     let manifest = fixture_manifest(command.tenant().clone(), namespace);
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -435,22 +408,28 @@ fn fixture_at(
         vec![first_id],
     )
     .expect("second job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "sample-owner",
+        format!("sample-{namespace}"),
+    )
+    .expect("repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(idempotency_key).expect("idempotency"),
         Sha256Digest::from_bytes([request_digest; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "sample-owner",
-            format!("sample-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Verify",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         object(format!("logical/{namespace}/source"), 1),
         object_with_media(
@@ -463,12 +442,12 @@ fn fixture_at(
         root_id,
         "push",
         object(format!("logical/{namespace}/event"), 3),
-        vec![9; 20],
+        head_sha,
         vec![first, second],
         admitted_at,
     )
     .actor("sample-actor")
-    .trust_snapshot(trusted_snapshot(namespace))
+    .trust_snapshot(trust_snapshot)
     .base_context(object_with_media(
         format!("logical/{namespace}/base-context.pb"),
         4,
@@ -745,15 +724,20 @@ async fn admission_is_atomic_exact_and_has_no_concrete_jobs() -> TestResult {
             2,
             2,
         );
+        let replacement_bootstrap =
+            github_manifest_fixture::fixture_github_repository_bootstrap(
+                replacement,
+                UnixMillis::new(database_now_ms(&database).await?),
+            );
         database
             .store()
-            .bootstrap_github_provider_repository(
-                github_manifest_fixture::fixture_github_repository_bootstrap(
-                    replacement,
-                    UnixMillis::new(database_now_ms(&database).await?),
-                ),
-            )
+            .bootstrap_github_provider_repository(replacement_bootstrap.clone())
             .await?;
+        crate::support::seed_fresh_github_workflow_permission_defaults(
+            &database,
+            &replacement_bootstrap,
+        )
+        .await?;
         let delivery_id = authenticated.claim().delivery_id();
         let origin = EventSubjectOrigin::ProviderDelivery(delivery_id);
         let subject_id = EventSubjectId::derive(
@@ -1309,11 +1293,18 @@ async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> Test
         assert_eq!(left.run_id(), right.run_id());
         assert_eq!(left.run_number(), right.run_number());
 
+        let conflicting_trust_snapshot =
+            crate::support::authenticated_github_trust_snapshot_for_actor(
+                command.repository(),
+                command.git_ref(),
+                command.head_sha(),
+                "conflicting-authenticated-github-fixture-actor",
+            )?;
         let conflicting_trust = logical_command_at_with_trust_snapshot(
             &command,
             command.idempotency().clone(),
             command.admitted_at(),
-            trusted_snapshot(201),
+            conflicting_trust_snapshot,
         )?;
         assert!(matches!(
             database

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
@@ -2126,21 +2126,26 @@ async fn fixture(
         LogicalWorkflowJobKind::Steps,
         Vec::new(),
     )?];
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("renewal-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("renewal-{namespace}"))?,
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("renewal-{namespace}"),
-        )?,
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Renewal ACK",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(format!("renewal/{namespace}/source"), 1, "application/json"),
         admission_object(
@@ -2153,10 +2158,11 @@ async fn fixture(
         invocation_id,
         "push",
         admission_object(format!("renewal/{namespace}/event"), 3, "application/json"),
-        vec![9; 20],
+        head_sha,
         admitted_jobs,
         UnixMillis::new(database_now_ms(database).await?),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(admission_object(
         format!("renewal/{namespace}/base-context"),
         4,
@@ -2175,15 +2181,13 @@ async fn fixture(
 #[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -2305,6 +2309,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
@@ -31,12 +31,10 @@ use automata_ci_store::{
     LogicalWorkSelectionId, LogicalWorkSelectionRepository as _,
     LogicalWorkflowAdmissionRepository as _, LogicalWorkflowInvocationId, LogicalWorkflowJobId,
     LogicalWorkflowJobKind, ObjectKey, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, TenantScope, WorkflowAdmissionIdempotency,
-    WorkflowConcurrency, WorkflowSnapshotId,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, TenantScope, WorkflowAdmissionIdempotency, WorkflowConcurrency,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -414,15 +412,15 @@ async fn admit_authenticated_fixture(
     fixture: &Fixture,
 ) -> TestResult<Uuid> {
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        fixture.manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     ensure_fixture_authority(
         database,
         fixture,
@@ -464,26 +462,14 @@ async fn admit_authenticated_fixture(
     if claimed.claim().delivery_id() != accepted.delivery_id() {
         return Err("the fixture claimed a different provider delivery".into());
     }
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let authenticated_claim = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -606,6 +592,7 @@ fn logical_command_at(
     if let Some(concurrency) = command.concurrency() {
         builder = builder.concurrency(Some(concurrency.clone()));
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 
@@ -1100,6 +1087,7 @@ fn fixture_with_visibility_and_dependencies(
 }
 
 #[allow(clippy::too_many_arguments)] // Fixture axes are explicit at call sites.
+#[allow(clippy::too_many_lines)] // Builds the full authenticated admission graph.
 fn fixture_with_options(
     tenant: &str,
     namespace: u128,
@@ -1145,19 +1133,27 @@ fn fixture_with_options(
             .expect("admitted logical job")
         })
         .collect();
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        namespace.to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("run-finalization-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            namespace.to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1182,10 +1178,11 @@ fn fixture_with_options(
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         logical_jobs,
         UnixMillis::new(1_000),
-    );
+    )
+    .trust_snapshot(trust_snapshot);
     if include_base_context {
         command = command.base_context(admission_object(
             format!("run-finalization/{namespace}/base-context"),

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
@@ -366,21 +366,26 @@ async fn admit_authenticated_fixture(
     );
     let job = LogicalWorkflowJobId::from_uuid(Uuid::from_u128(namespace + 6))?;
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("admission-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant,
         WorkflowAdmissionIdempotency::provider_delivery(format!("admission-{namespace}"))?,
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("admission-{namespace}"),
-        )?,
+        repository,
         WorkflowId::from_uuid(Uuid::from_u128(namespace + 2)),
         ".ci/workflows/ci.yml",
         "Admission guard",
-        "refs/heads/main",
+        git_ref,
         WorkflowSnapshotId::from_uuid(Uuid::from_u128(namespace + 3)),
         admission_object(
             format!("admission/{namespace}/source"),
@@ -401,7 +406,7 @@ async fn admit_authenticated_fixture(
             3,
             "application/json",
         ),
-        vec![9; 20],
+        head_sha,
         vec![AdmittedLogicalWorkflowJob::new(
             job,
             WorkflowJobKey::new("build")?,
@@ -411,6 +416,7 @@ async fn admit_authenticated_fixture(
         )?],
         now,
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(admission_object(
         format!("admission/{namespace}/base-context"),
         4,
@@ -433,15 +439,13 @@ async fn authenticate_fixture(
     fixture: &mut AuthenticatedFixture,
 ) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -562,6 +566,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
@@ -45,10 +45,8 @@ use automata_ci_store::{
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     OpenRunnerSession, ProtectedGithubRuntimeAuthority, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, RegisterProviderDeliveryWorkflowInventory,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
     RenewLogicalActivationPreparation, RenewLogicalInstanceMaterialization,
     RenewLogicalJobActivation, ReusableSecretPermission,
     RevalidateGithubRuntimeAuthorityRevocation, RoutingDocument, RunnerGeneration,
@@ -114,19 +112,21 @@ fn logical_fixture(
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        "project",
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("job-authority-{namespace}"))
             .expect("idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            "project",
-        )
-        .expect("repository"),
+        repository.clone(),
         workflow_id,
         WORKFLOW_PATH,
         "CI",
@@ -151,9 +151,17 @@ fn logical_fixture(
             0x13,
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha.clone(),
         vec![logical_job],
         database_epoch,
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .base_context(admission_object(
         format!("job-authority/{namespace}/base-context"),
@@ -291,7 +299,8 @@ fn retime_logical_admission(
         command.head_sha().to_vec(),
         command.jobs().to_vec(),
         admitted_at,
-    );
+    )
+    .trust_snapshot(command.trust_snapshot().clone());
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
@@ -306,16 +315,16 @@ async fn admit_signed_workflow(
 ) -> TestResult {
     let tenant = TenantScope::from_authenticated_tenant_id(&fixture.tenant)?;
     let manifest = &fixture.manifest;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        database_epoch,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                database_epoch,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await
         .map_err(|error| format!("repository bootstrap failed: {error:?}"))?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks = service_authority(
         manifest,
         namespace_id(manifest, 1),
@@ -430,26 +439,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 fn namespace_id(manifest: &GithubProviderManifest, suffix: u128) -> u128 {

--- a/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
@@ -55,13 +55,11 @@ use automata_ci_store::{
     LogicalWorkSelectionStoreError, LogicalWorkflowAdmissionRepository as _,
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     OpenRunnerSession, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
-    RegisterProviderDeliveryWorkflowInventory, ReserveGithubOidcAuthority, RetainGithubOidcKey,
-    ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, PublishLogicalJobActivation, ReserveGithubOidcAuthority,
+    RetainGithubOidcKey, ReusableSecretPermission, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
     WorkflowPlanRepository as _, WorkflowSnapshotId, github_oidc_rs256_public_key_fingerprint,
 };
 use sha2::{Digest as _, Sha256};
@@ -270,13 +268,16 @@ fn logical_oidc_fixture_with_profile(
         Vec::new(),
     )
     .expect("test logical job");
+    let repository =
+        AdmissionRepository::new(repository_id, "github", "4242", "example", "project")
+            .expect("test repository");
+    let head_sha = vec![0x14; 20];
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("oidc-live-{namespace}"))
             .expect("test idempotency"),
         digest(0x40),
-        AdmissionRepository::new(repository_id, "github", "4242", "example", "project")
-            .expect("test repository"),
+        repository.clone(),
         workflow_id,
         WORKFLOW_PATH,
         "OIDC",
@@ -293,9 +294,17 @@ fn logical_oidc_fixture_with_profile(
         invocation_id,
         "push",
         admission_object(format!("oidc/{namespace}/event"), 0x13, "application/json"),
-        vec![0x14; 20],
+        head_sha.clone(),
         vec![logical_job],
         UnixMillis::new(1_000),
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .base_context(admission_object(
         format!("oidc/{namespace}/base-context"),
@@ -415,7 +424,8 @@ fn retime_logical_admission(
         command.head_sha().to_vec(),
         command.jobs().to_vec(),
         admitted_at,
-    );
+    )
+    .trust_snapshot(command.trust_snapshot().clone());
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
@@ -433,15 +443,15 @@ async fn admit_signed_oidc_workflow(
     let installation = manifest.installation_id();
     let provider_repository_id = manifest.github_repository_id();
     let bootstrap_at = database_now(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        bootstrap_at,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                bootstrap_at,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks_authority = GithubServerServiceAuthorityIdentity::new(
         tenant.clone(),
         GithubServerServiceAuthorityId::from_uuid(Uuid::from_u128(40_011))?,
@@ -549,26 +559,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalOidcFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 async fn claim_oidc_activation(

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -5,14 +5,15 @@ use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptManifestPinnedGithubRepositoryDispatch,
     AcceptProviderDelivery, AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun,
     AdmittedLogicalWorkflowJob, AuthenticatedGithubDeliveryClaim, BeginGithubCheckRunCreate,
-    BindGithubCheckRun, BindGithubCheckSuite, ClaimGithubCheckProjection, ClaimProviderDelivery,
-    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, CompleteProviderDelivery,
-    EnsureGithubServerServiceAuthority, GithubAuthenticatedEvent, GithubAuthenticatedEventKind,
-    GithubCheckDesiredProjection, GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName,
-    GithubCheckProjectionAction, GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId,
-    GithubCheckRunBindingFence, GithubCheckRunId, GithubCheckSubjectId, GithubCheckSuiteId,
-    GithubCheckTerminalCause, GithubProviderManifest, GithubProviderManifestLimits,
-    GithubProviderManifestRepository as _, GithubProviderManifestRevision, GithubProviderOrigins,
+    BindGithubCheckRun, BindGithubCheckSuite, BootstrapGithubProviderRepository,
+    ClaimGithubCheckProjection, ClaimProviderDelivery, ClaimedGithubCheckProjection,
+    CompleteGithubCheckProjection, CompleteProviderDelivery, EnsureGithubServerServiceAuthority,
+    GithubAuthenticatedEvent, GithubAuthenticatedEventKind, GithubCheckDesiredProjection,
+    GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
+    GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
+    GithubCheckRunId, GithubCheckSubjectId, GithubCheckSuiteId, GithubCheckTerminalCause,
+    GithubProviderManifest, GithubProviderManifestLimits, GithubProviderManifestRepository as _,
+    GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubProviderWorkflowSelection,
     GithubRepositoryDispatchEvidenceRepository as _, GithubRepositoryDispatchResolution,
     GithubRepositoryDispatchResolutionAuthority, GithubRepositoryName,
@@ -738,7 +739,7 @@ async fn all_direct_inventory_fans_out_with_durable_partial_progress() -> TestRe
 
         let command = logical_command_at_path(
             &fixture,
-            "logical-all-direct-build",
+            "delivery-all-direct",
             0x62,
             21,
             0x2_800,
@@ -1067,7 +1068,7 @@ async fn setup_create_before_admission(
     let delivery_claim = claim_delivery(database, accepted.delivery_id(), 0x28b, 60_000).await?;
     let inventory = ProviderDeliveryWorkflowInventory::new(
         fixture.manifest.digest(),
-        "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        "0909090909090909090909090909090909090909",
         Sha256Digest::from_bytes([0x56; 32]),
         vec![ProviderDeliveryWorkflowInventoryEntry::new(
             CREATE_BEFORE_ADMISSION_WORKFLOW_PATH,
@@ -1158,7 +1159,7 @@ async fn admit_create_before_admission_workflow(
     let admitted_at = database_now(database.pool()).await?;
     let command = logical_command_at_path(
         &scenario.fixture,
-        "logical-create-before-link",
+        "delivery-create-before-link",
         0x66,
         25,
         0x2_8a0,
@@ -1526,6 +1527,7 @@ struct Fixture {
     tenant: TenantScope,
     connection: ProviderConnectionId,
     manifest: GithubProviderManifest,
+    bootstrap: BootstrapGithubProviderRepository,
     activated_at: UnixMillis,
     checks_authority: GithubServerServiceAuthorityIdentity,
     private_source_authority: Option<GithubServerServiceAuthorityIdentity>,
@@ -1559,6 +1561,8 @@ async fn bootstrap_all_direct(
         GithubProviderWorkflowSelection::all_direct(),
     )
     .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &fixture.bootstrap)
+        .await?;
     ensure_fixture_authorities(database, fixture, at).await
 }
 
@@ -1623,14 +1627,13 @@ async fn bootstrap_manifest_only_with_selection(
         [6; 32],
         selection,
     );
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(at),
+    );
     let bootstrapped = database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
     let activated_at = bootstrapped
         .manifest()
@@ -1656,6 +1659,7 @@ async fn bootstrap_manifest_only_with_selection(
         tenant,
         connection,
         manifest,
+        bootstrap,
         activated_at,
         checks_authority,
         private_source_authority,
@@ -2251,18 +2255,20 @@ fn logical_command_at_path(
         "application/json",
     )
     .expect("event object");
+    let repository = AdmissionRepository::new(
+        fixture.manifest.repository_id(),
+        "github",
+        REPOSITORY_ID.to_string(),
+        "automata-ci",
+        "automata",
+    )
+    .expect("repository");
+    let head_sha = HEAD_SHA.to_vec();
     AdmitLogicalWorkflowRun::builder(
         fixture.tenant.clone(),
         WorkflowAdmissionIdempotency::provider_delivery(idempotency_key).expect("idempotency"),
         Sha256Digest::from_bytes([request_digest_byte; 32]),
-        AdmissionRepository::new(
-            fixture.manifest.repository_id(),
-            "github",
-            REPOSITORY_ID.to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository.clone(),
         workflow_id,
         workflow_path,
         "Automata CI",
@@ -2275,9 +2281,17 @@ fn logical_command_at_path(
         root_invocation_id,
         "push",
         event,
-        HEAD_SHA.to_vec(),
+        head_sha.clone(),
         vec![job],
         admitted_at,
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .actor("octocat")
     .build()

--- a/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
@@ -60,18 +60,16 @@ use automata_ci_store::{
     ManagedSecretDeliveryProposal, ObjectKey, OpenRunnerSession, PrepareJobEnvironment,
     ProtectedEnvironmentRepository as _, ProtectedEnvironmentStoreError, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, RegisterProviderDeliveryWorkflowInventory, RepositoryId,
-    RepositorySecretId, RepositorySecretManagementRepository as _, RepositorySecretMutationId,
-    RepositorySecretName, RepositorySecretProviderMutationResult, RepositorySecretVersionId,
-    ReserveRepositorySecretVersionMutation, ReserveRepositorySecretVersionMutationOutcome,
-    ResolveManagedSecretAuthority, ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument,
-    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet,
-    SecretCustodyRepository as _, SecretWorkloadGrantId, StableRunnerSlot, TenantScope,
-    VerifySecretCustody, VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency,
-    WorkflowSnapshotId,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
+    RepositoryId, RepositorySecretId, RepositorySecretManagementRepository as _,
+    RepositorySecretMutationId, RepositorySecretName, RepositorySecretProviderMutationResult,
+    RepositorySecretVersionId, ReserveRepositorySecretVersionMutation,
+    ReserveRepositorySecretVersionMutationOutcome, ResolveManagedSecretAuthority,
+    ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet, SecretCustodyRepository as _,
+    SecretWorkloadGrantId, StableRunnerSlot, TenantScope, VerifySecretCustody,
+    VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Transaction};
@@ -305,23 +303,29 @@ fn logical_fixture_with_requirements(
     )
     .expect("test logical job")
     .with_credential_requirements(credential_requirements);
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        "project",
+    )
+    .expect("test repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(delivery_key.clone())
             .expect("test idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            "project",
-        )
-        .expect("test repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Managed secret",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object("secret/source".to_owned(), 0x11, "application/yaml"),
         admission_object(
@@ -334,7 +338,7 @@ fn logical_fixture_with_requirements(
         invocation_id,
         "push",
         admission_object("secret/event".to_owned(), 0x13, "application/json"),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -343,6 +347,7 @@ fn logical_fixture_with_requirements(
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("test logical admission");
     LogicalFixture {
@@ -417,26 +422,14 @@ async fn admit_authenticated_fixture(
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    digest(0x90),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
@@ -456,15 +449,15 @@ async fn bootstrap_manifest(
     manifest: &GithubProviderManifest,
 ) -> TestResult {
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -519,6 +512,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/security/observability.rs
+++ b/crates/automata-ci-postgres/tests/store/security/observability.rs
@@ -34,13 +34,11 @@ use automata_ci_store::{
     LogicalWorkSelectionRepository as _, LogicalWorkflowAdmissionRepository as _,
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     ProviderConnectionId, ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity,
-    ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, RunnerCommandPayload, RunnerGeneration,
-    RunnerOperationKind, RunnerSessionFence, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
-    WorkflowAdmissionIdempotency, WorkflowRunStatus, WorkflowSnapshotId,
+    ProviderDeliveryRepository as _, ProviderInstallationId, ProviderRepositoryCoordinates,
+    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerSessionFence, SessionEpoch,
+    TenantScope, WORKFLOW_ADMISSION_EPOCH, WorkflowAdmissionIdempotency, WorkflowRunStatus,
+    WorkflowSnapshotId,
 };
 use uuid::Uuid;
 
@@ -705,6 +703,7 @@ async fn insert_logical_metrics_state(
     })
 }
 
+#[allow(clippy::too_many_lines)] // Builds the complete authenticated metrics graph.
 async fn build_logical_metrics_fixture(
     database: &TestDatabase,
     seed: &MetricsSeed,
@@ -745,21 +744,26 @@ async fn build_logical_metrics_fixture(
     let pending_job = LogicalWorkflowJobId::from_uuid(Uuid::new_v4())?;
     let delivery_key = format!("metrics-logical-{suffix}");
     let admitted_at = UnixMillis::new(database_now_ms(database).await?);
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        provider_repository_id.get().to_string(),
+        "automata",
+        format!("metrics-{suffix}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![20; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant,
         WorkflowAdmissionIdempotency::provider_delivery(delivery_key.clone())?,
         Sha256Digest::from_bytes([14; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            provider_repository_id.get().to_string(),
-            "automata",
-            format!("metrics-{suffix}"),
-        )?,
+        repository,
         WorkflowId::from_uuid(Uuid::new_v4()),
         ".ci/workflows/ci.yml",
         "Metrics",
-        "refs/heads/main",
+        git_ref,
         WorkflowSnapshotId::from_uuid(Uuid::new_v4()),
         logical_metrics_object(
             format!("metrics/{suffix}/workflow.yml"),
@@ -780,7 +784,7 @@ async fn build_logical_metrics_fixture(
             18,
             "application/json",
         ),
-        vec![20; 20],
+        head_sha,
         vec![
             logical_metrics_job(active_job, "active", 0),
             logical_metrics_job(expired_job, "expired", 1),
@@ -794,6 +798,7 @@ async fn build_logical_metrics_fixture(
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
     .actor("metrics-observer")
+    .trust_snapshot(trust_snapshot)
     .build()?;
     Ok(LogicalMetricsFixture {
         suffix,
@@ -855,26 +860,14 @@ async fn admit_logical_metrics_fixture(
         .await?
         .ok_or("accepted metrics delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     fixture.command = logical_metrics_command_at(&fixture.command, claimed.claimed_at())?;
     database
         .store()
@@ -896,15 +889,15 @@ async fn bootstrap_logical_metrics_manifest(
     database: &TestDatabase,
     manifest: &GithubProviderManifest,
 ) -> TestResult {
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(database_now_ms(database).await?),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(database_now_ms(database).await?),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -984,6 +977,7 @@ fn logical_metrics_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.actor(command.actor().unwrap_or_default()).build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/support/mod.rs
+++ b/crates/automata-ci-postgres/tests/support/mod.rs
@@ -3,10 +3,13 @@ use std::{error::Error, future::Future, sync::Arc};
 use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, JobId, JobIrVersion, OperatingSystem, RunId, RunnerCapabilities, RunnerId,
-    RunnerPlatform, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
+    RunnerPlatform, RunnerRequirements, RunnerSessionId, Sha256Digest, TrustActorEvidence,
+    TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind,
+    TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion, UnixMillis,
 };
 use automata_ci_key_management::{
-    KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes,
+    EncryptedEnvelope, KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial,
+    SecretBytes, WrappedDataKey,
 };
 use automata_ci_postgres::store::PostgresStore;
 #[allow(unused_imports)] // Consolidated binaries consume different fixture subsets.
@@ -14,11 +17,23 @@ pub use automata_ci_postgres::test_support::{
     PostgresTestDatabase as TestDatabase, TestClock, TestResult,
 };
 use automata_ci_store::{
-    AdmitLogicalWorkflowRun, GithubProviderManifest, OpenRunnerSession, ProviderDeliveryClaimFence,
+    AcquireGithubServerServiceHandoff, AdmissionRepository, AdmitLogicalWorkflowRun,
+    BeginGithubServerServiceMint, BootstrapGithubProviderRepository,
+    ClaimNextGithubServerServiceMaintenance, EnsureGithubServerServiceAuthority,
+    FinalizeGithubWorkflowPermissionObservation, FinishGithubServerServiceMint,
+    GithubProviderManifest, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
+    GithubServerServiceAuthorityRepository as _, GithubServerServiceAuthoritySelector,
+    GithubServerServiceAuthorityState, GithubServerServiceEnvelopeMetadata,
+    GithubServerServiceHandoffId, GithubServerServiceIssuanceState,
+    GithubServerServiceMaintenanceOutcome, GithubServerServiceScope, GithubServerServiceWorkerId,
+    GithubWorkflowPermissionDefaultsObservation,
+    GithubWorkflowPermissionDefaultsObservationRepository as _,
+    MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, OpenRunnerSession,
+    ProtectedGithubServerServiceCredential, ProviderDeliveryClaimFence,
     ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
     ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    RegisterProviderDeliveryWorkflowInventory, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence,
+    RegisterProviderDeliveryWorkflowInventory, ReleaseGithubServerServiceHandoff, RoutingDocument,
+    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence,
 };
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -66,7 +81,7 @@ pub async fn register_provider_delivery_workflow_inventory(
                 claim,
                 ProviderDeliveryWorkflowInventory::new(
                     manifest.digest(),
-                    "1414141414141414141414141414141414141414",
+                    lower_hex(command.head_sha()),
                     automata_ci_core::Sha256Digest::from_bytes([0x90; 32]),
                     vec![ProviderDeliveryWorkflowInventoryEntry::new(
                         command.workflow_path(),
@@ -78,6 +93,273 @@ pub async fn register_provider_delivery_workflow_inventory(
         )
         .await?;
     Ok(())
+}
+
+/// Builds a sealed same-repository push trust snapshot for the admitted coordinates.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+pub fn authenticated_github_trust_snapshot(
+    repository: &AdmissionRepository,
+    git_ref: &str,
+    head_sha: &[u8],
+) -> TestResult<TrustSnapshot> {
+    authenticated_github_trust_snapshot_for_actor(
+        repository,
+        git_ref,
+        head_sha,
+        "authenticated-github-fixture-actor",
+    )
+}
+
+/// Builds a sealed same-repository push trust snapshot for exact coordinates and actor.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+pub fn authenticated_github_trust_snapshot_for_actor(
+    repository: &AdmissionRepository,
+    git_ref: &str,
+    head_sha: &[u8],
+    actor_id: &str,
+) -> TestResult<TrustSnapshot> {
+    let actor = TrustActorEvidence::new(actor_id, TrustActorKind::User, TrustAutomationKind::None)?;
+    let repository = TrustRepositoryEvidence::new(
+        repository.provider_repository_id(),
+        "authenticated-github-fixture-owner",
+    )?;
+    Ok(TrustPolicy::current().evaluate(
+        TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
+            .with_original_actor(actor.clone())
+            .with_triggering_actor(actor)
+            .with_repositories(repository.clone(), repository)
+            .with_refs(git_ref, git_ref, git_ref)
+            .with_revisions(
+                lower_hex(head_sha),
+                lower_hex(head_sha),
+                lower_hex(head_sha),
+            )
+            .with_fork(false)
+            .with_token_recursion(TrustTokenRecursion::Suppressed),
+    )?)
+}
+
+/// Establishes the exact fresh workflow-permission observation required by
+/// authenticated GitHub logical admission.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+#[allow(clippy::too_many_lines)] // Mirrors the complete production claim/handoff/finalize flow.
+pub async fn seed_fresh_github_workflow_permission_defaults(
+    database: &TestDatabase,
+    bootstrap: &BootstrapGithubProviderRepository,
+) -> TestResult {
+    let manifest = bootstrap.manifest().manifest();
+    database
+        .store()
+        .prepare_github_workflow_permission_target(manifest)
+        .await?;
+    let mut authority_id_bytes = [0_u8; 16];
+    authority_id_bytes.copy_from_slice(&manifest.digest().as_bytes()[..16]);
+    authority_id_bytes[0] ^= 0xa7;
+    let authority = GithubServerServiceAuthorityIdentity::new(
+        manifest.tenant().clone(),
+        GithubServerServiceAuthorityId::from_uuid(Uuid::from_bytes(authority_id_bytes))?,
+        manifest.repository_id(),
+        manifest.connection_id(),
+        manifest.installation_id(),
+        manifest.github_app_id(),
+        manifest.github_repository_id(),
+        manifest.github_repository_name().clone(),
+        GithubServerServiceScope::WorkflowPermissionsRead,
+        manifest.app_client_id().clone(),
+        manifest.jwt_issuer(),
+        manifest.app_key_spki_sha256(),
+        manifest.app_configuration_revision(),
+        manifest.policy_revision(),
+        Sha256Digest::from_bytes([0x7a; 32]),
+    )?;
+    database
+        .store()
+        .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
+            authority.clone(),
+            bootstrap.manifest().applied_at(),
+        )?)
+        .await?;
+
+    ensure_workflow_permission_credential(database, &authority).await?;
+    let selector = GithubServerServiceAuthoritySelector::from_identity(&authority);
+
+    let observation_started_at = UnixMillis::new(database_now_ms(database).await?);
+    let candidate = automata_ci_store::GithubWorkflowPermissionObservationCandidate::new(
+        bootstrap,
+        &authority,
+        automata_ci_store::GithubServerServiceConsumerId::from_uuid(Uuid::new_v4())?,
+        GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+        observation_started_at,
+    )?;
+    database
+        .store()
+        .claim_github_workflow_permission_observation(candidate.clone())
+        .await?;
+    let expected_default = candidate.expected_default();
+    let handoff_id = GithubServerServiceHandoffId::from_uuid(Uuid::new_v4())?;
+    let handoff_observed_at = candidate.claimed_at();
+    let handoff = database
+        .store()
+        .acquire_github_server_service_handoff(AcquireGithubServerServiceHandoff::new(
+            selector.clone(),
+            handoff_id,
+            candidate.consumer(),
+            handoff_observed_at,
+            UnixMillis::new(handoff_observed_at.get() + MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS),
+        )?)
+        .await?;
+    let observed_at = UnixMillis::new(database_now_ms(database).await?);
+    let release = ReleaseGithubServerServiceHandoff::new(
+        selector,
+        handoff.handoff_id(),
+        candidate.consumer(),
+        observed_at,
+    )?;
+    let observation = GithubWorkflowPermissionDefaultsObservation::new(
+        bootstrap,
+        candidate,
+        &release,
+        handoff.receipt().key().generation(),
+        expected_default,
+        false,
+        observed_at,
+    )?;
+    let finalized = database
+        .store()
+        .finalize_github_workflow_permission_observation(
+            FinalizeGithubWorkflowPermissionObservation::new(
+                bootstrap.clone(),
+                release,
+                observation,
+            )?,
+        )
+        .await?;
+    if !finalized {
+        return Err("workflow-permission observation did not activate".into());
+    }
+    Ok(())
+}
+
+async fn ensure_workflow_permission_credential(
+    database: &TestDatabase,
+    authority: &GithubServerServiceAuthorityIdentity,
+) -> TestResult {
+    let wait_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let now_ms = database_now_ms(database).await?;
+        let minimum_usable_until = now_ms
+            .checked_add(MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS)
+            .and_then(|value| value.checked_add(60_000))
+            .ok_or("workflow-permission credential horizon overflow")?;
+        let descriptor = database
+            .store()
+            .inspect_github_server_service_authority(authority.tenant(), authority.authority_id())
+            .await?;
+        let current = database
+            .store()
+            .inspect_current_github_server_service_issuance(
+                authority.tenant(),
+                authority.authority_id(),
+            )
+            .await?;
+        if descriptor.identity() != authority
+            || descriptor.state() != GithubServerServiceAuthorityState::Active
+        {
+            return Err("workflow-permission authority is not active and exact".into());
+        }
+        if current.is_some_and(|receipt| {
+            descriptor.current_generation() == Some(receipt.key().generation())
+                && receipt.state() == GithubServerServiceIssuanceState::Ready
+                && receipt
+                    .usable_until()
+                    .is_some_and(|until| until.get() >= minimum_usable_until)
+        }) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= wait_deadline {
+            return Err("workflow-permission credential did not become ready".into());
+        }
+
+        let selector = GithubServerServiceAuthoritySelector::from_identity(authority);
+        let outcome = database
+            .store()
+            .claim_next_github_server_service_maintenance(
+                ClaimNextGithubServerServiceMaintenance::for_authority(
+                    selector,
+                    GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+                    UnixMillis::new(now_ms),
+                    UnixMillis::new(now_ms + 60_000),
+                )?,
+            )
+            .await?;
+        match outcome {
+            Some(GithubServerServiceMaintenanceOutcome::Mint(claimed)) => {
+                let claimed = *claimed;
+                let started_at = UnixMillis::new(database_now_ms(database).await?);
+                database
+                    .store()
+                    .begin_github_server_service_mint(BeginGithubServerServiceMint::new(
+                        &claimed, started_at,
+                    )?)
+                    .await?;
+                let committed_at_ms = database_now_ms(database).await?;
+                let receipt = claimed.receipt();
+                let metadata = GithubServerServiceEnvelopeMetadata::new(
+                    authority.clone(),
+                    receipt.key().generation(),
+                    receipt.requested_at(),
+                    receipt.request_deadline(),
+                    UnixMillis::new(committed_at_ms + 3_600_000),
+                    32,
+                    Sha256Digest::from_bytes([0x7b; 32]),
+                )?;
+                let credential = ProtectedGithubServerServiceCredential::new(
+                    metadata,
+                    EncryptedEnvelope::from_parts(
+                        1,
+                        WrappedDataKey::new(
+                            KeyId::new("authenticated-fixture-workflow-permission-v1")?,
+                            vec![0x7c; 48],
+                        )?,
+                        [0x7d; 12],
+                        vec![0x7e; 48],
+                    )?,
+                )?;
+                database
+                    .store()
+                    .finish_github_server_service_mint(&FinishGithubServerServiceMint::ready(
+                        claimed.claim().clone(),
+                        credential,
+                        UnixMillis::new(committed_at_ms),
+                    )?)
+                    .await?;
+            }
+            Some(GithubServerServiceMaintenanceOutcome::Reduced { .. }) | None => {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            Some(GithubServerServiceMaintenanceOutcome::Revocation(_)) => {
+                return Err("unexpected workflow-permission revocation work".into());
+            }
+        }
+    }
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
+    Ok(
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint")
+            .fetch_one(database.pool())
+            .await?,
+    )
 }
 
 pub fn test_runner_payload_key_provider() -> Arc<dyn KeyEncryptionProvider> {


### PR DESCRIPTION
Closes #227.

## Summary

- derive provider-delivery inventory revisions from each command's exact lowercase head SHA and align delivery identities with logical-admission idempotency keys
- seed the canonical fresh GitHub workflow-permission evidence through the public authority mint, credential handoff, observation, and atomic finalization APIs
- attach an exact same-repository push trust snapshot to every successful authenticated fixture and preserve it across command retiming
- cover manifest rotation with distinct valid app evidence and a fresh matching permission observation
- keep the change entirely in PostgreSQL integration-test support and the 15 affected test modules

This is stacked on #237 because these authenticated paths persist the provider event envelope introduced there.

## Validation

- `cargo check --locked -p automata-ci-postgres --test postgres --all-features`
- strict aggregate Clippy passes with only the two established parent lint classes allowed; without the `too_many_lines` baseline allowance, the sole diagnostic is the unchanged 123-line `assert_logical_admission_shape`
- all 16 authored files pass pinned rustfmt checks; `git diff --check` passes
- PostgreSQL 18.4 stress overlay: two concurrent first-time permission seeders, one sequential replay, and `authenticated_admission_is_pristine_and_direct_authority_inserts_fail` passed 1/1; the diagnostic-only duplicate calls were removed afterward
- all 15 affected PostgreSQL modules were executed serially against fresh isolated namespaces, and every namespace was cleaned

The fixture-level manifest, inventory, permission, delivery-linkage, and trust-origin failures are resolved. The remaining ignored-test failures are later independent defects now exposed by valid admission evidence: chiefly #229's immutable preparation/trust propagation mismatch, plus existing subject-evidence concurrency/claim-order and stale assertion/query cases. The exact concurrent-replay control on the clean #237 parent already fails during its older fixture setup (`InvalidTrustSnapshot`); this branch advances it to the separate signed-subject-evidence concurrency failure.
