### PR TITLE
fix(podman): drive service healthchecks in runner cgroup

### DIFF
--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -947,6 +947,8 @@ impl PodmanInner {
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
+        let mut next_health_check = Instant::now();
+        let mut health_interval = None;
         loop {
             if cancellation.is_cancelled() {
                 return Err(provider_error::known(
@@ -976,10 +978,94 @@ impl PodmanInner {
                     ));
                 }
                 ServiceReadiness::Waiting => {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    thread::sleep(SERVICE_HEALTH_POLL_INTERVAL.min(remaining));
+                    let now = Instant::now();
+                    if now >= next_health_check {
+                        let interval = if let Some(interval) = health_interval {
+                            interval
+                        } else {
+                            let interval = self.service_health_interval(
+                                entry,
+                                names,
+                                fingerprint,
+                                deadline,
+                                cancellation,
+                            )?;
+                            health_interval = Some(interval);
+                            interval
+                        };
+                        self.run_service_healthcheck(
+                            entry,
+                            names,
+                            fingerprint,
+                            deadline,
+                            cancellation,
+                        )?;
+                        next_health_check = Instant::now()
+                            .checked_add(interval)
+                            .unwrap_or(deadline)
+                            .min(deadline);
+                    } else {
+                        let remaining = deadline.saturating_duration_since(now);
+                        let until_check = next_health_check.saturating_duration_since(now);
+                        thread::sleep(SERVICE_HEALTH_POLL_INTERVAL.min(remaining).min(until_check));
+                    }
                 }
             }
+        }
+    }
+
+    fn service_health_interval(
+        &self,
+        entry: &ServiceManifestEntry,
+        names: &ResourceNames,
+        fingerprint: &str,
+        deadline: Instant,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Duration, ProviderError> {
+        let inspection = self.verify_service_for_spec(
+            entry,
+            names,
+            fingerprint,
+            deadline,
+            cancellation,
+            ProviderStage::Start,
+        )?;
+        let mut arguments = self.base_arguments();
+        arguments.extend(os_args(["container", "inspect", "--format"]));
+        arguments.push(SERVICE_HEALTH_CONFIGURATION_FORMAT.into());
+        arguments.push(inspection.identifier().into());
+        let output = Self::require_success(
+            self.run(arguments, deadline, cancellation, ProviderStage::Start),
+            ProviderStage::Start,
+            None,
+        )?;
+        parse_service_health_interval(output.stdout())
+            .ok_or_else(|| provider_error::invalid_state(ProviderStage::Start))
+    }
+
+    fn run_service_healthcheck(
+        &self,
+        entry: &ServiceManifestEntry,
+        names: &ResourceNames,
+        fingerprint: &str,
+        deadline: Instant,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ProviderError> {
+        let inspection = self.verify_service_for_spec(
+            entry,
+            names,
+            fingerprint,
+            deadline,
+            cancellation,
+            ProviderStage::Start,
+        )?;
+        let mut arguments = self.base_arguments();
+        arguments.extend(os_args(["healthcheck", "run"]));
+        arguments.push(inspection.identifier().into());
+        let output = self.run(arguments, deadline, cancellation, ProviderStage::Start);
+        match output.termination() {
+            CommandTermination::Exited(Some(0 | 1)) if !output.was_truncated() => Ok(()),
+            _ => Self::require_success(output, ProviderStage::Start, None).map(|_| ()),
         }
     }
 
@@ -4592,6 +4678,16 @@ fn parse_service_readiness(
     }
 }
 
+fn parse_service_health_interval(bytes: &[u8]) -> Option<Duration> {
+    let serde_json::Value::Object(configuration) =
+        serde_json::from_slice::<serde_json::Value>(bytes).ok()?
+    else {
+        return None;
+    };
+    let nanoseconds = configuration.get("Interval")?.as_u64()?;
+    (nanoseconds > 0).then(|| Duration::from_nanos(nanoseconds))
+}
+
 fn service_inspection_format() -> String {
     format!("{}\n{{{{.Id}}}}", label_format(true, true))
 }
@@ -4946,5 +5042,16 @@ mod capability_contract_tests {
             JobContainerEngine::AttemptScopedDockerApi,
             true,
         ));
