### PR TITLE
fix(results): terminalize expired active leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   termination handling when an adapter reaches a cancellation checkpoint; it
   does not prove remote work quiesced or a durable operation cancelled. That
   requires proving the exact sandbox absent.
+- Expired active runner leases now commit blob-free, database-authoritative
+  failure evidence. Logical jobs, workflow runs, concurrency groups, and
+  provider checks therefore always reach a terminal state after runner loss.
 - PostgreSQL product connections now accept one exact `postgresql://` TCP URL
   with explicit host, port, user, non-empty password, and database. Query and
   fragment options, socket paths, `.pgpass`, ambient `PG*` configuration, and

--- a/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/maintenance.rs
@@ -87,6 +87,20 @@ async fn concurrent_maintenance_requeues_unstarted_and_loses_started_work_once()
         assert_eq!(lost.lifecycle(), JobLifecycle::Lost);
         assert_eq!(lost.lease_failures(), 1);
         assert_database_time_bound(lost.changed_at(), lower_bound, upper_bound);
+        let terminal: (String, String, i64, i64) = sqlx::query_as(
+            r"
+            SELECT terminal_authority, conclusion, completed_at_ms, committed_at_ms
+            FROM attempt_terminal_results
+            WHERE attempt_id = $1
+            ",
+        )
+        .bind(lost_attempt.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(terminal.0, "server_lease_expiry");
+        assert_eq!(terminal.1, "failure");
+        assert_eq!(terminal.2, lost.changed_at().get());
+        assert_eq!(terminal.3, lost.changed_at().get());
         assert_eq!(
             started_at(&database, retry_attempt).await?,
             retry_started_at

--- a/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
+++ b/crates/automata-ci-postgres/tests/store/orchestration/logical_instance_result.rs
@@ -163,6 +163,97 @@ async fn queued_cancellation_accepts_released_lease_fencing_history() -> TestRes
     .await
 }
 
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn lease_expiry_projects_blob_free_failure_even_with_continue_on_error() -> TestResult {
+    run_with_database(|database| async move {
+        let (fixture, prepared, attempt_id) =
+            seed_materialized_instance_for_cancellation(&database).await?;
+        let lost_at = database_now_ms(&database).await?;
+        let updated = sqlx::query(
+            r"
+            UPDATE job_attempts
+            SET lifecycle = 'lost', lease_failures = 1, changed_at_ms = $2
+            WHERE id = $1 AND lifecycle = 'queued'
+            ",
+        )
+        .bind(attempt_id.as_uuid())
+        .bind(lost_at)
+        .execute(database.pool())
+        .await?
+        .rows_affected();
+        assert_eq!(updated, 1);
+        sqlx::query(
+            r"
+            INSERT INTO attempt_terminal_results (
+                attempt_id, terminal_authority, conclusion,
+                completed_at_ms, committed_at_ms
+            ) VALUES ($1, 'server_lease_expiry', 'failure', $2, $2)
+            ",
+        )
+        .bind(attempt_id.as_uuid())
+        .bind(lost_at)
+        .execute(database.pool())
+        .await?;
+
+        let observed_at = database_now_ms(&database).await?;
+        let claimed = expect_result_claimed(
+            database
+                .store()
+                .claim_logical_instance_result(result_claim(
+                    LogicalInstanceResultTarget::new(
+                        TenantScope::from_authenticated_tenant_id(&fixture.tenant)?,
+                        attempt_id,
+                    )?,
+                    29_350,
+                    observed_at,
+                    observed_at + 3_000,
+                ))
+                .await?,
+        );
+        assert!(claimed.descriptor().is_server_lease_expiry());
+        assert!(claimed.descriptor().terminal_result().is_none());
+        let commit = CommitLogicalInstanceResult::new_server_lease_expiry(
+            &claimed,
+            &prepared.encoded,
+            &prepared.envelope,
+            UnixMillis::new(observed_at + 100),
+        )?;
+        assert_eq!(commit.raw_conclusion(), JobConclusion::Failure);
+        assert_eq!(commit.effective_conclusion(), JobConclusion::Failure);
+        assert!(!commit.continue_on_error());
+        assert!(commit.outputs().is_empty());
+        let receipt = database
+            .store()
+            .commit_logical_instance_result(commit)
+            .await?;
+        assert_eq!(receipt.effective_conclusion(), JobConclusion::Failure);
+
+        let projected: (String, String, String, i32) = sqlx::query_as(
+            r"
+            SELECT terminal_authority, raw_conclusion,
+                   effective_conclusion, output_count
+            FROM logical_workflow_instance_results
+            WHERE attempt_id = $1
+            ",
+        )
+        .bind(attempt_id.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert_eq!(
+            projected,
+            (
+                "server_lease_expiry".to_owned(),
+                "failure".to_owned(),
+                "failure".to_owned(),
+                0,
+            )
+        );
+        Ok(())
+    })
+    .await
+}
+
 async fn seed_materialized_instance_for_cancellation(
     database: &TestDatabase,
 ) -> TestResult<(Fixture, PreparedInstance, automata_ci_core::AttemptId)> {

--- a/crates/automata-ci-store-postgres/migrations/0043_terminalize_expired_active_leases.sql
+++ b/crates/automata-ci-store-postgres/migrations/0043_terminalize_expired_active_leases.sql
@@ -1,0 +1,355 @@
+ALTER TABLE attempt_terminal_results
+    DROP CONSTRAINT attempt_terminal_results_terminal_authority_shape;
+
+ALTER TABLE attempt_terminal_results
+    ADD CONSTRAINT attempt_terminal_results_terminal_authority_shape CHECK ((
+        terminal_authority = 'runner'
+        AND runner_session_id IS NOT NULL AND operation_id IS NOT NULL
+        AND runner_id IS NOT NULL AND runner_session_epoch IS NOT NULL
+        AND runner_generation IS NOT NULL AND runner_slot IS NOT NULL
+        AND lease_id IS NOT NULL AND fencing_token IS NOT NULL
+        AND result_schema IS NOT NULL AND result_size_bytes IS NOT NULL
+        AND result_digest IS NOT NULL AND result_object_key IS NOT NULL
+        AND server_cancellation_operation_id IS NULL
+        AND server_cancellation_digest IS NULL
+    ) OR (
+        terminal_authority = 'server_cancellation'
+        AND runner_session_id IS NULL AND operation_id IS NULL
+        AND runner_id IS NULL AND runner_session_epoch IS NULL
+        AND runner_generation IS NULL AND runner_slot IS NULL
+        AND lease_id IS NULL AND fencing_token IS NULL
+        AND result_schema IS NULL AND result_size_bytes IS NULL
+        AND result_digest IS NULL AND result_object_key IS NULL
+        AND server_cancellation_operation_id IS NOT NULL
+        AND server_cancellation_operation_id <> '00000000-0000-0000-0000-000000000000'
+        AND server_cancellation_digest IS NOT NULL
+        AND conclusion = 'cancelled'
+    ) OR (
+        terminal_authority = 'server_lease_expiry'
+        AND runner_session_id IS NULL AND operation_id IS NULL
+        AND runner_id IS NULL AND runner_session_epoch IS NULL
+        AND runner_generation IS NULL AND runner_slot IS NULL
+        AND lease_id IS NULL AND fencing_token IS NULL
+        AND result_schema IS NULL AND result_size_bytes IS NULL
+        AND result_digest IS NULL AND result_object_key IS NULL
+        AND server_cancellation_operation_id IS NULL
+        AND server_cancellation_digest IS NULL
+        AND conclusion = 'failure'
+    ));
+
+ALTER TABLE logical_workflow_instance_results
+    DROP CONSTRAINT logical_workflow_instance_results_terminal_authority_shape;
+
+ALTER TABLE logical_workflow_instance_results
+    ADD CONSTRAINT logical_workflow_instance_results_terminal_authority_shape CHECK ((
+        terminal_authority = 'runner'
+        AND octet_length(result_digest) = 32
+        AND octet_length(result_object_key) BETWEEN 1 AND 1024
+        AND result_object_key !~ '[[:cntrl:]]'
+        AND left(result_object_key, 1) <> '/'
+        AND result_object_key !~ '(^|/)\.\.(/|$)'
+        AND result_size_bytes BETWEEN 1 AND 16777216
+        AND result_media_type = 'application/vnd.automata.job-result+json'
+        AND result_schema = 1
+        AND server_cancellation_operation_id IS NULL
+        AND server_cancellation_digest IS NULL
+    ) OR (
+        terminal_authority = 'server_cancellation'
+        AND result_digest IS NULL AND result_object_key IS NULL
+        AND result_size_bytes IS NULL AND result_media_type IS NULL
+        AND result_schema IS NULL
+        AND server_cancellation_operation_id IS NOT NULL
+        AND server_cancellation_digest IS NOT NULL
+        AND raw_conclusion = 'cancelled' AND effective_conclusion = 'cancelled'
+        AND secret_exposure_class = 'secretless' AND output_count = 0
+    ) OR (
+        terminal_authority = 'server_lease_expiry'
+        AND result_digest IS NULL AND result_object_key IS NULL
+        AND result_size_bytes IS NULL AND result_media_type IS NULL
+        AND result_schema IS NULL
+        AND server_cancellation_operation_id IS NULL
+        AND server_cancellation_digest IS NULL
+        AND raw_conclusion = 'failure' AND effective_conclusion = 'failure'
+        AND output_count = 0
+    ));
+
+CREATE OR REPLACE FUNCTION automata_validate_server_lease_expiry_terminal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    attempt job_attempts%ROWTYPE;
+BEGIN
+    IF NEW.terminal_authority IS DISTINCT FROM 'server_lease_expiry' THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT * INTO STRICT attempt FROM job_attempts WHERE id = NEW.attempt_id;
+    IF attempt.lifecycle <> 'lost'
+       OR attempt.lease_failures <= 0
+       OR attempt.lease_id IS NOT NULL OR attempt.runner_id IS NOT NULL
+       OR attempt.runner_session_id IS NOT NULL
+       OR attempt.runner_session_epoch IS NOT NULL
+       OR attempt.runner_generation IS NOT NULL OR attempt.runner_slot IS NOT NULL
+       OR attempt.lease_issued_at_ms IS NOT NULL
+       OR attempt.lease_expires_at_ms IS NOT NULL
+       OR NEW.conclusion <> 'failure'
+       OR NEW.completed_at_ms <> attempt.changed_at_ms
+       OR NEW.committed_at_ms <> attempt.changed_at_ms
+    THEN
+        RAISE EXCEPTION 'server lease-expiry terminal lacks exact lost-attempt authority'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+EXCEPTION
+    WHEN NO_DATA_FOUND OR TOO_MANY_ROWS THEN
+        RAISE EXCEPTION 'server lease-expiry terminal lacks exact lost-attempt authority'
+            USING ERRCODE = '23514';
+END;
+$$;
+
+CREATE TRIGGER attempt_terminal_results_validate_server_lease_expiry
+    BEFORE INSERT OR UPDATE ON attempt_terminal_results
+    FOR EACH ROW EXECUTE FUNCTION automata_validate_server_lease_expiry_terminal();
+
+CREATE OR REPLACE FUNCTION automata_refresh_logical_workflow_instance_result_due(target_attempt_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO logical_workflow_instance_result_due (
+        attempt_id, tenant_id, run_id, invocation_id, logical_job_id,
+        source_order, ready_at_ms, available_at_ms
+    )
+    SELECT terminal.attempt_id, repository.tenant_id,
+           concrete.run_id, concrete.invocation_id, concrete.logical_job_id,
+           logical_job.source_order, terminal.committed_at_ms,
+           COALESCE(claim.expires_at_ms, terminal.committed_at_ms)
+    FROM attempt_terminal_results AS terminal
+    JOIN job_attempts AS attempt ON attempt.id = terminal.attempt_id
+    JOIN jobs AS job ON job.id = attempt.job_id
+    JOIN logical_workflow_concrete_jobs AS concrete
+      ON concrete.job_id = job.id AND concrete.initial_attempt_id = attempt.id
+    JOIN logical_workflow_materialization_claims AS materialization
+      ON materialization.instance_id = concrete.instance_id
+    JOIN logical_workflow_instances AS instance
+      ON instance.id = concrete.instance_id AND instance.run_id = concrete.run_id
+     AND instance.invocation_id = concrete.invocation_id
+     AND instance.logical_job_id = concrete.logical_job_id
+    JOIN logical_workflow_jobs AS logical_job
+      ON logical_job.run_id = concrete.run_id
+     AND logical_job.invocation_id = concrete.invocation_id
+     AND logical_job.id = concrete.logical_job_id
+    JOIN logical_workflow_invocations AS invocation
+      ON invocation.run_id = logical_job.run_id
+     AND invocation.id = logical_job.invocation_id
+    JOIN logical_workflow_runs AS marker ON marker.run_id = concrete.run_id
+    JOIN workflow_runs AS run ON run.id = marker.run_id
+    JOIN repositories AS repository ON repository.id = run.repository_id
+    LEFT JOIN logical_workflow_instance_result_claims AS claim
+      ON claim.attempt_id = terminal.attempt_id
+    WHERE terminal.attempt_id = target_attempt_id
+      AND materialization.state = 'materialized'
+      AND job.run_id = concrete.run_id
+      AND job.admission_epoch = 1 AND job.job_ir_schema = 1
+      AND job.job_ir_digest = instance.job_ir_digest
+      AND job.job_ir_object_key = instance.job_ir_object_key
+      AND job.job_ir_size_bytes = instance.job_ir_size_bytes
+      AND instance.job_ir_version = 1
+      AND instance.job_ir_media_type = 'application/vnd.automata.job-ir.protobuf'
+      AND ((terminal.terminal_authority = 'runner' AND terminal.result_schema = 1)
+           OR terminal.terminal_authority IN ('server_cancellation', 'server_lease_expiry'))
+      AND terminal.logical_workflow_logical_job_id = concrete.logical_job_id
+      AND terminal.logical_workflow_terminal_ordinal > 0
+      AND terminal.completed_at_ms >= 0
+      AND terminal.committed_at_ms >= terminal.completed_at_ms
+      AND ((terminal.conclusion = 'success' AND attempt.lifecycle = 'succeeded')
+        OR (terminal.conclusion = 'failure' AND attempt.lifecycle IN ('failed', 'lost'))
+        OR (terminal.conclusion = 'cancelled' AND attempt.lifecycle = 'cancelled')
+        OR (terminal.conclusion = 'timed_out' AND attempt.lifecycle = 'timed_out')
+        OR (terminal.conclusion = 'skipped' AND attempt.lifecycle = 'skipped'))
+      AND logical_job.execution_kind = 'steps' AND logical_job.state = 'activated'
+      AND invocation.plan_schema = 1 AND invocation.state IN ('pending', 'active')
+      AND marker.orchestration_schema = 1 AND marker.state IN ('pending', 'active')
+      AND run.admission_epoch = 1 AND run.plan_schema = 1
+      AND (claim.attempt_id IS NULL OR claim.state = 'projecting')
+    ON CONFLICT (attempt_id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id, run_id = EXCLUDED.run_id,
+        invocation_id = EXCLUDED.invocation_id,
+        logical_job_id = EXCLUDED.logical_job_id,
+        source_order = EXCLUDED.source_order,
+        ready_at_ms = EXCLUDED.ready_at_ms,
+        available_at_ms = EXCLUDED.available_at_ms;
+
+    IF NOT FOUND THEN
+        DELETE FROM logical_workflow_instance_result_due
+        WHERE attempt_id = target_attempt_id;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_validate_logical_workflow_instance_result_claim() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM attempt_terminal_results AS terminal
+        JOIN job_attempts AS attempt ON attempt.id = terminal.attempt_id
+        JOIN jobs AS job ON job.id = attempt.job_id
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.job_id = job.id AND concrete.initial_attempt_id = attempt.id
+        JOIN logical_workflow_materialization_claims AS materialization
+          ON materialization.instance_id = concrete.instance_id
+        JOIN logical_workflow_instances AS instance
+          ON instance.id = concrete.instance_id AND instance.run_id = concrete.run_id
+         AND instance.invocation_id = concrete.invocation_id
+         AND instance.logical_job_id = concrete.logical_job_id
+        JOIN logical_workflow_jobs AS logical_job
+          ON logical_job.run_id = concrete.run_id
+         AND logical_job.invocation_id = concrete.invocation_id
+         AND logical_job.id = concrete.logical_job_id
+        JOIN logical_workflow_invocations AS invocation
+          ON invocation.run_id = logical_job.run_id
+         AND invocation.id = logical_job.invocation_id
+        JOIN logical_workflow_runs AS marker ON marker.run_id = concrete.run_id
+        JOIN workflow_runs AS run ON run.id = marker.run_id
+        WHERE terminal.attempt_id = NEW.attempt_id
+          AND concrete.run_id = NEW.run_id
+          AND concrete.invocation_id = NEW.invocation_id
+          AND concrete.logical_job_id = NEW.logical_job_id
+          AND concrete.instance_id = NEW.instance_id
+          AND concrete.job_id = NEW.job_id
+          AND materialization.state = 'materialized'
+          AND job.run_id = concrete.run_id
+          AND job.admission_epoch = 1 AND job.job_ir_schema = 1
+          AND job.job_ir_digest = instance.job_ir_digest
+          AND job.job_ir_object_key = instance.job_ir_object_key
+          AND job.job_ir_size_bytes = instance.job_ir_size_bytes
+          AND instance.job_ir_version = 1
+          AND instance.job_ir_media_type = 'application/vnd.automata.job-ir.protobuf'
+          AND ((terminal.terminal_authority = 'runner' AND terminal.result_schema = 1)
+               OR terminal.terminal_authority IN ('server_cancellation', 'server_lease_expiry'))
+          AND terminal.completed_at_ms >= 0
+          AND terminal.committed_at_ms >= terminal.completed_at_ms
+          AND NEW.claimed_at_ms >= terminal.committed_at_ms
+          AND ((terminal.conclusion = 'success' AND attempt.lifecycle = 'succeeded')
+            OR (terminal.conclusion = 'failure' AND attempt.lifecycle IN ('failed', 'lost'))
+            OR (terminal.conclusion = 'cancelled' AND attempt.lifecycle = 'cancelled')
+            OR (terminal.conclusion = 'timed_out' AND attempt.lifecycle = 'timed_out')
+            OR (terminal.conclusion = 'skipped' AND attempt.lifecycle = 'skipped'))
+          AND logical_job.execution_kind = 'steps' AND logical_job.state = 'activated'
+          AND invocation.plan_schema = 1 AND invocation.state IN ('pending', 'active')
+          AND marker.orchestration_schema = 1 AND marker.state IN ('pending', 'active')
+          AND run.admission_epoch = 1 AND run.plan_schema = 1
+    ) THEN
+        RAISE EXCEPTION 'logical workflow result claim lacks one exact current terminal attempt'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_validate_logical_workflow_instance_result() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM logical_workflow_instance_result_claims AS claim
+        JOIN attempt_terminal_results AS terminal ON terminal.attempt_id = claim.attempt_id
+        JOIN job_attempts AS attempt ON attempt.id = terminal.attempt_id
+        JOIN jobs AS job ON job.id = attempt.job_id
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.instance_id = claim.instance_id
+         AND concrete.job_id = claim.job_id
+         AND concrete.initial_attempt_id = claim.attempt_id
+        JOIN logical_workflow_instances AS instance ON instance.id = concrete.instance_id
+        JOIN workflow_runs AS run ON run.id = concrete.run_id
+        WHERE claim.attempt_id = NEW.attempt_id
+          AND claim.run_id = NEW.run_id
+          AND claim.invocation_id = NEW.invocation_id
+          AND claim.logical_job_id = NEW.logical_job_id
+          AND claim.instance_id = NEW.instance_id
+          AND claim.job_id = NEW.job_id
+          AND claim.descriptor_digest = NEW.descriptor_digest
+          AND claim.state = 'projecting'
+          AND claim.owner_id = NEW.claim_owner_id
+          AND claim.generation = NEW.claim_generation
+          AND claim.claimed_at_ms = NEW.claim_started_at_ms
+          AND claim.expires_at_ms = NEW.claim_expires_at_ms
+          AND NEW.finalized_at_ms >= claim.claimed_at_ms
+          AND NEW.finalized_at_ms < claim.expires_at_ms
+          AND terminal.terminal_authority = NEW.terminal_authority
+          AND (
+              (terminal.terminal_authority = 'runner'
+               AND terminal.result_digest = NEW.result_digest
+               AND terminal.result_object_key = NEW.result_object_key
+               AND terminal.result_size_bytes = NEW.result_size_bytes
+               AND terminal.result_schema = NEW.result_schema
+               AND NEW.server_cancellation_operation_id IS NULL
+               AND NEW.server_cancellation_digest IS NULL
+               AND ((attempt.secret_exposure_class = 'secretless'
+                     AND NEW.secret_exposure_class = 'secretless')
+                 OR (attempt.secret_exposure_class = 'capability_only'
+                     AND NEW.secret_exposure_class IN ('secretless', 'capability_only'))
+                 OR (attempt.secret_exposure_class = 'readable_secret'
+                     AND NEW.secret_exposure_class = 'readable_secret')))
+           OR (terminal.terminal_authority = 'server_cancellation'
+               AND terminal.server_cancellation_operation_id =
+                   NEW.server_cancellation_operation_id
+               AND terminal.server_cancellation_digest = NEW.server_cancellation_digest
+               AND NEW.result_digest IS NULL AND NEW.result_object_key IS NULL
+               AND NEW.result_size_bytes IS NULL AND NEW.result_schema IS NULL
+               AND NEW.secret_exposure_class = 'secretless' AND NEW.output_count = 0)
+           OR (terminal.terminal_authority = 'server_lease_expiry'
+               AND NEW.result_digest IS NULL AND NEW.result_object_key IS NULL
+               AND NEW.result_size_bytes IS NULL AND NEW.result_schema IS NULL
+               AND NEW.server_cancellation_operation_id IS NULL
+               AND NEW.server_cancellation_digest IS NULL
+               AND NEW.output_count = 0
+               AND ((attempt.secret_exposure_class = 'secretless'
+                     AND NEW.secret_exposure_class = 'secretless')
+                 OR (attempt.secret_exposure_class = 'capability_only'
+                     AND NEW.secret_exposure_class IN ('secretless', 'capability_only'))
+                 OR (attempt.secret_exposure_class = 'readable_secret'
+                     AND NEW.secret_exposure_class = 'readable_secret')))
+          )
+          AND terminal.conclusion = NEW.raw_conclusion
+          AND terminal.completed_at_ms = NEW.result_completed_at_ms
+          AND terminal.committed_at_ms = NEW.result_committed_at_ms
+          AND terminal.logical_workflow_logical_job_id = NEW.logical_job_id
+          AND terminal.logical_workflow_terminal_ordinal = NEW.terminal_ordinal
+          AND job.run_id = NEW.run_id
+          AND job.job_ir_digest = NEW.job_ir_digest
+          AND job.job_ir_object_key = NEW.job_ir_object_key
+          AND job.job_ir_size_bytes = NEW.job_ir_size_bytes
+          AND job.job_ir_schema = NEW.job_ir_schema
+          AND job.admission_epoch = 1
+          AND instance.run_id = NEW.run_id
+          AND instance.invocation_id = NEW.invocation_id
+          AND instance.logical_job_id = NEW.logical_job_id
+          AND instance.job_ir_digest = NEW.job_ir_digest
+          AND instance.job_ir_object_key = NEW.job_ir_object_key
+          AND instance.job_ir_size_bytes = NEW.job_ir_size_bytes
+          AND instance.job_ir_media_type = NEW.job_ir_media_type
+          AND instance.job_ir_version = NEW.job_ir_schema
+          AND run.admission_epoch = 1 AND run.plan_schema = 1
+    ) THEN
+        RAISE EXCEPTION 'logical workflow instance result lacks exact terminal authority/fence evidence'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+INSERT INTO attempt_terminal_results (
+    attempt_id, terminal_authority, conclusion, completed_at_ms, committed_at_ms
+)
+SELECT attempt.id, 'server_lease_expiry', 'failure',
+       attempt.changed_at_ms, attempt.changed_at_ms
+FROM job_attempts AS attempt
+WHERE attempt.lifecycle = 'lost'
+  AND attempt.lease_failures > 0
+  AND NOT EXISTS (
+      SELECT 1 FROM attempt_terminal_results AS terminal
+      WHERE terminal.attempt_id = attempt.id
+  );

--- a/crates/automata-ci-store-postgres/src/logical_instance_result.rs
+++ b/crates/automata-ci-store-postgres/src/logical_instance_result.rs
@@ -1281,7 +1281,7 @@ fn target_query() -> &'static str {
       AND (
           (terminal.terminal_authority = 'runner'
            AND terminal.result_schema = $5)
-          OR terminal.terminal_authority = 'server_cancellation'
+          OR terminal.terminal_authority IN ('server_cancellation', 'server_lease_expiry')
       )
       AND terminal.logical_workflow_logical_job_id = concrete.logical_job_id
       AND terminal.logical_workflow_terminal_ordinal > 0
@@ -1293,6 +1293,7 @@ fn target_query() -> &'static str {
           OR (terminal.conclusion = 'cancelled' AND attempt.lifecycle = 'cancelled')
           OR (terminal.conclusion = 'timed_out' AND attempt.lifecycle = 'timed_out')
           OR (terminal.conclusion = 'skipped' AND attempt.lifecycle = 'skipped')
+          OR (terminal.conclusion = 'failure' AND attempt.lifecycle = 'lost')
       )
       AND logical_job.execution_kind = 'steps'
       AND invocation.plan_schema = $6
@@ -1587,6 +1588,53 @@ fn decode_descriptor(
             )
             .map_err(corrupt_value)
         }
+        "server_lease_expiry" => {
+            let result_fields_absent = decode_optional_digest(row, "result_digest")?.is_none()
+                && row
+                    .try_get::<Option<String>, _>("result_object_key")
+                    .map_err(operation_error)?
+                    .is_none()
+                && row
+                    .try_get::<Option<i64>, _>("result_size_bytes")
+                    .map_err(operation_error)?
+                    .is_none()
+                && row
+                    .try_get::<Option<i32>, _>("result_schema")
+                    .map_err(operation_error)?
+                    .is_none();
+            let server_fields_absent = row
+                .try_get::<Option<Uuid>, _>("server_cancellation_operation_id")
+                .map_err(operation_error)?
+                .is_none()
+                && decode_optional_digest(row, "server_cancellation_digest")?.is_none();
+            if !result_fields_absent
+                || !server_fields_absent
+                || raw_conclusion != JobConclusion::Failure
+            {
+                return Err(StoreError::corrupt_data(
+                    "server lease-expiry terminal has an invalid tagged shape",
+                )
+                .into());
+            }
+            LogicalInstanceResultDescriptor::new_server_lease_expiry(
+                target,
+                run_id,
+                invocation_id,
+                logical_job_id,
+                instance_id,
+                job_id,
+                logical_key,
+                matrix_index,
+                matrix_total,
+                matrix_digest,
+                terminal_ordinal,
+                job_ir_object,
+                maximum_secret_exposure,
+                result_completed_at,
+                result_committed_at,
+            )
+            .map_err(corrupt_value)
+        }
         _ => Err(StoreError::corrupt_data("unknown terminal authority").into()),
     }
 }
