### PR TITLE
test(store-postgres): align clock offers with protocol v2

### DIFF
--- a/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
@@ -312,11 +312,12 @@ async fn concurrency_groups_are_repository_scoped_case_insensitive_and_single_re
         let second_repository = seed_control_plane(database.pool(), 1).await?;
         seed_run_number_counter(&database, &first_repository).await?;
         seed_run_number_counter(&database, &second_repository).await?;
-        let snapshot_id = WorkflowSnapshotId::from_uuid(uuid::Uuid::new_v4());
+        let first_snapshot_id = WorkflowSnapshotId::from_uuid(uuid::Uuid::new_v4());
+        let second_snapshot_id = WorkflowSnapshotId::from_uuid(uuid::Uuid::new_v4());
 
         let first_active = admission_case_with_group(
             &first_repository,
-            snapshot_id,
+            first_snapshot_id,
             111,
             10,
             "Deploy-Main",
@@ -325,7 +326,7 @@ async fn concurrency_groups_are_repository_scoped_case_insensitive_and_single_re
         )?;
         let second_active = admission_case_with_group(
             &second_repository,
-            snapshot_id,
+            second_snapshot_id,
             112,
             10,
             "DEPLOY-MAIN",
@@ -349,7 +350,7 @@ async fn concurrency_groups_are_repository_scoped_case_insensitive_and_single_re
 
         let replaced = admission_case_with_group(
             &first_repository,
-            snapshot_id,
+            first_snapshot_id,
             113,
             20,
             "deploy-main",
@@ -358,7 +359,7 @@ async fn concurrency_groups_are_repository_scoped_case_insensitive_and_single_re
         )?;
         let replacement = admission_case_with_group(
             &first_repository,
-            snapshot_id,
+            first_snapshot_id,
             114,
             30,
             "DePlOy-MaIn",

--- a/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
@@ -57,7 +57,7 @@ use crate::support::{
 };
 
 const LEASE_REQUEST_KIND: &str = "automata.runner.lease-request.v1";
-const LEASE_OFFER_KIND: &str = "automata.runner.lease-offer.v1";
+const LEASE_OFFER_KIND: &str = "automata.runner.lease-offer.v2";
 const HEARTBEAT_KIND: &str = "automata.runner.lease-heartbeat.v1";
 const LEASE_RESPONSE_KIND: &str = "automata.runner.lease-response.v1";
 const RUNNER_RESPONSE_KEY_PURPOSE: &str = "control-plane/runner-rpc-response:v1";


### PR DESCRIPTION
## Summary

- update runner-clock lease-offer fixtures from protocol v1 to the authenticated production v2 kind
- preserve the production metadata checks and schema unchanged

The affected contracts now reach their clock, revocation, locking, resolver, and encrypted-receipt assertions.

## Validation

- independently reviewed source gate: `runner_clock` 23/23
- independently reviewed strict Clippy gate: green
- fresh-main transplant has the same stable patch ID and byte-identical full diff as approved commit `0b6d9134`
- `rustfmt --edition 2024 --check` on all three touched execution fixtures
- `git diff --check` on the fresh stack
- `cargo check --locked -p automata-ci-postgres --all-features --test postgres`

Stacked on PR #279.

Closes #275
