### PR TITLE
ci: keep pull request validation on the critical path

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -1,10 +1,9 @@
-name: CI
+name: Main CI
 
 on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -390,6 +389,15 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 12
+      rustfs:
+        image: docker.io/rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c
+        env:
+          RUSTFS_ACCESS_KEY: automata-local
+          RUSTFS_SECRET_KEY: automata-local-secret-change-me
+          RUSTFS_SSE_S3_MASTER_KEY: YXV0b21hdGEtbG9jYWwtc3NlLW1hc3Rlci1rZXktdjE=
+          RUSTFS_ADDRESS: 0.0.0.0:9000
+        ports:
+          - 9000:9000
     env:
       AUTOMATA_TEST_DATABASE_URL: postgresql://automata_ci:automata-ci-local-only@127.0.0.1:5432/automata_ci
       AUTOMATA_TEST_DATABASE_NAMESPACE: res01_${{ github.run_id }}_${{ github.run_attempt }}
@@ -456,24 +464,14 @@ jobs:
           npm ci --prefix target/exact-actions/download-artifact --ignore-scripts --no-audit --no-fund
           npm ci --prefix target/exact-actions/cache --ignore-scripts --no-audit --no-fund
 
-      - name: Start pinned production-compatible object store
+      - name: Wait for pinned production-compatible object store
         run: |
-          docker run --detach --rm \
-            --name automata-res01-rustfs \
-            --publish 127.0.0.1:9000:9000 \
-            --env RUSTFS_ACCESS_KEY="$AUTOMATA_TEST_S3_ACCESS_KEY" \
-            --env RUSTFS_SECRET_KEY="$AUTOMATA_TEST_S3_SECRET_KEY" \
-            --env RUSTFS_SSE_S3_MASTER_KEY=YXV0b21hdGEtbG9jYWwtc3NlLW1hc3Rlci1rZXktdjE= \
-            --env RUSTFS_ADDRESS=0.0.0.0:9000 \
-            docker.io/rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c \
-            /data
           for ((attempt = 1; attempt <= 30; attempt += 1)); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
               exit 0
             fi
             sleep 2
           done
-          docker logs automata-res01-rustfs
           exit 1
 
       - name: Initialize and verify immutable object storage
@@ -504,10 +502,6 @@ jobs:
           path: target/agent-scratch/exact-client-real-store/**/redacted-results-transcript.json
           if-no-files-found: error
           retention-days: 14
-
-      - name: Stop object store
-        if: ${{ always() }}
-        run: docker rm --force automata-res01-rustfs 2>/dev/null || true
 
   renderer_tests:
     name: Rust renderer tests
