### PR TITLE
test(secret): share provider test support

### DIFF
--- a/crates/automata-ci-secret/tests/port_contract.rs
+++ b/crates/automata-ci-secret/tests/port_contract.rs
@@ -1,116 +1,8 @@
-use std::{
-    future::Future,
-    sync::{
-        LazyLock,
-        atomic::{AtomicUsize, Ordering},
-    },
-    task::{Context, Poll, Waker},
-};
+use automata_ci_secret::{ProviderCapability, ProviderErrorKind, SecretProvider};
 
-use async_trait::async_trait;
-use automata_ci_secret::{
-    CreateSecretVersionRequest, CreatedSecretVersion, DestroySecretVersionRequest,
-    ProviderCapabilities, ProviderCapability, ProviderError, ProviderErrorKind, ProviderHealth,
-    ProviderOperationContext, ProviderRequestId, ProviderSecretLocator, ProviderVersionId,
-    ReconcileCreateSecretVersionRequest, RepositoryScopeId, ResolveSecretVersionRequest,
-    ResolvedSecretVersion, SecretAtRestProtection, SecretDescriptor, SecretId, SecretName,
-    SecretProvider, SecretProviderId, SecretScope, TenantScopeId,
-};
+use crate::support::{DefaultMethodProvider, poll_immediately_ready, reconciliation_request};
 
 static_assertions::assert_obj_safe!(SecretProvider);