@@ -1632,6 +1680,7 @@ fn claimed_from_durable(
     ClaimedLogicalInstanceResult::new(descriptor, claim, replayed).map_err(corrupt_value)
 }
 
+#[allow(clippy::too_many_lines)] // One insert binds every closed terminal-authority shape.
 async fn insert_instance_result(
     transaction: &mut Transaction<'_, Postgres>,
     request: &CommitLogicalInstanceResult,
@@ -1666,6 +1715,16 @@ async fn insert_instance_result(
             None,
             Some(cancellation.operation_id().as_uuid()),
             Some(cancellation.digest().as_bytes().to_vec()),
+        ),
+        automata_ci_store::LogicalInstanceTerminalAuthority::ServerLeaseExpiry => (
+            "server_lease_expiry",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ),
     };
     sqlx::query(
@@ -1873,6 +1932,30 @@ fn terminal_projection_evidence_matches(
                 && decode_optional_digest(row, "server_cancellation_digest")?
                     == Some(cancellation.digest()))
         }
+        automata_ci_store::LogicalInstanceTerminalAuthority::ServerLeaseExpiry => Ok(authority
+            == "server_lease_expiry"
+            && decode_optional_digest(row, "result_digest")?.is_none()
+            && row
+                .try_get::<Option<String>, _>("result_object_key")
+                .map_err(operation_error)?
+                .is_none()
+            && row
+                .try_get::<Option<i64>, _>("result_size_bytes")
+                .map_err(operation_error)?
+                .is_none()
+            && row
+                .try_get::<Option<String>, _>("result_media_type")
+                .map_err(operation_error)?
+                .is_none()
+            && row
+                .try_get::<Option<i16>, _>("result_schema")
+                .map_err(operation_error)?
+                .is_none()
+            && row
+                .try_get::<Option<Uuid>, _>("server_cancellation_operation_id")
+                .map_err(operation_error)?
+                .is_none()
+            && decode_optional_digest(row, "server_cancellation_digest")?.is_none()),
     }
 }
 