@@ -603,7 +597,6 @@ jobs:
 
   renderer:
     name: Reproduce embedded renderer
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -800,7 +793,6 @@ jobs:
           RENDERER_TESTS_RESULT: ${{ needs.renderer_tests.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RENDERER_RESULT: ${{ needs.renderer.result }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           [[ "$DIST_BUILD_RESULT" == success ]]
           [[ "$VERIFY_RESULT" == success ]]
@@ -810,10 +802,6 @@ jobs:
           [[ "$RUST_COVERAGE_RESULT" == success ]]
           [[ "$RENDERER_TESTS_RESULT" == success ]]
           [[ "$FRONTEND_RESULT" == success ]]
-          if [[ "$EVENT_NAME" == pull_request ]]; then
-            [[ "$RENDERER_RESULT" == success || "$RENDERER_RESULT" == skipped ]]
-          else
-            [[ "$RENDERER_RESULT" == success ]]
-          fi
+          [[ "$RENDERER_RESULT" == success ]]
           [[ "$AUTOMATA_EXPECTED_GIT_SHA" == "$GITHUB_SHA" ]]
           printf 'validated distribution candidate %s\n' "$GITHUB_SHA"

--- a/.ci/workflows/pull-request.yml
+++ b/.ci/workflows/pull-request.yml
@@ -1,0 +1,115 @@
+name: Pull request CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AUTOMATA_BUILD_GIT_SHA: ${{ github.sha }}
+  AUTOMATA_EXPECTED_GIT_SHA: ${{ github.sha }}
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+  SCCACHE_IDLE_TIMEOUT: "0"
+  SCCACHE_SERVER_UDS: '\x00automata-sccache'
+  TMPDIR: ${{ github.workspace }}/target/task-tmp/pr
+
+jobs:
+  critical_rust:
+    name: Critical Rust checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      CARGO_BUILD_JOBS: "4"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare job scratch directory
+        run: install -d -m 0700 -- "$TMPDIR"
+
+      - name: Configure shared Rust compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      - name: Start Rust compiler cache
+        run: env TMPDIR=/tmp sccache --start-server
+
+      - name: Restore Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+          key: cargo-ubuntu-24.04-rust-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-ubuntu-24.04-rust-1.97.1-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Test the critical execution path
+        run: >-
+          cargo test
+          --locked
+          --all-features
+          --lib
+          --no-fail-fast
+          -p automata-ci-control
+          -p automata-ci-core
+          -p automata-ci-github-delivery
+          -p automata-ci-job-executor-github
+          -p automata-ci-results-github
+          -p automata-ci-runner-runtime
+          -p automata-ci-sandbox-podman
+          -p automata-ci-store-postgres
+          -p automata-ci-workflow-github
+          -p automata-ci-workflow-service
+
+      - name: Validate workflow syntax
+        run: |
+          ./scripts/ci/install-actionlint.sh target/ci-tools
+          target/ci-tools/actionlint .ci/workflows/*.yml
+
+  frontend:
+    name: Critical frontend checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@6044e13b5c5b3787591c17e66ffed8b0a91d94e5 # v6.3.0
+        with:
+          node-version: 24.19.0
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci --no-audit --prefer-offline
+
+      - name: Test and build the frontend
+        run: npm run check

--- a/crates/automata-ci/src/app/web/routes.rs
+++ b/crates/automata-ci/src/app/web/routes.rs
@@ -1288,6 +1288,17 @@ async fn run_detail(
         .await
     {
         Ok(Some(data)) => data,
+        Ok(None) if context.viewer().is_none() && context.sign_in_action().is_some() => {
+            let mut return_path = format!(
+                "/{}/{}/actions/runs/{run_id}",
+                repository_path.owner, repository_path.name
+            );
+            if let Some(query) = raw_query.as_deref().filter(|query| !query.is_empty()) {
+                return_path.push('?');
+                return_path.push_str(query);
+            }
+            return deep_link_sign_in(state, &context, return_path).await;
+        }
         Ok(None) => return not_found(),
         Err(error) => return data_error_response(error),
     };
@@ -1370,26 +1381,7 @@ async fn job_log(
                 return_path.push('?');
                 return_path.push_str(query);
             }
-            let csp_nonce = match new_csp_nonce() {
-                Ok(nonce) => nonce,
-                Err(error) => {
-                    error!(%error, "failed to generate a CSP nonce");
-                    return internal_server_error();
-                }
-            };
-            let request_json = match model::deep_link_sign_in(
-                client_assets(),
-                csp_nonce.clone(),
-                &context,
-                return_path,
-            ) {
-                Ok(request) => request,
-                Err(error) => {
-                    error!(%error, "failed to assemble deep-link sign-in page");
-                    return internal_server_error();
-                }
-            };
-            return render(state, request_json, csp_nonce).await;
+            return deep_link_sign_in(state, &context, return_path).await;
         }
         Ok(None) => return not_found(),
         Err(error) => return data_error_response(error),
@@ -1423,6 +1415,29 @@ async fn job_log(
             return internal_server_error();
         }
     };
+    render(state, request_json, csp_nonce).await
+}
+
+async fn deep_link_sign_in(
+    state: WebState,
+    context: &RequestContext,
+    return_path: String,
+) -> Response<Body> {
+    let csp_nonce = match new_csp_nonce() {
+        Ok(nonce) => nonce,
+        Err(error) => {
+            error!(%error, "failed to generate a CSP nonce");
+            return internal_server_error();
+        }
+    };
+    let request_json =
+        match model::deep_link_sign_in(client_assets(), csp_nonce.clone(), context, return_path) {
+            Ok(request) => request,
+            Err(error) => {
+                error!(%error, "failed to assemble deep-link sign-in page");
+                return internal_server_error();
+            }
+        };
     render(state, request_json, csp_nonce).await
 }
 
@@ -4928,6 +4943,43 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(data.calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn anonymous_missing_and_denied_run_links_share_an_exact_sign_in_handoff() {
+        for outcome in [FakeOutcome::Missing, FakeOutcome::Unauthorized] {
+            let (app, renderer, data) = test_router(outcome);
+            let context = RequestContext::new(
+                TenantId::new("acme-production").expect("tenant"),
+                AuthorizationContext::anonymous(),
+                None,
+                Some(crate::app::github_auth::GITHUB_WEB_BEGIN_PATH.to_owned()),
+            )
+            .expect("anonymous sign-in context");
+            let app = app.layer(Extension(context));
+            let uri =
+                format!("/acme-labs/payments-api/actions/runs/{RUN_ID}?job_cursor=request_job");
+
+            let response = get(&app, &uri).await;
+            let page = renderer.page();
+
+            assert_page_headers(&response, &page);
+            assert_eq!(page["page"]["kind"], "deep-link-sign-in");
+            assert_eq!(
+                page["page"]["shell"]["signIn"]["action"],
+                crate::app::github_auth::GITHUB_WEB_BEGIN_PATH
+            );
+            assert_eq!(page["page"]["shell"]["signIn"]["returnPath"], uri);
+            assert_eq!(
+                data.calls(),
+                vec![RecordedCall::RunDetail {
+                    repository: repository_path(),
+                    run_id: run_id(),
+                    job_cursor: Some("request_job".to_owned()),
+                    limit: RUN_JOB_PAGE_SIZE,
+                }]
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- split PR validation into two critical-path jobs while keeping the comprehensive suite on main/manual runs
- run pinned RustFS as an admitted workflow service instead of imperatively calling the Docker API
- preserve exact workflow-run deep links through GitHub sign-in when a browser session expires

## Validation
- `cargo fmt --all -- --check`
- `actionlint .ci/workflows/*.yml`
- focused run/job deep-link unit tests
- `cargo check -p automata-ci --tests`
- critical Rust package tests (local)
- `npm run check` (local)