### PR TITLE
feat(storage): enforce exact S3 connection authority

### DIFF
--- a/.ci/workflows/pull-request.yml
+++ b/.ci/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
-      CARGO_BUILD_JOBS: "4"
+      CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   until exact native mutation evidence is qualified. The command is independent
   of `local doctor`, Docker, the network, and GitHub tokens, and performs no
   admission, scheduling, execution, or Check Run operation.
+- Exact private-CA HTTPS trust for S3-compatible storage and a hidden,
+  current-only `automata internal object-store ensure-bucket` image command.
+  Server, initializer, and runner use closed bounded credential/trust
+  configuration and the production AWS SDK client path; runner product schema
+  4 requires the same explicit trust choice. Config and SDK clients are one
+  inseparable store, canonical private-CA bytes and signing usage fail closed,
+  connected-store diagnostics expose no bound state, validated transport is
+  one closed security mode, and bucket creation is region-correct, idempotent,
+  conflict-reverified, and bounded by one total deadline.
 
 ### Known limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,18 +373,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "automata-ci-blob",
+ "automata-ci-tls",
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "base64 0.23.1",
  "bytes",
- "pem-rfc7468",
  "rcgen",
  "rustls",
  "thiserror",
  "tokio",
  "tokio-rustls",
  "url",
- "x509-parser",
  "zeroize",
 ]
 
