### PR TITLE
refactor(execution): make cancellation authority explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- Sandbox cancellation now crosses provider boundaries as an explicit
+  `Active | Terminate` disposition. `Terminate` authorizes provider-specific
+  termination handling when an adapter reaches a cancellation checkpoint; it
+  does not prove remote work quiesced or a durable operation cancelled. That
+  requires proving the exact sandbox absent.
 - PostgreSQL product connections now accept one exact `postgresql://` TCP URL
   with explicit host, port, user, non-empty password, and database. Query and
   fragment options, socket paths, `.pgpass`, ambient `PG*` configuration, and

--- a/crates/automata-ci-execution/README.md
+++ b/crates/automata-ci-execution/README.md
@@ -10,6 +10,12 @@ sandbox adapters implement `SandboxProvider` directly. Providers that
 advertise service-container support return the complete healthy discovery view
 through `SandboxProvider::service_bindings`.
 
+Cooperative cancellation is a closed `Active | Terminate` disposition.
+`Terminate` authorizes provider-specific termination handling when an adapter
+reaches a cancellation checkpoint. The disposition or an adapter return is not
+evidence that remote work has quiesced; callers must prove the exact sandbox
+absent before treating an uncertain durable mutation as cancelled.
+
 - [Runner architecture](https://github.com/automata-ci/automata/blob/main/docs/architecture.md)
 - API documentation: run `cargo doc -p automata-ci-execution --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-execution/src/endpoint.rs
+++ b/crates/automata-ci-execution/src/endpoint.rs
@@ -12,15 +12,37 @@ const MAX_ENVIRONMENT_NAME_BYTES: usize = 128;
 const MAX_ENVIRONMENT_VALUE_BYTES: usize = 1024 * 1024;
 const MAX_ENVIRONMENT_BYTES: usize = 4 * 1024 * 1024;
 
+/// Meaning of a cooperative cancellation observation at a provider boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CancellationDisposition {
+    /// No cancellation has been requested.
+    Active,
+    /// Request provider-specific termination handling at a checkpoint.
+    ///
+    /// The durable runner may still require exact sandbox destruction before
+    /// it records cancellation as complete.
+    Terminate,
+}
+
+impl CancellationDisposition {
+    /// Reports whether the provider is authorized to terminate backend work.
+    #[must_use]
+    pub const fn requires_termination(self) -> bool {
+        matches!(self, Self::Terminate)
+    }
+}
+
 /// Cooperative cancellation source shared across provider boundaries.
 pub trait Cancellation: Send + Sync {
-    /// Returns whether the caller has requested cancellation.
+    /// Returns the current cancellation meaning.
     ///
-    /// Adapters should check this between bounded backend phases. A `true`
-    /// result requests prompt termination; it does not prove that an in-flight
-    /// backend mutation was rolled back.
+    /// Adapters observe this at their cancellation checkpoints. Termination
+    /// authorizes provider-specific handling; the disposition or an adapter
+    /// return does not prove remote work quiesced or an in-flight mutation
+    /// rolled back. Durable cancellation is complete only after the exact
+    /// sandbox is proven absent.
     #[must_use]
-    fn is_cancelled(&self) -> bool;
+    fn disposition(&self) -> CancellationDisposition;
 }
 
 /// Cancellation source that never requests cancellation.
@@ -28,8 +50,8 @@ pub trait Cancellation: Send + Sync {
 pub struct NeverCancelled;
 
 impl Cancellation for NeverCancelled {
-    fn is_cancelled(&self) -> bool {
-        false
+    fn disposition(&self) -> CancellationDisposition {
+        CancellationDisposition::Active
     }
 }
 
@@ -374,16 +396,19 @@ impl fmt::Debug for ExecutionCommand {
     }
 }
 
-/// How an execution command terminated.
+/// Adapter-reported outcome of an execution command.
+///
+/// This value records the endpoint's observation; it is not evidence that a
+/// remotely initiated process has quiesced.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExecutionTermination {
     /// The process exited normally with the supplied platform exit status.
     Exited(i32),
     /// The process terminated because it received a signal.
     Signalled,
-    /// The endpoint stopped the process after the command deadline elapsed.
+    /// The endpoint observed the command deadline and reported a timeout.
     TimedOut,
-    /// The endpoint stopped the process after cooperative cancellation.
+    /// The endpoint observed cooperative cancellation and reported it.
     Cancelled,
 }
 
@@ -551,7 +576,7 @@ impl ExecutionOutput {
         })
     }
 
-    /// Returns how the command terminated.
+    /// Returns the endpoint's reported command outcome.
     #[must_use]
     pub const fn termination(&self) -> ExecutionTermination {
         self.termination
@@ -797,7 +822,10 @@ impl CopyFromRequest {
 }
 
 /// Attached execution port. Capabilities are explicit; unsupported operations
-/// return [`crate::ExecutionErrorKind::UnsupportedCapability`].
+/// return [`crate::ExecutionErrorKind::UnsupportedCapability`]. Termination is
+/// provider-specific authority observed at adapter cancellation checkpoints;
+/// the disposition or an endpoint return is not evidence that remotely
+/// initiated work has quiesced.
 pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
     /// Returns the exact opaque sandbox handle to which this endpoint is bound.
     fn handle(&self) -> &SandboxHandle;

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -37,10 +37,10 @@ mod value;
 pub use automata_ci_core::{EnvironmentProfile, EnvironmentProfileId, OperationId, Sha256Digest};
 pub use capability::{ProviderCapabilities, SandboxCapability};
 pub use endpoint::{
-    Cancellation, CopyFromRequest, CopyToRequest, EnvironmentName, EnvironmentValue,
-    EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEndpoint, ExecutionEnvironment,
-    ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream, ExecutionSignal,
-    ExecutionTermination, NeverCancelled, SignalRequest, WaitRequest,
+    Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentName,
+    EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEndpoint,
+    ExecutionEnvironment, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream,
+    ExecutionSignal, ExecutionTermination, NeverCancelled, SignalRequest, WaitRequest,
 };
 pub use error::{
     ExecutionError, ExecutionErrorKind, ExecutionStage, OperationOutcome, ProviderError,

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -354,6 +354,10 @@ pub enum DestroyDisposition {
 }
 
 /// Provider-neutral, object-safe whole-job isolation port.
+///
+/// Termination is provider-specific authority observed at adapter cancellation
+/// checkpoints. The disposition or a provider return is not evidence that
+/// remotely initiated work has quiesced.
 pub trait SandboxProvider: fmt::Debug + Send + Sync {
     /// Returns the stable identifier for this provider implementation.
     fn provider_id(&self) -> &ProviderId;

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -1,17 +1,23 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use automata_ci_execution::{
-    EnvironmentName, EnvironmentProfile, EnvironmentProfileId, EnvironmentValue,
-    EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEnvironment, ExecutionOutput,
-    ExecutionOutputRecord, ExecutionOutputStream, ExecutionTermination, ImmutableImage,
-    MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES, MAX_EXECUTION_OUTPUT_RECORDS,
-    NetworkPolicy, OperationId, ProviderCapabilities, ProviderId, ResourceLimits,
-    RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration, SandboxHandle,
-    SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding, ServiceContainerBindings,
-    ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy,
-    ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol, Sha256Digest,
-    TargetPath, ValueError,
+    CancellationDisposition, EnvironmentName, EnvironmentProfile, EnvironmentProfileId,
+    EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
+    ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream, ExecutionTermination,
+    ImmutableImage, MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES,
+    MAX_EXECUTION_OUTPUT_RECORDS, NetworkPolicy, OperationId, ProviderCapabilities, ProviderId,
+    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration,
+    SandboxHandle, SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
+    ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol,
+    Sha256Digest, TargetPath, ValueError,
 };
+
+#[test]
+fn only_termination_authorizes_backend_termination_handling() {
+    assert!(!CancellationDisposition::Active.requires_termination());
+    assert!(CancellationDisposition::Terminate.requires_termination());
+}
 
 const IMAGE: &str = "docker.io/library/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -22,11 +22,12 @@ use automata_ci_core::{
     UnixMillis, ValueSource, ValueTemplate, WORKFLOW_EVENT_MEDIA_TYPE,
 };
 use automata_ci_execution::{
-    Cancellation, CopyFromRequest, CopyToRequest, DestroySandbox, ExecutionArgv, ExecutionCommand,
-    ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionTermination,
-    NetworkPolicy, ProviderCapabilities, ProviderError, ProviderErrorKind, RootFilesystemPolicy,
-    SandboxCapability, SandboxGeneration, SandboxHandle, SandboxLaunch, SandboxProvider,
-    SandboxState, ServiceContainerBindings, ServiceContainerSpecs, TargetPath, TargetPlatform,
+    Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, DestroySandbox,
+    ExecutionArgv, ExecutionCommand, ExecutionEndpoint, ExecutionError, ExecutionErrorKind,
+    ExecutionOutput, ExecutionTermination, NetworkPolicy, ProviderCapabilities, ProviderError,
+    ProviderErrorKind, RootFilesystemPolicy, SandboxCapability, SandboxGeneration, SandboxHandle,
+    SandboxLaunch, SandboxProvider, SandboxState, ServiceContainerBindings, ServiceContainerSpecs,
+    TargetPath, TargetPlatform,
 };
 use automata_ci_expression_github::{
     ExtensionFunctionResult, GithubEvaluationContext, GithubExpressionEvaluator,
@@ -298,7 +299,7 @@ impl SandboxExpressionFunctions {
         .ok()?;
         let output = self
             .endpoint
-            .exec(&command, &CancellationBridge(&self.cancellation))
+            .exec(&command, &ProviderCancellationBridge(&self.cancellation))
             .ok()?;
         if self.cancellation.is_cancelled()
             || output.was_truncated()
@@ -3034,7 +3035,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| ActionLoadError::Executor(invalid_job()))?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)
             .map_err(ActionLoadError::Executor)?;
         let selected = match (
@@ -3074,7 +3075,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| ActionLoadError::Executor(invalid_job()))?;
         let bytes = endpoint
-            .copy_from(&copy, &CancellationBridge(cancellation))
+            .copy_from(&copy, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)
             .map_err(ActionLoadError::Executor)?;
         let (preferred_bytes, fallback_bytes) = if selected == candidates.action_yml() {
@@ -3874,7 +3875,7 @@ impl GithubJobExecutor {
             self.config.maximum_output_bytes(),
         )?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         require_success(&output)?;
         let request = action_content::copy_archive_request(
@@ -3887,7 +3888,7 @@ impl GithubJobExecutor {
             action.archive(),
         )?;
         endpoint
-            .copy_to(&request, &CancellationBridge(cancellation))
+            .copy_to(&request, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         let command = action_content::extract_archive_command(
             self.ports.operation_ids.operation_id(
@@ -3903,7 +3904,7 @@ impl GithubJobExecutor {
             self.config.maximum_output_bytes(),
         )?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         require_success(&output)?;
         Ok(action_paths)
@@ -4702,7 +4703,7 @@ impl GithubJobExecutor {
         events: &Arc<dyn ExecutionEvents>,
         cancellation: &dyn ExecutorCancellation,
     ) -> Result<ObtainedSandbox, ExecutorAdapterError> {
-        let cancellation = CancellationBridge(cancellation);
+        let cancellation = ProviderCancellationBridge(cancellation);
         let generation = SandboxGeneration::new(request.lease().fencing_token().get())
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
         let handle = if let Some(recovered) = request.recovered_sandbox() {
@@ -4836,7 +4837,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         require_success(&output)
     }
@@ -4861,7 +4862,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::ResourceExhausted))?;
         endpoint
-            .copy_to(&request, &CancellationBridge(cancellation))
+            .copy_to(&request, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)
     }
 
@@ -4910,7 +4911,7 @@ impl GithubJobExecutor {
                 observe_phase_failure(error, attempt_id, execution.phase, "build_phase_command")
             })?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)
             .map_err(|error| {
                 observe_phase_failure(error, attempt_id, execution.phase, "execute_phase")
@@ -5184,16 +5185,17 @@ impl GithubJobExecutor {
                 limit,
             )
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-            let bytes = match endpoint.copy_from(&request, &CancellationBridge(cancellation)) {
-                Ok(bytes) => bytes,
-                Err(error)
-                    if *kind == CommandFileKind::StepSummary
-                        && error.kind() == ExecutionErrorKind::NotFound =>
-                {
-                    Vec::new()
-                }
-                Err(error) => return Err(map_execution_error(error)),
-            };
+            let bytes =
+                match endpoint.copy_from(&request, &ProviderCancellationBridge(cancellation)) {
+                    Ok(bytes) => bytes,
+                    Err(error)
+                        if *kind == CommandFileKind::StepSummary
+                            && error.kind() == ExecutionErrorKind::NotFound =>
+                    {
+                        Vec::new()
+                    }
+                    Err(error) => return Err(map_execution_error(error)),
+                };
             if cancellation.is_cancelled() {
                 return Err(ExecutorAdapterError::new(
                     ExecutorAdapterErrorKind::Cancelled,
@@ -5275,7 +5277,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
         let bytes = endpoint
-            .copy_from(&request, &CancellationBridge(cancellation))
+            .copy_from(&request, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         if cancellation.is_cancelled() {
             return Err(ExecutorAdapterError::new(
@@ -5394,7 +5396,7 @@ impl GithubJobExecutor {
         )
         .map_err(|_| invalid_job())?;
         let output = endpoint
-            .exec(&command, &CancellationBridge(cancellation))
+            .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         if cancellation.is_cancelled() || output.termination() == ExecutionTermination::Cancelled {
             return Err(cancelled());
@@ -5468,7 +5470,7 @@ impl GithubJobExecutor {
         match self
             .ports
             .provider
-            .destroy(&destroy, &CancellationBridge(cancellation))
+            .destroy(&destroy, &ProviderCancellationBridge(cancellation))
         {
             Ok(_) => events
                 .provider_operation_completed(operation_id)
@@ -5690,11 +5692,15 @@ fn reconcile_execution_cancellation(
     }
 }
 
-struct CancellationBridge<'a>(&'a dyn ExecutorCancellation);
+struct ProviderCancellationBridge<'a>(&'a dyn ExecutorCancellation);
 
-impl Cancellation for CancellationBridge<'_> {
-    fn is_cancelled(&self) -> bool {
-        self.0.is_cancelled()
+impl Cancellation for ProviderCancellationBridge<'_> {
+    fn disposition(&self) -> CancellationDisposition {
+        if self.0.is_cancelled() {
+            CancellationDisposition::Terminate
+        } else {
+            CancellationDisposition::Active
+        }
     }
 }
 
@@ -7706,7 +7712,10 @@ mod tests {
     };
 
     use automata_ci_core::AttemptId;
-    use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream, TargetPath};
+    use automata_ci_execution::{
+        Cancellation, CancellationDisposition, ExecutionOutputRecord, ExecutionOutputStream,
+        TargetPath,
+    };
     use automata_ci_expression_github::GithubValue;
     use automata_ci_github_runtime::{
         CommandFileDecoder, CommandFileKind, CommandFilePlatform, GithubCommandFileDecoder,
@@ -7718,11 +7727,28 @@ mod tests {
         ActionBudgetRejection, ActionExecutionBudget, AttemptPaths, CleanupCancellation,
         ExecutorAdapterErrorKind, GithubStatus, JobConclusion, MAX_ACTION_INVOCATIONS,
         MAX_ACTION_NESTING_DEPTH, MAX_COMPOSITE_CHILD_STEPS, MAX_COMPOSITE_DERIVED_BYTES,
-        MAX_EVENT_DEPTH, SecretMasker, action_invocation_count_rejection,
-        composite_child_step_rejection, composite_derived_bytes_rejection, encode_action_outputs,
-        event_depth_rejection, github_value_from_json, parse_output_with_cancellation,
-        reconcile_cancelled_operation, reconcile_post_operation, resource_exhausted,
+        MAX_EVENT_DEPTH, ProviderCancellationBridge, SecretMasker,
+        action_invocation_count_rejection, composite_child_step_rejection,
+        composite_derived_bytes_rejection, encode_action_outputs, event_depth_rejection,
+        github_value_from_json, parse_output_with_cancellation, reconcile_cancelled_operation,
+        reconcile_post_operation, resource_exhausted,
     };
+
+    #[test]
+    fn shutdown_authorizes_endpoint_and_provider_termination_handling() {
+        let cancellation = ExecutionCancellation::new();
+        assert_eq!(
+            ProviderCancellationBridge(&cancellation).disposition(),
+            CancellationDisposition::Active
+        );
+
+        cancellation.signal(ExecutionCancellationReason::Shutdown);
+
+        assert_eq!(
+            ProviderCancellationBridge(&cancellation).disposition(),
+            CancellationDisposition::Terminate
+        );
+    }
 
     #[test]
     fn command_file_paths_are_stable_for_recovery_and_isolated_by_phase_and_attempt() {

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -1422,7 +1422,7 @@ impl ExecutionEndpoint for FakeEndpoint {
         let program = request.argv().program().as_str();
         let mut state = self.state.lock().expect("endpoint lock");
         state.commands.push(request.clone());
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return execution_output(ExecutionTermination::Cancelled, Vec::new(), false)
                 .map_err(|_| execution_error(ExecutionStage::Exec));
         }

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -942,7 +942,10 @@ impl ProfileAdmissionContext<'_> {
                     &self.cleanup_cancellation,
                 );
                 if output.termination() == ExecutionTermination::Cancelled
-                    && self.provisioning_cancellation.is_cancelled()
+                    && self
+                        .provisioning_cancellation
+                        .disposition()
+                        .requires_termination()
                 {
                     return Err(ProfileAdmissionError::execution(
                         ProfileAdmissionErrorKind::ExecutionFailed,
@@ -1220,16 +1223,24 @@ fn operation_id(
 struct ProvisioningCancellation<'cancellation>(&'cancellation ProbeCancellation);
 
 impl Cancellation for ProvisioningCancellation<'_> {
-    fn is_cancelled(&self) -> bool {
-        self.0.is_cancelled()
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.is_cancelled() {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 
 struct CleanupCancellation<'cancellation>(&'cancellation ProbeCancellation);
 
 impl Cancellation for CleanupCancellation<'_> {
-    fn is_cancelled(&self) -> bool {
-        self.0.is_forced()
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.is_forced() {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 
@@ -1344,7 +1355,7 @@ mod tests {
             spec: &SandboxSpec,
             cancellation: &dyn Cancellation,
         ) -> Result<SandboxRecord, ProviderError> {
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(cancelled(ProviderStage::CreateSandbox));
             }
             let handle =
@@ -1388,7 +1399,7 @@ mod tests {
             handle: &SandboxHandle,
             cancellation: &dyn Cancellation,
         ) -> Result<Box<dyn ExecutionEndpoint>, ProviderError> {
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(cancelled(ProviderStage::Attach));
             }
             let mut state = self.state.lock().expect("fake state");
@@ -1418,7 +1429,7 @@ mod tests {
                 .expect("fake state")
                 .calls
                 .push(Call::Inspect(handle.clone()));
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(cancelled(ProviderStage::Inspect));
             }
             if self.behavior == FakeBehavior::InspectAndDestroyFailure {
@@ -1447,7 +1458,7 @@ mod tests {
             request: &DestroySandbox,
             cancellation: &dyn Cancellation,
         ) -> Result<DestroyDisposition, ProviderError> {
-            let cancelled = cancellation.is_cancelled();
+            let cancelled = cancellation.disposition().requires_termination();
             let mut state = self.state.lock().expect("fake state");
             let first_destroy = !state
                 .calls
@@ -1556,7 +1567,7 @@ mod tests {
                 .expect("fake state")
                 .calls
                 .push(Call::Exec(Box::new(request.clone())));
-            let termination = if cancellation.is_cancelled() {
+            let termination = if cancellation.disposition().requires_termination() {
                 ExecutionTermination::Cancelled
             } else if let FakeBehavior::ExecTermination(termination) = self.behavior {
                 termination
@@ -1636,7 +1647,7 @@ mod tests {
                 .expect("fake state")
                 .calls
                 .push(Call::CopyTo(request.clone()));
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 Err(ExecutionError::new(
                     ExecutionErrorKind::Cancelled,
                     ExecutionStage::CopyTo,

--- a/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
@@ -63,7 +63,7 @@ impl KubernetesExecutionEndpoint {
         cancellation: &dyn Cancellation,
         stage: ExecutionStage,
     ) -> Result<GuestResponse, ExecutionError> {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
         }
         let frame = encode_frame(request)
@@ -158,7 +158,7 @@ impl KubernetesExecutionEndpoint {
             }
         })
         .map_err(|kind| execution_error(map_provider_error(kind), stage))?;
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
         }
         let response = decode_frame(&response)
@@ -171,7 +171,7 @@ impl KubernetesExecutionEndpoint {
 }
 
 async fn cancellation_requested(cancellation: &dyn Cancellation) {
-    while !cancellation.is_cancelled() {
+    while !cancellation.disposition().requires_termination() {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }

--- a/crates/automata-ci-sandbox-kubernetes/src/provider.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/provider.rs
@@ -128,7 +128,7 @@ impl SandboxProvider for KubernetesSandboxProvider {
                 operation_timeout,
             )
             .await?;
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(ProviderErrorKind::Cancelled);
             }
             create_or_verify_pod(&pods, objects.pod, &fingerprint, operation_timeout).await?;
@@ -149,7 +149,7 @@ impl SandboxProvider for KubernetesSandboxProvider {
                 Some(handle.clone()),
             )
         })?;
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(ProviderError::new(
                 ProviderErrorKind::Cancelled,
                 ProviderStage::Start,
@@ -526,7 +526,7 @@ async fn wait_until_ready(
 ) -> Result<SandboxState, ProviderErrorKind> {
     let started = Instant::now();
     loop {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(ProviderErrorKind::Cancelled);
         }
         let remaining = deadline.saturating_sub(started.elapsed());
@@ -644,7 +644,7 @@ fn ensure_not_cancelled(
     cancellation: &dyn Cancellation,
     stage: ProviderStage,
 ) -> Result<(), ProviderError> {
-    if cancellation.is_cancelled() {
+    if cancellation.disposition().requires_termination() {
         return Err(provider_error(ProviderErrorKind::Cancelled, stage));
     }
     Ok(())

--- a/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
@@ -59,8 +59,12 @@ impl TestCancellation {
 }
 
 impl Cancellation for TestCancellation {
-    fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::SeqCst)
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.load(Ordering::SeqCst) {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 

--- a/crates/automata-ci-sandbox-kubernetes/tests/provider.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/provider.rs
@@ -47,8 +47,12 @@ impl TestCancellation {
 }
 
 impl Cancellation for TestCancellation {
-    fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::SeqCst)
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.load(Ordering::SeqCst) {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 

--- a/crates/automata-ci-sandbox-macos/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-macos/src/endpoint.rs
@@ -296,7 +296,7 @@ impl MacosVirtualizationEndpoint {
         cancellation: &dyn Cancellation,
     ) -> Result<(), ExecutionError> {
         self.require_running(ExecutionStage::CopyTo)?;
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(error(ExecutionErrorKind::Cancelled, ExecutionStage::CopyTo));
         }
         if !owned_target(&self.entry, request.target()) {
@@ -329,7 +329,7 @@ impl MacosVirtualizationEndpoint {
         cancellation: &dyn Cancellation,
     ) -> Result<Vec<u8>, ExecutionError> {
         self.require_running(ExecutionStage::CopyFrom)?;
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(error(
                 ExecutionErrorKind::Cancelled,
                 ExecutionStage::CopyFrom,

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -809,7 +809,7 @@ fn resume_create(
     {
         return entry.record();
     }
-    if cancellation.is_cancelled() {
+    if cancellation.disposition().requires_termination() {
         return Err(uncertain(
             ProviderErrorKind::Cancelled,
             ProviderStage::CreateWorkspace,
@@ -1640,7 +1640,7 @@ fn require_not_cancelled(
     cancellation: &dyn Cancellation,
     stage: ProviderStage,
 ) -> Result<(), ProviderError> {
-    if cancellation.is_cancelled() {
+    if cancellation.disposition().requires_termination() {
         Err(known(ProviderErrorKind::Cancelled, stage))
     } else {
         Ok(())

--- a/crates/automata-ci-sandbox-macos/src/vm.rs
+++ b/crates/automata-ci-sandbox-macos/src/vm.rs
@@ -354,7 +354,9 @@ fn read_frame_controlled(
             match receiver.recv_timeout(CONTROL_POLL_INTERVAL) {
                 Ok(result) => return result,
                 Err(RecvTimeoutError::Disconnected) => return Err(io_failure()),
-                Err(RecvTimeoutError::Timeout) if cancellation.is_cancelled() => {
+                Err(RecvTimeoutError::Timeout)
+                    if cancellation.disposition().requires_termination() =>
+                {
                     let _ = child.kill();
                     let _ = child.wait();
                     return Err(io::Error::from(io::ErrorKind::Interrupted));

--- a/crates/automata-ci-sandbox-podman/src/command.rs
+++ b/crates/automata-ci-sandbox-podman/src/command.rs
@@ -1367,7 +1367,7 @@ fn execute_system(
     environment: &PodmanProcessEnvironment,
     cancellation: &dyn Cancellation,
 ) -> CommandOutput {
-    if cancellation.is_cancelled() {
+    if cancellation.disposition().requires_termination() {
         return interrupted_before_stdin(request, CommandTermination::Cancelled);
     }
     let now = Instant::now();
@@ -1512,7 +1512,9 @@ fn wait_for_child(
             Ok(ChildExitObservation::Exited(status)) => {
                 return CommandTermination::Exited(status);
             }
-            Ok(ChildExitObservation::Running) if cancellation.is_cancelled() => {
+            Ok(ChildExitObservation::Running)
+                if cancellation.disposition().requires_termination() =>
+            {
                 terminate_process_group(child, TERMINATION_GRACE);
                 return CommandTermination::Cancelled;
             }

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -950,7 +950,7 @@ impl PodmanInner {
         let mut next_health_check = Instant::now();
         let mut health_interval = None;
         loop {
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(provider_error::known(
                     ProviderErrorKind::Cancelled,
                     ProviderStage::Start,
@@ -1874,7 +1874,7 @@ impl PodmanInner {
         stage: ProviderStage,
     ) -> Result<Vec<u16>, ProviderError> {
         loop {
-            if cancellation.is_cancelled() {
+            if cancellation.disposition().requires_termination() {
                 return Err(provider_error::known(ProviderErrorKind::Cancelled, stage));
             }
             if Instant::now() >= deadline {

--- a/crates/automata-ci-sandbox-podman/tests/command_executor.rs
+++ b/crates/automata-ci-sandbox-podman/tests/command_executor.rs
@@ -34,8 +34,12 @@ impl AtomicCancellation {
 }
 
 impl Cancellation for AtomicCancellation {
-    fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::Acquire)
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.load(Ordering::Acquire) {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 

--- a/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
+++ b/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
@@ -78,8 +78,12 @@ printf 'attempt-scoped-docker-ok\n'
 struct AtomicCancellation(AtomicBool);
 
 impl Cancellation for AtomicCancellation {
-    fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::Acquire)
+    fn disposition(&self) -> automata_ci_execution::CancellationDisposition {
+        if self.0.load(Ordering::Acquire) {
+            automata_ci_execution::CancellationDisposition::Terminate
+        } else {
+            automata_ci_execution::CancellationDisposition::Active
+        }
     }
 }
 

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -457,7 +457,7 @@ impl PodmanCommandExecutor for FakePodman {
         environment: &PodmanProcessEnvironment,
         cancellation: &dyn automata_ci_execution::Cancellation,
     ) -> CommandOutput {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return interrupted_before_input(request, CommandTermination::Cancelled);
         }
         let arguments = request

--- a/crates/automata-ci-sandbox-windows/src/command.rs
+++ b/crates/automata-ci-sandbox-windows/src/command.rs
@@ -299,7 +299,7 @@ fn execute_system(
 ) -> RuntimeCommandOutput {
     use std::os::windows::process::CommandExt as _;
 
-    if cancellation.is_cancelled() {
+    if cancellation.disposition().requires_termination() {
         return RuntimeCommandOutput::terminated(RuntimeCommandTermination::Cancelled);
     }
     let mut command = Command::new(request.program());
@@ -346,7 +346,7 @@ fn capture_child(
         .checked_add(request.timeout())
         .unwrap_or_else(Instant::now);
     let termination = loop {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             terminate(child);
             break RuntimeCommandTermination::Cancelled;
         }

--- a/crates/automata-ci-sandbox-windows/src/provider.rs
+++ b/crates/automata-ci-sandbox-windows/src/provider.rs
@@ -507,7 +507,7 @@ impl ProviderInner {
         fingerprint: &str,
         cancellation: &dyn Cancellation,
     ) -> Result<SandboxRecord, ProviderError> {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(error::known(
                 ProviderErrorKind::Cancelled,
                 ProviderStage::CreateSandbox,
@@ -1060,7 +1060,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
         names: &ResourceName,
         cancellation: &dyn Cancellation,
     ) -> Result<DestroyDisposition, ProviderError> {
-        if cancellation.is_cancelled() {
+        if cancellation.disposition().requires_termination() {
             return Err(error::known(
                 ProviderErrorKind::Cancelled,
                 ProviderStage::DestroySandbox,


### PR DESCRIPTION
## Outcome

Replaces the provider-facing cancellation boolean with a closed `Active | Terminate` disposition. Every current sandbox provider, execution endpoint, profile-admission adapter, and GitHub job-executor bridge now consumes the explicit authority.

`Terminate` is intentionally observation-only: it authorizes provider-specific handling at adapter checkpoints, but neither the disposition nor an adapter-reported outcome proves remote work quiesced. Durable callers must still prove the exact sandbox absent.

This is the first small dependency PR in the split of draft #173.

## Related issue

Related to #173.

## Trust and compatibility impact

This changes the public Rust cancellation trait with no compatibility alias. There is no wire, storage, credential, or GitHub Actions behavior change. All in-tree providers and endpoints are migrated in the same commit. Cancellation reporting is documented as fail-closed and never treated as proof of remote process termination.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p automata-ci-execution -p automata-ci-job-executor-github --all-targets --all-features --locked`
- strict Clippy with `-D warnings` for execution, job executor, runner, and all four sandbox adapters
- full affected provider suites, including Podman 81 unit + 72 integration tests
- Windows GNU cross-target checks and strict Clippy for supported subsets
- macOS strict library Clippy; all-target macOS remains blocked by one pre-existing unchanged `manual_let_else` lint in `sandbox-macos/src/persistence.rs`
- independent strict review and exact rebase rereview: CLEAN

## AI assistance

OpenAI Codex helped extract the change from the larger draft, migrate implementations, run validation, and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
