### PR TITLE
test(podman): bound backend socket paths

### DIFF
--- a/crates/automata-ci-sandbox-podman/src/docker.rs
+++ b/crates/automata-ci-sandbox-podman/src/docker.rs
@@ -3425,8 +3425,8 @@ mod observer_tests {
     }
 
     fn temporary_backend_socket() -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "automata-podman-backend-{}-{}.sock",
+        PathBuf::from("/tmp").join(format!(
+            "automata-podman-{}-{}.sock",
             std::process::id(),
             NEXT_BACKEND_SOCKET.fetch_add(1, AtomicOrdering::Relaxed),
         ))


### PR DESCRIPTION
## Summary

- make Unix-domain backend test sockets independent of runner workspace and TMPDIR depth
- preserve collision safety with the process ID and atomic test-local ordinal

## Verification

- observer test module passes with an intentionally overlong TMPDIR
- 19 tests passed
