### PR TITLE
refactor(github-delivery): share event fixtures

### DIFF
--- a/crates/automata-ci-github-delivery/tests/delivery_service.rs
+++ b/crates/automata-ci-github-delivery/tests/delivery_service.rs
@@ -14,12 +14,6 @@ use automata_ci_blob::{
     MediaType, PutBlobOutcome, VerifiedBlob,
 };
 use automata_ci_core::{Sha256Digest, UnixMillis};
-use automata_ci_github::{
-    GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
-    GithubRepositoryVisibility as GithubRepositoryVisibilityFact, GithubSealedEventEnvelopeV1,
-    GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook,
-    rehydrate_stored_authenticated_github_webhook,
-};
 use automata_ci_github_delivery::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubChangedFileSelection,
     GithubChangedFilesDisposition, GithubDeliveryClock, GithubDeliveryPrivateRepositoryAction,
@@ -64,9 +58,7 @@ use automata_ci_store::{
 };
 use automata_ci_workflow_service::{GithubWorkflowPlanVerifier, WorkflowAdmissionService};
 use bytes::Bytes;
-use flate2::{Compression, write::GzEncoder};
 use sha2::{Digest as _, Sha256};
-use tar::{Builder, EntryType, Header};
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -74,15 +66,12 @@ use uuid::Uuid;
 use super::subject_evidence::{
     fixture_check_head_sha, fixture_subject_evidence, fixture_subject_evidence_with_head,
 };
+use super::support::{
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, ZERO,
+    archive, provider_event_envelope, push_body,
+};
 
-const BEFORE: &str = "fedcba9876543210fedcba9876543210fedcba98";
-const AFTER: &str = "0123456789abcdef0123456789abcdef01234567";
-const ZERO: &str = "0000000000000000000000000000000000000000";
-const OWNER: &str = "octo-private";
-const REPOSITORY: &str = "private-repository";
-const REPOSITORY_ID: u64 = 9_001;
-const REPOSITORY_OWNER_ID: u64 = 8_001;
-const INSTALLATION_ID: u64 = 4_242;
+const DELIVERY: &str = "delivery-service-1";
 const TOKEN_MARKER: &str = "delivery-service-token-marker";
 const INITIAL_NOW: i64 = 100;
 const CLAIM_MILLIS: i64 = 50;
