### PR TITLE
test(github): consolidate authenticated webhook fixtures

### DIFF
--- a/crates/automata-ci-github/tests/event_envelope.rs
+++ b/crates/automata-ci-github/tests/event_envelope.rs
@@ -1,4 +1,7 @@
-use std::fmt::Write as _;
+use crate::support::{
+    BASE_SHA, GROUP_SHA, HEAD_SHA, MERGE_SHA, base_repository, head_repository, json_body,
+    signed_webhook_headers,
+};
 
 use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
 use automata_ci_core::{
@@ -10,18 +13,12 @@ use automata_ci_github::{
     GithubEventEnvelopeError, GithubEventFacts, GithubEventRegistryV1, GithubEventTrustFact,
     GithubSealedEventEnvelopeV1, GithubTrustDerivation, GithubWebhookVerifier,
     GithubWorkflowEventKind, MAX_GITHUB_EVENT_ENVELOPE_BYTES, VerifiedGithubWebhook,
-    X_GITHUB_DELIVERY, X_GITHUB_EVENT, X_HUB_SIGNATURE_256, derive_github_trust_snapshot,
+    derive_github_trust_snapshot,
 };
 use bytes::Bytes;
-use reqwest::header::{HeaderMap, HeaderValue};
-use ring::hmac;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"event-envelope-test-secret";
-const BASE_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
-const HEAD_SHA: &str = "89abcdef0123456789abcdef0123456789abcdef";
-const MERGE_SHA: &str = "76543210fedcba9876543210fedcba9876543210";
-const GROUP_SHA: &str = "fedcba9876543210fedcba9876543210fedcba98";
 
 #[test]
 fn registry_and_envelopes_cover_every_workflow_event_exactly_once() {
@@ -464,8 +461,8 @@ fn descriptor_for(
 }
 
 fn normalize(payload: &Value, event_name: &str) -> VerifiedGithubWebhook {
-    let body = serde_json::to_vec(payload).expect("JSON fixture");
-    let headers = signed_headers(&body, event_name, "sensitive-delivery");
+    let body = json_body(payload);
+    let headers = signed_webhook_headers(SECRET, &body, event_name, "sensitive-delivery");
     GithubWebhookVerifier::new(SECRET)
         .expect("verifier")
         .authenticate(&headers, Bytes::from(body))
@@ -474,50 +471,8 @@ fn normalize(payload: &Value, event_name: &str) -> VerifiedGithubWebhook {
         .expect("normalized")
 }
 
-fn signed_headers(body: &[u8], event_name: &str, delivery_id: &str) -> HeaderMap {
-    let key = hmac::Key::new(hmac::HMAC_SHA256, SECRET);
-    let tag = hmac::sign(&key, body);
-    let mut signature = String::from("sha256=");
-    for byte in tag.as_ref() {
-        write!(&mut signature, "{byte:02x}").expect("signature encoding");
-    }
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&signature).expect("signature header"),
-    );
-    headers.insert(
-        X_GITHUB_EVENT,
-        HeaderValue::from_str(event_name).expect("event header"),
-    );
-    headers.insert(
-        X_GITHUB_DELIVERY,
-        HeaderValue::from_str(delivery_id).expect("delivery header"),
-    );
-    headers
-}
-
 fn actor(id: u64, login: &str, kind: &str) -> Value {
     json!({ "id": id, "login": login, "type": kind })
-}
-
-fn repository(id: u64, owner_id: u64, owner: &str, name: &str) -> Value {
-    json!({
-        "id": id,
-        "private": false,
-        "visibility": "public",
-        "name": name,
-        "full_name": format!("{owner}/{name}"),
-        "owner": { "id": owner_id, "login": owner }
-    })
-}
-
-fn base_repository() -> Value {
-    repository(41, 11, "example", "base-repository")
-}
-
-fn head_repository() -> Value {
-    repository(42, 12, "contributor", "head-repository")
 }
 
 fn push_payload() -> Value {

--- a/crates/automata-ci-github/tests/stored_push_rehydration.rs
+++ b/crates/automata-ci-github/tests/stored_push_rehydration.rs
@@ -1,14 +1,11 @@
-use crate::support::webhook_signature;
+use crate::support::{json_body, signed_webhook_headers, webhook_body_digest};
 
 use automata_ci_github::{
     GITHUB_PUSH_EVENT_MEDIA_TYPE, GithubRepositoryVisibility, GithubStoredPushError,
     GithubWebhookBodyDigest, GithubWebhookVerifier, MAX_GITHUB_WEBHOOK_BODY_BYTES,
-    StoredAuthenticatedGithubPush, X_GITHUB_DELIVERY, X_GITHUB_EVENT, X_HUB_SIGNATURE_256,
-    rehydrate_stored_authenticated_github_push,
+    StoredAuthenticatedGithubPush, rehydrate_stored_authenticated_github_push,
 };
 use bytes::Bytes;
-use reqwest::header::{HeaderMap, HeaderValue};
-use ring::digest;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"stored-push-equivalence-secret";
@@ -23,18 +20,18 @@ const REPOSITORY_NAME: &str = "automata";
 
 #[test]
 fn durable_rehydration_is_exactly_equivalent_to_the_hmac_path() {
-    let body = encode(&valid_payload());
+    let body = json_body(&valid_payload());
     let hmac_push = GithubWebhookVerifier::new(SECRET)
         .expect("verifier")
         .verify(
-            &signed_headers(SECRET, &body, DELIVERY),
+            &signed_webhook_headers(SECRET, &body, "push", DELIVERY),
             Bytes::copy_from_slice(&body),
         )
         .expect("authenticated push");
 
     let stored_push = rehydrate_stored_authenticated_github_push(evidence(
         Bytes::copy_from_slice(&body),
-        body_digest(&body),
+        webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
         GITHUB_PUSH_EVENT_MEDIA_TYPE,
         DELIVERY,
@@ -69,17 +66,17 @@ fn durable_rehydration_is_exactly_equivalent_to_the_hmac_path() {
 fn durable_rehydration_accepts_the_exact_webhook_ceiling() {
     let mut payload = valid_payload();
     payload["padding"] = json!("");
-    let empty_padding = encode(&payload);
+    let empty_padding = json_body(&payload);
     let padding_bytes = MAX_GITHUB_WEBHOOK_BODY_BYTES
         .checked_sub(empty_padding.len())
         .expect("base push is smaller than the webhook ceiling");
     payload["padding"] = json!("x".repeat(padding_bytes));
-    let body = encode(&payload);
+    let body = json_body(&payload);
     assert_eq!(body.len(), MAX_GITHUB_WEBHOOK_BODY_BYTES);
 
     let stored = rehydrate_stored_authenticated_github_push(evidence(
         Bytes::from(body.clone()),
-        body_digest(&body),
+        webhook_body_digest(&body),
         u64::try_from(body.len()).expect("exact webhook ceiling fits u64"),
         GITHUB_PUSH_EVENT_MEDIA_TYPE,
         DELIVERY,
@@ -96,7 +93,7 @@ fn durable_rehydration_accepts_the_exact_webhook_ceiling() {
 fn durable_coordinates_and_stale_body_bytes_fail_before_normalization() {
     let malformed = Bytes::from_static(b"private-malformed-body-marker:{");
     let size = u64::try_from(malformed.len()).expect("fixture size fits u64");
-    let digest = body_digest(&malformed);
+    let digest = webhook_body_digest(&malformed);
 
     assert_eq!(
         rehydrate_stored_authenticated_github_push(evidence(
@@ -159,8 +156,8 @@ fn durable_coordinates_and_stale_body_bytes_fail_before_normalization() {
         GithubStoredPushError::InvalidDurableIdentity
     );
 
-    let original = encode(&valid_payload());
-    let original_digest = body_digest(&original);
+    let original = json_body(&valid_payload());
+    let original_digest = webhook_body_digest(&original);
     let mut changed = original;
     changed.push(b' ');
     assert_eq!(
@@ -184,9 +181,9 @@ fn durable_coordinates_and_stale_body_bytes_fail_before_normalization() {
 fn every_durable_identity_mismatch_precedes_push_normalization() {
     let mut invalid_ref_payload = valid_payload();
     invalid_ref_payload["ref"] = json!("not-a-full-ref");
-    let body = encode(&invalid_ref_payload);
+    let body = json_body(&invalid_ref_payload);
     let size = u64::try_from(body.len()).expect("fixture size fits u64");
-    let digest = body_digest(&body);
+    let digest = webhook_body_digest(&body);
 
     for stored in [
         evidence(
@@ -258,9 +255,9 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
 fn every_invalid_durable_identity_precedes_push_normalization() {
     let mut invalid_ref_payload = valid_payload();
     invalid_ref_payload["ref"] = json!("not-a-full-ref");
-    let body = encode(&invalid_ref_payload);
+    let body = json_body(&invalid_ref_payload);
     let size = u64::try_from(body.len()).expect("fixture size fits u64");
-    let digest = body_digest(&body);
+    let digest = webhook_body_digest(&body);
 
     for stored in [
         evidence(
@@ -363,10 +360,10 @@ fn stored_repository_owner_identity_rejects_missing_malformed_tampered_and_misma
         assert_stored_error(&mismatched, GithubStoredPushError::IdentityMismatch);
     }
 
-    let original = encode(&valid_payload());
+    let original = json_body(&valid_payload());
     let mut tampered = valid_payload();
     tampered["repository"]["owner"]["id"] = json!(REPOSITORY_OWNER_ID + 1);
-    let tampered = encode(&tampered);
+    let tampered = json_body(&tampered);
     assert_eq!(
         tampered.len(),
         original.len(),
@@ -375,7 +372,7 @@ fn stored_repository_owner_identity_rejects_missing_malformed_tampered_and_misma
     assert_eq!(
         rehydrate_stored_authenticated_github_push(evidence(
             Bytes::from(tampered.clone()),
-            body_digest(&original),
+            webhook_body_digest(&original),
             u64::try_from(tampered.len()).expect("fixture size fits u64"),
             GITHUB_PUSH_EVENT_MEDIA_TYPE,
             DELIVERY,
@@ -431,10 +428,10 @@ fn stored_evidence_debug_and_errors_redact_body_and_identity_values() {
     payload["repository"]["owner"]["login"] = json!("private-owner-marker");
     payload["repository"]["full_name"] = json!("private-owner-marker/private-name-marker");
     payload["repository"]["name"] = json!("private-name-marker");
-    let body = encode(&payload);
+    let body = json_body(&payload);
     let stored = evidence(
         Bytes::copy_from_slice(&body),
-        body_digest(&body),
+        webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
         "private-media-marker",
         "private-delivery-marker",
@@ -451,14 +448,14 @@ fn stored_evidence_debug_and_errors_redact_body_and_identity_values() {
         "private-name-marker",
         "private-delivery-marker",
         "private-media-marker",
-        &body_digest(&body).to_string(),
+        &webhook_body_digest(&body).to_string(),
     ] {
         assert!(!debug.contains(marker), "stored Debug leaked {marker}");
     }
 
     let error = rehydrate_stored_authenticated_github_push(evidence(
         Bytes::copy_from_slice(&body),
-        body_digest(&body),
+        webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
         GITHUB_PUSH_EVENT_MEDIA_TYPE,
         "private-delivery-marker",
@@ -535,10 +532,10 @@ fn evidence_with_owner_id(
 }
 
 fn assert_stored_error(payload: &Value, expected: GithubStoredPushError) {
-    let body = encode(payload);
+    let body = json_body(payload);
     let error = rehydrate_stored_authenticated_github_push(evidence(
         Bytes::copy_from_slice(&body),
-        body_digest(&body),
+        webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
         GITHUB_PUSH_EVENT_MEDIA_TYPE,
         DELIVERY,
@@ -577,29 +574,4 @@ fn valid_payload() -> Value {
             { "id": AFTER, "message": "not interpreted as a diff" }
         ]
     })
-}
-
-fn encode(payload: &Value) -> Vec<u8> {
-    serde_json::to_vec(payload).expect("JSON fixture")
-}
-
-fn body_digest(body: &[u8]) -> GithubWebhookBodyDigest {
-    let digest = digest::digest(&digest::SHA256, body);
-    let mut bytes = [0_u8; 32];
-    bytes.copy_from_slice(digest.as_ref());
-    GithubWebhookBodyDigest::from_bytes(bytes)
-}
-
-fn signed_headers(secret: &[u8], body: &[u8], delivery: &str) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&webhook_signature(secret, body)).expect("signature header"),
-    );
-    headers.insert(X_GITHUB_EVENT, HeaderValue::from_static("push"));
-    headers.insert(
-        X_GITHUB_DELIVERY,
-        HeaderValue::from_str(delivery).expect("delivery header"),
-    );
-    headers
 }

--- a/crates/automata-ci-github/tests/support/mod.rs
+++ b/crates/automata-ci-github/tests/support/mod.rs
@@ -6,21 +6,70 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use automata_ci_github::{GithubHttpEndpoint, GithubHttpLimits};
+use automata_ci_github::{
+    GithubHttpEndpoint, GithubHttpLimits, GithubWebhookBodyDigest, X_GITHUB_DELIVERY,
+    X_GITHUB_EVENT, X_HUB_SIGNATURE_256,
+};
 use axum::{
     Router,
     body::{Body, to_bytes},
     extract::State,
-    http::{HeaderMap, Request, Response, StatusCode},
+    http::{HeaderMap, HeaderValue, Request, Response, StatusCode},
     routing::any,
 };
-use ring::hmac;
+use ring::{digest, hmac};
+use serde_json::{Value, json};
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use url::Url;
 
 const MAX_FIXTURE_REQUEST_BYTES: usize = 1_048_576;
+pub(crate) const BASE_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+pub(crate) const HEAD_SHA: &str = "89abcdef0123456789abcdef0123456789abcdef";
+pub(crate) const MERGE_SHA: &str = "76543210fedcba9876543210fedcba9876543210";
+pub(crate) const GROUP_SHA: &str = "fedcba9876543210fedcba9876543210fedcba98";
 
-pub(crate) fn webhook_signature(secret: &[u8], body: &[u8]) -> String {
+pub(crate) fn json_body(payload: &Value) -> Vec<u8> {
+    serde_json::to_vec(payload).expect("JSON fixture")
+}
+
+pub(crate) fn webhook_body_digest(body: &[u8]) -> GithubWebhookBodyDigest {
+    let digest = digest::digest(&digest::SHA256, body);
+    let mut bytes = [0_u8; 32];
+    bytes.copy_from_slice(digest.as_ref());
+    GithubWebhookBodyDigest::from_bytes(bytes)
+}
+
+pub(crate) fn signed_webhook_headers(
+    secret: &[u8],
+    body: &[u8],
+    event: &str,
+    delivery: &str,
+) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        X_HUB_SIGNATURE_256,
+        HeaderValue::from_str(&webhook_signature(secret, body)).expect("signature header"),
+    );
+    headers.insert(
+        X_GITHUB_EVENT,
+        HeaderValue::from_str(event).expect("event header"),
+    );
+    headers.insert(
+        X_GITHUB_DELIVERY,
+        HeaderValue::from_str(delivery).expect("delivery header"),
+    );
+    headers
+}
+
+pub(crate) fn base_repository() -> Value {
+    repository(41, 11, "example", "base-repository")
+}
+
+pub(crate) fn head_repository() -> Value {
+    repository(42, 12, "contributor", "head-repository")
+}
+
+fn webhook_signature(secret: &[u8], body: &[u8]) -> String {
     let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
     let tag = hmac::sign(&key, body);
     let mut encoded = String::from("sha256=");
@@ -28,6 +77,17 @@ pub(crate) fn webhook_signature(secret: &[u8], body: &[u8]) -> String {
         write!(encoded, "{byte:02x}").expect("write signature");
     }
     encoded
+}
+
+fn repository(id: u64, owner_id: u64, owner: &str, name: &str) -> Value {
+    json!({
+        "id": id,
+        "private": false,
+        "visibility": "public",
+        "name": name,
+        "full_name": format!("{owner}/{name}"),
+        "owner": { "id": owner_id, "login": owner }
+    })
 }
 
 #[derive(Clone, Debug)]

--- a/crates/automata-ci-github/tests/webhook_event_normalization.rs
+++ b/crates/automata-ci-github/tests/webhook_event_normalization.rs
@@ -1,22 +1,20 @@
-use std::fmt::Write as _;
+use crate::support::{
+    BASE_SHA, GROUP_SHA, HEAD_SHA, MERGE_SHA, base_repository, head_repository, json_body,
+    signed_webhook_headers, webhook_body_digest,
+};
 
 use automata_ci_github::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubCheckRunAction, GithubMergeGroupAction,
     GithubPullRequestAction, GithubPushRefKind, GithubRepositoryVisibility,
-    GithubStoredWebhookError, GithubWebhookBodyDigest, GithubWebhookError, GithubWebhookVerifier,
-    StoredAuthenticatedGithubWebhook, VerifiedGithubWebhook, X_GITHUB_DELIVERY, X_GITHUB_EVENT,
-    X_HUB_SIGNATURE_256, rehydrate_stored_authenticated_github_webhook,
+    GithubStoredWebhookError, GithubWebhookError, GithubWebhookVerifier,
+    StoredAuthenticatedGithubWebhook, VerifiedGithubWebhook,
+    rehydrate_stored_authenticated_github_webhook,
 };
 use bytes::Bytes;
-use reqwest::header::{HeaderMap, HeaderValue};
-use ring::{digest, hmac};
+use ring::digest;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"independent synthetic webhook secret";
-const BASE_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
-const HEAD_SHA: &str = "89abcdef0123456789abcdef0123456789abcdef";
-const MERGE_SHA: &str = "76543210fedcba9876543210fedcba9876543210";
-const GROUP_SHA: &str = "fedcba9876543210fedcba9876543210fedcba98";
 
 #[test]
 fn check_run_controls_retain_exact_signed_identity() {
@@ -86,7 +84,7 @@ fn check_suite_rerequest_retains_suite_app_sender_and_revision() {
 
 #[test]
 fn pull_request_normalization_retains_exact_dispatch_evidence() {
-    let body = encode(&pull_request_payload());
+    let body = json_body(&pull_request_payload());
     let event = normalize_bytes(&body, "pull_request", "delivery-pr-7").expect("normalized event");
 
     assert_eq!(event.delivery_id(), "delivery-pr-7");
@@ -165,7 +163,7 @@ fn unmerged_pull_request_without_materialized_merge_revision_uses_head_revision(
 
 #[test]
 fn merge_group_normalization_retains_exact_dispatch_evidence() {
-    let body = encode(&merge_group_payload());
+    let body = json_body(&merge_group_payload());
     let event =
         normalize_bytes(&body, "merge_group", "delivery-group-9").expect("normalized merge group");
 
@@ -190,7 +188,7 @@ fn merge_group_normalization_retains_exact_dispatch_evidence() {
 
 #[test]
 fn repository_dispatch_normalization_retains_bounded_custom_evidence() {
-    let body = encode(&repository_dispatch_payload());
+    let body = json_body(&repository_dispatch_payload());
     let event = normalize_bytes(&body, "repository_dispatch", "delivery-custom-3")
         .expect("normalized repository dispatch");
 
@@ -299,7 +297,7 @@ fn only_documented_event_actions_are_admitted() {
 
 #[test]
 fn duplicate_or_malformed_json_is_rejected_before_typed_decoding() {
-    let canonical = String::from_utf8(encode(&pull_request_payload())).expect("UTF-8 JSON");
+    let canonical = String::from_utf8(json_body(&pull_request_payload())).expect("UTF-8 JSON");
     let duplicate_action = canonical.replacen(
         "\"action\":\"opened\"",
         "\"action\":\"opened\",\"action\":\"closed\"",
@@ -327,7 +325,8 @@ fn duplicate_or_malformed_json_is_rejected_before_typed_decoding() {
         GithubWebhookError::MalformedPayload,
     );
 
-    let dispatch = String::from_utf8(encode(&repository_dispatch_payload())).expect("UTF-8 JSON");
+    let dispatch =
+        String::from_utf8(json_body(&repository_dispatch_payload())).expect("UTF-8 JSON");
     let duplicate_client_value =
         dispatch.replacen("\"sequence\":3", "\"sequence\":3,\"sequence\":4", 1);
     assert_bytes_error(
@@ -428,7 +427,7 @@ fn merge_group_revisions_and_full_branch_refs_are_strict() {
 #[test]
 fn normalized_debug_redacts_authenticated_and_selector_values() {
     let payload = pull_request_payload();
-    let body = encode(&payload);
+    let body = json_body(&payload);
     let event = normalize_bytes(&body, "pull_request", "private-delivery-marker")
         .expect("normalized event");
     let debug = format!("{event:?}");
@@ -448,7 +447,7 @@ fn normalized_debug_redacts_authenticated_and_selector_values() {
 
 #[test]
 fn repository_dispatch_debug_redacts_custom_values() {
-    let body = encode(&repository_dispatch_payload());
+    let body = json_body(&repository_dispatch_payload());
     let event = normalize_bytes(&body, "repository_dispatch", "private-custom-delivery")
         .expect("normalized event");
     let debug = format!("{event:?}");
@@ -481,7 +480,7 @@ fn durable_event_v1_rehydrates_each_supported_kind_without_reserialization() {
             "durable-custom-3",
         ),
     ] {
-        let body = encode(&payload);
+        let body = json_body(&payload);
         let stored = stored_event_v1(&body, event_name, delivery_id);
         let event = rehydrate_stored_authenticated_github_webhook(stored)
             .expect("rehydrated authenticated event");
@@ -498,7 +497,7 @@ fn durable_event_v1_rejects_envelope_drift_and_duplicate_json() {
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         "application/vnd.automata.github-authenticated-event+json"
     );
-    let body = encode(&pull_request_payload());
+    let body = json_body(&pull_request_payload());
     let wrong_event = stored_event_v1(&body, "merge_group", "durable-pr-7");
     assert_eq!(
         rehydrate_stored_authenticated_github_webhook(wrong_event)
@@ -593,10 +592,6 @@ fn repository_dispatch_payload() -> Value {
     })
 }
 
-fn base_repository() -> Value {
-    repository(41, 11, "example", "base-repository")
-}
-
 fn check_run_payload(action: &str, requested_action: Option<&str>) -> Value {
     let mut payload = json!({
         "action": action,
@@ -635,26 +630,11 @@ fn check_suite_payload() -> Value {
     })
 }
 
-fn head_repository() -> Value {
-    repository(42, 12, "contributor", "head-repository")
-}
-
-fn repository(id: u64, owner_id: u64, owner: &str, name: &str) -> Value {
-    json!({
-        "id": id,
-        "private": false,
-        "visibility": "public",
-        "name": name,
-        "full_name": format!("{owner}/{name}"),
-        "owner": { "id": owner_id, "login": owner }
-    })
-}
-
 fn normalize_payload(
     payload: &Value,
     event_name: &str,
 ) -> Result<VerifiedGithubWebhook, GithubWebhookError> {
-    normalize_bytes(&encode(payload), event_name, "synthetic-delivery")
+    normalize_bytes(&json_body(payload), event_name, "synthetic-delivery")
 }
 
 fn normalize_bytes(
@@ -662,7 +642,7 @@ fn normalize_bytes(
     event_name: &str,
     delivery_id: &str,
 ) -> Result<VerifiedGithubWebhook, GithubWebhookError> {
-    let headers = signed_headers(body, event_name, delivery_id);
+    let headers = signed_webhook_headers(SECRET, body, event_name, delivery_id);
     GithubWebhookVerifier::new(SECRET)
         .expect("verifier")
         .authenticate(&headers, Bytes::copy_from_slice(body))?
@@ -674,7 +654,7 @@ fn assert_invalid_pull_request(payload: &Value) {
 }
 
 fn assert_payload_error(payload: &Value, event_name: &str, expected: GithubWebhookError) {
-    assert_bytes_error(&encode(payload), event_name, expected);
+    assert_bytes_error(&json_body(payload), event_name, expected);
 }
 
 fn assert_bytes_error(body: &[u8], event_name: &str, expected: GithubWebhookError) {
@@ -684,46 +664,14 @@ fn assert_bytes_error(body: &[u8], event_name: &str, expected: GithubWebhookErro
     );
 }
 
-fn encode(payload: &Value) -> Vec<u8> {
-    serde_json::to_vec(payload).expect("JSON fixture")
-}
-
-fn signed_headers(body: &[u8], event_name: &str, delivery_id: &str) -> HeaderMap {
-    let key = hmac::Key::new(hmac::HMAC_SHA256, SECRET);
-    let tag = hmac::sign(&key, body);
-    let mut signature = String::from("sha256=");
-    for byte in tag.as_ref() {
-        write!(&mut signature, "{byte:02x}").expect("write signature");
-    }
-
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&signature).expect("signature header"),
-    );
-    headers.insert(
-        X_GITHUB_EVENT,
-        HeaderValue::from_str(event_name).expect("event header"),
-    );
-    headers.insert(
-        X_GITHUB_DELIVERY,
-        HeaderValue::from_str(delivery_id).expect("delivery header"),
-    );
-    headers
-}
-
 fn stored_event_v1(
     body: &[u8],
     event_name: &str,
     delivery_id: &str,
 ) -> StoredAuthenticatedGithubWebhook {
-    let body_digest: [u8; 32] = digest::digest(&digest::SHA256, body)
-        .as_ref()
-        .try_into()
-        .expect("SHA-256 length");
     StoredAuthenticatedGithubWebhook::from_durable_coordinates(
         Bytes::copy_from_slice(body),
-        GithubWebhookBodyDigest::from_bytes(body_digest),
+        webhook_body_digest(body),
         u64::try_from(body.len()).expect("fixture size"),
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         event_name,

--- a/crates/automata-ci-github/tests/webhook_verification.rs
+++ b/crates/automata-ci-github/tests/webhook_verification.rs
@@ -1,4 +1,4 @@
-use crate::support::webhook_signature;
+use crate::support::{json_body, signed_webhook_headers};
 
 use automata_ci_github::{
     GithubPushRefKind, GithubRepositoryVisibility, GithubWebhookError, GithubWebhookEventMetadata,
@@ -7,7 +7,7 @@ use automata_ci_github::{
 };
 use automata_ci_scm::ExactRevision;
 use bytes::Bytes;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::HeaderValue;
 use ring::digest;
 use serde_json::{Value, json};
 
@@ -20,8 +20,8 @@ const REPOSITORY_OWNER_ID: u64 = 9_876_543;
 
 #[test]
 fn valid_push_preserves_exact_authenticated_and_provider_evidence() {
-    let body = encode(&valid_payload());
-    let headers = signed_headers(SECRET, &body, "push", "delivery-123");
+    let body = json_body(&valid_payload());
+    let headers = signed_webhook_headers(SECRET, &body, "push", "delivery-123");
     let boundary = GithubWebhookVerifier::new(SECRET).expect("verifier");
     let split = [
         &body[..13],
@@ -80,8 +80,8 @@ fn valid_push_preserves_exact_authenticated_and_provider_evidence() {
 
 #[test]
 fn every_required_header_must_be_present_exactly_once() {
-    let body = encode(&valid_payload());
-    let base = signed_headers(SECRET, &body, "push", "delivery-123");
+    let body = json_body(&valid_payload());
+    let base = signed_webhook_headers(SECRET, &body, "push", "delivery-123");
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
 
     for name in [X_HUB_SIGNATURE_256, X_GITHUB_EVENT, X_GITHUB_DELIVERY] {
@@ -108,8 +108,8 @@ fn every_required_header_must_be_present_exactly_once() {
 
 #[test]
 fn signature_encoding_is_exactly_canonical_lowercase_sha256() {
-    let body = encode(&valid_payload());
-    let base = signed_headers(SECRET, &body, "push", "delivery-123");
+    let body = json_body(&valid_payload());
+    let base = signed_webhook_headers(SECRET, &body, "push", "delivery-123");
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
     let malformed = [
         format!("SHA256={}", "0".repeat(64)),
@@ -139,14 +139,15 @@ fn signature_encoding_is_exactly_canonical_lowercase_sha256() {
 fn body_limit_is_enforced_before_and_while_buffering() {
     assert_eq!(MAX_GITHUB_WEBHOOK_BODY_BYTES, 25 * 1024 * 1024);
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
-    let mut exact = encode(&valid_payload());
+    let mut exact = json_body(&valid_payload());
     exact.resize(MAX_GITHUB_WEBHOOK_BODY_BYTES, b' ');
     let minus_one = &exact[..MAX_GITHUB_WEBHOOK_BODY_BYTES - 1];
-    let minus_one_headers = signed_headers(SECRET, minus_one, "push", "delivery-limit-minus-one");
+    let minus_one_headers =
+        signed_webhook_headers(SECRET, minus_one, "push", "delivery-limit-minus-one");
     verifier
         .verify(&minus_one_headers, Bytes::copy_from_slice(minus_one))
         .expect("one byte below the limit is accepted");
-    let exact_headers = signed_headers(SECRET, &exact, "push", "delivery-limit");
+    let exact_headers = signed_webhook_headers(SECRET, &exact, "push", "delivery-limit");
     verifier
         .verify(&exact_headers, Bytes::copy_from_slice(&exact))
         .expect("exact limit is accepted");
@@ -177,8 +178,8 @@ fn body_limit_is_enforced_before_and_while_buffering() {
 #[test]
 fn authentication_covers_exact_raw_bytes_and_precedes_json() {
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
-    let body = encode(&valid_payload());
-    let headers = signed_headers(SECRET, &body, "push", "delivery-exact");
+    let body = json_body(&valid_payload());
+    let headers = signed_webhook_headers(SECRET, &body, "push", "delivery-exact");
     let mut changed = body.clone();
     changed.push(b' ');
     assert_eq!(
@@ -189,14 +190,14 @@ fn authentication_covers_exact_raw_bytes_and_precedes_json() {
     );
 
     let malformed = b"raw-body-private-marker:{";
-    let wrong_headers = signed_headers(b"wrong secret", malformed, "push", "delivery-json");
+    let wrong_headers = signed_webhook_headers(b"wrong secret", malformed, "push", "delivery-json");
     assert_eq!(
         verifier
             .verify(&wrong_headers, Bytes::from_static(malformed))
             .expect_err("authentication precedes JSON"),
         GithubWebhookError::AuthenticationFailed
     );
-    let authenticated_headers = signed_headers(SECRET, malformed, "push", "delivery-json");
+    let authenticated_headers = signed_webhook_headers(SECRET, malformed, "push", "delivery-json");
     assert_eq!(
         verifier
             .verify(&authenticated_headers, Bytes::from_static(malformed))
@@ -208,7 +209,7 @@ fn authentication_covers_exact_raw_bytes_and_precedes_json() {
 #[test]
 fn authenticated_non_push_envelopes_are_available_before_event_support() {
     let body = b"generic-body-marker:not-json";
-    let headers = signed_headers(SECRET, body, "repository_dispatch", "delivery-event");
+    let headers = signed_webhook_headers(SECRET, body, "repository_dispatch", "delivery-event");
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
     let authenticated = verifier
         .authenticate_chunks(&headers, [&body[..9], &body[9..]])
@@ -234,17 +235,17 @@ fn authenticated_non_push_envelopes_are_available_before_event_support() {
 
 #[test]
 fn unauthenticated_headers_remain_distinct_durable_evidence() {
-    let body = encode(&valid_payload());
+    let body = json_body(&valid_payload());
     let verifier = GithubWebhookVerifier::new(SECRET).expect("verifier");
     let first = verifier
         .verify(
-            &signed_headers(SECRET, &body, "push", "delivery-one"),
+            &signed_webhook_headers(SECRET, &body, "push", "delivery-one"),
             Bytes::copy_from_slice(&body),
         )
         .expect("first delivery");
     let second = verifier
         .verify(
-            &signed_headers(SECRET, &body, "push", "delivery-two"),
+            &signed_webhook_headers(SECRET, &body, "push", "delivery-two"),
             Bytes::copy_from_slice(&body),
         )
         .expect("second delivery");
@@ -317,11 +318,11 @@ fn repository_owner_id_is_required_positive_and_postgres_bigint_representable() 
 
 #[test]
 fn repository_owner_id_is_covered_by_the_exact_body_signature() {
-    let body = encode(&valid_payload());
-    let headers = signed_headers(SECRET, &body, "push", "delivery-owner-id");
+    let body = json_body(&valid_payload());
+    let headers = signed_webhook_headers(SECRET, &body, "push", "delivery-owner-id");
     let mut tampered_payload = valid_payload();
     tampered_payload["repository"]["owner"]["id"] = json!(9_876_544);
-    let tampered_body = encode(&tampered_payload);
+    let tampered_body = json_body(&tampered_payload);
     assert_eq!(
         tampered_body.len(),
         body.len(),
@@ -531,8 +532,8 @@ fn retained_strings_and_provider_commit_collection_are_bounded() {
     excessive["commits"] = Value::Array(commit_entries(MAX_GITHUB_PUSH_COMMITS + 1));
     assert_malformed_payload(&excessive);
 
-    let body = encode(&valid_payload());
-    let headers = signed_headers(SECRET, &body, "push", &"d".repeat(129));
+    let body = json_body(&valid_payload());
+    let headers = signed_webhook_headers(SECRET, &body, "push", &"d".repeat(129));
     let boundary = GithubWebhookVerifier::new(SECRET).expect("verifier");
     assert_eq!(
         boundary
@@ -573,8 +574,8 @@ fn secrets_raw_payloads_and_signatures_never_appear_in_debug_or_errors() {
     payload["private_marker"] = json!("unique-raw-body-leak-marker");
     payload["repository"]["owner"]["login"] = json!("private-owner-marker");
     payload["repository"]["full_name"] = json!("private-owner-marker/automata");
-    let body = encode(&payload);
-    let headers = signed_headers(secret, &body, "push", "private-delivery-marker");
+    let body = json_body(&payload);
+    let headers = signed_webhook_headers(secret, &body, "push", "private-delivery-marker");
     let boundary = GithubWebhookVerifier::new(secret).expect("verifier");
     let push = boundary
         .verify(&headers, Bytes::copy_from_slice(&body))
@@ -598,7 +599,7 @@ fn secrets_raw_payloads_and_signatures_never_appear_in_debug_or_errors() {
         assert!(!push_debug.contains(marker), "leaked marker: {marker}");
     }
 
-    let wrong_headers = signed_headers(b"another secret", &body, "push", "delivery-error");
+    let wrong_headers = signed_webhook_headers(b"another secret", &body, "push", "delivery-error");
     let error = boundary
         .verify(&wrong_headers, Bytes::from(body))
         .expect_err("wrong HMAC");
@@ -678,11 +679,11 @@ fn commit_entries(count: usize) -> Vec<Value> {
 fn verify_payload(
     payload: &Value,
 ) -> Result<automata_ci_github::VerifiedGithubPush, GithubWebhookError> {
-    let body = encode(payload);
+    let body = json_body(payload);
     GithubWebhookVerifier::new(SECRET)
         .expect("verifier")
         .verify(
-            &signed_headers(SECRET, &body, "push", "delivery-payload"),
+            &signed_webhook_headers(SECRET, &body, "push", "delivery-payload"),
             Bytes::from(body),
         )
 }
@@ -699,25 +700,4 @@ fn assert_malformed_payload(payload: &Value) {
         verify_payload(payload).expect_err("malformed payload"),
         GithubWebhookError::MalformedPayload
     );
-}
-
-fn encode(payload: &Value) -> Vec<u8> {
-    serde_json::to_vec(payload).expect("JSON fixture")
-}
-
-fn signed_headers(secret: &[u8], body: &[u8], event: &str, delivery: &str) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        X_HUB_SIGNATURE_256,
-        HeaderValue::from_str(&webhook_signature(secret, body)).expect("signature header"),
-    );
-    headers.insert(
-        X_GITHUB_EVENT,
-        HeaderValue::from_str(event).expect("event header"),
-    );
-    headers.insert(
-        X_GITHUB_DELIVERY,
-        HeaderValue::from_str(delivery).expect("delivery header"),
-    );
-    headers
 }


### PR DESCRIPTION
Closes #336\n\n## Summary\n\n- consolidate authenticated webhook JSON, digest, HMAC header, repository, and revision fixtures in one private test-support boundary\n- replace four signed-header builders, three JSON encoders, two digest implementations, two repository-builder sets, and eight duplicate SHA constants\n- preserve all distinct payload builders, optional-actor coverage, raw-byte authentication, durable push identity, and exact header semantics\n- remove 85 net lines across one cohesive five-file test-only bundle; production code and public APIs are unchanged\n\n## Validation\n\n- cargo fmt --all -- --check\n- git diff --check plus exact scope/definition/call-count and payload-boundary scans\n- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-github --all-targets --all-features\n- four focused suites: event envelope 13/13, event normalization 18/18, stored push rehydration 8/8, webhook verification 17/17\n- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-github --all-targets --all-features on current main (19 unit + 127 integration passed; 1 configured live-network test ignored)\n- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-github --all-targets --all-features -- -D warnings\n- exact-base replay retained identical patch ID and binary diff after unrelated main advancement\n- final semantic audit on the exact frozen head found no issues