### PR TITLE
refactor(workflow-github): share compiler test support

### DIFF
--- a/crates/automata-ci-workflow-github/tests/ci_workflow.rs
+++ b/crates/automata-ci-workflow-github/tests/ci_workflow.rs
@@ -5,12 +5,7 @@ use automata_ci_workflow_github::YamlNodeKind;
 #[test]
 fn source_ast_retains_mapping_order_and_scalar_styles() {
     let source = include_str!("fixtures/valid.yml");
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("plan");
     let entries = plan.document().root().as_mapping().expect("root mapping");
 

--- a/crates/automata-ci-workflow-github/tests/compiler.rs
+++ b/crates/automata-ci-workflow-github/tests/compiler.rs
@@ -2,8 +2,7 @@ use crate::support;
 
 use automata_ci_core::{WorkflowEventProvenance, WorkflowPlan, WorkflowPlanVersion};
 use automata_ci_workflow_github::{
-    CompilationDisposition, CompileWorkflowRequest, DiagnosticKind, GithubEventMetadata,
-    GithubWorkflowCompiler, WorkflowNotSelectedReason,
+    CompilationDisposition, DiagnosticKind, GithubEventMetadata, WorkflowNotSelectedReason,
 };
 
 fn event(name: &str) -> WorkflowEventProvenance {
@@ -15,18 +14,16 @@ fn event(name: &str) -> WorkflowEventProvenance {
 
 fn compile(source: &str, event_name: &str) -> automata_ci_workflow_github::CompilationReport {
     let parsed = support::parse(source);
-    let request = CompileWorkflowRequest::new(
+    let metadata = match event_name {
+        "push" => Some(GithubEventMetadata::push(false)),
+        "pull_request" => Some(GithubEventMetadata::pull_request("opened", "main")),
+        _ => None,
+    };
+    support::compile(
         parsed.plan().expect("loss-aware source plan"),
         event(event_name),
-    );
-    let request = match event_name {
-        "push" => request.with_event_metadata(GithubEventMetadata::push(false)),
-        "pull_request" => {
-            request.with_event_metadata(GithubEventMetadata::pull_request("opened", "main"))
-        }
-        _ => request,
-    };
-    GithubWorkflowCompiler::new().compile(request)
+        metadata,
+    )
 }
 
 #[test]
@@ -38,13 +35,12 @@ jobs:
     steps:
       - run: echo verify
 ";
-    let parsed = support::parse(source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let source_plan = parsed.plan().expect("source plan");
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
-        source_plan,
+    let parsed = support::parse_accepted(source);
+    let report = support::compile(
+        parsed.plan().expect("source plan"),
         event("workflow_dispatch"),
-    ));
+        None,
+    );
 
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());
     let plan = report.plan().expect("current plan");

--- a/crates/automata-ci-workflow-github/tests/diagnostics.rs
+++ b/crates/automata-ci-workflow-github/tests/diagnostics.rs
@@ -56,8 +56,7 @@ fn unknown_fields_are_preserved_and_rejected_as_unsupported() {
 #[test]
 fn anchors_and_aliases_retain_original_evidence_and_decode_from_an_expanded_tree() {
     let source = include_str!("fixtures/aliases.yml");
-    let report = support::parse(source);
-    assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    let report = support::parse_accepted(source);
 
     let plan = report.plan().expect("plan");
     let jobs = plan.document().root().as_mapping().expect("root")[3]

--- a/crates/automata-ci-workflow-github/tests/early_capability_rejection.rs
+++ b/crates/automata-ci-workflow-github/tests/early_capability_rejection.rs
@@ -1,7 +1,7 @@
 use crate::support;
 
 use automata_ci_core::WorkflowEventProvenance;
-use automata_ci_workflow_github::{CompileWorkflowRequest, DiagnosticKind, GithubWorkflowCompiler};
+use automata_ci_workflow_github::DiagnosticKind;
 
 fn assert_rejected_before_plan(source: &str, code: &str, exact_span: &str) {
     assert_rejected_before_plan_for_event(source, "workflow_dispatch", code, exact_span);
@@ -13,13 +13,13 @@ fn assert_rejected_before_plan_for_event(
     code: &str,
     exact_span: &str,
 ) {
-    let parsed = support::parse(source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
+    let parsed = support::parse_accepted(source);
     let source_plan = parsed.plan().expect("source plan");
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let report = support::compile(
         source_plan,
         WorkflowEventProvenance::new("github", event_name),
-    ));
+        None,
+    );
 
     assert!(
         report.plan().is_none(),

--- a/crates/automata-ci-workflow-github/tests/event_configuration.rs
+++ b/crates/automata-ci-workflow-github/tests/event_configuration.rs
@@ -2,8 +2,8 @@ use crate::support;
 
 use automata_ci_core::WorkflowEventProvenance;
 use automata_ci_workflow_github::{
-    CompilationDisposition, CompilationReport, CompileWorkflowRequest, GithubEventMetadata,
-    GithubWorkflowCompiler, WorkflowNotSelectedReason,
+    CompilationReport, CompileWorkflowRequest, GithubEventMetadata, GithubWorkflowCompiler,
+    WorkflowNotSelectedReason,
 };
 
 fn compile(
@@ -11,58 +11,15 @@ fn compile(
     event_name: &str,
     metadata: Option<GithubEventMetadata>,
 ) -> CompilationReport {
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    let request = CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", event_name)
             .with_delivery_id("synthetic-event-configuration")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    );
-    let request = match metadata {
-        Some(metadata) => request.with_event_metadata(metadata),
-        None => request,
-    };
-    GithubWorkflowCompiler::new().compile(request)
-}
-
-fn assert_rejected_with(report: &CompilationReport, code: &str) {
-    assert!(
-        report.plan().is_none(),
-        "unexpected plan: {:#?}",
-        report.plan()
-    );
-    assert!(
-        report.disposition() == CompilationDisposition::Rejected,
-        "unexpected disposition: {:?}",
-        report.disposition()
-    );
-    assert!(
-        report
-            .diagnostics()
-            .iter()
-            .any(|diagnostic| diagnostic.code() == code),
-        "missing diagnostic `{code}`: {:#?}",
-        report.diagnostics()
-    );
-}
-
-fn assert_not_selected(report: &CompilationReport, reason: WorkflowNotSelectedReason) {
-    assert_eq!(report.plan(), None);
-    assert_eq!(
-        report.disposition(),
-        CompilationDisposition::NotSelected(reason)
-    );
-    assert!(
-        report.diagnostics().is_empty(),
-        "{:#?}",
-        report.diagnostics()
-    );
+        metadata,
+    )
 }
 
 #[test]
@@ -103,7 +60,7 @@ fn empty_dispatch_and_reusable_workflow_contracts_are_admitted() {
 #[test]
 fn configured_dispatch_inputs_require_verified_payload_evidence() {
     let source = "on:\n  workflow_dispatch:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(source, "workflow_dispatch", None),
         "github.compile.event_metadata_required",
     );
@@ -127,7 +84,7 @@ fn schedule_admission_requires_the_exact_firing_cron() {
         ));
     assert!(replay.is_accepted(), "{:#?}", replay.diagnostics());
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             "schedule",
@@ -135,11 +92,11 @@ fn schedule_admission_requires_the_exact_firing_cron() {
         ),
         WorkflowNotSelectedReason::ScheduleNotConfigured,
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(source, "schedule", None),
         "github.compile.event_metadata_required",
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(source, "schedule", Some(GithubEventMetadata::push(false))),
         "github.compile.event_metadata_mismatch",
     );
@@ -174,7 +131,7 @@ fn merge_group_requires_exact_authenticated_metadata() {
         configured_selected.diagnostics()
     );
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             "merge_group",
@@ -185,7 +142,7 @@ fn merge_group_requires_exact_authenticated_metadata() {
         ),
         WorkflowNotSelectedReason::EventFiltersNotMatched,
     );
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             configured,
             "merge_group",
@@ -197,7 +154,7 @@ fn merge_group_requires_exact_authenticated_metadata() {
         WorkflowNotSelectedReason::EventFiltersNotMatched,
     );
     let unsupported_type = "on:\n  merge_group:\n    types: [destroyed]\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             unsupported_type,
             "merge_group",
@@ -208,11 +165,11 @@ fn merge_group_requires_exact_authenticated_metadata() {
         ),
         "github.compile.unsupported_merge_group_type",
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(source, "merge_group", None),
         "github.compile.event_metadata_required",
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             source,
             "merge_group",
@@ -220,7 +177,7 @@ fn merge_group_requires_exact_authenticated_metadata() {
         ),
         "github.compile.event_metadata_mismatch",
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             source,
             "merge_group",
@@ -270,6 +227,6 @@ fn malformed_or_not_yet_evaluable_event_configuration_is_diagnostic() {
             "github.compile.invalid_workflow_call_configuration",
         ),
     ] {
-        assert_rejected_with(&compile(source, event_name, metadata), code);
+        support::assert_rejected_with(&compile(source, event_name, metadata), code);
     }
 }

