### PR TITLE
docs(ui): correct browser live-log ownership

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,9 +208,13 @@ renderer runs as a resource-limited WASI component without filesystem, network,
 environment, or subprocess access. Node.js is a build dependency, not a server
 dependency.
 
-Every route returns complete HTML. Browser JavaScript adds small conveniences
-such as theme preference, log filtering, and form state; it does not own page
-data or live log transport.
+Every initial route returns complete server-rendered HTML. Browser JavaScript
+adds theme preference, log filtering, and form state, and active job logs
+revalidate bounded JSON snapshots. For resumable delivery, the shared UI
+selects advertised transports, strictly decodes SSE, advances checkpoints,
+reconnects, and falls back to snapshot polling. Rust retains authentication,
+authorization, and durable log-data authority. See
+[ADR 0004](architecture-decisions/0004-resumable-live-log-delivery.md).
 
 ## Planned providers and topology
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -34,7 +34,7 @@ The browser bundle hydrates the same document. JavaScript enhances the theme
 toggle, in-page log filtering, and repository-settings draft and submission
 states. Links, GET filters, settings forms, and RBAC management forms retain
 their native behavior when JavaScript is absent or fails. There is no SPA router
-and no client-only page-data fetch.
+and every initial page route remains a complete server-rendered document.
 
 ## Source architecture
 
@@ -52,13 +52,17 @@ src/
 └── validation/   exact validation of the untrusted host boundary
 ```
 
-Production pages receive validated models and render ordinary links and forms;
-they do not fetch data or know how the static demo is routed. The demo owns its
-sample data and its small query-preserving GET adapter, and production source
-never imports test fixtures. The adapter is reinstalled on hot module replacement
-so routing changes do not leave a stale submit handler. `styles.css` only
-declares the cascade order and imports the focused modules documented in
-`src/styles/README.md`.
+Production pages receive validated initial models and render ordinary links and
+forms; they do not own generic page-data loading or know how the static demo is
+routed. The active job-log page revalidates bounded JSON snapshots. The shared
+live-log package selects advertised transports, strictly decodes SSE, advances
+checkpoints, reconnects, and falls back to snapshot polling, as
+specified by [ADR 0004](../docs/architecture-decisions/0004-resumable-live-log-delivery.md).
+The demo owns its sample data and its small query-preserving GET adapter, and
+production source never imports test fixtures. The adapter is reinstalled on hot
+module replacement so routing changes do not leave a stale submit handler.
+`styles.css` only declares the cascade order and imports the focused modules
+documented in `src/styles/README.md`.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Correct the web architecture documentation to match the current live-log boundary:

- initial page routes remain complete server-rendered HTML
- an active job-log page performs bounded JSON revalidation in the browser
- the shared UI owns advertised transport selection, strict SSE decoding, checkpoints, reconnects, and snapshot fallback
- Rust retains authentication, authorization, and durable log-data authority

The architecture guide and UI README now agree with ADR 0004 and the implemented controller/SSE path, without claiming generic client-side page-data ownership.

## Validation

- exact two-file prose diff
- `git diff --check`
- stale-denial search
- ADR links and implementation evidence verified
- independent review: approved, no findings

Closes #294
