### PR TITLE
test(results): consolidate shared fixture primitives

### DIFF
--- a/crates/automata-ci-results-github/tests/artifact_admission.rs
+++ b/crates/automata-ci-results-github/tests/artifact_admission.rs
@@ -1,9 +1,8 @@
+mod fixture_support;
+
 use std::{
     collections::BTreeMap,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
@@ -11,7 +10,7 @@ use automata_ci_blob::{
     BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
     PutBlobOutcome, VerifiedBlob,
 };
-use automata_ci_core::{AttemptId, FencingToken, JobId, RunId, Sha256Digest};
+use automata_ci_core::Sha256Digest;
 use automata_ci_results_github::{
     ArtifactBlock, ArtifactBlockReservation, ArtifactFinalizationClaim,
     ArtifactFinalizationReservation, ArtifactFinalizationWork, ArtifactId, ArtifactRepository,
@@ -20,39 +19,12 @@ use automata_ci_results_github::{
     CompleteArtifactFinalization, CreateArtifact, CreateArtifactOutcome, ExecutionAuthority,
     FinalizeArtifactOutcome, ListArtifacts, LoadArtifactFinalization, PublishedArtifactMetadata,
     RecordArtifactVerification, RenewArtifactFinalization, ReserveArtifactBlock,
-    ResolveArtifactDownload, ResultsClock, ResultsIdGenerator, ResultsLimits,
-    ResultsServiceErrorKind, UploadId, VerifiedArtifactFinalization,
+    ResolveArtifactDownload, ResultsLimits, ResultsServiceErrorKind, UploadId,
+    VerifiedArtifactFinalization,
 };
 use bytes::Bytes;
+use fixture_support::{FixedIds, MutableClock as TestClock, fresh_execution_authority};
 use uuid::Uuid;
-
-#[derive(Debug)]
-struct TestClock(AtomicU64);
-
-impl TestClock {
-    fn new(now: u64) -> Self {
-        Self(AtomicU64::new(now))
-    }
-
-    fn set(&self, now: u64) {
-        self.0.store(now, Ordering::SeqCst);
-    }
-}
-
-impl ResultsClock for TestClock {
-    fn now_seconds(&self) -> u64 {
-        self.0.load(Ordering::SeqCst)
-    }
-}
-
-#[derive(Debug)]
-struct FixedIds(UploadId);
-
-impl ResultsIdGenerator for FixedIds {
-    fn next_upload_id(&self) -> UploadId {
-        self.0
-    }
-}
 
 #[derive(Debug, Default)]
 struct ObservedBlobStore {
@@ -566,12 +538,7 @@ struct Fixture {
 }
 
 async fn fixture(limits: ResultsLimits) -> Fixture {
-    let authority = ExecutionAuthority::new(
-        RunId::new(),
-        JobId::new(),
-        AttemptId::new(),
-        FencingToken::new(7).expect("fencing token"),
-    );
+    let authority = fresh_execution_authority(7);
     let upload_id = UploadId::from_uuid(Uuid::new_v4());
     let repository = Arc::new(AdmissionRepository {
         artifact_id: ArtifactId::new(41).expect("artifact id"),

--- a/crates/automata-ci-results-github/tests/cache_http.rs
+++ b/crates/automata-ci-results-github/tests/cache_http.rs
@@ -1,3 +1,4 @@
+mod fixture_support;
 mod http_support;
 
 use std::{
@@ -9,46 +10,29 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_blob::MemoryBlobStore;
-use automata_ci_core::{AttemptId, FencingToken, JobId, RunId, Sha256Digest};
+use automata_ci_core::Sha256Digest;
 use automata_ci_results_github::{
-    CacheAccessScope, CacheAuthority, CacheBlock, CacheEntryId, CacheFinalizationPreparation,
-    CacheLimits, CachePermission, CacheProtocolEntryId, CacheRepository, CacheRepositoryError,
+    CacheAuthority, CacheBlock, CacheEntryId, CacheFinalizationPreparation, CacheLimits,
+    CachePermission, CacheProtocolEntryId, CacheRepository, CacheRepositoryError,
     CacheRepositoryErrorKind, CacheService, CommitCacheBlocks, CompleteCacheBlock,
     CompleteCacheFinalization, CreateCacheEntry, CreatedCacheEntry, ExecutionAuthority,
     FinalizedCacheEntry, GithubCacheApi, GithubCacheHttpLimits, HmacResultsAuthority,
     HmacResultsAuthorityConfig, LookupCacheEntry, NoopResultsObserver, PrepareCacheFinalization,
     PreparedCacheFinalization, ReserveCacheBlock, ResolveCacheDownload, ResultsClock,
-    ResultsHttpMethod, ResultsHttpRoute, ResultsHttpStatusClass, ResultsIdGenerator,
-    ResultsObserver, ResultsPublicEndpoint, RuntimeTokenIssuer as _, UploadId,
+    ResultsHttpMethod, ResultsHttpRoute, ResultsHttpStatusClass, ResultsObserver,
+    ResultsPublicEndpoint, RuntimeTokenIssuer as _, UploadId,
 };
 use axum::{
     body::Body,
     http::{Request, StatusCode, header},
 };
 use bytes::Bytes;
+use fixture_support::{FixedClock, FixedIds, cache_authority, fresh_execution_authority};
 use http_body_util::BodyExt as _;
 use http_support::{assert_private_rejection, isolated_node_command, path_and_query};
 use tower::ServiceExt as _;
 use url::Url;
 use uuid::Uuid;
-
-#[derive(Clone, Copy, Debug)]
-struct FixedClock(u64);
-
-impl ResultsClock for FixedClock {
-    fn now_seconds(&self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct FixedIds(UploadId);
-
-impl ResultsIdGenerator for FixedIds {
-    fn next_upload_id(&self) -> UploadId {
-        self.0
-    }
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum HttpEvent {
@@ -455,13 +439,7 @@ fn issue_cache_token(
     repository: &str,
     scopes: &[(&str, CachePermission)],
 ) -> String {
-    let scopes = scopes
-        .iter()
-        .map(|(cache_ref, permission)| {
-            CacheAccessScope::new(*cache_ref, *permission).expect("cache scope")
-        })
-        .collect();
-    let cache = CacheAuthority::new(repository, scopes).expect("cache authority");
+    let cache = cache_authority(repository, scopes);
     authority
         .issue(execution, cache, 600)
         .expect("token")
@@ -513,12 +491,7 @@ fn fixture_with_url_observer_and_limits(
         )
         .expect("authority"),
     );
-    let execution = ExecutionAuthority::new(
-        RunId::new(),
-        JobId::new(),
-        AttemptId::new(),
-        FencingToken::new(9).expect("fence"),
-    );
+    let execution = fresh_execution_authority(9);
     let token = issue_cache_token(
         authority.as_ref(),
         execution,

--- a/crates/automata-ci-results-github/tests/fixture_support/mod.rs
+++ b/crates/automata-ci-results-github/tests/fixture_support/mod.rs
@@ -1,0 +1,73 @@
+// Integration-test targets compile this shared module independently and use different subsets.
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use automata_ci_core::{AttemptId, FencingToken, JobId, RunId};
+use automata_ci_results_github::{
+    CacheAccessScope, CacheAuthority, CachePermission, ExecutionAuthority, ResultsClock,
+    ResultsIdGenerator, UploadId,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FixedClock(pub(crate) u64);
+
+impl ResultsClock for FixedClock {
+    fn now_seconds(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct MutableClock(AtomicU64);
+
+impl MutableClock {
+    pub(crate) fn new(now: u64) -> Self {
+        Self(AtomicU64::new(now))
+    }
+
+    pub(crate) fn set(&self, now: u64) {
+        self.0.store(now, Ordering::SeqCst);
+    }
+}
+
+impl ResultsClock for MutableClock {
+    fn now_seconds(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FixedIds(pub(crate) UploadId);
+
+impl ResultsIdGenerator for FixedIds {
+    fn next_upload_id(&self) -> UploadId {
+        self.0
+    }
+}
+
+pub(crate) fn fresh_execution_authority(fence: u64) -> ExecutionAuthority {
+    ExecutionAuthority::new(
+        RunId::new(),
+        JobId::new(),
+        AttemptId::new(),
+        FencingToken::new(fence).expect("positive fencing token"),
+    )
+}
+
+pub(crate) fn cache_authority(
+    repository: &str,
+    scopes: &[(&str, CachePermission)],
+) -> CacheAuthority {
+    let scopes = scopes
+        .iter()
+        .map(|(cache_ref, permission)| {
+            CacheAccessScope::new(*cache_ref, *permission).expect("cache scope")
+        })
+        .collect();
+    CacheAuthority::new(repository, scopes).expect("cache authority")
+}
+
+pub(crate) fn read_write_cache_authority(repository: &str, cache_ref: &str) -> CacheAuthority {
+    cache_authority(repository, &[(cache_ref, CachePermission::ReadWrite)])
+}

--- a/crates/automata-ci-results-github/tests/http_compatibility.rs
+++ b/crates/automata-ci-results-github/tests/http_compatibility.rs
@@ -1,3 +1,4 @@
+mod fixture_support;
 mod http_support;
 
 use std::{
@@ -7,19 +8,18 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType, MemoryBlobStore};
-use automata_ci_core::{AttemptId, FencingToken, JobId, RunId, Sha256Digest};
+use automata_ci_core::{AttemptId, FencingToken, JobId, Sha256Digest};
 use automata_ci_results_github::{
     ArtifactBlock, ArtifactBlockReservation, ArtifactFinalizationClaim,
     ArtifactFinalizationReservation, ArtifactFinalizationWork, ArtifactId, ArtifactRepository,
     ArtifactRepositoryError, ArtifactRepositoryErrorKind, ArtifactService,
-    BeginArtifactFinalization, CacheAccessScope, CacheAuthority, CachePermission,
-    CommitArtifactBlocks, CommittedArtifact, CompleteArtifactBlock, CompleteArtifactFinalization,
-    CreateArtifact, CreateArtifactOutcome, ExecutionAuthority, FinalizeArtifactOutcome,
-    GithubResultsApi, GithubResultsHttpLimits, HmacResultsAuthority, HmacResultsAuthorityConfig,
-    ListArtifacts, LoadArtifactFinalization, PublishedArtifactMetadata, RecordArtifactVerification,
-    RenewArtifactFinalization, ReserveArtifactBlock, ResolveArtifactDownload, ResultsClock,
-    ResultsIdGenerator, ResultsLimits, ResultsPublicEndpoint, RuntimeTokenIssuer as _, UploadId,
-    VerifiedArtifactFinalization,
+    BeginArtifactFinalization, CommitArtifactBlocks, CommittedArtifact, CompleteArtifactBlock,
+    CompleteArtifactFinalization, CreateArtifact, CreateArtifactOutcome, ExecutionAuthority,
+    FinalizeArtifactOutcome, GithubResultsApi, GithubResultsHttpLimits, HmacResultsAuthority,
+    HmacResultsAuthorityConfig, ListArtifacts, LoadArtifactFinalization, PublishedArtifactMetadata,
+    RecordArtifactVerification, RenewArtifactFinalization, ReserveArtifactBlock,
+    ResolveArtifactDownload, ResultsLimits, ResultsPublicEndpoint, RuntimeTokenIssuer as _,
+    UploadId, VerifiedArtifactFinalization,
 };
 use axum::{
     body::Body,
@@ -27,41 +27,15 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bytes::Bytes;
+use fixture_support::{
+    FixedClock, FixedIds, fresh_execution_authority, read_write_cache_authority,
+};
 use http_body_util::BodyExt as _;
 use http_support::{assert_private_rejection, isolated_node_command, path_and_query};
 use sha2::Digest as _;
 use tower::ServiceExt as _;
 use url::Url;
 use uuid::Uuid;
-
-#[derive(Debug)]
-struct FixedClock(u64);
-
-fn cache_authority() -> CacheAuthority {
-    CacheAuthority::new(
-        "automata-ci/automata",
-        vec![
-            CacheAccessScope::new("refs/heads/main", CachePermission::ReadWrite)
-                .expect("cache scope"),
-        ],
-    )
-    .expect("cache authority")
-}
-
-impl ResultsClock for FixedClock {
-    fn now_seconds(&self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug)]
-struct FixedIds(UploadId);
-
-impl ResultsIdGenerator for FixedIds {
-    fn next_upload_id(&self) -> UploadId {
-        self.0
-    }
-}
 
 #[derive(Debug)]
 struct FakeRepository {
@@ -506,14 +480,13 @@ fn fixture_with_url_and_limits(public_url: &str, limits: GithubResultsHttpLimits
         )
         .expect("token authority"),
     );
-    let execution = ExecutionAuthority::new(
-        RunId::new(),
-        JobId::new(),
-        AttemptId::new(),
-        FencingToken::new(3).expect("fence"),
-    );
+    let execution = fresh_execution_authority(3);
     let token = token_authority
-        .issue(execution, cache_authority(), 600)
+        .issue(
+            execution,
+            read_write_cache_authority("automata-ci/automata", "refs/heads/main"),
+            600,
+        )
         .expect("runtime token")
         .expose_secret()
         .to_owned();
@@ -877,7 +850,11 @@ async fn exact_v7_twirp_and_azure_block_upload_flow_succeeds() {
     );
     let consumer_token = fixture
         .token_authority
-        .issue(consumer, cache_authority(), 600)
+        .issue(
+            consumer,
+            read_write_cache_authority("automata-ci/automata", "refs/heads/main"),
+            600,
+        )
         .expect("consumer runtime token")
         .expose_secret()
         .to_owned();

--- a/crates/automata-ci-results-github/tests/postgres_artifacts.rs
+++ b/crates/automata-ci-results-github/tests/postgres_artifacts.rs
@@ -20,7 +20,10 @@ use automata_ci_results_github::{
 use automata_ci_store::StableRunnerSlot;
 use bytes::Bytes;
 use sqlx::PgPool;
-use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+use support::{
+    fixtures::{database_now_millis, database_now_seconds},
+    postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane},
+};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -1572,22 +1575,6 @@ fn list_digest(ids: &[String]) -> Sha256Digest {
         hasher.update(id.as_bytes());
     }
     Sha256Digest::from_bytes(hasher.finalize().into())
-}
-
-async fn database_now_seconds(database: &TestDatabase) -> TestResult<u64> {
-    let database_now: i64 =
-        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT")
-            .fetch_one(database.pool())
-            .await?;
-    Ok(u64::try_from(database_now)?)
-}
-
-async fn database_now_millis(database: &TestDatabase) -> TestResult<UnixMillis> {
-    let database_now: i64 =
-        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
-            .fetch_one(database.pool())
-            .await?;
-    Ok(UnixMillis::new(database_now))
 }
 
 async fn expire_finalization_claim(database: &TestDatabase, upload_id: UploadId) -> TestResult {

--- a/crates/automata-ci-results-github/tests/postgres_cache.rs
+++ b/crates/automata-ci-results-github/tests/postgres_cache.rs
@@ -1,3 +1,4 @@
+mod fixture_support;
 mod support;
 
 use std::{io, time::Duration};
@@ -11,15 +12,19 @@ use automata_ci_core::{
 };
 use automata_ci_postgres::test_support::TestClock;
 use automata_ci_results_github::{
-    CacheAccessScope, CacheAuthority, CacheBlock, CacheEntryId, CacheFinalizationPreparation,
-    CacheKey, CachePermission, CacheRepository as _, CacheRepositoryErrorKind, CacheVersion,
-    CommitCacheBlocks, CompleteCacheBlock, CompleteCacheFinalization, CreateCacheEntry,
-    ExecutionAuthority, LookupCacheEntry, PostgresCacheRepository, PrepareCacheFinalization,
-    ReserveCacheBlock, ResolveCacheDownload,
+    CacheAuthority, CacheBlock, CacheEntryId, CacheFinalizationPreparation, CacheKey,
+    CacheRepository as _, CacheRepositoryErrorKind, CacheVersion, CommitCacheBlocks,
+    CompleteCacheBlock, CompleteCacheFinalization, CreateCacheEntry, ExecutionAuthority,
+    LookupCacheEntry, PostgresCacheRepository, PrepareCacheFinalization, ReserveCacheBlock,
+    ResolveCacheDownload,
 };
 use automata_ci_store::{RunnerSessionFence, StableRunnerSlot};
+use fixture_support::read_write_cache_authority;
 use sqlx::PgPool;
-use support::postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane};
+use support::{
+    fixtures::{database_now_millis, database_now_seconds, database_now_seconds_from_pool},
+    postgres::{TestDatabase, TestResult, run_with_database, seed_control_plane},
+};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -28,7 +33,7 @@ use uuid::Uuid;
 async fn cache_transactions_are_immutable_fenced_and_cross_run_readable() -> TestResult {
     run_with_database(|database| async move {
         let (repository, execution, session_fence, lease_guard) = active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let entry_id = CacheEntryId::new(Uuid::new_v4())?;
         let creation_database_before = database_now_seconds(&database).await?;
         let forged_fast_creation = creation_database_before + 30;
@@ -383,7 +388,7 @@ async fn cache_transactions_are_immutable_fenced_and_cross_run_readable() -> Tes
         let wrong_repository = repository
             .lookup(LookupCacheEntry {
                 execution: reader,
-                cache: cache_authority("sibling/repository", "refs/heads/main"),
+                cache: read_write_cache_authority("sibling/repository", "refs/heads/main"),
                 key: CacheKey::new("cargo-linux")?,
                 restore_keys: Vec::new(),
                 version: CacheVersion::new("version-1")?,
@@ -428,7 +433,7 @@ async fn cache_retention_and_touch_use_database_time_under_caller_skew() -> Test
         const INACTIVITY_SECONDS: u64 = 40;
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let (live_id, _live_digest) = finalize_small_entry(
             &repository,
             execution,
@@ -592,7 +597,7 @@ async fn cache_touch_rechecks_exact_expiry_after_the_entry_lock_wait() -> TestRe
         let clock = TestClock::freeze_at_database_now(database.pool()).await?;
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let (entry_id, digest) = finalize_small_entry(
             &repository,
             execution,
@@ -701,7 +706,7 @@ async fn cache_entry_cardinality_is_bounded_even_for_zero_byte_entries() -> Test
     run_with_database(|database| async move {
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         // Keep the target after the injected `1000...` cohort when database-second
         // timestamps tie, so the UUID tiebreak deterministically evicts row two.
         let target = CacheEntryId::new(Uuid::parse_str("f0000000-0000-4000-8000-000000000000")?)?;
@@ -847,7 +852,7 @@ async fn concurrent_creates_respect_the_exact_cap_with_repeatable_read_sessions(
     run_with_database(|database| async move {
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let seed = CacheEntryId::new(Uuid::new_v4())?;
         repository
             .create(create_request(execution, cache.clone(), seed, "cap-seed"))
@@ -924,7 +929,7 @@ async fn concurrent_finalizations_include_the_serialized_predecessor_in_quota() 
     run_with_database(|database| async move {
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let (first_id, first_digest) = prepare_small_entry(
             &repository,
             execution,
@@ -1018,7 +1023,7 @@ async fn a_touch_commits_before_eviction_selects_the_current_lru_entry() -> Test
     run_with_database(|database| async move {
         let (repository, execution, _session_fence, _lease_guard) =
             active_attempt(&database).await?;
-        let cache = cache_authority("automata/results-test", "refs/heads/main");
+        let cache = read_write_cache_authority("automata/results-test", "refs/heads/main");
         let (oldest_id, _oldest_digest) = finalize_small_entry(
             &repository,
             execution,
@@ -1488,14 +1493,6 @@ async fn second_run_attempt(
     ))
 }
 
-fn cache_authority(repository: &str, cache_ref: &str) -> CacheAuthority {
-    CacheAuthority::new(
-        repository,
-        vec![CacheAccessScope::new(cache_ref, CachePermission::ReadWrite).expect("cache scope")],
-    )
-    .expect("cache authority")
-}
-
 fn create_request(
     execution: ExecutionAuthority,
     cache: CacheAuthority,
@@ -1669,24 +1666,4 @@ fn assert_database_timestamp_window(
         "{label} must persist database time, not the future caller observation"
     );
     Ok(())
-}
-
-async fn database_now_seconds(database: &TestDatabase) -> TestResult<u64> {
-    database_now_seconds_from_pool(database.pool()).await
-}
-
-async fn database_now_seconds_from_pool(pool: &PgPool) -> TestResult<u64> {
-    let database_now: i64 =
-        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT")
-            .fetch_one(pool)
-            .await?;
-    Ok(u64::try_from(database_now)?)
-}
-
-async fn database_now_millis(database: &TestDatabase) -> TestResult<UnixMillis> {
-    let database_now: i64 =
-        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
-            .fetch_one(database.pool())
-            .await?;
-    Ok(UnixMillis::new(database_now))
 }

--- a/crates/automata-ci-results-github/tests/runtime_authority.rs
+++ b/crates/automata-ci-results-github/tests/runtime_authority.rs
@@ -1,7 +1,6 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+mod fixture_support;
+
+use std::sync::Arc;
 
 use automata_ci_control::runner_control::{
     RuntimeAuthorityIssueRequest, RuntimeAuthorityIssuer as _,
@@ -19,34 +18,16 @@ use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_results_github::{
     CacheAccessScope, CachePermission, CacheRepositoryMetadata, GITHUB_RESULTS_RUNTIME_AUTHORITY,
     GithubResultsRuntimeAuthorityIssuer, HmacResultsAuthority, HmacResultsAuthorityConfig,
-    ResultsClock, ResultsPublicEndpoint, RuntimeTokenVerifier as _, TokenError,
+    ResultsPublicEndpoint, RuntimeTokenVerifier as _, TokenError,
 };
 use automata_ci_store::{
     JobIrMetadata, ObjectKey, RunnerGeneration, RunnerSessionFence, SessionEpoch, StableRunnerSlot,
 };
+use fixture_support::MutableClock;
 use sha2::{Digest as _, Sha256};
 use url::Url;
 
 const SIGNING_KEY: &[u8] = b"runtime-authority-test-signing-key-material-v1";
-
-#[derive(Debug)]
-struct MutableClock(AtomicU64);
-
-impl MutableClock {
-    fn new(now: u64) -> Self {
-        Self(AtomicU64::new(now))
-    }
-
-    fn set(&self, now: u64) {
-        self.0.store(now, Ordering::SeqCst);
-    }
-}
-
-impl ResultsClock for MutableClock {
-    fn now_seconds(&self) -> u64 {
-        self.0.load(Ordering::SeqCst)
-    }
-}
 
 fn job() -> JobIrEnvelope {
     job_for("owner/repository", "refs/heads/feature", "push")

--- a/crates/automata-ci-results-github/tests/support/fixtures.rs
+++ b/crates/automata-ci-results-github/tests/support/fixtures.rs
@@ -1,0 +1,27 @@
+// Integration-test targets compile this shared module independently and use different subsets.
+#![allow(dead_code)]
+
+use automata_ci_core::UnixMillis;
+use sqlx::PgPool;
+
+use super::postgres::{TestDatabase, TestResult};
+
+pub(crate) async fn database_now_seconds(database: &TestDatabase) -> TestResult<u64> {
+    database_now_seconds_from_pool(database.pool()).await
+}
+
+pub(crate) async fn database_now_seconds_from_pool(pool: &PgPool) -> TestResult<u64> {
+    let database_now: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT")
+            .fetch_one(pool)
+            .await?;
+    Ok(u64::try_from(database_now)?)
+}
+
+pub(crate) async fn database_now_millis(database: &TestDatabase) -> TestResult<UnixMillis> {
+    let database_now: i64 =
+        sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(database.pool())
+            .await?;
+    Ok(UnixMillis::new(database_now))
+}

--- a/crates/automata-ci-results-github/tests/support/mod.rs
+++ b/crates/automata-ci-results-github/tests/support/mod.rs
@@ -1,1 +1,2 @@
+pub mod fixtures;
 pub mod postgres;

--- a/crates/automata-ci-results-github/tests/token_security.rs
+++ b/crates/automata-ci-results-github/tests/token_security.rs
@@ -1,16 +1,15 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+mod fixture_support;
 
-use automata_ci_core::{AttemptId, FencingToken, JobId, RunId};
+use std::sync::Arc;
+
+use automata_ci_core::{JobId, RunId};
 use automata_ci_results_github::{
-    ArtifactId, CacheAccessScope, CacheAuthority, CacheEntryId, CachePermission,
-    ExecutionAuthority, HmacResultsAuthority, HmacResultsAuthorityConfig, ResultsClock,
+    ArtifactId, CacheEntryId, CachePermission, HmacResultsAuthority, HmacResultsAuthorityConfig,
     ResultsPublicEndpoint, RuntimeTokenIssuer as _, RuntimeTokenVerifier, SignedCacheCapability,
     SignedDownloadCapability, SignedUploadCapability, TokenError, UploadId,
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use fixture_support::{MutableClock, cache_authority, fresh_execution_authority};
 use ring::hmac;
 use serde_json::{Value, json};
 use url::Url;
@@ -18,25 +17,11 @@ use uuid::Uuid;
 
 const SECRET: &[u8] = b"automata-results-test-key-material-32-bytes-minimum";
 const RUNTIME_LABEL: &[u8] = b"automata/results/runtime-jwt/hs256/v1";
-
-#[derive(Debug)]
-struct MutableClock(AtomicU64);
-
-impl MutableClock {
-    fn new(now: u64) -> Self {
-        Self(AtomicU64::new(now))
-    }
-
-    fn set(&self, now: u64) {
-        self.0.store(now, Ordering::SeqCst);
-    }
-}
-
-impl ResultsClock for MutableClock {
-    fn now_seconds(&self) -> u64 {
-        self.0.load(Ordering::SeqCst)
-    }
-}
+const CACHE_REPOSITORY: &str = "automata-ci/automata";
+const CACHE_SCOPES: &[(&str, CachePermission)] = &[
+    ("refs/heads/feature", CachePermission::ReadWrite),
+    ("refs/heads/main", CachePermission::Read),
+];
 
 fn authority(clock: Arc<MutableClock>) -> HmacResultsAuthority {
     let config = HmacResultsAuthorityConfig::new(
@@ -56,35 +41,13 @@ fn authority(clock: Arc<MutableClock>) -> HmacResultsAuthority {
     HmacResultsAuthority::new(SECRET, config, clock).expect("valid authority")
 }
 
-fn execution() -> ExecutionAuthority {
-    ExecutionAuthority::new(
-        RunId::new(),
-        JobId::new(),
-        AttemptId::new(),
-        FencingToken::new(7).expect("positive fence"),
-    )
-}
-
-fn cache_authority() -> CacheAuthority {
-    CacheAuthority::new(
-        "automata-ci/automata",
-        vec![
-            CacheAccessScope::new("refs/heads/feature", CachePermission::ReadWrite)
-                .expect("cache scope"),
-            CacheAccessScope::new("refs/heads/main", CachePermission::Read)
-                .expect("default-branch cache scope"),
-        ],
-    )
-    .expect("cache authority")
-}
-
 #[test]
 fn issued_runtime_token_has_exact_results_scope_and_round_trips() {
     let clock = Arc::new(MutableClock::new(10_000));
     let authority = authority(clock);
-    let execution = execution();
+    let execution = fresh_execution_authority(7);
 
-    let cache = cache_authority();
+    let cache = cache_authority(CACHE_REPOSITORY, CACHE_SCOPES);
     let token = authority
         .issue(execution, cache.clone(), 600)
         .expect("token issued");
@@ -123,7 +86,11 @@ fn signature_tampering_and_expiry_are_rejected() {
     let clock = Arc::new(MutableClock::new(20_000));
     let authority = authority(Arc::clone(&clock));
     let token = authority
-        .issue(execution(), cache_authority(), 60)
+        .issue(
+            fresh_execution_authority(7),
+            cache_authority(CACHE_REPOSITORY, CACHE_SCOPES),
+            60,
+        )
         .expect("token issued");
     let mut parts = token
         .expose_secret()
@@ -148,7 +115,7 @@ fn signature_tampering_and_expiry_are_rejected() {
 fn validly_signed_ambiguous_scope_and_algorithm_confusion_are_rejected() {
     let clock = Arc::new(MutableClock::new(30_000));
     let authority = authority(clock);
-    let execution = execution();
+    let execution = fresh_execution_authority(7);
     let common = json!({
         "iss": "automata-tests",
         "aud": "actions-results",
@@ -194,7 +161,7 @@ fn validly_signed_ambiguous_scope_and_algorithm_confusion_are_rejected() {
 #[test]
 fn missing_or_invalid_current_cache_access_controls_are_rejected() {
     let authority = authority(Arc::new(MutableClock::new(35_000)));
-    let execution = execution();
+    let execution = fresh_execution_authority(7);
     let header = json!({"alg":"HS256", "typ":"JWT", "kid":"test-v1"});
     let base = json!({
         "iss": "automata-tests",


### PR DESCRIPTION
Closes #340.

This is one subsystem-sized test cleanup for automata-ci-results-github: 10 files, 189 additions, 259 deletions (70 net lines removed). It centralizes the exact clock, ID-generator, fresh execution-authority, cache-authority, and PostgreSQL database-time fixtures used across artifact, cache, token, and runtime-authority contracts.

Preserved invariants:
- mutable clocks remain SeqCst
- all fencing values and fresh identity boundaries are unchanged
- the HTTP consumer still reuses the original run ID with a distinct job/attempt/fence
- cache scope order and permissions are unchanged
- PostgreSQL time queries and conversions are unchanged
- production code, schemas, repository doubles, HTTP payloads, and blob namespaces are untouched

Validation:
- cargo fmt --all -- --check
- cargo check --locked -p automata-ci-results-github --all-targets --all-features
- cargo test --locked -p automata-ci-results-github --all-targets --all-features (17 unit + 54 executable integration tests passed; configured external tests ignored)
- cargo clippy --locked -p automata-ci-results-github --all-targets --all-features -- -D warnings
- PostgreSQL 18.4: postgres_artifacts 13/13 and postgres_cache 7/7
- owned database/session cleanup audit: 0/0

Independent review found no issues. Current open PRs have zero exact-file overlap; the remaining copies in #173-owned RustFS/exact-client targets are deliberately excluded to avoid rebase churn.