### PR TITLE
test(workflow): share activation location fixtures

### DIFF
--- a/crates/automata-ci-workflow-service/tests/activation.rs
+++ b/crates/automata-ci-workflow-service/tests/activation.rs
@@ -1,3 +1,5 @@
+use crate::support::{located, span};
+
 use std::{
     collections::BTreeMap,
     sync::{
@@ -14,9 +16,9 @@ use automata_ci_core::{
     LogicalRunnerTemplate, LogicalStepKind, LogicalStepTemplate, LogicalTimeoutTemplate,
     MatrixAxis, MatrixAxisValues, MatrixPatch, MatrixPatchSet, MatrixTemplate, MatrixValue,
     MatrixValueTemplate, NeedContext, NeedOutput, OutputSensitivity, PlanEvaluationPhase,
-    PlanExpression, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan, SecretBinding,
-    StepJobTemplate, WorkflowEventProvenance, WorkflowJobKey, WorkflowPlan,
-    WorkflowSourceProvenance, WorkflowStepKey, WorkflowStrategyTemplate,
+    PlanExpression, PlanSourceOrigin, SecretBinding, StepJobTemplate, WorkflowEventProvenance,
+    WorkflowJobKey, WorkflowPlan, WorkflowSourceProvenance, WorkflowStepKey,
+    WorkflowStrategyTemplate,
 };
 use automata_ci_workflow_service::{
     ActivateLogicalJobRequest, ActivationEvaluationContext, ActivationStatus, ActivationValue,
@@ -24,19 +26,6 @@ use automata_ci_workflow_service::{
     LogicalJobActivator, ValidatedLogicalJob, ValidatedLogicalPlan,
 };
 use thiserror::Error;
-
-fn span() -> PlanSourceSpan {
-    PlanSourceSpan::new(
-        "synthetic.yml",
-        PlanSourceLocation::new(0, 1, 1).expect("start"),
-        PlanSourceLocation::new(1, 1, 2).expect("end"),
-    )
-    .expect("span")
-}
-
-fn located<T>(value: T) -> Located<T> {
-    Located::new(value, span())
-}
 
 fn expression(source: &str, contexts: Vec<ExpressionContext>) -> CompiledExpressionTemplate {
     let mut instructions = contexts

--- a/crates/automata-ci-workflow-service/tests/github_activation.rs
+++ b/crates/automata-ci-workflow-service/tests/github_activation.rs
@@ -1,13 +1,15 @@
+use crate::support::{located, span};
+
 use std::{collections::BTreeMap, sync::Arc, thread};
 
 use automata_ci_core::{
     CompiledBooleanTemplate, CompiledExpressionTemplate, CompiledPositiveIntegerTemplate,
     CompiledValueTemplate, ContextValue, ExpressionContext, ExpressionProgram, ExpressionSegment,
-    JobConclusion, Located, LogicalJobKind, LogicalRunStepTemplate, LogicalRunnerTemplate,
-    LogicalStepKind, LogicalStepTemplate, MatrixTemplate, NeedContext, NeedOutput,
-    OutputSensitivity, PlanEvaluationPhase, PlanExpression, PlanSourceLocation, PlanSourceOrigin,
-    PlanSourceSpan, StepJobTemplate, WorkflowEventProvenance, WorkflowJobKey, WorkflowPlan,
-    WorkflowSourceProvenance, WorkflowStepKey, WorkflowStrategyTemplate,
+    JobConclusion, LogicalJobKind, LogicalRunStepTemplate, LogicalRunnerTemplate, LogicalStepKind,
+    LogicalStepTemplate, MatrixTemplate, NeedContext, NeedOutput, OutputSensitivity,
+    PlanEvaluationPhase, PlanExpression, PlanSourceOrigin, StepJobTemplate,
+    WorkflowEventProvenance, WorkflowJobKey, WorkflowPlan, WorkflowSourceProvenance,
+    WorkflowStepKey, WorkflowStrategyTemplate,
 };
 use automata_ci_expression_github::{GithubObject, GithubValue};
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
@@ -16,19 +18,6 @@ use automata_ci_workflow_service::{
     GithubActivationEvaluationError, GithubLogicalActivationEvaluator, LogicalActivationError,
     LogicalJobActivation, LogicalJobActivator, ValidatedLogicalPlan,
 };
-
-fn span() -> PlanSourceSpan {
-    PlanSourceSpan::new(
-        "synthetic.yml",
-        PlanSourceLocation::new(0, 1, 1).expect("start"),
-        PlanSourceLocation::new(1, 1, 2).expect("end"),
-    )
-    .expect("span")
-}
-
-fn located<T>(value: T) -> Located<T> {
-    Located::new(value, span())
-}
 
 fn compiled(
     source: &str,

--- a/crates/automata-ci-workflow-service/tests/support/mod.rs
+++ b/crates/automata-ci-workflow-service/tests/support/mod.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use automata_ci_core::{JobRuntimeContext, OperationId, WorkflowEventProvenance};
+use automata_ci_core::{
+    JobRuntimeContext, Located, OperationId, PlanSourceLocation, PlanSourceSpan,
+    WorkflowEventProvenance,
+};
 use automata_ci_store::{TenantScope, WorkflowAdmissionIdempotency};
 use automata_ci_workflow_github::{
     CompilationReport, CompileWorkflowRequest, GithubEventMetadata, GithubWorkflowCompiler,
@@ -34,6 +37,19 @@ pub const GIT_REF: &str = "refs/heads/main";
 pub const WORKFLOW_PATH: &str = ".ci/workflows/ci.yml";
 pub const SECOND_WORKFLOW_PATH: &str = ".ci/workflows/secondary.yml";
 pub const DELIVERY: &str = "delivery-workflow-admission-42";
+
+pub(crate) fn span() -> PlanSourceSpan {
+    PlanSourceSpan::new(
+        "synthetic.yml",
+        PlanSourceLocation::new(0, 1, 1).expect("start"),
+        PlanSourceLocation::new(1, 1, 2).expect("end"),
+    )
+    .expect("span")
+}
+
+pub(crate) fn located<T>(value: T) -> Located<T> {
+    Located::new(value, span())
+}
 
 pub fn ci_request(
     tenant: &str,


### PR DESCRIPTION
## Summary

Consolidate the workflow-service integration tests’ byte-for-byte identical plan-location helpers into the existing shared support module.

The shared `span` and `located` bodies are unchanged. All 83 consumer calls remain in place across activation and GitHub activation tests.

## Validation

- workflow-service all-target/all-feature check
- tests: 48 unit + 150 integration passed; 1 configured S3 test ignored
- strict Clippy with the established aggregate allowances
- formatting, diff, body-identity, call-count, topology, and rebase-identity checks
- independent review: approved, no findings

Closes #315