-
-#[derive(Debug)]
-struct DefaultReconciliationProvider {
-    id: SecretProviderId,
-    create_calls: AtomicUsize,
-}
-
-impl DefaultReconciliationProvider {
-    fn new() -> Self {
-        Self {
-            id: SecretProviderId::new("default-reconciliation").expect("provider ID"),
-            create_calls: AtomicUsize::new(0),
-        }
-    }
-}
-
-#[async_trait]
-impl SecretProvider for DefaultReconciliationProvider {
-    fn provider_id(&self) -> &SecretProviderId {
-        &self.id
-    }
-
-    fn capabilities(&self) -> &ProviderCapabilities {
-        static CAPABILITIES: LazyLock<ProviderCapabilities> =
-            LazyLock::new(ProviderCapabilities::default);
-        &CAPABILITIES
-    }
-
-    fn at_rest_protection(&self) -> SecretAtRestProtection {
-        SecretAtRestProtection::ProviderManagedEncryption
-    }
-
-    async fn health(
-        &self,
-        _context: &ProviderOperationContext,
-    ) -> Result<ProviderHealth, ProviderError> {
-        Ok(ProviderHealth::Healthy)
-    }
-
-    async fn create_version(
-        &self,
-        _request: CreateSecretVersionRequest,
-    ) -> Result<CreatedSecretVersion, ProviderError> {
-        self.create_calls.fetch_add(1, Ordering::Relaxed);
-        Err(ProviderError::unsupported())
-    }
-
-    async fn resolve_version(
-        &self,
-        _request: ResolveSecretVersionRequest,
-    ) -> Result<ResolvedSecretVersion, ProviderError> {
-        Err(ProviderError::unsupported())
-    }
-
-    async fn destroy_version(
-        &self,
-        _request: DestroySecretVersionRequest,
-    ) -> Result<(), ProviderError> {
-        Err(ProviderError::unsupported())
-    }
-}
-
-fn poll_immediately_ready<F: Future>(future: F) -> F::Output {
-    let mut context = Context::from_waker(Waker::noop());
-    let mut future = Box::pin(future);
-    match future.as_mut().poll(&mut context) {
-        Poll::Ready(output) => output,
-        Poll::Pending => panic!("default provider reconciliation unexpectedly yielded"),
-    }
-}
-
-fn reconciliation_request() -> ReconcileCreateSecretVersionRequest {
-    let tenant_id = TenantScopeId::new("tenant-a").expect("tenant ID");
-    ReconcileCreateSecretVersionRequest::new(
-        ProviderOperationContext::new(
-            tenant_id.clone(),
-            ProviderRequestId::new("durable-create-request").expect("request ID"),
-        ),
-        SecretDescriptor::new(
-            SecretId::new("secret-a").expect("secret ID"),
-            SecretName::new("DEPLOY_TOKEN").expect("secret name"),
-            SecretScope::repository(
-                tenant_id,
-                RepositoryScopeId::new("repository-a").expect("repository ID"),
-            ),
-        ),
-        Some(automata_ci_secret::ExistingSecretVersion::new(
-            ProviderSecretLocator::new("opaque-locator").expect("locator"),
-            ProviderVersionId::new("opaque-version").expect("version"),
-        )),
-    )
-    .expect("reconciliation request")
-}
 
 #[test]
 fn secret_provider_is_object_safe() {
@@ -120,7 +12,7 @@ fn secret_provider_is_object_safe() {
 
 #[test]
 fn default_reconciliation_is_closed_and_never_delegates_to_create() {
-    let provider = DefaultReconciliationProvider::new();
+    let provider = DefaultMethodProvider::new("default-reconciliation");
     let erased: &dyn SecretProvider = &provider;
     assert!(
         !erased
@@ -129,10 +21,16 @@ fn default_reconciliation_is_closed_and_never_delegates_to_create() {
     );
 
     for _ in 0..2 {
-        let error =
-            poll_immediately_ready(erased.reconcile_create_version(reconciliation_request()))
-                .expect_err("default reconciliation must fail closed");
+        let error = poll_immediately_ready(
+            erased.reconcile_create_version(reconciliation_request(
+                "durable-create-request",
+                "opaque-locator",
+                "opaque-version",
+            )),
+            "default provider reconciliation unexpectedly yielded",
+        )
+        .expect_err("default reconciliation must fail closed");
         assert_eq!(error.kind(), ProviderErrorKind::Unsupported);
     }
-    assert_eq!(provider.create_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(provider.create_call_count(), 0);
 }

--- a/crates/automata-ci-secret/tests/provider_dispatch.rs
+++ b/crates/automata-ci-secret/tests/provider_dispatch.rs
@@ -7,20 +7,22 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
-    task::{Context, Poll, Waker},
 };
 
 use async_trait::async_trait;
 use automata_ci_secret::{
     CreateSecretVersionRequest, CreatedSecretVersion, DestroySecretVersionRequest,
-    ExistingSecretVersion, ProviderCapabilities, ProviderCapability, ProviderError,
-    ProviderErrorKind, ProviderHealth, ProviderLease, ProviderLeaseExpiration, ProviderLeaseId,
-    ProviderOperationContext, ProviderRequestId, ProviderSecretLocator, ProviderVersionId,
-    ReconcileCreateSecretVersionOutcome, ReconcileCreateSecretVersionRequest,
-    RenewProviderLeaseRequest, RevokeProviderLeaseRequest, SecretAtRestProtection,
-    SecretDescriptor, SecretId, SecretName, SecretProvider, SecretProviderDispatchError,
-    SecretProviderId, SecretProviderRegistry, SecretScope, SecretValue, TenantScopeId,
-    WorkloadContext, WorkloadId,
+    ProviderCapabilities, ProviderCapability, ProviderError, ProviderErrorKind, ProviderHealth,
+    ProviderLease, ProviderLeaseExpiration, ProviderLeaseId, ProviderOperationContext,
+    ProviderSecretLocator, ProviderVersionId, ReconcileCreateSecretVersionOutcome,
+    ReconcileCreateSecretVersionRequest, RenewProviderLeaseRequest, RevokeProviderLeaseRequest,
+    SecretAtRestProtection, SecretProvider, SecretProviderDispatchError, SecretProviderId,
+    SecretProviderRegistry, SecretValue, WorkloadContext, WorkloadId,
+};
+
+use crate::support::{
+    existing_version, poll_immediately_ready, provider_context, reconciliation_request,
+    repository_scope, secret_descriptor,
 };
 
 #[derive(Default)]
@@ -168,15 +170,15 @@ fn health_routes_only_to_the_exact_provider_without_default_fallback() {
     let target = ProviderFixture::new("target", &[], None);
     let registry = registry(&default, [&target]);
 
-    let health =
-        ready(registry.dispatch_health(&target.id, &context("health"))).expect("target health");
+    let health = ready(registry.dispatch_health(&target.id, &provider_context("request-health")))
+        .expect("target health");
     assert_eq!(health, ProviderHealth::Healthy);
     assert_eq!(target.calls.health.load(Ordering::Relaxed), 1);
     assert_eq!(default.calls.health.load(Ordering::Relaxed), 0);
 
     let missing = SecretProviderId::new("missing-provider").expect("missing ID");
     assert_eq!(
-        ready(registry.dispatch_health(&missing, &context("health"))),
+        ready(registry.dispatch_health(&missing, &provider_context("request-health"))),
         Err(SecretProviderDispatchError::Rejected)
     );
     assert_eq!(default.calls.health.load(Ordering::Relaxed), 0);
@@ -216,9 +218,11 @@ fn reconciliation_requires_capability_and_never_delegates_to_create() {
     );
     let registry = registry(&create_only, [&capable]);
 
-    let reconciled =
-        ready(registry.dispatch_reconcile_create_version(&capable.id, reconcile_request()))
-            .expect("reconciled version");
+    let reconciled = ready(registry.dispatch_reconcile_create_version(
+        &capable.id,
+        reconciliation_request("request-reconcile", "existing-locator", "existing-version"),
+    ))
+    .expect("reconciled version");
     assert!(matches!(
         reconciled,
         ReconcileCreateSecretVersionOutcome::AlreadyCommitted(_)
@@ -227,7 +231,10 @@ fn reconciliation_requires_capability_and_never_delegates_to_create() {
     assert_eq!(capable.calls.create.load(Ordering::Relaxed), 0);
 
     assert_eq!(
-        ready(registry.dispatch_reconcile_create_version(&create_only.id, reconcile_request(),)),
+        ready(registry.dispatch_reconcile_create_version(
+            &create_only.id,
+            reconciliation_request("request-reconcile", "existing-locator", "existing-version"),
+        )),
         Err(SecretProviderDispatchError::Rejected)
     );
     assert_eq!(create_only.calls.reconcile.load(Ordering::Relaxed), 0);
@@ -318,7 +325,7 @@ fn sanitized_provider_errors_pass_through_without_retry_or_adapter_debug() {
     let provider = ProviderFixture::new("failing", &[], Some(failure));
     let registry = registry(&provider, []);
 
-    let error = ready(registry.dispatch_health(&provider.id, &context("health")))
+    let error = ready(registry.dispatch_health(&provider.id, &provider_context("request-health")))
         .expect_err("provider failure");
     assert_eq!(error, SecretProviderDispatchError::Provider(failure));
     assert_eq!(provider.calls.health.load(Ordering::Relaxed), 1);
@@ -343,76 +350,32 @@ fn registry<const N: usize>(
 }
 
 fn ready<F: Future>(future: F) -> F::Output {
-    let mut context = Context::from_waker(Waker::noop());
-    let mut future = Box::pin(future);
-    match future.as_mut().poll(&mut context) {
-        Poll::Ready(output) => output,
-        Poll::Pending => panic!("in-memory provider unexpectedly yielded"),
-    }
-}
-
-fn tenant() -> TenantScopeId {
-    TenantScopeId::new("tenant-a").expect("tenant ID")
-}
-
-fn scope() -> SecretScope {
-    SecretScope::repository(
-        tenant(),
-        automata_ci_secret::RepositoryScopeId::new("repository-a").expect("repository ID"),
-    )
-}
-
-fn descriptor() -> SecretDescriptor {
-    SecretDescriptor::new(
-        SecretId::new("secret-a").expect("secret ID"),
-        SecretName::new("DEPLOY_TOKEN").expect("secret name"),
-        scope(),
-    )
+    poll_immediately_ready(future, "in-memory provider unexpectedly yielded")
 }
 
 fn workload() -> WorkloadContext {
-    WorkloadContext::new(WorkloadId::new("workload-a").expect("workload ID"), scope())
-        .expect("workload context")
-}
-
-fn context(operation: &str) -> ProviderOperationContext {
-    ProviderOperationContext::new(
-        tenant(),
-        ProviderRequestId::new(format!("request-{operation}")).expect("request ID"),
+    WorkloadContext::new(
+        WorkloadId::new("workload-a").expect("workload ID"),
+        repository_scope(),
     )
-}
-
-fn predecessor() -> ExistingSecretVersion {
-    ExistingSecretVersion::new(
-        ProviderSecretLocator::new("existing-locator").expect("locator"),
-        ProviderVersionId::new("existing-version").expect("version"),
-    )
+    .expect("workload context")
 }
 
 fn create_request() -> CreateSecretVersionRequest {
     CreateSecretVersionRequest::new(
-        context("create"),
-        descriptor(),
-        Some(predecessor()),
+        provider_context("request-create"),
+        secret_descriptor(),
+        Some(existing_version("existing-locator", "existing-version")),
         SecretValue::from_utf8("create-secret".to_owned()).expect("secret value"),
     )
     .expect("create request")
 }
 
-fn reconcile_request() -> ReconcileCreateSecretVersionRequest {
-    ReconcileCreateSecretVersionRequest::new(
-        context("reconcile"),
-        descriptor(),
-        Some(predecessor()),
-    )
-    .expect("reconciliation request")
-}
-
 fn resolve_request() -> automata_ci_secret::ResolveSecretVersionRequest {
     automata_ci_secret::ResolveSecretVersionRequest::new(
-        context("resolve"),
+        provider_context("request-resolve"),
         workload(),
-        descriptor(),
+        secret_descriptor(),
         ProviderSecretLocator::new("requested-locator").expect("locator"),
         ProviderVersionId::new("requested-version").expect("version"),
     )
@@ -421,8 +384,8 @@ fn resolve_request() -> automata_ci_secret::ResolveSecretVersionRequest {
 
 fn destroy_request() -> DestroySecretVersionRequest {
     DestroySecretVersionRequest::new(
-        context("destroy"),
-        descriptor(),
+        provider_context("request-destroy"),
+        secret_descriptor(),
         ProviderSecretLocator::new("destroy-locator").expect("locator"),
         ProviderVersionId::new("destroy-version").expect("version"),
     )
@@ -431,7 +394,7 @@ fn destroy_request() -> DestroySecretVersionRequest {
 
 fn renew_request() -> RenewProviderLeaseRequest {
     RenewProviderLeaseRequest::new(
-        context("renew"),
+        provider_context("request-renew"),
         workload(),
         ProviderLeaseId::new("renew-lease").expect("lease ID"),
     )
@@ -440,7 +403,7 @@ fn renew_request() -> RenewProviderLeaseRequest {
 
 fn revoke_request() -> RevokeProviderLeaseRequest {
     RevokeProviderLeaseRequest::new(
-        context("revoke"),
+        provider_context("request-revoke"),
         ProviderLeaseId::new("revoke-lease").expect("lease ID"),
     )
 }

--- a/crates/automata-ci-secret/tests/provider_registry.rs
+++ b/crates/automata-ci-secret/tests/provider_registry.rs
@@ -1,79 +1,9 @@
-use std::{fmt, sync::Arc};
-
-use async_trait::async_trait;
 use automata_ci_secret::{
-    CreateSecretVersionRequest, CreatedSecretVersion, DestroySecretVersionRequest,
-    MAX_REGISTERED_SECRET_PROVIDERS, ProviderError, ProviderHealth, ProviderOperationContext,
-    ResolveSecretVersionRequest, ResolvedSecretVersion, SecretAtRestProtection, SecretProvider,
-    SecretProviderId, SecretProviderRegistry, SecretProviderRegistryError,
+    MAX_REGISTERED_SECRET_PROVIDERS, SecretAtRestProtection, SecretProviderId,
+    SecretProviderRegistry, SecretProviderRegistryError,
 };
 
-struct FakeProvider {
-    id: SecretProviderId,
-}
-
-impl FakeProvider {
-    fn new(id: &str) -> Self {
-        Self {
-            id: SecretProviderId::new(id).expect("test provider ID"),
-        }
-    }
-}
-
-impl fmt::Debug for FakeProvider {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("FakeProvider(configuration=must-not-appear)")
-    }
-}
-
-#[async_trait]
-impl SecretProvider for FakeProvider {
-    fn provider_id(&self) -> &SecretProviderId {
-        &self.id
-    }
-
-    fn capabilities(&self) -> &automata_ci_secret::ProviderCapabilities {
-        static CAPABILITIES: std::sync::LazyLock<automata_ci_secret::ProviderCapabilities> =
-            std::sync::LazyLock::new(automata_ci_secret::ProviderCapabilities::default);
-        &CAPABILITIES
-    }
-
-    fn at_rest_protection(&self) -> SecretAtRestProtection {
-        SecretAtRestProtection::ProviderManagedEncryption
-    }
-
-    async fn health(
-        &self,
-        _context: &ProviderOperationContext,
-    ) -> Result<ProviderHealth, ProviderError> {
-        Ok(ProviderHealth::Healthy)
-    }
-
-    async fn create_version(
-        &self,
-        _request: CreateSecretVersionRequest,
-    ) -> Result<CreatedSecretVersion, ProviderError> {
-        Err(ProviderError::unsupported())
-    }
-
-    async fn resolve_version(
-        &self,
-        _request: ResolveSecretVersionRequest,
-    ) -> Result<ResolvedSecretVersion, ProviderError> {
-        Err(ProviderError::unsupported())
-    }
-
-    async fn destroy_version(
-        &self,
-        _request: DestroySecretVersionRequest,
-    ) -> Result<(), ProviderError> {
-        Err(ProviderError::unsupported())
-    }
-}
-
-fn provider(id: &str) -> Arc<dyn SecretProvider> {
-    Arc::new(FakeProvider::new(id))
-}
+use crate::support::provider_adapter as provider;
 
 #[test]
 fn registry_selects_only_exact_registered_providers() {

--- a/crates/automata-ci-secret/tests/secret.rs
+++ b/crates/automata-ci-secret/tests/secret.rs
@@ -2,3 +2,4 @@ mod domain_contract;
 mod port_contract;
 mod provider_dispatch;
 mod provider_registry;
+mod support;

--- a/crates/automata-ci-secret/tests/support.rs
+++ b/crates/automata-ci-secret/tests/support.rs
@@ -1,0 +1,138 @@
+use std::sync::{Arc, LazyLock, atomic::AtomicUsize, atomic::Ordering};
+use std::task::{Context, Poll, Waker};
+use std::{fmt, future::Future};
+
+use automata_ci_secret::{
+    CreateSecretVersionRequest, CreatedSecretVersion, DestroySecretVersionRequest,
+    ExistingSecretVersion, ProviderCapabilities, ProviderError, ProviderHealth,
+    ProviderOperationContext, ProviderRequestId, ProviderSecretLocator, ProviderVersionId,
+    ReconcileCreateSecretVersionRequest, RepositoryScopeId, ResolveSecretVersionRequest,
+    ResolvedSecretVersion, SecretAtRestProtection, SecretDescriptor, SecretId, SecretName,
+    SecretProvider, SecretProviderId, SecretScope, TenantScopeId,
+};
+
+pub(super) struct DefaultMethodProvider {
+    id: SecretProviderId,
+    create_calls: AtomicUsize,
+}
+
+impl DefaultMethodProvider {
+    pub(super) fn new(id: &str) -> Self {
+        Self {
+            id: SecretProviderId::new(id).expect("test provider ID"),
+            create_calls: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn create_call_count(&self) -> usize {
+        self.create_calls.load(Ordering::Relaxed)
+    }
+}
+
+impl fmt::Debug for DefaultMethodProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DefaultMethodProvider(configuration=must-not-appear)")
+    }
+}
+
+#[async_trait::async_trait]
+impl SecretProvider for DefaultMethodProvider {
+    fn provider_id(&self) -> &SecretProviderId {
+        &self.id
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        static CAPABILITIES: LazyLock<ProviderCapabilities> =
+            LazyLock::new(ProviderCapabilities::default);
+        &CAPABILITIES
+    }
+
+    fn at_rest_protection(&self) -> SecretAtRestProtection {
+        SecretAtRestProtection::ProviderManagedEncryption
+    }
+
+    async fn health(
+        &self,
+        _context: &ProviderOperationContext,
+    ) -> Result<ProviderHealth, ProviderError> {
+        Ok(ProviderHealth::Healthy)
+    }
+
+    async fn create_version(
+        &self,
+        _request: CreateSecretVersionRequest,
+    ) -> Result<CreatedSecretVersion, ProviderError> {
+        self.create_calls.fetch_add(1, Ordering::Relaxed);
+        Err(ProviderError::unsupported())
+    }
+
+    async fn resolve_version(
+        &self,
+        _request: ResolveSecretVersionRequest,
+    ) -> Result<ResolvedSecretVersion, ProviderError> {
+        Err(ProviderError::unsupported())
+    }
+
+    async fn destroy_version(
+        &self,
+        _request: DestroySecretVersionRequest,
+    ) -> Result<(), ProviderError> {
+        Err(ProviderError::unsupported())
+    }
+}
+
+pub(super) fn provider_adapter(id: &str) -> Arc<dyn SecretProvider> {
+    Arc::new(DefaultMethodProvider::new(id))
+}
+
+pub(super) fn poll_immediately_ready<F: Future>(future: F, pending_message: &str) -> F::Output {
+    let mut context = Context::from_waker(Waker::noop());
+    let mut future = Box::pin(future);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(output) => output,
+        Poll::Pending => panic!("{pending_message}"),
+    }
+}
+
+pub(super) fn repository_scope() -> SecretScope {
+    let tenant = TenantScopeId::new("tenant-a").expect("tenant ID");
+    SecretScope::repository(
+        tenant,
+        RepositoryScopeId::new("repository-a").expect("repository ID"),
+    )
+}
+
+pub(super) fn secret_descriptor() -> SecretDescriptor {
+    SecretDescriptor::new(
+        SecretId::new("secret-a").expect("secret ID"),
+        SecretName::new("DEPLOY_TOKEN").expect("secret name"),
+        repository_scope(),
+    )
+}
+
+pub(super) fn provider_context(request_id: &str) -> ProviderOperationContext {
+    ProviderOperationContext::new(
+        TenantScopeId::new("tenant-a").expect("tenant ID"),
+        ProviderRequestId::new(request_id).expect("request ID"),
+    )
+}
+
+pub(super) fn existing_version(locator: &str, version: &str) -> ExistingSecretVersion {
+    ExistingSecretVersion::new(
+        ProviderSecretLocator::new(locator).expect("locator"),
+        ProviderVersionId::new(version).expect("version"),
+    )
+}
+
+pub(super) fn reconciliation_request(
+    request_id: &str,
+    locator: &str,
+    version: &str,
+) -> ReconcileCreateSecretVersionRequest {
+    ReconcileCreateSecretVersionRequest::new(
+        provider_context(request_id),
+        secret_descriptor(),
+        Some(existing_version(locator, version)),
+    )
+    .expect("reconciliation request")
+}


### PR DESCRIPTION
Closes #334\n\n## Summary\n\n- add one private support module for the automata-ci-secret integration target\n- replace duplicate port-contract and registry provider doubles with one default-method fixture\n- share immediate polling and exact tenant/scope/descriptor/context/version/reconciliation builders\n- preserve the dispatch recorder, all seven operation identities/counters, default-method coverage, and diagnostics\n- remove 70 net lines in one cohesive five-file test-support bundle; production code and public APIs are unchanged\n\n## Validation\n\n- cargo fmt --all -- --check\n- git diff --check plus exact scope/topology/call-count/identity scans\n- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-secret --all-targets --all-features\n- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-secret --test secret (22/22 passed)\n- focused default-reconciliation, dispatch-reconciliation, and registry-debug contracts (3/3 passed)\n- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-secret --all-targets --all-features -- -D warnings\n- independent review on the exact head: approved, no findings