### PR TITLE
docs: correct runtime-authority transport claims

### DIFF
--- a/crates/automata-ci-runner-transport/src/server.rs
+++ b/crates/automata-ci-runner-transport/src/server.rs
@@ -150,7 +150,7 @@ impl RunnerControlServer {
         self
     }
 
-    /// Installs the only value-bearing route on this dedicated mTLS listener.
+    /// Installs the dedicated value-bearing managed-secret route on this mTLS listener.
     ///
     /// The route is absent unless explicitly composed. It reauthenticates the
     /// peer certificate for every request and receives no connection-cached

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -438,7 +438,8 @@ durable binding exists and may remain one during an outage.
 | `automata_ci_runner_control_retries_total` | counter | `kind` |
 
 Control kinds are exactly `handshake`, `lease_request`, `lease_response`,
-`heartbeat`, `job_state`, `job_result`, `log_batch`, and `command_ack`.
+`heartbeat`, `job_state`, `job_result`, `log_batch`, `command_ack`,
+`runtime_authority_request`, and `runtime_authority_ack`.
 Outcomes are `success`, `transport_error`, `timeout`, `cancelled`, `http_error`,
 or `invalid_response`. The supplied control-failure recording rule includes the
 four error outcomes and excludes deliberate cancellation.


### PR DESCRIPTION
## Summary

- correct the runner transport Rustdoc now that `/Sync` also carries value-bearing runtime-authority grants
- add `runtime_authority_request` and `runtime_authority_ack` to the documented control-request metric kinds

Both omissions were introduced when runtime-authority delivery landed after the original documentation. This is documentation-only; no runtime behavior changes.

## Validation

- `cargo fmt --package automata-ci-runner-transport -- --check`
- `CARGO_BUILD_JOBS=1 cargo check -p automata-ci-runner-transport --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo doc -p automata-ci-runner-transport --all-features --no-deps`
- `git diff --check`
- independent review: approved, no findings

Closes #288
