### PR TITLE
refactor(auth): share device poll interval bound

### DIFF
--- a/crates/automata-ci-auth/src/github/flow.rs
+++ b/crates/automata-ci-auth/src/github/flow.rs
@@ -22,7 +22,7 @@ use super::{
 
 const DEVICE_SLOW_DOWN_SECONDS: u64 = 5;
 const MAX_DEVICE_FLOW_SECONDS: u64 = 3_600;
-const MAX_DEVICE_POLL_INTERVAL_SECONDS: u64 = 300;
+pub(super) const MAX_DEVICE_POLL_INTERVAL_SECONDS: u64 = 300;
 
 /// Provider protocol for state-bound browser and device authorization flows.
 #[derive(Debug)]

--- a/crates/automata-ci-auth/src/github/transaction_state.rs
+++ b/crates/automata-ci-auth/src/github/transaction_state.rs
@@ -12,12 +12,12 @@ use crate::{
 use super::{
     DeviceAuthorization, DeviceAuthorizationParts, DeviceAuthorizationStatus, GithubEndpoints,
     WebAuthorizationTransaction, WebAuthorizationTransactionParts,
+    flow::MAX_DEVICE_POLL_INTERVAL_SECONDS,
 };
 
 const WEB_HEADER: &[u8; 8] = b"AUTWST02";
 const DEVICE_HEADER: &[u8; 8] = b"AUTDST02";
 const MAX_DEVICE_CODE_BYTES: usize = 4_096;
-const MAX_DEVICE_POLL_INTERVAL_SECONDS: u64 = 300;
 
 /// Single current-format codec for provider state held under repository encryption.
 #[derive(Clone, Copy, Debug, Default)]


### PR DESCRIPTION
## Summary

Consolidate the duplicated GitHub device-poll interval bound into the existing `flow` module.

Both private modules continue to validate against the exact same `u64 = 300` limit. The canonical constant is visible only within the private `github` module hierarchy and is not publicly re-exported.

## Validation

- Auth all-target/all-feature check
- Auth tests: 132 passed
- strict Clippy with `-D warnings`
- formatting, diff, declaration/use, visibility, and overlap checks
- independent review: approved, no findings

Closes #323
