### PR TITLE
test(renderer): isolate recovery probe environment

### DIFF
--- a/scripts/ui/tests/regenerate-renderer-atomicity.test.sh
+++ b/scripts/ui/tests/regenerate-renderer-atomicity.test.sh
@@ -667,10 +667,8 @@ set -e
     -d "${entrypoint_temporary}" && -d "${entrypoint_state}/active" ]]
 
 set +e
-/usr/bin/env \
-    -u CARGO_BUILD_JOBS \
-    -u CARGO_PROFILE_DEV_DEBUG \
-    -u CARGO_PROFILE_TEST_DEBUG \
+/usr/bin/env -i \
+    PATH=/usr/bin:/bin \
     CARGO_HOME=/noncanonical/cargo \
     RUSTUP_HOME=/noncanonical/rustup \
     bash "${entrypoint_repository}/scripts/ui/regenerate-renderer.sh" \


### PR DESCRIPTION
## Summary

- run the renderer entrypoint recovery probe from an empty environment
- retain only the exact PATH and intentionally invalid Cargo/Rustup homes required by the probe
- prevent workflow-level compiler settings from changing which preflight invariant the test exercises

## Validation

- `CARGO_BUILD_JOBS=4 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=lld" RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 scripts/ui/tests/regenerate-renderer-atomicity.test.sh`
- `shellcheck -x scripts/ui/tests/regenerate-renderer-atomicity.test.sh`