### PR TITLE
test(postgres): inject noncurrent custody canary past schema guards

### DIFF
--- a/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
@@ -59,12 +59,10 @@ use automata_ci_store::{
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind,
     MarkGithubRuntimeAuthorityIndeterminate, ObjectKey, OpenRunnerSession,
     ProtectedGithubRuntimeAuthority, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
-    QuarantineGithubRuntimeAuthority, ReconcileGithubRuntimeAuthorities,
-    RegisterProviderDeliveryWorkflowInventory, RejectGithubRuntimeAuthorityMint,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, PublishLogicalJobActivation, QuarantineGithubRuntimeAuthority,
+    ReconcileGithubRuntimeAuthorities, RejectGithubRuntimeAuthorityMint,
     RetryGithubRuntimeAuthorityMint, RetryGithubRuntimeAuthorityRevocation,
     ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerOperationKind,
     RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion, StableRunnerSlot,
@@ -140,23 +138,29 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "automata-ci",
+        "automata",
+    )
+    .expect("repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("runtime-authority-{namespace}"))
             .expect("idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         WORKFLOW_PATH,
         "CI",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(
             format!("runtime-authority/{namespace}/source"),
@@ -177,7 +181,7 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
             0x13,
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         database_epoch,
     )
@@ -186,6 +190,7 @@ fn logical_fixture(namespace: u128, database_epoch: UnixMillis) -> LogicalFixtur
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     LogicalFixture {
@@ -292,6 +297,7 @@ fn retime_logical_admission(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 
@@ -328,16 +334,16 @@ async fn admit_signed_workflow(
     database_epoch: UnixMillis,
 ) -> TestResult {
     let manifest = &fixture.manifest;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        database_epoch,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                database_epoch,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await
         .map_err(|error| format!("repository bootstrap failed: {error:?}"))?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -430,26 +436,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 async fn select_orchestration(

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
@@ -915,6 +915,20 @@ async fn assert_scheduling_policy_roundtrip_and_conflict(
             .await?,
         Some(scheduling_policy.clone())
     );
+    let foreign_scope = LogicalJobSchedulingPolicyScope::new(
+        TenantScope::from_authenticated_tenant_id("activation-policy-other-tenant")?,
+        scheduling_scope.run_id(),
+        scheduling_scope.invocation_id(),
+        scheduling_scope.logical_job_id(),
+    )?;
+    assert_eq!(
+        database
+            .store()
+            .resolved_logical_job_scheduling_policy(&foreign_scope)
+            .await?,
+        None,
+        "the scheduling policy read must remain tenant scoped"
+    );
 
     let changed_policy = ResolvedLogicalJobSchedulingPolicy::for_claim(
         claimed.claim(),

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
@@ -83,6 +83,7 @@ fn admission_base_context(namespace: u128) -> AdmissionObject {
     runtime_context_object(format!("activation/{namespace}/base-context.pb"), 4)
 }
 
+#[allow(clippy::too_many_lines)] // Builds one complete authenticated logical fixture.
 async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> TestResult<Fixture> {
     let tenant_scope = TenantScope::from_authenticated_tenant_id(tenant)?;
     let connection = ProviderConnectionId::from_uuid(Uuid::from_u128(namespace + 20))?;
@@ -138,19 +139,26 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
         vec![first_job],
     )
     .expect("second job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("sample-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![9; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("activation-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("sample-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Verify",
@@ -167,11 +175,12 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
         invocation_id,
         "push",
         admission_object(format!("activation/{namespace}/event"), 3),
-        vec![9; 20],
+        head_sha,
         vec![first, second],
         UnixMillis::new(database_now_ms(database).await?),
     )
     .base_context(admission_base_context(namespace))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical workflow fixture");
     Ok(Fixture {
@@ -187,15 +196,13 @@ async fn fixture(database: &TestDatabase, tenant: &str, namespace: u128) -> Test
 #[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -318,6 +325,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
@@ -1163,15 +1163,15 @@ async fn fixture_with_visibility(
         GithubProviderManifestLimits::github_dot_com_ci(),
         GithubProviderManifestRevision::new(1)?,
     );
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks = GithubServerServiceAuthorityIdentity::new(
         tenant_scope.clone(),
         GithubServerServiceAuthorityId::from_uuid(Uuid::from_u128(namespace + 21))?,
@@ -1265,23 +1265,27 @@ async fn fixture_with_visibility(
         &[2; 64],
         "application/json",
     );
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "automata-ci",
+        "automata",
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![3; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope.clone(),
         WorkflowAdmissionIdempotency::provider_delivery(format!("preparation-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([30; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository,
         workflow,
         ".ci/workflows/ci.yml",
         "Automata CI",
-        "refs/heads/main",
+        git_ref,
         snapshot,
         object(
             format!("preparation/{namespace}/source"),
@@ -1298,10 +1302,11 @@ async fn fixture_with_visibility(
         invocation,
         "push",
         event.clone(),
-        vec![3; 20],
+        head_sha,
         jobs,
         UnixMillis::new(configured_at),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(object(
         format!("preparation/{namespace}/base-context.pb"),
         &[4; 64],
@@ -1323,7 +1328,7 @@ async fn fixture_with_visibility(
                         visibility,
                         "automata-ci/automata",
                     )?,
-                    format!("activation-preparation-{namespace}"),
+                    command.idempotency().key(),
                 )?,
                 Sha256Digest::from_bytes([29; 32]),
                 crate::support::authenticated_github_event_object(&event)?,
@@ -1411,6 +1416,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
@@ -32,13 +32,14 @@ use automata_ci_store::{
     LogicalJobOrchestrationSelectionOutcome, LogicalJobResultClaimOutcome,
     LogicalJobResultRepository as _, LogicalJobResultTarget, LogicalJobResultWorkerId,
     LogicalMaterializationRepository as _, LogicalMaterializationWorkerId, LogicalWorkSelectionId,
-    LogicalWorkSelectionRepository as _, LogicalWorkflowAdmissionRepository as _,
-    LogicalWorkflowAdmissionStoreError, LogicalWorkflowInvocationId, LogicalWorkflowJobId,
-    LogicalWorkflowJobKind, ObjectKey, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
-    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
-    ProviderRepositoryVisibility, PublishLogicalJobActivation, RenewLogicalActivationPreparation,
-    ReusableSecretPermission, TenantScope, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    LogicalWorkSelectionRepository as _, LogicalWorkSelectionStoreError,
+    LogicalWorkflowAdmissionRepository as _, LogicalWorkflowAdmissionStoreError,
+    LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
+    ProviderConnectionId, ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity,
+    ProviderDeliveryRepository as _, ProviderInstallationId, ProviderRepositoryCoordinates,
+    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    PublishLogicalJobActivation, RenewLogicalActivationPreparation, ReusableSecretPermission,
+    StoreError, TenantScope, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -365,6 +366,14 @@ async fn preparation_is_dependency_ready_fenced_replayable_and_workspace_bound()
         };
         assert!(replay.is_replay());
         assert_eq!(replay.claim(), winner.claim());
+        assert_eq!(replay.descriptor(), winner.descriptor());
+        assert!(
+            !replay
+                .descriptor()
+                .execution()
+                .trust_snapshot()
+                .is_construction_placeholder()
+        );
 
         let stale = BindLogicalActivationPreparation::new(
             winner.descriptor().clone(),
@@ -688,6 +697,102 @@ async fn github_shaped_admission_without_historical_provider_evidence_has_no_pro
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
+async fn missing_and_malformed_trust_snapshots_fail_closed_during_preparation() -> TestResult {
+    run_with_database(|database| async move {
+        let fixture = fixture(
+            &database,
+            "activation-preparation-malformed-trust",
+            134_000,
+            JobAuthorityProfile::Standard,
+        )
+        .await?;
+        let mut corruption = database.pool().begin().await?;
+        sqlx::query(
+            "ALTER TABLE workflow_run_trust_snapshots \
+             DISABLE TRIGGER workflow_run_trust_snapshots_reject_update_delete",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        sqlx::query(
+            "UPDATE workflow_run_trust_snapshots \
+             SET snapshot_digest = $2 WHERE run_id = $1",
+        )
+        .bind(fixture.command.run_id().as_uuid())
+        .bind([0x44_u8; 32].as_slice())
+        .execute(&mut *corruption)
+        .await?;
+        sqlx::query(
+            "ALTER TABLE workflow_run_trust_snapshots \
+             ENABLE TRIGGER workflow_run_trust_snapshots_reject_update_delete",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        corruption.commit().await?;
+        assert!(matches!(
+            database
+                .store()
+                .claim_next_logical_job_orchestration(ClaimNextLogicalJobOrchestration::new(
+                    LogicalWorkSelectionId::from_uuid(Uuid::from_u128(234_000))?,
+                    worker(234_001),
+                    UnixMillis::new(database_now_ms(&database).await?),
+                    60_000,
+                )?)
+                .await,
+            Err(LogicalWorkSelectionStoreError::Store(StoreError::CorruptData(message)))
+                if message.contains("trust snapshot digest")
+        ));
+        assert_no_preparation_evidence(&database, fixture.command.run_id()).await?;
+        Ok(())
+    })
+    .await?;
+
+    run_with_database(|database| async move {
+        let fixture = fixture(
+            &database,
+            "activation-preparation-missing-trust",
+            135_000,
+            JobAuthorityProfile::Standard,
+        )
+        .await?;
+        let mut corruption = database.pool().begin().await?;
+        sqlx::query(
+            "ALTER TABLE workflow_run_trust_snapshots \
+             DISABLE TRIGGER workflow_run_trust_snapshots_reject_update_delete",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        sqlx::query("DELETE FROM workflow_run_trust_snapshots WHERE run_id = $1")
+            .bind(fixture.command.run_id().as_uuid())
+            .execute(&mut *corruption)
+            .await?;
+        sqlx::query(
+            "ALTER TABLE workflow_run_trust_snapshots \
+             ENABLE TRIGGER workflow_run_trust_snapshots_reject_update_delete",
+        )
+        .execute(&mut *corruption)
+        .await?;
+        corruption.commit().await?;
+        assert!(matches!(
+            database
+                .store()
+                .claim_next_logical_job_orchestration(ClaimNextLogicalJobOrchestration::new(
+                    LogicalWorkSelectionId::from_uuid(Uuid::from_u128(235_000))?,
+                    worker(235_001),
+                    UnixMillis::new(database_now_ms(&database).await?),
+                    60_000,
+                )?)
+                .await,
+            Err(LogicalWorkSelectionStoreError::Store(StoreError::CorruptData(message)))
+                if message == "locked preparation authority was rejected"
+        ));
+        assert_no_preparation_evidence(&database, fixture.command.run_id()).await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 and AUTOMATA_TEST_DATABASE_URL"]
 async fn selector_quarantines_expired_max_generation_and_advances_to_newer_work() -> TestResult {
     run_with_database(|database| async move {
         let fixture = fixture(
@@ -989,11 +1094,45 @@ async fn select_orchestration_preparation(
         ))
         .await?;
     match consumed.authority() {
-        ConsumedLogicalJobOrchestrationAuthority::Preparation(claimed) => Ok(claimed.clone()),
+        ConsumedLogicalJobOrchestrationAuthority::Preparation(claimed) => {
+            assert_eq!(
+                claimed.descriptor().execution().trust_snapshot(),
+                fixture.command.trust_snapshot(),
+            );
+            assert!(
+                !claimed
+                    .descriptor()
+                    .execution()
+                    .trust_snapshot()
+                    .is_construction_placeholder()
+            );
+            Ok(claimed.clone())
+        }
         authority @ ConsumedLogicalJobOrchestrationAuthority::Activation(_) => {
             Err(format!("expected preparation authority, got {authority:?}").into())
         }
     }
+}
+
+async fn assert_no_preparation_evidence(database: &TestDatabase, run_id: RunId) -> TestResult {
+    let evidence_count: i64 = sqlx::query_scalar(
+        r"
+        SELECT (
+            SELECT count(*)
+            FROM logical_workflow_activation_preparation_claims
+            WHERE run_id = $1
+        ) + (
+            SELECT count(*)
+            FROM logical_workflow_activation_preparations
+            WHERE run_id = $1
+        )
+        ",
+    )
+    .bind(run_id.as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(evidence_count, 0);
+    Ok(())
 }
 
 async fn bind_preparation(
@@ -1047,7 +1186,13 @@ async fn select_activation(
         ))
         .await?;
     match consumed.authority() {
-        ConsumedLogicalJobOrchestrationAuthority::Activation(claimed) => Ok(claimed.clone()),
+        ConsumedLogicalJobOrchestrationAuthority::Activation(claimed) => {
+            assert_eq!(
+                claimed.execution().trust_snapshot(),
+                fixture.command.trust_snapshot(),
+            );
+            Ok(claimed.clone())
+        }
         authority @ ConsumedLogicalJobOrchestrationAuthority::Preparation(_) => {
             Err(format!("expected activation authority, got {authority:?}").into())
         }

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -45,13 +45,11 @@ use automata_ci_store::{
     LogicalWorkflowAdmissionRepository as _, LogicalWorkflowInvocationId, LogicalWorkflowJobId,
     LogicalWorkflowJobKind, ObjectKey, OpenRunnerSession, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, QuarantineLogicalInstanceResult,
-    RegisterProviderDeliveryWorkflowInventory, ReusableSecretPermission, RoutingDocument,
-    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, TenantScope,
-    WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
+    QuarantineLogicalInstanceResult, ReusableSecretPermission, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, RunnerSessionFence, TenantScope, WorkflowAdmissionIdempotency,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -1198,6 +1196,7 @@ async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
     )
 }
 
+#[allow(clippy::too_many_lines)] // Builds one complete authenticated logical fixture.
 fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile) -> Fixture {
     let tenant_scope = TenantScope::from_authenticated_tenant_id(tenant).expect("tenant");
     let repository_visibility = match authority_profile {
@@ -1249,19 +1248,27 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("result-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1278,7 +1285,7 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         invocation_id,
         "push",
         admission_object(format!("instance-result/{namespace}/event"), 0x13),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -1287,6 +1294,7 @@ fn fixture(tenant: &str, namespace: u128, authority_profile: JobAuthorityProfile
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     Fixture {
@@ -1307,15 +1315,15 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
     let github_repository = manifest.github_repository_id();
     let repository_visibility = manifest.repository_visibility();
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     ensure_instance_result_server_authorities(database, fixture, configured_at).await?;
     let delivery_observed_at = database_now_ms(database).await?;
     let accepted = database
@@ -1332,7 +1340,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
                         repository_visibility,
                         format!("example/project-{namespace}"),
                     )?,
-                    format!("instance-result-{namespace}"),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -1361,26 +1369,14 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -1473,6 +1469,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
@@ -1307,19 +1307,27 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("logical-result-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1344,7 +1352,7 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -1353,6 +1361,7 @@ fn fixture(tenant: &str, namespace: u128) -> Fixture {
         &[0x15; 512],
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("logical admission");
     Fixture {
@@ -1410,6 +1419,21 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         )
         .expect("build job"),
     ];
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!(
@@ -1417,14 +1441,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         ))
         .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1449,7 +1466,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         logical_jobs,
         UnixMillis::new(1_000),
     )
@@ -1458,6 +1475,7 @@ fn dependency_fixtures(tenant: &str, namespace: u128) -> [Fixture; 3] {
         &[0x15; 512],
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("dependency admission");
     [base_id, prepare_id, build_id].map(|logical_job_id| Fixture {
@@ -1509,15 +1527,15 @@ fn fixture_manifest(tenant: TenantScope, namespace: u128) -> GithubProviderManif
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture) -> TestResult {
     let manifest = &fixture.manifest;
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -1556,7 +1574,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
                         manifest.repository_visibility(),
                         manifest.github_repository_name().as_str(),
                     )?,
-                    format!("logical-job-result-{}", fixture.namespace),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -1639,6 +1657,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -2027,6 +2027,16 @@ async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
     )
 }
 
+fn lower_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
 async fn wait_until_database_after(database: &TestDatabase, target_ms: i64) -> TestResult {
     while database_now_ms(database).await? <= target_ms {
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -2074,23 +2084,27 @@ async fn fixture_with_concurrency(
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository_id.get().to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("materialize-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository_id.get().to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(format!("materialization/{namespace}/source"), 0x11),
         admission_object_from_bytes(
@@ -2103,10 +2117,11 @@ async fn fixture_with_concurrency(
         invocation_id,
         "push",
         admission_object(format!("materialization/{namespace}/event"), 0x13),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(clock_origin_ms),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(runtime_context_object(
         format!("materialization/{namespace}/base-context.pb"),
         0x15,
@@ -2522,15 +2537,13 @@ async fn admit_authenticated_fixture(
     publish_publicly: bool,
 ) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
 
     let manifest = &fixture.manifest;
     database
@@ -2590,7 +2603,7 @@ async fn admit_authenticated_fixture(
                         manifest.repository_visibility(),
                         manifest.github_repository_name().as_str(),
                     )?,
-                    format!("materialization-{}", fixture.namespace),
+                    fixture.command.idempotency().key(),
                 )?,
                 fixture.command.request_digest(),
                 crate::support::authenticated_github_event_object(fixture.command.event())?,
@@ -2626,7 +2639,7 @@ async fn admit_authenticated_fixture(
                 claimed.claim(),
                 ProviderDeliveryWorkflowInventory::new(
                     fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
+                    lower_hex(fixture.command.head_sha()),
                     Sha256Digest::from_bytes([0x90; 32]),
                     vec![
                         ProviderDeliveryWorkflowInventoryEntry::new(
@@ -2704,6 +2717,7 @@ fn logical_command_at(
         builder = builder.base_context(base_context.clone());
     }
     builder = builder.concurrency(command.concurrency().cloned());
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -160,6 +160,17 @@ async fn sealed_reusable_child_reaches_materialization_and_tampering_fails_close
             .ok_or("planned reusable call was not selected for autonomous publication")?;
         assert_eq!(ready_call.child_invocation_id(), child_invocation_id);
         assert_eq!(
+            ready_call.preparation().execution().trust_snapshot(),
+            fixture.command.trust_snapshot(),
+        );
+        assert!(
+            !ready_call
+                .preparation()
+                .execution()
+                .trust_snapshot()
+                .is_construction_placeholder()
+        );
+        assert_eq!(
             ready_call.permissions().digest(),
             publication.permission_digest()
         );

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -239,6 +239,15 @@ async fn stage_authenticated_admission(
             UnixMillis::new(configured_at),
         )?)
         .await?;
+    stage_authenticated_delivery(database, &manifest, command, namespace).await
+}
+
+async fn stage_authenticated_delivery(
+    database: &TestDatabase,
+    manifest: &GithubProviderManifest,
+    command: &AdmitLogicalWorkflowRun,
+    namespace: u128,
+) -> TestResult<(AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim)> {
     let delivery_observed_at = database_now_ms(database).await?;
     let accepted = database
         .store()
@@ -285,7 +294,7 @@ async fn stage_authenticated_admission(
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
     crate::support::register_provider_delivery_workflow_inventory(
         database,
-        &manifest,
+        manifest,
         command,
         claimed.claim(),
         claimed.claimed_at(),
@@ -455,6 +464,104 @@ fn fixture_at(
     ))
     .build()
     .expect("logical admission fixture")
+}
+
+fn fixture_for_same_workflow(
+    workflow: &AdmitLogicalWorkflowRun,
+    idempotency_key: &str,
+    request_digest: u8,
+    namespace: u128,
+) -> AdmitLogicalWorkflowRun {
+    let distinct = fixture(
+        workflow.tenant().as_str(),
+        idempotency_key,
+        request_digest,
+        namespace,
+    );
+    AdmitLogicalWorkflowRun::builder(
+        workflow.tenant().clone(),
+        distinct.idempotency().clone(),
+        distinct.request_digest(),
+        workflow.repository().clone(),
+        workflow.workflow_id(),
+        workflow.workflow_path(),
+        workflow.workflow_name(),
+        workflow.git_ref(),
+        workflow.snapshot_id(),
+        workflow.source().clone(),
+        workflow.plan().clone(),
+        distinct.run_id(),
+        distinct.run_attempt(),
+        distinct.root_invocation_id(),
+        distinct.event_name(),
+        distinct.event().clone(),
+        distinct.head_sha().to_vec(),
+        distinct.jobs().to_vec(),
+        distinct.admitted_at(),
+    )
+    .actor(distinct.actor().expect("provider admission actor"))
+    .trust_snapshot(workflow.trust_snapshot().clone())
+    .base_context(
+        distinct
+            .base_context()
+            .expect("provider admission base context")
+            .clone(),
+    )
+    .build()
+    .expect("same-workflow logical admission fixture")
+}
+
+async fn assert_workflow_enable_state_history(
+    database: &TestDatabase,
+    command: &AdmitLogicalWorkflowRun,
+    expected: &[(i64, &str)],
+) -> TestResult {
+    let history: Vec<(i64, String)> = sqlx::query_as(
+        r"
+        SELECT state_revision, enable_state::text
+        FROM workflow_enable_state_revisions
+        WHERE tenant_id = $1
+          AND repository_id = $2
+          AND workflow_id = $3
+        ORDER BY state_revision
+        ",
+    )
+    .bind(command.tenant().as_str())
+    .bind(command.repository().id().as_uuid())
+    .bind(command.workflow_id().as_uuid())
+    .fetch_all(database.pool())
+    .await?;
+    assert_eq!(
+        history,
+        expected
+            .iter()
+            .map(|(revision, state)| (*revision, (*state).to_owned()))
+            .collect::<Vec<_>>()
+    );
+    let current: (i64, String) = sqlx::query_as(
+        r"
+        SELECT current.state_revision, revision.enable_state::text
+        FROM workflow_enable_state_current AS current
+        JOIN workflow_enable_state_revisions AS revision
+          ON revision.tenant_id = current.tenant_id
+         AND revision.repository_id = current.repository_id
+         AND revision.workflow_id = current.workflow_id
+         AND revision.state_revision = current.state_revision
+        WHERE current.tenant_id = $1
+          AND current.repository_id = $2
+          AND current.workflow_id = $3
+        ",
+    )
+    .bind(command.tenant().as_str())
+    .bind(command.repository().id().as_uuid())
+    .bind(command.workflow_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    let expected_current = expected
+        .last()
+        .ok_or("expected enable-state history is empty")?;
+    assert_eq!(current, (expected_current.0, expected_current.1.to_owned()));
+    Ok(())
 }
 
 async fn assert_logical_admission_shape(
@@ -910,6 +1017,136 @@ async fn admission_is_atomic_exact_and_has_no_concrete_jobs() -> TestResult {
 
 #[tokio::test]
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+#[allow(clippy::too_many_lines)] // One sequential proof covers initialization, reuse, and disable.
+async fn distinct_provider_admissions_reuse_exact_workflow_enable_state() -> TestResult {
+    run_with_database(|database| async move {
+        const TENANT: &str = "logical-enable-state-reuse";
+        const WORKFLOW_NAMESPACE: u128 = 2_450;
+
+        seed_tenant(&database, TENANT).await?;
+        let first_fixture = fixture(TENANT, "delivery-enable-first", 0xa1, WORKFLOW_NAMESPACE);
+        let second_fixture = fixture_for_same_workflow(
+            &first_fixture,
+            "delivery-enable-second",
+            0xa2,
+            WORKFLOW_NAMESPACE + 10,
+        );
+        let disabled_fixture = fixture_for_same_workflow(
+            &first_fixture,
+            "delivery-enable-disabled",
+            0xa3,
+            WORKFLOW_NAMESPACE + 20,
+        );
+        let manifest = fixture_manifest(first_fixture.tenant().clone(), WORKFLOW_NAMESPACE);
+
+        let (first_command, first_claim) =
+            stage_authenticated_admission(&database, &first_fixture, WORKFLOW_NAMESPACE).await?;
+        let first = database
+            .store()
+            .admit_authenticated_github_delivery(
+                first_command.clone(),
+                first_claim,
+                first_command.admitted_at(),
+            )
+            .await?;
+        assert!(!first.is_replay());
+
+        let (second_command, second_claim) =
+            stage_authenticated_delivery(&database, &manifest, &second_fixture, WORKFLOW_NAMESPACE)
+                .await?;
+        let second = database
+            .store()
+            .admit_authenticated_github_delivery(
+                second_command.clone(),
+                second_claim,
+                second_command.admitted_at(),
+            )
+            .await?;
+        assert!(!second.is_replay());
+        assert_ne!(first.run_id(), second.run_id());
+        assert_workflow_enable_state_history(&database, &first_command, &[(1, "enabled")]).await?;
+
+        let disabled = WorkflowEnableStateRecord::new(
+            first_command.tenant().clone(),
+            first_command.repository().id(),
+            first_command.workflow_id(),
+            first_command.workflow_path(),
+            WorkflowEnableStateRevision::new(2)?,
+            WorkflowEnableState::Disabled,
+            UnixMillis::new(database_now_ms(&database).await?),
+        )?;
+        let disabled_state = database
+            .store()
+            .set_workflow_enable_state(SetWorkflowEnableState::new(
+                disabled,
+                Some(WorkflowEnableStateRevision::new(1)?),
+            )?)
+            .await?;
+        assert!(!disabled_state.is_replay());
+
+        let (disabled_command, disabled_claim) = stage_authenticated_delivery(
+            &database,
+            &manifest,
+            &disabled_fixture,
+            WORKFLOW_NAMESPACE,
+        )
+        .await?;
+        let disabled_delivery_id = disabled_claim.claim().delivery_id();
+        assert!(matches!(
+            database
+                .store()
+                .admit_authenticated_github_delivery(
+                    disabled_command.clone(),
+                    disabled_claim,
+                    disabled_command.admitted_at(),
+                )
+                .await,
+            Err(LogicalWorkflowAdmissionStoreError::WorkflowDisabled)
+        ));
+        let disabled_run_counts: (i64, i64) = sqlx::query_as(
+            r"
+            SELECT (SELECT count(*) FROM workflow_runs WHERE id = $1),
+                   (SELECT count(*) FROM workflow_admission_receipts WHERE run_id = $1)
+            ",
+        )
+        .bind(disabled_command.run_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(disabled_run_counts, (0, 0));
+        let terminal: (i64, String, Option<Uuid>, Option<String>) = sqlx::query_as(
+            r"
+            SELECT count(*) OVER (), progress.outcome_kind, progress.run_id, progress.reason
+            FROM event_subject_selections AS selection
+            JOIN event_subject_progress AS progress
+              ON progress.tenant_id = selection.tenant_id
+             AND progress.subject_id = selection.subject_id
+             AND progress.selection_digest = selection.selection_digest
+            WHERE selection.origin_kind_name = 'provider_delivery'
+              AND selection.origin_id = $1
+              AND selection.workflow_path = $2
+            ",
+        )
+        .bind(disabled_delivery_id.as_uuid())
+        .bind(disabled_command.workflow_path())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            terminal,
+            (1, "skipped".into(), None, Some("workflow.disabled".into()))
+        );
+        assert_workflow_enable_state_history(
+            &database,
+            &first_command,
+            &[(1, "enabled"), (2, "disabled")],
+        )
+        .await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
 #[allow(clippy::too_many_lines)] // One proof covers disable CAS, concurrent terminalization, and SQL guards.
 async fn disabled_state_blocks_new_event_admission_but_remains_versioned() -> TestResult {
     run_with_database(|database| async move {
@@ -1292,6 +1529,7 @@ async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> Test
         assert_ne!(left.is_replay(), right.is_replay());
         assert_eq!(left.run_id(), right.run_id());
         assert_eq!(left.run_number(), right.run_number());
+        assert_workflow_enable_state_history(&database, &command, &[(1, "enabled")]).await?;
 
         let conflicting_trust_snapshot =
             crate::support::authenticated_github_trust_snapshot_for_actor(

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1195,6 +1195,23 @@ async fn disabled_state_blocks_new_event_admission_but_remains_versioned() -> Te
         let command = fixture("logical-disabled", "delivery-disabled", 43, 130);
         let (command, authenticated) =
             stage_authenticated_admission(&database, &command, 130).await?;
+        let workflow_id: Uuid = sqlx::query_scalar(
+            r"
+            INSERT INTO workflow_definitions (
+                id, repository_id, path, created_at_ms, updated_at_ms
+            ) VALUES ($1,$2,$3,$4,$4)
+            ON CONFLICT (repository_id, path)
+            DO UPDATE SET updated_at_ms = EXCLUDED.updated_at_ms
+            RETURNING id
+            ",
+        )
+        .bind(command.workflow_id().as_uuid())
+        .bind(command.repository().id().as_uuid())
+        .bind(command.workflow_path())
+        .bind(command.admitted_at().get())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(workflow_id, command.workflow_id().as_uuid());
         let disabled = WorkflowEnableStateRecord::new(
             command.tenant().clone(),
             command.repository().id(),

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1562,6 +1562,7 @@ async fn logical_admission_replay_rejects_forward_plan_and_orchestration_schemas
 
 #[tokio::test]
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+#[allow(clippy::too_many_lines)] // One race proof covers replay and both conflict boundaries.
 async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> TestResult {
     run_with_database(|database| async move {
         seed_tenant(&database, "logical-replay").await?;
@@ -1588,6 +1589,46 @@ async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> Test
         assert_eq!(left.run_id(), right.run_id());
         assert_eq!(left.run_number(), right.run_number());
         assert_workflow_enable_state_history(&database, &command, &[(1, "enabled")]).await?;
+        let exact_counts: (i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT
+                (SELECT count(*)
+                   FROM workflow_admission_receipts
+                  WHERE tenant_id = $1
+                    AND idempotency_kind = $2
+                    AND idempotency_key = $3
+                    AND repository_id = $4
+                    AND run_id = $5),
+                (SELECT count(*)
+                   FROM workflow_runs
+                  WHERE repository_id = $4 AND id = $5),
+                (SELECT count(*)
+                   FROM github_workflow_run_subject_evidence
+                  WHERE tenant_id = $1
+                    AND repository_id = $4
+                    AND run_id = $5
+                    AND provider_delivery_id = $6
+                    AND workflow_path = $7),
+                (SELECT count(*)
+                   FROM github_check_subjects
+                  WHERE tenant_id = $1
+                    AND repository_id = $4
+                    AND provider_delivery_id = $6
+                    AND subject_kind = 'workflow'
+                    AND subject_key = $7
+                    AND workflow_run_id = $5)
+            ",
+        )
+        .bind(command.tenant().as_str())
+        .bind(command.idempotency().kind())
+        .bind(command.idempotency().key())
+        .bind(command.repository().id().as_uuid())
+        .bind(command.run_id().as_uuid())
+        .bind(authenticated.claim().delivery_id().as_uuid())
+        .bind(command.workflow_path())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(exact_counts, (1, 1, 1, 1));
 
         let conflicting_trust_snapshot =
             crate::support::authenticated_github_trust_snapshot_for_actor(

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -8,9 +8,7 @@ use automata_ci_auth::{
 };
 use automata_ci_core::{
     JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile, OperationId, RunId, Sha256Digest,
-    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
-    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
-    UnixMillis, WorkflowId, WorkflowJobKey,
+    TrustSnapshot, UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AdmissionObject,
@@ -78,33 +76,6 @@ fn object_with_media(key: String, digest: u8, media_type: &str) -> AdmissionObje
         media_type,
     )
     .expect("admission object")
-}
-
-fn trusted_snapshot(namespace: u128) -> TrustSnapshot {
-    let repository_id = namespace.to_string();
-    TrustPolicy::current()
-        .evaluate(
-            TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
-                .with_original_actor(
-                    TrustActorEvidence::new(
-                        format!("actor-{namespace}"),
-                        TrustActorKind::User,
-                        TrustAutomationKind::None,
-                    )
-                    .expect("actor evidence"),
-                )
-                .with_repositories(
-                    TrustRepositoryEvidence::new(repository_id.as_str(), "owner-1")
-                        .expect("source repository"),
-                    TrustRepositoryEvidence::new(repository_id.as_str(), "owner-1")
-                        .expect("target repository"),
-                )
-                .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
-                .with_revisions("source-sha", "target-sha", "execution-sha")
-                .with_fork(false)
-                .with_token_recursion(TrustTokenRecursion::Suppressed),
-        )
-        .expect("trusted snapshot")
 }
 
 async fn prepare_job(
@@ -206,8 +177,10 @@ fn fixture_manifest_binding(
         GithubServerServiceAppClientId::new(format!("Iv1.logical-orchestration-{namespace}"))
             .expect("app client ID"),
         GithubServerServiceJwtIssuer::AppClientId,
-        Sha256Digest::from_bytes([0x71; 32]),
-        GithubServerServiceRevision::new(1).expect("configuration revision"),
+        Sha256Digest::from_bytes(
+            [u8::try_from(0x70 + manifest_revision).expect("small manifest revision"); 32],
+        ),
+        GithubServerServiceRevision::new(manifest_revision).expect("configuration revision"),
         GithubProviderWebhookVerifierFingerprint::from_sha256(Sha256Digest::from_bytes([0x72; 32]))
             .expect("webhook fingerprint"),
         GithubServerServiceRevision::new(1).expect("webhook revision"),
@@ -234,15 +207,15 @@ async fn stage_authenticated_admission(
 ) -> TestResult<(AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim)> {
     let manifest = fixture_manifest(command.tenant().clone(), namespace);
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -435,22 +408,28 @@ fn fixture_at(
         vec![first_id],
     )
     .expect("second job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "sample-owner",
+        format!("sample-{namespace}"),
+    )
+    .expect("repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(idempotency_key).expect("idempotency"),
         Sha256Digest::from_bytes([request_digest; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "sample-owner",
-            format!("sample-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Verify",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         object(format!("logical/{namespace}/source"), 1),
         object_with_media(
@@ -463,12 +442,12 @@ fn fixture_at(
         root_id,
         "push",
         object(format!("logical/{namespace}/event"), 3),
-        vec![9; 20],
+        head_sha,
         vec![first, second],
         admitted_at,
     )
     .actor("sample-actor")
-    .trust_snapshot(trusted_snapshot(namespace))
+    .trust_snapshot(trust_snapshot)
     .base_context(object_with_media(
         format!("logical/{namespace}/base-context.pb"),
         4,
@@ -745,15 +724,20 @@ async fn admission_is_atomic_exact_and_has_no_concrete_jobs() -> TestResult {
             2,
             2,
         );
+        let replacement_bootstrap =
+            github_manifest_fixture::fixture_github_repository_bootstrap(
+                replacement,
+                UnixMillis::new(database_now_ms(&database).await?),
+            );
         database
             .store()
-            .bootstrap_github_provider_repository(
-                github_manifest_fixture::fixture_github_repository_bootstrap(
-                    replacement,
-                    UnixMillis::new(database_now_ms(&database).await?),
-                ),
-            )
+            .bootstrap_github_provider_repository(replacement_bootstrap.clone())
             .await?;
+        crate::support::seed_fresh_github_workflow_permission_defaults(
+            &database,
+            &replacement_bootstrap,
+        )
+        .await?;
         let delivery_id = authenticated.claim().delivery_id();
         let origin = EventSubjectOrigin::ProviderDelivery(delivery_id);
         let subject_id = EventSubjectId::derive(
@@ -1309,11 +1293,18 @@ async fn concurrent_replay_has_one_insert_and_changed_digest_conflicts() -> Test
         assert_eq!(left.run_id(), right.run_id());
         assert_eq!(left.run_number(), right.run_number());
 
+        let conflicting_trust_snapshot =
+            crate::support::authenticated_github_trust_snapshot_for_actor(
+                command.repository(),
+                command.git_ref(),
+                command.head_sha(),
+                "conflicting-authenticated-github-fixture-actor",
+            )?;
         let conflicting_trust = logical_command_at_with_trust_snapshot(
             &command,
             command.idempotency().clone(),
             command.admitted_at(),
-            trusted_snapshot(201),
+            conflicting_trust_snapshot,
         )?;
         assert!(matches!(
             database

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1018,8 +1018,14 @@ async fn admission_is_atomic_exact_and_has_no_concrete_jobs() -> TestResult {
                 .store()
                 .record_event_subject_progress(cross_workflow_progress)
                 .await,
-            Err(EventSubjectStoreError::Operation(_))
+            Err(EventSubjectStoreError::Conflict)
         ));
+        let cross_workflow_progress_count: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM event_subject_progress WHERE subject_id = $1")
+                .bind(wrong_subject_id.as_uuid())
+                .fetch_one(database.pool())
+                .await?;
+        assert_eq!(cross_workflow_progress_count, 0);
         Ok(())
     })
     .await

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -1057,6 +1057,31 @@ async fn distinct_provider_admissions_reuse_exact_workflow_enable_state() -> Tes
             .await?;
         assert!(!first.is_replay());
 
+        let replayed_at = UnixMillis::new(
+            database_now_ms(&database)
+                .await?
+                .max(first_command.admitted_at().get() + 1),
+        );
+        let retimed_first_command = logical_command_at(&first_command, replayed_at)?;
+        let replay = database
+            .store()
+            .admit_authenticated_github_delivery(retimed_first_command, first_claim, replayed_at)
+            .await?;
+        assert!(replay.is_replay());
+        assert_eq!(replay.run_id(), first.run_id());
+        let replay_evidence: (i64, i64, i64, i64) = sqlx::query_as(
+            r"
+            SELECT (SELECT count(*) FROM workflow_runs WHERE id = $1),
+                   (SELECT count(*) FROM workflow_admission_receipts WHERE run_id = $1),
+                   (SELECT count(*) FROM workflow_run_trust_snapshots WHERE run_id = $1),
+                   (SELECT count(*) FROM event_subject_progress WHERE run_id = $1)
+            ",
+        )
+        .bind(first.run_id().as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(replay_evidence, (1, 1, 1, 1));
+
         let (second_command, second_claim) =
             stage_authenticated_delivery(&database, &manifest, &second_fixture, WORKFLOW_NAMESPACE)
                 .await?;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -8,7 +8,11 @@ use automata_ci_auth::{
 };
 use automata_ci_core::{
     JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile, OperationId, RunId, Sha256Digest,
-    TrustSnapshot, UnixMillis, WorkflowId, WorkflowJobKey,
+    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustCacheAuthority,
+    TrustEnvironmentAuthority, TrustEventKind, TrustEvidence, TrustOidcAuthority, TrustOriginKind,
+    TrustOutputAuthority, TrustPermissionAuthority, TrustPolicy, TrustRepositoryEvidence,
+    TrustResultsAuthority, TrustSecretAuthority, TrustSnapshot, TrustSourceClass,
+    TrustTokenRecursion, UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AdmissionObject,
@@ -1859,9 +1863,45 @@ async fn seed_dispatch_actor(
     Ok((actor, role_id))
 }
 
+fn workflow_dispatch_trust_snapshot(
+    signed: &AdmitLogicalWorkflowRun,
+    actor: &ManagementActor,
+    repository_owner_id: &str,
+) -> TrustSnapshot {
+    let actor = TrustActorEvidence::new(
+        actor.principal_id().as_str(),
+        TrustActorKind::User,
+        TrustAutomationKind::None,
+    )
+    .expect("workflow dispatch actor trust evidence");
+    let repository = TrustRepositoryEvidence::new(
+        signed.repository().provider_repository_id(),
+        repository_owner_id,
+    )
+    .expect("workflow dispatch repository trust evidence");
+    let revision = lower_hex(signed.head_sha());
+    TrustPolicy::current()
+        .evaluate(
+            TrustEvidence::new(
+                TrustOriginKind::WorkflowDispatch,
+                TrustEventKind::WorkflowDispatch,
+            )
+            .with_original_actor(actor.clone())
+            .with_triggering_actor(actor)
+            .with_repositories(repository.clone(), repository)
+            .with_refs(signed.git_ref(), signed.git_ref(), signed.git_ref())
+            .with_revisions(revision.as_str(), revision.as_str(), revision.as_str())
+            .with_fork(false)
+            .with_token_recursion(TrustTokenRecursion::External),
+        )
+        .expect("workflow dispatch trust snapshot")
+}
+
+#[allow(clippy::too_many_arguments)] // Fixture keeps independently varied dispatch facts explicit.
 fn workflow_dispatch_fixture(
     signed: &AdmitLogicalWorkflowRun,
     actor: &ManagementActor,
+    repository_owner_id: &str,
     source: AdmissionObject,
     operation_id: OperationId,
     digest: u8,
@@ -1916,6 +1956,11 @@ fn workflow_dispatch_fixture(
         admitted_at,
     )
     .actor(actor.principal_id().as_str())
+    .trust_snapshot(workflow_dispatch_trust_snapshot(
+        signed,
+        actor,
+        repository_owner_id,
+    ))
     .base_context(object_with_media(
         format!("logical/{namespace}/dispatch-context.pb"),
         0x92,
@@ -1980,6 +2025,7 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
         let substituted_dispatch = workflow_dispatch_fixture(
             &signed,
             &actor,
+            source.repository_owner_id(),
             substituted_source.clone(),
             substituted_operation,
             0xed,
@@ -2014,11 +2060,85 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
         let dispatch = workflow_dispatch_fixture(
             &signed,
             &actor,
+            source.repository_owner_id(),
             signed.source().clone(),
             operation_id,
             0x93,
             800,
             admitted_at,
+        );
+        let trust_snapshot = dispatch.trust_snapshot();
+        assert!(!trust_snapshot.is_construction_placeholder());
+        assert!(trust_snapshot.evidence_complete());
+        assert_eq!(trust_snapshot.source_class(), TrustSourceClass::SameRepository);
+        let evidence = trust_snapshot.evidence();
+        assert_eq!(
+            (
+                evidence.origin(),
+                evidence.event(),
+                evidence.fork(),
+                evidence.upstream(),
+                evidence.token_recursion(),
+            ),
+            (
+                TrustOriginKind::WorkflowDispatch,
+                TrustEventKind::WorkflowDispatch,
+                Some(false),
+                None,
+                TrustTokenRecursion::External,
+            )
+        );
+        for actor_evidence in [evidence.original_actor(), evidence.triggering_actor()] {
+            let actor_evidence = actor_evidence.expect("dispatch actor trust evidence");
+            assert_eq!(actor_evidence.id(), actor.principal_id().as_str());
+            assert_eq!(actor_evidence.kind(), TrustActorKind::User);
+            assert_eq!(actor_evidence.automation(), TrustAutomationKind::None);
+        }
+        for repository in [evidence.source_repository(), evidence.target_repository()] {
+            let repository = repository.expect("dispatch repository trust evidence");
+            assert_eq!(repository.id(), source.repository().provider_repository_id());
+            assert_eq!(repository.owner_id(), source.repository_owner_id());
+        }
+        assert_eq!(
+            (
+                evidence.source_ref(),
+                evidence.target_ref(),
+                evidence.execution_ref(),
+            ),
+            (Some(signed.git_ref()), Some(signed.git_ref()), Some(signed.git_ref()))
+        );
+        assert_eq!(
+            (
+                evidence.source_revision(),
+                evidence.target_revision(),
+                evidence.execution_revision(),
+            ),
+            (
+                Some(commit_sha.as_str()),
+                Some(commit_sha.as_str()),
+                Some(commit_sha.as_str()),
+            )
+        );
+        let authority = trust_snapshot.authority();
+        assert_eq!(
+            (
+                authority.permissions(),
+                authority.secrets(),
+                authority.cache(),
+                authority.environment(),
+                authority.oidc(),
+                authority.outputs(),
+                authority.results(),
+            ),
+            (
+                TrustPermissionAuthority::Requested,
+                TrustSecretAuthority::Eligible,
+                TrustCacheAuthority::ReadWrite,
+                TrustEnvironmentAuthority::Eligible,
+                TrustOidcAuthority::Eligible,
+                TrustOutputAuthority::Standard,
+                TrustResultsAuthority::Standard,
+            )
         );
         let claim = AuthenticatedWorkflowDispatchClaim::new(
             actor.clone(),
@@ -2107,6 +2227,7 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
         let changed = workflow_dispatch_fixture(
             &signed,
             &actor,
+            source.repository_owner_id(),
             signed.source().clone(),
             operation_id,
             0x94,
@@ -2167,6 +2288,7 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
         let disabled_dispatch = workflow_dispatch_fixture(
             &signed,
             &actor,
+            source.repository_owner_id(),
             signed.source().clone(),
             disabled_operation,
             0x95,
@@ -2212,6 +2334,7 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
         let changed_disabled = workflow_dispatch_fixture(
             &signed,
             &actor,
+            source.repository_owner_id(),
             signed.source().clone(),
             disabled_operation,
             0x96,

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -198,6 +198,12 @@ fn fixture_manifest_binding(
         GithubInstallationBindingGeneration::new(installation_generation)
             .expect("installation generation"),
     )
+    .with_repository_owner_id(
+        ProviderRepositoryOwnerId::new(
+            u64::try_from(namespace + 104).expect("repository owner ID"),
+        )
+        .expect("repository owner ID"),
+    )
 }
 
 async fn stage_authenticated_admission(
@@ -1933,6 +1939,7 @@ async fn authenticated_dispatch_resolves_signed_source_audits_and_replays_exactl
             .await?
             .ok_or("signed source was not resolved")?;
         assert_eq!(source.repository(), signed.repository());
+        assert_eq!(source.repository_owner_id(), "804");
         assert_eq!(source.workflow_id(), signed.workflow_id());
         assert_eq!(source.workflow_path(), signed.workflow_path());
         assert_eq!(source.source(), signed.source());

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
@@ -2126,21 +2126,26 @@ async fn fixture(
         LogicalWorkflowJobKind::Steps,
         Vec::new(),
     )?];
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("renewal-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("renewal-{namespace}"))?,
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("renewal-{namespace}"),
-        )?,
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Renewal ACK",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object(format!("renewal/{namespace}/source"), 1, "application/json"),
         admission_object(
@@ -2153,10 +2158,11 @@ async fn fixture(
         invocation_id,
         "push",
         admission_object(format!("renewal/{namespace}/event"), 3, "application/json"),
-        vec![9; 20],
+        head_sha,
         admitted_jobs,
         UnixMillis::new(database_now_ms(database).await?),
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(admission_object(
         format!("renewal/{namespace}/base-context"),
         4,
@@ -2175,15 +2181,13 @@ async fn fixture(
 #[allow(clippy::too_many_lines)] // The fixture stages one complete authenticated delivery transaction.
 async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixture) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -2305,6 +2309,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
@@ -31,12 +31,10 @@ use automata_ci_store::{
     LogicalWorkSelectionId, LogicalWorkSelectionRepository as _,
     LogicalWorkflowAdmissionRepository as _, LogicalWorkflowInvocationId, LogicalWorkflowJobId,
     LogicalWorkflowJobKind, ObjectKey, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, TenantScope, WorkflowAdmissionIdempotency,
-    WorkflowConcurrency, WorkflowSnapshotId,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, TenantScope, WorkflowAdmissionIdempotency, WorkflowConcurrency,
+    WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
@@ -414,15 +412,15 @@ async fn admit_authenticated_fixture(
     fixture: &Fixture,
 ) -> TestResult<Uuid> {
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        fixture.manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     ensure_fixture_authority(
         database,
         fixture,
@@ -464,26 +462,14 @@ async fn admit_authenticated_fixture(
     if claimed.claim().delivery_id() != accepted.delivery_id() {
         return Err("the fixture claimed a different provider delivery".into());
     }
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let authenticated_claim = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -606,6 +592,7 @@ fn logical_command_at(
     if let Some(concurrency) = command.concurrency() {
         builder = builder.concurrency(Some(concurrency.clone()));
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 
@@ -1100,6 +1087,7 @@ fn fixture_with_visibility_and_dependencies(
 }
 
 #[allow(clippy::too_many_arguments)] // Fixture axes are explicit at call sites.
+#[allow(clippy::too_many_lines)] // Builds the full authenticated admission graph.
 fn fixture_with_options(
     tenant: &str,
     namespace: u128,
@@ -1145,19 +1133,27 @@ fn fixture_with_options(
             .expect("admitted logical job")
         })
         .collect();
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        namespace.to_string(),
+        "example",
+        format!("project-{namespace}"),
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot = crate::support::authenticated_github_trust_snapshot(
+        &repository,
+        "refs/heads/main",
+        &head_sha,
+    )
+    .expect("trust snapshot");
     let mut command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("run-finalization-{namespace}"))
             .expect("idempotency"),
         Sha256Digest::from_bytes([0x40; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            namespace.to_string(),
-            "example",
-            format!("project-{namespace}"),
-        )
-        .expect("repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "CI",
@@ -1182,10 +1178,11 @@ fn fixture_with_options(
             &[0x13; 512],
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha,
         logical_jobs,
         UnixMillis::new(1_000),
-    );
+    )
+    .trust_snapshot(trust_snapshot);
     if include_base_context {
         command = command.base_context(admission_object(
             format!("run-finalization/{namespace}/base-context"),

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
@@ -366,21 +366,26 @@ async fn admit_authenticated_fixture(
     );
     let job = LogicalWorkflowJobId::from_uuid(Uuid::from_u128(namespace + 6))?;
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        github_repository.get().to_string(),
+        "sample-owner",
+        format!("admission-{namespace}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![9; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant,
         WorkflowAdmissionIdempotency::provider_delivery(format!("admission-{namespace}"))?,
         Sha256Digest::from_bytes([41; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            github_repository.get().to_string(),
-            "sample-owner",
-            format!("admission-{namespace}"),
-        )?,
+        repository,
         WorkflowId::from_uuid(Uuid::from_u128(namespace + 2)),
         ".ci/workflows/ci.yml",
         "Admission guard",
-        "refs/heads/main",
+        git_ref,
         WorkflowSnapshotId::from_uuid(Uuid::from_u128(namespace + 3)),
         admission_object(
             format!("admission/{namespace}/source"),
@@ -401,7 +406,7 @@ async fn admit_authenticated_fixture(
             3,
             "application/json",
         ),
-        vec![9; 20],
+        head_sha,
         vec![AdmittedLogicalWorkflowJob::new(
             job,
             WorkflowJobKey::new("build")?,
@@ -411,6 +416,7 @@ async fn admit_authenticated_fixture(
         )?],
         now,
     )
+    .trust_snapshot(trust_snapshot)
     .base_context(admission_object(
         format!("admission/{namespace}/base-context"),
         4,
@@ -433,15 +439,13 @@ async fn authenticate_fixture(
     fixture: &mut AuthenticatedFixture,
 ) -> TestResult {
     let now = UnixMillis::new(database_now_ms(database).await?);
+    let bootstrap =
+        github_manifest_fixture::fixture_github_repository_bootstrap(fixture.manifest.clone(), now);
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                fixture.manifest.clone(),
-                now,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let manifest = &fixture.manifest;
     database
         .store()
@@ -562,6 +566,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_job_runtime_authority.rs
@@ -45,10 +45,8 @@ use automata_ci_store::{
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     OpenRunnerSession, ProtectedGithubRuntimeAuthority, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, RegisterProviderDeliveryWorkflowInventory,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
     RenewLogicalActivationPreparation, RenewLogicalInstanceMaterialization,
     RenewLogicalJobActivation, ReusableSecretPermission,
     RevalidateGithubRuntimeAuthorityRevocation, RoutingDocument, RunnerGeneration,
@@ -114,19 +112,21 @@ fn logical_fixture(
         Vec::new(),
     )
     .expect("logical job");
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        "project",
+    )
+    .expect("repository");
+    let head_sha = vec![0x14; 20];
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("job-authority-{namespace}"))
             .expect("idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            "project",
-        )
-        .expect("repository"),
+        repository.clone(),
         workflow_id,
         WORKFLOW_PATH,
         "CI",
@@ -151,9 +151,17 @@ fn logical_fixture(
             0x13,
             "application/json",
         ),
-        vec![0x14; 20],
+        head_sha.clone(),
         vec![logical_job],
         database_epoch,
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .base_context(admission_object(
         format!("job-authority/{namespace}/base-context"),
@@ -291,7 +299,8 @@ fn retime_logical_admission(
         command.head_sha().to_vec(),
         command.jobs().to_vec(),
         admitted_at,
-    );
+    )
+    .trust_snapshot(command.trust_snapshot().clone());
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
@@ -306,16 +315,16 @@ async fn admit_signed_workflow(
 ) -> TestResult {
     let tenant = TenantScope::from_authenticated_tenant_id(&fixture.tenant)?;
     let manifest = &fixture.manifest;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        database_epoch,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                database_epoch,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await
         .map_err(|error| format!("repository bootstrap failed: {error:?}"))?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks = service_authority(
         manifest,
         namespace_id(manifest, 1),
@@ -430,26 +439,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 fn namespace_id(manifest: &GithubProviderManifest, suffix: u128) -> u128 {

--- a/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
@@ -55,13 +55,11 @@ use automata_ci_store::{
     LogicalWorkSelectionStoreError, LogicalWorkflowAdmissionRepository as _,
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     OpenRunnerSession, ProviderConnectionId, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
-    RegisterProviderDeliveryWorkflowInventory, ReserveGithubOidcAuthority, RetainGithubOidcKey,
-    ReusableSecretPermission, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
-    StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
+    ProviderDeliveryIdentity, ProviderDeliveryRepository as _, ProviderInstallationId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, PublishLogicalJobActivation, ReserveGithubOidcAuthority,
+    RetainGithubOidcKey, ReusableSecretPermission, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
     WorkflowPlanRepository as _, WorkflowSnapshotId, github_oidc_rs256_public_key_fingerprint,
 };
 use sha2::{Digest as _, Sha256};
@@ -270,13 +268,16 @@ fn logical_oidc_fixture_with_profile(
         Vec::new(),
     )
     .expect("test logical job");
+    let repository =
+        AdmissionRepository::new(repository_id, "github", "4242", "example", "project")
+            .expect("test repository");
+    let head_sha = vec![0x14; 20];
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(format!("oidc-live-{namespace}"))
             .expect("test idempotency"),
         digest(0x40),
-        AdmissionRepository::new(repository_id, "github", "4242", "example", "project")
-            .expect("test repository"),
+        repository.clone(),
         workflow_id,
         WORKFLOW_PATH,
         "OIDC",
@@ -293,9 +294,17 @@ fn logical_oidc_fixture_with_profile(
         invocation_id,
         "push",
         admission_object(format!("oidc/{namespace}/event"), 0x13, "application/json"),
-        vec![0x14; 20],
+        head_sha.clone(),
         vec![logical_job],
         UnixMillis::new(1_000),
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .base_context(admission_object(
         format!("oidc/{namespace}/base-context"),
@@ -415,7 +424,8 @@ fn retime_logical_admission(
         command.head_sha().to_vec(),
         command.jobs().to_vec(),
         admitted_at,
-    );
+    )
+    .trust_snapshot(command.trust_snapshot().clone());
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
@@ -433,15 +443,15 @@ async fn admit_signed_oidc_workflow(
     let installation = manifest.installation_id();
     let provider_repository_id = manifest.github_repository_id();
     let bootstrap_at = database_now(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        bootstrap_at,
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                bootstrap_at,
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     let checks_authority = GithubServerServiceAuthorityIdentity::new(
         tenant.clone(),
         GithubServerServiceAuthorityId::from_uuid(Uuid::from_u128(40_011))?,
@@ -549,26 +559,14 @@ async fn register_workflow_inventory(
     fixture: &LogicalOidcFixture,
     claimed: &ClaimedProviderDelivery,
 ) -> TestResult {
-    let inventory = ProviderDeliveryWorkflowInventory::new(
-        fixture.manifest.digest(),
-        "1414141414141414141414141414141414141414",
-        digest(0x90),
-        vec![ProviderDeliveryWorkflowInventoryEntry::new(
-            WORKFLOW_PATH,
-            ProviderDeliveryWorkflowSourceState::Ready(fixture.command.source().digest()),
-        )?],
-    )?;
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                inventory,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
-    Ok(())
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await
 }
 
 async fn claim_oidc_activation(

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -5,14 +5,15 @@ use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptManifestPinnedGithubRepositoryDispatch,
     AcceptProviderDelivery, AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun,
     AdmittedLogicalWorkflowJob, AuthenticatedGithubDeliveryClaim, BeginGithubCheckRunCreate,
-    BindGithubCheckRun, BindGithubCheckSuite, ClaimGithubCheckProjection, ClaimProviderDelivery,
-    ClaimedGithubCheckProjection, CompleteGithubCheckProjection, CompleteProviderDelivery,
-    EnsureGithubServerServiceAuthority, GithubAuthenticatedEvent, GithubAuthenticatedEventKind,
-    GithubCheckDesiredProjection, GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName,
-    GithubCheckProjectionAction, GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId,
-    GithubCheckRunBindingFence, GithubCheckRunId, GithubCheckSubjectId, GithubCheckSuiteId,
-    GithubCheckTerminalCause, GithubProviderManifest, GithubProviderManifestLimits,
-    GithubProviderManifestRepository as _, GithubProviderManifestRevision, GithubProviderOrigins,
+    BindGithubCheckRun, BindGithubCheckSuite, BootstrapGithubProviderRepository,
+    ClaimGithubCheckProjection, ClaimProviderDelivery, ClaimedGithubCheckProjection,
+    CompleteGithubCheckProjection, CompleteProviderDelivery, EnsureGithubServerServiceAuthority,
+    GithubAuthenticatedEvent, GithubAuthenticatedEventKind, GithubCheckDesiredProjection,
+    GithubCheckDetailsTarget, GithubCheckHeadSha, GithubCheckName, GithubCheckProjectionAction,
+    GithubCheckProjectionOutbox as _, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
+    GithubCheckRunId, GithubCheckSubjectId, GithubCheckSuiteId, GithubCheckTerminalCause,
+    GithubProviderManifest, GithubProviderManifestLimits, GithubProviderManifestRepository as _,
+    GithubProviderManifestRevision, GithubProviderOrigins,
     GithubProviderWebhookVerifierFingerprint, GithubProviderWorkflowSelection,
     GithubRepositoryDispatchEvidenceRepository as _, GithubRepositoryDispatchResolution,
     GithubRepositoryDispatchResolutionAuthority, GithubRepositoryName,
@@ -738,7 +739,7 @@ async fn all_direct_inventory_fans_out_with_durable_partial_progress() -> TestRe
 
         let command = logical_command_at_path(
             &fixture,
-            "logical-all-direct-build",
+            "delivery-all-direct",
             0x62,
             21,
             0x2_800,
@@ -1067,7 +1068,7 @@ async fn setup_create_before_admission(
     let delivery_claim = claim_delivery(database, accepted.delivery_id(), 0x28b, 60_000).await?;
     let inventory = ProviderDeliveryWorkflowInventory::new(
         fixture.manifest.digest(),
-        "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        "0909090909090909090909090909090909090909",
         Sha256Digest::from_bytes([0x56; 32]),
         vec![ProviderDeliveryWorkflowInventoryEntry::new(
             CREATE_BEFORE_ADMISSION_WORKFLOW_PATH,
@@ -1158,7 +1159,7 @@ async fn admit_create_before_admission_workflow(
     let admitted_at = database_now(database.pool()).await?;
     let command = logical_command_at_path(
         &scenario.fixture,
-        "logical-create-before-link",
+        "delivery-create-before-link",
         0x66,
         25,
         0x2_8a0,
@@ -1526,6 +1527,7 @@ struct Fixture {
     tenant: TenantScope,
     connection: ProviderConnectionId,
     manifest: GithubProviderManifest,
+    bootstrap: BootstrapGithubProviderRepository,
     activated_at: UnixMillis,
     checks_authority: GithubServerServiceAuthorityIdentity,
     private_source_authority: Option<GithubServerServiceAuthorityIdentity>,
@@ -1559,6 +1561,8 @@ async fn bootstrap_all_direct(
         GithubProviderWorkflowSelection::all_direct(),
     )
     .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &fixture.bootstrap)
+        .await?;
     ensure_fixture_authorities(database, fixture, at).await
 }
 
@@ -1623,14 +1627,13 @@ async fn bootstrap_manifest_only_with_selection(
         [6; 32],
         selection,
     );
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(at),
+    );
     let bootstrapped = database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
     let activated_at = bootstrapped
         .manifest()
@@ -1656,6 +1659,7 @@ async fn bootstrap_manifest_only_with_selection(
         tenant,
         connection,
         manifest,
+        bootstrap,
         activated_at,
         checks_authority,
         private_source_authority,
@@ -2251,18 +2255,20 @@ fn logical_command_at_path(
         "application/json",
     )
     .expect("event object");
+    let repository = AdmissionRepository::new(
+        fixture.manifest.repository_id(),
+        "github",
+        REPOSITORY_ID.to_string(),
+        "automata-ci",
+        "automata",
+    )
+    .expect("repository");
+    let head_sha = HEAD_SHA.to_vec();
     AdmitLogicalWorkflowRun::builder(
         fixture.tenant.clone(),
         WorkflowAdmissionIdempotency::provider_delivery(idempotency_key).expect("idempotency"),
         Sha256Digest::from_bytes([request_digest_byte; 32]),
-        AdmissionRepository::new(
-            fixture.manifest.repository_id(),
-            "github",
-            REPOSITORY_ID.to_string(),
-            "automata-ci",
-            "automata",
-        )
-        .expect("repository"),
+        repository.clone(),
         workflow_id,
         workflow_path,
         "Automata CI",
@@ -2275,9 +2281,17 @@ fn logical_command_at_path(
         root_invocation_id,
         "push",
         event,
-        HEAD_SHA.to_vec(),
+        head_sha.clone(),
         vec![job],
         admitted_at,
+    )
+    .trust_snapshot(
+        crate::support::authenticated_github_trust_snapshot(
+            &repository,
+            "refs/heads/main",
+            &head_sha,
+        )
+        .expect("authenticated GitHub trust snapshot"),
     )
     .actor("octocat")
     .build()

--- a/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_subject_evidence.rs
@@ -498,6 +498,16 @@ async fn authenticated_event_readers_reject_forward_envelope_schemas() -> TestRe
                 .await,
             Err(GithubSubjectEvidenceStoreError::CorruptData)
         ));
+        let pending_claim = claim_delivery(&database, pending.delivery_id(), 0x183, 60_000).await?;
+        let rejected = database
+            .store()
+            .reject_provider_delivery(RejectProviderDelivery::new(
+                pending_claim.claim(),
+                ProviderDeliveryFailureKind::new("github.subject_evidence.invalid")?,
+                pending_claim.claimed_at(),
+            )?)
+            .await?;
+        assert_eq!(rejected.state(), ProviderDeliveryState::Rejected);
 
         let resolved_request = repository_dispatch_acceptance(
             &fixture,
@@ -509,7 +519,7 @@ async fn authenticated_event_readers_reject_forward_envelope_schemas() -> TestRe
             .store()
             .accept_manifest_pinned_github_repository_dispatch(resolved_request)
             .await?;
-        let claim = claim_delivery(&database, accepted.delivery_id(), 0x183, 60_000).await?;
+        let claim = claim_delivery(&database, accepted.delivery_id(), 0x184, 60_000).await?;
         let resolution = GithubRepositoryDispatchResolution::new(
             GithubCheckHeadSha::new(HEAD_SHA)?,
             GithubRepositoryDispatchResolutionAuthority::PrivateSourceAuthority,

--- a/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
@@ -60,18 +60,16 @@ use automata_ci_store::{
     ManagedSecretDeliveryProposal, ObjectKey, OpenRunnerSession, PrepareJobEnvironment,
     ProtectedEnvironmentRepository as _, ProtectedEnvironmentStoreError, ProviderConnectionId,
     ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity, ProviderDeliveryRepository as _,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    PublishLogicalJobActivation, RegisterProviderDeliveryWorkflowInventory, RepositoryId,
-    RepositorySecretId, RepositorySecretManagementRepository as _, RepositorySecretMutationId,
-    RepositorySecretName, RepositorySecretProviderMutationResult, RepositorySecretVersionId,
-    ReserveRepositorySecretVersionMutation, ReserveRepositorySecretVersionMutationOutcome,
-    ResolveManagedSecretAuthority, ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument,
-    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet,
-    SecretCustodyRepository as _, SecretWorkloadGrantId, StableRunnerSlot, TenantScope,
-    VerifySecretCustody, VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency,
-    WorkflowSnapshotId,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, PublishLogicalJobActivation,
+    RepositoryId, RepositorySecretId, RepositorySecretManagementRepository as _,
+    RepositorySecretMutationId, RepositorySecretName, RepositorySecretProviderMutationResult,
+    RepositorySecretVersionId, ReserveRepositorySecretVersionMutation,
+    ReserveRepositorySecretVersionMutationOutcome, ResolveManagedSecretAuthority,
+    ReusableSecretPermission, ReviewJobEnvironment, RoutingDocument, RunnerGeneration,
+    RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet, SecretCustodyRepository as _,
+    SecretWorkloadGrantId, StableRunnerSlot, TenantScope, VerifySecretCustody,
+    VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Transaction};
@@ -305,23 +303,29 @@ fn logical_fixture_with_requirements(
     )
     .expect("test logical job")
     .with_credential_requirements(credential_requirements);
+    let repository = AdmissionRepository::new(
+        repository_id,
+        "github",
+        manifest.github_repository_id().get().to_string(),
+        "example",
+        "project",
+    )
+    .expect("test repository");
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![0x14; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)
+            .expect("authenticated GitHub trust snapshot");
     let command = AdmitLogicalWorkflowRun::builder(
         tenant_scope,
         WorkflowAdmissionIdempotency::provider_delivery(delivery_key.clone())
             .expect("test idempotency"),
         digest(0x40),
-        AdmissionRepository::new(
-            repository_id,
-            "github",
-            manifest.github_repository_id().get().to_string(),
-            "example",
-            "project",
-        )
-        .expect("test repository"),
+        repository,
         workflow_id,
         ".ci/workflows/ci.yml",
         "Managed secret",
-        "refs/heads/main",
+        git_ref,
         snapshot_id,
         admission_object("secret/source".to_owned(), 0x11, "application/yaml"),
         admission_object(
@@ -334,7 +338,7 @@ fn logical_fixture_with_requirements(
         invocation_id,
         "push",
         admission_object("secret/event".to_owned(), 0x13, "application/json"),
-        vec![0x14; 20],
+        head_sha,
         vec![logical_job],
         UnixMillis::new(1_000),
     )
@@ -343,6 +347,7 @@ fn logical_fixture_with_requirements(
         0x15,
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
+    .trust_snapshot(trust_snapshot)
     .build()
     .expect("test logical admission");
     LogicalFixture {
@@ -417,26 +422,14 @@ async fn admit_authenticated_fixture(
         .await?
         .ok_or("accepted GitHub delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    digest(0x90),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     let command = logical_command_at(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
@@ -456,15 +449,15 @@ async fn bootstrap_manifest(
     manifest: &GithubProviderManifest,
 ) -> TestResult {
     let configured_at = database_now_ms(database).await?;
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(configured_at),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(configured_at),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -519,6 +512,7 @@ fn logical_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/security/observability.rs
+++ b/crates/automata-ci-postgres/tests/store/security/observability.rs
@@ -34,13 +34,11 @@ use automata_ci_store::{
     LogicalWorkSelectionRepository as _, LogicalWorkflowAdmissionRepository as _,
     LogicalWorkflowInvocationId, LogicalWorkflowJobId, LogicalWorkflowJobKind, ObjectKey,
     ProviderConnectionId, ProviderDeliveryClaimOwnerId, ProviderDeliveryIdentity,
-    ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
-    ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RegisterProviderDeliveryWorkflowInventory, RunnerCommandPayload, RunnerGeneration,
-    RunnerOperationKind, RunnerSessionFence, SessionEpoch, TenantScope, WORKFLOW_ADMISSION_EPOCH,
-    WorkflowAdmissionIdempotency, WorkflowRunStatus, WorkflowSnapshotId,
+    ProviderDeliveryRepository as _, ProviderInstallationId, ProviderRepositoryCoordinates,
+    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    RunnerCommandPayload, RunnerGeneration, RunnerOperationKind, RunnerSessionFence, SessionEpoch,
+    TenantScope, WORKFLOW_ADMISSION_EPOCH, WorkflowAdmissionIdempotency, WorkflowRunStatus,
+    WorkflowSnapshotId,
 };
 use uuid::Uuid;
 
@@ -705,6 +703,7 @@ async fn insert_logical_metrics_state(
     })
 }
 
+#[allow(clippy::too_many_lines)] // Builds the complete authenticated metrics graph.
 async fn build_logical_metrics_fixture(
     database: &TestDatabase,
     seed: &MetricsSeed,
@@ -745,21 +744,26 @@ async fn build_logical_metrics_fixture(
     let pending_job = LogicalWorkflowJobId::from_uuid(Uuid::new_v4())?;
     let delivery_key = format!("metrics-logical-{suffix}");
     let admitted_at = UnixMillis::new(database_now_ms(database).await?);
+    let repository = AdmissionRepository::new(
+        manifest.repository_id(),
+        "github",
+        provider_repository_id.get().to_string(),
+        "automata",
+        format!("metrics-{suffix}"),
+    )?;
+    let git_ref = "refs/heads/main";
+    let head_sha = vec![20; 20];
+    let trust_snapshot =
+        crate::support::authenticated_github_trust_snapshot(&repository, git_ref, &head_sha)?;
     let command = AdmitLogicalWorkflowRun::builder(
         tenant,
         WorkflowAdmissionIdempotency::provider_delivery(delivery_key.clone())?,
         Sha256Digest::from_bytes([14; 32]),
-        AdmissionRepository::new(
-            manifest.repository_id(),
-            "github",
-            provider_repository_id.get().to_string(),
-            "automata",
-            format!("metrics-{suffix}"),
-        )?,
+        repository,
         WorkflowId::from_uuid(Uuid::new_v4()),
         ".ci/workflows/ci.yml",
         "Metrics",
-        "refs/heads/main",
+        git_ref,
         WorkflowSnapshotId::from_uuid(Uuid::new_v4()),
         logical_metrics_object(
             format!("metrics/{suffix}/workflow.yml"),
@@ -780,7 +784,7 @@ async fn build_logical_metrics_fixture(
             18,
             "application/json",
         ),
-        vec![20; 20],
+        head_sha,
         vec![
             logical_metrics_job(active_job, "active", 0),
             logical_metrics_job(expired_job, "expired", 1),
@@ -794,6 +798,7 @@ async fn build_logical_metrics_fixture(
         "application/vnd.automata.job-runtime-context.protobuf",
     ))
     .actor("metrics-observer")
+    .trust_snapshot(trust_snapshot)
     .build()?;
     Ok(LogicalMetricsFixture {
         suffix,
@@ -855,26 +860,14 @@ async fn admit_logical_metrics_fixture(
         .await?
         .ok_or("accepted metrics delivery was not claimable")?;
     assert_eq!(claimed.claim().delivery_id(), accepted.delivery_id());
-    database
-        .store()
-        .register_provider_delivery_workflow_inventory(
-            RegisterProviderDeliveryWorkflowInventory::new(
-                claimed.claim(),
-                ProviderDeliveryWorkflowInventory::new(
-                    fixture.manifest.digest(),
-                    "1414141414141414141414141414141414141414",
-                    Sha256Digest::from_bytes([0x90; 32]),
-                    vec![ProviderDeliveryWorkflowInventoryEntry::new(
-                        fixture.command.workflow_path(),
-                        ProviderDeliveryWorkflowSourceState::Ready(
-                            fixture.command.source().digest(),
-                        ),
-                    )?],
-                )?,
-                claimed.claimed_at(),
-            )?,
-        )
-        .await?;
+    crate::support::register_provider_delivery_workflow_inventory(
+        database,
+        &fixture.manifest,
+        &fixture.command,
+        claimed.claim(),
+        claimed.claimed_at(),
+    )
+    .await?;
     fixture.command = logical_metrics_command_at(&fixture.command, claimed.claimed_at())?;
     database
         .store()
@@ -896,15 +889,15 @@ async fn bootstrap_logical_metrics_manifest(
     database: &TestDatabase,
     manifest: &GithubProviderManifest,
 ) -> TestResult {
+    let bootstrap = github_manifest_fixture::fixture_github_repository_bootstrap(
+        manifest.clone(),
+        UnixMillis::new(database_now_ms(database).await?),
+    );
     database
         .store()
-        .bootstrap_github_provider_repository(
-            github_manifest_fixture::fixture_github_repository_bootstrap(
-                manifest.clone(),
-                UnixMillis::new(database_now_ms(database).await?),
-            ),
-        )
+        .bootstrap_github_provider_repository(bootstrap.clone())
         .await?;
+    crate::support::seed_fresh_github_workflow_permission_defaults(database, &bootstrap).await?;
     database
         .store()
         .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
@@ -984,6 +977,7 @@ fn logical_metrics_command_at(
     if let Some(base_context) = command.base_context() {
         builder = builder.base_context(base_context.clone());
     }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
     Ok(builder.actor(command.actor().unwrap_or_default()).build()?)
 }
 

--- a/crates/automata-ci-postgres/tests/store/security/secret_custody.rs
+++ b/crates/automata-ci-postgres/tests/store/security/secret_custody.rs
@@ -188,6 +188,21 @@ async fn noncurrent_canary_schema_fails_closed() -> TestResult {
             VerifySecretCustodyOutcome::Verified(_)
         ));
 
+        // Model storage corruption below the schema boundary. Ordinary writes
+        // must retain both guards; this fixture needs to reach the repository's
+        // independent decoder check instead.
+        sqlx::query(
+            "ALTER TABLE secret_custody_key_canaries \
+             DISABLE TRIGGER secret_custody_key_canaries_update_forbidden",
+        )
+        .execute(database.pool())
+        .await?;
+        sqlx::query(
+            "ALTER TABLE secret_custody_key_canaries \
+             DROP CONSTRAINT secret_custody_key_canaries_canary_schema",
+        )
+        .execute(database.pool())
+        .await?;
         sqlx::query(
             "UPDATE secret_custody_key_canaries \
              SET canary_schema = 2 \

--- a/crates/automata-ci-postgres/tests/support/mod.rs
+++ b/crates/automata-ci-postgres/tests/support/mod.rs
@@ -3,10 +3,13 @@ use std::{error::Error, future::Future, sync::Arc};
 use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, JobId, JobIrVersion, OperatingSystem, RunId, RunnerCapabilities, RunnerId,
-    RunnerPlatform, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
+    RunnerPlatform, RunnerRequirements, RunnerSessionId, Sha256Digest, TrustActorEvidence,
+    TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind,
+    TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion, UnixMillis,
 };
 use automata_ci_key_management::{
-    KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes,
+    EncryptedEnvelope, KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial,
+    SecretBytes, WrappedDataKey,
 };
 use automata_ci_postgres::store::PostgresStore;
 #[allow(unused_imports)] // Consolidated binaries consume different fixture subsets.
@@ -14,11 +17,23 @@ pub use automata_ci_postgres::test_support::{
     PostgresTestDatabase as TestDatabase, TestClock, TestResult,
 };
 use automata_ci_store::{
-    AdmitLogicalWorkflowRun, GithubProviderManifest, OpenRunnerSession, ProviderDeliveryClaimFence,
+    AcquireGithubServerServiceHandoff, AdmissionRepository, AdmitLogicalWorkflowRun,
+    BeginGithubServerServiceMint, BootstrapGithubProviderRepository,
+    ClaimNextGithubServerServiceMaintenance, EnsureGithubServerServiceAuthority,
+    FinalizeGithubWorkflowPermissionObservation, FinishGithubServerServiceMint,
+    GithubProviderManifest, GithubServerServiceAuthorityId, GithubServerServiceAuthorityIdentity,
+    GithubServerServiceAuthorityRepository as _, GithubServerServiceAuthoritySelector,
+    GithubServerServiceAuthorityState, GithubServerServiceEnvelopeMetadata,
+    GithubServerServiceHandoffId, GithubServerServiceIssuanceState,
+    GithubServerServiceMaintenanceOutcome, GithubServerServiceScope, GithubServerServiceWorkerId,
+    GithubWorkflowPermissionDefaultsObservation,
+    GithubWorkflowPermissionDefaultsObservationRepository as _,
+    MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, OpenRunnerSession,
+    ProtectedGithubServerServiceCredential, ProviderDeliveryClaimFence,
     ProviderDeliveryRepository as _, ProviderDeliveryWorkflowInventory,
     ProviderDeliveryWorkflowInventoryEntry, ProviderDeliveryWorkflowSourceState,
-    RegisterProviderDeliveryWorkflowInventory, RoutingDocument, RunnerGeneration,
-    RunnerProtocolVersion, RunnerSessionFence,
+    RegisterProviderDeliveryWorkflowInventory, ReleaseGithubServerServiceHandoff, RoutingDocument,
+    RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence,
 };
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -66,7 +81,7 @@ pub async fn register_provider_delivery_workflow_inventory(
                 claim,
                 ProviderDeliveryWorkflowInventory::new(
                     manifest.digest(),
-                    "1414141414141414141414141414141414141414",
+                    lower_hex(command.head_sha()),
                     automata_ci_core::Sha256Digest::from_bytes([0x90; 32]),
                     vec![ProviderDeliveryWorkflowInventoryEntry::new(
                         command.workflow_path(),
@@ -78,6 +93,273 @@ pub async fn register_provider_delivery_workflow_inventory(
         )
         .await?;
     Ok(())
+}
+
+/// Builds a sealed same-repository push trust snapshot for the admitted coordinates.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+pub fn authenticated_github_trust_snapshot(
+    repository: &AdmissionRepository,
+    git_ref: &str,
+    head_sha: &[u8],
+) -> TestResult<TrustSnapshot> {
+    authenticated_github_trust_snapshot_for_actor(
+        repository,
+        git_ref,
+        head_sha,
+        "authenticated-github-fixture-actor",
+    )
+}
+
+/// Builds a sealed same-repository push trust snapshot for exact coordinates and actor.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+pub fn authenticated_github_trust_snapshot_for_actor(
+    repository: &AdmissionRepository,
+    git_ref: &str,
+    head_sha: &[u8],
+    actor_id: &str,
+) -> TestResult<TrustSnapshot> {
+    let actor = TrustActorEvidence::new(actor_id, TrustActorKind::User, TrustAutomationKind::None)?;
+    let repository = TrustRepositoryEvidence::new(
+        repository.provider_repository_id(),
+        "authenticated-github-fixture-owner",
+    )?;
+    Ok(TrustPolicy::current().evaluate(
+        TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
+            .with_original_actor(actor.clone())
+            .with_triggering_actor(actor)
+            .with_repositories(repository.clone(), repository)
+            .with_refs(git_ref, git_ref, git_ref)
+            .with_revisions(
+                lower_hex(head_sha),
+                lower_hex(head_sha),
+                lower_hex(head_sha),
+            )
+            .with_fork(false)
+            .with_token_recursion(TrustTokenRecursion::Suppressed),
+    )?)
+}
+
+/// Establishes the exact fresh workflow-permission observation required by
+/// authenticated GitHub logical admission.
+#[allow(dead_code)] // Consolidated integration modules consume different fixture subsets.
+#[allow(clippy::too_many_lines)] // Mirrors the complete production claim/handoff/finalize flow.
+pub async fn seed_fresh_github_workflow_permission_defaults(
+    database: &TestDatabase,
+    bootstrap: &BootstrapGithubProviderRepository,
+) -> TestResult {
+    let manifest = bootstrap.manifest().manifest();
+    database
+        .store()
+        .prepare_github_workflow_permission_target(manifest)
+        .await?;
+    let mut authority_id_bytes = [0_u8; 16];
+    authority_id_bytes.copy_from_slice(&manifest.digest().as_bytes()[..16]);
+    authority_id_bytes[0] ^= 0xa7;
+    let authority = GithubServerServiceAuthorityIdentity::new(
+        manifest.tenant().clone(),
+        GithubServerServiceAuthorityId::from_uuid(Uuid::from_bytes(authority_id_bytes))?,
+        manifest.repository_id(),
+        manifest.connection_id(),
+        manifest.installation_id(),
+        manifest.github_app_id(),
+        manifest.github_repository_id(),
+        manifest.github_repository_name().clone(),
+        GithubServerServiceScope::WorkflowPermissionsRead,
+        manifest.app_client_id().clone(),
+        manifest.jwt_issuer(),
+        manifest.app_key_spki_sha256(),
+        manifest.app_configuration_revision(),
+        manifest.policy_revision(),
+        Sha256Digest::from_bytes([0x7a; 32]),
+    )?;
+    database
+        .store()
+        .ensure_github_server_service_authority(EnsureGithubServerServiceAuthority::new(
+            authority.clone(),
+            bootstrap.manifest().applied_at(),
+        )?)
+        .await?;
+
+    ensure_workflow_permission_credential(database, &authority).await?;
+    let selector = GithubServerServiceAuthoritySelector::from_identity(&authority);
+
+    let observation_started_at = UnixMillis::new(database_now_ms(database).await?);
+    let candidate = automata_ci_store::GithubWorkflowPermissionObservationCandidate::new(
+        bootstrap,
+        &authority,
+        automata_ci_store::GithubServerServiceConsumerId::from_uuid(Uuid::new_v4())?,
+        GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+        observation_started_at,
+    )?;
+    database
+        .store()
+        .claim_github_workflow_permission_observation(candidate.clone())
+        .await?;
+    let expected_default = candidate.expected_default();
+    let handoff_id = GithubServerServiceHandoffId::from_uuid(Uuid::new_v4())?;
+    let handoff_observed_at = candidate.claimed_at();
+    let handoff = database
+        .store()
+        .acquire_github_server_service_handoff(AcquireGithubServerServiceHandoff::new(
+            selector.clone(),
+            handoff_id,
+            candidate.consumer(),
+            handoff_observed_at,
+            UnixMillis::new(handoff_observed_at.get() + MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS),
+        )?)
+        .await?;
+    let observed_at = UnixMillis::new(database_now_ms(database).await?);
+    let release = ReleaseGithubServerServiceHandoff::new(
+        selector,
+        handoff.handoff_id(),
+        candidate.consumer(),
+        observed_at,
+    )?;
+    let observation = GithubWorkflowPermissionDefaultsObservation::new(
+        bootstrap,
+        candidate,
+        &release,
+        handoff.receipt().key().generation(),
+        expected_default,
+        false,
+        observed_at,
+    )?;
+    let finalized = database
+        .store()
+        .finalize_github_workflow_permission_observation(
+            FinalizeGithubWorkflowPermissionObservation::new(
+                bootstrap.clone(),
+                release,
+                observation,
+            )?,
+        )
+        .await?;
+    if !finalized {
+        return Err("workflow-permission observation did not activate".into());
+    }
+    Ok(())
+}
+
+async fn ensure_workflow_permission_credential(
+    database: &TestDatabase,
+    authority: &GithubServerServiceAuthorityIdentity,
+) -> TestResult {
+    let wait_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let now_ms = database_now_ms(database).await?;
+        let minimum_usable_until = now_ms
+            .checked_add(MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS)
+            .and_then(|value| value.checked_add(60_000))
+            .ok_or("workflow-permission credential horizon overflow")?;
+        let descriptor = database
+            .store()
+            .inspect_github_server_service_authority(authority.tenant(), authority.authority_id())
+            .await?;
+        let current = database
+            .store()
+            .inspect_current_github_server_service_issuance(
+                authority.tenant(),
+                authority.authority_id(),
+            )
+            .await?;
+        if descriptor.identity() != authority
+            || descriptor.state() != GithubServerServiceAuthorityState::Active
+        {
+            return Err("workflow-permission authority is not active and exact".into());
+        }
+        if current.is_some_and(|receipt| {
+            descriptor.current_generation() == Some(receipt.key().generation())
+                && receipt.state() == GithubServerServiceIssuanceState::Ready
+                && receipt
+                    .usable_until()
+                    .is_some_and(|until| until.get() >= minimum_usable_until)
+        }) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= wait_deadline {
+            return Err("workflow-permission credential did not become ready".into());
+        }
+
+        let selector = GithubServerServiceAuthoritySelector::from_identity(authority);
+        let outcome = database
+            .store()
+            .claim_next_github_server_service_maintenance(
+                ClaimNextGithubServerServiceMaintenance::for_authority(
+                    selector,
+                    GithubServerServiceWorkerId::from_uuid(Uuid::new_v4())?,
+                    UnixMillis::new(now_ms),
+                    UnixMillis::new(now_ms + 60_000),
+                )?,
+            )
+            .await?;
+        match outcome {
+            Some(GithubServerServiceMaintenanceOutcome::Mint(claimed)) => {
+                let claimed = *claimed;
+                let started_at = UnixMillis::new(database_now_ms(database).await?);
+                database
+                    .store()
+                    .begin_github_server_service_mint(BeginGithubServerServiceMint::new(
+                        &claimed, started_at,
+                    )?)
+                    .await?;
+                let committed_at_ms = database_now_ms(database).await?;
+                let receipt = claimed.receipt();
+                let metadata = GithubServerServiceEnvelopeMetadata::new(
+                    authority.clone(),
+                    receipt.key().generation(),
+                    receipt.requested_at(),
+                    receipt.request_deadline(),
+                    UnixMillis::new(committed_at_ms + 3_600_000),
+                    32,
+                    Sha256Digest::from_bytes([0x7b; 32]),
+                )?;
+                let credential = ProtectedGithubServerServiceCredential::new(
+                    metadata,
+                    EncryptedEnvelope::from_parts(
+                        1,
+                        WrappedDataKey::new(
+                            KeyId::new("authenticated-fixture-workflow-permission-v1")?,
+                            vec![0x7c; 48],
+                        )?,
+                        [0x7d; 12],
+                        vec![0x7e; 48],
+                    )?,
+                )?;
+                database
+                    .store()
+                    .finish_github_server_service_mint(&FinishGithubServerServiceMint::ready(
+                        claimed.claim().clone(),
+                        credential,
+                        UnixMillis::new(committed_at_ms),
+                    )?)
+                    .await?;
+            }
+            Some(GithubServerServiceMaintenanceOutcome::Reduced { .. }) | None => {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            Some(GithubServerServiceMaintenanceOutcome::Revocation(_)) => {
+                return Err("unexpected workflow-permission revocation work".into());
+            }
+        }
+    }
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
+    Ok(
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint")
+            .fetch_one(database.pool())
+            .await?,
+    )
 }
 
 pub fn test_runner_payload_key_provider() -> Arc<dyn KeyEncryptionProvider> {

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -77,6 +77,7 @@ mod server_cancellation_terminal;
 mod web;
 mod workflow_enable_state;
 mod workflow_rerun;
+mod workflow_run_trust_snapshot;
 mod workflow_runtime_policy;
 
 pub use github_oidc::{

--- a/crates/automata-ci-store-postgres/src/logical_activation.rs
+++ b/crates/automata-ci-store-postgres/src/logical_activation.rs
@@ -69,9 +69,11 @@ impl LogicalActivationRepository for PostgresStore {
                    publication.effective_max_parallel,
                    publication.instance_count
             FROM logical_workflow_activation_publications AS publication
-            JOIN logical_workflow_runs AS run
-              ON run.run_id = publication.run_id
-            WHERE run.tenant_id = $1
+            JOIN logical_workflow_runs AS marker
+              ON marker.run_id = publication.run_id
+            JOIN workflow_runs AS run ON run.id = marker.run_id
+            JOIN repositories AS repository ON repository.id = run.repository_id
+            WHERE repository.tenant_id = $1
               AND publication.run_id = $2
               AND publication.invocation_id = $3
               AND publication.logical_job_id = $4

--- a/crates/automata-ci-store-postgres/src/logical_activation.rs
+++ b/crates/automata-ci-store-postgres/src/logical_activation.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use automata_ci_core::{
     JOB_IR_SCHEMA_VERSION, JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile, RunId,
-    RunIdAlias, Sha256Digest, TRUST_SNAPSHOT_SCHEMA_V1, TRUST_SNAPSHOT_V1_MEDIA_TYPE,
-    TrustSnapshot, UnixMillis, WorkflowId, WorkflowJobKey,
+    RunIdAlias, Sha256Digest, UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use sqlx::{Postgres, Row as _, Transaction, postgres::PgRow};
 use uuid::Uuid;
@@ -16,6 +15,7 @@ use super::{
     protected_environment::{
         job_event_trust_name, job_source_kind_name, reusable_secret_permission_name,
     },
+    workflow_run_trust_snapshot::decode_trust_snapshot,
 };
 use automata_ci_store::{
     ActivatedLogicalInstanceDescriptor, AdmissionObject, ClaimLogicalJobActivation,
@@ -1852,41 +1852,6 @@ fn decode_digest_bytes(
         .try_into()
         .map_err(|_| StoreError::corrupt_data(format!("{field} is not SHA-256")))?;
     Ok(Sha256Digest::from_bytes(bytes))
-}
-
-fn decode_trust_snapshot(row: &PgRow) -> Result<TrustSnapshot, LogicalActivationStoreError> {
-    let schema: i16 = row
-        .try_get("trust_snapshot_schema")
-        .map_err(operation_error)?;
-    if schema != i16::try_from(TRUST_SNAPSHOT_SCHEMA_V1).unwrap_or(i16::MAX) {
-        return Err(StoreError::corrupt_data("unsupported durable trust snapshot schema").into());
-    }
-    let policy_revision: i64 = row
-        .try_get("trust_policy_revision")
-        .map_err(operation_error)?;
-    let policy_digest = decode_digest(row, "trust_policy_digest")?;
-    let snapshot_digest = decode_digest(row, "trust_snapshot_digest")?;
-    let snapshot_bytes: Vec<u8> = row
-        .try_get("trust_snapshot_bytes")
-        .map_err(operation_error)?;
-    let media_type: String = row.try_get("trust_media_type").map_err(operation_error)?;
-    if media_type != TRUST_SNAPSHOT_V1_MEDIA_TYPE {
-        return Err(
-            StoreError::corrupt_data("unsupported durable trust snapshot media type").into(),
-        );
-    }
-    let snapshot = TrustSnapshot::from_canonical_bytes(&snapshot_bytes, snapshot_digest)
-        .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
-    let exact_metadata = i64::try_from(snapshot.policy_revision().get()).ok()
-        == Some(policy_revision)
-        && snapshot.policy_digest() == policy_digest;
-    if !exact_metadata {
-        return Err(StoreError::corrupt_data(
-            "durable trust snapshot metadata disagrees with its canonical bytes",
-        )
-        .into());
-    }
-    Ok(snapshot)
 }
 
 fn parse_authority_profile(

--- a/crates/automata-ci-store-postgres/src/logical_activation_preparation.rs
+++ b/crates/automata-ci-store-postgres/src/logical_activation_preparation.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use super::{
     PostgresStore, durable_schema::current_durable_schemas,
     logical_graph::lock_active_logical_graph, pg_bigint,
+    workflow_run_trust_snapshot::decode_trust_snapshot,
     workflow_runtime_policy::load_pinned_runtime_policy_for_run,
 };
 use automata_ci_store::{
@@ -1178,6 +1179,7 @@ fn build_descriptor(
             .with_triggering_actor(triggering_actor)
             .map_err(corrupt_value)?;
     }
+    execution = execution.with_trust_snapshot(decode_trust_snapshot(row)?);
     let authority_profile =
         parse_authority_profile(&get_string(row, prefix, "authority_profile")?)?;
     let runner_policy =

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1743,6 +1743,13 @@ async fn require_workflow_enabled(
         WHERE workflow.repository_id = $2
           AND workflow.id = $3
           AND workflow.path = $4
+          AND NOT EXISTS (
+              SELECT 1
+              FROM workflow_enable_state_current AS current
+              WHERE current.tenant_id = $1
+                AND current.repository_id = $2
+                AND current.workflow_id = $3
+          )
         ON CONFLICT DO NOTHING
         ",
     )
@@ -1758,7 +1765,15 @@ async fn require_workflow_enabled(
         r"
         INSERT INTO workflow_enable_state_current (
             tenant_id, repository_id, workflow_id, state_revision
-        ) VALUES ($1,$2,$3,1)
+        )
+        SELECT $1,$2,$3,1
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM workflow_enable_state_current AS current
+            WHERE current.tenant_id = $1
+              AND current.repository_id = $2
+              AND current.workflow_id = $3
+        )
         ON CONFLICT DO NOTHING
         ",
     )

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -59,6 +59,8 @@ const WORKFLOW_DISPATCH_PERMISSION: &str = "runs:dispatch";
 const WORKFLOW_DISPATCH_AUDIT_ACTION: &str = "workflow.dispatch";
 const WORKFLOW_DISPATCH_AUDIT_RESOURCE_KIND: &str = "workflow_run";
 const WORKFLOW_DISPATCH_AUDIT_ID_DOMAIN: &[u8] = b"automata.workflow-dispatch.audit.v1\0";
+// SHA-256 prefix for `automata.logical-admission.idempotency-lock.v1`.
+const LOGICAL_ADMISSION_IDEMPOTENCY_LOCK_NAMESPACE: i64 = 0x2fee_1fa8_b154_7857;
 
 const fn logical_workflow_job_kind_name(kind: LogicalWorkflowJobKind) -> &'static str {
     match kind {
@@ -338,6 +340,15 @@ async fn admit_logical_workflow_transaction(
 ) -> Result<LogicalWorkflowAdmissionReceipt, LogicalWorkflowAdmissionStoreError> {
     validate_subject_evidence_boundary(&command, &subject_evidence)?;
     let mut transaction = store.pool.begin().await.map_err(operation_error)?;
+    // A waiter must observe the leader's commit in its next statement even
+    // when the pool or session default uses a persistent snapshot.
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        .execute(&mut *transaction)
+        .await
+        .map_err(operation_error)?;
+    // Disabled admissions intentionally have no receipt, so serialize the key
+    // before deciding whether this transaction is a new admission or a replay.
+    lock_logical_admission_idempotency(&mut transaction, &command).await?;
     let dispatch_actor =
         authorize_dispatch_subject(&mut transaction, &command, &subject_evidence).await?;
     let github_subject_evidence_required = matches!(
@@ -1366,6 +1377,30 @@ fn subject_evidence_error(
             StoreError::corrupt_data("signed GitHub subject evidence rejected admission").into()
         }
     }
+}
+
+async fn lock_logical_admission_idempotency(
+    transaction: &mut Transaction<'_, Postgres>,
+    command: &AdmitLogicalWorkflowRun,
+) -> Result<(), LogicalWorkflowAdmissionStoreError> {
+    let tenant = command.tenant().as_str();
+    let kind = command.idempotency().kind();
+    let key = command.idempotency().key();
+    // Byte-length framing keeps delimiter-bearing identities distinct. A hash
+    // collision can only serialize unrelated admissions; it cannot split one key.
+    let lock_identity = format!(
+        "{}:{tenant}|{}:{kind}|{}:{key}",
+        tenant.len(),
+        kind.len(),
+        key.len(),
+    );
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, $2))")
+        .bind(lock_identity)
+        .bind(LOGICAL_ADMISSION_IDEMPOTENCY_LOCK_NAMESPACE)
+        .execute(&mut **transaction)
+        .await
+        .map_err(operation_error)?;
+    Ok(())
 }
 
 async fn admission_receipt_exists(

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -195,7 +195,7 @@ async fn resolve_authenticated_dispatch_source(
         r"
         SELECT DISTINCT repository.scm_provider,
                repository.provider_repository_id,
-               current_manifest.github_repository_owner_id,
+               manifest.github_repository_owner_id,
                repository.owner, repository.name, workflow.path,
                snapshot.source_digest, snapshot.source_object_key,
                snapshot.source_size_bytes, snapshot.source_media_type
@@ -203,6 +203,12 @@ async fn resolve_authenticated_dispatch_source(
         JOIN github_provider_manifest_current AS current_manifest
           ON current_manifest.tenant_id = repository.tenant_id
          AND current_manifest.repository_id = repository.id
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = current_manifest.tenant_id
+         AND manifest.repository_id = current_manifest.repository_id
+         AND manifest.provider_connection_id = current_manifest.provider_connection_id
+         AND manifest.manifest_revision = current_manifest.manifest_revision
+         AND manifest.manifest_digest = current_manifest.manifest_digest
         JOIN workflow_definitions AS workflow
           ON workflow.repository_id = repository.id
         JOIN workflow_runs AS run
@@ -226,7 +232,7 @@ async fn resolve_authenticated_dispatch_source(
           AND run.git_ref = $4
           AND run.head_sha = $5
           AND run.admission_epoch = $6
-          AND current_manifest.github_repository_owner_id IS NOT NULL
+          AND manifest.github_repository_owner_id IS NOT NULL
         LIMIT 2
         ",
     )

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -392,7 +392,7 @@ async fn admit_logical_workflow_transaction(
     if !claimed {
         let (receipt, admitted_at) =
             replay_receipt(&mut transaction, &command, github_subject_evidence_required).await?;
-        validate_trust_snapshot_replay(&mut transaction, &command).await?;
+        validate_trust_snapshot_replay(&mut transaction, &command, admitted_at).await?;
         validate_replayed_subject_evidence(
             &mut transaction,
             &command,
@@ -2063,6 +2063,7 @@ async fn insert_trust_snapshot(
 async fn validate_trust_snapshot_replay(
     transaction: &mut Transaction<'_, Postgres>,
     command: &AdmitLogicalWorkflowRun,
+    durable_admitted_at: UnixMillis,
 ) -> Result<(), LogicalWorkflowAdmissionStoreError> {
     let row = sqlx::query(
         r"
@@ -2109,7 +2110,7 @@ async fn validate_trust_snapshot_replay(
         && row
             .try_get::<i64, _>("created_at_ms")
             .map_err(operation_error)?
-            == command.admitted_at().get();
+            == durable_admitted_at.get();
     if !exact {
         return Err(LogicalWorkflowAdmissionStoreError::IdempotencyConflict);
     }

--- a/crates/automata-ci-store-postgres/src/sql/logical_activation_preparation_locked_target.sql
+++ b/crates/automata-ci-store-postgres/src/sql/logical_activation_preparation_locked_target.sql
@@ -9,6 +9,12 @@ SELECT job.logical_key, job.source_order, job.created_at_ms,
        run.triggering_actor,
        run.public_run_id_alias AS run_id_alias,
        run.run_number, run.run_attempt,
+       trust.snapshot_schema AS trust_snapshot_schema,
+       trust.policy_revision AS trust_policy_revision,
+       trust.policy_digest AS trust_policy_digest,
+       trust.snapshot_digest AS trust_snapshot_digest,
+       trust.snapshot_bytes AS trust_snapshot_bytes,
+       trust.media_type AS trust_media_type,
        invocation.plan_digest, invocation.plan_object_key,
        invocation.plan_size_bytes, invocation.plan_media_type,
        run.event_digest, run.event_object_key, run.event_size_bytes,
@@ -89,6 +95,7 @@ LEFT JOIN logical_workflow_reusable_call_publications AS reusable_call
  AND reusable_call.child_invocation_id = invocation.id
  AND reusable_call.child_graph_sealed_at_ms IS NOT NULL
 JOIN workflow_runs AS run ON run.id = marker.run_id
+JOIN workflow_run_trust_snapshots AS trust ON trust.run_id = run.id
 JOIN repositories AS repository ON repository.id = run.repository_id
 JOIN github_workflow_run_manifest_origins AS origin
   ON origin.tenant_id = repository.tenant_id

--- a/crates/automata-ci-store-postgres/src/workflow_run_trust_snapshot.rs
+++ b/crates/automata-ci-store-postgres/src/workflow_run_trust_snapshot.rs
@@ -1,0 +1,52 @@
+use automata_ci_core::{
+    Sha256Digest, TRUST_SNAPSHOT_SCHEMA_V1, TRUST_SNAPSHOT_V1_MEDIA_TYPE, TrustSnapshot,
+};
+use automata_ci_store::StoreError;
+use sqlx::{Row as _, postgres::PgRow};
+
+/// Decodes and validates one canonical run-bound trust snapshot projection.
+pub(super) fn decode_trust_snapshot(row: &PgRow) -> Result<TrustSnapshot, StoreError> {
+    let schema: i16 = row
+        .try_get("trust_snapshot_schema")
+        .map_err(StoreError::operation)?;
+    if schema != i16::try_from(TRUST_SNAPSHOT_SCHEMA_V1).unwrap_or(i16::MAX) {
+        return Err(StoreError::corrupt_data(
+            "unsupported durable trust snapshot schema",
+        ));
+    }
+    let policy_revision: i64 = row
+        .try_get("trust_policy_revision")
+        .map_err(StoreError::operation)?;
+    let policy_digest = decode_digest(row, "trust_policy_digest")?;
+    let snapshot_digest = decode_digest(row, "trust_snapshot_digest")?;
+    let snapshot_bytes: Vec<u8> = row
+        .try_get("trust_snapshot_bytes")
+        .map_err(StoreError::operation)?;
+    let media_type: String = row
+        .try_get("trust_media_type")
+        .map_err(StoreError::operation)?;
+    if media_type != TRUST_SNAPSHOT_V1_MEDIA_TYPE {
+        return Err(StoreError::corrupt_data(
+            "unsupported durable trust snapshot media type",
+        ));
+    }
+    let snapshot = TrustSnapshot::from_canonical_bytes(&snapshot_bytes, snapshot_digest)
+        .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
+    let exact_metadata = i64::try_from(snapshot.policy_revision().get()).ok()
+        == Some(policy_revision)
+        && snapshot.policy_digest() == policy_digest;
+    if !exact_metadata {
+        return Err(StoreError::corrupt_data(
+            "durable trust snapshot metadata disagrees with its canonical bytes",
+        ));
+    }
+    Ok(snapshot)
+}
+
+fn decode_digest(row: &PgRow, column: &str) -> Result<Sha256Digest, StoreError> {
+    let value: Vec<u8> = row.try_get(column).map_err(StoreError::operation)?;
+    let bytes: [u8; 32] = value
+        .try_into()
+        .map_err(|_| StoreError::corrupt_data(format!("{column} is not SHA-256")))?;
+    Ok(Sha256Digest::from_bytes(bytes))
+}


### PR DESCRIPTION
## Summary

- explicitly bypass the canary table's immutable-update trigger and current-schema CHECK in the corruption fixture
- retain the existing `canary_schema = 2` injection
- prove the repository's independent decoder fails closed with `CorruptData`

Both production guards remain unchanged. The ALTERs are confined to the test's disposable database clone, which is removed after the callback.

## Validation

- targeted rustfmt and `git diff --check`
- strict PostgreSQL test-target Clippy
- exact PostgreSQL 18.4 regression: 1/1
- full `secret_custody` PostgreSQL module: 6/6
- official namespace cleanup and database/activity audit
- independent review: approved, no findings

## Stacking

This test-only checkpoint is based on exact #260 head `93d7a950b226c62774cc35bd04b2a28ebc72f962`. No open PR overlaps the authored file.

Closes #272
