### PR TITLE
test(postgres): consolidate and repair logical fixtures

### DIFF
--- a/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runtime_authority.rs
@@ -1,4 +1,8 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::{
+    activation_content_reference, deterministic_job_id, job_content_reference,
+    retime_logical_admission,
+};
 
 use std::{collections::BTreeMap, time::Duration};
 
@@ -11,12 +15,12 @@ use automata_ci_control::{
     },
 };
 use automata_ci_core::{
-    Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobContentReference,
-    JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
-    JobLifecycle, JobRuntimeContext, JobSource, Lease, LeaseId, OperatingSystem, OperationId,
-    RunId, RunValueTemplates, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
-    StrategyContext, UnixMillis, ValueTemplate, WorkflowJobKey,
+    Architecture, AttemptId, ContextValue, FencingToken, JobAuthorityProfile, JobExecutionContext,
+    JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion, JobLifecycle, JobRuntimeContext,
+    JobSource, Lease, LeaseId, OperatingSystem, OperationId, RunId, RunValueTemplates,
+    RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements, RunnerSessionId,
+    RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, StrategyContext,
+    UnixMillis, ValueTemplate, WorkflowJobKey,
 };
 use automata_ci_key_management::{ENVELOPE_SCHEMA_V1, EncryptedEnvelope, KeyId, WrappedDataKey};
 use automata_ci_store::{
@@ -267,38 +271,6 @@ async fn seed_tenant(database: &TestDatabase, tenant: &str) -> TestResult {
     .execute(database.pool())
     .await?;
     Ok(())
-}
-
-fn retime_logical_admission(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 fn namespace_id(manifest: &GithubProviderManifest, suffix: u128) -> u128 {
@@ -554,46 +526,6 @@ async fn select_materialization(
         .clone())
 }
 
-fn concrete_job_id(
-    run_id: RunId,
-    invocation_id: LogicalWorkflowInvocationId,
-    logical_job_id: LogicalWorkflowJobId,
-    matrix_digest: Sha256Digest,
-) -> JobId {
-    let mut hasher = Sha256::new();
-    hasher.update(b"automata.workflow-service.logical-job-id.v1\0");
-    hasher.update(run_id.as_uuid().as_bytes());
-    hasher.update(invocation_id.as_uuid().as_bytes());
-    hasher.update(logical_job_id.as_uuid().as_bytes());
-    hasher.update(0_u32.to_be_bytes());
-    hasher.update(1_u32.to_be_bytes());
-    hasher.update(matrix_digest.as_bytes());
-    let output: [u8; 32] = hasher.finalize().into();
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&output[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x80;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    JobId::from_uuid(Uuid::from_bytes(bytes))
-}
-
-fn content_reference(object: &AdmissionObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn activation_reference(object: &LogicalActivationObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
 fn prepare_instance(
     fixture: &LogicalFixture,
     claimed: &ClaimedLogicalJobActivation,
@@ -630,7 +562,7 @@ fn prepare_instance(
     )
     .expect("step");
     let job = JobIr::new(
-        concrete_job_id(
+        deterministic_job_id(
             fixture.command.run_id(),
             fixture.command.root_invocation_id(),
             fixture.logical_job_id,
@@ -648,8 +580,8 @@ fn prepare_instance(
         execution.workflow_name(),
         execution.git_ref(),
         workspace,
-        content_reference(claimed.event()),
-        activation_reference(&runtime),
+        job_content_reference(claimed.event()),
+        activation_content_reference(&runtime),
     )
     .with_run_id_alias(execution.run_id_alias())
     .with_run_number(execution.run_number())

--- a/crates/automata-ci-postgres/tests/store/fixture.rs
+++ b/crates/automata-ci-postgres/tests/store/fixture.rs
@@ -1,0 +1,93 @@
+use automata_ci_core::{JobContentReference, RunId, Sha256Digest, UnixMillis};
+use automata_ci_store::{
+    AdmissionObject, AdmitLogicalWorkflowRun, LogicalActivationObject, LogicalWorkflowInvocationId,
+    LogicalWorkflowJobId, ObjectKey,
+};
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+use crate::support::TestResult;
+
+pub(super) fn retime_logical_admission(
+    command: &AdmitLogicalWorkflowRun,
+    admitted_at: UnixMillis,
+) -> TestResult<AdmitLogicalWorkflowRun> {
+    let mut builder = AdmitLogicalWorkflowRun::builder(
+        command.tenant().clone(),
+        command.idempotency().clone(),
+        command.request_digest(),
+        command.repository().clone(),
+        command.workflow_id(),
+        command.workflow_path(),
+        command.workflow_name(),
+        command.git_ref(),
+        command.snapshot_id(),
+        command.source().clone(),
+        command.plan().clone(),
+        command.run_id(),
+        command.run_attempt(),
+        command.root_invocation_id(),
+        command.event_name(),
+        command.event().clone(),
+        command.head_sha().to_vec(),
+        command.jobs().to_vec(),
+        admitted_at,
+    );
+    if let Some(base_context) = command.base_context() {
+        builder = builder.base_context(base_context.clone());
+    }
+    builder = builder.trust_snapshot(command.trust_snapshot().clone());
+    Ok(builder.build()?)
+}
+
+pub(super) fn job_content_reference(object: &AdmissionObject) -> JobContentReference {
+    JobContentReference::new(
+        object.object_key().as_str(),
+        object.digest(),
+        object.encoded_size(),
+        object.media_type(),
+    )
+}
+
+pub(super) fn activation_content_reference(
+    object: &LogicalActivationObject,
+) -> JobContentReference {
+    JobContentReference::new(
+        object.object_key().as_str(),
+        object.digest(),
+        object.encoded_size(),
+        object.media_type(),
+    )
+}
+
+pub(super) fn deterministic_job_id(
+    run_id: RunId,
+    invocation_id: LogicalWorkflowInvocationId,
+    logical_job_id: LogicalWorkflowJobId,
+    matrix_digest: Sha256Digest,
+) -> automata_ci_core::JobId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"automata.workflow-service.logical-job-id.v1\0");
+    hasher.update(run_id.as_uuid().as_bytes());
+    hasher.update(invocation_id.as_uuid().as_bytes());
+    hasher.update(logical_job_id.as_uuid().as_bytes());
+    hasher.update(0_u32.to_be_bytes());
+    hasher.update(1_u32.to_be_bytes());
+    hasher.update(matrix_digest.as_bytes());
+    let digest: [u8; 32] = hasher.finalize().into();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    automata_ci_core::JobId::from_uuid(Uuid::from_bytes(bytes))
+}
+
+pub(super) fn context_object(key: &str, digest: u8) -> AdmissionObject {
+    AdmissionObject::new(
+        Sha256Digest::from_bytes([digest; 32]),
+        ObjectKey::new(key).expect("context key"),
+        128,
+        "application/vnd.automata.job-runtime-context.protobuf",
+    )
+    .expect("context object")
+}

--- a/crates/automata-ci-postgres/tests/store/fixture.rs
+++ b/crates/automata-ci-postgres/tests/store/fixture.rs
@@ -1,12 +1,24 @@
 use automata_ci_core::{JobContentReference, RunId, Sha256Digest, UnixMillis};
 use automata_ci_store::{
     AdmissionObject, AdmitLogicalWorkflowRun, LogicalActivationObject, LogicalWorkflowInvocationId,
-    LogicalWorkflowJobId, ObjectKey,
+    LogicalWorkflowJobId, ObjectKey, WorkflowAdmissionIdempotency,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::support::TestResult;
+
+pub(super) fn authenticated_github_idempotency(
+    command: &AdmitLogicalWorkflowRun,
+) -> TestResult<WorkflowAdmissionIdempotency> {
+    let delivery_key = command.idempotency().key();
+    Ok(WorkflowAdmissionIdempotency::namespaced_provider_delivery(
+        command.repository().provider(),
+        command.repository().provider_repository_id(),
+        &delivery_key,
+        command.workflow_path(),
+    )?)
+}
 
 pub(super) fn retime_logical_admission(
     command: &AdmitLogicalWorkflowRun,
@@ -14,7 +26,7 @@ pub(super) fn retime_logical_admission(
 ) -> TestResult<AdmitLogicalWorkflowRun> {
     let mut builder = AdmitLogicalWorkflowRun::builder(
         command.tenant().clone(),
-        command.idempotency().clone(),
+        authenticated_github_idempotency(command)?,
         command.request_digest(),
         command.repository().clone(),
         command.workflow_id(),

--- a/crates/automata-ci-postgres/tests/store/mod.rs
+++ b/crates/automata-ci-postgres/tests/store/mod.rs
@@ -4,6 +4,8 @@ mod contracts;
 #[cfg(feature = "test-support")]
 mod execution;
 #[cfg(feature = "test-support")]
+mod fixture;
+#[cfg(feature = "test-support")]
 mod orchestration;
 #[cfg(feature = "test-support")]
 mod provider;

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation.rs
@@ -1,4 +1,5 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::retime_logical_admission;
 
 use automata_ci_core::{
     JOB_IR_SCHEMA_VERSION, JOB_RUNTIME_CONTEXT_SCHEMA_VERSION, JobAuthorityProfile,
@@ -279,7 +280,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         claimed.claimed_at(),
     )
     .await?;
-    fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
+    fixture.command = retime_logical_admission(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -295,38 +296,6 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         )
         .await?;
     Ok(())
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_activation_preparation.rs
@@ -1,14 +1,18 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::{
+    activation_content_reference, context_object, deterministic_job_id, job_content_reference,
+    retime_logical_admission,
+};
 
 use automata_ci_core::{
-    CompiledValueTemplate, ContextValue, JobAuthorityProfile, JobConclusion, JobContentReference,
-    JobExecutionContext, JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest,
-    JobRuntimeContext, JobSource, Located, LogicalJobKind, LogicalJobTemplate,
-    LogicalRunStepTemplate, LogicalRunnerTemplate, LogicalStepKind, LogicalStepTemplate,
-    PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan, RunId, RunValueTemplates,
-    RunnerRequirements, RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
-    StrategyContext, UnixMillis, ValueTemplate, WorkflowEventProvenance, WorkflowId,
-    WorkflowJobKey, WorkflowPlan, WorkflowSourceProvenance, WorkflowStepKey,
+    CompiledValueTemplate, ContextValue, JobAuthorityProfile, JobConclusion, JobExecutionContext,
+    JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest, JobRuntimeContext, JobSource,
+    Located, LogicalJobKind, LogicalJobTemplate, LogicalRunStepTemplate, LogicalRunnerTemplate,
+    LogicalStepKind, LogicalStepTemplate, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan,
+    RunId, RunValueTemplates, RunnerRequirements, RuntimeBoolean, SemanticStep, Sha256Digest,
+    ShellTemplate, StepId, StepIr, StrategyContext, UnixMillis, ValueTemplate,
+    WorkflowEventProvenance, WorkflowId, WorkflowJobKey, WorkflowPlan, WorkflowSourceProvenance,
+    WorkflowStepKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
@@ -956,8 +960,8 @@ fn prepared_materialization(
         execution.workflow_name(),
         execution.git_ref(),
         workspace,
-        content_reference(claimed.event()),
-        activation_reference(&runtime),
+        job_content_reference(claimed.event()),
+        activation_content_reference(&runtime),
     )
     .with_run_id_alias(execution.run_id_alias())
     .with_run_number(execution.run_number())
@@ -1005,46 +1009,6 @@ fn prepared_materialization(
         runtime_context,
         runtime_encoded,
     }
-}
-
-fn deterministic_job_id(
-    run_id: RunId,
-    invocation_id: LogicalWorkflowInvocationId,
-    logical_job_id: LogicalWorkflowJobId,
-    matrix_digest: Sha256Digest,
-) -> automata_ci_core::JobId {
-    let mut hasher = Sha256::new();
-    hasher.update(b"automata.workflow-service.logical-job-id.v1\0");
-    hasher.update(run_id.as_uuid().as_bytes());
-    hasher.update(invocation_id.as_uuid().as_bytes());
-    hasher.update(logical_job_id.as_uuid().as_bytes());
-    hasher.update(0_u32.to_be_bytes());
-    hasher.update(1_u32.to_be_bytes());
-    hasher.update(matrix_digest.as_bytes());
-    let digest: [u8; 32] = hasher.finalize().into();
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&digest[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x80;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    automata_ci_core::JobId::from_uuid(Uuid::from_bytes(bytes))
-}
-
-fn content_reference(object: &AdmissionObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn activation_reference(object: &LogicalActivationObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
 }
 
 async fn claim_preparation(
@@ -1242,16 +1206,6 @@ fn tenant(fixture: &Fixture) -> TestResult<TenantScope> {
 
 fn worker(value: u128) -> LogicalActivationWorkerId {
     LogicalActivationWorkerId::from_uuid(Uuid::from_u128(value)).expect("worker")
-}
-
-fn context_object(key: &str, digest: u8) -> AdmissionObject {
-    AdmissionObject::new(
-        Sha256Digest::from_bytes([digest; 32]),
-        ObjectKey::new(key).expect("context key"),
-        128,
-        "application/vnd.automata.job-runtime-context.protobuf",
-    )
-    .expect("context object")
 }
 
 async fn fixture(
@@ -1510,7 +1464,7 @@ async fn fixture_with_visibility(
         claimed.claimed_at(),
     )
     .await?;
-    command = logical_command_at(&command, claimed.claimed_at())?;
+    command = retime_logical_admission(&command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -1531,38 +1485,6 @@ async fn fixture_with_visibility(
         plan,
         plan_bytes,
     })
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -1,4 +1,8 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::{
+    activation_content_reference, deterministic_job_id, job_content_reference,
+    retime_logical_admission,
+};
 
 use std::collections::BTreeMap;
 
@@ -9,13 +13,13 @@ use automata_ci_control::{
     runner_control::repository::RunnerSessionRepository as _,
 };
 use automata_ci_core::{
-    Architecture, ContextValue, JobAuthorityProfile, JobConclusion, JobContentReference,
-    JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
-    JobOutputDefinition, JobPermissionRequest, JobResult, JobResultOutput, JobRuntimeContext,
-    JobSecretExposure, JobSource, OperatingSystem, OperationId, OutputSensitivity, RunId,
-    RunValueTemplates, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
-    StrategyContext, UnixMillis, ValueTemplate, WorkflowId, WorkflowJobKey,
+    Architecture, ContextValue, JobAuthorityProfile, JobConclusion, JobExecutionContext,
+    JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion, JobOutputDefinition,
+    JobPermissionRequest, JobResult, JobResultOutput, JobRuntimeContext, JobSecretExposure,
+    JobSource, OperatingSystem, OperationId, OutputSensitivity, RunId, RunValueTemplates,
+    RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements, RunnerSessionId,
+    RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, StrategyContext,
+    UnixMillis, ValueTemplate, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
@@ -1383,7 +1387,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         claimed.claimed_at(),
         claimed.expires_at(),
     )?;
-    let command = logical_command_at(&fixture.command, claimed.claimed_at())?;
+    let command = retime_logical_admission(&fixture.command, claimed.claimed_at())?;
     database
         .store()
         .admit_authenticated_github_delivery(command.clone(), authenticated, command.admitted_at())
@@ -1439,38 +1443,6 @@ async fn ensure_instance_result_server_authorities(
             .await?;
     }
     Ok(())
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 async fn claim_activation(
@@ -1657,8 +1629,8 @@ fn prepared_instance(
         execution.workflow_name(),
         execution.git_ref(),
         workspace,
-        admission_reference(claimed.event()),
-        activation_reference(&runtime),
+        job_content_reference(claimed.event()),
+        activation_content_reference(&runtime),
     )
     .with_run_id_alias(execution.run_id_alias())
     .with_run_number(execution.run_number())
@@ -2005,44 +1977,4 @@ fn admission_object_with_media(key: String, digest: u8, media_type: &str) -> Adm
         media_type,
     )
     .expect("admission object")
-}
-
-fn admission_reference(object: &AdmissionObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn activation_reference(object: &LogicalActivationObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn deterministic_job_id(
-    run_id: RunId,
-    invocation_id: LogicalWorkflowInvocationId,
-    logical_job_id: LogicalWorkflowJobId,
-    matrix_digest: Sha256Digest,
-) -> JobId {
-    let mut hasher = Sha256::new();
-    hasher.update(b"automata.workflow-service.logical-job-id.v1\0");
-    hasher.update(run_id.as_uuid().as_bytes());
-    hasher.update(invocation_id.as_uuid().as_bytes());
-    hasher.update(logical_job_id.as_uuid().as_bytes());
-    hasher.update(0_u32.to_be_bytes());
-    hasher.update(1_u32.to_be_bytes());
-    hasher.update(matrix_digest.as_bytes());
-    let digest: [u8; 32] = hasher.finalize().into();
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&digest[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x80;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    JobId::from_uuid(Uuid::from_bytes(bytes))
 }

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_job_result.rs
@@ -1,22 +1,25 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::{
+    activation_content_reference, job_content_reference, retime_logical_admission,
+};
 
 use std::collections::BTreeMap;
 
 use automata_ci_control::runner_control::repository::RunnerSessionRepository as _;
 use automata_ci_core::{
     Architecture, CompiledValueTemplate, ContextValue, JobAuthorityProfile, JobConclusion,
-    JobContentReference, JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope,
-    JobIrVersion, JobOutputDefinition, JobResult, JobResultOutput, JobRuntimeContext,
-    JobSecretExposure, JobSource, Located, LogicalJobKind, LogicalJobOutputDefinition,
-    LogicalJobOutputSource, LogicalJobTemplate, LogicalOutputMergePolicy, LogicalRunStepTemplate,
-    LogicalRunnerTemplate, LogicalStepKind, LogicalStepTemplate, MatrixAxis, MatrixAxisValues,
-    MatrixPatchSet, MatrixTemplate, MatrixValue, MatrixValueTemplate, OperatingSystem,
-    OutputSensitivity, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan, RunId,
-    RunValueTemplates, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
-    StepJobTemplate, StrategyContext, UnixMillis, ValueTemplate, WorkflowEventProvenance,
-    WorkflowId, WorkflowJobKey, WorkflowOutputKey, WorkflowPlan, WorkflowSourceProvenance,
-    WorkflowStepKey, WorkflowStrategyTemplate,
+    JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersion,
+    JobOutputDefinition, JobResult, JobResultOutput, JobRuntimeContext, JobSecretExposure,
+    JobSource, Located, LogicalJobKind, LogicalJobOutputDefinition, LogicalJobOutputSource,
+    LogicalJobTemplate, LogicalOutputMergePolicy, LogicalRunStepTemplate, LogicalRunnerTemplate,
+    LogicalStepKind, LogicalStepTemplate, MatrixAxis, MatrixAxisValues, MatrixPatchSet,
+    MatrixTemplate, MatrixValue, MatrixValueTemplate, OperatingSystem, OutputSensitivity,
+    PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan, RunId, RunValueTemplates,
+    RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements, RunnerSessionId,
+    RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, StepJobTemplate,
+    StrategyContext, UnixMillis, ValueTemplate, WorkflowEventProvenance, WorkflowId,
+    WorkflowJobKey, WorkflowOutputKey, WorkflowPlan, WorkflowSourceProvenance, WorkflowStepKey,
+    WorkflowStrategyTemplate,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
@@ -1616,7 +1619,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         claimed.claimed_at(),
     )
     .await?;
-    let command = logical_command_at(&fixture.command, claimed.claimed_at())?;
+    let command = retime_logical_admission(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -1628,38 +1631,6 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &Fixture)
         .admit_authenticated_github_delivery(command.clone(), authenticated, command.admitted_at())
         .await?;
     Ok(())
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 async fn seed_tenant(database: &TestDatabase, tenant: &str) -> TestResult {
@@ -1912,8 +1883,8 @@ fn prepared_instance(
         execution.workflow_name(),
         execution.git_ref(),
         workspace,
-        admission_reference(claimed.event()),
-        activation_reference(&runtime),
+        job_content_reference(claimed.event()),
+        activation_content_reference(&runtime),
     )
     .with_run_id_alias(execution.run_id_alias())
     .with_run_number(execution.run_number())
@@ -2236,24 +2207,6 @@ fn admission_object(key: String, bytes: &[u8], media: &str) -> AdmissionObject {
         media,
     )
     .expect("admission object")
-}
-
-fn admission_reference(object: &AdmissionObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn activation_reference(object: &LogicalActivationObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
 }
 
 fn deterministic_job_id(

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_renewal_ack.rs
@@ -1,13 +1,16 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::{
+    activation_content_reference, context_object, deterministic_job_id, job_content_reference,
+    retime_logical_admission,
+};
 
 use std::collections::BTreeMap;
 
 use automata_ci_core::{
-    ContextValue, JobAuthorityProfile, JobContentReference, JobExecutionContext,
-    JobInstanceIdentity, JobIr, JobIrEnvelope, JobRuntimeContext, JobSource, RunId,
-    RunValueTemplates, RunnerRequirements, RuntimeBoolean, SemanticStep, Sha256Digest,
-    ShellTemplate, StepId, StepIr, StrategyContext, UnixMillis, ValueTemplate, WorkflowId,
-    WorkflowJobKey,
+    ContextValue, JobAuthorityProfile, JobExecutionContext, JobInstanceIdentity, JobIr,
+    JobIrEnvelope, JobRuntimeContext, JobSource, RunId, RunValueTemplates, RunnerRequirements,
+    RuntimeBoolean, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr, StrategyContext,
+    UnixMillis, ValueTemplate, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
@@ -2267,7 +2270,7 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         claimed.claimed_at(),
     )
     .await?;
-    fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
+    fixture.command = retime_logical_admission(&fixture.command, claimed.claimed_at())?;
     let authenticated = AuthenticatedGithubDeliveryClaim::new(
         claimed.claim(),
         claimed.attempt(),
@@ -2283,38 +2286,6 @@ async fn admit_authenticated_fixture(database: &TestDatabase, fixture: &mut Fixt
         )
         .await?;
     Ok(())
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2373,8 +2344,8 @@ fn prepared_instance(
         execution.workflow_name(),
         execution.git_ref(),
         format!("/runner/work/{namespace}"),
-        content_reference(claimed.event()),
-        activation_reference(&runtime),
+        job_content_reference(claimed.event()),
+        activation_content_reference(&runtime),
     )
     .with_run_id_alias(execution.run_id_alias())
     .with_run_number(execution.run_number())
@@ -2424,46 +2395,6 @@ fn prepared_instance(
     }
 }
 
-fn deterministic_job_id(
-    run_id: RunId,
-    invocation_id: LogicalWorkflowInvocationId,
-    logical_job_id: LogicalWorkflowJobId,
-    matrix_digest: Sha256Digest,
-) -> automata_ci_core::JobId {
-    let mut hasher = Sha256::new();
-    hasher.update(b"automata.workflow-service.logical-job-id.v1\0");
-    hasher.update(run_id.as_uuid().as_bytes());
-    hasher.update(invocation_id.as_uuid().as_bytes());
-    hasher.update(logical_job_id.as_uuid().as_bytes());
-    hasher.update(0_u32.to_be_bytes());
-    hasher.update(1_u32.to_be_bytes());
-    hasher.update(matrix_digest.as_bytes());
-    let digest: [u8; 32] = hasher.finalize().into();
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&digest[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x80;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    automata_ci_core::JobId::from_uuid(Uuid::from_bytes(bytes))
-}
-
-fn content_reference(object: &AdmissionObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
-fn activation_reference(object: &LogicalActivationObject) -> JobContentReference {
-    JobContentReference::new(
-        object.object_key().as_str(),
-        object.digest(),
-        object.encoded_size(),
-        object.media_type(),
-    )
-}
-
 fn admission_object(key: String, digest: u8, media_type: &str) -> AdmissionObject {
     AdmissionObject::new(
         Sha256Digest::from_bytes([digest; 32]),
@@ -2472,16 +2403,6 @@ fn admission_object(key: String, digest: u8, media_type: &str) -> AdmissionObjec
         media_type,
     )
     .expect("admission object")
-}
-
-fn context_object(key: &str, digest: u8) -> AdmissionObject {
-    AdmissionObject::new(
-        Sha256Digest::from_bytes([digest; 32]),
-        ObjectKey::new(key).expect("context key"),
-        128,
-        "application/vnd.automata.job-runtime-context.protobuf",
-    )
-    .expect("context object")
 }
 
 async fn database_now_ms(database: &TestDatabase) -> TestResult<i64> {

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_run_finalization.rs
@@ -1,4 +1,5 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::authenticated_github_idempotency;
 
 use automata_ci_core::{
     CompiledValueTemplate, JobAuthorityProfile, JobConclusion, Located, LogicalJobKind,
@@ -567,7 +568,7 @@ fn logical_command_at(
 ) -> TestResult<AdmitLogicalWorkflowRun> {
     let mut builder = AdmitLogicalWorkflowRun::builder(
         command.tenant().clone(),
-        command.idempotency().clone(),
+        authenticated_github_idempotency(command)?,
         command.request_digest(),
         command.repository().clone(),
         command.workflow_id(),

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_work_selection.rs
@@ -1,4 +1,5 @@
 use crate::github_manifest_fixture;
+use crate::store::fixture::retime_logical_admission;
 
 use std::sync::Arc;
 
@@ -521,7 +522,7 @@ async fn authenticate_fixture(
         claimed.claimed_at(),
     )
     .await?;
-    fixture.command = logical_command_at(&fixture.command, claimed.claimed_at())?;
+    fixture.command = retime_logical_admission(&fixture.command, claimed.claimed_at())?;
     database
         .store()
         .admit_authenticated_github_delivery(
@@ -536,38 +537,6 @@ async fn authenticate_fixture(
         )
         .await?;
     Ok(())
-}
-
-fn logical_command_at(
-    command: &AdmitLogicalWorkflowRun,
-    admitted_at: UnixMillis,
-) -> TestResult<AdmitLogicalWorkflowRun> {
-    let mut builder = AdmitLogicalWorkflowRun::builder(
-        command.tenant().clone(),
-        command.idempotency().clone(),
-        command.request_digest(),
-        command.repository().clone(),
-        command.workflow_id(),
-        command.workflow_path(),
-        command.workflow_name(),
-        command.git_ref(),
-        command.snapshot_id(),
-        command.source().clone(),
-        command.plan().clone(),
-        command.run_id(),
-        command.run_attempt(),
-        command.root_invocation_id(),
-        command.event_name(),
-        command.event().clone(),
-        command.head_sha().to_vec(),
-        command.jobs().to_vec(),
-        admitted_at,
-    );
-    if let Some(base_context) = command.base_context() {
-        builder = builder.base_context(base_context.clone());
-    }
-    builder = builder.trust_snapshot(command.trust_snapshot().clone());
-    Ok(builder.build()?)
 }
 
 fn admission_object(key: String, digest: u8, media_type: &str) -> AdmissionObject {


### PR DESCRIPTION
Closes #331\n\n## Summary\n\n- replace 23 duplicate logical-orchestration fixture definitions with five private shared helpers\n- preserve all 25 typed call sites across six orchestration modules and runtime-authority coverage\n- align authenticated fixture admissions with the exact production provider/repository/delivery/workflow idempotency namespace\n- keep the specialized run-finalization builder local while applying that same canonical derivation\n- remove 294 net lines across one cohesive 10-file PostgreSQL test-support bundle\n- deliberately exclude logical_materialization.rs (#202 dirty worktree), logical_orchestration.rs (#173/#197 overlap), and provider/security overlap\n\n## Validation\n\n- targeted Rustfmt and git diff --check\n- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-postgres --all-targets --all-features\n- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-postgres --all-targets --all-features (15 passed, 442 live tests ignored)\n- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-postgres --all-targets --all-features -- -D warnings with the established large-futures and too-many-lines test allowances\n- PostgreSQL 18.4 live modules: logical_activation 5/5, logical_activation_preparation 5/5, logical_instance_result 6/6, logical_job_result 5/5, logical_renewal_ack 6/6, logical_work_selection 2/2, logical_run_finalization 4/4, runtime_authority 32/32 (65/65 total)\n- isolated namespace cleanup plus direct catalog/session audit: 0 databases, 0 sessions\n- independent review on exact rebased head: approved, no findings\n\n## Regression repaired\n\nProduction validation added in #268 derives one durable key from the provider, provider repository ID, inbox delivery ID, and workflow path. The affected test fixtures still retimed commands with their opaque delivery key, so live admissions failed with signed GitHub subject evidence rejected admission. This bundle makes the consolidated test fixture reproduce the production contract.