### PR TITLE
fix(ci): start compiler cache on short notifier

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  SCCACHE_IDLE_TIMEOUT: "0"
   SCCACHE_SERVER_UDS: '\x00automata-sccache'
   TMPDIR: ${{ github.workspace }}/target/task-tmp/ci
 
@@ -48,6 +49,9 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
+
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
 
       - name: Restore Cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -143,6 +147,9 @@ jobs:
         with:
           version: v0.17.0
 
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
+
       - name: Restore Cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -186,6 +193,9 @@ jobs:
         with:
           version: v0.17.0
 
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
+
       - name: Restore Cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -226,6 +236,9 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
+
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
 
       - name: Restore Cargo registry and cargo-deny
         id: dependency-audit-cargo-cache
@@ -294,6 +307,9 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
+
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
 
       - name: Restore Cargo registry and coverage tool
         id: coverage-cargo-cache
@@ -519,6 +535,9 @@ jobs:
         with:
           version: v0.17.0
 
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
+
       - name: Restore Cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -623,6 +642,9 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
+
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
 
       - name: Restore Cargo registry and SBOM tool
         id: distribution-cargo-cache

--- a/scripts/ci/tests/rust-build-cache.test.py
+++ b/scripts/ci/tests/rust-build-cache.test.py
@@ -18,6 +18,7 @@ CACHE_ACTION = (
 )
 SCRATCH_PREPARATION = 'run: install -d -m 0700 -- "$TMPDIR"'
 SHORT_ABSTRACT_SOCKET = "SCCACHE_SERVER_UDS: '\\x00automata-sccache'"
+SHORT_STARTUP = "run: env TMPDIR=/tmp sccache --start-server"
 RUST_JOBS = (
     "verify",
     "rust_lint",
@@ -44,6 +45,9 @@ def main() -> None:
     assert workflow.count(SHORT_ABSTRACT_SOCKET) == 1, (
         "sccache must use one short abstract socket independent of workspace depth"
     )
+    assert workflow.count('SCCACHE_IDLE_TIMEOUT: "0"') == 1, (
+        "the job-scoped sccache server must survive until post-job statistics"
+    )
     for job in RUST_JOBS:
         body = job_body(workflow, job)
         assert "RUSTC_WRAPPER: sccache" in body, f"{job} lost the rustc wrapper"
@@ -58,7 +62,16 @@ def main() -> None:
         assert body.index(SCRATCH_PREPARATION) < body.index(SCCACHE_ACTION), (
             f"{job} must prepare its scratch directory before sccache starts"
         )
+        assert body.count(SHORT_STARTUP) == 1, (
+            f"{job} must start sccache once with a path-length-safe notifier"
+        )
+        assert body.index(SCCACHE_ACTION) < body.index(SHORT_STARTUP), (
+            f"{job} must install sccache before starting it"
+        )
         assert CACHE_ACTION in body, f"{job} lost the pinned Cargo cache action"
+        assert body.index(SHORT_STARTUP) < body.index(CACHE_ACTION), (
+            f"{job} must start sccache before restoring build inputs"
+        )
         assert "~/.cargo/registry/cache" in body
         assert "~/.cargo/registry/index" in body
         assert "~/.cargo/registry/src" in body


### PR DESCRIPTION
## Summary
- explicitly start each job-scoped sccache server with a short `/tmp` startup notifier
- retain the abstract server socket and keep the daemon alive through post-job statistics
- preserve the repository-local `TMPDIR` for the actual build
- enforce installer/start/cache ordering in the workflow contract test

## Validation
- exact sccache v0.17.0 start/show-stats/stop probe with the configured abstract socket
- `python3 scripts/ci/tests/rust-build-cache.test.py`
- `target/ci-tools/actionlint .ci/workflows/*.yml`
- `git diff --check`

## Live failure addressed
sccache v0.17.0 creates an internal startup-notification Unix socket under `TMPDIR` before its configured server socket comes online. Automata workspace paths exceed `sockaddr_un.sun_path`; the explicit startup keeps that internal notifier under `/tmp` without changing build scratch placement.