### PR TITLE
test(results): share HTTP compatibility helpers

### DIFF
--- a/crates/automata-ci-results-github/tests/cache_http.rs
+++ b/crates/automata-ci-results-github/tests/cache_http.rs
@@ -1,3 +1,5 @@
+mod http_support;
+
 use std::{
     collections::BTreeMap,
     path::PathBuf,
@@ -25,6 +27,7 @@ use axum::{
 };
 use bytes::Bytes;
 use http_body_util::BodyExt as _;
+use http_support::{assert_private_rejection, isolated_node_command, path_and_query};
 use tower::ServiceExt as _;
 use url::Url;
 use uuid::Uuid;
@@ -562,12 +565,6 @@ fn fixture_with_url_observer_and_limits(
     }
 }
 
-fn assert_private_rejection(response: &axum::response::Response, status: StatusCode) {
-    assert_eq!(response.status(), status);
-    assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
-    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
-}
-
 #[tokio::test]
 async fn cache_router_and_extractor_rejections_are_private() {
     let fixture =
@@ -790,28 +787,6 @@ async fn official_actions_cache_5_0_5_client_completes_cache_v2_offline() {
         "official cache-v2 client exited with {}",
         output.status
     );
-}
-
-fn isolated_node_command() -> std::process::Command {
-    let mut command = std::process::Command::new("node");
-    command.env_clear();
-    for name in [
-        "PATH",
-        "PATHEXT",
-        "SystemRoot",
-        "WINDIR",
-        "ComSpec",
-        "HOME",
-        "USERPROFILE",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-    ] {
-        if let Some(value) = std::env::var_os(name) {
-            command.env(name, value);
-        }
-    }
-    command
 }
 
 #[tokio::test]
@@ -1271,11 +1246,4 @@ async fn json_body(response: axum::response::Response) -> serde_json::Value {
             .to_bytes(),
     )
     .expect("JSON response")
-}
-
-fn path_and_query(url: &Url) -> String {
-    url.query().map_or_else(
-        || url.path().to_owned(),
-        |query| format!("{}?{query}", url.path()),
-    )
 }

--- a/crates/automata-ci-results-github/tests/http_compatibility.rs
+++ b/crates/automata-ci-results-github/tests/http_compatibility.rs
@@ -1,3 +1,5 @@
+mod http_support;
+
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -26,6 +28,7 @@ use axum::{
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use http_body_util::BodyExt as _;
+use http_support::{assert_private_rejection, isolated_node_command, path_and_query};
 use sha2::Digest as _;
 use tower::ServiceExt as _;
 use url::Url;
@@ -531,12 +534,6 @@ fn fixture_with_url_and_limits(public_url: &str, limits: GithubResultsHttpLimits
     }
 }
 
-fn assert_private_rejection(response: &axum::response::Response, status: StatusCode) {
-    assert_eq!(response.status(), status);
-    assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
-    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
-}
-
 #[tokio::test]
 async fn artifact_router_and_extractor_rejections_are_private() {
     let fixture = fixture_with_limits(
@@ -694,28 +691,6 @@ async fn run_official_artifact_clients(
         );
     }
     server.abort();
-}
-
-fn isolated_node_command() -> std::process::Command {
-    let mut command = std::process::Command::new("node");
-    command.env_clear();
-    for name in [
-        "PATH",
-        "PATHEXT",
-        "SystemRoot",
-        "WINDIR",
-        "ComSpec",
-        "HOME",
-        "USERPROFILE",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-    ] {
-        if let Some(value) = std::env::var_os(name) {
-            command.env(name, value);
-        }
-    }
-    command
 }
 
 #[tokio::test]
@@ -1120,11 +1095,4 @@ fn twirp_request(path: &str, token: &str, value: &serde_json::Value) -> Request<
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(value.to_string()))
         .expect("request")
-}
-
-fn path_and_query(url: &Url) -> String {
-    url.query().map_or_else(
-        || url.path().to_owned(),
-        |query| format!("{}?{query}", url.path()),
-    )
 }

--- a/crates/automata-ci-results-github/tests/http_support/mod.rs
+++ b/crates/automata-ci-results-github/tests/http_support/mod.rs
@@ -1,0 +1,37 @@
+use axum::http::{StatusCode, header};
+use url::Url;
+
+pub(crate) fn isolated_node_command() -> std::process::Command {
+    let mut command = std::process::Command::new("node");
+    command.env_clear();
+    for name in [
+        "PATH",
+        "PATHEXT",
+        "SystemRoot",
+        "WINDIR",
+        "ComSpec",
+        "HOME",
+        "USERPROFILE",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
+}
+
+pub(crate) fn assert_private_rejection(response: &axum::response::Response, status: StatusCode) {
+    assert_eq!(response.status(), status);
+    assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+}
+
+pub(crate) fn path_and_query(url: &Url) -> String {
+    url.query().map_or_else(
+        || url.path().to_owned(),
+        |query| format!("{}?{query}", url.path()),
+    )
+}


### PR DESCRIPTION
## Summary

Consolidate three byte-for-byte identical Results HTTP integration-test helpers into a shared nested support module:

- isolated Node command construction
- private-response rejection assertion
- URL path-and-query extraction

The module is registered only by the two existing integration-test roots, so it does not become its own test target. All 18 caller sites and exact behavior remain unchanged.

## Validation

- Results GitHub all-target/all-feature check
- tests: 71 passed, 27 environment-gated ignored
- strict Clippy with `-D warnings`
- workspace formatting, diff, body-identity, caller-count, and Cargo target checks
- independent review: approved, no findings

Closes #314
