### PR TITLE
refactor(postgres): enforce exact connection authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,17 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   one closed security mode, and bucket creation is region-correct, idempotent,
   conflict-reverified, and bounded by one total deadline.
 
+### Changed
+
+- PostgreSQL product connections now accept one exact `postgresql://` TCP URL
+  with explicit host, port, user, non-empty password, and database. Query and
+  fragment options, socket paths, `.pgpass`, ambient `PG*` configuration, and
+  the `postgres://` alias are rejected. Transport is closed to Web PKI
+  verify-full, an explicitly additive private-CA verify-full union, or
+  literal-loopback plaintext. Domain adapters are imported from their owning
+  crates; the former `automata-ci-postgres` compatibility namespaces were
+  removed, and that crate now owns shared integration-test support only.
+
 ### Known limitations
 
 - This bootstrap release is not production-ready and has not passed the full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "automata-ci-protocol",
  "automata-ci-protocol-protobuf",
  "automata-ci-store",
+ "automata-ci-store-postgres",
  "axum",
  "base64 0.23.1",
  "bytes",
@@ -1132,6 +1133,9 @@ dependencies = [
  "automata-ci-oidc-github",
  "automata-ci-schedule",
  "automata-ci-store",
+ "automata-ci-tls",
+ "percent-encoding",
+ "rcgen",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1140,7 +1144,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ k8s-openapi = { version = "0.28.0", features = ["v1_34"] }
 kube = { version = "4.2.0", default-features = false, features = ["client", "ring", "rustls-tls", "ws"] }
 libc = "0.2.189"
 pem-rfc7468 = { version = "1.0.0", default-features = false, features = ["std"] }
+percent-encoding = "2.3.2"
 processkit = { version = "=3.3.1", default-features = false, features = ["limits"] }
 prometheus-client = "=0.25.0"
 prost = { version = "=0.14.4", default-features = false, features = ["derive"] }

--- a/crates/automata-ci-auth-postgres/README.md
+++ b/crates/automata-ci-auth-postgres/README.md
@@ -4,5 +4,6 @@ PostgreSQL persistence for Automata human authentication, authorization,
 provider-token custody, GitHub identity mapping, RBAC, and runner enrollment.
 
 This is a concrete adapter crate. Portable callers should depend on the ports
-in `automata-ci-auth`; the `automata-ci-postgres` facade preserves the existing
-`auth` namespace for server composition.
+in `automata-ci-auth`; product composition and integration tests import this
+adapter directly. `automata-ci-postgres` owns only shared PostgreSQL test
+support and does not re-export adapter namespaces.

--- a/crates/automata-ci-postgres/Cargo.toml
+++ b/crates/automata-ci-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-postgres"
-description = "Compatibility facade for Automata's domain-specific PostgreSQL adapters"
+description = "Shared PostgreSQL integration-test support for Automata's domain adapters"
 publish.workspace = true
 version.workspace = true
 edition.workspace = true
@@ -26,11 +26,7 @@ path = "examples/postgres-test-cleanup.rs"
 required-features = ["test-support"]
 
 [dependencies]
-automata-ci-auth-postgres.workspace = true
-automata-ci-provisioning-postgres.workspace = true
-automata-ci-runner-auth-postgres.workspace = true
-automata-ci-secret-postgres.workspace = true
-automata-ci-store-postgres.workspace = true
+automata-ci-store-postgres = { workspace = true, features = ["test-support"] }
 sqlx.workspace = true
 tokio.workspace = true
 uuid.workspace = true
@@ -38,6 +34,7 @@ uuid.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 automata-ci-auth.workspace = true
+automata-ci-auth-postgres.workspace = true
 automata-ci-blob.workspace = true
 automata-ci-control = { workspace = true, features = ["adapter-spi"] }
 automata-ci-core.workspace = true
@@ -45,8 +42,11 @@ automata-ci-key-management.workspace = true
 automata-ci-oidc-github.workspace = true
 automata-ci-protocol.workspace = true
 automata-ci-provisioning.workspace = true
+automata-ci-provisioning-postgres.workspace = true
+automata-ci-runner-auth-postgres.workspace = true
 automata-ci-schedule.workspace = true
 automata-ci-secret.workspace = true
+automata-ci-secret-postgres.workspace = true
 automata-ci-store = { workspace = true, features = ["adapter-spi"] }
 automata-ci-workflow-service.workspace = true
 serde.workspace = true

--- a/crates/automata-ci-postgres/README.md
+++ b/crates/automata-ci-postgres/README.md
@@ -1,17 +1,9 @@
 # automata-ci-postgres
 
-Compatibility facade for Automata's domain-specific PostgreSQL adapters. Its
-public namespaces re-export the independently compiled adapter crates:
-
-- `auth` from `automata-ci-auth-postgres`;
-- `provisioning` from `automata-ci-provisioning-postgres`;
-- `runner_auth` from `automata-ci-runner-auth-postgres`;
-- `secret` from `automata-ci-secret-postgres`;
-- `store` from `automata-ci-store-postgres`.
-
-New code should depend directly on the smallest domain crate it uses. The
-facade preserves existing source compatibility and owns the consolidated
-PostgreSQL integration-test target and unstable `test-support` feature.
+Shared PostgreSQL integration-test support for Automata's independently
+compiled domain adapters. Product code depends directly on the smallest domain
+crate it uses; this package owns only the consolidated PostgreSQL test target,
+its cleanup utility, and the explicitly enabled `test-support` fixture API.
 
 Schema migrations belong to `automata-ci-store-postgres`. All PostgreSQL
 integration suites compile into the explicit `postgres` target; run the

--- a/crates/automata-ci-postgres/src/lib.rs
+++ b/crates/automata-ci-postgres/src/lib.rs
@@ -1,20 +1,9 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-//! Compatibility facade for Automata's domain-specific `PostgreSQL` adapters.
+//! Shared `PostgreSQL` integration-test support for Automata's domain adapters.
 
 #[cfg(all(test, not(feature = "test-support")))]
 mod test_support;
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support;
-
-/// Human authentication, authorization, and runner-enrollment adapters.
-pub use automata_ci_auth_postgres as auth;
-/// Atomic external workspace-management adapters.
-pub use automata_ci_provisioning_postgres as provisioning;
-/// Durable runner-machine authentication adapter.
-pub use automata_ci_runner_auth_postgres as runner_auth;
-/// Built-in encrypted secret-provider adapter.
-pub use automata_ci_secret_postgres as secret;
-/// Durable control-plane storage adapter.
-pub use automata_ci_store_postgres as store;

--- a/crates/automata-ci-postgres/src/test_support/mod.rs
+++ b/crates/automata-ci-postgres/src/test_support/mod.rs
@@ -26,7 +26,7 @@ use sqlx::PgPool;
 use tokio::sync::OnceCell;
 
 #[cfg(feature = "test-support")]
-use crate::store::PostgresStore;
+use automata_ci_store_postgres::PostgresStore;
 
 /// Environment variable containing the isolated `PostgreSQL` server URL.
 const DATABASE_URL_ENVIRONMENT: &str = "AUTOMATA_TEST_DATABASE_URL";

--- a/crates/automata-ci-postgres/tests/auth/cli_session_activation.rs
+++ b/crates/automata-ci-postgres/tests/auth/cli_session_activation.rs
@@ -13,7 +13,7 @@ use automata_ci_auth::{
     },
     time::UnixTimestamp,
 };