@@ -1813,7 +1802,8 @@ fn delivery_template(
     stored_visibility: ProviderRepositoryVisibility,
     deleted: bool,
 ) -> (DeliveryTemplate, BlobDescriptor, Bytes) {
-    let body = push_body(stored_visibility, deleted);
+    let after = if deleted { ZERO } else { AFTER };
+    let body = push_body("refs/heads/main", after, deleted, 0, stored_visibility);
     let digest = Sha256Digest::from_bytes(Sha256::digest(&body).into());
     let key_text = format!("provider-deliveries/github/event/sha256/{digest}.json");
     let descriptor = BlobDescriptor::new(
@@ -1829,7 +1819,8 @@ fn delivery_template(
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
     )
     .expect("raw event");
-    let event_envelope = provider_event_envelope(&body, &descriptor, stored_visibility);
+    let event_envelope =
+        provider_event_envelope(&body, &descriptor, "push", DELIVERY, stored_visibility);
     let delivery_id = ProviderDeliveryId::from_uuid(Uuid::from_u128(1)).expect("delivery ID");
     let repository = ProviderRepositoryCoordinates::new(
         ProviderRepositoryId::new(REPOSITORY_ID).expect("repository"),
@@ -1843,7 +1834,7 @@ fn delivery_template(
         ProviderConnectionId::from_uuid(Uuid::from_u128(3)).expect("connection"),
         ProviderInstallationId::new(INSTALLATION_ID).expect("installation"),
         repository,
-        "delivery-service-1",
+        DELIVERY,
     )
     .expect("delivery identity");
     (
@@ -1860,54 +1851,6 @@ fn delivery_template(
     )
 }
 
-fn provider_event_envelope(
-    body: &Bytes,
-    descriptor: &BlobDescriptor,
-    visibility: ProviderRepositoryVisibility,
-) -> ProviderDeliveryEventEnvelope {
-    let visibility = match visibility {
-        ProviderRepositoryVisibility::Public => GithubRepositoryVisibilityFact::Public,
-        ProviderRepositoryVisibility::Private => GithubRepositoryVisibilityFact::Private,
-    };
-    let stored = StoredAuthenticatedGithubWebhook::from_durable_coordinates(
-        body.clone(),
-        GithubWebhookBodyDigest::from_bytes(*descriptor.digest().as_bytes()),
-        descriptor.size(),
-        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
-        "push",
-        "delivery-service-1",
-        INSTALLATION_ID,
-        REPOSITORY_ID,
-        REPOSITORY_OWNER_ID,
-        visibility,
-        OWNER,
-        REPOSITORY,
-    );
-    let event =
-        rehydrate_stored_authenticated_github_webhook(stored).expect("verified webhook fixture");
-    let sealed = GithubSealedEventEnvelopeV1::seal(&event, descriptor.clone())
-        .expect("sealed event envelope fixture");
-    ProviderDeliveryEventEnvelope::new(
-        sealed.schema(),
-        sealed.registry_schema(),
-        sealed.digest(),
-        sealed.canonical_bytes().to_vec(),
-        GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
-    )
-    .expect("durable event envelope fixture")
-}
-
-fn push_body(visibility: ProviderRepositoryVisibility, deleted: bool) -> Bytes {
-    let (private, visibility) = match visibility {
-        ProviderRepositoryVisibility::Public => (false, "public"),
-        ProviderRepositoryVisibility::Private => (true, "private"),
-    };
-    let after = if deleted { ZERO } else { AFTER };
-    Bytes::from(format!(
-        r#"{{"ref":"refs/heads/main","before":"{BEFORE}","after":"{after}","created":false,"deleted":{deleted},"forced":false,"repository":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}},"installation":{{"id":{INSTALLATION_ID}}},"commits":[]}}"#,
-    ))
-}
-
 fn repository_source() -> RepositorySource {
     RepositorySource::from_bytes(
         ScmProviderId::new("github").expect("provider"),
@@ -1919,41 +1862,6 @@ fn repository_source() -> RepositorySource {
             b"on: push\n".to_vec(),
         )])),
     )
-}
-
-fn archive(files: BTreeMap<&str, Vec<u8>>) -> Bytes {
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut builder = Builder::new(encoder);
-    append_archive_entry(&mut builder, "repository-root", EntryType::Directory, &[]);
-    for (path, bytes) in files {
-        append_archive_entry(
-            &mut builder,
-            &format!("repository-root/{path}"),
-            EntryType::Regular,
-            &bytes,
-        );
-    }
-    let encoder = builder.into_inner().expect("finish tar");
-    Bytes::from(encoder.finish().expect("finish gzip"))
-}
-
-fn append_archive_entry(
-    builder: &mut Builder<GzEncoder<Vec<u8>>>,
-    path: &str,
-    entry_type: EntryType,
-    bytes: &[u8],
-) {
-    let mut header = Header::new_gnu();
-    header.set_entry_type(entry_type);
-    header.set_mode(if entry_type.is_dir() { 0o755 } else { 0o644 });
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
-    header.set_size(u64::try_from(bytes.len()).expect("entry size"));
-    header.set_cksum();
-    builder
-        .append_data(&mut header, path, bytes)
-        .expect("append archive entry");
 }
 
 async fn run_once(

--- a/crates/automata-ci-github-delivery/tests/github_delivery.rs
+++ b/crates/automata-ci-github-delivery/tests/github_delivery.rs
@@ -1,4 +1,5 @@
 mod subject_evidence;
+mod support;
 
 mod checks_publisher;
 mod delivery_service;

--- a/crates/automata-ci-github-delivery/tests/support/mod.rs
+++ b/crates/automata-ci-github-delivery/tests/support/mod.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeMap;
+
+use automata_ci_blob::BlobDescriptor;
+use automata_ci_github::{
+    GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
+    GithubRepositoryVisibility as GithubRepositoryVisibilityFact, GithubSealedEventEnvelopeV1,
+    GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook,
+    rehydrate_stored_authenticated_github_webhook,
+};
+use automata_ci_github_delivery::GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE;
+use automata_ci_store::{ProviderDeliveryEventEnvelope, ProviderRepositoryVisibility};
+use bytes::Bytes;
+use flate2::{Compression, write::GzEncoder};
+use tar::{Builder, EntryType, Header};
+
+pub(super) const BEFORE: &str = "fedcba9876543210fedcba9876543210fedcba98";
+pub(super) const AFTER: &str = "0123456789abcdef0123456789abcdef01234567";
+pub(super) const ZERO: &str = "0000000000000000000000000000000000000000";
+pub(super) const OWNER: &str = "octo-private";
+pub(super) const REPOSITORY: &str = "private-repository";
+pub(super) const REPOSITORY_ID: u64 = 9_001;
+pub(super) const REPOSITORY_OWNER_ID: u64 = 8_001;
+pub(super) const INSTALLATION_ID: u64 = 4_242;
+
+pub(super) fn archive<T: AsRef<[u8]>>(files: BTreeMap<&str, T>) -> Bytes {
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut builder = Builder::new(encoder);
+    append_archive_entry(&mut builder, "repository-root", EntryType::Directory, &[]);
+    for (path, bytes) in files {
+        append_archive_entry(
+            &mut builder,
+            &format!("repository-root/{path}"),
+            EntryType::Regular,
+            bytes.as_ref(),
+        );
+    }
+    let encoder = builder.into_inner().expect("finish tar");
+    Bytes::from(encoder.finish().expect("finish gzip"))
+}
+
+fn append_archive_entry(
+    builder: &mut Builder<GzEncoder<Vec<u8>>>,
+    path: &str,
+    entry_type: EntryType,
+    bytes: &[u8],
+) {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(if entry_type.is_dir() { 0o755 } else { 0o644 });
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(u64::try_from(bytes.len()).expect("entry size"));
+    header.set_cksum();
+    builder
+        .append_data(&mut header, path, bytes)
+        .expect("append archive entry");
+}
+
+pub(super) fn provider_event_envelope(
+    body: &Bytes,
+    descriptor: &BlobDescriptor,
+    event_name: &str,
+    delivery: &str,
+    visibility: ProviderRepositoryVisibility,
+) -> ProviderDeliveryEventEnvelope {
+    let visibility = match visibility {
+        ProviderRepositoryVisibility::Public => GithubRepositoryVisibilityFact::Public,
+        ProviderRepositoryVisibility::Private => GithubRepositoryVisibilityFact::Private,
+    };
+    let stored = StoredAuthenticatedGithubWebhook::from_durable_coordinates(
+        body.clone(),
+        GithubWebhookBodyDigest::from_bytes(*descriptor.digest().as_bytes()),
+        descriptor.size(),
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+        event_name,
+        delivery,
+        INSTALLATION_ID,
+        REPOSITORY_ID,
+        REPOSITORY_OWNER_ID,
+        visibility,
+        OWNER,
+        REPOSITORY,
+    );
+    let event =
+        rehydrate_stored_authenticated_github_webhook(stored).expect("verified webhook fixture");
+    let sealed = GithubSealedEventEnvelopeV1::seal(&event, descriptor.clone())
+        .expect("sealed event envelope fixture");
+    ProviderDeliveryEventEnvelope::new(
+        sealed.schema(),
+        sealed.registry_schema(),
+        sealed.digest(),
+        sealed.canonical_bytes().to_vec(),
+        GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
+    )
+    .expect("durable event envelope fixture")
+}
+
+pub(super) fn push_body(
+    git_ref: &str,
+    after: &str,
+    deleted: bool,
+    commit_count: usize,
+    visibility: ProviderRepositoryVisibility,
+) -> Bytes {
+    let commits = (1..=commit_count)
+        .map(|value| format!(r#"{{"id":"{value:040x}"}}"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let (private, visibility) = match visibility {
+        ProviderRepositoryVisibility::Public => (false, "public"),
+        ProviderRepositoryVisibility::Private => (true, "private"),
+    };
+    Bytes::from(format!(
+        r#"{{"ref":"{git_ref}","before":"{BEFORE}","after":"{after}","created":false,"deleted":{deleted},"forced":false,"repository":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}},"installation":{{"id":{INSTALLATION_ID}}},"commits":[{commits}]}}"#,
+    ))
+}

--- a/crates/automata-ci-github-delivery/tests/worker.rs
+++ b/crates/automata-ci-github-delivery/tests/worker.rs
@@ -13,12 +13,7 @@ use automata_ci_blob::{
     MediaType, PutBlobOutcome, VerifiedBlob,
 };
 use automata_ci_core::{Sha256Digest, UnixMillis};
-use automata_ci_github::{
-    GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE, GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX, GithubPushRefKind,
-    GithubRepositoryVisibility as GithubRepositoryVisibilityFact, GithubSealedEventEnvelopeV1,
-    GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook,
-    rehydrate_stored_authenticated_github_webhook,
-};
+use automata_ci_github::{GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX, GithubPushRefKind};
 use automata_ci_github_delivery::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubDeliveryClock, GithubDeliverySourceAuthority,
     GithubDeliveryWorker, GithubDeliveryWorkerConfig, GithubDeliveryWorkerConfigurationError,
@@ -58,25 +53,19 @@ use automata_ci_store::{
 };
 use automata_ci_workflow_github::RepositoryWorkflowDiscoveryLimits;
 use bytes::Bytes;
-use flate2::{Compression, write::GzEncoder};
 use sha2::{Digest as _, Sha256};
-use tar::{Builder, EntryType, Header};
 use uuid::Uuid;
 
 use super::subject_evidence::{
     fixture_all_direct_subject_evidence, fixture_check_head_sha, fixture_github_runtime_policy,
     fixture_subject_evidence, fixture_subject_evidence_with_head,
 };
+use super::support::{
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, ZERO,
+    archive, provider_event_envelope, push_body,
+};
 
-const BEFORE: &str = "fedcba9876543210fedcba9876543210fedcba98";
-const AFTER: &str = "0123456789abcdef0123456789abcdef01234567";
 const STALE_MERGE: &str = "89abcdef0123456789abcdef0123456789abcdef";
-const ZERO: &str = "0000000000000000000000000000000000000000";
-const OWNER: &str = "octo-private";
-const REPOSITORY: &str = "private-repository";
-const REPOSITORY_ID: u64 = 9_001;
-const REPOSITORY_OWNER_ID: u64 = 8_001;
-const INSTALLATION_ID: u64 = 4_242;
 const DELIVERY: &str = "delivery-worker-1";
 const CREDENTIAL_MARKER: &str = "installation-token-private-marker";
 
@@ -904,45 +893,6 @@ struct ClaimedFixture {
     check_head_sha: GithubCheckHeadSha,
 }
 
-fn provider_event_envelope(
-    body: &Bytes,
-    descriptor: &BlobDescriptor,
-    event_name: &str,
-    delivery_id: &str,
-    visibility: ProviderRepositoryVisibility,
-) -> ProviderDeliveryEventEnvelope {
-    let visibility = match visibility {
-        ProviderRepositoryVisibility::Public => GithubRepositoryVisibilityFact::Public,
-        ProviderRepositoryVisibility::Private => GithubRepositoryVisibilityFact::Private,
-    };
-    let stored = StoredAuthenticatedGithubWebhook::from_durable_coordinates(
-        body.clone(),
-        GithubWebhookBodyDigest::from_bytes(*descriptor.digest().as_bytes()),
-        descriptor.size(),
-        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
-        event_name,
-        delivery_id,
-        INSTALLATION_ID,
-        REPOSITORY_ID,
-        REPOSITORY_OWNER_ID,
-        visibility,
-        OWNER,
-        REPOSITORY,
-    );
-    let event =
-        rehydrate_stored_authenticated_github_webhook(stored).expect("verified webhook fixture");
-    let sealed = GithubSealedEventEnvelopeV1::seal(&event, descriptor.clone())
-        .expect("sealed event envelope fixture");
-    ProviderDeliveryEventEnvelope::new(
-        sealed.schema(),
-        sealed.registry_schema(),
-        sealed.digest(),
-        sealed.canonical_bytes().to_vec(),
-        GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
-    )
-    .expect("durable event envelope fixture")
-}
-
 fn claimed_with_event_envelope(
     claimed: &ClaimedProviderDelivery,
     event_envelope: ProviderDeliveryEventEnvelope,
@@ -976,7 +926,7 @@ fn claimed_fixture_with_visibility(
     visibility: ProviderRepositoryVisibility,
 ) -> ClaimedFixture {
     let after = if deleted { ZERO } else { AFTER };
-    let body = push_body(git_ref, after, deleted, visibility);
+    let body = push_body(git_ref, after, deleted, 0, visibility);
     let digest = Sha256Digest::from_bytes(Sha256::digest(&body).into());
     let key_text = format!("{GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX}/{digest}.json");
     let descriptor = BlobDescriptor::new(
@@ -1206,21 +1156,6 @@ fn pending_repository_dispatch_evidence(
     .expect("pending repository dispatch")
 }
 
-fn push_body(
-    git_ref: &str,
-    after: &str,
-    deleted: bool,
-    visibility: ProviderRepositoryVisibility,
-) -> Bytes {
-    let (private, visibility) = match visibility {
-        ProviderRepositoryVisibility::Public => (false, "public"),
-        ProviderRepositoryVisibility::Private => (true, "private"),
-    };
-    Bytes::from(format!(
-        r#"{{"ref":"{git_ref}","before":"{BEFORE}","after":"{after}","created":false,"deleted":{deleted},"forced":false,"repository":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}},"installation":{{"id":{INSTALLATION_ID}}},"commits":[]}}"#,
-    ))
-}
-
 fn repository_source(archive: Bytes) -> RepositorySource {
     RepositorySource::from_bytes(
         ScmProviderId::new("github").expect("provider"),
@@ -1320,41 +1255,6 @@ fn skipped() -> ProviderDeliveryWorkflowConclusion {
         reason: ProviderDeliveryFailureKind::new("github.workflow.not_selected")
             .expect("failure kind"),
     }
-}
-
-fn archive(files: BTreeMap<&str, Vec<u8>>) -> Bytes {
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut builder = Builder::new(encoder);
-    append_archive_entry(&mut builder, "repository-root", EntryType::Directory, &[]);
-    for (path, bytes) in files {
-        append_archive_entry(
-            &mut builder,
-            &format!("repository-root/{path}"),
-            EntryType::Regular,
-            &bytes,
-        );
-    }
-    let encoder = builder.into_inner().expect("finish tar");
-    Bytes::from(encoder.finish().expect("finish gzip"))
-}
-
-fn append_archive_entry(
-    builder: &mut Builder<GzEncoder<Vec<u8>>>,
-    path: &str,
-    entry_type: EntryType,
-    bytes: &[u8],
-) {
-    let mut header = Header::new_gnu();
-    header.set_entry_type(entry_type);
-    header.set_mode(if entry_type.is_dir() { 0o755 } else { 0o644 });
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
-    header.set_size(u64::try_from(bytes.len()).expect("entry size"));
-    header.set_cksum();
-    builder
-        .append_data(&mut header, path, bytes)
-        .expect("append archive entry");
 }
 
 #[tokio::test]
@@ -1751,7 +1651,7 @@ async fn public_repository_dispatch_resolution_is_credential_free() {
 async fn repository_dispatch_resolution_failure_creates_no_check_or_workflow() {
     let fixture = repository_dispatch_claimed_fixture(ProviderRepositoryVisibility::Private);
     let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-        BTreeMap::new(),
+        BTreeMap::<&str, Vec<u8>>::new(),
     ))));
     let resolver = Arc::new(RecordingResolver::failing(ScmError::new(
         automata_ci_scm::ScmErrorKind::Unavailable,
@@ -2033,7 +1933,7 @@ async fn pinned_manifest_exceeding_a_local_ceiling_rejects_before_source_io() {
 async fn deleted_pinned_branch_completes_without_source_authority_or_processing() {
     let fixture = claimed_fixture("refs/heads/main", true, 1);
     let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-        BTreeMap::new(),
+        BTreeMap::<&str, Vec<u8>>::new(),
     ))));
     let processor = Arc::new(RecordingProcessor::returning(skipped()));
     let deliveries = Arc::new(RecordingDeliveries::new(fixture.receipt));
@@ -2103,7 +2003,7 @@ async fn non_pinned_git_ref_rejects_before_source_or_workflow_processing() {
 async fn private_live_ref_rejects_public_authority_before_provider_io() {
     let fixture = claimed_fixture("refs/heads/main", false, 1);
     let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-        BTreeMap::new(),
+        BTreeMap::<&str, Vec<u8>>::new(),
     ))));
     let processor = Arc::new(RecordingProcessor::returning(skipped()));
     let deliveries = Arc::new(RecordingDeliveries::new(fixture.receipt));
@@ -2136,7 +2036,7 @@ async fn rehydrated_push_head_must_match_the_pinned_check_before_source_io() {
         fixture.body.clone(),
     ));
     let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-        BTreeMap::new(),
+        BTreeMap::<&str, Vec<u8>>::new(),
     ))));
     let processor = Arc::new(RecordingProcessor::returning(skipped()));
     let deliveries = Arc::new(RecordingDeliveries::new(fixture.receipt));
