### PR TITLE
fix(postgres): make migration 41 parse as PL/pgSQL

### DIFF
--- a/crates/automata-ci-store-postgres/migrations/0041_private_pull_request_files_authority.sql
+++ b/crates/automata-ci-store-postgres/migrations/0041_private_pull_request_files_authority.sql
@@ -243,13 +243,13 @@ BEGIN
             OR check_outbox.claimed_at_ms > NEW.granted_at_ms
             OR check_outbox.state_updated_at_ms > NEW.granted_at_ms
             OR check_outbox.claim_expires_at_ms <= NEW.granted_at_ms
-            OR NEW.required_through_ms::NUMERIC >
-                check_outbox.claim_expires_at_ms::NUMERIC
-                + CASE NEW.consumer_action
+            OR NEW.required_through_ms::NUMERIC
+                > check_outbox.claim_expires_at_ms::NUMERIC
+                + (CASE NEW.consumer_action
                     WHEN 'publish_check_run' THEN 600000
                     ELSE 300000
-                  END
-            OR CASE NEW.consumer_action
+                END)
+            OR (CASE NEW.consumer_action
                 WHEN 'ensure_check_suite' THEN check_outbox.claim_action <> 'ensure_suite'
                 WHEN 'create_check_run' THEN
                     check_outbox.claim_action <> 'prepare_run_create'
@@ -257,7 +257,7 @@ BEGIN
                     check_outbox.claim_action <> 'reconcile_run_create'
                 WHEN 'publish_check_run' THEN check_outbox.claim_action <> 'publish'
                 ELSE TRUE
-               END
+            END)
             OR check_subject.tenant_id <> authority.tenant_id
             OR check_subject.repository_id <> authority.repository_id
             OR check_subject.provider_connection_id <>

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -167,7 +167,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0041_private_pull_request_files_authority.sql",
-        "8bdd45b0680b2f08e273c5b3f2386e293c946d63925af1a166df389884467f5eaa76535f3871b1cd0c723aa0fe794b44",
+        "a458499937bd5133caeee8271f961e0d8c96e2db9d58ac0cd538ed1e6f99687aa03cdae3ea111bbe526a18075d56d5ba",
     ),
 ];
 


### PR DESCRIPTION
## Summary
- parenthesize both CASE expressions in migration 41 so PostgreSQL parses the trigger function
- freeze the corrected digest for the previously unshippable migration

Migration 41 has not applied in production: the original bytes fail before SQLx can record the version. Appending migration 42 would therefore be unreachable.

## Validation
- executed the complete migration inside `BEGIN` / `ROLLBACK` against production PostgreSQL
- `cargo test -p automata-ci-store-postgres --lib migration_layout`
- `cargo fmt --all -- --check`
- `git diff --check`