--- a/crates/automata-ci-workflow-github/tests/job_containers.rs
+++ b/crates/automata-ci-workflow-github/tests/job_containers.rs
@@ -2,8 +2,7 @@ use crate::support;
 
 use automata_ci_core::{LogicalJobKind, TransportProtocol, WorkflowEventProvenance};
 use automata_ci_workflow_github::{
-    CompileWorkflowRequest, DiagnosticKind, GithubWorkflowCompiler, GithubWorkflowSourcePlan, Job,
-    JobContainer, JobServices, ScalarResolution,
+    DiagnosticKind, GithubWorkflowSourcePlan, Job, JobContainer, JobServices, ScalarResolution,
 };
 
 const MALFORMED_CONTAINER_DIAGNOSTICS: [(&str, &str); 14] = [
@@ -152,12 +151,7 @@ jobs:
       - run: echo verify
 "#;
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("source plan");
     let job = plan.workflow().jobs()[0].job();
 
@@ -265,12 +259,7 @@ jobs:
       - run: echo verify
 "#;
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let job = report.plan().expect("source plan").workflow().jobs()[0].job();
     assert!(matches!(
         job.container(),
@@ -455,17 +444,13 @@ jobs:
       - run: echo verify
 ";
 
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
+    let parsed = support::parse_accepted(source);
     let source_plan = parsed.plan().expect("source plan");
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let report = support::compile(
         source_plan,
         WorkflowEventProvenance::new("github", "workflow_dispatch"),
-    ));
+        None,
+    );
     assert!(report.plan().is_none());
     let container = report
         .diagnostics()
@@ -508,12 +493,12 @@ jobs:
       - run: echo verify
 "#;
 
-    let parsed = support::parse(source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    let report = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch"),
-    ));
+        None,
+    );
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());
     let LogicalJobKind::Steps(job) = report.plan().expect("plan").jobs()[0].execution() else {
         panic!("step job");
@@ -541,12 +526,12 @@ jobs:
 #[test]
 fn current_lowering_rejects_unimplemented_or_invalid_service_surface() {
     for (source, code) in UNSUPPORTED_SERVICE_CASES {
-        let parsed = support::parse(source);
-        assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-        let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+        let parsed = support::parse_accepted(source);
+        let report = support::compile(
             parsed.plan().expect("source plan"),
             WorkflowEventProvenance::new("github", "workflow_dispatch"),
-        ));
+            None,
+        );
         assert!(report.plan().is_none(), "unexpected plan for `{code}`");
         assert!(
             report

--- a/crates/automata-ci-workflow-github/tests/job_outputs_environment.rs
+++ b/crates/automata-ci-workflow-github/tests/job_outputs_environment.rs
@@ -1,10 +1,7 @@
 use crate::support;
 
 use automata_ci_core::WorkflowEventProvenance;
-use automata_ci_workflow_github::{
-    CompileWorkflowRequest, DiagnosticKind, GithubWorkflowCompiler, JobEnvironment,
-    ScalarResolution,
-};
+use automata_ci_workflow_github::{DiagnosticKind, JobEnvironment, ScalarResolution};
 
 #[test]
 fn source_model_decodes_job_outputs_and_both_environment_forms() {
@@ -29,12 +26,7 @@ jobs:
       - run: echo publish
 "#;
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("source plan");
 
     let package = plan.workflow().jobs()[0].job();
@@ -195,10 +187,11 @@ fn current_lowering_fails_closed_for_malformed_output_and_environment_shapes() {
             _ => unreachable!("test field is fixed"),
         }
 
-        let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+        let report = support::compile(
             plan,
             WorkflowEventProvenance::new("github", "workflow_dispatch"),
-        ));
+            None,
+        );
         assert!(report.plan().is_none(), "{field}: {value}");
         let diagnostics = report
             .diagnostics()
@@ -227,16 +220,12 @@ jobs:
         run: echo build
 ";
 
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    let report = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch"),
-    ));
+        None,
+    );
 
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());
     let job = &report.plan().expect("current plan").jobs()[0];

