### PR TITLE
fix(postgres): serialize logical admission idempotency

### DIFF
--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1562,6 +1562,7 @@ async fn logical_admission_replay_rejects_forward_plan_and_orchestration_schemas
 
 #[tokio::test]
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+#[allow(clippy::too_many_lines)] // One race proof covers replay and both conflict boundaries.
 async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> TestResult {
     run_with_database(|database| async move {
         seed_tenant(&database, "logical-replay").await?;
@@ -1588,6 +1589,46 @@ async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> Test
         assert_eq!(left.run_id(), right.run_id());
         assert_eq!(left.run_number(), right.run_number());
         assert_workflow_enable_state_history(&database, &command, &[(1, "enabled")]).await?;
+        let exact_counts: (i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+                (SELECT count(*)
+                   FROM workflow_admission_receipts
+                  WHERE tenant_id = $1
+                    AND idempotency_kind = $2
+                    AND idempotency_key = $3
+                    AND repository_id = $4
+                    AND run_id = $5),
+                (SELECT count(*)
+                   FROM workflow_runs
+                  WHERE repository_id = $4 AND id = $5),
+                (SELECT count(*)
+                   FROM github_workflow_run_subject_evidence
+                  WHERE tenant_id = $1
+                    AND repository_id = $4
+                    AND run_id = $5
+                    AND provider_delivery_id = $6
+                    AND workflow_path = $7),
+                (SELECT count(*)
+                   FROM github_check_subjects
+                  WHERE tenant_id = $1
+                    AND repository_id = $4
+                    AND provider_delivery_id = $6
+                    AND subject_kind = 'workflow'
+                    AND subject_key = $7
+                    AND workflow_run_id = $5)
+            ",
+        )
+        .bind(command.tenant().as_str())
+        .bind(command.idempotency().kind())
+        .bind(command.idempotency().key())
+        .bind(command.repository().id().as_uuid())
+        .bind(command.run_id().as_uuid())
+        .bind(authenticated.claim().delivery_id().as_uuid())
+        .bind(command.workflow_path())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(exact_counts, (1, 1, 1, 1));
 
         let conflicting_trust_snapshot =
             crate::support::authenticated_github_trust_snapshot_for_actor(

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -59,6 +59,8 @@ const WORKFLOW_DISPATCH_PERMISSION: &str = "runs:dispatch";
 const WORKFLOW_DISPATCH_AUDIT_ACTION: &str = "workflow.dispatch";
 const WORKFLOW_DISPATCH_AUDIT_RESOURCE_KIND: &str = "workflow_run";
 const WORKFLOW_DISPATCH_AUDIT_ID_DOMAIN: &[u8] = b"automata.workflow-dispatch.audit.v1\0";
+// SHA-256 prefix for `automata.logical-admission.idempotency-lock.v1`.
+const LOGICAL_ADMISSION_IDEMPOTENCY_LOCK_NAMESPACE: i64 = 0x2fee_1fa8_b154_7857;
 
 const fn logical_workflow_job_kind_name(kind: LogicalWorkflowJobKind) -> &'static str {
     match kind {
@@ -338,6 +340,15 @@ async fn admit_logical_workflow_transaction(
 ) -> Result<LogicalWorkflowAdmissionReceipt, LogicalWorkflowAdmissionStoreError> {
     validate_subject_evidence_boundary(&command, &subject_evidence)?;
     let mut transaction = store.pool.begin().await.map_err(operation_error)?;
+    // A waiter must observe the leader's commit in its next statement even
+    // when the pool or session default uses a persistent snapshot.
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        .execute(&mut *transaction)
+        .await
+        .map_err(operation_error)?;
+    // Disabled admissions intentionally have no receipt, so serialize the key
+    // before deciding whether this transaction is a new admission or a replay.
+    lock_logical_admission_idempotency(&mut transaction, &command).await?;
     let dispatch_actor =
         authorize_dispatch_subject(&mut transaction, &command, &subject_evidence).await?;
     let github_subject_evidence_required = matches!(
@@ -1366,6 +1377,30 @@ fn subject_evidence_error(
             StoreError::corrupt_data("signed GitHub subject evidence rejected admission").into()
         }
     }
+}
+
+async fn lock_logical_admission_idempotency(
+    transaction: &mut Transaction<'_, Postgres>,
+    command: &AdmitLogicalWorkflowRun,
+) -> Result<(), LogicalWorkflowAdmissionStoreError> {
+    let tenant = command.tenant().as_str();
+    let kind = command.idempotency().kind();
+    let key = command.idempotency().key();
+    // Byte-length framing keeps delimiter-bearing identities distinct. A hash
+    // collision can only serialize unrelated admissions; it cannot split one key.
+    let lock_identity = format!(
+        "{}:{tenant}|{}:{kind}|{}:{key}",
+        tenant.len(),
+        kind.len(),
+        key.len(),
+    );
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, $2))")
+        .bind(lock_identity)
+        .bind(LOGICAL_ADMISSION_IDEMPOTENCY_LOCK_NAMESPACE)
+        .execute(&mut **transaction)
+        .await
+        .map_err(operation_error)?;
+    Ok(())
 }
 
 async fn admission_receipt_exists(


### PR DESCRIPTION
Closes #255.

## Summary

- pin the logical-admission transaction to READ COMMITTED so a waiter receives a fresh post-lock statement snapshot regardless of pool/session defaults
- acquire a transaction-scoped advisory lock on the exact `(tenant, idempotency kind, idempotency key)` tuple before authorization, receipt inspection, subject selection, or any row/advisory lock
- use a documented SHA-256-prefix namespace and byte-length-framed UTF-8 identity so delimiter-bearing values cannot alias
- strengthen the existing concurrent replay contract to require exactly one finalized receipt, run, signed GitHub evidence row, and linked per-workflow Check

The previous ordering let two identical admissions both choose the new-admission path before either claimed the receipt. The loser then resumed after the winner had linked the shared Check and failed subject authority instead of replaying. Serializing the durable idempotency decision fixes that race without weakening Check selection or moving receipt creation ahead of disabled-event handling.

## Lock and replay invariants

- the new idempotency advisory is the transaction's first lock
- successful leader commit makes the waiter observe and validate the finalized receipt, trust snapshot, and subject evidence
- leader rollback releases the transaction lock and leaves the waiter free to become the new admission
- disabled admissions remain receipt-free, but exact concurrent calls serialize over the one durable skipped subject
- distinct idempotency keys remain concurrent; a 64-bit hash collision can only over-serialize unrelated keys
- existing repository, subject, receipt, and concurrency lock order remains downstream and unchanged

## Validation

- targeted `rustfmt` and `git diff --check`
- store-postgres all-target/all-feature check
- strict store-postgres Clippy with `-D warnings`
- postgres test-target check and strict Clippy with only inherited `large_futures` / `too_many_lines` allowances
- PostgreSQL 18.4 exact concurrent replay: 5/5 passed
- PostgreSQL 18.4 exact disabled-state contract: 1/1 passed
- PostgreSQL 18.4 full `logical_orchestration` module: 7/7 passed
- independent static lock-order and identity-framing review: approved, no findings

All isolated PostgreSQL namespaces were officially cleaned and audited at zero databases and sessions.

## Stacking

Stacked on #257 (`fix/disabled-state-workflow-fixture`) at exact parent `6f02186c444310dcfd67ba3f93f9d9a0466f9e66`.