@@ -1142,6 +1141,17 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "automata-ci-tls"
+version = "0.1.0"
+dependencies = [
+ "pem-rfc7468",
+ "rcgen",
+ "rustls",
+ "thiserror",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,9 +377,14 @@ dependencies = [
  "aws-smithy-http-client",
  "base64 0.23.1",
  "bytes",
+ "pem-rfc7468",
+ "rcgen",
+ "rustls",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "url",
+ "x509-parser",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/automata-ci-service-proxy",
     "crates/automata-ci-store",
     "crates/automata-ci-store-postgres",
+    "crates/automata-ci-tls",
     "crates/automata-ci-ui-renderer",
     "crates/automata-ci-workflow-github",
     "crates/automata-ci-workflow-service",
@@ -119,6 +120,7 @@ automata-ci-secret = { path = "crates/automata-ci-secret", version = "0.1.0" }
 automata-ci-secret-postgres = { path = "crates/automata-ci-secret-postgres", version = "0.1.0" }
 automata-ci-store = { path = "crates/automata-ci-store", version = "0.1.0" }
 automata-ci-store-postgres = { path = "crates/automata-ci-store-postgres", version = "0.1.0" }
+automata-ci-tls = { path = "crates/automata-ci-tls", version = "0.1.0" }
 automata-ci-ui-renderer = { path = "crates/automata-ci-ui-renderer", version = "0.1.0" }
 automata-ci-workflow-github = { path = "crates/automata-ci-workflow-github", version = "0.1.0" }
 automata-ci-workflow-service = { path = "crates/automata-ci-workflow-service", version = "0.1.0" }

--- a/crates/automata-ci-action-github/tests/live_checkout_pipeline.rs
+++ b/crates/automata-ci-action-github/tests/live_checkout_pipeline.rs
@@ -7,9 +7,7 @@ use automata_ci_action::{
 use automata_ci_action_github::{
     ActionExecution, ActionMetadataDecoder, GithubActionMetadataDecoder, JavascriptRuntime,
 };
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_github::GithubHttpEndpoint;
 use automata_ci_scm::{RepositoryId, RevisionSpec};
 use url::Url;
@@ -45,7 +43,7 @@ async fn resolves_and_decodes_the_exact_checkout_action() {
         None,
     )
     .expect("test S3 credentials");
-    let blobs = S3BlobStore::new(config.client(credentials), &config);
+    let blobs = config.connect(credentials).expect("test S3 store");
     let github =
         GithubHttpEndpoint::github_dot_com("automata-live-test/0.1.0").expect("GitHub endpoint");
     let repository = RepositoryId::new("actions/checkout").expect("repository");

--- a/crates/automata-ci-action/tests/live_github_rustfs.rs
+++ b/crates/automata-ci-action/tests/live_github_rustfs.rs
@@ -4,9 +4,7 @@ use automata_ci_action::{
     ActionBundleLimits, ActionDefinitionKind, ActionResolver, ActionSubpath,
     ImmutableActionResolver, RepositoryActionRequest,
 };
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_github::GithubHttpEndpoint;
 use automata_ci_scm::{RepositoryId, RevisionSpec};
 use url::Url;
@@ -41,7 +39,7 @@ async fn resolves_pinned_checkout_from_github_into_rustfs() {
         None,
     )
     .expect("test S3 credentials");
-    let store = S3BlobStore::new(config.client(credentials), &config);
+    let store = config.connect(credentials).expect("test S3 store");
     let github = GithubHttpEndpoint::github_dot_com("automata-live-test/0.1.0").unwrap();
     let repository = RepositoryId::new("actions/checkout").unwrap();
     let revision = RevisionSpec::new(CHECKOUT_COMMIT).unwrap();

--- a/crates/automata-ci-blob-s3/Cargo.toml
+++ b/crates/automata-ci-blob-s3/Cargo.toml
@@ -22,18 +22,17 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 automata-ci-blob.workspace = true
+automata-ci-tls.workspace = true
 aws-sdk-s3.workspace = true
 aws-smithy-http-client.workspace = true
 base64.workspace = true
 bytes.workspace = true
-pem-rfc7468.workspace = true
-rustls.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
-x509-parser.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true
+rustls.workspace = true
 tokio-rustls.workspace = true

--- a/crates/automata-ci-blob-s3/Cargo.toml
+++ b/crates/automata-ci-blob-s3/Cargo.toml
@@ -26,7 +26,14 @@ aws-sdk-s3.workspace = true
 aws-smithy-http-client.workspace = true
 base64.workspace = true
 bytes.workspace = true
+pem-rfc7468.workspace = true
+rustls.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
+x509-parser.workspace = true
 zeroize.workspace = true
+
+[dev-dependencies]
+rcgen.workspace = true
+tokio-rustls.workspace = true

--- a/crates/automata-ci-blob-s3/README.md
+++ b/crates/automata-ci-blob-s3/README.md
@@ -8,6 +8,25 @@ state for coordination.
 The control plane and runner compose this adapter behind `automata-ci-blob`.
 PostgreSQL remains the coordination authority for the product.
 
+HTTPS clients use one closed trust policy. `S3TlsTrust::web_pki()` selects the
+platform Web PKI store. `S3TlsTrust::private_ca(...)` accepts exactly one valid
+X.509 CA certificate and installs it into an otherwise empty trust store; it
+never merges or retries with Web PKI roots. Private-CA input is capped at 1 MiB
+and is incompatible with plaintext endpoints. Its bytes must be the canonical
+RFC 7468 encoding with 64-column Base64, LF line endings, one terminal LF, and
+no preamble or trailing bytes. A present KeyUsage must include `keyCertSign`.
+
+`S3BlobStoreConfig::connect` is the sole public construction boundary, so the
+SDK client, validated endpoint/namespace, credentials, and exact trust policy
+cannot be rebound independently. Connected-store debug output is one fixed
+redacted value and exposes none of that bound state. The resulting store's production
+`ensure_bucket` operation performs `HeadBucket`, creates only after an exact
+not-found response, and requires a final successful `HeadBucket` after creation
+or a creation conflict. Creation omits `LocationConstraint` only for
+`us-east-1` and sends every other validated region exactly. The complete
+sequence shares the validated operation deadline and never treats a conflict
+alone as success.
+
 - [Control-plane configuration](https://github.com/automata-ci/automata/blob/main/crates/automata-ci/README.md)
 - API documentation: run `cargo doc -p automata-ci-blob-s3 --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-blob-s3/src/adapter.rs
+++ b/crates/automata-ci-blob-s3/src/adapter.rs
@@ -1,13 +1,19 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use async_trait::async_trait;
 use automata_ci_blob::{
     BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
     PutBlobOutcome, VerifiedBlob,
 };
-use aws_sdk_s3::{Client, error::ProvideErrorMetadata, primitives::ByteStream};
+use aws_sdk_s3::{
+    Client,
+    error::{ProvideErrorMetadata, SdkError},
+    primitives::ByteStream,
+    types::{BucketLocationConstraint, CreateBucketConfiguration},
+};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bytes::{Bytes, BytesMut};
+use thiserror::Error;
 use tokio::time::{Instant, timeout_at};
 
 use crate::{S3AtRestEncryption, S3BlobStoreConfig};
@@ -17,26 +23,116 @@ const SIZE_METADATA_KEY: &str = "automata-size";
 const MAX_GET_ATTEMPTS: u32 = 3;
 
 /// S3-compatible implementation of immutable blob operations.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct S3BlobStore {
     client: Client,
+    region: String,
     bucket: String,
     prefix: Option<String>,
     operation_timeout: Duration,
     at_rest_encryption: S3AtRestEncryption,
 }
 
+impl fmt::Debug for S3BlobStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("S3BlobStore([connection redacted])")
+    }
+}
+
+/// Successful result of idempotently making one exact bucket ready.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EnsureBucketOutcome {
+    /// The configured bucket was already accessible to these credentials.
+    AlreadyExists,
+    /// This invocation created the configured bucket and verified access.
+    Created,
+}
+
+/// Sanitized failure while making one exact configured bucket ready.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum EnsureBucketError {
+    /// The initial exact-bucket inspection failed with a result other than not found.
+    #[error("initial S3 bucket inspection failed")]
+    InitialInspection,
+    /// Creating the exact configured bucket failed with a result other than conflict.
+    #[error("S3 bucket creation failed")]
+    Creation,
+    /// The required post-create exact-bucket inspection did not succeed.
+    #[error("final S3 bucket inspection failed")]
+    FinalInspection,
+    /// The complete inspect/create/reinspect sequence exceeded one total deadline.
+    #[error("S3 bucket initialization exceeded its total deadline")]
+    Deadline,
+}
+
 impl S3BlobStore {
-    /// Binds any externally configured SDK client to validated namespace policy.
-    #[must_use]
-    pub fn new(client: Client, config: &S3BlobStoreConfig) -> Self {
+    pub(crate) fn from_validated(client: Client, config: &S3BlobStoreConfig) -> Self {
         Self {
             client,
+            region: config.region().to_owned(),
             bucket: config.bucket().to_owned(),
             prefix: config.prefix().map(str::to_owned),
             operation_timeout: config.operation_timeout(),
             at_rest_encryption: config.at_rest_encryption().clone(),
         }
+    }
+
+    /// Idempotently ensures that this store's exact configured bucket is accessible.
+    ///
+    /// Only an HTTP not-found response to the initial `HeadBucket` can authorize a
+    /// `CreateBucket`. A creation conflict is treated as an ambiguous concurrent
+    /// race, never as success by itself; the final `HeadBucket` must still succeed.
+    /// Every SDK operation shares one wall-clock deadline. Bucket creation omits
+    /// `LocationConstraint` only for `us-east-1`; every other validated signing
+    /// region is sent as the exact location constraint.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized stage-specific failure. Provider response bodies and
+    /// configuration values are not retained in the error.
+    pub async fn ensure_bucket(&self) -> Result<EnsureBucketOutcome, EnsureBucketError> {
+        let deadline = Instant::now() + self.operation_timeout;
+        let initial = timeout_at(
+            deadline,
+            self.client.head_bucket().bucket(&self.bucket).send(),
+        )
+        .await
+        .map_err(|_| EnsureBucketError::Deadline)?;
+        match initial {
+            Ok(_) => return Ok(EnsureBucketOutcome::AlreadyExists),
+            Err(error) if response_status(&error) == Some(404) => {}
+            Err(_) => return Err(EnsureBucketError::InitialInspection),
+        }
+
+        let create = self.client.create_bucket().bucket(&self.bucket);
+        let create = if self.region == "us-east-1" {
+            create
+        } else {
+            create.create_bucket_configuration(
+                CreateBucketConfiguration::builder()
+                    .location_constraint(BucketLocationConstraint::from(self.region.as_str()))
+                    .build(),
+            )
+        };
+        let create = timeout_at(deadline, create.send())
+            .await
+            .map_err(|_| EnsureBucketError::Deadline)?;
+        let outcome = match create {
+            Ok(_) => EnsureBucketOutcome::Created,
+            Err(error) if response_status(&error) == Some(409) => {
+                EnsureBucketOutcome::AlreadyExists
+            }
+            Err(_) => return Err(EnsureBucketError::Creation),
+        };
+
+        timeout_at(
+            deadline,
+            self.client.head_bucket().bucket(&self.bucket).send(),
+        )
+        .await
+        .map_err(|_| EnsureBucketError::Deadline)?
+        .map_err(|_| EnsureBucketError::FinalInspection)?;
+        Ok(outcome)
     }
 
     fn object_key(&self, descriptor: &BlobDescriptor) -> String {
@@ -234,7 +330,7 @@ fn existing_object_error(error: BlobStoreError) -> BlobStoreError {
     }
 }
 
-fn response_status<E>(error: &aws_sdk_s3::error::SdkError<E>) -> Option<u16> {
+fn response_status<E>(error: &SdkError<E>) -> Option<u16> {
     error
         .raw_response()
         .map(|response| response.status().as_u16())

--- a/crates/automata-ci-blob-s3/src/config.rs
+++ b/crates/automata-ci-blob-s3/src/config.rs
@@ -1,11 +1,10 @@
 use std::{fmt, net::IpAddr, time::Duration};
 
+use automata_ci_tls::{MAX_CA_CERTIFICATE_PEM_BYTES, ValidatedCaCertificate};
 use aws_sdk_s3::{Client, config::Region};
 use aws_smithy_http_client::tls::{TlsContext, TrustStore};
-use rustls::{RootCertStore, pki_types::CertificateDer};
 use thiserror::Error;
 use url::{Host, Url};
-use x509_parser::parse_x509_certificate;
 use zeroize::Zeroizing;
 
 use crate::adapter::S3BlobStore;
@@ -17,7 +16,7 @@ const MAX_KMS_KEY_ID_BYTES: usize = 2_048;
 const MAX_OPERATION_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// Maximum accepted size of one exact private S3 CA certificate in PEM form.
-pub const MAX_S3_PRIVATE_CA_PEM_BYTES: usize = 1024 * 1024;
+pub const MAX_S3_PRIVATE_CA_PEM_BYTES: usize = MAX_CA_CERTIFICATE_PEM_BYTES;
 
 /// Closed trust policy for authenticating an HTTPS S3 endpoint.
 #[derive(Clone, Eq, PartialEq)]
@@ -28,7 +27,7 @@ pub struct S3TlsTrust {
 #[derive(Clone, Eq, PartialEq)]
 enum S3TlsTrustPolicy {
     WebPki,
-    PrivateCa { certificate_pem: Vec<u8> },
+    PrivateCa(ValidatedCaCertificate),
 }
 
 impl S3TlsTrust {
@@ -51,48 +50,18 @@ impl S3TlsTrust {
     /// terminal LF, and no trailing data or second document. When `KeyUsage` is
     /// present, it must authorize certificate signing.
     pub fn private_ca(certificate_pem: impl Into<Vec<u8>>) -> Result<Self, S3BlobStoreConfigError> {
-        let certificate_pem = certificate_pem.into();
-        if certificate_pem.is_empty() || certificate_pem.len() > MAX_S3_PRIVATE_CA_PEM_BYTES {
-            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
-        }
-        let (label, certificate_der) = pem_rfc7468::decode_vec(&certificate_pem)
-            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
-        if label != "CERTIFICATE" {
-            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
-        }
-        let canonical_pem = pem_rfc7468::encode_string(
-            "CERTIFICATE",
-            pem_rfc7468::LineEnding::LF,
-            &certificate_der,
-        )
-        .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
-        if canonical_pem.as_bytes() != certificate_pem {
-            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
-        }
-        let (remaining, certificate) = parse_x509_certificate(&certificate_der)
-            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
-        let key_usage = certificate
-            .key_usage()
-            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
-        if !remaining.is_empty()
-            || !certificate.tbs_certificate.is_ca()
-            || key_usage.is_some_and(|usage| !usage.value.key_cert_sign())
-        {
-            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
-        }
-        RootCertStore::empty()
-            .add(CertificateDer::from(certificate_der))
+        let certificate = ValidatedCaCertificate::new(certificate_pem)
             .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
         Ok(Self {
-            mode: S3TlsTrustPolicy::PrivateCa { certificate_pem },
+            mode: S3TlsTrustPolicy::PrivateCa(certificate),
         })
     }
 
     fn tls_context(&self) -> Result<TlsContext, S3BlobStoreConfigError> {
         let trust_store = match &self.mode {
             S3TlsTrustPolicy::WebPki => TrustStore::default(),
-            S3TlsTrustPolicy::PrivateCa { certificate_pem } => {
-                TrustStore::empty().with_pem_certificate(certificate_pem.clone())
+            S3TlsTrustPolicy::PrivateCa(certificate) => {
+                TrustStore::empty().with_pem_certificate(certificate.as_pem().to_vec())
             }
         };
         TlsContext::builder()
@@ -102,7 +71,7 @@ impl S3TlsTrust {
     }
 
     const fn is_private_ca(&self) -> bool {
-        matches!(&self.mode, S3TlsTrustPolicy::PrivateCa { .. })
+        matches!(&self.mode, S3TlsTrustPolicy::PrivateCa(_))
     }
 }
 
@@ -110,7 +79,7 @@ impl fmt::Debug for S3TlsTrust {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match &self.mode {
             S3TlsTrustPolicy::WebPki => "S3TlsTrust::WebPki",
-            S3TlsTrustPolicy::PrivateCa { .. } => "S3TlsTrust::PrivateCa([certificate redacted])",
+            S3TlsTrustPolicy::PrivateCa(_) => "S3TlsTrust::PrivateCa([certificate redacted])",
         })
     }
 }

--- a/crates/automata-ci-blob-s3/src/config.rs
+++ b/crates/automata-ci-blob-s3/src/config.rs
@@ -1,15 +1,119 @@
 use std::{fmt, net::IpAddr, time::Duration};
 
 use aws_sdk_s3::{Client, config::Region};
+use aws_smithy_http_client::tls::{TlsContext, TrustStore};
+use rustls::{RootCertStore, pki_types::CertificateDer};
 use thiserror::Error;
 use url::{Host, Url};
+use x509_parser::parse_x509_certificate;
 use zeroize::Zeroizing;
+
+use crate::adapter::S3BlobStore;
 
 const MAX_BUCKET_BYTES: usize = 63;
 const MAX_PREFIX_BYTES: usize = 1_024;
 const MAX_REGION_BYTES: usize = 64;
 const MAX_KMS_KEY_ID_BYTES: usize = 2_048;
 const MAX_OPERATION_TIMEOUT: Duration = Duration::from_mins(5);
+
+/// Maximum accepted size of one exact private S3 CA certificate in PEM form.
+pub const MAX_S3_PRIVATE_CA_PEM_BYTES: usize = 1024 * 1024;
+
+/// Closed trust policy for authenticating an HTTPS S3 endpoint.
+#[derive(Clone, Eq, PartialEq)]
+pub struct S3TlsTrust {
+    mode: S3TlsTrustPolicy,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+enum S3TlsTrustPolicy {
+    WebPki,
+    PrivateCa { certificate_pem: Vec<u8> },
+}
+
+impl S3TlsTrust {
+    /// Selects the platform Web PKI root store.
+    #[must_use]
+    pub const fn web_pki() -> Self {
+        Self {
+            mode: S3TlsTrustPolicy::WebPki,
+        }
+    }
+
+    /// Creates an exact single-private-CA trust policy.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized input, malformed or non-certificate PEM, malformed
+    /// X.509, and certificates that are not marked as certificate authorities.
+    /// The source bytes must be the canonical RFC 7468 encoding: no preamble,
+    /// exactly 64 Base64 characters per non-final line, LF line endings, one
+    /// terminal LF, and no trailing data or second document. When `KeyUsage` is
+    /// present, it must authorize certificate signing.
+    pub fn private_ca(certificate_pem: impl Into<Vec<u8>>) -> Result<Self, S3BlobStoreConfigError> {
+        let certificate_pem = certificate_pem.into();
+        if certificate_pem.is_empty() || certificate_pem.len() > MAX_S3_PRIVATE_CA_PEM_BYTES {
+            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
+        }
+        let (label, certificate_der) = pem_rfc7468::decode_vec(&certificate_pem)
+            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
+        if label != "CERTIFICATE" {
+            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
+        }
+        let canonical_pem = pem_rfc7468::encode_string(
+            "CERTIFICATE",
+            pem_rfc7468::LineEnding::LF,
+            &certificate_der,
+        )
+        .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
+        if canonical_pem.as_bytes() != certificate_pem {
+            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
+        }
+        let (remaining, certificate) = parse_x509_certificate(&certificate_der)
+            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
+        let key_usage = certificate
+            .key_usage()
+            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
+        if !remaining.is_empty()
+            || !certificate.tbs_certificate.is_ca()
+            || key_usage.is_some_and(|usage| !usage.value.key_cert_sign())
+        {
+            return Err(S3BlobStoreConfigError::InvalidPrivateCa);
+        }
+        RootCertStore::empty()
+            .add(CertificateDer::from(certificate_der))
+            .map_err(|_| S3BlobStoreConfigError::InvalidPrivateCa)?;
+        Ok(Self {
+            mode: S3TlsTrustPolicy::PrivateCa { certificate_pem },
+        })
+    }
+
+    fn tls_context(&self) -> Result<TlsContext, S3BlobStoreConfigError> {
+        let trust_store = match &self.mode {
+            S3TlsTrustPolicy::WebPki => TrustStore::default(),
+            S3TlsTrustPolicy::PrivateCa { certificate_pem } => {
+                TrustStore::empty().with_pem_certificate(certificate_pem.clone())
+            }
+        };
+        TlsContext::builder()
+            .with_trust_store(trust_store)
+            .build()
+            .map_err(|_| S3BlobStoreConfigError::InvalidTlsContext)
+    }
+
+    const fn is_private_ca(&self) -> bool {
+        matches!(&self.mode, S3TlsTrustPolicy::PrivateCa { .. })
+    }
+}
+
+impl fmt::Debug for S3TlsTrust {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match &self.mode {
+            S3TlsTrustPolicy::WebPki => "S3TlsTrust::WebPki",
+            S3TlsTrustPolicy::PrivateCa { .. } => "S3TlsTrust::PrivateCa([certificate redacted])",
+        })
+    }
+}
 
 /// Required server-side encryption policy for every immutable object.
 ///
@@ -165,6 +269,7 @@ pub struct S3BlobStoreConfig {
     bucket: String,
     prefix: Option<String>,
     force_path_style: bool,
+    tls_trust: S3TlsTrust,
     operation_timeout: Duration,
     at_rest_encryption: S3AtRestEncryption,
 }
@@ -175,6 +280,7 @@ struct UnvalidatedS3BlobStoreConfig {
     bucket: String,
     prefix: Option<String>,
     force_path_style: bool,
+    tls_trust: S3TlsTrust,
     operation_timeout: Duration,
     at_rest_encryption: S3AtRestEncryption,
 }
@@ -198,6 +304,7 @@ impl S3BlobStoreConfig {
         bucket: impl Into<String>,
         prefix: Option<String>,
         force_path_style: bool,
+        tls_trust: S3TlsTrust,
         operation_timeout: Duration,
     ) -> Result<Self, S3BlobStoreConfigError> {
         Self::validate(
@@ -207,6 +314,7 @@ impl S3BlobStoreConfig {
                 bucket: bucket.into(),
                 prefix,
                 force_path_style,
+                tls_trust,
                 operation_timeout,
                 at_rest_encryption: S3AtRestEncryption::default(),
             },
@@ -234,6 +342,7 @@ impl S3BlobStoreConfig {
                 bucket: bucket.into(),
                 prefix,
                 force_path_style: true,
+                tls_trust: S3TlsTrust::web_pki(),
                 operation_timeout,
                 at_rest_encryption: S3AtRestEncryption::default(),
             },
@@ -251,9 +360,13 @@ impl S3BlobStoreConfig {
             bucket,
             prefix,
             force_path_style,
+            tls_trust,
             operation_timeout,
             at_rest_encryption,
         } = candidate;
+        if endpoint.scheme() != "https" && tls_trust.is_private_ca() {
+            return Err(S3BlobStoreConfigError::PrivateCaRequiresHttps);
+        }
         let allow_loopback_http = matches!(endpoint_policy, EndpointPolicy::LoopbackDevelopment);
         validate_endpoint(&endpoint, allow_loopback_http)?;
         validate_region(&region)?;
@@ -268,22 +381,27 @@ impl S3BlobStoreConfig {
             bucket,
             prefix,
             force_path_style,
+            tls_trust,
             operation_timeout,
             at_rest_encryption,
         })
     }
 
-    /// Constructs a statically authenticated S3 SDK client.
+    /// Connects this validated policy to one statically authenticated S3 store.
     ///
-    /// The adapter also accepts an externally constructed [`Client`] so a
-    /// deployment may use any SDK credential provider without changing this
-    /// domain configuration.
-    #[must_use]
-    pub fn client(&self, credentials: StaticS3Credentials) -> Client {
+    /// # Errors
+    ///
+    /// Returns a sanitized error if the validated exact TLS trust policy cannot
+    /// be converted into the SDK HTTP client's TLS context.
+    pub fn connect(
+        self,
+        credentials: StaticS3Credentials,
+    ) -> Result<S3BlobStore, S3BlobStoreConfigError> {
         let http_client = aws_smithy_http_client::Builder::new()
             .tls_provider(aws_smithy_http_client::tls::Provider::Rustls(
                 aws_smithy_http_client::tls::rustls_provider::CryptoMode::Ring,
             ))
+            .tls_context(self.tls_trust.tls_context()?)
             .build_https();
         let config = aws_sdk_s3::Config::builder()
             .behavior_version_latest()
@@ -293,7 +411,14 @@ impl S3BlobStoreConfig {
             .credentials_provider(credentials.into_sdk())
             .force_path_style(self.force_path_style)
             .build();
-        Client::from_conf(config)
+        Ok(S3BlobStore::from_validated(
+            Client::from_conf(config),
+            &self,
+        ))
+    }
+
+    pub(crate) fn region(&self) -> &str {
+        &self.region
     }
 
     /// Returns the bucket name without credentials.
@@ -319,6 +444,23 @@ impl S3BlobStoreConfig {
     pub fn with_at_rest_encryption(mut self, encryption: S3AtRestEncryption) -> Self {
         self.at_rest_encryption = encryption;
         self
+    }
+
+    /// Rebinds this already-validated target to one exact TLS trust policy.
+    ///
+    /// This preserves the validated endpoint, namespace, addressing, deadline,
+    /// and encryption policy. It exists for products that validate their
+    /// non-secret S3 shape before loading a bounded private-CA source.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a private-CA policy for a plaintext loopback configuration.
+    pub fn with_tls_trust(mut self, tls_trust: S3TlsTrust) -> Result<Self, S3BlobStoreConfigError> {
+        if self.endpoint.scheme() != "https" && tls_trust.is_private_ca() {
+            return Err(S3BlobStoreConfigError::PrivateCaRequiresHttps);
+        }
+        self.tls_trust = tls_trust;
+        Ok(self)
     }
 
     /// Returns the encryption policy verified on every object read.
@@ -355,6 +497,15 @@ pub enum S3BlobStoreConfigError {
     /// The KMS key identifier is empty, oversized, padded, or contains control characters.
     #[error("S3 KMS key identity is invalid")]
     InvalidKmsKeyId,
+    /// The private trust source is not exactly one valid X.509 CA certificate.
+    #[error("S3 private CA source must contain exactly one valid X.509 CA certificate")]
+    InvalidPrivateCa,
+    /// Exact private-CA trust was selected for a plaintext endpoint.
+    #[error("S3 private CA trust requires an HTTPS endpoint")]
+    PrivateCaRequiresHttps,
+    /// The selected exact TLS trust context could not be constructed.
+    #[error("S3 TLS trust context is invalid")]
+    InvalidTlsContext,
 }
 
 fn validate_kms_key_id(value: String) -> Result<String, S3BlobStoreConfigError> {

--- a/crates/automata-ci-blob-s3/src/lib.rs
+++ b/crates/automata-ci-blob-s3/src/lib.rs
@@ -9,7 +9,8 @@
 mod adapter;
 mod config;
 
-pub use adapter::S3BlobStore;
+pub use adapter::{EnsureBucketError, EnsureBucketOutcome, S3BlobStore};
 pub use config::{
-    S3AtRestEncryption, S3BlobStoreConfig, S3BlobStoreConfigError, StaticS3Credentials,
+    MAX_S3_PRIVATE_CA_PEM_BYTES, S3AtRestEncryption, S3BlobStoreConfig, S3BlobStoreConfigError,
+    S3TlsTrust, StaticS3Credentials,
 };

--- a/crates/automata-ci-blob-s3/tests/blob_s3.rs
+++ b/crates/automata-ci-blob-s3/tests/blob_s3.rs
@@ -1,3 +1,5 @@
+mod bucket;
 mod configuration;
 mod get_retry;
 mod rustfs_contract;
+mod tls_trust;

--- a/crates/automata-ci-blob-s3/tests/bucket.rs
+++ b/crates/automata-ci-blob-s3/tests/bucket.rs
@@ -1,0 +1,340 @@
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use automata_ci_blob_s3::{
+    EnsureBucketError, EnsureBucketOutcome, S3BlobStoreConfig, StaticS3Credentials,
+};
+use aws_sdk_s3::types::BucketLocationConstraint;
+use tokio::{
+    net::{TcpListener, TcpStream},
+    task::{JoinHandle, JoinSet},
+    time::Instant,
+};
+use url::Url;
+
+#[tokio::test]
+async fn existing_bucket_needs_only_one_exact_head() {
+    let fixture = S3Fixture::spawn([Response::Status("200 OK")]).await;
+
+    let outcome = fixture.ensure(Duration::from_secs(1)).await;
+
+    assert_eq!(outcome, Ok(EnsureBucketOutcome::AlreadyExists));
+    assert_eq!(fixture.requests(), ["HEAD /automata-tests/"]);
+}
+
+#[tokio::test]
+async fn absent_bucket_is_created_then_reinspected() {
+    let fixture = S3Fixture::spawn([
+        Response::Status("404 Not Found"),
+        Response::Status("200 OK"),
+        Response::Status("200 OK"),
+    ])
+    .await;
+
+    let outcome = fixture.ensure(Duration::from_secs(1)).await;
+
+    assert_eq!(outcome, Ok(EnsureBucketOutcome::Created));
+    assert_eq!(
+        fixture.requests(),
+        [
+            "HEAD /automata-tests/",
+            "PUT /automata-tests/",
+            "HEAD /automata-tests/"
+        ]
+    );
+    assert!(fixture.create_body().is_empty());
+}
+
+#[tokio::test]
+async fn every_non_us_east_1_region_is_the_exact_create_location_constraint() {
+    let regions = BucketLocationConstraint::values()
+        .iter()
+        .copied()
+        .chain(["future-region-1"]);
+    for region in regions {
+        let fixture = S3Fixture::spawn([
+            Response::Status("404 Not Found"),
+            Response::Status("200 OK"),
+            Response::Status("200 OK"),
+        ])
+        .await;
+
+        assert_eq!(
+            fixture
+                .ensure_in_region(region, Duration::from_secs(1))
+                .await,
+            Ok(EnsureBucketOutcome::Created),
+            "region {region}"
+        );
+        assert_eq!(
+            fixture.create_body(),
+            format!(
+                "<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><LocationConstraint>{region}</LocationConstraint></CreateBucketConfiguration>"
+            )
+            .as_bytes(),
+            "region {region}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn create_conflict_is_accepted_only_after_a_successful_final_head() {
+    let accepted = S3Fixture::spawn([
+        Response::Status("404 Not Found"),
+        Response::Status("409 Conflict"),
+        Response::Status("200 OK"),
+    ])
+    .await;
+    assert_eq!(
+        accepted.ensure(Duration::from_secs(1)).await,
+        Ok(EnsureBucketOutcome::AlreadyExists)
+    );
+    assert_eq!(accepted.requests().len(), 3);
+
+    let rejected = S3Fixture::spawn([
+        Response::Status("404 Not Found"),
+        Response::Status("409 Conflict"),
+        Response::Status("403 Forbidden"),
+    ])
+    .await;
+    assert_eq!(
+        rejected.ensure(Duration::from_secs(1)).await,
+        Err(EnsureBucketError::FinalInspection)
+    );
+    assert_eq!(rejected.requests().len(), 3);
+}
+
+#[tokio::test]
+async fn non_not_found_inspection_never_authorizes_creation() {
+    for status in ["401 Unauthorized", "403 Forbidden"] {
+        let fixture = S3Fixture::spawn([Response::Status(status)]).await;
+
+        assert_eq!(
+            fixture.ensure(Duration::from_millis(500)).await,
+            Err(EnsureBucketError::InitialInspection)
+        );
+        assert!(
+            fixture
+                .requests()
+                .iter()
+                .all(|request| request.starts_with("HEAD "))
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_stage_shares_one_total_deadline() {
+    let fixture = S3Fixture::spawn([Response::Status("404 Not Found"), Response::Stall]).await;
+    let started = Instant::now();
+
+    let outcome = fixture.ensure(Duration::from_millis(150)).await;
+
+    assert_eq!(outcome, Err(EnsureBucketError::Deadline));
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert_eq!(
+        fixture.requests(),
+        ["HEAD /automata-tests/", "PUT /automata-tests/"]
+    );
+}
+
+#[derive(Clone, Copy)]
+enum Response {
+    Status(&'static str),
+    Stall,
+}
+
+struct S3Fixture {
+    endpoint: Url,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    task: JoinHandle<()>,
+}
+
+impl S3Fixture {
+    async fn spawn(responses: impl IntoIterator<Item = Response>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind bucket fixture");
+        let endpoint = Url::parse(&format!(
+            "http://{}/",
+            listener.local_addr().expect("bucket fixture address")
+        ))
+        .expect("bucket fixture URL");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let responses = Arc::new(Mutex::new(responses.into_iter().collect::<VecDeque<_>>()));
+        let task_requests = Arc::clone(&requests);
+        let task_responses = Arc::clone(&responses);
+        let task = tokio::spawn(async move {
+            let mut handlers = JoinSet::new();
+            loop {
+                tokio::select! {
+                    accepted = listener.accept() => {
+                        let (stream, _) = accepted.expect("accept bucket request");
+                        let requests = Arc::clone(&task_requests);
+                        let response = task_responses
+                            .lock()
+                            .expect("bucket response lock")
+                            .pop_front()
+                            .expect("unexpected bucket request");
+                        handlers.spawn(async move {
+                            serve(stream, requests, response)
+                                .await
+                                .expect("serve bucket response");
+                        });
+                    }
+                    completed = handlers.join_next(), if !handlers.is_empty() => {
+                        completed.expect("bucket handler join").expect("bucket handler");
+                    }
+                }
+            }
+        });
+        Self {
+            endpoint,
+            requests,
+            task,
+        }
+    }
+
+    async fn ensure(
+        &self,
+        operation_timeout: Duration,
+    ) -> Result<EnsureBucketOutcome, EnsureBucketError> {
+        self.ensure_in_region("us-east-1", operation_timeout).await
+    }
+
+    async fn ensure_in_region(
+        &self,
+        region: &str,
+        operation_timeout: Duration,
+    ) -> Result<EnsureBucketOutcome, EnsureBucketError> {
+        let config = S3BlobStoreConfig::loopback_development(
+            self.endpoint.clone(),
+            region,
+            "automata-tests",
+            None,
+            operation_timeout,
+        )
+        .expect("bucket fixture config");
+        let credentials = StaticS3Credentials::new("test-access", "test-secret", None)
+            .expect("bucket fixture credentials");
+        config
+            .connect(credentials)
+            .expect("bucket fixture S3 store")
+            .ensure_bucket()
+            .await
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests
+            .lock()
+            .expect("bucket request lock")
+            .iter()
+            .map(|request| request.target.clone())
+            .collect()
+    }
+
+    fn create_body(&self) -> Vec<u8> {
+        self.requests
+            .lock()
+            .expect("bucket request lock")
+            .iter()
+            .find(|request| request.target.starts_with("PUT "))
+            .expect("create request")
+            .body
+            .clone()
+    }
+}
+
+impl Drop for S3Fixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn serve(
+    stream: TcpStream,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    response: Response,
+) -> io::Result<()> {
+    let request = read_request(&stream).await?;
+    requests.lock().expect("bucket request lock").push(request);
+    match response {
+        Response::Status(status) => {
+            stream.writable().await?;
+            let body = format!(
+                "HTTP/1.1 {status}\r\ncontent-length: 0\r\nconnection: close\r\nx-amz-request-id: fixture\r\n\r\n"
+            );
+            stream.try_write(body.as_bytes())?;
+            Ok(())
+        }
+        Response::Stall => std::future::pending().await,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RecordedRequest {
+    target: String,
+    body: Vec<u8>,
+}
+
+async fn read_request(stream: &TcpStream) -> io::Result<RecordedRequest> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4 * 1_024];
+    let header_end = loop {
+        if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index + 4;
+        }
+        stream.readable().await?;
+        match stream.try_read(&mut buffer) {
+            Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+            Ok(received) => {
+                request.extend_from_slice(&buffer[..received]);
+                if request.len() > 32 * 1_024 {
+                    return Err(io::Error::from(io::ErrorKind::InvalidData));
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error),
+        }
+    };
+    let head = std::str::from_utf8(&request[..header_end])
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+    let target = head
+        .split("\r\n")
+        .next()
+        .and_then(|line| line.strip_suffix(" HTTP/1.1"))
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?
+        .to_owned();
+    let content_length = head
+        .split("\r\n")
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .map(|(_, value)| value.trim().parse::<usize>())
+        .transpose()
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?
+        .unwrap_or(0);
+    let complete_length = header_end
+        .checked_add(content_length)
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+    while request.len() < complete_length {
+        stream.readable().await?;
+        match stream.try_read(&mut buffer) {
+            Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+            Ok(received) => {
+                request.extend_from_slice(&buffer[..received]);
+                if request.len() > 64 * 1_024 {
+                    return Err(io::Error::from(io::ErrorKind::InvalidData));
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(RecordedRequest {
+        target,
+        body: request[header_end..complete_length].to_vec(),
+    })
+}

--- a/crates/automata-ci-blob-s3/tests/configuration.rs
+++ b/crates/automata-ci-blob-s3/tests/configuration.rs
@@ -1,6 +1,12 @@
 use std::time::Duration;
 
-use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
+use automata_ci_blob_s3::{
+    MAX_S3_PRIVATE_CA_PEM_BYTES, S3AtRestEncryption, S3BlobStoreConfig, S3BlobStoreConfigError,
+    S3TlsTrust, StaticS3Credentials,
+};
+use rcgen::{
+    BasicConstraints, CertificateParams, CustomExtension, DnType, IsCa, KeyPair, KeyUsagePurpose,
+};
 use url::Url;
 
 #[test]
@@ -11,6 +17,7 @@ fn production_requires_a_credential_free_https_root_endpoint() {
         "automata-production",
         Some("tenant-a".to_owned()),
         false,
+        S3TlsTrust::web_pki(),
         Duration::from_secs(10),
     );
     assert!(valid.is_ok());
@@ -28,6 +35,7 @@ fn production_requires_a_credential_free_https_root_endpoint() {
                 "automata-production",
                 None,
                 false,
+                S3TlsTrust::web_pki(),
                 Duration::from_secs(10),
             )
             .is_err(),
@@ -80,6 +88,7 @@ fn namespaces_and_credentials_fail_closed() {
                 bucket,
                 None,
                 false,
+                S3TlsTrust::web_pki(),
                 Duration::from_secs(10),
             )
             .is_err(),
@@ -94,6 +103,7 @@ fn namespaces_and_credentials_fail_closed() {
                 "automata-production",
                 Some(prefix.to_owned()),
                 false,
+                S3TlsTrust::web_pki(),
                 Duration::from_secs(10),
             )
             .is_err(),
@@ -124,6 +134,64 @@ fn credential_debug_output_is_redacted() {
 }
 
 #[test]
+fn connected_store_debug_output_is_minimal_after_credentials_and_private_ca_are_bound() {
+    let ca_identity_marker = "connected-store-private-ca-marker";
+    let key = KeyPair::generate().expect("private CA key");
+    let mut params = CertificateParams::new(Vec::<String>::new()).expect("private CA params");
+    params
+        .distinguished_name
+        .push(DnType::CommonName, ca_identity_marker);
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let certificate_pem = params
+        .self_signed(&key)
+        .expect("private CA certificate")
+        .pem()
+        .into_bytes();
+    let ca_pem_marker = std::str::from_utf8(&certificate_pem)
+        .expect("private CA PEM is ASCII")
+        .lines()
+        .nth(1)
+        .expect("private CA PEM body")
+        .get(..32)
+        .expect("private CA PEM marker")
+        .to_owned();
+    let config = S3BlobStoreConfig::new(
+        Url::parse("https://objects.example.test/").expect("URL"),
+        "us-east-1",
+        "automata-production",
+        None,
+        false,
+        S3TlsTrust::private_ca(certificate_pem).expect("one exact private CA"),
+        Duration::from_secs(10),
+    )
+    .expect("S3 configuration");
+    let credential_markers = [
+        "connected-store-access-marker",
+        "connected-store-secret-marker",
+        "connected-store-session-marker",
+    ];
+    let store = config
+        .connect(
+            StaticS3Credentials::new(
+                credential_markers[0],
+                credential_markers[1],
+                Some(credential_markers[2].to_owned()),
+            )
+            .expect("credentials"),
+        )
+        .expect("connected store");
+
+    let debug = format!("{store:?}");
+    assert_eq!(debug, "S3BlobStore([connection redacted])");
+    for marker in credential_markers {
+        assert!(!debug.contains(marker));
+    }
+    assert!(!debug.contains(ca_identity_marker));
+    assert!(!debug.contains(&ca_pem_marker));
+}
+
+#[test]
 fn encryption_at_rest_is_mandatory_and_kms_identity_is_exact() {
     let config = S3BlobStoreConfig::new(
         Url::parse("https://objects.example.test/").expect("URL"),
@@ -131,6 +199,7 @@ fn encryption_at_rest_is_mandatory_and_kms_identity_is_exact() {
         "automata-production",
         None,
         false,
+        S3TlsTrust::web_pki(),
         Duration::from_secs(10),
     )
     .expect("S3 configuration");
@@ -145,4 +214,148 @@ fn encryption_at_rest_is_mandatory_and_kms_identity_is_exact() {
         assert!(S3AtRestEncryption::aws_kms(invalid).is_err());
         assert!(S3AtRestEncryption::aws_kms_dsse(invalid).is_err());
     }
+}
+
+#[test]
+fn private_ca_trust_accepts_exactly_one_valid_ca_and_redacts_it() {
+    let ca_pem = certificate_pem(true);
+    let trust = S3TlsTrust::private_ca(ca_pem.clone()).expect("one exact private CA");
+    assert_eq!(
+        format!("{trust:?}"),
+        "S3TlsTrust::PrivateCa([certificate redacted])"
+    );
+    S3TlsTrust::private_ca(certificate_pem_with_usage(true, Vec::new()))
+        .expect("a CA without KeyUsage remains a valid trust anchor");
+
+    let mut bundle = ca_pem.clone();
+    bundle.extend_from_slice(&certificate_pem(true));
+    let mut preamble = b"deployment preamble\n".to_vec();
+    preamble.extend_from_slice(&ca_pem);
+    let mut trailing_data = ca_pem.clone();
+    trailing_data.extend_from_slice(b"trailing data");
+    let mut trailing_newline = ca_pem.clone();
+    trailing_newline.push(b'\n');
+    let mut missing_terminal_newline = ca_pem.clone();
+    assert_eq!(missing_terminal_newline.pop(), Some(b'\n'));
+    let crlf = String::from_utf8(ca_pem.clone())
+        .expect("certificate PEM is ASCII")
+        .replace('\n', "\r\n")
+        .into_bytes();
+    let ca_with_malformed_key_usage =
+        certificate_pem_with_usage(true, vec![KeyUsagePurpose::DigitalSignature]);
+    let ca_with_malformed_key_usage_encoding = certificate_pem_with_malformed_key_usage();
+    for invalid in [
+        Vec::new(),
+        b"not a PEM certificate".to_vec(),
+        certificate_pem(false),
+        ca_with_malformed_key_usage,
+        ca_with_malformed_key_usage_encoding,
+        bundle,
+        preamble,
+        trailing_data,
+        trailing_newline,
+        missing_terminal_newline,
+        crlf,
+        vec![b'x'; MAX_S3_PRIVATE_CA_PEM_BYTES + 1],
+    ] {
+        assert_eq!(
+            S3TlsTrust::private_ca(invalid),
+            Err(S3BlobStoreConfigError::InvalidPrivateCa)
+        );
+    }
+}
+
+#[test]
+fn private_ca_trust_is_incompatible_with_plaintext() {
+    let trust = S3TlsTrust::private_ca(certificate_pem(true)).expect("private CA");
+    let direct = S3BlobStoreConfig::new(
+        Url::parse("http://127.0.0.1:9000/").expect("URL"),
+        "us-east-1",
+        "automata-tests",
+        None,
+        true,
+        trust.clone(),
+        Duration::from_secs(10),
+    );
+    assert_eq!(direct, Err(S3BlobStoreConfigError::PrivateCaRequiresHttps));
+    let result = S3BlobStoreConfig::loopback_development(
+        Url::parse("http://127.0.0.1:9000/").expect("URL"),
+        "us-east-1",
+        "automata-tests",
+        None,
+        Duration::from_secs(10),
+    )
+    .expect("loopback configuration")
+    .with_tls_trust(trust);
+    assert_eq!(result, Err(S3BlobStoreConfigError::PrivateCaRequiresHttps));
+}
+
+#[test]
+fn validated_https_shape_can_bind_one_late_loaded_exact_trust_policy() {
+    let endpoint = Url::parse("https://objects.example.test/").expect("URL");
+    let trust = S3TlsTrust::private_ca(certificate_pem(true)).expect("private CA");
+    let rebound = S3BlobStoreConfig::new(
+        endpoint.clone(),
+        "us-east-1",
+        "automata-production",
+        Some("tenant-a".to_owned()),
+        true,
+        S3TlsTrust::web_pki(),
+        Duration::from_secs(10),
+    )
+    .expect("validated HTTPS shape")
+    .with_tls_trust(trust.clone())
+    .expect("late trust binding");
+    let direct = S3BlobStoreConfig::new(
+        endpoint,
+        "us-east-1",
+        "automata-production",
+        Some("tenant-a".to_owned()),
+        true,
+        trust,
+        Duration::from_secs(10),
+    )
+    .expect("direct exact configuration");
+    assert_eq!(rebound, direct);
+}
+
+fn certificate_pem(is_ca: bool) -> Vec<u8> {
+    let key_usages = if is_ca {
+        vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign]
+    } else {
+        Vec::new()
+    };
+    certificate_pem_with_usage(is_ca, key_usages)
+}
+
+fn certificate_pem_with_usage(is_ca: bool, key_usages: Vec<KeyUsagePurpose>) -> Vec<u8> {
+    let key = KeyPair::generate().expect("certificate key");
+    let mut params = CertificateParams::new(Vec::<String>::new()).expect("certificate params");
+    if is_ca {
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    }
+    params.key_usages = key_usages;
+    params
+        .self_signed(&key)
+        .expect("self-signed certificate")
+        .pem()
+        .into_bytes()
+}
+
+fn certificate_pem_with_malformed_key_usage() -> Vec<u8> {
+    let key = KeyPair::generate().expect("certificate key");
+    let mut params = CertificateParams::new(Vec::<String>::new()).expect("certificate params");
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params
+        .custom_extensions
+        .push(CustomExtension::from_oid_content(
+            &[2, 5, 29, 15],
+            // KeyUsage's extnValue must contain a DER BIT STRING, not BOOLEAN.
+            vec![0x01, 0x01, 0xff],
+        ));
+    params
+        .self_signed(&key)
+        .expect("self-signed certificate")
+        .pem()
+        .into_bytes()
 }

--- a/crates/automata-ci-blob-s3/tests/configuration.rs
+++ b/crates/automata-ci-blob-s3/tests/configuration.rs
@@ -1,12 +1,9 @@
 use std::time::Duration;
 
 use automata_ci_blob_s3::{
-    MAX_S3_PRIVATE_CA_PEM_BYTES, S3AtRestEncryption, S3BlobStoreConfig, S3BlobStoreConfigError,
-    S3TlsTrust, StaticS3Credentials,
+    S3AtRestEncryption, S3BlobStoreConfig, S3BlobStoreConfigError, S3TlsTrust, StaticS3Credentials,
 };
-use rcgen::{
-    BasicConstraints, CertificateParams, CustomExtension, DnType, IsCa, KeyPair, KeyUsagePurpose,
-};
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
 use url::Url;
 
 #[test]
@@ -217,52 +214,17 @@ fn encryption_at_rest_is_mandatory_and_kms_identity_is_exact() {
 }
 
 #[test]
-fn private_ca_trust_accepts_exactly_one_valid_ca_and_redacts_it() {
+fn private_ca_trust_consumes_the_shared_validated_ca_and_redacts_it() {
     let ca_pem = certificate_pem(true);
-    let trust = S3TlsTrust::private_ca(ca_pem.clone()).expect("one exact private CA");
+    let trust = S3TlsTrust::private_ca(ca_pem).expect("one exact private CA");
     assert_eq!(
         format!("{trust:?}"),
         "S3TlsTrust::PrivateCa([certificate redacted])"
     );
-    S3TlsTrust::private_ca(certificate_pem_with_usage(true, Vec::new()))
-        .expect("a CA without KeyUsage remains a valid trust anchor");
-
-    let mut bundle = ca_pem.clone();
-    bundle.extend_from_slice(&certificate_pem(true));
-    let mut preamble = b"deployment preamble\n".to_vec();
-    preamble.extend_from_slice(&ca_pem);
-    let mut trailing_data = ca_pem.clone();
-    trailing_data.extend_from_slice(b"trailing data");
-    let mut trailing_newline = ca_pem.clone();
-    trailing_newline.push(b'\n');
-    let mut missing_terminal_newline = ca_pem.clone();
-    assert_eq!(missing_terminal_newline.pop(), Some(b'\n'));
-    let crlf = String::from_utf8(ca_pem.clone())
-        .expect("certificate PEM is ASCII")
-        .replace('\n', "\r\n")
-        .into_bytes();
-    let ca_with_malformed_key_usage =
-        certificate_pem_with_usage(true, vec![KeyUsagePurpose::DigitalSignature]);
-    let ca_with_malformed_key_usage_encoding = certificate_pem_with_malformed_key_usage();
-    for invalid in [
-        Vec::new(),
-        b"not a PEM certificate".to_vec(),
-        certificate_pem(false),
-        ca_with_malformed_key_usage,
-        ca_with_malformed_key_usage_encoding,
-        bundle,
-        preamble,
-        trailing_data,
-        trailing_newline,
-        missing_terminal_newline,
-        crlf,
-        vec![b'x'; MAX_S3_PRIVATE_CA_PEM_BYTES + 1],
-    ] {
-        assert_eq!(
-            S3TlsTrust::private_ca(invalid),
-            Err(S3BlobStoreConfigError::InvalidPrivateCa)
-        );
-    }
+    assert_eq!(
+        S3TlsTrust::private_ca(certificate_pem(false)),
+        Err(S3BlobStoreConfigError::InvalidPrivateCa)
+    );
 }
 
 #[test]
@@ -335,24 +297,6 @@ fn certificate_pem_with_usage(is_ca: bool, key_usages: Vec<KeyUsagePurpose>) -> 
         params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     }
     params.key_usages = key_usages;
-    params
-        .self_signed(&key)
-        .expect("self-signed certificate")
-        .pem()
-        .into_bytes()
-}
-
-fn certificate_pem_with_malformed_key_usage() -> Vec<u8> {
-    let key = KeyPair::generate().expect("certificate key");
-    let mut params = CertificateParams::new(Vec::<String>::new()).expect("certificate params");
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    params
-        .custom_extensions
-        .push(CustomExtension::from_oid_content(
-            &[2, 5, 29, 15],
-            // KeyUsage's extnValue must contain a DER BIT STRING, not BOOLEAN.
-            vec![0x01, 0x01, 0xff],
-        ));
     params
         .self_signed(&key)
         .expect("self-signed certificate")

--- a/crates/automata-ci-blob-s3/tests/get_retry.rs
+++ b/crates/automata-ci-blob-s3/tests/get_retry.rs
@@ -215,7 +215,7 @@ impl S3Fixture {
         .expect("fixture S3 config");
         let credentials = StaticS3Credentials::new("test-access", "test-secret", None)
             .expect("fixture credentials");
-        S3BlobStore::new(config.client(credentials), &config)
+        config.connect(credentials).expect("fixture S3 store")
     }
 
     fn request_count(&self) -> usize {

--- a/crates/automata-ci-blob-s3/tests/rustfs_contract.rs
+++ b/crates/automata-ci-blob-s3/tests/rustfs_contract.rs
@@ -3,9 +3,7 @@ use std::{env, time::Duration};
 use automata_ci_blob::{
     BlobKey, BlobPayload, BlobStoreErrorKind, ImmutableBlobStore, MediaType, PutBlobOutcome,
 };
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use bytes::Bytes;
 use url::Url;
 
@@ -31,10 +29,13 @@ async fn rustfs_conditional_put_and_verified_read_contract() {
         )
         .expect("test S3 KMS key identity"),
     );
-    let client = config
-        .client(StaticS3Credentials::new(access_key, secret_key, None).expect("test credentials"));
-    ensure_bucket(&client, &bucket).await;
-    let store = S3BlobStore::new(client, &config);
+    let store = config
+        .connect(StaticS3Credentials::new(access_key, secret_key, None).expect("test credentials"))
+        .expect("test S3 store");
+    store
+        .ensure_bucket()
+        .await
+        .expect("test bucket must be ready");
     let payload = BlobPayload::from_bytes(
         BlobKey::new("stable-object").expect("key"),
         MediaType::new("application/octet-stream").expect("media type"),
@@ -72,28 +73,4 @@ async fn rustfs_conditional_put_and_verified_read_contract() {
         .await
         .expect_err("immutable overwrite");
     assert_eq!(error.kind(), BlobStoreErrorKind::Conflict);
-}
-
-async fn ensure_bucket(client: &aws_sdk_s3::Client, bucket: &str) {
-    if client.head_bucket().bucket(bucket).send().await.is_ok() {
-        return;
-    }
-
-    if let Err(error) = client.create_bucket().bucket(bucket).send().await {
-        let status = error
-            .raw_response()
-            .map(|response| response.status().as_u16());
-        assert_eq!(
-            status,
-            Some(409),
-            "test bucket creation must succeed or report an existing bucket"
-        );
-    }
-
-    client
-        .head_bucket()
-        .bucket(bucket)
-        .send()
-        .await
-        .expect("test bucket must be accessible after initialization");
 }

--- a/crates/automata-ci-blob-s3/tests/tls_trust.rs
+++ b/crates/automata-ci-blob-s3/tests/tls_trust.rs
@@ -1,0 +1,170 @@
+use std::{sync::Arc, time::Duration};
+
+use automata_ci_blob_s3::{
+    EnsureBucketError, EnsureBucketOutcome, S3BlobStore, S3BlobStoreConfig, S3TlsTrust,
+    StaticS3Credentials,
+};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose, IsCa,
+    KeyPair, KeyUsagePurpose,
+};
+use rustls::{
+    ServerConfig,
+    crypto::ring,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::TcpListener,
+    task::JoinHandle,
+};
+use tokio_rustls::TlsAcceptor;
+use url::Url;
+
+#[tokio::test]
+async fn aws_sdk_uses_only_the_selected_exact_private_ca() {
+    let trusted = TestAuthority::new("trusted private S3 root");
+    let trusted_fixture = TlsS3Fixture::spawn(&trusted).await;
+    let trusted_config = https_config(
+        trusted_fixture.endpoint.clone(),
+        S3TlsTrust::private_ca(trusted.pem()).expect("trusted private CA"),
+    );
+
+    assert_eq!(
+        connected_store(trusted_config).ensure_bucket().await,
+        Ok(EnsureBucketOutcome::AlreadyExists)
+    );
+
+    let wrong = TestAuthority::new("wrong private S3 root");
+    let wrong_fixture = TlsS3Fixture::spawn(&trusted).await;
+    let wrong_config = https_config(
+        wrong_fixture.endpoint.clone(),
+        S3TlsTrust::private_ca(wrong.pem()).expect("wrong private CA"),
+    );
+    assert!(matches!(
+        connected_store(wrong_config).ensure_bucket().await,
+        Err(EnsureBucketError::InitialInspection | EnsureBucketError::Deadline)
+    ));
+
+    let web_pki_fixture = TlsS3Fixture::spawn(&trusted).await;
+    let web_pki_config = https_config(web_pki_fixture.endpoint.clone(), S3TlsTrust::web_pki());
+    assert!(matches!(
+        connected_store(web_pki_config).ensure_bucket().await,
+        Err(EnsureBucketError::InitialInspection | EnsureBucketError::Deadline)
+    ));
+}
+
+fn https_config(endpoint: Url, trust: S3TlsTrust) -> S3BlobStoreConfig {
+    S3BlobStoreConfig::new(
+        endpoint,
+        "us-east-1",
+        "automata-tests",
+        None,
+        true,
+        trust,
+        Duration::from_secs(1),
+    )
+    .expect("TLS S3 fixture configuration")
+}
+
+fn connected_store(config: S3BlobStoreConfig) -> S3BlobStore {
+    config
+        .connect(
+            StaticS3Credentials::new("test-access", "test-secret", None)
+                .expect("TLS fixture credentials"),
+        )
+        .expect("TLS fixture S3 store")
+}
+
+struct TestAuthority {
+    issuer: CertifiedIssuer<'static, KeyPair>,
+}
+
+impl TestAuthority {
+    fn new(name: &str) -> Self {
+        let key = KeyPair::generate().expect("generate private CA key");
+        let mut params = CertificateParams::new(Vec::<String>::new()).expect("private CA params");
+        params.distinguished_name.push(DnType::CommonName, name);
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        Self {
+            issuer: CertifiedIssuer::self_signed(params, key).expect("self-sign private CA"),
+        }
+    }
+
+    fn pem(&self) -> Vec<u8> {
+        self.issuer.pem().into_bytes()
+    }
+
+    fn server_config(&self) -> ServerConfig {
+        let key = KeyPair::generate().expect("generate S3 server key");
+        let mut params =
+            CertificateParams::new(vec!["127.0.0.1".to_owned()]).expect("S3 server params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "127.0.0.1");
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        let certificate = params
+            .signed_by(&key, &self.issuer)
+            .expect("sign S3 server certificate");
+        ServerConfig::builder_with_provider(Arc::new(ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .expect("TLS protocol versions")
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![CertificateDer::from(certificate.der().as_ref().to_vec())],
+                PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key.serialize_der())),
+            )
+            .expect("S3 server TLS identity")
+    }
+}
+
+struct TlsS3Fixture {
+    endpoint: Url,
+    task: JoinHandle<()>,
+}
+
+impl TlsS3Fixture {
+    async fn spawn(authority: &TestAuthority) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind TLS S3 fixture");
+        let endpoint = Url::parse(&format!(
+            "https://{}/",
+            listener.local_addr().expect("TLS S3 fixture address")
+        ))
+        .expect("TLS S3 fixture URL");
+        let acceptor = TlsAcceptor::from(Arc::new(authority.server_config()));
+        let task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.expect("accept TLS S3 client");
+                let Ok(mut stream) = acceptor.accept(stream).await else {
+                    continue;
+                };
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 4 * 1_024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let received = stream.read(&mut buffer).await.expect("read TLS S3 request");
+                    if received == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..received]);
+                }
+                stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\nx-amz-request-id: tls-fixture\r\n\r\n",
+                    )
+                    .await
+                    .expect("write TLS S3 response");
+            }
+        });
+        Self { endpoint, task }
+    }
+}
+
+impl Drop for TlsS3Fixture {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/crates/automata-ci-results-github/tests/cache_rustfs.rs
+++ b/crates/automata-ci-results-github/tests/cache_rustfs.rs
@@ -2,9 +2,7 @@ mod support;
 
 use std::{env, sync::Arc, time::Duration};
 
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_control::adapter_spi::{
     AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
 };
@@ -65,10 +63,8 @@ async fn finalized_cache_blocks_are_verified_and_ranged_from_rustfs() -> TestRes
         .with_at_rest_encryption(S3AtRestEncryption::aws_kms(env::var(
             "AUTOMATA_TEST_S3_KMS_KEY_ID",
         )?)?);
-        let objects = Arc::new(S3BlobStore::new(
-            config.client(StaticS3Credentials::new(access_key, secret_key, None)?),
-            &config,
-        ));
+        let objects =
+            Arc::new(config.connect(StaticS3Credentials::new(access_key, secret_key, None)?)?);
         let upload_id = UploadId::from_uuid(Uuid::new_v4());
         let repository: Arc<dyn CacheRepository> =
             Arc::new(PostgresCacheRepository::new(database.pool().clone()));

--- a/crates/automata-ci-results-github/tests/exact_client_real_store.rs
+++ b/crates/automata-ci-results-github/tests/exact_client_real_store.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 use automata_ci_blob::ImmutableBlobStore;
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_control::adapter_spi::{
     AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
 };
@@ -331,14 +329,12 @@ fn real_results_router(
     .with_at_rest_encryption(S3AtRestEncryption::aws_kms(
         environment.s3_kms_key_id.clone(),
     )?);
-    let objects: Arc<dyn ImmutableBlobStore> = Arc::new(S3BlobStore::new(
-        s3_config.client(StaticS3Credentials::new(
+    let objects: Arc<dyn ImmutableBlobStore> =
+        Arc::new(s3_config.connect(StaticS3Credentials::new(
             environment.s3_access_key.clone(),
             environment.s3_secret_key.clone(),
             None,
-        )?),
-        &s3_config,
-    ));
+        )?)?);
     let observer = Arc::new(RecordingObserver::default());
     let public_observer: Arc<dyn ResultsObserver> = observer.clone();
     let objects: Arc<dyn ImmutableBlobStore> = Arc::new(ObservedResultsBlobStore::new(

--- a/crates/automata-ci-results-github/tests/rustfs_results.rs
+++ b/crates/automata-ci-results-github/tests/rustfs_results.rs
@@ -3,9 +3,7 @@ mod support;
 use std::{env, sync::Arc, time::Duration};
 
 use automata_ci_blob::ImmutableBlobStore as _;
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_control::adapter_spi::{
     AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
 };
@@ -60,10 +58,8 @@ async fn finalized_manifest_and_blocks_are_verified_in_rustfs() -> TestResult {
         .with_at_rest_encryption(S3AtRestEncryption::aws_kms(env::var(
             "AUTOMATA_TEST_S3_KMS_KEY_ID",
         )?)?);
-        let objects = Arc::new(S3BlobStore::new(
-            config.client(StaticS3Credentials::new(access_key, secret_key, None)?),
-            &config,
-        ));
+        let objects =
+            Arc::new(config.connect(StaticS3Credentials::new(access_key, secret_key, None)?)?);
         let upload_id = UploadId::from_uuid(Uuid::new_v4());
         let repository = Arc::new(PostgresArtifactRepository::new(database.pool().clone()));
         let service = ArtifactService::new(

--- a/crates/automata-ci-runner/README.md
+++ b/crates/automata-ci-runner/README.md
@@ -157,6 +157,15 @@ the private journal state root. A warm job
 therefore reads local disk first and falls back to the shared object store; it
 does not contact GitHub again.
 
+Runner product schema 4 requires an explicit object-store trust policy.
+`web_pki` uses platform roots; `private_ca` loads exactly one bounded CA through
+an existing secure-input descriptor and installs it into an otherwise empty
+root store. The PEM bytes must use canonical RFC 7468 64-column/LF encoding
+with one terminal LF and no surrounding data; a present KeyUsage must include
+`keyCertSign`. Private trust is HTTPS-only and never retries with Web PKI. The
+runner, server, and image initializer must select the same endpoint trust,
+bucket, and prefix for one installation.
+
 The local archive cache is bounded to 256 entries, 512 MiB total, and 16 MiB per
 compressed archive. Its sibling reference index is crash-durable and retains at
 most 4,096 exact references. Both are recreated automatically and require no

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -21,14 +21,26 @@ follow the
 [profile publication guide](https://github.com/automata-ci/automata/blob/main/images/github-hosted-ubuntu-24.04-x64/README.md)
 before trusting a protected-main candidate.
 
-Product schema v3 accepts exactly one sandbox provider. Host runners use the
+Product schema v4 accepts exactly one sandbox provider. Host runners use the
 top-level `podman` object and require `state.podman`. Kubernetes runners omit
 `state.podman`, `state.windows_hyperv`, and `state.macos_virtualization` and use
 a top-level `kubernetes` object. Windows and macOS runners use their matching
-provider name in both locations. Schema v1, schema v2, `windows_native`, and the
+provider name in both locations. All non-v4 schemas, `windows_native`, and the
 removed macOS native key are rejected, not migrated. The runner loads
 credentials through Kubernetes' standard in-cluster or ambient kubeconfig
 discovery; the JSON remains secret-free.
+
+`object_store.tls_trust` is mandatory and has exactly one of two current
+shapes: `{ "mode": "web_pki" }`, or `{ "mode": "private_ca",
+"certificate_source": { ... } }`. The private-CA source uses the same bounded
+file, environment, or macOS Keychain descriptor contract as other runner
+secure inputs and must contain exactly one canonically encoded RFC 7468 X.509
+CA certificate: 64-column Base64, LF line endings, one terminal LF, no
+preamble/trailing bytes, and `keyCertSign` when KeyUsage is present.
+Private mode installs that certificate into an otherwise empty root store; it
+never merges or retries with platform roots. `loopback_development: true` is
+valid only for a literal-loopback HTTP endpoint with `web_pki` selected; HTTPS
+requires it to be false, and private-CA trust always requires HTTPS.
 
 The Podman BuildKit surface is a separate, default-off opt-in. Configure it
 only with the attempt-scoped Docker API and one locally preloaded, untagged
@@ -419,6 +431,8 @@ Before enrollment, each instance `N` expects:
   `0600`;
 - `AUTOMATA_S3_ACCESS_KEY_ID` and `AUTOMATA_S3_SECRET_ACCESS_KEY` — credentials
   for the configured RustFS bucket;
+- the exact owner-only private-CA file selected by
+  `object_store.tls_trust.certificate_source`, when private trust is enabled;
 - instance-specific durable journal and spool directories owned by the runner
   account;
 - transient Podman state and runtime directories beneath the dedicated tmpfs
@@ -535,7 +549,8 @@ sandbox mounts.
    capability.
 3. Verify the runner-control certificate SAN, trust chain, and configured URL.
 4. Verify the certificate-to-runner database mapping.
-5. Confirm the runner and server use the same S3 bucket and prefix.
+5. Confirm the runner and server use the same S3 endpoint, trust policy,
+   bucket, and prefix.
 6. Audit the Git and Results firewall tables and packet path.
 7. Inspect the runner journal and spool paths under the service account.
 

--- a/crates/automata-ci-runner/config/runner.local-1.example.json
+++ b/crates/automata-ci-runner/config/runner.local-1.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "runner_id": "6e561f8b-9098-418d-b573-d82f5c73006e",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {
@@ -110,6 +110,7 @@
     "bucket": "automata-dev",
     "prefix": "automata/v1",
     "loopback_development": true,
+    "tls_trust": { "mode": "web_pki" },
     "operation_timeout_seconds": 30,
     "access_key_id": {
       "kind": "environment",

--- a/crates/automata-ci-runner/config/runner.local-2.example.json
+++ b/crates/automata-ci-runner/config/runner.local-2.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "runner_id": "2f269f2a-1d5d-4a48-9f9e-797ea2fc97e2",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {
@@ -110,6 +110,7 @@
     "bucket": "automata-dev",
     "prefix": "automata/v1",
     "loopback_development": true,
+    "tls_trust": { "mode": "web_pki" },
     "operation_timeout_seconds": 30,
     "access_key_id": {
       "kind": "environment",

--- a/crates/automata-ci-runner/config/runner.local-3.example.json
+++ b/crates/automata-ci-runner/config/runner.local-3.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "runner_id": "a3e2f8e1-7094-4ca5-a904-82991e0c8df3",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {
@@ -110,6 +110,7 @@
     "bucket": "automata-dev",
     "prefix": "automata/v1",
     "loopback_development": true,
+    "tls_trust": { "mode": "web_pki" },
     "operation_timeout_seconds": 30,
     "access_key_id": {
       "kind": "environment",

--- a/crates/automata-ci-runner/config/runner.macos.example.json
+++ b/crates/automata-ci-runner/config/runner.macos.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "runner_id": "75934d27-b027-45df-94c4-97e5a91f4011",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {
@@ -102,6 +102,7 @@
     "bucket": "automata-runner",
     "prefix": "automata/v1",
     "loopback_development": false,
+    "tls_trust": { "mode": "web_pki" },
     "operation_timeout_seconds": 30,
     "access_key_id": {
       "kind": "macos_keychain",

--- a/crates/automata-ci-runner/config/runner.windows.example.json
+++ b/crates/automata-ci-runner/config/runner.windows.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "runner_id": "6e561f8b-9098-418d-b573-d82f5c73006e",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {
@@ -111,6 +111,7 @@
     "bucket": "automata-runner",
     "prefix": "automata/v1",
     "loopback_development": false,
+    "tls_trust": { "mode": "web_pki" },
     "operation_timeout_seconds": 30,
     "access_key_id": {
       "kind": "environment",

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -5,7 +5,7 @@ use automata_ci_action_github::{
     GithubActionMetadataDecoder, GithubActionMetadataLimits, JavascriptRuntime,
 };
 use automata_ci_blob::ImmutableBlobStore;
-use automata_ci_blob_s3::{S3BlobStore, S3BlobStoreConfig, StaticS3Credentials};
+use automata_ci_blob_s3::{MAX_S3_PRIVATE_CA_PEM_BYTES, S3TlsTrust, StaticS3Credentials};
 use automata_ci_core::{ContainerCapabilities, ContainerFeature, RunnerCapabilities};
 use automata_ci_execution::{ProviderCapabilities, SandboxCapability};
 use automata_ci_job_executor_github::{
@@ -63,7 +63,7 @@ use super::state::RuntimeMountSnapshot;
 use super::{
     ClientTlsMaterialError, ProductStateRootError, RunnerProductConfig, RunnerProductConfigError,
     RunnerProviderConfig, SecretSource, StandardGithubContext,
-    config::required_podman_state_root,
+    config::{ObjectStoreTlsTrust, required_podman_state_root},
     metrics::RunnerMetrics,
     profile_admission::{
         ProfileAdmissionOutcome, ProfileAdmissionPolicy, admit_environment_profiles,
@@ -1093,31 +1093,31 @@ fn build_object_store(
     config: &RunnerProductConfig,
 ) -> Result<Arc<dyn ImmutableBlobStore>, RunnerProductError> {
     let object_store = config.object_store();
-    let store_config = if object_store.loopback_development() {
-        S3BlobStoreConfig::loopback_development(
-            object_store.endpoint().clone(),
-            object_store.region(),
-            object_store.bucket(),
-            object_store.prefix().map(str::to_owned),
-            object_store.operation_timeout(),
-        )
-    } else {
-        S3BlobStoreConfig::new(
-            object_store.endpoint().clone(),
-            object_store.region(),
-            object_store.bucket(),
-            object_store.prefix().map(str::to_owned),
-            object_store.force_path_style(),
-            object_store.operation_timeout(),
-        )
-    }?;
+    let store_config = match object_store.tls_trust() {
+        ObjectStoreTlsTrust::WebPki => object_store.store_config().clone(),
+        ObjectStoreTlsTrust::PrivateCa { certificate_source } => object_store
+            .store_config()
+            .clone()
+            .with_tls_trust(load_s3_private_ca(certificate_source)?)?,
+    };
     let credentials = load_s3_credentials(
         object_store.access_key_id(),
         object_store.secret_access_key(),
         object_store.session_token(),
     )?;
-    let client = store_config.client(credentials);
-    Ok(Arc::new(S3BlobStore::new(client, &store_config)))
+    Ok(Arc::new(store_config.connect(credentials)?))
+}
+
+/// Loads the exact configured S3 HTTPS trust policy from its bounded source.
+///
+/// # Errors
+///
+/// Returns a sanitized product error when a private CA source is unavailable,
+/// excessive, malformed, or not exactly one X.509 CA certificate.
+fn load_s3_private_ca(certificate_source: &SecretSource) -> Result<S3TlsTrust, RunnerProductError> {
+    let mut certificate_pem = certificate_source.read(MAX_S3_PRIVATE_CA_PEM_BYTES)?;
+    S3TlsTrust::private_ca(std::mem::take(&mut *certificate_pem))
+        .map_err(RunnerProductError::ObjectStore)
 }
 
 fn build_toolchain(
@@ -1426,9 +1426,91 @@ mod tests {
         net::{IpAddr, Ipv4Addr, SocketAddr},
     };
 
+    #[cfg(unix)]
+    use std::{fs, os::unix::fs::PermissionsExt as _, path::PathBuf};
+
     use automata_ci_metrics::OPENMETRICS_CONTENT_TYPE;
 
+    #[cfg(unix)]
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair, KeyUsagePurpose};
+
     use super::*;
+
+    #[cfg(unix)]
+    struct PrivateCaFixture {
+        root: PathBuf,
+        source: SecretSource,
+    }
+
+    #[cfg(unix)]
+    impl PrivateCaFixture {
+        fn new(bytes: &[u8]) -> Self {
+            let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(std::path::Path::parent)
+                .expect("workspace root")
+                .join("target/runner-s3-private-ca-tests")
+                .join(uuid::Uuid::new_v4().simple().to_string());
+            fs::create_dir_all(&root).expect("create private CA fixture root");
+            fs::set_permissions(&root, fs::Permissions::from_mode(0o700))
+                .expect("restrict private CA fixture root");
+            let path = root.join("ca.pem");
+            fs::write(&path, bytes).expect("write private CA fixture");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                .expect("restrict private CA fixture");
+            Self {
+                root,
+                source: SecretSource::File { path },
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for PrivateCaFixture {
+        fn drop(&mut self) {
+            let _ignored = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_ca_binding_loads_one_bounded_exact_redacted_source() {
+        let key = KeyPair::generate().expect("private CA key");
+        let mut params = CertificateParams::new(Vec::<String>::new()).expect("private CA params");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let pem = params
+            .self_signed(&key)
+            .expect("self-signed private CA")
+            .pem();
+        let certificate = PrivateCaFixture::new(pem.as_bytes());
+        let trust = load_s3_private_ca(&certificate.source).expect("one exact private CA");
+        assert_eq!(
+            format!("{trust:?}"),
+            "S3TlsTrust::PrivateCa([certificate redacted])"
+        );
+        assert!(!format!("{trust:?}").contains(&pem));
+
+        let malformed = PrivateCaFixture::new(b"private CA content must never escape");
+        assert!(matches!(
+            load_s3_private_ca(&malformed.source),
+            Err(RunnerProductError::ObjectStore(
+                automata_ci_blob_s3::S3BlobStoreConfigError::InvalidPrivateCa
+            ))
+        ));
+
+        let oversized = PrivateCaFixture::new(&vec![
+            b'x';
+            automata_ci_blob_s3::MAX_S3_PRIVATE_CA_PEM_BYTES
+                + 1
+        ]);
+        assert!(matches!(
+            load_s3_private_ca(&oversized.source),
+            Err(RunnerProductError::SecureInput(
+                super::super::SecureInputError::InvalidSize
+            ))
+        ));
+    }
 
     #[derive(Debug, Default)]
     struct StartupEffects {

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use automata_ci_blob_s3::S3BlobStoreConfig;
 use automata_ci_core::{
     Architecture, ContainerCapabilities, ContainerFeature, EnvironmentProfile,
     EnvironmentProfileId, IsolationLevel, OperatingSystem, ResourceCapacity, RunnerCapabilities,
@@ -33,7 +34,7 @@ use super::files::{
 use super::spool_crypto::MAX_DECRYPT_ONLY_CONTENT_KEYS;
 
 /// Current on-disk runner product configuration schema.
-pub const RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION: u16 = 3;
+pub const RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION: u16 = 4;
 /// Hard ceiling applied before parsing a runner configuration document.
 pub const MAX_RUNNER_CONFIG_BYTES: usize = 256 * 1024;
 const PODMAN_RUNTIME_ROOT_NAME: &str = "automata-ci-podman";
@@ -198,7 +199,7 @@ impl RunnerProductConfig {
 
     /// Returns immutable action-bundle object-store policy and credential sources.
     #[must_use]
-    pub const fn object_store(&self) -> &ObjectStoreProductConfig {
+    pub(crate) const fn object_store(&self) -> &ObjectStoreProductConfig {
         &self.object_store
     }
 
@@ -791,81 +792,39 @@ impl ToolchainConfig {
     }
 }
 
-/// S3-compatible immutable action-bundle store configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ObjectStoreProductConfig {
-    endpoint: Url,
-    region: String,
-    bucket: String,
-    prefix: Option<String>,
-    force_path_style: bool,
-    loopback_development: bool,
-    operation_timeout: Duration,
+pub(crate) struct ObjectStoreProductConfig {
+    store_config: S3BlobStoreConfig,
+    tls_trust: ObjectStoreTlsTrust,
     access_key_id: SecretSource,
     secret_access_key: SecretSource,
     session_token: Option<SecretSource>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ObjectStoreTlsTrust {
+    WebPki,
+    PrivateCa { certificate_source: SecretSource },
+}
+
 impl ObjectStoreProductConfig {
-    /// Returns the validated S3-compatible API endpoint.
-    #[must_use]
-    pub const fn endpoint(&self) -> &Url {
-        &self.endpoint
+    pub(crate) const fn store_config(&self) -> &S3BlobStoreConfig {
+        &self.store_config
     }
 
-    /// Returns the signing region.
-    #[must_use]
-    pub fn region(&self) -> &str {
-        &self.region
+    pub(crate) const fn tls_trust(&self) -> &ObjectStoreTlsTrust {
+        &self.tls_trust
     }
 
-    /// Returns the bucket containing immutable action bundles.
-    #[must_use]
-    pub fn bucket(&self) -> &str {
-        &self.bucket
-    }
-
-    /// Returns the optional object-key namespace prefix.
-    #[must_use]
-    pub fn prefix(&self) -> Option<&str> {
-        self.prefix.as_deref()
-    }
-
-    /// Reports whether requests use path-style bucket addressing.
-    ///
-    /// This is always true for loopback development mode.
-    #[must_use]
-    pub const fn force_path_style(&self) -> bool {
-        self.force_path_style
-    }
-
-    /// Reports whether explicitly loopback-only development transport is enabled.
-    #[must_use]
-    pub const fn loopback_development(&self) -> bool {
-        self.loopback_development
-    }
-
-    /// Returns the deadline applied to each object-store operation.
-    #[must_use]
-    pub const fn operation_timeout(&self) -> Duration {
-        self.operation_timeout
-    }
-
-    /// Returns the source of the S3 access-key identifier.
-    #[must_use]
-    pub const fn access_key_id(&self) -> &SecretSource {
+    pub(crate) const fn access_key_id(&self) -> &SecretSource {
         &self.access_key_id
     }
 
-    /// Returns the source of the S3 secret access key.
-    #[must_use]
-    pub const fn secret_access_key(&self) -> &SecretSource {
+    pub(crate) const fn secret_access_key(&self) -> &SecretSource {
         &self.secret_access_key
     }
 
-    /// Returns the optional source of a temporary S3 session token.
-    #[must_use]
-    pub const fn session_token(&self) -> Option<&SecretSource> {
+    pub(crate) const fn session_token(&self) -> Option<&SecretSource> {
         self.session_token.as_ref()
     }
 }
@@ -2594,10 +2553,32 @@ struct RawObjectStoreProductConfig {
     force_path_style: bool,
     #[serde(default)]
     loopback_development: bool,
+    tls_trust: RawObjectStoreTlsTrust,
     operation_timeout_seconds: u64,
     access_key_id: SecretSource,
     secret_access_key: SecretSource,
     session_token: Option<SecretSource>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+enum RawObjectStoreTlsTrust {
+    WebPki {},
+    PrivateCa { certificate_source: SecretSource },
+}
+
+impl RawObjectStoreTlsTrust {
+    fn validate(self) -> Result<ObjectStoreTlsTrust, RunnerProductConfigError> {
+        match self {
+            Self::WebPki {} => Ok(ObjectStoreTlsTrust::WebPki),
+            Self::PrivateCa { certificate_source } => {
+                certificate_source
+                    .validate()
+                    .map_err(RunnerProductConfigError::SecureInput)?;
+                Ok(ObjectStoreTlsTrust::PrivateCa { certificate_source })
+            }
+        }
+    }
 }
 
 impl RawObjectStoreProductConfig {
@@ -2616,35 +2597,31 @@ impl RawObjectStoreProductConfig {
         }
         let endpoint =
             Url::parse(&self.endpoint).map_err(|_| RunnerProductConfigError::InvalidObjectStore)?;
+        let tls_trust = self.tls_trust.validate()?;
         let operation_timeout = Duration::from_secs(self.operation_timeout_seconds);
-        let effective_force_path_style = self.force_path_style || self.loopback_development;
-        if self.loopback_development {
-            automata_ci_blob_s3::S3BlobStoreConfig::loopback_development(
-                endpoint.clone(),
-                self.region.clone(),
-                self.bucket.clone(),
-                self.prefix.clone(),
+        let store_config = match (endpoint.scheme(), self.loopback_development, &tls_trust) {
+            ("http", true, ObjectStoreTlsTrust::WebPki) => S3BlobStoreConfig::loopback_development(
+                endpoint,
+                self.region,
+                self.bucket,
+                self.prefix,
                 operation_timeout,
-            )
-        } else {
-            automata_ci_blob_s3::S3BlobStoreConfig::new(
-                endpoint.clone(),
-                self.region.clone(),
-                self.bucket.clone(),
-                self.prefix.clone(),
+            ),
+            ("https", false, _) => S3BlobStoreConfig::new(
+                endpoint,
+                self.region,
+                self.bucket,
+                self.prefix,
                 self.force_path_style,
+                automata_ci_blob_s3::S3TlsTrust::web_pki(),
                 operation_timeout,
-            )
+            ),
+            _ => return Err(RunnerProductConfigError::InvalidObjectStore),
         }
         .map_err(|_| RunnerProductConfigError::InvalidObjectStore)?;
         Ok(ObjectStoreProductConfig {
-            endpoint,
-            region: self.region,
-            bucket: self.bucket,
-            prefix: self.prefix,
-            force_path_style: effective_force_path_style,
-            loopback_development: self.loopback_development,
-            operation_timeout,
+            store_config,
+            tls_trust,
             access_key_id: self.access_key_id,
             secret_access_key: self.secret_access_key,
             session_token: self.session_token,

--- a/crates/automata-ci-runner/src/product/mod.rs
+++ b/crates/automata-ci-runner/src/product/mod.rs
@@ -19,10 +19,10 @@ pub use composition::{
 };
 pub use config::{
     ClientTlsSources, ExecutorProductConfig, GithubProductConfig, KubernetesProductConfig,
-    MacosVirtualizationProductConfig, MetricsProductConfig, ObjectStoreProductConfig,
-    PodmanProductConfig, RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION, RunnerProductConfig,
-    RunnerProductConfigError, RunnerProviderConfig, SpoolProtectionConfig, StateRoots,
-    ToolchainConfig, WindowsHyperVProductConfig,
+    MacosVirtualizationProductConfig, MetricsProductConfig, PodmanProductConfig,
+    RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION, RunnerProductConfig, RunnerProductConfigError,
+    RunnerProviderConfig, SpoolProtectionConfig, StateRoots, ToolchainConfig,
+    WindowsHyperVProductConfig,
 };
 pub use context::StandardGithubContext;
 pub use files::{SecretSource, SecureInputError};

--- a/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
+++ b/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
@@ -1188,6 +1188,7 @@ fn write_runner_config(
             "bucket": S3_BUCKET,
             "prefix": S3_PREFIX,
             "loopback_development": true,
+            "tls_trust": {"mode": "web_pki"},
             "operation_timeout_seconds": 5,
             "access_key_id": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_S3_ACCESS_KEY"},
             "secret_access_key": {"kind": "environment", "name": "AUTOMATA_PROCESS_E2E_S3_SECRET_KEY"},

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -115,6 +115,7 @@ fn valid_configuration() -> String {
     "bucket": "automata-dev",
     "prefix": "automata/v1",
     "loopback_development": true,
+    "tls_trust": {{"mode": "web_pki"}},
     "operation_timeout_seconds": 30,
     "access_key_id": {{"kind": "environment", "name": "AUTOMATA_S3_ACCESS_KEY_ID"}},
     "secret_access_key": {{"kind": "environment", "name": "AUTOMATA_S3_SECRET_ACCESS_KEY"}}
@@ -212,7 +213,6 @@ fn validated_config_preserves_exact_runner_and_profile_inventory() {
             .features()
             .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
     );
-    assert!(config.object_store().force_path_style());
     assert!(
         config
             .podman()
@@ -279,6 +279,73 @@ fn validated_config_preserves_exact_runner_and_profile_inventory() {
         PROFILE_DIGEST
             .parse::<Sha256Digest>()
             .expect("digest fixture")
+    );
+}
+
+#[test]
+fn object_store_tls_trust_is_mandatory_current_and_transport_exact() {
+    let original: serde_json::Value =
+        serde_json::from_str(&valid_configuration()).expect("configuration JSON");
+
+    let mut missing = original.clone();
+    missing["object_store"]
+        .as_object_mut()
+        .expect("object-store object")
+        .remove("tls_trust");
+    assert_eq!(
+        parse_value(&missing).expect_err("TLS trust must be explicit"),
+        RunnerProductConfigError::InvalidDocument
+    );
+
+    let mut obsolete = original.clone();
+    obsolete["schema_version"] = serde_json::json!(3);
+    assert_eq!(
+        parse_value(&obsolete).expect_err("schema 3 must not be interpreted as current"),
+        RunnerProductConfigError::UnsupportedSchema
+    );
+
+    for invalid in [
+        serde_json::json!({}),
+        serde_json::json!({"mode": "private_ca"}),
+        serde_json::json!({
+            "mode": "web_pki",
+            "certificate_source": {"kind": "file", "path": "/run/secrets/s3-ca.pem"}
+        }),
+        serde_json::json!({"mode": "private-ca", "certificate_source": {"kind": "file", "path": "/run/secrets/s3-ca.pem"}}),
+        serde_json::json!({"mode": "private_ca", "certificate_source": "inline CA"}),
+    ] {
+        let mut changed = original.clone();
+        changed["object_store"]["tls_trust"] = invalid;
+        assert_eq!(
+            parse_value(&changed).expect_err("noncurrent trust shape must fail closed"),
+            RunnerProductConfigError::InvalidDocument
+        );
+    }
+
+    let private_ca = serde_json::json!({
+        "mode": "private_ca",
+        "certificate_source": {"kind": "file", "path": "/run/secrets/s3-ca.pem"}
+    });
+    let mut private_https = original.clone();
+    private_https["object_store"]["endpoint"] =
+        serde_json::json!("https://objects.internal.example/");
+    private_https["object_store"]["loopback_development"] = serde_json::json!(false);
+    private_https["object_store"]["tls_trust"] = private_ca.clone();
+    parse_value(&private_https).expect("exact private CA over HTTPS");
+
+    let mut private_http = original.clone();
+    private_http["object_store"]["tls_trust"] = private_ca;
+    assert_eq!(
+        parse_value(&private_http).expect_err("private CA cannot configure plaintext"),
+        RunnerProductConfigError::InvalidObjectStore
+    );
+
+    let mut inert_loopback = private_https;
+    inert_loopback["object_store"]["tls_trust"] = serde_json::json!({"mode": "web_pki"});
+    inert_loopback["object_store"]["loopback_development"] = serde_json::json!(true);
+    assert_eq!(
+        parse_value(&inert_loopback).expect_err("loopback plaintext mode cannot be inert on HTTPS"),
+        RunnerProductConfigError::InvalidObjectStore
     );
 }
 

--- a/crates/automata-ci-tls/Cargo.toml
+++ b/crates/automata-ci-tls/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "automata-ci-tls"
+description = "Validated TLS trust material shared by Automata infrastructure adapters"
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+pem-rfc7468.workspace = true
+rustls.workspace = true
+thiserror.workspace = true
+x509-parser.workspace = true
+
+[dev-dependencies]
+rcgen.workspace = true

--- a/crates/automata-ci-tls/README.md
+++ b/crates/automata-ci-tls/README.md
@@ -1,0 +1,9 @@
+# automata-ci-tls
+
+`automata-ci-tls` validates the exact certificate-authority document shared by
+Automata infrastructure adapters. It deliberately owns no network client,
+connector, or policy fallback.
+
+- [Architecture documentation](https://github.com/automata-ci/automata/blob/main/docs/architecture.md)
+- API documentation: run `cargo doc -p automata-ci-tls --open` from a source checkout.
+- [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-tls/src/lib.rs
+++ b/crates/automata-ci-tls/src/lib.rs
@@ -1,0 +1,191 @@
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+//! Validated TLS trust material for infrastructure adapters.
+//!
+//! This crate owns only the exact certificate-authority document boundary.
+//! Transport clients and trust-policy selection remain with their consuming
+//! adapters.
+
+use std::fmt;
+
+use rustls::{RootCertStore, pki_types::CertificateDer};
+use thiserror::Error;
+use x509_parser::parse_x509_certificate;
+
+/// Maximum accepted size of one exact CA certificate in canonical PEM form.
+pub const MAX_CA_CERTIFICATE_PEM_BYTES: usize = 1024 * 1024;
+
+/// One canonical RFC 7468 X.509 certificate authorized to sign certificates.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ValidatedCaCertificate {
+    certificate_pem: Vec<u8>,
+}
+
+impl ValidatedCaCertificate {
+    /// Validates one exact CA certificate in canonical RFC 7468 PEM form.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized input, malformed or non-certificate PEM, malformed
+    /// X.509, and certificates that are not marked as certificate authorities.
+    /// The source bytes must contain no preamble, use LF line endings, contain
+    /// exactly 64 Base64 characters per non-final line, end in one newline, and
+    /// contain no trailing data or second document. When `KeyUsage` is present,
+    /// it must authorize certificate signing.
+    pub fn new(certificate_pem: impl Into<Vec<u8>>) -> Result<Self, CaCertificateError> {
+        let certificate_pem = certificate_pem.into();
+        if certificate_pem.is_empty() || certificate_pem.len() > MAX_CA_CERTIFICATE_PEM_BYTES {
+            return Err(CaCertificateError);
+        }
+        let (label, certificate_der) =
+            pem_rfc7468::decode_vec(&certificate_pem).map_err(|_| CaCertificateError)?;
+        if label != "CERTIFICATE" {
+            return Err(CaCertificateError);
+        }
+        let canonical_pem = pem_rfc7468::encode_string(
+            "CERTIFICATE",
+            pem_rfc7468::LineEnding::LF,
+            &certificate_der,
+        )
+        .map_err(|_| CaCertificateError)?;
+        if canonical_pem.as_bytes() != certificate_pem {
+            return Err(CaCertificateError);
+        }
+        let (remaining, certificate) =
+            parse_x509_certificate(&certificate_der).map_err(|_| CaCertificateError)?;
+        let key_usage = certificate.key_usage().map_err(|_| CaCertificateError)?;
+        if !remaining.is_empty()
+            || !certificate.tbs_certificate.is_ca()
+            || key_usage.is_some_and(|usage| !usage.value.key_cert_sign())
+        {
+            return Err(CaCertificateError);
+        }
+        RootCertStore::empty()
+            .add(CertificateDer::from(certificate_der))
+            .map_err(|_| CaCertificateError)?;
+        Ok(Self { certificate_pem })
+    }
+
+    /// Returns the exact validated canonical PEM document.
+    #[must_use]
+    pub fn as_pem(&self) -> &[u8] {
+        &self.certificate_pem
+    }
+}
+
+impl fmt::Debug for ValidatedCaCertificate {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ValidatedCaCertificate([certificate redacted])")
+    }
+}
+
+/// A CA source was not one exact canonical certificate-authority document.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("CA source must contain exactly one valid canonical X.509 CA certificate")]
+pub struct CaCertificateError;
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{
+        BasicConstraints, CertificateParams, CustomExtension, DnType, IsCa, KeyPair,
+        KeyUsagePurpose,
+    };
+
+    use super::*;
+
+    fn certificate_pem(is_ca: bool, key_usages: Vec<KeyUsagePurpose>) -> Vec<u8> {
+        let key = KeyPair::generate().expect("CA key");
+        let mut params = CertificateParams::default();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Automata infrastructure test CA");
+        if is_ca {
+            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        }
+        params.key_usages = key_usages;
+        params
+            .self_signed(&key)
+            .expect("self-signed CA")
+            .pem()
+            .into_bytes()
+    }
+
+    fn ca_pem() -> Vec<u8> {
+        certificate_pem(
+            true,
+            vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign],
+        )
+    }
+
+    fn certificate_pem_with_malformed_key_usage() -> Vec<u8> {
+        let key = KeyPair::generate().expect("certificate key");
+        let mut params = CertificateParams::default();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params
+            .custom_extensions
+            .push(CustomExtension::from_oid_content(
+                &[2, 5, 29, 15],
+                // KeyUsage's extnValue must contain a DER BIT STRING, not BOOLEAN.
+                vec![0x01, 0x01, 0xff],
+            ));
+        params
+            .self_signed(&key)
+            .expect("self-signed certificate")
+            .pem()
+            .into_bytes()
+    }
+
+    #[test]
+    fn accepts_one_canonical_ca_and_redacts_debug() {
+        let marker = "Automata infrastructure test CA";
+        let certificate_pem = ca_pem();
+        let certificate = ValidatedCaCertificate::new(certificate_pem.clone()).expect("valid CA");
+
+        assert_eq!(certificate.as_pem(), certificate_pem);
+        let debug = format!("{certificate:?}");
+        assert_eq!(debug, "ValidatedCaCertificate([certificate redacted])");
+        assert!(!debug.contains(marker));
+        assert!(!debug.contains("BEGIN CERTIFICATE"));
+    }
+
+    #[test]
+    fn rejects_non_ca_noncanonical_and_multiple_documents() {
+        let ca_pem = ca_pem();
+        ValidatedCaCertificate::new(certificate_pem(true, Vec::new()))
+            .expect("a CA without KeyUsage remains a valid trust anchor");
+        let mut doubled = ca_pem.clone();
+        doubled.extend_from_slice(&ca_pem);
+        let mut preamble = b"deployment preamble\n".to_vec();
+        preamble.extend_from_slice(&ca_pem);
+        let mut trailing_data = ca_pem.clone();
+        trailing_data.extend_from_slice(b"trailing data");
+        let mut trailing_newline = ca_pem.clone();
+        trailing_newline.push(b'\n');
+        let mut missing_terminal_newline = ca_pem.clone();
+        assert_eq!(missing_terminal_newline.pop(), Some(b'\n'));
+        let crlf = String::from_utf8(ca_pem.clone())
+            .expect("certificate PEM is ASCII")
+            .replace('\n', "\r\n")
+            .into_bytes();
+
+        for invalid in [
+            Vec::new(),
+            b"not a PEM certificate".to_vec(),
+            certificate_pem(false, Vec::new()),
+            certificate_pem(true, vec![KeyUsagePurpose::DigitalSignature]),
+            certificate_pem_with_malformed_key_usage(),
+            doubled,
+            preamble,
+            trailing_data,
+            trailing_newline,
+            missing_terminal_newline,
+            crlf,
+            vec![b'a'; MAX_CA_CERTIFICATE_PEM_BYTES + 1],
+        ] {
+            assert_eq!(
+                ValidatedCaCertificate::new(invalid),
+                Err(CaCertificateError)
+            );
+        }
+    }
+}

--- a/crates/automata-ci-workflow-service/tests/live_admission.rs
+++ b/crates/automata-ci-workflow-service/tests/live_admission.rs
@@ -7,9 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_blob::{BlobDescriptor, BlobKey, ImmutableBlobStore as _, MediaType};
-use automata_ci_blob_s3::{
-    S3AtRestEncryption, S3BlobStore, S3BlobStoreConfig, StaticS3Credentials,
-};
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_core::UnixMillis;
 use automata_ci_store::{
     AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim, LogicalWorkflowAdmissionReceipt,
@@ -42,12 +40,11 @@ async fn authenticated_admission_publishes_exact_evidence_to_rustfs_before_commi
     .with_at_rest_encryption(S3AtRestEncryption::aws_kms(required_environment(
         "AUTOMATA_TEST_S3_KMS_KEY_ID",
     ))?);
-    let client = config.client(StaticS3Credentials::new(
+    let blobs = Arc::new(config.connect(StaticS3Credentials::new(
         required_environment("AUTOMATA_TEST_S3_ACCESS_KEY"),
         required_environment("AUTOMATA_TEST_S3_SECRET_KEY"),
         None,
-    )?);
-    let blobs = Arc::new(S3BlobStore::new(client, &config));
+    )?)?);
     let repository = Arc::new(RecordingRepository::default());
     let service = WorkflowAdmissionService::with_system_ports(
         blobs.clone(),

--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -168,6 +168,27 @@ artifact objects; runners verify those exact keys and publish immutable action
 bundles. A differing prefix fails closed as a missing object and is never
 searched or guessed.
 
+HTTPS object storage has one explicit trust mode. The default
+`--s3-tls-trust web-pki` uses the platform Web PKI roots. To trust a private
+service, select `--s3-tls-trust private-ca` and provide exactly one bounded CA
+certificate through `--s3-private-ca-source env:NAME` or
+`--s3-private-ca-source file:/absolute/path`. Private-CA mode starts from an
+empty root store, never adds Web PKI roots, and never retries under a different
+trust policy. The source is subject to the same secure-file and redaction rules
+as other privileged inputs and is capped at 1 MiB. It must be one canonical
+RFC 7468 certificate with 64-column Base64, LF line endings, one terminal LF,
+no preamble/trailing bytes, and `keyCertSign` whenever KeyUsage is present.
+
+For example, an HTTPS S3-compatible service with its own CA uses:
+
+```console
+automata server \
+  --s3-endpoint https://objects.internal.example/ \
+  --s3-tls-trust private-ca \
+  --s3-private-ca-source file:/run/secrets/object-store-ca.pem \
+  --s3-bucket automata
+```
+
 For local RustFS, explicitly allow a literal loopback HTTP endpoint:
 
 ```console
@@ -181,7 +202,10 @@ automata server \
 ```
 
 Plain HTTP object-store endpoints anywhere other than literal loopback are
-rejected even when the development option is present.
+rejected. `--s3-allow-loopback-http` is also rejected for an HTTPS endpoint or
+with private-CA trust, so it cannot remain as an inert or ambiguous setting.
+After argument validation, connection security is exactly one closed state:
+Web PKI HTTPS, exact-private-CA HTTPS, or literal-loopback plaintext.
 
 Object writes use provider-managed AES-256 (`SSE-S3`) by default. Set
 `--s3-kms-key-id` to select `SSE-KMS` with one exact non-secret key identity;

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -33,6 +33,9 @@ pub enum Command {
     Runner(RunnerArgs),
     /// Inspect control-plane status.
     Admin(AdminArgs),
+    /// Run image-internal service initialization operations.
+    #[command(hide = true)]
+    Internal(InternalArgs),
 }
 
 impl Command {
@@ -46,9 +49,47 @@ impl Command {
             Self::Rerun(args) => Some(&args.operator),
             Self::Runner(args) => Some(&args.operator),
             Self::Admin(args) => Some(&args.operator),
-            Self::Server(_) | Self::Preview(_) | Self::Local(_) => None,
+            Self::Server(_) | Self::Preview(_) | Self::Local(_) | Self::Internal(_) => None,
         }
     }
+}
+
+#[derive(Debug, Args)]
+/// Image-internal service initialization namespace.
+pub struct InternalArgs {
+    /// Internal service boundary to initialize.
+    #[command(subcommand)]
+    pub command: InternalCommand,
+}
+
+#[derive(Debug, Subcommand)]
+/// Closed image-internal service initialization boundaries.
+pub enum InternalCommand {
+    /// Initialize the configured object-store boundary.
+    ObjectStore(InternalObjectStoreArgs),
+}
+
+#[derive(Debug, Args)]
+/// Image-internal object-store initialization operations.
+pub struct InternalObjectStoreArgs {
+    /// Exact object-store initialization operation.
+    #[command(subcommand)]
+    pub command: InternalObjectStoreCommand,
+}
+
+#[derive(Debug, Subcommand)]
+/// Current object-store initialization operations.
+pub enum InternalObjectStoreCommand {
+    /// Ensure the exact configured bucket exists and is accessible.
+    EnsureBucket(InternalEnsureBucketArgs),
+}
+
+#[derive(Debug, Args)]
+/// Exact bucket initialization inputs.
+pub struct InternalEnsureBucketArgs {
+    /// Production S3 connection, trust, deadline, and credential-source inputs.
+    #[command(flatten)]
+    pub s3: S3ConnectionArgs,
 }
 
 #[derive(Debug, Args)]
@@ -303,6 +344,92 @@ pub enum DatabaseTransport {
     VerifyFull,
     /// Disable TLS only for a Unix socket or literal loopback address.
     LoopbackPlaintext,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+/// Exact HTTPS trust policy for the S3 endpoint.
+pub enum S3TlsTrustMode {
+    /// Authenticate through the platform Web PKI root store.
+    #[default]
+    WebPki,
+    /// Authenticate through exactly one deployment-provided private CA.
+    PrivateCa,
+}
+
+#[derive(Debug, Args)]
+/// Shared S3 endpoint, trust, deadline, and credential-source inputs.
+pub struct S3ConnectionArgs {
+    /// Credential-free S3-compatible endpoint origin.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_ENDPOINT",
+        default_value = "https://s3.amazonaws.com/"
+    )]
+    pub s3_endpoint: String,
+
+    /// S3 signing region.
+    #[arg(long, env = "AUTOMATA_S3_REGION", default_value = "us-east-1")]
+    pub s3_region: String,
+
+    /// Exact S3 bucket owned by this Automata installation.
+    #[arg(long, env = "AUTOMATA_S3_BUCKET", default_value = "automata")]
+    pub s3_bucket: String,
+
+    /// Use path-style bucket addressing for the S3 adapter.
+    #[arg(long, env = "AUTOMATA_S3_FORCE_PATH_STYLE")]
+    pub s3_force_path_style: bool,
+
+    /// Exact HTTPS server trust policy.
+    #[arg(long, env = "AUTOMATA_S3_TLS_TRUST", value_enum, default_value_t)]
+    pub s3_tls_trust: S3TlsTrustMode,
+
+    /// Exact private-CA PEM reference, required only with `private-ca` trust.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_PRIVATE_CA_SOURCE",
+        value_name = "env:NAME|file:PATH"
+    )]
+    pub s3_private_ca_source: Option<SecretSource>,
+
+    /// Permit plaintext only for a literal-loopback HTTP endpoint.
+    #[arg(long, env = "AUTOMATA_S3_ALLOW_LOOPBACK_HTTP")]
+    pub s3_allow_loopback_http: bool,
+
+    /// Total wall-clock deadline for one object-store operation.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_OPERATION_TIMEOUT_SECONDS",
+        default_value_t = 30,
+        value_parser = clap::value_parser!(u64).range(1..=300)
+    )]
+    pub s3_operation_timeout_seconds: u64,
+
+    /// S3 access-key reference; secret values are never accepted in argv.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_ACCESS_KEY_SOURCE",
+        default_value = "env:AUTOMATA_S3_ACCESS_KEY",
+        value_name = "env:NAME|file:PATH"
+    )]
+    pub s3_access_key_source: SecretSource,
+
+    /// S3 secret-key reference; secret values are never accepted in argv.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_SECRET_KEY_SOURCE",
+        default_value = "env:AUTOMATA_S3_SECRET_KEY",
+        value_name = "env:NAME|file:PATH"
+    )]
+    pub s3_secret_key_source: SecretSource,
+
+    /// Optional S3 session-token reference.
+    #[arg(
+        long,
+        env = "AUTOMATA_S3_SESSION_TOKEN_SOURCE",
+        value_name = "env:NAME|file:PATH"
+    )]
+    pub s3_session_token_source: Option<SecretSource>,
 }
 
 #[derive(Debug, Args)]
@@ -583,29 +710,13 @@ pub struct ServerArgs {
     #[arg(long, env = "AUTOMATA_DATABASE_TRANSPORT", value_enum, default_value_t)]
     pub database_transport: DatabaseTransport,
 
-    /// Credential-free S3-compatible endpoint origin.
-    #[arg(
-        long,
-        env = "AUTOMATA_S3_ENDPOINT",
-        default_value = "https://s3.amazonaws.com/"
-    )]
-    pub s3_endpoint: String,
-
-    /// S3 signing region.
-    #[arg(long, env = "AUTOMATA_S3_REGION", default_value = "us-east-1")]
-    pub s3_region: String,
-
-    /// S3 bucket containing immutable Automata objects.
-    #[arg(long, env = "AUTOMATA_S3_BUCKET", default_value = "automata")]
-    pub s3_bucket: String,
+    /// S3 endpoint, trust, deadline, and credential-source inputs.
+    #[command(flatten)]
+    pub s3: S3ConnectionArgs,
 
     /// Optional key prefix reserved for this Automata installation.
     #[arg(long, env = "AUTOMATA_S3_PREFIX")]
     pub s3_prefix: Option<String>,
-
-    /// Use path-style bucket addressing for the S3 adapter.
-    #[arg(long, env = "AUTOMATA_S3_FORCE_PATH_STYLE")]
-    pub s3_force_path_style: bool,
 
     /// Exact KMS key identity for S3 server-side encryption.
     ///
@@ -614,45 +725,6 @@ pub struct ServerArgs {
     /// key identity as well as the expected encryption algorithm.
     #[arg(long, env = "AUTOMATA_S3_KMS_KEY_ID", value_name = "KEY_ID")]
     pub s3_kms_key_id: Option<String>,
-
-    /// Permit plain HTTP only when the S3 endpoint is a literal loopback host.
-    #[arg(long, env = "AUTOMATA_S3_ALLOW_LOOPBACK_HTTP")]
-    pub s3_allow_loopback_http: bool,
-
-    /// All-attempt timeout for one immutable object-store operation.
-    #[arg(
-        long,
-        env = "AUTOMATA_S3_OPERATION_TIMEOUT_SECONDS",
-        default_value_t = 30,
-        value_parser = clap::value_parser!(u64).range(1..=300)
-    )]
-    pub s3_operation_timeout_seconds: u64,
-
-    /// S3 access-key reference; secret values are never accepted in argv.
-    #[arg(
-        long,
-        env = "AUTOMATA_S3_ACCESS_KEY_SOURCE",
-        default_value = "env:AUTOMATA_S3_ACCESS_KEY",
-        value_name = "env:NAME|file:PATH"
-    )]
-    pub s3_access_key_source: SecretSource,
-
-    /// S3 secret-key reference; secret values are never accepted in argv.
-    #[arg(
-        long,
-        env = "AUTOMATA_S3_SECRET_KEY_SOURCE",
-        default_value = "env:AUTOMATA_S3_SECRET_KEY",
-        value_name = "env:NAME|file:PATH"
-    )]
-    pub s3_secret_key_source: SecretSource,
-
-    /// Optional S3 session-token reference.
-    #[arg(
-        long,
-        env = "AUTOMATA_S3_SESSION_TOKEN_SOURCE",
-        value_name = "env:NAME|file:PATH"
-    )]
-    pub s3_session_token_source: Option<SecretSource>,
 
     /// PEM certificate for the CA that authenticates runner clients.
     #[arg(

--- a/crates/automata-ci/src/cli/execution.rs
+++ b/crates/automata-ci/src/cli/execution.rs
@@ -221,8 +221,8 @@ pub async fn execute_control_plane_command(
         }
         Command::Rerun(args) => execute_rerun_command(server_url, output, args).await,
         Command::Runner(args) => execute_runner_command(server_url, output, args).await,
-        Command::Server(_) | Command::Preview(_) | Command::Local(_) => {
-            bail!("local and service commands cannot be sent to a running control plane")
+        Command::Server(_) | Command::Preview(_) | Command::Local(_) | Command::Internal(_) => {
+            bail!("local, internal, and service commands cannot be sent to a running control plane")
         }
     }
 }

--- a/crates/automata-ci/src/cli/mod.rs
+++ b/crates/automata-ci/src/cli/mod.rs
@@ -36,11 +36,12 @@ use clap::{CommandFactory, FromArgMatches, Parser, error::ErrorKind};
 
 pub use commands::{
     AdminArgs, AdminCommand, AuthArgs, AuthCommand, Command, DatabaseTransport,
-    EnvironmentReviewArgs, EnvironmentReviewDecision, LocalArgs, LocalCheckArgs, LocalCommand,
-    LocalContainerEngine, LocalDoctorArgs, LocalWorkflowInput, OperatorArgs, PreviewArgs,
-    RerunArgs, RerunSelection, RunnerArgs, RunnerCommand, RunnerTokenArgs, SecretArgs,
-    SecretCommand, SecretCreateArgs, SecretDeleteArgs, SecretListArgs, SecretProviderArgs,
-    SecretProviderCommand, ServerArgs,
+    EnvironmentReviewArgs, EnvironmentReviewDecision, InternalArgs, InternalCommand,
+    InternalEnsureBucketArgs, InternalObjectStoreArgs, InternalObjectStoreCommand, LocalArgs,
+    LocalCheckArgs, LocalCommand, LocalContainerEngine, LocalDoctorArgs, LocalWorkflowInput,
+    OperatorArgs, PreviewArgs, RerunArgs, RerunSelection, RunnerArgs, RunnerCommand,
+    RunnerTokenArgs, S3ConnectionArgs, S3TlsTrustMode, SecretArgs, SecretCommand, SecretCreateArgs,
+    SecretDeleteArgs, SecretListArgs, SecretProviderArgs, SecretProviderCommand, ServerArgs,
 };
 pub use output::OutputFormat;
 pub use values::{RepositoryRef, SecretScope};

--- a/crates/automata-ci/src/internal.rs
+++ b/crates/automata-ci/src/internal.rs
@@ -1,0 +1,28 @@
+use anyhow::{Context as _, Result};
+use automata_ci_blob_s3::S3AtRestEncryption;
+
+use crate::{
+    cli::{InternalArgs, InternalCommand, InternalEnsureBucketArgs, InternalObjectStoreCommand},
+    server::S3ConnectionConfig,
+};
+
+pub(crate) async fn execute(args: &InternalArgs) -> Result<()> {
+    match &args.command {
+        InternalCommand::ObjectStore(args) => match &args.command {
+            InternalObjectStoreCommand::EnsureBucket(args) => ensure_exact_bucket(args).await,
+        },
+    }
+}
+
+async fn ensure_exact_bucket(args: &InternalEnsureBucketArgs) -> Result<()> {
+    let connection = S3ConnectionConfig::from_args(&args.s3, None, S3AtRestEncryption::aes256())
+        .context("invalid object-store initialization configuration")?;
+    let store = crate::object_store::connect(&connection)
+        .context("failed to configure object-store initialization")?;
+    store
+        .ensure_bucket()
+        .await
+        .context("failed to initialize object-store bucket")?;
+    println!("object-store bucket ready");
+    Ok(())
+}

--- a/crates/automata-ci/src/lib.rs
+++ b/crates/automata-ci/src/lib.rs
@@ -12,7 +12,9 @@ pub mod app;
 /// Immutable executable version and source-revision metadata.
 pub mod build_info;
 pub mod cli;
+mod internal;
 mod local;
+mod object_store;
 pub mod preview;
 pub mod server;
 /// Cooperative process-shutdown coordination.
@@ -59,10 +61,11 @@ async fn execute(cli: Cli) -> Result<()> {
         Command::Server(args) => Box::pin(server::serve(args)).await,
         Command::Preview(args) => preview::serve(args).await,
         Command::Local(args) => Box::pin(local::execute(args)).await,
+        Command::Internal(args) => Box::pin(internal::execute(args)).await,
         command => {
-            let operator = command
-                .operator()
-                .expect("local and service commands are handled before operator dispatch");
+            let operator = command.operator().expect(
+                "local, internal, and service commands are handled before operator dispatch",
+            );
             cli::execute_control_plane_command(&operator.server_url, operator.output, command).await
         }
     }

--- a/crates/automata-ci/src/object_store.rs
+++ b/crates/automata-ci/src/object_store.rs
@@ -1,0 +1,46 @@
+use automata_ci_blob_s3::{
+    MAX_S3_PRIVATE_CA_PEM_BYTES, S3BlobStore, S3BlobStoreConfigError, S3TlsTrust,
+    StaticS3Credentials,
+};
+use thiserror::Error;
+
+use crate::server::{S3ConnectionConfig, S3Transport, SecretLoadError};
+
+pub(crate) fn connect(
+    connection: &S3ConnectionConfig,
+) -> Result<S3BlobStore, ObjectStoreConnectionError> {
+    let config = match connection.transport() {
+        S3Transport::WebPki | S3Transport::LoopbackPlaintext => connection.store_config().clone(),
+        S3Transport::PrivateCa { certificate_source } => {
+            let tls_trust = certificate_source
+                .load_bytes(MAX_S3_PRIVATE_CA_PEM_BYTES)
+                .map(|pem| pem.to_vec())
+                .and_then(|pem| {
+                    S3TlsTrust::private_ca(pem).map_err(|_| SecretLoadError::InvalidCertificate)
+                })?;
+            connection
+                .store_config()
+                .clone()
+                .with_tls_trust(tls_trust)?
+        }
+    };
+    let access_key = connection.load_access_key()?;
+    let secret_key = connection.load_secret_key()?;
+    let session_token = connection.load_session_token()?;
+    let credentials = StaticS3Credentials::new(
+        access_key.as_str(),
+        secret_key.as_str(),
+        session_token
+            .as_ref()
+            .map(|value| value.as_str().to_owned()),
+    )?;
+    Ok(config.connect(credentials)?)
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ObjectStoreConnectionError {
+    #[error("an object-store source could not be loaded")]
+    Secret(#[from] SecretLoadError),
+    #[error("object-store SDK configuration is invalid")]
+    Configuration(#[from] S3BlobStoreConfigError),
+}

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -16,9 +16,7 @@ use automata_ci_auth_postgres::{
     PostgresDelegatedActorResolver, PostgresHumanRbacManagementRepository,
 };
 use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType};
-use automata_ci_blob_s3::{
-    S3BlobStore, S3BlobStoreConfig, S3BlobStoreConfigError, StaticS3Credentials,
-};
+use automata_ci_blob_s3::S3BlobStoreConfigError;
 use automata_ci_control::lease::{
     LeaseClock, LeaseIdGenerator, RandomLeaseIdGenerator, RunnableScanLimit, SystemLeaseClock,
     repository::RunnerLeaseRequestRepository,
@@ -1813,40 +1811,15 @@ impl ReadinessProbe for ImmutableBlobReadinessProbe {
 fn build_blob_store(
     config: &ServerConfig,
 ) -> Result<Arc<dyn ImmutableBlobStore>, ServerCompositionError> {
-    let blob_config = if config.s3_endpoint.scheme() == "http" {
-        if !config.s3_allow_loopback_http {
-            return Err(ServerCompositionError::InsecureS3Endpoint);
+    let store = crate::object_store::connect(&config.s3).map_err(|error| match error {
+        crate::object_store::ObjectStoreConnectionError::Secret(error) => {
+            ServerCompositionError::Secret(error)
         }
-        S3BlobStoreConfig::loopback_development(
-            config.s3_endpoint.clone(),
-            config.s3_region.clone(),
-            config.s3_bucket.clone(),
-            config.s3_prefix.clone(),
-            config.s3_operation_timeout,
-        )?
-    } else {
-        S3BlobStoreConfig::new(
-            config.s3_endpoint.clone(),
-            config.s3_region.clone(),
-            config.s3_bucket.clone(),
-            config.s3_prefix.clone(),
-            config.s3_force_path_style,
-            config.s3_operation_timeout,
-        )?
-    };
-    let blob_config = blob_config.with_at_rest_encryption(config.s3_at_rest_encryption.clone());
-    let access_key = config.load_s3_access_key()?;
-    let secret_key = config.load_s3_secret_key()?;
-    let session_token = config.load_s3_session_token()?;
-    let credentials = StaticS3Credentials::new(
-        access_key.as_str(),
-        secret_key.as_str(),
-        session_token
-            .as_ref()
-            .map(|value| value.as_str().to_owned()),
-    )?;
-    let client = blob_config.client(credentials);
-    Ok(Arc::new(S3BlobStore::new(client, &blob_config)))
+        crate::object_store::ObjectStoreConnectionError::Configuration(error) => {
+            ServerCompositionError::S3(error)
+        }
+    })?;
+    Ok(Arc::new(store))
 }
 
 fn load_server_tls(config: &ServerConfig) -> Result<ServerTlsConfig, ServerCompositionError> {
@@ -1983,9 +1956,6 @@ pub enum ServerCompositionError {
     /// A fresh process-local autonomous workflow worker identity was invalid.
     #[error("autonomous workflow worker identity is invalid")]
     InvalidAutonomousWorkflowWorker,
-    /// Plain HTTP was not explicitly permitted for a loopback S3 endpoint.
-    #[error("plain HTTP S3 requires the explicit loopback-development option")]
-    InsecureS3Endpoint,
     /// A PEM source was malformed, empty, excessive, or contained multiple keys.
     #[error("runner TLS PEM material is invalid")]
     InvalidTlsPem,

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -17,7 +17,7 @@ use url::Url;
 use zeroize::Zeroizing;
 
 use automata_ci_auth::{github::GithubClientId, installation::InstallationTenant};
-use automata_ci_blob_s3::S3AtRestEncryption;
+use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, S3TlsTrust};
 use automata_ci_control::maintenance::{
     LeaseFailureLimit, MaintenanceBatchSize, StaleSessionTimeoutMillis,
 };
@@ -30,7 +30,7 @@ use automata_ci_provisioning::{
 use automata_ci_results_github::ResultsPublicEndpoint;
 use automata_ci_store_postgres::PostgresTransportSecurity;
 
-use crate::cli::{DatabaseTransport, ServerArgs};
+use crate::cli::{DatabaseTransport, S3ConnectionArgs, S3TlsTrustMode, ServerArgs};
 
 use super::github_oidc::GithubOidcConfig;
 
@@ -295,6 +295,9 @@ pub enum SecretLoadError {
         /// Required byte length.
         expected: usize,
     },
+    /// A bounded certificate source was not the required exact X.509 document.
+    #[error("referenced certificate is invalid")]
+    InvalidCertificate,
 }
 
 /// Validated product configuration for one control-plane replica.
@@ -316,17 +319,7 @@ pub struct ServerConfig {
     pub(crate) database_url: SecretSource,
     pub(crate) database_max_connections: u32,
     pub(crate) database_transport_security: PostgresTransportSecurity,
-    pub(crate) s3_endpoint: Url,
-    pub(crate) s3_region: String,
-    pub(crate) s3_bucket: String,
-    pub(crate) s3_prefix: Option<String>,
-    pub(crate) s3_force_path_style: bool,
-    pub(crate) s3_at_rest_encryption: S3AtRestEncryption,
-    pub(crate) s3_allow_loopback_http: bool,
-    pub(crate) s3_operation_timeout: Duration,
-    pub(crate) s3_access_key: SecretSource,
-    pub(crate) s3_secret_key: SecretSource,
-    pub(crate) s3_session_token: Option<SecretSource>,
+    pub(crate) s3: S3ConnectionConfig,
     pub(crate) runner_client_ca_certificate: SecretSource,
     pub(crate) runner_client_ca_private_key: SecretSource,
     pub(crate) runner_server_ca: SecretSource,
@@ -339,6 +332,121 @@ pub struct ServerConfig {
     pub(crate) maximum_lease_failures: LeaseFailureLimit,
     pub(crate) stale_runner_session_timeout: StaleSessionTimeoutMillis,
     pub(crate) fallback_tenant_id: String,
+}
+
+/// Shared validated S3 connection, trust, deadline, and credential sources.
+#[derive(Clone, Debug)]
+pub(crate) struct S3ConnectionConfig {
+    store_config: S3BlobStoreConfig,
+    transport: S3Transport,
+    access_key: SecretSource,
+    secret_key: SecretSource,
+    session_token: Option<SecretSource>,
+}
+
+/// Exact transport and server-authentication policy for one validated S3 endpoint.
+#[derive(Clone, Debug)]
+pub(crate) enum S3Transport {
+    /// HTTPS authenticated by the platform Web PKI roots.
+    WebPki,
+    /// HTTPS authenticated by exactly one bounded deployment-provided CA.
+    PrivateCa { certificate_source: SecretSource },
+    /// Plaintext restricted to an exact literal-loopback HTTP endpoint.
+    LoopbackPlaintext,
+}
+
+impl S3ConnectionConfig {
+    pub(crate) fn from_args(
+        args: &S3ConnectionArgs,
+        prefix: Option<String>,
+        at_rest_encryption: S3AtRestEncryption,
+    ) -> Result<Self, ServerConfigError> {
+        let sources = [
+            Some(&args.s3_access_key_source),
+            Some(&args.s3_secret_key_source),
+            args.s3_session_token_source.as_ref(),
+            args.s3_private_ca_source.as_ref(),
+        ];
+        if sources
+            .into_iter()
+            .flatten()
+            .any(|source| !source.is_valid_reference())
+        {
+            return Err(ServerConfigError::InvalidSecretSource);
+        }
+        let tls_transport = match (args.s3_tls_trust, args.s3_private_ca_source.as_ref()) {
+            (S3TlsTrustMode::WebPki, None) => S3Transport::WebPki,
+            (S3TlsTrustMode::PrivateCa, Some(source)) => S3Transport::PrivateCa {
+                certificate_source: source.clone(),
+            },
+            (S3TlsTrustMode::WebPki, Some(_)) | (S3TlsTrustMode::PrivateCa, None) => {
+                return Err(ServerConfigError::InvalidS3TlsTrust);
+            }
+        };
+        let endpoint =
+            Url::parse(&args.s3_endpoint).map_err(|_| ServerConfigError::InvalidS3Endpoint)?;
+        let transport = match (
+            endpoint.scheme(),
+            args.s3_allow_loopback_http,
+            tls_transport,
+        ) {
+            ("https", false, transport) => transport,
+            ("http", true, S3Transport::WebPki) => S3Transport::LoopbackPlaintext,
+            ("https" | "http", _, _) => return Err(ServerConfigError::InvalidS3Transport),
+            _ => return Err(ServerConfigError::InvalidS3Endpoint),
+        };
+        let operation_timeout = positive_seconds(args.s3_operation_timeout_seconds)?;
+        let store_config = match &transport {
+            S3Transport::WebPki | S3Transport::PrivateCa { .. } => S3BlobStoreConfig::new(
+                endpoint.clone(),
+                args.s3_region.clone(),
+                args.s3_bucket.clone(),
+                prefix,
+                args.s3_force_path_style,
+                S3TlsTrust::web_pki(),
+                operation_timeout,
+            ),
+            S3Transport::LoopbackPlaintext => S3BlobStoreConfig::loopback_development(
+                endpoint.clone(),
+                args.s3_region.clone(),
+                args.s3_bucket.clone(),
+                prefix,
+                operation_timeout,
+            ),
+        }
+        .map_err(|_| ServerConfigError::InvalidS3Configuration)?
+        .with_at_rest_encryption(at_rest_encryption);
+        Ok(Self {
+            store_config,
+            transport,
+            access_key: args.s3_access_key_source.clone(),
+            secret_key: args.s3_secret_key_source.clone(),
+            session_token: args.s3_session_token_source.clone(),
+        })
+    }
+
+    pub(crate) const fn transport(&self) -> &S3Transport {
+        &self.transport
+    }
+
+    pub(crate) const fn store_config(&self) -> &S3BlobStoreConfig {
+        &self.store_config
+    }
+
+    pub(crate) fn load_access_key(&self) -> Result<Zeroizing<String>, SecretLoadError> {
+        self.access_key.load_scalar(MAX_S3_CREDENTIAL_BYTES)
+    }
+
+    pub(crate) fn load_secret_key(&self) -> Result<Zeroizing<String>, SecretLoadError> {
+        self.secret_key.load_scalar(MAX_S3_CREDENTIAL_BYTES)
+    }
+
+    pub(crate) fn load_session_token(&self) -> Result<Option<Zeroizing<String>>, SecretLoadError> {
+        self.session_token
+            .as_ref()
+            .map(|source| source.load_scalar(MAX_S3_CREDENTIAL_BYTES))
+            .transpose()
+    }
 }
 
 /// Complete opt-in configuration for the private shard-management listener.
@@ -632,13 +740,12 @@ impl ServerConfig {
         validate_server_secret_sources(args)?;
         validate_local_listeners(args)?;
         validate_fallback_tenant(&args.fallback_tenant_id)?;
-        let s3_endpoint =
-            Url::parse(&args.s3_endpoint).map_err(|_| ServerConfigError::InvalidS3Endpoint)?;
         let s3_at_rest_encryption = s3_at_rest_encryption(args.s3_kms_key_id.as_deref())?;
+        let s3 =
+            S3ConnectionConfig::from_args(&args.s3, args.s3_prefix.clone(), s3_at_rest_encryption)?;
         if args.database_max_connections == 0 {
             return Err(ServerConfigError::InvalidDatabaseConnections);
         }
-        let s3_operation_timeout = positive_seconds(args.s3_operation_timeout_seconds)?;
         let readiness_probe_interval = positive_seconds(args.readiness_probe_interval_seconds)?;
         let maintenance_interval = positive_seconds(args.maintenance_interval_seconds)?;
         let maintenance_batch_size = MaintenanceBatchSize::new(args.maintenance_batch_size)
@@ -694,17 +801,7 @@ impl ServerConfig {
                     PostgresTransportSecurity::LoopbackPlaintext
                 }
             },
-            s3_endpoint,
-            s3_region: args.s3_region.clone(),
-            s3_bucket: args.s3_bucket.clone(),
-            s3_prefix: args.s3_prefix.clone(),
-            s3_force_path_style: args.s3_force_path_style,
-            s3_at_rest_encryption,
-            s3_allow_loopback_http: args.s3_allow_loopback_http,
-            s3_operation_timeout,
-            s3_access_key: args.s3_access_key_source.clone(),
-            s3_secret_key: args.s3_secret_key_source.clone(),
-            s3_session_token: args.s3_session_token_source.clone(),
+            s3,
             runner_client_ca_certificate: args.runner_client_ca_certificate_source.clone(),
             runner_client_ca_private_key: args.runner_client_ca_key_source.clone(),
             runner_server_ca: args.runner_server_ca_source.clone(),
@@ -770,23 +867,6 @@ impl ServerConfig {
 
     pub(crate) fn load_database_url(&self) -> Result<Zeroizing<String>, SecretLoadError> {
         self.database_url.load_scalar(MAX_DATABASE_URL_BYTES)
-    }
-
-    pub(crate) fn load_s3_access_key(&self) -> Result<Zeroizing<String>, SecretLoadError> {
-        self.s3_access_key.load_scalar(MAX_S3_CREDENTIAL_BYTES)
-    }
-
-    pub(crate) fn load_s3_secret_key(&self) -> Result<Zeroizing<String>, SecretLoadError> {
-        self.s3_secret_key.load_scalar(MAX_S3_CREDENTIAL_BYTES)
-    }
-
-    pub(crate) fn load_s3_session_token(
-        &self,
-    ) -> Result<Option<Zeroizing<String>>, SecretLoadError> {
-        self.s3_session_token
-            .as_ref()
-            .map(|source| source.load_scalar(MAX_S3_CREDENTIAL_BYTES))
-            .transpose()
     }
 
     pub(crate) fn load_client_ca_pem(&self) -> Result<Zeroizing<Vec<u8>>, SecretLoadError> {
@@ -1229,8 +1309,6 @@ fn validate_server_secret_sources(args: &ServerArgs) -> Result<(), ServerConfigE
         &args.database_url_source,
         &args.results_signing_key_source,
         &args.control_plane_encryption_key_source,
-        &args.s3_access_key_source,
-        &args.s3_secret_key_source,
         &args.runner_client_ca_certificate_source,
         &args.runner_client_ca_key_source,
         &args.runner_server_ca_source,
@@ -1238,7 +1316,6 @@ fn validate_server_secret_sources(args: &ServerArgs) -> Result<(), ServerConfigE
         &args.runner_server_key_source,
     ];
     let optional = [
-        args.s3_session_token_source.as_ref(),
         args.github_oidc_config_source.as_ref(),
         args.conformance_export_token_source.as_ref(),
         args.management_client_ca_certificate_source.as_ref(),
@@ -1379,6 +1456,15 @@ pub enum ServerConfigError {
     /// The configured server-side encryption key identity is malformed.
     #[error("S3 server-side encryption configuration is invalid")]
     InvalidS3Encryption,
+    /// The S3 endpoint, namespace, region, addressing, or deadline is invalid.
+    #[error("S3 connection configuration is invalid")]
+    InvalidS3Configuration,
+    /// The explicit S3 HTTPS trust mode and private-CA source are inconsistent.
+    #[error("S3 TLS trust configuration is invalid")]
+    InvalidS3TlsTrust,
+    /// The explicit S3 plaintext-development policy does not match the endpoint.
+    #[error("S3 transport configuration is invalid")]
+    InvalidS3Transport,
     /// The `PostgreSQL` pool size is zero.
     #[error("database maximum connections must be greater than zero")]
     InvalidDatabaseConnections,

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -65,6 +65,7 @@ pub use config::{
     SecretSource, ServerConfig, ServerConfigError, VersionedSecretSource,
     VersionedSecretSourceParseError,
 };
+pub(crate) use config::{S3ConnectionConfig, S3Transport};
 pub use github_oidc::{GithubOidcConfig, GithubOidcProductError};
 pub use github_provider::{
     GithubProviderBootstrapError, GithubProviderBootstrapPlan, GithubProviderBootstrapReady,

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -1,8 +1,9 @@
 use automata_ci::cli::{
-    AuthCommand, Cli, Command, EnvironmentReviewDecision, LocalCommand, LocalContainerEngine,
-    OutputFormat, RepositoryRef, RerunSelection, SecretCommand, SecretProviderCommand, SecretScope,
+    AuthCommand, Cli, Command, EnvironmentReviewDecision, InternalCommand,
+    InternalObjectStoreCommand, LocalCommand, LocalContainerEngine, OutputFormat, RepositoryRef,
+    RerunSelection, S3TlsTrustMode, SecretCommand, SecretProviderCommand, SecretScope,
 };
-use automata_ci::server::{ServerConfig, ServerConfigError};
+use automata_ci::server::{SecretSource, ServerConfig, ServerConfigError};
 use clap::{CommandFactory as _, Parser as _};
 
 #[test]
@@ -109,6 +110,97 @@ fn local_check_is_explicit_source_only_workflow_dispatch_validation() {
 }
 
 #[test]
+fn internal_object_store_bucket_initialization_is_hidden_exact_and_redacted() {
+    let marker = "AUTOMATA_INTERNAL_PRIVATE_CA_MARKER";
+    let cli = Cli::try_parse_from([
+        "automata",
+        "internal",
+        "object-store",
+        "ensure-bucket",
+        "--s3-endpoint",
+        "https://objects.example.test/",
+        "--s3-bucket",
+        "automata-local",
+        "--s3-tls-trust",
+        "private-ca",
+        "--s3-private-ca-source",
+        &format!("env:{marker}"),
+        "--s3-access-key-source",
+        "file:/run/secrets/s3-access-key",
+        "--s3-secret-key-source",
+        "file:/run/secrets/s3-secret-key",
+    ])
+    .expect("internal ensure-bucket command must parse");
+    let Command::Internal(internal) = cli.command else {
+        panic!("internal command expected");
+    };
+    let InternalCommand::ObjectStore(object_store) = internal.command;
+    let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
+    assert_eq!(args.s3.s3_tls_trust, S3TlsTrustMode::PrivateCa);
+    let debug = format!("{args:?}");
+    assert!(debug.contains("[redacted]"));
+    assert!(!debug.contains(marker));
+
+    let mut command = Cli::command();
+    let internal = command
+        .find_subcommand_mut("internal")
+        .expect("internal namespace");
+    assert!(internal.is_hide_set());
+    assert!(
+        !Cli::command()
+            .render_long_help()
+            .to_string()
+            .contains("internal")
+    );
+
+    for unsupported in [
+        vec!["automata", "__local-service-init"],
+        vec!["automata", "internal", "object-store", "init"],
+        vec!["automata", "internal", "ensure-bucket"],
+    ] {
+        assert!(Cli::try_parse_from(unsupported).is_err());
+    }
+    assert!(
+        Cli::try_parse_from([
+            "automata",
+            "internal",
+            "object-store",
+            "ensure-bucket",
+            "--s3-access-key",
+            "raw-secret",
+        ])
+        .is_err(),
+        "the internal command must not accept raw credential arguments"
+    );
+}
+
+#[test]
+fn internal_private_ca_raw_values_become_redacted_invalid_sources() {
+    let marker = "raw-private-ca-secret-marker";
+    let cli = Cli::try_parse_from([
+        "automata",
+        "internal",
+        "object-store",
+        "ensure-bucket",
+        "--s3-tls-trust",
+        "private-ca",
+        "--s3-private-ca-source",
+        marker,
+    ])
+    .expect("raw input must become a redacted invalid source sentinel");
+    let Command::Internal(internal) = cli.command else {
+        panic!("internal command expected");
+    };
+    let InternalCommand::ObjectStore(object_store) = internal.command;
+    let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
+    assert!(matches!(
+        args.s3.s3_private_ca_source,
+        Some(SecretSource::Invalid)
+    ));
+    assert!(!format!("{args:?}").contains(marker));
+}
+
+#[test]
 fn server_rejects_an_invalid_socket_address_during_parsing() {
     let result = Cli::try_parse_from(["automata", "server", "--listen", "not-an-address"]);
 
@@ -187,6 +279,7 @@ fn only_operational_top_level_commands_are_advertised() {
     let command = Cli::command();
     let names = command
         .get_subcommands()
+        .filter(|command| !command.is_hide_set())
         .map(clap::Command::get_name)
         .collect::<Vec<_>>();
 

--- a/crates/automata-ci/tests/internal_object_store_process.rs
+++ b/crates/automata-ci/tests/internal_object_store_process.rs
@@ -1,0 +1,171 @@
+#![cfg(unix)]
+
+use std::{
+    fs::{self, OpenOptions},
+    io::{Read as _, Write as _},
+    net::TcpListener,
+    os::unix::fs::OpenOptionsExt as _,
+    path::PathBuf,
+    process::Command,
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use uuid::Uuid;
+
+#[test]
+fn internal_command_initializes_the_exact_bucket_through_production_s3() {
+    let fixture = SecureSources::new();
+    let access_key = fixture.write("access-key", b"test-access");
+    let secret_key = fixture.write("secret-key", b"test-secret");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind internal S3 fixture");
+    let address = listener.local_addr().expect("internal S3 fixture address");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking internal S3 fixture");
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let task_requests = Arc::clone(&requests);
+    let task = thread::spawn(move || {
+        let statuses = ["404 Not Found", "200 OK", "200 OK"];
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut served = 0;
+        while served < statuses.len() && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(2)))
+                        .expect("internal S3 read timeout");
+                    let mut request = Vec::new();
+                    let mut buffer = [0_u8; 4 * 1_024];
+                    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        let received = stream.read(&mut buffer).expect("internal S3 request");
+                        if received == 0 {
+                            break;
+                        }
+                        request.extend_from_slice(&buffer[..received]);
+                    }
+                    let request = String::from_utf8(request).expect("internal S3 request text");
+                    let first_line = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.strip_suffix(" HTTP/1.1"))
+                        .expect("internal S3 request line");
+                    task_requests
+                        .lock()
+                        .expect("internal S3 request lock")
+                        .push(first_line.to_owned());
+                    write!(
+                        stream,
+                        "HTTP/1.1 {}\r\ncontent-length: 0\r\nconnection: close\r\nx-amz-request-id: process-fixture\r\n\r\n",
+                        statuses[served]
+                    )
+                    .expect("internal S3 response");
+                    served += 1;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(error) => panic!("internal S3 accept failed: {error}"),
+            }
+        }
+        assert_eq!(served, statuses.len(), "internal S3 request count");
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_automata"))
+        .args([
+            "internal",
+            "object-store",
+            "ensure-bucket",
+            "--s3-endpoint",
+            &format!("http://{address}/"),
+            "--s3-bucket",
+            "automata-tests",
+            "--s3-allow-loopback-http",
+            "--s3-operation-timeout-seconds",
+            "5",
+            "--s3-access-key-source",
+            &format!("file:{}", access_key.display()),
+            "--s3-secret-key-source",
+            &format!("file:{}", secret_key.display()),
+        ])
+        .output()
+        .expect("run internal object-store initializer");
+    task.join().expect("internal S3 fixture task");
+
+    assert!(
+        output.status.success(),
+        "internal initializer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, b"object-store bucket ready\n");
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        *requests.lock().expect("internal S3 request lock"),
+        [
+            "HEAD /automata-tests/",
+            "PUT /automata-tests/",
+            "HEAD /automata-tests/"
+        ]
+    );
+}
+
+#[test]
+fn internal_private_ca_load_failure_is_bounded_and_sanitized() {
+    let fixture = SecureSources::new();
+    let marker = "private-ca-content-must-never-escape";
+    let ca = fixture.write("private-ca", marker.as_bytes());
+    let output = Command::new(env!("CARGO_BIN_EXE_automata"))
+        .args([
+            "internal",
+            "object-store",
+            "ensure-bucket",
+            "--s3-endpoint",
+            "https://127.0.0.1:1/",
+            "--s3-tls-trust",
+            "private-ca",
+            "--s3-private-ca-source",
+            &format!("file:{}", ca.display()),
+        ])
+        .output()
+        .expect("run invalid private-CA initializer");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("referenced certificate is invalid"));
+    assert!(!stderr.contains(marker));
+    assert!(!stderr.contains(&ca.display().to_string()));
+}
+
+struct SecureSources {
+    directory: PathBuf,
+}
+
+impl SecureSources {
+    fn new() -> Self {
+        let directory = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+            .join("internal-object-store")
+            .join(Uuid::new_v4().to_string());
+        fs::create_dir_all(&directory).expect("create secure source directory");
+        Self { directory }
+    }
+
+    fn write(&self, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = self.directory.join(name);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .expect("create secure source");
+        file.write_all(bytes).expect("write secure source");
+        path
+    }
+}
+
+impl Drop for SecureSources {
+    fn drop(&mut self) {
+        let _ignored = fs::remove_dir_all(&self.directory);
+    }
+}

--- a/crates/automata-ci/tests/server_config.rs
+++ b/crates/automata-ci/tests/server_config.rs
@@ -202,7 +202,7 @@ fn secret_file_loading_rejects_unsafe_paths_and_permissions() {
 }
 
 #[test]
-fn server_configuration_validates_non_secret_endpoint_fields() {
+fn server_configuration_validates_complete_non_secret_s3_shape() {
     let cli = Cli::try_parse_from(["automata", "server", "--s3-endpoint", "not an endpoint"])
         .expect("endpoint validation belongs to server configuration");
     let Command::Server(args) = cli.command else {
@@ -211,6 +211,102 @@ fn server_configuration_validates_non_secret_endpoint_fields() {
     assert!(matches!(
         ServerConfig::from_args(&args),
         Err(ServerConfigError::InvalidS3Endpoint)
+    ));
+
+    let cli = Cli::try_parse_from(["automata", "server", "--s3-prefix", "/absolute"])
+        .expect("namespace validation belongs to server configuration");
+    let Command::Server(args) = cli.command else {
+        panic!("server command expected");
+    };
+    assert!(matches!(
+        ServerConfig::from_args(&args),
+        Err(ServerConfigError::InvalidS3Configuration)
+    ));
+}
+
+#[test]
+fn server_s3_trust_policy_is_closed_and_exact() {
+    let private = Cli::try_parse_from([
+        "automata",
+        "server",
+        "--results-public-url",
+        "https://results.example.test/",
+        "--s3-tls-trust",
+        "private-ca",
+        "--s3-private-ca-source",
+        "file:/run/secrets/s3-private-ca.pem",
+    ])
+    .expect("exact private CA syntax");
+    let Command::Server(private) = private.command else {
+        panic!("server command expected");
+    };
+    ServerConfig::from_args(&private).expect("complete private-CA trust policy");
+
+    for arguments in [
+        vec![
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--s3-tls-trust",
+            "private-ca",
+        ],
+        vec![
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--s3-private-ca-source",
+            "file:/run/secrets/unrequested-ca.pem",
+        ],
+    ] {
+        let cli = Cli::try_parse_from(arguments).expect("trust syntax");
+        let Command::Server(args) = cli.command else {
+            panic!("server command expected");
+        };
+        assert!(matches!(
+            ServerConfig::from_args(&args),
+            Err(ServerConfigError::InvalidS3TlsTrust)
+        ));
+    }
+}
+
+#[test]
+fn server_private_ca_and_loopback_plaintext_are_incompatible() {
+    let private_plaintext = Cli::try_parse_from([
+        "automata",
+        "server",
+        "--s3-endpoint",
+        "http://127.0.0.1:9000/",
+        "--s3-allow-loopback-http",
+        "--s3-tls-trust",
+        "private-ca",
+        "--s3-private-ca-source",
+        "file:/run/secrets/s3-private-ca.pem",
+    ])
+    .expect("explicit transport syntax");
+    let Command::Server(args) = private_plaintext.command else {
+        panic!("server command expected");
+    };
+    assert!(matches!(
+        ServerConfig::from_args(&args),
+        Err(ServerConfigError::InvalidS3Transport)
+    ));
+
+    let inert_plaintext_flag = Cli::try_parse_from([
+        "automata",
+        "server",
+        "--s3-endpoint",
+        "https://objects.example.test/",
+        "--s3-allow-loopback-http",
+    ])
+    .expect("explicit transport syntax");
+    let Command::Server(args) = inert_plaintext_flag.command else {
+        panic!("server command expected");
+    };
+    assert!(matches!(
+        ServerConfig::from_args(&args),
+        Err(ServerConfigError::InvalidS3Transport)
     ));
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ minutes.
 
 The checked-in
 [`runner.windows.example.json`](../crates/automata-ci-runner/config/runner.windows.example.json)
-selects `windows_hyperv` and schema version 3. It defines an absolute local
+selects `windows_hyperv` and schema version 4. It defines an absolute local
 container CLI path and SHA-256, a digest-qualified Windows Server Core image,
 an in-image guest executable, an in-container workspace, disabled networking,
 a writable container root, `ContainerUser`, and CPU, memory, and process

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -749,6 +749,21 @@ the inert ID-held engine lock, union discovery, `up`, `status`, `down`, and exac
 reset. The command layer remains private until these operations are convergent
 and their destructive boundary is proven.
 
+The renderer consumes the current hidden image boundary
+`automata internal object-store ensure-bucket`; it does not invent a shell
+client, test helper, compatibility alias, or placeholder service-init command.
+The initializer and server share the production S3 connection parser and the
+sole validated-config-to-store AWS SDK construction boundary. Runner product
+schema 4 independently requires the same closed
+trust choice for every runner-side S3 client. Local HTTPS rendering selects
+exact private-CA trust and mounted bounded `SecretSource` file references for
+the CA and credentials on all three surfaces; the private root is never merged
+with Web PKI roots. Initialization may create the exact bucket only after
+`HeadBucket` reports not found, and creation conflicts require a successful
+final `HeadBucket` under the same total deadline.
+Every non-`us-east-1` bucket creation carries the exact validated region as its
+S3 `LocationConstraint`; `us-east-1` alone omits it.
+
 Gate: persistent volumes never carry a mutable plan digest; every replaceable
 resource carries the current digest; unknown managed keys, unexpected roles,
 and mixed digests fail closed. Concurrent mutation tests prove graceful

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -2,8 +2,8 @@
 
 Automata supports macOS jobs only through a disposable macOS 15-or-newer ARM64
 virtual machine on an Apple Silicon macOS 15+ host. The former native provider
-has been deleted. Schema v2 has no `macos_native` key, no schema-v1 migration,
-and no host-shared resource mode.
+has been deleted. Current runner product schema v4 has no `macos_native` key,
+no migration from a noncurrent schema, and no host-shared resource mode.
 
 ## Why Virtualization.framework
 
@@ -221,30 +221,12 @@ code requirement, runner identity, endpoints, and credential sources. The
 environment profile manifest digest must exactly equal
 `macos_virtualization.template_manifest_sha256`.
 
-The only accepted boundary is:
-
-```json
-{
-  "schema_version": 3,
-  "state": { "macos_virtualization": "/Volumes/AutomataVM/state" },
-  "macos_virtualization": {
-    "helper_executable": "/Library/Automata/bin/automata-macos-vm-helper",
-    "helper_sha256": "<64 lowercase hex>",
-    "helper_code_requirement": "<strict designated requirement>",
-    "template_manifest": "/Volumes/AutomataVM/templates/macos-15-arm64-v1/manifest.json",
-    "template_manifest_sha256": "<64 lowercase hex>",
-    "storage_volume_uuid": "<uppercase APFS volume UUID>",
-    "storage_quota_bytes": 274877906944,
-    "boot_timeout_seconds": 300,
-    "stop_timeout_seconds": 10
-  },
-  "executor": {
-    "network": "disabled",
-    "root_filesystem": "writable",
-    "privilege": "unprivileged"
-  }
-}
-```
+The linked checked-in example is the sole complete current boundary: runner
+product schema 4. It selects the `macos_virtualization` provider, a writable
+unprivileged executor with networking disabled, and the mandatory closed
+`object_store.tls_trust` policy. Do not reconstruct a product document from a
+partial provider-only excerpt; noncurrent schemas are rejected rather than
+migrated or defaulted.
 
 Run one runner process and one slot per provider root:
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -330,7 +330,7 @@ The provider configuration is closed:
   and
 - a bounded lifecycle timeout.
 
-The runner configuration schema selects exactly one provider. The Windows
+Current runner product schema v4 selects exactly one provider. The Windows
 provider requires one or more digest-attested environment profiles with:
 
 - an immutable digest-qualified Windows image reference;
@@ -725,7 +725,7 @@ for each advertised profile.
 First-PR component scope:
 
 - [x] Add the explicit Windows Hyper-V container launch variant.
-- [x] Add schema-v3 `windows_hyperv` configuration and remove
+- [x] Keep the current schema-v4 `windows_hyperv` configuration and remove
       `windows_native`.
 - [x] Require disabled network, unprivileged workload, writable container root,
       no services, zero GPU, and no ephemeral-disk claim.


### PR DESCRIPTION
## Outcome

Makes the S3-compatible object-store boundary explicit and inseparable from its validated connection authority:

- server and runner require one closed WebPKI, exact private-CA, or literal-loopback plaintext transport policy;
- `S3BlobStoreConfig::connect` is the sole public client construction path, so endpoint, region, bucket, prefix, path style, deadline, encryption, credentials, and trust cannot be mixed with another client;
- a hidden `automata internal object-store ensure-bucket` command performs production bucket bootstrap through that same connection;
- bucket creation is region-correct, idempotent, conflict-reverified, and bounded by one total deadline;
- one shared `ValidatedCaCertificate` type owns canonical single-CA parsing for infrastructure adapters;
- runner product schema 4 makes object-store trust mandatory and updates every checked-in configuration.

This is the next independently mergeable layer extracted from draft #173.

## Related issue

Part of #173.

## Trust and compatibility impact

Private-CA mode accepts exactly one canonical RFC 7468 CA certificate, starts from an empty trust store, validates CA and certificate-signing semantics, and permits no WebPKI fallback. Plaintext is restricted to a literal loopback HTTP endpoint. HTTPS and plaintext policies cannot cross.

Credential, CA, connected-client, and configuration Debug/error surfaces are redacted. The AWS SDK client is private to the bound store; repository-wide construction audit finds `Client::from_conf` only inside that factory. Bucket bootstrap sends the exact region constraint outside `us-east-1`, rechecks create conflicts, and shares one deadline across all operations.

No PostgreSQL, guest protocol, replay, sandbox-provider, or local lifecycle behavior is included.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- strict Clippy for `automata-ci-tls`, `automata-ci-blob-s3`, `automata-ci-runner`, and `automata-ci`
- S3/TLS suites: 22 passed, 1 explicitly configured live-service test ignored
- Automata CLI, server-config, and internal bootstrap suites: 70 passed
- runner library/config/secret-source suites, including exact private-CA composition
- `cargo check --workspace --all-targets --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc` for all affected packages
- `cargo deny`
- Windows GNU and x86-64 musl all-target/all-feature checks
- independent strict review of exact range `26408a8a..f83ab412`: CLEAN

The monolithic workspace all-target test command was killed by the host during final linking with exit 137. The same affected targets passed when split and single-job; no compiler or test diagnostic preceded the host kill.

## AI assistance

OpenAI Codex reconstructed and squashed this final boundary from draft #173, adapted it to current main ownership, ran the qualification matrix, and performed a separate read-only strict review.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.