--- a/crates/automata-ci-workflow-github/tests/job_resources.rs
+++ b/crates/automata-ci-workflow-github/tests/job_resources.rs
@@ -4,22 +4,17 @@ use automata_ci_core::{
     CompiledValueTemplate, ExpressionContext, LogicalJobKind, WorkflowEventProvenance,
     WorkflowPlanVersion,
 };
-use automata_ci_workflow_github::{CompileWorkflowRequest, GithubWorkflowCompiler};
 
 fn compile(source: &str) -> automata_ci_workflow_github::CompilationReport {
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch")
             .with_delivery_id("resource-test")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    ))
+        None,
+    )
 }
 
 #[test]

--- a/crates/automata-ci-workflow-github/tests/job_strategy.rs
+++ b/crates/automata-ci-workflow-github/tests/job_strategy.rs
@@ -2,9 +2,8 @@ use crate::support;
 
 use automata_ci_core::WorkflowEventProvenance;
 use automata_ci_workflow_github::{
-    BooleanValue, CompileWorkflowRequest, DiagnosticKind, GithubEventMetadata,
-    GithubWorkflowCompiler, MatrixConfigurations, MatrixDimensionValues, MatrixValue,
-    ScalarResolution, StrategyMatrix,
+    BooleanValue, DiagnosticKind, GithubEventMetadata, MatrixConfigurations, MatrixDimensionValues,
+    MatrixValue, ScalarResolution, StrategyMatrix,
 };
 
 #[test]
@@ -34,12 +33,7 @@ jobs:
       - run: echo test
 ";
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("source plan");
     let strategy = plan.workflow().jobs()[0]
         .job()
@@ -135,12 +129,7 @@ jobs:
       - run: echo mixed
 ";
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("source plan");
     assert!(matches!(
         plan.workflow().jobs()[0]
@@ -369,10 +358,11 @@ fn compiler_fails_closed_when_malformed_strategy_was_retained() {
         let plan = parsed.plan().expect("loss-aware source plan");
         assert!(plan.workflow().jobs()[0].job().strategy().is_none());
 
-        let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+        let report = support::compile(
             plan,
             WorkflowEventProvenance::new("github", "workflow_dispatch"),
-        ));
+            None,
+        );
         assert!(report.plan().is_none(), "strategy value {value}");
         let diagnostics = report
             .diagnostics()
@@ -419,18 +409,11 @@ jobs:
     ];
 
     for source in cases {
-        let parsed = support::parse(source);
-        assert!(
-            parsed.is_accepted(),
-            "source diagnostics: {:#?}",
-            parsed.diagnostics()
-        );
-        let report = GithubWorkflowCompiler::new().compile(
-            CompileWorkflowRequest::new(
-                parsed.plan().expect("source plan"),
-                WorkflowEventProvenance::new("github", "push").with_git_ref("refs/heads/main"),
-            )
-            .with_event_metadata(GithubEventMetadata::push(false)),
+        let parsed = support::parse_accepted(source);
+        let report = support::compile(
+            parsed.plan().expect("source plan"),
+            WorkflowEventProvenance::new("github", "push").with_git_ref("refs/heads/main"),
+            Some(GithubEventMetadata::push(false)),
         );
         assert!(report.is_accepted(), "{:#?}", report.diagnostics());
         assert!(

--- a/crates/automata-ci-workflow-github/tests/logical_compiler.rs
+++ b/crates/automata-ci-workflow-github/tests/logical_compiler.rs
@@ -8,22 +8,17 @@ use automata_ci_core::{
     MatrixValue as PlanMatrixValue, MatrixValueTemplate, OutputSensitivity,
     ReusableSecretForwarding, WorkflowEventProvenance, WorkflowPlanVersion,
 };
-use automata_ci_workflow_github::{CompileWorkflowRequest, GithubWorkflowCompiler};
 
 fn compile(source: &str, event: &str) -> automata_ci_workflow_github::CompilationReport {
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", event)
             .with_delivery_id("synthetic-current")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    ))
+        None,
+    )
 }
 
 fn assert_rejected(source: &str, code: &str) {

--- a/crates/automata-ci-workflow-github/tests/permissions.rs
+++ b/crates/automata-ci-workflow-github/tests/permissions.rs
@@ -4,9 +4,7 @@ use automata_ci_core::{
     PermissionLevel as PlanPermissionLevel, WorkflowEventProvenance, WorkflowPermissions,
 };
 use automata_ci_github_permissions::GITHUB_WORKFLOW_PERMISSIONS;
-use automata_ci_workflow_github::{
-    CompileWorkflowRequest, GithubWorkflowCompiler, PermissionLevel, Permissions,
-};
+use automata_ci_workflow_github::{PermissionLevel, Permissions};
 
 const JOB: &str = r"
 jobs:
@@ -48,15 +46,15 @@ fn id_token_write_and_none_survive_current_logical_compilation() {
         "    runs-on: linux",
         "    permissions:\n      id-token: none\n    runs-on: linux",
     );
-    let parsed = support::parse(&source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let report = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(&source);
+    let report = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch")
             .with_delivery_id("synthetic-permissions")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    ));
