### PR TITLE
refactor(secret): share mutation request prefix

### DIFF
--- a/crates/automata-ci-secret-postgres/src/provider.rs
+++ b/crates/automata-ci-secret-postgres/src/provider.rs
@@ -20,8 +20,8 @@ use super::{
         ReconcileCreateVersionRecord, ResolveVersionRecord,
     },
     support::{
-        ValidatedSecretDescriptor, canonical_uuid, encryption_context, locator, map_envelope_error,
-        version_id,
+        VERSION_MUTATION_REQUEST_PREFIX, ValidatedSecretDescriptor, canonical_uuid,
+        encryption_context, locator, map_envelope_error, version_id,
     },
 };
 
@@ -30,8 +30,6 @@ pub const BUILTIN_POSTGRES_PROVIDER_ID: &str = "builtin";
 
 /// Domain-separation purpose for encrypted built-in secret values.
 pub const BUILTIN_SECRET_VALUE_KEY_PURPOSE: &str = "secrets/builtin-value:v1";
-
-const VERSION_MUTATION_REQUEST_PREFIX: &str = "secret-version:";
 
 /// PostgreSQL-backed built-in implementation of the secret-provider boundary.
 pub struct PostgresSecretProvider {

--- a/crates/automata-ci-secret-postgres/src/storage.rs
+++ b/crates/automata-ci-secret-postgres/src/storage.rs
@@ -8,11 +8,10 @@ use automata_ci_store::SECRET_MUTATION_CONFIRMATION_TTL_MILLIS;
 use sqlx::{Error as SqlxError, FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
-use super::support::ValidatedSecretDescriptor;
+use super::support::{VERSION_MUTATION_REQUEST_PREFIX, ValidatedSecretDescriptor};
 
 const BUILTIN_ADAPTER_KIND: &str = "builtin_postgres";
 const BUILTIN_STORAGE_KIND: &str = "built_in_ciphertext";
-const VERSION_MUTATION_REQUEST_PREFIX: &str = "secret-version:";
 const MAX_DATABASE_CIPHERTEXT_BYTES: usize = 131_072;
 const MAX_DATABASE_WRAPPED_KEY_BYTES: usize = 4_096;
 

--- a/crates/automata-ci-secret-postgres/src/support.rs
+++ b/crates/automata-ci-secret-postgres/src/support.rs
@@ -7,6 +7,8 @@ use automata_ci_secret::{
 };
 use uuid::Uuid;
 
+pub(super) const VERSION_MUTATION_REQUEST_PREFIX: &str = "secret-version:";
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ValidatedSecretDescriptor {
     tenant_id: String,


### PR DESCRIPTION
## Summary

Consolidate the duplicated secret-version mutation request prefix into the existing private support module.

The exact `secret-version:` namespace and all three production uses remain unchanged across provider parsing and storage formatting/parsing.

## Validation

- secret-postgres all-target/all-feature check
- secret-postgres tests: 5 passed
- strict Clippy with `-D warnings`
- formatting, diff, declaration/use, literal, and rebase-identity checks
- independent review: approved, no findings

Closes #324
