### PR TITLE
test(core): share trusted push snapshot fixture

### DIFF
--- a/crates/automata-ci-core/tests/core.rs
+++ b/crates/automata-ci-core/tests/core.rs
@@ -15,5 +15,6 @@ mod log_contract;
 mod logical_workflow_plan;
 mod resource_allocation;
 mod sha256_digest;
+mod support;
 mod trust_snapshot;
 mod value_template;

--- a/crates/automata-ci-core/tests/job_ir.rs
+++ b/crates/automata-ci-core/tests/job_ir.rs
@@ -6,11 +6,11 @@ use automata_ci_core::{
     JobIr, JobIrEnvelope, JobOutputDefinition, JobPermissionGrant, JobPermissionRequest, JobSource,
     JobValidationError, OutputSensitivity, PermissionLevel, RunId, RunValueTemplates,
     RunnerRequirements, RuntimeBoolean, RuntimePositiveInteger, RuntimeTimeoutTemplate,
-    SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, TrustActorEvidence, TrustActorKind,
-    TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy,
-    TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion, ValueSource, ValueTemplate,
+    SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, ValueSource, ValueTemplate,
     WorkflowId,
 };
+
+use crate::support::trusted_push_snapshot;
 
 fn expression(source: &str, root: &str) -> ExpressionProgram {
     ExpressionProgram::new(
@@ -103,25 +103,6 @@ fn current_job(outputs: Vec<JobOutputDefinition>) -> JobIr {
         ])
         .expect("job working-directory template"),
     )
-}
-
-fn trusted_push_snapshot() -> TrustSnapshot {
-    let repository =
-        TrustRepositoryEvidence::new("100", "10").expect("stable repository trust evidence");
-    TrustPolicy::current()
-        .evaluate(
-            TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
-                .with_original_actor(
-                    TrustActorEvidence::new("200", TrustActorKind::User, TrustAutomationKind::None)
-                        .expect("stable actor trust evidence"),
-                )
-                .with_repositories(repository.clone(), repository)
-                .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
-                .with_revisions("0123456789abcdef", "0123456789abcdef", "0123456789abcdef")
-                .with_fork(false)
-                .with_token_recursion(TrustTokenRecursion::Suppressed),
-        )
-        .expect("complete same-repository trust snapshot")
 }
 
 fn current_envelope(outputs: Vec<JobOutputDefinition>) -> JobIrEnvelope {

--- a/crates/automata-ci-core/tests/job_validation.rs
+++ b/crates/automata-ci-core/tests/job_validation.rs
@@ -5,10 +5,10 @@ use automata_ci_core::{
     JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobSource, JobValidationError,
     RUNNER_REQUIREMENTS_SCHEMA_VERSION, RunId, RunValueTemplates, RunnerRequirements,
     RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, TransportProtocol,
-    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
-    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
     ValueTemplate, WorkflowId,
 };
+
+use crate::support::trusted_push_snapshot;
 
 fn test_step() -> StepIr {
     StepIr::new_literal_name(
@@ -40,25 +40,6 @@ fn base_job(steps: Vec<StepIr>) -> JobIr {
     )
     .with_trust_snapshot(trusted_push_snapshot())
     .with_timeout_seconds(600)
-}
-
-fn trusted_push_snapshot() -> TrustSnapshot {
-    let repository =
-        TrustRepositoryEvidence::new("100", "10").expect("stable repository trust evidence");
-    TrustPolicy::current()
-        .evaluate(
-            TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
-                .with_original_actor(
-                    TrustActorEvidence::new("200", TrustActorKind::User, TrustAutomationKind::None)
-                        .expect("stable actor trust evidence"),
-                )
-                .with_repositories(repository.clone(), repository)
-                .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
-                .with_revisions("0123456789abcdef", "0123456789abcdef", "0123456789abcdef")
-                .with_fork(false)
-                .with_token_recursion(TrustTokenRecursion::Suppressed),
-        )
-        .expect("complete same-repository trust snapshot")
 }
 
 fn envelope_with_job(job: JobIr) -> JobIrEnvelope {

--- a/crates/automata-ci-core/tests/support.rs
+++ b/crates/automata-ci-core/tests/support.rs
@@ -1,0 +1,23 @@
+use automata_ci_core::{
+    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
+    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
+};
+
+pub(crate) fn trusted_push_snapshot() -> TrustSnapshot {
+    let repository =
+        TrustRepositoryEvidence::new("100", "10").expect("stable repository trust evidence");
+    TrustPolicy::current()
+        .evaluate(
+            TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
+                .with_original_actor(
+                    TrustActorEvidence::new("200", TrustActorKind::User, TrustAutomationKind::None)
+                        .expect("stable actor trust evidence"),
+                )
+                .with_repositories(repository.clone(), repository)
+                .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
+                .with_revisions("0123456789abcdef", "0123456789abcdef", "0123456789abcdef")
+                .with_fork(false)
+                .with_token_recursion(TrustTokenRecursion::Suppressed),
+        )
+        .expect("complete same-repository trust snapshot")
+}


### PR DESCRIPTION
## Summary

Consolidate two byte-for-byte identical Core integration-test `trusted_push_snapshot` fixtures into a shared test-support module.

The shared helper preserves the exact actor, repository, refs, revisions, fork status, and token-recursion evidence. The Core integration crate now has one definition and two callers.

## Validation

- Core all-target/all-feature check
- Core tests: 57 unit + 123 integration passed
- strict Clippy with `-D warnings`
- workspace formatting, diff, body-identity, and topology checks
- independent review: approved, no findings

Closes #308
