### PR TITLE
feat(local): add sealed snapshot workflow checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   stable JSON schema 3 and human output report its bounded name. The internal
   adapter can strictly inspect or create-and-adopt a repository-agnostic
   installation identity anchor without exposing a product mutation command.
+- Internal `LocalSnapshot` foundation for tracked and non-ignored live-worktree
+  source. It hashes the exact deterministic archive consumed by the existing
+  bounded workflow discovery, pins filesystem ancestors without following
+  links, normalizes tracked symlinks from Git mode, rejects Windows reparse
+  points, sparse or assume-unchanged index state, and bounded
+  Unicode-normalized portable path-graph aliases, supports exactly one explicit
+  `.github/workflows` or `.ci/workflows` namespace, and exposes no partial
+  admission, execution, GitHub authentication, or Check Run path.
 
 ### Known limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,23 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   stable JSON schema 3 and human output report its bounded name. The internal
   adapter can strictly inspect or create-and-adopt a repository-agnostic
   installation identity anchor without exposing a product mutation command.
-- Internal `LocalSnapshot` foundation for tracked and non-ignored live-worktree
-  source. It hashes the exact deterministic archive consumed by the existing
-  bounded workflow discovery, pins filesystem ancestors without following
-  links, normalizes tracked symlinks from Git mode, rejects Windows reparse
-  points, sparse or assume-unchanged index state, and bounded
-  Unicode-normalized portable path-graph aliases, supports exactly one explicit
-  `.github/workflows` or `.ci/workflows` namespace, and exposes no partial
-  admission, execution, GitHub authentication, or Check Run path.
+- Read-only `automata local check [WORKFLOW]` over a private, bounded snapshot
+  of tracked and non-ignored live-worktree source. It hashes the exact
+  deterministic archive consumed by shared workflow discovery, pins filesystem
+  ancestors without following links, normalizes tracked symlinks from Git mode,
+  rejects sparse or assume-unchanged index state and portable path-graph
+  aliases, and accepts only direct `.github/workflows/*.{yml,yaml}` members. The
+  optional selector is one exact canonical archive path, and the selected root
+  must declare `workflow_dispatch`. Reachable reusable workflows must be local
+  members of the same snapshot; remote, dynamic, missing, cyclic, or invalid
+  calls fail closed. The shared compiler and reusable-call traversal validate
+  typed inputs, secrets, outputs, propagation, and resource bounds. Human and
+  JSON reports contain only value-free external credential names and closed
+  built-in requirements such as `github_token`, never values, absolute paths,
+  archive bytes, or repository identity. Windows source capture remains closed
+  until exact native mutation evidence is qualified. The command is independent
+  of `local doctor`, Docker, the network, and GitHub tokens, and performs no
+  admission, scheduling, execution, or Check Run operation.
 
 ### Known limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,12 +606,18 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "automata-ci-core",
+ "automata-ci-workflow-github",
  "bollard",
+ "bytes",
+ "cap-fs-ext",
+ "cap-std",
+ "flate2",
  "processkit",
  "rustix",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "thiserror",
  "tokio",
  "uuid",
@@ -1152,11 +1158,13 @@ dependencies = [
  "automata-ci-github-permissions",
  "automata-ci-schedule",
  "flate2",
+ "focaccia",
  "jiff",
  "saphyr-parser",
  "serde_json",
  "tar",
  "thiserror",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2385,6 +2393,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "focaccia"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef16690750b6e9a238378f57d3c1325d42e2d82e29b7dfd75f6d387d753b050"
 
 [[package]]
 name = "foldhash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,8 +607,8 @@ dependencies = [
  "async-trait",
  "automata-ci-core",
  "automata-ci-workflow-github",
+ "automata-ci-workflow-service",
  "bollard",
- "bytes",
  "cap-fs-ext",
  "cap-std",
  "flate2",
@@ -620,6 +620,7 @@ dependencies = [
  "tar",
  "thiserror",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 
@@ -1162,6 +1163,7 @@ dependencies = [
  "jiff",
  "saphyr-parser",
  "serde_json",
+ "sha2 0.11.0",
  "tar",
  "thiserror",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,9 +125,12 @@ automata-ci-workflow-service = { path = "crates/automata-ci-workflow-service", v
 axum = { version = "0.8.4", features = ["http1", "json", "tokio"] }
 base64 = "0.23.1"
 bytes = "=1.12.1"
+cap-fs-ext = "4.0.2"
+cap-std = "4.0.2"
 clap = { version = "4.5.45", features = ["derive", "env"] }
 futures = "0.3.31"
 flate2 = { version = "1.1.9", default-features = false, features = ["rust_backend"] }
+focaccia = "2.0.0"
 getrandom = "0.4.3"
 http = "1.3.1"
 http-body-util = "=0.1.4"
@@ -159,6 +162,7 @@ thiserror = "2.0.16"
 time = { version = "0.3.55", default-features = false, features = ["parsing", "std"] }
 tar = { version = "0.4.46", default-features = false }
 tokio = { version = "1.47.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+unicode-normalization = "0.1.25"
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring"] }
 tokio-stream = { version = "0.1.17", default-features = false }
 tokio-util = { version = "=0.7.19", default-features = false, features = ["rt"] }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ secrets, OIDC, and Buildx/BuildKit have narrower experimental or component-only
 boundaries. Check [Compatibility](docs/compatibility.md) before evaluating a
 workflow.
 
-## Check a local host
+## Check a local host and workflow
 
 Automata includes a read-only preflight for the planned disposable local
 installation. It checks the supported host tuple, Docker Engine, Docker Compose
@@ -57,9 +57,25 @@ cargo run --locked -p automata-ci -- local doctor
 cargo run --locked -p automata-ci -- local doctor --json
 ```
 
-`automata local up` is planned and is not present in the command. The durable
-development assembly remains the supported way to exercise the complete
-control plane from a source checkout.
+From a Git worktree, the source-only check seals tracked and non-ignored live
+bytes once, selects an explicit local `workflow_dispatch`, compiles reachable
+same-snapshot reusable workflows, validates their typed call contracts and call
+graph, propagates mapped or inherited root secret requirements, and reports
+static secret and variable names without admitting or running anything:
+
+```console
+cargo run --locked -p automata-ci -- local check
+cargo run --locked -p automata-ci -- local check .github/workflows/ci.yml \
+  --input target=staging --json
+```
+
+Omit the canonical repository-relative workflow path only when the repository
+contains exactly one direct workflow. Input values are used only in the
+bounded in-process compiler and are excluded from reports and debug output.
+
+`automata local run` and `automata local up` are planned and are not present in
+the command. The durable development assembly remains the supported way to
+exercise the complete control plane from a source checkout.
 
 ## How it works
 

--- a/crates/automata-ci-github-delivery/src/processor.rs
+++ b/crates/automata-ci-github-delivery/src/processor.rs
@@ -26,8 +26,9 @@ use automata_ci_store::{
 use automata_ci_workflow_github::{
     CompilationDisposition, CompileWorkflowRequest, GithubChangedFiles, GithubEventMetadata,
     GithubWorkflowCompiler, GithubWorkflowFrontend, GithubWorkflowSourcePlan, ParseWorkflowRequest,
-    RepositoryWorkflowDiscoveryLimits, SourceId, SourceOrigin, SourceProvenance,
-    WorkflowFrontend as _, WorkflowNotSelectedReason, discover_repository_workflows,
+    RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryPolicy, SourceId, SourceOrigin,
+    SourceProvenance, WorkflowFrontend as _, WorkflowNotSelectedReason,
+    discover_repository_workflows,
 };
 use automata_ci_workflow_service::{
     AdmissionRepositoryCoordinates, RepositoryWorkflowSource, WorkflowAdmissionError,
@@ -1306,19 +1307,23 @@ fn repository_workflow_sources(
         limits.workflow_max_bytes(),
     )
     .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)?;
-    discover_repository_workflows(source.bytes(), discovery_limits)
-        .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)
-        .map(|workflows| {
-            workflows
-                .into_iter()
-                .filter_map(|workflow| {
-                    let (path, source) = workflow.into_parts();
-                    source
-                        .ok()
-                        .map(|source| RepositoryWorkflowSource::new(path, Bytes::from(source)))
-                })
-                .collect()
-        })
+    discover_repository_workflows(
+        source.bytes(),
+        discovery_limits,
+        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
+    )
+    .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)
+    .map(|workflows| {
+        workflows
+            .into_iter()
+            .filter_map(|workflow| {
+                let (path, source) = workflow.into_parts();
+                source
+                    .ok()
+                    .map(|source| RepositoryWorkflowSource::new(path, Bytes::from(source)))
+            })
+            .collect()
+    })
 }
 
 fn valid_authenticated_event_request(request: &GithubDeliveryWorkflowRequest<'_>) -> bool {

--- a/crates/automata-ci-github-delivery/src/processor.rs
+++ b/crates/automata-ci-github-delivery/src/processor.rs
@@ -26,9 +26,8 @@ use automata_ci_store::{
 use automata_ci_workflow_github::{
     CompilationDisposition, CompileWorkflowRequest, GithubChangedFiles, GithubEventMetadata,
     GithubWorkflowCompiler, GithubWorkflowFrontend, GithubWorkflowSourcePlan, ParseWorkflowRequest,
-    RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryPolicy, SourceId, SourceOrigin,
-    SourceProvenance, WorkflowFrontend as _, WorkflowNotSelectedReason,
-    discover_repository_workflows,
+    RepositoryWorkflowDiscoveryLimits, SourceId, SourceOrigin, SourceProvenance,
+    WorkflowFrontend as _, WorkflowNotSelectedReason, discover_github_delivery_workflows,
 };
 use automata_ci_workflow_service::{
     AdmissionRepositoryCoordinates, RepositoryWorkflowSource, WorkflowAdmissionError,
@@ -1307,23 +1306,19 @@ fn repository_workflow_sources(
         limits.workflow_max_bytes(),
     )
     .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)?;
-    discover_repository_workflows(
-        source.bytes(),
-        discovery_limits,
-        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
-    )
-    .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)
-    .map(|workflows| {
-        workflows
-            .into_iter()
-            .filter_map(|workflow| {
-                let (path, source) = workflow.into_parts();
-                source
-                    .ok()
-                    .map(|source| RepositoryWorkflowSource::new(path, Bytes::from(source)))
-            })
-            .collect()
-    })
+    discover_github_delivery_workflows(source.bytes(), discovery_limits)
+        .map_err(|_| GithubDeliveryWorkflowProcessorError::InvariantViolation)
+        .map(|workflows| {
+            workflows
+                .into_iter()
+                .filter_map(|workflow| {
+                    let (path, source) = workflow.into_parts();
+                    source
+                        .ok()
+                        .map(|source| RepositoryWorkflowSource::new(path, Bytes::from(source)))
+                })
+                .collect()
+        })
 }
 
 fn valid_authenticated_event_request(request: &GithubDeliveryWorkflowRequest<'_>) -> bool {

--- a/crates/automata-ci-github-delivery/src/schedule.rs
+++ b/crates/automata-ci-github-delivery/src/schedule.rs
@@ -40,9 +40,9 @@ use automata_ci_store::{
 };
 use automata_ci_workflow_github::{
     CompilationDisposition, CompileWorkflowRequest, GithubEventMetadata, GithubWorkflowCompiler,
-    GithubWorkflowFrontend, ParseWorkflowRequest, RepositoryWorkflowDiscoveryLimits,
-    RepositoryWorkflowDiscoveryPolicy, SourceId, SourceOrigin, SourceProvenance,
-    WorkflowFrontend as _, discover_repository_workflows, extract_github_schedule_entries,
+    GithubWorkflowFrontend, ParseWorkflowRequest, RepositoryWorkflowDiscoveryLimits, SourceId,
+    SourceOrigin, SourceProvenance, WorkflowFrontend as _, discover_github_delivery_workflows,
+    extract_github_schedule_entries,
 };
 use automata_ci_workflow_service::{
     AUTOMATA_GITHUB_SCHEDULE_EVIDENCE_V1_MEDIA_TYPE, AdmissionRepositoryCoordinates,
@@ -1046,10 +1046,9 @@ impl GithubScheduleService {
                 _ => FireFailure::InvalidRegistry,
             })?
             .into_bytes();
-        let workflows = discover_repository_workflows(
+        let workflows = discover_github_delivery_workflows(
             &archive,
             discovery_limits(manifest).map_err(|()| FireFailure::InvalidRegistry)?,
-            RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
         )
         .map_err(|_| FireFailure::InvalidRegistry)?;
         let mut available = Vec::new();
@@ -1294,12 +1293,8 @@ fn registry_entries(
     archive: &[u8],
     _archive_digest: Sha256Digest,
 ) -> Result<Vec<GithubScheduleRegistryEntry>, ()> {
-    let workflows = discover_repository_workflows(
-        archive,
-        discovery_limits(manifest)?,
-        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
-    )
-    .map_err(|_| ())?;
+    let workflows =
+        discover_github_delivery_workflows(archive, discovery_limits(manifest)?).map_err(|_| ())?;
     let mut definitions = Vec::new();
     for workflow in workflows {
         let (path, source) = workflow.into_parts();

--- a/crates/automata-ci-github-delivery/src/schedule.rs
+++ b/crates/automata-ci-github-delivery/src/schedule.rs
@@ -40,9 +40,9 @@ use automata_ci_store::{
 };
 use automata_ci_workflow_github::{
     CompilationDisposition, CompileWorkflowRequest, GithubEventMetadata, GithubWorkflowCompiler,
-    GithubWorkflowFrontend, ParseWorkflowRequest, RepositoryWorkflowDiscoveryLimits, SourceId,
-    SourceOrigin, SourceProvenance, WorkflowFrontend as _, discover_repository_workflows,
-    extract_github_schedule_entries,
+    GithubWorkflowFrontend, ParseWorkflowRequest, RepositoryWorkflowDiscoveryLimits,
+    RepositoryWorkflowDiscoveryPolicy, SourceId, SourceOrigin, SourceProvenance,
+    WorkflowFrontend as _, discover_repository_workflows, extract_github_schedule_entries,
 };
 use automata_ci_workflow_service::{
     AUTOMATA_GITHUB_SCHEDULE_EVIDENCE_V1_MEDIA_TYPE, AdmissionRepositoryCoordinates,
@@ -1049,6 +1049,7 @@ impl GithubScheduleService {
         let workflows = discover_repository_workflows(
             &archive,
             discovery_limits(manifest).map_err(|()| FireFailure::InvalidRegistry)?,
+            RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
         )
         .map_err(|_| FireFailure::InvalidRegistry)?;
         let mut available = Vec::new();
@@ -1293,8 +1294,12 @@ fn registry_entries(
     archive: &[u8],
     _archive_digest: Sha256Digest,
 ) -> Result<Vec<GithubScheduleRegistryEntry>, ()> {
-    let workflows =
-        discover_repository_workflows(archive, discovery_limits(manifest)?).map_err(|_| ())?;
+    let workflows = discover_repository_workflows(
+        archive,
+        discovery_limits(manifest)?,
+        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
+    )
+    .map_err(|_| ())?;
     let mut definitions = Vec::new();
     for workflow in workflows {
         let (path, source) = workflow.into_parts();

--- a/crates/automata-ci-github-delivery/src/worker.rs
+++ b/crates/automata-ci-github-delivery/src/worker.rs
@@ -48,7 +48,7 @@ use automata_ci_store::{
 use automata_ci_workflow_github::{
     RepositoryWorkflowDiscoveryError, RepositoryWorkflowDiscoveryFailure,
     RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryOutcome,
-    discover_repository_workflows,
+    RepositoryWorkflowDiscoveryPolicy, discover_repository_workflows,
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
@@ -1424,6 +1424,7 @@ impl GithubDeliveryWorker {
         let workflows = discover_repository_workflows(
             source.bytes(),
             manifest_discovery_limits(evidence.manifest())?,
+            RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
         )
         .map_err(|error| ProcessingFailure::reject(discovery_failure_kind(error)))?;
         self.all_direct_workflow_outcomes(
@@ -2512,8 +2513,16 @@ const fn discovery_failure_kind(error: RepositoryWorkflowDiscoveryError) -> &'st
             "github.repository_archive.resource_limit"
         }
         RepositoryWorkflowDiscoveryError::UnsafePath => "github.repository_archive.unsafe_path",
+        RepositoryWorkflowDiscoveryError::UnsafeLink => "github.repository_archive.unsafe_link",
         RepositoryWorkflowDiscoveryError::DuplicatePath => {
             "github.repository_archive.duplicate_path"
+        }
+        RepositoryWorkflowDiscoveryError::PathAlias => "github.repository_archive.path_alias",
+        RepositoryWorkflowDiscoveryError::PathTypeConflict => {
+            "github.repository_archive.path_type_conflict"
+        }
+        RepositoryWorkflowDiscoveryError::NamespaceAlias => {
+            "github.repository_archive.workflow_namespace_alias"
         }
         RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry => {
             "github.repository_archive.unsupported_entry"
@@ -2656,10 +2665,26 @@ mod lease_tests {
     use super::*;
 
     #[test]
-    fn github_actions_workflow_authority_has_a_specific_archive_failure() {
+    fn archive_authority_and_graph_failures_have_specific_failure_kinds() {
         assert_eq!(
             discovery_failure_kind(RepositoryWorkflowDiscoveryError::UnsupportedWorkflowLocation),
             "github.repository_archive.unsupported_workflow_location"
+        );
+        assert_eq!(
+            discovery_failure_kind(RepositoryWorkflowDiscoveryError::UnsafeLink),
+            "github.repository_archive.unsafe_link"
+        );
+        assert_eq!(
+            discovery_failure_kind(RepositoryWorkflowDiscoveryError::PathAlias),
+            "github.repository_archive.path_alias"
+        );
+        assert_eq!(
+            discovery_failure_kind(RepositoryWorkflowDiscoveryError::PathTypeConflict),
+            "github.repository_archive.path_type_conflict"
+        );
+        assert_eq!(
+            discovery_failure_kind(RepositoryWorkflowDiscoveryError::NamespaceAlias),
+            "github.repository_archive.workflow_namespace_alias"
         );
     }
 

--- a/crates/automata-ci-github-delivery/src/worker.rs
+++ b/crates/automata-ci-github-delivery/src/worker.rs
@@ -48,7 +48,7 @@ use automata_ci_store::{
 use automata_ci_workflow_github::{
     RepositoryWorkflowDiscoveryError, RepositoryWorkflowDiscoveryFailure,
     RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryOutcome,
-    RepositoryWorkflowDiscoveryPolicy, discover_repository_workflows,
+    discover_github_delivery_workflows,
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
@@ -1421,10 +1421,9 @@ impl GithubDeliveryWorker {
         let evidence = prepared.resolved_evidence().ok_or_else(|| {
             ProcessingFailure::reject("github.repository_dispatch.unresolved_source")
         })?;
-        let workflows = discover_repository_workflows(
+        let workflows = discover_github_delivery_workflows(
             source.bytes(),
             manifest_discovery_limits(evidence.manifest())?,
-            RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
         )
         .map_err(|error| ProcessingFailure::reject(discovery_failure_kind(error)))?;
         self.all_direct_workflow_outcomes(

--- a/crates/automata-ci-github/tests/github.rs
+++ b/crates/automata-ci-github/tests/github.rs
@@ -13,3 +13,4 @@ mod repository_snapshots;
 mod stored_push_rehydration;
 mod webhook_event_normalization;
 mod webhook_verification;
+mod workflow_permissions;

--- a/crates/automata-ci-github/tests/workflow_permissions.rs
+++ b/crates/automata-ci-github/tests/workflow_permissions.rs
@@ -1,4 +1,4 @@
-mod support;
+use crate::support;
 
 use std::time::{Duration, Instant};
 
@@ -109,11 +109,14 @@ async fn schema_drift_redirects_and_expired_deadlines_fail_closed() {
     }
     assert_eq!(fixture.remaining_responses(), 0);
 
+    let expired_deadline = Instant::now()
+        .checked_sub(Duration::from_millis(1))
+        .expect("the monotonic clock represents one millisecond in the past");
     let error = endpoint
         .workflow_permission_defaults(GithubWorkflowPermissionDefaultsRequest::new(
             &repository,
             &token,
-            Instant::now() - Duration::from_millis(1),
+            expired_deadline,
         ))
         .await
         .expect_err("expired deadline");

--- a/crates/automata-ci-local/Cargo.toml
+++ b/crates/automata-ci-local/Cargo.toml
@@ -16,10 +16,16 @@ homepage.workspace = true
 [dependencies]
 async-trait.workspace = true
 automata-ci-core.workspace = true
+automata-ci-workflow-github.workspace = true
 bollard.workspace = true
+bytes.workspace = true
+cap-fs-ext.workspace = true
+cap-std.workspace = true
+flate2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tar.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/crates/automata-ci-local/Cargo.toml
+++ b/crates/automata-ci-local/Cargo.toml
@@ -17,8 +17,8 @@ homepage.workspace = true
 async-trait.workspace = true
 automata-ci-core.workspace = true
 automata-ci-workflow-github.workspace = true
+automata-ci-workflow-service.workspace = true
 bollard.workspace = true
-bytes.workspace = true
 cap-fs-ext.workspace = true
 cap-std.workspace = true
 flate2.workspace = true
@@ -28,6 +28,7 @@ sha2.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 uuid.workspace = true
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/automata-ci-local/README.md
+++ b/crates/automata-ci-local/README.md
@@ -7,13 +7,14 @@ API compatibility; and Compose plugin version 2.20.0 or newer. It will supervise
 the local Compose project without adding container-engine behavior to the
 control-plane crate.
 
-The user-visible slice remains a read-only host preflight. Context discovery is
+The user-visible slice remains read-only: it provides both host preflight and
+snapshot-backed workflow checking. During `local doctor`, context discovery is
 completed first, subsequent daemon probes are pinned to that exact local
 Unix-socket or Windows-named-pipe endpoint, and JSON schema 3 reports the
 bounded context name. The private endpoint URI is retained only so the library
 adapter can connect to the same daemon and reverify its identity.
 
-The internal `LocalSnapshot` foundation uses live bytes for staged additions
+The private local-snapshot foundation uses live bytes for staged additions
 and tracked modifications, omits tracked deletions and ignored files, and seals
 each leaf through descriptor- or handle-relative, no-follow ancestor traversal.
 It pins the requested directory before Git runs, resolves Git's reported prefix
@@ -25,17 +26,30 @@ verified before and after the process. Caller-path or `.git` locator links,
 nested-repository confusion, locator retargeting, and `core.worktree`
 redirection therefore cannot select a separate tree.
 Git mode deterministically represents tracked executable files and symlinks,
-including Windows symlink placeholders. Contained Unix symlinks are preserved;
-Windows reparse points and junctions fail closed. Sparse-checkout and
-assume-unchanged index flags are rejected because they can hide live state.
-Ignored-path classification is one bounded NUL-safe batch per scan. Index
-conflicts, submodules, escaping or cyclic links, path-prefix type conflicts,
-namespace aliases, Unicode-normalization or full-case-fold aliases,
-nonportable device names, non-Unicode paths, bounded component-trie or ustar
-exhaustion, special files, and concurrent mutation are rejected.
-`.github/workflows` and `.ci/workflows` are explicit first-class locations; a
-worktree containing both namespaces is ambiguous and fails rather than
-preferring or falling back to either one.
+including symlink placeholders. Contained Unix symlinks are preserved in the
+archive; shared archive policy rejects escaping links, cycles, and aliases
+before analysis. Sparse-checkout and assume-unchanged index flags are rejected
+because they can hide live state. Ignored-path classification is one bounded
+NUL-safe batch per scan. Index conflicts, submodules, path-prefix type
+conflicts, Unicode-normalization or full-case-fold aliases, nonportable device
+names, non-Unicode paths, bounded component-trie or ustar exhaustion, special
+files, and concurrent mutation fail closed. The current source checkpoint is
+available on Unix and fails closed on Windows until exact native mutation
+evidence has been qualified.
+
+`local check` consumes that archive through one high-level analysis boundary.
+Only direct `.github/workflows/*.{yml,yaml}` members are eligible, and an
+optional selector must be the exact canonical member path. It accepts only an
+explicit local `workflow_dispatch`, recompiles reachable same-archive reusable
+workflows, rejects remote or dynamic calls, and validates typed call contracts,
+cycles, propagation, and bounds through the shared traversal. Reports retain
+only discovered source metadata and value-free external secret/variable names
+plus closed built-in requirements. `github.token` and `secrets.GITHUB_TOKEN`
+are reported as the non-promptable `github_token` built-in; this checkpoint
+does not supply it for execution. Local source and event provenance is distinct
+from GitHub delivery evidence. The command is independent of `local doctor`,
+Docker, network access, and GitHub tokens, and performs no admission, scheduling,
+execution, or Check publication.
 
 The first engine adapter can inspect or create-and-adopt one immutable external
 identity volume for a named installation. It always post-inspects Docker's
@@ -50,12 +64,15 @@ the existing control plane. A separate `--installation` name is the explicit
 way to request another deployment/capacity domain.
 
 No product command creates, adopts, or deletes an engine resource yet. The
-snapshot foundation has no product command and does not compile an event,
+snapshot boundary is consumed by `automata local check`, which compiles an
+explicit local manual-dispatch event and all reachable same-snapshot reusable
+workflows through the shared compiler and credential analysis. It does not
 admit or run work, mint GitHub evidence, request a token, or publish a Check
 Run. Desired specification persistence, product-owned Compose rendering,
-workers, workflow execution, and GitHub connection are added only with their own
-tested contracts. There is still no host installation manifest, mirrored
+workers, workflow execution, and GitHub connection are added only with their
+own tested contracts. There is still no host installation manifest, mirrored
 resource inventory, lifecycle state machine, or secret value in this crate.
 
 This crate has no command-line parser. The `automata` product maps its public
-CLI into the typed requests exposed here.
+CLI into the high-level local-check request; snapshot and archive authority stay
+private.

--- a/crates/automata-ci-local/README.md
+++ b/crates/automata-ci-local/README.md
@@ -13,6 +13,30 @@ Unix-socket or Windows-named-pipe endpoint, and JSON schema 3 reports the
 bounded context name. The private endpoint URI is retained only so the library
 adapter can connect to the same daemon and reverify its identity.
 
+The internal `LocalSnapshot` foundation uses live bytes for staged additions
+and tracked modifications, omits tracked deletions and ignored files, and seals
+each leaf through descriptor- or handle-relative, no-follow ancestor traversal.
+It pins the requested directory before Git runs, resolves Git's reported prefix
+back to that same directory identity, and pins the worktree, Git directory,
+common directory, and no-follow `.git` locator. A regular `.git` file is admitted
+only for a linked worktree and its exact bytes are retained. Every later Git
+query is explicitly bound to those pinned authorities and their identities are
+verified before and after the process. Caller-path or `.git` locator links,
+nested-repository confusion, locator retargeting, and `core.worktree`
+redirection therefore cannot select a separate tree.
+Git mode deterministically represents tracked executable files and symlinks,
+including Windows symlink placeholders. Contained Unix symlinks are preserved;
+Windows reparse points and junctions fail closed. Sparse-checkout and
+assume-unchanged index flags are rejected because they can hide live state.
+Ignored-path classification is one bounded NUL-safe batch per scan. Index
+conflicts, submodules, escaping or cyclic links, path-prefix type conflicts,
+namespace aliases, Unicode-normalization or full-case-fold aliases,
+nonportable device names, non-Unicode paths, bounded component-trie or ustar
+exhaustion, special files, and concurrent mutation are rejected.
+`.github/workflows` and `.ci/workflows` are explicit first-class locations; a
+worktree containing both namespaces is ambiguous and fails rather than
+preferring or falling back to either one.
+
 The first engine adapter can inspect or create-and-adopt one immutable external
 identity volume for a named installation. It always post-inspects Docker's
 deterministic volume name, exact Automata-managed labels, local driver/scope,
@@ -25,11 +49,13 @@ retain their own admission, authorization, secret, cache, and history scope in
 the existing control plane. A separate `--installation` name is the explicit
 way to request another deployment/capacity domain.
 
-No product command creates, adopts, or deletes an engine resource yet. Desired
-specification persistence, product-owned Compose rendering, workers, workflow
-execution, and GitHub connection are added only with their own tested
-contracts. There is still no host installation manifest, mirrored resource
-inventory, lifecycle state machine, or secret value in this crate.
+No product command creates, adopts, or deletes an engine resource yet. The
+snapshot foundation has no product command and does not compile an event,
+admit or run work, mint GitHub evidence, request a token, or publish a Check
+Run. Desired specification persistence, product-owned Compose rendering,
+workers, workflow execution, and GitHub connection are added only with their own
+tested contracts. There is still no host installation manifest, mirrored
+resource inventory, lifecycle state machine, or secret value in this crate.
 
 This crate has no command-line parser. The `automata` product maps its public
 CLI into the typed requests exposed here.

--- a/crates/automata-ci-local/src/check.rs
+++ b/crates/automata-ci-local/src/check.rs
@@ -1,0 +1,927 @@
+use std::{fmt, path::PathBuf};
+
+use automata_ci_core::Sha256Digest;
+use automata_ci_workflow_github::{
+    Diagnostic, GithubWorkflowDispatchInputs, RepositoryWorkflowDiscoveryLimits,
+};
+use automata_ci_workflow_service::{
+    BuiltInCredentialRequirement, LocalGithubArchiveAnalysis,
+    LocalGithubArchiveAnalysisFailureKind, ReusableWorkflowLimits, analyze_local_github_archive,
+};
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    snapshot::{LocalSnapshot, LocalSnapshotErrorCode, LocalSnapshotRequest, capture_snapshot},
+    snapshot_limits::local_snapshot_limits,
+};
+
+const LOCAL_CHECK_SCHEMA: u32 = 1;
+
+/// Read-only request to validate one workflow from one exact local snapshot.
+#[derive(Clone)]
+pub struct LocalCheckRequest {
+    directory: PathBuf,
+    workflow: Option<String>,
+    inputs: GithubWorkflowDispatchInputs,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    reusable_limits: ReusableWorkflowLimits,
+}
+
+impl fmt::Debug for LocalCheckRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalCheckRequest")
+            .field("workflow", &self.workflow)
+            .field("inputs", &self.inputs)
+            .field("limits", &self.limits)
+            .field("reusable_limits", &self.reusable_limits)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LocalCheckRequest {
+    /// Creates a bounded source-only local validation request.
+    #[must_use]
+    pub fn new(
+        directory: impl Into<PathBuf>,
+        workflow: Option<String>,
+        inputs: GithubWorkflowDispatchInputs,
+    ) -> Self {
+        Self {
+            directory: directory.into(),
+            workflow,
+            inputs,
+            limits: local_snapshot_limits(),
+            reusable_limits: ReusableWorkflowLimits::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_limits(mut self, limits: RepositoryWorkflowDiscoveryLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+}
+
+/// Stable result of read-only local workflow validation.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckReport {
+    schema: u32,
+    valid: bool,
+    source: Option<LocalCheckSource>,
+    required_root_secrets: Vec<String>,
+    required_built_in_credentials: Vec<BuiltInCredentialRequirement>,
+    workflows: Vec<LocalCheckedWorkflow>,
+    diagnostics: Vec<LocalCheckDiagnostic>,
+    issue: Option<LocalCheckIssue>,
+}
+
+impl LocalCheckReport {
+    /// Returns whether capture, exact selection, compilation, reusable-call
+    /// validation, and credential discovery all succeeded.
+    #[must_use]
+    pub const fn valid(&self) -> bool {
+        self.valid
+    }
+
+    /// Returns value-free snapshot evidence when capture succeeded.
+    #[must_use]
+    pub const fn source(&self) -> Option<&LocalCheckSource> {
+        self.source.as_ref()
+    }
+
+    /// Returns canonical external secret names required at the root boundary.
+    #[must_use]
+    pub fn required_root_secrets(&self) -> &[String] {
+        &self.required_root_secrets
+    }
+
+    /// Returns closed provider-built-in credentials required by reachable jobs.
+    #[must_use]
+    pub fn required_built_in_credentials(&self) -> &[BuiltInCredentialRequirement] {
+        &self.required_built_in_credentials
+    }
+
+    /// Returns checked root and reachable reusable workflows in path order.
+    #[must_use]
+    pub fn workflows(&self) -> &[LocalCheckedWorkflow] {
+        &self.workflows
+    }
+
+    /// Returns value-free frontend and compiler diagnostics.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[LocalCheckDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Returns the stable failure, when validation did not complete.
+    #[must_use]
+    pub const fn issue(&self) -> Option<&LocalCheckIssue> {
+        self.issue.as_ref()
+    }
+
+    fn success(source: LocalCheckSource, analysis: &LocalGithubArchiveAnalysis) -> Self {
+        Self {
+            schema: LOCAL_CHECK_SCHEMA,
+            valid: true,
+            source: Some(source),
+            required_root_secrets: analysis.required_root_secrets().to_vec(),
+            required_built_in_credentials: analysis.required_built_in_credentials().to_vec(),
+            workflows: analysis
+                .workflows()
+                .iter()
+                .map(LocalCheckedWorkflow::from_analysis)
+                .collect(),
+            diagnostics: diagnostics(analysis.diagnostics()),
+            issue: None,
+        }
+    }
+
+    fn failure(
+        source: Option<LocalCheckSource>,
+        code: LocalCheckIssueCode,
+        diagnostics: Vec<LocalCheckDiagnostic>,
+    ) -> Self {
+        Self {
+            schema: LOCAL_CHECK_SCHEMA,
+            valid: false,
+            source,
+            required_root_secrets: Vec::new(),
+            required_built_in_credentials: Vec::new(),
+            workflows: Vec::new(),
+            diagnostics,
+            issue: Some(LocalCheckIssue {
+                code,
+                message: code.message(),
+            }),
+        }
+    }
+}
+
+/// Value-free source evidence retained by a local check.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckSource {
+    snapshot_digest: Sha256Digest,
+    head: String,
+    dirty: bool,
+    workflow_path: Option<String>,
+    entry_count: usize,
+    expanded_bytes: u64,
+}
+
+impl LocalCheckSource {
+    /// Returns the selected canonical repository-relative workflow path.
+    #[must_use]
+    pub fn workflow_path(&self) -> Option<&str> {
+        self.workflow_path.as_deref()
+    }
+
+    /// Returns whether the sealed live worktree differed from `HEAD`.
+    #[must_use]
+    pub const fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Returns SHA-256 over the exact archive bytes compiled by the check.
+    #[must_use]
+    pub const fn snapshot_digest(&self) -> Sha256Digest {
+        self.snapshot_digest
+    }
+
+    fn from_snapshot(snapshot: &LocalSnapshot) -> Self {
+        Self {
+            snapshot_digest: snapshot.digest(),
+            head: snapshot.head().to_owned(),
+            dirty: snapshot.dirty(),
+            workflow_path: None,
+            entry_count: snapshot.entry_count(),
+            expanded_bytes: snapshot.expanded_bytes(),
+        }
+    }
+}
+
+/// Value-free requirements for one compiled workflow source.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckedWorkflow {
+    path: String,
+    reusable: bool,
+    jobs: Vec<LocalCheckedJob>,
+}
+
+impl LocalCheckedWorkflow {
+    /// Returns the canonical repository-relative source path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns jobs in source order.
+    #[must_use]
+    pub fn jobs(&self) -> &[LocalCheckedJob] {
+        &self.jobs
+    }
+
+    /// Returns whether this source was loaded through a reachable reusable call.
+    #[must_use]
+    pub const fn reusable(&self) -> bool {
+        self.reusable
+    }
+
+    fn from_analysis(value: &automata_ci_workflow_service::LocalGithubAnalyzedWorkflow) -> Self {
+        Self {
+            path: value.path().to_owned(),
+            reusable: value.reusable(),
+            jobs: value
+                .jobs()
+                .iter()
+                .map(LocalCheckedJob::from_analysis)
+                .collect(),
+        }
+    }
+}
+
+/// Static credential names and execution kind discovered for one logical job.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckedJob {
+    id: String,
+    kind: &'static str,
+    secrets: Vec<String>,
+    variables: Vec<String>,
+    built_in_credentials: Vec<BuiltInCredentialRequirement>,
+}
+
+impl LocalCheckedJob {
+    /// Returns the source-level job identifier.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns `steps` or `reusable_workflow` for the compiled job kind.
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Returns sorted canonical external secret names without values.
+    #[must_use]
+    pub fn secrets(&self) -> &[String] {
+        &self.secrets
+    }
+
+    /// Returns sorted canonical variable names without values.
+    #[must_use]
+    pub fn variables(&self) -> &[String] {
+        &self.variables
+    }
+
+    /// Returns closed provider-built-in requirements in stable order.
+    #[must_use]
+    pub fn built_in_credentials(&self) -> &[BuiltInCredentialRequirement] {
+        &self.built_in_credentials
+    }
+
+    fn from_analysis(value: &automata_ci_workflow_service::LocalGithubAnalyzedJob) -> Self {
+        Self {
+            id: value.key().to_owned(),
+            kind: if value.reusable() {
+                "reusable_workflow"
+            } else {
+                "steps"
+            },
+            secrets: value.secrets().to_vec(),
+            variables: value.variables().to_vec(),
+            built_in_credentials: value.built_in_credentials().to_vec(),
+        }
+    }
+}
+
+/// Sanitized source-bound diagnostic containing no source or input value.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckDiagnostic {
+    kind: &'static str,
+    severity: &'static str,
+    code: String,
+    source: String,
+    line: usize,
+    column: usize,
+}
+
+impl LocalCheckDiagnostic {
+    /// Returns the stable dialect diagnostic code.
+    #[must_use]
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    /// Returns the canonical source path for this diagnostic.
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Returns the one-based source line.
+    #[must_use]
+    pub const fn line(&self) -> usize {
+        self.line
+    }
+
+    /// Returns the one-based source column.
+    #[must_use]
+    pub const fn column(&self) -> usize {
+        self.column
+    }
+}
+
+/// Stable failure class for a local workflow check.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalCheckIssueCode {
+    /// Exact local snapshot capture failed.
+    Snapshot,
+    /// Cooperative shutdown interrupted local analysis.
+    Cancelled,
+    /// The sealed archive violated its bounded policy.
+    Archive,
+    /// No direct `.github/workflows` YAML workflow was discovered.
+    WorkflowMissing,
+    /// More than one workflow requires an explicit canonical selector.
+    WorkflowSelectionRequired,
+    /// The supplied workflow selector is not one exact discovered path.
+    WorkflowNotFound,
+    /// A selected workflow source is empty, oversized, or not UTF-8.
+    WorkflowSource,
+    /// The GitHub Actions frontend rejected a selected source.
+    Frontend,
+    /// The root does not accept the explicit local `workflow_dispatch` selection.
+    Compilation,
+    /// A same-snapshot reusable workflow or call contract was rejected.
+    ReusableWorkflow,
+    /// Static credential-reference discovery rejected dynamic or invalid access.
+    CredentialDiscovery,
+}
+
+impl LocalCheckIssueCode {
+    /// Returns the stable snake-case report code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Snapshot => "snapshot",
+            Self::Cancelled => "cancelled",
+            Self::Archive => "archive",
+            Self::WorkflowMissing => "workflow_missing",
+            Self::WorkflowSelectionRequired => "workflow_selection_required",
+            Self::WorkflowNotFound => "workflow_not_found",
+            Self::WorkflowSource => "workflow_source",
+            Self::Frontend => "frontend",
+            Self::Compilation => "compilation",
+            Self::ReusableWorkflow => "reusable_workflow",
+            Self::CredentialDiscovery => "credential_discovery",
+        }
+    }
+
+    const fn message(self) -> &'static str {
+        match self {
+            Self::Snapshot => "the exact local Git worktree snapshot could not be sealed",
+            Self::Cancelled => "local workflow analysis was cancelled",
+            Self::Archive => "the sealed worktree archive violates local analysis policy",
+            Self::WorkflowMissing => "add a direct YAML workflow under .github/workflows",
+            Self::WorkflowSelectionRequired => {
+                "multiple workflows were discovered; supply one exact canonical path"
+            }
+            Self::WorkflowNotFound => {
+                "workflow must be one exact discovered .github/workflows path"
+            }
+            Self::WorkflowSource => "a selected workflow source is invalid",
+            Self::Frontend => "a selected workflow was rejected by the GitHub Actions frontend",
+            Self::Compilation => {
+                "the root workflow must accept the explicit local workflow_dispatch selection"
+            }
+            Self::ReusableWorkflow => {
+                "a reachable same-snapshot reusable workflow or call contract is invalid"
+            }
+            Self::CredentialDiscovery => {
+                "a workflow contains a dynamic or invalid credential reference"
+            }
+        }
+    }
+}
+
+/// One sanitized local-check failure.
+#[derive(Clone, Debug, Serialize)]
+pub struct LocalCheckIssue {
+    code: LocalCheckIssueCode,
+    message: &'static str,
+}
+
+impl LocalCheckIssue {
+    /// Returns the stable failure class.
+    #[must_use]
+    pub const fn code(&self) -> LocalCheckIssueCode {
+        self.code
+    }
+
+    /// Returns the actionable value-free failure description.
+    #[must_use]
+    pub const fn message(&self) -> &'static str {
+        self.message
+    }
+}
+
+/// Captures and validates one exact local workflow without admission,
+/// execution, Docker, network, or provider side effects.
+pub async fn check_workflow(
+    request: LocalCheckRequest,
+    cancellation: CancellationToken,
+) -> LocalCheckReport {
+    let snapshot = match capture_snapshot(
+        LocalSnapshotRequest::new(request.directory, request.limits),
+        &cancellation,
+    )
+    .await
+    {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let code = if error.code() == LocalSnapshotErrorCode::Cancelled {
+                LocalCheckIssueCode::Cancelled
+            } else {
+                LocalCheckIssueCode::Snapshot
+            };
+            return LocalCheckReport::failure(None, code, Vec::new());
+        }
+    };
+    let mut source = LocalCheckSource::from_snapshot(&snapshot);
+    let expected_digest = snapshot.digest();
+    let archive = snapshot.into_archive();
+    let selector = request.workflow;
+    let inputs = request.inputs;
+    let archive_limits = request.limits;
+    let reusable_limits = request.reusable_limits;
+    let worker_cancellation = cancellation.clone();
+    let analysis = tokio::task::spawn_blocking(move || {
+        analyze_local_github_archive(
+            &archive,
+            selector.as_deref(),
+            inputs,
+            archive_limits,
+            reusable_limits,
+            &|| worker_cancellation.is_cancelled(),
+        )
+    })
+    .await;
+    let analysis = match analysis {
+        Ok(Ok(analysis)) => analysis,
+        Ok(Err(failure)) => {
+            return LocalCheckReport::failure(
+                Some(source),
+                issue_code(failure.kind()),
+                diagnostics(failure.diagnostics()),
+            );
+        }
+        Err(_) => {
+            return LocalCheckReport::failure(
+                Some(source),
+                if cancellation.is_cancelled() {
+                    LocalCheckIssueCode::Cancelled
+                } else {
+                    LocalCheckIssueCode::Archive
+                },
+                Vec::new(),
+            );
+        }
+    };
+    if analysis.snapshot_digest() != expected_digest {
+        return LocalCheckReport::failure(
+            Some(source),
+            LocalCheckIssueCode::Archive,
+            diagnostics(analysis.diagnostics()),
+        );
+    }
+    source.workflow_path = Some(analysis.selected_path().to_owned());
+    LocalCheckReport::success(source, &analysis)
+}
+
+const fn issue_code(kind: LocalGithubArchiveAnalysisFailureKind) -> LocalCheckIssueCode {
+    match kind {
+        LocalGithubArchiveAnalysisFailureKind::Cancelled => LocalCheckIssueCode::Cancelled,
+        LocalGithubArchiveAnalysisFailureKind::Archive => LocalCheckIssueCode::Archive,
+        LocalGithubArchiveAnalysisFailureKind::WorkflowMissing => {
+            LocalCheckIssueCode::WorkflowMissing
+        }
+        LocalGithubArchiveAnalysisFailureKind::WorkflowSelectionRequired => {
+            LocalCheckIssueCode::WorkflowSelectionRequired
+        }
+        LocalGithubArchiveAnalysisFailureKind::WorkflowNotFound => {
+            LocalCheckIssueCode::WorkflowNotFound
+        }
+        LocalGithubArchiveAnalysisFailureKind::WorkflowSource => {
+            LocalCheckIssueCode::WorkflowSource
+        }
+        LocalGithubArchiveAnalysisFailureKind::Frontend => LocalCheckIssueCode::Frontend,
+        LocalGithubArchiveAnalysisFailureKind::Compilation => LocalCheckIssueCode::Compilation,
+        LocalGithubArchiveAnalysisFailureKind::ReusableWorkflow => {
+            LocalCheckIssueCode::ReusableWorkflow
+        }
+        LocalGithubArchiveAnalysisFailureKind::CredentialDiscovery => {
+            LocalCheckIssueCode::CredentialDiscovery
+        }
+    }
+}
+
+fn diagnostics(values: &[Diagnostic]) -> Vec<LocalCheckDiagnostic> {
+    values
+        .iter()
+        .map(|diagnostic| LocalCheckDiagnostic {
+            kind: diagnostic.kind().as_str(),
+            severity: diagnostic.severity().as_str(),
+            code: diagnostic.code().to_owned(),
+            source: diagnostic.primary_span().source_id().as_str().to_owned(),
+            line: diagnostic.primary_span().start().line(),
+            column: diagnostic.primary_span().start().column(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    };
+
+    use automata_ci_workflow_github::{
+        GithubWorkflowDispatchInputs, RepositoryWorkflowDiscoveryLimits,
+    };
+    use automata_ci_workflow_service::BuiltInCredentialRequirement;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    use super::{LocalCheckIssueCode, LocalCheckRequest, check_workflow};
+
+    fn empty_inputs() -> GithubWorkflowDispatchInputs {
+        GithubWorkflowDispatchInputs::try_new(Vec::<(String, String)>::new()).unwrap()
+    }
+
+    #[test]
+    fn request_debug_omits_directory_and_input_values() {
+        let private_directory = "/private/local-check-directory";
+        let private_value = "private-local-check-input";
+        let request = LocalCheckRequest::new(
+            private_directory,
+            Some(".github/workflows/check.yml".to_owned()),
+            GithubWorkflowDispatchInputs::try_new([("target", private_value)]).unwrap(),
+        );
+        let debug = format!("{request:?}");
+        assert!(!debug.contains(private_directory));
+        assert!(!debug.contains(private_value));
+    }
+
+    #[tokio::test]
+    async fn dirty_snapshot_validates_reusable_contracts_without_retaining_values() {
+        let fixture = Fixture::new();
+        fixture.write(
+            ".github/workflows/root.yml",
+            r"on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        type: boolean
+        required: true
+jobs:
+  invoke:
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      token: ${{ secrets.root_token }}
+",
+        );
+        fixture.write(
+            ".github/workflows/reusable.yml",
+            r"on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+jobs:
+  test:
+    runs-on: linux
+    steps:
+      - run: echo '${{ vars.region }}' '${{ secrets.token }}'
+",
+        );
+        fixture.commit_all();
+        fixture.write("dirty.txt", "unreportable-source-marker\n");
+        let inputs = GithubWorkflowDispatchInputs::try_new([("deploy", true)]).unwrap();
+
+        let first = check_workflow(
+            LocalCheckRequest::new(
+                fixture.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                inputs.clone(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        let repeated = check_workflow(
+            LocalCheckRequest::new(
+                fixture.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                inputs,
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert!(first.valid(), "{:#?}", first.issue());
+        assert!(first.source().unwrap().dirty());
+        assert_eq!(
+            first.source().unwrap().snapshot_digest(),
+            repeated.source().unwrap().snapshot_digest()
+        );
+        assert_eq!(first.required_root_secrets(), &["ROOT_TOKEN"]);
+        assert_eq!(first.workflows().len(), 2);
+        let reusable = first
+            .workflows()
+            .iter()
+            .find(|workflow| workflow.reusable())
+            .unwrap();
+        assert_eq!(reusable.jobs()[0].secrets(), &["TOKEN"]);
+        assert_eq!(reusable.jobs()[0].variables(), &["REGION"]);
+        let json = serde_json::to_string(&first).unwrap();
+        assert!(!json.contains("unreportable-source-marker"));
+        assert!(!json.contains(fixture.path().to_string_lossy().as_ref()));
+        assert!(!json.contains("repository_id"));
+        assert!(!json.contains("environment_required"));
+    }
+
+    #[tokio::test]
+    async fn exact_github_selector_and_workflow_dispatch_are_mandatory() {
+        let fixture = Fixture::new();
+        fixture.write(
+            ".github/workflows/a.yml",
+            "on: push\njobs:\n  a:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        );
+        fixture.write(
+            ".github/workflows/b.yml",
+            "on: workflow_dispatch\njobs:\n  b:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        );
+        fixture.commit_all();
+
+        let ambiguous = check_workflow(
+            LocalCheckRequest::new(fixture.path(), None, empty_inputs()),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            ambiguous.issue().unwrap().code(),
+            LocalCheckIssueCode::WorkflowSelectionRequired
+        );
+        let push = check_workflow(
+            LocalCheckRequest::new(
+                fixture.path(),
+                Some(".github/workflows/a.yml".to_owned()),
+                empty_inputs(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            push.issue().unwrap().code(),
+            LocalCheckIssueCode::Compilation
+        );
+        let shorthand = check_workflow(
+            LocalCheckRequest::new(fixture.path(), Some("b.yml".to_owned()), empty_inputs()),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            shorthand.issue().unwrap().code(),
+            LocalCheckIssueCode::WorkflowNotFound
+        );
+
+        let automata_namespace = Fixture::new();
+        automata_namespace.write(
+            ".ci/workflows/not-local-github.yml",
+            "on: workflow_dispatch\njobs:\n  ignored:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        );
+        automata_namespace.commit_all();
+        let rejected = check_workflow(
+            LocalCheckRequest::new(automata_namespace.path(), None, empty_inputs()),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            rejected.issue().unwrap().code(),
+            LocalCheckIssueCode::Archive
+        );
+    }
+
+    #[tokio::test]
+    async fn reusable_contract_cycles_remote_calls_and_missing_secrets_fail() {
+        let missing = Fixture::new();
+        missing.write(
+            ".github/workflows/root.yml",
+            "on: workflow_dispatch\njobs:\n  call:\n    uses: ./.github/workflows/callee.yml\n",
+        );
+        missing.write(
+            ".github/workflows/callee.yml",
+            "on:\n  workflow_call:\n    secrets:\n      token:\n        required: true\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        );
+        missing.commit_all();
+        let report = check_workflow(
+            LocalCheckRequest::new(
+                missing.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                empty_inputs(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            report.issue().unwrap().code(),
+            LocalCheckIssueCode::ReusableWorkflow
+        );
+
+        let cycle = Fixture::new();
+        cycle.write(
+            ".github/workflows/root.yml",
+            "on: workflow_dispatch\njobs:\n  call:\n    uses: ./.github/workflows/a.yml\n",
+        );
+        cycle.write(
+            ".github/workflows/a.yml",
+            "on: workflow_call\njobs:\n  call:\n    uses: ./.github/workflows/b.yml\n",
+        );
+        cycle.write(
+            ".github/workflows/b.yml",
+            "on: workflow_call\njobs:\n  call:\n    uses: ./.github/workflows/a.yml\n",
+        );
+        cycle.commit_all();
+        let report = check_workflow(
+            LocalCheckRequest::new(
+                cycle.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                empty_inputs(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            report.issue().unwrap().code(),
+            LocalCheckIssueCode::ReusableWorkflow
+        );
+
+        let remote = Fixture::new();
+        remote.write(
+            ".github/workflows/root.yml",
+            "on: workflow_dispatch\njobs:\n  call:\n    uses: owner/repository/.github/workflows/a.yml@main\n",
+        );
+        remote.commit_all();
+        let report = check_workflow(
+            LocalCheckRequest::new(
+                remote.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                empty_inputs(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            report.issue().unwrap().code(),
+            LocalCheckIssueCode::ReusableWorkflow
+        );
+    }
+
+    #[tokio::test]
+    async fn github_token_is_builtin_and_never_promptable() {
+        let fixture = Fixture::new();
+        fixture.write(
+            ".github/workflows/root.yml",
+            r"on: workflow_dispatch
+jobs:
+  direct:
+    runs-on: linux
+    steps:
+      - run: echo '${{ github.token }}' '${{ secrets.GITHUB_TOKEN }}'
+  call:
+    uses: ./.github/workflows/callee.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+",
+        );
+        fixture.write(
+            ".github/workflows/callee.yml",
+            r"on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+jobs:
+  use:
+    runs-on: linux
+    steps:
+      - run: echo '${{ secrets.token }}'
+",
+        );
+        fixture.commit_all();
+        let report = check_workflow(
+            LocalCheckRequest::new(
+                fixture.path(),
+                Some(".github/workflows/root.yml".to_owned()),
+                empty_inputs(),
+            ),
+            CancellationToken::new(),
+        )
+        .await;
+        assert!(report.valid(), "{:#?}", report.issue());
+        assert!(report.required_root_secrets().is_empty());
+        assert_eq!(
+            report.required_built_in_credentials(),
+            &[BuiltInCredentialRequirement::GithubToken]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_small_capture_bounds_fail_closed() {
+        let fixture = Fixture::new();
+        fixture.write(
+            ".github/workflows/check.yml",
+            "on: workflow_dispatch\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        );
+        fixture.commit_all();
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = check_workflow(
+            LocalCheckRequest::new(fixture.path(), None, empty_inputs()),
+            cancellation,
+        )
+        .await;
+        assert_eq!(
+            cancelled.issue().unwrap().code(),
+            LocalCheckIssueCode::Cancelled
+        );
+
+        let limits = RepositoryWorkflowDiscoveryLimits::new(1, 1, 1, 1, 1, 1, 1).unwrap();
+        let bounded = check_workflow(
+            LocalCheckRequest::new(fixture.path(), None, empty_inputs()).with_limits(limits),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(
+            bounded.issue().unwrap().code(),
+            LocalCheckIssueCode::Snapshot
+        );
+    }
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir()
+                .join(format!("automata-local-check-{}", Uuid::new_v4().simple()));
+            fs::create_dir(&root).unwrap();
+            let fixture = Self { root };
+            fixture.git(&["init", "--quiet"]);
+            fixture.git(&["config", "user.name", "Automata Test"]);
+            fixture.git(&["config", "user.email", "automata@example.invalid"]);
+            fixture
+        }
+
+        fn path(&self) -> &Path {
+            &self.root
+        }
+
+        fn write(&self, path: &str, value: &str) {
+            let path = self.root.join(path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, value).unwrap();
+        }
+
+        fn commit_all(&self) {
+            self.git(&["add", "--all"]);
+            self.git(&["commit", "--quiet", "--message", "fixture"]);
+        }
+
+        fn git(&self, arguments: &[&str]) {
+            assert!(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(&self.root)
+                    .args(arguments)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+}

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -1,8 +1,9 @@
 //! Cross-platform boundary for disposable local Automata installations.
 //!
-//! The crate owns Docker Engine discovery without depending on the product CLI.
-//! Lifecycle mutation is added in separately reviewed slices; [`inspect`] is
-//! read-only and creates no engine resources or host state.
+//! The crate owns Docker Engine discovery and exact local workflow inspection
+//! without depending on the product CLI. Lifecycle mutation is added in
+//! separately reviewed slices; [`inspect`] and [`check_workflow`] are read-only
+//! and create no engine resources, admission records, or host state.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -16,18 +17,24 @@ use tokio::{
     time::timeout,
 };
 
+mod check;
 mod engine;
 mod installation;
+#[cfg(unix)]
 mod snapshot;
+#[cfg(not(unix))]
+#[path = "snapshot_unsupported.rs"]
+mod snapshot;
+mod snapshot_limits;
 
+pub use check::{
+    LocalCheckDiagnostic, LocalCheckIssue, LocalCheckIssueCode, LocalCheckReport,
+    LocalCheckRequest, LocalCheckSource, LocalCheckedJob, LocalCheckedWorkflow, check_workflow,
+};
 pub use engine::{DockerInstallationAdapter, LocalEngineError, LocalEngineErrorCode};
 pub use installation::{
     ComposeProjectName, Installation, InstallationId, InstallationName, InstallationNameError,
     InstallationSelectorKey,
-};
-pub use snapshot::{
-    LocalSnapshot, LocalSnapshotError, LocalSnapshotErrorCode, LocalSnapshotRequest,
-    capture_snapshot,
 };
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -18,11 +18,16 @@ use tokio::{
 
 mod engine;
 mod installation;
+mod snapshot;
 
 pub use engine::{DockerInstallationAdapter, LocalEngineError, LocalEngineErrorCode};
 pub use installation::{
     ComposeProjectName, Installation, InstallationId, InstallationName, InstallationNameError,
     InstallationSelectorKey,
+};
+pub use snapshot::{
+    LocalSnapshot, LocalSnapshotError, LocalSnapshotErrorCode, LocalSnapshotRequest,
+    capture_snapshot,
 };
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
@@ -529,9 +534,11 @@ async fn capture_docker(probe: DoctorProbe, arguments: &[&str]) -> ProbeOutput {
         return ProbeOutput::Failure(CommandFailure::Failed);
     };
     let captured = timeout(COMMAND_TIMEOUT, async {
-        tokio::try_join!(read_bounded(stdout), read_bounded(stderr), async {
-            child.wait().await.map_err(|_error| CaptureFailure::Io)
-        })
+        tokio::try_join!(
+            read_bounded(stdout, MAX_COMMAND_STREAM_BYTES),
+            read_bounded(stderr, MAX_COMMAND_STREAM_BYTES),
+            async { child.wait().await.map_err(|_error| CaptureFailure::Io) }
+        )
     })
     .await;
     let (stdout, stderr, status) = match captured {
@@ -572,8 +579,11 @@ enum CaptureFailure {
     OutputTooLarge,
 }
 
-async fn read_bounded<R: AsyncRead + Unpin>(mut reader: R) -> Result<Vec<u8>, CaptureFailure> {
-    let mut bytes = Vec::with_capacity(MAX_COMMAND_STREAM_BYTES.min(4096));
+async fn read_bounded<R: AsyncRead + Unpin>(
+    mut reader: R,
+    maximum_bytes: usize,
+) -> Result<Vec<u8>, CaptureFailure> {
+    let mut bytes = Vec::with_capacity(maximum_bytes.min(4096));
     let mut chunk = [0_u8; 4096];
     loop {
         let count = reader
@@ -583,7 +593,7 @@ async fn read_bounded<R: AsyncRead + Unpin>(mut reader: R) -> Result<Vec<u8>, Ca
         if count == 0 {
             break;
         }
-        let remaining = MAX_COMMAND_STREAM_BYTES.saturating_sub(bytes.len());
+        let remaining = maximum_bytes.saturating_sub(bytes.len());
         if count > remaining {
             return Err(CaptureFailure::OutputTooLarge);
         }
@@ -1613,7 +1623,7 @@ mod tests {
     async fn command_capture_rejects_output_above_the_bound() {
         let input = tokio::io::repeat(7).take((MAX_COMMAND_STREAM_BYTES + 1) as u64);
         assert_eq!(
-            read_bounded(input).await,
+            read_bounded(input, MAX_COMMAND_STREAM_BYTES).await,
             Err(CaptureFailure::OutputTooLarge)
         );
     }

--- a/crates/automata-ci-local/src/snapshot.rs
+++ b/crates/automata-ci-local/src/snapshot.rs
@@ -1,0 +1,3297 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    io::{self, Cursor, Read as _, Write},
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use automata_ci_core::Sha256Digest;
+use automata_ci_workflow_github::{
+    RepositoryPathValidationError, RepositoryPathValidator, RepositoryWorkflowDiscoveryError,
+    RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryOutcome,
+    RepositoryWorkflowDiscoveryPolicy, RepositoryWorkflowLocation, discover_repository_workflows,
+};
+use bytes::Bytes;
+use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt as _, ambient_authority};
+use cap_std::fs::{Dir, File, Metadata, OpenOptions};
+use flate2::{Compression, GzBuilder};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use tar::{Builder as TarBuilder, EntryType, Header};
+use thiserror::Error;
+use tokio::{io::AsyncWriteExt as _, process::Command as ProcessCommand, time::timeout};
+
+use super::{
+    CaptureFailure, CommandFailure, MAX_COMMAND_STREAM_BYTES, read_bounded, spawn_contained,
+    terminate_process_tree, terminate_remaining_process_tree,
+};
+
+const SNAPSHOT_ROOT: &str = "worktree";
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_GIT_COORDINATE_FIELD_BYTES: usize = 16 * 1_024;
+const MAX_GIT_COORDINATES_BYTES: usize = 4 * (MAX_GIT_COORDINATE_FIELD_BYTES + 2);
+const MAX_GIT_LOCATOR_BYTES: usize = MAX_GIT_COORDINATE_FIELD_BYTES;
+const MAX_GIT_HEAD_BYTES: usize = 128;
+
+/// Request to seal one live Git worktree into a bounded immutable snapshot.
+#[derive(Clone, Debug)]
+pub struct LocalSnapshotRequest {
+    directory: PathBuf,
+    limits: RepositoryWorkflowDiscoveryLimits,
+}
+
+impl LocalSnapshotRequest {
+    /// Creates a request rooted at a worktree or any directory beneath it.
+    #[must_use]
+    pub fn new(directory: impl Into<PathBuf>, limits: RepositoryWorkflowDiscoveryLimits) -> Self {
+        Self {
+            directory: directory.into(),
+            limits,
+        }
+    }
+
+    /// Returns the caller-supplied worktree search directory.
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    /// Returns the shared snapshot-construction and workflow-discovery limits.
+    #[must_use]
+    pub const fn limits(&self) -> RepositoryWorkflowDiscoveryLimits {
+        self.limits
+    }
+}
+
+/// One sealed local source archive and the workflow bytes discovered from that
+/// exact archive.
+///
+/// The inventory is Git's tracked index names plus non-ignored untracked names.
+/// Tracked deletions are absent, staged additions are present, and all regular
+/// file bytes come from the live worktree rather than the index. Git's tracked
+/// mode determines executable and symbolic-link representation, including the
+/// ordinary-file placeholders used by Windows checkouts. Index conflicts and
+/// submodules fail closed, as do sparse-checkout and assume-unchanged flags
+/// that can hide live state. No source operation updates the index or invokes
+/// hooks or automatic maintenance.
+#[derive(Clone, Debug)]
+pub struct LocalSnapshot {
+    root: PathBuf,
+    head: String,
+    dirty: bool,
+    digest: Sha256Digest,
+    archive: Bytes,
+    entry_count: usize,
+    expanded_bytes: u64,
+    workflow_location: Option<RepositoryWorkflowLocation>,
+    workflows: Vec<RepositoryWorkflowDiscoveryOutcome>,
+}
+
+impl LocalSnapshot {
+    /// Returns the absolute, pinned worktree root reported by Git.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the exact commit at `HEAD` while the worktree was sealed.
+    #[must_use]
+    pub fn head(&self) -> &str {
+        &self.head
+    }
+
+    /// Returns whether Git reported staged, unstaged, or non-ignored untracked
+    /// worktree state while the snapshot was sealed.
+    #[must_use]
+    pub const fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Returns SHA-256 over the exact deterministic gzip bytes retained here.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    /// Returns the exact immutable tar.gz bytes consumed by workflow discovery.
+    #[must_use]
+    pub const fn archive_bytes(&self) -> &Bytes {
+        &self.archive
+    }
+
+    /// Returns the number of regular-file and symbolic-link entries in the
+    /// sealed live-worktree inventory.
+    #[must_use]
+    pub const fn entry_count(&self) -> usize {
+        self.entry_count
+    }
+
+    /// Returns the sum of regular-file bytes retained in the archive.
+    #[must_use]
+    pub const fn expanded_bytes(&self) -> u64 {
+        self.expanded_bytes
+    }
+
+    /// Returns the one explicit workflow namespace present in the worktree.
+    /// Repositories containing both namespaces are rejected during capture.
+    #[must_use]
+    pub const fn workflow_location(&self) -> Option<RepositoryWorkflowLocation> {
+        self.workflow_location
+    }
+
+    /// Returns deterministic path outcomes decoded from the retained archive.
+    #[must_use]
+    pub fn workflows(&self) -> &[RepositoryWorkflowDiscoveryOutcome] {
+        &self.workflows
+    }
+}
+
+/// Seals a bounded, deterministic snapshot without changing Git or the
+/// worktree.
+///
+/// # Errors
+///
+/// Fails closed when the requested directory cannot be pinned before Git runs,
+/// Git's reported root and repository authority do not resolve back to that
+/// directory, the `.git` locator is not a no-follow directory or an exact
+/// linked-worktree gitfile, Git state is ambiguous, an ancestor cannot be
+/// opened without following a link, a path or file type is unsafe, a resource
+/// bound is exceeded, or the inventory mutates while it is being read. Windows
+/// reparse points, including junctions, are not admitted.
+pub async fn capture_snapshot(
+    request: LocalSnapshotRequest,
+) -> Result<LocalSnapshot, LocalSnapshotError> {
+    capture_snapshot_with_git(request, Path::new("git")).await
+}
+
+async fn capture_snapshot_with_git(
+    request: LocalSnapshotRequest,
+    git: &Path,
+) -> Result<LocalSnapshot, LocalSnapshotError> {
+    let requested_path = std::path::absolute(request.directory())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
+    let requested = PinnedDirectory::open(&requested_path)?;
+    let coordinates = discover_git_coordinates(git, &requested_path).await?;
+    requested.verify_ambient_path(&requested_path)?;
+    let authority = GitAuthority::pin(coordinates, &requested)?;
+    verify_bound_git_coordinates(git, &authority, LocalSnapshotErrorCode::NotGitWorktree).await?;
+    let path_validator =
+        RepositoryPathValidator::new(SNAPSHOT_ROOT, request.limits().maximum_entry_path_bytes())
+            .map_err(local_path_validation_error)?;
+    let initial = capture_git_state(git, &authority, request.limits()).await?;
+    let inventory = parse_inventory(&initial, request.limits(), path_validator)?;
+    let initial_scan = scan_worktree(git, &authority, request.limits(), path_validator).await?;
+    let captured = capture_entries(
+        &authority.worktree,
+        &inventory,
+        request.limits(),
+        path_validator,
+    )?;
+    let workflow_location = workflow_location(&captured.entries)?;
+    let final_state = capture_git_state(git, &authority, request.limits()).await?;
+    let final_scan = scan_worktree(git, &authority, request.limits(), path_validator).await?;
+    verify_git_state(&initial, &final_state)?;
+    if initial_scan != final_scan {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    verify_deleted_paths(&authority.worktree, &captured.deleted_paths)?;
+    verify_bound_git_coordinates(git, &authority, LocalSnapshotErrorCode::ConcurrentMutation)
+        .await?;
+    requested.verify_ambient_path(&requested_path)?;
+    authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
+
+    let archive = build_archive(&captured.entries, request.limits())?;
+    let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
+    let workflows = discover_repository_workflows(
+        &archive,
+        request.limits(),
+        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot { workflow_location },
+    )
+    .map_err(local_discovery_error)?;
+
+    Ok(LocalSnapshot {
+        root: authority.worktree_path,
+        head: initial.head,
+        dirty: !initial.status.is_empty(),
+        digest,
+        archive: Bytes::from(archive),
+        entry_count: captured.entries.len(),
+        expanded_bytes: captured.expanded_bytes,
+        workflow_location,
+        workflows,
+    })
+}
+
+fn local_discovery_error(error: RepositoryWorkflowDiscoveryError) -> LocalSnapshotError {
+    LocalSnapshotError::new(match error {
+        RepositoryWorkflowDiscoveryError::ResourceLimit => LocalSnapshotErrorCode::ResourceLimit,
+        RepositoryWorkflowDiscoveryError::UnsafePath => LocalSnapshotErrorCode::UnsafePath,
+        RepositoryWorkflowDiscoveryError::UnsafeLink
+        | RepositoryWorkflowDiscoveryError::NamespaceAlias => LocalSnapshotErrorCode::UnsafeSymlink,
+        RepositoryWorkflowDiscoveryError::PathAlias => LocalSnapshotErrorCode::CaseCollision,
+        RepositoryWorkflowDiscoveryError::PathTypeConflict => {
+            LocalSnapshotErrorCode::PathTypeConflict
+        }
+        _ => LocalSnapshotErrorCode::WorkflowDiscovery,
+    })
+}
+
+#[derive(Debug)]
+struct GitState {
+    head: String,
+    index: Vec<u8>,
+    inventory: Vec<u8>,
+    status: Vec<u8>,
+}
+
+async fn capture_git_state(
+    git: &Path,
+    authority: &GitAuthority,
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<GitState, LocalSnapshotError> {
+    let inventory_limit = git_inventory_output_limit(limits)?;
+    let index_limit = git_index_output_limit(limits)?;
+    let status_limit = git_status_output_limit(limits)?;
+    let head = capture_bound_git(
+        git,
+        authority,
+        &["rev-parse", "--verify", "HEAD^{commit}"],
+        MAX_GIT_HEAD_BYTES,
+    )
+    .await?;
+    let index = capture_bound_git(
+        git,
+        authority,
+        &["ls-files", "--cached", "--stage", "-v", "-z"],
+        index_limit,
+    )
+    .await?;
+    let inventory = capture_bound_git(
+        git,
+        authority,
+        &[
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
+        inventory_limit,
+    )
+    .await?;
+    let status = capture_bound_git(
+        git,
+        authority,
+        &["status", "--porcelain=v2", "--untracked-files=all", "-z"],
+        status_limit,
+    )
+    .await?;
+    Ok(GitState {
+        head: parse_head(&head)?,
+        index,
+        inventory,
+        status,
+    })
+}
+
+async fn capture_bound_git(
+    git: &Path,
+    authority: &GitAuthority,
+    arguments: &[&str],
+    maximum_stdout_bytes: usize,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    capture_bound_git_request(git, authority, arguments, None, maximum_stdout_bytes, false).await
+}
+
+async fn capture_bound_git_with_input(
+    git: &Path,
+    authority: &GitAuthority,
+    arguments: &[&str],
+    input: &[u8],
+    maximum_stdout_bytes: usize,
+    allow_no_matches: bool,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    capture_bound_git_request(
+        git,
+        authority,
+        arguments,
+        Some(input),
+        maximum_stdout_bytes,
+        allow_no_matches,
+    )
+    .await
+}
+
+async fn capture_bound_git_request(
+    git: &Path,
+    authority: &GitAuthority,
+    arguments: &[&str],
+    input: Option<&[u8]>,
+    maximum_stdout_bytes: usize,
+    allow_no_matches: bool,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
+    let captured = capture_git_request(
+        git,
+        GitInvocation::Bound(authority),
+        arguments,
+        input,
+        maximum_stdout_bytes,
+        allow_no_matches,
+    )
+    .await;
+    authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
+    captured
+}
+
+async fn capture_discovery_git(
+    git: &Path,
+    directory: &Path,
+    arguments: &[&str],
+    maximum_stdout_bytes: usize,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    capture_git_request(
+        git,
+        GitInvocation::Discovery(directory),
+        arguments,
+        None,
+        maximum_stdout_bytes,
+        false,
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum GitInvocation<'a> {
+    Discovery(&'a Path),
+    Bound(&'a GitAuthority),
+}
+
+async fn capture_git_request(
+    git: &Path,
+    invocation: GitInvocation<'_>,
+    arguments: &[&str],
+    input: Option<&[u8]>,
+    maximum_stdout_bytes: usize,
+    allow_no_matches: bool,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    let mut command = ProcessCommand::new(git);
+    command
+        .arg("--no-optional-locks")
+        .args(["-c", "core.fsmonitor=false"])
+        .args(["-c", "core.untrackedCache=false"])
+        .args(["-c", "core.preloadIndex=false"])
+        .args(["-c", "maintenance.auto=false"])
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_git_invocation(&mut command, invocation);
+    command.args(arguments);
+    let (mut child, mut containment) = spawn_contained(command).map_err(|failure| {
+        LocalSnapshotError::new(if failure == CommandFailure::NotFound {
+            LocalSnapshotErrorCode::GitUnavailable
+        } else {
+            LocalSnapshotErrorCode::GitCommand
+        })
+    })?;
+    let Some(stdout) = child.stdout.take() else {
+        terminate_process_tree(&mut child, &mut containment).await;
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
+    };
+    let Some(stderr) = child.stderr.take() else {
+        terminate_process_tree(&mut child, &mut containment).await;
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
+    };
+    let mut stdin = child.stdin.take();
+    let captured = timeout(GIT_COMMAND_TIMEOUT, async {
+        tokio::try_join!(
+            read_bounded(stdout, maximum_stdout_bytes),
+            read_bounded(stderr, MAX_COMMAND_STREAM_BYTES),
+            async {
+                if let Some(input) = input {
+                    let mut writer = stdin.take().ok_or(CaptureFailure::Io)?;
+                    writer
+                        .write_all(input)
+                        .await
+                        .map_err(|_error| CaptureFailure::Io)?;
+                    writer
+                        .shutdown()
+                        .await
+                        .map_err(|_error| CaptureFailure::Io)?;
+                }
+                Ok::<(), CaptureFailure>(())
+            },
+            async { child.wait().await.map_err(|_error| CaptureFailure::Io) }
+        )
+    })
+    .await;
+    let (stdout, stderr, (), status) = match captured {
+        Ok(Ok(value)) => value,
+        Ok(Err(CaptureFailure::OutputTooLarge)) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ResourceLimit,
+            ));
+        }
+        Ok(Err(CaptureFailure::Io)) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
+        }
+        Err(_) => {
+            terminate_process_tree(&mut child, &mut containment).await;
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitTimeout));
+        }
+    };
+    terminate_remaining_process_tree(&mut containment);
+    drop(stderr);
+    if !(status.success() || allow_no_matches && status.code() == Some(1)) {
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
+    }
+    Ok(stdout)
+}
+
+fn configure_git_invocation(command: &mut ProcessCommand, invocation: GitInvocation<'_>) {
+    match invocation {
+        GitInvocation::Discovery(directory) => {
+            command.arg("-C").arg(directory);
+        }
+        GitInvocation::Bound(authority) => {
+            command
+                .arg("--git-dir")
+                .arg(&authority.git_directory_path)
+                .arg("--work-tree")
+                .arg(&authority.worktree_path)
+                .arg("-C")
+                .arg(&authority.worktree_path)
+                .env("GIT_COMMON_DIR", &authority.common_directory_path);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GitCoordinates {
+    worktree_root: PathBuf,
+    git_directory: PathBuf,
+    common_directory: PathBuf,
+    prefix: Vec<String>,
+}
+
+async fn discover_git_coordinates(
+    git: &Path,
+    directory: &Path,
+) -> Result<GitCoordinates, LocalSnapshotError> {
+    let output = capture_discovery_git(
+        git,
+        directory,
+        &[
+            "rev-parse",
+            "--path-format=absolute",
+            "--show-toplevel",
+            "--absolute-git-dir",
+            "--git-common-dir",
+            "--show-prefix",
+        ],
+        MAX_GIT_COORDINATES_BYTES,
+    )
+    .await?;
+    parse_git_coordinates(&output)
+}
+
+fn parse_git_coordinates(output: &[u8]) -> Result<GitCoordinates, LocalSnapshotError> {
+    let text = std::str::from_utf8(output)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NonUnicodePath))?;
+    if text.contains('\0') {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    }
+    let text = text
+        .strip_suffix('\n')
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
+    let mut fields = text
+        .split('\n')
+        .map(|field| field.strip_suffix('\r').unwrap_or(field));
+    let (Some(worktree_root), Some(git_directory), Some(common_directory), Some(prefix)) =
+        (fields.next(), fields.next(), fields.next(), fields.next())
+    else {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    };
+    if fields.next().is_some() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    }
+    Ok(GitCoordinates {
+        worktree_root: parse_git_coordinate_path(worktree_root)?,
+        git_directory: parse_git_coordinate_path(git_directory)?,
+        common_directory: parse_git_coordinate_path(common_directory)?,
+        prefix: parse_git_prefix(prefix)?,
+    })
+}
+
+fn parse_git_coordinate_path(value: &str) -> Result<PathBuf, LocalSnapshotError> {
+    if value.is_empty()
+        || value.len() > MAX_GIT_COORDINATE_FIELD_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    }
+    let path = PathBuf::from(value);
+    if !path.is_absolute()
+        || path.components().any(|component| {
+            !matches!(
+                component,
+                std::path::Component::Prefix(_)
+                    | std::path::Component::RootDir
+                    | std::path::Component::Normal(_)
+            )
+        })
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    }
+    Ok(path)
+}
+
+fn parse_git_prefix(value: &str) -> Result<Vec<String>, LocalSnapshotError> {
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    if value.len() > MAX_GIT_COORDINATE_FIELD_BYTES {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    }
+    let Some(value) = value.strip_suffix('/') else {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::NotGitWorktree,
+        ));
+    };
+    let mut components = Vec::new();
+    for component in value.split('/') {
+        if component.is_empty()
+            || matches!(component, "." | "..")
+            || component.contains('\\')
+            || component.chars().any(char::is_control)
+        {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::NotGitWorktree,
+            ));
+        }
+        components.push(component.to_owned());
+    }
+    Ok(components)
+}
+
+async fn verify_bound_git_coordinates(
+    git: &Path,
+    authority: &GitAuthority,
+    failure: LocalSnapshotErrorCode,
+) -> Result<(), LocalSnapshotError> {
+    let output = capture_bound_git(
+        git,
+        authority,
+        &[
+            "rev-parse",
+            "--path-format=absolute",
+            "--show-toplevel",
+            "--absolute-git-dir",
+            "--git-common-dir",
+            "--show-prefix",
+        ],
+        MAX_GIT_COORDINATES_BYTES,
+    )
+    .await?;
+    let coordinates = parse_git_coordinates(&output)?;
+    if !coordinates.prefix.is_empty() {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    let reported_worktree = PinnedDirectory::open_for(&coordinates.worktree_root, failure)?;
+    let reported_git_directory = PinnedDirectory::open_for(&coordinates.git_directory, failure)?;
+    let reported_common_directory =
+        PinnedDirectory::open_for(&coordinates.common_directory, failure)?;
+    authority
+        .worktree
+        .verify_same_identity(&reported_worktree, failure)?;
+    authority
+        .git_directory
+        .verify_same_identity(&reported_git_directory, failure)?;
+    authority
+        .common_directory
+        .verify_same_identity(&reported_common_directory, failure)
+}
+
+fn parse_head(output: &[u8]) -> Result<String, LocalSnapshotError> {
+    let head = parse_one_git_line(output, LocalSnapshotErrorCode::GitOutput)?;
+    if !matches!(head.len(), 40 | 64)
+        || !head
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+    }
+    Ok(head.to_owned())
+}
+
+fn parse_one_git_line(
+    output: &[u8],
+    code: LocalSnapshotErrorCode,
+) -> Result<&str, LocalSnapshotError> {
+    let text = std::str::from_utf8(output).map_err(|_| LocalSnapshotError::new(code))?;
+    let text = text
+        .strip_suffix('\n')
+        .and_then(|line| line.strip_suffix('\r').or(Some(line)))
+        .ok_or_else(|| LocalSnapshotError::new(code))?;
+    if text.is_empty() || text.contains(['\r', '\n', '\0']) {
+        return Err(LocalSnapshotError::new(code));
+    }
+    Ok(text)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrackedMode {
+    Regular,
+    Executable,
+    Symlink,
+}
+
+#[derive(Debug)]
+struct GitInventory {
+    paths: Vec<String>,
+    tracked_modes: BTreeMap<String, TrackedMode>,
+}
+
+fn parse_inventory(
+    state: &GitState,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    path_validator: RepositoryPathValidator,
+) -> Result<GitInventory, LocalSnapshotError> {
+    let tracked_modes = parse_index(&state.index, limits, path_validator)?;
+    let records = nul_records(&state.inventory)?;
+    if records.len() >= limits.maximum_entries() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let mut paths = BTreeSet::new();
+    for raw in records {
+        let path = parse_repository_path(raw, path_validator)?;
+        if !paths.insert(path) {
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+        }
+    }
+    Ok(GitInventory {
+        paths: paths.into_iter().collect(),
+        tracked_modes,
+    })
+}
+
+fn parse_index(
+    output: &[u8],
+    limits: RepositoryWorkflowDiscoveryLimits,
+    path_validator: RepositoryPathValidator,
+) -> Result<BTreeMap<String, TrackedMode>, LocalSnapshotError> {
+    let records = nul_records(output)?;
+    if records.len() > limits.maximum_entries() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let mut modes = BTreeMap::new();
+    for record in records {
+        let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+        };
+        let metadata = std::str::from_utf8(&record[..tab])
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput))?;
+        let (tag, metadata) = metadata
+            .split_once(' ')
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput))?;
+        if tag.len() != 1 {
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+        }
+        match tag.as_bytes()[0] {
+            b'H' => {}
+            b'S' | b's' => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::SparseCheckout,
+                ));
+            }
+            byte if byte.is_ascii_lowercase() => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::AssumeUnchanged,
+                ));
+            }
+            _ => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::IndexAmbiguity,
+                ));
+            }
+        }
+        let mut fields = metadata.split(' ');
+        let mode = fields
+            .next()
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput))?;
+        let object = fields
+            .next()
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput))?;
+        let stage = fields
+            .next()
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput))?;
+        if fields.next().is_some()
+            || !matches!(object.len(), 40 | 64)
+            || !object.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || stage != "0"
+        {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::IndexAmbiguity,
+            ));
+        }
+        let mode = match mode {
+            "100644" => TrackedMode::Regular,
+            "100755" => TrackedMode::Executable,
+            "120000" => TrackedMode::Symlink,
+            "160000" => {
+                return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::Submodule));
+            }
+            _ => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::IndexAmbiguity,
+                ));
+            }
+        };
+        let path = parse_repository_path(&record[tab + 1..], path_validator)?;
+        if modes.insert(path, mode).is_some() {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::IndexAmbiguity,
+            ));
+        }
+    }
+    Ok(modes)
+}
+
+fn nul_records(output: &[u8]) -> Result<Vec<&[u8]>, LocalSnapshotError> {
+    if output.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !output.ends_with(&[0]) {
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+    }
+    Ok(output[..output.len() - 1]
+        .split(|byte| *byte == 0)
+        .collect())
+}
+
+fn parse_repository_path(
+    raw: &[u8],
+    validator: RepositoryPathValidator,
+) -> Result<String, LocalSnapshotError> {
+    validator
+        .validate_entry(raw)
+        .map(str::to_owned)
+        .map_err(local_path_validation_error)
+}
+
+fn local_path_validation_error(error: RepositoryPathValidationError) -> LocalSnapshotError {
+    LocalSnapshotError::new(match error {
+        RepositoryPathValidationError::NonUnicode => LocalSnapshotErrorCode::NonUnicodePath,
+        RepositoryPathValidationError::ResourceLimit => LocalSnapshotErrorCode::ResourceLimit,
+        RepositoryPathValidationError::Unsafe => LocalSnapshotErrorCode::UnsafePath,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorktreeScanEntry {
+    path: String,
+    kind: WorktreeScanEntryKind,
+    stamp: MetadataStamp,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorktreeScanEntryKind {
+    Directory,
+    File,
+    Symlink,
+    Unsupported,
+}
+
+struct ScanDirectory {
+    handle: Dir,
+    path: Option<String>,
+}
+
+struct PinnedDirectory {
+    handle: Dir,
+    identity: DirectoryIdentity,
+}
+
+impl PinnedDirectory {
+    fn open(path: &Path) -> Result<Self, LocalSnapshotError> {
+        Self::open_for(path, LocalSnapshotErrorCode::NotGitWorktree)
+    }
+
+    fn open_for(path: &Path, failure: LocalSnapshotErrorCode) -> Result<Self, LocalSnapshotError> {
+        let handle = open_absolute_directory_nofollow(path, failure)?;
+        let opened = handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&opened, failure)?;
+        let identity = DirectoryIdentity::new(&opened);
+        let current_handle = open_absolute_directory_nofollow(path, failure)?;
+        let current = current_handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&current, failure)?;
+        if identity != DirectoryIdentity::new(&current) {
+            return Err(LocalSnapshotError::new(failure));
+        }
+        Ok(Self { handle, identity })
+    }
+
+    fn verify_same_identity(
+        &self,
+        other: &Self,
+        failure: LocalSnapshotErrorCode,
+    ) -> Result<(), LocalSnapshotError> {
+        let own = self
+            .handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        let reported = other
+            .handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&own, failure)?;
+        require_directory(&reported, failure)?;
+        if DirectoryIdentity::new(&own) != self.identity
+            || DirectoryIdentity::new(&reported) != other.identity
+            || self.identity != other.identity
+        {
+            return Err(LocalSnapshotError::new(failure));
+        }
+        Ok(())
+    }
+
+    fn verify_descendant(
+        &self,
+        components: &[String],
+        expected: &Self,
+        failure: LocalSnapshotErrorCode,
+    ) -> Result<(), LocalSnapshotError> {
+        let mut current = self.clone_handle(failure)?;
+        for component in components {
+            let before = current
+                .symlink_metadata(component)
+                .map_err(|_| LocalSnapshotError::new(failure))?;
+            require_directory(&before, failure)?;
+            let child = current
+                .open_dir_nofollow(component)
+                .map_err(|_| LocalSnapshotError::new(failure))?;
+            let opened = child
+                .dir_metadata()
+                .map_err(|_| LocalSnapshotError::new(failure))?;
+            require_directory(&opened, failure)?;
+            if DirectoryIdentity::new(&before) != DirectoryIdentity::new(&opened) {
+                return Err(LocalSnapshotError::new(failure));
+            }
+            current = child;
+        }
+        let resolved = Self {
+            identity: DirectoryIdentity::new(
+                &current
+                    .dir_metadata()
+                    .map_err(|_| LocalSnapshotError::new(failure))?,
+            ),
+            handle: current,
+        };
+        self.verify_handle_identity(failure)?;
+        expected.verify_same_identity(&resolved, failure)
+    }
+
+    fn verify_handle_identity(
+        &self,
+        failure: LocalSnapshotErrorCode,
+    ) -> Result<(), LocalSnapshotError> {
+        let metadata = self
+            .handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&metadata, failure)?;
+        if DirectoryIdentity::new(&metadata) != self.identity {
+            return Err(LocalSnapshotError::new(failure));
+        }
+        Ok(())
+    }
+
+    fn verify_ambient_path(&self, path: &Path) -> Result<(), LocalSnapshotError> {
+        self.verify_ambient_path_for(path, LocalSnapshotErrorCode::ConcurrentMutation)
+    }
+
+    fn verify_ambient_path_for(
+        &self,
+        path: &Path,
+        failure: LocalSnapshotErrorCode,
+    ) -> Result<(), LocalSnapshotError> {
+        let opened = self
+            .handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&opened, failure)?;
+        let current_handle = open_absolute_directory_nofollow(path, failure)?;
+        let current = current_handle
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&current, failure)?;
+        if DirectoryIdentity::new(&current) != self.identity
+            || DirectoryIdentity::new(&opened) != self.identity
+        {
+            return Err(LocalSnapshotError::new(failure));
+        }
+        Ok(())
+    }
+
+    fn root_handle(&self) -> Result<Dir, LocalSnapshotError> {
+        self.clone_handle(LocalSnapshotErrorCode::ConcurrentMutation)
+    }
+
+    fn clone_handle(&self, failure: LocalSnapshotErrorCode) -> Result<Dir, LocalSnapshotError> {
+        self.handle
+            .try_clone()
+            .map_err(|_| LocalSnapshotError::new(failure))
+    }
+
+    fn locate_parent<'a>(
+        &self,
+        path: &'a str,
+    ) -> Result<Option<(Dir, &'a str)>, LocalSnapshotError> {
+        let mut components = path.split('/').peekable();
+        let mut current = self.root_handle()?;
+        while let Some(component) = components.next() {
+            if components.peek().is_none() {
+                return Ok(Some((current, component)));
+            }
+            let before = match current.symlink_metadata(component) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+                Err(_) => {
+                    return Err(LocalSnapshotError::new(
+                        LocalSnapshotErrorCode::ConcurrentMutation,
+                    ));
+                }
+            };
+            require_directory(&before, LocalSnapshotErrorCode::UnsafeAncestor)?;
+            let child = current
+                .open_dir_nofollow(component)
+                .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+            let opened = child
+                .dir_metadata()
+                .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+            require_directory(&opened, LocalSnapshotErrorCode::UnsafeAncestor)?;
+            if DirectoryIdentity::new(&before) != DirectoryIdentity::new(&opened) {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::ConcurrentMutation,
+                ));
+            }
+            current = child;
+        }
+        Err(LocalSnapshotError::new(LocalSnapshotErrorCode::UnsafePath))
+    }
+}
+
+struct GitAuthority {
+    worktree_path: PathBuf,
+    git_directory_path: PathBuf,
+    common_directory_path: PathBuf,
+    worktree: PinnedDirectory,
+    git_directory: PinnedDirectory,
+    common_directory: PinnedDirectory,
+    locator: GitLocator,
+}
+
+impl GitAuthority {
+    fn pin(
+        coordinates: GitCoordinates,
+        requested: &PinnedDirectory,
+    ) -> Result<Self, LocalSnapshotError> {
+        let worktree = PinnedDirectory::open(&coordinates.worktree_root)?;
+        worktree.verify_descendant(
+            &coordinates.prefix,
+            requested,
+            LocalSnapshotErrorCode::NotGitWorktree,
+        )?;
+        let git_directory = PinnedDirectory::open(&coordinates.git_directory)?;
+        let common_directory = PinnedDirectory::open(&coordinates.common_directory)?;
+        let locator = GitLocator::pin(&worktree, &git_directory, &common_directory)?;
+        let authority = Self {
+            worktree_path: coordinates.worktree_root,
+            git_directory_path: coordinates.git_directory,
+            common_directory_path: coordinates.common_directory,
+            worktree,
+            git_directory,
+            common_directory,
+            locator,
+        };
+        authority.verify(LocalSnapshotErrorCode::NotGitWorktree)?;
+        Ok(authority)
+    }
+
+    fn verify(&self, failure: LocalSnapshotErrorCode) -> Result<(), LocalSnapshotError> {
+        self.worktree
+            .verify_ambient_path_for(&self.worktree_path, failure)?;
+        self.locator.verify(&self.worktree, failure)?;
+        self.git_directory
+            .verify_ambient_path_for(&self.git_directory_path, failure)?;
+        self.common_directory
+            .verify_ambient_path_for(&self.common_directory_path, failure)
+    }
+}
+
+enum GitLocator {
+    Directory(PinnedDirectory),
+    LinkedWorktreeFile(GitFileEvidence),
+}
+
+impl GitLocator {
+    fn pin(
+        worktree: &PinnedDirectory,
+        git_directory: &PinnedDirectory,
+        common_directory: &PinnedDirectory,
+    ) -> Result<Self, LocalSnapshotError> {
+        let metadata = worktree
+            .handle
+            .symlink_metadata(".git")
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
+        require_no_windows_reparse(&metadata)?;
+        if metadata.is_dir() {
+            let directory = open_git_locator_directory(
+                worktree,
+                &metadata,
+                LocalSnapshotErrorCode::NotGitWorktree,
+            )?;
+            directory
+                .verify_same_identity(git_directory, LocalSnapshotErrorCode::NotGitWorktree)?;
+            git_directory
+                .verify_same_identity(common_directory, LocalSnapshotErrorCode::NotGitWorktree)?;
+            return Ok(Self::Directory(directory));
+        }
+        if !metadata.is_file() {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::NotGitWorktree,
+            ));
+        }
+        let evidence = capture_git_file(worktree, LocalSnapshotErrorCode::NotGitWorktree)?;
+        let target = parse_git_file_target(&evidence.bytes)?;
+        let target_directory = PinnedDirectory::open(&target)?;
+        target_directory
+            .verify_same_identity(git_directory, LocalSnapshotErrorCode::NotGitWorktree)?;
+        git_directory.verify_handle_identity(LocalSnapshotErrorCode::NotGitWorktree)?;
+        common_directory.verify_handle_identity(LocalSnapshotErrorCode::NotGitWorktree)?;
+        if git_directory.identity == common_directory.identity {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::NotGitWorktree,
+            ));
+        }
+        Ok(Self::LinkedWorktreeFile(evidence))
+    }
+
+    fn verify(
+        &self,
+        worktree: &PinnedDirectory,
+        failure: LocalSnapshotErrorCode,
+    ) -> Result<(), LocalSnapshotError> {
+        match self {
+            Self::Directory(expected) => {
+                let metadata = worktree
+                    .handle
+                    .symlink_metadata(".git")
+                    .map_err(|_| LocalSnapshotError::new(failure))?;
+                require_no_windows_reparse(&metadata)?;
+                if !metadata.is_dir() {
+                    return Err(LocalSnapshotError::new(failure));
+                }
+                let current = open_git_locator_directory(worktree, &metadata, failure)?;
+                expected.verify_same_identity(&current, failure)
+            }
+            Self::LinkedWorktreeFile(expected) => {
+                let current = capture_git_file(worktree, failure)?;
+                if &current != expected {
+                    return Err(LocalSnapshotError::new(failure));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct GitFileEvidence {
+    stamp: MetadataStamp,
+    bytes: Vec<u8>,
+}
+
+fn open_git_locator_directory(
+    worktree: &PinnedDirectory,
+    before: &Metadata,
+    failure: LocalSnapshotErrorCode,
+) -> Result<PinnedDirectory, LocalSnapshotError> {
+    require_directory(before, failure)?;
+    let handle = worktree
+        .handle
+        .open_dir_nofollow(".git")
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    let opened = handle
+        .dir_metadata()
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    require_directory(&opened, failure)?;
+    let identity = DirectoryIdentity::new(&opened);
+    if identity != DirectoryIdentity::new(before) {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    Ok(PinnedDirectory { handle, identity })
+}
+
+fn capture_git_file(
+    worktree: &PinnedDirectory,
+    failure: LocalSnapshotErrorCode,
+) -> Result<GitFileEvidence, LocalSnapshotError> {
+    let before = worktree
+        .handle
+        .symlink_metadata(".git")
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    require_no_windows_reparse(&before)?;
+    if !before.is_file() {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    let stamp = MetadataStamp::new(&before);
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options.follow(FollowSymlinks::No);
+    let mut file = worktree
+        .handle
+        .open_with(".git", &options)
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    let opened = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    require_no_windows_reparse(&opened)?;
+    if !opened.is_file() || MetadataStamp::new(&opened) != stamp {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    let maximum = u64::try_from(MAX_GIT_LOCATOR_BYTES)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(maximum + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    if bytes.len() > MAX_GIT_LOCATOR_BYTES {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let opened_after = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    let ambient_after = worktree
+        .handle
+        .symlink_metadata(".git")
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    require_no_windows_reparse(&opened_after)?;
+    require_no_windows_reparse(&ambient_after)?;
+    if !opened_after.is_file()
+        || !ambient_after.is_file()
+        || MetadataStamp::new(&opened_after) != stamp
+        || MetadataStamp::new(&ambient_after) != stamp
+    {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    Ok(GitFileEvidence { stamp, bytes })
+}
+
+fn parse_git_file_target(bytes: &[u8]) -> Result<PathBuf, LocalSnapshotError> {
+    let line = parse_one_git_line(bytes, LocalSnapshotErrorCode::NotGitWorktree)?;
+    let target = line
+        .strip_prefix("gitdir: ")
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
+    parse_git_coordinate_path(target)
+}
+
+fn open_absolute_directory_nofollow(
+    path: &Path,
+    failure: LocalSnapshotErrorCode,
+) -> Result<Dir, LocalSnapshotError> {
+    if !path.is_absolute() {
+        return Err(LocalSnapshotError::new(failure));
+    }
+    let anchor = path
+        .ancestors()
+        .last()
+        .filter(|ancestor| ancestor.has_root())
+        .ok_or_else(|| LocalSnapshotError::new(failure))?;
+    let relative = path
+        .strip_prefix(anchor)
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    let ambient = fs::symlink_metadata(anchor).map_err(|_| LocalSnapshotError::new(failure))?;
+    require_ambient_directory(&ambient, failure)?;
+    let mut current = Dir::open_ambient_dir(anchor, ambient_authority())
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    let opened = current
+        .dir_metadata()
+        .map_err(|_| LocalSnapshotError::new(failure))?;
+    require_directory(&opened, failure)?;
+    let confirmed = Dir::open_ambient_dir(anchor, ambient_authority())
+        .and_then(|directory| directory.dir_metadata())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    require_directory(&confirmed, failure)?;
+    if DirectoryIdentity::new(&opened) != DirectoryIdentity::new(&confirmed) {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+
+    for component in relative.components() {
+        let std::path::Component::Normal(name) = component else {
+            return Err(LocalSnapshotError::new(failure));
+        };
+        let component_path = Path::new(name);
+        let before = current
+            .symlink_metadata(component_path)
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&before, LocalSnapshotErrorCode::UnsafeAncestor)?;
+        let child = current
+            .open_dir_nofollow(component_path)
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        let after = child
+            .dir_metadata()
+            .map_err(|_| LocalSnapshotError::new(failure))?;
+        require_directory(&after, LocalSnapshotErrorCode::UnsafeAncestor)?;
+        if DirectoryIdentity::new(&before) != DirectoryIdentity::new(&after) {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ConcurrentMutation,
+            ));
+        }
+        current = child;
+    }
+    Ok(current)
+}
+
+fn require_directory(
+    metadata: &Metadata,
+    code: LocalSnapshotErrorCode,
+) -> Result<(), LocalSnapshotError> {
+    require_no_windows_reparse(metadata)?;
+    if !metadata.is_dir() {
+        return Err(LocalSnapshotError::new(code));
+    }
+    Ok(())
+}
+
+fn require_ambient_directory(
+    metadata: &fs::Metadata,
+    code: LocalSnapshotErrorCode,
+) -> Result<(), LocalSnapshotError> {
+    require_no_ambient_windows_reparse(metadata)?;
+    if !metadata.is_dir() {
+        return Err(LocalSnapshotError::new(code));
+    }
+    Ok(())
+}
+
+async fn scan_worktree(
+    git: &Path,
+    authority: &GitAuthority,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    path_validator: RepositoryPathValidator,
+) -> Result<Vec<WorktreeScanEntry>, LocalSnapshotError> {
+    let maximum_observed = limits.maximum_path_graph_nodes();
+    let mut observed = 0_usize;
+    let mut directories = vec![ScanDirectory {
+        handle: authority.worktree.root_handle()?,
+        path: None,
+    }];
+    let mut scanned = Vec::new();
+    while let Some(directory) = directories.pop() {
+        let children = directory
+            .handle
+            .entries()
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+        for child in children {
+            let child = child
+                .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+            let name = child.file_name();
+            if directory.path.is_none() && name == std::ffi::OsStr::new(".git") {
+                continue;
+            }
+            observed = observed
+                .checked_add(1)
+                .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+            if observed > maximum_observed {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::ResourceLimit,
+                ));
+            }
+            let name_text = name
+                .to_str()
+                .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::NonUnicodePath))?;
+            let path = directory.path.as_ref().map_or_else(
+                || name_text.to_owned(),
+                |parent| format!("{parent}/{name_text}"),
+            );
+            let metadata = directory
+                .handle
+                .symlink_metadata(&name)
+                .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+            require_no_windows_reparse(&metadata)?;
+            validate_scanned_path(&path, &metadata, path_validator)?;
+            let file_type = metadata.file_type();
+            let stamp = MetadataStamp::new(&metadata);
+            let kind = if file_type.is_dir() {
+                let child = directory.handle.open_dir_nofollow(&name).map_err(|_| {
+                    LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation)
+                })?;
+                let opened = child.dir_metadata().map_err(|_| {
+                    LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation)
+                })?;
+                require_directory(&opened, LocalSnapshotErrorCode::UnsafeAncestor)?;
+                if DirectoryIdentity::new(&opened) != DirectoryIdentity::new(&metadata) {
+                    return Err(LocalSnapshotError::new(
+                        LocalSnapshotErrorCode::ConcurrentMutation,
+                    ));
+                }
+                directories.push(ScanDirectory {
+                    handle: child,
+                    path: Some(path.clone()),
+                });
+                WorktreeScanEntryKind::Directory
+            } else if file_type.is_file() {
+                WorktreeScanEntryKind::File
+            } else if file_type.is_symlink() {
+                WorktreeScanEntryKind::Symlink
+            } else {
+                WorktreeScanEntryKind::Unsupported
+            };
+            scanned.push(WorktreeScanEntry { path, kind, stamp });
+        }
+    }
+    scanned.sort_by(|left, right| left.path.cmp(&right.path));
+    let ignored = ignored_paths(git, authority, &scanned, limits).await?;
+    scanned.retain(|entry| !ignored.contains(&entry.path));
+    if scanned
+        .iter()
+        .any(|entry| entry.kind == WorktreeScanEntryKind::Unsupported)
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::UnsupportedEntry,
+        ));
+    }
+    Ok(scanned)
+}
+
+fn validate_scanned_path(
+    path: &str,
+    metadata: &Metadata,
+    validator: RepositoryPathValidator,
+) -> Result<(), LocalSnapshotError> {
+    if metadata.is_dir() {
+        validator
+            .validate_entry_ancestor(path.as_bytes())
+            .map_err(local_path_validation_error)?;
+    } else {
+        parse_repository_path(path.as_bytes(), validator)?;
+    }
+    Ok(())
+}
+
+async fn ignored_paths(
+    git: &Path,
+    authority: &GitAuthority,
+    scanned: &[WorktreeScanEntry],
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<BTreeSet<String>, LocalSnapshotError> {
+    if scanned.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let mut input = Vec::new();
+    let maximum_input_bytes = checked_output_limit(limits, 1)?;
+    for entry in scanned {
+        let next_length = input
+            .len()
+            .checked_add(entry.path.len())
+            .and_then(|length| length.checked_add(1))
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+        if next_length > maximum_input_bytes {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ResourceLimit,
+            ));
+        }
+        input.extend_from_slice(entry.path.as_bytes());
+        input.push(0);
+    }
+    let output = capture_bound_git_with_input(
+        git,
+        authority,
+        &["check-ignore", "--stdin", "-z"],
+        &input,
+        input.len(),
+        true,
+    )
+    .await?;
+    let candidates = scanned
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut ignored = BTreeSet::new();
+    for raw in nul_records(&output)? {
+        let path = std::str::from_utf8(raw)
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NonUnicodePath))?;
+        if !candidates.contains(path) || !ignored.insert(path.to_owned()) {
+            return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitOutput));
+        }
+    }
+    Ok(ignored)
+}
+
+#[derive(Debug)]
+struct CapturedInventory {
+    entries: Vec<CapturedEntry>,
+    deleted_paths: Vec<String>,
+    expanded_bytes: u64,
+}
+
+#[derive(Debug)]
+struct CapturedEntry {
+    path: String,
+    payload: CapturedPayload,
+}
+
+#[derive(Debug)]
+enum CapturedPayload {
+    File { bytes: Vec<u8>, executable: bool },
+    Symlink { target: String },
+}
+
+fn capture_entries(
+    worktree: &PinnedDirectory,
+    inventory: &GitInventory,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    path_validator: RepositoryPathValidator,
+) -> Result<CapturedInventory, LocalSnapshotError> {
+    let mut entries = Vec::with_capacity(inventory.paths.len());
+    let mut deleted_paths = Vec::new();
+    let mut expanded_bytes = 0_u64;
+    for path in &inventory.paths {
+        let tracked = inventory.tracked_modes.get(path).copied();
+        let Some((parent, name)) = worktree.locate_parent(path)? else {
+            if tracked.is_some() {
+                deleted_paths.push(path.clone());
+                continue;
+            }
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ConcurrentMutation,
+            ));
+        };
+        let before = match parent.symlink_metadata(name) {
+            Ok(metadata) => metadata,
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound
+                    && inventory.tracked_modes.contains_key(path) =>
+            {
+                deleted_paths.push(path.clone());
+                continue;
+            }
+            Err(_) => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::ConcurrentMutation,
+                ));
+            }
+        };
+        require_no_windows_reparse(&before)?;
+        let before_stamp = MetadataStamp::new(&before);
+        let payload = match tracked {
+            Some(TrackedMode::Symlink) if before.file_type().is_symlink() => {
+                capture_filesystem_symlink(&parent, name, path_validator)?
+            }
+            Some(TrackedMode::Symlink) if before.is_file() => {
+                capture_symlink_placeholder(&parent, name, &before, before_stamp, path_validator)?
+            }
+            Some(TrackedMode::Symlink) => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::UnsupportedEntry,
+                ));
+            }
+            Some(TrackedMode::Regular | TrackedMode::Executable)
+                if before.file_type().is_symlink() =>
+            {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::IndexAmbiguity,
+                ));
+            }
+            _ if before.file_type().is_symlink() => {
+                capture_filesystem_symlink(&parent, name, path_validator)?
+            }
+            _ if before.is_file() => {
+                let remaining = limits
+                    .maximum_expanded_bytes()
+                    .checked_sub(expanded_bytes)
+                    .ok_or_else(|| {
+                        LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit)
+                    })?;
+                let (payload, read_bytes) =
+                    capture_regular_file(&parent, name, &before, before_stamp, remaining, tracked)?;
+                expanded_bytes = expanded_bytes.checked_add(read_bytes).ok_or_else(|| {
+                    LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit)
+                })?;
+                payload
+            }
+            _ => {
+                return Err(LocalSnapshotError::new(
+                    LocalSnapshotErrorCode::UnsupportedEntry,
+                ));
+            }
+        };
+        let after = parent
+            .symlink_metadata(name)
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+        require_no_windows_reparse(&after)?;
+        if MetadataStamp::new(&after) != before_stamp {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ConcurrentMutation,
+            ));
+        }
+        entries.push(CapturedEntry {
+            path: path.clone(),
+            payload,
+        });
+    }
+    Ok(CapturedInventory {
+        entries,
+        deleted_paths,
+        expanded_bytes,
+    })
+}
+
+fn capture_regular_file(
+    parent: &Dir,
+    name: &str,
+    before: &Metadata,
+    before_stamp: MetadataStamp,
+    remaining: u64,
+    tracked: Option<TrackedMode>,
+) -> Result<(CapturedPayload, u64), LocalSnapshotError> {
+    if before.len() > remaining {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let mut file = open_regular_nofollow(parent, name)?;
+    let opened = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    if !opened.is_file() || MetadataStamp::new(&opened) != before_stamp {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    let maximum_read = remaining
+        .checked_add(1)
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    let mut bytes = Vec::with_capacity(
+        usize::try_from(before.len())
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?,
+    );
+    std::io::Read::by_ref(&mut file)
+        .take(maximum_read)
+        .read_to_end(&mut bytes)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    let read_bytes = u64::try_from(bytes.len())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    if read_bytes > remaining {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let after_open = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    if MetadataStamp::new(&after_open) != before_stamp {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    Ok((
+        CapturedPayload::File {
+            bytes,
+            executable: executable(before, tracked),
+        },
+        read_bytes,
+    ))
+}
+
+fn capture_filesystem_symlink(
+    parent: &Dir,
+    name: &str,
+    validator: RepositoryPathValidator,
+) -> Result<CapturedPayload, LocalSnapshotError> {
+    let target = parent
+        .read_link_contents(name)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    let target = target
+        .to_str()
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::NonUnicodePath))?;
+    captured_symlink(target.as_bytes(), validator)
+}
+
+fn capture_symlink_placeholder(
+    parent: &Dir,
+    name: &str,
+    before: &Metadata,
+    before_stamp: MetadataStamp,
+    validator: RepositoryPathValidator,
+) -> Result<CapturedPayload, LocalSnapshotError> {
+    let mut file = open_regular_nofollow(parent, name)?;
+    let opened = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    if !opened.is_file() || MetadataStamp::new(&opened) != before_stamp {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    let maximum = u64::try_from(automata_ci_workflow_github::USTAR_LINK_NAME_BYTES)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(maximum + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    if bytes.len() > automata_ci_workflow_github::USTAR_LINK_NAME_BYTES {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let after = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    if MetadataStamp::new(&after) != before_stamp || before.len() != after.len() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    captured_symlink(&bytes, validator)
+}
+
+fn captured_symlink(
+    raw_target: &[u8],
+    validator: RepositoryPathValidator,
+) -> Result<CapturedPayload, LocalSnapshotError> {
+    let target = validator
+        .validate_symlink_target(raw_target)
+        .map_err(local_link_validation_error)?;
+    Ok(CapturedPayload::Symlink {
+        target: target.to_owned(),
+    })
+}
+
+fn local_link_validation_error(error: RepositoryPathValidationError) -> LocalSnapshotError {
+    LocalSnapshotError::new(match error {
+        RepositoryPathValidationError::NonUnicode => LocalSnapshotErrorCode::NonUnicodePath,
+        RepositoryPathValidationError::ResourceLimit => LocalSnapshotErrorCode::ResourceLimit,
+        RepositoryPathValidationError::Unsafe => LocalSnapshotErrorCode::UnsafeSymlink,
+    })
+}
+
+fn workflow_location(
+    entries: &[CapturedEntry],
+) -> Result<Option<RepositoryWorkflowLocation>, LocalSnapshotError> {
+    let mut automata = false;
+    let mut github = false;
+    for entry in entries {
+        let mut components = entry.path.split('/');
+        match (components.next(), components.next()) {
+            (Some(".ci"), Some("workflows")) => automata = true,
+            (Some(".github"), Some("workflows")) => github = true,
+            _ => {}
+        }
+    }
+    match (automata, github) {
+        (true, true) => Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::AmbiguousWorkflowLocation,
+        )),
+        (true, false) => Ok(Some(RepositoryWorkflowLocation::Automata)),
+        (false, true) => Ok(Some(RepositoryWorkflowLocation::Github)),
+        (false, false) => Ok(None),
+    }
+}
+
+fn verify_git_state(initial: &GitState, final_state: &GitState) -> Result<(), LocalSnapshotError> {
+    if initial.head != final_state.head
+        || initial.index != final_state.index
+        || initial.inventory != final_state.inventory
+        || initial.status != final_state.status
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    Ok(())
+}
+
+fn verify_deleted_paths(
+    worktree: &PinnedDirectory,
+    deleted_paths: &[String],
+) -> Result<(), LocalSnapshotError> {
+    for path in deleted_paths {
+        if let Some((parent, name)) = worktree.locate_parent(path)? {
+            match parent.symlink_metadata(name) {
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                _ => {
+                    return Err(LocalSnapshotError::new(
+                        LocalSnapshotErrorCode::ConcurrentMutation,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn build_archive(
+    entries: &[CapturedEntry],
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<Vec<u8>, LocalSnapshotError> {
+    if entries.len() >= limits.maximum_entries() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    let maximum_archive_bytes = usize::try_from(limits.maximum_compressed_bytes())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    let compressed = Vec::with_capacity(maximum_archive_bytes.min(64 * 1_024));
+    let writer = BoundedWriter::new(compressed, maximum_archive_bytes);
+    let encoder = GzBuilder::new()
+        .mtime(0)
+        .operating_system(255)
+        .write(writer, Compression::new(6));
+    let maximum_decompressed_bytes = usize::try_from(limits.maximum_decompressed_bytes())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+    let writer = BoundedWriter::new(encoder, maximum_decompressed_bytes);
+    let mut archive = TarBuilder::new(writer);
+    append_root(&mut archive).map_err(|error| archive_error(&error))?;
+    for entry in entries {
+        append_entry(&mut archive, entry).map_err(|error| archive_error(&error))?;
+    }
+    let writer = archive
+        .into_inner()
+        .map_err(|error| archive_error(&error))?;
+    let encoder = writer.into_inner();
+    let writer = encoder.finish().map_err(|error| archive_error(&error))?;
+    Ok(writer.into_inner())
+}
+
+fn append_root<W: Write>(archive: &mut TarBuilder<W>) -> io::Result<()> {
+    let mut header = deterministic_header(EntryType::Directory, 0, 0o755);
+    header.set_path(SNAPSHOT_ROOT)?;
+    header.set_cksum();
+    archive.append(&header, io::empty())
+}
+
+fn append_entry<W: Write>(archive: &mut TarBuilder<W>, entry: &CapturedEntry) -> io::Result<()> {
+    let archive_path = format!("{SNAPSHOT_ROOT}/{}", entry.path);
+    match &entry.payload {
+        CapturedPayload::File { bytes, executable } => {
+            let size = u64::try_from(bytes.len())
+                .map_err(|_| io::Error::from(io::ErrorKind::FileTooLarge))?;
+            let mode = if *executable { 0o755 } else { 0o644 };
+            let mut header = deterministic_header(EntryType::Regular, size, mode);
+            header.set_path(archive_path)?;
+            header.set_cksum();
+            archive.append(&header, Cursor::new(bytes))
+        }
+        CapturedPayload::Symlink { target } => {
+            let mut header = deterministic_header(EntryType::Symlink, 0, 0o777);
+            header.set_path(archive_path)?;
+            header.set_link_name_literal(target.as_bytes())?;
+            header.set_cksum();
+            archive.append(&header, io::empty())
+        }
+    }
+}
+
+fn deterministic_header(entry_type: EntryType, size: u64, mode: u32) -> Header {
+    let mut header = Header::new_ustar();
+    header.set_entry_type(entry_type);
+    header.set_size(size);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header
+}
+
+fn archive_error(error: &io::Error) -> LocalSnapshotError {
+    LocalSnapshotError::new(if error.kind() == io::ErrorKind::FileTooLarge {
+        LocalSnapshotErrorCode::ResourceLimit
+    } else {
+        LocalSnapshotErrorCode::ArchiveEncoding
+    })
+}
+
+#[derive(Debug)]
+struct BoundedWriter<W> {
+    inner: W,
+    maximum_bytes: usize,
+    written_bytes: usize,
+}
+
+impl<W> BoundedWriter<W> {
+    const fn new(inner: W, maximum_bytes: usize) -> Self {
+        Self {
+            inner,
+            maximum_bytes,
+            written_bytes: 0,
+        }
+    }
+
+    fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for BoundedWriter<W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if buffer.len() > self.maximum_bytes.saturating_sub(self.written_bytes) {
+            return Err(io::Error::from(io::ErrorKind::FileTooLarge));
+        }
+        let written = self.inner.write(buffer)?;
+        self.written_bytes = self
+            .written_bytes
+            .checked_add(written)
+            .ok_or_else(|| io::Error::from(io::ErrorKind::FileTooLarge))?;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn git_inventory_output_limit(
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<usize, LocalSnapshotError> {
+    checked_output_limit(limits, 1)
+}
+
+fn git_index_output_limit(
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<usize, LocalSnapshotError> {
+    checked_output_limit(limits, 96)
+}
+
+fn git_status_output_limit(
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<usize, LocalSnapshotError> {
+    checked_output_limit(
+        limits,
+        limits
+            .maximum_entry_path_bytes()
+            .checked_add(256)
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?,
+    )
+}
+
+fn checked_output_limit(
+    limits: RepositoryWorkflowDiscoveryLimits,
+    overhead_per_entry: usize,
+) -> Result<usize, LocalSnapshotError> {
+    limits
+        .maximum_entry_path_bytes()
+        .checked_add(overhead_per_entry)
+        .and_then(|per_entry| per_entry.checked_mul(limits.maximum_entries()))
+        .and_then(|total| total.checked_add(1))
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))
+}
+
+fn open_regular_nofollow(parent: &Dir, name: &str) -> Result<File, LocalSnapshotError> {
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    configure_regular_open(&mut options);
+    let file = parent
+        .open_with(name, &options)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    require_no_windows_reparse(&metadata)?;
+    if !metadata.is_file() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ConcurrentMutation,
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn configure_regular_open(options: &mut OpenOptions) {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    let flags = i32::try_from(rustix::fs::OFlags::NONBLOCK.bits())
+        .expect("Unix nonblocking flag must fit c_int");
+    options.custom_flags(flags);
+}
+
+#[cfg(windows)]
+fn configure_regular_open(options: &mut OpenOptions) {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    options.share_mode(FILE_SHARE_READ);
+}
+
+fn executable(metadata: &Metadata, tracked: Option<TrackedMode>) -> bool {
+    tracked.map_or_else(
+        || untracked_executable(metadata),
+        |mode| mode == TrackedMode::Executable,
+    )
+}
+
+#[cfg(unix)]
+fn untracked_executable(metadata: &Metadata) -> bool {
+    use cap_std::fs::MetadataExt as _;
+
+    metadata.mode() & 0o111 != 0
+}
+
+#[cfg(windows)]
+const fn untracked_executable(_metadata: &Metadata) -> bool {
+    false
+}
+
+fn require_no_windows_reparse(metadata: &Metadata) -> Result<(), LocalSnapshotError> {
+    if metadata_is_windows_reparse(metadata) {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::UnsupportedEntry,
+        ));
+    }
+    Ok(())
+}
+
+fn require_no_ambient_windows_reparse(metadata: &fs::Metadata) -> Result<(), LocalSnapshotError> {
+    if ambient_metadata_is_windows_reparse(metadata) {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::UnsupportedEntry,
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+const fn metadata_is_windows_reparse(_metadata: &Metadata) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn metadata_is_windows_reparse(metadata: &Metadata) -> bool {
+    use cap_std::fs::MetadataExt as _;
+
+    windows_reparse_attributes(metadata.file_attributes())
+}
+
+#[cfg(unix)]
+const fn ambient_metadata_is_windows_reparse(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn ambient_metadata_is_windows_reparse(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+
+    windows_reparse_attributes(metadata.file_attributes())
+}
+
+#[cfg(any(test, windows))]
+const fn windows_reparse_attributes(attributes: u32) -> bool {
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DirectoryIdentity {
+    device: u64,
+    inode: u64,
+}
+
+impl DirectoryIdentity {
+    fn new(metadata: &Metadata) -> Self {
+        use cap_fs_ext::MetadataExt as _;
+
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MetadataStamp {
+    device: u64,
+    inode: u64,
+    mode: u32,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
+
+#[cfg(unix)]
+impl MetadataStamp {
+    fn new(metadata: &Metadata) -> Self {
+        use cap_std::fs::MetadataExt as _;
+
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            mode: metadata.mode(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MetadataStamp {
+    device: u64,
+    inode: u64,
+    attributes: u32,
+    created: u64,
+    modified: u64,
+    length: u64,
+}
+
+#[cfg(windows)]
+impl MetadataStamp {
+    fn new(metadata: &Metadata) -> Self {
+        use cap_fs_ext::MetadataExt as _;
+        use cap_std::fs::MetadataExt as _;
+
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            attributes: metadata.file_attributes(),
+            created: metadata.creation_time(),
+            modified: metadata.last_write_time(),
+            length: metadata.file_size(),
+        }
+    }
+}
+
+/// Stable fail-closed class for local snapshot construction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum LocalSnapshotErrorCode {
+    /// The Git executable was unavailable.
+    GitUnavailable,
+    /// Git did not complete a required read-only query.
+    GitCommand,
+    /// A Git query exceeded its deadline.
+    GitTimeout,
+    /// Git emitted a malformed response.
+    GitOutput,
+    /// The requested directory did not resolve to one pinned worktree and Git authority.
+    NotGitWorktree,
+    /// One path cannot be represented as deterministic UTF-8 archive evidence.
+    NonUnicodePath,
+    /// One repository-relative path is noncanonical or reserved.
+    UnsafePath,
+    /// The requested directory or one selected path has an unsafe ancestor.
+    UnsafeAncestor,
+    /// A symlink escapes, cycles, aliases a workflow namespace, or is nonportable.
+    UnsafeSymlink,
+    /// An index conflict or unsupported staged mode made the source ambiguous.
+    IndexAmbiguity,
+    /// A tracked entry was hidden from the live tree by sparse checkout.
+    SparseCheckout,
+    /// A tracked entry was marked assume-unchanged and could hide live bytes.
+    AssumeUnchanged,
+    /// Gitlinks are not accepted as sealed local source.
+    Submodule,
+    /// A requested ancestor or selected entry is a socket, device, FIFO,
+    /// Windows reparse point, or another unsafe filesystem type.
+    UnsupportedEntry,
+    /// Two selected paths differ only by case.
+    CaseCollision,
+    /// A selected file or link is also an ancestor of another selected path.
+    PathTypeConflict,
+    /// Both `.ci/workflows` and `.github/workflows` namespaces were present.
+    AmbiguousWorkflowLocation,
+    /// A pinned directory, Git authority, index, inventory, status, or `HEAD`
+    /// changed during capture.
+    ConcurrentMutation,
+    /// A configured entry, path, expanded-byte, command-output, or archive bound was exceeded.
+    ResourceLimit,
+    /// Deterministic tar.gz encoding failed.
+    ArchiveEncoding,
+    /// The retained archive failed the shared workflow discovery contract.
+    WorkflowDiscovery,
+}
+
+impl LocalSnapshotErrorCode {
+    /// Returns one sanitized actionable failure description.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::GitUnavailable => "install Git and make it available on PATH",
+            Self::GitCommand => "Git could not inspect the requested worktree",
+            Self::GitTimeout => "Git worktree inspection timed out",
+            Self::GitOutput => "Git returned an unsupported worktree response",
+            Self::NotGitWorktree => {
+                "run this command from one direct or standard linked Git worktree"
+            }
+            Self::NonUnicodePath => "the worktree contains a path that is not valid Unicode",
+            Self::UnsafePath => "the worktree contains a noncanonical or reserved path",
+            Self::UnsafeAncestor => {
+                "the requested directory or a selected path has an unsafe ancestor"
+            }
+            Self::UnsafeSymlink => "the worktree contains an escaping or unsafe symlink",
+            Self::IndexAmbiguity => "resolve the Git index conflict or unsupported staged mode",
+            Self::SparseCheckout => {
+                "disable sparse checkout before sealing an exact local snapshot"
+            }
+            Self::AssumeUnchanged => {
+                "clear every assume-unchanged index flag before sealing a local snapshot"
+            }
+            Self::Submodule => "local snapshots do not admit ambiguous submodule content",
+            Self::UnsupportedEntry => {
+                "the requested path or worktree contains a reparse point or unsupported entry"
+            }
+            Self::CaseCollision => "the Git inventory contains case-colliding paths",
+            Self::PathTypeConflict => {
+                "the Git inventory contains conflicting file and directory paths"
+            }
+            Self::AmbiguousWorkflowLocation => {
+                "keep workflows in exactly one of .github/workflows or .ci/workflows"
+            }
+            Self::ConcurrentMutation => {
+                "the worktree or Git authority changed while its snapshot was being sealed"
+            }
+            Self::ResourceLimit => "the worktree snapshot exceeds a configured resource limit",
+            Self::ArchiveEncoding => "the worktree could not be encoded deterministically",
+            Self::WorkflowDiscovery => "the sealed archive failed workflow discovery",
+        }
+    }
+}
+
+impl std::fmt::Display for LocalSnapshotErrorCode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.message())
+    }
+}
+
+/// Sanitized local snapshot failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("{code}")]
+pub struct LocalSnapshotError {
+    code: LocalSnapshotErrorCode,
+}
+
+impl LocalSnapshotError {
+    const fn new(code: LocalSnapshotErrorCode) -> Self {
+        Self { code }
+    }
+
+    /// Returns the stable failure class.
+    #[must_use]
+    pub const fn code(self) -> LocalSnapshotErrorCode {
+        self.code
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    };
+
+    use automata_ci_core::Sha256Digest;
+    use automata_ci_workflow_github::{
+        RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowLocation,
+    };
+    use flate2::read::MultiGzDecoder;
+    use sha2::{Digest as _, Sha256};
+    use uuid::Uuid;
+
+    #[cfg(unix)]
+    use super::capture_snapshot_with_git;
+    use super::{LocalSnapshotErrorCode, LocalSnapshotRequest, capture_snapshot};
+
+    const WORKFLOW: &str =
+        "on: push\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n";
+
+    #[tokio::test]
+    async fn clean_dirty_ignored_and_cloned_worktrees_have_deterministic_exact_archives() {
+        let fixture = Fixture::new();
+        fixture.write(".gitignore", "ignored/\n");
+        fixture.write(".github/workflows/ci.yml", WORKFLOW);
+        fixture.write("tracked.txt", "clean\n");
+        fixture.commit_all("initial");
+        let git_before = fixture.git_tree_evidence();
+
+        let clean = fixture.capture().await.expect("clean snapshot");
+        let repeated = fixture.capture().await.expect("repeated clean snapshot");
+        assert_eq!(clean.digest(), repeated.digest());
+        assert_eq!(clean.archive_bytes(), repeated.archive_bytes());
+        assert!(!clean.dirty());
+        assert_eq!(
+            clean.workflow_location(),
+            Some(RepositoryWorkflowLocation::Github)
+        );
+        assert_eq!(clean.workflows().len(), 1);
+        assert_eq!(clean.workflows()[0].path(), ".github/workflows/ci.yml");
+        assert_eq!(clean.workflows()[0].result().unwrap(), WORKFLOW.as_bytes());
+        assert_eq!(
+            clean.digest(),
+            Sha256Digest::from_bytes(Sha256::digest(clean.archive_bytes()).into())
+        );
+        assert_eq!(&clean.archive_bytes()[4..8], &[0, 0, 0, 0]);
+        assert_eq!(clean.archive_bytes()[9], 255);
+        assert_eq!(fixture.git_tree_evidence(), git_before);
+
+        let clone = Fixture::clone_from(fixture.path());
+        let cloned = clone.capture().await.expect("cloned clean snapshot");
+        assert_eq!(cloned.digest(), clean.digest());
+        assert_eq!(cloned.archive_bytes(), clean.archive_bytes());
+
+        fixture.write("tracked.txt", "dirty tracked bytes\n");
+        fixture.write("untracked.txt", "untracked bytes\n");
+        fixture.write("ignored/cache.bin", "ignored one\n");
+        let dirty = fixture.capture().await.expect("dirty snapshot");
+        let repeated_dirty = fixture.capture().await.expect("repeated dirty snapshot");
+        assert!(dirty.dirty());
+        assert_ne!(dirty.digest(), clean.digest());
+        assert_eq!(dirty.digest(), repeated_dirty.digest());
+        assert_eq!(dirty.archive_bytes(), repeated_dirty.archive_bytes());
+
+        fixture.write("ignored/cache.bin", "ignored content changed completely\n");
+        let ignored_change = fixture.capture().await.expect("ignored change snapshot");
+        assert_eq!(ignored_change.digest(), dirty.digest());
+        assert_eq!(ignored_change.archive_bytes(), dirty.archive_bytes());
+    }
+
+    #[tokio::test]
+    async fn requested_subdirectories_are_bound_to_the_reported_worktree_root() {
+        let fixture = Fixture::new();
+        fixture.write("nested/file.txt", "tracked\n");
+        fixture.commit_all("subdirectory invocation");
+
+        let root = fixture.capture().await.expect("root snapshot");
+        let nested = capture_snapshot(LocalSnapshotRequest::new(
+            fixture.path().join("nested"),
+            RepositoryWorkflowDiscoveryLimits::default(),
+        ))
+        .await
+        .expect("nested invocation");
+        assert_eq!(nested.root(), fixture.path());
+        assert_eq!(nested.archive_bytes(), root.archive_bytes());
+
+        let nested_repository = fixture.path().join("nested");
+        fixture.git(&["-C", "nested", "init", "--quiet"]);
+        fixture.git(&["-C", "nested", "config", "user.name", "Automata Test"]);
+        fixture.git(&[
+            "-C",
+            "nested",
+            "config",
+            "user.email",
+            "automata@example.invalid",
+        ]);
+        fixture.git(&["-C", "nested", "add", "--all"]);
+        fixture.git(&[
+            "-C",
+            "nested",
+            "commit",
+            "--quiet",
+            "--message",
+            "nested repository",
+        ]);
+        let nested_authority = capture_snapshot(LocalSnapshotRequest::new(
+            &nested_repository,
+            RepositoryWorkflowDiscoveryLimits::default(),
+        ))
+        .await
+        .expect("nested repository authority");
+        assert_eq!(nested_authority.root(), nested_repository);
+
+        fixture.git(&[
+            "-C",
+            "nested",
+            "config",
+            "core.worktree",
+            fixture.path().to_str().expect("Unicode fixture path"),
+        ]);
+        assert_eq!(
+            capture_snapshot(LocalSnapshotRequest::new(
+                &nested_repository,
+                RepositoryWorkflowDiscoveryLimits::default(),
+            ))
+            .await
+            .unwrap_err()
+            .code(),
+            LocalSnapshotErrorCode::NotGitWorktree
+        );
+
+        let redirected = Fixture::new();
+        let other_worktree = Fixture::new();
+        redirected.git(&[
+            "config",
+            "core.worktree",
+            other_worktree
+                .path()
+                .to_str()
+                .expect("Unicode fixture path"),
+        ]);
+        assert_eq!(
+            redirected.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::NotGitWorktree
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn git_locator_accepts_only_direct_or_linked_worktree_authority() {
+        use std::os::unix::fs::symlink;
+
+        let primary = Fixture::new();
+        primary.write("tracked.txt", "tracked\n");
+        primary.commit_all("linked worktree fixture");
+        let linked_root = std::env::temp_dir().join(format!(
+            "automata-local-snapshot-linked-{}",
+            Uuid::new_v4().simple()
+        ));
+        primary.git(&[
+            "worktree",
+            "add",
+            "--quiet",
+            linked_root.to_str().expect("Unicode fixture path"),
+            "HEAD",
+        ]);
+        let linked = Fixture { root: linked_root };
+        let linked_snapshot = linked.capture().await.expect("linked worktree snapshot");
+        assert_eq!(linked_snapshot.root(), linked.path());
+
+        let symlink_locator = Fixture::new();
+        symlink_locator.write("tracked.txt", "tracked\n");
+        symlink_locator.commit_all("symlink locator fixture");
+        fs::rename(
+            symlink_locator.path().join(".git"),
+            symlink_locator.path().join(".git-real"),
+        )
+        .expect("move Git directory");
+        symlink(".git-real", symlink_locator.path().join(".git"))
+            .expect("create Git locator symlink");
+        assert_eq!(
+            symlink_locator.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::NotGitWorktree
+        );
+
+        let separate_git_directory = Fixture::new();
+        separate_git_directory.write("tracked.txt", "tracked\n");
+        separate_git_directory.commit_all("separate Git directory fixture");
+        let storage = separate_git_directory.path().join(".git-storage");
+        fs::rename(separate_git_directory.path().join(".git"), &storage)
+            .expect("move separate Git directory");
+        fs::write(
+            separate_git_directory.path().join(".git"),
+            format!("gitdir: {}\n", storage.display()),
+        )
+        .expect("write separate Git locator");
+        assert_eq!(
+            separate_git_directory.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::NotGitWorktree
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn linked_worktree_gitfile_mutation_is_detected() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let primary = Fixture::new();
+        primary.write("tracked.txt", "tracked\n");
+        primary.commit_all("linked mutation fixture");
+        let linked_root = std::env::temp_dir().join(format!(
+            "automata-local-snapshot-linked-mutation-{}",
+            Uuid::new_v4().simple()
+        ));
+        primary.git(&[
+            "worktree",
+            "add",
+            "--quiet",
+            linked_root.to_str().expect("Unicode fixture path"),
+            "HEAD",
+        ]);
+        let linked = Fixture { root: linked_root };
+        let linked_wrapper = primary.path().join(".git/fake-linked-git");
+        fs::write(
+            &linked_wrapper,
+            format!(
+                "#!/bin/sh\nset -eu\ncase \" $* \" in\n  *' status '*)\n    git \"$@\"\n    result=$?\n    printf 'gitdir: %s\\n' '{}' > '{}'\n    exit \"$result\"\n    ;;\nesac\nexec git \"$@\"\n",
+                primary.path().join(".git").display(),
+                linked.path().join(".git").display()
+            ),
+        )
+        .expect("write linked-worktree Git wrapper");
+        fs::set_permissions(&linked_wrapper, fs::Permissions::from_mode(0o700))
+            .expect("make linked-worktree Git wrapper executable");
+        let linked_error = capture_snapshot_with_git(
+            LocalSnapshotRequest::new(linked.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            &linked_wrapper,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            linked_error.code(),
+            LocalSnapshotErrorCode::ConcurrentMutation
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn linked_worktree_git_directory_retargeting_is_detected() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let admin_primary = Fixture::new();
+        admin_primary.write("tracked.txt", "tracked\n");
+        admin_primary.commit_all("linked Git directory mutation fixture");
+        let admin_linked_root = std::env::temp_dir().join(format!(
+            "automata-local-snapshot-linked-admin-mutation-{}",
+            Uuid::new_v4().simple()
+        ));
+        admin_primary.git(&[
+            "worktree",
+            "add",
+            "--quiet",
+            admin_linked_root.to_str().expect("Unicode fixture path"),
+            "HEAD",
+        ]);
+        let admin_linked = Fixture {
+            root: admin_linked_root,
+        };
+        let admin_directory = PathBuf::from(admin_linked.git_stdout(&[
+            "rev-parse",
+            "--path-format=absolute",
+            "--absolute-git-dir",
+        ]));
+        let moved_admin_directory = admin_directory.with_extension("original");
+        let admin_wrapper = admin_primary.path().join(".git/fake-admin-git");
+        fs::write(
+            &admin_wrapper,
+            format!(
+                "#!/bin/sh\nset -eu\ncase \" $* \" in\n  *' status '*)\n    git \"$@\"\n    result=$?\n    mv '{}' '{}'\n    mkdir '{}'\n    exit \"$result\"\n    ;;\nesac\nexec git \"$@\"\n",
+                admin_directory.display(),
+                moved_admin_directory.display(),
+                admin_directory.display()
+            ),
+        )
+        .expect("write linked Git-directory wrapper");
+        fs::set_permissions(&admin_wrapper, fs::Permissions::from_mode(0o700))
+            .expect("make linked Git-directory wrapper executable");
+        let admin_error = capture_snapshot_with_git(
+            LocalSnapshotRequest::new(
+                admin_linked.path(),
+                RepositoryWorkflowDiscoveryLimits::default(),
+            ),
+            &admin_wrapper,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            admin_error.code(),
+            LocalSnapshotErrorCode::ConcurrentMutation
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn direct_worktree_git_directory_retargeting_is_detected() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let direct = Fixture::new();
+        direct.write("tracked.txt", "tracked\n");
+        direct.commit_all("directory mutation fixture");
+        let direct_wrapper = direct.path().join(".git/fake-direct-git");
+        fs::write(
+            &direct_wrapper,
+            format!(
+                "#!/bin/sh\nset -eu\ncase \" $* \" in\n  *' status '*)\n    git \"$@\"\n    result=$?\n    mv '{}' '{}'\n    mkdir '{}'\n    exit \"$result\"\n    ;;\nesac\nexec git \"$@\"\n",
+                direct.path().join(".git").display(),
+                direct.path().join(".git-original").display(),
+                direct.path().join(".git").display()
+            ),
+        )
+        .expect("write direct-worktree Git wrapper");
+        fs::set_permissions(&direct_wrapper, fs::Permissions::from_mode(0o700))
+            .expect("make direct-worktree Git wrapper executable");
+        let direct_error = capture_snapshot_with_git(
+            LocalSnapshotRequest::new(direct.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            &direct_wrapper,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            direct_error.code(),
+            LocalSnapshotErrorCode::ConcurrentMutation
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn caller_symlink_ancestor_is_rejected_before_git_runs() {
+        use std::os::unix::fs::symlink;
+
+        let repository = Fixture::new();
+        repository.write("nested/tracked", "tracked\n");
+        repository.commit_all("caller symlink fixture");
+        let alias_host = Fixture::new();
+        symlink(repository.path(), alias_host.path().join("alias"))
+            .expect("create caller path alias");
+
+        let error = capture_snapshot_with_git(
+            LocalSnapshotRequest::new(
+                alias_host.path().join("alias/nested"),
+                RepositoryWorkflowDiscoveryLimits::default(),
+            ),
+            Path::new("/definitely-not-an-automata-test-git"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code(), LocalSnapshotErrorCode::UnsafeAncestor);
+    }
+
+    #[tokio::test]
+    async fn live_worktree_bytes_and_deletions_win_over_index_content() {
+        let fixture = Fixture::new();
+        fixture.write(".github/workflows/ci.yml", WORKFLOW);
+        fixture.write("deleted.txt", "delete me\n");
+        fixture.write("staged.txt", "committed\n");
+        fixture.commit_all("initial");
+
+        fixture.write("staged.txt", "staged bytes\n");
+        fixture.git(&["add", "staged.txt"]);
+        fixture.write("staged.txt", "live bytes after staging\n");
+        fs::remove_file(fixture.path().join("deleted.txt")).expect("delete tracked file");
+
+        let snapshot = fixture.capture().await.expect("dirty source snapshot");
+        let files = archive_files(snapshot.archive_bytes());
+        assert_eq!(
+            files.get("staged.txt").unwrap(),
+            b"live bytes after staging\n"
+        );
+        assert!(!files.contains_key("deleted.txt"));
+        assert_eq!(
+            files.get(".github/workflows/ci.yml").unwrap(),
+            WORKFLOW.as_bytes()
+        );
+    }
+
+    #[tokio::test]
+    async fn sparse_and_assume_unchanged_index_flags_fail_closed_while_clean() {
+        let sparse = Fixture::new();
+        sparse.write("included/keep.txt", "keep\n");
+        sparse.write("excluded/hidden.txt", "hidden\n");
+        sparse.commit_all("sparse source");
+        sparse.git(&["sparse-checkout", "init", "--cone"]);
+        sparse.git(&["sparse-checkout", "set", "included"]);
+        assert!(!sparse.path().join("excluded/hidden.txt").exists());
+        assert_eq!(sparse.git_stdout(&["status", "--porcelain"]), "");
+        assert_eq!(
+            sparse.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::SparseCheckout
+        );
+
+        let assumed = Fixture::new();
+        assumed.write("tracked.txt", "committed\n");
+        assumed.commit_all("assume-unchanged source");
+        assumed.git(&["update-index", "--assume-unchanged", "tracked.txt"]);
+        assumed.write("tracked.txt", "live bytes hidden from status\n");
+        assert_eq!(assumed.git_stdout(&["status", "--porcelain"]), "");
+        assert_eq!(
+            assumed.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::AssumeUnchanged
+        );
+    }
+
+    #[tokio::test]
+    async fn case_collisions_and_dual_workflow_namespaces_fail_closed() {
+        let case_fixture = Fixture::new();
+        case_fixture.write("README", "upper\n");
+        case_fixture.write("readme", "lower\n");
+        case_fixture.commit_all("case collision");
+        assert_eq!(
+            case_fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::CaseCollision
+        );
+
+        let namespace_fixture = Fixture::new();
+        namespace_fixture.write(".github/workflows/ci.yml", WORKFLOW);
+        namespace_fixture.write(".ci/workflows/ci.yml", WORKFLOW);
+        namespace_fixture.commit_all("dual namespaces");
+        assert_eq!(
+            namespace_fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::AmbiguousWorkflowLocation
+        );
+
+        let automata_fixture = Fixture::new();
+        automata_fixture.write(".ci/workflows/ci.yml", WORKFLOW);
+        automata_fixture.commit_all("Automata authority");
+        let automata = automata_fixture
+            .capture()
+            .await
+            .expect("explicit Automata workflow location");
+        assert_eq!(
+            automata.workflow_location(),
+            Some(RepositoryWorkflowLocation::Automata)
+        );
+        assert_eq!(automata.workflows()[0].path(), ".ci/workflows/ci.yml");
+
+        let sigma_fixture = Fixture::new();
+        sigma_fixture.write("Σ/one", "one\n");
+        sigma_fixture.write("ς/two", "two\n");
+        sigma_fixture.commit_all("Unicode sigma collision");
+        assert_eq!(
+            sigma_fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::CaseCollision
+        );
+
+        let normalization_fixture = Fixture::new();
+        normalization_fixture.write("caf\u{e9}/one", "one\n");
+        normalization_fixture.write("cafe\u{301}/two", "two\n");
+        normalization_fixture.commit_all("Unicode normalization collision");
+        assert_eq!(
+            normalization_fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::CaseCollision
+        );
+
+        let namespace_spelling = Fixture::new();
+        namespace_spelling.write(".github/WORKFLOWS/ci.yml", WORKFLOW);
+        namespace_spelling.commit_all("noncanonical workflow namespace");
+        assert_eq!(
+            namespace_spelling.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafePath
+        );
+    }
+
+    #[tokio::test]
+    async fn expanded_entry_and_encoded_archive_bounds_are_independent() {
+        let fixture = Fixture::new();
+        fixture.write("file.txt", "12345");
+        fixture.commit_all("bounded");
+
+        let expanded = limits(1_024 * 1_024, 4, 10);
+        assert_eq!(
+            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), expanded))
+                .await
+                .unwrap_err()
+                .code(),
+            LocalSnapshotErrorCode::ResourceLimit
+        );
+
+        let exact_entries = limits(1_024 * 1_024, 1_024 * 1_024, 2);
+        fixture
+            .capture_with_limits(exact_entries)
+            .await
+            .expect("one root and one file fit the exact entry bound");
+        fixture.write("second.txt", "x");
+        assert_eq!(
+            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), exact_entries))
+                .await
+                .unwrap_err()
+                .code(),
+            LocalSnapshotErrorCode::ResourceLimit
+        );
+
+        fs::remove_file(fixture.path().join("second.txt")).expect("remove bound fixture");
+        let decompressed = RepositoryWorkflowDiscoveryLimits::new(
+            1_024 * 1_024,
+            1,
+            10,
+            1_024 * 1_024,
+            4_096,
+            10,
+            1_024 * 1_024,
+        )
+        .expect("decompressed-byte test limits");
+        assert_eq!(
+            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), decompressed))
+                .await
+                .unwrap_err()
+                .code(),
+            LocalSnapshotErrorCode::ResourceLimit
+        );
+
+        let encoded = limits(1, 1_024 * 1_024, 10);
+        assert_eq!(
+            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), encoded))
+                .await
+                .unwrap_err()
+                .code(),
+            LocalSnapshotErrorCode::ResourceLimit
+        );
+    }
+
+    #[tokio::test]
+    async fn gitlink_submodules_are_rejected_before_filesystem_capture() {
+        let fixture = Fixture::new();
+        fixture.write("tracked.txt", "tracked\n");
+        fixture.commit_all("submodule base");
+        let head = fixture.git_stdout(&["rev-parse", "HEAD"]);
+        let cache_info = format!("160000,{head},module");
+        fixture.git(&["update-index", "--add", "--cacheinfo", &cache_info]);
+
+        assert_eq!(
+            fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::Submodule
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn safe_symlinks_are_preserved_and_escaping_symlinks_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = Fixture::new();
+        fixture.write(".github/workflows/ci.yml", WORKFLOW);
+        fixture.write("data/value.txt", "value\n");
+        fs::create_dir(fixture.path().join("links")).expect("create symlink directory");
+        symlink("../data/value.txt", fixture.path().join("links/value"))
+            .expect("create safe symlink");
+        fixture.commit_all("safe symlink");
+        let snapshot = fixture.capture().await.expect("safe symlink snapshot");
+        let links = archive_symlinks(snapshot.archive_bytes());
+        assert_eq!(
+            links.get("links/value").map(String::as_str),
+            Some("../data/value.txt")
+        );
+
+        fs::remove_file(fixture.path().join("links/value")).expect("remove safe symlink");
+        symlink("../../../outside", fixture.path().join("links/value"))
+            .expect("create escaping symlink");
+        assert_eq!(
+            fixture.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafeSymlink
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn git_symlink_mode_normalizes_placeholders_and_rejects_regular_file_type_changes() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = Fixture::new();
+        fixture.write("data/value.txt", "value\n");
+        fs::create_dir(fixture.path().join("links")).expect("create link parent");
+        symlink("../data/value.txt", fixture.path().join("links/value"))
+            .expect("create tracked symlink");
+        fixture.commit_all("tracked symlink");
+        let native = fixture.capture().await.expect("native symlink snapshot");
+
+        fs::remove_file(fixture.path().join("links/value")).expect("remove native symlink");
+        fixture.write("links/value", "../data/value.txt");
+        let placeholder = fixture
+            .capture()
+            .await
+            .expect("Git-mode symlink placeholder snapshot");
+        assert_eq!(placeholder.archive_bytes(), native.archive_bytes());
+        assert_eq!(placeholder.digest(), native.digest());
+
+        let type_change = Fixture::new();
+        type_change.write("regular", "regular\n");
+        type_change.write("target", "target\n");
+        type_change.commit_all("tracked regular file");
+        fs::remove_file(type_change.path().join("regular")).expect("remove regular file");
+        symlink("target", type_change.path().join("regular")).expect("replace with symlink");
+        assert_eq!(
+            type_change.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::IndexAmbiguity
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlink_ancestors_and_workflow_namespace_aliases_fail_closed() {
+        use std::os::unix::fs::symlink;
+
+        let ancestor = Fixture::new();
+        ancestor.write("directory/file", "tracked\n");
+        ancestor.commit_all("tracked directory");
+        fs::remove_dir_all(ancestor.path().join("directory")).expect("remove tracked directory");
+        symlink("replacement", ancestor.path().join("directory"))
+            .expect("replace ancestor with symlink");
+        assert_eq!(
+            ancestor.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafeAncestor
+        );
+
+        let nondirectory = Fixture::new();
+        nondirectory.write("directory/file", "tracked\n");
+        nondirectory.commit_all("tracked directory");
+        fs::remove_dir_all(nondirectory.path().join("directory"))
+            .expect("remove tracked directory");
+        nondirectory.write("directory", "replacement file\n");
+        assert_eq!(
+            nondirectory.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafeAncestor
+        );
+
+        let namespace = Fixture::new();
+        namespace.write(".ci/workflows/ci.yml", WORKFLOW);
+        symlink(".ci", namespace.path().join("alternate")).expect("alias workflow namespace");
+        namespace.commit_all("namespace alias");
+        assert_eq!(
+            namespace.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafeSymlink
+        );
+
+        let cycle = Fixture::new();
+        symlink("two", cycle.path().join("one")).expect("first cycle link");
+        symlink("one", cycle.path().join("two")).expect("second cycle link");
+        cycle.write("tracked", "tracked\n");
+        cycle.commit_all("symlink cycle");
+        assert_eq!(
+            cycle.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsafeSymlink
+        );
+    }
+
+    #[tokio::test]
+    async fn ustar_path_shape_component_aliases_and_nested_deletions_are_exact() {
+        let exact = Fixture::new();
+        exact.write(&"a".repeat(100), "exact ustar name field\n");
+        exact.write(
+            &format!("{}/{}", "p".repeat(146), "n".repeat(100)),
+            "exact ustar prefix and name fields\n",
+        );
+        exact.commit_all("exact ustar path");
+        exact.capture().await.expect("exact ustar path boundary");
+
+        let oversized = Fixture::new();
+        oversized.write(&"a".repeat(101), "unsplittable ustar path\n");
+        oversized.write(
+            &format!("{}/{}", "p".repeat(147), "n".repeat(100)),
+            "oversized ustar prefix field\n",
+        );
+        oversized.commit_all("oversized ustar path");
+        assert_eq!(
+            oversized.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::ResourceLimit
+        );
+
+        let aliases = Fixture::new();
+        aliases.write("Directory/one", "one\n");
+        aliases.write("directory/two", "two\n");
+        aliases.commit_all("component aliases");
+        assert_eq!(
+            aliases.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::CaseCollision
+        );
+
+        let deletion = Fixture::new();
+        deletion.write("nested/deleted", "delete me\n");
+        deletion.write("retained", "retain me\n");
+        deletion.commit_all("nested deletion");
+        fs::remove_dir_all(deletion.path().join("nested")).expect("delete tracked directory");
+        let snapshot = deletion.capture().await.expect("nested deletion snapshot");
+        let files = archive_files(snapshot.archive_bytes());
+        assert!(!files.contains_key("nested/deleted"));
+        assert_eq!(files.get("retained").unwrap(), b"retain me\n");
+    }
+
+    #[test]
+    fn windows_reparse_attribute_is_fail_closed() {
+        use super::windows_reparse_attributes;
+
+        assert!(!windows_reparse_attributes(0));
+        assert!(windows_reparse_attributes(0x0000_0400));
+        assert!(windows_reparse_attributes(0xffff_ffff));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absolute_directory_open_pins_each_ancestor_without_following_links() {
+        use std::os::unix::fs::symlink;
+
+        use super::open_absolute_directory_nofollow;
+
+        let fixture = Fixture::new();
+        fs::create_dir_all(fixture.path().join("real/leaf")).expect("create real directories");
+        symlink("real", fixture.path().join("alias")).expect("create ancestor symlink");
+        open_absolute_directory_nofollow(
+            &fixture.path().join("real/leaf"),
+            LocalSnapshotErrorCode::NotGitWorktree,
+        )
+        .expect("ordinary ancestors");
+        assert_eq!(
+            open_absolute_directory_nofollow(
+                &fixture.path().join("alias/leaf"),
+                LocalSnapshotErrorCode::NotGitWorktree,
+            )
+            .unwrap_err()
+            .code(),
+            LocalSnapshotErrorCode::UnsafeAncestor
+        );
+    }
+
+    #[test]
+    fn pinned_directory_identity_ignores_mutable_directory_metadata() {
+        use super::{MetadataStamp, PinnedDirectory};
+
+        let fixture = Fixture::new();
+        let pinned = PinnedDirectory::open(fixture.path()).expect("pin fixture directory");
+        let before = MetadataStamp::new(
+            &pinned
+                .handle
+                .dir_metadata()
+                .expect("read initial directory metadata"),
+        );
+        fs::write(fixture.path().join("transient"), b"mutation")
+            .expect("mutate directory metadata");
+        let after = MetadataStamp::new(
+            &pinned
+                .handle
+                .dir_metadata()
+                .expect("read changed directory metadata"),
+        );
+        assert_ne!(
+            before, after,
+            "fixture must change a mutable directory stamp"
+        );
+        pinned
+            .verify_ambient_path(fixture.path())
+            .expect("stable directory identity survives metadata changes");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn non_unicode_fifo_and_socket_entries_fail_closed() {
+        use std::{
+            ffi::OsString,
+            os::unix::{ffi::OsStringExt as _, net::UnixListener},
+        };
+
+        let non_unicode = Fixture::new();
+        let invalid = OsString::from_vec(b"invalid-\xff".to_vec());
+        fs::write(non_unicode.path().join(invalid), b"bytes").expect("write non-Unicode path");
+        non_unicode.write("tracked.txt", "tracked\n");
+        non_unicode.commit_all("non-Unicode fixture");
+        assert_eq!(
+            non_unicode.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::NonUnicodePath
+        );
+
+        let fifo = Fixture::new();
+        fifo.write("tracked.txt", "tracked\n");
+        fifo.commit_all("fifo fixture");
+        let fifo_status = Command::new("mkfifo")
+            .arg(fifo.path().join("pipe"))
+            .status()
+            .expect("run mkfifo");
+        assert!(fifo_status.success(), "create FIFO fixture");
+        assert_eq!(
+            fifo.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsupportedEntry
+        );
+
+        let ignored_fifo = Fixture::new();
+        ignored_fifo.write(".gitignore", "ignored-pipe\n");
+        ignored_fifo.write("tracked.txt", "tracked\n");
+        ignored_fifo.commit_all("ignored FIFO fixture");
+        let ignored_fifo_status = Command::new("mkfifo")
+            .arg(ignored_fifo.path().join("ignored-pipe"))
+            .status()
+            .expect("run mkfifo for ignored fixture");
+        assert!(ignored_fifo_status.success(), "create ignored FIFO fixture");
+        ignored_fifo
+            .capture()
+            .await
+            .expect("ignored special entries are outside the selected inventory");
+
+        let socket = Fixture::new();
+        socket.write("tracked.txt", "tracked\n");
+        socket.commit_all("socket fixture");
+        let _listener =
+            UnixListener::bind(socket.path().join("service.sock")).expect("create Unix socket");
+        assert_eq!(
+            socket.capture().await.unwrap_err().code(),
+            LocalSnapshotErrorCode::UnsupportedEntry
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mutation_between_git_inventory_and_file_capture_is_detected() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let fixture = Fixture::new();
+        fixture.write("tracked.txt", "initial\n");
+        fixture.commit_all("mutation fixture");
+        let wrapper = fixture.path().join(".git/fake-git");
+        let marker = fixture.path().join(".git/mutation-marker");
+        let target = fixture.path().join("tracked.txt");
+        fs::write(
+            &wrapper,
+            format!(
+                "#!/bin/sh\nset -eu\ncase \" $* \" in\n  *' status '*)\n    if [ ! -e '{}' ]; then\n      git \"$@\"\n      result=$?\n      : > '{}'\n      printf '%s\\n' mutation >> '{}'\n      exit \"$result\"\n    fi\n    ;;\nesac\nexec git \"$@\"\n",
+                marker.display(),
+                marker.display(),
+                target.display()
+            ),
+        )
+        .expect("write fake Git wrapper");
+        fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o700))
+            .expect("make fake Git executable");
+
+        let error = capture_snapshot_with_git(
+            LocalSnapshotRequest::new(fixture.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            &wrapper,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code(), LocalSnapshotErrorCode::ConcurrentMutation);
+    }
+
+    fn limits(compressed: u64, expanded: u64, entries: usize) -> RepositoryWorkflowDiscoveryLimits {
+        RepositoryWorkflowDiscoveryLimits::new(
+            compressed,
+            expanded.max(1),
+            entries,
+            expanded,
+            4_096,
+            entries,
+            expanded,
+        )
+        .expect("test limits")
+    }
+
+    fn archive_files(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+        use std::io::Read as _;
+
+        let mut archive = tar::Archive::new(MultiGzDecoder::new(bytes));
+        let mut files = BTreeMap::new();
+        for entry in archive.entries().expect("archive entries") {
+            let mut entry = entry.expect("archive entry");
+            if !entry.header().entry_type().is_file() {
+                continue;
+            }
+            let path = entry.path().expect("archive path").into_owned();
+            let path = path
+                .strip_prefix("worktree")
+                .expect("snapshot root")
+                .to_str()
+                .expect("Unicode archive path")
+                .trim_start_matches('/')
+                .to_owned();
+            let mut contents = Vec::new();
+            entry.read_to_end(&mut contents).expect("archive contents");
+            files.insert(path, contents);
+        }
+        files
+    }
+
+    #[cfg(unix)]
+    fn archive_symlinks(bytes: &[u8]) -> BTreeMap<String, String> {
+        let mut archive = tar::Archive::new(MultiGzDecoder::new(bytes));
+        let mut links = BTreeMap::new();
+        for entry in archive.entries().expect("archive entries") {
+            let entry = entry.expect("archive entry");
+            if !entry.header().entry_type().is_symlink() {
+                continue;
+            }
+            let path = entry.path().expect("archive path").into_owned();
+            let path = path
+                .strip_prefix("worktree")
+                .expect("snapshot root")
+                .to_str()
+                .expect("Unicode archive path")
+                .trim_start_matches('/')
+                .to_owned();
+            let target = entry
+                .link_name()
+                .expect("symlink target")
+                .expect("present symlink target")
+                .into_owned()
+                .to_str()
+                .expect("Unicode symlink target")
+                .to_owned();
+            links.insert(path, target);
+        }
+        links
+    }
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "automata-local-snapshot-{}",
+                Uuid::new_v4().simple()
+            ));
+            fs::create_dir(&root).expect("create fixture root");
+            let fixture = Self { root };
+            fixture.git(&["init", "--quiet"]);
+            fixture.git(&["config", "user.name", "Automata Test"]);
+            fixture.git(&["config", "user.email", "automata@example.invalid"]);
+            fixture
+        }
+
+        fn clone_from(source: &Path) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "automata-local-snapshot-clone-{}",
+                Uuid::new_v4().simple()
+            ));
+            let output = Command::new("git")
+                .args(["clone", "--quiet"])
+                .arg(source)
+                .arg(&root)
+                .output()
+                .expect("clone fixture");
+            assert!(output.status.success(), "git clone failed");
+            Self { root }
+        }
+
+        fn path(&self) -> &Path {
+            &self.root
+        }
+
+        fn write(&self, path: &str, contents: &str) {
+            let path = self.root.join(path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create fixture parent");
+            }
+            fs::write(path, contents).expect("write fixture file");
+        }
+
+        fn git(&self, arguments: &[&str]) {
+            let output = Command::new("git")
+                .arg("--no-optional-locks")
+                .args(["-c", "maintenance.auto=false"])
+                .arg("-C")
+                .arg(&self.root)
+                .args(arguments)
+                .output()
+                .expect("run fixture Git command");
+            assert!(
+                output.status.success(),
+                "git {arguments:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        fn git_stdout(&self, arguments: &[&str]) -> String {
+            let output = Command::new("git")
+                .arg("--no-optional-locks")
+                .args(["-c", "maintenance.auto=false"])
+                .arg("-C")
+                .arg(&self.root)
+                .args(arguments)
+                .output()
+                .expect("run fixture Git command");
+            assert!(output.status.success(), "git {arguments:?} failed");
+            String::from_utf8(output.stdout)
+                .expect("Git fixture output must be UTF-8")
+                .trim()
+                .to_owned()
+        }
+
+        fn commit_all(&self, message: &str) {
+            self.git(&["add", "--all"]);
+            self.git(&["commit", "--quiet", "--message", message]);
+        }
+
+        async fn capture(&self) -> Result<super::LocalSnapshot, super::LocalSnapshotError> {
+            self.capture_with_limits(RepositoryWorkflowDiscoveryLimits::default())
+                .await
+        }
+
+        async fn capture_with_limits(
+            &self,
+            limits: RepositoryWorkflowDiscoveryLimits,
+        ) -> Result<super::LocalSnapshot, super::LocalSnapshotError> {
+            capture_snapshot(LocalSnapshotRequest::new(&self.root, limits)).await
+        }
+
+        fn git_tree_evidence(&self) -> Vec<(String, Vec<u8>, Option<std::time::SystemTime>)> {
+            let mut evidence = Vec::new();
+            collect_git_evidence(
+                &self.root.join(".git"),
+                &self.root.join(".git"),
+                &mut evidence,
+            );
+            evidence.sort_by(|left, right| left.0.cmp(&right.0));
+            evidence
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ignored = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn collect_git_evidence(
+        root: &Path,
+        directory: &Path,
+        evidence: &mut Vec<(String, Vec<u8>, Option<std::time::SystemTime>)>,
+    ) {
+        let mut entries = fs::read_dir(directory)
+            .expect("read Git evidence directory")
+            .map(|entry| entry.expect("read Git evidence entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path).expect("Git evidence metadata");
+            if metadata.is_dir() {
+                collect_git_evidence(root, &path, evidence);
+            } else if metadata.is_file() {
+                evidence.push((
+                    path.strip_prefix(root)
+                        .expect("Git evidence root")
+                        .to_string_lossy()
+                        .into_owned(),
+                    fs::read(&path).expect("read Git evidence file"),
+                    metadata.modified().ok(),
+                ));
+            }
+        }
+    }
+}

--- a/crates/automata-ci-local/src/snapshot.rs
+++ b/crates/automata-ci-local/src/snapshot.rs
@@ -35,6 +35,9 @@ const MAX_GIT_HEAD_BYTES: usize = 128;
 const TRUSTED_GIT_EXECUTABLE: &str = "/usr/bin/git";
 const GIT_NULL_DEVICE: &str = "/dev/null";
 
+#[cfg(test)]
+static SNAPSHOT_CAPTURE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[derive(Debug)]
 struct GitExecutable {
     path: PathBuf,
@@ -311,6 +314,13 @@ async fn capture_snapshot_with_executable(
     git: &GitExecutable,
     cancellation: &CancellationToken,
 ) -> Result<LocalSnapshot, LocalSnapshotError> {
+    // The native tests deliberately exercise real Git processes and mutate
+    // repository authority. Serializing those captures keeps unrelated test
+    // fixtures from exhausting the host process boundary and obscuring the
+    // exact failure class under test.
+    #[cfg(test)]
+    let _test_capture_guard = SNAPSHOT_CAPTURE_TEST_LOCK.lock().await;
+
     check_cancelled(cancellation)?;
     validate_local_snapshot_limits(request.limits())?;
     let requested_path = std::path::absolute(request.directory())
@@ -784,9 +794,7 @@ fn parse_git_coordinates(output: &[u8]) -> Result<GitCoordinates, LocalSnapshotE
     let text = text
         .strip_suffix('\n')
         .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
-    let mut fields = text
-        .split('\n')
-        .map(|field| field.strip_suffix('\r').unwrap_or(field));
+    let mut fields = text.split('\n');
     let (Some(worktree_root), Some(git_directory), Some(common_directory), Some(prefix)) =
         (fields.next(), fields.next(), fields.next(), fields.next())
     else {
@@ -923,7 +931,6 @@ fn parse_one_git_line(
     let text = std::str::from_utf8(output).map_err(|_| LocalSnapshotError::new(code))?;
     let text = text
         .strip_suffix('\n')
-        .and_then(|line| line.strip_suffix('\r').or(Some(line)))
         .ok_or_else(|| LocalSnapshotError::new(code))?;
     if text.is_empty() || text.contains(['\r', '\n', '\0']) {
         return Err(LocalSnapshotError::new(code));
@@ -2519,6 +2526,26 @@ mod tests {
 
     const WORKFLOW: &str =
         "on: push\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n";
+
+    #[test]
+    fn git_text_evidence_requires_canonical_lf_framing() {
+        assert!(super::parse_git_coordinates(b"/worktree\n/git\n/common\n\n").is_ok());
+        assert!(super::parse_git_coordinates(b"/worktree\r\n/git\n/common\n\n").is_err());
+        assert!(
+            super::parse_one_git_line(
+                b"0123456789012345678901234567890123456789\n",
+                LocalSnapshotErrorCode::GitOutput,
+            )
+            .is_ok()
+        );
+        assert!(
+            super::parse_one_git_line(
+                b"0123456789012345678901234567890123456789\r\n",
+                LocalSnapshotErrorCode::GitOutput,
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn archive_cancellation_is_terminal_not_retryable_io() {

--- a/crates/automata-ci-local/src/snapshot.rs
+++ b/crates/automata-ci-local/src/snapshot.rs
@@ -9,23 +9,21 @@ use std::{
 
 use automata_ci_core::Sha256Digest;
 use automata_ci_workflow_github::{
-    RepositoryPathValidationError, RepositoryPathValidator, RepositoryWorkflowDiscoveryError,
-    RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowDiscoveryOutcome,
-    RepositoryWorkflowDiscoveryPolicy, RepositoryWorkflowLocation, discover_repository_workflows,
+    RepositoryPathValidationError, RepositoryPathValidator, RepositoryWorkflowDiscoveryLimits,
 };
-use bytes::Bytes;
 use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt as _, ambient_authority};
 use cap_std::fs::{Dir, File, Metadata, OpenOptions};
 use flate2::{Compression, GzBuilder};
-use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 use tar::{Builder as TarBuilder, EntryType, Header};
 use thiserror::Error;
 use tokio::{io::AsyncWriteExt as _, process::Command as ProcessCommand, time::timeout};
+use tokio_util::sync::CancellationToken;
 
 use super::{
-    CaptureFailure, CommandFailure, MAX_COMMAND_STREAM_BYTES, read_bounded, spawn_contained,
-    terminate_process_tree, terminate_remaining_process_tree,
+    CaptureFailure, CommandFailure, MAX_COMMAND_STREAM_BYTES, read_bounded,
+    snapshot_limits::local_snapshot_limits, spawn_contained, terminate_process_tree,
+    terminate_remaining_process_tree,
 };
 
 const SNAPSHOT_ROOT: &str = "worktree";
@@ -34,10 +32,151 @@ const MAX_GIT_COORDINATE_FIELD_BYTES: usize = 16 * 1_024;
 const MAX_GIT_COORDINATES_BYTES: usize = 4 * (MAX_GIT_COORDINATE_FIELD_BYTES + 2);
 const MAX_GIT_LOCATOR_BYTES: usize = MAX_GIT_COORDINATE_FIELD_BYTES;
 const MAX_GIT_HEAD_BYTES: usize = 128;
+const TRUSTED_GIT_EXECUTABLE: &str = "/usr/bin/git";
+const GIT_NULL_DEVICE: &str = "/dev/null";
+
+#[derive(Debug)]
+struct GitExecutable {
+    path: PathBuf,
+    identity: ExecutableIdentity,
+    #[cfg(test)]
+    fixture: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ExecutableIdentity {
+    device: u64,
+    inode: u64,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+    mode: u32,
+    owner: u32,
+}
+
+impl GitExecutable {
+    fn resolve() -> Result<Self, LocalSnapshotError> {
+        let path = PathBuf::from(TRUSTED_GIT_EXECUTABLE);
+        let metadata = trusted_executable_metadata(&path)?;
+        Ok(Self {
+            path,
+            identity: ExecutableIdentity::new(&metadata),
+            #[cfg(test)]
+            fixture: false,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn verify(&self) -> Result<(), LocalSnapshotError> {
+        #[cfg(test)]
+        if self.fixture {
+            return Ok(());
+        }
+        let metadata = trusted_executable_metadata(&self.path)?;
+        if ExecutableIdentity::new(&metadata) != self.identity {
+            return Err(LocalSnapshotError::new(
+                LocalSnapshotErrorCode::GitExecutableChanged,
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn fixture(path: &Path) -> Self {
+        Self {
+            path: path.to_owned(),
+            identity: ExecutableIdentity {
+                device: 0,
+                inode: 0,
+                length: 0,
+                modified_seconds: 0,
+                modified_nanoseconds: 0,
+                changed_seconds: 0,
+                changed_nanoseconds: 0,
+                mode: 0,
+                owner: 0,
+            },
+            fixture: true,
+        }
+    }
+}
+
+impl ExecutableIdentity {
+    fn new(metadata: &fs::Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt as _;
+
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+            mode: metadata.mode(),
+            owner: metadata.uid(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn trusted_executable_metadata(path: &Path) -> Result<fs::Metadata, LocalSnapshotError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    if !path.is_absolute() {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::GitUnavailable,
+        ));
+    }
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::GitUnavailable))?;
+    if !metadata.is_file()
+        || metadata.uid() != 0
+        || metadata.permissions().mode() & 0o111 == 0
+        || metadata.permissions().mode() & 0o022 != 0
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::GitUnavailable,
+        ));
+    }
+    Ok(metadata)
+}
+
+fn check_cancelled(cancellation: &CancellationToken) -> Result<(), LocalSnapshotError> {
+    if cancellation.is_cancelled() {
+        Err(LocalSnapshotError::new(LocalSnapshotErrorCode::Cancelled))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_local_snapshot_limits(
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<(), LocalSnapshotError> {
+    let maximum = local_snapshot_limits();
+    if limits.maximum_compressed_bytes() > maximum.maximum_compressed_bytes()
+        || limits.maximum_decompressed_bytes() > maximum.maximum_decompressed_bytes()
+        || limits.maximum_entries() > maximum.maximum_entries()
+        || limits.maximum_expanded_bytes() > maximum.maximum_expanded_bytes()
+        || limits.maximum_entry_path_bytes() > maximum.maximum_entry_path_bytes()
+        || limits.maximum_workflows() > maximum.maximum_workflows()
+        || limits.maximum_workflow_bytes() > maximum.maximum_workflow_bytes()
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::ResourceLimit,
+        ));
+    }
+    Ok(())
+}
 
 /// Request to seal one live Git worktree into a bounded immutable snapshot.
 #[derive(Clone, Debug)]
-pub struct LocalSnapshotRequest {
+pub(crate) struct LocalSnapshotRequest {
     directory: PathBuf,
     limits: RepositoryWorkflowDiscoveryLimits,
 }
@@ -45,7 +184,10 @@ pub struct LocalSnapshotRequest {
 impl LocalSnapshotRequest {
     /// Creates a request rooted at a worktree or any directory beneath it.
     #[must_use]
-    pub fn new(directory: impl Into<PathBuf>, limits: RepositoryWorkflowDiscoveryLimits) -> Self {
+    pub(crate) fn new(
+        directory: impl Into<PathBuf>,
+        limits: RepositoryWorkflowDiscoveryLimits,
+    ) -> Self {
         Self {
             directory: directory.into(),
             limits,
@@ -54,19 +196,18 @@ impl LocalSnapshotRequest {
 
     /// Returns the caller-supplied worktree search directory.
     #[must_use]
-    pub fn directory(&self) -> &Path {
+    pub(crate) fn directory(&self) -> &Path {
         &self.directory
     }
 
     /// Returns the shared snapshot-construction and workflow-discovery limits.
     #[must_use]
-    pub const fn limits(&self) -> RepositoryWorkflowDiscoveryLimits {
+    pub(crate) const fn limits(&self) -> RepositoryWorkflowDiscoveryLimits {
         self.limits
     }
 }
 
-/// One sealed local source archive and the workflow bytes discovered from that
-/// exact archive.
+/// One private sealed local source archive.
 ///
 /// The inventory is Git's tracked index names plus non-ignored untracked names.
 /// Tracked deletions are absent, staged additions are present, and all regular
@@ -76,75 +217,72 @@ impl LocalSnapshotRequest {
 /// submodules fail closed, as do sparse-checkout and assume-unchanged flags
 /// that can hide live state. No source operation updates the index or invokes
 /// hooks or automatic maintenance.
-#[derive(Clone, Debug)]
-pub struct LocalSnapshot {
-    root: PathBuf,
+pub(crate) struct LocalSnapshot {
     head: String,
     dirty: bool,
     digest: Sha256Digest,
-    archive: Bytes,
+    archive: Vec<u8>,
     entry_count: usize,
     expanded_bytes: u64,
-    workflow_location: Option<RepositoryWorkflowLocation>,
-    workflows: Vec<RepositoryWorkflowDiscoveryOutcome>,
+}
+
+impl std::fmt::Debug for LocalSnapshot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalSnapshot")
+            .field("head", &self.head)
+            .field("dirty", &self.dirty)
+            .field("digest", &self.digest)
+            .field("entry_count", &self.entry_count)
+            .field("expanded_bytes", &self.expanded_bytes)
+            .finish_non_exhaustive()
+    }
 }
 
 impl LocalSnapshot {
-    /// Returns the absolute, pinned worktree root reported by Git.
-    #[must_use]
-    pub fn root(&self) -> &Path {
-        &self.root
-    }
-
     /// Returns the exact commit at `HEAD` while the worktree was sealed.
     #[must_use]
-    pub fn head(&self) -> &str {
+    pub(crate) fn head(&self) -> &str {
         &self.head
     }
 
     /// Returns whether Git reported staged, unstaged, or non-ignored untracked
     /// worktree state while the snapshot was sealed.
     #[must_use]
-    pub const fn dirty(&self) -> bool {
+    pub(crate) const fn dirty(&self) -> bool {
         self.dirty
     }
 
     /// Returns SHA-256 over the exact deterministic gzip bytes retained here.
     #[must_use]
-    pub const fn digest(&self) -> Sha256Digest {
+    pub(crate) const fn digest(&self) -> Sha256Digest {
         self.digest
     }
 
     /// Returns the exact immutable tar.gz bytes consumed by workflow discovery.
+    #[cfg(test)]
     #[must_use]
-    pub const fn archive_bytes(&self) -> &Bytes {
+    pub(crate) fn archive_bytes(&self) -> &[u8] {
         &self.archive
+    }
+
+    /// Consumes the private snapshot into the exact archive passed to the
+    /// sealed workflow-analysis boundary.
+    pub(crate) fn into_archive(self) -> Vec<u8> {
+        self.archive
     }
 
     /// Returns the number of regular-file and symbolic-link entries in the
     /// sealed live-worktree inventory.
     #[must_use]
-    pub const fn entry_count(&self) -> usize {
+    pub(crate) const fn entry_count(&self) -> usize {
         self.entry_count
     }
 
     /// Returns the sum of regular-file bytes retained in the archive.
     #[must_use]
-    pub const fn expanded_bytes(&self) -> u64 {
+    pub(crate) const fn expanded_bytes(&self) -> u64 {
         self.expanded_bytes
-    }
-
-    /// Returns the one explicit workflow namespace present in the worktree.
-    /// Repositories containing both namespaces are rejected during capture.
-    #[must_use]
-    pub const fn workflow_location(&self) -> Option<RepositoryWorkflowLocation> {
-        self.workflow_location
-    }
-
-    /// Returns deterministic path outcomes decoded from the retained archive.
-    #[must_use]
-    pub fn workflows(&self) -> &[RepositoryWorkflowDiscoveryOutcome] {
-        &self.workflows
     }
 }
 
@@ -160,84 +298,128 @@ impl LocalSnapshot {
 /// opened without following a link, a path or file type is unsafe, a resource
 /// bound is exceeded, or the inventory mutates while it is being read. Windows
 /// reparse points, including junctions, are not admitted.
-pub async fn capture_snapshot(
+pub(crate) async fn capture_snapshot(
     request: LocalSnapshotRequest,
+    cancellation: &CancellationToken,
 ) -> Result<LocalSnapshot, LocalSnapshotError> {
-    capture_snapshot_with_git(request, Path::new("git")).await
+    let git = GitExecutable::resolve()?;
+    capture_snapshot_with_executable(request, &git, cancellation).await
 }
 
-async fn capture_snapshot_with_git(
+async fn capture_snapshot_with_executable(
     request: LocalSnapshotRequest,
-    git: &Path,
+    git: &GitExecutable,
+    cancellation: &CancellationToken,
 ) -> Result<LocalSnapshot, LocalSnapshotError> {
+    check_cancelled(cancellation)?;
+    validate_local_snapshot_limits(request.limits())?;
     let requested_path = std::path::absolute(request.directory())
         .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
     let requested = PinnedDirectory::open(&requested_path)?;
-    let coordinates = discover_git_coordinates(git, &requested_path).await?;
+    let coordinates = discover_git_coordinates(git, &requested_path, cancellation).await?;
     requested.verify_ambient_path(&requested_path)?;
     let authority = GitAuthority::pin(coordinates, &requested)?;
-    verify_bound_git_coordinates(git, &authority, LocalSnapshotErrorCode::NotGitWorktree).await?;
+    verify_bound_git_coordinates(
+        git,
+        &authority,
+        LocalSnapshotErrorCode::NotGitWorktree,
+        cancellation,
+    )
+    .await?;
     let path_validator =
         RepositoryPathValidator::new(SNAPSHOT_ROOT, request.limits().maximum_entry_path_bytes())
             .map_err(local_path_validation_error)?;
-    let initial = capture_git_state(git, &authority, request.limits()).await?;
+    let initial = capture_git_state(git, &authority, request.limits(), cancellation).await?;
     let inventory = parse_inventory(&initial, request.limits(), path_validator)?;
-    let initial_scan = scan_worktree(git, &authority, request.limits(), path_validator).await?;
-    let captured = capture_entries(
-        &authority.worktree,
-        &inventory,
+    let initial_scan = scan_worktree(
+        git,
+        &authority,
         request.limits(),
         path_validator,
-    )?;
-    let workflow_location = workflow_location(&captured.entries)?;
-    let final_state = capture_git_state(git, &authority, request.limits()).await?;
-    let final_scan = scan_worktree(git, &authority, request.limits(), path_validator).await?;
+        cancellation,
+    )
+    .await?;
+    let capture_worktree = authority.worktree.clone_pinned()?;
+    let capture_cancellation = cancellation.clone();
+    let limits = request.limits();
+    let captured = run_blocking(LocalSnapshotErrorCode::ConcurrentMutation, move || {
+        capture_entries(
+            &capture_worktree,
+            &inventory,
+            limits,
+            path_validator,
+            &capture_cancellation,
+        )
+    })
+    .await?;
+    let final_state = capture_git_state(git, &authority, request.limits(), cancellation).await?;
+    let final_scan = scan_worktree(
+        git,
+        &authority,
+        request.limits(),
+        path_validator,
+        cancellation,
+    )
+    .await?;
     verify_git_state(&initial, &final_state)?;
     if initial_scan != final_scan {
         return Err(LocalSnapshotError::new(
             LocalSnapshotErrorCode::ConcurrentMutation,
         ));
     }
-    verify_deleted_paths(&authority.worktree, &captured.deleted_paths)?;
-    verify_bound_git_coordinates(git, &authority, LocalSnapshotErrorCode::ConcurrentMutation)
-        .await?;
+    let CapturedInventory {
+        entries,
+        deleted_paths,
+        expanded_bytes,
+    } = captured;
+    let deletion_worktree = authority.worktree.clone_pinned()?;
+    let deletion_cancellation = cancellation.clone();
+    run_blocking(LocalSnapshotErrorCode::ConcurrentMutation, move || {
+        verify_deleted_paths(&deletion_worktree, &deleted_paths, &deletion_cancellation)
+    })
+    .await?;
+    verify_bound_git_coordinates(
+        git,
+        &authority,
+        LocalSnapshotErrorCode::ConcurrentMutation,
+        cancellation,
+    )
+    .await?;
     requested.verify_ambient_path(&requested_path)?;
     authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
+    git.verify()?;
+    check_cancelled(cancellation)?;
 
-    let archive = build_archive(&captured.entries, request.limits())?;
-    let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
-    let workflows = discover_repository_workflows(
-        &archive,
-        request.limits(),
-        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot { workflow_location },
-    )
-    .map_err(local_discovery_error)?;
-
+    let entry_count = entries.len();
+    let archive_cancellation = cancellation.clone();
+    let limits = request.limits();
+    let (archive, digest) = run_blocking(LocalSnapshotErrorCode::ArchiveEncoding, move || {
+        let archive = build_archive(&entries, limits, &archive_cancellation)?;
+        let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
+        Ok((archive, digest))
+    })
+    .await?;
     Ok(LocalSnapshot {
-        root: authority.worktree_path,
         head: initial.head,
         dirty: !initial.status.is_empty(),
         digest,
-        archive: Bytes::from(archive),
-        entry_count: captured.entries.len(),
-        expanded_bytes: captured.expanded_bytes,
-        workflow_location,
-        workflows,
+        archive,
+        entry_count,
+        expanded_bytes,
     })
 }
 
-fn local_discovery_error(error: RepositoryWorkflowDiscoveryError) -> LocalSnapshotError {
-    LocalSnapshotError::new(match error {
-        RepositoryWorkflowDiscoveryError::ResourceLimit => LocalSnapshotErrorCode::ResourceLimit,
-        RepositoryWorkflowDiscoveryError::UnsafePath => LocalSnapshotErrorCode::UnsafePath,
-        RepositoryWorkflowDiscoveryError::UnsafeLink
-        | RepositoryWorkflowDiscoveryError::NamespaceAlias => LocalSnapshotErrorCode::UnsafeSymlink,
-        RepositoryWorkflowDiscoveryError::PathAlias => LocalSnapshotErrorCode::CaseCollision,
-        RepositoryWorkflowDiscoveryError::PathTypeConflict => {
-            LocalSnapshotErrorCode::PathTypeConflict
-        }
-        _ => LocalSnapshotErrorCode::WorkflowDiscovery,
-    })
+#[cfg(test)]
+async fn capture_snapshot_with_git(
+    request: LocalSnapshotRequest,
+    git: &Path,
+) -> Result<LocalSnapshot, LocalSnapshotError> {
+    capture_snapshot_with_executable(
+        request,
+        &GitExecutable::fixture(git),
+        &CancellationToken::new(),
+    )
+    .await
 }
 
 #[derive(Debug)]
@@ -249,9 +431,10 @@ struct GitState {
 }
 
 async fn capture_git_state(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     limits: RepositoryWorkflowDiscoveryLimits,
+    cancellation: &CancellationToken,
 ) -> Result<GitState, LocalSnapshotError> {
     let inventory_limit = git_inventory_output_limit(limits)?;
     let index_limit = git_index_output_limit(limits)?;
@@ -261,6 +444,7 @@ async fn capture_git_state(
         authority,
         &["rev-parse", "--verify", "HEAD^{commit}"],
         MAX_GIT_HEAD_BYTES,
+        cancellation,
     )
     .await?;
     let index = capture_bound_git(
@@ -268,6 +452,7 @@ async fn capture_git_state(
         authority,
         &["ls-files", "--cached", "--stage", "-v", "-z"],
         index_limit,
+        cancellation,
     )
     .await?;
     let inventory = capture_bound_git(
@@ -281,6 +466,7 @@ async fn capture_git_state(
             "-z",
         ],
         inventory_limit,
+        cancellation,
     )
     .await?;
     let status = capture_bound_git(
@@ -288,6 +474,7 @@ async fn capture_git_state(
         authority,
         &["status", "--porcelain=v2", "--untracked-files=all", "-z"],
         status_limit,
+        cancellation,
     )
     .await?;
     Ok(GitState {
@@ -299,21 +486,32 @@ async fn capture_git_state(
 }
 
 async fn capture_bound_git(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     arguments: &[&str],
     maximum_stdout_bytes: usize,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
-    capture_bound_git_request(git, authority, arguments, None, maximum_stdout_bytes, false).await
+    capture_bound_git_request(
+        git,
+        authority,
+        arguments,
+        None,
+        maximum_stdout_bytes,
+        false,
+        cancellation,
+    )
+    .await
 }
 
 async fn capture_bound_git_with_input(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     arguments: &[&str],
     input: &[u8],
     maximum_stdout_bytes: usize,
     allow_no_matches: bool,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
     capture_bound_git_request(
         git,
@@ -322,18 +520,22 @@ async fn capture_bound_git_with_input(
         Some(input),
         maximum_stdout_bytes,
         allow_no_matches,
+        cancellation,
     )
     .await
 }
 
 async fn capture_bound_git_request(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     arguments: &[&str],
     input: Option<&[u8]>,
     maximum_stdout_bytes: usize,
     allow_no_matches: bool,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
+    check_cancelled(cancellation)?;
+    git.verify()?;
     authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
     let captured = capture_git_request(
         git,
@@ -342,17 +544,20 @@ async fn capture_bound_git_request(
         input,
         maximum_stdout_bytes,
         allow_no_matches,
+        cancellation,
     )
     .await;
     authority.verify(LocalSnapshotErrorCode::ConcurrentMutation)?;
+    git.verify()?;
     captured
 }
 
 async fn capture_discovery_git(
-    git: &Path,
+    git: &GitExecutable,
     directory: &Path,
     arguments: &[&str],
     maximum_stdout_bytes: usize,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
     capture_git_request(
         git,
@@ -361,6 +566,7 @@ async fn capture_discovery_git(
         None,
         maximum_stdout_bytes,
         false,
+        cancellation,
     )
     .await
 }
@@ -372,37 +578,17 @@ enum GitInvocation<'a> {
 }
 
 async fn capture_git_request(
-    git: &Path,
+    git: &GitExecutable,
     invocation: GitInvocation<'_>,
     arguments: &[&str],
     input: Option<&[u8]>,
     maximum_stdout_bytes: usize,
     allow_no_matches: bool,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
-    let mut command = ProcessCommand::new(git);
-    command
-        .arg("--no-optional-locks")
-        .args(["-c", "core.fsmonitor=false"])
-        .args(["-c", "core.untrackedCache=false"])
-        .args(["-c", "core.preloadIndex=false"])
-        .args(["-c", "maintenance.auto=false"])
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_COMMON_DIR")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_OBJECT_DIRECTORY")
-        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
-        .stdin(if input.is_some() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    configure_git_invocation(&mut command, invocation);
-    command.args(arguments);
+    check_cancelled(cancellation)?;
+    git.verify()?;
+    let command = configured_git_command(git, invocation, arguments, input.is_some());
     let (mut child, mut containment) = spawn_contained(command).map_err(|failure| {
         LocalSnapshotError::new(if failure == CommandFailure::NotFound {
             LocalSnapshotErrorCode::GitUnavailable
@@ -419,7 +605,7 @@ async fn capture_git_request(
         return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
     };
     let mut stdin = child.stdin.take();
-    let captured = timeout(GIT_COMMAND_TIMEOUT, async {
+    let mut operation = Box::pin(timeout(GIT_COMMAND_TIMEOUT, async {
         tokio::try_join!(
             read_bounded(stdout, maximum_stdout_bytes),
             read_bounded(stderr, MAX_COMMAND_STREAM_BYTES),
@@ -439,8 +625,17 @@ async fn capture_git_request(
             },
             async { child.wait().await.map_err(|_error| CaptureFailure::Io) }
         )
-    })
-    .await;
+    }));
+    let captured = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => None,
+        captured = &mut operation => Some(captured),
+    };
+    drop(operation);
+    let Some(captured) = captured else {
+        terminate_process_tree(&mut child, &mut containment).await;
+        return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::Cancelled));
+    };
     let (stdout, stderr, (), status) = match captured {
         Ok(Ok(value)) => value,
         Ok(Err(CaptureFailure::OutputTooLarge)) => {
@@ -459,11 +654,75 @@ async fn capture_git_request(
         }
     };
     terminate_remaining_process_tree(&mut containment);
-    drop(stderr);
     if !(status.success() || allow_no_matches && status.code() == Some(1)) {
         return Err(LocalSnapshotError::new(LocalSnapshotErrorCode::GitCommand));
     }
+    drop(stderr);
+    git.verify()?;
+    check_cancelled(cancellation)?;
     Ok(stdout)
+}
+
+fn configured_git_command(
+    git: &GitExecutable,
+    invocation: GitInvocation<'_>,
+    arguments: &[&str],
+    input_present: bool,
+) -> ProcessCommand {
+    let mut command = ProcessCommand::new(git.path());
+    let hooks_path = format!("core.hooksPath={GIT_NULL_DEVICE}");
+    let excludes_file = format!("core.excludesFile={GIT_NULL_DEVICE}");
+    let attributes_file = format!("core.attributesFile={GIT_NULL_DEVICE}");
+    command
+        .env_clear()
+        .arg("--no-optional-locks")
+        .arg("--no-pager")
+        .arg("--no-replace-objects")
+        .args(["-c", "core.fsmonitor=false"])
+        .args(["-c", "core.untrackedCache=false"])
+        .args(["-c", "core.preloadIndex=false"])
+        .args(["-c", hooks_path.as_str()])
+        .args(["-c", excludes_file.as_str()])
+        .args(["-c", attributes_file.as_str()])
+        .args(["-c", "credential.helper="])
+        .args(["-c", "credential.interactive=never"])
+        .args(["-c", "protocol.allow=never"])
+        .args(["-c", "protocol.file.allow=never"])
+        .args(["-c", "core.useReplaceRefs=false"])
+        .args(["-c", "gc.auto=0"])
+        .args(["-c", "maintenance.auto=false"])
+        .env("LC_ALL", "C")
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_SYSTEM", GIT_NULL_DEVICE)
+        .env("GIT_CONFIG_GLOBAL", GIT_NULL_DEVICE)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_PROTOCOL_FROM_USER", "0")
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .env("GIT_PAGER", "")
+        .env("GIT_TRACE", "0")
+        .env("GIT_TRACE_PACKET", "0")
+        .env("GIT_TRACE_PERFORMANCE", "0")
+        .env("GIT_TRACE_SETUP", "0")
+        .env("GIT_TRACE_SHALLOW", "0")
+        .env("GIT_TRACE_CURL", "0")
+        .env("GIT_TRACE_FSMONITOR", "0")
+        .env("GIT_TRACE_PACK_ACCESS", "0")
+        .env("GIT_TRACE_REFS", "0")
+        .env("GIT_TRACE2", "0")
+        .env("GIT_TRACE2_EVENT", "0")
+        .env("GIT_TRACE2_PERF", "0")
+        .stdin(if input_present {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    configure_git_invocation(&mut command, invocation);
+    command.args(arguments);
+    command
 }
 
 fn configure_git_invocation(command: &mut ProcessCommand, invocation: GitInvocation<'_>) {
@@ -478,8 +737,7 @@ fn configure_git_invocation(command: &mut ProcessCommand, invocation: GitInvocat
                 .arg("--work-tree")
                 .arg(&authority.worktree_path)
                 .arg("-C")
-                .arg(&authority.worktree_path)
-                .env("GIT_COMMON_DIR", &authority.common_directory_path);
+                .arg(&authority.worktree_path);
         }
     }
 }
@@ -493,8 +751,9 @@ struct GitCoordinates {
 }
 
 async fn discover_git_coordinates(
-    git: &Path,
+    git: &GitExecutable,
     directory: &Path,
+    cancellation: &CancellationToken,
 ) -> Result<GitCoordinates, LocalSnapshotError> {
     let output = capture_discovery_git(
         git,
@@ -508,6 +767,7 @@ async fn discover_git_coordinates(
             "--show-prefix",
         ],
         MAX_GIT_COORDINATES_BYTES,
+        cancellation,
     )
     .await?;
     parse_git_coordinates(&output)
@@ -605,9 +865,10 @@ fn parse_git_prefix(value: &str) -> Result<Vec<String>, LocalSnapshotError> {
 }
 
 async fn verify_bound_git_coordinates(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     failure: LocalSnapshotErrorCode,
+    cancellation: &CancellationToken,
 ) -> Result<(), LocalSnapshotError> {
     let output = capture_bound_git(
         git,
@@ -621,6 +882,7 @@ async fn verify_bound_git_coordinates(
             "--show-prefix",
         ],
         MAX_GIT_COORDINATES_BYTES,
+        cancellation,
     )
     .await?;
     let coordinates = parse_git_coordinates(&output)?;
@@ -975,6 +1237,13 @@ impl PinnedDirectory {
         self.clone_handle(LocalSnapshotErrorCode::ConcurrentMutation)
     }
 
+    fn clone_pinned(&self) -> Result<Self, LocalSnapshotError> {
+        Ok(Self {
+            handle: self.clone_handle(LocalSnapshotErrorCode::ConcurrentMutation)?,
+            identity: self.identity,
+        })
+    }
+
     fn clone_handle(&self, failure: LocalSnapshotErrorCode) -> Result<Dir, LocalSnapshotError> {
         self.handle
             .try_clone()
@@ -1017,6 +1286,19 @@ impl PinnedDirectory {
         }
         Err(LocalSnapshotError::new(LocalSnapshotErrorCode::UnsafePath))
     }
+}
+
+async fn run_blocking<T, F>(
+    join_failure: LocalSnapshotErrorCode,
+    operation: F,
+) -> Result<T, LocalSnapshotError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, LocalSnapshotError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|_| LocalSnapshotError::new(join_failure))?
 }
 
 struct GitAuthority {
@@ -1082,7 +1364,6 @@ impl GitLocator {
             .handle
             .symlink_metadata(".git")
             .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::NotGitWorktree))?;
-        require_no_windows_reparse(&metadata)?;
         if metadata.is_dir() {
             let directory = open_git_locator_directory(
                 worktree,
@@ -1126,7 +1407,6 @@ impl GitLocator {
                     .handle
                     .symlink_metadata(".git")
                     .map_err(|_| LocalSnapshotError::new(failure))?;
-                require_no_windows_reparse(&metadata)?;
                 if !metadata.is_dir() {
                     return Err(LocalSnapshotError::new(failure));
                 }
@@ -1179,7 +1459,6 @@ fn capture_git_file(
         .handle
         .symlink_metadata(".git")
         .map_err(|_| LocalSnapshotError::new(failure))?;
-    require_no_windows_reparse(&before)?;
     if !before.is_file() {
         return Err(LocalSnapshotError::new(failure));
     }
@@ -1194,7 +1473,6 @@ fn capture_git_file(
     let opened = file
         .metadata()
         .map_err(|_| LocalSnapshotError::new(failure))?;
-    require_no_windows_reparse(&opened)?;
     if !opened.is_file() || MetadataStamp::new(&opened) != stamp {
         return Err(LocalSnapshotError::new(failure));
     }
@@ -1217,8 +1495,6 @@ fn capture_git_file(
         .handle
         .symlink_metadata(".git")
         .map_err(|_| LocalSnapshotError::new(failure))?;
-    require_no_windows_reparse(&opened_after)?;
-    require_no_windows_reparse(&ambient_after)?;
     if !opened_after.is_file()
         || !ambient_after.is_file()
         || MetadataStamp::new(&opened_after) != stamp
@@ -1300,7 +1576,6 @@ fn require_directory(
     metadata: &Metadata,
     code: LocalSnapshotErrorCode,
 ) -> Result<(), LocalSnapshotError> {
-    require_no_windows_reparse(metadata)?;
     if !metadata.is_dir() {
         return Err(LocalSnapshotError::new(code));
     }
@@ -1311,7 +1586,6 @@ fn require_ambient_directory(
     metadata: &fs::Metadata,
     code: LocalSnapshotErrorCode,
 ) -> Result<(), LocalSnapshotError> {
-    require_no_ambient_windows_reparse(metadata)?;
     if !metadata.is_dir() {
         return Err(LocalSnapshotError::new(code));
     }
@@ -1319,24 +1593,54 @@ fn require_ambient_directory(
 }
 
 async fn scan_worktree(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     limits: RepositoryWorkflowDiscoveryLimits,
     path_validator: RepositoryPathValidator,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<WorktreeScanEntry>, LocalSnapshotError> {
+    check_cancelled(cancellation)?;
+    let worktree = authority.worktree.clone_pinned()?;
+    let worker_cancellation = cancellation.clone();
+    let mut scanned = run_blocking(LocalSnapshotErrorCode::ConcurrentMutation, move || {
+        scan_worktree_filesystem(&worktree, limits, path_validator, &worker_cancellation)
+    })
+    .await?;
+    let ignored = ignored_paths(git, authority, &scanned, limits, cancellation).await?;
+    scanned.retain(|entry| !ignored.contains(&entry.path));
+    if scanned
+        .iter()
+        .any(|entry| entry.kind == WorktreeScanEntryKind::Unsupported)
+    {
+        return Err(LocalSnapshotError::new(
+            LocalSnapshotErrorCode::UnsupportedEntry,
+        ));
+    }
+    Ok(scanned)
+}
+
+fn scan_worktree_filesystem(
+    worktree: &PinnedDirectory,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    path_validator: RepositoryPathValidator,
+    cancellation: &CancellationToken,
+) -> Result<Vec<WorktreeScanEntry>, LocalSnapshotError> {
+    check_cancelled(cancellation)?;
     let maximum_observed = limits.maximum_path_graph_nodes();
     let mut observed = 0_usize;
     let mut directories = vec![ScanDirectory {
-        handle: authority.worktree.root_handle()?,
+        handle: worktree.root_handle()?,
         path: None,
     }];
     let mut scanned = Vec::new();
     while let Some(directory) = directories.pop() {
+        check_cancelled(cancellation)?;
         let children = directory
             .handle
             .entries()
             .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
         for child in children {
+            check_cancelled(cancellation)?;
             let child = child
                 .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
             let name = child.file_name();
@@ -1362,7 +1666,6 @@ async fn scan_worktree(
                 .handle
                 .symlink_metadata(&name)
                 .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
-            require_no_windows_reparse(&metadata)?;
             validate_scanned_path(&path, &metadata, path_validator)?;
             let file_type = metadata.file_type();
             let stamp = MetadataStamp::new(&metadata);
@@ -1395,16 +1698,6 @@ async fn scan_worktree(
         }
     }
     scanned.sort_by(|left, right| left.path.cmp(&right.path));
-    let ignored = ignored_paths(git, authority, &scanned, limits).await?;
-    scanned.retain(|entry| !ignored.contains(&entry.path));
-    if scanned
-        .iter()
-        .any(|entry| entry.kind == WorktreeScanEntryKind::Unsupported)
-    {
-        return Err(LocalSnapshotError::new(
-            LocalSnapshotErrorCode::UnsupportedEntry,
-        ));
-    }
     Ok(scanned)
 }
 
@@ -1424,10 +1717,11 @@ fn validate_scanned_path(
 }
 
 async fn ignored_paths(
-    git: &Path,
+    git: &GitExecutable,
     authority: &GitAuthority,
     scanned: &[WorktreeScanEntry],
     limits: RepositoryWorkflowDiscoveryLimits,
+    cancellation: &CancellationToken,
 ) -> Result<BTreeSet<String>, LocalSnapshotError> {
     if scanned.is_empty() {
         return Ok(BTreeSet::new());
@@ -1435,6 +1729,7 @@ async fn ignored_paths(
     let mut input = Vec::new();
     let maximum_input_bytes = checked_output_limit(limits, 1)?;
     for entry in scanned {
+        check_cancelled(cancellation)?;
         let next_length = input
             .len()
             .checked_add(entry.path.len())
@@ -1455,6 +1750,7 @@ async fn ignored_paths(
         &input,
         input.len(),
         true,
+        cancellation,
     )
     .await?;
     let candidates = scanned
@@ -1496,11 +1792,13 @@ fn capture_entries(
     inventory: &GitInventory,
     limits: RepositoryWorkflowDiscoveryLimits,
     path_validator: RepositoryPathValidator,
+    cancellation: &CancellationToken,
 ) -> Result<CapturedInventory, LocalSnapshotError> {
     let mut entries = Vec::with_capacity(inventory.paths.len());
     let mut deleted_paths = Vec::new();
     let mut expanded_bytes = 0_u64;
     for path in &inventory.paths {
+        check_cancelled(cancellation)?;
         let tracked = inventory.tracked_modes.get(path).copied();
         let Some((parent, name)) = worktree.locate_parent(path)? else {
             if tracked.is_some() {
@@ -1526,15 +1824,19 @@ fn capture_entries(
                 ));
             }
         };
-        require_no_windows_reparse(&before)?;
         let before_stamp = MetadataStamp::new(&before);
         let payload = match tracked {
             Some(TrackedMode::Symlink) if before.file_type().is_symlink() => {
                 capture_filesystem_symlink(&parent, name, path_validator)?
             }
-            Some(TrackedMode::Symlink) if before.is_file() => {
-                capture_symlink_placeholder(&parent, name, &before, before_stamp, path_validator)?
-            }
+            Some(TrackedMode::Symlink) if before.is_file() => capture_symlink_placeholder(
+                &parent,
+                name,
+                &before,
+                before_stamp,
+                path_validator,
+                cancellation,
+            )?,
             Some(TrackedMode::Symlink) => {
                 return Err(LocalSnapshotError::new(
                     LocalSnapshotErrorCode::UnsupportedEntry,
@@ -1551,14 +1853,15 @@ fn capture_entries(
                 capture_filesystem_symlink(&parent, name, path_validator)?
             }
             _ if before.is_file() => {
-                let remaining = limits
-                    .maximum_expanded_bytes()
-                    .checked_sub(expanded_bytes)
-                    .ok_or_else(|| {
-                        LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit)
-                    })?;
-                let (payload, read_bytes) =
-                    capture_regular_file(&parent, name, &before, before_stamp, remaining, tracked)?;
+                let (payload, read_bytes) = capture_regular_file(
+                    &parent,
+                    name,
+                    &before,
+                    before_stamp,
+                    remaining_expanded_bytes(limits, expanded_bytes)?,
+                    tracked,
+                    cancellation,
+                )?;
                 expanded_bytes = expanded_bytes.checked_add(read_bytes).ok_or_else(|| {
                     LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit)
                 })?;
@@ -1573,7 +1876,6 @@ fn capture_entries(
         let after = parent
             .symlink_metadata(name)
             .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
-        require_no_windows_reparse(&after)?;
         if MetadataStamp::new(&after) != before_stamp {
             return Err(LocalSnapshotError::new(
                 LocalSnapshotErrorCode::ConcurrentMutation,
@@ -1591,6 +1893,16 @@ fn capture_entries(
     })
 }
 
+fn remaining_expanded_bytes(
+    limits: RepositoryWorkflowDiscoveryLimits,
+    expanded_bytes: u64,
+) -> Result<u64, LocalSnapshotError> {
+    limits
+        .maximum_expanded_bytes()
+        .checked_sub(expanded_bytes)
+        .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))
+}
+
 fn capture_regular_file(
     parent: &Dir,
     name: &str,
@@ -1598,6 +1910,7 @@ fn capture_regular_file(
     before_stamp: MetadataStamp,
     remaining: u64,
     tracked: Option<TrackedMode>,
+    cancellation: &CancellationToken,
 ) -> Result<(CapturedPayload, u64), LocalSnapshotError> {
     if before.len() > remaining {
         return Err(LocalSnapshotError::new(
@@ -1620,10 +1933,7 @@ fn capture_regular_file(
         usize::try_from(before.len())
             .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?,
     );
-    std::io::Read::by_ref(&mut file)
-        .take(maximum_read)
-        .read_to_end(&mut bytes)
-        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    read_file_cancellable(&mut file, maximum_read, &mut bytes, cancellation)?;
     let read_bytes = u64::try_from(bytes.len())
         .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
     if read_bytes > remaining {
@@ -1648,6 +1958,39 @@ fn capture_regular_file(
     ))
 }
 
+fn read_file_cancellable(
+    file: &mut File,
+    maximum_bytes: u64,
+    output: &mut Vec<u8>,
+    cancellation: &CancellationToken,
+) -> Result<(), LocalSnapshotError> {
+    const READ_CHUNK_BYTES: usize = 64 * 1_024;
+
+    let mut buffer = vec![0_u8; READ_CHUNK_BYTES].into_boxed_slice();
+    while u64::try_from(output.len())
+        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?
+        < maximum_bytes
+    {
+        check_cancelled(cancellation)?;
+        let remaining = maximum_bytes
+            .checked_sub(
+                u64::try_from(output.len())
+                    .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?,
+            )
+            .ok_or_else(|| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+        let read_limit = usize::try_from(remaining.min(READ_CHUNK_BYTES as u64))
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
+        let read = file
+            .read(&mut buffer[..read_limit])
+            .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+        if read == 0 {
+            break;
+        }
+        output.extend_from_slice(&buffer[..read]);
+    }
+    check_cancelled(cancellation)
+}
+
 fn capture_filesystem_symlink(
     parent: &Dir,
     name: &str,
@@ -1668,6 +2011,7 @@ fn capture_symlink_placeholder(
     before: &Metadata,
     before_stamp: MetadataStamp,
     validator: RepositoryPathValidator,
+    cancellation: &CancellationToken,
 ) -> Result<CapturedPayload, LocalSnapshotError> {
     let mut file = open_regular_nofollow(parent, name)?;
     let opened = file
@@ -1681,10 +2025,7 @@ fn capture_symlink_placeholder(
     let maximum = u64::try_from(automata_ci_workflow_github::USTAR_LINK_NAME_BYTES)
         .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
     let mut bytes = Vec::new();
-    std::io::Read::by_ref(&mut file)
-        .take(maximum + 1)
-        .read_to_end(&mut bytes)
-        .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
+    read_file_cancellable(&mut file, maximum + 1, &mut bytes, cancellation)?;
     if bytes.len() > automata_ci_workflow_github::USTAR_LINK_NAME_BYTES {
         return Err(LocalSnapshotError::new(
             LocalSnapshotErrorCode::ResourceLimit,
@@ -1721,29 +2062,6 @@ fn local_link_validation_error(error: RepositoryPathValidationError) -> LocalSna
     })
 }
 
-fn workflow_location(
-    entries: &[CapturedEntry],
-) -> Result<Option<RepositoryWorkflowLocation>, LocalSnapshotError> {
-    let mut automata = false;
-    let mut github = false;
-    for entry in entries {
-        let mut components = entry.path.split('/');
-        match (components.next(), components.next()) {
-            (Some(".ci"), Some("workflows")) => automata = true,
-            (Some(".github"), Some("workflows")) => github = true,
-            _ => {}
-        }
-    }
-    match (automata, github) {
-        (true, true) => Err(LocalSnapshotError::new(
-            LocalSnapshotErrorCode::AmbiguousWorkflowLocation,
-        )),
-        (true, false) => Ok(Some(RepositoryWorkflowLocation::Automata)),
-        (false, true) => Ok(Some(RepositoryWorkflowLocation::Github)),
-        (false, false) => Ok(None),
-    }
-}
-
 fn verify_git_state(initial: &GitState, final_state: &GitState) -> Result<(), LocalSnapshotError> {
     if initial.head != final_state.head
         || initial.index != final_state.index
@@ -1760,8 +2078,10 @@ fn verify_git_state(initial: &GitState, final_state: &GitState) -> Result<(), Lo
 fn verify_deleted_paths(
     worktree: &PinnedDirectory,
     deleted_paths: &[String],
+    cancellation: &CancellationToken,
 ) -> Result<(), LocalSnapshotError> {
     for path in deleted_paths {
+        check_cancelled(cancellation)?;
         if let Some((parent, name)) = worktree.locate_parent(path)? {
             match parent.symlink_metadata(name) {
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {}
@@ -1779,7 +2099,9 @@ fn verify_deleted_paths(
 fn build_archive(
     entries: &[CapturedEntry],
     limits: RepositoryWorkflowDiscoveryLimits,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, LocalSnapshotError> {
+    check_cancelled(cancellation)?;
     if entries.len() >= limits.maximum_entries() {
         return Err(LocalSnapshotError::new(
             LocalSnapshotErrorCode::ResourceLimit,
@@ -1797,15 +2119,20 @@ fn build_archive(
         .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ResourceLimit))?;
     let writer = BoundedWriter::new(encoder, maximum_decompressed_bytes);
     let mut archive = TarBuilder::new(writer);
-    append_root(&mut archive).map_err(|error| archive_error(&error))?;
+    append_root(&mut archive).map_err(|error| archive_error(&error, cancellation))?;
     for entry in entries {
-        append_entry(&mut archive, entry).map_err(|error| archive_error(&error))?;
+        check_cancelled(cancellation)?;
+        append_entry(&mut archive, entry, cancellation)
+            .map_err(|error| archive_error(&error, cancellation))?;
     }
     let writer = archive
         .into_inner()
-        .map_err(|error| archive_error(&error))?;
+        .map_err(|error| archive_error(&error, cancellation))?;
     let encoder = writer.into_inner();
-    let writer = encoder.finish().map_err(|error| archive_error(&error))?;
+    let writer = encoder
+        .finish()
+        .map_err(|error| archive_error(&error, cancellation))?;
+    check_cancelled(cancellation)?;
     Ok(writer.into_inner())
 }
 
@@ -1816,7 +2143,11 @@ fn append_root<W: Write>(archive: &mut TarBuilder<W>) -> io::Result<()> {
     archive.append(&header, io::empty())
 }
 
-fn append_entry<W: Write>(archive: &mut TarBuilder<W>, entry: &CapturedEntry) -> io::Result<()> {
+fn append_entry<W: Write>(
+    archive: &mut TarBuilder<W>,
+    entry: &CapturedEntry,
+    cancellation: &CancellationToken,
+) -> io::Result<()> {
     let archive_path = format!("{SNAPSHOT_ROOT}/{}", entry.path);
     match &entry.payload {
         CapturedPayload::File { bytes, executable } => {
@@ -1826,7 +2157,10 @@ fn append_entry<W: Write>(archive: &mut TarBuilder<W>, entry: &CapturedEntry) ->
             let mut header = deterministic_header(EntryType::Regular, size, mode);
             header.set_path(archive_path)?;
             header.set_cksum();
-            archive.append(&header, Cursor::new(bytes))
+            archive.append(
+                &header,
+                CancellableReader::new(Cursor::new(bytes), cancellation),
+            )
         }
         CapturedPayload::Symlink { target } => {
             let mut header = deterministic_header(EntryType::Symlink, 0, 0o777);
@@ -1835,6 +2169,29 @@ fn append_entry<W: Write>(archive: &mut TarBuilder<W>, entry: &CapturedEntry) ->
             header.set_cksum();
             archive.append(&header, io::empty())
         }
+    }
+}
+
+struct CancellableReader<'a, R> {
+    inner: R,
+    cancellation: &'a CancellationToken,
+}
+
+impl<'a, R> CancellableReader<'a, R> {
+    const fn new(inner: R, cancellation: &'a CancellationToken) -> Self {
+        Self {
+            inner,
+            cancellation,
+        }
+    }
+}
+
+impl<R: io::Read> io::Read for CancellableReader<'_, R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.cancellation.is_cancelled() {
+            return Err(io::Error::other("cancelled"));
+        }
+        self.inner.read(buffer)
     }
 }
 
@@ -1849,8 +2206,10 @@ fn deterministic_header(entry_type: EntryType, size: u64, mode: u32) -> Header {
     header
 }
 
-fn archive_error(error: &io::Error) -> LocalSnapshotError {
-    LocalSnapshotError::new(if error.kind() == io::ErrorKind::FileTooLarge {
+fn archive_error(error: &io::Error, cancellation: &CancellationToken) -> LocalSnapshotError {
+    LocalSnapshotError::new(if cancellation.is_cancelled() {
+        LocalSnapshotErrorCode::Cancelled
+    } else if error.kind() == io::ErrorKind::FileTooLarge {
         LocalSnapshotErrorCode::ResourceLimit
     } else {
         LocalSnapshotErrorCode::ArchiveEncoding
@@ -1942,7 +2301,6 @@ fn open_regular_nofollow(parent: &Dir, name: &str) -> Result<File, LocalSnapshot
     let metadata = file
         .metadata()
         .map_err(|_| LocalSnapshotError::new(LocalSnapshotErrorCode::ConcurrentMutation))?;
-    require_no_windows_reparse(&metadata)?;
     if !metadata.is_file() {
         return Err(LocalSnapshotError::new(
             LocalSnapshotErrorCode::ConcurrentMutation,
@@ -1951,21 +2309,12 @@ fn open_regular_nofollow(parent: &Dir, name: &str) -> Result<File, LocalSnapshot
     Ok(file)
 }
 
-#[cfg(unix)]
 fn configure_regular_open(options: &mut OpenOptions) {
     use cap_std::fs::OpenOptionsExt as _;
 
     let flags = i32::try_from(rustix::fs::OFlags::NONBLOCK.bits())
         .expect("Unix nonblocking flag must fit c_int");
     options.custom_flags(flags);
-}
-
-#[cfg(windows)]
-fn configure_regular_open(options: &mut OpenOptions) {
-    use cap_std::fs::OpenOptionsExt as _;
-
-    const FILE_SHARE_READ: u32 = 0x0000_0001;
-    options.share_mode(FILE_SHARE_READ);
 }
 
 fn executable(metadata: &Metadata, tracked: Option<TrackedMode>) -> bool {
@@ -1975,64 +2324,10 @@ fn executable(metadata: &Metadata, tracked: Option<TrackedMode>) -> bool {
     )
 }
 
-#[cfg(unix)]
 fn untracked_executable(metadata: &Metadata) -> bool {
     use cap_std::fs::MetadataExt as _;
 
     metadata.mode() & 0o111 != 0
-}
-
-#[cfg(windows)]
-const fn untracked_executable(_metadata: &Metadata) -> bool {
-    false
-}
-
-fn require_no_windows_reparse(metadata: &Metadata) -> Result<(), LocalSnapshotError> {
-    if metadata_is_windows_reparse(metadata) {
-        return Err(LocalSnapshotError::new(
-            LocalSnapshotErrorCode::UnsupportedEntry,
-        ));
-    }
-    Ok(())
-}
-
-fn require_no_ambient_windows_reparse(metadata: &fs::Metadata) -> Result<(), LocalSnapshotError> {
-    if ambient_metadata_is_windows_reparse(metadata) {
-        return Err(LocalSnapshotError::new(
-            LocalSnapshotErrorCode::UnsupportedEntry,
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-const fn metadata_is_windows_reparse(_metadata: &Metadata) -> bool {
-    false
-}
-
-#[cfg(windows)]
-fn metadata_is_windows_reparse(metadata: &Metadata) -> bool {
-    use cap_std::fs::MetadataExt as _;
-
-    windows_reparse_attributes(metadata.file_attributes())
-}
-
-#[cfg(unix)]
-const fn ambient_metadata_is_windows_reparse(_metadata: &fs::Metadata) -> bool {
-    false
-}
-
-#[cfg(windows)]
-fn ambient_metadata_is_windows_reparse(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-
-    windows_reparse_attributes(metadata.file_attributes())
-}
-
-#[cfg(any(test, windows))]
-const fn windows_reparse_attributes(attributes: u32) -> bool {
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-    attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2052,7 +2347,6 @@ impl DirectoryIdentity {
     }
 }
 
-#[cfg(unix)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct MetadataStamp {
     device: u64,
@@ -2065,7 +2359,6 @@ struct MetadataStamp {
     changed_nanoseconds: i64,
 }
 
-#[cfg(unix)]
 impl MetadataStamp {
     fn new(metadata: &Metadata) -> Self {
         use cap_std::fs::MetadataExt as _;
@@ -2083,41 +2376,16 @@ impl MetadataStamp {
     }
 }
 
-#[cfg(windows)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct MetadataStamp {
-    device: u64,
-    inode: u64,
-    attributes: u32,
-    created: u64,
-    modified: u64,
-    length: u64,
-}
-
-#[cfg(windows)]
-impl MetadataStamp {
-    fn new(metadata: &Metadata) -> Self {
-        use cap_fs_ext::MetadataExt as _;
-        use cap_std::fs::MetadataExt as _;
-
-        Self {
-            device: metadata.dev(),
-            inode: metadata.ino(),
-            attributes: metadata.file_attributes(),
-            created: metadata.creation_time(),
-            modified: metadata.last_write_time(),
-            length: metadata.file_size(),
-        }
-    }
-}
-
 /// Stable fail-closed class for local snapshot construction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum LocalSnapshotErrorCode {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LocalSnapshotErrorCode {
+    /// This checkpoint has not qualified exact mutation evidence on the host platform.
+    /// Cooperative shutdown interrupted snapshot construction.
+    Cancelled,
     /// The Git executable was unavailable.
     GitUnavailable,
+    /// The pinned trusted Git executable changed during capture.
+    GitExecutableChanged,
     /// Git did not complete a required read-only query.
     GitCommand,
     /// A Git query exceeded its deadline.
@@ -2132,7 +2400,7 @@ pub enum LocalSnapshotErrorCode {
     UnsafePath,
     /// The requested directory or one selected path has an unsafe ancestor.
     UnsafeAncestor,
-    /// A symlink escapes, cycles, aliases a workflow namespace, or is nonportable.
+    /// A symlink target is noncanonical, absolute, or nonportable.
     UnsafeSymlink,
     /// An index conflict or unsupported staged mode made the source ambiguous.
     IndexAmbiguity,
@@ -2145,12 +2413,6 @@ pub enum LocalSnapshotErrorCode {
     /// A requested ancestor or selected entry is a socket, device, FIFO,
     /// Windows reparse point, or another unsafe filesystem type.
     UnsupportedEntry,
-    /// Two selected paths differ only by case.
-    CaseCollision,
-    /// A selected file or link is also an ancestor of another selected path.
-    PathTypeConflict,
-    /// Both `.ci/workflows` and `.github/workflows` namespaces were present.
-    AmbiguousWorkflowLocation,
     /// A pinned directory, Git authority, index, inventory, status, or `HEAD`
     /// changed during capture.
     ConcurrentMutation,
@@ -2158,16 +2420,18 @@ pub enum LocalSnapshotErrorCode {
     ResourceLimit,
     /// Deterministic tar.gz encoding failed.
     ArchiveEncoding,
-    /// The retained archive failed the shared workflow discovery contract.
-    WorkflowDiscovery,
 }
 
 impl LocalSnapshotErrorCode {
     /// Returns one sanitized actionable failure description.
     #[must_use]
-    pub const fn message(self) -> &'static str {
+    pub(crate) const fn message(self) -> &'static str {
         match self {
-            Self::GitUnavailable => "install Git and make it available on PATH",
+            Self::Cancelled => "local snapshot construction was cancelled",
+            Self::GitUnavailable => "install Git at the trusted system executable path",
+            Self::GitExecutableChanged => {
+                "the trusted Git executable changed while the worktree was inspected"
+            }
             Self::GitCommand => "Git could not inspect the requested worktree",
             Self::GitTimeout => "Git worktree inspection timed out",
             Self::GitOutput => "Git returned an unsupported worktree response",
@@ -2179,7 +2443,7 @@ impl LocalSnapshotErrorCode {
             Self::UnsafeAncestor => {
                 "the requested directory or a selected path has an unsafe ancestor"
             }
-            Self::UnsafeSymlink => "the worktree contains an escaping or unsafe symlink",
+            Self::UnsafeSymlink => "the worktree contains a noncanonical or unsafe symlink target",
             Self::IndexAmbiguity => "resolve the Git index conflict or unsupported staged mode",
             Self::SparseCheckout => {
                 "disable sparse checkout before sealing an exact local snapshot"
@@ -2191,19 +2455,11 @@ impl LocalSnapshotErrorCode {
             Self::UnsupportedEntry => {
                 "the requested path or worktree contains a reparse point or unsupported entry"
             }
-            Self::CaseCollision => "the Git inventory contains case-colliding paths",
-            Self::PathTypeConflict => {
-                "the Git inventory contains conflicting file and directory paths"
-            }
-            Self::AmbiguousWorkflowLocation => {
-                "keep workflows in exactly one of .github/workflows or .ci/workflows"
-            }
             Self::ConcurrentMutation => {
                 "the worktree or Git authority changed while its snapshot was being sealed"
             }
             Self::ResourceLimit => "the worktree snapshot exceeds a configured resource limit",
             Self::ArchiveEncoding => "the worktree could not be encoded deterministically",
-            Self::WorkflowDiscovery => "the sealed archive failed workflow discovery",
         }
     }
 }
@@ -2217,7 +2473,7 @@ impl std::fmt::Display for LocalSnapshotErrorCode {
 /// Sanitized local snapshot failure.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 #[error("{code}")]
-pub struct LocalSnapshotError {
+pub(crate) struct LocalSnapshotError {
     code: LocalSnapshotErrorCode,
 }
 
@@ -2228,7 +2484,7 @@ impl LocalSnapshotError {
 
     /// Returns the stable failure class.
     #[must_use]
-    pub const fn code(self) -> LocalSnapshotErrorCode {
+    pub(crate) const fn code(self) -> LocalSnapshotErrorCode {
         self.code
     }
 }
@@ -2244,18 +2500,71 @@ mod tests {
 
     use automata_ci_core::Sha256Digest;
     use automata_ci_workflow_github::{
-        RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowLocation,
+        GithubWorkflowDispatchInputs, RepositoryWorkflowDiscoveryLimits,
+    };
+    use automata_ci_workflow_service::{
+        LocalGithubArchiveAnalysisFailureKind, ReusableWorkflowLimits, analyze_local_github_archive,
     };
     use flate2::read::MultiGzDecoder;
     use sha2::{Digest as _, Sha256};
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     #[cfg(unix)]
     use super::capture_snapshot_with_git;
-    use super::{LocalSnapshotErrorCode, LocalSnapshotRequest, capture_snapshot};
+    use super::{
+        LocalSnapshotErrorCode, LocalSnapshotRequest, capture_snapshot, local_snapshot_limits,
+        validate_local_snapshot_limits,
+    };
 
     const WORKFLOW: &str =
         "on: push\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n";
+
+    #[test]
+    fn archive_cancellation_is_terminal_not_retryable_io() {
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let mut reader =
+            super::CancellableReader::new(std::io::Cursor::new(b"payload"), &cancellation);
+        let error = std::io::copy(&mut reader, &mut std::io::sink())
+            .expect_err("cancellation must terminate the copy");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            super::archive_error(&error, &cancellation).code(),
+            LocalSnapshotErrorCode::Cancelled
+        );
+    }
+
+    fn assert_archive_policy_rejects(snapshot: &super::LocalSnapshot) {
+        let error = analyze_local_github_archive(
+            snapshot.archive_bytes(),
+            None,
+            GithubWorkflowDispatchInputs::try_new(std::iter::empty::<(String, String)>())
+                .expect("empty dispatch inputs"),
+            local_snapshot_limits(),
+            ReusableWorkflowLimits::default(),
+            &|| false,
+        )
+        .expect_err("unsafe archive graph must fail before workflow selection");
+        assert_eq!(error.kind(), LocalGithubArchiveAnalysisFailureKind::Archive);
+    }
+
+    #[test]
+    fn local_snapshot_peak_shape_has_fixed_materially_lower_bounds() {
+        let limits = local_snapshot_limits();
+        assert_eq!(limits.maximum_compressed_bytes(), 32 * 1024 * 1024);
+        assert_eq!(limits.maximum_decompressed_bytes(), 64 * 1024 * 1024);
+        assert_eq!(limits.maximum_expanded_bytes(), 32 * 1024 * 1024);
+        assert_eq!(limits.maximum_entries(), 20_000);
+        assert_eq!(limits.maximum_workflow_bytes(), 1024 * 1024);
+        assert!(validate_local_snapshot_limits(limits).is_ok());
+        assert_eq!(
+            validate_local_snapshot_limits(RepositoryWorkflowDiscoveryLimits::default()),
+            Err(super::LocalSnapshotError::new(
+                LocalSnapshotErrorCode::ResourceLimit
+            ))
+        );
+    }
 
     #[tokio::test]
     async fn clean_dirty_ignored_and_cloned_worktrees_have_deterministic_exact_archives() {
@@ -2271,13 +2580,6 @@ mod tests {
         assert_eq!(clean.digest(), repeated.digest());
         assert_eq!(clean.archive_bytes(), repeated.archive_bytes());
         assert!(!clean.dirty());
-        assert_eq!(
-            clean.workflow_location(),
-            Some(RepositoryWorkflowLocation::Github)
-        );
-        assert_eq!(clean.workflows().len(), 1);
-        assert_eq!(clean.workflows()[0].path(), ".github/workflows/ci.yml");
-        assert_eq!(clean.workflows()[0].result().unwrap(), WORKFLOW.as_bytes());
         assert_eq!(
             clean.digest(),
             Sha256Digest::from_bytes(Sha256::digest(clean.archive_bytes()).into())
@@ -2314,13 +2616,12 @@ mod tests {
         fixture.commit_all("subdirectory invocation");
 
         let root = fixture.capture().await.expect("root snapshot");
-        let nested = capture_snapshot(LocalSnapshotRequest::new(
-            fixture.path().join("nested"),
-            RepositoryWorkflowDiscoveryLimits::default(),
-        ))
+        let nested = capture_snapshot(
+            LocalSnapshotRequest::new(fixture.path().join("nested"), local_snapshot_limits()),
+            &CancellationToken::new(),
+        )
         .await
         .expect("nested invocation");
-        assert_eq!(nested.root(), fixture.path());
         assert_eq!(nested.archive_bytes(), root.archive_bytes());
 
         let nested_repository = fixture.path().join("nested");
@@ -2342,13 +2643,13 @@ mod tests {
             "--message",
             "nested repository",
         ]);
-        let nested_authority = capture_snapshot(LocalSnapshotRequest::new(
-            &nested_repository,
-            RepositoryWorkflowDiscoveryLimits::default(),
-        ))
+        let nested_authority = capture_snapshot(
+            LocalSnapshotRequest::new(&nested_repository, local_snapshot_limits()),
+            &CancellationToken::new(),
+        )
         .await
         .expect("nested repository authority");
-        assert_eq!(nested_authority.root(), nested_repository);
+        assert!(!nested_authority.archive_bytes().is_empty());
 
         fixture.git(&[
             "-C",
@@ -2358,10 +2659,10 @@ mod tests {
             fixture.path().to_str().expect("Unicode fixture path"),
         ]);
         assert_eq!(
-            capture_snapshot(LocalSnapshotRequest::new(
-                &nested_repository,
-                RepositoryWorkflowDiscoveryLimits::default(),
-            ))
+            capture_snapshot(
+                LocalSnapshotRequest::new(&nested_repository, local_snapshot_limits(),),
+                &CancellationToken::new(),
+            )
             .await
             .unwrap_err()
             .code(),
@@ -2404,8 +2705,9 @@ mod tests {
             "HEAD",
         ]);
         let linked = Fixture { root: linked_root };
+        let primary_snapshot = primary.capture().await.expect("primary worktree snapshot");
         let linked_snapshot = linked.capture().await.expect("linked worktree snapshot");
-        assert_eq!(linked_snapshot.root(), linked.path());
+        assert_eq!(linked_snapshot.digest(), primary_snapshot.digest());
 
         let symlink_locator = Fixture::new();
         symlink_locator.write("tracked.txt", "tracked\n");
@@ -2472,7 +2774,7 @@ mod tests {
         fs::set_permissions(&linked_wrapper, fs::Permissions::from_mode(0o700))
             .expect("make linked-worktree Git wrapper executable");
         let linked_error = capture_snapshot_with_git(
-            LocalSnapshotRequest::new(linked.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            LocalSnapshotRequest::new(linked.path(), local_snapshot_limits()),
             &linked_wrapper,
         )
         .await
@@ -2525,10 +2827,7 @@ mod tests {
         fs::set_permissions(&admin_wrapper, fs::Permissions::from_mode(0o700))
             .expect("make linked Git-directory wrapper executable");
         let admin_error = capture_snapshot_with_git(
-            LocalSnapshotRequest::new(
-                admin_linked.path(),
-                RepositoryWorkflowDiscoveryLimits::default(),
-            ),
+            LocalSnapshotRequest::new(admin_linked.path(), local_snapshot_limits()),
             &admin_wrapper,
         )
         .await
@@ -2561,7 +2860,7 @@ mod tests {
         fs::set_permissions(&direct_wrapper, fs::Permissions::from_mode(0o700))
             .expect("make direct-worktree Git wrapper executable");
         let direct_error = capture_snapshot_with_git(
-            LocalSnapshotRequest::new(direct.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            LocalSnapshotRequest::new(direct.path(), local_snapshot_limits()),
             &direct_wrapper,
         )
         .await
@@ -2587,7 +2886,7 @@ mod tests {
         let error = capture_snapshot_with_git(
             LocalSnapshotRequest::new(
                 alias_host.path().join("alias/nested"),
-                RepositoryWorkflowDiscoveryLimits::default(),
+                local_snapshot_limits(),
             ),
             Path::new("/definitely-not-an-automata-test-git"),
         )
@@ -2650,56 +2949,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn case_collisions_and_dual_workflow_namespaces_fail_closed() {
-        let case_fixture = Fixture::new();
-        case_fixture.write("README", "upper\n");
-        case_fixture.write("readme", "lower\n");
-        case_fixture.commit_all("case collision");
-        assert_eq!(
-            case_fixture.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::CaseCollision
-        );
-
-        let namespace_fixture = Fixture::new();
-        namespace_fixture.write(".github/workflows/ci.yml", WORKFLOW);
-        namespace_fixture.write(".ci/workflows/ci.yml", WORKFLOW);
-        namespace_fixture.commit_all("dual namespaces");
-        assert_eq!(
-            namespace_fixture.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::AmbiguousWorkflowLocation
-        );
-
-        let automata_fixture = Fixture::new();
-        automata_fixture.write(".ci/workflows/ci.yml", WORKFLOW);
-        automata_fixture.commit_all("Automata authority");
-        let automata = automata_fixture
-            .capture()
-            .await
-            .expect("explicit Automata workflow location");
-        assert_eq!(
-            automata.workflow_location(),
-            Some(RepositoryWorkflowLocation::Automata)
-        );
-        assert_eq!(automata.workflows()[0].path(), ".ci/workflows/ci.yml");
-
-        let sigma_fixture = Fixture::new();
-        sigma_fixture.write("Σ/one", "one\n");
-        sigma_fixture.write("ς/two", "two\n");
-        sigma_fixture.commit_all("Unicode sigma collision");
-        assert_eq!(
-            sigma_fixture.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::CaseCollision
-        );
-
-        let normalization_fixture = Fixture::new();
-        normalization_fixture.write("caf\u{e9}/one", "one\n");
-        normalization_fixture.write("cafe\u{301}/two", "two\n");
-        normalization_fixture.commit_all("Unicode normalization collision");
-        assert_eq!(
-            normalization_fixture.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::CaseCollision
-        );
-
+    async fn noncanonical_workflow_namespace_spelling_fails_closed() {
         let namespace_spelling = Fixture::new();
         namespace_spelling.write(".github/WORKFLOWS/ci.yml", WORKFLOW);
         namespace_spelling.commit_all("noncanonical workflow namespace");
@@ -2717,10 +2967,13 @@ mod tests {
 
         let expanded = limits(1_024 * 1_024, 4, 10);
         assert_eq!(
-            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), expanded))
-                .await
-                .unwrap_err()
-                .code(),
+            capture_snapshot(
+                LocalSnapshotRequest::new(fixture.path(), expanded),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err()
+            .code(),
             LocalSnapshotErrorCode::ResourceLimit
         );
 
@@ -2731,10 +2984,13 @@ mod tests {
             .expect("one root and one file fit the exact entry bound");
         fixture.write("second.txt", "x");
         assert_eq!(
-            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), exact_entries))
-                .await
-                .unwrap_err()
-                .code(),
+            capture_snapshot(
+                LocalSnapshotRequest::new(fixture.path(), exact_entries),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err()
+            .code(),
             LocalSnapshotErrorCode::ResourceLimit
         );
 
@@ -2750,19 +3006,25 @@ mod tests {
         )
         .expect("decompressed-byte test limits");
         assert_eq!(
-            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), decompressed))
-                .await
-                .unwrap_err()
-                .code(),
+            capture_snapshot(
+                LocalSnapshotRequest::new(fixture.path(), decompressed),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err()
+            .code(),
             LocalSnapshotErrorCode::ResourceLimit
         );
 
         let encoded = limits(1, 1_024 * 1_024, 10);
         assert_eq!(
-            capture_snapshot(LocalSnapshotRequest::new(fixture.path(), encoded))
-                .await
-                .unwrap_err()
-                .code(),
+            capture_snapshot(
+                LocalSnapshotRequest::new(fixture.path(), encoded),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap_err()
+            .code(),
             LocalSnapshotErrorCode::ResourceLimit
         );
     }
@@ -2784,7 +3046,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn safe_symlinks_are_preserved_and_escaping_symlinks_are_rejected() {
+    async fn symlinks_are_captured_exactly_and_archive_policy_rejects_escapes() {
         use std::os::unix::fs::symlink;
 
         let fixture = Fixture::new();
@@ -2804,10 +3066,11 @@ mod tests {
         fs::remove_file(fixture.path().join("links/value")).expect("remove safe symlink");
         symlink("../../../outside", fixture.path().join("links/value"))
             .expect("create escaping symlink");
-        assert_eq!(
-            fixture.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::UnsafeSymlink
-        );
+        let escaping = fixture
+            .capture()
+            .await
+            .expect("exact escaping-link snapshot");
+        assert_archive_policy_rejects(&escaping);
     }
 
     #[cfg(unix)]
@@ -2875,20 +3138,19 @@ mod tests {
         namespace.write(".ci/workflows/ci.yml", WORKFLOW);
         symlink(".ci", namespace.path().join("alternate")).expect("alias workflow namespace");
         namespace.commit_all("namespace alias");
-        assert_eq!(
-            namespace.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::UnsafeSymlink
-        );
+        let namespace = namespace
+            .capture()
+            .await
+            .expect("exact namespace-link snapshot");
+        assert_archive_policy_rejects(&namespace);
 
         let cycle = Fixture::new();
         symlink("two", cycle.path().join("one")).expect("first cycle link");
         symlink("one", cycle.path().join("two")).expect("second cycle link");
         cycle.write("tracked", "tracked\n");
         cycle.commit_all("symlink cycle");
-        assert_eq!(
-            cycle.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::UnsafeSymlink
-        );
+        let cycle = cycle.capture().await.expect("exact cyclic-link snapshot");
+        assert_archive_policy_rejects(&cycle);
     }
 
     #[tokio::test]
@@ -2918,10 +3180,10 @@ mod tests {
         aliases.write("Directory/one", "one\n");
         aliases.write("directory/two", "two\n");
         aliases.commit_all("component aliases");
-        assert_eq!(
-            aliases.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::CaseCollision
-        );
+        let alias_snapshot = aliases.capture().await.expect("exact alias archive");
+        let alias_files = archive_files(alias_snapshot.archive_bytes());
+        assert_eq!(alias_files.get("Directory/one").unwrap(), b"one\n");
+        assert_eq!(alias_files.get("directory/two").unwrap(), b"two\n");
 
         let deletion = Fixture::new();
         deletion.write("nested/deleted", "delete me\n");
@@ -2932,15 +3194,6 @@ mod tests {
         let files = archive_files(snapshot.archive_bytes());
         assert!(!files.contains_key("nested/deleted"));
         assert_eq!(files.get("retained").unwrap(), b"retain me\n");
-    }
-
-    #[test]
-    fn windows_reparse_attribute_is_fail_closed() {
-        use super::windows_reparse_attributes;
-
-        assert!(!windows_reparse_attributes(0));
-        assert!(windows_reparse_attributes(0x0000_0400));
-        assert!(windows_reparse_attributes(0xffff_ffff));
     }
 
     #[cfg(unix)]
@@ -3079,7 +3332,7 @@ mod tests {
             .expect("make fake Git executable");
 
         let error = capture_snapshot_with_git(
-            LocalSnapshotRequest::new(fixture.path(), RepositoryWorkflowDiscoveryLimits::default()),
+            LocalSnapshotRequest::new(fixture.path(), local_snapshot_limits()),
             &wrapper,
         )
         .await
@@ -3238,15 +3491,18 @@ mod tests {
         }
 
         async fn capture(&self) -> Result<super::LocalSnapshot, super::LocalSnapshotError> {
-            self.capture_with_limits(RepositoryWorkflowDiscoveryLimits::default())
-                .await
+            self.capture_with_limits(local_snapshot_limits()).await
         }
 
         async fn capture_with_limits(
             &self,
             limits: RepositoryWorkflowDiscoveryLimits,
         ) -> Result<super::LocalSnapshot, super::LocalSnapshotError> {
-            capture_snapshot(LocalSnapshotRequest::new(&self.root, limits)).await
+            capture_snapshot(
+                LocalSnapshotRequest::new(&self.root, limits),
+                &CancellationToken::new(),
+            )
+            .await
         }
 
         fn git_tree_evidence(&self) -> Vec<(String, Vec<u8>, Option<std::time::SystemTime>)> {

--- a/crates/automata-ci-local/src/snapshot_limits.rs
+++ b/crates/automata-ci-local/src/snapshot_limits.rs
@@ -1,0 +1,26 @@
+use automata_ci_workflow_github::RepositoryWorkflowDiscoveryLimits;
+
+// Capture retains bounded Git inventories and one expanded file inventory while
+// constructing one compressed archive. These local-only ceilings keep the peak
+// materially below the shared delivery-scale bounds; the result retains none
+// of those buffers after analysis.
+const MAX_COMPRESSED_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_DECOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_ENTRIES: usize = 20_000;
+const MAX_EXPANDED_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_ENTRY_PATH_BYTES: usize = 4_096;
+const MAX_WORKFLOWS: usize = 128;
+const MAX_WORKFLOW_BYTES: u64 = 1024 * 1024;
+
+pub(crate) fn local_snapshot_limits() -> RepositoryWorkflowDiscoveryLimits {
+    RepositoryWorkflowDiscoveryLimits::new(
+        MAX_COMPRESSED_BYTES,
+        MAX_DECOMPRESSED_BYTES,
+        MAX_ENTRIES,
+        MAX_EXPANDED_BYTES,
+        MAX_ENTRY_PATH_BYTES,
+        MAX_WORKFLOWS,
+        MAX_WORKFLOW_BYTES,
+    )
+    .expect("fixed local snapshot limits must satisfy shared hard bounds")
+}

--- a/crates/automata-ci-local/src/snapshot_unsupported.rs
+++ b/crates/automata-ci-local/src/snapshot_unsupported.rs
@@ -1,0 +1,95 @@
+use std::path::PathBuf;
+
+use automata_ci_core::Sha256Digest;
+use automata_ci_workflow_github::RepositoryWorkflowDiscoveryLimits;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone, Debug)]
+pub(crate) struct LocalSnapshotRequest;
+
+impl LocalSnapshotRequest {
+    #[must_use]
+    pub(crate) fn new(
+        directory: impl Into<PathBuf>,
+        limits: RepositoryWorkflowDiscoveryLimits,
+    ) -> Self {
+        let _ = (directory.into(), limits);
+        Self
+    }
+}
+
+pub(crate) enum LocalSnapshot {}
+
+impl LocalSnapshot {
+    pub(crate) fn head(&self) -> &str {
+        match *self {}
+    }
+
+    pub(crate) const fn dirty(&self) -> bool {
+        match *self {}
+    }
+
+    pub(crate) const fn digest(&self) -> Sha256Digest {
+        match *self {}
+    }
+
+    pub(crate) fn into_archive(self) -> Vec<u8> {
+        match self {}
+    }
+
+    pub(crate) const fn entry_count(&self) -> usize {
+        match *self {}
+    }
+
+    pub(crate) const fn expanded_bytes(&self) -> u64 {
+        match *self {}
+    }
+}
+
+pub(crate) async fn capture_snapshot(
+    request: LocalSnapshotRequest,
+    cancellation: &CancellationToken,
+) -> Result<LocalSnapshot, LocalSnapshotError> {
+    let _ = (request, cancellation);
+    Err(LocalSnapshotError {
+        code: LocalSnapshotErrorCode::UnsupportedPlatform,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LocalSnapshotErrorCode {
+    UnsupportedPlatform,
+    Cancelled,
+}
+
+impl LocalSnapshotErrorCode {
+    #[must_use]
+    pub(crate) const fn message(self) -> &'static str {
+        match self {
+            Self::UnsupportedPlatform => {
+                "exact local snapshot mutation evidence is not qualified on this platform"
+            }
+            Self::Cancelled => "local snapshot construction was cancelled",
+        }
+    }
+}
+
+impl std::fmt::Display for LocalSnapshotErrorCode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.message())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("{code}")]
+pub(crate) struct LocalSnapshotError {
+    code: LocalSnapshotErrorCode,
+}
+
+impl LocalSnapshotError {
+    #[must_use]
+    pub(crate) const fn code(self) -> LocalSnapshotErrorCode {
+        self.code
+    }
+}

--- a/crates/automata-ci-workflow-github/Cargo.toml
+++ b/crates/automata-ci-workflow-github/Cargo.toml
@@ -21,11 +21,13 @@ automata-ci-core.workspace = true
 automata-ci-github-permissions.workspace = true
 automata-ci-schedule.workspace = true
 flate2.workspace = true
+focaccia.workspace = true
 jiff.workspace = true
 saphyr-parser.workspace = true
 serde_json.workspace = true
 tar.workspace = true
 thiserror.workspace = true
+unicode-normalization.workspace = true
 
 [dev-dependencies]
 

--- a/crates/automata-ci-workflow-github/Cargo.toml
+++ b/crates/automata-ci-workflow-github/Cargo.toml
@@ -25,6 +25,7 @@ focaccia.workspace = true
 jiff.workspace = true
 saphyr-parser.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 unicode-normalization.workspace = true

--- a/crates/automata-ci-workflow-github/src/compiler.rs
+++ b/crates/automata-ci-workflow-github/src/compiler.rs
@@ -7,15 +7,45 @@ mod safety;
 mod trigger;
 
 use automata_ci_core::{
-    ContextValue, Located, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan,
+    ContextValue, Located, PlanSourceLocation, PlanSourceOrigin, PlanSourceSpan, Sha256Digest,
     WorkflowEventProvenance, WorkflowPlan, WorkflowSourceProvenance,
 };
 
 use crate::{
-    Diagnostic, DiagnosticKind, DiagnosticSeverity, EventName, GithubEventMetadata,
+    Diagnostic, DiagnosticKind, DiagnosticSeverity, EventName, EventTrigger, GithubEventMetadata,
     GithubWorkflowDispatchContract, GithubWorkflowSourcePlan, PreservedField, SourceOrigin,
     SourceSpan, TriggerConfiguration,
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LocalWorkflowSourceEvidence {
+    snapshot_digest: Sha256Digest,
+}
+
+impl LocalWorkflowSourceEvidence {
+    pub(crate) const fn new(snapshot_digest: Sha256Digest) -> Self {
+        Self { snapshot_digest }
+    }
+
+    const fn snapshot_digest(self) -> Sha256Digest {
+        self.snapshot_digest
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LocalWorkflowDispatchEvidence {
+    source: LocalWorkflowSourceEvidence,
+    inputs: crate::GithubWorkflowDispatchInputs,
+}
+
+impl LocalWorkflowDispatchEvidence {
+    pub(crate) const fn new(
+        source: LocalWorkflowSourceEvidence,
+        inputs: crate::GithubWorkflowDispatchInputs,
+    ) -> Self {
+        Self { source, inputs }
+    }
+}
 
 /// Borrowed request to select and compile one GitHub event invocation.
 #[derive(Clone, Debug)]
@@ -31,6 +61,17 @@ enum EventSelection {
     Unverified,
     Metadata(GithubEventMetadata),
     Preselected(Option<GithubEventMetadata>),
+    LocalWorkflowDispatch(LocalWorkflowDispatchEvidence),
+    LocalWorkflowCall(LocalWorkflowSourceEvidence),
+}
+
+impl EventSelection {
+    const fn source_provider(&self) -> &'static str {
+        match self {
+            Self::Unverified | Self::Metadata(_) | Self::Preselected(_) => "github",
+            Self::LocalWorkflowDispatch(_) | Self::LocalWorkflowCall(_) => "local",
+        }
+    }
 }
 
 impl<'plan> CompileWorkflowRequest<'plan> {
@@ -95,6 +136,39 @@ impl<'plan> CompileWorkflowRequest<'plan> {
             source_plan,
             event,
             selection: EventSelection::Preselected(Some(metadata)),
+        }
+    }
+
+    /// Selects an explicit local `workflow_dispatch` invocation.
+    ///
+    /// This is the only initial local-event constructor. It emits `local`
+    /// source/event provenance and verifies the source repository revision is
+    /// the exact evidence digest. It never accepts GitHub delivery metadata.
+    #[must_use]
+    pub(crate) fn for_local_workflow_dispatch(
+        source_plan: &'plan GithubWorkflowSourcePlan,
+        evidence: LocalWorkflowDispatchEvidence,
+    ) -> Self {
+        Self {
+            source_plan,
+            event: WorkflowEventProvenance::new("local", "workflow_dispatch"),
+            selection: EventSelection::LocalWorkflowDispatch(evidence),
+        }
+    }
+
+    /// Compiles one same-snapshot reusable workflow for `workflow_call`.
+    ///
+    /// The request remains local source authority even though the parsed
+    /// syntax and expression dialect are GitHub Actions compatible.
+    #[must_use]
+    pub(crate) fn for_local_workflow_call(
+        source_plan: &'plan GithubWorkflowSourcePlan,
+        evidence: LocalWorkflowSourceEvidence,
+    ) -> Self {
+        Self {
+            source_plan,
+            event: WorkflowEventProvenance::new("local", "workflow_call"),
+            selection: EventSelection::LocalWorkflowCall(evidence),
         }
     }
 
@@ -350,7 +424,10 @@ fn has_errors(diagnostics: &[Diagnostic]) -> bool {
         .any(|diagnostic| diagnostic.severity() == DiagnosticSeverity::Error)
 }
 
-fn compile_source(context: &CompileContext<'_>) -> WorkflowSourceProvenance {
+fn compile_source(
+    context: &CompileContext<'_>,
+    source_provider: &'static str,
+) -> WorkflowSourceProvenance {
     let provenance = context.source.source().provenance();
     let origin = match provenance.origin() {
         SourceOrigin::Repository {
@@ -369,7 +446,7 @@ fn compile_source(context: &CompileContext<'_>) -> WorkflowSourceProvenance {
             name: name.to_string(),
         },
     };
-    WorkflowSourceProvenance::new("github", provenance.id().as_str(), origin)
+    WorkflowSourceProvenance::new(source_provider, provenance.id().as_str(), origin)
 }
 
 fn compile_event(
@@ -377,15 +454,7 @@ fn compile_event(
     selection: &EventSelection,
     context: &mut CompileContext<'_>,
 ) -> CompiledEvent {
-    if event.provider() != "github" {
-        context.semantic(
-            "github.compile.event_provider",
-            format!(
-                "GitHub workflow compiler cannot accept `{}` event provenance",
-                event.provider()
-            ),
-            context.source.workflow().span().clone(),
-        );
+    if !validate_event_authority(&event, selection, context) {
         return CompiledEvent::Rejected;
     }
     let Some(triggers) = context.source.workflow().triggers() else {
@@ -433,6 +502,24 @@ fn compile_event(
     let Some(span) = context.span(selected.span()) else {
         return CompiledEvent::Rejected;
     };
+    compile_selected_event(
+        event,
+        selection,
+        selected,
+        selected_dispatch_contract,
+        span,
+        context,
+    )
+}
+
+fn compile_selected_event(
+    event: WorkflowEventProvenance,
+    selection: &EventSelection,
+    selected: &EventTrigger,
+    selected_dispatch_contract: Option<GithubWorkflowDispatchContract>,
+    span: PlanSourceSpan,
+    context: &mut CompileContext<'_>,
+) -> CompiledEvent {
     match selection {
         EventSelection::Preselected(metadata) => compile_preselected_event(
             event,
@@ -467,7 +554,89 @@ fn compile_event(
             context,
         )
         .with_event(event, span),
+        EventSelection::LocalWorkflowDispatch(evidence) => {
+            if !matches!(selected.name().value(), EventName::WorkflowDispatch) {
+                context.semantic(
+                    "github.compile.local_event_selection",
+                    "local source checking selects only an explicit workflow_dispatch trigger",
+                    selected.span().clone(),
+                );
+                return CompiledEvent::Rejected;
+            }
+            trigger::local_workflow_dispatch_matches(
+                selected_dispatch_contract.as_ref(),
+                &evidence.inputs,
+                selected.span(),
+                context,
+            )
+            .with_event(event, span)
+        }
+        EventSelection::LocalWorkflowCall(_) => {
+            if !matches!(selected.name().value(), EventName::WorkflowCall) {
+                context.semantic(
+                    "github.compile.local_event_selection",
+                    "local reusable-workflow compilation selects only workflow_call",
+                    selected.span().clone(),
+                );
+                return CompiledEvent::Rejected;
+            }
+            trigger::event_matches(
+                &event,
+                selected.configuration(),
+                selected_dispatch_contract.as_ref(),
+                None,
+                selected.span(),
+                context,
+            )
+            .with_event(event, span)
+        }
     }
+}
+
+fn validate_event_authority(
+    event: &WorkflowEventProvenance,
+    selection: &EventSelection,
+    context: &mut CompileContext<'_>,
+) -> bool {
+    let expected_provider = selection.source_provider();
+    if event.provider() != expected_provider {
+        context.semantic(
+            "github.compile.event_provider",
+            format!(
+                "workflow source authority `{expected_provider}` cannot accept `{}` event provenance",
+                event.provider(),
+            ),
+            context.source.workflow().span().clone(),
+        );
+        return false;
+    }
+    if let Some(evidence) = match selection {
+        EventSelection::LocalWorkflowDispatch(evidence) => Some(evidence.source),
+        EventSelection::LocalWorkflowCall(evidence) => Some(*evidence),
+        EventSelection::Unverified
+        | EventSelection::Metadata(_)
+        | EventSelection::Preselected(_) => None,
+    } {
+        let SourceOrigin::Repository { revision, .. } =
+            context.source.source().provenance().origin()
+        else {
+            context.semantic(
+                "github.compile.local_source_origin",
+                "local workflow compilation requires repository snapshot provenance",
+                context.source.workflow().span().clone(),
+            );
+            return false;
+        };
+        if revision.as_ref() != evidence.snapshot_digest().to_string() {
+            context.semantic(
+                "github.compile.local_snapshot_mismatch",
+                "local workflow source revision does not match its snapshot evidence",
+                context.source.workflow().span().clone(),
+            );
+            return false;
+        }
+    }
+    true
 }
 
 fn compile_preselected_event(

--- a/crates/automata-ci-workflow-github/src/compiler/logical.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/logical.rs
@@ -264,13 +264,7 @@ pub(super) fn compile(request: CompileWorkflowRequest<'_>) -> CompilationReport 
             &mut context,
         )
     });
-    if !workflow_references.is_empty() {
-        context.semantic(
-            "github.compile.workflow_needs_reference",
-            "workflow-level fields cannot reference job results",
-            workflow.span().clone(),
-        );
-    }
+    reject_workflow_need_references(&workflow_references, workflow.span(), &mut context);
 
     let mut pending = workflow
         .jobs()
@@ -321,6 +315,20 @@ pub(super) fn compile(request: CompileWorkflowRequest<'_>) -> CompilationReport 
         _ => None,
     };
     finish_compilation(event, plan, context.diagnostics)
+}
+
+fn reject_workflow_need_references(
+    references: &BTreeMap<ParsedNeedReference, SourceSpan>,
+    workflow_span: &SourceSpan,
+    context: &mut CompileContext<'_>,
+) {
+    if !references.is_empty() {
+        context.semantic(
+            "github.compile.workflow_needs_reference",
+            "workflow-level fields cannot reference job results",
+            workflow_span.clone(),
+        );
+    }
 }
 
 fn finish_compilation(

--- a/crates/automata-ci-workflow-github/src/compiler/logical.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/logical.rs
@@ -217,6 +217,7 @@ struct CompiledJobBody {
 }
 
 pub(super) fn compile(request: CompileWorkflowRequest<'_>) -> CompilationReport {
+    let source_provider = request.selection.source_provider();
     let mut context = CompileContext {
         source: request.source_plan,
         diagnostics: Vec::new(),
@@ -229,7 +230,7 @@ pub(super) fn compile(request: CompileWorkflowRequest<'_>) -> CompilationReport 
     if !matches!(event, CompiledEvent::Selected { .. }) {
         return finish_compilation(event, None, context.diagnostics);
     }
-    let source = compile_source(&context);
+    let source = compile_source(&context, source_provider);
     let name = compile_workflow_name(workflow.name(), &mut context);
     let mut workflow_references = BTreeMap::new();
     let run_name = workflow.run_name().and_then(|value| {

--- a/crates/automata-ci-workflow-github/src/compiler/trigger.rs
+++ b/crates/automata-ci-workflow-github/src/compiler/trigger.rs
@@ -735,8 +735,37 @@ fn workflow_dispatch_matches(
             return TriggerSelection::Rejected;
         }
     };
-    let Some(inputs) = resolve_workflow_dispatch_inputs(contract, inputs, trigger_span, context)
-    else {
+    let Some(inputs) = resolve_workflow_dispatch_inputs(
+        contract,
+        inputs,
+        DispatchInputAuthority::GithubVerified,
+        trigger_span,
+        context,
+    ) else {
+        return TriggerSelection::Rejected;
+    };
+    TriggerSelection::Selected(Some(CompiledWorkflowDispatch {
+        contract: contract.clone(),
+        inputs,
+    }))
+}
+
+pub(super) fn local_workflow_dispatch_matches(
+    contract: Option<&GithubWorkflowDispatchContract>,
+    inputs: &crate::GithubWorkflowDispatchInputs,
+    trigger_span: &SourceSpan,
+    context: &mut CompileContext<'_>,
+) -> TriggerSelection {
+    let Some(contract) = contract else {
+        return TriggerSelection::Rejected;
+    };
+    let Some(inputs) = resolve_workflow_dispatch_inputs(
+        contract,
+        inputs,
+        DispatchInputAuthority::LocalExplicit,
+        trigger_span,
+        context,
+    ) else {
         return TriggerSelection::Rejected;
     };
     TriggerSelection::Selected(Some(CompiledWorkflowDispatch {
@@ -768,9 +797,25 @@ pub(super) fn compile_preselected_workflow_dispatch(
     }
 }
 
+#[derive(Clone, Copy)]
+enum DispatchInputAuthority {
+    GithubVerified,
+    LocalExplicit,
+}
+
+impl DispatchInputAuthority {
+    const fn description(self) -> &'static str {
+        match self {
+            Self::GithubVerified => "verified workflow_dispatch payload",
+            Self::LocalExplicit => "explicit local workflow_dispatch selection",
+        }
+    }
+}
+
 fn resolve_workflow_dispatch_inputs(
     contract: &GithubWorkflowDispatchContract,
     payload: &crate::GithubWorkflowDispatchInputs,
+    authority: DispatchInputAuthority,
     trigger_span: &SourceSpan,
     context: &mut CompileContext<'_>,
 ) -> Option<ContextValue> {
@@ -779,7 +824,10 @@ fn resolve_workflow_dispatch_inputs(
         if !contract.inputs().contains_key(key) {
             context.semantic(
                 "github.compile.unknown_workflow_dispatch_input",
-                format!("verified workflow_dispatch payload supplied undeclared input `{key}`"),
+                format!(
+                    "{} supplied undeclared input `{key}`",
+                    authority.description()
+                ),
                 trigger_span.clone(),
             );
             valid = false;
@@ -792,7 +840,9 @@ fn resolve_workflow_dispatch_inputs(
             Some(value) => {
                 coerce_workflow_dispatch_input(key, definition, value, trigger_span, context)
             }
-            None => default_workflow_dispatch_input(key, definition, trigger_span, context),
+            None => {
+                default_workflow_dispatch_input(key, definition, authority, trigger_span, context)
+            }
         };
         match value {
             Some(value) => {
@@ -878,6 +928,7 @@ fn coerce_workflow_dispatch_input(
 fn default_workflow_dispatch_input(
     key: &WorkflowInputKey,
     definition: &GithubWorkflowDispatchInputDefinition,
+    authority: DispatchInputAuthority,
     trigger_span: &SourceSpan,
     context: &mut CompileContext<'_>,
 ) -> Option<ContextValue> {
@@ -891,7 +942,7 @@ fn default_workflow_dispatch_input(
         None if definition.required() => {
             context.semantic(
                 "github.compile.required_workflow_dispatch_input_missing",
-                format!("verified workflow_dispatch payload omitted required input `{key}`"),
+                format!("{} omitted required input `{key}`", authority.description()),
                 trigger_span.clone(),
             );
             None

--- a/crates/automata-ci-workflow-github/src/diagnostic.rs
+++ b/crates/automata-ci-workflow-github/src/diagnostic.rs
@@ -14,6 +14,19 @@ pub enum DiagnosticKind {
     ResourceLimit,
 }
 
+impl DiagnosticKind {
+    /// Returns the stable machine-readable stage name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Syntax => "syntax",
+            Self::Semantic => "semantic",
+            Self::Unsupported => "unsupported",
+            Self::ResourceLimit => "resource_limit",
+        }
+    }
+}
+
 /// Whether a diagnostic prevents the source plan from being accepted.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -22,6 +35,17 @@ pub enum DiagnosticSeverity {
     Warning,
     /// The source cannot be accepted by the relevant frontend stage.
     Error,
+}
+
+impl DiagnosticSeverity {
+    /// Returns the stable machine-readable severity name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
 }
 
 /// A secondary, source-bound location that provides context for a diagnostic.

--- a/crates/automata-ci-workflow-github/src/lib.rs
+++ b/crates/automata-ci-workflow-github/src/lib.rs
@@ -9,6 +9,7 @@ mod expression;
 mod frontend;
 mod model;
 mod repository_archive;
+mod repository_path;
 mod runner_profile;
 mod schedule;
 mod source;
@@ -51,7 +52,10 @@ pub use repository_archive::{
     MAX_REPOSITORY_WORKFLOW_PATH_BYTES, RepositoryWorkflowDiscoveryError,
     RepositoryWorkflowDiscoveryFailure, RepositoryWorkflowDiscoveryLimits,
     RepositoryWorkflowDiscoveryLimitsError, RepositoryWorkflowDiscoveryOutcome,
-    discover_repository_workflows,
+    RepositoryWorkflowDiscoveryPolicy, RepositoryWorkflowLocation, discover_repository_workflows,
+};
+pub use repository_path::{
+    RepositoryPathValidationError, RepositoryPathValidator, USTAR_LINK_NAME_BYTES,
 };
 pub use runner_profile::{
     GithubRunnerProfileCatalog, GithubRunnerProfileError, GithubRunnerProfileMapping,

--- a/crates/automata-ci-workflow-github/src/lib.rs
+++ b/crates/automata-ci-workflow-github/src/lib.rs
@@ -7,6 +7,7 @@ mod decode;
 mod diagnostic;
 mod expression;
 mod frontend;
+mod local_archive;
 mod model;
 mod repository_archive;
 mod repository_path;
@@ -30,6 +31,11 @@ pub use frontend::{
     FrontendReport, GithubFrontendReport, GithubWorkflowFrontend, ParseWorkflowRequest,
     WorkflowFrontend,
 };
+pub use local_archive::{
+    LocalGithubArchiveCompilation, LocalGithubArchiveCompilationFailure,
+    LocalGithubArchiveCompilationFailureKind, LocalGithubCompiledReusableWorkflow,
+    compile_local_github_archive,
+};
 pub use model::{
     ActionStep, BooleanValue, Concurrency, ConcurrencyQueue, ContainerCredentials,
     ContainerEnvironment, ContainerSequence, Defaults, DetailedConcurrency, DetailedContainer,
@@ -52,7 +58,7 @@ pub use repository_archive::{
     MAX_REPOSITORY_WORKFLOW_PATH_BYTES, RepositoryWorkflowDiscoveryError,
     RepositoryWorkflowDiscoveryFailure, RepositoryWorkflowDiscoveryLimits,
     RepositoryWorkflowDiscoveryLimitsError, RepositoryWorkflowDiscoveryOutcome,
-    RepositoryWorkflowDiscoveryPolicy, RepositoryWorkflowLocation, discover_repository_workflows,
+    RepositoryWorkflowLocation, discover_github_delivery_workflows,
 };
 pub use repository_path::{
     RepositoryPathValidationError, RepositoryPathValidator, USTAR_LINK_NAME_BYTES,

--- a/crates/automata-ci-workflow-github/src/local_archive.rs
+++ b/crates/automata-ci-workflow-github/src/local_archive.rs
@@ -1,0 +1,489 @@
+//! Closed local-archive compilation for the GitHub Actions dialect.
+
+use std::{collections::BTreeMap, path::Path, sync::Arc};
+
+use automata_ci_core::{LogicalJobKind, Sha256Digest, WorkflowPlan};
+use sha2::{Digest as _, Sha256};
+
+use crate::compiler::{LocalWorkflowDispatchEvidence, LocalWorkflowSourceEvidence};
+use crate::repository_archive::discover_local_github_workflows;
+use crate::{
+    CompilationDisposition, CompileWorkflowRequest, Diagnostic, GithubWorkflowCompiler,
+    GithubWorkflowDispatchInputs, GithubWorkflowFrontend, ParseWorkflowRequest,
+    RepositoryWorkflowDiscoveryLimits, SourceId, SourceOrigin, SourceProvenance,
+    WorkflowFrontend as _,
+};
+
+const LOCAL_SOURCE_REPOSITORY: &str = "local";
+const MAX_LOCAL_WORKFLOW_SELECTOR_BYTES: usize = 1_024;
+
+/// Closed failure class for exact local GitHub-workflow archive compilation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LocalGithubArchiveCompilationFailureKind {
+    /// Cooperative cancellation interrupted archive inspection or compilation.
+    Cancelled,
+    /// The sealed archive failed its local `.github/workflows` policy.
+    Archive,
+    /// The archive contains no direct `.github/workflows` YAML workflow.
+    WorkflowMissing,
+    /// More than one workflow requires one exact canonical selector.
+    WorkflowSelectionRequired,
+    /// The supplied selector is not one exact discovered workflow path.
+    WorkflowNotFound,
+    /// A selected source is empty, oversized, or not UTF-8.
+    WorkflowSource,
+    /// The source frontend rejected the selected root workflow.
+    Frontend,
+    /// Explicit local `workflow_dispatch` selection rejected the root workflow.
+    Compilation,
+    /// A reachable reusable workflow is missing, remote, dynamic, invalid, or excessive.
+    ReusableWorkflow,
+}
+
+/// Sanitized local archive compilation failure with source diagnostics.
+#[derive(Clone, Debug)]
+pub struct LocalGithubArchiveCompilationFailure {
+    kind: LocalGithubArchiveCompilationFailureKind,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl LocalGithubArchiveCompilationFailure {
+    /// Returns the stable failure class.
+    #[must_use]
+    pub const fn kind(&self) -> LocalGithubArchiveCompilationFailureKind {
+        self.kind
+    }
+
+    /// Returns value-free source diagnostics produced before failure.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    fn new(kind: LocalGithubArchiveCompilationFailureKind) -> Self {
+        Self {
+            kind,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn with_diagnostics(
+        kind: LocalGithubArchiveCompilationFailureKind,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Self {
+        Self { kind, diagnostics }
+    }
+}
+
+/// One reachable reusable workflow compiled from membership-proven archive bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalGithubCompiledReusableWorkflow {
+    path: String,
+    source_digest: Sha256Digest,
+    plan: WorkflowPlan,
+}
+
+impl LocalGithubCompiledReusableWorkflow {
+    /// Returns the exact canonical same-archive source path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns SHA-256 over this workflow's exact discovered source bytes.
+    #[must_use]
+    pub const fn source_digest(&self) -> Sha256Digest {
+        self.source_digest
+    }
+
+    /// Returns the local-only `workflow_call` plan.
+    #[must_use]
+    pub const fn plan(&self) -> &WorkflowPlan {
+        &self.plan
+    }
+}
+
+/// Complete root and reachable reusable compilation derived from one archive.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalGithubArchiveCompilation {
+    snapshot_digest: Sha256Digest,
+    selected_path: String,
+    root_source_digest: Sha256Digest,
+    root_plan: WorkflowPlan,
+    reusable_workflows: Vec<LocalGithubCompiledReusableWorkflow>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl LocalGithubArchiveCompilation {
+    /// Returns SHA-256 over the exact sealed archive bytes inspected here.
+    #[must_use]
+    pub const fn snapshot_digest(&self) -> Sha256Digest {
+        self.snapshot_digest
+    }
+
+    /// Returns the exact selected canonical `.github/workflows` path.
+    #[must_use]
+    pub fn selected_path(&self) -> &str {
+        &self.selected_path
+    }
+
+    /// Returns SHA-256 over the exact selected root source bytes.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn root_source_digest(&self) -> Sha256Digest {
+        self.root_source_digest
+    }
+
+    /// Returns the local-only root `workflow_dispatch` plan.
+    #[must_use]
+    pub const fn root_plan(&self) -> &WorkflowPlan {
+        &self.root_plan
+    }
+
+    /// Returns only reachable same-archive reusable workflows in path order.
+    #[must_use]
+    pub fn reusable_workflows(&self) -> &[LocalGithubCompiledReusableWorkflow] {
+        &self.reusable_workflows
+    }
+
+    /// Returns all value-free root and reusable source diagnostics.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+}
+
+/// Discovers and compiles one exact local GitHub workflow archive without
+/// provider admission or execution authority.
+///
+/// The archive digest, local source provenance, root membership, and reusable
+/// membership are derived internally from `archive_bytes`. Callers cannot
+/// provide or coordinate any of those values independently. Only direct
+/// `.github/workflows/*.{yml,yaml}` sources and same-archive relative reusable
+/// references are accepted.
+///
+/// # Errors
+///
+/// Returns a sanitized failure for cancellation, unsafe or excessive archive
+/// content, non-exact selection, rejected source, unsupported trigger, or an
+/// invalid reachable reusable reference.
+pub fn compile_local_github_archive(
+    archive_bytes: &[u8],
+    selector: Option<&str>,
+    inputs: GithubWorkflowDispatchInputs,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<LocalGithubArchiveCompilation, LocalGithubArchiveCompilationFailure> {
+    check_cancelled(cancellation)?;
+    if selector.is_some_and(|path| !valid_selector(path)) {
+        return Err(LocalGithubArchiveCompilationFailure::new(
+            LocalGithubArchiveCompilationFailureKind::WorkflowNotFound,
+        ));
+    }
+    let snapshot_digest = Sha256Digest::from_bytes(Sha256::digest(archive_bytes).into());
+    let discovered =
+        discover_local_github_workflows(archive_bytes, limits, cancellation).map_err(|error| {
+            LocalGithubArchiveCompilationFailure::new(
+                if matches!(error, crate::RepositoryWorkflowDiscoveryError::Cancelled) {
+                    LocalGithubArchiveCompilationFailureKind::Cancelled
+                } else {
+                    LocalGithubArchiveCompilationFailureKind::Archive
+                },
+            )
+        })?;
+    check_cancelled(cancellation)?;
+
+    let mut available = discovered
+        .into_iter()
+        .map(crate::RepositoryWorkflowDiscoveryOutcome::into_parts)
+        .collect::<BTreeMap<_, _>>();
+    let selected_path = select_workflow(&available, selector)?.to_owned();
+    let selected_source = available
+        .get(&selected_path)
+        .ok_or_else(|| {
+            LocalGithubArchiveCompilationFailure::new(
+                LocalGithubArchiveCompilationFailureKind::WorkflowNotFound,
+            )
+        })?
+        .as_ref()
+        .map_err(|_| {
+            LocalGithubArchiveCompilationFailure::new(
+                LocalGithubArchiveCompilationFailureKind::WorkflowSource,
+            )
+        })?;
+    let root_source_digest = Sha256Digest::from_bytes(Sha256::digest(selected_source).into());
+    let (root_plan, diagnostics) = compile_source(
+        &selected_path,
+        selected_source,
+        snapshot_digest,
+        LocalCompilationEvent::WorkflowDispatch(inputs),
+        cancellation,
+    )?;
+    let (reusable_workflows, diagnostics) = compile_reusable_workflows(
+        &root_plan,
+        &selected_path,
+        snapshot_digest,
+        &mut available,
+        limits,
+        diagnostics,
+        cancellation,
+    )?;
+
+    Ok(LocalGithubArchiveCompilation {
+        snapshot_digest,
+        selected_path,
+        root_source_digest,
+        root_plan,
+        reusable_workflows,
+        diagnostics,
+    })
+}
+
+fn compile_reusable_workflows(
+    root_plan: &WorkflowPlan,
+    selected_path: &str,
+    snapshot_digest: Sha256Digest,
+    available: &mut BTreeMap<String, Result<Vec<u8>, crate::RepositoryWorkflowDiscoveryFailure>>,
+    limits: RepositoryWorkflowDiscoveryLimits,
+    mut diagnostics: Vec<Diagnostic>,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<
+    (Vec<LocalGithubCompiledReusableWorkflow>, Vec<Diagnostic>),
+    LocalGithubArchiveCompilationFailure,
+> {
+    let mut pending = reusable_references(root_plan);
+    let mut reusable = BTreeMap::new();
+    while let Some(reference) = pending.pop() {
+        check_cancelled(cancellation)?;
+        let path = resolve_local_reference(&reference)?;
+        if path == selected_path {
+            return Err(LocalGithubArchiveCompilationFailure::with_diagnostics(
+                LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+                diagnostics,
+            ));
+        }
+        if reusable.contains_key(&path) {
+            continue;
+        }
+        if reusable.len() >= limits.maximum_workflows() {
+            return Err(LocalGithubArchiveCompilationFailure::with_diagnostics(
+                LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+                diagnostics,
+            ));
+        }
+        let source = available
+            .remove(&path)
+            .ok_or_else(|| {
+                LocalGithubArchiveCompilationFailure::with_diagnostics(
+                    LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+                    diagnostics.clone(),
+                )
+            })?
+            .map_err(|_| {
+                LocalGithubArchiveCompilationFailure::with_diagnostics(
+                    LocalGithubArchiveCompilationFailureKind::WorkflowSource,
+                    diagnostics.clone(),
+                )
+            })?;
+        let source_digest = Sha256Digest::from_bytes(Sha256::digest(&source).into());
+        let (plan, source_diagnostics) = compile_source(
+            &path,
+            &source,
+            snapshot_digest,
+            LocalCompilationEvent::WorkflowCall,
+            cancellation,
+        )
+        .map_err(|failure| {
+            let mut all = diagnostics.clone();
+            all.extend_from_slice(failure.diagnostics());
+            LocalGithubArchiveCompilationFailure::with_diagnostics(
+                LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+                all,
+            )
+        })?;
+        if plan.logical().invocation().is_none() {
+            return Err(LocalGithubArchiveCompilationFailure::with_diagnostics(
+                LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+                diagnostics,
+            ));
+        }
+        pending.extend(reusable_references(&plan));
+        diagnostics.extend(source_diagnostics);
+        reusable.insert(
+            path.clone(),
+            LocalGithubCompiledReusableWorkflow {
+                path,
+                source_digest,
+                plan,
+            },
+        );
+    }
+
+    Ok((reusable.into_values().collect(), diagnostics))
+}
+
+fn select_workflow<'a>(
+    available: &'a BTreeMap<String, Result<Vec<u8>, crate::RepositoryWorkflowDiscoveryFailure>>,
+    selector: Option<&str>,
+) -> Result<&'a str, LocalGithubArchiveCompilationFailure> {
+    match selector {
+        Some(path) => available
+            .get_key_value(path)
+            .map(|(path, _)| path.as_str())
+            .ok_or_else(|| {
+                LocalGithubArchiveCompilationFailure::new(
+                    LocalGithubArchiveCompilationFailureKind::WorkflowNotFound,
+                )
+            }),
+        None => match available
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .as_slice()
+        {
+            [] => Err(LocalGithubArchiveCompilationFailure::new(
+                LocalGithubArchiveCompilationFailureKind::WorkflowMissing,
+            )),
+            [path] => Ok(path),
+            _ => Err(LocalGithubArchiveCompilationFailure::new(
+                LocalGithubArchiveCompilationFailureKind::WorkflowSelectionRequired,
+            )),
+        },
+    }
+}
+
+enum LocalCompilationEvent {
+    WorkflowDispatch(GithubWorkflowDispatchInputs),
+    WorkflowCall,
+}
+
+fn compile_source(
+    path: &str,
+    source: &[u8],
+    snapshot_digest: Sha256Digest,
+    event: LocalCompilationEvent,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<(WorkflowPlan, Vec<Diagnostic>), LocalGithubArchiveCompilationFailure> {
+    check_cancelled(cancellation)?;
+    let source = std::str::from_utf8(source).map_err(|_| {
+        LocalGithubArchiveCompilationFailure::new(
+            LocalGithubArchiveCompilationFailureKind::WorkflowSource,
+        )
+    })?;
+    let revision = snapshot_digest.to_string();
+    let provenance = SourceProvenance::new(
+        SourceId::new(path),
+        SourceOrigin::Repository {
+            repository: Arc::from(LOCAL_SOURCE_REPOSITORY),
+            revision: Arc::from(revision),
+            path: Arc::from(path),
+        },
+    );
+    let parsed =
+        GithubWorkflowFrontend::default().parse(ParseWorkflowRequest::new(provenance, source));
+    let mut diagnostics = parsed.diagnostics().to_vec();
+    if !parsed.is_accepted() {
+        return Err(LocalGithubArchiveCompilationFailure::with_diagnostics(
+            LocalGithubArchiveCompilationFailureKind::Frontend,
+            diagnostics,
+        ));
+    }
+    let source_plan = parsed.plan().ok_or_else(|| {
+        LocalGithubArchiveCompilationFailure::with_diagnostics(
+            LocalGithubArchiveCompilationFailureKind::Frontend,
+            diagnostics.clone(),
+        )
+    })?;
+    check_cancelled(cancellation)?;
+    let evidence = LocalWorkflowSourceEvidence::new(snapshot_digest);
+    let request = match event {
+        LocalCompilationEvent::WorkflowDispatch(inputs) => {
+            CompileWorkflowRequest::for_local_workflow_dispatch(
+                source_plan,
+                LocalWorkflowDispatchEvidence::new(evidence, inputs),
+            )
+        }
+        LocalCompilationEvent::WorkflowCall => {
+            CompileWorkflowRequest::for_local_workflow_call(source_plan, evidence)
+        }
+    };
+    let compiled = GithubWorkflowCompiler::new().compile(request);
+    diagnostics.extend_from_slice(compiled.diagnostics());
+    if compiled.disposition() != CompilationDisposition::Accepted {
+        return Err(LocalGithubArchiveCompilationFailure::with_diagnostics(
+            LocalGithubArchiveCompilationFailureKind::Compilation,
+            diagnostics,
+        ));
+    }
+    let (plan, _) = compiled.into_parts();
+    let plan = plan.ok_or_else(|| {
+        LocalGithubArchiveCompilationFailure::with_diagnostics(
+            LocalGithubArchiveCompilationFailureKind::Compilation,
+            diagnostics.clone(),
+        )
+    })?;
+    check_cancelled(cancellation)?;
+    Ok((plan, diagnostics))
+}
+
+fn reusable_references(plan: &WorkflowPlan) -> Vec<String> {
+    plan.jobs()
+        .iter()
+        .filter_map(|job| match job.execution() {
+            LogicalJobKind::ReusableWorkflow(call) => Some(call.reference().value().clone()),
+            LogicalJobKind::Steps(_) => None,
+        })
+        .collect()
+}
+
+fn resolve_local_reference(
+    reference: &str,
+) -> Result<String, LocalGithubArchiveCompilationFailure> {
+    let Some(path) = reference.strip_prefix("./") else {
+        return Err(LocalGithubArchiveCompilationFailure::new(
+            LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+        ));
+    };
+    if !valid_selector(path) {
+        return Err(LocalGithubArchiveCompilationFailure::new(
+            LocalGithubArchiveCompilationFailureKind::ReusableWorkflow,
+        ));
+    }
+    Ok(path.to_owned())
+}
+
+fn valid_selector(path: &str) -> bool {
+    if path.is_empty()
+        || path.len() > MAX_LOCAL_WORKFLOW_SELECTOR_BYTES
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains('\\')
+        || path.chars().any(char::is_control)
+    {
+        return false;
+    }
+    let components = path.split('/').collect::<Vec<_>>();
+    let [dot_github, workflows, file] = components.as_slice() else {
+        return false;
+    };
+    *dot_github == ".github"
+        && *workflows == "workflows"
+        && !file.is_empty()
+        && !matches!(*file, "." | "..")
+        && matches!(
+            Path::new(file).extension().and_then(|value| value.to_str()),
+            Some("yml" | "yaml")
+        )
+}
+
+fn check_cancelled(
+    cancellation: &dyn Fn() -> bool,
+) -> Result<(), LocalGithubArchiveCompilationFailure> {
+    if cancellation() {
+        Err(LocalGithubArchiveCompilationFailure::new(
+            LocalGithubArchiveCompilationFailureKind::Cancelled,
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/automata-ci-workflow-github/src/model/workflow_dispatch.rs
+++ b/crates/automata-ci-workflow-github/src/model/workflow_dispatch.rs
@@ -186,6 +186,8 @@ pub enum GithubWorkflowDispatchInputsError {
     InvalidInputKey,
     /// The payload repeats an input identifier.
     DuplicateInputKey,
+    /// An input string contains control characters.
+    InvalidInputValue,
     /// The aggregate identifier and value character budget is exceeded.
     PayloadTooLarge,
 }
@@ -203,6 +205,8 @@ impl fmt::Display for GithubWorkflowDispatchInputsError {
             Self::DuplicateInputKey => {
                 formatter.write_str("workflow_dispatch payload input identifiers must be unique")
             }
+            Self::InvalidInputValue => formatter
+                .write_str("workflow_dispatch payload input values must not contain control text"),
             Self::PayloadTooLarge => write!(
                 formatter,
                 "workflow_dispatch input identifiers and values may contain at most {MAX_GITHUB_WORKFLOW_DISPATCH_INPUT_CHARACTERS} aggregate characters"
@@ -213,12 +217,12 @@ impl fmt::Display for GithubWorkflowDispatchInputsError {
 
 impl Error for GithubWorkflowDispatchInputsError {}
 
-/// Bounded input properties from a provider-verified manual-dispatch event.
+/// Bounded input properties from one explicit manual-dispatch selection.
 ///
 /// Construction validates only the provider payload's canonical shape and
 /// resource bounds. The compiler subsequently validates these values against
-/// the exact source contract before exposing an `inputs` context. Callers must
-/// construct this type only from integrity-verified provider evidence.
+/// the exact source contract before exposing an `inputs` context. Provider or
+/// local authority is carried separately from this value-only shape.
 #[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct GithubWorkflowDispatchInputs {
@@ -247,6 +251,9 @@ impl GithubWorkflowDispatchInputs {
             let key = WorkflowInputKey::new(key.into())
                 .map_err(|_| GithubWorkflowDispatchInputsError::InvalidInputKey)?;
             let value = value.into();
+            if value.contains_control_text() {
+                return Err(GithubWorkflowDispatchInputsError::InvalidInputValue);
+            }
             characters = characters
                 .checked_add(key.as_str().chars().count())
                 .and_then(|count| count.checked_add(value.character_count()))
@@ -301,6 +308,13 @@ impl GithubWorkflowDispatchInputValue {
                 }
             }
             Self::String(value) => value.chars().count(),
+        }
+    }
+
+    fn contains_control_text(&self) -> bool {
+        match self {
+            Self::Boolean(_) => false,
+            Self::String(value) => value.chars().any(char::is_control),
         }
     }
 }

--- a/crates/automata-ci-workflow-github/src/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/src/repository_archive.rs
@@ -64,35 +64,22 @@ impl RepositoryWorkflowLocation {
     }
 }
 
-/// Exact archive trust policy used by repository workflow discovery.
-///
-/// GitHub delivery archives retain their established `.ci/workflows`
-/// authority and reject every symbolic link. A local snapshot declares its one
-/// workflow namespace, or explicitly declares that it has none, and may contain
-/// links that pass the portable contained-target and archive-graph checks.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RepositoryWorkflowDiscoveryPolicy {
-    /// A remote GitHub repository archive used by authenticated delivery and
-    /// schedule processing.
+pub(crate) enum RepositoryWorkflowDiscoveryPolicy {
     GithubDelivery,
-    /// An immutable archive sealed from a local Git worktree.
-    LocalSnapshot {
-        /// The one namespace present in the snapshot, or `None` when the
-        /// snapshot asserts that neither workflow namespace exists.
-        workflow_location: Option<RepositoryWorkflowLocation>,
-    },
+    LocalGithubArchive,
 }
 
 impl RepositoryWorkflowDiscoveryPolicy {
-    const fn workflow_location(self) -> Option<RepositoryWorkflowLocation> {
+    const fn workflow_location(self) -> RepositoryWorkflowLocation {
         match self {
-            Self::GithubDelivery => Some(RepositoryWorkflowLocation::Automata),
-            Self::LocalSnapshot { workflow_location } => workflow_location,
+            Self::GithubDelivery => RepositoryWorkflowLocation::Automata,
+            Self::LocalGithubArchive => RepositoryWorkflowLocation::Github,
         }
     }
 
     const fn allows_symlinks(self) -> bool {
-        matches!(self, Self::LocalSnapshot { .. })
+        matches!(self, Self::LocalGithubArchive)
     }
 }
 
@@ -356,8 +343,8 @@ impl RepositoryWorkflowDiscoveryOutcome {
     }
 }
 
-/// Validates one exact tar.gz repository archive and discovers direct GitHub
-/// workflow files.
+/// Validates one authenticated GitHub-delivery archive and discovers direct
+/// Automata workflow files.
 ///
 /// The archive is never extracted. It must contain one explicit, safe root
 /// directory and only canonical paths beneath that root. Every entry and all
@@ -372,11 +359,40 @@ impl RepositoryWorkflowDiscoveryOutcome {
 /// aliased, duplicate, or type-conflicting paths; a prohibited or unsafe link;
 /// unsupported archive metadata; a non-regular workflow entry; a workflow
 /// namespace that conflicts with `policy`; or archive-wide resource exhaustion.
-pub fn discover_repository_workflows(
+pub fn discover_github_delivery_workflows(
+    archive_bytes: &[u8],
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, RepositoryWorkflowDiscoveryError> {
+    discover_repository_workflows(
+        archive_bytes,
+        limits,
+        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
+        &|| false,
+    )
+}
+
+pub(crate) fn discover_local_github_workflows(
+    archive_bytes: &[u8],
+    limits: RepositoryWorkflowDiscoveryLimits,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, RepositoryWorkflowDiscoveryError> {
+    discover_repository_workflows(
+        archive_bytes,
+        limits,
+        RepositoryWorkflowDiscoveryPolicy::LocalGithubArchive,
+        cancellation,
+    )
+}
+
+fn discover_repository_workflows(
     archive_bytes: &[u8],
     limits: RepositoryWorkflowDiscoveryLimits,
     policy: RepositoryWorkflowDiscoveryPolicy,
+    cancellation: &dyn Fn() -> bool,
 ) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, RepositoryWorkflowDiscoveryError> {
+    if cancellation() {
+        return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+    }
     let compressed_bytes = u64::try_from(archive_bytes.len())
         .map_err(|_| RepositoryWorkflowDiscoveryError::ResourceLimit)?;
     if compressed_bytes > limits.maximum_compressed_bytes() {
@@ -389,12 +405,17 @@ pub fn discover_repository_workflows(
         decoder,
         limits.maximum_decompressed_bytes(),
         limit_state.clone(),
+        cancellation,
     );
     let mut archive = tar::Archive::new(reader);
-    let workflows = inspect_archive_entries(&mut archive, limits, policy, &limit_state)?;
+    let workflows =
+        inspect_archive_entries(&mut archive, limits, policy, &limit_state, cancellation)?;
     let mut reader = archive.into_inner();
     verify_tar_termination(&mut reader, &limit_state)?;
 
+    if cancellation() {
+        return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+    }
     Ok(workflows
         .into_iter()
         .map(|(path, result)| RepositoryWorkflowDiscoveryOutcome { path, result })
@@ -406,6 +427,7 @@ fn inspect_archive_entries<R: io::Read>(
     limits: RepositoryWorkflowDiscoveryLimits,
     policy: RepositoryWorkflowDiscoveryPolicy,
     limit_state: &ReadLimitState,
+    cancellation: &dyn Fn() -> bool,
 ) -> Result<
     BTreeMap<String, Result<Vec<u8>, RepositoryWorkflowDiscoveryFailure>>,
     RepositoryWorkflowDiscoveryError,
@@ -416,10 +438,13 @@ fn inspect_archive_entries<R: io::Read>(
         .map_err(|_| read_error(limit_state))?
         .raw(true);
     for entry in entries {
+        if cancellation() {
+            return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+        }
         let entry = entry.map_err(|_| read_error(limit_state))?;
         inspection.inspect_entry(entry, limits, limit_state)?;
     }
-    inspection.finish(limit_state)
+    inspection.finish(limit_state, cancellation)
 }
 
 struct ArchiveInspection {
@@ -530,10 +555,7 @@ impl ArchiveInspection {
             return Err(RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry);
         }
 
-        let is_workflow = self
-            .policy
-            .workflow_location()
-            .is_some_and(|location| is_direct_workflow(&relative_components, location));
+        let is_workflow = is_direct_workflow(&relative_components, self.policy.workflow_location());
         if is_workflow && !entry_type.is_file() {
             return Err(RepositoryWorkflowDiscoveryError::UnsupportedWorkflowEntry);
         }
@@ -666,6 +688,7 @@ impl ArchiveInspection {
     fn finish(
         self,
         limit_state: &ReadLimitState,
+        cancellation: &dyn Fn() -> bool,
     ) -> Result<
         BTreeMap<String, Result<Vec<u8>, RepositoryWorkflowDiscoveryFailure>>,
         RepositoryWorkflowDiscoveryError,
@@ -685,7 +708,7 @@ impl ArchiveInspection {
         let validator = self
             .path_validator
             .ok_or(RepositoryWorkflowDiscoveryError::MissingArchiveRoot)?;
-        self.graph.validate_links(validator)?;
+        self.graph.validate_links(validator, cancellation)?;
         Ok(self.workflows)
     }
 }
@@ -761,7 +784,7 @@ fn is_direct_workflow(relative_components: &[&str], location: RepositoryWorkflow
 
 fn workflow_location_conflicts(
     relative_components: &[&str],
-    location: Option<RepositoryWorkflowLocation>,
+    location: RepositoryWorkflowLocation,
 ) -> bool {
     if relative_components.len() < 2 || relative_components[1] != "workflows" {
         return false;
@@ -771,7 +794,7 @@ fn workflow_location_conflicts(
         ".github" => Some(RepositoryWorkflowLocation::Github),
         _ => None,
     };
-    actual.is_some() && actual != location
+    actual.is_some_and(|actual| actual != location)
 }
 
 fn validate_symlink<R: io::Read>(
@@ -966,6 +989,7 @@ impl ArchivePathGraph {
     fn validate_links(
         &self,
         validator: RepositoryPathValidator,
+        cancellation: &dyn Fn() -> bool,
     ) -> Result<(), RepositoryWorkflowDiscoveryError> {
         let hop_limit = self
             .nodes
@@ -975,6 +999,9 @@ impl ArchivePathGraph {
             .min(MAX_SYMLINK_RESOLUTION_HOPS);
         let mut directory_aliases = Vec::new();
         for node in 1..self.nodes.len() {
+            if cancellation() {
+                return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+            }
             let ArchiveNodeKind::Symlink(target) = &self.nodes[node].kind else {
                 continue;
             };
@@ -989,17 +1016,21 @@ impl ArchivePathGraph {
                 directory_aliases.push((self.nodes[node].parent, target));
             }
         }
-        self.validate_directory_containment(&directory_aliases)
+        self.validate_directory_containment(&directory_aliases, cancellation)
     }
 
     fn validate_directory_containment(
         &self,
         aliases: &[(usize, usize)],
+        cancellation: &dyn Fn() -> bool,
     ) -> Result<(), RepositoryWorkflowDiscoveryError> {
         let mut outgoing = vec![Vec::new(); self.nodes.len()];
         let mut incoming = vec![0_usize; self.nodes.len()];
         let mut directory_count = 0_usize;
         for (parent, node) in self.nodes.iter().enumerate() {
+            if cancellation() {
+                return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+            }
             if !node.kind.is_directory() {
                 continue;
             }
@@ -1025,6 +1056,9 @@ impl ArchivePathGraph {
             .collect::<VecDeque<_>>();
         let mut visited = 0_usize;
         while let Some(node) = ready.pop_front() {
+            if cancellation() {
+                return Err(RepositoryWorkflowDiscoveryError::Cancelled);
+            }
             visited += 1;
             for child in outgoing[node].iter().copied() {
                 incoming[child] -= 1;
@@ -1322,12 +1356,21 @@ struct ReadLimitState(Rc<ReadState>);
 #[derive(Default)]
 struct ReadState {
     exceeded: Cell<bool>,
+    cancelled: Cell<bool>,
     stream_tail: RefCell<StreamTail>,
 }
 
 impl ReadLimitState {
     fn mark_exceeded(&self) {
         self.0.exceeded.set(true);
+    }
+
+    fn mark_cancelled(&self) {
+        self.0.cancelled.set(true);
+    }
+
+    fn cancelled(&self) -> bool {
+        self.0.cancelled.get()
     }
 
     fn exceeded(&self) -> bool {
@@ -1386,24 +1429,35 @@ impl StreamTail {
     }
 }
 
-struct BoundedReader<R> {
+struct BoundedReader<'a, R> {
     inner: R,
     remaining: u64,
     limit_state: ReadLimitState,
+    cancellation: &'a dyn Fn() -> bool,
 }
 
-impl<R> BoundedReader<R> {
-    fn new(inner: R, maximum_bytes: u64, limit_state: ReadLimitState) -> Self {
+impl<'a, R> BoundedReader<'a, R> {
+    fn new(
+        inner: R,
+        maximum_bytes: u64,
+        limit_state: ReadLimitState,
+        cancellation: &'a dyn Fn() -> bool,
+    ) -> Self {
         Self {
             inner,
             remaining: maximum_bytes,
             limit_state,
+            cancellation,
         }
     }
 }
 
-impl<R: io::Read> io::Read for BoundedReader<R> {
+impl<R: io::Read> io::Read for BoundedReader<'_, R> {
     fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        if (self.cancellation)() {
+            self.limit_state.mark_cancelled();
+            return Err(io::Error::other("cancelled"));
+        }
         if bytes.is_empty() {
             return Ok(0);
         }
@@ -1429,7 +1483,9 @@ impl<R: io::Read> io::Read for BoundedReader<R> {
 }
 
 fn read_error(limit_state: &ReadLimitState) -> RepositoryWorkflowDiscoveryError {
-    if limit_state.exceeded() {
+    if limit_state.cancelled() {
+        RepositoryWorkflowDiscoveryError::Cancelled
+    } else if limit_state.exceeded() {
         RepositoryWorkflowDiscoveryError::ResourceLimit
     } else {
         RepositoryWorkflowDiscoveryError::Malformed
@@ -1456,6 +1512,8 @@ impl Error for RepositoryWorkflowDiscoveryLimitsError {}
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RepositoryWorkflowDiscoveryError {
+    /// Cooperative local analysis cancellation interrupted archive inspection.
+    Cancelled,
     /// Gzip or tar framing, sizes, padding, or termination are invalid.
     Malformed,
     /// A configured or implementation-wide resource ceiling was exceeded.
@@ -1486,6 +1544,7 @@ pub enum RepositoryWorkflowDiscoveryError {
 impl fmt::Display for RepositoryWorkflowDiscoveryError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
+            Self::Cancelled => "repository archive inspection was cancelled",
             Self::Malformed => "repository archive is malformed",
             Self::ResourceLimit => "repository archive exceeds a configured resource limit",
             Self::UnsafePath => "repository archive contains an unsafe path",
@@ -1513,13 +1572,35 @@ impl Error for RepositoryWorkflowDiscoveryError {}
 #[cfg(test)]
 mod limit_contract_tests {
     use super::{
-        ArchiveNodeKind, ArchivePathGraph, MAX_COMPRESSED_BYTES, MAX_DECOMPRESSED_BYTES,
-        MAX_ENTRY_COUNT, MAX_ENTRY_PATH_BYTES, MAX_EXPANDED_BYTES, MAX_GLOBAL_PAX_BYTES,
-        MAX_REPOSITORY_WORKFLOW_PATH_BYTES, MAX_WORKFLOW_BYTES, MAX_WORKFLOW_COUNT,
-        RepositoryArchiveLimitRejection, RepositoryWorkflowDiscoveryError,
-        archive_policy_limit_rejection, global_pax_byte_rejection,
-        repository_workflow_path_byte_rejection,
+        ArchiveNodeKind, ArchivePathGraph, BoundedReader, MAX_COMPRESSED_BYTES,
+        MAX_DECOMPRESSED_BYTES, MAX_ENTRY_COUNT, MAX_ENTRY_PATH_BYTES, MAX_EXPANDED_BYTES,
+        MAX_GLOBAL_PAX_BYTES, MAX_REPOSITORY_WORKFLOW_PATH_BYTES, MAX_WORKFLOW_BYTES,
+        MAX_WORKFLOW_COUNT, ReadLimitState, RepositoryArchiveLimitRejection,
+        RepositoryWorkflowDiscoveryError, archive_policy_limit_rejection,
+        global_pax_byte_rejection, read_error, repository_workflow_path_byte_rejection,
     };
+
+    #[test]
+    fn cancellation_stops_standard_readers_instead_of_requesting_a_retry() {
+        use std::io::Read as _;
+
+        let state = ReadLimitState::default();
+        let cancelled = || true;
+        let mut reader = BoundedReader::new(
+            std::io::Cursor::new(b"payload"),
+            64,
+            state.clone(),
+            &cancelled,
+        );
+        let error = reader
+            .read_to_end(&mut Vec::new())
+            .expect_err("cancellation must terminate the read");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            read_error(&state),
+            RepositoryWorkflowDiscoveryError::Cancelled
+        );
+    }
 
     #[test]
     fn derived_component_storage_has_an_exact_cumulative_byte_boundary() {

--- a/crates/automata-ci-workflow-github/src/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/src/repository_archive.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     error::Error,
     fmt,
     io::{self, Cursor, Read as _},
@@ -8,6 +8,9 @@ use std::{
 };
 
 use flate2::read::MultiGzDecoder;
+
+use crate::repository_path::PortablePathKey;
+use crate::{RepositoryPathValidationError, RepositoryPathValidator};
 
 const TAR_BLOCK_BYTES: usize = 512;
 const TAR_BLOCK_BYTES_U64: u64 = 512;
@@ -19,6 +22,14 @@ const MAX_ENTRY_PATH_BYTES: usize = 16_384;
 const MAX_WORKFLOW_COUNT: usize = 1_024;
 const MAX_WORKFLOW_BYTES: u64 = 16_777_216;
 const MAX_GLOBAL_PAX_BYTES: u64 = 65_536;
+// Each link gets an independent bound; archive ordering never consumes budget
+// needed by a later valid link.
+const MAX_SYMLINK_RESOLUTION_HOPS: usize = 256;
+const MAX_PATH_GRAPH_NODES: usize = 1_000_000;
+const MAX_PATH_GRAPH_COMPONENT_BYTES: usize = 64 * 1_024 * 1_024;
+const PATH_GRAPH_NODES_PER_ENTRY: usize = 4;
+const PATH_GRAPH_BYTES_PER_SOURCE_BYTE: usize = 4;
+const PORTABLE_USTAR_PATH_BYTES: usize = 256;
 const OBSERVED_STREAM_TAIL_BYTES: usize = 2 * 1_024;
 
 use crate::MAX_GITHUB_WORKFLOW_SOURCE_BYTES;
@@ -29,6 +40,61 @@ use crate::MAX_GITHUB_WORKFLOW_SOURCE_BYTES;
 /// workflow-outcome path bound. It is defined here as well because this
 /// source-level frontend must not depend on the persistence crate.
 pub const MAX_REPOSITORY_WORKFLOW_PATH_BYTES: usize = 1_024;
+
+/// One explicit repository namespace from which direct workflow files may be
+/// discovered.
+///
+/// Callers choose the namespace from their source-authority policy. Discovery
+/// never falls back to the other namespace, and the presence of the other
+/// workflow authority fails closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RepositoryWorkflowLocation {
+    /// Automata-owned workflows under `.ci/workflows`.
+    Automata,
+    /// GitHub Actions workflows under `.github/workflows`.
+    Github,
+}
+
+impl RepositoryWorkflowLocation {
+    const fn directory(self) -> &'static str {
+        match self {
+            Self::Automata => ".ci",
+            Self::Github => ".github",
+        }
+    }
+}
+
+/// Exact archive trust policy used by repository workflow discovery.
+///
+/// GitHub delivery archives retain their established `.ci/workflows`
+/// authority and reject every symbolic link. A local snapshot declares its one
+/// workflow namespace, or explicitly declares that it has none, and may contain
+/// links that pass the portable contained-target and archive-graph checks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RepositoryWorkflowDiscoveryPolicy {
+    /// A remote GitHub repository archive used by authenticated delivery and
+    /// schedule processing.
+    GithubDelivery,
+    /// An immutable archive sealed from a local Git worktree.
+    LocalSnapshot {
+        /// The one namespace present in the snapshot, or `None` when the
+        /// snapshot asserts that neither workflow namespace exists.
+        workflow_location: Option<RepositoryWorkflowLocation>,
+    },
+}
+
+impl RepositoryWorkflowDiscoveryPolicy {
+    const fn workflow_location(self) -> Option<RepositoryWorkflowLocation> {
+        match self {
+            Self::GithubDelivery => Some(RepositoryWorkflowLocation::Automata),
+            Self::LocalSnapshot { workflow_location } => workflow_location,
+        }
+    }
+
+    const fn allows_symlinks(self) -> bool {
+        matches!(self, Self::LocalSnapshot { .. })
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RepositoryArchiveLimitRejection {
@@ -192,6 +258,34 @@ impl RepositoryWorkflowDiscoveryLimits {
     pub const fn maximum_workflow_bytes(self) -> u64 {
         self.workflow_bytes
     }
+
+    /// Returns the maximum number of derived component-trie nodes admitted
+    /// while validating archive and local path graphs.
+    #[must_use]
+    pub const fn maximum_path_graph_nodes(self) -> usize {
+        match self.entries.checked_mul(PATH_GRAPH_NODES_PER_ENTRY) {
+            Some(value) if value < MAX_PATH_GRAPH_NODES => value,
+            _ => MAX_PATH_GRAPH_NODES,
+        }
+    }
+
+    /// Returns the maximum cumulative bytes retained by derived component
+    /// spellings and portable identity keys.
+    #[must_use]
+    pub const fn maximum_path_graph_component_bytes(self) -> usize {
+        let path_bytes = if self.entry_path_bytes < PORTABLE_USTAR_PATH_BYTES {
+            self.entry_path_bytes
+        } else {
+            PORTABLE_USTAR_PATH_BYTES
+        };
+        let Some(source_bytes) = self.entries.checked_mul(path_bytes) else {
+            return MAX_PATH_GRAPH_COMPONENT_BYTES;
+        };
+        match source_bytes.checked_mul(PATH_GRAPH_BYTES_PER_SOURCE_BYTE) {
+            Some(value) if value < MAX_PATH_GRAPH_COMPONENT_BYTES => value,
+            _ => MAX_PATH_GRAPH_COMPONENT_BYTES,
+        }
+    }
 }
 
 impl Default for RepositoryWorkflowDiscoveryLimits {
@@ -274,13 +368,14 @@ impl RepositoryWorkflowDiscoveryOutcome {
 ///
 /// # Errors
 ///
-/// Returns a fail-closed error for a non-tar.gz or malformed archive, unsafe or
-/// duplicate paths, unsupported archive metadata, non-regular workflow
-/// entries, any repository-owned GitHub Actions workflow directory, or any
-/// archive-wide configured resource-limit exhaustion.
+/// Returns a fail-closed error for a non-tar.gz or malformed archive; unsafe,
+/// aliased, duplicate, or type-conflicting paths; a prohibited or unsafe link;
+/// unsupported archive metadata; a non-regular workflow entry; a workflow
+/// namespace that conflicts with `policy`; or archive-wide resource exhaustion.
 pub fn discover_repository_workflows(
     archive_bytes: &[u8],
     limits: RepositoryWorkflowDiscoveryLimits,
+    policy: RepositoryWorkflowDiscoveryPolicy,
 ) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, RepositoryWorkflowDiscoveryError> {
     let compressed_bytes = u64::try_from(archive_bytes.len())
         .map_err(|_| RepositoryWorkflowDiscoveryError::ResourceLimit)?;
@@ -296,7 +391,7 @@ pub fn discover_repository_workflows(
         limit_state.clone(),
     );
     let mut archive = tar::Archive::new(reader);
-    let workflows = inspect_archive_entries(&mut archive, limits, &limit_state)?;
+    let workflows = inspect_archive_entries(&mut archive, limits, policy, &limit_state)?;
     let mut reader = archive.into_inner();
     verify_tar_termination(&mut reader, &limit_state)?;
 
@@ -309,12 +404,13 @@ pub fn discover_repository_workflows(
 fn inspect_archive_entries<R: io::Read>(
     archive: &mut tar::Archive<R>,
     limits: RepositoryWorkflowDiscoveryLimits,
+    policy: RepositoryWorkflowDiscoveryPolicy,
     limit_state: &ReadLimitState,
 ) -> Result<
     BTreeMap<String, Result<Vec<u8>, RepositoryWorkflowDiscoveryFailure>>,
     RepositoryWorkflowDiscoveryError,
 > {
-    let mut inspection = ArchiveInspection::default();
+    let mut inspection = ArchiveInspection::new(policy, limits);
     let entries = archive
         .entries()
         .map_err(|_| read_error(limit_state))?
@@ -326,10 +422,11 @@ fn inspect_archive_entries<R: io::Read>(
     inspection.finish(limit_state)
 }
 
-#[derive(Default)]
 struct ArchiveInspection {
+    policy: RepositoryWorkflowDiscoveryPolicy,
     root: Option<String>,
-    seen_paths: BTreeSet<String>,
+    path_validator: Option<RepositoryPathValidator>,
+    graph: ArchivePathGraph,
     workflows: BTreeMap<String, Result<Vec<u8>, RepositoryWorkflowDiscoveryFailure>>,
     entry_count: usize,
     expanded_bytes: u64,
@@ -338,6 +435,23 @@ struct ArchiveInspection {
 }
 
 impl ArchiveInspection {
+    fn new(
+        policy: RepositoryWorkflowDiscoveryPolicy,
+        limits: RepositoryWorkflowDiscoveryLimits,
+    ) -> Self {
+        Self {
+            policy,
+            root: None,
+            path_validator: None,
+            graph: ArchivePathGraph::new(limits),
+            workflows: BTreeMap::new(),
+            entry_count: 0,
+            expanded_bytes: 0,
+            saw_global_pax: false,
+            pending_data_end: None,
+        }
+    }
+
     fn inspect_entry<R: io::Read>(
         &mut self,
         mut entry: tar::Entry<'_, R>,
@@ -387,35 +501,44 @@ impl ArchiveInspection {
             || entry_type.is_gnu_longlink()
             || entry_type.is_pax_local_extensions()
             || entry_type.is_gnu_sparse()
-            || entry_type.is_symlink()
             || entry_type.is_hard_link()
         {
             return Err(RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry);
         }
-
-        let path = entry.path_bytes();
-        let components = canonical_components(path.as_ref(), limits.maximum_entry_path_bytes())?;
-        let (archive_root, relative_components) = components
-            .split_first()
-            .ok_or(RepositoryWorkflowDiscoveryError::UnsafePath)?;
-        self.validate_root(archive_root, relative_components, entry_type)?;
-
-        let relative_path = relative_components.join("/");
-        if !self.seen_paths.insert(relative_path.clone()) {
-            return Err(RepositoryWorkflowDiscoveryError::DuplicatePath);
+        if entry_type.is_dir() && declared_size != 0 {
+            return Err(RepositoryWorkflowDiscoveryError::Malformed);
         }
 
-        if is_github_actions_workflow_path(relative_components) {
+        let raw_path = entry.path_bytes();
+        let (archive_root, relative_path) = archive_path_parts(
+            raw_path.as_ref(),
+            limits.maximum_entry_path_bytes(),
+            entry_type,
+        )?;
+        let Some(relative_path) =
+            self.validate_root(archive_root, relative_path, entry_type, limits)?
+        else {
+            consume_entry(&mut entry, declared_size, limit_state)?;
+            return Ok(());
+        };
+        let relative_components = relative_path.split('/').collect::<Vec<_>>();
+
+        if workflow_location_conflicts(&relative_components, self.policy.workflow_location()) {
             return Err(RepositoryWorkflowDiscoveryError::UnsupportedWorkflowLocation);
         }
+        if entry_type.is_symlink() && !self.policy.allows_symlinks() {
+            return Err(RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry);
+        }
 
-        let is_workflow = is_direct_workflow(relative_components);
+        let is_workflow = self
+            .policy
+            .workflow_location()
+            .is_some_and(|location| is_direct_workflow(&relative_components, location));
         if is_workflow && !entry_type.is_file() {
             return Err(RepositoryWorkflowDiscoveryError::UnsupportedWorkflowEntry);
         }
-        if !entry_type.is_file() && !entry_type.is_dir() {
-            return Err(RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry);
-        }
+        let node_kind = self.classify_node(&entry, entry_type, declared_size)?;
+        self.graph.insert(&relative_path, node_kind)?;
 
         if is_workflow {
             if repository_workflow_path_byte_rejection(relative_path.len()).is_some() {
@@ -433,23 +556,61 @@ impl ArchiveInspection {
         }
     }
 
+    fn classify_node<R: io::Read>(
+        &self,
+        entry: &tar::Entry<'_, R>,
+        entry_type: tar::EntryType,
+        declared_size: u64,
+    ) -> Result<ArchiveNodeKind, RepositoryWorkflowDiscoveryError> {
+        if entry_type.is_symlink() {
+            let validator = self
+                .path_validator
+                .ok_or(RepositoryWorkflowDiscoveryError::MissingArchiveRoot)?;
+            return validate_symlink(entry, declared_size, validator).map(ArchiveNodeKind::Symlink);
+        }
+        if entry_type.is_file() {
+            return Ok(ArchiveNodeKind::File);
+        }
+        if entry_type.is_dir() {
+            return Ok(ArchiveNodeKind::Directory);
+        }
+        Err(RepositoryWorkflowDiscoveryError::UnsupportedArchiveEntry)
+    }
+
     fn validate_root(
         &mut self,
         archive_root: &str,
-        relative_components: &[&str],
+        relative_path: Option<&str>,
         entry_type: tar::EntryType,
-    ) -> Result<(), RepositoryWorkflowDiscoveryError> {
+        limits: RepositoryWorkflowDiscoveryLimits,
+    ) -> Result<Option<String>, RepositoryWorkflowDiscoveryError> {
         if let Some(expected_root) = self.root.as_deref() {
             if archive_root != expected_root {
                 return Err(RepositoryWorkflowDiscoveryError::UnsafePath);
             }
+            if relative_path.is_none() {
+                return Err(RepositoryWorkflowDiscoveryError::DuplicatePath);
+            }
         } else {
-            if !relative_components.is_empty() || !entry_type.is_dir() {
+            if relative_path.is_some() || !entry_type.is_dir() {
                 return Err(RepositoryWorkflowDiscoveryError::UnsafePath);
             }
+            let validator =
+                RepositoryPathValidator::new(archive_root, limits.maximum_entry_path_bytes())
+                    .map_err(path_validation_error)?;
             self.root = Some(archive_root.to_owned());
+            self.path_validator = Some(validator);
         }
-        Ok(())
+        let Some(relative_path) = relative_path else {
+            return Ok(None);
+        };
+        let validator = self
+            .path_validator
+            .ok_or(RepositoryWorkflowDiscoveryError::MissingArchiveRoot)?;
+        let relative_path = validator
+            .validate_entry(relative_path.as_bytes())
+            .map_err(path_validation_error)?;
+        Ok(Some(relative_path.to_owned()))
     }
 
     fn validate_previous_padding(
@@ -521,6 +682,10 @@ impl ArchiveInspection {
         if self.root.is_none() {
             return Err(RepositoryWorkflowDiscoveryError::MissingArchiveRoot);
         }
+        let validator = self
+            .path_validator
+            .ok_or(RepositoryWorkflowDiscoveryError::MissingArchiveRoot)?;
+        self.graph.validate_links(validator)?;
         Ok(self.workflows)
     }
 }
@@ -546,10 +711,11 @@ fn checked_expanded_size(
     Ok(next)
 }
 
-fn canonical_components(
+fn archive_path_parts(
     raw: &[u8],
     maximum_path_bytes: usize,
-) -> Result<Vec<&str>, RepositoryWorkflowDiscoveryError> {
+    entry_type: tar::EntryType,
+) -> Result<(&str, Option<&str>), RepositoryWorkflowDiscoveryError> {
     if raw.is_empty()
         || raw.len() > maximum_path_bytes
         || raw.starts_with(b"/")
@@ -564,36 +730,450 @@ fn canonical_components(
     }
     let path =
         std::str::from_utf8(raw).map_err(|_| RepositoryWorkflowDiscoveryError::UnsafePath)?;
-    let mut components = path.split('/').collect::<Vec<_>>();
-    if components
-        .last()
-        .is_some_and(|component| component.is_empty())
-    {
-        components.pop();
-    }
-    if components.is_empty()
-        || components
-            .iter()
-            .any(|component| component.is_empty() || matches!(*component, "." | ".."))
-    {
+    let path = if let Some(path) = path.strip_suffix('/') {
+        if !entry_type.is_dir() || path.ends_with('/') {
+            return Err(RepositoryWorkflowDiscoveryError::UnsafePath);
+        }
+        path
+    } else {
+        path
+    };
+    if path.is_empty() {
         return Err(RepositoryWorkflowDiscoveryError::UnsafePath);
     }
-    Ok(components)
+    let (root, relative) = path
+        .split_once('/')
+        .map_or((path, None), |(root, relative)| (root, Some(relative)));
+    if root.is_empty() || relative.is_some_and(str::is_empty) {
+        return Err(RepositoryWorkflowDiscoveryError::UnsafePath);
+    }
+    Ok((root, relative))
 }
 
-fn is_direct_workflow(relative_components: &[&str]) -> bool {
+fn is_direct_workflow(relative_components: &[&str], location: RepositoryWorkflowLocation) -> bool {
     relative_components.len() == 3
-        && relative_components[0] == ".ci"
+        && relative_components[0] == location.directory()
         && relative_components[1] == "workflows"
         && relative_components[2]
             .rsplit_once('.')
             .is_some_and(|(_, extension)| matches!(extension, "yml" | "yaml"))
 }
 
-fn is_github_actions_workflow_path(relative_components: &[&str]) -> bool {
-    relative_components.len() >= 2
-        && relative_components[0] == ".github"
-        && relative_components[1] == "workflows"
+fn workflow_location_conflicts(
+    relative_components: &[&str],
+    location: Option<RepositoryWorkflowLocation>,
+) -> bool {
+    if relative_components.len() < 2 || relative_components[1] != "workflows" {
+        return false;
+    }
+    let actual = match relative_components[0] {
+        ".ci" => Some(RepositoryWorkflowLocation::Automata),
+        ".github" => Some(RepositoryWorkflowLocation::Github),
+        _ => None,
+    };
+    actual.is_some() && actual != location
+}
+
+fn validate_symlink<R: io::Read>(
+    entry: &tar::Entry<'_, R>,
+    declared_size: u64,
+    validator: RepositoryPathValidator,
+) -> Result<String, RepositoryWorkflowDiscoveryError> {
+    if declared_size != 0 {
+        return Err(RepositoryWorkflowDiscoveryError::Malformed);
+    }
+    let target = entry
+        .link_name_bytes()
+        .ok_or(RepositoryWorkflowDiscoveryError::UnsafeLink)?;
+    validator
+        .validate_symlink_target(target.as_ref())
+        .map(str::to_owned)
+        .map_err(link_validation_error)
+}
+
+fn path_validation_error(error: RepositoryPathValidationError) -> RepositoryWorkflowDiscoveryError {
+    match error {
+        RepositoryPathValidationError::ResourceLimit => {
+            RepositoryWorkflowDiscoveryError::ResourceLimit
+        }
+        RepositoryPathValidationError::NonUnicode | RepositoryPathValidationError::Unsafe => {
+            RepositoryWorkflowDiscoveryError::UnsafePath
+        }
+    }
+}
+
+fn link_validation_error(error: RepositoryPathValidationError) -> RepositoryWorkflowDiscoveryError {
+    match error {
+        RepositoryPathValidationError::ResourceLimit => {
+            RepositoryWorkflowDiscoveryError::ResourceLimit
+        }
+        RepositoryPathValidationError::NonUnicode | RepositoryPathValidationError::Unsafe => {
+            RepositoryWorkflowDiscoveryError::UnsafeLink
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ArchiveNodeKind {
+    ImplicitDirectory,
+    Directory,
+    File,
+    Symlink(String),
+}
+
+impl ArchiveNodeKind {
+    const fn is_directory(&self) -> bool {
+        matches!(self, Self::ImplicitDirectory | Self::Directory)
+    }
+
+    const fn same_explicit_type(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Directory, Self::Directory)
+                | (Self::File, Self::File)
+                | (Self::Symlink(_), Self::Symlink(_))
+        )
+    }
+}
+
+struct ArchiveGraphNode {
+    parent: usize,
+    spelling: String,
+    kind: ArchiveNodeKind,
+    children: BTreeMap<PortablePathKey, usize>,
+}
+
+struct ArchivePathGraph {
+    nodes: Vec<ArchiveGraphNode>,
+    maximum_nodes: usize,
+    maximum_component_bytes: usize,
+    component_bytes: usize,
+}
+
+impl ArchivePathGraph {
+    fn new(limits: RepositoryWorkflowDiscoveryLimits) -> Self {
+        Self::with_limits(
+            limits.maximum_path_graph_nodes(),
+            limits.maximum_path_graph_component_bytes(),
+        )
+    }
+
+    fn with_limits(maximum_nodes: usize, maximum_component_bytes: usize) -> Self {
+        Self {
+            nodes: vec![ArchiveGraphNode {
+                parent: 0,
+                spelling: String::new(),
+                kind: ArchiveNodeKind::ImplicitDirectory,
+                children: BTreeMap::new(),
+            }],
+            maximum_nodes,
+            maximum_component_bytes,
+            component_bytes: 0,
+        }
+    }
+
+    fn insert(
+        &mut self,
+        path: &str,
+        kind: ArchiveNodeKind,
+    ) -> Result<(), RepositoryWorkflowDiscoveryError> {
+        if matches!(kind, ArchiveNodeKind::Symlink(_)) && workflow_namespace_anchor(path) {
+            return Err(RepositoryWorkflowDiscoveryError::NamespaceAlias);
+        }
+        let mut components = path.split('/').peekable();
+        let mut leaf_kind = Some(kind);
+        let mut parent = 0_usize;
+        while let Some(component) = components.next() {
+            let leaf = components.peek().is_none();
+            let key = RepositoryPathValidator::portable_key(component);
+            let existing = self.nodes[parent].children.get(&key).copied();
+            let node = if let Some(node) = existing {
+                if self.nodes[node].spelling != component {
+                    return Err(RepositoryWorkflowDiscoveryError::PathAlias);
+                }
+                if leaf {
+                    let kind = leaf_kind
+                        .take()
+                        .ok_or(RepositoryWorkflowDiscoveryError::PathTypeConflict)?;
+                    match &self.nodes[node].kind {
+                        ArchiveNodeKind::ImplicitDirectory
+                            if matches!(kind, ArchiveNodeKind::Directory) =>
+                        {
+                            self.nodes[node].kind = kind;
+                        }
+                        ArchiveNodeKind::ImplicitDirectory => {
+                            return Err(RepositoryWorkflowDiscoveryError::PathTypeConflict);
+                        }
+                        existing if existing.same_explicit_type(&kind) => {
+                            return Err(RepositoryWorkflowDiscoveryError::DuplicatePath);
+                        }
+                        _ => return Err(RepositoryWorkflowDiscoveryError::PathTypeConflict),
+                    }
+                } else if !self.nodes[node].kind.is_directory() {
+                    return Err(RepositoryWorkflowDiscoveryError::PathTypeConflict);
+                }
+                node
+            } else {
+                let kind = if leaf {
+                    leaf_kind
+                        .take()
+                        .ok_or(RepositoryWorkflowDiscoveryError::PathTypeConflict)?
+                } else {
+                    ArchiveNodeKind::ImplicitDirectory
+                };
+                self.insert_node(parent, component, key, kind)?
+            };
+            parent = node;
+        }
+        Ok(())
+    }
+
+    fn insert_node(
+        &mut self,
+        parent: usize,
+        component: &str,
+        key: PortablePathKey,
+        kind: ArchiveNodeKind,
+    ) -> Result<usize, RepositoryWorkflowDiscoveryError> {
+        if self.nodes.len().saturating_sub(1) >= self.maximum_nodes {
+            return Err(RepositoryWorkflowDiscoveryError::ResourceLimit);
+        }
+        let additional_bytes = component
+            .len()
+            .checked_add(key.storage_bytes())
+            .ok_or(RepositoryWorkflowDiscoveryError::ResourceLimit)?;
+        let component_bytes = self
+            .component_bytes
+            .checked_add(additional_bytes)
+            .ok_or(RepositoryWorkflowDiscoveryError::ResourceLimit)?;
+        if component_bytes > self.maximum_component_bytes {
+            return Err(RepositoryWorkflowDiscoveryError::ResourceLimit);
+        }
+        let node = self.nodes.len();
+        self.nodes.push(ArchiveGraphNode {
+            parent,
+            spelling: component.to_owned(),
+            kind,
+            children: BTreeMap::new(),
+        });
+        if self.nodes[parent].children.insert(key, node).is_some() {
+            return Err(RepositoryWorkflowDiscoveryError::PathAlias);
+        }
+        self.component_bytes = component_bytes;
+        Ok(node)
+    }
+
+    fn validate_links(
+        &self,
+        validator: RepositoryPathValidator,
+    ) -> Result<(), RepositoryWorkflowDiscoveryError> {
+        let hop_limit = self
+            .nodes
+            .iter()
+            .filter(|node| matches!(node.kind, ArchiveNodeKind::Symlink(_)))
+            .count()
+            .min(MAX_SYMLINK_RESOLUTION_HOPS);
+        let mut directory_aliases = Vec::new();
+        for node in 1..self.nodes.len() {
+            let ArchiveNodeKind::Symlink(target) = &self.nodes[node].kind else {
+                continue;
+            };
+            let path = self.node_components(node);
+            let resolved = self.resolve_link(&path, target, validator, hop_limit)?;
+            if workflow_namespace_anchor_components(&resolved) {
+                return Err(RepositoryWorkflowDiscoveryError::NamespaceAlias);
+            }
+            if let Some(target) = self.lookup_exact(&resolved)?
+                && self.nodes[target].kind.is_directory()
+            {
+                directory_aliases.push((self.nodes[node].parent, target));
+            }
+        }
+        self.validate_directory_containment(&directory_aliases)
+    }
+
+    fn validate_directory_containment(
+        &self,
+        aliases: &[(usize, usize)],
+    ) -> Result<(), RepositoryWorkflowDiscoveryError> {
+        let mut outgoing = vec![Vec::new(); self.nodes.len()];
+        let mut incoming = vec![0_usize; self.nodes.len()];
+        let mut directory_count = 0_usize;
+        for (parent, node) in self.nodes.iter().enumerate() {
+            if !node.kind.is_directory() {
+                continue;
+            }
+            directory_count += 1;
+            for child in node.children.values().copied() {
+                if self.nodes[child].kind.is_directory() {
+                    outgoing[parent].push(child);
+                    incoming[child] += 1;
+                }
+            }
+        }
+        for &(parent, target) in aliases {
+            outgoing[parent].push(target);
+            incoming[target] += 1;
+        }
+        let mut ready = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(node, entry)| {
+                (entry.kind.is_directory() && incoming[node] == 0).then_some(node)
+            })
+            .collect::<VecDeque<_>>();
+        let mut visited = 0_usize;
+        while let Some(node) = ready.pop_front() {
+            visited += 1;
+            for child in outgoing[node].iter().copied() {
+                incoming[child] -= 1;
+                if incoming[child] == 0 {
+                    ready.push_back(child);
+                }
+            }
+        }
+        if visited != directory_count {
+            return Err(RepositoryWorkflowDiscoveryError::UnsafeLink);
+        }
+        Ok(())
+    }
+
+    fn resolve_link(
+        &self,
+        link_path: &[String],
+        target: &str,
+        validator: RepositoryPathValidator,
+        hop_limit: usize,
+    ) -> Result<Vec<String>, RepositoryWorkflowDiscoveryError> {
+        let mut resolved = link_path[..link_path.len().saturating_sub(1)].to_vec();
+        let mut pending = VecDeque::new();
+        prepend_target_components(&mut pending, target);
+        let mut followed = BTreeSet::new();
+        let mut remaining_hops = hop_limit;
+        while let Some(component) = pending.pop_front() {
+            match component.as_str() {
+                "." => self.require_resolution_directory(&resolved)?,
+                ".." => {
+                    self.require_resolution_directory(&resolved)?;
+                    resolved
+                        .pop()
+                        .ok_or(RepositoryWorkflowDiscoveryError::UnsafeLink)?;
+                }
+                component => {
+                    resolved.push(component.to_owned());
+                    validator
+                        .validate_resolved_components(&resolved, pending.is_empty())
+                        .map_err(link_validation_error)?;
+                    if workflow_namespace_components(&resolved) {
+                        return Err(RepositoryWorkflowDiscoveryError::NamespaceAlias);
+                    }
+                    match self.lookup_exact(&resolved)? {
+                        Some(node)
+                            if matches!(self.nodes[node].kind, ArchiveNodeKind::Symlink(_)) =>
+                        {
+                            if !followed.insert(node) {
+                                return Err(RepositoryWorkflowDiscoveryError::UnsafeLink);
+                            }
+                            remaining_hops = remaining_hops
+                                .checked_sub(1)
+                                .ok_or(RepositoryWorkflowDiscoveryError::ResourceLimit)?;
+                            let ArchiveNodeKind::Symlink(target) = &self.nodes[node].kind else {
+                                unreachable!("matched symbolic-link node")
+                            };
+                            resolved.pop();
+                            prepend_target_components(&mut pending, target);
+                        }
+                        Some(node)
+                            if matches!(self.nodes[node].kind, ArchiveNodeKind::File)
+                                && !pending.is_empty() =>
+                        {
+                            return Err(RepositoryWorkflowDiscoveryError::PathTypeConflict);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        if resolved.is_empty() {
+            return Err(RepositoryWorkflowDiscoveryError::UnsafeLink);
+        }
+        validator
+            .validate_resolved_components(&resolved, true)
+            .map_err(link_validation_error)?;
+        Ok(resolved)
+    }
+
+    fn require_resolution_directory(
+        &self,
+        resolved: &[String],
+    ) -> Result<(), RepositoryWorkflowDiscoveryError> {
+        if resolved.is_empty() {
+            return Ok(());
+        }
+        match self.lookup_exact(resolved)? {
+            Some(node) if self.nodes[node].kind.is_directory() => Ok(()),
+            Some(node) if matches!(self.nodes[node].kind, ArchiveNodeKind::File) => {
+                Err(RepositoryWorkflowDiscoveryError::PathTypeConflict)
+            }
+            Some(_) | None => Err(RepositoryWorkflowDiscoveryError::UnsafeLink),
+        }
+    }
+
+    fn lookup_exact(
+        &self,
+        components: &[String],
+    ) -> Result<Option<usize>, RepositoryWorkflowDiscoveryError> {
+        let mut node = 0_usize;
+        for component in components {
+            let key = RepositoryPathValidator::portable_key(component);
+            let Some(child) = self.nodes[node].children.get(&key).copied() else {
+                return Ok(None);
+            };
+            if self.nodes[child].spelling != *component {
+                return Err(RepositoryWorkflowDiscoveryError::PathAlias);
+            }
+            node = child;
+        }
+        Ok(Some(node))
+    }
+
+    fn node_components(&self, mut node: usize) -> Vec<String> {
+        let mut components = Vec::new();
+        while node != 0 {
+            components.push(self.nodes[node].spelling.clone());
+            node = self.nodes[node].parent;
+        }
+        components.reverse();
+        components
+    }
+}
+
+fn prepend_target_components(pending: &mut VecDeque<String>, target: &str) {
+    for component in target.split('/').rev() {
+        pending.push_front(component.to_owned());
+    }
+}
+
+fn workflow_namespace_components(components: &[String]) -> bool {
+    components.len() >= 2
+        && [".ci", ".github"]
+            .iter()
+            .any(|root| RepositoryPathValidator::portable_equivalent(&components[0], root))
+        && RepositoryPathValidator::portable_equivalent(&components[1], "workflows")
+}
+
+fn workflow_namespace_anchor_components(components: &[String]) -> bool {
+    components.len() == 1
+        && [".ci", ".github"]
+            .iter()
+            .any(|root| RepositoryPathValidator::portable_equivalent(&components[0], root))
+        || workflow_namespace_components(components)
+}
+
+fn workflow_namespace_anchor(path: &str) -> bool {
+    let components = path.split('/').map(str::to_owned).collect::<Vec<_>>();
+    workflow_namespace_anchor_components(&components)
 }
 
 fn consume_entry<R: io::Read>(
@@ -882,13 +1462,22 @@ pub enum RepositoryWorkflowDiscoveryError {
     ResourceLimit,
     /// An archive path is non-canonical, escaping, absolute, or otherwise unsafe.
     UnsafePath,
+    /// A symbolic-link target is escaping, cyclic, nonportable, or otherwise unsafe.
+    UnsafeLink,
     /// Two archive entries resolve to the same canonical relative path.
     DuplicatePath,
+    /// Two archive path spellings alias under the portable case policy.
+    PathAlias,
+    /// An archive path is both a non-directory node and an ancestor of another node.
+    PathTypeConflict,
+    /// A symbolic link aliases a workflow namespace authority.
+    NamespaceAlias,
     /// The archive uses an unsupported entry type or metadata extension.
     UnsupportedArchiveEntry,
     /// A direct workflow path is not represented by a regular file.
     UnsupportedWorkflowEntry,
-    /// The repository contains the GitHub Actions workflow authority.
+    /// The repository contains a workflow authority other than the explicitly
+    /// selected location.
     UnsupportedWorkflowLocation,
     /// The archive did not begin with the required single explicit root directory.
     MissingArchiveRoot,
@@ -899,14 +1488,20 @@ impl fmt::Display for RepositoryWorkflowDiscoveryError {
         formatter.write_str(match self {
             Self::Malformed => "repository archive is malformed",
             Self::ResourceLimit => "repository archive exceeds a configured resource limit",
-            Self::UnsafePath => "repository archive contains an unsafe path or link",
+            Self::UnsafePath => "repository archive contains an unsafe path",
+            Self::UnsafeLink => "repository archive contains an unsafe symbolic link",
             Self::DuplicatePath => "repository archive contains a duplicate path",
+            Self::PathAlias => "repository archive contains nonportable path aliases",
+            Self::PathTypeConflict => "repository archive contains conflicting path node types",
+            Self::NamespaceAlias => {
+                "repository archive contains a symbolic-link workflow namespace alias"
+            }
             Self::UnsupportedArchiveEntry => {
                 "repository archive contains unsupported metadata or an entry type"
             }
             Self::UnsupportedWorkflowEntry => "repository workflow path is not a regular file",
             Self::UnsupportedWorkflowLocation => {
-                "repository workflows must use the .ci/workflows directory"
+                "repository archive contains a conflicting workflow location"
             }
             Self::MissingArchiveRoot => "repository archive root is missing",
         })
@@ -918,12 +1513,25 @@ impl Error for RepositoryWorkflowDiscoveryError {}
 #[cfg(test)]
 mod limit_contract_tests {
     use super::{
-        MAX_COMPRESSED_BYTES, MAX_DECOMPRESSED_BYTES, MAX_ENTRY_COUNT, MAX_ENTRY_PATH_BYTES,
-        MAX_EXPANDED_BYTES, MAX_GLOBAL_PAX_BYTES, MAX_REPOSITORY_WORKFLOW_PATH_BYTES,
-        MAX_WORKFLOW_BYTES, MAX_WORKFLOW_COUNT, RepositoryArchiveLimitRejection,
+        ArchiveNodeKind, ArchivePathGraph, MAX_COMPRESSED_BYTES, MAX_DECOMPRESSED_BYTES,
+        MAX_ENTRY_COUNT, MAX_ENTRY_PATH_BYTES, MAX_EXPANDED_BYTES, MAX_GLOBAL_PAX_BYTES,
+        MAX_REPOSITORY_WORKFLOW_PATH_BYTES, MAX_WORKFLOW_BYTES, MAX_WORKFLOW_COUNT,
+        RepositoryArchiveLimitRejection, RepositoryWorkflowDiscoveryError,
         archive_policy_limit_rejection, global_pax_byte_rejection,
         repository_workflow_path_byte_rejection,
     };
+
+    #[test]
+    fn derived_component_storage_has_an_exact_cumulative_byte_boundary() {
+        let mut graph = ArchivePathGraph::with_limits(3, 4);
+        graph
+            .insert("a/b", ArchiveNodeKind::File)
+            .expect("two spellings and two keys use four bytes");
+        assert_eq!(
+            graph.insert("c", ArchiveNodeKind::File),
+            Err(RepositoryWorkflowDiscoveryError::ResourceLimit)
+        );
+    }
 
     #[test]
     fn archive_compressed_byte_limit_has_exact_boundaries() {

--- a/crates/automata-ci-workflow-github/src/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/src/repository_archive.rs
@@ -327,7 +327,7 @@ impl RepositoryWorkflowDiscoveryOutcome {
     /// Returns the exact accepted bytes or the closed path-local failure.
     ///
     /// Archive-wide integrity and resource failures are returned by
-    /// [`discover_repository_workflows`] instead of appearing here.
+    /// [`discover_github_delivery_workflows`] instead of appearing here.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-workflow-github/src/repository_path.rs
+++ b/crates/automata-ci-workflow-github/src/repository_path.rs
@@ -1,0 +1,523 @@
+use std::{cmp::Ordering, fmt};
+
+use focaccia::unicode_full_casecmp;
+use unicode_normalization::UnicodeNormalization as _;
+
+const USTAR_NAME_BYTES: usize = 100;
+const USTAR_PREFIX_BYTES: usize = 155;
+const USTAR_PATH_BYTES: usize = USTAR_PREFIX_BYTES + 1 + USTAR_NAME_BYTES;
+
+/// Maximum link-name byte length representable by a POSIX ustar header.
+pub const USTAR_LINK_NAME_BYTES: usize = 100;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PortablePathKey(String);
+
+impl PortablePathKey {
+    pub(crate) fn storage_bytes(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl PartialEq for PortablePathKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for PortablePathKey {}
+
+impl PartialOrd for PortablePathKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PortablePathKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        unicode_full_casecmp(&self.0, &other.0)
+    }
+}
+
+/// One archive-root-relative portable repository-path policy.
+///
+/// The validator applies one canonical policy to live-worktree paths, archive
+/// entry paths, and symbolic-link targets. It rejects forms that acquire
+/// different meanings on Unix and Windows, including drive prefixes, NTFS
+/// alternate streams, reserved device names, trailing dots or spaces, and
+/// paths that the deterministic ustar encoder cannot represent.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RepositoryPathValidator {
+    archive_root_bytes: usize,
+    maximum_archive_path_bytes: usize,
+}
+
+impl RepositoryPathValidator {
+    /// Creates a validator for entries beneath one explicit archive root.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsafe root or a configured path ceiling that cannot contain
+    /// the root itself.
+    pub fn new(
+        archive_root: &str,
+        maximum_archive_path_bytes: usize,
+    ) -> Result<Self, RepositoryPathValidationError> {
+        if archive_root.as_bytes().contains(&b'/') || archive_root.as_bytes().contains(&b'\\') {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+        validate_component(archive_root)?;
+        if archive_root.chars().any(char::is_control) {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+        if archive_root.len() > maximum_archive_path_bytes || archive_root.len() > USTAR_NAME_BYTES
+        {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        Ok(Self {
+            archive_root_bytes: archive_root.len(),
+            maximum_archive_path_bytes,
+        })
+    }
+
+    /// Validates one nonempty repository-relative entry path.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-Unicode, over-limit, noncanonical, nonportable, or
+    /// ustar-unrepresentable paths.
+    pub fn validate_entry(self, raw: &[u8]) -> Result<&str, RepositoryPathValidationError> {
+        let path = self.validate_relative_shape(raw)?;
+        if !ustar_path_representable(self.archive_root_bytes, raw) {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        Ok(path)
+    }
+
+    /// Validates a repository-relative directory used only as an ancestor of
+    /// encoded entries.
+    ///
+    /// Such a directory is not emitted as its own tar entry, but its complete
+    /// rooted spelling must fit the ustar prefix field available to every
+    /// descendant.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-Unicode, over-limit, noncanonical, or nonportable paths.
+    pub fn validate_entry_ancestor(
+        self,
+        raw: &[u8],
+    ) -> Result<&str, RepositoryPathValidationError> {
+        let path = self.validate_relative_shape(raw)?;
+        if self.full_length(raw)? > USTAR_PREFIX_BYTES {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        Ok(path)
+    }
+
+    /// Validates one relative symbolic-link target without resolving it.
+    ///
+    /// `.` and `..` components are retained for graph-aware resolution because
+    /// an intermediate symbolic link changes the directory to which a later
+    /// parent component applies.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-Unicode, over-limit, absolute, malformed, or nonportable
+    /// targets. Containment, cycles, case aliases, and namespace aliases are
+    /// decided later against the complete archive graph.
+    pub fn validate_symlink_target(
+        self,
+        raw: &[u8],
+    ) -> Result<&str, RepositoryPathValidationError> {
+        if raw.is_empty() || raw.starts_with(b"/") || raw.contains(&b'\\') {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+        if raw.len() > self.maximum_archive_path_bytes.min(USTAR_LINK_NAME_BYTES) {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        let target =
+            std::str::from_utf8(raw).map_err(|_| RepositoryPathValidationError::NonUnicode)?;
+        if target.chars().any(char::is_control) {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+
+        for component in target.split('/') {
+            match component {
+                "" => return Err(RepositoryPathValidationError::Unsafe),
+                "." | ".." => {}
+                component => {
+                    validate_component(component)?;
+                }
+            }
+        }
+        Ok(target)
+    }
+
+    #[must_use]
+    pub(crate) fn portable_key(path: &str) -> PortablePathKey {
+        PortablePathKey(path.nfkd().collect())
+    }
+
+    pub(crate) fn portable_equivalent(left: &str, right: &str) -> bool {
+        Self::portable_key(left) == Self::portable_key(right)
+    }
+
+    pub(crate) fn validate_resolved_components(
+        self,
+        components: &[String],
+        terminal: bool,
+    ) -> Result<(), RepositoryPathValidationError> {
+        let relative_bytes = components
+            .iter()
+            .try_fold(components.len().saturating_sub(1), |total, component| {
+                total.checked_add(component.len())
+            })
+            .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+        let full_length = self
+            .archive_root_bytes
+            .checked_add(1)
+            .and_then(|length| length.checked_add(relative_bytes))
+            .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+        if components.is_empty()
+            || full_length > self.maximum_archive_path_bytes
+            || full_length > USTAR_PATH_BYTES
+        {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        if !terminal {
+            return if full_length <= USTAR_PREFIX_BYTES {
+                Ok(())
+            } else {
+                Err(RepositoryPathValidationError::ResourceLimit)
+            };
+        }
+        if full_length <= USTAR_NAME_BYTES
+            || self.archive_root_bytes <= USTAR_PREFIX_BYTES && relative_bytes <= USTAR_NAME_BYTES
+        {
+            return Ok(());
+        }
+        let mut left_bytes = 0_usize;
+        for (index, component) in components.iter().enumerate() {
+            left_bytes = left_bytes
+                .checked_add(component.len())
+                .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+            if index + 1 == components.len() {
+                break;
+            }
+            let prefix = self
+                .archive_root_bytes
+                .checked_add(1)
+                .and_then(|bytes| bytes.checked_add(left_bytes))
+                .and_then(|bytes| bytes.checked_add(index))
+                .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+            let name = relative_bytes
+                .checked_sub(left_bytes)
+                .and_then(|bytes| bytes.checked_sub(index + 1))
+                .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+            if prefix <= USTAR_PREFIX_BYTES && name <= USTAR_NAME_BYTES {
+                return Ok(());
+            }
+        }
+        Err(RepositoryPathValidationError::ResourceLimit)
+    }
+
+    fn validate_relative_shape(self, raw: &[u8]) -> Result<&str, RepositoryPathValidationError> {
+        if raw.is_empty() || raw.starts_with(b"/") || raw.contains(&b'\\') {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+        if self.full_length(raw)? > USTAR_PATH_BYTES {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        let path =
+            std::str::from_utf8(raw).map_err(|_| RepositoryPathValidationError::NonUnicode)?;
+        validate_repository_path(path)?;
+        Ok(path)
+    }
+
+    fn full_length(self, relative_path: &[u8]) -> Result<usize, RepositoryPathValidationError> {
+        let full_length = self
+            .archive_root_bytes
+            .checked_add(1)
+            .and_then(|length| length.checked_add(relative_path.len()))
+            .ok_or(RepositoryPathValidationError::ResourceLimit)?;
+        if full_length > self.maximum_archive_path_bytes {
+            return Err(RepositoryPathValidationError::ResourceLimit);
+        }
+        Ok(full_length)
+    }
+}
+
+fn validate_repository_path(path: &str) -> Result<(), RepositoryPathValidationError> {
+    if path.chars().any(char::is_control) {
+        return Err(RepositoryPathValidationError::Unsafe);
+    }
+    let mut components = path.split('/');
+    let first = components
+        .next()
+        .ok_or(RepositoryPathValidationError::Unsafe)?;
+    validate_component(first)?;
+    let namespace = canonical_namespace(first)?;
+    if let Some(second) = components.next() {
+        validate_component(second)?;
+        if namespace && portable_equivalent(second, "workflows") && second != "workflows" {
+            return Err(RepositoryPathValidationError::Unsafe);
+        }
+    }
+    for component in components {
+        validate_component(component)?;
+    }
+    Ok(())
+}
+
+fn validate_component(component: &str) -> Result<(), RepositoryPathValidationError> {
+    if component.is_empty()
+        || matches!(component, "." | "..")
+        || component.ends_with('.')
+        || component.ends_with(' ')
+        || portable_equivalent(component, ".git")
+        || component
+            .chars()
+            .any(|character| matches!(character, ':' | '<' | '>' | '"' | '|' | '?' | '*'))
+        || windows_reserved_component(component)
+    {
+        return Err(RepositoryPathValidationError::Unsafe);
+    }
+    Ok(())
+}
+
+fn canonical_namespace(component: &str) -> Result<bool, RepositoryPathValidationError> {
+    let canonical = [".ci", ".github"]
+        .into_iter()
+        .find(|candidate| portable_equivalent(component, candidate));
+    if canonical.is_some_and(|candidate| component != candidate) {
+        return Err(RepositoryPathValidationError::Unsafe);
+    }
+    Ok(canonical.is_some())
+}
+
+fn portable_equivalent(left: &str, right: &str) -> bool {
+    RepositoryPathValidator::portable_equivalent(left, right)
+}
+
+fn windows_reserved_component(component: &str) -> bool {
+    let stem = component
+        .split('.')
+        .next()
+        .unwrap_or(component)
+        .trim_end_matches(' ');
+    if matches_ignore_ascii_case(
+        stem,
+        &["CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$"],
+    ) {
+        return true;
+    }
+    let Some((prefix, suffix)) = stem.as_bytes().split_at_checked(3) else {
+        return false;
+    };
+    (prefix.eq_ignore_ascii_case(b"COM") || prefix.eq_ignore_ascii_case(b"LPT"))
+        && (matches!(suffix, [b'1'..=b'9'])
+            || suffix == "¹".as_bytes()
+            || suffix == "²".as_bytes()
+            || suffix == "³".as_bytes())
+}
+
+fn matches_ignore_ascii_case(value: &str, candidates: &[&str]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| value.eq_ignore_ascii_case(candidate))
+}
+
+fn ustar_path_representable(root_bytes: usize, relative_path: &[u8]) -> bool {
+    let full_length = root_bytes
+        .checked_add(1)
+        .and_then(|length| length.checked_add(relative_path.len()));
+    let Some(full_length) = full_length else {
+        return false;
+    };
+    if full_length <= USTAR_NAME_BYTES {
+        return true;
+    }
+    if full_length > USTAR_PATH_BYTES {
+        return false;
+    }
+
+    if root_bytes <= USTAR_PREFIX_BYTES && relative_path.len() <= USTAR_NAME_BYTES {
+        return true;
+    }
+    relative_path
+        .iter()
+        .enumerate()
+        .filter(|(_, byte)| **byte == b'/')
+        .any(|(slash, _)| {
+            let prefix = root_bytes + 1 + slash;
+            let name = relative_path.len() - slash - 1;
+            prefix <= USTAR_PREFIX_BYTES && name <= USTAR_NAME_BYTES
+        })
+}
+
+/// Stable failure class for portable repository-path validation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RepositoryPathValidationError {
+    /// The path is not valid UTF-8.
+    NonUnicode,
+    /// The path or target exceeds its configured or ustar byte ceiling.
+    ResourceLimit,
+    /// The path has an absolute, escaping, reserved, or nonportable form.
+    Unsafe,
+}
+
+impl fmt::Display for RepositoryPathValidationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::NonUnicode => "repository path is not valid Unicode",
+            Self::ResourceLimit => "repository path exceeds its byte limit",
+            Self::Unsafe => "repository path is unsafe or nonportable",
+        })
+    }
+}
+
+impl std::error::Error for RepositoryPathValidationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RepositoryPathValidationError as Error, RepositoryPathValidator, USTAR_LINK_NAME_BYTES,
+    };
+
+    #[test]
+    fn root_and_ustar_path_bounds_are_exact() {
+        assert_eq!(
+            RepositoryPathValidator::new("nested/root", usize::MAX),
+            Err(Error::Unsafe)
+        );
+        assert_eq!(
+            RepositoryPathValidator::new(r"nested\root", usize::MAX),
+            Err(Error::Unsafe)
+        );
+        assert_eq!(
+            RepositoryPathValidator::new("worktree", 7),
+            Err(Error::ResourceLimit)
+        );
+        let root_only = RepositoryPathValidator::new("worktree", 8).expect("exact root bound");
+        assert_eq!(root_only.validate_entry(b"x"), Err(Error::ResourceLimit));
+
+        let validator = RepositoryPathValidator::new("worktree", usize::MAX).expect("validator");
+        let one_name = vec![b'a'; 100];
+        assert!(validator.validate_entry(&one_name).is_ok());
+        let unsplittable = vec![b'a'; 101];
+        assert_eq!(
+            validator.validate_entry(&unsplittable),
+            Err(Error::ResourceLimit)
+        );
+        let splittable = format!("{}/{}", "a".repeat(146), "b".repeat(100));
+        assert!(validator.validate_entry(splittable.as_bytes()).is_ok());
+        assert!(
+            validator
+                .validate_entry_ancestor("a".repeat(146).as_bytes())
+                .is_ok()
+        );
+        assert_eq!(
+            validator.validate_entry_ancestor("a".repeat(147).as_bytes()),
+            Err(Error::ResourceLimit)
+        );
+        let oversized_prefix = format!("{}/{}", "a".repeat(147), "b".repeat(100));
+        assert_eq!(
+            validator.validate_entry(oversized_prefix.as_bytes()),
+            Err(Error::ResourceLimit)
+        );
+    }
+
+    #[test]
+    fn portable_entry_policy_rejects_windows_alias_forms() {
+        let validator = RepositoryPathValidator::new("worktree", 4_096).expect("validator");
+        for path in [
+            b"C:/source".as_slice(),
+            b"file:stream",
+            b"CON",
+            b"aux.txt",
+            b"COM1.log",
+            "LPT¹.txt".as_bytes(),
+            b"CON .txt",
+            b"Lpt9",
+            b"trailing.",
+            b"trailing ",
+            b"bad?name",
+            b".GITHUB/workflows/ci.yml",
+            b"path/.git/config",
+        ] {
+            assert_eq!(
+                validator.validate_entry(path),
+                Err(Error::Unsafe),
+                "{path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn portable_identity_uses_normalization_and_full_case_folding() {
+        let key = RepositoryPathValidator::portable_key;
+        assert_eq!(key("Σ"), key("σ"));
+        assert_eq!(key("Σ"), key("ς"));
+        assert_eq!(key("caf\u{e9}"), key("cafe\u{301}"));
+        assert_eq!(key("\u{fb03}"), key("ffi"));
+
+        let validator = RepositoryPathValidator::new("worktree", 4_096).expect("validator");
+        for path in [
+            ".CI/workflows/ci.yml",
+            ".github/WORKFLOWS/ci.yml",
+            ".github/Workflows/ci.yml",
+            ".\u{ff27}\u{ff29}\u{ff34}/config",
+        ] {
+            assert_eq!(
+                validator.validate_entry(path.as_bytes()),
+                Err(Error::Unsafe),
+                "namespace or Git spelling {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn symlink_target_has_exact_ustar_boundary_and_preserves_graph_components() {
+        let validator = RepositoryPathValidator::new("worktree", 4_096).expect("validator");
+        let exact = vec![b'a'; USTAR_LINK_NAME_BYTES];
+        assert_eq!(
+            validator
+                .validate_symlink_target(&exact)
+                .expect("exact target"),
+            std::str::from_utf8(&exact).expect("ASCII target")
+        );
+        let oversized = vec![b'a'; USTAR_LINK_NAME_BYTES + 1];
+        assert_eq!(
+            validator.validate_symlink_target(&oversized),
+            Err(Error::ResourceLimit)
+        );
+        assert_eq!(
+            validator
+                .validate_symlink_target(b"../data/value")
+                .expect("graph-sensitive target"),
+            "../data/value"
+        );
+        for target in [b"../../outside".as_slice(), b"../.GITHUB/workflows"] {
+            assert_eq!(
+                validator
+                    .validate_symlink_target(target)
+                    .expect("graph decides containment and top-level spelling"),
+                std::str::from_utf8(target).expect("ASCII target")
+            );
+        }
+        for target in [
+            b"C:/outside".as_slice(),
+            b"file:stream",
+            b"../CON",
+            b"../trailing.",
+            b"bad//target",
+        ] {
+            assert_eq!(
+                validator.validate_symlink_target(target),
+                Err(Error::Unsafe),
+                "{target:?}"
+            );
+        }
+    }
+}

--- a/crates/automata-ci-workflow-github/tests/local_authority.rs
+++ b/crates/automata-ci-workflow-github/tests/local_authority.rs
@@ -1,0 +1,270 @@
+use std::io;
+
+use automata_ci_core::{PlanSourceOrigin, Sha256Digest};
+use automata_ci_workflow_github::{
+    GithubWorkflowDispatchInputs, GithubWorkflowDispatchInputsError,
+    LocalGithubArchiveCompilationFailureKind, MAX_GITHUB_WORKFLOW_DISPATCH_INPUT_CHARACTERS,
+    MAX_GITHUB_WORKFLOW_DISPATCH_INPUTS, RepositoryWorkflowDiscoveryLimits,
+    compile_local_github_archive,
+};
+use flate2::{Compression, GzBuilder};
+use sha2::{Digest as _, Sha256};
+use tar::{Builder, EntryType, Header};
+
+const ROOT_PATH: &str = ".github/workflows/root.yml";
+const ROOT: &str = "worktree";
+const DISPATCH: &str = r"on:
+  workflow_dispatch:
+    inputs:
+      enabled:
+        type: boolean
+        required: true
+jobs:
+  check:
+    runs-on: linux
+    steps:
+      - run: true
+";
+const SIMPLE_DISPATCH: &[u8] =
+    b"on: workflow_dispatch\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n";
+
+#[test]
+fn sealed_archive_derives_local_source_and_event_authority() {
+    let archive = archive(&[Entry::File(ROOT_PATH, DISPATCH.as_bytes())]);
+    let inputs = GithubWorkflowDispatchInputs::try_new([("enabled", true)]).unwrap();
+    let report =
+        compile_local_github_archive(&archive, Some(ROOT_PATH), inputs, limits(), &|| false)
+            .expect("sealed local archive");
+
+    let expected_digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
+    assert_eq!(report.snapshot_digest(), expected_digest);
+    assert_eq!(report.selected_path(), ROOT_PATH);
+    assert_eq!(report.root_plan().source().provider(), "local");
+    assert_eq!(report.root_plan().event().provider(), "local");
+    assert_eq!(report.root_plan().event().name(), "workflow_dispatch");
+    assert!(report.root_plan().event().delivery_id().is_none());
+    assert!(report.root_plan().event().commit_sha().is_none());
+    let PlanSourceOrigin::Repository {
+        repository,
+        revision,
+        path,
+    } = report.root_plan().source().origin()
+    else {
+        panic!("repository-shaped local provenance")
+    };
+    assert_eq!(repository, "local");
+    assert_eq!(revision, &expected_digest.to_string());
+    assert_eq!(path, ROOT_PATH);
+}
+
+#[test]
+fn exact_selector_github_namespace_and_explicit_dispatch_fail_closed() {
+    let two = archive(&[
+        Entry::File(ROOT_PATH, DISPATCH.as_bytes()),
+        Entry::File(
+            ".github/workflows/second.yml",
+            b"on: workflow_dispatch\njobs:\n  ok:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        ),
+    ]);
+    assert_eq!(
+        compile(&two, None).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::WorkflowSelectionRequired
+    );
+    assert_eq!(
+        compile(&two, Some("root.yml")).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::WorkflowNotFound
+    );
+
+    let automata_namespace = archive(&[Entry::File(".ci/workflows/root.yml", DISPATCH.as_bytes())]);
+    assert_eq!(
+        compile(&automata_namespace, None).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::Archive
+    );
+
+    let push = archive(&[Entry::File(
+        ROOT_PATH,
+        b"on: push\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+    )]);
+    assert_eq!(
+        compile(&push, Some(ROOT_PATH)).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::Compilation
+    );
+}
+
+#[test]
+fn reachable_reusable_workflows_must_be_same_archive_local_members() {
+    let local = archive(&[
+        Entry::File(
+            ROOT_PATH,
+            b"on: workflow_dispatch\njobs:\n  call:\n    uses: ./.github/workflows/callee.yml\n",
+        ),
+        Entry::File(
+            ".github/workflows/callee.yml",
+            b"on: workflow_call\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+        ),
+    ]);
+    let compiled = compile(&local, Some(ROOT_PATH)).expect("same-archive reusable call");
+    assert_eq!(compiled.reusable_workflows().len(), 1);
+    let callee = &compiled.reusable_workflows()[0];
+    assert_eq!(callee.path(), ".github/workflows/callee.yml");
+    assert_eq!(callee.plan().source().provider(), "local");
+    assert_eq!(callee.plan().event().provider(), "local");
+    assert_eq!(callee.plan().event().name(), "workflow_call");
+
+    for reference in [
+        "owner/repository/.github/workflows/callee.yml@main",
+        "./.github/workflows/missing.yml",
+    ] {
+        let body = format!("on: workflow_dispatch\njobs:\n  call:\n    uses: {reference}\n");
+        let rejected = archive(&[Entry::File(ROOT_PATH, body.as_bytes())]);
+        assert_eq!(
+            compile(&rejected, Some(ROOT_PATH)).unwrap_err().kind(),
+            LocalGithubArchiveCompilationFailureKind::ReusableWorkflow
+        );
+    }
+}
+
+#[test]
+fn local_archive_symlinks_are_contained_and_cannot_alias_workflow_authority() {
+    let contained = archive(&[
+        Entry::File(ROOT_PATH, SIMPLE_DISPATCH),
+        Entry::File("target", b"target"),
+        Entry::Symlink("safe/link", "../target"),
+    ]);
+    compile(&contained, Some(ROOT_PATH)).expect("contained unrelated symlink");
+
+    let alias = archive(&[
+        Entry::File(ROOT_PATH, SIMPLE_DISPATCH),
+        Entry::Symlink("alternate", ".github"),
+    ]);
+    assert_eq!(
+        compile(&alias, Some(ROOT_PATH)).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::Archive
+    );
+
+    let cycle = archive(&[
+        Entry::File(ROOT_PATH, SIMPLE_DISPATCH),
+        Entry::Symlink("one", "two"),
+        Entry::Symlink("two", "one"),
+    ]);
+    assert_eq!(
+        compile(&cycle, Some(ROOT_PATH)).unwrap_err().kind(),
+        LocalGithubArchiveCompilationFailureKind::Archive
+    );
+}
+
+#[test]
+fn canonical_inputs_are_bounded_redacted_and_cancellable() {
+    let too_many = (0..=MAX_GITHUB_WORKFLOW_DISPATCH_INPUTS)
+        .map(|index| (format!("input_{index}"), String::new()));
+    assert_eq!(
+        GithubWorkflowDispatchInputs::try_new(too_many),
+        Err(GithubWorkflowDispatchInputsError::TooManyInputs)
+    );
+    assert_eq!(
+        GithubWorkflowDispatchInputs::try_new([(
+            "input",
+            "x".repeat(MAX_GITHUB_WORKFLOW_DISPATCH_INPUT_CHARACTERS),
+        )]),
+        Err(GithubWorkflowDispatchInputsError::PayloadTooLarge)
+    );
+    assert_eq!(
+        GithubWorkflowDispatchInputs::try_new([("input", "line\nbreak".to_owned())]),
+        Err(GithubWorkflowDispatchInputsError::InvalidInputValue)
+    );
+    let redacted =
+        GithubWorkflowDispatchInputs::try_new([("input", "private-value".to_owned())]).unwrap();
+    assert!(!format!("{redacted:?}").contains("private-value"));
+
+    let archive = archive(&[Entry::File(ROOT_PATH, DISPATCH.as_bytes())]);
+    let cancelled = compile_local_github_archive(
+        &archive,
+        Some(ROOT_PATH),
+        GithubWorkflowDispatchInputs::try_new([("enabled", true)]).unwrap(),
+        limits(),
+        &|| true,
+    )
+    .unwrap_err();
+    assert_eq!(
+        cancelled.kind(),
+        LocalGithubArchiveCompilationFailureKind::Cancelled
+    );
+}
+
+fn compile(
+    bytes: &[u8],
+    selector: Option<&str>,
+) -> Result<
+    automata_ci_workflow_github::LocalGithubArchiveCompilation,
+    automata_ci_workflow_github::LocalGithubArchiveCompilationFailure,
+> {
+    compile_local_github_archive(
+        bytes,
+        selector,
+        GithubWorkflowDispatchInputs::try_new(Vec::<(String, String)>::new()).unwrap(),
+        limits(),
+        &|| false,
+    )
+}
+
+fn limits() -> RepositoryWorkflowDiscoveryLimits {
+    RepositoryWorkflowDiscoveryLimits::new(
+        1024 * 1024,
+        2 * 1024 * 1024,
+        100,
+        1024 * 1024,
+        4_096,
+        16,
+        64 * 1024,
+    )
+    .unwrap()
+}
+
+enum Entry<'a> {
+    File(&'a str, &'a [u8]),
+    Symlink(&'a str, &'a str),
+}
+
+fn archive(entries: &[Entry<'_>]) -> Vec<u8> {
+    let encoder = GzBuilder::new()
+        .mtime(0)
+        .write(Vec::new(), Compression::fast());
+    let mut builder = Builder::new(encoder);
+    append_directory(&mut builder, ROOT).unwrap();
+    for entry in entries {
+        match entry {
+            Entry::File(path, bytes) => {
+                let mut header = Header::new_ustar();
+                header.set_entry_type(EntryType::Regular);
+                header.set_mode(0o644);
+                header.set_size(u64::try_from(bytes.len()).unwrap());
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, format!("{ROOT}/{path}"), *bytes)
+                    .unwrap();
+            }
+            Entry::Symlink(path, target) => {
+                let mut header = Header::new_ustar();
+                header.set_entry_type(EntryType::Symlink);
+                header.set_mode(0o777);
+                header.set_size(0);
+                header.set_link_name(target).unwrap();
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, format!("{ROOT}/{path}"), io::empty())
+                    .unwrap();
+            }
+        }
+    }
+    let encoder = builder.into_inner().unwrap();
+    encoder.finish().unwrap()
+}
+
+fn append_directory<W: io::Write>(builder: &mut Builder<W>, path: &str) -> io::Result<()> {
+    let mut header = Header::new_ustar();
+    header.set_entry_type(EntryType::Directory);
+    header.set_mode(0o755);
+    header.set_size(0);
+    header.set_cksum();
+    builder.append_data(&mut header, path, io::empty())
+}

--- a/crates/automata-ci-workflow-github/tests/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/tests/repository_archive.rs
@@ -3,8 +3,7 @@ use std::io::Write as _;
 use automata_ci_workflow_github::{
     MAX_REPOSITORY_WORKFLOW_PATH_BYTES, RepositoryWorkflowDiscoveryError as DiscoveryError,
     RepositoryWorkflowDiscoveryFailure as DiscoveryFailure, RepositoryWorkflowDiscoveryLimits,
-    RepositoryWorkflowDiscoveryOutcome, RepositoryWorkflowDiscoveryPolicy,
-    RepositoryWorkflowLocation, discover_repository_workflows,
+    RepositoryWorkflowDiscoveryOutcome, discover_github_delivery_workflows,
 };
 use flate2::{Compression, write::GzEncoder};
 
@@ -88,66 +87,6 @@ fn rejects_the_github_actions_workflow_directory_as_a_second_runtime_authority()
 }
 
 #[test]
-fn workflow_locations_are_explicit_and_never_fall_back() {
-    let github_archive = archive(&[
-        directory(ROOT),
-        regular(
-            b"repository-deadbeef/.github/workflows/ci.yml",
-            b"name: github\n",
-        ),
-    ]);
-    let discovered = discover_repository_workflows(
-        &github_archive,
-        limits(),
-        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
-            workflow_location: Some(RepositoryWorkflowLocation::Github),
-        },
-    )
-    .expect("explicit GitHub workflow location");
-    assert_eq!(discovered.len(), 1);
-    assert_eq!(discovered[0].path(), ".github/workflows/ci.yml");
-    assert_eq!(discovered[0].result(), Ok(b"name: github\n".as_slice()));
-    assert_eq!(
-        discover_automata_workflows(&github_archive, limits()),
-        Err(DiscoveryError::UnsupportedWorkflowLocation)
-    );
-
-    let automata_archive = archive(&[
-        directory(ROOT),
-        regular(
-            b"repository-deadbeef/.ci/workflows/ci.yml",
-            b"name: automata\n",
-        ),
-    ]);
-    assert_eq!(
-        discover_repository_workflows(
-            &automata_archive,
-            limits(),
-            RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
-                workflow_location: Some(RepositoryWorkflowLocation::Github),
-            },
-        ),
-        Err(DiscoveryError::UnsupportedWorkflowLocation)
-    );
-    assert_eq!(
-        discover_automata_workflows(&automata_archive, limits())
-            .expect("explicit Automata workflow location")[0]
-            .path(),
-        ".ci/workflows/ci.yml"
-    );
-    assert_eq!(
-        discover_repository_workflows(
-            &automata_archive,
-            limits(),
-            RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
-                workflow_location: None,
-            },
-        ),
-        Err(DiscoveryError::UnsupportedWorkflowLocation)
-    );
-}
-
-#[test]
 fn a_root_only_repository_has_no_workflows() {
     let archive = archive(&[directory(ROOT)]);
     assert!(
@@ -215,7 +154,7 @@ fn rejects_directories_and_special_entries_at_workflow_paths() {
 }
 
 #[test]
-fn remote_archives_reject_links_while_local_archives_validate_contained_targets() {
+fn github_delivery_archives_reject_links() {
     let safe = archive(&[
         directory(ROOT),
         link(b"repository-deadbeef/dir/link", b'2', b"../target"),
@@ -223,11 +162,6 @@ fn remote_archives_reject_links_while_local_archives_validate_contained_targets(
     assert_eq!(
         discover(&safe),
         Err(DiscoveryError::UnsupportedArchiveEntry)
-    );
-    assert!(
-        discover_local(&safe, RepositoryWorkflowLocation::Automata)
-            .expect("contained local symlink")
-            .is_empty()
     );
 
     let workflow = archive(&[
@@ -242,10 +176,6 @@ fn remote_archives_reject_links_while_local_archives_validate_contained_targets(
         discover(&workflow),
         Err(DiscoveryError::UnsupportedArchiveEntry)
     );
-    assert_eq!(
-        discover_local(&workflow, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::UnsupportedWorkflowEntry)
-    );
 
     let hardlink = archive(&[
         directory(ROOT),
@@ -255,44 +185,19 @@ fn remote_archives_reject_links_while_local_archives_validate_contained_targets(
         discover(&hardlink),
         Err(DiscoveryError::UnsupportedArchiveEntry)
     );
-
-    for target in [
-        b"../../outside".as_slice(),
-        b"/absolute",
-        b"bad\\target",
-        b"non-utf8-\xff",
-        b"",
-    ] {
-        let archive = archive(&[
-            directory(ROOT),
-            link(b"repository-deadbeef/link", b'2', target),
-        ]);
-        assert_eq!(
-            discover_local(&archive, RepositoryWorkflowLocation::Automata),
-            Err(DiscoveryError::UnsafeLink)
-        );
-    }
 }
 
 #[test]
 fn rejects_prefix_type_conflicts_and_portable_path_aliases() {
-    for entries in [
-        vec![
-            directory(ROOT),
-            regular(b"repository-deadbeef/node", b"file"),
-            regular(b"repository-deadbeef/node/child", b"child"),
-        ],
-        vec![
-            directory(ROOT),
-            regular(b"repository-deadbeef/node/child", b"child"),
-            link(b"repository-deadbeef/node", b'2', b"target"),
-        ],
-    ] {
-        assert_eq!(
-            discover_local(&archive(&entries), RepositoryWorkflowLocation::Automata),
-            Err(DiscoveryError::PathTypeConflict)
-        );
-    }
+    let prefix_conflict = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/node", b"file"),
+        regular(b"repository-deadbeef/node/child", b"child"),
+    ]);
+    assert_eq!(
+        discover(&prefix_conflict),
+        Err(DiscoveryError::PathTypeConflict)
+    );
 
     let case_alias = archive(&[
         directory(ROOT),
@@ -354,182 +259,6 @@ fn derived_path_graph_node_limit_has_an_exact_amplification_boundary() {
     assert_eq!(
         discover_automata_workflows(&amplified, exact_limits),
         Err(DiscoveryError::ResourceLimit)
-    );
-}
-
-#[test]
-fn local_link_graph_rejects_namespace_aliases_case_aliases_and_cycles() {
-    let namespace_alias = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/.ci/"),
-        directory(b"repository-deadbeef/.ci/workflows/"),
-        regular(b"repository-deadbeef/.ci/workflows/ci.yml", b"name: ci\n"),
-        link(b"repository-deadbeef/alternate", b'2', b".ci"),
-    ]);
-    assert_eq!(
-        discover_local(&namespace_alias, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::NamespaceAlias)
-    );
-
-    let namespace_descendant_alias = archive(&[
-        directory(ROOT),
-        regular(b"repository-deadbeef/.ci/workflows/ci.yml", b"name: ci\n"),
-        link(
-            b"repository-deadbeef/alternate",
-            b'2',
-            b".ci/workflows/ci.yml",
-        ),
-    ]);
-    assert_eq!(
-        discover_local(
-            &namespace_descendant_alias,
-            RepositoryWorkflowLocation::Automata
-        ),
-        Err(DiscoveryError::NamespaceAlias)
-    );
-
-    let target_case_alias = archive(&[
-        directory(ROOT),
-        regular(b"repository-deadbeef/Target", b"target"),
-        link(b"repository-deadbeef/link", b'2', b"target"),
-    ]);
-    assert_eq!(
-        discover_local(&target_case_alias, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::PathAlias)
-    );
-
-    let cycle = archive(&[
-        directory(ROOT),
-        link(b"repository-deadbeef/one", b'2', b"two"),
-        link(b"repository-deadbeef/two", b'2', b"one"),
-    ]);
-    assert_eq!(
-        discover_local(&cycle, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::UnsafeLink)
-    );
-
-    let target_traverses_file = archive(&[
-        directory(ROOT),
-        regular(b"repository-deadbeef/file", b"file"),
-        link(b"repository-deadbeef/link", b'2', b"file/child"),
-    ]);
-    assert_eq!(
-        discover_local(&target_traverses_file, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::PathTypeConflict)
-    );
-
-    let suffix = "x".repeat(94);
-    let first_target = format!("two/{suffix}");
-    let second_target = format!("three/{suffix}");
-    let third_target = format!("four/{suffix}");
-    let expanding_chain = archive(&[
-        directory(ROOT),
-        link(b"repository-deadbeef/one", b'2', first_target.as_bytes()),
-        link(b"repository-deadbeef/two", b'2', second_target.as_bytes()),
-        link(b"repository-deadbeef/three", b'2', third_target.as_bytes()),
-        link(b"repository-deadbeef/four", b'2', b"target"),
-    ]);
-    assert_eq!(
-        discover_local(&expanding_chain, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::ResourceLimit)
-    );
-}
-
-#[test]
-fn local_link_graph_rejects_directory_containment_cycles() {
-    let directory_self_cycle = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/dir/"),
-        link(b"repository-deadbeef/dir/self", b'2', b"."),
-    ]);
-    assert_eq!(
-        discover_local(&directory_self_cycle, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::UnsafeLink)
-    );
-
-    let indirect_directory_cycle = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/dir/"),
-        link(b"repository-deadbeef/bridge", b'2', b"dir"),
-        link(b"repository-deadbeef/dir/self", b'2', b"../bridge"),
-    ]);
-    assert_eq!(
-        discover_local(
-            &indirect_directory_cycle,
-            RepositoryWorkflowLocation::Automata
-        ),
-        Err(DiscoveryError::UnsafeLink)
-    );
-
-    let mutual_directory_cycle = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/one/"),
-        directory(b"repository-deadbeef/two/"),
-        link(b"repository-deadbeef/one/to-two", b'2', b"../two"),
-        link(b"repository-deadbeef/two/to-one", b'2', b"../one"),
-    ]);
-    assert_eq!(
-        discover_local(
-            &mutual_directory_cycle,
-            RepositoryWorkflowLocation::Automata
-        ),
-        Err(DiscoveryError::UnsafeLink)
-    );
-}
-
-#[test]
-fn parent_components_apply_after_intermediate_link_expansion() {
-    let namespace_alias = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/safe/"),
-        directory(b"repository-deadbeef/target/"),
-        link(b"repository-deadbeef/safe/alias", b'2', b"../target"),
-        link(
-            b"repository-deadbeef/safe/link",
-            b'2',
-            b"alias/../.ci/workflows",
-        ),
-    ]);
-    assert_eq!(
-        discover_local(&namespace_alias, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::NamespaceAlias)
-    );
-
-    let escape = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/safe/"),
-        directory(b"repository-deadbeef/target/"),
-        link(b"repository-deadbeef/safe/alias", b'2', b"../target"),
-        link(
-            b"repository-deadbeef/safe/link",
-            b'2',
-            b"alias/../../outside",
-        ),
-    ]);
-    assert_eq!(
-        discover_local(&escape, RepositoryWorkflowLocation::Automata),
-        Err(DiscoveryError::UnsafeLink)
-    );
-}
-
-#[test]
-fn each_link_resolution_has_an_independent_hop_bound() {
-    let shared_chain = archive(&[
-        directory(ROOT),
-        directory(b"repository-deadbeef/destination/"),
-        regular(b"repository-deadbeef/destination/a", b"a"),
-        regular(b"repository-deadbeef/destination/b", b"b"),
-        regular(b"repository-deadbeef/destination/c", b"c"),
-        link(b"repository-deadbeef/bridge-one", b'2', b"bridge-two"),
-        link(b"repository-deadbeef/bridge-two", b'2', b"destination"),
-        link(b"repository-deadbeef/one", b'2', b"bridge-one/a"),
-        link(b"repository-deadbeef/two", b'2', b"bridge-one/b"),
-        link(b"repository-deadbeef/three", b'2', b"bridge-one/c"),
-    ]);
-    assert!(
-        discover_local(&shared_chain, RepositoryWorkflowLocation::Automata)
-            .expect("independent valid link chains")
-            .is_empty()
     );
 }
 
@@ -871,24 +600,7 @@ fn discover_automata_workflows(
     bytes: &[u8],
     limits: RepositoryWorkflowDiscoveryLimits,
 ) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, DiscoveryError> {
-    discover_repository_workflows(
-        bytes,
-        limits,
-        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
-    )
-}
-
-fn discover_local(
-    bytes: &[u8],
-    location: RepositoryWorkflowLocation,
-) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, DiscoveryError> {
-    discover_repository_workflows(
-        bytes,
-        limits(),
-        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
-            workflow_location: Some(location),
-        },
-    )
+    discover_github_delivery_workflows(bytes, limits)
 }
 
 fn limits() -> RepositoryWorkflowDiscoveryLimits {

--- a/crates/automata-ci-workflow-github/tests/repository_archive.rs
+++ b/crates/automata-ci-workflow-github/tests/repository_archive.rs
@@ -3,7 +3,8 @@ use std::io::Write as _;
 use automata_ci_workflow_github::{
     MAX_REPOSITORY_WORKFLOW_PATH_BYTES, RepositoryWorkflowDiscoveryError as DiscoveryError,
     RepositoryWorkflowDiscoveryFailure as DiscoveryFailure, RepositoryWorkflowDiscoveryLimits,
-    RepositoryWorkflowDiscoveryOutcome, discover_repository_workflows,
+    RepositoryWorkflowDiscoveryOutcome, RepositoryWorkflowDiscoveryPolicy,
+    RepositoryWorkflowLocation, discover_repository_workflows,
 };
 use flate2::{Compression, write::GzEncoder};
 
@@ -26,7 +27,7 @@ fn discovers_exact_direct_workflows_in_deterministic_path_order() {
         regular(b"repository-deadbeef/README.md", b"read me"),
     ]);
 
-    let discovered = discover_repository_workflows(&archive, limits()).expect("valid archive");
+    let discovered = discover_automata_workflows(&archive, limits()).expect("valid archive");
     assert_eq!(discovered.len(), 2);
     assert_eq!(discovered[0].path(), ".ci/workflows/a.yml");
     assert_eq!(discovered[0].result(), Ok(b"name: a\n".as_slice()));
@@ -46,7 +47,7 @@ fn discovery_accepts_only_exact_lowercase_yml_and_yaml_extensions() {
         regular(b"repository-deadbeef/.ci/workflows/f", b"f"),
     ]);
 
-    let discovered = discover_repository_workflows(&archive, limits()).expect("valid archive");
+    let discovered = discover_automata_workflows(&archive, limits()).expect("valid archive");
     assert_eq!(
         discovered
             .iter()
@@ -87,10 +88,70 @@ fn rejects_the_github_actions_workflow_directory_as_a_second_runtime_authority()
 }
 
 #[test]
+fn workflow_locations_are_explicit_and_never_fall_back() {
+    let github_archive = archive(&[
+        directory(ROOT),
+        regular(
+            b"repository-deadbeef/.github/workflows/ci.yml",
+            b"name: github\n",
+        ),
+    ]);
+    let discovered = discover_repository_workflows(
+        &github_archive,
+        limits(),
+        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
+            workflow_location: Some(RepositoryWorkflowLocation::Github),
+        },
+    )
+    .expect("explicit GitHub workflow location");
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].path(), ".github/workflows/ci.yml");
+    assert_eq!(discovered[0].result(), Ok(b"name: github\n".as_slice()));
+    assert_eq!(
+        discover_automata_workflows(&github_archive, limits()),
+        Err(DiscoveryError::UnsupportedWorkflowLocation)
+    );
+
+    let automata_archive = archive(&[
+        directory(ROOT),
+        regular(
+            b"repository-deadbeef/.ci/workflows/ci.yml",
+            b"name: automata\n",
+        ),
+    ]);
+    assert_eq!(
+        discover_repository_workflows(
+            &automata_archive,
+            limits(),
+            RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
+                workflow_location: Some(RepositoryWorkflowLocation::Github),
+            },
+        ),
+        Err(DiscoveryError::UnsupportedWorkflowLocation)
+    );
+    assert_eq!(
+        discover_automata_workflows(&automata_archive, limits())
+            .expect("explicit Automata workflow location")[0]
+            .path(),
+        ".ci/workflows/ci.yml"
+    );
+    assert_eq!(
+        discover_repository_workflows(
+            &automata_archive,
+            limits(),
+            RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
+                workflow_location: None,
+            },
+        ),
+        Err(DiscoveryError::UnsupportedWorkflowLocation)
+    );
+}
+
+#[test]
 fn a_root_only_repository_has_no_workflows() {
     let archive = archive(&[directory(ROOT)]);
     assert!(
-        discover_repository_workflows(&archive, limits())
+        discover_automata_workflows(&archive, limits())
             .expect("root-only archive")
             .is_empty()
     );
@@ -125,7 +186,7 @@ fn rejects_unsafe_or_non_utf8_entry_paths() {
 }
 
 #[test]
-fn rejects_duplicate_and_trailing_slash_aliased_paths() {
+fn rejects_duplicate_paths_and_exact_path_type_conflicts() {
     let duplicate = archive(&[
         directory(ROOT),
         regular(b"repository-deadbeef/file", b"one"),
@@ -138,7 +199,7 @@ fn rejects_duplicate_and_trailing_slash_aliased_paths() {
         directory(b"repository-deadbeef/path/"),
         regular(b"repository-deadbeef/path", b"body"),
     ]);
-    assert_eq!(discover(&alias), Err(DiscoveryError::DuplicatePath));
+    assert_eq!(discover(&alias), Err(DiscoveryError::PathTypeConflict));
 }
 
 #[test]
@@ -154,24 +215,322 @@ fn rejects_directories_and_special_entries_at_workflow_paths() {
 }
 
 #[test]
-fn rejects_every_symlink_and_hard_link_even_outside_workflow_paths() {
-    for kind in *b"12" {
-        for path in [
-            b"repository-deadbeef/safe-looking-link".as_slice(),
+fn remote_archives_reject_links_while_local_archives_validate_contained_targets() {
+    let safe = archive(&[
+        directory(ROOT),
+        link(b"repository-deadbeef/dir/link", b'2', b"../target"),
+    ]);
+    assert_eq!(
+        discover(&safe),
+        Err(DiscoveryError::UnsupportedArchiveEntry)
+    );
+    assert!(
+        discover_local(&safe, RepositoryWorkflowLocation::Automata)
+            .expect("contained local symlink")
+            .is_empty()
+    );
+
+    let workflow = archive(&[
+        directory(ROOT),
+        link(
             b"repository-deadbeef/.ci/workflows/ci.yml",
-        ] {
-            let archive = archive(&[
-                directory(ROOT),
-                link(path, kind, b"repository-deadbeef/regular-target"),
-            ]);
-            assert_eq!(
-                discover(&archive),
-                Err(DiscoveryError::UnsupportedArchiveEntry),
-                "entry type {kind:?} at {}",
-                String::from_utf8_lossy(path)
-            );
-        }
+            b'2',
+            b"../source.yml",
+        ),
+    ]);
+    assert_eq!(
+        discover(&workflow),
+        Err(DiscoveryError::UnsupportedArchiveEntry)
+    );
+    assert_eq!(
+        discover_local(&workflow, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::UnsupportedWorkflowEntry)
+    );
+
+    let hardlink = archive(&[
+        directory(ROOT),
+        link(b"repository-deadbeef/link", b'1', b"target"),
+    ]);
+    assert_eq!(
+        discover(&hardlink),
+        Err(DiscoveryError::UnsupportedArchiveEntry)
+    );
+
+    for target in [
+        b"../../outside".as_slice(),
+        b"/absolute",
+        b"bad\\target",
+        b"non-utf8-\xff",
+        b"",
+    ] {
+        let archive = archive(&[
+            directory(ROOT),
+            link(b"repository-deadbeef/link", b'2', target),
+        ]);
+        assert_eq!(
+            discover_local(&archive, RepositoryWorkflowLocation::Automata),
+            Err(DiscoveryError::UnsafeLink)
+        );
     }
+}
+
+#[test]
+fn rejects_prefix_type_conflicts_and_portable_path_aliases() {
+    for entries in [
+        vec![
+            directory(ROOT),
+            regular(b"repository-deadbeef/node", b"file"),
+            regular(b"repository-deadbeef/node/child", b"child"),
+        ],
+        vec![
+            directory(ROOT),
+            regular(b"repository-deadbeef/node/child", b"child"),
+            link(b"repository-deadbeef/node", b'2', b"target"),
+        ],
+    ] {
+        assert_eq!(
+            discover_local(&archive(&entries), RepositoryWorkflowLocation::Automata),
+            Err(DiscoveryError::PathTypeConflict)
+        );
+    }
+
+    let case_alias = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/Directory/one", b"one"),
+        regular(b"repository-deadbeef/directory/two", b"two"),
+    ]);
+    assert_eq!(discover(&case_alias), Err(DiscoveryError::PathAlias));
+
+    let sigma_alias = archive(&[
+        directory(ROOT),
+        regular("repository-deadbeef/Σ/one".as_bytes(), b"one"),
+        regular("repository-deadbeef/ς/two".as_bytes(), b"two"),
+    ]);
+    assert_eq!(discover(&sigma_alias), Err(DiscoveryError::PathAlias));
+
+    let normalization_alias = archive(&[
+        directory(ROOT),
+        regular("repository-deadbeef/caf\u{e9}/one".as_bytes(), b"one"),
+        regular("repository-deadbeef/cafe\u{301}/two".as_bytes(), b"two"),
+    ]);
+    assert_eq!(
+        discover(&normalization_alias),
+        Err(DiscoveryError::PathAlias)
+    );
+}
+
+#[test]
+fn workflow_namespace_components_require_one_canonical_spelling() {
+    for path in [
+        b"repository-deadbeef/.CI/workflows/ci.yml".as_slice(),
+        b"repository-deadbeef/.github/WORKFLOWS/ci.yml",
+        b"repository-deadbeef/.ci/Workflows/ci.yml",
+    ] {
+        assert_eq!(
+            discover(&archive(&[directory(ROOT), regular(path, b"workflow")])),
+            Err(DiscoveryError::UnsafePath),
+            "namespace spelling {path:?}"
+        );
+    }
+}
+
+#[test]
+fn derived_path_graph_node_limit_has_an_exact_amplification_boundary() {
+    let exact = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/a/b/c/d/e/f/g/h", b"body"),
+    ]);
+    let exact_limits = configured(MIB, MIB, 2, MIB, 100, 1, 16);
+    assert!(
+        discover_automata_workflows(&exact, exact_limits)
+            .expect("eight derived nodes fit the four-per-entry budget")
+            .is_empty()
+    );
+
+    let amplified = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/a/b/c/d/e/f/g/h/i", b"body"),
+    ]);
+    assert_eq!(
+        discover_automata_workflows(&amplified, exact_limits),
+        Err(DiscoveryError::ResourceLimit)
+    );
+}
+
+#[test]
+fn local_link_graph_rejects_namespace_aliases_case_aliases_and_cycles() {
+    let namespace_alias = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/.ci/"),
+        directory(b"repository-deadbeef/.ci/workflows/"),
+        regular(b"repository-deadbeef/.ci/workflows/ci.yml", b"name: ci\n"),
+        link(b"repository-deadbeef/alternate", b'2', b".ci"),
+    ]);
+    assert_eq!(
+        discover_local(&namespace_alias, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::NamespaceAlias)
+    );
+
+    let namespace_descendant_alias = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/.ci/workflows/ci.yml", b"name: ci\n"),
+        link(
+            b"repository-deadbeef/alternate",
+            b'2',
+            b".ci/workflows/ci.yml",
+        ),
+    ]);
+    assert_eq!(
+        discover_local(
+            &namespace_descendant_alias,
+            RepositoryWorkflowLocation::Automata
+        ),
+        Err(DiscoveryError::NamespaceAlias)
+    );
+
+    let target_case_alias = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/Target", b"target"),
+        link(b"repository-deadbeef/link", b'2', b"target"),
+    ]);
+    assert_eq!(
+        discover_local(&target_case_alias, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::PathAlias)
+    );
+
+    let cycle = archive(&[
+        directory(ROOT),
+        link(b"repository-deadbeef/one", b'2', b"two"),
+        link(b"repository-deadbeef/two", b'2', b"one"),
+    ]);
+    assert_eq!(
+        discover_local(&cycle, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::UnsafeLink)
+    );
+
+    let target_traverses_file = archive(&[
+        directory(ROOT),
+        regular(b"repository-deadbeef/file", b"file"),
+        link(b"repository-deadbeef/link", b'2', b"file/child"),
+    ]);
+    assert_eq!(
+        discover_local(&target_traverses_file, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::PathTypeConflict)
+    );
+
+    let suffix = "x".repeat(94);
+    let first_target = format!("two/{suffix}");
+    let second_target = format!("three/{suffix}");
+    let third_target = format!("four/{suffix}");
+    let expanding_chain = archive(&[
+        directory(ROOT),
+        link(b"repository-deadbeef/one", b'2', first_target.as_bytes()),
+        link(b"repository-deadbeef/two", b'2', second_target.as_bytes()),
+        link(b"repository-deadbeef/three", b'2', third_target.as_bytes()),
+        link(b"repository-deadbeef/four", b'2', b"target"),
+    ]);
+    assert_eq!(
+        discover_local(&expanding_chain, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::ResourceLimit)
+    );
+}
+
+#[test]
+fn local_link_graph_rejects_directory_containment_cycles() {
+    let directory_self_cycle = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/dir/"),
+        link(b"repository-deadbeef/dir/self", b'2', b"."),
+    ]);
+    assert_eq!(
+        discover_local(&directory_self_cycle, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::UnsafeLink)
+    );
+
+    let indirect_directory_cycle = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/dir/"),
+        link(b"repository-deadbeef/bridge", b'2', b"dir"),
+        link(b"repository-deadbeef/dir/self", b'2', b"../bridge"),
+    ]);
+    assert_eq!(
+        discover_local(
+            &indirect_directory_cycle,
+            RepositoryWorkflowLocation::Automata
+        ),
+        Err(DiscoveryError::UnsafeLink)
+    );
+
+    let mutual_directory_cycle = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/one/"),
+        directory(b"repository-deadbeef/two/"),
+        link(b"repository-deadbeef/one/to-two", b'2', b"../two"),
+        link(b"repository-deadbeef/two/to-one", b'2', b"../one"),
+    ]);
+    assert_eq!(
+        discover_local(
+            &mutual_directory_cycle,
+            RepositoryWorkflowLocation::Automata
+        ),
+        Err(DiscoveryError::UnsafeLink)
+    );
+}
+
+#[test]
+fn parent_components_apply_after_intermediate_link_expansion() {
+    let namespace_alias = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/safe/"),
+        directory(b"repository-deadbeef/target/"),
+        link(b"repository-deadbeef/safe/alias", b'2', b"../target"),
+        link(
+            b"repository-deadbeef/safe/link",
+            b'2',
+            b"alias/../.ci/workflows",
+        ),
+    ]);
+    assert_eq!(
+        discover_local(&namespace_alias, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::NamespaceAlias)
+    );
+
+    let escape = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/safe/"),
+        directory(b"repository-deadbeef/target/"),
+        link(b"repository-deadbeef/safe/alias", b'2', b"../target"),
+        link(
+            b"repository-deadbeef/safe/link",
+            b'2',
+            b"alias/../../outside",
+        ),
+    ]);
+    assert_eq!(
+        discover_local(&escape, RepositoryWorkflowLocation::Automata),
+        Err(DiscoveryError::UnsafeLink)
+    );
+}
+
+#[test]
+fn each_link_resolution_has_an_independent_hop_bound() {
+    let shared_chain = archive(&[
+        directory(ROOT),
+        directory(b"repository-deadbeef/destination/"),
+        regular(b"repository-deadbeef/destination/a", b"a"),
+        regular(b"repository-deadbeef/destination/b", b"b"),
+        regular(b"repository-deadbeef/destination/c", b"c"),
+        link(b"repository-deadbeef/bridge-one", b'2', b"bridge-two"),
+        link(b"repository-deadbeef/bridge-two", b'2', b"destination"),
+        link(b"repository-deadbeef/one", b'2', b"bridge-one/a"),
+        link(b"repository-deadbeef/two", b'2', b"bridge-one/b"),
+        link(b"repository-deadbeef/three", b'2', b"bridge-one/c"),
+    ]);
+    assert!(
+        discover_local(&shared_chain, RepositoryWorkflowLocation::Automata)
+            .expect("independent valid link chains")
+            .is_empty()
+    );
 }
 
 #[test]
@@ -201,7 +560,7 @@ fn isolates_empty_and_oversized_workflows_from_valid_siblings() {
         regular(b"repository-deadbeef/.ci/workflows/m-empty.yml", b""),
     ]);
     let outcomes =
-        discover_repository_workflows(&archive, configured(MIB, MIB, 10, MIB, 4_096, 10, 4))
+        discover_automata_workflows(&archive, configured(MIB, MIB, 10, MIB, 4_096, 10, 4))
             .expect("path-local failures do not reject valid siblings");
 
     assert_eq!(
@@ -237,7 +596,7 @@ fn archive_wide_failures_override_all_path_local_outcomes() {
         entry(b"repository-deadbeef/device", b'3', b""),
     ]);
     assert_eq!(
-        discover_repository_workflows(
+        discover_automata_workflows(
             &special_sibling,
             configured(MIB, MIB, 10, MIB, 4_096, 10, 4),
         ),
@@ -253,7 +612,7 @@ fn archive_wide_failures_override_all_path_local_outcomes() {
     let oversized_body_offset = 512 + 512;
     corrupt_padding[oversized_body_offset + 5] = 1;
     assert_eq!(
-        discover_repository_workflows(
+        discover_automata_workflows(
             &gzip(&corrupt_padding),
             configured(MIB, MIB, 10, MIB, 4_096, 10, 4),
         ),
@@ -273,7 +632,7 @@ fn path_local_failures_are_exactly_bounded_and_redacted() {
         regular(b"repository-deadbeef/.ci/workflows/zero.yml", b""),
     ]);
     let outcomes =
-        discover_repository_workflows(&archive, configured(MIB, MIB, 10, MIB, 4_096, 10, 4))
+        discover_automata_workflows(&archive, configured(MIB, MIB, 10, MIB, 4_096, 10, 4))
             .expect("per-path byte outcomes");
 
     assert_eq!(outcomes[0].result(), Ok(b"1234".as_slice()));
@@ -295,7 +654,7 @@ fn workflow_count_and_expanded_byte_limits_remain_archive_wide() {
         regular(b"repository-deadbeef/.ci/workflows/valid.yml", b"ok"),
     ]);
     assert_eq!(
-        discover_repository_workflows(&two_workflows, configured(MIB, MIB, 10, MIB, 4_096, 1, 4),),
+        discover_automata_workflows(&two_workflows, configured(MIB, MIB, 10, MIB, 4_096, 1, 4),),
         Err(DiscoveryError::ResourceLimit)
     );
 
@@ -304,7 +663,7 @@ fn workflow_count_and_expanded_byte_limits_remain_archive_wide() {
         regular(b"repository-deadbeef/.ci/workflows/oversized.yml", b"12345"),
     ]);
     assert_eq!(
-        discover_repository_workflows(&oversized, configured(MIB, MIB, 10, 4, 4_096, 10, 4),),
+        discover_automata_workflows(&oversized, configured(MIB, MIB, 10, 4, 4_096, 10, 4),),
         Err(DiscoveryError::ResourceLimit)
     );
 }
@@ -340,7 +699,7 @@ fn enforces_each_independent_resource_limit() {
         16,
     );
     assert_eq!(
-        discover_repository_workflows(&one_workflow, compressed_limit),
+        discover_automata_workflows(&one_workflow, compressed_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
@@ -358,26 +717,26 @@ fn enforces_each_independent_resource_limit() {
     .expect("length");
     let decompressed_limit = configured(MIB, raw_length - 1, 10, MIB, 4_096, 10, 16);
     assert_eq!(
-        discover_repository_workflows(&one_workflow, decompressed_limit),
+        discover_automata_workflows(&one_workflow, decompressed_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
     let entry_limit = configured(MIB, MIB, 1, MIB, 4_096, 10, 16);
     assert_eq!(
-        discover_repository_workflows(&one_workflow, entry_limit),
+        discover_automata_workflows(&one_workflow, entry_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
     let expanded = archive(&[directory(ROOT), regular(b"repository-deadbeef/data", b"12")]);
     let expanded_limit = configured(MIB, MIB, 10, 1, 4_096, 10, 1);
     assert_eq!(
-        discover_repository_workflows(&expanded, expanded_limit),
+        discover_automata_workflows(&expanded, expanded_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
     let path_limit = configured(MIB, MIB, 10, MIB, ROOT.len(), 10, 16);
     assert_eq!(
-        discover_repository_workflows(&one_workflow, path_limit),
+        discover_automata_workflows(&one_workflow, path_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
@@ -388,12 +747,12 @@ fn enforces_each_independent_resource_limit() {
     ]);
     let workflow_count_limit = configured(MIB, MIB, 10, MIB, 4_096, 1, 16);
     assert_eq!(
-        discover_repository_workflows(&two_workflows, workflow_count_limit),
+        discover_automata_workflows(&two_workflows, workflow_count_limit),
         Err(DiscoveryError::ResourceLimit)
     );
 
     let workflow_size_limit = configured(MIB, MIB, 10, MIB, 4_096, 10, 3);
-    let outcomes = discover_repository_workflows(&one_workflow, workflow_size_limit)
+    let outcomes = discover_automata_workflows(&one_workflow, workflow_size_limit)
         .expect("per-workflow size exhaustion is path-local");
     assert_eq!(outcomes[0].result(), Err(DiscoveryFailure::Oversized));
 }
@@ -505,7 +864,31 @@ fn invalid_limit_sets_are_rejected() {
 }
 
 fn discover(bytes: &[u8]) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, DiscoveryError> {
-    discover_repository_workflows(bytes, limits())
+    discover_automata_workflows(bytes, limits())
+}
+
+fn discover_automata_workflows(
+    bytes: &[u8],
+    limits: RepositoryWorkflowDiscoveryLimits,
+) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, DiscoveryError> {
+    discover_repository_workflows(
+        bytes,
+        limits,
+        RepositoryWorkflowDiscoveryPolicy::GithubDelivery,
+    )
+}
+
+fn discover_local(
+    bytes: &[u8],
+    location: RepositoryWorkflowLocation,
+) -> Result<Vec<RepositoryWorkflowDiscoveryOutcome>, DiscoveryError> {
+    discover_repository_workflows(
+        bytes,
+        limits(),
+        RepositoryWorkflowDiscoveryPolicy::LocalSnapshot {
+            workflow_location: Some(location),
+        },
+    )
 }
 
 fn limits() -> RepositoryWorkflowDiscoveryLimits {

--- a/crates/automata-ci-workflow-github/tests/workflow_github.rs
+++ b/crates/automata-ci-workflow-github/tests/workflow_github.rs
@@ -9,6 +9,7 @@ mod job_outputs_environment;
 mod job_resources;
 mod job_strategy;
 mod limits;
+mod local_authority;
 mod logical_compiler;
 mod permissions;
 mod port_contract;

--- a/crates/automata-ci-workflow-service/src/credential_requirements.rs
+++ b/crates/automata-ci-workflow-service/src/credential_requirements.rs
@@ -3,8 +3,8 @@
 use std::collections::BTreeSet;
 
 use automata_ci_core::{
-    ExpressionInstruction, ExpressionLiteral, ExpressionProgram, LogicalJobTemplate,
-    LogicalWorkflowPlan, Sha256Digest,
+    ExpressionInstruction, ExpressionLiteral, ExpressionProgram, LogicalJobKind,
+    LogicalJobTemplate, LogicalWorkflowPlan, ReusableSecretForwarding, Sha256Digest,
 };
 use automata_ci_store::{
     JobCredentialRequirements, JobEnvironmentRequirement, ProtectedEnvironmentValueError,
@@ -17,7 +17,44 @@ use thiserror::Error;
 const ENVIRONMENT_TEMPLATE_DIGEST_DOMAIN: &[u8] =
     b"automata.workflow.deployment-environment-template.v1\0";
 
-/// Discovers exact static `secrets.<name>` and `vars.<name>` uses.
+/// Closed built-in credential supplied by provider-bound runtime authority.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltInCredentialRequirement {
+    /// GitHub's job-bound token exposed as `github.token` and `secrets.GITHUB_TOKEN`.
+    GithubToken,
+}
+
+/// Static external and provider-built-in requirements for one logical job.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiscoveredJobCredentials {
+    external: JobCredentialRequirements,
+    built_in: Vec<BuiltInCredentialRequirement>,
+}
+
+impl DiscoveredJobCredentials {
+    /// Returns secret, variable, and protected-environment requirements that
+    /// must be resolved outside provider-built-in runtime authority.
+    #[must_use]
+    pub const fn external(&self) -> &JobCredentialRequirements {
+        &self.external
+    }
+
+    /// Returns provider-built-in credentials in stable order.
+    #[must_use]
+    pub fn built_in(&self) -> &[BuiltInCredentialRequirement] {
+        &self.built_in
+    }
+}
+
+pub(crate) fn built_in_secret_requirement(name: &str) -> Option<BuiltInCredentialRequirement> {
+    name.eq_ignore_ascii_case("GITHUB_TOKEN")
+        .then_some(BuiltInCredentialRequirement::GithubToken)
+}
+
+/// Discovers exact static `secrets.<name>`, `vars.<name>`, and provider
+/// built-in credential uses, including name-only caller sources in
+/// reusable-workflow secret mappings.
 ///
 /// The complete serialized logical job is walked so new template-bearing fields
 /// fail into the same analysis without a second hand-maintained field list.
@@ -26,27 +63,65 @@ const ENVIRONMENT_TEMPLATE_DIGEST_DOMAIN: &[u8] =
 ///
 /// Rejects whole-context and dynamic-name access, malformed durable programs,
 /// or invalid canonical names.
-pub fn discover_job_credential_requirements(
+pub fn discover_job_credentials(
     workflow: &LogicalWorkflowPlan,
     job: &LogicalJobTemplate,
-) -> Result<JobCredentialRequirements, CredentialDiscoveryError> {
+) -> Result<DiscoveredJobCredentials, CredentialDiscoveryError> {
     let value = serde_json::to_value((workflow.environment(), job))
         .map_err(|_| CredentialDiscoveryError::InvalidLogicalPlan)?;
     let mut programs = Vec::new();
     collect_programs(&value, &mut programs)?;
     let mut secrets = BTreeSet::new();
     let mut variables = BTreeSet::new();
+    let mut built_in = BTreeSet::new();
     for program in programs {
-        scan_program(&program, &mut secrets, &mut variables)?;
+        scan_program(&program, &mut secrets, &mut variables, &mut built_in)?;
     }
+    if let LogicalJobKind::ReusableWorkflow(invocation) = job.execution()
+        && let ReusableSecretForwarding::Mapping(bindings) = invocation.secrets()
+    {
+        for binding in bindings {
+            let source = binding.source().value().as_str();
+            if let Some(requirement) = built_in_secret_requirement(source) {
+                built_in.insert(requirement);
+            } else {
+                secrets.insert(source.to_owned());
+            }
+        }
+    }
+    classify_builtin_secrets(&mut secrets, &mut built_in);
     let environment = match job.deployment() {
         None => JobEnvironmentRequirement::None,
         Some(deployment) => {
             JobEnvironmentRequirement::Environment(template_digest(deployment.name().value())?)
         }
     };
-    JobCredentialRequirements::new(environment, secrets, variables)
-        .map_err(CredentialDiscoveryError::InvalidRequirements)
+    let external = JobCredentialRequirements::new(environment, secrets, variables)
+        .map_err(CredentialDiscoveryError::InvalidRequirements)?;
+    Ok(DiscoveredJobCredentials {
+        external,
+        built_in: built_in.into_iter().collect(),
+    })
+}
+
+pub(crate) fn discover_external_job_credentials(
+    workflow: &LogicalWorkflowPlan,
+    job: &LogicalJobTemplate,
+) -> Result<JobCredentialRequirements, CredentialDiscoveryError> {
+    discover_job_credentials(workflow, job).map(|credentials| credentials.external)
+}
+
+fn classify_builtin_secrets(
+    secrets: &mut BTreeSet<String>,
+    built_in: &mut BTreeSet<BuiltInCredentialRequirement>,
+) {
+    for name in std::mem::take(secrets) {
+        if let Some(requirement) = built_in_secret_requirement(&name) {
+            built_in.insert(requirement);
+        } else {
+            secrets.insert(name);
+        }
+    }
 }
 
 fn template_digest(value: &impl Serialize) -> Result<Sha256Digest, CredentialDiscoveryError> {
@@ -92,6 +167,7 @@ fn collect_programs(
 #[derive(Clone)]
 enum TraceKind {
     SensitiveRoot(SensitiveContext),
+    GithubRoot,
     LiteralString(String),
     Value,
 }
@@ -107,6 +183,7 @@ struct Trace {
     kind: TraceKind,
     secrets: BTreeSet<String>,
     variables: BTreeSet<String>,
+    built_in: BTreeSet<BuiltInCredentialRequirement>,
 }
 
 impl Trace {
@@ -115,6 +192,7 @@ impl Trace {
             kind: TraceKind::Value,
             secrets: BTreeSet::new(),
             variables: BTreeSet::new(),
+            built_in: BTreeSet::new(),
         }
     }
 }
@@ -123,6 +201,7 @@ fn scan_program(
     program: &ExpressionProgram,
     secrets: &mut BTreeSet<String>,
     variables: &mut BTreeSet<String>,
+    built_in: &mut BTreeSet<BuiltInCredentialRequirement>,
 ) -> Result<(), CredentialDiscoveryError> {
     let mut stack = Vec::with_capacity(program.instructions().len());
     for instruction in program.instructions() {
@@ -140,6 +219,7 @@ fn scan_program(
                 kind: match name.as_str() {
                     "secrets" => TraceKind::SensitiveRoot(SensitiveContext::Secrets),
                     "vars" => TraceKind::SensitiveRoot(SensitiveContext::Variables),
+                    "github" => TraceKind::GithubRoot,
                     _ => TraceKind::Value,
                 },
                 ..Trace::value()
@@ -167,11 +247,15 @@ fn scan_program(
     let [trace] = stack.as_slice() else {
         return Err(CredentialDiscoveryError::InvalidLogicalPlan);
     };
-    if matches!(trace.kind, TraceKind::SensitiveRoot(_)) {
+    if matches!(
+        trace.kind,
+        TraceKind::SensitiveRoot(_) | TraceKind::GithubRoot
+    ) {
         return Err(CredentialDiscoveryError::DynamicReference);
     }
     secrets.extend(trace.secrets.iter().cloned());
     variables.extend(trace.variables.iter().cloned());
+    built_in.extend(trace.built_in.iter().copied());
     Ok(())
 }
 
@@ -181,6 +265,7 @@ fn index_sensitive(mut target: Trace, index: Trace) -> Result<Trace, CredentialD
     }
     target.secrets.extend(index.secrets);
     target.variables.extend(index.variables);
+    target.built_in.extend(index.built_in);
     if let TraceKind::SensitiveRoot(context) = target.kind {
         let TraceKind::LiteralString(name) = index.kind else {
             return Err(CredentialDiscoveryError::DynamicReference);
@@ -192,6 +277,15 @@ fn index_sensitive(mut target: Trace, index: Trace) -> Result<Trace, CredentialD
             SensitiveContext::Variables => {
                 target.variables.insert(name);
             }
+        }
+    } else if matches!(target.kind, TraceKind::GithubRoot) {
+        let TraceKind::LiteralString(name) = index.kind else {
+            return Err(CredentialDiscoveryError::DynamicReference);
+        };
+        if name.eq_ignore_ascii_case("token") {
+            target
+                .built_in
+                .insert(BuiltInCredentialRequirement::GithubToken);
         }
     }
     target.kind = TraceKind::Value;
@@ -207,11 +301,15 @@ fn combine(stack: &mut Vec<Trace>, count: usize) -> Result<Trace, CredentialDisc
         let trace = stack
             .pop()
             .ok_or(CredentialDiscoveryError::InvalidLogicalPlan)?;
-        if matches!(trace.kind, TraceKind::SensitiveRoot(_)) {
+        if matches!(
+            trace.kind,
+            TraceKind::SensitiveRoot(_) | TraceKind::GithubRoot
+        ) {
             return Err(CredentialDiscoveryError::DynamicReference);
         }
         output.secrets.extend(trace.secrets);
         output.variables.extend(trace.variables);
+        output.built_in.extend(trace.built_in);
     }
     Ok(output)
 }
@@ -273,7 +371,9 @@ mod tests {
         ]);
         let mut secrets = BTreeSet::new();
         let mut variables = BTreeSet::new();
-        scan_program(&expression, &mut secrets, &mut variables).expect("static references");
+        let mut built_in = BTreeSet::new();
+        scan_program(&expression, &mut secrets, &mut variables, &mut built_in)
+            .expect("static references");
         let requirements =
             JobCredentialRequirements::new(JobEnvironmentRequirement::None, secrets, variables)
                 .expect("requirements");
@@ -300,9 +400,51 @@ mod tests {
             ]),
         ] {
             assert_eq!(
-                scan_program(&expression, &mut BTreeSet::new(), &mut BTreeSet::new()),
+                scan_program(
+                    &expression,
+                    &mut BTreeSet::new(),
+                    &mut BTreeSet::new(),
+                    &mut BTreeSet::new(),
+                ),
                 Err(CredentialDiscoveryError::DynamicReference)
             );
         }
+    }
+
+    #[test]
+    fn github_token_spellings_are_closed_builtins() {
+        for (root, property) in [("github", "token"), ("secrets", "github_token")] {
+            let expression = program(vec![
+                ExpressionInstruction::NamedValue {
+                    name: root.to_owned(),
+                },
+                string(property),
+                ExpressionInstruction::Index,
+            ]);
+            let mut secrets = BTreeSet::new();
+            let mut variables = BTreeSet::new();
+            let mut built_in = BTreeSet::new();
+            scan_program(&expression, &mut secrets, &mut variables, &mut built_in)
+                .expect("static builtin");
+            classify_builtin_secrets(&mut secrets, &mut built_in);
+            assert!(secrets.is_empty());
+            assert_eq!(
+                built_in,
+                BTreeSet::from([BuiltInCredentialRequirement::GithubToken])
+            );
+        }
+
+        let mut duplicate_spellings = BTreeSet::from([
+            "GITHUB_TOKEN".to_owned(),
+            "github_token".to_owned(),
+            "EXTERNAL".to_owned(),
+        ]);
+        let mut built_in = BTreeSet::new();
+        classify_builtin_secrets(&mut duplicate_spellings, &mut built_in);
+        assert_eq!(duplicate_spellings, BTreeSet::from(["EXTERNAL".to_owned()]));
+        assert_eq!(
+            built_in,
+            BTreeSet::from([BuiltInCredentialRequirement::GithubToken])
+        );
     }
 }

--- a/crates/automata-ci-workflow-service/src/credential_requirements.rs
+++ b/crates/automata-ci-workflow-service/src/credential_requirements.rs
@@ -25,24 +25,20 @@ pub enum BuiltInCredentialRequirement {
     GithubToken,
 }
 
-/// Static external and provider-built-in requirements for one logical job.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DiscoveredJobCredentials {
+pub(crate) struct DiscoveredJobCredentials {
     external: JobCredentialRequirements,
     built_in: Vec<BuiltInCredentialRequirement>,
 }
 
 impl DiscoveredJobCredentials {
-    /// Returns secret, variable, and protected-environment requirements that
-    /// must be resolved outside provider-built-in runtime authority.
     #[must_use]
-    pub const fn external(&self) -> &JobCredentialRequirements {
+    pub(crate) const fn external(&self) -> &JobCredentialRequirements {
         &self.external
     }
 
-    /// Returns provider-built-in credentials in stable order.
     #[must_use]
-    pub fn built_in(&self) -> &[BuiltInCredentialRequirement] {
+    pub(crate) fn built_in(&self) -> &[BuiltInCredentialRequirement] {
         &self.built_in
     }
 }
@@ -52,18 +48,7 @@ pub(crate) fn built_in_secret_requirement(name: &str) -> Option<BuiltInCredentia
         .then_some(BuiltInCredentialRequirement::GithubToken)
 }
 
-/// Discovers exact static `secrets.<name>`, `vars.<name>`, and provider
-/// built-in credential uses, including name-only caller sources in
-/// reusable-workflow secret mappings.
-///
-/// The complete serialized logical job is walked so new template-bearing fields
-/// fail into the same analysis without a second hand-maintained field list.
-///
-/// # Errors
-///
-/// Rejects whole-context and dynamic-name access, malformed durable programs,
-/// or invalid canonical names.
-pub fn discover_job_credentials(
+pub(crate) fn discover_job_credentials(
     workflow: &LogicalWorkflowPlan,
     job: &LogicalJobTemplate,
 ) -> Result<DiscoveredJobCredentials, CredentialDiscoveryError> {

--- a/crates/automata-ci-workflow-service/src/lib.rs
+++ b/crates/automata-ci-workflow-service/src/lib.rs
@@ -51,7 +51,10 @@ pub use autonomous_workflow::{
     AutonomousWorkflowPhaseExecutor, AutonomousWorkflowQueue, AutonomousWorkflowRenewalOutcome,
     AutonomousWorkflowService,
 };
-pub use credential_requirements::{CredentialDiscoveryError, discover_job_credential_requirements};
+pub use credential_requirements::{
+    BuiltInCredentialRequirement, CredentialDiscoveryError, DiscoveredJobCredentials,
+    discover_job_credentials,
+};
 pub use github::GithubWorkflowPlanVerifier;
 pub use github_activation::{
     GithubActivationContext, GithubActivationEvaluationError, GithubActivationSession,
@@ -93,11 +96,14 @@ pub use reusable_runtime::{
 pub use reusable_workflow::{
     CatalogedReusableWorkflow, ExpandReusableWorkflowRequest, ExpandedReusableInput,
     ExpandedReusableJob, ExpandedReusableOutput, ExpandedReusableOutputMapping,
-    ExpandedReusableSecret, GithubReusableWorkflowCatalog, MAX_REUSABLE_WORKFLOW_CATALOG_ENTRIES,
+    ExpandedReusableSecret, GithubReusableWorkflowCatalog, LocalGithubAnalyzedJob,
+    LocalGithubAnalyzedWorkflow, LocalGithubArchiveAnalysis, LocalGithubArchiveAnalysisFailure,
+    LocalGithubArchiveAnalysisFailureKind, MAX_REUSABLE_WORKFLOW_CATALOG_ENTRIES,
     MAX_REUSABLE_WORKFLOW_DEPTH, MAX_REUSABLE_WORKFLOW_EXPANDED_JOBS,
     MAX_REUSABLE_WORKFLOW_INVOCATIONS, RepositoryWorkflowSource, ReusableInputBindingSource,
     ReusableWorkflowExpander, ReusableWorkflowExpansion, ReusableWorkflowExpansionError,
     ReusableWorkflowInvocationExpansion, ReusableWorkflowLimits, ReusableWorkflowPermissions,
+    analyze_local_github_archive,
 };
 pub use run_finalization::{
     LOGICAL_RUN_FINALIZATION_CLAIM_MILLIS, LogicalRunFinalizationError,

--- a/crates/automata-ci-workflow-service/src/lib.rs
+++ b/crates/automata-ci-workflow-service/src/lib.rs
@@ -51,10 +51,7 @@ pub use autonomous_workflow::{
     AutonomousWorkflowPhaseExecutor, AutonomousWorkflowQueue, AutonomousWorkflowRenewalOutcome,
     AutonomousWorkflowService,
 };
-pub use credential_requirements::{
-    BuiltInCredentialRequirement, CredentialDiscoveryError, DiscoveredJobCredentials,
-    discover_job_credentials,
-};
+pub use credential_requirements::{BuiltInCredentialRequirement, CredentialDiscoveryError};
 pub use github::GithubWorkflowPlanVerifier;
 pub use github_activation::{
     GithubActivationContext, GithubActivationEvaluationError, GithubActivationSession,

--- a/crates/automata-ci-workflow-service/src/orchestration.rs
+++ b/crates/automata-ci-workflow-service/src/orchestration.rs
@@ -656,7 +656,10 @@ impl GithubLogicalJobOrchestrationService {
             return Ok(activation_relational_failure());
         };
         let Ok(credential_requirements) =
-            crate::discover_job_credential_requirements(plan.logical(), &logical_job)
+            crate::credential_requirements::discover_external_job_credentials(
+                plan.logical(),
+                &logical_job,
+            )
         else {
             return Ok(activation_payload_failure());
         };

--- a/crates/automata-ci-workflow-service/src/reusable_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/reusable_workflow.rs
@@ -16,19 +16,26 @@ use std::{
 use automata_ci_core::{
     CompiledValueTemplate, ExpressionInstruction, ExpressionLiteral, ExpressionSegment,
     InvocationInputDefault, InvocationInputType, LogicalJobKind, LogicalJobOutputSource,
-    OutputSensitivity, PermissionLevel, PermissionSnapshotRequest, PlanSourceOrigin,
-    ReusableSecretForwarding, ReusableWorkflowInvocation, RunId, Sha256Digest,
+    LogicalJobTemplate, OutputSensitivity, PermissionLevel, PermissionSnapshotRequest,
+    PlanSourceOrigin, ReusableSecretForwarding, ReusableWorkflowInvocation, RunId, Sha256Digest,
     WorkflowInvocationContract, WorkflowJobKey, WorkflowPermissions, WorkflowPlan,
 };
 use automata_ci_store::{LogicalWorkflowInvocationId, LogicalWorkflowJobId};
 use automata_ci_workflow_github::{
-    CompileWorkflowRequest, Diagnostic, GithubWorkflowCompiler, GithubWorkflowFrontend,
-    ParseWorkflowRequest, SourceId, SourceOrigin, SourceProvenance, WorkflowFrontend as _,
+    CompileWorkflowRequest, Diagnostic, GithubWorkflowCompiler, GithubWorkflowDispatchInputs,
+    GithubWorkflowFrontend, LocalGithubArchiveCompilation,
+    LocalGithubArchiveCompilationFailureKind, ParseWorkflowRequest,
+    RepositoryWorkflowDiscoveryLimits, RepositoryWorkflowLocation, SourceId, SourceOrigin,
+    SourceProvenance, WorkflowFrontend as _, compile_local_github_archive,
 };
 use bytes::Bytes;
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use uuid::Uuid;
+
+use crate::credential_requirements::{
+    BuiltInCredentialRequirement, built_in_secret_requirement, discover_job_credentials,
+};
 
 /// Maximum repository workflow files accepted by one reusable catalog.
 pub const MAX_REUSABLE_WORKFLOW_CATALOG_ENTRIES: usize = 50;
@@ -47,6 +54,193 @@ const REUSABLE_INVOCATION_ID_DOMAIN: &[u8] = b"automata.reusable-workflow.invoca
 const REUSABLE_JOB_ID_DOMAIN: &[u8] = b"automata.reusable-workflow.job.v1\0";
 const ROOT_JOB_ID_DOMAIN: &[u8] = b"automata.admission.logical-job.v1\0";
 const EXPANSION_DIGEST_DOMAIN: &[u8] = b"automata.reusable-workflow.expansion.v1\0";
+
+/// Stable failure class for sealed local GitHub workflow analysis.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LocalGithubArchiveAnalysisFailureKind {
+    /// Cooperative cancellation interrupted bounded analysis.
+    Cancelled,
+    /// The sealed archive violates its local workflow policy.
+    Archive,
+    /// The archive contains no direct `.github/workflows` workflow.
+    WorkflowMissing,
+    /// More than one workflow requires one exact canonical selector.
+    WorkflowSelectionRequired,
+    /// The supplied selector is not one exact archive member.
+    WorkflowNotFound,
+    /// A selected workflow source is empty, excessive, or not UTF-8.
+    WorkflowSource,
+    /// The GitHub Actions frontend rejected a selected source.
+    Frontend,
+    /// Explicit local `workflow_dispatch` selection rejected the root.
+    Compilation,
+    /// A reusable call, contract, cycle, or propagation rule was rejected.
+    ReusableWorkflow,
+    /// Static credential-name discovery rejected a dynamic or invalid access.
+    CredentialDiscovery,
+}
+
+/// Sanitized failure from sealed local GitHub workflow analysis.
+#[derive(Clone, Debug)]
+pub struct LocalGithubArchiveAnalysisFailure {
+    kind: LocalGithubArchiveAnalysisFailureKind,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl LocalGithubArchiveAnalysisFailure {
+    /// Returns the stable failure class.
+    #[must_use]
+    pub const fn kind(&self) -> LocalGithubArchiveAnalysisFailureKind {
+        self.kind
+    }
+
+    /// Returns value-free source diagnostics collected before failure.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+}
+
+/// One logical job discovered by sealed local GitHub workflow analysis.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalGithubAnalyzedJob {
+    key: String,
+    reusable: bool,
+    secrets: Vec<String>,
+    variables: Vec<String>,
+    built_in_credentials: Vec<BuiltInCredentialRequirement>,
+}
+
+impl LocalGithubAnalyzedJob {
+    /// Returns the source-level logical job key.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Returns whether the job invokes another reusable workflow.
+    #[must_use]
+    pub const fn reusable(&self) -> bool {
+        self.reusable
+    }
+
+    /// Returns canonical external secret names without values.
+    #[must_use]
+    pub fn secrets(&self) -> &[String] {
+        &self.secrets
+    }
+
+    /// Returns canonical repository-variable names without values.
+    #[must_use]
+    pub fn variables(&self) -> &[String] {
+        &self.variables
+    }
+
+    /// Returns closed provider-built-in requirements in stable order.
+    #[must_use]
+    pub fn built_in_credentials(&self) -> &[BuiltInCredentialRequirement] {
+        &self.built_in_credentials
+    }
+}
+
+/// One root or reachable same-archive workflow analyzed locally.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalGithubAnalyzedWorkflow {
+    path: String,
+    reusable: bool,
+    jobs: Vec<LocalGithubAnalyzedJob>,
+}
+
+impl LocalGithubAnalyzedWorkflow {
+    /// Returns the exact canonical `.github/workflows` archive member.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns whether this workflow was reached through `workflow_call`.
+    #[must_use]
+    pub const fn reusable(&self) -> bool {
+        self.reusable
+    }
+
+    /// Returns jobs in source order.
+    #[must_use]
+    pub fn jobs(&self) -> &[LocalGithubAnalyzedJob] {
+        &self.jobs
+    }
+}
+
+/// Value-free analysis derived from one exact sealed local archive.
+#[derive(Clone, Debug)]
+pub struct LocalGithubArchiveAnalysis {
+    snapshot_digest: Sha256Digest,
+    selected_path: String,
+    required_root_secrets: Vec<String>,
+    required_built_in_credentials: Vec<BuiltInCredentialRequirement>,
+    workflows: Vec<LocalGithubAnalyzedWorkflow>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl LocalGithubArchiveAnalysis {
+    /// Returns SHA-256 over the exact archive bytes that were analyzed.
+    #[must_use]
+    pub const fn snapshot_digest(&self) -> Sha256Digest {
+        self.snapshot_digest
+    }
+
+    /// Returns the exact selected canonical root workflow path.
+    #[must_use]
+    pub fn selected_path(&self) -> &str {
+        &self.selected_path
+    }
+
+    /// Returns external secret names required at the root boundary.
+    #[must_use]
+    pub fn required_root_secrets(&self) -> &[String] {
+        &self.required_root_secrets
+    }
+
+    /// Returns provider-built-in credentials required anywhere reachable.
+    #[must_use]
+    pub fn required_built_in_credentials(&self) -> &[BuiltInCredentialRequirement] {
+        &self.required_built_in_credentials
+    }
+
+    /// Returns the root and reachable workflows in canonical path order.
+    #[must_use]
+    pub fn workflows(&self) -> &[LocalGithubAnalyzedWorkflow] {
+        &self.workflows
+    }
+
+    /// Returns all value-free frontend and compiler diagnostics.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CatalogSourceAuthority {
+    GithubDelivery,
+    LocalGithubArchive,
+}
+
+impl CatalogSourceAuthority {
+    const fn provider(self) -> &'static str {
+        match self {
+            Self::GithubDelivery => "github",
+            Self::LocalGithubArchive => "local",
+        }
+    }
+
+    const fn workflow_location(self) -> RepositoryWorkflowLocation {
+        match self {
+            Self::GithubDelivery => RepositoryWorkflowLocation::Automata,
+            Self::LocalGithubArchive => RepositoryWorkflowLocation::Github,
+        }
+    }
+}
 
 /// Independent hard-bounded limits applied while constructing an expansion.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -219,11 +413,19 @@ impl GithubReusableWorkflowCatalog {
         else {
             return Err(ReusableWorkflowExpansionError::RootPlanMismatch);
         };
-        validate_plan_origin(root_plan, &repository, &revision, root_path)?;
+        let root_path = canonical_workflow_path(root_path, RepositoryWorkflowLocation::Automata)?;
+        validate_plan_origin(
+            root_plan,
+            CatalogSourceAuthority::GithubDelivery,
+            &repository,
+            &revision,
+            &root_path,
+        )?;
 
         let mut available = BTreeMap::new();
         for source in sources {
-            let path = canonical_workflow_path(source.path())?;
+            let path =
+                canonical_workflow_path(source.path(), RepositoryWorkflowLocation::Automata)?;
             if source.source().is_empty()
                 || validate_reusable_workflow_source_bytes(source.source().len()).is_err()
             {
@@ -243,8 +445,8 @@ impl GithubReusableWorkflowCatalog {
             .collect::<Vec<_>>();
         let mut entries = BTreeMap::new();
         while let Some(reference) = pending.pop() {
-            let path = resolve_local_reference(&reference)?;
-            if path == *root_path {
+            let path = resolve_local_reference(&reference, RepositoryWorkflowLocation::Automata)?;
+            if path == root_path {
                 return Err(ReusableWorkflowExpansionError::Cycle(path));
             }
             if entries.contains_key(&path) {
@@ -258,15 +460,7 @@ impl GithubReusableWorkflowCatalog {
             let source = available
                 .get(&path)
                 .ok_or_else(|| ReusableWorkflowExpansionError::MissingCatalogPath(path.clone()))?;
-            let plan = compile_github_source(
-                &repository,
-                &revision,
-                &path,
-                source,
-                automata_ci_core::WorkflowEventProvenance::new("github", "workflow_call")
-                    .with_commit_sha(&revision),
-                false,
-            )?;
+            let plan = compile_reusable_source(&repository, &revision, &path, source)?;
             if plan.logical().invocation().is_none() {
                 return Err(ReusableWorkflowExpansionError::MissingInvocationContract(
                     path,
@@ -316,7 +510,8 @@ impl GithubReusableWorkflowCatalog {
         validate_reusable_catalog_entry_count(sources.len())?;
         let mut entries = BTreeMap::new();
         for source in sources {
-            let path = canonical_workflow_path(source.path())?;
+            let path =
+                canonical_workflow_path(source.path(), RepositoryWorkflowLocation::Automata)?;
             if source.source().is_empty() {
                 return Err(ReusableWorkflowExpansionError::InvalidSourceSize);
             }
@@ -324,15 +519,7 @@ impl GithubReusableWorkflowCatalog {
             if entries.contains_key(&path) {
                 return Err(ReusableWorkflowExpansionError::DuplicateCatalogPath(path));
             }
-            let plan = compile_github_source(
-                &repository,
-                &revision,
-                &path,
-                source.source(),
-                automata_ci_core::WorkflowEventProvenance::new("github", "workflow_call")
-                    .with_commit_sha(&revision),
-                false,
-            )?;
+            let plan = compile_reusable_source(&repository, &revision, &path, source.source())?;
             if plan.logical().invocation().is_none() {
                 return Err(ReusableWorkflowExpansionError::MissingInvocationContract(
                     path,
@@ -375,16 +562,311 @@ impl GithubReusableWorkflowCatalog {
     pub fn entries(&self) -> impl ExactSizeIterator<Item = &CatalogedReusableWorkflow> {
         self.entries.values()
     }
+}
+
+#[derive(Clone, Copy)]
+struct ResolvedCatalogEntry<'a> {
+    path: &'a str,
+    source_digest: Sha256Digest,
+    plan_digest: Sha256Digest,
+    plan: &'a WorkflowPlan,
+}
+
+trait ReusableWorkflowCatalogResolver {
+    fn authority(&self) -> CatalogSourceAuthority;
+    fn repository(&self) -> &str;
+    fn revision(&self) -> &str;
+    fn resolve(
+        &self,
+        reference: &str,
+    ) -> Result<ResolvedCatalogEntry<'_>, ReusableWorkflowExpansionError>;
+}
+
+impl ReusableWorkflowCatalogResolver for GithubReusableWorkflowCatalog {
+    fn authority(&self) -> CatalogSourceAuthority {
+        CatalogSourceAuthority::GithubDelivery
+    }
+
+    fn repository(&self) -> &str {
+        &self.repository
+    }
+
+    fn revision(&self) -> &str {
+        &self.revision
+    }
 
     fn resolve(
         &self,
         reference: &str,
-    ) -> Result<&CatalogedReusableWorkflow, ReusableWorkflowExpansionError> {
-        let path = resolve_local_reference(reference)?;
-        self.entries
+    ) -> Result<ResolvedCatalogEntry<'_>, ReusableWorkflowExpansionError> {
+        let path = resolve_local_reference(reference, self.authority().workflow_location())?;
+        let entry = self
+            .entries
             .get(&path)
-            .ok_or(ReusableWorkflowExpansionError::MissingCatalogPath(path))
+            .ok_or(ReusableWorkflowExpansionError::MissingCatalogPath(path))?;
+        Ok(ResolvedCatalogEntry {
+            path: entry.path(),
+            source_digest: entry.source_digest(),
+            plan_digest: entry.plan_digest(),
+            plan: entry.plan(),
+        })
     }
+}
+
+struct LocalReusableWorkflowCatalog<'a> {
+    compilation: &'a LocalGithubArchiveCompilation,
+    repository: &'static str,
+    revision: String,
+    plan_digests: BTreeMap<String, Sha256Digest>,
+}
+
+impl<'a> LocalReusableWorkflowCatalog<'a> {
+    fn new(
+        compilation: &'a LocalGithubArchiveCompilation,
+    ) -> Result<Self, ReusableWorkflowExpansionError> {
+        let plan_digests = compilation
+            .reusable_workflows()
+            .iter()
+            .map(|workflow| Ok((workflow.path().to_owned(), digest_plan(workflow.plan())?)))
+            .collect::<Result<_, ReusableWorkflowExpansionError>>()?;
+        Ok(Self {
+            compilation,
+            repository: "local",
+            revision: compilation.snapshot_digest().to_string(),
+            plan_digests,
+        })
+    }
+}
+
+impl ReusableWorkflowCatalogResolver for LocalReusableWorkflowCatalog<'_> {
+    fn authority(&self) -> CatalogSourceAuthority {
+        CatalogSourceAuthority::LocalGithubArchive
+    }
+
+    fn repository(&self) -> &str {
+        self.repository
+    }
+
+    fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    fn resolve(
+        &self,
+        reference: &str,
+    ) -> Result<ResolvedCatalogEntry<'_>, ReusableWorkflowExpansionError> {
+        let path = resolve_local_reference(reference, self.authority().workflow_location())?;
+        let workflow = self
+            .compilation
+            .reusable_workflows()
+            .iter()
+            .find(|workflow| workflow.path() == path)
+            .ok_or_else(|| ReusableWorkflowExpansionError::MissingCatalogPath(path.clone()))?;
+        let plan_digest = self
+            .plan_digests
+            .get(&path)
+            .copied()
+            .ok_or(ReusableWorkflowExpansionError::InvalidIdentity)?;
+        Ok(ResolvedCatalogEntry {
+            path: workflow.path(),
+            source_digest: workflow.source_digest(),
+            plan_digest,
+            plan: workflow.plan(),
+        })
+    }
+}
+
+/// Compiles and analyzes one exact local GitHub workflow archive without
+/// creating provider evidence, admission state, Checks, or executable work.
+///
+/// Local source authority and reusable membership are created only inside the
+/// sealed archive compiler. This boundary then runs the same recursive
+/// input/output/secret/cycle contract traversal used by durable expansion,
+/// under a symbolic credential policy. The returned value retains no archive
+/// or workflow source bytes and no executable plan.
+///
+/// # Errors
+///
+/// Returns a value-free failure for archive policy, exact selection,
+/// parse/compile rejection, reusable-call contract rejection, credential
+/// discovery failure, resource exhaustion, or cooperative cancellation.
+pub fn analyze_local_github_archive(
+    archive_bytes: &[u8],
+    selector: Option<&str>,
+    inputs: GithubWorkflowDispatchInputs,
+    archive_limits: RepositoryWorkflowDiscoveryLimits,
+    reusable_limits: ReusableWorkflowLimits,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<LocalGithubArchiveAnalysis, LocalGithubArchiveAnalysisFailure> {
+    let compilation = compile_local_github_archive(
+        archive_bytes,
+        selector,
+        inputs,
+        archive_limits,
+        cancellation,
+    )
+    .map_err(|failure| local_compilation_failure(&failure))?;
+    let diagnostics = compilation.diagnostics().to_vec();
+    if cancellation() {
+        return Err(LocalGithubArchiveAnalysisFailure {
+            kind: LocalGithubArchiveAnalysisFailureKind::Cancelled,
+            diagnostics,
+        });
+    }
+
+    let catalog = LocalReusableWorkflowCatalog::new(&compilation)
+        .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+    let root_path = canonical_workflow_path(
+        compilation.selected_path(),
+        RepositoryWorkflowLocation::Github,
+    )
+    .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+    validate_plan_origin(
+        compilation.root_plan(),
+        catalog.authority(),
+        catalog.repository(),
+        catalog.revision(),
+        &root_path,
+    )
+    .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+    let root_plan_digest = digest_plan(compilation.root_plan())
+        .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+    let mut counts = TraversalCounts {
+        limits: reusable_limits,
+        invocation_count: 0,
+        job_count: 0,
+    };
+    let mut policy = SymbolicCredentialPolicy;
+    let mut active_paths = Vec::new();
+    let requirements = traverse_reusable_invocation(
+        &catalog,
+        &mut policy,
+        &mut counts,
+        TraversalNode {
+            workflow_path: &root_path,
+            plan: compilation.root_plan(),
+            depth: 0,
+            source_digest: compilation.root_source_digest(),
+            plan_digest: root_plan_digest,
+            root: true,
+        },
+        (),
+        &mut active_paths,
+        cancellation,
+    )
+    .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+
+    let mut workflows = Vec::with_capacity(compilation.reusable_workflows().len() + 1);
+    workflows.push(
+        analyze_local_workflow(&root_path, false, compilation.root_plan(), cancellation).map_err(
+            |kind| LocalGithubArchiveAnalysisFailure {
+                kind,
+                diagnostics: diagnostics.clone(),
+            },
+        )?,
+    );
+    for reusable in compilation.reusable_workflows() {
+        workflows.push(
+            analyze_local_workflow(reusable.path(), true, reusable.plan(), cancellation).map_err(
+                |kind| LocalGithubArchiveAnalysisFailure {
+                    kind,
+                    diagnostics: diagnostics.clone(),
+                },
+            )?,
+        );
+    }
+    workflows.sort_by(|left, right| left.path.cmp(&right.path));
+
+    Ok(LocalGithubArchiveAnalysis {
+        snapshot_digest: compilation.snapshot_digest(),
+        selected_path: root_path,
+        required_root_secrets: requirements.external.into_iter().collect(),
+        required_built_in_credentials: requirements.built_in.into_iter().collect(),
+        workflows,
+        diagnostics,
+    })
+}
+
+fn analyze_local_workflow(
+    path: &str,
+    reusable: bool,
+    plan: &WorkflowPlan,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<LocalGithubAnalyzedWorkflow, LocalGithubArchiveAnalysisFailureKind> {
+    let mut jobs = Vec::with_capacity(plan.jobs().len());
+    for job in plan.jobs() {
+        if cancellation() {
+            return Err(LocalGithubArchiveAnalysisFailureKind::Cancelled);
+        }
+        let credentials = discover_job_credentials(plan.logical(), job)
+            .map_err(|_| LocalGithubArchiveAnalysisFailureKind::CredentialDiscovery)?;
+        jobs.push(LocalGithubAnalyzedJob {
+            key: job.key().value().to_string(),
+            reusable: matches!(job.execution(), LogicalJobKind::ReusableWorkflow(_)),
+            secrets: credentials.external().secret_names().to_vec(),
+            variables: credentials.external().variable_names().to_vec(),
+            built_in_credentials: credentials.built_in().to_vec(),
+        });
+    }
+    Ok(LocalGithubAnalyzedWorkflow {
+        path: path.to_owned(),
+        reusable,
+        jobs,
+    })
+}
+
+fn local_compilation_failure(
+    failure: &automata_ci_workflow_github::LocalGithubArchiveCompilationFailure,
+) -> LocalGithubArchiveAnalysisFailure {
+    let kind = match failure.kind() {
+        LocalGithubArchiveCompilationFailureKind::Cancelled => {
+            LocalGithubArchiveAnalysisFailureKind::Cancelled
+        }
+        LocalGithubArchiveCompilationFailureKind::Archive => {
+            LocalGithubArchiveAnalysisFailureKind::Archive
+        }
+        LocalGithubArchiveCompilationFailureKind::WorkflowMissing => {
+            LocalGithubArchiveAnalysisFailureKind::WorkflowMissing
+        }
+        LocalGithubArchiveCompilationFailureKind::WorkflowSelectionRequired => {
+            LocalGithubArchiveAnalysisFailureKind::WorkflowSelectionRequired
+        }
+        LocalGithubArchiveCompilationFailureKind::WorkflowNotFound => {
+            LocalGithubArchiveAnalysisFailureKind::WorkflowNotFound
+        }
+        LocalGithubArchiveCompilationFailureKind::WorkflowSource => {
+            LocalGithubArchiveAnalysisFailureKind::WorkflowSource
+        }
+        LocalGithubArchiveCompilationFailureKind::Frontend => {
+            LocalGithubArchiveAnalysisFailureKind::Frontend
+        }
+        LocalGithubArchiveCompilationFailureKind::Compilation => {
+            LocalGithubArchiveAnalysisFailureKind::Compilation
+        }
+        LocalGithubArchiveCompilationFailureKind::ReusableWorkflow => {
+            LocalGithubArchiveAnalysisFailureKind::ReusableWorkflow
+        }
+    };
+    LocalGithubArchiveAnalysisFailure {
+        kind,
+        diagnostics: failure.diagnostics().to_vec(),
+    }
+}
+
+fn local_reusable_failure(
+    error: &ReusableWorkflowExpansionError,
+    diagnostics: Vec<Diagnostic>,
+) -> LocalGithubArchiveAnalysisFailure {
+    let kind = match error {
+        ReusableWorkflowExpansionError::Cancelled => {
+            LocalGithubArchiveAnalysisFailureKind::Cancelled
+        }
+        ReusableWorkflowExpansionError::CredentialRequirements => {
+            LocalGithubArchiveAnalysisFailureKind::CredentialDiscovery
+        }
+        _ => LocalGithubArchiveAnalysisFailureKind::ReusableWorkflow,
+    };
+    LocalGithubArchiveAnalysisFailure { kind, diagnostics }
 }
 
 /// Canonical least-authority provider permission ceiling for one invocation.
@@ -840,7 +1322,7 @@ pub enum ReusableWorkflowExpansionError {
     /// A repository or immutable revision coordinate is invalid.
     #[error("reusable workflow repository coordinates are invalid")]
     InvalidRepositoryCoordinate,
-    /// A path is not a canonical direct `.ci` YAML path.
+    /// A path is not canonical in the authority's exact workflow namespace.
     #[error("reusable workflow path is not canonical")]
     InvalidWorkflowPath,
     /// A call uses something other than a canonical `./...` repository-local reference.
@@ -933,6 +1415,12 @@ pub enum ReusableWorkflowExpansionError {
     /// A durable identity unexpectedly became nil.
     #[error("reusable workflow deterministic identity is invalid")]
     InvalidIdentity,
+    /// Static secret-name discovery rejected a malformed or dynamic reference.
+    #[error("reusable workflow credential requirements are invalid")]
+    CredentialRequirements,
+    /// Cooperative cancellation interrupted reusable-workflow traversal.
+    #[error("reusable workflow analysis was cancelled")]
+    Cancelled,
 }
 
 const fn validate_reusable_catalog_entry_count(
@@ -1019,14 +1507,440 @@ const fn validate_reusable_permission_grant_count(
     Ok(())
 }
 
-struct ExpansionContext<'a> {
+struct ExpansionContext {
     run_id: RunId,
-    catalog: &'a GithubReusableWorkflowCatalog,
-    limits: ReusableWorkflowLimits,
     invocation_ids: BTreeSet<Uuid>,
     job_ids: BTreeSet<Uuid>,
     invocations: Vec<ReusableWorkflowInvocationExpansion>,
+}
+
+struct TraversalCounts {
+    limits: ReusableWorkflowLimits,
+    invocation_count: usize,
     job_count: usize,
+}
+
+#[derive(Clone, Copy)]
+struct TraversalNode<'a> {
+    workflow_path: &'a str,
+    plan: &'a WorkflowPlan,
+    depth: usize,
+    source_digest: Sha256Digest,
+    plan_digest: Sha256Digest,
+    root: bool,
+}
+
+trait CredentialTraversalPolicy {
+    type Seed;
+    type State;
+    type Edge;
+    type Output;
+
+    fn enter(
+        &mut self,
+        node: &TraversalNode<'_>,
+        seed: Self::Seed,
+    ) -> Result<Self::State, ReusableWorkflowExpansionError>;
+
+    fn prepare_edge(
+        &mut self,
+        parent: &mut Self::State,
+        job: &LogicalJobTemplate,
+        call: &ReusableWorkflowInvocation,
+        callee: ResolvedCatalogEntry<'_>,
+        inputs: Vec<ExpandedReusableInput>,
+        outputs: Vec<ExpandedReusableOutputMapping>,
+    ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError>;
+
+    fn finish_edge(
+        &mut self,
+        parent: &mut Self::State,
+        edge: Self::Edge,
+        child: Self::Output,
+    ) -> Result<(), ReusableWorkflowExpansionError>;
+
+    fn finish(
+        &mut self,
+        state: Self::State,
+    ) -> Result<Self::Output, ReusableWorkflowExpansionError>;
+}
+
+fn traverse_reusable_invocation<C, P>(
+    catalog: &C,
+    policy: &mut P,
+    counts: &mut TraversalCounts,
+    node: TraversalNode<'_>,
+    seed: P::Seed,
+    active_paths: &mut Vec<String>,
+    cancellation: &dyn Fn() -> bool,
+) -> Result<P::Output, ReusableWorkflowExpansionError>
+where
+    C: ReusableWorkflowCatalogResolver,
+    P: CredentialTraversalPolicy,
+{
+    if cancellation() {
+        return Err(ReusableWorkflowExpansionError::Cancelled);
+    }
+    validate_reusable_workflow_depth(node.depth, counts.limits.maximum_depth())?;
+    counts.invocation_count = counts
+        .invocation_count
+        .checked_add(1)
+        .ok_or(ReusableWorkflowExpansionError::InvocationLimitExceeded)?;
+    validate_reusable_workflow_invocation_count(
+        counts.invocation_count,
+        counts.limits.maximum_invocations(),
+    )?;
+    counts.job_count = counts
+        .job_count
+        .checked_add(node.plan.jobs().len())
+        .ok_or(ReusableWorkflowExpansionError::JobLimitExceeded)?;
+    validate_reusable_workflow_job_count(counts.job_count, counts.limits.maximum_jobs())?;
+    if active_paths
+        .iter()
+        .any(|active| active == node.workflow_path)
+    {
+        return Err(ReusableWorkflowExpansionError::Cycle(
+            node.workflow_path.to_owned(),
+        ));
+    }
+    active_paths.push(node.workflow_path.to_owned());
+    let result = (|| {
+        let mut state = policy.enter(&node, seed)?;
+        for job in node.plan.jobs() {
+            if cancellation() {
+                return Err(ReusableWorkflowExpansionError::Cancelled);
+            }
+            let LogicalJobKind::ReusableWorkflow(call) = job.execution() else {
+                continue;
+            };
+            if job.strategy().is_some() {
+                return Err(ReusableWorkflowExpansionError::MatrixCallUnsupported);
+            }
+            let callee = catalog.resolve(call.reference().value())?;
+            if active_paths.iter().any(|active| active == callee.path) {
+                return Err(ReusableWorkflowExpansionError::Cycle(
+                    callee.path.to_owned(),
+                ));
+            }
+            validate_plan_origin(
+                callee.plan,
+                catalog.authority(),
+                catalog.repository(),
+                catalog.revision(),
+                callee.path,
+            )?;
+            let contract = callee.plan.logical().invocation().ok_or_else(|| {
+                ReusableWorkflowExpansionError::MissingInvocationContract(callee.path.to_owned())
+            })?;
+            let inputs = validate_inputs(call, contract)?;
+            let outputs = validate_call_outputs(job.outputs(), contract)?;
+            let (child_seed, edge) =
+                policy.prepare_edge(&mut state, job, call, callee, inputs, outputs)?;
+            let child = traverse_reusable_invocation(
+                catalog,
+                policy,
+                counts,
+                TraversalNode {
+                    workflow_path: callee.path,
+                    plan: callee.plan,
+                    depth: node.depth + 1,
+                    source_digest: callee.source_digest,
+                    plan_digest: callee.plan_digest,
+                    root: false,
+                },
+                child_seed,
+                active_paths,
+                cancellation,
+            )?;
+            policy.finish_edge(&mut state, edge, child)?;
+        }
+        policy.finish(state)
+    })();
+    active_paths.pop();
+    result
+}
+
+#[derive(Clone)]
+struct MaterializedTraversalSeed {
+    id: LogicalWorkflowInvocationId,
+    parent_id: Option<LogicalWorkflowInvocationId>,
+    caller_job_id: Option<LogicalWorkflowJobId>,
+    permissions: ReusableWorkflowPermissions,
+    inputs: Vec<ExpandedReusableInput>,
+    secrets: Vec<ExpandedReusableSecret>,
+    available_secret_names: BTreeSet<String>,
+    outputs: Vec<ExpandedReusableOutput>,
+    caller_outputs: Vec<ExpandedReusableOutputMapping>,
+}
+
+struct MaterializedTraversalState {
+    invocation_index: usize,
+    id: LogicalWorkflowInvocationId,
+    permissions: ReusableWorkflowPermissions,
+    available_secret_names: BTreeSet<String>,
+}
+
+struct MaterializedCredentialPolicy<'a> {
+    context: &'a mut ExpansionContext,
+}
+
+impl CredentialTraversalPolicy for MaterializedCredentialPolicy<'_> {
+    type Seed = MaterializedTraversalSeed;
+    type State = MaterializedTraversalState;
+    type Edge = ();
+    type Output = ();
+
+    fn enter(
+        &mut self,
+        node: &TraversalNode<'_>,
+        seed: Self::Seed,
+    ) -> Result<Self::State, ReusableWorkflowExpansionError> {
+        let jobs = expanded_jobs(self.context, seed.id, node.plan, node.root)?;
+        let invocation_index = self.context.invocations.len();
+        let id = seed.id;
+        let permissions = seed.permissions.clone();
+        let available_secret_names = seed.available_secret_names.clone();
+        self.context
+            .invocations
+            .push(ReusableWorkflowInvocationExpansion {
+                id,
+                parent_id: seed.parent_id,
+                caller_job_id: seed.caller_job_id,
+                depth: u16::try_from(node.depth)
+                    .map_err(|_| ReusableWorkflowExpansionError::DepthLimitExceeded)?,
+                workflow_path: node.workflow_path.to_owned(),
+                source_digest: node.source_digest,
+                plan_digest: node.plan_digest,
+                permissions: seed.permissions,
+                inputs: seed.inputs,
+                secrets: seed.secrets,
+                outputs: seed.outputs,
+                caller_outputs: seed.caller_outputs,
+                jobs,
+            });
+        Ok(MaterializedTraversalState {
+            invocation_index,
+            id,
+            permissions,
+            available_secret_names,
+        })
+    }
+
+    fn prepare_edge(
+        &mut self,
+        parent: &mut Self::State,
+        job: &LogicalJobTemplate,
+        call: &ReusableWorkflowInvocation,
+        callee: ResolvedCatalogEntry<'_>,
+        inputs: Vec<ExpandedReusableInput>,
+        caller_outputs: Vec<ExpandedReusableOutputMapping>,
+    ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError> {
+        let contract = callee.plan.logical().invocation().ok_or_else(|| {
+            ReusableWorkflowExpansionError::MissingInvocationContract(callee.path.to_owned())
+        })?;
+        let secrets = validate_secrets(call, contract, &parent.available_secret_names)?;
+        let available_secret_names = secrets
+            .iter()
+            .map(|binding| binding.target.clone())
+            .collect();
+        let caller_job_id = self.context.invocations[parent.invocation_index]
+            .jobs
+            .iter()
+            .find(|expanded| expanded.key() == job.key().value())
+            .map(ExpandedReusableJob::id)
+            .ok_or(ReusableWorkflowExpansionError::InvalidIdentity)?;
+        let invocation_id = derived_invocation_id(
+            self.context.run_id,
+            parent.id,
+            caller_job_id,
+            callee.path,
+            callee.source_digest,
+        )?;
+        if !self.context.invocation_ids.insert(invocation_id.as_uuid()) {
+            return Err(ReusableWorkflowExpansionError::IdentityCollision);
+        }
+        let permissions = parent
+            .permissions
+            .reduce(job.permissions())
+            .reduce(callee.plan.logical().permissions());
+        Ok((
+            MaterializedTraversalSeed {
+                id: invocation_id,
+                parent_id: Some(parent.id),
+                caller_job_id: Some(caller_job_id),
+                permissions,
+                inputs,
+                secrets,
+                available_secret_names,
+                outputs: contract_outputs(contract),
+                caller_outputs,
+            },
+            (),
+        ))
+    }
+
+    fn finish_edge(
+        &mut self,
+        _parent: &mut Self::State,
+        (): Self::Edge,
+        (): Self::Output,
+    ) -> Result<(), ReusableWorkflowExpansionError> {
+        Ok(())
+    }
+
+    fn finish(
+        &mut self,
+        _state: Self::State,
+    ) -> Result<Self::Output, ReusableWorkflowExpansionError> {
+        Ok(())
+    }
+}
+
+enum SymbolicSecretEdge {
+    Mapping(BTreeMap<String, SymbolicSecretSource>),
+    Inherit,
+}
+
+enum SymbolicSecretSource {
+    External(String),
+    BuiltIn(BuiltInCredentialRequirement),
+}
+
+#[derive(Default)]
+struct SymbolicCredentialRequirements {
+    external: BTreeSet<String>,
+    built_in: BTreeSet<BuiltInCredentialRequirement>,
+}
+
+struct SymbolicCredentialPolicy;
+
+impl CredentialTraversalPolicy for SymbolicCredentialPolicy {
+    type Seed = ();
+    type State = SymbolicCredentialRequirements;
+    type Edge = SymbolicSecretEdge;
+    type Output = SymbolicCredentialRequirements;
+
+    fn enter(
+        &mut self,
+        node: &TraversalNode<'_>,
+        (): Self::Seed,
+    ) -> Result<Self::State, ReusableWorkflowExpansionError> {
+        let mut required = SymbolicCredentialRequirements::default();
+        for job in node.plan.jobs() {
+            let credentials = discover_job_credentials(node.plan.logical(), job)
+                .map_err(|_| ReusableWorkflowExpansionError::CredentialRequirements)?;
+            required
+                .external
+                .extend(credentials.external().secret_names().iter().cloned());
+            required
+                .built_in
+                .extend(credentials.built_in().iter().copied());
+        }
+        if let Some(contract) = node.plan.logical().invocation() {
+            for secret in contract.secrets().iter().filter(|secret| secret.required()) {
+                let name = secret.key().value().as_str();
+                if let Some(requirement) = built_in_secret_requirement(name) {
+                    required.built_in.insert(requirement);
+                } else {
+                    required.external.insert(name.to_ascii_uppercase());
+                }
+            }
+        }
+        Ok(required)
+    }
+
+    fn prepare_edge(
+        &mut self,
+        _parent: &mut Self::State,
+        _job: &LogicalJobTemplate,
+        call: &ReusableWorkflowInvocation,
+        callee: ResolvedCatalogEntry<'_>,
+        _inputs: Vec<ExpandedReusableInput>,
+        _outputs: Vec<ExpandedReusableOutputMapping>,
+    ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError> {
+        let contract = callee.plan.logical().invocation().ok_or_else(|| {
+            ReusableWorkflowExpansionError::MissingInvocationContract(callee.path.to_owned())
+        })?;
+        Ok(((), symbolic_secret_edge(call, contract)?))
+    }
+
+    fn finish_edge(
+        &mut self,
+        parent: &mut Self::State,
+        edge: Self::Edge,
+        child: Self::Output,
+    ) -> Result<(), ReusableWorkflowExpansionError> {
+        parent.built_in.extend(child.built_in);
+        match edge {
+            SymbolicSecretEdge::Inherit => parent.external.extend(child.external),
+            SymbolicSecretEdge::Mapping(bindings) => {
+                for target in child.external {
+                    let source = bindings.get(&target).ok_or_else(|| {
+                        ReusableWorkflowExpansionError::MissingRequiredSecret(target.clone())
+                    })?;
+                    match source {
+                        SymbolicSecretSource::External(source) => {
+                            parent.external.insert(source.clone());
+                        }
+                        SymbolicSecretSource::BuiltIn(requirement) => {
+                            parent.built_in.insert(*requirement);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &mut self,
+        state: Self::State,
+    ) -> Result<Self::Output, ReusableWorkflowExpansionError> {
+        Ok(state)
+    }
+}
+
+fn symbolic_secret_edge(
+    call: &ReusableWorkflowInvocation,
+    contract: &WorkflowInvocationContract,
+) -> Result<SymbolicSecretEdge, ReusableWorkflowExpansionError> {
+    let definitions = contract
+        .secrets()
+        .iter()
+        .map(|definition| (definition.key().value().as_str(), definition))
+        .collect::<BTreeMap<_, _>>();
+    match call.secrets() {
+        ReusableSecretForwarding::Inherit(_) => Ok(SymbolicSecretEdge::Inherit),
+        ReusableSecretForwarding::Mapping(values) => {
+            let mut bindings = BTreeMap::new();
+            for binding in values {
+                let target = binding.target().value().as_str();
+                if !definitions.contains_key(target) {
+                    return Err(ReusableWorkflowExpansionError::UnknownSecret(
+                        target.to_owned(),
+                    ));
+                }
+                let source = binding.source().value().as_str();
+                bindings.insert(
+                    target.to_ascii_uppercase(),
+                    if let Some(requirement) = built_in_secret_requirement(source) {
+                        SymbolicSecretSource::BuiltIn(requirement)
+                    } else {
+                        SymbolicSecretSource::External(source.to_ascii_uppercase())
+                    },
+                );
+            }
+            for definition in contract.secrets() {
+                let target = definition.key().value().as_str().to_ascii_uppercase();
+                if definition.required() && !bindings.contains_key(&target) {
+                    return Err(ReusableWorkflowExpansionError::MissingRequiredSecret(
+                        target,
+                    ));
+                }
+            }
+            Ok(SymbolicSecretEdge::Mapping(bindings))
+        }
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1034,24 +1948,25 @@ fn expand_reusable_workflow(
     request: ExpandReusableWorkflowRequest<'_>,
     limits: ReusableWorkflowLimits,
 ) -> Result<ReusableWorkflowExpansion, ReusableWorkflowExpansionError> {
-    let root_path = canonical_workflow_path(request.root_path)?;
+    let root_path =
+        canonical_workflow_path(request.root_path, RepositoryWorkflowLocation::Automata)?;
     if request.root_source.is_empty() {
         return Err(ReusableWorkflowExpansionError::InvalidSourceSize);
     }
     validate_reusable_workflow_source_bytes(request.root_source.len())?;
     validate_plan_origin(
         request.root_plan,
+        CatalogSourceAuthority::GithubDelivery,
         request.catalog.repository(),
         request.catalog.revision(),
         &root_path,
     )?;
-    let recompiled_root = compile_github_source(
+    let recompiled_root = recompile_root_source(
         request.catalog.repository(),
         request.catalog.revision(),
         &root_path,
         request.root_source,
         request.root_plan.event().clone(),
-        true,
     )
     .map_err(|error| match error {
         ReusableWorkflowExpansionError::FrontendRejected(_)
@@ -1076,34 +1991,44 @@ fn expand_reusable_workflow(
         .map_or_else(Vec::new, contract_outputs);
     let mut context = ExpansionContext {
         run_id: request.run_id,
-        catalog: request.catalog,
-        limits,
         invocation_ids: BTreeSet::from([request.root_invocation_id.as_uuid()]),
         job_ids: BTreeSet::new(),
         invocations: Vec::new(),
+    };
+    let mut counts = TraversalCounts {
+        limits,
+        invocation_count: 0,
         job_count: 0,
     };
     let mut active_paths = Vec::new();
-    expand_invocation(
-        &mut context,
-        InvocationRequest {
+    let mut policy = MaterializedCredentialPolicy {
+        context: &mut context,
+    };
+    traverse_reusable_invocation(
+        request.catalog,
+        &mut policy,
+        &mut counts,
+        TraversalNode {
+            workflow_path: &root_path,
+            plan: request.root_plan,
+            depth: 0,
+            source_digest: root_source_digest,
+            plan_digest: root_plan_digest,
+            root: true,
+        },
+        MaterializedTraversalSeed {
             id: request.root_invocation_id,
             parent_id: None,
             caller_job_id: None,
-            depth: 0,
-            workflow_path: &root_path,
-            source_digest: root_source_digest,
-            plan_digest: root_plan_digest,
-            plan: request.root_plan,
             permissions: root_permissions,
             inputs: Vec::new(),
             secrets: Vec::new(),
             available_secret_names: request.root_secret_names.clone(),
             outputs: root_outputs,
             caller_outputs: Vec::new(),
-            root: true,
         },
         &mut active_paths,
+        &|| false,
     )?;
 
     let digest = expansion_digest(
@@ -1119,161 +2044,12 @@ fn expand_reusable_workflow(
     })
 }
 
-struct InvocationRequest<'a> {
-    id: LogicalWorkflowInvocationId,
-    parent_id: Option<LogicalWorkflowInvocationId>,
-    caller_job_id: Option<LogicalWorkflowJobId>,
-    depth: usize,
-    workflow_path: &'a str,
-    source_digest: Sha256Digest,
-    plan_digest: Sha256Digest,
-    plan: &'a WorkflowPlan,
-    permissions: ReusableWorkflowPermissions,
-    inputs: Vec<ExpandedReusableInput>,
-    secrets: Vec<ExpandedReusableSecret>,
-    available_secret_names: BTreeSet<String>,
-    outputs: Vec<ExpandedReusableOutput>,
-    caller_outputs: Vec<ExpandedReusableOutputMapping>,
-    root: bool,
-}
-
-// Keeping the recursive push/pop and fail-closed edge construction together
-// makes the active-cycle stack and partially built ledger easier to audit.
-#[allow(clippy::too_many_lines)]
-fn expand_invocation(
-    context: &mut ExpansionContext<'_>,
-    request: InvocationRequest<'_>,
-    active_paths: &mut Vec<String>,
-) -> Result<(), ReusableWorkflowExpansionError> {
-    validate_reusable_workflow_depth(request.depth, context.limits.maximum_depth())?;
-    let projected_invocations = context
-        .invocations
-        .len()
-        .checked_add(1)
-        .ok_or(ReusableWorkflowExpansionError::InvocationLimitExceeded)?;
-    validate_reusable_workflow_invocation_count(
-        projected_invocations,
-        context.limits.maximum_invocations(),
-    )?;
-    if active_paths
-        .iter()
-        .any(|candidate| candidate == request.workflow_path)
-    {
-        return Err(ReusableWorkflowExpansionError::Cycle(
-            request.workflow_path.to_owned(),
-        ));
-    }
-    active_paths.push(request.workflow_path.to_owned());
-
-    let jobs = expanded_jobs(context, request.id, request.plan, request.root)?;
-    let invocation_index = context.invocations.len();
-    context
-        .invocations
-        .push(ReusableWorkflowInvocationExpansion {
-            id: request.id,
-            parent_id: request.parent_id,
-            caller_job_id: request.caller_job_id,
-            depth: u16::try_from(request.depth)
-                .map_err(|_| ReusableWorkflowExpansionError::DepthLimitExceeded)?,
-            workflow_path: request.workflow_path.to_owned(),
-            source_digest: request.source_digest,
-            plan_digest: request.plan_digest,
-            permissions: request.permissions.clone(),
-            inputs: request.inputs,
-            secrets: request.secrets,
-            outputs: request.outputs,
-            caller_outputs: request.caller_outputs,
-            jobs,
-        });
-
-    for job in request.plan.jobs() {
-        let LogicalJobKind::ReusableWorkflow(call) = job.execution() else {
-            continue;
-        };
-        if job.strategy().is_some() {
-            active_paths.pop();
-            return Err(ReusableWorkflowExpansionError::MatrixCallUnsupported);
-        }
-        let callee = context.catalog.resolve(call.reference().value())?;
-        if active_paths
-            .iter()
-            .any(|candidate| candidate == callee.path())
-        {
-            active_paths.pop();
-            return Err(ReusableWorkflowExpansionError::Cycle(
-                callee.path().to_owned(),
-            ));
-        }
-        let contract = callee.plan().logical().invocation().ok_or_else(|| {
-            ReusableWorkflowExpansionError::MissingInvocationContract(callee.path().to_owned())
-        })?;
-        let inputs = validate_inputs(call, contract)?;
-        let secrets = validate_secrets(call, contract, &request.available_secret_names)?;
-        let caller_outputs = validate_call_outputs(job.outputs(), contract)?;
-        let available_secret_names = secrets
-            .iter()
-            .map(|binding| binding.target.clone())
-            .collect();
-        let caller_job_id = context.invocations[invocation_index]
-            .jobs
-            .iter()
-            .find(|expanded| expanded.key() == job.key().value())
-            .map(ExpandedReusableJob::id)
-            .ok_or(ReusableWorkflowExpansionError::InvalidIdentity)?;
-        let invocation_id = derived_invocation_id(
-            context.run_id,
-            request.id,
-            caller_job_id,
-            callee.path(),
-            callee.source_digest(),
-        )?;
-        if !context.invocation_ids.insert(invocation_id.as_uuid()) {
-            active_paths.pop();
-            return Err(ReusableWorkflowExpansionError::IdentityCollision);
-        }
-        let permissions = request
-            .permissions
-            .reduce(job.permissions())
-            .reduce(callee.plan().logical().permissions());
-        let outputs = contract_outputs(contract);
-        expand_invocation(
-            context,
-            InvocationRequest {
-                id: invocation_id,
-                parent_id: Some(request.id),
-                caller_job_id: Some(caller_job_id),
-                depth: request.depth + 1,
-                workflow_path: callee.path(),
-                source_digest: callee.source_digest(),
-                plan_digest: callee.plan_digest(),
-                plan: callee.plan(),
-                permissions,
-                inputs,
-                secrets,
-                available_secret_names,
-                outputs,
-                caller_outputs,
-                root: false,
-            },
-            active_paths,
-        )?;
-    }
-    active_paths.pop();
-    Ok(())
-}
-
 fn expanded_jobs(
-    context: &mut ExpansionContext<'_>,
+    context: &mut ExpansionContext,
     invocation_id: LogicalWorkflowInvocationId,
     plan: &WorkflowPlan,
     root: bool,
 ) -> Result<Vec<ExpandedReusableJob>, ReusableWorkflowExpansionError> {
-    let projected_jobs = context
-        .job_count
-        .checked_add(plan.jobs().len())
-        .ok_or(ReusableWorkflowExpansionError::JobLimitExceeded)?;
-    validate_reusable_workflow_job_count(projected_jobs, context.limits.maximum_jobs())?;
-    context.job_count = projected_jobs;
     let mut ids = BTreeMap::new();
     for job in plan.jobs() {
         let id = if root {
@@ -1416,17 +2192,31 @@ fn validate_secrets(
                     ));
                 }
                 let source = binding.source().value().as_str();
-                if !available.contains(source) {
+                let Some(source) = available
+                    .iter()
+                    .find(|candidate| candidate.eq_ignore_ascii_case(source))
+                else {
                     return Err(ReusableWorkflowExpansionError::UnavailableSecret(
                         source.to_owned(),
                     ));
-                }
-                supplied.insert(target, source.to_owned());
+                };
+                supplied.insert(target, source.clone());
             }
         }
         ReusableSecretForwarding::Inherit(_) => {
             for source in available {
                 supplied.insert(source.as_str(), source.clone());
+            }
+            for definition in contract.secrets() {
+                let target = definition.key().value().as_str();
+                let Some(source) = available
+                    .iter()
+                    .find(|candidate| candidate.eq_ignore_ascii_case(target))
+                else {
+                    continue;
+                };
+                supplied.remove(source.as_str());
+                supplied.insert(target, source.clone());
             }
         }
     }
@@ -1548,13 +2338,48 @@ const fn minimum_permission(left: PermissionLevel, right: PermissionLevel) -> Pe
     }
 }
 
-fn compile_github_source(
+fn compile_reusable_source(
+    repository: &str,
+    revision: &str,
+    path: &str,
+    source: &[u8],
+) -> Result<WorkflowPlan, ReusableWorkflowExpansionError> {
+    compile_source(
+        repository,
+        revision,
+        path,
+        source,
+        ReusableCompilationSelection::GithubWorkflowCall,
+    )
+}
+
+fn recompile_root_source(
     repository: &str,
     revision: &str,
     path: &str,
     source: &[u8],
     event: automata_ci_core::WorkflowEventProvenance,
-    preselected: bool,
+) -> Result<WorkflowPlan, ReusableWorkflowExpansionError> {
+    compile_source(
+        repository,
+        revision,
+        path,
+        source,
+        ReusableCompilationSelection::GithubPreselected(event),
+    )
+}
+
+enum ReusableCompilationSelection {
+    GithubPreselected(automata_ci_core::WorkflowEventProvenance),
+    GithubWorkflowCall,
+}
+
+fn compile_source(
+    repository: &str,
+    revision: &str,
+    path: &str,
+    source: &[u8],
+    selection: ReusableCompilationSelection,
 ) -> Result<WorkflowPlan, ReusableWorkflowExpansionError> {
     let source = std::str::from_utf8(source)
         .map_err(|_| ReusableWorkflowExpansionError::InvalidSourceEncoding)?;
@@ -1576,10 +2401,15 @@ fn compile_github_source(
     let source_plan = parsed
         .plan()
         .ok_or_else(|| ReusableWorkflowExpansionError::FrontendRejected("no plan".to_owned()))?;
-    let request = if preselected {
-        CompileWorkflowRequest::for_preselected_event(source_plan, event)
-    } else {
-        CompileWorkflowRequest::new(source_plan, event)
+    let request = match selection {
+        ReusableCompilationSelection::GithubPreselected(event) => {
+            CompileWorkflowRequest::for_preselected_event(source_plan, event)
+        }
+        ReusableCompilationSelection::GithubWorkflowCall => CompileWorkflowRequest::new(
+            source_plan,
+            automata_ci_core::WorkflowEventProvenance::new("github", "workflow_call")
+                .with_commit_sha(revision),
+        ),
     };
     let compiled = GithubWorkflowCompiler::new().compile(request);
     if !compiled.is_accepted() {
@@ -1595,6 +2425,7 @@ fn compile_github_source(
 
 fn validate_plan_origin(
     plan: &WorkflowPlan,
+    authority: CatalogSourceAuthority,
     repository: &str,
     revision: &str,
     path: &str,
@@ -1607,7 +2438,7 @@ fn validate_plan_origin(
     else {
         return Err(ReusableWorkflowExpansionError::RootPlanMismatch);
     };
-    if plan.source().provider() != "github"
+    if plan.source().provider() != authority.provider()
         || plan.source().source_id() != path
         || plan_repository != repository
         || plan_revision != revision
@@ -1618,7 +2449,10 @@ fn validate_plan_origin(
     Ok(())
 }
 
-fn canonical_workflow_path(value: &str) -> Result<String, ReusableWorkflowExpansionError> {
+fn canonical_workflow_path(
+    value: &str,
+    workflow_location: RepositoryWorkflowLocation,
+) -> Result<String, ReusableWorkflowExpansionError> {
     validate_reusable_workflow_path_bytes(value.len())?;
     if value.is_empty()
         || value.starts_with('/')
@@ -1633,7 +2467,11 @@ fn canonical_workflow_path(value: &str) -> Result<String, ReusableWorkflowExpans
         return Err(ReusableWorkflowExpansionError::InvalidWorkflowPath);
     };
     let extension = Path::new(file).extension();
-    if *dot_ci != ".ci"
+    let expected_directory = match workflow_location {
+        RepositoryWorkflowLocation::Automata => ".ci",
+        RepositoryWorkflowLocation::Github => ".github",
+    };
+    if *dot_ci != expected_directory
         || *workflows != "workflows"
         || file.is_empty()
         || *file == "."
@@ -1645,14 +2483,21 @@ fn canonical_workflow_path(value: &str) -> Result<String, ReusableWorkflowExpans
     Ok(value.to_owned())
 }
 
-fn resolve_local_reference(reference: &str) -> Result<String, ReusableWorkflowExpansionError> {
-    let Some(file) = reference.strip_prefix("./.ci/workflows/") else {
+fn resolve_local_reference(
+    reference: &str,
+    workflow_location: RepositoryWorkflowLocation,
+) -> Result<String, ReusableWorkflowExpansionError> {
+    let prefix = match workflow_location {
+        RepositoryWorkflowLocation::Automata => "./.ci/workflows/",
+        RepositoryWorkflowLocation::Github => "./.github/workflows/",
+    };
+    let Some(file) = reference.strip_prefix(prefix) else {
         return Err(ReusableWorkflowExpansionError::NonLocalReference);
     };
     if file.is_empty() || file.contains('/') || file.contains('\\') {
         return Err(ReusableWorkflowExpansionError::NonLocalReference);
     }
-    canonical_workflow_path(&format!(".ci/workflows/{file}"))
+    canonical_workflow_path(reference.trim_start_matches("./"), workflow_location)
         .map_err(|_| ReusableWorkflowExpansionError::NonLocalReference)
 }
 

--- a/crates/automata-ci-workflow-service/src/reusable_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/reusable_workflow.rs
@@ -731,12 +731,39 @@ pub fn analyze_local_github_archive(
     .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
     let root_plan_digest = digest_plan(compilation.root_plan())
         .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
+    let mut workflow_analyses = BTreeMap::new();
+    let root_analysis =
+        analyze_local_workflow(&root_path, false, compilation.root_plan(), cancellation).map_err(
+            |kind| LocalGithubArchiveAnalysisFailure {
+                kind,
+                diagnostics: diagnostics.clone(),
+            },
+        )?;
+    workflow_analyses.insert(root_path.clone(), root_analysis);
+    for reusable in compilation.reusable_workflows() {
+        let entry = analyze_local_workflow(reusable.path(), true, reusable.plan(), cancellation)
+            .map_err(|kind| LocalGithubArchiveAnalysisFailure {
+                kind,
+                diagnostics: diagnostics.clone(),
+            })?;
+        if workflow_analyses
+            .insert(reusable.path().to_owned(), entry)
+            .is_some()
+        {
+            return Err(local_reusable_failure(
+                &ReusableWorkflowExpansionError::InvalidIdentity,
+                diagnostics,
+            ));
+        }
+    }
     let mut counts = TraversalCounts {
         limits: reusable_limits,
         invocation_count: 0,
         job_count: 0,
     };
-    let mut policy = SymbolicCredentialPolicy;
+    let mut policy = SymbolicCredentialPolicy {
+        analyses: &workflow_analyses,
+    };
     let mut active_paths = Vec::new();
     let requirements = traverse_reusable_invocation(
         &catalog,
@@ -756,26 +783,10 @@ pub fn analyze_local_github_archive(
     )
     .map_err(|error| local_reusable_failure(&error, diagnostics.clone()))?;
 
-    let mut workflows = Vec::with_capacity(compilation.reusable_workflows().len() + 1);
-    workflows.push(
-        analyze_local_workflow(&root_path, false, compilation.root_plan(), cancellation).map_err(
-            |kind| LocalGithubArchiveAnalysisFailure {
-                kind,
-                diagnostics: diagnostics.clone(),
-            },
-        )?,
-    );
-    for reusable in compilation.reusable_workflows() {
-        workflows.push(
-            analyze_local_workflow(reusable.path(), true, reusable.plan(), cancellation).map_err(
-                |kind| LocalGithubArchiveAnalysisFailure {
-                    kind,
-                    diagnostics: diagnostics.clone(),
-                },
-            )?,
-        );
-    }
-    workflows.sort_by(|left, right| left.path.cmp(&right.path));
+    let workflows = workflow_analyses
+        .into_values()
+        .map(|analysis| analysis.workflow)
+        .collect();
 
     Ok(LocalGithubArchiveAnalysis {
         snapshot_digest: compilation.snapshot_digest(),
@@ -787,19 +798,31 @@ pub fn analyze_local_github_archive(
     })
 }
 
+struct AnalyzedLocalWorkflow {
+    workflow: LocalGithubAnalyzedWorkflow,
+    requirements: SymbolicCredentialRequirements,
+}
+
 fn analyze_local_workflow(
     path: &str,
     reusable: bool,
     plan: &WorkflowPlan,
     cancellation: &dyn Fn() -> bool,
-) -> Result<LocalGithubAnalyzedWorkflow, LocalGithubArchiveAnalysisFailureKind> {
+) -> Result<AnalyzedLocalWorkflow, LocalGithubArchiveAnalysisFailureKind> {
     let mut jobs = Vec::with_capacity(plan.jobs().len());
+    let mut requirements = SymbolicCredentialRequirements::default();
     for job in plan.jobs() {
         if cancellation() {
             return Err(LocalGithubArchiveAnalysisFailureKind::Cancelled);
         }
         let credentials = discover_job_credentials(plan.logical(), job)
             .map_err(|_| LocalGithubArchiveAnalysisFailureKind::CredentialDiscovery)?;
+        requirements
+            .external
+            .extend(credentials.external().secret_names().iter().cloned());
+        requirements
+            .built_in
+            .extend(credentials.built_in().iter().copied());
         jobs.push(LocalGithubAnalyzedJob {
             key: job.key().value().to_string(),
             reusable: matches!(job.execution(), LogicalJobKind::ReusableWorkflow(_)),
@@ -808,10 +831,23 @@ fn analyze_local_workflow(
             built_in_credentials: credentials.built_in().to_vec(),
         });
     }
-    Ok(LocalGithubAnalyzedWorkflow {
-        path: path.to_owned(),
-        reusable,
-        jobs,
+    if let Some(contract) = plan.logical().invocation() {
+        for secret in contract.secrets().iter().filter(|secret| secret.required()) {
+            let name = secret.key().value().as_str();
+            if let Some(requirement) = built_in_secret_requirement(name) {
+                requirements.built_in.insert(requirement);
+            } else {
+                requirements.external.insert(name.to_ascii_uppercase());
+            }
+        }
+    }
+    Ok(AnalyzedLocalWorkflow {
+        workflow: LocalGithubAnalyzedWorkflow {
+            path: path.to_owned(),
+            reusable,
+            jobs,
+        },
+        requirements,
     })
 }
 
@@ -1530,6 +1566,15 @@ struct TraversalNode<'a> {
     root: bool,
 }
 
+struct TraversalEdge<'node, 'catalog> {
+    job: &'node LogicalJobTemplate,
+    call: &'node ReusableWorkflowInvocation,
+    callee: ResolvedCatalogEntry<'catalog>,
+    contract: &'catalog WorkflowInvocationContract,
+    inputs: Vec<ExpandedReusableInput>,
+    outputs: Vec<ExpandedReusableOutputMapping>,
+}
+
 trait CredentialTraversalPolicy {
     type Seed;
     type State;
@@ -1545,11 +1590,7 @@ trait CredentialTraversalPolicy {
     fn prepare_edge(
         &mut self,
         parent: &mut Self::State,
-        job: &LogicalJobTemplate,
-        call: &ReusableWorkflowInvocation,
-        callee: ResolvedCatalogEntry<'_>,
-        inputs: Vec<ExpandedReusableInput>,
-        outputs: Vec<ExpandedReusableOutputMapping>,
+        edge: TraversalEdge<'_, '_>,
     ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError>;
 
     fn finish_edge(
@@ -1634,8 +1675,17 @@ where
             })?;
             let inputs = validate_inputs(call, contract)?;
             let outputs = validate_call_outputs(job.outputs(), contract)?;
-            let (child_seed, edge) =
-                policy.prepare_edge(&mut state, job, call, callee, inputs, outputs)?;
+            let (child_seed, edge) = policy.prepare_edge(
+                &mut state,
+                TraversalEdge {
+                    job,
+                    call,
+                    callee,
+                    contract,
+                    inputs,
+                    outputs,
+                },
+            )?;
             let child = traverse_reusable_invocation(
                 catalog,
                 policy,
@@ -1729,16 +1779,9 @@ impl CredentialTraversalPolicy for MaterializedCredentialPolicy<'_> {
     fn prepare_edge(
         &mut self,
         parent: &mut Self::State,
-        job: &LogicalJobTemplate,
-        call: &ReusableWorkflowInvocation,
-        callee: ResolvedCatalogEntry<'_>,
-        inputs: Vec<ExpandedReusableInput>,
-        caller_outputs: Vec<ExpandedReusableOutputMapping>,
+        edge: TraversalEdge<'_, '_>,
     ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError> {
-        let contract = callee.plan.logical().invocation().ok_or_else(|| {
-            ReusableWorkflowExpansionError::MissingInvocationContract(callee.path.to_owned())
-        })?;
-        let secrets = validate_secrets(call, contract, &parent.available_secret_names)?;
+        let secrets = validate_secrets(edge.call, edge.contract, &parent.available_secret_names)?;
         let available_secret_names = secrets
             .iter()
             .map(|binding| binding.target.clone())
@@ -1746,34 +1789,34 @@ impl CredentialTraversalPolicy for MaterializedCredentialPolicy<'_> {
         let caller_job_id = self.context.invocations[parent.invocation_index]
             .jobs
             .iter()
-            .find(|expanded| expanded.key() == job.key().value())
+            .find(|expanded| expanded.key() == edge.job.key().value())
             .map(ExpandedReusableJob::id)
             .ok_or(ReusableWorkflowExpansionError::InvalidIdentity)?;
         let invocation_id = derived_invocation_id(
             self.context.run_id,
             parent.id,
             caller_job_id,
-            callee.path,
-            callee.source_digest,
+            edge.callee.path,
+            edge.callee.source_digest,
         )?;
         if !self.context.invocation_ids.insert(invocation_id.as_uuid()) {
             return Err(ReusableWorkflowExpansionError::IdentityCollision);
         }
         let permissions = parent
             .permissions
-            .reduce(job.permissions())
-            .reduce(callee.plan.logical().permissions());
+            .reduce(edge.job.permissions())
+            .reduce(edge.callee.plan.logical().permissions());
         Ok((
             MaterializedTraversalSeed {
                 id: invocation_id,
                 parent_id: Some(parent.id),
                 caller_job_id: Some(caller_job_id),
                 permissions,
-                inputs,
+                inputs: edge.inputs,
                 secrets,
                 available_secret_names,
-                outputs: contract_outputs(contract),
-                caller_outputs,
+                outputs: contract_outputs(edge.contract),
+                caller_outputs: edge.outputs,
             },
             (),
         ))
@@ -1806,15 +1849,17 @@ enum SymbolicSecretSource {
     BuiltIn(BuiltInCredentialRequirement),
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct SymbolicCredentialRequirements {
     external: BTreeSet<String>,
     built_in: BTreeSet<BuiltInCredentialRequirement>,
 }
 
-struct SymbolicCredentialPolicy;
+struct SymbolicCredentialPolicy<'a> {
+    analyses: &'a BTreeMap<String, AnalyzedLocalWorkflow>,
+}
 
-impl CredentialTraversalPolicy for SymbolicCredentialPolicy {
+impl CredentialTraversalPolicy for SymbolicCredentialPolicy<'_> {
     type Seed = ();
     type State = SymbolicCredentialRequirements;
     type Edge = SymbolicSecretEdge;
@@ -1825,43 +1870,18 @@ impl CredentialTraversalPolicy for SymbolicCredentialPolicy {
         node: &TraversalNode<'_>,
         (): Self::Seed,
     ) -> Result<Self::State, ReusableWorkflowExpansionError> {
-        let mut required = SymbolicCredentialRequirements::default();
-        for job in node.plan.jobs() {
-            let credentials = discover_job_credentials(node.plan.logical(), job)
-                .map_err(|_| ReusableWorkflowExpansionError::CredentialRequirements)?;
-            required
-                .external
-                .extend(credentials.external().secret_names().iter().cloned());
-            required
-                .built_in
-                .extend(credentials.built_in().iter().copied());
-        }
-        if let Some(contract) = node.plan.logical().invocation() {
-            for secret in contract.secrets().iter().filter(|secret| secret.required()) {
-                let name = secret.key().value().as_str();
-                if let Some(requirement) = built_in_secret_requirement(name) {
-                    required.built_in.insert(requirement);
-                } else {
-                    required.external.insert(name.to_ascii_uppercase());
-                }
-            }
-        }
-        Ok(required)
+        self.analyses
+            .get(node.workflow_path)
+            .map(|analysis| analysis.requirements.clone())
+            .ok_or(ReusableWorkflowExpansionError::InvalidIdentity)
     }
 
     fn prepare_edge(
         &mut self,
         _parent: &mut Self::State,
-        _job: &LogicalJobTemplate,
-        call: &ReusableWorkflowInvocation,
-        callee: ResolvedCatalogEntry<'_>,
-        _inputs: Vec<ExpandedReusableInput>,
-        _outputs: Vec<ExpandedReusableOutputMapping>,
+        edge: TraversalEdge<'_, '_>,
     ) -> Result<(Self::Seed, Self::Edge), ReusableWorkflowExpansionError> {
-        let contract = callee.plan.logical().invocation().ok_or_else(|| {
-            ReusableWorkflowExpansionError::MissingInvocationContract(callee.path.to_owned())
-        })?;
-        Ok(((), symbolic_secret_edge(call, contract)?))
+        Ok(((), symbolic_secret_edge(edge.call, edge.contract)?))
     }
 
     fn finish_edge(
@@ -2365,12 +2385,12 @@ fn recompile_root_source(
         revision,
         path,
         source,
-        ReusableCompilationSelection::GithubPreselected(event),
+        ReusableCompilationSelection::GithubPreselected(Box::new(event)),
     )
 }
 
 enum ReusableCompilationSelection {
-    GithubPreselected(automata_ci_core::WorkflowEventProvenance),
+    GithubPreselected(Box<automata_ci_core::WorkflowEventProvenance>),
     GithubWorkflowCall,
 }
 
@@ -2403,7 +2423,7 @@ fn compile_source(
         .ok_or_else(|| ReusableWorkflowExpansionError::FrontendRejected("no plan".to_owned()))?;
     let request = match selection {
         ReusableCompilationSelection::GithubPreselected(event) => {
-            CompileWorkflowRequest::for_preselected_event(source_plan, event)
+            CompileWorkflowRequest::for_preselected_event(source_plan, *event)
         }
         ReusableCompilationSelection::GithubWorkflowCall => CompileWorkflowRequest::new(
             source_plan,

--- a/crates/automata-ci-workflow-service/src/service.rs
+++ b/crates/automata-ci-workflow-service/src/service.rs
@@ -676,7 +676,10 @@ fn build_command(
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             let credential_requirements =
-                crate::discover_job_credential_requirements(request.plan().logical(), job)?;
+                crate::credential_requirements::discover_external_job_credentials(
+                    request.plan().logical(),
+                    job,
+                )?;
             AdmittedLogicalWorkflowJob::new(id, key, source_order, kind, prerequisites)
                 .map(|job| job.with_credential_requirements(credential_requirements))
                 .map_err(WorkflowAdmissionError::LogicalValue)
@@ -952,10 +955,11 @@ fn prepare_reusable_workflow_expansion(
                     .iter()
                     .find(|candidate| candidate.key().value() == job.key())
                     .ok_or(WorkflowAdmissionError::Internal)?;
-                let credential_requirements = crate::discover_job_credential_requirements(
-                    invocation_plan.logical(),
-                    logical_job,
-                )?;
+                let credential_requirements =
+                    crate::credential_requirements::discover_external_job_credentials(
+                        invocation_plan.logical(),
+                        logical_job,
+                    )?;
                 Ok(AdmittedReusableJob::new(
                     job.id(),
                     job.key().clone(),

--- a/crates/automata-ci-workflow-service/tests/reusable_workflow.rs
+++ b/crates/automata-ci-workflow-service/tests/reusable_workflow.rs
@@ -236,6 +236,16 @@ jobs:
         "    secrets:\n      token: ${{ secrets.ROOT_TOKEN }}\n",
         "    secrets: inherit\n",
     );
+    let available_required = BTreeSet::from(["TOKEN".to_owned()]);
+    let satisfied = expand_with_secrets(
+        &required_inherit,
+        &required_catalog,
+        &available_required,
+        None,
+    )
+    .expect("case-insensitive inherited secret satisfies the declared contract");
+    assert_eq!(satisfied.invocations()[1].secrets()[0].target(), "token");
+    assert_eq!(satisfied.invocations()[1].secrets()[0].source(), "TOKEN");
     assert_eq!(
         expand_with_secrets(&required_inherit, &required_catalog, &BTreeSet::new(), None,),
         Err(ReusableWorkflowExpansionError::MissingRequiredSecret(

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::{fmt, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use clap::{Args, Subcommand, ValueEnum};
 use uuid::Uuid;
@@ -64,6 +64,8 @@ pub struct LocalArgs {
 pub enum LocalCommand {
     /// Check this host without creating containers or local state.
     Doctor(LocalDoctorArgs),
+    /// Validate one exact local workflow without admission or execution.
+    Check(LocalCheckArgs),
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum, serde::Serialize)]
@@ -87,6 +89,65 @@ pub struct LocalDoctorArgs {
     /// Render one stable JSON document instead of a human-readable report.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+/// Read-only exact-snapshot workflow validation options.
+pub struct LocalCheckArgs {
+    /// Canonical repository-relative workflow path; omit only when exactly one exists.
+    pub workflow: Option<String>,
+    /// Manual-dispatch input in `NAME=VALUE` form.
+    #[arg(long = "input", value_name = "NAME=VALUE")]
+    pub inputs: Vec<LocalWorkflowInput>,
+    /// Render one stable JSON document instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One redacted local manual-dispatch input parsed from the command line.
+#[derive(Clone, Eq, PartialEq)]
+pub struct LocalWorkflowInput {
+    name: String,
+    value: String,
+}
+
+impl LocalWorkflowInput {
+    /// Returns the canonical input name candidate.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl FromStr for LocalWorkflowInput {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (name, value) = value
+            .split_once('=')
+            .ok_or("local workflow inputs must use NAME=VALUE")?;
+        if name.is_empty() {
+            return Err("local workflow input names must not be empty");
+        }
+        Ok(Self {
+            name: name.to_owned(),
+            value: value.to_owned(),
+        })
+    }
+}
+
+impl fmt::Debug for LocalWorkflowInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalWorkflowInput")
+            .field("name", &self.name)
+            .field("value", &"[redacted]")
+            .finish()
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/automata-ci/src/cli/mod.rs
+++ b/crates/automata-ci/src/cli/mod.rs
@@ -36,10 +36,11 @@ use clap::{CommandFactory, FromArgMatches, Parser, error::ErrorKind};
 
 pub use commands::{
     AdminArgs, AdminCommand, AuthArgs, AuthCommand, Command, DatabaseTransport,
-    EnvironmentReviewArgs, EnvironmentReviewDecision, LocalArgs, LocalCommand,
-    LocalContainerEngine, LocalDoctorArgs, OperatorArgs, PreviewArgs, RerunArgs, RerunSelection,
-    RunnerArgs, RunnerCommand, RunnerTokenArgs, SecretArgs, SecretCommand, SecretCreateArgs,
-    SecretDeleteArgs, SecretListArgs, SecretProviderArgs, SecretProviderCommand, ServerArgs,
+    EnvironmentReviewArgs, EnvironmentReviewDecision, LocalArgs, LocalCheckArgs, LocalCommand,
+    LocalContainerEngine, LocalDoctorArgs, LocalWorkflowInput, OperatorArgs, PreviewArgs,
+    RerunArgs, RerunSelection, RunnerArgs, RunnerCommand, RunnerTokenArgs, SecretArgs,
+    SecretCommand, SecretCreateArgs, SecretDeleteArgs, SecretListArgs, SecretProviderArgs,
+    SecretProviderCommand, ServerArgs,
 };
 pub use output::OutputFormat;
 pub use values::{RepositoryRef, SecretScope};

--- a/crates/automata-ci/src/local/mod.rs
+++ b/crates/automata-ci/src/local/mod.rs
@@ -1,15 +1,50 @@
 use anyhow::{Result, bail};
 use automata_ci_local::{
     ComposeFrontend, DoctorReport, DoctorRequest, Engine, EngineArchitecture, EngineEndpoint,
-    EngineRequest, inspect,
+    EngineRequest, LocalCheckReport, LocalCheckRequest, check_workflow, inspect,
 };
+use automata_ci_workflow_github::GithubWorkflowDispatchInputs;
+use automata_ci_workflow_service::BuiltInCredentialRequirement;
+use tokio_util::sync::CancellationToken;
 
-use crate::cli::{LocalArgs, LocalCommand, LocalContainerEngine, LocalDoctorArgs};
+use crate::cli::{LocalArgs, LocalCheckArgs, LocalCommand, LocalContainerEngine, LocalDoctorArgs};
 
 pub(crate) async fn execute(args: &LocalArgs) -> Result<()> {
     match &args.command {
         LocalCommand::Doctor(args) => Box::pin(doctor(args)).await,
+        LocalCommand::Check(args) => Box::pin(check(args)).await,
     }
+}
+
+async fn check(args: &LocalCheckArgs) -> Result<()> {
+    let inputs = GithubWorkflowDispatchInputs::try_new(
+        args.inputs
+            .iter()
+            .map(|input| (input.name().to_owned(), input.value().to_owned())),
+    )?;
+    let directory = std::env::current_dir()?;
+    let request = LocalCheckRequest::new(directory, args.workflow.clone(), inputs);
+    let cancellation = CancellationToken::new();
+    let mut checking = Box::pin(check_workflow(request, cancellation.clone()));
+    let report = tokio::select! {
+        biased;
+        () = crate::shutdown::wait_without_logging() => {
+            cancellation.cancel();
+            let _ = checking.await;
+            bail!("local workflow check interrupted by a process shutdown signal")
+        }
+        report = &mut checking => report,
+    };
+    if args.json {
+        serde_json::to_writer_pretty(std::io::stdout().lock(), &report)?;
+        println!();
+    } else {
+        print_human_check_report(&report);
+    }
+    if !report.valid() {
+        bail!("local workflow check failed; resolve the source issues above")
+    }
+    Ok(())
 }
 
 async fn doctor(args: &LocalDoctorArgs) -> Result<()> {
@@ -83,6 +118,92 @@ fn print_human_report(report: &DoctorReport) {
             issue.code(),
             issue.message()
         );
+    }
+}
+
+fn print_human_check_report(report: &LocalCheckReport) {
+    println!(
+        "Automata local workflow check: {}",
+        if report.valid() { "valid" } else { "invalid" }
+    );
+    if let Some(source) = report.source() {
+        println!(
+            "Snapshot: {} ({})",
+            source.snapshot_digest(),
+            if source.dirty() {
+                "dirty worktree"
+            } else {
+                "clean worktree"
+            }
+        );
+        if let Some(path) = source.workflow_path() {
+            println!("Workflow: {path}");
+        }
+    }
+    if !report.required_root_secrets().is_empty() {
+        println!(
+            "Required root secrets: {}",
+            report.required_root_secrets().join(", ")
+        );
+    }
+    if !report.required_built_in_credentials().is_empty() {
+        println!(
+            "Provider built-ins required: {} (not supplied by local check)",
+            report
+                .required_built_in_credentials()
+                .iter()
+                .map(|requirement| built_in_credential_name(*requirement))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    for workflow in report.workflows() {
+        println!(
+            "{}: {}",
+            if workflow.reusable() {
+                "Reusable workflow"
+            } else {
+                "Root workflow"
+            },
+            workflow.path()
+        );
+        for job in workflow.jobs() {
+            println!("  Job: {} ({})", job.id(), job.kind());
+            if !job.secrets().is_empty() {
+                println!("    Secrets: {}", job.secrets().join(", "));
+            }
+            if !job.variables().is_empty() {
+                println!("    Variables: {}", job.variables().join(", "));
+            }
+            if !job.built_in_credentials().is_empty() {
+                println!(
+                    "    Provider built-ins: {}",
+                    job.built_in_credentials()
+                        .iter()
+                        .map(|requirement| built_in_credential_name(*requirement))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+        }
+    }
+    for diagnostic in report.diagnostics() {
+        println!(
+            "Diagnostic ({}): {}:{}:{}",
+            diagnostic.code(),
+            diagnostic.source(),
+            diagnostic.line(),
+            diagnostic.column()
+        );
+    }
+    if let Some(issue) = report.issue() {
+        println!("Problem ({}): {}", issue.code().as_str(), issue.message());
+    }
+}
+
+const fn built_in_credential_name(requirement: BuiltInCredentialRequirement) -> &'static str {
+    match requirement {
+        BuiltInCredentialRequirement::GithubToken => "github_token",
     }
 }
 

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -35,7 +35,9 @@ fn local_doctor_is_an_explicit_read_only_preflight() {
     let Command::Local(local) = cli.command else {
         panic!("local command expected");
     };
-    let LocalCommand::Doctor(args) = local.command;
+    let LocalCommand::Doctor(args) = local.command else {
+        panic!("local doctor command expected");
+    };
     assert_eq!(args.engine, LocalContainerEngine::Docker);
     assert!(args.json);
 
@@ -68,6 +70,41 @@ fn local_doctor_is_an_explicit_read_only_preflight() {
         ])
         .is_err(),
         "engine-owned local state must not expose a host state-directory option"
+    );
+}
+
+#[test]
+fn local_check_is_explicit_source_only_workflow_dispatch_validation() {
+    let cli = Cli::try_parse_from([
+        "automata",
+        "local",
+        "check",
+        ".github/workflows/ci.yml",
+        "--input",
+        "target=staging",
+        "--json",
+    ])
+    .expect("local check must parse");
+    let Command::Local(local) = cli.command else {
+        panic!("local command expected");
+    };
+    let LocalCommand::Check(args) = local.command else {
+        panic!("local check command expected");
+    };
+    assert_eq!(args.workflow.as_deref(), Some(".github/workflows/ci.yml"));
+    assert_eq!(args.inputs.len(), 1);
+    assert_eq!(args.inputs[0].name(), "target");
+    assert!(args.json);
+    assert!(format!("{args:?}").contains("target"));
+    assert!(!format!("{args:?}").contains("staging"));
+
+    assert!(
+        Cli::try_parse_from(["automata", "local", "check", "--event", "push"]).is_err(),
+        "local check must not fabricate provider event evidence"
+    );
+    assert!(
+        Cli::try_parse_from(["automata", "local", "check", "--input", "missing-separator"])
+            .is_err()
     );
 }
 

--- a/crates/automata-ci/tests/local_check_process.rs
+++ b/crates/automata-ci/tests/local_check_process.rs
@@ -1,0 +1,515 @@
+use std::{fs, path::Path, process::Command};
+
+#[cfg(unix)]
+use std::{
+    os::unix::fs::PermissionsExt as _,
+    os::unix::net::UnixListener,
+    path::PathBuf,
+    process::Stdio,
+    thread,
+    time::{Duration, Instant},
+};
+
+#[cfg(unix)]
+use rustix::process::{Pid, Signal, kill_process};
+
+use serde_json::Value;
+use uuid::Uuid;
+
+#[test]
+fn local_check_process_is_deterministic_read_only_and_redacts_input_values() {
+    let fixture = Fixture::new();
+    fixture.write(
+        ".github/workflows/check.yml",
+        r"on:
+  workflow_dispatch:
+    inputs:
+      token_hint:
+        type: string
+        required: true
+jobs:
+  check:
+    runs-on: linux
+    steps:
+      - run: echo '${{ secrets.api_token }}' '${{ vars.region }}'
+",
+    );
+    fixture.commit_all();
+    fixture.write("dirty.txt", "uncommitted exact bytes\n");
+    let status_before = fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]);
+    let sensitive = "local-input-value-must-not-appear";
+    let environment_marker = "local-environment-value-must-not-appear";
+
+    let first = fixture.automata_with_hostile_service_environment(&[
+        "local",
+        "check",
+        "--input",
+        &format!("token_hint={sensitive}"),
+        "--json",
+    ]);
+    let repeated = fixture.automata_with_hostile_service_environment(&[
+        "local",
+        "check",
+        "--input",
+        &format!("token_hint={sensitive}"),
+        "--json",
+    ]);
+
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert!(repeated.status.success());
+    assert_eq!(first.stdout, repeated.stdout);
+    assert!(
+        !first
+            .stdout
+            .windows(sensitive.len())
+            .any(|window| window == sensitive.as_bytes())
+    );
+    assert!(!String::from_utf8_lossy(&first.stdout).contains(environment_marker));
+    assert!(!String::from_utf8_lossy(&first.stderr).contains(environment_marker));
+    assert!(
+        !first
+            .stderr
+            .windows(sensitive.len())
+            .any(|window| window == sensitive.as_bytes())
+    );
+    assert!(
+        !first
+            .stdout
+            .windows(fixture.path().as_os_str().len())
+            .any(|window| window == fixture.path().to_string_lossy().as_bytes())
+    );
+    let document: Value = serde_json::from_slice(&first.stdout).expect("one JSON document");
+    assert_eq!(document["schema"], 1);
+    assert_eq!(document["valid"], true);
+    assert_eq!(document["source"]["dirty"], true);
+    assert_eq!(document["required_root_secrets"][0], "API_TOKEN");
+    assert_eq!(
+        document["workflows"][0]["jobs"][0]["secrets"][0],
+        "API_TOKEN"
+    );
+    assert_eq!(
+        document["workflows"][0]["jobs"][0]["variables"][0],
+        "REGION"
+    );
+    assert_eq!(
+        fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]),
+        status_before,
+        "local check must not mutate Git or the worktree"
+    );
+
+    let human = fixture.automata_with_hostile_service_environment(&[
+        "local",
+        "check",
+        "--input",
+        &format!("token_hint={sensitive}"),
+    ]);
+    assert!(human.status.success());
+    let human_stdout = String::from_utf8_lossy(&human.stdout);
+    let human_stderr = String::from_utf8_lossy(&human.stderr);
+    assert!(!human_stdout.contains(sensitive));
+    assert!(!human_stderr.contains(sensitive));
+    assert!(!human_stdout.contains(environment_marker));
+    assert!(!human_stderr.contains(environment_marker));
+    assert!(!human_stdout.contains(fixture.path().to_string_lossy().as_ref()));
+}
+
+#[test]
+fn invalid_workflow_still_emits_one_value_free_json_report() {
+    let fixture = Fixture::new();
+    fixture.write(
+        ".github/workflows/check.yml",
+        "on: push\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+    );
+    fixture.commit_all();
+    let output = fixture.automata(&["local", "check", "--json"]);
+
+    assert!(!output.status.success());
+    let document: Value = serde_json::from_slice(&output.stdout).expect("failure JSON document");
+    assert_eq!(document["schema"], 1);
+    assert_eq!(document["valid"], false);
+    assert_eq!(document["issue"]["code"], "compilation");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr)
+            .contains(fixture.path().to_string_lossy().as_ref())
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn hostile_git_environment_cannot_execute_or_mutate_and_never_leaks() {
+    let fixture = Fixture::new();
+    fixture.write(
+        ".github/workflows/check.yml",
+        "on: workflow_dispatch\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+    );
+    fixture.commit_all();
+    let hostile = HostileGitEnvironment::new(&fixture);
+    let status_before = fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]);
+    let output = hostile.run(&fixture);
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!hostile.execution_marker.exists());
+    assert!(!hostile.trace.exists());
+    assert!(!hostile.trace2.exists());
+    assert!(!hostile.trace2_perf.exists());
+    assert!(
+        matches!(hostile.listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock)
+    );
+    assert_eq!(
+        fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]),
+        status_before,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("local check JSON");
+    let stderr = String::from_utf8(output.stderr).expect("local check stderr");
+    let fixture_path = fixture.path().to_string_lossy();
+    let hostile_path = hostile.root.to_string_lossy();
+    for private in [
+        fixture_path.as_ref(),
+        hostile_path.as_ref(),
+        HOSTILE_PRIVATE_VALUE,
+    ] {
+        assert!(!stdout.contains(private));
+        assert!(!stderr.contains(private));
+    }
+}
+
+#[cfg(unix)]
+const HOSTILE_PRIVATE_VALUE: &str = "hostile-git-private-environment-value";
+
+#[cfg(unix)]
+struct HostileGitEnvironment {
+    root: PathBuf,
+    fake_bin: PathBuf,
+    home: PathBuf,
+    xdg: PathBuf,
+    global_config: PathBuf,
+    system_config: PathBuf,
+    helper: PathBuf,
+    execution_marker: PathBuf,
+    trace: PathBuf,
+    trace2: PathBuf,
+    trace2_perf: PathBuf,
+    socket_path: PathBuf,
+    listener: UnixListener,
+    _socket_guard: SocketFileGuard,
+}
+
+#[cfg(unix)]
+impl HostileGitEnvironment {
+    fn new(fixture: &Fixture) -> Self {
+        let root = fixture.path().join("hostile-git-environment");
+        let fake_bin = root.join("bin");
+        let home = root.join("home");
+        let xdg = root.join("xdg");
+        let markers = root.join("markers");
+        for directory in [&fake_bin, &home, &xdg, &markers] {
+            fs::create_dir_all(directory).expect("create hostile fixture directory");
+        }
+        let execution_marker = markers.join("executed");
+        install_marker_program(&fake_bin.join("git"), &execution_marker);
+        let helper = root.join("host-helper");
+        install_marker_program(&helper, &execution_marker);
+        let hooks = root.join("hooks");
+        fs::create_dir(&hooks).expect("create hostile hooks directory");
+        install_marker_program(&hooks.join("post-index-change"), &execution_marker);
+        let global_config = root.join("global.gitconfig");
+        let system_config = root.join("system.gitconfig");
+        let config = format!(
+            "[core]\n\tfsmonitor = {}\n\thooksPath = {}\n[credential]\n\thelper = !{}\n[maintenance]\n\tauto = true\n",
+            helper.display(),
+            hooks.display(),
+            helper.display(),
+        );
+        fs::write(&global_config, &config).expect("write hostile global config");
+        fs::write(&system_config, &config).expect("write hostile system config");
+        let trace = root.join("git-trace-private-path-marker");
+        let trace2 = root.join("git-trace2-private-path-marker");
+        let trace2_perf = root.join("git-trace2-perf-private-path-marker");
+        let socket_path = std::env::temp_dir().join(format!(
+            "automata-local-check-{}.socket",
+            Uuid::new_v4().simple()
+        ));
+        let listener = UnixListener::bind(&socket_path).expect("bind hostile trace2 socket");
+        listener
+            .set_nonblocking(true)
+            .expect("make trace2 listener nonblocking");
+        let socket_guard = SocketFileGuard(socket_path.clone());
+        Self {
+            root,
+            fake_bin,
+            home,
+            xdg,
+            global_config,
+            system_config,
+            helper,
+            execution_marker,
+            trace,
+            trace2,
+            trace2_perf,
+            socket_path,
+            listener,
+            _socket_guard: socket_guard,
+        }
+    }
+
+    fn run(&self, fixture: &Fixture) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_automata"))
+            .current_dir(fixture.path())
+            .args(["local", "check", "--json"])
+            .env("PATH", &self.fake_bin)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", &self.xdg)
+            .env("GIT_CONFIG_GLOBAL", &self.global_config)
+            .env("GIT_CONFIG_SYSTEM", &self.system_config)
+            .env("GIT_CONFIG_NOSYSTEM", "0")
+            .env("GIT_CONFIG_COUNT", "1")
+            .env("GIT_CONFIG_KEY_0", "core.fsmonitor")
+            .env("GIT_CONFIG_VALUE_0", &self.helper)
+            .env("GIT_DIR", self.root.join("fake.git"))
+            .env("GIT_COMMON_DIR", self.root.join("fake-common.git"))
+            .env("GIT_WORK_TREE", &self.root)
+            .env("GIT_INDEX_FILE", self.root.join("fake-index"))
+            .env("GIT_OBJECT_DIRECTORY", self.root.join("fake-objects"))
+            .env(
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+                self.root.join("fake-alternates"),
+            )
+            .env("GIT_NAMESPACE", HOSTILE_PRIVATE_VALUE)
+            .env("GIT_SHALLOW_FILE", self.root.join("fake-shallow"))
+            .env("GIT_REPLACE_REF_BASE", HOSTILE_PRIVATE_VALUE)
+            .env("GIT_EXEC_PATH", &self.fake_bin)
+            .env("GIT_PAGER", &self.helper)
+            .env("GIT_EDITOR", &self.helper)
+            .env("GIT_SEQUENCE_EDITOR", &self.helper)
+            .env("GIT_ASKPASS", &self.helper)
+            .env("SSH_ASKPASS", &self.helper)
+            .env("GIT_SSH_COMMAND", &self.helper)
+            .env("GIT_TRACE", &self.trace)
+            .env("GIT_TRACE_PACKET", &self.trace)
+            .env("GIT_TRACE_PERFORMANCE", &self.trace)
+            .env("GIT_TRACE_SETUP", &self.trace)
+            .env("GIT_TRACE_SHALLOW", &self.trace)
+            .env("GIT_TRACE_CURL", &self.trace)
+            .env("GIT_TRACE2", &self.trace2)
+            .env("GIT_TRACE2_PERF", &self.trace2_perf)
+            .env(
+                "GIT_TRACE2_EVENT",
+                format!("af_unix:{}", self.socket_path.display()),
+            )
+            .env("AUTOMATA_HOSTILE_PRIVATE", HOSTILE_PRIVATE_VALUE)
+            .output()
+            .expect("run hostile-environment local check")
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupting_large_capture_awaits_shutdown_and_leaves_no_residue() {
+    let fixture = Fixture::new();
+    fixture.write(
+        ".github/workflows/check.yml",
+        "on: workflow_dispatch\njobs:\n  check:\n    runs-on: linux\n    steps:\n      - run: true\n",
+    );
+    fixture.write_binary("large-source.bin", deterministic_bytes(28 * 1024 * 1024));
+    fixture.commit_all();
+    let status_before = fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]);
+    let entries_before = fixture.root_entries();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_automata"))
+        .current_dir(fixture.path())
+        .args(["local", "check", "--json"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start large local check");
+    thread::sleep(Duration::from_millis(20));
+    let raw_pid = i32::try_from(child.id()).expect("child PID fits pid_t");
+    let pid = Pid::from_raw(raw_pid).expect("nonzero child PID");
+    kill_process(pid, Signal::INT).expect("interrupt local check");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().expect("poll local check").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("interrupted local check did not await bounded worker shutdown");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    let output = child
+        .wait_with_output()
+        .expect("collect interrupted local check");
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "interruption must not emit partial JSON"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("interruption diagnostics");
+    assert!(stderr.contains("local workflow check interrupted by a process shutdown signal"));
+    assert!(!stderr.contains(fixture.path().to_string_lossy().as_ref()));
+    assert_eq!(fixture.root_entries(), entries_before);
+    assert_eq!(
+        fixture.git_stdout(&["status", "--porcelain=v2", "--untracked-files=all"]),
+        status_before,
+    );
+}
+
+#[cfg(unix)]
+fn install_marker_program(path: &Path, marker: &Path) {
+    fs::write(
+        path,
+        format!("#!/bin/sh\n: > '{}'\nexit 97\n", marker.display()),
+    )
+    .expect("write hostile program");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .expect("make hostile program executable");
+}
+
+#[cfg(unix)]
+fn deterministic_bytes(length: usize) -> Vec<u8> {
+    let mut state = 0x9e37_79b9_u32;
+    let mut bytes = Vec::with_capacity(length);
+    for _ in 0..length {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        bytes.push(state.to_le_bytes()[0]);
+    }
+    bytes
+}
+
+#[cfg(unix)]
+struct SocketFileGuard(std::path::PathBuf);
+
+#[cfg(unix)]
+impl Drop for SocketFileGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+struct Fixture {
+    root: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "automata-local-check-process-{}",
+            Uuid::new_v4().simple()
+        ));
+        fs::create_dir(&root).expect("create fixture");
+        let fixture = Self { root };
+        fixture.git(&["init", "--quiet"]);
+        fixture.git(&["config", "user.name", "Automata Test"]);
+        fixture.git(&["config", "user.email", "automata@example.invalid"]);
+        fixture
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+
+    fn write(&self, path: &str, value: &str) {
+        let path = self.root.join(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        fs::write(path, value).expect("write fixture");
+    }
+
+    #[cfg(unix)]
+    fn write_binary(&self, path: &str, value: Vec<u8>) {
+        let path = self.root.join(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        fs::write(path, value).expect("write binary fixture");
+    }
+
+    #[cfg(unix)]
+    fn root_entries(&self) -> Vec<String> {
+        let mut entries = fs::read_dir(&self.root)
+            .expect("read fixture root")
+            .map(|entry| {
+                entry
+                    .expect("read fixture entry")
+                    .file_name()
+                    .into_string()
+                    .expect("Unicode fixture entry")
+            })
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries
+    }
+
+    fn commit_all(&self) {
+        self.git(&["add", "--all"]);
+        self.git(&["commit", "--quiet", "--message", "fixture"]);
+    }
+
+    fn git(&self, arguments: &[&str]) {
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&self.root)
+                .args(arguments)
+                .status()
+                .expect("run Git")
+                .success()
+        );
+    }
+
+    fn git_stdout(&self, arguments: &[&str]) -> Vec<u8> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&self.root)
+            .args(arguments)
+            .output()
+            .expect("run Git");
+        assert!(output.status.success());
+        output.stdout
+    }
+
+    fn automata(&self, arguments: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_automata"))
+            .current_dir(&self.root)
+            .args(arguments)
+            .output()
+            .expect("run automata")
+    }
+
+    fn automata_with_hostile_service_environment(
+        &self,
+        arguments: &[&str],
+    ) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_automata"))
+            .current_dir(&self.root)
+            .args(arguments)
+            .env("DOCKER_HOST", "tcp://127.0.0.1:1")
+            .env("GITHUB_TOKEN", "local-environment-value-must-not-appear")
+            .env("GH_TOKEN", "local-environment-value-must-not-appear")
+            .env("HTTP_PROXY", "http://127.0.0.1:1")
+            .env("HTTPS_PROXY", "http://127.0.0.1:1")
+            .output()
+            .expect("run service-independent local check")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -296,6 +296,23 @@ and the worker composition remain planned; follow the
 [local installation and deployment roadmap](maintainers/roadmaps/local-installation.md) for
 their merge and host-qualification gates.
 
+The internal local-source foundation seals tracked and non-ignored live bytes
+through pinned, no-follow ancestor handles and feeds every exact digest-bound
+archive through source-policy-specific workflow discovery. Git mode normalizes
+tracked symlinks across native Unix links and Windows placeholders; Windows
+reparse points and junctions fail closed. Sparse and assume-unchanged index
+flags cannot hide live bytes, ignored paths are classified in bounded batches,
+and portable path identity uses a bounded Unicode-normalized full-case-folded
+component trie. Its adversarial fixture suite is available with:
+
+```console
+cargo test --locked -p automata-ci-local snapshot::tests
+```
+
+There is deliberately no `automata local check` command yet. Exact local event
+semantics, same-tree reusable-workflow compilation, and admission must land
+together before that public validation surface is truthful.
+
 The opt-in live adapter contract creates one randomly named identity volume,
 adopts the same UUID through the public adapter, then re-inspects and removes
 only that exact unattached fixture:

--- a/docs/development.md
+++ b/docs/development.md
@@ -296,22 +296,45 @@ and the worker composition remain planned; follow the
 [local installation and deployment roadmap](maintainers/roadmaps/local-installation.md) for
 their merge and host-qualification gates.
 
-The internal local-source foundation seals tracked and non-ignored live bytes
-through pinned, no-follow ancestor handles and feeds every exact digest-bound
-archive through source-policy-specific workflow discovery. Git mode normalizes
-tracked symlinks across native Unix links and Windows placeholders; Windows
-reparse points and junctions fail closed. Sparse and assume-unchanged index
-flags cannot hide live bytes, ignored paths are classified in bounded batches,
-and portable path identity uses a bounded Unicode-normalized full-case-folded
-component trie. Its adversarial fixture suite is available with:
+The local-source path seals tracked and non-ignored live bytes through pinned,
+no-follow ancestor handles and feeds the exact digest-bound archive through the
+shared workflow discovery policy. Git mode normalizes tracked symlinks across
+native Unix links and placeholders. Sparse and assume-unchanged index flags
+cannot hide live bytes, ignored paths are classified in bounded batches, and
+portable path identity uses a bounded Unicode-normalized full-case-folded
+component trie. The current checkpoint fails closed on Windows until exact
+native mutation evidence is qualified. Its adversarial fixture suite is
+available with:
 
 ```console
 cargo test --locked -p automata-ci-local snapshot::tests
 ```
 
-There is deliberately no `automata local check` command yet. Exact local event
-semantics, same-tree reusable-workflow compilation, and admission must land
-together before that public validation surface is truthful.
+Use the same source path without starting Docker or mutating Git:
+
+```console
+cargo run --locked -p automata-ci -- local check
+cargo run --locked -p automata-ci -- local check .github/workflows/ci.yml \
+  --input target=staging --json
+```
+
+`local check` captures the archive once and accepts only direct canonical
+`.github/workflows/*.{yml,yaml}` members. When more than one workflow exists,
+pass its exact repository-relative path; filename, stem, display-name, and
+`.ci/workflows` fallbacks do not exist. The root must explicitly declare
+`workflow_dispatch`. Reachable reusable calls are recompiled only from members
+of that same archive, while remote, dynamic, missing, and cyclic calls fail
+closed. The shared traversal validates typed inputs, secret forwarding,
+outputs, propagation, and expansion bounds. Reports contain external secret
+and variable names plus closed built-in requirements such as `github_token`,
+but never input values, secret values, absolute paths, archive bytes, or a
+repository identity. `github_token` is not a promptable user secret, and this
+read-only checkpoint does not claim it can supply one for execution.
+
+The command is independent of `local doctor`, Docker, network access, and a
+GitHub token. It never admits, schedules, or runs work, contacts GitHub, or
+creates a Check Run; local admission and execution remain later roadmap
+checkpoints.
 
 The opt-in live adapter contract creates one randomly named identity volume,
 adopts the same UUID through the public adapter, then re-inspects and removes

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -2,7 +2,8 @@
 
 - Roadmap status: Active
 - Available slice: read-only `automata local doctor` from a reviewed source checkout
-- Current implementation checkpoint: 2B.1, pinned Docker context and immutable identity anchor
+- Current implementation checkpoints: 2B.1 pinned Docker context and immutable
+  identity anchor, plus the internal source-sealing foundation of 3B
 - Date: 2026-08-15
 
 This roadmap owns the work required to make Automata easy to evaluate on one
@@ -182,6 +183,7 @@ onboarding path:
 | Existing path | Reusable capability | Remaining local gap |
 | --- | --- | --- |
 | `automata local doctor` | Cross-platform host, Docker, Compose, and architecture preflight | It is deliberately read-only; checkpoint 2A retired checkpoint 1's proposed native state-root input, and checkpoint 2B.1 makes installation identity engine-owned |
+| `automata-ci-local` snapshot foundation | Deterministic bounded live-worktree archive, explicit workflow-location policy, and shared archive discovery | It remains an internal library seam until truthful local event compilation, same-tree reusable workflows, repository identity, and admission are composed |
 | `automata-ci-local` Engine adapter | Exact-endpoint Docker connection plus strict identity-anchor inspect/create/adopt with fake and opt-in live tests | No product command calls the mutation API until desired intent and convergent lifecycle contracts land |
 | Control-plane configuration and container build | Complete server configuration and product images | Configuration and bootstrap are manual and Unix-oriented |
 | GitHub workflow crates | Frontend, compiler, typed workflow contracts, reusable-workflow handling | They need a separately authorized local snapshot source |
@@ -454,9 +456,10 @@ maps aliases to those exact profiles and records the mapping as run provenance.
 
 The new source boundary builds a deterministic, bounded archive from Git's
 tracked and non-ignored worktree inventory. It rejects unsafe file types,
-escaping symlinks, submodule ambiguity, case collisions, and concurrent
-mutation. The archive digest—not a possibly dirty HEAD—is the execution source
-identity. The source adapter also derives the canonical repository identity
+escaping symlinks, submodule ambiguity, sparse or assume-unchanged index state,
+Unicode-normalization and full-case-fold collisions, and concurrent mutation.
+The archive digest—not a possibly dirty HEAD—is the execution source identity.
+The source adapter also derives the canonical repository identity
 used by local admission. Before assigning that provenance contract version 1,
 its exact versioned byte preimage must define Git worktrees, symlinks,
 non-Unicode paths, case behavior, checkout moves, and clones on Linux, macOS,
@@ -774,6 +777,20 @@ workflow service, admission transaction, scheduler, cancellation, logs, and
 history. Define and retain the exact canonical repository identity as admitted
 source provenance here, not as an engine installation binding. Add
 `automata local check` as a read-only view of that path.
+
+Status: internal foundation available, checkpoint gate incomplete. The library
+seals Git's tracked plus non-ignored live-worktree inventory through pinned
+no-follow ancestor handles, normalizes tracked symlinks from Git mode, detects
+mutation, and hashes the exact deterministic gzip bytes consumed by shared
+repository archive discovery. Windows reparse points and junctions, portable
+component-trie bounds and aliases, link cycles, sparse or assume-unchanged
+index flags, and workflow-namespace aliases fail closed. Ignored paths are
+classified through one bounded NUL-safe batch per worktree scan.
+`.github/workflows` and `.ci/workflows` are explicit first-class policies; if
+both namespaces are present the source fails as ambiguous. There is deliberately
+no partial `automata local check` command before event compilation, same-tree
+reusable-workflow loading, canonical repository identity, and local source
+provenance can be validated together.
 
 Gate: clean and dirty worktrees produce deterministic digests; ignored files,
 `.git`, sockets, devices, escaping symlinks, submodule ambiguity, concurrent

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -1,10 +1,11 @@
 # Local installation and deployment roadmap
 
 - Roadmap status: Active
-- Available slice: read-only `automata local doctor` from a reviewed source checkout
+- Available slice: read-only `automata local doctor` and source-only
+  `automata local check` from a reviewed source checkout
 - Current implementation checkpoints: 2B.1 pinned Docker context and immutable
-  identity anchor, plus the internal source-sealing foundation of 3B
-- Date: 2026-08-15
+  identity anchor, plus the read-only source-validation portion of 3B
+- Date: 2026-08-16
 
 This roadmap owns the work required to make Automata easy to evaluate on one
 machine, run repository-scoped work through a repository-agnostic local
@@ -41,7 +42,7 @@ The optional workflow selector and concurrency flag are predictable:
 
 ```console
 automata local run .github/workflows/ci.yml
-automata local run ci --workers 3
+automata local run .github/workflows/ci.yml --workers 3
 ```
 
 For the first topology, `--workers N` means `N` concurrent job slots on one
@@ -86,18 +87,21 @@ repository-relative path resolves directly. A filename, stem, or workflow
 display name is accepted only when it is unique. Interactive ambiguity opens a
 picker; non-interactive and JSON modes report the sorted choices and fail.
 
-Direct `.github/workflows/*.yml|yaml` and `.ci/workflows/*.yml|yaml` files are
-eligible; nested files are not initially. Supporting `.github/workflows` in the
-explicit local source adapter does not change the autonomous GitHub provider's
-discovery policy. Local compatibility also does not imply full GitHub Actions
-parity: unsupported syntax, actions, events, dynamic secret references, and
-runner selectors fail during read-only inspection.
+Only direct `.github/workflows/*.yml|yaml` files are eligible; nested files and
+`.ci/workflows` aliases are not. This explicit local source policy does not
+change the autonomous GitHub provider's production discovery policy. Local
+compatibility also does not imply full GitHub Actions parity: unsupported
+syntax, actions, events, dynamic secret references, and runner selectors fail
+during read-only inspection.
 
-The first event set contains declared `workflow_dispatch` and a truthful local
-`push` context. A local event is never represented as a signed GitHub delivery,
-and it never produces a GitHub Check. `actions/checkout` resolves to the admitted
-snapshot; it does not silently fetch another revision or invent a
-`GITHUB_TOKEN`.
+The available read-only check accepts only declared `workflow_dispatch`. A
+later executable slice may add a separately typed, truthful local `push`
+context, but a local event is never represented as a signed GitHub delivery and
+never produces a GitHub Check. `actions/checkout` will resolve to the admitted
+snapshot; it must not silently fetch another revision. `github.token` and
+`secrets.GITHUB_TOKEN` are closed built-in requirements, never promptable user
+secrets; the current check reports that requirement but does not claim to
+supply it for execution.
 
 The initial selector registry accepts `automata-local`, `ubuntu-24.04`, and a
 release-pinned `ubuntu-latest` alias. It records the exact local image, OS, and
@@ -158,12 +162,13 @@ platform choice, not installation identity or a public lifecycle selector.
 An installation is a repository-agnostic deployment and runner-capacity domain:
 the same selected installation may admit snapshots from different repositories,
 and repository identity never enters its selector key, engine labels, Compose
-project, or desired specification. Repository identity is derived and retained
-with `LocalSnapshot` admission instead. Repositories sharing one installation
-form one trusted set and share its runner capacity; separate installation names
-are useful for distinct trust sets or destructive test environments, but names
-on the same administrator-controlled daemon are not a hostile-code isolation
-boundary.
+project, or desired specification. The read-only check deliberately derives or
+reports no repository identity; a durable repository identity contract is
+deferred until local admission actually consumes and qualifies it. Repositories
+sharing one installation form one trusted set and share its runner capacity;
+separate installation names are useful for distinct trust sets or destructive
+test environments, but names on the same administrator-controlled daemon are
+not a hostile-code isolation boundary.
 JSON reserves stdout for one stable document and never prompts.
 Non-interactive execution never reads values from implicit environment
 variables or command arguments. Secret setters use hidden TTY input when no
@@ -183,7 +188,7 @@ onboarding path:
 | Existing path | Reusable capability | Remaining local gap |
 | --- | --- | --- |
 | `automata local doctor` | Cross-platform host, Docker, Compose, and architecture preflight | It is deliberately read-only; checkpoint 2A retired checkpoint 1's proposed native state-root input, and checkpoint 2B.1 makes installation identity engine-owned |
-| `automata-ci-local` snapshot foundation | Deterministic bounded live-worktree archive, explicit workflow-location policy, and shared archive discovery | It remains an internal library seam until truthful local event compilation, same-tree reusable workflows, repository identity, and admission are composed |
+| `automata local check` | Deterministic bounded live-worktree archive, exact `.github/workflows` selection, local-only manual event compilation, reachable same-snapshot reusable workflows with typed call-graph and root-secret propagation, and value-free external/built-in credential discovery | It is deliberately read-only and fails closed on Windows; repository identity, local admission, scheduling, execution, and GitHub Checks remain absent |
 | `automata-ci-local` Engine adapter | Exact-endpoint Docker connection plus strict identity-anchor inspect/create/adopt with fake and opt-in live tests | No product command calls the mutation API until desired intent and convergent lifecycle contracts land |
 | Control-plane configuration and container build | Complete server configuration and product images | Configuration and bootstrap are manual and Unix-oriented |
 | GitHub workflow crates | Frontend, compiler, typed workflow contracts, reusable-workflow handling | They need a separately authorized local snapshot source |
@@ -249,7 +254,7 @@ adapter contract rather than a second operator-owned topology.
 local Git worktree
         |
         v
-bounded immutable snapshot ---- LocalSnapshot authority
+bounded immutable snapshot ---- future local admission authority
                                       |
                                       v
                              existing workflow service
@@ -459,19 +464,19 @@ tracked and non-ignored worktree inventory. It rejects unsafe file types,
 escaping symlinks, submodule ambiguity, sparse or assume-unchanged index state,
 Unicode-normalization and full-case-fold collisions, and concurrent mutation.
 The archive digest—not a possibly dirty HEAD—is the execution source identity.
-The source adapter also derives the canonical repository identity
-used by local admission. Before assigning that provenance contract version 1,
-its exact versioned byte preimage must define Git worktrees, symlinks,
-non-Unicode paths, case behavior, checkout moves, and clones on Linux, macOS,
-and Windows. HEAD, dirty state, repository identity, selected workflow, inputs,
-and architecture decisions remain explicit run provenance; none becomes local
-installation identity.
+The current check uses that digest only as its exact local revision and does not
+derive or report repository identity. Durable local admission will require a
+separately reviewed repository identity contract; its exact versioned byte
+preimage and native mutation evidence must be qualified before it exists.
+HEAD, dirty state, the selected workflow, inputs, and architecture decisions
+remain explicit run provenance; none becomes local installation identity.
 
-`LocalSnapshot` is a distinct admission authority accepted only in the local
-deployment context. It parameterizes source location and archive policy around
-the existing workflow frontend/compiler and then enters the existing workflow
-service. It cannot create signed-GitHub evidence, publish a Check Run, or enter
-the autonomous provider inbox.
+The planned sealed local-snapshot admission authority is accepted only in the
+local deployment context. It will parameterize source location and archive
+policy around the existing workflow frontend/compiler and then enter the
+existing workflow service. It cannot create signed-GitHub evidence, publish a
+Check Run, or enter the autonomous provider inbox. The available check stops
+before this authority boundary.
 
 Jobs receive a copy of the admitted immutable snapshot, never a writable host
 bind. Workflows that require GitHub API authority fail with an actionable
@@ -666,9 +671,9 @@ filesystem substrate.
 Land the first Docker Engine adapter and the engine-owned identity and desired
 intent contracts in two independently reviewable, strictly ordered slices.
 Installation identity is a repository-agnostic deployment/capacity boundary;
-repository and snapshot identity remain owned by later `LocalSnapshot`
-admission. Compose and fresh engine inspection are resource truth throughout,
-and no host manifest mirrors them.
+repository and snapshot identity remain questions for later local admission.
+Compose and fresh engine inspection are resource truth throughout, and no host
+manifest mirrors them.
 
 #### 2B.1. Pinned Docker context and immutable identity anchor
 
@@ -774,32 +779,42 @@ Add bounded Git worktree snapshotting and a provider-distinct local source
 authority. Parameterize source location/archive loading around the existing
 GitHub Actions frontend and compiler. Feed compiled requests into the existing
 workflow service, admission transaction, scheduler, cancellation, logs, and
-history. Define and retain the exact canonical repository identity as admitted
-source provenance here, not as an engine installation binding. Add
-`automata local check` as a read-only view of that path.
+history. Define a durable repository identity only when admission consumes and
+qualifies it, never as an engine installation binding. `automata local check`
+is the read-only source-analysis precursor and intentionally exposes neither
+repository identity nor admission authority.
 
-Status: internal foundation available, checkpoint gate incomplete. The library
-seals Git's tracked plus non-ignored live-worktree inventory through pinned
-no-follow ancestor handles, normalizes tracked symlinks from Git mode, detects
-mutation, and hashes the exact deterministic gzip bytes consumed by shared
-repository archive discovery. Windows reparse points and junctions, portable
-component-trie bounds and aliases, link cycles, sparse or assume-unchanged
-index flags, and workflow-namespace aliases fail closed. Ignored paths are
-classified through one bounded NUL-safe batch per worktree scan.
-`.github/workflows` and `.ci/workflows` are explicit first-class policies; if
-both namespaces are present the source fails as ambiguous. There is deliberately
-no partial `automata local check` command before event compilation, same-tree
-reusable-workflow loading, canonical repository identity, and local source
-provenance can be validated together.
+Status: read-only source validation available, admission gate incomplete. The
+library seals Git's tracked plus non-ignored live-worktree inventory through
+pinned no-follow ancestor handles, normalizes tracked symlinks from Git mode,
+detects mutation, and hashes the exact deterministic gzip bytes consumed by
+shared repository archive discovery. Portable component-trie bounds and
+aliases, link cycles, sparse or assume-unchanged index flags, and workflow
+namespace aliases fail closed. Ignored paths are classified through one
+bounded NUL-safe batch per worktree scan. Source capture currently fails closed
+on Windows until exact native mutation evidence is qualified.
+
+Only direct `.github/workflows` members are eligible, with an exact canonical
+selector required when discovery is ambiguous; `.ci`, filename, stem, and
+display-name fallbacks do not exist. `automata local check` composes local event
+compilation, reachable same-snapshot reusable-workflow loading, the shared typed
+call-graph traversal, root-secret propagation, snapshot revision, and local
+source provenance without entering admission. Remote and dynamic reusable calls
+fail explicitly. Its only current event is an explicit local
+`workflow_dispatch`; it cannot synthesize GitHub delivery evidence. Reports
+contain value-free external names and closed built-in requirements, never
+credential or input values, absolute paths, archive bytes, environment values,
+or repository identity.
 
 Gate: clean and dirty worktrees produce deterministic digests; ignored files,
 `.git`, sockets, devices, escaping symlinks, submodule ambiguity, concurrent
 mutation, oversized archives, and case collisions fail closed; direct
-`.github/workflows` and `.ci/workflows` files and admitted same-tree reusable
-workflows use the existing compiler; the versioned repository-identity preimage
-has cross-platform worktree, symlink, non-Unicode, case, move, and clone
-fixtures; no source operation mutates Git; and no local subject can enter
-signed-GitHub admission or create a GitHub Check.
+`.github/workflows` files and same-snapshot reusable workflows use the existing
+compiler and canonical call-contract traversal; hostile Git environment,
+cancellation, bounds, redaction, and dirty-worktree fixtures pass; no source
+operation mutates Git; and no local subject can enter signed-GitHub admission or
+create a GitHub Check. Durable repository identity and Windows source capture
+remain separate future qualification gates rather than weak checkpoint claims.
 
 ### 3C. Arch secretless vertical slice
 
@@ -875,8 +890,9 @@ finds no honest common contract, record that decision and do not add a library.
 Confirm or create the designated dummy repository under `AlexanderDzhoganov`,
 then test its local checkout without installing a GitHub App. Commit a redacted,
 executable smoke harness and evidence format covering `.github/workflows`,
-`.ci/workflows`, typed inputs, a user secret, a variable, dispatch, truthful
-local push, cancellation, restart, persistence, and cleanup.
+exact canonical selectors, typed inputs, a user secret, a variable, dispatch,
+truthful local push once that event exists, cancellation, restart, persistence,
+and cleanup.
 
 Gate: the one-command run works from clean state; the second secret-bearing run
 does not prompt; `--workers 3` overlaps three jobs; history and logs are useful;

--- a/scripts/ci/tests/integration-test-targets.test.py
+++ b/scripts/ci/tests/integration-test-targets.test.py
@@ -134,6 +134,7 @@ POSTGRES_TEST_SUPPORT_MODULES = frozenset({
     ("crates/automata-ci-postgres/tests/auth/mod.rs", "request_auth"),
     ("crates/automata-ci-postgres/tests/auth/mod.rs", "sign_in"),
     ("crates/automata-ci-postgres/tests/store/mod.rs", "execution"),
+    ("crates/automata-ci-postgres/tests/store/mod.rs", "fixture"),
     ("crates/automata-ci-postgres/tests/store/mod.rs", "orchestration"),
     ("crates/automata-ci-postgres/tests/store/mod.rs", "provider"),
     ("crates/automata-ci-postgres/tests/store/mod.rs", "security"),


### PR DESCRIPTION
## Outcome

Adds a complete read-only local workflow validation path:

- seals a deterministic, bounded, no-follow snapshot of the requested Git worktree;
- adds `automata local check [WORKFLOW] [--input NAME=VALUE]... [--json]`;
- compiles the selected local `workflow_dispatch` workflow and all reachable same-snapshot reusable workflows;
- reports only value-free external credential requirements and closed built-in requirements;
- rejects path aliases, authority changes, unsupported Git state, remote or dynamic reusable calls, cycles, mutation, and resource-limit violations.

This is the first independently mergeable stack layer extracted from draft #173. It performs no admission, scheduling, execution, Docker mutation, GitHub delivery, or Check publication.

## Related issue

Part of #173.

## Trust and compatibility impact

The new snapshot boundary pins caller, worktree, Git directory, common directory, and locator identities; binds every Git query to the sealed authority; rejects symlink/reparse redirects, sparse and assume-unchanged state, nonportable aliases, special files, and concurrent mutation; and validates archive paths and links through one bounded shared authority.

Local workflow evidence is intentionally distinct from GitHub delivery evidence. Only explicit local `workflow_dispatch` roots and same-snapshot reusable workflows are accepted. Input values, archive bytes, absolute host paths, and repository identity are omitted from reports and Debug output. Windows snapshot capture remains fail-closed until native mutation evidence is qualified.

No protocol, database schema, storage authority, runner, sandbox, or container-engine behavior changes in this layer.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- affected local, workflow-github, workflow-service, GitHub delivery, CLI, and GitHub aggregate test suites
- local-check process suite repeated 10 times
- process-containment and snapshot-cancellation stress suites repeated 10 times
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- workspace doctests
- `python scripts/ci/tests/integration-test-targets.test.py` — 28 packages, 358 Rust sources, 33 targets
- Windows GNU and x86-64 musl cross-checks for `automata-ci-local`
- independent strict review of exact range `98c44a03..85f3d5ff`: CLEAN

A broad `automata-ci` library run still encounters pre-existing current-main GitHub/provider fixture failures; the affected suites above are green and representative failures were reproduced on the exact base.

## AI assistance

OpenAI Codex reconstructed this vertical slice from draft #173, ran the qualification matrix, and performed a separate read-only strict review.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.