+        None,
+    );
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());
     let logical = report.plan().expect("logical plan").logical();
 
@@ -97,10 +95,11 @@ fn every_catalog_permission_accepts_exactly_its_declared_levels() {
                 parsed.diagnostics()
             );
             if allowed {
-                let compiled = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+                let compiled = support::compile(
                     parsed.plan().expect("source plan"),
                     WorkflowEventProvenance::new("github", "workflow_dispatch"),
-                ));
+                    None,
+                );
                 assert!(
                     compiled.is_accepted(),
                     "{}:{level}: {:#?}",
@@ -144,12 +143,12 @@ fn an_unknown_permission_is_rejected_at_its_exact_key_span() {
 #[test]
 fn an_explicit_empty_mapping_is_a_valid_deny_all_request() {
     let source = format!("on: workflow_dispatch\npermissions: {{}}\n{JOB}");
-    let parsed = support::parse(&source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let compiled = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(&source);
+    let compiled = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch"),
-    ));
+        None,
+    );
     assert!(compiled.is_accepted(), "{:#?}", compiled.diagnostics());
     let WorkflowPermissions::Mapping(grants) = compiled
         .plan()

--- a/crates/automata-ci-workflow-github/tests/reusable_workflow_jobs.rs
+++ b/crates/automata-ci-workflow-github/tests/reusable_workflow_jobs.rs
@@ -2,8 +2,7 @@ use crate::support;
 
 use automata_ci_core::{LogicalJobKind, ReusableSecretForwarding, WorkflowEventProvenance};
 use automata_ci_workflow_github::{
-    CompileWorkflowRequest, DiagnosticKind, GithubEventMetadata, GithubWorkflowCompiler,
-    ReusableWorkflowSecrets, ScalarResolution,
+    DiagnosticKind, GithubEventMetadata, ReusableWorkflowSecrets, ScalarResolution,
 };
 
 #[test]
@@ -35,12 +34,7 @@ jobs:
     secrets: inherit
 ";
 
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "source diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("source plan");
 
     let local_job = plan.workflow().jobs()[1].job();
@@ -322,18 +316,11 @@ jobs:
     secrets: inherit
 ";
 
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    let report = GithubWorkflowCompiler::new().compile(
-        CompileWorkflowRequest::new(
-            parsed.plan().expect("source plan"),
-            WorkflowEventProvenance::new("github", "push").with_git_ref("refs/heads/main"),
-        )
-        .with_event_metadata(GithubEventMetadata::push(false)),
+    let parsed = support::parse_accepted(source);
+    let report = support::compile(
+        parsed.plan().expect("source plan"),
+        WorkflowEventProvenance::new("github", "push").with_git_ref("refs/heads/main"),
+        Some(GithubEventMetadata::push(false)),
     );
 
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());

--- a/crates/automata-ci-workflow-github/tests/schedule_contract.rs
+++ b/crates/automata-ci-workflow-github/tests/schedule_contract.rs
@@ -90,8 +90,7 @@ fn timezone_evaluation_skips_gaps_and_retains_both_fold_instants() {
 #[test]
 fn extraction_preserves_order_and_defaults_timezone_to_utc() {
     let source = "on:\n  schedule:\n    - cron: '15 4 * * MON-FRI'\n    - cron: '45 16 * * 2,4'\n      timezone: Europe/Sofia\njobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: true\n";
-    let parsed = support::parse(source);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
+    let parsed = support::parse_accepted(source);
     let entries = extract_github_schedule_entries(parsed.plan().expect("source plan"))
         .expect("valid schedules");
     assert_eq!(entries.len(), 2);

--- a/crates/automata-ci-workflow-github/tests/support/mod.rs
+++ b/crates/automata-ci-workflow-github/tests/support/mod.rs
@@ -1,6 +1,8 @@
+use automata_ci_core::WorkflowEventProvenance;
 use automata_ci_workflow_github::{
-    GithubFrontendReport, GithubWorkflowFrontend, ParseWorkflowRequest, SourceProvenance,
-    WorkflowFrontend,
+    CompilationDisposition, CompilationReport, CompileWorkflowRequest, GithubEventMetadata,
+    GithubFrontendReport, GithubWorkflowCompiler, GithubWorkflowFrontend, GithubWorkflowSourcePlan,
+    ParseWorkflowRequest, SourceProvenance, WorkflowFrontend, WorkflowNotSelectedReason,
 };
 
 pub fn parse(source: &str) -> GithubFrontendReport {
@@ -8,4 +10,61 @@ pub fn parse(source: &str) -> GithubFrontendReport {
         SourceProvenance::memory("test.yml"),
         source,
     ))
+}
+
+pub(super) fn parse_accepted(source: &str) -> GithubFrontendReport {
+    let report = parse(source);
+    assert!(
+        report.is_accepted(),
+        "source diagnostics: {:#?}",
+        report.diagnostics()
+    );
+    report
+}
+
+pub(super) fn compile(
+    source_plan: &GithubWorkflowSourcePlan,
+    event: WorkflowEventProvenance,
+    metadata: Option<GithubEventMetadata>,
+) -> CompilationReport {
+    let request = CompileWorkflowRequest::new(source_plan, event);
+    let request = match metadata {
+        Some(metadata) => request.with_event_metadata(metadata),
+        None => request,
+    };
+    GithubWorkflowCompiler::new().compile(request)
+}
+
+pub(super) fn assert_rejected_with(report: &CompilationReport, code: &str) {
+    assert!(
+        report.plan().is_none(),
+        "unexpected plan: {:#?}",
+        report.plan()
+    );
+    assert!(
+        report.disposition() == CompilationDisposition::Rejected,
+        "unexpected disposition: {:?}",
+        report.disposition()
+    );
+    assert!(
+        report
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code() == code),
+        "missing diagnostic `{code}`: {:#?}",
+        report.diagnostics()
+    );
+}
+
+pub(super) fn assert_not_selected(report: &CompilationReport, reason: WorkflowNotSelectedReason) {
+    assert_eq!(report.plan(), None);
+    assert_eq!(
+        report.disposition(),
+        CompilationDisposition::NotSelected(reason)
+    );
+    assert!(
+        report.diagnostics().is_empty(),
+        "ordinary non-selection must not emit diagnostics: {:#?}",
+        report.diagnostics()
+    );
 }

--- a/crates/automata-ci-workflow-github/tests/trigger_selection.rs
+++ b/crates/automata-ci-workflow-github/tests/trigger_selection.rs
@@ -20,52 +20,8 @@ fn compile(
     event: WorkflowEventProvenance,
     metadata: Option<GithubEventMetadata>,
 ) -> CompilationReport {
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    let request = CompileWorkflowRequest::new(parsed.plan().expect("source plan"), event);
-    let request = match metadata {
-        Some(metadata) => request.with_event_metadata(metadata),
-        None => request,
-    };
-    GithubWorkflowCompiler::new().compile(request)
-}
-
-fn assert_rejected_with(report: &CompilationReport, code: &str) {
-    assert!(
-        report.plan().is_none(),
-        "unexpected plan: {:#?}",
-        report.plan()
-    );
-    assert!(
-        report.disposition() == CompilationDisposition::Rejected,
-        "unexpected disposition: {:?}",
-        report.disposition()
-    );
-    assert!(
-        report
-            .diagnostics()
-            .iter()
-            .any(|diagnostic| diagnostic.code() == code),
-        "missing diagnostic `{code}`: {:#?}",
-        report.diagnostics()
-    );
-}
-
-fn assert_not_selected(report: &CompilationReport, reason: WorkflowNotSelectedReason) {
-    assert_eq!(report.plan(), None);
-    assert_eq!(
-        report.disposition(),
-        CompilationDisposition::NotSelected(reason)
-    );
-    assert!(
-        report.diagnostics().is_empty(),
-        "ordinary non-selection must not emit diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let parsed = support::parse_accepted(source);
+    support::compile(parsed.plan().expect("source plan"), event, metadata)
 }
 
 #[test]
@@ -94,7 +50,7 @@ fn filtered_workflow_selects_only_live_main_pushes() {
             WorkflowNotSelectedReason::DeletedPush,
         ),
     ] {
-        assert_not_selected(
+        support::assert_not_selected(
             &compile(FILTERED_WORKFLOW, event("push", git_ref), Some(metadata)),
             reason,
         );
@@ -104,7 +60,7 @@ fn filtered_workflow_selects_only_live_main_pushes() {
 #[test]
 fn event_absence_is_structured_non_selection_without_diagnostics() {
     let source = "on: workflow_dispatch\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("push", "refs/heads/main"),
@@ -117,7 +73,7 @@ fn event_absence_is_structured_non_selection_without_diagnostics() {
 #[test]
 fn event_absence_does_not_compile_an_unrelated_workflow_body() {
     let source = "on: workflow_dispatch\njobs:\n  test:\n    runs-on: linux\n    environment: production\n    steps:\n      - run: true\n";
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("pull_request", "refs/pull/1/merge"),
@@ -149,7 +105,7 @@ fn path_filter_demand_does_not_compile_the_workflow_body() {
 #[test]
 fn a_selected_event_still_rejects_an_unsupported_workflow_body() {
     let source = "on: pull_request\njobs:\n  test:\n    runs-on: linux\n    environment: production\n    steps:\n      - run: true\n";
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             source,
             event("pull_request", "refs/pull/1/merge"),
@@ -169,7 +125,7 @@ fn repository_dispatch_types_select_only_the_exact_custom_event() {
     );
     assert!(matching.is_accepted(), "{:#?}", matching.diagnostics());
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             filtered,
             event("repository_dispatch", "refs/heads/main"),
@@ -190,7 +146,7 @@ fn repository_dispatch_types_select_only_the_exact_custom_event() {
 #[test]
 fn repository_dispatch_requires_exact_bounded_metadata() {
     let source = "on: repository_dispatch\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             source,
             event("repository_dispatch", "refs/heads/main"),
@@ -198,7 +154,7 @@ fn repository_dispatch_requires_exact_bounded_metadata() {
         ),
         "github.compile.event_metadata_required",
     );
-    assert_rejected_with(
+    support::assert_rejected_with(
         &compile(
             source,
             event("repository_dispatch", "refs/heads/main"),
@@ -207,7 +163,7 @@ fn repository_dispatch_requires_exact_bounded_metadata() {
         "github.compile.event_metadata_mismatch",
     );
     for event_type in [String::new(), "x".repeat(101), "bad\nevent".to_owned()] {
-        assert_rejected_with(
+        support::assert_rejected_with(
             &compile(
                 source,
                 event("repository_dispatch", "refs/heads/main"),
@@ -233,7 +189,7 @@ fn pull_requests_use_github_default_actions() {
         );
     }
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             FILTERED_WORKFLOW,
             event("pull_request", "refs/pull/42/merge"),
@@ -257,7 +213,7 @@ fn pull_request_branch_filters_use_target_base_never_event_or_head_ref() {
         matching_base.diagnostics()
     );
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("pull_request", "refs/heads/main"),
@@ -277,7 +233,7 @@ fn explicit_pull_request_types_replace_the_default_action_set() {
     );
     assert!(closed.is_accepted(), "{:#?}", closed.diagnostics());
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("pull_request", "refs/pull/42/merge"),
@@ -297,7 +253,7 @@ fn ordered_negative_patterns_exclude_and_later_reinclude() {
     );
     assert!(reincluded.is_accepted(), "{:#?}", reincluded.diagnostics());
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("push", "refs/heads/releases/10-alpha"),
@@ -317,7 +273,7 @@ fn push_branch_and_tag_filters_are_ref_kind_specific() {
     );
     assert!(tag.is_accepted(), "{:#?}", tag.diagnostics());
 
-    assert_not_selected(
+    support::assert_not_selected(
         &compile(
             source,
             event("push", "refs/heads/v2.10.1"),
@@ -355,7 +311,7 @@ fn changed_file_filters_require_verified_metadata_and_honor_ordered_patterns() {
     assert!(report.is_accepted(), "{:#?}", report.diagnostics());
 
     for path in ["src/generated/output.rs", "docs/readme.md"] {
-        assert_not_selected(
+        support::assert_not_selected(
             &compile(
                 source,
                 event("push", "refs/heads/main"),
@@ -440,7 +396,7 @@ fn tag_pushes_never_require_changed_file_metadata() {
 fn paths_ignore_requires_at_least_one_changed_file_outside_the_ignore_set() {
     let source = "on:\n  pull_request:\n    branches: [main]\n    paths-ignore: ['docs/**']\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
     for files in [Vec::<&str>::new(), vec!["docs/readme.md"]] {
-        assert_not_selected(
+        support::assert_not_selected(
             &compile(
                 source,
                 event("pull_request", "refs/pull/42/merge"),
@@ -492,7 +448,7 @@ fn invalid_changed_file_metadata_is_bounded_and_sanitized() {
             GithubChangedFiles::complete([format!("{sentinel}\n")]),
         )),
     );
-    assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
+    support::assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
     assert!(!format!("{:?}", report.diagnostics()).contains(sentinel));
 }
 
@@ -519,7 +475,7 @@ fn changed_file_metadata_enforces_event_specific_provider_windows() {
             GithubChangedFiles::complete(files),
         )),
     );
-    assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
+    support::assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
 
     let pull_request_source = "on:\n  pull_request:\n    paths: ['src/file-2999.rs']\njobs:\n  test:\n    runs-on: linux\n    steps:\n      - run: true\n";
     let files = (0..3_000).map(|index| format!("src/file-{index}.rs"));
@@ -544,7 +500,7 @@ fn changed_file_metadata_enforces_event_specific_provider_windows() {
             GithubChangedFiles::complete(files),
         )),
     );
-    assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
+    support::assert_rejected_with(&report, "github.compile.invalid_changed_files_metadata");
 }
 
 #[test]
@@ -576,7 +532,7 @@ fn push_and_pull_request_fail_closed_without_verified_metadata() {
         ("push", "refs/heads/main"),
         ("pull_request", "refs/pull/42/merge"),
     ] {
-        assert_rejected_with(
+        support::assert_rejected_with(
             &compile(FILTERED_WORKFLOW, event(name, git_ref), None),
             "github.compile.event_metadata_required",
         );
@@ -592,14 +548,11 @@ fn push_and_pull_request_fail_closed_without_verified_metadata() {
 
 #[test]
 fn preselected_recompilation_validates_the_exact_trigger_span() {
-    let parsed = support::parse(FILTERED_WORKFLOW);
-    assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let initial = GithubWorkflowCompiler::new().compile(
-        CompileWorkflowRequest::new(
-            parsed.plan().expect("source plan"),
-            event("push", "refs/heads/main"),
-        )
-        .with_event_metadata(GithubEventMetadata::push(false)),
+    let parsed = support::parse_accepted(FILTERED_WORKFLOW);
+    let initial = support::compile(
+        parsed.plan().expect("source plan"),
+        event("push", "refs/heads/main"),
+        Some(GithubEventMetadata::push(false)),
     );
     let plan = initial.plan().expect("initial plan");
     let replay =
@@ -611,9 +564,8 @@ fn preselected_recompilation_validates_the_exact_trigger_span() {
     assert_eq!(replay.plan(), Some(plan));
 
     let shifted_source = format!("\n{FILTERED_WORKFLOW}");
-    let shifted = support::parse(&shifted_source);
-    assert!(shifted.is_accepted(), "{:#?}", shifted.diagnostics());
-    assert_rejected_with(
+    let shifted = support::parse_accepted(&shifted_source);
+    support::assert_rejected_with(
         &GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::for_preselected_event(
             shifted.plan().expect("shifted plan"),
             plan.event().clone(),

--- a/crates/automata-ci-workflow-github/tests/workflow_dispatch_inputs.rs
+++ b/crates/automata-ci-workflow-github/tests/workflow_dispatch_inputs.rs
@@ -2,8 +2,8 @@ use crate::support;
 
 use automata_ci_core::{ContextValue, WorkflowEventProvenance};
 use automata_ci_workflow_github::{
-    CompilationDisposition, CompilationReport, CompileWorkflowRequest, GithubEventMetadata,
-    GithubWorkflowCompiler, GithubWorkflowDispatchInputDefault, GithubWorkflowDispatchInputType,
+    CompilationReport, CompileWorkflowRequest, GithubEventMetadata, GithubWorkflowCompiler,
+    GithubWorkflowDispatchInputDefault, GithubWorkflowDispatchInputType,
     GithubWorkflowDispatchInputValue, GithubWorkflowDispatchInputs,
     GithubWorkflowDispatchInputsError, MAX_GITHUB_WORKFLOW_DISPATCH_INPUT_CHARACTERS,
     MAX_GITHUB_WORKFLOW_DISPATCH_INPUTS,
@@ -12,24 +12,15 @@ use automata_ci_workflow_github::{
 const JOB: &str = "jobs:\n  verify:\n    runs-on: linux\n    steps:\n      - run: true\n";
 
 fn compile(source: &str, inputs: Option<GithubWorkflowDispatchInputs>) -> CompilationReport {
-    let parsed = support::parse(source);
-    assert!(
-        parsed.is_accepted(),
-        "source diagnostics: {:#?}",
-        parsed.diagnostics()
-    );
-    let request = CompileWorkflowRequest::new(
+    let parsed = support::parse_accepted(source);
+    support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch")
             .with_delivery_id("synthetic-dispatch")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    );
-    let request = match inputs {
-        Some(inputs) => request.with_event_metadata(GithubEventMetadata::workflow_dispatch(inputs)),
-        None => request,
-    };
-    GithubWorkflowCompiler::new().compile(request)
+        inputs.map(GithubEventMetadata::workflow_dispatch),
+    )
 }
 
 fn payload(
@@ -39,18 +30,9 @@ fn payload(
 }
 
 fn assert_rejected_with(report: &CompilationReport, code: &str) {
-    assert_eq!(report.disposition(), CompilationDisposition::Rejected);
-    assert!(report.plan().is_none());
+    support::assert_rejected_with(report, code);
     assert!(report.workflow_dispatch_contract().is_none());
     assert!(report.workflow_dispatch_inputs().is_none());
-    assert!(
-        report
-            .diagnostics()
-            .iter()
-            .any(|diagnostic| diagnostic.code() == code),
-        "missing diagnostic `{code}`: {:#?}",
-        report.diagnostics()
-    );
 }
 
 #[test]

--- a/crates/automata-ci-workflow-github/tests/yaml_aliases.rs
+++ b/crates/automata-ci-workflow-github/tests/yaml_aliases.rs
@@ -2,16 +2,14 @@ use crate::support;
 
 use automata_ci_core::{WorkflowEventProvenance, WorkflowPlan};
 use automata_ci_workflow_github::{
-    CompileWorkflowRequest, DiagnosticKind, GithubWorkflowCompiler, GithubWorkflowFrontend,
-    ParseWorkflowRequest, RunnerSelection, SourceProvenance, WorkflowFrontend, WorkflowParseLimits,
-    YamlNode, YamlNodeKind,
+    DiagnosticKind, GithubWorkflowFrontend, ParseWorkflowRequest, RunnerSelection,
+    SourceProvenance, WorkflowFrontend, WorkflowParseLimits, YamlNode, YamlNodeKind,
 };
 use serde_json::Value;
 
 #[test]
 fn scalar_sequence_mapping_and_whole_job_aliases_decode_before_compilation() {
-    let report = support::parse(include_str!("fixtures/aliases-equivalent.yml"));
-    assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    let report = support::parse_accepted(include_str!("fixtures/aliases-equivalent.yml"));
     let plan = report.plan().expect("source plan");
 
     assert!(contains_alias(plan.document().root()));
@@ -53,8 +51,7 @@ fn scalar_sequence_mapping_and_whole_job_aliases_decode_before_compilation() {
 
 #[test]
 fn alias_use_spans_are_primary_and_definition_spans_are_retained() {
-    let report = support::parse(include_str!("fixtures/aliases.yml"));
-    assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    let report = support::parse_accepted(include_str!("fixtures/aliases.yml"));
     let plan = report.plan().expect("source plan");
     let build = mapping_value(
         mapping_value(plan.expanded_document().root(), "jobs"),
@@ -78,8 +75,7 @@ fn alias_use_spans_are_primary_and_definition_spans_are_retained() {
 
 #[test]
 fn duplicate_anchor_names_rebind_only_subsequent_aliases() {
-    let report = support::parse(include_str!("fixtures/aliases-redefined.yml"));
-    assert!(report.is_accepted(), "{:#?}", report.diagnostics());
+    let report = support::parse_accepted(include_str!("fixtures/aliases-redefined.yml"));
     let jobs = report.plan().expect("source plan").workflow().jobs();
     assert_eq!(environment_value(jobs[0].job(), "GENERATION"), "first");
     assert_eq!(environment_value(jobs[1].job(), "GENERATION"), "second");
@@ -95,10 +91,11 @@ fn alias_expansion_cannot_hide_a_duplicate_mapping_key_from_compilation() {
         "expanded workflow remains inspectable: {:#?}",
         parsed.diagnostics()
     );
-    let compiled = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let compiled = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "push"),
-    ));
+        None,
+    );
     let diagnostic = compiled
         .diagnostics()
         .iter()
@@ -299,13 +296,14 @@ fn compile(source: &str) -> WorkflowPlan {
         source,
     ));
     assert!(parsed.is_accepted(), "{:#?}", parsed.diagnostics());
-    let compiled = GithubWorkflowCompiler::new().compile(CompileWorkflowRequest::new(
+    let compiled = support::compile(
         parsed.plan().expect("source plan"),
         WorkflowEventProvenance::new("github", "workflow_dispatch")
             .with_delivery_id("alias-equivalence")
             .with_commit_sha("0123456789abcdef0123456789abcdef01234567")
             .with_git_ref("refs/heads/main"),
-    ));
+        None,
+    );
     assert!(compiled.is_accepted(), "{:#?}", compiled.diagnostics());
     compiled.plan().expect("logical plan").clone()
 }

--- a/crates/automata-ci-workflow-github/tests/yaml_semantics.rs
+++ b/crates/automata-ci-workflow-github/tests/yaml_semantics.rs
@@ -9,12 +9,9 @@ const WORKFLOW_LF: &str =
 fn bom_and_newline_style_are_retained_but_do_not_change_semantics() {
     let bom = format!("\u{feff}{WORKFLOW_LF}");
     let crlf = WORKFLOW_LF.replace('\n', "\r\n");
-    let plain = support::parse(WORKFLOW_LF);
-    let with_bom = support::parse(&bom);
-    let with_crlf = support::parse(&crlf);
-    for report in [&plain, &with_bom, &with_crlf] {
-        assert!(report.is_accepted(), "{:#?}", report.diagnostics());
-    }
+    let plain = support::parse_accepted(WORKFLOW_LF);
+    let with_bom = support::parse_accepted(&bom);
+    let with_crlf = support::parse_accepted(&crlf);
     assert_eq!(with_bom.plan().expect("BOM plan").source().text(), bom);
     assert_eq!(with_crlf.plan().expect("CRLF plan").source().text(), crlf);
     assert_eq!(workflow_shape(&plain), workflow_shape(&with_bom));
@@ -69,22 +66,15 @@ fn empty_and_trailing_documents_are_rejected_as_document_count_errors() {
 
 #[test]
 fn quoted_and_unquoted_on_keys_decode_identically() {
-    let unquoted = support::parse(WORKFLOW_LF);
-    let quoted = support::parse(&WORKFLOW_LF.replacen("on:", "'on':", 1));
-    assert!(unquoted.is_accepted(), "{:#?}", unquoted.diagnostics());
-    assert!(quoted.is_accepted(), "{:#?}", quoted.diagnostics());
+    let unquoted = support::parse_accepted(WORKFLOW_LF);
+    let quoted = support::parse_accepted(&WORKFLOW_LF.replacen("on:", "'on':", 1));
     assert_eq!(workflow_shape(&unquoted), workflow_shape(&quoted));
 }
 
 #[test]
 fn yaml_1_2_does_not_resolve_on_off_yes_or_no_as_booleans() {
     let source = "on: push\nenv:\n  ON_VALUE: on\n  OFF_VALUE: off\n  YES_VALUE: yes\n  NO_VALUE: no\n  TRUE_VALUE: true\n  QUOTED_TRUE: 'true'\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo test\n";
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("plan");
     let root = plan.document().root().as_mapping().expect("mapping");
     let on_key = root[0].key().as_scalar().expect("on key");
@@ -118,12 +108,7 @@ fn yaml_1_2_does_not_resolve_on_off_yes_or_no_as_booleans() {
 #[test]
 fn yaml_1_2_numeric_resolution_rejects_underscores_and_signed_nondecimal_integers() {
     let source = "on: push\nenv:\n  UNDERSCORED_INTEGER: 1_000\n  UNDERSCORED_FLOAT: 1.0_0\n  SIGNED_HEX: -0x10\n  INTEGER: 1000\n  HEX: 0x10\n  FLOAT: .5\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo test\n";
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
 
     let env = mapping_value(report.plan().expect("plan").document().root(), "env");
     let resolutions = env
@@ -157,12 +142,7 @@ fn original_text_is_an_exact_round_trip_artifact() {
 #[test]
 fn spans_use_utf8_byte_offsets_and_one_based_display_locations() {
     let source = "name: 'café'\non: push\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo test\n";
-    let report = support::parse(source);
-    assert!(
-        report.is_accepted(),
-        "diagnostics: {:#?}",
-        report.diagnostics()
-    );
+    let report = support::parse_accepted(source);
     let plan = report.plan().expect("plan");
     let name = plan.document().root().as_mapping().expect("mapping")[0].value();
     assert_eq!(plan.source().slice(name.span()), Some("'café'"));


### PR DESCRIPTION
## Summary

- centralize plan-level initial compilation while keeping every event name, delivery ID, commit SHA, git ref, and provider metadata value at its caller
- share the existing accepted-parse boundary across accepted-only tests without touching rejected, loss-aware, replay, custom-source, or conditional parse paths
- consolidate identical rejected/non-selected report assertions while retaining the stronger workflow-dispatch state checks

This is one subsystem-sized cleanup: 18 files, 584 changed lines, and 150 net lines removed. All six preselected replay constructions remain explicit. Production behavior is unchanged.

## Validation

- cargo fmt --all -- --check
- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-workflow-github --all-targets --all-features
- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-workflow-github --test workflow_github --all-features (182 passed)
- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-workflow-github --all-targets --all-features -- -D warnings
- independent static and semantic review: approved, no findings

Closes #347.