### PR TITLE
refactor(auth): retire inert OAuth signup override

### DIFF
--- a/crates/automata-ci-auth/src/github/model.rs
+++ b/crates/automata-ci-auth/src/github/model.rs
@@ -138,7 +138,6 @@ pub struct GithubAppConfig {
     callback_uri: Url,
     endpoints: GithubEndpoints,
     web_transaction_ttl_seconds: u64,
-    allow_signup: bool,
 }
 
 impl GithubAppConfig {
@@ -167,15 +166,7 @@ impl GithubAppConfig {
             callback_uri,
             endpoints,
             web_transaction_ttl_seconds,
-            allow_signup: false,
         })
-    }
-
-    #[must_use]
-    /// Sets whether GitHub may offer account creation during authorization.
-    pub fn with_signup(mut self, allow_signup: bool) -> Self {
-        self.allow_signup = allow_signup;
-        self
     }
 
     /// Returns the provider identity associated with this GitHub App.
@@ -206,11 +197,6 @@ impl GithubAppConfig {
     pub const fn web_transaction_ttl_seconds(&self) -> u64 {
         self.web_transaction_ttl_seconds
     }
-
-    /// Reports whether GitHub may offer account creation during authorization.
-    pub const fn allow_signup(&self) -> bool {
-        self.allow_signup
-    }
 }
 
 impl fmt::Debug for GithubAppConfig {
@@ -226,7 +212,6 @@ impl fmt::Debug for GithubAppConfig {
                 "web_transaction_ttl_seconds",
                 &self.web_transaction_ttl_seconds,
             )
-            .field("allow_signup", &self.allow_signup)
             .finish()
     }
 }
@@ -531,13 +516,6 @@ pub(crate) fn append_web_authorization_query(
         .append_pair("state", state.expose_secret())
         .append_pair("code_challenge", challenge.as_str())
         .append_pair("code_challenge_method", "S256")
-        .append_pair(
-            "allow_signup",
-            if config.allow_signup() {
-                "true"
-            } else {
-                "false"
-            },
-        );
+        .append_pair("allow_signup", "false");
     endpoint
 }


### PR DESCRIPTION
## Summary

Remove the inert GitHub OAuth signup override from `GithubAppConfig`:

- delete the always-false field and its zero-call builder/getter
- remove the redundant Debug field
- emit the existing `allow_signup=false` authorization query directly

This exact cleanup previously landed in #50 and was restored only by the wholesale #55 revert. No repository caller or configuration has enabled signup since, and the existing false-value contract remains unchanged.

## Compatibility

This contracts a public pre-1.0 Rust API. The crate has no published release or crates.io package, and all repository consumers were audited.

## Validation

- auth all-target/all-feature check
- auth tests: 132 passed
- strict Clippy with `-D warnings`
- targeted rustfmt, diff, and stale-identifier scans
- independent review: approved, no findings

Closes #295
