### PR TITLE
refactor(postgres-tests): share lower-hex fixture helper

### DIFF
--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_materialization.rs
@@ -70,7 +70,7 @@ use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::support::{TestDatabase, TestResult, run_with_database};
+use crate::support::{TestDatabase, TestResult, lower_hex, run_with_database};
 
 struct Fixture {
     tenant: String,
@@ -2168,16 +2168,6 @@ async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {
             .fetch_one(database.pool())
             .await?,
     )
-}
-
-fn lower_hex(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-
-    let mut encoded = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
-    }
-    encoded
 }
 
 async fn wait_until_database_after(database: &TestDatabase, target_ms: i64) -> TestResult {

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_orchestration.rs
@@ -43,17 +43,7 @@ use automata_ci_store::{
 };
 use uuid::Uuid;
 
-use crate::support::{TestDatabase, TestResult, run_with_database};
-
-fn lower_hex(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-
-    let mut encoded = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
-    }
-    encoded
-}
+use crate::support::{TestDatabase, TestResult, lower_hex, run_with_database};
 
 async fn seed_tenant(database: &TestDatabase, tenant: &str) -> TestResult {
     sqlx::query(

--- a/crates/automata-ci-postgres/tests/support/mod.rs
+++ b/crates/automata-ci-postgres/tests/support/mod.rs
@@ -344,7 +344,7 @@ async fn ensure_workflow_permission_credential(
     }
 }
 
-fn lower_hex(bytes: &[u8]) -> String {
+pub(crate) fn lower_hex(bytes: &[u8]) -> String {
     use std::fmt::Write as _;
 
     let mut encoded = String::with_capacity(bytes.len() * 2);


### PR DESCRIPTION
## Summary

Consolidate three byte-for-byte identical PostgreSQL integration-test `lower_hex` helpers:

- expose the existing support helper within the test crate
- import it from logical materialization and logical orchestration tests
- remove the two local copies

This is test-only and preserves all seven call sites and exact lowercase two-character-per-byte encoding.

## Validation

- one helper definition and seven callers
- PostgreSQL test-target feature-gated check
- strict Clippy with `-D warnings`
- package rustfmt and diff checks
- independent review: approved, no findings

No live database run was needed for this structural-only consolidation.

Closes #300
