### PR TITLE
test(workflow): remove unused preselected recompiler

### DIFF
--- a/crates/automata-ci-workflow-service/tests/support/mod.rs
+++ b/crates/automata-ci-workflow-service/tests/support/mod.rs
@@ -97,25 +97,6 @@ pub fn compile_ci_at_path(
     GithubWorkflowCompiler::new().compile(request)
 }
 
-pub fn recompile_preselected(request: &WorkflowAdmissionRequest) -> CompilationReport {
-    let source = std::str::from_utf8(request.source()).expect("fixture source is UTF-8");
-    let provenance = SourceProvenance::new(
-        SourceId::new(request.workflow_path()),
-        SourceOrigin::Repository {
-            repository: Arc::from(request.repository().slug()),
-            revision: Arc::from(request.commit_sha()),
-            path: Arc::from(request.workflow_path()),
-        },
-    );
-    let parsed =
-        GithubWorkflowFrontend::default().parse(ParseWorkflowRequest::new(provenance, source));
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::for_preselected_event(
-        parsed.plan().expect("source plan"),
-        request.plan().event().clone(),
-    ))
-}
-
 fn request_from_compilation(
     tenant: &str,
     workflow_path: &str,


### PR DESCRIPTION
## Summary

Remove the unused `recompile_preselected` workflow-service test helper. It has no callers anywhere in the workspace and was hidden by the support module’s existing dead-code allowance.

The helper was removed in #50, restored only by the wholesale #55 revert, and remained unchanged and caller-free afterward. No other helper or allowance changes.

## Validation

- workflow-service all-target/all-feature check
- workflow-service tests: 198 passed, 1 configured S3 test ignored
- workspace rustfmt check
- diff and zero-occurrence scans
- independent review: approved, no findings

Closes #299
