### PR TITLE
refactor(cli): share table value escaping

### DIFF
--- a/crates/automata-ci/src/cli/auth.rs
+++ b/crates/automata-ci/src/cli/auth.rs
@@ -28,6 +28,7 @@ use zeroize::Zeroizing;
 use super::{
     AuthCommand, OutputFormat,
     credential_store::{CliAuthProcessLock, CliCredentialStore, SecretServiceCredentialStore},
+    output::escaped_table_value,
 };
 use crate::app::github_auth::{
     CLI_SESSION_PATH, GITHUB_DEVICE_BEGIN_PATH, GITHUB_DEVICE_POLL_PATH,
@@ -645,10 +646,6 @@ fn checked_poll_instant(delay: u64, deadline: Instant) -> Result<Instant> {
         bail!("GitHub device authorization expired");
     }
     Ok(poll_at)
-}
-
-fn escaped_table_value(value: &str) -> String {
-    value.chars().flat_map(char::escape_default).collect()
 }
 
 fn validate_verification_uri(value: &str) -> Result<Url, InvalidVerificationUri> {

--- a/crates/automata-ci/src/cli/output.rs
+++ b/crates/automata-ci/src/cli/output.rs
@@ -12,3 +12,7 @@ pub enum OutputFormat {
     /// One JSON document per line, suitable for streaming watches.
     JsonLines,
 }
+
+pub(super) fn escaped_table_value(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
+}

--- a/crates/automata-ci/src/cli/secret.rs
+++ b/crates/automata-ci/src/cli/secret.rs
@@ -33,6 +33,7 @@ use super::{
         discard_bounded_response, retry_after_seconds,
     },
     credential_store::{CliAuthProcessLock, CliCredentialStore, SecretServiceCredentialStore},
+    output::escaped_table_value,
 };
 use crate::app::secret_api::{
     BUILTIN_SECRET_PROVIDER_ACTIVATION_PATH, BUILTIN_SECRET_PROVIDER_PATH, MAX_SECRET_INGRESS_BYTES,
@@ -1018,10 +1019,6 @@ fn print_provider(output: OutputFormat, provider: &ProviderInspectionDocument) -
         }
     }
     Ok(())
-}
-
-fn escaped_table_value(value: &str) -> String {
-    value.chars().flat_map(char::escape_default).collect()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #321

## Summary

- move the byte-identical CLI table-value escaping helper into the existing private output module
- reuse that helper from auth and secret table rendering
- preserve all six call sites and exact escaping behavior

## Validation

- `cargo check --locked -p automata-ci --all-targets --all-features`
- `cargo test --locked -p automata-ci --lib cli::auth::tests` (9 passed)
- `cargo test --locked -p automata-ci --lib cli::secret::tests` (11 passed)
- prior strict `cargo clippy --locked -p automata-ci --all-targets --all-features -- -D warnings` on the identical patch
- targeted rustfmt, diff hygiene, singleton-definition/six-call scan
- independent review: approved, no findings

The patch was replayed byte-for-byte onto the current main; stable patch ID, binary diff hash, and range-diff are unchanged.