### PR TITLE
fix(ci): bound sccache socket path

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  SCCACHE_SERVER_UDS: '\x00automata-sccache'
   TMPDIR: ${{ github.workspace }}/target/task-tmp/ci
 
 jobs:

--- a/scripts/ci/tests/rust-build-cache.test.py
+++ b/scripts/ci/tests/rust-build-cache.test.py
@@ -17,6 +17,7 @@ CACHE_ACTION = (
     "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5"
 )
 SCRATCH_PREPARATION = 'run: install -d -m 0700 -- "$TMPDIR"'
+SHORT_ABSTRACT_SOCKET = "SCCACHE_SERVER_UDS: '\\x00automata-sccache'"
 RUST_JOBS = (
     "verify",
     "rust_lint",
@@ -40,6 +41,9 @@ def job_body(workflow: str, job: str) -> str:
 
 def main() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert workflow.count(SHORT_ABSTRACT_SOCKET) == 1, (
+        "sccache must use one short abstract socket independent of workspace depth"
+    )
     for job in RUST_JOBS:
         body = job_body(workflow, job)
         assert "RUSTC_WRAPPER: sccache" in body, f"{job} lost the rustc wrapper"


### PR DESCRIPTION
## Summary
- pin sccache to a short abstract Unix socket independent of the isolated workspace depth
- enforce the socket contract in the Rust cache workflow test

## Validation
- `python3 scripts/ci/tests/rust-build-cache.test.py`
- `target/ci-tools/actionlint .ci/workflows/*.yml`
- `git diff --check`

## Live failure addressed
Automata reached the Rust tooling steps, but sccache failed with `path must be shorter than SUN_LEN` because its default socket inherited the deeply isolated workspace `TMPDIR`. The abstract socket is scoped to the job sandbox and has no filesystem path-length dependency.