-use automata_ci_postgres::auth::{
+use automata_ci_auth_postgres::{
     PostgresHumanSessionRepository, PostgresRequestAuthenticationResolver,
 };
 use automata_ci_postgres::test_support::TestClock;

--- a/crates/automata-ci-postgres/tests/auth/contracts.rs
+++ b/crates/automata-ci-postgres/tests/auth/contracts.rs
@@ -5,12 +5,12 @@ use automata_ci_auth::{
     request_auth::RequestAuthenticationResolver, session::HumanSessionRepository,
     vault::ProviderTokenVault,
 };
-use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::auth::{
+use automata_ci_auth_postgres::{
     PostgresHumanSessionRepository, PostgresInstallationRepository,
     PostgresLoginTransactionRepository, PostgresProviderTokenVault,
     PostgresRequestAuthenticationResolver,
 };
+use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use static_assertions::assert_impl_all;
 

--- a/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
+++ b/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
@@ -6,7 +6,7 @@ use automata_ci_auth::{
     human::TenantId,
     time::UnixTimestamp,
 };
-use automata_ci_postgres::auth::PostgresDelegatedActorResolver;
+use automata_ci_auth_postgres::PostgresDelegatedActorResolver;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/auth/github_mapping_management.rs
+++ b/crates/automata-ci-postgres/tests/auth/github_mapping_management.rs
@@ -16,7 +16,7 @@ use automata_ci_auth::{
     session::SessionId,
     time::UnixTimestamp,
 };
-use automata_ci_postgres::auth::PostgresGithubMappingManagementRepository;
+use automata_ci_auth_postgres::PostgresGithubMappingManagementRepository;
 use automata_ci_postgres::test_support::TestClock;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/auth/github_membership.rs
+++ b/crates/automata-ci-postgres/tests/auth/github_membership.rs
@@ -11,7 +11,7 @@ use automata_ci_auth::{
     time::UnixTimestamp,
     vault::TokenVersion,
 };
-use automata_ci_postgres::auth::PostgresGithubMembershipRepository;
+use automata_ci_auth_postgres::PostgresGithubMembershipRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/auth/human_auth.rs
+++ b/crates/automata-ci-postgres/tests/auth/human_auth.rs
@@ -21,10 +21,10 @@ use automata_ci_auth::{
     },
     time::UnixTimestamp,
 };
-use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::auth::{
+use automata_ci_auth_postgres::{
     PostgresHumanSessionRepository, PostgresLoginTransactionRepository,
 };
+use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
 use automata_ci_postgres::test_support::TestClock;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/auth/installation.rs
+++ b/crates/automata-ci-postgres/tests/auth/installation.rs
@@ -36,14 +36,14 @@ use automata_ci_auth::{
         ProviderTokenMetadata, ProviderTokenSet, ProviderTokenVault,
     },
 };
+use automata_ci_auth_postgres::{
+    PostgresHumanSessionRepository, PostgresInstallationRepository,
+    PostgresLoginTransactionRepository, PostgresProviderTokenVault,
+};
 use automata_ci_key_management::{
     KeyEncryptionContext, KeyEncryptionError, KeyEncryptionProvider, WrappedDataKey,
 };
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::auth::{
-    PostgresHumanSessionRepository, PostgresInstallationRepository,
-    PostgresLoginTransactionRepository, PostgresProviderTokenVault,
-};
 use automata_ci_postgres::test_support::TestClock;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/auth/login_device_cas.rs
+++ b/crates/automata-ci-postgres/tests/auth/login_device_cas.rs
@@ -15,8 +15,8 @@ use automata_ci_auth::{
     secret::{SecretBytes as AuthSecretBytes, SecretString},
     time::UnixTimestamp,
 };
+use automata_ci_auth_postgres::PostgresLoginTransactionRepository;
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::auth::PostgresLoginTransactionRepository;
 use automata_ci_postgres::test_support::TestClock;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/auth/management.rs
+++ b/crates/automata-ci-postgres/tests/auth/management.rs
@@ -22,12 +22,7 @@ use automata_ci_auth::{
     session::SessionId,
     time::UnixTimestamp,
 };
-use automata_ci_control::runner_auth::RunnerMachineDirectory as _;
-use automata_ci_core::{
-    Architecture, MAX_REGISTERED_RUNNERS, OperatingSystem, RunnerCapabilities, RunnerGroup,
-    RunnerId, RunnerLabel, RunnerPlatform, Sha256Digest,
-};
-use automata_ci_postgres::auth::{
+use automata_ci_auth_postgres::{
     PostgresHumanRbacManagementRepository,
     management::{
         ConsumeRunnerEnrollment, CreateRunnerEnrollmentToken,
@@ -35,8 +30,13 @@ use automata_ci_postgres::auth::{
         PrepareRunnerEnrollment, RunnerEnrollmentConsumeOutcome, RunnerEnrollmentPrepareOutcome,
     },
 };
-use automata_ci_postgres::runner_auth::PostgresRunnerMachineDirectory;
+use automata_ci_control::runner_auth::RunnerMachineDirectory as _;
+use automata_ci_core::{
+    Architecture, MAX_REGISTERED_RUNNERS, OperatingSystem, RunnerCapabilities, RunnerGroup,
+    RunnerId, RunnerLabel, RunnerPlatform, Sha256Digest,
+};
 use automata_ci_postgres::test_support::TestClock;
+use automata_ci_runner_auth_postgres::PostgresRunnerMachineDirectory;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/auth/provider_tokens.rs
+++ b/crates/automata-ci-postgres/tests/auth/provider_tokens.rs
@@ -10,8 +10,8 @@ use automata_ci_auth::{
         ProviderTokenVaultError, TokenVersion,
     },
 };
+use automata_ci_auth_postgres::PostgresProviderTokenVault;
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::auth::PostgresProviderTokenVault;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/auth/request_auth.rs
+++ b/crates/automata-ci-postgres/tests/auth/request_auth.rs
@@ -22,7 +22,7 @@ use automata_ci_auth::{
     time::UnixTimestamp,
     vault::TokenVersion,
 };
-use automata_ci_postgres::auth::{
+use automata_ci_auth_postgres::{
     PostgresGithubMembershipRepository, PostgresRequestAuthenticationResolver,
 };
 use automata_ci_postgres::test_support::TestClock;

--- a/crates/automata-ci-postgres/tests/auth/sign_in.rs
+++ b/crates/automata-ci-postgres/tests/auth/sign_in.rs
@@ -36,13 +36,13 @@ use automata_ci_auth::{
         ProviderTokenMetadata, ProviderTokenSet, ProviderTokenVault,
     },
 };
+use automata_ci_auth_postgres::{
+    PostgresHumanSessionRepository, PostgresHumanSignInFinalizer,
+    PostgresLoginTransactionRepository, PostgresProviderTokenVault,
+};
 use automata_ci_key_management::{
     KeyEncryptionContext, KeyEncryptionError, KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring,
     LocalKeyMaterial, SecretBytes, WrappedDataKey,
-};
-use automata_ci_postgres::auth::{
-    PostgresHumanSessionRepository, PostgresHumanSignInFinalizer,
-    PostgresLoginTransactionRepository, PostgresProviderTokenVault,
 };
 use automata_ci_postgres::test_support::TestClock;
 use sqlx::PgPool;

--- a/crates/automata-ci-postgres/tests/provisioning/entitlement.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/entitlement.rs
@@ -1,6 +1,3 @@
-use automata_ci_postgres::provisioning::{
-    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
-};
 use automata_ci_provisioning::{
     ApplyWorkspaceEntitlementCommand, AuthorizedApplyWorkspaceEntitlement,
     AuthorizedProvisionWorkspace, ComputeSeconds, DelegatedActorIssuer, DisplayName,
@@ -8,6 +5,9 @@ use automata_ci_provisioning::{
     ExternalAccountSubject, OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority,
     ProvisioningAuthorityId, ShardId, WorkspaceEntitlementApplier, WorkspaceExecutionEntitlement,
     WorkspaceId, WorkspaceProvisioner,
+};
+use automata_ci_provisioning_postgres::{
+    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
 };
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/provisioning/github_provider.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/github_provider.rs
@@ -2,10 +2,6 @@ use std::sync::Arc;
 
 use automata_ci_core::JobAuthorityProfile;
 use automata_ci_key_management::KeyEncryptionProvider;
-use automata_ci_postgres::provisioning::{
-    PostgresGithubProviderConfigurationApplier, PostgresGithubProviderDesiredStateReader,
-    PostgresWorkspaceGithubRepositoriesApplier, PostgresWorkspaceProvisioner,
-};
 use automata_ci_provisioning::{
     ApplyGithubProviderConfigurationCommand, ApplyWorkspaceGithubRepositoriesCommand,
     AuthorizedApplyGithubProviderConfiguration, AuthorizedApplyWorkspaceGithubRepositories,
@@ -17,6 +13,10 @@ use automata_ci_provisioning::{
     OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId,
     ShardId, WorkspaceGithubRepositoriesApplier, WorkspaceGithubRepositoriesFailureKind,
     WorkspaceGithubRepositoriesRevision, WorkspaceId, WorkspaceProvisioner,
+};
+use automata_ci_provisioning_postgres::{
+    PostgresGithubProviderConfigurationApplier, PostgresGithubProviderDesiredStateReader,
+    PostgresWorkspaceGithubRepositoriesApplier, PostgresWorkspaceProvisioner,
 };
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,

--- a/crates/automata-ci-postgres/tests/provisioning/usage.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/usage.rs
@@ -1,7 +1,3 @@
-use automata_ci_postgres::provisioning::{
-    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
-    PostgresWorkspaceUsageExporter,
-};
 use automata_ci_provisioning::{
     ApplyWorkspaceEntitlementCommand, AuthorizedApplyWorkspaceEntitlement,
     AuthorizedListWorkspaceUsage, AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName,
@@ -9,6 +5,10 @@ use automata_ci_provisioning::{
     ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId, ShardId,
     UsageExportCursor, UsageExportFailureKind, UsageExportPageSize, WorkspaceEntitlementApplier,
     WorkspaceExecutionEntitlement, WorkspaceId, WorkspaceProvisioner, WorkspaceUsageExporter,
+};
+use automata_ci_provisioning_postgres::{
+    PostgresWorkspaceEntitlementApplier, PostgresWorkspaceProvisioner,
+    PostgresWorkspaceUsageExporter,
 };
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/provisioning/workspace.rs
+++ b/crates/automata-ci-postgres/tests/provisioning/workspace.rs
@@ -1,9 +1,9 @@
-use automata_ci_postgres::provisioning::PostgresWorkspaceProvisioner;
 use automata_ci_provisioning::{
     AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
     OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId,
     ProvisioningFailureKind, ShardId, WorkspaceId, WorkspaceProvisioner,
 };
+use automata_ci_provisioning_postgres::PostgresWorkspaceProvisioner;
 use uuid::Uuid;
 
 use crate::support::{TestResult, run_with_database};

--- a/crates/automata-ci-postgres/tests/runner_auth/contracts.rs
+++ b/crates/automata-ci-postgres/tests/runner_auth/contracts.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use automata_ci_control::runner_auth::RunnerMachineDirectory;
-use automata_ci_postgres::runner_auth::PostgresRunnerMachineDirectory;
+use automata_ci_runner_auth_postgres::PostgresRunnerMachineDirectory;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use static_assertions::assert_impl_all;
 

--- a/crates/automata-ci-postgres/tests/runner_auth/directory.rs
+++ b/crates/automata-ci-postgres/tests/runner_auth/directory.rs
@@ -19,9 +19,9 @@ use automata_ci_control::runner_control::{
 use automata_ci_core::{
     JOB_IR_SCHEMA_VERSION, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
 };
-use automata_ci_postgres::runner_auth::PostgresRunnerMachineDirectory;
 use automata_ci_postgres::test_support::TestClock;
 use automata_ci_protocol::SUPPORTED_PROTOCOL_RANGE;
+use automata_ci_runner_auth_postgres::PostgresRunnerMachineDirectory;
 use automata_ci_store::{CommandCursor, HeartbeatRunnerSession, RunnerGeneration, StoreError};
 use sha2::{Digest as _, Sha256};
 use sqlx::PgPool;

--- a/crates/automata-ci-postgres/tests/secret/contracts.rs
+++ b/crates/automata-ci-postgres/tests/secret/contracts.rs
@@ -1,13 +1,13 @@
 use std::{fmt::Debug, sync::Arc};
 
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::secret::{BUILTIN_POSTGRES_PROVIDER_ID, PostgresSecretProvider};
 use automata_ci_secret::{
     ProviderCapability, ProviderErrorKind, ProviderOperationContext, ProviderRequestId,
     ProviderSecretLocator, ProviderVersionId, RepositoryScopeId, ResolveSecretVersionRequest,
     SecretAtRestProtection, SecretDescriptor, SecretId, SecretName, SecretProvider, SecretScope,
     TenantScopeId, WorkloadContext, WorkloadId,
 };
+use automata_ci_secret_postgres::{BUILTIN_POSTGRES_PROVIDER_ID, PostgresSecretProvider};
 use sqlx::postgres::PgPoolOptions;
 use static_assertions::assert_impl_all;
 

--- a/crates/automata-ci-postgres/tests/secret/provider.rs
+++ b/crates/automata-ci-postgres/tests/secret/provider.rs
@@ -7,10 +7,6 @@ use automata_ci_auth::{
     time::UnixTimestamp,
 };
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
-use automata_ci_postgres::{
-    secret::PostgresSecretProvider,
-    store::{PostgresSecretCustodyRepository, PostgresSecretManagementRepository},
-};
 use automata_ci_secret::{
     CreateSecretVersionRequest, CreatedSecretVersion, DestroySecretVersionRequest,
     ExistingSecretVersion, ProviderErrorKind, ProviderHealth, ProviderOperationContext,
@@ -19,6 +15,7 @@ use automata_ci_secret::{
     ResolveSecretVersionRequest, SecretDescriptor, SecretId, SecretName, SecretProvider,
     SecretScope, SecretValue, TenantScopeId, WorkloadContext, WorkloadId,
 };
+use automata_ci_secret_postgres::PostgresSecretProvider;
 use automata_ci_store::{
     ActivateBuiltinSecretProvider, ActivateBuiltinSecretProviderOutcome,
     BuiltinRepositorySecretVersion, BuiltinSecretCleanupRepository, BuiltinSecretCleanupTask,
@@ -31,6 +28,9 @@ use automata_ci_store::{
     RepositorySecretVersionMutationReservation, ReserveRepositorySecretVersionMutation,
     ReserveRepositorySecretVersionMutationOutcome, SecretCleanupWorkerId, SecretCustodyKeySet,
     SecretCustodyRepository as _, VerifySecretCustody, VerifySecretCustodyOutcome,
+};
+use automata_ci_store_postgres::{
+    PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
 };
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/secret/provider_replay.rs
+++ b/crates/automata-ci-postgres/tests/secret/provider_replay.rs
@@ -12,9 +12,6 @@ use automata_ci_key_management::{
     LocalKeyMaterial, SecretBytes, WrappedDataKey,
 };
 use automata_ci_postgres::test_support::TestClock;
-use automata_ci_postgres::{
-    secret::PostgresSecretProvider, store::PostgresSecretCustodyRepository,
-};
 use automata_ci_secret::{
     CreateSecretVersionRequest, CreatedSecretVersion, ExistingSecretVersion, ProviderCapability,
     ProviderErrorKind, ProviderOperationContext, ProviderRequestId, ProviderSecretLocator,
@@ -22,10 +19,12 @@ use automata_ci_secret::{
     RepositoryScopeId, SecretDescriptor, SecretId, SecretName, SecretProvider, SecretScope,
     SecretValue, TenantScopeId,
 };
+use automata_ci_secret_postgres::PostgresSecretProvider;
 use automata_ci_store::{
     SECRET_MUTATION_CONFIRMATION_TTL_MILLIS, SecretCustodyKeySet, SecretCustodyRepository as _,
     VerifySecretCustody, VerifySecretCustodyOutcome,
 };
+use automata_ci_store_postgres::PostgresSecretCustodyRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-postgres/tests/store/contracts/github_oidc.rs
+++ b/crates/automata-ci-postgres/tests/store/contracts/github_oidc.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_oidc_github::{OidcIssuanceRepository, OidcKeyId};
-use automata_ci_postgres::store::{
-    PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository, PostgresStore,
-};
 use automata_ci_store::{
     GithubOidcAuthorityRepository, GithubOidcCurrentPolicy, GithubOidcCurrentnessClock,
     GithubOidcCurrentnessClockError, GithubOidcKeyRetentionRepository, GithubOidcKeyUse,
     GithubOidcLoadedKey, GithubOidcSubjectPolicyMode, GithubOidcSubjectPolicyRevision,
+};
+use automata_ci_store_postgres::{
+    PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository, PostgresStore,
 };
 use sqlx::postgres::PgPoolOptions;
 

--- a/crates/automata-ci-postgres/tests/store/contracts/secret_management.rs
+++ b/crates/automata-ci-postgres/tests/store/contracts/secret_management.rs
@@ -1,8 +1,8 @@
-use automata_ci_postgres::store::PostgresSecretManagementRepository;
 use automata_ci_store::{
     BuiltinSecretCleanupRepository, RepositorySecretManagementReadRepository,
     RepositorySecretManagementRepository, SecretMutationRecoveryRepository,
 };
+use automata_ci_store_postgres::PostgresSecretManagementRepository;
 
 #[tokio::test]
 async fn concrete_adapter_is_redacted_and_ports_are_object_safe() {

--- a/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/concurrency_cancellation.rs
@@ -24,7 +24,6 @@ use automata_ci_core::{
     AttemptId, FencingToken, JobId, JobIrVersion, LeaseGuard, LeaseId, OperationId, QueuePolicy,
     RunId, RunnerRequirements, Sha256Digest, UnixMillis, WorkflowId,
 };
-use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, AdmissionObject, AdmissionRepository, AdmitWorkflowRun,
     AdmittedWorkflowJob, CommandCursor, CommandReplayLimit, DocumentSchema, HumanRunScope,
@@ -34,6 +33,7 @@ use automata_ci_store::{
     WorkflowAdmissionRepository as _, WorkflowAdmissionStoreError, WorkflowConcurrency,
     WorkflowSnapshotId,
 };
+use automata_ci_store_postgres::PostgresStore;
 
 const GROUP: &str = "deploy-main";
 const CANCELLATION_REASON: &str = "superseded by a newer workflow run";

--- a/crates/automata-ci-postgres/tests/store/execution/g1.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/g1.rs
@@ -30,7 +30,6 @@ use automata_ci_core::{
     OperatingSystem, OperationId, RunnerCapabilities, RunnerFeature, RunnerGroup, RunnerLabel,
     RunnerPlatform, RunnerRequirements, RunnerSessionId, Sha256Digest, UnixMillis,
 };
-use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
     CommandSequence, DocumentSchema, EnqueueRunnerCommand, HeartbeatRunnerSession, JobDependency,
@@ -38,6 +37,7 @@ use automata_ci_store::{
     RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
     StableRunnerSlot, StoreError, WORKFLOW_ADMISSION_EPOCH, WorkflowPlanRepository as _,
 };
+use automata_ci_store_postgres::PostgresStore;
 
 use crate::support::{
     TestClock, TestDatabase, TestResult, run_with_database, runner_capability_document,

--- a/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_clock.rs
@@ -39,7 +39,6 @@ use automata_ci_core::{
 use automata_ci_key_management::{
     KeyEncryptionContext, KeyEncryptionError, KeyEncryptionProvider, SecretBytes, WrappedDataKey,
 };
-use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AttemptStoreError, CommandCursor, CommandReplayDisposition, CommandReplayLimit,
     CommandSequence, DocumentSchema, EnqueueRunnerCommand,
@@ -48,6 +47,7 @@ use automata_ci_store::{
     RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse, RunnerProtocolVersion,
     StableRunnerSlot, StoreError,
 };
+use automata_ci_store_postgres::PostgresStore;
 use sqlx::PgPool;
 use tokio::sync::Semaphore;
 

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -40,7 +40,6 @@ use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, JobConclusion, JobLifecycle, Lease, LeaseGuard,
     LeaseId, LogSequence, LogStreamId, OperationId, Sha256Digest, UnixMillis,
 };
-use automata_ci_postgres::store::PostgresLogCommitListener;
 use automata_ci_protocol::{
     CommandSequence as ProtocolCommandSequence, INITIAL_RUNTIME_AUTHORITY_GENERATION,
     RunnerSlotOrdinal, RuntimeAuthorityDeliveryBinding,
@@ -52,6 +51,7 @@ use automata_ci_store::{
     RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
     RunnerProtocolVersion, StableRunnerSlot, StoreError,
 };
+use automata_ci_store_postgres::PostgresLogCommitListener;
 
 use crate::support::{
     SeedData, TestClock, TestDatabase, TestResult, run_with_database, runner_capability_document,

--- a/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_payload_tombstones.rs
@@ -11,13 +11,13 @@ use automata_ci_control::{
     },
 };
 use automata_ci_core::{JobIrVersion, OperationId, RunnerSessionId, Sha256Digest, UnixMillis};
-use automata_ci_postgres::store::PostgresStore;
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CloseRunnerSession, CommandCursor, CommandReplayLimit,
     DocumentSchema, EnqueueRunnerCommand, OpenRunnerSession, RunnerCommandPayload,
     RunnerGeneration, RunnerOperationKind, RunnerOperationRequest, RunnerOperationResponse,
     RunnerPayloadTombstoneReason, RunnerProtocolVersion, RunnerSessionFence, StoreError,
 };
+use automata_ci_store_postgres::PostgresStore;
 
 use crate::support::{
     TestDatabase, TestResult, run_with_database, runner_capability_document, seed_control_plane,

--- a/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/web_reads.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 
 use crate::support::{TestDatabase, TestResult, run_with_database, seed_control_plane};
 
-use automata_ci_postgres::store::PostgresLiveLogTicketRepository;
+use automata_ci_store_postgres::PostgresLiveLogTicketRepository;
 
 #[derive(Clone, Copy, Debug)]
 #[allow(clippy::struct_field_names)]

--- a/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_oidc.rs
@@ -23,9 +23,6 @@ use automata_ci_oidc_github::{
     OidcServiceErrorKind, OidcSupportedClaims, OidcTokenLifetime, RequestBearerConfig,
     RequestBearerKey, RequestBearerKeyring, Rs256Keyring, Rs256SigningKey, RsaPublicJwk,
 };
-use automata_ci_postgres::store::{
-    PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository,
-};
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, ActivatedLogicalInstanceDescriptor,
     AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun, AdmittedLogicalWorkflowJob,
@@ -61,6 +58,9 @@ use automata_ci_store::{
     RetainGithubOidcKey, ReusableSecretPermission, RoutingDocument, RunnerGeneration,
     RunnerProtocolVersion, StableRunnerSlot, StoreError, TenantScope, WorkflowAdmissionIdempotency,
     WorkflowPlanRepository as _, WorkflowSnapshotId, github_oidc_rs256_public_key_fingerprint,
+};
+use automata_ci_store_postgres::{
+    PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/store/provider/github_schedule.rs
+++ b/crates/automata-ci-postgres/tests/store/provider/github_schedule.rs
@@ -7,7 +7,6 @@ use automata_ci_core::{
     TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy, TrustRepositoryEvidence,
     TrustTokenRecursion, UnixMillis, WorkflowId, WorkflowJobKey,
 };
-use automata_ci_postgres::store::PostgresStore;
 use automata_ci_schedule::CronExpression;
 use automata_ci_store::{
     AdmissionObject, AdmissionRepository, AdmitLogicalWorkflowRun, AdmittedLogicalWorkflowJob,
@@ -36,6 +35,7 @@ use automata_ci_store::{
     RegisterGithubScheduledCheckSubject, RetryGithubScheduleFire, TenantScope,
     WorkflowAdmissionIdempotency, WorkflowSnapshotId,
 };
+use automata_ci_store_postgres::PostgresStore;
 use uuid::Uuid;
 
 use crate::support::{TestResult, run_with_database};

--- a/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
+++ b/crates/automata-ci-postgres/tests/store/security/managed_secret_authority.rs
@@ -26,9 +26,6 @@ use automata_ci_key_management::{
     EnvelopeCodec, KeyEncryptionContext, KeyEncryptionProvider, KeyId, KeyPurpose,
     LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes,
 };
-use automata_ci_postgres::store::{
-    PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
-};
 use automata_ci_store::{
     AcceptManifestPinnedGithubDelivery, AcceptProviderDelivery, AcknowledgeManagedSecretDelivery,
     ActivatedLogicalInstanceDescriptor, AdmissionObject, AdmissionRepository,
@@ -70,6 +67,9 @@ use automata_ci_store::{
     RunnerProtocolVersion, RunnerSessionFence, SecretCustodyKeySet, SecretCustodyRepository as _,
     SecretWorkloadGrantId, StableRunnerSlot, TenantScope, VerifySecretCustody,
     VerifySecretCustodyOutcome, WorkflowAdmissionIdempotency, WorkflowSnapshotId,
+};
+use automata_ci_store_postgres::{
+    PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
 };
 use sha2::{Digest as _, Sha256};
 use sqlx::{PgPool, Postgres, Transaction};

--- a/crates/automata-ci-postgres/tests/store/security/secret_custody.rs
+++ b/crates/automata-ci-postgres/tests/store/security/secret_custody.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use automata_ci_key_management::{
     KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes,
 };
-use automata_ci_postgres::store::PostgresSecretCustodyRepository;
 use automata_ci_store::{
     SECRET_CUSTODY_CANARY_GENERATION, SecretCustodyKeySet, SecretCustodyRepository as _,
     SecretCustodyRepositoryError, VerifySecretCustody, VerifySecretCustodyOutcome,
 };
+use automata_ci_store_postgres::PostgresSecretCustodyRepository;
 
 use crate::support::{TestDatabase, TestResult, run_with_database};
 

--- a/crates/automata-ci-postgres/tests/store/security/secret_management.rs
+++ b/crates/automata-ci-postgres/tests/store/security/secret_management.rs
@@ -11,9 +11,6 @@ use automata_ci_key_management::{
     EnvelopeCodec, KeyEncryptionContext, KeyEncryptionProvider, KeyId, KeyPurpose,
     LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes,
 };
-use automata_ci_postgres::store::{
-    PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
-};
 use automata_ci_store::{
     ActivateBuiltinSecretProvider, ActivateBuiltinSecretProviderOutcome,
     BUILTIN_SECRET_PROVIDER_ID, BuiltinRepositorySecretVersion, BuiltinSecretCleanupRepository,
@@ -35,6 +32,9 @@ use automata_ci_store::{
     SecretCleanupWorkerId, SecretCustodyKeySet, SecretCustodyRepository as _,
     SecretMetadataPageSize, SecretMutationRecoveryFence, SecretMutationRecoveryReconciliation,
     SecretMutationRecoveryRepository, VerifySecretCustody, VerifySecretCustodyOutcome,
+};
+use automata_ci_store_postgres::{
+    PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
 };
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;

--- a/crates/automata-ci-postgres/tests/support/mod.rs
+++ b/crates/automata-ci-postgres/tests/support/mod.rs
@@ -11,7 +11,6 @@ use automata_ci_key_management::{
     EncryptedEnvelope, KeyEncryptionProvider, KeyId, LocalAes256GcmKeyring, LocalKeyMaterial,
     SecretBytes, WrappedDataKey,
 };
-use automata_ci_postgres::store::PostgresStore;
 #[allow(unused_imports)] // Consolidated binaries consume different fixture subsets.
 pub use automata_ci_postgres::test_support::{
     PostgresTestDatabase as TestDatabase, TestClock, TestResult,
@@ -35,6 +34,7 @@ use automata_ci_store::{
     RegisterProviderDeliveryWorkflowInventory, ReleaseGithubServerServiceHandoff, RoutingDocument,
     RunnerGeneration, RunnerProtocolVersion, RunnerSessionFence,
 };
+use automata_ci_store_postgres::PostgresStore;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-provisioning-grpc/README.md
+++ b/crates/automata-ci-provisioning-grpc/README.md
@@ -16,9 +16,9 @@ it only when a complete private management-listener configuration is supplied;
 standalone self-hosted deployments expose no placeholder endpoint. The product
 maps a dedicated-CA-verified leaf certificate through an exact SHA-256 pin to a
 stable shard-scoped authority, and supplies the durable
-`automata-ci-postgres` management transaction adapters. Entitlement snapshots
-are complete, monotonically revisioned workspace aggregates; the contract does
-not allocate rolling per-job budget slices.
+`automata-ci-provisioning-postgres` management transaction adapters.
+Entitlement snapshots are complete, monotonically revisioned workspace
+aggregates; the contract does not allocate rolling per-job budget slices.
 
 The usage-export schema defines an authority-scoped, cursor-paginated feed of
 immutable actual-execution facts. It is intentionally not registered or

--- a/crates/automata-ci-provisioning-postgres/README.md
+++ b/crates/automata-ci-provisioning-postgres/README.md
@@ -6,5 +6,6 @@ authority-scoped usage export. Provider credentials use the mandatory
 control-plane envelope key provider; readers return one repeatable-read current
 snapshot and never expose ciphertext as configuration.
 
-Portable callers should depend on `automata-ci-provisioning`; the
-`automata-ci-postgres` facade preserves the existing `provisioning` namespace.
+Portable callers should depend on `automata-ci-provisioning`; product
+composition and integration tests import this concrete adapter directly.
+`automata-ci-postgres` owns only shared PostgreSQL test support.

--- a/crates/automata-ci-provisioning/README.md
+++ b/crates/automata-ci-provisioning/README.md
@@ -10,7 +10,7 @@ idempotency identity, mutations, and export behind explicit ports.
 It contains no gRPC, HTTP, SQL, Cloud billing, or private Automata Cloud code.
 The public versioned wire schema lives beside its gRPC adapter in
 `automata-ci-provisioning-grpc`; the atomic PostgreSQL adapter lives in
-the `provisioning` namespace of `automata-ci-postgres`.
+`automata-ci-provisioning-postgres`.
 
 Usage export contains provider-neutral actual execution facts rather than
 prices, invoices, or Stripe objects. A consumer deduplicates stable event IDs

--- a/crates/automata-ci-results-github/Cargo.toml
+++ b/crates/automata-ci-results-github/Cargo.toml
@@ -40,6 +40,7 @@ automata-ci-control = { workspace = true, features = ["adapter-spi"] }
 automata-ci-postgres = { workspace = true, features = ["test-support"] }
 automata-ci-protocol-protobuf.workspace = true
 automata-ci-store.workspace = true
+automata-ci-store-postgres = { workspace = true, features = ["test-support"] }
 http-body-util.workspace = true
 tokio.workspace = true
 tower.workspace = true

--- a/crates/automata-ci-results-github/tests/support/postgres.rs
+++ b/crates/automata-ci-results-github/tests/support/postgres.rs
@@ -3,7 +3,6 @@ use automata_ci_core::{
     Architecture, JobId, JobIrVersion, OperatingSystem, RunId, RunnerCapabilities, RunnerId,
     RunnerPlatform, RunnerRequirements, RunnerSessionId, UnixMillis,
 };
-use automata_ci_postgres::store::PostgresStore;
 pub use automata_ci_postgres::test_support::{
     PostgresTestDatabase as TestDatabase, TestResult, run_with_database,
 };
@@ -11,6 +10,7 @@ use automata_ci_store::{
     OpenRunnerSession, RoutingDocument, RunnerGeneration, RunnerProtocolVersion,
     RunnerSessionFence, WORKFLOW_ADMISSION_EPOCH,
 };
+use automata_ci_store_postgres::PostgresStore;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/automata-ci-runner-auth-postgres/README.md
+++ b/crates/automata-ci-runner-auth-postgres/README.md
@@ -3,5 +3,6 @@
 PostgreSQL durable runner-machine authority lookup for Automata. Each lookup
 uses current server-owned state and never trusts runner-supplied identity.
 
-The `automata-ci-postgres` facade preserves the existing `runner_auth`
-namespace for server composition.
+Product composition and integration tests import this adapter directly.
+`automata-ci-postgres` owns only shared PostgreSQL test support and does not
+re-export adapter namespaces.

--- a/crates/automata-ci-secret-postgres/README.md
+++ b/crates/automata-ci-secret-postgres/README.md
@@ -4,4 +4,6 @@ Envelope-encrypted PostgreSQL storage for Automata's built-in secret provider.
 Plaintext is encrypted before SQL execution and envelopes are bound to the
 exact tenant and immutable secret version.
 
-The `automata-ci-postgres` facade preserves the existing `secret` namespace.
+Product composition and integration tests import this adapter directly.
+`automata-ci-postgres` owns only shared PostgreSQL test support and does not
+re-export adapter namespaces.

--- a/crates/automata-ci-store-postgres/Cargo.toml
+++ b/crates/automata-ci-store-postgres/Cargo.toml
@@ -11,6 +11,10 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 
+[features]
+default = []
+test-support = []
+
 [dependencies]
 async-trait.workspace = true
 automata-ci-auth.workspace = true
@@ -21,6 +25,8 @@ automata-ci-key-management.workspace = true
 automata-ci-oidc-github.workspace = true
 automata-ci-schedule.workspace = true
 automata-ci-store = { workspace = true, features = ["adapter-spi"] }
+automata-ci-tls.workspace = true
+percent-encoding.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -30,6 +36,11 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+url.workspace = true
+zeroize.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+rcgen.workspace = true

--- a/crates/automata-ci-store-postgres/README.md
+++ b/crates/automata-ci-store-postgres/README.md
@@ -5,8 +5,9 @@ provider, and managed-secret metadata repositories. This crate owns the SQLx
 migration lineage and concrete `PostgresStore` lifecycle.
 
 Portable callers should depend on the ports in `automata-ci-store` and
-`automata-ci-control`; the `automata-ci-postgres` facade preserves the existing
-`store` namespace for compatibility.
+`automata-ci-control`; product composition and integration tests import this
+concrete adapter directly. `automata-ci-postgres` owns only shared PostgreSQL
+test support.
 
 ## Schema migrations
 

--- a/crates/automata-ci-store-postgres/src/connection.rs
+++ b/crates/automata-ci-store-postgres/src/connection.rs
@@ -1,0 +1,597 @@
+use std::{env, ffi::OsStr, fmt, net::IpAddr, ops::Deref};
+
+use automata_ci_tls::{MAX_CA_CERTIFICATE_PEM_BYTES, ValidatedCaCertificate};
+use percent_encoding::percent_decode_str;
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use thiserror::Error;
+use url::Url;
+use zeroize::Zeroizing;
+
+const MAX_DATABASE_URL_BYTES: usize = 16 * 1024;
+const APPLICATION_NAME: &str = "automata-ci";
+const SEARCH_PATH: &str = "public";
+
+/// Maximum accepted size of the additive private `PostgreSQL` CA certificate.
+pub const MAX_POSTGRES_PRIVATE_CA_PEM_BYTES: usize = MAX_CA_CERTIFICATE_PEM_BYTES;
+
+/// Closed transport and server-authentication policy for `PostgreSQL`.
+pub struct PostgresTransportSecurity {
+    policy: PostgresTransportPolicy,
+}
+
+enum PostgresTransportPolicy {
+    WebPkiVerifyFull,
+    WebPkiPlusPrivateCaVerifyFull(ValidatedCaCertificate),
+    LoopbackPlaintext,
+}
+
+impl PostgresTransportSecurity {
+    /// Requires TLS, hostname verification, and the pinned Web PKI root set.
+    #[must_use]
+    pub const fn web_pki_verify_full() -> Self {
+        Self {
+            policy: PostgresTransportPolicy::WebPkiVerifyFull,
+        }
+    }
+
+    /// Requires TLS and hostname verification against the pinned Web PKI root
+    /// set plus one explicit deployment-provided CA.
+    ///
+    /// This mode deliberately names the union: `SQLx` adds the supplied CA to its
+    /// compiled Web PKI roots rather than replacing them.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized error unless `certificate_pem` is exactly one
+    /// canonical, bounded X.509 CA certificate.
+    pub fn web_pki_plus_private_ca_verify_full(
+        certificate_pem: impl Into<Vec<u8>>,
+    ) -> Result<Self, PostgresConnectionConfigError> {
+        let certificate = ValidatedCaCertificate::new(certificate_pem)
+            .map_err(|_| PostgresConnectionConfigError::InvalidPrivateCa)?;
+        Ok(Self {
+            policy: PostgresTransportPolicy::WebPkiPlusPrivateCaVerifyFull(certificate),
+        })
+    }
+
+    /// Disables TLS for an exact literal-loopback TCP endpoint.
+    ///
+    /// [`PostgresConnectionConfig::parse`] rejects domain names, remote
+    /// addresses, and Unix-domain sockets when this policy is selected.
+    #[must_use]
+    pub const fn loopback_plaintext() -> Self {
+        Self {
+            policy: PostgresTransportPolicy::LoopbackPlaintext,
+        }
+    }
+}
+
+impl fmt::Debug for PostgresTransportSecurity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match &self.policy {
+            PostgresTransportPolicy::WebPkiVerifyFull => {
+                "PostgresTransportSecurity::WebPkiVerifyFull"
+            }
+            PostgresTransportPolicy::WebPkiPlusPrivateCaVerifyFull(_) => {
+                "PostgresTransportSecurity::WebPkiPlusPrivateCaVerifyFull([certificate redacted])"
+            }
+            PostgresTransportPolicy::LoopbackPlaintext => {
+                "PostgresTransportSecurity::LoopbackPlaintext"
+            }
+        })
+    }
+}
+
+/// Validated exact `PostgreSQL` TCP connection configuration.
+pub struct PostgresConnectionConfig {
+    options: PgConnectOptions,
+    transport: RetainedTransportKind,
+}
+
+struct SensitiveUrl(Option<Url>);
+
+impl SensitiveUrl {
+    fn parse(value: &str) -> Result<Self, PostgresConnectionConfigError> {
+        Url::parse(value)
+            .map(|url| Self(Some(url)))
+            .map_err(|_| PostgresConnectionConfigError::InvalidUrl)
+    }
+}
+
+impl Deref for SensitiveUrl {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().expect("sensitive URL retained until drop")
+    }
+}
+
+impl fmt::Debug for SensitiveUrl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SensitiveUrl([redacted])")
+    }
+}
+
+impl Drop for SensitiveUrl {
+    fn drop(&mut self) {
+        if let Some(url) = self.0.take() {
+            let _serialized = Zeroizing::new(String::from(url));
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RetainedTransportKind {
+    WebPkiVerifyFull,
+    WebPkiPlusPrivateCaVerifyFull,
+    LoopbackPlaintext,
+}
+
+impl PostgresConnectionConfig {
+    /// Parses the current exact `postgresql://` connection contract.
+    ///
+    /// The URL must explicitly contain one TCP host, port, user, non-empty
+    /// password, and database. Query parameters, fragments, socket paths,
+    /// implicit fields, and the legacy `postgres://` alias are rejected. The
+    /// process environment must contain no key beginning with `PG`, preventing
+    /// `SQLx`/libpq environment and passfile semantics from becoming a second
+    /// configuration authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized error for an ambient `PostgreSQL` environment, an
+    /// invalid URL, or plaintext transport targeting anything except a literal
+    /// loopback IP address.
+    pub fn parse(
+        database_url: &str,
+        transport_security: PostgresTransportSecurity,
+    ) -> Result<Self, PostgresConnectionConfigError> {
+        Self::parse_with_environment(
+            database_url,
+            transport_security,
+            env::vars_os().map(|(key, _)| key),
+        )
+    }
+
+    fn parse_with_environment(
+        database_url: &str,
+        transport_security: PostgresTransportSecurity,
+        environment_keys: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    ) -> Result<Self, PostgresConnectionConfigError> {
+        reject_ambient_postgres_environment(environment_keys)?;
+        if database_url.is_empty()
+            || database_url.len() > MAX_DATABASE_URL_BYTES
+            || database_url.chars().any(char::is_control)
+            || !database_url.starts_with("postgresql://")
+        {
+            return Err(PostgresConnectionConfigError::InvalidUrl);
+        }
+        let url = SensitiveUrl::parse(database_url)?;
+        if url.scheme() != "postgresql"
+            || url.cannot_be_a_base()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(PostgresConnectionConfigError::InvalidUrl);
+        }
+
+        let host = canonical_tcp_host(&url)?;
+        let port = url
+            .port()
+            .filter(|port| *port != 0)
+            .ok_or(PostgresConnectionConfigError::InvalidUrl)?;
+        let username = decode_required_component(url.username())?;
+        let password = decode_required_component(
+            url.password()
+                .ok_or(PostgresConnectionConfigError::InvalidUrl)?,
+        )?;
+        let mut path_segments = url
+            .path_segments()
+            .ok_or(PostgresConnectionConfigError::InvalidUrl)?;
+        let database = decode_required_component(
+            path_segments
+                .next()
+                .ok_or(PostgresConnectionConfigError::InvalidUrl)?,
+        )?;
+        if path_segments.next().is_some() {
+            return Err(PostgresConnectionConfigError::InvalidUrl);
+        }
+
+        if matches!(
+            &transport_security.policy,
+            PostgresTransportPolicy::LoopbackPlaintext
+        ) && !literal_loopback(&url)
+        {
+            return Err(PostgresConnectionConfigError::InsecureTransport);
+        }
+
+        // `new_without_pgpass` still reads PG* variables in SQLx 0.9. Parsing
+        // rejected every such key immediately before this constructor. Every
+        // imported field is then set explicitly, and `apply_pgpass` is never
+        // called.
+        let options = PgConnectOptions::new_without_pgpass()
+            .host(&host)
+            .port(port)
+            .username(&username)
+            .password(&password)
+            .database(&database)
+            .application_name(APPLICATION_NAME)
+            .options([("search_path", SEARCH_PATH)]);
+        let (options, transport) = match transport_security.policy {
+            PostgresTransportPolicy::WebPkiVerifyFull => (
+                options.ssl_mode(PgSslMode::VerifyFull),
+                RetainedTransportKind::WebPkiVerifyFull,
+            ),
+            PostgresTransportPolicy::WebPkiPlusPrivateCaVerifyFull(certificate) => {
+                let options = options
+                    .ssl_mode(PgSslMode::VerifyFull)
+                    .ssl_root_cert_from_pem(certificate.as_pem().to_vec());
+                (
+                    options,
+                    RetainedTransportKind::WebPkiPlusPrivateCaVerifyFull,
+                )
+            }
+            PostgresTransportPolicy::LoopbackPlaintext => (
+                options.ssl_mode(PgSslMode::Disable),
+                RetainedTransportKind::LoopbackPlaintext,
+            ),
+        };
+        Ok(Self { options, transport })
+    }
+
+    pub(crate) fn into_connect_options(self) -> PgConnectOptions {
+        self.options
+    }
+}
+
+impl fmt::Debug for PostgresConnectionConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresConnectionConfig")
+            .field("endpoint", &"[redacted]")
+            .field("credentials", &"[redacted]")
+            .field("transport", &self.transport)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Rejection from the exact `PostgreSQL` connection boundary.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum PostgresConnectionConfigError {
+    /// A process environment key beginning with `PG` was present.
+    #[error("ambient PostgreSQL environment configuration is not permitted")]
+    AmbientEnvironment,
+    /// The URL was not the exact current TCP connection grammar.
+    #[error("PostgreSQL URL must contain exact explicit TCP connection fields")]
+    InvalidUrl,
+    /// Plaintext transport did not target a literal loopback IP address.
+    #[error("plaintext PostgreSQL requires a literal loopback TCP endpoint")]
+    InsecureTransport,
+    /// The additive private CA was not one valid canonical CA document.
+    #[error("PostgreSQL private CA source must contain one valid canonical CA certificate")]
+    InvalidPrivateCa,
+}
+
+fn reject_ambient_postgres_environment(
+    keys: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<(), PostgresConnectionConfigError> {
+    if keys.into_iter().any(|key| {
+        key.as_ref()
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("PG")
+    }) {
+        return Err(PostgresConnectionConfigError::AmbientEnvironment);
+    }
+    Ok(())
+}
+
+fn decode_required_component(
+    value: &str,
+) -> Result<Zeroizing<String>, PostgresConnectionConfigError> {
+    if value.is_empty() || !valid_percent_encoding(value.as_bytes()) {
+        return Err(PostgresConnectionConfigError::InvalidUrl);
+    }
+    let decoded = percent_decode_str(value)
+        .decode_utf8()
+        .map_err(|_| PostgresConnectionConfigError::InvalidUrl)?
+        .into_owned();
+    if decoded.is_empty() || decoded.chars().any(char::is_control) {
+        return Err(PostgresConnectionConfigError::InvalidUrl);
+    }
+    Ok(Zeroizing::new(decoded))
+}
+
+fn valid_percent_encoding(value: &[u8]) -> bool {
+    let mut index = 0;
+    while index < value.len() {
+        if value[index] != b'%' {
+            index += 1;
+            continue;
+        }
+        if index + 2 >= value.len()
+            || !value[index + 1].is_ascii_hexdigit()
+            || !value[index + 2].is_ascii_hexdigit()
+        {
+            return false;
+        }
+        index += 3;
+    }
+    true
+}
+
+fn literal_loopback(url: &Url) -> bool {
+    url.host_str()
+        .map(|host| {
+            host.strip_prefix('[')
+                .and_then(|host| host.strip_suffix(']'))
+                .unwrap_or(host)
+        })
+        .and_then(|host| host.parse::<IpAddr>().ok())
+        .is_some_and(|address| address.is_loopback())
+}
+
+fn canonical_tcp_host(url: &Url) -> Result<String, PostgresConnectionConfigError> {
+    let serialized_host = url
+        .host_str()
+        .ok_or(PostgresConnectionConfigError::InvalidUrl)?;
+    let host = serialized_host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(serialized_host);
+    if let Ok(address) = host.parse::<IpAddr>() {
+        return Ok(address.to_string());
+    }
+    if host.is_empty()
+        || host.len() > 253
+        || host
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'.')
+        || host.split('.').any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+                || !label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                || !label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+        })
+    {
+        return Err(PostgresConnectionConfigError::InvalidUrl);
+    }
+    Ok(host.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair, KeyUsagePurpose};
+
+    use super::*;
+
+    fn web_pki() -> PostgresTransportSecurity {
+        PostgresTransportSecurity::web_pki_verify_full()
+    }
+
+    fn ca_pem() -> Vec<u8> {
+        let key = KeyPair::generate().expect("CA key");
+        let mut params = CertificateParams::default();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        params
+            .self_signed(&key)
+            .expect("self-signed CA")
+            .pem()
+            .into_bytes()
+    }
+
+    #[test]
+    fn exact_url_builds_only_explicit_tcp_options() {
+        let config = PostgresConnectionConfig::parse(
+            "postgresql://automata:p%40ssword@database.invalid:6432/automata",
+            web_pki(),
+        )
+        .expect("exact URL");
+        let options = config.into_connect_options();
+
+        assert_eq!(options.get_host(), "database.invalid");
+        assert_eq!(options.get_port(), 6432);
+        assert_eq!(options.get_username(), "automata");
+        assert_eq!(options.get_database(), Some("automata"));
+        assert_eq!(options.get_socket(), None);
+        assert_eq!(options.get_application_name(), Some(APPLICATION_NAME));
+        assert_eq!(options.get_options(), Some("-c search_path=public"));
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyFull));
+    }
+
+    #[test]
+    fn additive_ca_mode_is_explicit_validated_and_redacted() {
+        let certificate_pem = ca_pem();
+        let pem_marker = std::str::from_utf8(&certificate_pem)
+            .expect("PEM is ASCII")
+            .lines()
+            .nth(1)
+            .expect("PEM body")
+            .get(..32)
+            .expect("PEM marker")
+            .to_owned();
+        let transport =
+            PostgresTransportSecurity::web_pki_plus_private_ca_verify_full(certificate_pem)
+                .expect("validated additive CA");
+        let transport_debug = format!("{transport:?}");
+        assert!(transport_debug.contains("WebPkiPlusPrivateCaVerifyFull"));
+        assert!(!transport_debug.contains(&pem_marker));
+
+        let config = PostgresConnectionConfig::parse(
+            "postgresql://automata:password@database.automata.invalid:5432/automata",
+            transport,
+        )
+        .expect("reserved local DNS identity");
+        let options = config.into_connect_options();
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyFull));
+        assert!(format!("{options:?}").contains("ssl_root_cert: Some"));
+
+        assert!(matches!(
+            PostgresTransportSecurity::web_pki_plus_private_ca_verify_full(b"not a CA".to_vec()),
+            Err(PostgresConnectionConfigError::InvalidPrivateCa)
+        ));
+    }
+
+    #[test]
+    fn rejects_every_implicit_or_alternate_url_shape_without_echoing_secrets() {
+        for invalid in [
+            "postgres://user:secret@database.invalid:5432/automata",
+            "POSTGRESQL://user:secret@database.invalid:5432/automata",
+            "postgresql://user:secret@database.invalid/automata",
+            "postgresql://user:secret@database.invalid:0/automata",
+            "postgresql://:secret@database.invalid:5432/automata",
+            "postgresql://user@database.invalid:5432/automata",
+            "postgresql://user:@database.invalid:5432/automata",
+            "postgresql://user:secret@:5432/automata",
+            "postgresql://user:secret@database.invalid:5432/",
+            "postgresql://user:secret@database.invalid:5432/automata/extra",
+            "postgresql://user:secret@database.invalid:5432/automata?sslmode=disable",
+            "postgresql://user:secret@database.invalid:5432/automata?host=%2Frun%2Fpostgresql",
+            "postgresql://user:secret@database.invalid:5432/automata#fragment",
+            "postgresql://user:%ZZ@database.invalid:5432/automata",
+            "postgresql://user:secret@database.invalid:5432/automata\n",
+            "postgresql:///automata?host=/run/postgresql&user=user&password=secret&port=5432",
+            "postgresql://user:secret@127.1:5432/automata",
+            "postgresql://user:secret@database_.invalid:5432/automata",
+            "postgresql://user:secret@-database.invalid:5432/automata",
+            "postgresql://user:secret@database.invalid.:5432/automata",
+        ] {
+            let Err(error) = PostgresConnectionConfig::parse(invalid, web_pki()) else {
+                panic!("invalid URL accepted: {invalid}");
+            };
+            assert_eq!(
+                error,
+                PostgresConnectionConfigError::InvalidUrl,
+                "{invalid}"
+            );
+            assert!(!error.to_string().contains("secret"));
+        }
+    }
+
+    #[test]
+    fn plaintext_accepts_only_literal_loopback_tcp() {
+        for (valid, expected_host) in [
+            (
+                "postgresql://user:secret@127.0.0.1:5432/automata",
+                "127.0.0.1",
+            ),
+            (
+                "postgresql://user:secret@127.42.0.9:5432/automata",
+                "127.42.0.9",
+            ),
+            ("postgresql://user:secret@[::1]:5432/automata", "::1"),
+        ] {
+            let config = PostgresConnectionConfig::parse(
+                valid,
+                PostgresTransportSecurity::loopback_plaintext(),
+            )
+            .unwrap_or_else(|error| panic!("literal loopback rejected: {valid}: {error}"));
+            let options = config.into_connect_options();
+            assert_eq!(options.get_host(), expected_host);
+            assert!(matches!(options.get_ssl_mode(), PgSslMode::Disable));
+        }
+
+        for invalid in [
+            "postgresql://user:secret@localhost:5432/automata",
+            "postgresql://user:secret@database.invalid:5432/automata",
+            "postgresql://user:secret@192.0.2.1:5432/automata",
+        ] {
+            assert!(
+                matches!(
+                    PostgresConnectionConfig::parse(
+                        invalid,
+                        PostgresTransportSecurity::loopback_plaintext(),
+                    ),
+                    Err(PostgresConnectionConfigError::InsecureTransport)
+                ),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_postgres_environment_key_and_passfile_authority_is_rejected() {
+        const URL: &str = "postgresql://user:password@database.invalid:5432/automata";
+        for key in [
+            "PGHOST",
+            "PGHOSTADDR",
+            "PGPORT",
+            "PGDATABASE",
+            "PGUSER",
+            "PGPASSWORD",
+            "PGPASSFILE",
+            "PGAPPNAME",
+            "PGOPTIONS",
+            "PGSSLMODE",
+            "PGSSLROOTCERT",
+            "PGSSLCERT",
+            "PGSSLKEY",
+            "PGSERVICE",
+            "PGSERVICEFILE",
+            "PGFUTURE_SQLX_OPTION",
+            "pghost",
+        ] {
+            assert_eq!(
+                reject_ambient_postgres_environment([key]),
+                Err(PostgresConnectionConfigError::AmbientEnvironment),
+                "{key}"
+            );
+            assert!(matches!(
+                PostgresConnectionConfig::parse_with_environment(URL, web_pki(), [key]),
+                Err(PostgresConnectionConfigError::AmbientEnvironment)
+            ));
+        }
+        assert_eq!(
+            reject_ambient_postgres_environment(["PATH", "PAGER"]),
+            Ok(())
+        );
+        PostgresConnectionConfig::parse_with_environment(URL, web_pki(), ["HOME", "APPDATA"])
+            .expect("default passfile location variables are inert without apply_pgpass");
+    }
+
+    #[test]
+    fn debug_and_errors_redact_connection_credentials_and_ca() {
+        let secret = "unique-database-password";
+        let config = PostgresConnectionConfig::parse(
+            &format!(
+                "postgresql://sensitive-user:{secret}@sensitive-host.invalid:5432/sensitive-database"
+            ),
+            web_pki(),
+        )
+        .expect("exact URL");
+        let debug = format!("{config:?}");
+        for marker in [
+            secret,
+            "sensitive-user",
+            "sensitive-host",
+            "sensitive-database",
+        ] {
+            assert!(!debug.contains(marker));
+        }
+        assert!(debug.contains("[redacted]"));
+    }
+
+    #[tokio::test]
+    async fn store_consumes_only_a_validated_configuration_and_nonzero_pool_bound() {
+        let config = PostgresConnectionConfig::parse(
+            "postgresql://automata:password@127.0.0.1:5432/automata",
+            PostgresTransportSecurity::loopback_plaintext(),
+        )
+        .expect("validated connection");
+
+        assert!(matches!(
+            crate::PostgresStore::connect(config, 0).await,
+            Err(crate::PostgresStoreError::InvalidPoolSize)
+        ));
+    }
+}

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 //! `PostgreSQL` implementation of Automata's durable store ports.
 
-use std::{fmt, net::IpAddr, str::FromStr as _, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use automata_ci_auth::authorization::{OutputVisibility, SecretExposureClass};
@@ -18,10 +18,7 @@ use automata_ci_core::{
     JobLifecycle, Lease, LeaseGuard, LeaseId, RunnerId, RunnerSessionId, UnixMillis,
 };
 use automata_ci_key_management::{EnvelopeCodec, KeyEncryptionProvider, KeyPurpose};
-use sqlx::{
-    PgConnection, PgPool, Row as _,
-    postgres::{PgConnectOptions, PgPoolOptions, PgSslMode},
-};
+use sqlx::{PgConnection, PgPool, Row as _, postgres::PgPoolOptions};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -39,6 +36,7 @@ mod schema_bindings_tests;
 
 mod admission;
 mod conformance;
+mod connection;
 mod durable_schema;
 mod event_subject;
 mod g1;
@@ -80,6 +78,10 @@ mod workflow_rerun;
 mod workflow_run_trust_snapshot;
 mod workflow_runtime_policy;
 
+pub use connection::{
+    MAX_POSTGRES_PRIVATE_CA_PEM_BYTES, PostgresConnectionConfig, PostgresConnectionConfigError,
+    PostgresTransportSecurity,
+};
 pub use github_oidc::{
     PostgresGithubOidcAuthorityRepository, PostgresGithubOidcIssuanceRepository,
 };
@@ -95,30 +97,15 @@ pub use secret_management::PostgresSecretManagementRepository;
 /// APIs where exposing the `PostgreSQL` driver as an error source is useful.
 #[derive(Debug, Error)]
 pub enum PostgresStoreError {
-    /// The connection URL or pool configuration is invalid.
-    #[error("PostgreSQL connection configuration is invalid")]
-    InvalidConfiguration,
-    /// Plaintext transport was requested for a non-local endpoint.
-    #[error("plaintext PostgreSQL is restricted to a local socket or literal loopback address")]
-    InsecureTransport,
+    /// The pool bound is zero.
+    #[error("PostgreSQL maximum connections must be greater than zero")]
+    InvalidPoolSize,
     /// Establishing the configured database pool failed.
     #[error("failed to connect to PostgreSQL")]
     Connection(#[source] sqlx::Error),
     /// Applying the embedded schema migrations failed.
     #[error("failed to migrate PostgreSQL")]
     Migration(#[source] sqlx::migrate::MigrateError),
-}
-
-/// Fail-closed transport policy for a `PostgreSQL` connection.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PostgresTransportSecurity {
-    /// Require TLS with both certificate-chain and hostname verification.
-    VerifyFull,
-    /// Explicit local-development exception that disables TLS.
-    ///
-    /// This mode accepts only a Unix-domain socket or a literal loopback IP
-    /// address. Hostnames such as `localhost` are deliberately rejected.
-    LoopbackPlaintext,
 }
 
 const RUNNER_COMMAND_ENCRYPTION_PURPOSE: &str = "control-plane/runner-command:v1";
@@ -450,22 +437,19 @@ pub struct PostgresStore {
 }
 
 impl PostgresStore {
-    /// Connects to `PostgreSQL` with a bounded pool and explicit transport policy.
+    /// Connects to `PostgreSQL` with a bounded pool and validated exact configuration.
     ///
     /// # Errors
     ///
-    /// Returns an error if the URL or pool bound is invalid, a plaintext policy
-    /// targets anything other than a local socket or literal loopback address,
-    /// or `PostgreSQL` cannot be reached.
+    /// Returns an error if the pool bound is zero or `PostgreSQL` cannot be reached.
     pub async fn connect(
-        database_url: &str,
+        connection: PostgresConnectionConfig,
         maximum_connections: u32,
-        transport_security: PostgresTransportSecurity,
     ) -> Result<Self, PostgresStoreError> {
         if maximum_connections == 0 {
-            return Err(PostgresStoreError::InvalidConfiguration);
+            return Err(PostgresStoreError::InvalidPoolSize);
         }
-        let options = connection_options(database_url, transport_security)?;
+        let options = connection.into_connect_options();
         let pool = PgPoolOptions::new()
             .max_connections(maximum_connections)
             .connect_with(options)
@@ -477,9 +461,9 @@ impl PostgresStore {
         })
     }
 
-    /// Creates the concrete adapter from an existing `sqlx` `PostgreSQL`
-    /// pool. This is an adapter-specific integration hook, not a portable
-    /// storage port.
+    /// Creates the concrete adapter from an existing `sqlx` `PostgreSQL` pool
+    /// for integration tests.
+    #[cfg(feature = "test-support")]
     #[must_use]
     pub fn from_postgres_pool(pool: PgPool) -> Self {
         Self {
@@ -511,9 +495,10 @@ impl PostgresStore {
             .ok_or(automata_ci_store::StoreError::RunnerPayloadEncryptionUnavailable)
     }
 
-    /// Returns the adapter's raw `sqlx` `PostgreSQL` pool for concrete
-    /// integration and migration tests. Portable callers should depend on
-    /// [`InternalAttemptRepository`] or [`TenantAttemptQuery`] instead.
+    /// Returns the adapter's raw `sqlx` `PostgreSQL` pool so the product can
+    /// compose the domain-specific adapters that share this exact connection
+    /// authority. Portable callers should depend on their narrow repository
+    /// ports instead.
     #[must_use]
     pub const fn postgres_pool(&self) -> &PgPool {
         &self.pool
@@ -551,89 +536,6 @@ impl PostgresStore {
         .ok_or(AttemptStoreError::NotFound(attempt_id))?;
 
         decode_snapshot(&row)
-    }
-}
-
-fn connection_options(
-    database_url: &str,
-    transport_security: PostgresTransportSecurity,
-) -> Result<PgConnectOptions, PostgresStoreError> {
-    let scheme = database_url
-        .split_once(':')
-        .map(|(scheme, _)| scheme)
-        .ok_or(PostgresStoreError::InvalidConfiguration)?;
-    if !scheme.eq_ignore_ascii_case("postgres") && !scheme.eq_ignore_ascii_case("postgresql") {
-        return Err(PostgresStoreError::InvalidConfiguration);
-    }
-    let options = PgConnectOptions::from_str(database_url)
-        .map_err(|_| PostgresStoreError::InvalidConfiguration)?;
-    match transport_security {
-        PostgresTransportSecurity::VerifyFull => Ok(options.ssl_mode(PgSslMode::VerifyFull)),
-        PostgresTransportSecurity::LoopbackPlaintext => {
-            let host = options.get_host();
-            let local_socket = options.get_socket().is_some() || host.starts_with('/');
-            let ip_literal = host
-                .strip_prefix('[')
-                .and_then(|host| host.strip_suffix(']'))
-                .unwrap_or(host);
-            let literal_loopback = ip_literal
-                .parse::<IpAddr>()
-                .is_ok_and(|address| address.is_loopback());
-            if !local_socket && !literal_loopback {
-                return Err(PostgresStoreError::InsecureTransport);
-            }
-            Ok(options.ssl_mode(PgSslMode::Disable))
-        }
-    }
-}
-
-#[cfg(test)]
-mod transport_security_tests {
-    use super::*;
-
-    #[test]
-    fn verified_transport_overrides_fallback_modes() {
-        let options = connection_options(
-            "postgresql://user:secret@database.example.test/automata?sslmode=disable",
-            PostgresTransportSecurity::VerifyFull,
-        )
-        .expect("verified transport configuration");
-        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyFull));
-    }
-
-    #[test]
-    fn plaintext_transport_accepts_only_effective_local_targets() {
-        for url in [
-            "postgresql://user@127.0.0.1/automata?sslmode=prefer",
-            "postgresql://user@[::1]/automata?sslmode=require",
-            "postgresql://user@%2Fvar%2Frun%2Fpostgresql/automata",
-        ] {
-            let options = connection_options(url, PostgresTransportSecurity::LoopbackPlaintext)
-                .unwrap_or_else(|error| panic!("explicit local target {url}: {error}"));
-            assert!(matches!(options.get_ssl_mode(), PgSslMode::Disable));
-        }
-
-        for url in [
-            "postgresql://user@localhost/automata",
-            "postgresql://user@database.example.test/automata",
-            "postgresql://user@127.0.0.1/automata?host=database.example.test",
-        ] {
-            assert!(matches!(
-                connection_options(url, PostgresTransportSecurity::LoopbackPlaintext),
-                Err(PostgresStoreError::InsecureTransport)
-            ));
-        }
-    }
-
-    #[test]
-    fn non_postgres_urls_are_rejected_without_echoing_the_input() {
-        let error = connection_options(
-            "https://user:unique-secret@example.test/automata",
-            PostgresTransportSecurity::VerifyFull,
-        )
-        .expect_err("wrong URL scheme");
-        assert!(matches!(error, PostgresStoreError::InvalidConfiguration));
-        assert!(!error.to_string().contains("unique-secret"));
     }
 }
 

--- a/crates/automata-ci-store/README.md
+++ b/crates/automata-ci-store/README.md
@@ -6,7 +6,8 @@ reconciliation, publication, and managed-secret metadata. Execution-control
 contracts for attempts, lease polling and runnable queues, cancellation,
 maintenance, and identifier-free state snapshots live in
 `automata-ci-control`. Database drivers, schema migrations, and concrete
-repositories live in `automata-ci-postgres`.
+repositories live in the owning domain adapter crates, including
+`automata-ci-store-postgres`.
 
 ## Tests
 

--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -136,10 +136,22 @@ This applies to database, object-store, runner TLS, Results signing,
 authentication, and wrapping-key credentials. References are redacted from
 debug and startup errors, and loaded values have context-specific size limits.
 
-Database connections force full TLS certificate and hostname verification.
-Local development may select `--database-transport loopback-plaintext`, but
-the effective target must be a Unix socket or literal loopback IP address;
-hostnames and remote addresses are rejected.
+Database URLs use one exact `postgresql://` TCP grammar with an explicit host,
+port, user, non-empty password, and database. Query parameters, fragments,
+socket paths, the `postgres://` alias, `.pgpass`, and every ambient `PG*`
+environment setting are rejected. Connections use the fixed `public` search
+path.
+
+The default `--database-transport web-pki-verify-full` requires TLS certificate
+and hostname verification through SQLx's compiled Web PKI roots. The explicit
+`web-pki-plus-private-ca-verify-full` mode adds one bounded canonical CA from
+`--database-private-ca-source`; SQLx retains the Web PKI roots in that mode, so
+it is intentionally a trust union rather than private-CA-only trust. Local
+development may select `loopback-plaintext`, but only with a literal-loopback
+TCP address. Hostnames, remote addresses, and Unix sockets are rejected.
+Generated local topology uses a reserved `.invalid` database DNS identity with
+the explicit Web-PKI-plus-private-CA union, so no public CA can issue for that
+name even though the compiled public roots remain installed.
 
 Required server sources are:
 

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -339,10 +339,12 @@ pub struct PreviewArgs {
 /// `PostgreSQL` transport policy selected at the product boundary.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum DatabaseTransport {
-    /// Require TLS certificate-chain and hostname verification.
+    /// Verify TLS through the compiled Web PKI roots.
     #[default]
-    VerifyFull,
-    /// Disable TLS only for a Unix socket or literal loopback address.
+    WebPkiVerifyFull,
+    /// Verify TLS through Web PKI plus one deployment-provided CA.
+    WebPkiPlusPrivateCaVerifyFull,
+    /// Disable TLS only for a literal loopback TCP address.
     LoopbackPlaintext,
 }
 
@@ -709,6 +711,17 @@ pub struct ServerArgs {
     /// Explicit database transport policy.
     #[arg(long, env = "AUTOMATA_DATABASE_TRANSPORT", value_enum, default_value_t)]
     pub database_transport: DatabaseTransport,
+
+    /// Additive private CA used only with `web-pki-plus-private-ca-verify-full`.
+    ///
+    /// `SQLx` retains its compiled Web PKI roots in this mode; the supplied
+    /// canonical CA certificate augments that root set and does not replace it.
+    #[arg(
+        long,
+        env = "AUTOMATA_DATABASE_PRIVATE_CA_SOURCE",
+        value_name = "env:NAME|file:PATH"
+    )]
+    pub database_private_ca_source: Option<SecretSource>,
 
     /// S3 endpoint, trust, deadline, and credential-source inputs.
     #[command(flatten)]

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -85,8 +85,9 @@ use automata_ci_store::{
     WorkflowRerunRepository,
 };
 use automata_ci_store_postgres::{
-    PostgresLiveLogTicketRepository, PostgresLogCommitListener, PostgresSecretCustodyRepository,
-    PostgresSecretManagementRepository, PostgresStore, PostgresStoreError,
+    PostgresConnectionConfig, PostgresConnectionConfigError, PostgresLiveLogTicketRepository,
+    PostgresLogCommitListener, PostgresSecretCustodyRepository, PostgresSecretManagementRepository,
+    PostgresStore, PostgresStoreError,
 };
 use automata_ci_workflow_service::{
     AdmissionClock, AutonomousWorkflowPhaseExecutor, AutonomousWorkflowService,
@@ -104,6 +105,7 @@ use rustls::{
 use thiserror::Error;
 use tokio::net::TcpListener;
 
+use super::config::DatabaseTransportLoadError;
 use super::github_job_runtime_authority::unavailable_github_job_runtime_authority_issuer;
 use super::github_oidc::{
     GithubOidcProductError, build_github_oidc_product, compose_runtime_authority_issuer,
@@ -787,15 +789,20 @@ struct DatabaseBuild {
 
 async fn connect_database(config: &ServerConfig) -> Result<DatabaseBuild, ServerCompositionError> {
     let database_url = config.load_database_url()?;
+    let transport_security = config
+        .load_database_transport()
+        .map_err(|error| match error {
+            DatabaseTransportLoadError::Secret(error) => ServerCompositionError::Secret(error),
+            DatabaseTransportLoadError::InvalidPrivateCa => {
+                ServerCompositionError::PostgresConfiguration(
+                    PostgresConnectionConfigError::InvalidPrivateCa,
+                )
+            }
+        })?;
+    let connection = PostgresConnectionConfig::parse(&database_url, transport_security)?;
     let payload_keyring = config.control_plane_encryption().load_local_keyring()?;
     let control_plane_key_provider: Arc<dyn KeyEncryptionProvider> = Arc::new(payload_keyring);
-    let store = PostgresStore::connect(
-        &database_url,
-        config.database_max_connections,
-        config.database_transport_security,
-    )
-    .await
-    .map_err(ServerCompositionError::from)?;
+    let store = PostgresStore::connect(connection, config.database_max_connections).await?;
     Ok(DatabaseBuild {
         store: store.with_runner_payload_encryption(Arc::clone(&control_plane_key_provider)),
         control_plane_key_provider,
@@ -1921,6 +1928,9 @@ pub enum ServerCompositionError {
     /// `PostgreSQL` could not connect or apply embedded migrations.
     #[error(transparent)]
     Postgres(#[from] PostgresStoreError),
+    /// The exact `PostgreSQL` URL, environment, or transport policy was invalid.
+    #[error(transparent)]
+    PostgresConfiguration(#[from] PostgresConnectionConfigError),
     /// S3 namespace or credential configuration was invalid.
     #[error(transparent)]
     S3(#[from] S3BlobStoreConfigError),

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -28,7 +28,7 @@ use automata_ci_provisioning::{
     DelegatedActorIssuer, ProvisioningAuthority, ProvisioningAuthorityId, ShardId,
 };
 use automata_ci_results_github::ResultsPublicEndpoint;
-use automata_ci_store_postgres::PostgresTransportSecurity;
+use automata_ci_store_postgres::{MAX_POSTGRES_PRIVATE_CA_PEM_BYTES, PostgresTransportSecurity};
 
 use crate::cli::{DatabaseTransport, S3ConnectionArgs, S3TlsTrustMode, ServerArgs};
 
@@ -300,6 +300,14 @@ pub enum SecretLoadError {
     InvalidCertificate,
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum DatabaseTransportLoadError {
+    #[error(transparent)]
+    Secret(#[from] SecretLoadError),
+    #[error("PostgreSQL private CA source is invalid")]
+    InvalidPrivateCa,
+}
+
 /// Validated product configuration for one control-plane replica.
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
@@ -318,7 +326,7 @@ pub struct ServerConfig {
     pub(crate) github_oidc: Option<GithubOidcConfig>,
     pub(crate) database_url: SecretSource,
     pub(crate) database_max_connections: u32,
-    pub(crate) database_transport_security: PostgresTransportSecurity,
+    pub(crate) database_transport: DatabaseTransportConfig,
     pub(crate) s3: S3ConnectionConfig,
     pub(crate) runner_client_ca_certificate: SecretSource,
     pub(crate) runner_client_ca_private_key: SecretSource,
@@ -332,6 +340,17 @@ pub struct ServerConfig {
     pub(crate) maximum_lease_failures: LeaseFailureLimit,
     pub(crate) stale_runner_session_timeout: StaleSessionTimeoutMillis,
     pub(crate) fallback_tenant_id: String,
+}
+
+/// Validated source-level `PostgreSQL` transport policy.
+#[derive(Clone, Debug)]
+pub(crate) enum DatabaseTransportConfig {
+    /// Verify through `SQLx`'s compiled Web PKI roots.
+    WebPkiVerifyFull,
+    /// Verify through compiled Web PKI roots plus one explicit private CA.
+    WebPkiPlusPrivateCaVerifyFull { certificate_source: SecretSource },
+    /// Disable TLS for an exact literal-loopback TCP URL.
+    LoopbackPlaintext,
 }
 
 /// Shared validated S3 connection, trust, deadline, and credential sources.
@@ -740,6 +759,7 @@ impl ServerConfig {
         validate_server_secret_sources(args)?;
         validate_local_listeners(args)?;
         validate_fallback_tenant(&args.fallback_tenant_id)?;
+        let database_transport = database_transport_configuration(args)?;
         let s3_at_rest_encryption = s3_at_rest_encryption(args.s3_kms_key_id.as_deref())?;
         let s3 =
             S3ConnectionConfig::from_args(&args.s3, args.s3_prefix.clone(), s3_at_rest_encryption)?;
@@ -795,12 +815,7 @@ impl ServerConfig {
             github_oidc,
             database_url: args.database_url_source.clone(),
             database_max_connections: args.database_max_connections,
-            database_transport_security: match args.database_transport {
-                DatabaseTransport::VerifyFull => PostgresTransportSecurity::VerifyFull,
-                DatabaseTransport::LoopbackPlaintext => {
-                    PostgresTransportSecurity::LoopbackPlaintext
-                }
-            },
+            database_transport,
             s3,
             runner_client_ca_certificate: args.runner_client_ca_certificate_source.clone(),
             runner_client_ca_private_key: args.runner_client_ca_key_source.clone(),
@@ -867,6 +882,27 @@ impl ServerConfig {
 
     pub(crate) fn load_database_url(&self) -> Result<Zeroizing<String>, SecretLoadError> {
         self.database_url.load_scalar(MAX_DATABASE_URL_BYTES)
+    }
+
+    pub(crate) fn load_database_transport(
+        &self,
+    ) -> Result<PostgresTransportSecurity, DatabaseTransportLoadError> {
+        match &self.database_transport {
+            DatabaseTransportConfig::WebPkiVerifyFull => {
+                Ok(PostgresTransportSecurity::web_pki_verify_full())
+            }
+            DatabaseTransportConfig::WebPkiPlusPrivateCaVerifyFull { certificate_source } => {
+                let certificate_pem =
+                    certificate_source.load_bytes(MAX_POSTGRES_PRIVATE_CA_PEM_BYTES)?;
+                PostgresTransportSecurity::web_pki_plus_private_ca_verify_full(
+                    certificate_pem.to_vec(),
+                )
+                .map_err(|_| DatabaseTransportLoadError::InvalidPrivateCa)
+            }
+            DatabaseTransportConfig::LoopbackPlaintext => {
+                Ok(PostgresTransportSecurity::loopback_plaintext())
+            }
+        }
     }
 
     pub(crate) fn load_client_ca_pem(&self) -> Result<Zeroizing<Vec<u8>>, SecretLoadError> {
@@ -1317,6 +1353,7 @@ fn validate_server_secret_sources(args: &ServerArgs) -> Result<(), ServerConfigE
     ];
     let optional = [
         args.github_oidc_config_source.as_ref(),
+        args.database_private_ca_source.as_ref(),
         args.conformance_export_token_source.as_ref(),
         args.management_client_ca_certificate_source.as_ref(),
         args.management_server_certificate_source.as_ref(),
@@ -1333,6 +1370,31 @@ fn validate_server_secret_sources(args: &ServerArgs) -> Result<(), ServerConfigE
         return Err(ServerConfigError::InvalidSecretSource);
     }
     Ok(())
+}
+
+fn database_transport_configuration(
+    args: &ServerArgs,
+) -> Result<DatabaseTransportConfig, ServerConfigError> {
+    match (
+        args.database_transport,
+        args.database_private_ca_source.as_ref(),
+    ) {
+        (DatabaseTransport::WebPkiVerifyFull, None) => {
+            Ok(DatabaseTransportConfig::WebPkiVerifyFull)
+        }
+        (DatabaseTransport::WebPkiPlusPrivateCaVerifyFull, Some(certificate_source)) => {
+            Ok(DatabaseTransportConfig::WebPkiPlusPrivateCaVerifyFull {
+                certificate_source: certificate_source.clone(),
+            })
+        }
+        (DatabaseTransport::LoopbackPlaintext, None) => {
+            Ok(DatabaseTransportConfig::LoopbackPlaintext)
+        }
+        (DatabaseTransport::WebPkiVerifyFull | DatabaseTransport::LoopbackPlaintext, Some(_))
+        | (DatabaseTransport::WebPkiPlusPrivateCaVerifyFull, None) => {
+            Err(ServerConfigError::InvalidDatabaseTransport)
+        }
+    }
 }
 
 fn validate_external_url(args: &ServerArgs, external_url: &Url) -> Result<(), ServerConfigError> {
@@ -1468,6 +1530,9 @@ pub enum ServerConfigError {
     /// The `PostgreSQL` pool size is zero.
     #[error("database maximum connections must be greater than zero")]
     InvalidDatabaseConnections,
+    /// The `PostgreSQL` transport and additive CA source are inconsistent.
+    #[error("database transport configuration is invalid")]
+    InvalidDatabaseTransport,
     /// A configured duration is zero.
     #[error("server durations must be greater than zero")]
     InvalidDuration,

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -1,5 +1,5 @@
 use automata_ci::cli::{
-    AuthCommand, Cli, Command, EnvironmentReviewDecision, InternalCommand,
+    AuthCommand, Cli, Command, DatabaseTransport, EnvironmentReviewDecision, InternalCommand,
     InternalObjectStoreCommand, LocalCommand, LocalContainerEngine, OutputFormat, RepositoryRef,
     RerunSelection, S3TlsTrustMode, SecretCommand, SecretProviderCommand, SecretScope,
 };
@@ -14,6 +14,8 @@ fn server_uses_a_loopback_default() {
         panic!("server command expected");
     };
     assert_eq!(args.listen.to_string(), "127.0.0.1:8080");
+    assert_eq!(args.database_transport, DatabaseTransport::WebPkiVerifyFull);
+    assert!(args.database_private_ca_source.is_none());
 }
 
 #[test]

--- a/crates/automata-ci/tests/server_config.rs
+++ b/crates/automata-ci/tests/server_config.rs
@@ -272,6 +272,73 @@ fn server_s3_trust_policy_is_closed_and_exact() {
 }
 
 #[test]
+fn server_database_transport_policy_names_the_exact_trust_union() {
+    let marker = "AUTOMATA_DATABASE_CA_REFERENCE_MARKER";
+    let private = Cli::try_parse_from([
+        "automata",
+        "server",
+        "--results-public-url",
+        "https://results.example.test/",
+        "--database-transport",
+        "web-pki-plus-private-ca-verify-full",
+        "--database-private-ca-source",
+        &format!("env:{marker}"),
+    ])
+    .expect("additive private CA syntax");
+    let Command::Server(private) = private.command else {
+        panic!("server command expected");
+    };
+    let config = ServerConfig::from_args(&private).expect("complete additive CA policy");
+    let debug = format!("{config:?}");
+    assert!(debug.contains("WebPkiPlusPrivateCaVerifyFull"));
+    assert!(!debug.contains(marker));
+
+    for arguments in [
+        vec![
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--database-transport",
+            "web-pki-plus-private-ca-verify-full",
+        ],
+        vec![
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--database-private-ca-source",
+            "file:/run/secrets/unrequested-database-ca.pem",
+        ],
+        vec![
+            "automata",
+            "server",
+            "--results-public-url",
+            "https://results.example.test/",
+            "--database-transport",
+            "loopback-plaintext",
+            "--database-private-ca-source",
+            "file:/run/secrets/unrequested-database-ca.pem",
+        ],
+    ] {
+        let cli = Cli::try_parse_from(arguments).expect("database trust syntax");
+        let Command::Server(args) = cli.command else {
+            panic!("server command expected");
+        };
+        assert!(matches!(
+            ServerConfig::from_args(&args),
+            Err(ServerConfigError::InvalidDatabaseTransport)
+        ));
+    }
+
+    assert!(
+        Cli::try_parse_from(["automata", "server", "--database-transport", "verify-full",])
+            .is_err(),
+        "the ambiguous legacy trust label must not remain accepted"
+    );
+}
+
+#[test]
 fn server_private_ca_and_loopback_plaintext_are_incompatible() {
     let private_plaintext = Cli::try_parse_from([
         "automata",

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -539,6 +539,14 @@ runner mTLS, Results, and the Docker socket are private to exact Compose
 networks or mounts. Job containers use a separate network and reach Results
 through an exact gateway/proxy; they cannot join the dependency network.
 
+The rendered PostgreSQL certificate uses one deterministic reserved `.invalid`
+DNS identity. The control plane selects the explicit
+Web-PKI-plus-private-CA verify-full policy: SQLx's compiled public roots remain
+in the declared trust union, while the reserved name prevents a public CA from
+issuing a competing certificate. Database URLs contain explicit TCP fields and
+no query parameters; ambient `PG*`, passfile, socket, and search-path authority
+is rejected.
+
 An optional public HTTPS origin is added only for GitHub connection. Its
 gateway exposes the minimum human callback, setup, and webhook routes. A tunnel
 provider must preserve webhook bytes and headers, persist its origin across


### PR DESCRIPTION
## Outcome

Makes the server's PostgreSQL connection a single, exact, validated authority instead of allowing SQLx environment, pgpass, socket, URL-alias, or query-option inputs to influence it.

The accepted contract is one explicit `postgresql://` TCP URL plus one closed transport policy: WebPKI verify-full, WebPKI plus one validated private CA verify-full, or literal-loopback plaintext. It also removes the obsolete `automata-ci-postgres` compatibility facade so production code imports the owning split adapters directly.

This is the next independently reviewable bottom layer extracted from #173.

## Related issue

Part of #173.

## Trust and compatibility impact

This intentionally tightens the PostgreSQL configuration boundary. `postgres://`, Unix sockets, query/fragment parameters, implicit URL fields, pgpass, and every ambient `PG*` variable are rejected. PostgreSQL credentials and connection components are redacted and transient owned copies are zeroized.

The private-CA mode is truthfully a WebPKI-plus-private-CA union because SQLx does not expose a rootless one-CA connector. Literal-loopback plaintext remains explicit and cannot be selected for non-loopback hosts.

The compatibility-facade reexports are removed; callers must import the owning Postgres adapter crates. No database schema or stored data is changed.

## Verification

Passed on the exact rebased commit:

- `cargo test -p automata-ci-store-postgres --all-targets --all-features --locked` — 47 passed.
- `cargo test -p automata-ci --test cli --test server_config --locked` — 69 passed.
- `cargo check --workspace --all-targets --all-features --locked`.
- `cargo clippy -p automata-ci-store-postgres -p automata-ci-postgres -p automata-ci-results-github -p automata-ci --all-targets --all-features --locked -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.

Before the final one-to-one rebase, the same patch also passed the consolidated Postgres aggregate, Windows GNU and Linux musl checks, warning-denied rustdoc, and `cargo deny`. An independent strict review found the final patch clean; range-diff after rebase was exact.

## AI assistance

OpenAI Codex helped extract this reviewed slice from the larger #173 branch, implement and test the refactor, and perform independent strict review. Every submitted change and gate result was reviewed.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