@@ -2207,6 +2107,7 @@ async fn invalid_or_rebound_event_envelopes_reject_before_blob_or_source_io() {
                     "refs/heads/other",
                     AFTER,
                     false,
+                    0,
                     ProviderRepositoryVisibility::Private,
                 );
                 let other_digest = Sha256Digest::from_bytes(Sha256::digest(&other_body).into());
@@ -2239,7 +2140,7 @@ async fn invalid_or_rebound_event_envelopes_reject_before_blob_or_source_io() {
         };
         fixture.claimed = claimed_with_event_envelope(&fixture.claimed, event_envelope);
         let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-            BTreeMap::new(),
+            BTreeMap::<&str, Vec<u8>>::new(),
         ))));
         let processor = Arc::new(RecordingProcessor::returning(skipped()));
         let deliveries = Arc::new(RecordingDeliveries::new(fixture.receipt));
@@ -2303,7 +2204,7 @@ async fn immutable_object_failures_are_durably_classified_before_source_io() {
             failure,
         ));
         let source = Arc::new(RecordingSourcePort::returning(repository_source(archive(
-            BTreeMap::new(),
+            BTreeMap::<&str, Vec<u8>>::new(),
         ))));
         let processor = Arc::new(RecordingProcessor::returning(skipped()));
         let deliveries = Arc::new(RecordingDeliveries::new(fixture.receipt));
