### PR TITLE
test(github): share webhook signature fixture

### DIFF
--- a/crates/automata-ci-github/tests/stored_push_rehydration.rs
+++ b/crates/automata-ci-github/tests/stored_push_rehydration.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write as _;
+use crate::support::webhook_signature;
 
 use automata_ci_github::{
     GITHUB_PUSH_EVENT_MEDIA_TYPE, GithubRepositoryVisibility, GithubStoredPushError,
@@ -8,7 +8,7 @@ use automata_ci_github::{
 };
 use bytes::Bytes;
 use reqwest::header::{HeaderMap, HeaderValue};
-use ring::{digest, hmac};
+use ring::digest;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"stored-push-equivalence-secret";
@@ -594,7 +594,7 @@ fn signed_headers(secret: &[u8], body: &[u8], delivery: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&signature(secret, body)).expect("signature header"),
+        HeaderValue::from_str(&webhook_signature(secret, body)).expect("signature header"),
     );
     headers.insert(X_GITHUB_EVENT, HeaderValue::from_static("push"));
     headers.insert(
@@ -602,14 +602,4 @@ fn signed_headers(secret: &[u8], body: &[u8], delivery: &str) -> HeaderMap {
         HeaderValue::from_str(delivery).expect("delivery header"),
     );
     headers
-}
-
-fn signature(secret: &[u8], body: &[u8]) -> String {
-    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
-    let tag = hmac::sign(&key, body);
-    let mut encoded = String::from("sha256=");
-    for byte in tag.as_ref() {
-        write!(encoded, "{byte:02x}").expect("write signature");
-    }
-    encoded
 }

--- a/crates/automata-ci-github/tests/support/mod.rs
+++ b/crates/automata-ci-github/tests/support/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, VecDeque},
+    fmt::Write as _,
     sync::{Arc, Mutex},
 };
 
@@ -13,10 +14,21 @@ use axum::{
     http::{HeaderMap, Request, Response, StatusCode},
     routing::any,
 };
+use ring::hmac;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use url::Url;
 
 const MAX_FIXTURE_REQUEST_BYTES: usize = 1_048_576;
+
+pub(crate) fn webhook_signature(secret: &[u8], body: &[u8]) -> String {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let tag = hmac::sign(&key, body);
+    let mut encoded = String::from("sha256=");
+    for byte in tag.as_ref() {
+        write!(encoded, "{byte:02x}").expect("write signature");
+    }
+    encoded
+}
 
 #[derive(Clone, Debug)]
 pub struct ResponseSpec {

--- a/crates/automata-ci-github/tests/webhook_verification.rs
+++ b/crates/automata-ci-github/tests/webhook_verification.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write as _;
+use crate::support::webhook_signature;
 
 use automata_ci_github::{
     GithubPushRefKind, GithubRepositoryVisibility, GithubWebhookError, GithubWebhookEventMetadata,
@@ -8,7 +8,7 @@ use automata_ci_github::{
 use automata_ci_scm::ExactRevision;
 use bytes::Bytes;
 use reqwest::header::{HeaderMap, HeaderValue};
-use ring::{digest, hmac};
+use ring::digest;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"correct horse battery staple webhook secret";
@@ -709,7 +709,7 @@ fn signed_headers(secret: &[u8], body: &[u8], event: &str, delivery: &str) -> He
     let mut headers = HeaderMap::new();
     headers.insert(
         X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&signature(secret, body)).expect("signature header"),
+        HeaderValue::from_str(&webhook_signature(secret, body)).expect("signature header"),
     );
     headers.insert(
         X_GITHUB_EVENT,
@@ -720,14 +720,4 @@ fn signed_headers(secret: &[u8], body: &[u8], event: &str, delivery: &str) -> He
         HeaderValue::from_str(delivery).expect("delivery header"),
     );
     headers
-}
-
-fn signature(secret: &[u8], body: &[u8]) -> String {
-    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
-    let tag = hmac::sign(&key, body);
-    let mut encoded = String::from("sha256=");
-    for byte in tag.as_ref() {
-        write!(encoded, "{byte:02x}").expect("write signature");
-    }
-    encoded
 }


### PR DESCRIPTION
## Summary

Consolidate two byte-for-byte identical GitHub webhook-signature test helpers into the existing integration-test support module.

The shared helper preserves the exact HMAC-SHA256 computation, `sha256=` prefix, and lowercase two-digit hex encoding. The test crate now has one definition and two callers.

## Validation

- GitHub all-target/all-feature check
- GitHub tests: 136 passed, 1 configured network test ignored
- strict Clippy with `-D warnings`
- workspace formatting, diff, body-identity, and topology checks
- independent review: approved, no findings

Closes #306
