### PR TITLE
refactor(results): share observability test support

### DIFF
--- a/crates/automata-ci-results-github/tests/http_observability.rs
+++ b/crates/automata-ci-results-github/tests/http_observability.rs
@@ -1,20 +1,13 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+mod observability_support;
 
-use async_trait::async_trait;
+use std::sync::Arc;
+
 use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType, MemoryBlobStore};
 use automata_ci_core::{AttemptId, FencingToken, JobId, RunId, Sha256Digest};
 use automata_ci_results_github::{
-    ARTIFACT_MANIFEST_MEDIA_TYPE, ArtifactBlockReservation, ArtifactFinalizationReservation,
-    ArtifactFinalizationWork, ArtifactId, ArtifactManifest, ArtifactManifestBlock, ArtifactName,
-    ArtifactRepository, ArtifactRepositoryError, ArtifactRepositoryErrorKind, ArtifactService,
-    BeginArtifactFinalization, CommitArtifactBlocks, CommittedArtifact, CompleteArtifactBlock,
-    CompleteArtifactFinalization, CreateArtifact, CreateArtifactOutcome, ExecutionAuthority,
-    FinalizeArtifactOutcome, GithubResultsApi, GithubResultsHttpLimits, ListArtifacts,
-    LoadArtifactFinalization, PublishedArtifactMetadata, RecordArtifactVerification,
-    RenewArtifactFinalization, ReserveArtifactBlock, ResultsHttpMethod, ResultsHttpRoute,
+    ARTIFACT_MANIFEST_MEDIA_TYPE, ArtifactId, ArtifactManifest, ArtifactManifestBlock,
+    ArtifactName, ArtifactRepository, ArtifactService, ExecutionAuthority, GithubResultsApi,
+    GithubResultsHttpLimits, PublishedArtifactMetadata, ResultsHttpMethod, ResultsHttpRoute,
     ResultsHttpStatusClass, ResultsIdGenerator, ResultsLimits, ResultsObserver, ResultsOperation,
     ResultsOperationOutcome, ResultsTransferDirection, RuntimeTokenClaims, RuntimeTokenVerifier,
     SignedDownloadCapability, SignedUploadCapability, SystemResultsClock, SystemResultsIdGenerator,
@@ -26,6 +19,10 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use http_body_util::BodyExt as _;
+use observability_support::{
+    observer::{HttpEvent, RecordingObserver},
+    repository::{ReserveBlockBehavior, TestArtifactRepository},
+};
 use sha2::{Digest as _, Sha256};
 use tokio::sync::Notify;
 use tower::ServiceExt as _;
@@ -37,185 +34,6 @@ const CREATE_PATH: &str = "/twirp/github.actions.results.api.v1.ArtifactService/
 fn upload_path(upload_id: UploadId) -> String {
     let block_id = STANDARD.encode([7_u8; 48]);
     format!("/_apis/results/artifacts/{upload_id}/blob?se=100&sig=x&comp=block&blockid={block_id}")
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum HttpEvent {
-    Started(ResultsHttpMethod, ResultsHttpRoute),
-    Completed(ResultsHttpMethod, ResultsHttpRoute, ResultsHttpStatusClass),
-    Finished(ResultsHttpMethod, ResultsHttpRoute),
-}
-
-#[derive(Clone, Debug, Default)]
-struct RecordingObserver {
-    events: Arc<Mutex<Vec<HttpEvent>>>,
-    operations: Arc<Mutex<Vec<(ResultsOperation, ResultsOperationOutcome)>>>,
-    transfers: Arc<Mutex<Vec<(ResultsTransferDirection, u64)>>>,
-}
-
-impl ResultsObserver for RecordingObserver {
-    fn results_http_request_started(&self, method: ResultsHttpMethod, route: ResultsHttpRoute) {
-        self.events
-            .lock()
-            .expect("HTTP events lock")
-            .push(HttpEvent::Started(method, route));
-    }
-
-    fn observe_results_http_request(
-        &self,
-        method: ResultsHttpMethod,
-        route: ResultsHttpRoute,
-        status: ResultsHttpStatusClass,
-        _duration: Duration,
-    ) {
-        self.events
-            .lock()
-            .expect("HTTP events lock")
-            .push(HttpEvent::Completed(method, route, status));
-    }
-
-    fn results_http_request_finished(&self, method: ResultsHttpMethod, route: ResultsHttpRoute) {
-        self.events
-            .lock()
-            .expect("HTTP events lock")
-            .push(HttpEvent::Finished(method, route));
-    }
-
-    fn observe_transfer_bytes(&self, direction: ResultsTransferDirection, bytes: u64) {
-        self.transfers
-            .lock()
-            .expect("transfer observations lock")
-            .push((direction, bytes));
-    }
-
-    fn observe_operation(
-        &self,
-        operation: ResultsOperation,
-        outcome: ResultsOperationOutcome,
-        _duration: Duration,
-    ) {
-        self.operations
-            .lock()
-            .expect("operation observations lock")
-            .push((operation, outcome));
-    }
-}
-
-#[derive(Debug)]
-enum ReserveBehavior {
-    Unavailable,
-    Ready,
-    Pending {
-        entered: Arc<Notify>,
-        release: Arc<Notify>,
-    },
-}
-
-#[derive(Debug)]
-struct TestRepository {
-    reserve: ReserveBehavior,
-    download: Option<PublishedArtifactMetadata>,
-}
-
-impl Default for TestRepository {
-    fn default() -> Self {
-        Self {
-            reserve: ReserveBehavior::Unavailable,
-            download: None,
-        }
-    }
-}
-
-fn unavailable() -> ArtifactRepositoryError {
-    ArtifactRepositoryError::new(ArtifactRepositoryErrorKind::Unavailable)
-}
-
-#[async_trait]
-impl ArtifactRepository for TestRepository {
-    async fn create(
-        &self,
-        _request: CreateArtifact,
-    ) -> Result<CreateArtifactOutcome, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn reserve_block(
-        &self,
-        _request: ReserveArtifactBlock,
-    ) -> Result<ArtifactBlockReservation, ArtifactRepositoryError> {
-        match &self.reserve {
-            ReserveBehavior::Unavailable => Err(unavailable()),
-            ReserveBehavior::Ready => Ok(ArtifactBlockReservation::Ready),
-            ReserveBehavior::Pending { entered, release } => {
-                entered.notify_one();
-                release.notified().await;
-                Err(unavailable())
-            }
-        }
-    }
-
-    async fn complete_block(
-        &self,
-        _request: CompleteArtifactBlock,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn commit_blocks(
-        &self,
-        _request: CommitArtifactBlocks,
-    ) -> Result<CommittedArtifact, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn begin_finalization(
-        &self,
-        _request: BeginArtifactFinalization,
-    ) -> Result<ArtifactFinalizationReservation, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn load_finalization(
-        &self,
-        _request: LoadArtifactFinalization,
-    ) -> Result<ArtifactFinalizationWork, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn renew_finalization(
-        &self,
-        _request: RenewArtifactFinalization,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn record_verification(
-        &self,
-        _request: RecordArtifactVerification,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn complete_finalization(
-        &self,
-        _request: CompleteArtifactFinalization,
-    ) -> Result<FinalizeArtifactOutcome, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn list(
-        &self,
-        _request: ListArtifacts,
-    ) -> Result<Vec<PublishedArtifactMetadata>, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn resolve_download(
-        &self,
-        _request: automata_ci_results_github::ResolveArtifactDownload,
-    ) -> Result<PublishedArtifactMetadata, ArtifactRepositoryError> {
-        self.download.clone().ok_or_else(unavailable)
-    }
 }
 
 #[derive(Debug, Default)]
@@ -276,7 +94,7 @@ impl SignedDownloadCapability for TestAuthority {
 
 fn router(observer: Arc<dyn ResultsObserver>) -> axum::Router {
     router_with(
-        Arc::new(TestRepository::default()),
+        Arc::new(TestArtifactRepository::default()),
         Arc::new(MemoryBlobStore::default()),
         Arc::new(TestAuthority::default()),
         observer,
@@ -326,26 +144,28 @@ async fn matched_route_red_observation_is_finite_and_balanced() {
         .expect("response");
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    assert_eq!(
-        *recorder.events.lock().expect("HTTP events lock"),
-        vec![
+    let observations = recorder.snapshot();
+    assert!(matches!(
+        observations.http_events.as_slice(),
+        [
             HttpEvent::Started(ResultsHttpMethod::Post, ResultsHttpRoute::CreateArtifact),
-            HttpEvent::Completed(
-                ResultsHttpMethod::Post,
-                ResultsHttpRoute::CreateArtifact,
-                ResultsHttpStatusClass::ClientError,
-            ),
+            HttpEvent::Completed {
+                method: ResultsHttpMethod::Post,
+                route: ResultsHttpRoute::CreateArtifact,
+                status: ResultsHttpStatusClass::ClientError,
+                ..
+            },
             HttpEvent::Finished(ResultsHttpMethod::Post, ResultsHttpRoute::CreateArtifact),
         ]
-    );
+    ));
 }
 
 #[tokio::test]
 async fn successful_upload_counts_only_the_accepted_body() {
     let recorder = RecordingObserver::default();
-    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestRepository {
-        reserve: ReserveBehavior::Ready,
-        download: None,
+    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
+        reserve_block: ReserveBlockBehavior::Ready,
+        ..TestArtifactRepository::default()
     });
     let authority = Arc::new(TestAuthority {
         accept_upload: true,
@@ -371,21 +191,20 @@ async fn successful_upload_counts_only_the_accepted_body() {
     .expect("response");
 
     assert_eq!(response.status(), StatusCode::CREATED);
+    let observations = recorder.snapshot();
     assert_eq!(
-        *recorder
+        observations
             .operations
-            .lock()
-            .expect("operation observations lock"),
+            .iter()
+            .map(|(operation, outcome, _)| (*operation, *outcome))
+            .collect::<Vec<_>>(),
         vec![(
             ResultsOperation::StageBlock,
             ResultsOperationOutcome::Success,
         )]
     );
     assert_eq!(
-        *recorder
-            .transfers
-            .lock()
-            .expect("transfer observations lock"),
+        observations.transfers,
         vec![(
             ResultsTransferDirection::Upload,
             u64::try_from(body.len()).expect("bounded body length"),
@@ -398,12 +217,12 @@ async fn dropped_request_records_cancelled_and_never_accepts_upload_bytes() {
     let recorder = RecordingObserver::default();
     let entered = Arc::new(Notify::new());
     let release = Arc::new(Notify::new());
-    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestRepository {
-        reserve: ReserveBehavior::Pending {
+    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
+        reserve_block: ReserveBlockBehavior::Pending {
             entered: Arc::clone(&entered),
             release,
         },
-        download: None,
+        ..TestArtifactRepository::default()
     });
     let authority = Arc::new(TestAuthority {
         accept_upload: true,
@@ -433,35 +252,32 @@ async fn dropped_request_records_cancelled_and_never_accepts_upload_bytes() {
             .is_cancelled()
     );
 
-    assert_eq!(
-        *recorder.events.lock().expect("HTTP events lock"),
-        vec![
+    let observations = recorder.snapshot();
+    assert!(matches!(
+        observations.http_events.as_slice(),
+        [
             HttpEvent::Started(ResultsHttpMethod::Put, ResultsHttpRoute::Upload),
-            HttpEvent::Completed(
-                ResultsHttpMethod::Put,
-                ResultsHttpRoute::Upload,
-                ResultsHttpStatusClass::Cancelled,
-            ),
+            HttpEvent::Completed {
+                method: ResultsHttpMethod::Put,
+                route: ResultsHttpRoute::Upload,
+                status: ResultsHttpStatusClass::Cancelled,
+                ..
+            },
             HttpEvent::Finished(ResultsHttpMethod::Put, ResultsHttpRoute::Upload),
         ]
-    );
+    ));
     assert_eq!(
-        *recorder
+        observations
             .operations
-            .lock()
-            .expect("operation observations lock"),
+            .iter()
+            .map(|(operation, outcome, _)| (*operation, *outcome))
+            .collect::<Vec<_>>(),
         vec![(
             ResultsOperation::StageBlock,
             ResultsOperationOutcome::Cancelled,
         )]
     );
-    assert!(
-        recorder
-            .transfers
-            .lock()
-            .expect("transfer observations lock")
-            .is_empty()
-    );
+    assert!(observations.transfers.is_empty());
 }
 
 #[tokio::test]
@@ -555,9 +371,9 @@ async fn download_bytes_count_only_frames_yielded_before_client_body_cancellatio
         created_at_seconds: 10,
         expires_at_seconds: None,
     };
-    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestRepository {
-        reserve: ReserveBehavior::Unavailable,
+    let repository: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
         download: Some(metadata),
+        ..TestArtifactRepository::default()
     });
     let object_port: Arc<dyn ImmutableBlobStore> = objects;
     let authority = Arc::new(TestAuthority {
@@ -582,22 +398,20 @@ async fn download_bytes_count_only_frames_yielded_before_client_body_cancellatio
     .await
     .expect("response");
     assert_eq!(response.status(), StatusCode::OK);
+    let observations = recorder.snapshot();
     assert_eq!(
-        *recorder
+        observations
             .operations
-            .lock()
-            .expect("operation observations lock"),
+            .iter()
+            .map(|(operation, outcome, _)| (*operation, *outcome))
+            .collect::<Vec<_>>(),
         vec![(
             ResultsOperation::PrepareDownload,
             ResultsOperationOutcome::Success,
         )]
     );
     assert!(
-        recorder
-            .transfers
-            .lock()
-            .expect("transfer observations lock")
-            .is_empty(),
+        observations.transfers.is_empty(),
         "building a response must not count unpolled download bytes"
     );
 
@@ -612,11 +426,13 @@ async fn download_bytes_count_only_frames_yielded_before_client_body_cancellatio
         bytes::Bytes::from_static(b"first yielded block")
     );
     drop(response_body);
+    let observations = recorder.snapshot();
     assert_eq!(
-        *recorder
+        observations
             .operations
-            .lock()
-            .expect("operation observations lock"),
+            .iter()
+            .map(|(operation, outcome, _)| (*operation, *outcome))
+            .collect::<Vec<_>>(),
         vec![
             (
                 ResultsOperation::PrepareDownload,
@@ -629,10 +445,7 @@ async fn download_bytes_count_only_frames_yielded_before_client_body_cancellatio
         ]
     );
     assert_eq!(
-        *recorder
-            .transfers
-            .lock()
-            .expect("transfer observations lock"),
+        observations.transfers,
         vec![(
             ResultsTransferDirection::Download,
             u64::try_from(first.len()).expect("bounded block length"),
@@ -656,18 +469,19 @@ async fn unknown_path_never_becomes_a_metric_label() {
         .expect("response");
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    let events = recorder.events.lock().expect("HTTP events lock");
-    assert_eq!(
-        *events,
-        vec![
+    let observations = recorder.snapshot();
+    assert!(matches!(
+        observations.http_events.as_slice(),
+        [
             HttpEvent::Started(ResultsHttpMethod::Other, ResultsHttpRoute::Unknown),
-            HttpEvent::Completed(
-                ResultsHttpMethod::Other,
-                ResultsHttpRoute::Unknown,
-                ResultsHttpStatusClass::ClientError,
-            ),
+            HttpEvent::Completed {
+                method: ResultsHttpMethod::Other,
+                route: ResultsHttpRoute::Unknown,
+                status: ResultsHttpStatusClass::ClientError,
+                ..
+            },
             HttpEvent::Finished(ResultsHttpMethod::Other, ResultsHttpRoute::Unknown),
         ]
-    );
-    assert!(!format!("{events:?}").contains(private_path));
+    ));
+    assert!(!format!("{:?}", observations.http_events).contains(private_path));
 }

--- a/crates/automata-ci-results-github/tests/observability_support/mod.rs
+++ b/crates/automata-ci-results-github/tests/observability_support/mod.rs
@@ -1,0 +1,5 @@
+// Integration-test targets compile this shared module independently and use different subsets.
+#![allow(dead_code)]
+
+pub(crate) mod observer;
+pub(crate) mod repository;

--- a/crates/automata-ci-results-github/tests/observability_support/observer.rs
+++ b/crates/automata-ci-results-github/tests/observability_support/observer.rs
@@ -1,0 +1,121 @@
+use std::{
+    sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
+};
+
+use automata_ci_results_github::{
+    ResultsBlobOperation, ResultsBlobOperationOutcome, ResultsHttpMethod, ResultsHttpRoute,
+    ResultsHttpStatusClass, ResultsObserver, ResultsOperation, ResultsOperationOutcome,
+    ResultsRepositoryOperation, ResultsRepositoryOperationOutcome, ResultsTransferDirection,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HttpEvent {
+    Started(ResultsHttpMethod, ResultsHttpRoute),
+    Completed {
+        method: ResultsHttpMethod,
+        route: ResultsHttpRoute,
+        status: ResultsHttpStatusClass,
+        duration: Duration,
+    },
+    Finished(ResultsHttpMethod, ResultsHttpRoute),
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ObservationSnapshot {
+    pub(crate) http_events: Vec<HttpEvent>,
+    pub(crate) operations: Vec<(ResultsOperation, ResultsOperationOutcome, Duration)>,
+    pub(crate) transfers: Vec<(ResultsTransferDirection, u64)>,
+    pub(crate) blob_operations: Vec<(ResultsBlobOperation, ResultsBlobOperationOutcome, Duration)>,
+    pub(crate) blob_bytes: Vec<(ResultsBlobOperation, u64)>,
+    pub(crate) repository_operations: Vec<(
+        ResultsRepositoryOperation,
+        ResultsRepositoryOperationOutcome,
+        Duration,
+    )>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RecordingObserver {
+    observations: Arc<Mutex<ObservationSnapshot>>,
+}
+
+impl RecordingObserver {
+    pub(crate) fn snapshot(&self) -> ObservationSnapshot {
+        self.observations().clone()
+    }
+
+    fn observations(&self) -> MutexGuard<'_, ObservationSnapshot> {
+        self.observations.lock().expect("results observations lock")
+    }
+}
+
+impl ResultsObserver for RecordingObserver {
+    fn observe_operation(
+        &self,
+        operation: ResultsOperation,
+        outcome: ResultsOperationOutcome,
+        duration: Duration,
+    ) {
+        self.observations()
+            .operations
+            .push((operation, outcome, duration));
+    }
+
+    fn observe_transfer_bytes(&self, direction: ResultsTransferDirection, bytes: u64) {
+        self.observations().transfers.push((direction, bytes));
+    }
+
+    fn results_http_request_started(&self, method: ResultsHttpMethod, route: ResultsHttpRoute) {
+        self.observations()
+            .http_events
+            .push(HttpEvent::Started(method, route));
+    }
+
+    fn observe_results_http_request(
+        &self,
+        method: ResultsHttpMethod,
+        route: ResultsHttpRoute,
+        status: ResultsHttpStatusClass,
+        duration: Duration,
+    ) {
+        self.observations().http_events.push(HttpEvent::Completed {
+            method,
+            route,
+            status,
+            duration,
+        });
+    }
+
+    fn results_http_request_finished(&self, method: ResultsHttpMethod, route: ResultsHttpRoute) {
+        self.observations()
+            .http_events
+            .push(HttpEvent::Finished(method, route));
+    }
+
+    fn observe_blob_operation(
+        &self,
+        operation: ResultsBlobOperation,
+        outcome: ResultsBlobOperationOutcome,
+        duration: Duration,
+    ) {
+        self.observations()
+            .blob_operations
+            .push((operation, outcome, duration));
+    }
+
+    fn observe_blob_bytes(&self, operation: ResultsBlobOperation, bytes: u64) {
+        self.observations().blob_bytes.push((operation, bytes));
+    }
+
+    fn observe_repository_operation(
+        &self,
+        operation: ResultsRepositoryOperation,
+        outcome: ResultsRepositoryOperationOutcome,
+        duration: Duration,
+    ) {
+        self.observations()
+            .repository_operations
+            .push((operation, outcome, duration));
+    }
+}

--- a/crates/automata-ci-results-github/tests/observability_support/repository.rs
+++ b/crates/automata-ci-results-github/tests/observability_support/repository.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use automata_ci_results_github::{
+    ArtifactBlockReservation, ArtifactFinalizationReservation, ArtifactFinalizationWork,
+    ArtifactRepository, ArtifactRepositoryError, ArtifactRepositoryErrorKind,
+    BeginArtifactFinalization, CommitArtifactBlocks, CommittedArtifact, CompleteArtifactBlock,
+    CompleteArtifactFinalization, CreateArtifact, CreateArtifactOutcome, FinalizeArtifactOutcome,
+    ListArtifacts, LoadArtifactFinalization, PublishedArtifactMetadata, RecordArtifactVerification,
+    RenewArtifactFinalization, ReserveArtifactBlock, ResolveArtifactDownload,
+};
+use tokio::sync::Notify;
+
+#[derive(Debug, Default)]
+pub(crate) enum ReserveBlockBehavior {
+    #[default]
+    Unavailable,
+    Ready,
+    Pending {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    },
+}
+
+#[derive(Debug, Default)]
+pub(crate) enum ListArtifactsBehavior {
+    #[default]
+    Unavailable,
+    Success,
+    Conflict,
+    Pending {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    },
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TestArtifactRepository {
+    pub(crate) reserve_block: ReserveBlockBehavior,
+    pub(crate) list_artifacts: ListArtifactsBehavior,
+    pub(crate) download: Option<PublishedArtifactMetadata>,
+}
+
+fn unavailable() -> ArtifactRepositoryError {
+    ArtifactRepositoryError::new(ArtifactRepositoryErrorKind::Unavailable)
+}
+
+#[async_trait]
+impl ArtifactRepository for TestArtifactRepository {
+    async fn create(
+        &self,
+        _request: CreateArtifact,
+    ) -> Result<CreateArtifactOutcome, ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn reserve_block(
+        &self,
+        _request: ReserveArtifactBlock,
+    ) -> Result<ArtifactBlockReservation, ArtifactRepositoryError> {
+        match &self.reserve_block {
+            ReserveBlockBehavior::Unavailable => Err(unavailable()),
+            ReserveBlockBehavior::Ready => Ok(ArtifactBlockReservation::Ready),
+            ReserveBlockBehavior::Pending { entered, release } => {
+                entered.notify_one();
+                release.notified().await;
+                Err(unavailable())
+            }
+        }
+    }
+
+    async fn complete_block(
+        &self,
+        _request: CompleteArtifactBlock,
+    ) -> Result<(), ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn commit_blocks(
+        &self,
+        _request: CommitArtifactBlocks,
+    ) -> Result<CommittedArtifact, ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn begin_finalization(
+        &self,
+        _request: BeginArtifactFinalization,
+    ) -> Result<ArtifactFinalizationReservation, ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn load_finalization(
+        &self,
+        _request: LoadArtifactFinalization,
+    ) -> Result<ArtifactFinalizationWork, ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn renew_finalization(
+        &self,
+        _request: RenewArtifactFinalization,
+    ) -> Result<(), ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn record_verification(
+        &self,
+        _request: RecordArtifactVerification,
+    ) -> Result<(), ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn complete_finalization(
+        &self,
+        _request: CompleteArtifactFinalization,
+    ) -> Result<FinalizeArtifactOutcome, ArtifactRepositoryError> {
+        Err(unavailable())
+    }
+
+    async fn list(
+        &self,
+        _request: ListArtifacts,
+    ) -> Result<Vec<PublishedArtifactMetadata>, ArtifactRepositoryError> {
+        match &self.list_artifacts {
+            ListArtifactsBehavior::Unavailable => Err(unavailable()),
+            ListArtifactsBehavior::Success => Ok(Vec::new()),
+            ListArtifactsBehavior::Conflict => Err(ArtifactRepositoryError::new(
+                ArtifactRepositoryErrorKind::Conflict,
+            )),
+            ListArtifactsBehavior::Pending { entered, release } => {
+                entered.notify_one();
+                release.notified().await;
+                Err(unavailable())
+            }
+        }
+    }
+
+    async fn resolve_download(
+        &self,
+        _request: ResolveArtifactDownload,
+    ) -> Result<PublishedArtifactMetadata, ArtifactRepositoryError> {
+        self.download.clone().ok_or_else(unavailable)
+    }
+}

--- a/crates/automata-ci-results-github/tests/repository_observability.rs
+++ b/crates/automata-ci-results-github/tests/repository_observability.rs
@@ -1,157 +1,18 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+mod observability_support;
 
-use async_trait::async_trait;
+use std::sync::Arc;
+
 use automata_ci_core::{AttemptId, FencingToken, JobId, RunId};
 use automata_ci_results_github::{
-    ArtifactBlockReservation, ArtifactFinalizationReservation, ArtifactFinalizationWork,
-    ArtifactName, ArtifactRepository, ArtifactRepositoryError, ArtifactRepositoryErrorKind,
-    BeginArtifactFinalization, CommitArtifactBlocks, CommittedArtifact, CompleteArtifactBlock,
-    CompleteArtifactFinalization, CreateArtifact, CreateArtifactOutcome, ExecutionAuthority,
-    FinalizeArtifactOutcome, ListArtifacts, LoadArtifactFinalization,
-    ObservedResultsArtifactRepository, PublishedArtifactMetadata, RecordArtifactVerification,
-    RenewArtifactFinalization, ReserveArtifactBlock, ResolveArtifactDownload, ResultsObserver,
-    ResultsRepositoryOperation, ResultsRepositoryOperationOutcome,
+    ArtifactName, ArtifactRepository, ArtifactRepositoryErrorKind, ExecutionAuthority,
+    ListArtifacts, ObservedResultsArtifactRepository, ResultsRepositoryOperation,
+    ResultsRepositoryOperationOutcome,
+};
+use observability_support::{
+    observer::RecordingObserver,
+    repository::{ListArtifactsBehavior, TestArtifactRepository},
 };
 use tokio::sync::Notify;
-
-#[derive(Clone, Debug, Default)]
-struct RecordingObserver {
-    operations: Arc<
-        Mutex<
-            Vec<(
-                ResultsRepositoryOperation,
-                ResultsRepositoryOperationOutcome,
-                Duration,
-            )>,
-        >,
-    >,
-}
-
-impl ResultsObserver for RecordingObserver {
-    fn observe_repository_operation(
-        &self,
-        operation: ResultsRepositoryOperation,
-        outcome: ResultsRepositoryOperationOutcome,
-        duration: Duration,
-    ) {
-        self.operations
-            .lock()
-            .expect("repository observations lock")
-            .push((operation, outcome, duration));
-    }
-}
-
-#[derive(Debug)]
-enum ListBehavior {
-    Success,
-    Conflict,
-    Pending {
-        entered: Arc<Notify>,
-        release: Arc<Notify>,
-    },
-}
-
-#[derive(Debug)]
-struct ListRepository {
-    behavior: ListBehavior,
-}
-
-fn unavailable() -> ArtifactRepositoryError {
-    ArtifactRepositoryError::new(ArtifactRepositoryErrorKind::Unavailable)
-}
-
-#[async_trait]
-impl ArtifactRepository for ListRepository {
-    async fn create(
-        &self,
-        _request: CreateArtifact,
-    ) -> Result<CreateArtifactOutcome, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn reserve_block(
-        &self,
-        _request: ReserveArtifactBlock,
-    ) -> Result<ArtifactBlockReservation, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn complete_block(
-        &self,
-        _request: CompleteArtifactBlock,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn commit_blocks(
-        &self,
-        _request: CommitArtifactBlocks,
-    ) -> Result<CommittedArtifact, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn begin_finalization(
-        &self,
-        _request: BeginArtifactFinalization,
-    ) -> Result<ArtifactFinalizationReservation, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn load_finalization(
-        &self,
-        _request: LoadArtifactFinalization,
-    ) -> Result<ArtifactFinalizationWork, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn renew_finalization(
-        &self,
-        _request: RenewArtifactFinalization,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn record_verification(
-        &self,
-        _request: RecordArtifactVerification,
-    ) -> Result<(), ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn complete_finalization(
-        &self,
-        _request: CompleteArtifactFinalization,
-    ) -> Result<FinalizeArtifactOutcome, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-
-    async fn list(
-        &self,
-        _request: ListArtifacts,
-    ) -> Result<Vec<PublishedArtifactMetadata>, ArtifactRepositoryError> {
-        match &self.behavior {
-            ListBehavior::Success => Ok(Vec::new()),
-            ListBehavior::Conflict => Err(ArtifactRepositoryError::new(
-                ArtifactRepositoryErrorKind::Conflict,
-            )),
-            ListBehavior::Pending { entered, release } => {
-                entered.notify_one();
-                release.notified().await;
-                Err(unavailable())
-            }
-        }
-    }
-
-    async fn resolve_download(
-        &self,
-        _request: ResolveArtifactDownload,
-    ) -> Result<PublishedArtifactMetadata, ArtifactRepositoryError> {
-        Err(unavailable())
-    }
-}
 
 fn list_request(name: &str) -> ListArtifacts {
     ListArtifacts {
@@ -172,16 +33,19 @@ fn list_request(name: &str) -> ListArtifacts {
 async fn repository_success_and_error_map_to_closed_identifier_free_outcomes() {
     for (behavior, expected) in [
         (
-            ListBehavior::Success,
+            ListArtifactsBehavior::Success,
             ResultsRepositoryOperationOutcome::Success,
         ),
         (
-            ListBehavior::Conflict,
+            ListArtifactsBehavior::Conflict,
             ResultsRepositoryOperationOutcome::Conflict,
         ),
     ] {
         let recorder = RecordingObserver::default();
-        let inner: Arc<dyn ArtifactRepository> = Arc::new(ListRepository { behavior });
+        let inner: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
+            list_artifacts: behavior,
+            ..TestArtifactRepository::default()
+        });
         let repository = ObservedResultsArtifactRepository::new(inner, Arc::new(recorder.clone()));
         let result = repository
             .list(list_request("private-artifact-marker"))
@@ -194,10 +58,8 @@ async fn repository_success_and_error_map_to_closed_identifier_free_outcomes() {
                 ArtifactRepositoryErrorKind::Conflict
             );
         }
-        let observations = recorder
-            .operations
-            .lock()
-            .expect("repository observations lock");
+        let observations = recorder.snapshot();
+        let observations = &observations.repository_operations;
         assert_eq!(observations.len(), 1);
         assert_eq!(
             (observations[0].0, observations[0].1),
@@ -210,8 +72,9 @@ async fn repository_success_and_error_map_to_closed_identifier_free_outcomes() {
 #[tokio::test]
 async fn adversarial_artifact_names_never_cross_the_typed_observer_boundary() {
     let recorder = RecordingObserver::default();
-    let inner: Arc<dyn ArtifactRepository> = Arc::new(ListRepository {
-        behavior: ListBehavior::Success,
+    let inner: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
+        list_artifacts: ListArtifactsBehavior::Success,
+        ..TestArtifactRepository::default()
     });
     let repository = ObservedResultsArtifactRepository::new(inner, Arc::new(recorder.clone()));
     let mut forbidden = Vec::new();
@@ -228,10 +91,8 @@ async fn adversarial_artifact_names_never_cross_the_typed_observer_boundary() {
         forbidden.push(name);
     }
 
-    let observations = recorder
-        .operations
-        .lock()
-        .expect("repository observations lock");
+    let observations = recorder.snapshot();
+    let observations = &observations.repository_operations;
     assert_eq!(observations.len(), forbidden.len());
     assert!(observations.iter().all(|(operation, outcome, _)| {
         *operation == ResultsRepositoryOperation::List
@@ -250,11 +111,12 @@ async fn adversarial_artifact_names_never_cross_the_typed_observer_boundary() {
 async fn dropped_repository_future_records_exactly_one_cancellation() {
     let recorder = RecordingObserver::default();
     let entered = Arc::new(Notify::new());
-    let inner: Arc<dyn ArtifactRepository> = Arc::new(ListRepository {
-        behavior: ListBehavior::Pending {
+    let inner: Arc<dyn ArtifactRepository> = Arc::new(TestArtifactRepository {
+        list_artifacts: ListArtifactsBehavior::Pending {
             entered: Arc::clone(&entered),
             release: Arc::new(Notify::new()),
         },
+        ..TestArtifactRepository::default()
     });
     let repository = ObservedResultsArtifactRepository::new(inner, Arc::new(recorder.clone()));
     let task = tokio::spawn(async move {
@@ -270,10 +132,8 @@ async fn dropped_repository_future_records_exactly_one_cancellation() {
             .is_cancelled()
     );
 
-    let observations = recorder
-        .operations
-        .lock()
-        .expect("repository observations lock");
+    let observations = recorder.snapshot();
+    let observations = &observations.repository_operations;
     assert_eq!(observations.len(), 1);
     assert_eq!(
         (observations[0].0, observations[0].1),

--- a/crates/automata-ci-results-github/tests/storage_observability.rs
+++ b/crates/automata-ci-results-github/tests/storage_observability.rs
@@ -1,7 +1,6 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+mod observability_support;
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use automata_ci_blob::{
@@ -9,36 +8,10 @@ use automata_ci_blob::{
     MediaType, MemoryBlobStore, PutBlobOutcome, VerifiedBlob,
 };
 use automata_ci_results_github::{
-    ObservedResultsBlobStore, ResultsBlobOperation, ResultsBlobOperationOutcome, ResultsObserver,
+    ObservedResultsBlobStore, ResultsBlobOperation, ResultsBlobOperationOutcome,
 };
+use observability_support::observer::RecordingObserver;
 use tokio::sync::Notify;
-
-#[derive(Clone, Debug, Default)]
-struct RecordingObserver {
-    operations: Arc<Mutex<Vec<(ResultsBlobOperation, ResultsBlobOperationOutcome, Duration)>>>,
-    bytes: Arc<Mutex<Vec<(ResultsBlobOperation, u64)>>>,
-}
-
-impl ResultsObserver for RecordingObserver {
-    fn observe_blob_operation(
-        &self,
-        operation: ResultsBlobOperation,
-        outcome: ResultsBlobOperationOutcome,
-        duration: Duration,
-    ) {
-        self.operations
-            .lock()
-            .expect("blob operation observations lock")
-            .push((operation, outcome, duration));
-    }
-
-    fn observe_blob_bytes(&self, operation: ResultsBlobOperation, bytes: u64) {
-        self.bytes
-            .lock()
-            .expect("blob byte observations lock")
-            .push((operation, bytes));
-    }
-}
 
 fn payload(key: &str, bytes: &'static [u8]) -> BlobPayload {
     BlobPayload::from_bytes(
@@ -67,10 +40,8 @@ async fn successful_put_and_get_record_only_closed_labels_and_actual_bytes() {
         .expect("get blob");
     assert_eq!(verified.bytes().as_ref(), b"immutable payload");
 
-    let operations = recorder
-        .operations
-        .lock()
-        .expect("blob operation observations lock");
+    let observations = recorder.snapshot();
+    let operations = &observations.blob_operations;
     assert_eq!(operations.len(), 2);
     assert_eq!(
         (operations[0].0, operations[0].1),
@@ -88,7 +59,7 @@ async fn successful_put_and_get_record_only_closed_labels_and_actual_bytes() {
     );
     assert!(!format!("{operations:?}").contains(private_key));
     assert_eq!(
-        *recorder.bytes.lock().expect("blob byte observations lock"),
+        observations.blob_bytes,
         vec![
             (ResultsBlobOperation::Put, descriptor.size()),
             (ResultsBlobOperation::Get, descriptor.size()),
@@ -139,10 +110,8 @@ async fn provider_errors_are_sanitized_and_never_emit_bytes() {
         BlobStoreErrorKind::Unavailable
     );
 
-    let operations = recorder
-        .operations
-        .lock()
-        .expect("blob operation observations lock");
+    let observations = recorder.snapshot();
+    let operations = &observations.blob_operations;
     assert_eq!(
         operations
             .iter()
@@ -159,13 +128,7 @@ async fn provider_errors_are_sanitized_and_never_emit_bytes() {
             ),
         ]
     );
-    assert!(
-        recorder
-            .bytes
-            .lock()
-            .expect("blob byte observations lock")
-            .is_empty()
-    );
+    assert!(observations.blob_bytes.is_empty());
 }
 
 #[derive(Debug)]
@@ -213,10 +176,8 @@ async fn dropped_provider_future_records_one_cancellation_without_bytes() {
             .is_cancelled()
     );
 
-    let operations = recorder
-        .operations
-        .lock()
-        .expect("blob operation observations lock");
+    let observations = recorder.snapshot();
+    let operations = &observations.blob_operations;
     assert_eq!(operations.len(), 1);
     assert_eq!(
         (operations[0].0, operations[0].1),
@@ -225,11 +186,5 @@ async fn dropped_provider_future_records_one_cancellation_without_bytes() {
             ResultsBlobOperationOutcome::Cancelled,
         )
     );
-    assert!(
-        recorder
-            .bytes
-            .lock()
-            .expect("blob byte observations lock")
-            .is_empty()
-    );
+    assert!(observations.blob_bytes.is_empty());
 }


### PR DESCRIPTION
## Summary

- replace three local observer implementations with one typed recorder covering all eight Results observer callbacks and retaining durations, directions, byte counts, and closed outcome enums
- replace two duplicated ArtifactRepository fakes with one typed repository whose reserve, list, and download behaviors remain independently explicit
- preserve the exact pending-notification/cancellation ordering and leave the storage-specific blob fakes local

This is one subsystem-sized cleanup: 6 files, 878 changed lines, and 100 net lines removed. Production behavior is unchanged.

## Validation

- cargo fmt --all -- --check
- CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-results-github --all-targets --all-features
- CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-results-github --all-features --test http_observability --test repository_observability --test storage_observability (11 passed)
- CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-results-github --all-targets --all-features -- -D warnings
- independent static and semantic review: approved, no findings

Closes #351.