@@ -1948,6 +2031,12 @@ fn decode_receipt(
             }
             automata_ci_store::LogicalInstanceTerminalAuthority::ServerCancellation(_) => {
                 secret_exposure == JobSecretExposure::Secretless && output_count == 0
+            }
+            automata_ci_store::LogicalInstanceTerminalAuthority::ServerLeaseExpiry => {
+                automata_ci_store::adapter_spi::logical_instance_accepts_terminal_secret_exposure(
+                    descriptor,
+                    secret_exposure,
+                ) && output_count == 0
             }
         }
         && row

--- a/crates/automata-ci-store-postgres/src/maintenance.rs
+++ b/crates/automata-ci-store-postgres/src/maintenance.rs
@@ -267,6 +267,35 @@ async fn apply_expired_attempt(
         ));
     }
 
+    if mutation.disposition == ExpiredAttemptDisposition::Lost {
+        let terminal_rows = sqlx::query(
+            r"
+            INSERT INTO attempt_terminal_results (
+                attempt_id, terminal_authority, conclusion,
+                completed_at_ms, committed_at_ms
+            )
+            SELECT id, 'server_lease_expiry', 'failure', changed_at_ms, changed_at_ms
+            FROM job_attempts
+            WHERE id = $1
+              AND lifecycle = 'lost'
+              AND changed_at_ms = $2
+              AND lease_failures = $3
+            ",
+        )
+        .bind(attempt_id.as_uuid())
+        .bind(mutation.decided_at.get())
+        .bind(mutation.next_failures)
+        .execute(&mut **transaction)
+        .await
+        .map_err(StoreError::operation)?
+        .rows_affected();
+        if terminal_rows != 1 {
+            return Err(StoreError::corrupt_data(
+                "lost attempt did not create exact lease-expiry terminal evidence",
+            ));
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -173,6 +173,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0042_github_provider_desired_state.sql",
         "5276d0877686f09d9c05c50b4675c2b82a9b93588d7865f3e4910d1daf7d39bd01c2826eb15edfcfd41b42e14269df98",
     ),
+    (
+        "0043_terminalize_expired_active_leases.sql",
+        "b4caf908ce785d736293e16c864320e9ea098e3cc76843539e91339f85c859f1482f57609ed865060e43aad0183c0ce1",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store/src/logical_instance_result.rs
+++ b/crates/automata-ci-store/src/logical_instance_result.rs
@@ -32,6 +32,8 @@ pub const MAX_LOGICAL_INSTANCE_RESULT_CLAIM_MILLIS: i64 = 15 * 60 * 1_000;
 const DESCRIPTOR_DIGEST_DOMAIN: &[u8] = b"automata.store.logical-instance-result-descriptor.v1\0";
 const SERVER_CANCELLATION_DESCRIPTOR_DOMAIN: &[u8] =
     b"automata.store.logical-instance-result.server-cancellation.v1\0";
+const SERVER_LEASE_EXPIRY_DESCRIPTOR_DOMAIN: &[u8] =
+    b"automata.store.logical-instance-result.server-lease-expiry.v1\0";
 const OUTPUTS_DIGEST_DOMAIN: &[u8] = b"automata.store.logical-instance-result-outputs.v1\0";
 const COMMIT_DIGEST_DOMAIN: &[u8] = b"automata.store.logical-instance-result-commit.v1\0";
 
@@ -391,6 +393,9 @@ pub enum LogicalInstanceTerminalAuthority {
     Runner(LogicalTerminalResultObject),
     /// The server cancelled an exact queued attempt before runner assignment.
     ServerCancellation(LogicalServerCancellationTerminal),
+    /// The control plane proved that an active lease expired and the runner
+    /// can no longer authoritatively finish the attempt.
+    ServerLeaseExpiry,
 }
 
 /// Store-authenticated terminal attempt and immutable object descriptors.
@@ -505,6 +510,51 @@ impl LogicalInstanceResultDescriptor {
             job_ir_object,
             maximum_secret_exposure,
             JobConclusion::Cancelled,
+            result_completed_at,
+            result_committed_at,
+        )
+    }
+
+    /// Rehydrates control-plane lease-expiry authority without a result blob.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid identities, matrix coordinates, object descriptors, or
+    /// terminal timestamps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_server_lease_expiry(
+        target: LogicalInstanceResultTarget,
+        run_id: RunId,
+        invocation_id: LogicalWorkflowInvocationId,
+        logical_job_id: LogicalWorkflowJobId,
+        instance_id: LogicalWorkflowInstanceId,
+        job_id: JobId,
+        logical_key: WorkflowJobKey,
+        matrix_index: u32,
+        matrix_total: u32,
+        matrix_digest: Sha256Digest,
+        terminal_ordinal: LogicalInstanceTerminalOrdinal,
+        job_ir_object: LogicalActivationObject,
+        maximum_secret_exposure: JobSecretExposure,
+        result_completed_at: UnixMillis,
+        result_committed_at: UnixMillis,
+    ) -> Result<Self, LogicalInstanceResultValueError> {
+        Self::new_with_authority(
+            target,
+            run_id,
+            invocation_id,
+            logical_job_id,
+            instance_id,
+            job_id,
+            logical_key,
+            matrix_index,
+            matrix_total,
+            matrix_digest,
+            terminal_ordinal,
+            LogicalInstanceTerminalAuthority::ServerLeaseExpiry,
+            job_ir_object,
+            maximum_secret_exposure,
+            JobConclusion::Failure,
             result_completed_at,
             result_committed_at,
         )
@@ -665,7 +715,8 @@ impl LogicalInstanceResultDescriptor {
     pub const fn terminal_result(&self) -> Option<&LogicalTerminalResultObject> {
         match &self.terminal_authority {
             LogicalInstanceTerminalAuthority::Runner(result) => Some(result),
-            LogicalInstanceTerminalAuthority::ServerCancellation(_) => None,
+            LogicalInstanceTerminalAuthority::ServerCancellation(_)
+            | LogicalInstanceTerminalAuthority::ServerLeaseExpiry => None,
         }
     }
 
@@ -673,11 +724,21 @@ impl LogicalInstanceResultDescriptor {
     #[must_use]
     pub const fn server_cancellation(&self) -> Option<&LogicalServerCancellationTerminal> {
         match &self.terminal_authority {
-            LogicalInstanceTerminalAuthority::Runner(_) => None,
             LogicalInstanceTerminalAuthority::ServerCancellation(cancellation) => {
                 Some(cancellation)
             }
+            LogicalInstanceTerminalAuthority::Runner(_)
+            | LogicalInstanceTerminalAuthority::ServerLeaseExpiry => None,
         }
+    }
+
+    /// Returns whether the control plane terminalized an expired active lease.
+    #[must_use]
+    pub const fn is_server_lease_expiry(&self) -> bool {
+        matches!(
+            self.terminal_authority,
+            LogicalInstanceTerminalAuthority::ServerLeaseExpiry
+        )
     }
 
     /// Returns the immutable `JobIR` object descriptor.
@@ -1195,6 +1256,70 @@ impl CommitLogicalInstanceResult {
         })
     }
 
+    /// Builds a zero-output infrastructure failure from exact lease-expiry authority.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-expiry authority, invalid `JobIR`, identity drift, or a
+    /// commit outside the live claim.
+    pub fn new_server_lease_expiry(
+        claimed: &ClaimedLogicalInstanceResult,
+        encoded_job_ir: &[u8],
+        envelope: &JobIrEnvelope,
+        finalized_at: UnixMillis,
+    ) -> Result<Self, LogicalInstanceResultValueError> {
+        let descriptor = claimed.descriptor();
+        let claim = claimed.claim().clone();
+        if !descriptor.is_server_lease_expiry()
+            || descriptor.raw_conclusion() != JobConclusion::Failure
+        {
+            return Err(LogicalInstanceResultValueError::TerminalAuthorityMismatch);
+        }
+        if finalized_at < claim.claimed_at() || finalized_at >= claim.expires_at() {
+            return Err(LogicalInstanceResultValueError::CommitOutsideClaim);
+        }
+        validate_blob(
+            encoded_job_ir,
+            descriptor.job_ir().encoded_size(),
+            descriptor.job_ir().digest(),
+            LogicalInstanceResultValueError::JobIrBlobMismatch,
+        )?;
+        envelope
+            .validate()
+            .map_err(|_| LogicalInstanceResultValueError::InvalidJobIr)?;
+        if envelope.schema_version() != JOB_IR_SCHEMA_VERSION {
+            return Err(LogicalInstanceResultValueError::InvalidJobIr);
+        }
+        validate_job_ir_identity(descriptor, envelope)?;
+        let outputs = Vec::new();
+        let outputs_digest = output_set_digest(&outputs);
+        // Infrastructure loss is outside job-authored failure semantics and
+        // therefore cannot be masked by `continue-on-error`.
+        let continue_on_error = false;
+        let effective_conclusion = JobConclusion::Failure;
+        let secret_exposure = descriptor.maximum_secret_exposure();
+        let commit_digest = result_commit_digest(
+            &claim,
+            descriptor,
+            effective_conclusion,
+            continue_on_error,
+            secret_exposure,
+            outputs_digest,
+            finalized_at,
+        );
+        Ok(Self {
+            claim,
+            raw_conclusion: JobConclusion::Failure,
+            effective_conclusion,
+            continue_on_error,
+            secret_exposure,
+            outputs,
+            outputs_digest,
+            commit_digest,
+            finalized_at,
+        })
+    }
+
     /// Returns the exact live claim proof.
     #[must_use]
     pub const fn claim(&self) -> &LogicalInstanceResultClaimFence {
@@ -1663,6 +1788,9 @@ fn descriptor_digest(
             hasher.update(SERVER_CANCELLATION_DESCRIPTOR_DOMAIN);
             hasher.update(cancellation.operation_id().as_uuid().as_bytes());
             hasher.update(cancellation.digest().as_bytes());
+        }
+        LogicalInstanceTerminalAuthority::ServerLeaseExpiry => {
+            hasher.update(SERVER_LEASE_EXPIRY_DESCRIPTOR_DOMAIN);
         }
     }
     hash_job_ir_object(&mut hasher, job_ir_object);

--- a/crates/automata-ci-workflow-service/src/result_projection.rs
+++ b/crates/automata-ci-workflow-service/src/result_projection.rs
@@ -184,6 +184,7 @@ impl LogicalResultProjectionService {
         }
     }
 
