### PR TITLE
refactor(results): share canonical HTTP scalar parsing

### DIFF
--- a/crates/automata-ci-results-github/src/cache_http.rs
+++ b/crates/automata-ci-results-github/src/cache_http.rs
@@ -19,7 +19,10 @@ use crate::{
     CacheEntryId, CacheService, CacheServiceError, CacheServiceErrorKind, ResultsHttpRoute,
     ResultsObserver, RuntimeTokenClaims, RuntimeTokenVerifier, SignedCacheCapability, TokenError,
     azure::{AzureProtocolError, parse_block_list, validate_block_id},
-    http::{admit_results_upload, harden_results_response, results_upload_admission},
+    http::{
+        admit_results_upload, content_length_matches, harden_results_response, parse_canonical_u64,
+        results_upload_admission,
+    },
     observer::{NoopResultsObserver, ResultsHttpObservation},
 };
 
@@ -628,33 +631,6 @@ fn parse_entry_id(value: &str) -> Result<CacheEntryId, ()> {
         return Err(());
     }
     CacheEntryId::new(uuid).map_err(|_| ())
-}
-
-fn content_length_matches(headers: &HeaderMap, actual: usize) -> bool {
-    let mut values = headers.get_all(header::CONTENT_LENGTH).iter();
-    let Some(value) = values.next() else {
-        return false;
-    };
-    if values.next().is_some() {
-        return false;
-    }
-    value
-        .to_str()
-        .ok()
-        .and_then(|value| parse_canonical_u64(value).ok())
-        .and_then(|value| usize::try_from(value).ok())
-        == Some(actual)
-}
-
-fn parse_canonical_u64(value: &str) -> Result<u64, ()> {
-    if value.is_empty()
-        || value.len() > 20
-        || !value.bytes().all(|byte| byte.is_ascii_digit())
-        || (value.len() > 1 && value.starts_with('0'))
-    {
-        return Err(());
-    }
-    value.parse().map_err(|_| ())
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/automata-ci-results-github/src/http.rs
+++ b/crates/automata-ci-results-github/src/http.rs
@@ -774,7 +774,7 @@ fn parse_timestamp(value: &str) -> Result<u64, ()> {
     u64::try_from(timestamp.unix_timestamp()).map_err(|_| ())
 }
 
-fn parse_canonical_u64(value: &str) -> Result<u64, ()> {
+pub(crate) fn parse_canonical_u64(value: &str) -> Result<u64, ()> {
     if value.is_empty()
         || value.len() > 20
         || !value.bytes().all(|byte| byte.is_ascii_digit())
@@ -791,7 +791,7 @@ fn parse_artifact_id(value: &str) -> Result<ArtifactId, ()> {
         .and_then(|value| ArtifactId::new(value).map_err(|_| ()))
 }
 
-fn content_length_matches(headers: &HeaderMap, actual: usize) -> bool {
+pub(crate) fn content_length_matches(headers: &HeaderMap, actual: usize) -> bool {
     let mut values = headers.get_all(header::CONTENT_LENGTH).iter();
     let Some(value) = values.next() else {
         return false;


### PR DESCRIPTION
## Summary

- keep the canonical unsigned-decimal and exact `Content-Length` helpers in the existing Results HTTP module
- reuse those helpers from the cache HTTP adapter and remove its byte-identical private copies
- preserve every call site and rejection path while keeping visibility crate-internal

Closes #278

## Validation

- targeted `rustfmt --edition 2024 --check` and `git diff --check`
- stale-definition scan confirms one definition of each helper and all artifact/cache callers remain
- `CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-results-github --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-results-github --all-features`
- `CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-results-github --all-targets --all-features -- -D warnings`
- final rebase verified unchanged target blobs, stable patch ID, and full binary diff
- independent read-only review approved with no findings

The package check was repeated after the first main replay. The full tests and strict Clippy were run on the same byte-identical patch before that replay; both subsequent main revisions leave the target blobs unchanged.
