### PR TITLE
fix(postgres): validate trust replay at durable time

### DIFF
--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1057,6 +1057,31 @@ async fn distinct_provider_admissions_reuse_exact_workflow_enable_state() -> Tes
             .await?;
         assert!(!first.is_replay());
 
+        let replayed_at = UnixMillis::new(
+            database_now_ms(&database)
+                .await?
+                .max(first_command.admitted_at().get() + 1),
+        );
+        let retimed_first_command = logical_command_at(&first_command, replayed_at)?;
+        let replay = database
+            .store()
+            .admit_authenticated_github_delivery(retimed_first_command, first_claim, replayed_at)
+            .await?;
+        assert!(replay.is_replay());
+        assert_eq!(replay.run_id(), first.run_id());
+        let replay_evidence: (i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT (SELECT count(*) FROM workflow_runs WHERE id = $1),
+                   (SELECT count(*) FROM workflow_admission_receipts WHERE run_id = $1),
+                   (SELECT count(*) FROM workflow_run_trust_snapshots WHERE run_id = $1),
+                   (SELECT count(*) FROM event_subject_progress WHERE run_id = $1)
+            ",
+        )
+        .bind(first.run_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(replay_evidence, (1, 1, 1, 1));
+
         let (second_command, second_claim) =
             stage_authenticated_delivery(&database, &manifest, &second_fixture, WORKFLOW_NAMESPACE)
                 .await?;

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -392,7 +392,7 @@ async fn admit_logical_workflow_transaction(
     if !claimed {
         let (receipt, admitted_at) =
             replay_receipt(&mut transaction, &command, github_subject_evidence_required).await?;
-        validate_trust_snapshot_replay(&mut transaction, &command).await?;
+        validate_trust_snapshot_replay(&mut transaction, &command, admitted_at).await?;
         validate_replayed_subject_evidence(
             &mut transaction,
             &command,
@@ -2063,6 +2063,7 @@ async fn insert_trust_snapshot(
 async fn validate_trust_snapshot_replay(
     transaction: &mut Transaction<'_, Postgres>,
     command: &AdmitLogicalWorkflowRun,
+    durable_admitted_at: UnixMillis,
 ) -> Result<(), LogicalWorkflowAdmissionStoreError> {
     let row = sqlx::query(
         r"
@@ -2109,7 +2110,7 @@ async fn validate_trust_snapshot_replay(
         && row
             .try_get::<i64, _>("created_at_ms")
             .map_err(operation_error)?
-            == command.admitted_at().get();
+            == durable_admitted_at.get();
     if !exact {
         return Err(LogicalWorkflowAdmissionStoreError::IdempotencyConflict);
     }


### PR DESCRIPTION
## Summary

- validate immutable trust-snapshot creation time against the original durable admission time already returned by receipt replay
- preserve every schema, policy, digest, byte, media-type, query, bind, and row-lock check
- prove an exact authenticated command can be retimed and replayed without duplicating run, receipt, trust, or event evidence

Closes #250.

## Stacking

This PR is stacked on #249 (`fix/authenticated-dispatch-manifest-owner`). The production hunk is disjoint from the current-manifest owner lookup and #246 enable-state initializer.

## Validation

- targeted rustfmt and `git diff --check`
- scoped store-postgres check
- strict store-postgres Clippy
- PostgreSQL aggregate test-target Clippy with established inherited `large-futures` / `too_many_lines` allowances
- baseline differential: test-only retimed replay on unchanged production fails solely with `IdempotencyConflict`
- PostgreSQL 18.4 fixed exact test: 1/1 independently
- exact replay evidence remains `(run, receipt, trust snapshot, event terminal) = (1, 1, 1, 1)`
- isolated namespaces/templates removed; database audit returned zero
