### PR TITLE
fix(ci): bound dependency audit output

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Audit dependencies
         run: |
-          cargo deny --locked --workspace --all-features check advisories bans licenses sources
+          cargo deny --locked --workspace --all-features check --hide-inclusion-graph advisories bans licenses sources
           crates/automata-ci-protocol-protobuf/tools/protobuf-codegen.sh audit
 
   rust_coverage:

--- a/crates/automata-ci-protocol-protobuf/tools/protobuf-codegen.sh
+++ b/crates/automata-ci-protocol-protobuf/tools/protobuf-codegen.sh
@@ -124,5 +124,5 @@ esac
 if [[ "${mode}" == audit ]]; then
     TMPDIR="${scratch}/temp" CARGO_TARGET_DIR="${scratch}/cargo-target" \
         "${cargo_command}" deny --manifest-path "${scratch}/Cargo.toml" \
-        --config "${repository_root}/deny.toml" --locked check
+        --config "${repository_root}/deny.toml" --locked check --hide-inclusion-graph
 fi

--- a/scripts/ci/tests/rust-build-cache.test.py
+++ b/scripts/ci/tests/rust-build-cache.test.py
@@ -91,6 +91,16 @@ def main() -> None:
     for gate in ("rust_lint", "rust_docs", "dependency_audit"):
         assert f"- {gate}" in distribution, f"distribution no longer requires {gate}"
     assert "cargo-deny --version 0.20.2" in workflow
+    dependency_audit = job_body(workflow, "dependency_audit")
+    assert "check --hide-inclusion-graph advisories bans licenses sources" in dependency_audit, (
+        "dependency audit output must remain inside the runner command-output bound"
+    )
+    protobuf_audit = (
+        ROOT / ".." / "crates" / "automata-ci-protocol-protobuf" / "tools" / "protobuf-codegen.sh"
+    ).read_text(encoding="utf-8")
+    assert "--locked check --hide-inclusion-graph" in protobuf_audit, (
+        "protobuf dependency audit output must remain bounded"
+    )
     assert "cargo-llvm-cov --version 0.8.7" in workflow
     assert "cargo-cyclonedx --version 0.5.9" in workflow
     print("verified parallel Rust gates and bounded shared compiler caches")


### PR DESCRIPTION
## Summary
- suppress cargo-deny inclusion graphs while preserving all audit findings
- apply the same bounded output mode to the isolated protobuf codegen audit
- fail the CI contract test if either audit loses the bounded mode

## Production evidence
The unbounded audit emitted 344593 bytes locally and exceeded Automata runner command output limits. The bounded root audit emits 10816 bytes and the protobuf audit emits 3911 bytes.

## Validation
- python3 scripts/ci/tests/rust-build-cache.test.py
- actionlint .ci/workflows/*.yml
- protobuf-codegen.sh audit
- cargo deny --locked --workspace --all-features check --hide-inclusion-graph advisories bans licenses sources
- git diff --check