### PR TITLE
docs(workflow): mark scheduled admission experimental

### DIFF
--- a/crates/automata-ci-workflow-service/README.md
+++ b/crates/automata-ci-workflow-service/README.md
@@ -32,8 +32,9 @@ an exact replay returns the same run with `200`.
 
 A first-party CLI command, browser form, mutable branch/tag resolution, and
 complete repository variable and secret-reference hydration remain product
-work. Scheduled workflow synthesis is a separate unsupported control-plane
-surface.
+work. Scheduled workflows are discovered and admitted by the separate
+product-supervised GitHub schedule service. The [compatibility matrix](https://github.com/automata-ci/automata/blob/main/docs/compatibility.md#v01-implementation-status)
+records their experimental status and remaining acceptance gates.
 
 - [Architecture documentation](https://github.com/automata-ci/automata/blob/main/docs/architecture.md)
 - API documentation: run `cargo doc -p automata-ci-workflow-service --open` from a source checkout.


### PR DESCRIPTION
## Summary

Correct the workflow-service README’s stale statement that scheduled workflow synthesis is unsupported. The product-supervised GitHub schedule service now discovers and admits scheduled fires, while the compatibility matrix classifies that surface as experimental.

The manual-dispatch documentation is unchanged. The parity backlog is intentionally untouched because #191 already modifies that file.

## Validation

- exact one-file documentation diff
- `git diff --check`
- verified the compatibility link, anchor, and `Scheduled workflows | Experimental` row
- verified the composed `GithubScheduleService` discovery and admission path
- independent review: approved, no findings

Closes #290
