### PR TITLE
test(auth): share provider identity fixtures

### DIFF
--- a/crates/automata-ci-auth/tests/builder_validation.rs
+++ b/crates/automata-ci-auth/tests/builder_validation.rs
@@ -1,18 +1,13 @@
+mod support;
+
 use std::collections::BTreeSet;
 
 use automata_ci_auth::{
-    human::{ProviderId, ProviderSubject},
     time::UnixTimestamp,
     vault::{ProviderGrantKind, ProviderTokenMetadata, ProviderTokenMetadataError},
 };
 
-fn provider_id() -> ProviderId {
-    ProviderId::new("github").expect("provider ID")
-}
-
-fn provider_subject() -> ProviderSubject {
-    ProviderSubject::new("42").expect("provider subject")
-}
+use support::{provider_id, provider_subject};
 
 #[test]
 fn token_metadata_builder_validates_each_optional_collection_and_lifetime() {

--- a/crates/automata-ci-auth/tests/domain_value_contracts.rs
+++ b/crates/automata-ci-auth/tests/domain_value_contracts.rs
@@ -3,9 +3,7 @@ mod support;
 use std::collections::BTreeSet;
 
 use automata_ci_auth::{
-    human::{
-        AuthenticatedHuman, PrincipalId, ProviderCredential, ProviderId, ProviderSubject, TenantId,
-    },
+    human::{AuthenticatedHuman, PrincipalId, ProviderCredential, TenantId},
     machine::{AuthenticatedMachine, ExternalRunnerIdentity, MachineIdentityError},
     time::UnixTimestamp,
     vault::{
@@ -16,15 +14,7 @@ use automata_ci_auth::{
 };
 use serde_json::json;
 
-use support::secret;
-
-fn provider_id() -> ProviderId {
-    ProviderId::new("github").expect("provider ID")
-}
-
-fn provider_subject() -> ProviderSubject {
-    ProviderSubject::new("42").expect("provider subject")
-}
+use support::{provider_id, provider_subject, secret};
 
 fn valid_metadata() -> ProviderTokenMetadata {
     ProviderTokenMetadata::builder(

--- a/crates/automata-ci-auth/tests/support/mod.rs
+++ b/crates/automata-ci-auth/tests/support/mod.rs
@@ -12,7 +12,7 @@ use automata_ci_auth::{
         GithubEndpointError, GithubEndpointFuture, GithubEndpoints, GithubMembershipSnapshot,
         GithubTokenResponse, GithubUser, RefreshTokenRequest, WebTokenExchangeRequest,
     },
-    human::ProviderId,
+    human::{ProviderId, ProviderSubject},
     secret::{RandomnessError, SecretString, SecureRandom},
     time::{Clock, UnixTimestamp},
 };
@@ -212,6 +212,14 @@ impl GithubEndpoint for MockGithubEndpoint {
         let response = next_or_unavailable(&self.memberships);
         Box::pin(async move { response })
     }
+}
+
+pub(crate) fn provider_id() -> ProviderId {
+    ProviderId::new("github").expect("provider ID")
+}
+
+pub(crate) fn provider_subject() -> ProviderSubject {
+    ProviderSubject::new("42").expect("provider subject")
 }
 
 pub fn config() -> GithubAppConfig {


### PR DESCRIPTION
## Summary

Consolidate the Auth integration tests’ byte-for-byte identical provider identity helpers into the existing shared support module.

The shared `provider_id` and `provider_subject` bodies are unchanged. All 18 caller sites remain in place across builder-validation and domain-value contracts.

## Validation

- Auth all-target/all-feature check
- Auth tests: 132 passed
- strict Clippy with `-D warnings` and the established aggregate allowances
- formatting, diff, body-identity, call-count, topology, and rebase-identity checks
- independent review: approved, no findings

Closes #318
