### PR TITLE
refactor(github): retire unused provenance constants

### DIFF
--- a/crates/automata-ci-expression-github/src/lib.rs
+++ b/crates/automata-ci-expression-github/src/lib.rs
@@ -21,9 +21,3 @@ pub use context::{
 pub use error::{GithubExpressionEvaluationError, GithubExpressionEvaluationErrorKind};
 pub use evaluator::{GithubExpressionEvaluator, GithubExpressionLimits};
 pub use value::{GithubObject, GithubSensitiveValue, GithubValue, GithubValueError};
-
-/// Upstream compatibility baseline used for evaluator behavior.
-pub const GITHUB_EXPRESSION_RUNTIME_BASELINE: &str = "actions/runner@v2.336.0";
-/// Immutable upstream source revision for the compatibility baseline.
-pub const GITHUB_EXPRESSION_RUNTIME_BASELINE_COMMIT: &str =
-    "98aabcd429c4e8402406c56ce2d26387fed3b9ce";

--- a/crates/automata-ci-github-runtime/src/lib.rs
+++ b/crates/automata-ci-github-runtime/src/lib.rs
@@ -57,30 +57,6 @@ pub const GITHUB_RUNTIME_PROTOCOL_BASELINE_COMMIT: &str =
 /// This does not advance [`GITHUB_RUNTIME_PROTOCOL_BASELINE`].
 pub const GITHUB_RUNTIME_ARTIFACTS_DELTA_COMMIT: &str = "35e45850b519df66a669e2c91e0917804a33d0c7";
 
-/// Upstream parser for both stdout/stderr workflow-command syntaxes.
-pub const UPSTREAM_ACTION_COMMAND_SOURCE: &str = "src/Runner.Common/ActionCommand.cs";
-
-/// Upstream command state machine and command-extension behavior.
-pub const UPSTREAM_ACTION_COMMAND_MANAGER_SOURCE: &str =
-    "src/Runner.Worker/ActionCommandManager.cs";
-
-/// Upstream command-file grammar and application behavior.
-pub const UPSTREAM_FILE_COMMAND_MANAGER_SOURCE: &str = "src/Runner.Worker/FileCommandManager.cs";
-
-/// Complete upstream review set for command parsing and phase semantics.
-pub const GITHUB_RUNTIME_PROTOCOL_UPSTREAM_SOURCES: &[&str] = &[
-    UPSTREAM_ACTION_COMMAND_SOURCE,
-    UPSTREAM_ACTION_COMMAND_MANAGER_SOURCE,
-    UPSTREAM_FILE_COMMAND_MANAGER_SOURCE,
-    "src/Runner.Worker/ActionRunner.cs",
-    "src/Runner.Worker/ExecutionContext.cs",
-    "src/Test/L0/Worker/ActionCommandL0.cs",
-    "src/Test/L0/Worker/ActionCommandManagerL0.cs",
-    "src/Test/L0/Worker/SetEnvFileCommandL0.cs",
-    "src/Test/L0/Worker/SetOutputFileCommandL0.cs",
-    "src/Test/L0/Worker/SaveStateFileCommandL0.cs",
-];
-
 /// Complete upstream review set for the artifacts environment-file delta.
 pub const GITHUB_RUNTIME_ARTIFACTS_DELTA_UPSTREAM_SOURCES: &[&str] = &[
     "src/Runner.Common/Constants.cs",


### PR DESCRIPTION
## Summary

Remove six public provenance constants with no consumers:

- the unused expression-runtime baseline pair
- three runtime upstream-source scalars and their otherwise-unused aggregate array

The actively asserted runtime baseline/delta constants and artifacts source inventory remain. Equivalent provenance stays recorded in the expression and runtime READMEs, including the exact runtime ten-file review set.

These constants were removed in #50, restored only by the wholesale #55 revert, and never acquired a consumer afterward.

## Compatibility

This contracts a pre-release public Rust surface. Both crates remain `0.1.0`, have no published crates.io package or repository release, and all repository consumers were audited.

## Validation

- both owning packages: all-target/all-feature check
- 86 owning-package tests passed
- strict Clippy with `-D warnings`
- workspace formatting, diff, stale-identifier, and README provenance checks
- independent review: approved, no findings

Closes #303