@@ -2489,7 +2390,7 @@ fn configuration_rejects_unrepresentable_outcome_and_provider_bounds() {
     ));
     let source = Arc::new(RecordingSourcePort::with_provider(
         "gitlab",
-        repository_source(archive(BTreeMap::new())),
+        repository_source(archive(BTreeMap::<&str, Vec<u8>>::new())),
     ));
     let result = GithubDeliveryWorker::new(
         Arc::new(FixtureBlobStore::exact(fixture.descriptor, fixture.body)),

--- a/crates/automata-ci-github-delivery/tests/workflow_processor.rs
+++ b/crates/automata-ci-github-delivery/tests/workflow_processor.rs
@@ -12,12 +12,7 @@ use automata_ci_blob::{
     BlobDescriptor, BlobKey, BlobPayload, ImmutableBlobStore as _, MediaType, MemoryBlobStore,
 };
 use automata_ci_core::{Sha256Digest, UnixMillis, WorkflowPlan};
-use automata_ci_github::{
-    GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE, GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX,
-    GithubRepositoryVisibility as GithubRepositoryVisibilityFact, GithubSealedEventEnvelopeV1,
-    GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook,
-    rehydrate_stored_authenticated_github_webhook,
-};
+use automata_ci_github::GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX;
 use automata_ci_github_delivery::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubChangedFileSelection,
     GithubChangedFilesDisposition, GithubDeliveryClock, GithubDeliveryPrivateRepositoryAction,
@@ -59,20 +54,15 @@ use automata_ci_store::{
 };
 use automata_ci_workflow_service::{GithubWorkflowPlanVerifier, WorkflowAdmissionService};
 use bytes::Bytes;
-use flate2::{Compression, write::GzEncoder};
 use sha2::{Digest as _, Sha256};
-use tar::{Builder, EntryType, Header};
 use uuid::Uuid;
 
 use super::subject_evidence::fixture_subject_evidence;
+use super::support::{
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, archive,
+    provider_event_envelope, push_body,
+};
 
-const BEFORE: &str = "fedcba9876543210fedcba9876543210fedcba98";
-const AFTER: &str = "0123456789abcdef0123456789abcdef01234567";
-const OWNER: &str = "octo-private";
-const REPOSITORY: &str = "private-repository";
-const REPOSITORY_ID: u64 = 9_001;
-const REPOSITORY_OWNER_ID: u64 = 8_001;
-const INSTALLATION_ID: u64 = 4_242;
 const DELIVERY: &str = "delivery-workflow-processor-1";
 const WORKFLOW_PATH: &str = ".ci/workflows/ci.yml";
 const ALTERNATE_WORKFLOW_PATH: &str = ".ci/workflows/alternate.yml";
@@ -645,7 +635,7 @@ async fn harness_with_visibility(
     visibility: ProviderRepositoryVisibility,
 ) -> Harness {
     let blobs = Arc::new(MemoryBlobStore::default());
-    let body = push_body(commit_count, visibility);
+    let body = push_body("refs/heads/main", AFTER, false, commit_count, visibility);
     let digest = Sha256Digest::from_bytes(Sha256::digest(&body).into());
     let raw_key = format!("{GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX}/{digest}.json");
     let raw_payload = BlobPayload::from_bytes(
@@ -665,7 +655,8 @@ async fn harness_with_visibility(
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
     )
     .expect("raw event");
-    let event_envelope = provider_event_envelope(&body, &raw_descriptor, "push", visibility);
+    let event_envelope =
+        provider_event_envelope(&body, &raw_descriptor, "push", DELIVERY, visibility);
     let claimed = claimed(raw_event, event_envelope, visibility);
     let logical = Arc::new(LogicalAdmissions::default());
     let admission = WorkflowAdmissionService::with_system_ports(
@@ -746,7 +737,7 @@ async fn pull_request_harness_with_visibility(
     )
     .expect("raw event");
     let event_envelope =
-        provider_event_envelope(&body, &raw_descriptor, "pull_request", visibility);
+        provider_event_envelope(&body, &raw_descriptor, "pull_request", DELIVERY, visibility);
     let claimed = claimed(raw_event, event_envelope, visibility);
     let logical = Arc::new(LogicalAdmissions::default());
     let admission = WorkflowAdmissionService::with_system_ports(
@@ -790,44 +781,6 @@ async fn pull_request_harness_with_visibility(
         deliveries,
         credentials,
     }
-}
-
-fn provider_event_envelope(
-    body: &Bytes,
-    descriptor: &BlobDescriptor,
-    event_name: &str,
-    visibility: ProviderRepositoryVisibility,
-) -> ProviderDeliveryEventEnvelope {
-    let visibility = match visibility {
-        ProviderRepositoryVisibility::Public => GithubRepositoryVisibilityFact::Public,
-        ProviderRepositoryVisibility::Private => GithubRepositoryVisibilityFact::Private,
-    };
-    let stored = StoredAuthenticatedGithubWebhook::from_durable_coordinates(
-        body.clone(),
-        GithubWebhookBodyDigest::from_bytes(*descriptor.digest().as_bytes()),
-        descriptor.size(),
-        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
-        event_name,
-        DELIVERY,
-        INSTALLATION_ID,
-        REPOSITORY_ID,
-        REPOSITORY_OWNER_ID,
-        visibility,
-        OWNER,
-        REPOSITORY,
-    );
-    let event =
-        rehydrate_stored_authenticated_github_webhook(stored).expect("verified webhook fixture");
-    let sealed = GithubSealedEventEnvelopeV1::seal(&event, descriptor.clone())
-        .expect("sealed event envelope fixture");
-    ProviderDeliveryEventEnvelope::new(
-        sealed.schema(),
-        sealed.registry_schema(),
-        sealed.digest(),
-        sealed.canonical_bytes().to_vec(),
-        GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
-    )
-    .expect("durable event envelope fixture")
 }
 
 fn claimed(
@@ -877,20 +830,6 @@ fn claimed(
     .expect("claimed delivery")
 }
 
-fn push_body(commit_count: usize, visibility: ProviderRepositoryVisibility) -> Bytes {
-    let commits = (1..=commit_count)
-        .map(|value| format!(r#"{{"id":"{value:040x}"}}"#))
-        .collect::<Vec<_>>()
-        .join(",");
-    let (private, visibility) = match visibility {
-        ProviderRepositoryVisibility::Public => (false, "public"),
-        ProviderRepositoryVisibility::Private => (true, "private"),
-    };
-    Bytes::from(format!(
-        r#"{{"ref":"refs/heads/main","before":"{BEFORE}","after":"{AFTER}","created":false,"deleted":false,"forced":false,"repository":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}},"installation":{{"id":{INSTALLATION_ID}}},"commits":[{commits}]}}"#,
-    ))
-}
-
 fn pull_request_body() -> Bytes {
     pull_request_body_with_visibility(ProviderRepositoryVisibility::Private)
 }
@@ -903,41 +842,6 @@ fn pull_request_body_with_visibility(visibility: ProviderRepositoryVisibility) -
     Bytes::from(format!(
         r#"{{"action":"opened","number":7,"pull_request":{{"number":7,"merged":false,"merge_commit_sha":"{AFTER}","head":{{"ref":"feature/topic","sha":"{AFTER}","repo":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}}}},"base":{{"ref":"main","sha":"{BEFORE}","repo":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}}}}}},"repository":{{"id":{REPOSITORY_ID},"private":{private},"visibility":"{visibility}","name":"{REPOSITORY}","full_name":"{OWNER}/{REPOSITORY}","owner":{{"id":{REPOSITORY_OWNER_ID},"login":"{OWNER}"}}}},"installation":{{"id":{INSTALLATION_ID}}},"sender":{{"id":301}}}}"#
     ))
-}
-
-fn archive(files: BTreeMap<&str, &[u8]>) -> Bytes {
-    let encoder = GzEncoder::new(Vec::new(), Compression::default());
-    let mut builder = Builder::new(encoder);
-    append_entry(&mut builder, "repository-root", EntryType::Directory, &[]);
-    for (path, bytes) in files {
-        append_entry(
-            &mut builder,
-            &format!("repository-root/{path}"),
-            EntryType::Regular,
-            bytes,
-        );
-    }
-    let encoder = builder.into_inner().expect("finish tar");
-    Bytes::from(encoder.finish().expect("finish gzip"))
-}
-
-fn append_entry(
-    builder: &mut Builder<GzEncoder<Vec<u8>>>,
-    path: &str,
-    entry_type: EntryType,
-    bytes: &[u8],
-) {
-    let mut header = Header::new_gnu();
-    header.set_entry_type(entry_type);
-    header.set_mode(if entry_type.is_dir() { 0o755 } else { 0o644 });
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
-    header.set_size(u64::try_from(bytes.len()).expect("entry size"));
-    header.set_cksum();
-    builder
-        .append_data(&mut header, path, bytes)
-        .expect("append archive entry");
 }
 
 async fn process(
@@ -1021,7 +925,16 @@ async fn accepted_path_replays_durable_progress_without_readmission() {
     let source = read_admission_object(&harness.blobs, first.source()).await;
     assert_eq!(source.as_ref(), ACCEPTED_WORKFLOW);
     let event = read_admission_object(&harness.blobs, first.event()).await;
-    assert_eq!(event, push_body(0, ProviderRepositoryVisibility::Private));
+    assert_eq!(
+        event,
+        push_body(
+            "refs/heads/main",
+            AFTER,
+            false,
+            0,
+            ProviderRepositoryVisibility::Private,
+        )
+    );
 
     let completions = harness.deliveries.completions();
     assert_eq!(completions.len(), 2);


### PR DESCRIPTION
## Summary

- share deterministic repository archives, sealed provider-event envelopes, and push payload construction across the Delivery integration suite
- centralize the common repository coordinates while keeping event names, delivery IDs, refs, SHAs, deletion state, commit counts, and visibility explicit at call sites
- remove three local archive builders, three envelope builders, three push builders, and repeated coordinate constants

This is one subsystem-sized cleanup: 5 files, 482 changed lines, and 160 net lines removed. Production behavior is unchanged.

## Validation

- cargo fmt --all -- --check
- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-github-delivery --all-targets --all-features
- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-github-delivery --test github_delivery --all-features (107 passed)
- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-github-delivery --all-targets --all-features -- -D warnings
- independent static and semantic review: approved, no findings

Closes #344.