+    }
+
+    #[test]
+    fn service_health_interval_requires_positive_canonical_nanoseconds() {
+        assert_eq!(
+            parse_service_health_interval(br#"{"Interval":5000000000}"#),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(parse_service_health_interval(br#"{"Interval":0}"#), None);
+        assert_eq!(parse_service_health_interval(br#"{"Interval":"5s"}"#), None);
+        assert_eq!(parse_service_health_interval(b"null"), None);
     }
 }

--- a/crates/automata-ci-sandbox-podman/tests/service_containers.rs
+++ b/crates/automata-ci-sandbox-podman/tests/service_containers.rs
@@ -734,6 +734,36 @@ fn health_readiness_obeys_the_aggregate_deadline_and_retains_recovery() {
 }
 
 #[test]
+fn provider_drives_healthchecks_inside_its_delegated_cgroup() {
+    let fixture = Fixture::new_with_service_proxy("service-active-healthcheck");
+    fixture.fake.require_active_healthcheck();
+    let spec = service_spec(OperationId::new());
+    let created = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("provider-owned healthcheck makes the service ready");
+    assert!(
+        fixture
+            .fake
+            .commands()
+            .iter()
+            .any(|command| { podman_command(command).starts_with(&["healthcheck", "run"]) })
+    );
+    fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                spec.generation(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("cleanup actively checked service");
+    assert!(fixture.fake.is_empty());
+}
+
+#[test]
 fn override_health_policy_fails_closed_when_backend_omits_the_healthcheck() {
     let fixture = Fixture::new_with_service_proxy("service-health-config-drift");
     fixture.fake.omit_health_configuration();

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -103,6 +103,7 @@ struct FakeState {
     next_container_id: u64,
     next_service_address: u8,
     keep_health_starting: bool,
+    require_active_healthcheck: bool,
     omit_health_configuration: bool,
     port_output: Option<CommandOutput>,
     fail_once: Option<Vec<String>>,
@@ -379,6 +380,13 @@ impl FakePodman {
 
     pub(crate) fn keep_health_starting(&self) {
         self.state.lock().expect("fake lock").keep_health_starting = true;
+    }
+
+    pub(crate) fn require_active_healthcheck(&self) {
+        self.state
+            .lock()
+            .expect("fake lock")
+            .require_active_healthcheck = true;
     }
 
     pub(crate) fn omit_health_configuration(&self) {
@@ -923,6 +931,23 @@ fn execute_fake_inspection(state: &FakeState, command: &[String]) -> Option<Comm
 
 fn execute_fake_lifecycle(state: &mut FakeState, command: &[String]) -> Option<CommandOutput> {
     let output = match command {
+        [healthcheck, run, token] if healthcheck == "healthcheck" && run == "run" => {
+            let Some(name) = container_name(state, token) else {
+                return Some(CommandOutput::failure(1, Vec::new()));
+            };
+            let keep_starting = state.keep_health_starting;
+            let Some(container) = state.containers.get_mut(&name) else {
+                return Some(CommandOutput::failure(1, Vec::new()));
+            };
+            if !container.health_configured {
+                CommandOutput::failure(125, Vec::new())
+            } else if keep_starting {
+                CommandOutput::failure(1, b"unhealthy\n".to_vec())
+            } else {
+                container.health = Some("healthy".to_owned());
+                CommandOutput::success(b"healthy\n".to_vec())
+            }
+        }
         [kind, action, rest @ ..] if action == "create" && kind == "network" => {
             let mut resource = new_resource(rest, None);
             state.next_container_id = state.next_container_id.saturating_add(1);
@@ -948,7 +973,10 @@ fn execute_fake_lifecycle(state: &mut FakeState, command: &[String]) -> Option<C
                 return Some(CommandOutput::failure(1, Vec::new()));
             };
             container.state = Some("running".to_owned());
-            if !state.keep_health_starting && container.health.as_deref() == Some("starting") {
+            if !state.keep_health_starting
+                && !state.require_active_healthcheck
+                && container.health.as_deref() == Some("starting")
+            {
                 container.health = Some("healthy".to_owned());
             }
             CommandOutput::success(Vec::new())


### PR DESCRIPTION
## Outcome

Service-container jobs no longer wait for Podman's out-of-process health scheduler. The provider actively runs each configured healthcheck from the runner process, inside the runner's delegated systemd cgroup, and respects the inspected health interval and aggregate operation deadline.

This fixes production jobs where PostgreSQL was ready in seconds but remained in `starting` for three minutes because a separately scheduled rootless healthcheck could not cross into the runner-owned cgroup.

## Design

- The provider remains the sole owner of service readiness.
- Health configuration is re-inspected and interval parsing fails closed.
- Exit 0 and healthcheck exit 1 are treated as valid health observations; Podman's resulting state still decides readiness or failure.
- Cancellation remains polled at the existing bounded cadence while waiting for the next configured check.
- No fallback, compatibility path, or external scheduler dependency was added.

## Verification

- All 72 `automata-ci-sandbox-podman` integration tests pass.
- New regression requires a provider-driven healthcheck before the fake service can become healthy.
- Existing aggregate-deadline/recovery regression still passes.
- Pinned clippy for all Podman targets/features passes with warnings denied.
- Formatting and diff checks pass.

## Production evidence

On both production runner hosts, the pinned PostgreSQL service initialized and accepted connections in about two seconds, while `.State.Health` remained `starting` with no health log until the three-minute provider deadline. A manually launched healthcheck from an SSH scope could not cross into the runner-owned cgroup, confirming why readiness must be driven by the runner process itself.