+    #[allow(clippy::too_many_lines)] // Keeps the three closed terminal-authority paths together.
     async fn project_instance(
         &self,
         claimed: ClaimedLogicalInstanceResult,
@@ -223,7 +224,8 @@ impl LogicalResultProjectionService {
                 };
                 Some((encoded_result, result))
             }
-            LogicalInstanceTerminalAuthority::ServerCancellation(_) => None,
+            LogicalInstanceTerminalAuthority::ServerCancellation(_)
+            | LogicalInstanceTerminalAuthority::ServerLeaseExpiry => None,
         };
         let job_ir_object = claimed.descriptor().job_ir();
         let protocol_maximum = u64::try_from(self.protocol_limits.max_frame_bytes())
@@ -256,21 +258,34 @@ impl LogicalResultProjectionService {
                 .await;
         };
         let finalized_at = self.clock.now();
-        let commit_result = match runner_result {
-            Some((encoded_result, result)) => CommitLogicalInstanceResult::new(
-                &claimed,
-                &encoded_result,
-                &result,
-                &encoded_job_ir,
-                &job_ir,
-                finalized_at,
-            ),
-            None => CommitLogicalInstanceResult::new_server_cancellation(
-                &claimed,
-                &encoded_job_ir,
-                &job_ir,
-                finalized_at,
-            ),
+        let commit_result = match (runner_result, claimed.descriptor().terminal_authority()) {
+            (Some((encoded_result, result)), LogicalInstanceTerminalAuthority::Runner(_)) => {
+                CommitLogicalInstanceResult::new(
+                    &claimed,
+                    &encoded_result,
+                    &result,
+                    &encoded_job_ir,
+                    &job_ir,
+                    finalized_at,
+                )
+            }
+            (None, LogicalInstanceTerminalAuthority::ServerCancellation(_)) => {
+                CommitLogicalInstanceResult::new_server_cancellation(
+                    &claimed,
+                    &encoded_job_ir,
+                    &job_ir,
+                    finalized_at,
+                )
+            }
+            (None, LogicalInstanceTerminalAuthority::ServerLeaseExpiry) => {
+                CommitLogicalInstanceResult::new_server_lease_expiry(
+                    &claimed,
+                    &encoded_job_ir,
+                    &job_ir,
+                    finalized_at,
+                )
+            }
+            _ => Err(LogicalInstanceResultValueError::TerminalAuthorityMismatch),
         };
         let commit = match commit_result {
             Ok(commit) => commit,


### PR DESCRIPTION
## Summary
- commit database-authenticated failure evidence atomically when an active runner lease expires
- project lost attempts into blob-free logical failure results so jobs, workflow runs, concurrency groups, and GitHub checks always finalize
- backfill existing lost attempts and enforce the closed terminal-authority shapes in PostgreSQL

## Verification
- cargo fmt --check
- cargo test -p automata-ci-store -p automata-ci-store-postgres -p automata-ci-workflow-service --lib (148 passed)
- all six frozen migration-layout tests
- targeted clippy with -D warnings for store, store-postgres, workflow-service, and postgres integration crates
- disposable PostgreSQL 18 integration: concurrent lease maintenance terminalizes exactly once
- disposable PostgreSQL 18 integration: lease-expiry evidence projects a zero-output effective failure even when the job declares continue-on-error
- git diff --check