### PR TITLE
refactor(api): retire definition-only convenience methods

### DIFF
--- a/crates/automata-ci-auth/src/login.rs
+++ b/crates/automata-ci-auth/src/login.rs
@@ -682,15 +682,6 @@ impl LoginTransactionProof {
             Self::Device { .. } => None,
         }
     }
-
-    #[must_use]
-    /// Returns the device-poll proof when device-based.
-    pub const fn device_poll_proof(&self) -> Option<&LoginTransactionBinding> {
-        match self {
-            Self::Browser { .. } => None,
-            Self::Device { poll_proof } => Some(poll_proof),
-        }
-    }
 }
 
 /// Exact non-secret identity, purpose, provider, and proof tuple for lookup.

--- a/crates/automata-ci-core/src/execution/attempt.rs
+++ b/crates/automata-ci-core/src/execution/attempt.rs
@@ -188,20 +188,6 @@ impl JobAttemptState {
         Ok(active.clone())
     }
 
-    /// Cancels or skips work that has not yet been leased.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AttemptStateError::Transition`] unless this is a valid queued
-    /// transition to `cancelled` or `skipped`.
-    pub fn resolve_queued(&mut self, terminal: JobLifecycle) -> Result<(), AttemptStateError> {
-        self.lifecycle
-            .validate_transition(terminal)
-            .map_err(AttemptStateError::Transition)?;
-        self.lifecycle = terminal;
-        Ok(())
-    }
-
     /// Validates invariants after reading this state from durable storage.
     ///
     /// # Errors

--- a/crates/automata-ci-core/src/log.rs
+++ b/crates/automata-ci-core/src/log.rs
@@ -180,12 +180,6 @@ impl LogFrame {
     pub const fn is_end_of_stream(&self) -> bool {
         self.end_of_stream
     }
-
-    /// Consumes the frame and returns its raw payload bytes.
-    #[must_use]
-    pub fn into_payload(self) -> Vec<u8> {
-        self.payload
-    }
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-runner-transport/src/limits.rs
+++ b/crates/automata-ci-runner-transport/src/limits.rs
@@ -71,30 +71,6 @@ impl TransportLimits {
         Ok(self)
     }
 
-    /// Changes the HTTP/2 header, per-stream send-buffer, and stream ceilings.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ConfigurationError`] if a value is zero or the send buffer
-    /// cannot be represented by the HTTP/2 implementation.
-    pub fn with_http2_limits(
-        mut self,
-        header_list_bytes: u32,
-        send_buffer_bytes: usize,
-        concurrent_streams_per_connection: u32,
-    ) -> Result<Self, ConfigurationError> {
-        require_nonzero(&header_list_bytes)?;
-        require_nonzero(&send_buffer_bytes)?;
-        require_nonzero(&concurrent_streams_per_connection)?;
-        if send_buffer_bytes > u32::MAX as usize {
-            return Err(ConfigurationError::InvalidLimit);
-        }
-        self.header_list_bytes = header_list_bytes;
-        self.send_buffer_bytes = send_buffer_bytes;
-        self.concurrent_streams_per_connection = concurrent_streams_per_connection;
-        Ok(self)
-    }
-
     /// Changes connection-level and request-level admission ceilings.
     ///
     /// # Errors

--- a/crates/automata-ci-store/src/github_oidc.rs
+++ b/crates/automata-ci-store/src/github_oidc.rs
@@ -461,12 +461,6 @@ impl GithubOidcAuthorityProposal {
         self.request_bearer_verification_skew_seconds
     }
 
-    /// Returns the deadline through which the request-bearer key must remain loaded.
-    #[must_use]
-    pub const fn request_bearer_key_not_after_seconds(&self) -> u64 {
-        self.expires_at_seconds + self.request_bearer_verification_skew_seconds
-    }
-
     /// Returns the inclusive request-bearer issuance second.
     #[must_use]
     pub const fn issued_at_seconds(&self) -> u64 {

--- a/crates/automata-ci-store/src/outbox.rs
+++ b/crates/automata-ci-store/src/outbox.rs
@@ -306,11 +306,6 @@ impl CommandReplayPage {
         &self.commands
     }
 
-    #[must_use]
-    pub fn into_commands(self) -> Vec<DurableRunnerCommand> {
-        self.commands
-    }
-
     pub fn pop(&mut self) -> Option<DurableRunnerCommand> {
         self.commands.pop()
     }

--- a/crates/automata-ci-workflow-github/src/syntax/ast.rs
+++ b/crates/automata-ci-workflow-github/src/syntax/ast.rs
@@ -258,11 +258,6 @@ impl YamlDocument {
         &self.root
     }
 
-    /// Returns whether the source included an explicit `---` document start.
-    pub const fn has_explicit_start(&self) -> bool {
-        self.explicit_start
-    }
-
     /// Returns the exact source span covering the document.
     pub fn span(&self) -> &SourceSpan {
         &self.span

--- a/crates/automata-ci-workflow-service/src/github_activation.rs
+++ b/crates/automata-ci-workflow-service/src/github_activation.rs
@@ -135,12 +135,6 @@ impl GithubLogicalActivationEvaluator {
     }
 
     #[must_use]
-    /// Returns the configured copyable expression evaluator.
-    pub const fn expression_evaluator(&self) -> GithubExpressionEvaluator {
-        self.evaluator
-    }
-
-    #[must_use]
     /// Returns the immutable provider context used for each activation.
     pub const fn github(&self) -> &GithubActivationContext {
         &self.github


### PR DESCRIPTION
## Summary

Retire eight public convenience methods that have no callers anywhere in the workspace:

- `LoginTransactionProof::device_poll_proof`
- `JobAttemptState::resolve_queued`
- `LogFrame::into_payload`
- `TransportLimits::with_http2_limits`
- `GithubOidcAuthorityProposal::request_bearer_key_not_after_seconds`
- `CommandReplayPage::into_commands`
- `YamlDocument::has_explicit_start`
- `GithubLogicalActivationEvaluator::expression_evaluator`

This exact subset was removed in #50 and restored only by the wholesale #55 revert; none acquired a caller afterward. The patch removes only the methods and their attached documentation/attributes—no fields, derives, validation, serialization, error conversion, or runtime behavior changes.

## Compatibility

This intentionally contracts source API in six publishable `0.1.0` crates. The repository has no tags or GitHub releases, the packages are not present on crates.io, and the changelog records no published crate, archive, or image.

## Validation

- targeted formatting, `git diff --check`, and exact stale-symbol scan
- all-target/all-feature checks for owning packages and reverse consumers
- all six owning-package test suites
- strict Clippy with only the established aggregate-test `large-futures` / `too-many-lines` allowances
- independent history/API/overlap review: approved, no findings

## Scope

Exactly 8 files and 75 deletions. No open PR overlaps any changed file.

Closes #284
