### PR TITLE
test(runner): retire unused burst payload override

### DIFF
--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -1775,7 +1775,6 @@ impl JobExecutor for CleanupIsolationExecutor {
 #[derive(Debug)]
 pub struct BurstLogExecutor {
     data_frames: usize,
-    payload_bytes: Option<usize>,
     conclusion: JobConclusion,
 }
 
@@ -1847,15 +1846,6 @@ impl BurstLogExecutor {
     pub const fn new(data_frames: usize) -> Self {
         Self {
             data_frames,
-            payload_bytes: None,
-            conclusion: JobConclusion::Success,
-        }
-    }
-
-    pub const fn with_payload_bytes(data_frames: usize, payload_bytes: usize) -> Self {
-        Self {
-            data_frames,
-            payload_bytes: Some(payload_bytes),
             conclusion: JobConclusion::Success,
         }
     }
@@ -1863,7 +1853,6 @@ impl BurstLogExecutor {
     pub const fn with_conclusion(data_frames: usize, conclusion: JobConclusion) -> Self {
         Self {
             data_frames,
-            payload_bytes: None,
             conclusion,
         }
     }
@@ -2041,10 +2030,7 @@ impl JobExecutor for BurstLogExecutor {
                     .transition(JobLifecycle::Running)
                     .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
                 for index in 0..self.data_frames {
-                    let payload = self.payload_bytes.map_or_else(
-                        || format!("frame-{index:04}").into_bytes(),
-                        |bytes| vec![b'x'; bytes],
-                    );
+                    let payload = format!("frame-{index:04}").into_bytes();
                     events
                         .emit_log(LogEvent::new(LogChannel::Stdout, payload))
                         .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;


### PR DESCRIPTION
## Summary

Remove the unused `BurstLogExecutor::with_payload_bytes` test override and its dead optional state.

All five live constructions already use the `None` branch, so the executor now directly emits the same `frame-{index:04}` payload. This exact bounded cleanup landed in #50, was restored only by the wholesale #55 revert, and never acquired a caller.

## Validation

- runner-runtime all-target/all-feature check
- runner-runtime tests: 4 unit + 77 integration passed
- strict Clippy with `-D warnings` and the established aggregate allowances
- formatting, diff, stale-symbol, and construction scans
- independent review: approved, no findings

Closes #313
