### PR TITLE
fix(web): restore login and clickable job contract

### DIFF
--- a/crates/automata-ci/src/app/web/routes.rs
+++ b/crates/automata-ci/src/app/web/routes.rs
@@ -2052,7 +2052,8 @@ fn html_response(html: String, csp_nonce: &str) -> Response<Body> {
     let mut response = Html(html).into_response();
     let csp = format!(
         "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src data:; \
-         form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; \
+         form-action 'self' {GITHUB_AUTHORIZATION_ORIGIN}; frame-ancestors 'none'; \
+         img-src 'self' data:; \
          script-src 'self' 'nonce-{csp_nonce}'; style-src 'self'"
     );
     let Ok(csp) = HeaderValue::from_str(&csp) else {
@@ -2060,6 +2061,13 @@ fn html_response(html: String, csp_nonce: &str) -> Response<Body> {
         return internal_server_error();
     };
     apply_page_headers(response.headers_mut(), csp);
+    // Signed-out pages post to the same-origin login receiver, which redirects
+    // the browser to GitHub. Browsers enforce `form-action` across that entire
+    // redirect chain, and the login receiver requires an exact Origin header.
+    response.headers_mut().insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("same-origin"),
+    );
     response
 }
 
@@ -3618,7 +3626,7 @@ mod tests {
     }
 
     fn assert_page_headers(response: &Response<Body>, page: &Value) {
-        assert_page_headers_with_referrer(response, page, "no-referrer");
+        assert_page_headers_with_referrer(response, page, "same-origin");
     }
 
     fn assert_page_headers_with_referrer(
@@ -3643,13 +3651,8 @@ mod tests {
             .expect("CSP must be valid text");
         assert!(csp.contains(&format!("'nonce-{nonce}'")));
         assert!(csp.contains("frame-ancestors 'none'"));
-        if page["page"]["kind"] == "setup" {
-            assert!(csp.contains("form-action 'self' https://github.com"));
-            assert!(!csp.contains("form-action *"));
-        } else {
-            assert!(csp.contains("form-action 'self';"));
-            assert!(!csp.contains(GITHUB_AUTHORIZATION_ORIGIN));
-        }
+        assert!(csp.contains("form-action 'self' https://github.com"));
+        assert!(!csp.contains("form-action *"));
     }
 
     fn assert_error_page_headers(response: &Response<Body>, status: StatusCode) {
@@ -4863,7 +4866,10 @@ mod tests {
         assert_eq!(page["page"]["job"]["attempt"], 3);
         assert!(page["page"]["job"]["runnerLabel"].is_null());
         assert!(page["page"]["job"]["durationLabel"].is_null());
-        assert!(page["page"]["jobs"][1]["href"].is_null());
+        assert_eq!(
+            page["page"]["jobs"][1]["href"],
+            format!("/acme-labs/payments-api/actions/runs/{RUN_ID}/jobs/{OTHER_JOB_ID}")
+        );
         assert_eq!(page["page"]["search"]["query"], "retry warning");
         assert_eq!(page["page"]["search"]["action"], path);
         assert!(page["page"]["search"].get("refreshHref").is_none());


### PR DESCRIPTION
## Summary
- allow the fixed GitHub authorization origin in the dynamic page form CSP so sign-in redirects are not blocked
- retain the exact same-origin Origin header required by the login receiver
- update the stale job-navigation assertion to the already-shipped clickable-job behavior

## Validation
- 
running 48 tests
test app::web::routes::tests::artifact_names_are_header_encoded ... ok
test app::web::routes::tests::anonymous_repository_settings_data_fails_closed ... ok
test app::web::routes::tests::artifact_download_streams_exact_bytes_with_safe_content_headers ... ok
test app::web::routes::tests::immutable_roles_and_cross_tenant_binding_scopes_fail_closed_in_projection ... ok
test app::web::routes::tests::cursors_use_one_bounded_alias_free_alphabet ... ok
test app::web::routes::tests::identifiers_require_one_canonical_non_nil_representation ... ok
test app::web::routes::tests::editable_repository_settings_fail_closed_without_csrf_capability ... ok
test app::web::routes::tests::anonymous_missing_and_denied_run_links_share_an_exact_sign_in_handoff ... ok
test app::web::routes::tests::armed_setup_get_is_queryless_uncached_and_value_free ... ok
test app::web::routes::tests::route_segments_reject_dot_aliases_and_conditional_assets_accept_weak_matches ... ok
test app::web::routes::tests::empty_repository_directory_is_honest_and_repository_neutral ... ok
test app::web::routes::tests::missing_and_unauthorized_resources_have_identical_not_found_responses ... ok
test app::web::routes::tests::job_snapshot_is_bounded_no_store_json_with_conditional_revalidation ... ok
test app::web::routes::tests::job_log_preserves_search_pagination_and_job_navigation ... ok
test app::web::routes::tests::anonymous_missing_and_denied_job_links_share_an_exact_sign_in_handoff ... ok
test app::web::routes::tests::root_redirects_only_the_exact_empty_query_to_the_repository_directory ... ok
test app::web::routes::tests::rbac_binding_list_preserves_sources_and_never_mutates_provider_observations ... ok
test app::web::routes::tests::corrupt_scope_and_invalid_model_data_fail_closed ... ok
test app::web::routes::tests::unavailable_data_is_retryable_without_invoking_the_renderer ... ok
test app::web::routes::tests::unmatched_pages_use_the_accessible_branded_not_found_document ... ok
test app::web::routes::tests::run_detail_exposes_canonical_child_links_and_honest_nulls ... ok
test app::web::routes::tests::setup_route_is_absent_without_the_fresh_availability_port ... ok
test app::web::routes::tests::setup_get_freshly_closes_after_the_armed_state_transitions ... ok
test app::web::routes::tests::invalid_identifiers_and_queries_fail_before_data_access ... ok
test app::web::routes::tests::direct_grant_overflow_and_unavailability_render_no_grant_form ... ok
test app::web::routes::tests::workflow_route_scopes_the_query_and_uses_canonical_navigation ... ok
test app::web::routes::tests::access_navigation_requires_a_viewer_and_the_composed_management_surface ... ok
test app::web::routes::tests::rbac_management_routes_are_absent_without_the_authorized_data_port ... ok
test app::web::routes::tests::setup_availability_failures_close_before_rendering ... ok
test app::web::routes::tests::repository_settings_token_cannot_bypass_denied_update_authority ... ok
test app::web::routes::tests::rbac_user_list_reauthorizes_and_renders_only_the_truthful_read ... ok
test app::web::routes::tests::repository_directory_exposes_only_authorized_destinations_and_exact_next_page ... ok
test app::web::routes::tests::paginated_actions_sign_in_returns_to_the_exact_viewed_page ... ok
test app::web::routes::tests::repository_settings_reject_untrusted_notice_queries ... ok
test app::web::routes::tests::rbac_user_detail_uses_the_exact_member_and_read_only_joined_assignments ... ok
test app::web::routes::tests::repository_run_list_preserves_domain_identity_filters_and_nullable_data ... ok
test app::web::routes::tests::repository_directory_routes_secret_metadata_only_rows_to_secrets ... ok
test app::web::routes::tests::nested_pages_reject_data_from_a_different_parent_scope ... ok
test app::web::routes::tests::rbac_detail_routes_reject_bad_ids_before_lookup_and_hide_absent_targets ... ok
test app::web::routes::tests::rbac_role_list_projects_only_current_readable_roles ... ok
test app::web::routes::tests::rbac_role_detail_projects_the_complete_catalog_without_mutation_capabilities ... ok
test app::web::routes::tests::rbac_user_list_requires_matching_authentication_and_a_canonical_cursor ... ok
test app::web::routes::tests::repository_settings_expose_one_exact_verified_mutation_capability ... ok
test app::web::routes::tests::rbac_user_list_preserves_closed_read_outcomes ... ok
test app::web::routes::tests::rbac_posts_are_exact_prg_surfaces_with_closed_notices ... ok
test app::web::routes::tests::rbac_mutation_forms_require_the_exact_page_read_revision_and_capability ... ok
test app::web::routes::tests::every_rbac_mutation_model_satisfies_the_pinned_embedded_renderer ... ok
test app::web::routes::tests::every_routed_rbac_page_satisfies_the_embedded_renderer_contract ... ok

test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out; finished in 25.64s
