### PR TITLE
test(runner-transport): consolidate typed transport fixtures

### DIFF
--- a/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
+++ b/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
@@ -14,7 +14,7 @@ use automata_ci_runner_transport::{
     RunnerControlHandler, SYNC_PATH, TransportLimits,
 };
 use bytes::Bytes;
-use http::{Method, Request, Response, StatusCode, Uri, Version, header::CONTENT_TYPE};
+use http::{HeaderValue, Method, Response, StatusCode, Uri, Version, header::CONTENT_TYPE};
 use http_body_util::{BodyExt as _, Full};
 use hyper::{server::conn::http2, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 
 use support::{
     HandlerMode, RecordingVerifier, TestHandler, TestPki, client, heartbeat_request, hello_request,
-    poll_request, raw_h2_sender, spawn_server,
+    poll_request, raw_h2_sender, raw_request, spawn_server,
 };
 
 #[derive(Debug, Default)]
@@ -291,18 +291,26 @@ async fn one_h2_connection_runs_concurrent_long_polls_without_affinity() {
             .await
             .expect("one h2 connection");
     let mut second_sender = first_sender.clone();
-    let first = poll_request();
-    let second = poll_request();
+    let first = poll_request().canonical_bytes().clone();
+    let second = poll_request().canonical_bytes().clone();
 
     let first_response = first_sender.send_request(raw_request(
         running.address,
+        Method::POST,
         SYNC_PATH,
-        first.canonical_bytes().clone(),
+        Version::HTTP_2,
+        Full::new(first.clone()).boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(first.len().into()),
     ));
     let second_response = second_sender.send_request(raw_request(
         running.address,
+        Method::POST,
         SYNC_PATH,
-        second.canonical_bytes().clone(),
+        Version::HTTP_2,
+        Full::new(second.clone()).boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(second.len().into()),
     ));
     let (first_response, second_response) = tokio::join!(first_response, second_response);
     assert_eq!(first_response.expect("first poll").status(), StatusCode::OK);
@@ -494,28 +502,6 @@ impl RunnerControlHandler for WrongSessionHandler {
             )))
         })
     }
-}
-
-fn raw_request(
-    address: std::net::SocketAddr,
-    path: &str,
-    body: Bytes,
-) -> Request<support::RawBody> {
-    let body_len = body.len();
-    let mut request = Request::new(Full::new(body).boxed_unsync());
-    *request.method_mut() = Method::POST;
-    *request.version_mut() = Version::HTTP_2;
-    *request.uri_mut() = format!("https://{address}{path}")
-        .parse()
-        .expect("request URI");
-    request.headers_mut().insert(
-        CONTENT_TYPE,
-        http::HeaderValue::from_static(PROTOBUF_CONTENT_TYPE),
-    );
-    request
-        .headers_mut()
-        .insert(http::header::CONTENT_LENGTH, body_len.into());
-    request
 }
 
 async fn spawn_fixed_response_server(

--- a/crates/automata-ci-runner-transport/tests/http_contract.rs
+++ b/crates/automata-ci-runner-transport/tests/http_contract.rs
@@ -1,16 +1,16 @@
 use crate::support;
 
-use std::{convert::Infallible, net::SocketAddr, time::Duration};
+use std::{convert::Infallible, time::Duration};
 
 use automata_ci_auth::machine::MachineAuthenticationError;
 use automata_ci_runner_transport::{HANDSHAKE_PATH, PROTOBUF_CONTENT_TYPE, TransportLimits};
 use bytes::Bytes;
-use http::{Method, Request, StatusCode, Version, header::CONTENT_TYPE};
+use http::{HeaderValue, Method, StatusCode, Version};
 use http_body_util::{BodyExt as _, Channel, Full};
 
 use support::{
-    HandlerMode, RawBody, RawSender, RecordingVerifier, RunningServer, TestHandler, TestPki,
-    hello_request, raw_h2_sender, spawn_server,
+    HandlerMode, RawSender, RecordingVerifier, RunningServer, TestHandler, TestPki, hello_request,
+    raw_h2_sender, raw_request, spawn_server,
 };
 
 #[tokio::test]
@@ -24,11 +24,14 @@ async fn declared_oversized_body_is_rejected_before_authentication_or_reading() 
     let running = spawn_server(&pki, verifier.clone(), handler.clone(), &limits).await;
     let (mut sender, connection) = connected_sender(&running, &pki).await;
     let (_body_sender, body) = Channel::<Bytes, Infallible>::new(1);
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         body.boxed_unsync(),
-        Some(33),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(33_usize.into()),
     );
 
     let response = sender.send_request(request).await.expect("error response");
@@ -59,11 +62,14 @@ async fn streamed_body_without_content_length_is_rejected() {
         .await
         .expect("stream body");
     drop(body_sender);
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         body.boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
         None,
-        PROTOBUF_CONTENT_TYPE,
     );
 
     let response = sender.send_request(request).await.expect("error response");
@@ -91,11 +97,14 @@ async fn stalled_body_hits_incremental_read_deadline_without_handler_invocation(
     let running = spawn_server(&pki, verifier.clone(), handler.clone(), &limits).await;
     let (mut sender, connection) = connected_sender(&running, &pki).await;
     let (_body_sender, body) = Channel::<Bytes, Infallible>::new(1);
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         body.boxed_unsync(),
-        Some(16),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(16_usize.into()),
     );
 
     let response = sender
@@ -124,11 +133,14 @@ async fn malformed_protobuf_never_reaches_handler() {
     .await;
     let (mut sender, connection) = connected_sender(&running, &pki).await;
     let malformed = Bytes::from_static(&[0xff, 0xff, 0xff]);
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         Full::new(malformed.clone()).boxed_unsync(),
-        Some(malformed.len()),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(malformed.len().into()),
     );
 
     let response = sender
@@ -159,11 +171,14 @@ async fn machine_authentication_finishes_before_a_stalled_body_is_polled() {
     let running = spawn_server(&pki, verifier.clone(), handler.clone(), &limits).await;
     let (mut sender, connection) = connected_sender(&running, &pki).await;
     let (_body_sender, body) = Channel::<Bytes, Infallible>::new(1);
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         body.boxed_unsync(),
-        Some(16),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(16_usize.into()),
     );
 
     let response = tokio::time::timeout(Duration::from_millis(250), sender.send_request(request))
@@ -192,11 +207,16 @@ async fn content_type_must_match_exactly() {
     .await;
     let (mut sender, connection) = connected_sender(&running, &pki).await;
     let body = hello_request().canonical_bytes().clone();
-    let request = request(
+    let request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         Full::new(body.clone()).boxed_unsync(),
-        Some(body.len()),
-        "application/protobuf; charset=binary",
+        Some(HeaderValue::from_static(
+            "application/protobuf; charset=binary",
+        )),
+        Some(body.len().into()),
     );
 
     let response = sender.send_request(request).await.expect("media response");
@@ -227,21 +247,27 @@ async fn admission_is_bounded_before_a_second_body_is_read() {
     let (mut second_sender, connection) = connected_sender(&running, &pki).await;
     let mut first_sender = second_sender.clone();
     let first_body = hello_request().canonical_bytes().clone();
-    let first_request = request(
+    let first_request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         Full::new(first_body.clone()).boxed_unsync(),
-        Some(first_body.len()),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(first_body.len().into()),
     );
     let first_task = tokio::spawn(async move { first_sender.send_request(first_request).await });
     handler.wait_until_started().await;
 
     let (_stalled_sender, stalled_body) = Channel::<Bytes, Infallible>::new(1);
-    let second_request = request(
+    let second_request = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         stalled_body.boxed_unsync(),
-        Some(16),
-        PROTOBUF_CONTENT_TYPE,
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(16_usize.into()),
     );
     let second_response = second_sender
         .send_request(second_request)
@@ -269,27 +295,4 @@ async fn connected_sender(
     raw_h2_sender(running.address, pki.raw_client_config(Some(&pki.client)))
         .await
         .expect("valid raw h2 client")
-}
-
-fn request(
-    address: SocketAddr,
-    body: RawBody,
-    content_length: Option<usize>,
-    content_type: &'static str,
-) -> Request<RawBody> {
-    let mut request = Request::new(body);
-    *request.method_mut() = Method::POST;
-    *request.version_mut() = Version::HTTP_2;
-    *request.uri_mut() = format!("https://{address}{HANDSHAKE_PATH}")
-        .parse()
-        .expect("request URI");
-    request
-        .headers_mut()
-        .insert(CONTENT_TYPE, http::HeaderValue::from_static(content_type));
-    if let Some(content_length) = content_length {
-        request
-            .headers_mut()
-            .insert(http::header::CONTENT_LENGTH, content_length.into());
-    }
-    request
 }

--- a/crates/automata-ci-runner-transport/tests/server_lifecycle.rs
+++ b/crates/automata-ci-runner-transport/tests/server_lifecycle.rs
@@ -1,218 +1,47 @@
 use crate::support;
 
 use std::{
-    fmt,
     io::ErrorKind,
-    net::{Ipv4Addr, SocketAddr},
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
-use automata_ci_auth::machine::MachineIdentityVerifier;
-use automata_ci_protocol::ProtocolLimits;
 use automata_ci_runner_transport::{
-    ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, HANDSHAKE_PATH,
-    HandlerFuture, PROTOBUF_CONTENT_TYPE, RunnerControlHandler, RunnerControlServer,
-    RunnerTransportConnectionEvent, RunnerTransportObserver, RunnerTransportTlsOutcome, ServeError,
+    ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, HandlerFuture,
+    RunnerControlHandler, RunnerTransportConnectionEvent, RunnerTransportTlsOutcome,
     TransportLimits,
 };
-use http::{Method, Request, StatusCode, Version, header::CONTENT_TYPE};
-use http_body_util::{BodyExt as _, Full};
+use http::StatusCode;
+use http_body_util::BodyExt as _;
 use tokio::{
     io::AsyncReadExt as _,
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     sync::Notify,
-    task::JoinHandle,
     time::{advance, timeout},
 };
-use tokio_util::sync::CancellationToken;
 
 use support::{
-    HandlerMode, RawBody, RecordingVerifier, TestHandler, TestPki, hello_request, raw_h2_sender,
+    HandlerMode, Http2Terminal, RecordingTransportObserver, RecordingVerifier, TEST_WATCHDOG,
+    TestHandler, TestPki, raw_h2_sender, raw_hello_request, spawn_server_with_observer,
 };
-
-const TEST_WATCHDOG: Duration = Duration::from_secs(5);
-
-#[derive(Default)]
-struct LifecycleObserver {
-    connections: Mutex<Vec<RunnerTransportConnectionEvent>>,
-    tls: Mutex<Vec<RunnerTransportTlsOutcome>>,
-    changed: Notify,
-}
-
-impl fmt::Debug for LifecycleObserver {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("LifecycleObserver").finish()
-    }
-}
-
-impl LifecycleObserver {
-    fn connection_events(&self) -> Vec<RunnerTransportConnectionEvent> {
-        self.connections
-            .lock()
-            .expect("connection event lock")
-            .clone()
-    }
-
-    fn tls_outcomes(&self) -> Vec<RunnerTransportTlsOutcome> {
-        self.tls.lock().expect("TLS outcome lock").clone()
-    }
-
-    async fn wait_for_connection(&self, expected: RunnerTransportConnectionEvent, count: usize) {
-        timeout(TEST_WATCHDOG, async {
-            loop {
-                let changed = self.changed.notified();
-                let observed = self
-                    .connections
-                    .lock()
-                    .expect("connection event lock")
-                    .iter()
-                    .filter(|event| **event == expected)
-                    .count();
-                if observed >= count {
-                    return;
-                }
-                changed.await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| {
-            panic!("connection observer did not record {count} {expected:?} events")
-        });
-    }
-
-    async fn wait_for_http2_terminal_count(&self, count: usize) {
-        timeout(TEST_WATCHDOG, async {
-            loop {
-                let changed = self.changed.notified();
-                let observed = self
-                    .connections
-                    .lock()
-                    .expect("connection event lock")
-                    .iter()
-                    .filter(|event| {
-                        matches!(
-                            event,
-                            RunnerTransportConnectionEvent::Http2Closed
-                                | RunnerTransportConnectionEvent::Http2Error
-                        )
-                    })
-                    .count();
-                if observed >= count {
-                    return;
-                }
-                changed.await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("connection observer did not record {count} HTTP/2 terminals"));
-    }
-
-    async fn wait_for_tls(&self, expected: RunnerTransportTlsOutcome, count: usize) {
-        timeout(TEST_WATCHDOG, async {
-            loop {
-                let changed = self.changed.notified();
-                let observed = self
-                    .tls
-                    .lock()
-                    .expect("TLS outcome lock")
-                    .iter()
-                    .filter(|outcome| **outcome == expected)
-                    .count();
-                if observed >= count {
-                    return;
-                }
-                changed.await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("TLS observer did not record {count} {expected:?} outcomes"));
-    }
-}
-
-impl RunnerTransportObserver for LifecycleObserver {
-    fn observe_connection(&self, event: RunnerTransportConnectionEvent) {
-        self.connections
-            .lock()
-            .expect("connection event lock")
-            .push(event);
-        self.changed.notify_waiters();
-    }
-
-    fn observe_tls(&self, outcome: RunnerTransportTlsOutcome, _duration: Duration) {
-        self.tls.lock().expect("TLS outcome lock").push(outcome);
-        self.changed.notify_waiters();
-    }
-}
-
-struct LifecycleServer {
-    address: SocketAddr,
-    shutdown: CancellationToken,
-    task: JoinHandle<Result<(), ServeError>>,
-}
-
-impl LifecycleServer {
-    async fn finish(self) {
-        timeout(TEST_WATCHDOG, self.task)
-            .await
-            .expect("server task watchdog")
-            .expect("server task")
-            .expect("server serve result");
-    }
-
-    async fn stop(self) {
-        self.shutdown.cancel();
-        self.finish().await;
-    }
-}
-
-async fn spawn_lifecycle_server(
-    pki: &TestPki,
-    verifier: Arc<dyn MachineIdentityVerifier>,
-    handler: Arc<dyn RunnerControlHandler>,
-    limits: &TransportLimits,
-    observer: Arc<LifecycleObserver>,
-) -> LifecycleServer {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-        .await
-        .expect("bind lifecycle server");
-    let address = listener.local_addr().expect("lifecycle server address");
-    let server = RunnerControlServer::new(
-        listener,
-        &pki.server_tls(),
-        verifier,
-        handler,
-        ProtocolLimits::default(),
-        *limits,
-    )
-    .expect("lifecycle server")
-    .with_observer(observer);
-    let shutdown = CancellationToken::new();
-    let task = tokio::spawn(server.serve(shutdown.clone()));
-    LifecycleServer {
-        address,
-        shutdown,
-        task,
-    }
-}
 
 #[tokio::test]
 async fn connection_limit_rejects_excess_and_reuses_released_permit() {
     let pki = TestPki::new();
-    let observer = Arc::new(LifecycleObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::Reply);
     let limits = TransportLimits::default()
         .with_concurrency_limits(1, 16, 16)
         .expect("one concurrent connection");
-    let running = spawn_lifecycle_server(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
         &limits,
-        Arc::clone(&observer),
+        observer.clone(),
     )
     .await;
 
@@ -221,10 +50,10 @@ async fn connection_limit_rejects_excess_and_reuses_released_permit() {
             .await
             .expect("first admitted H2 connection");
     observer
-        .wait_for_connection(RunnerTransportConnectionEvent::Admitted, 1)
+        .wait_for(RunnerTransportConnectionEvent::Admitted, 1, TEST_WATCHDOG)
         .await;
     observer
-        .wait_for_tls(RunnerTransportTlsOutcome::Accepted, 1)
+        .wait_for(RunnerTransportTlsOutcome::Accepted, 1, TEST_WATCHDOG)
         .await;
 
     let rejected = raw_h2_sender(running.address, pki.raw_client_config(Some(&pki.client)));
@@ -236,7 +65,7 @@ async fn connection_limit_rejects_excess_and_reuses_released_permit() {
         "the excess TCP connection must be closed before TLS/H2 admission"
     );
     observer
-        .wait_for_connection(RunnerTransportConnectionEvent::Overloaded, 1)
+        .wait_for(RunnerTransportConnectionEvent::Overloaded, 1, TEST_WATCHDOG)
         .await;
     assert_eq!(
         observer.tls_outcomes(),
@@ -247,7 +76,7 @@ async fn connection_limit_rejects_excess_and_reuses_released_permit() {
     drop(first_sender);
     first_connection.abort();
     let _ = first_connection.await;
-    observer.wait_for_http2_terminal_count(1).await;
+    observer.wait_for(Http2Terminal, 1, TEST_WATCHDOG).await;
 
     let (mut reused_sender, reused_connection) =
         raw_h2_sender(running.address, pki.raw_client_config(Some(&pki.client)))
@@ -271,7 +100,7 @@ async fn connection_limit_rejects_excess_and_reuses_released_permit() {
     drop(reused_sender);
     reused_connection.abort();
     let _ = reused_connection.await;
-    observer.wait_for_http2_terminal_count(2).await;
+    observer.wait_for(Http2Terminal, 2, TEST_WATCHDOG).await;
     running.stop().await;
 
     let events = observer.connection_events();
@@ -296,7 +125,7 @@ async fn fixed_connection_lifetime_emits_one_terminal_and_reuses_the_permit() {
     const LIFETIME: Duration = Duration::from_secs(5);
 
     let pki = TestPki::new();
-    let observer = Arc::new(LifecycleObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::Reply);
     let limits = TransportLimits::default()
         .with_server_request_timeouts(
@@ -312,12 +141,12 @@ async fn fixed_connection_lifetime_emits_one_terminal_and_reuses_the_permit() {
         .expect("bounded lifetime drain")
         .with_concurrency_limits(1, 16, 16)
         .expect("one concurrent connection");
-    let running = spawn_lifecycle_server(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
         &limits,
-        Arc::clone(&observer),
+        observer.clone(),
     )
     .await;
 
@@ -326,10 +155,10 @@ async fn fixed_connection_lifetime_emits_one_terminal_and_reuses_the_permit() {
             .await
             .expect("first H2 connection");
     observer
-        .wait_for_connection(RunnerTransportConnectionEvent::Admitted, 1)
+        .wait_for(RunnerTransportConnectionEvent::Admitted, 1, TEST_WATCHDOG)
         .await;
     observer
-        .wait_for_tls(RunnerTransportTlsOutcome::Accepted, 1)
+        .wait_for(RunnerTransportTlsOutcome::Accepted, 1, TEST_WATCHDOG)
         .await;
     assert_eq!(
         observer.tls_outcomes(),
@@ -340,7 +169,11 @@ async fn fixed_connection_lifetime_emits_one_terminal_and_reuses_the_permit() {
     yield_to_connection_lifetime().await;
     advance(LIFETIME + Duration::from_millis(1)).await;
     observer
-        .wait_for_connection(RunnerTransportConnectionEvent::LifetimeExpired, 1)
+        .wait_for(
+            RunnerTransportConnectionEvent::LifetimeExpired,
+            1,
+            TEST_WATCHDOG,
+        )
         .await;
     assert_eq!(
         observer.connection_events(),
@@ -399,17 +232,17 @@ async fn fixed_connection_lifetime_emits_one_terminal_and_reuses_the_permit() {
 #[tokio::test]
 async fn shutdown_cancels_in_flight_handler_and_drains_its_response() {
     let pki = TestPki::new();
-    let observer = Arc::new(LifecycleObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = CancellationCompletingHandler::new();
     let limits = TransportLimits::default()
         .with_graceful_shutdown_timeout(Duration::from_hours(1))
         .expect("long graceful shutdown watchdog");
-    let running = spawn_lifecycle_server(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
         &limits,
-        Arc::clone(&observer),
+        observer.clone(),
     )
     .await;
     let (sender, connection) =
@@ -433,7 +266,7 @@ async fn shutdown_cancels_in_flight_handler_and_drains_its_response() {
     });
     handler.wait_until_started().await;
 
-    running.shutdown.cancel();
+    running.request_shutdown();
     handler.wait_until_completed().await;
     assert_eq!(
         timeout(TEST_WATCHDOG, response_task)
@@ -463,19 +296,19 @@ async fn stalled_h2_shutdown_is_aborted_once_by_the_listener_deadline() {
     const GRACE: Duration = Duration::from_secs(1);
 
     let pki = TestPki::new();
-    let observer = Arc::new(LifecycleObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::WaitForCancellation);
     let limits = TransportLimits::default()
         .with_graceful_shutdown_timeout(GRACE)
         .expect("one-second grace period")
         .with_concurrency_limits(1, 16, 16)
         .expect("one concurrent connection");
-    let running = spawn_lifecycle_server(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
         &limits,
-        Arc::clone(&observer),
+        observer.clone(),
     )
     .await;
     let (mut sender, connection) =
@@ -488,7 +321,7 @@ async fn stalled_h2_shutdown_is_aborted_once_by_the_listener_deadline() {
 
     tokio::time::pause();
     let shutdown_started = tokio::time::Instant::now();
-    running.shutdown.cancel();
+    running.request_shutdown();
     yield_to_shutdown_drain().await;
     wait_for_handler_cancellation(&handler).await;
     assert_eq!(
@@ -502,7 +335,7 @@ async fn stalled_h2_shutdown_is_aborted_once_by_the_listener_deadline() {
             .expect("grace exceeds one millisecond"),
     )
     .await;
-    assert!(!running.task.is_finished());
+    assert!(!running.is_finished());
     assert_eq!(
         observer.connection_events(),
         [RunnerTransportConnectionEvent::Admitted]
@@ -510,13 +343,13 @@ async fn stalled_h2_shutdown_is_aborted_once_by_the_listener_deadline() {
 
     advance(Duration::from_millis(2)).await;
     for _ in 0..8 {
-        if running.task.is_finished() {
+        if running.is_finished() {
             break;
         }
         tokio::task::yield_now().await;
     }
     assert!(
-        running.task.is_finished(),
+        running.is_finished(),
         "the listener must abort an H2 stream that exceeds its drain deadline"
     );
     assert_eq!(
@@ -553,29 +386,29 @@ async fn grace_timeout_aborts_a_connection_stalled_before_tls() {
     const GRACE: Duration = Duration::from_secs(1);
 
     let pki = TestPki::new();
-    let observer = Arc::new(LifecycleObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::Reply);
     let limits = TransportLimits::default()
         .with_graceful_shutdown_timeout(GRACE)
         .expect("one-second grace period");
-    let running = spawn_lifecycle_server(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
         &limits,
-        Arc::clone(&observer),
+        observer.clone(),
     )
     .await;
     let mut stalled = TcpStream::connect(running.address)
         .await
         .expect("stalled TCP connection");
     observer
-        .wait_for_connection(RunnerTransportConnectionEvent::Admitted, 1)
+        .wait_for(RunnerTransportConnectionEvent::Admitted, 1, TEST_WATCHDOG)
         .await;
 
     tokio::time::pause();
     let shutdown_started = tokio::time::Instant::now();
-    running.shutdown.cancel();
+    running.request_shutdown();
     yield_to_shutdown_drain().await;
 
     advance(
@@ -584,18 +417,18 @@ async fn grace_timeout_aborts_a_connection_stalled_before_tls() {
             .expect("grace exceeds one millisecond"),
     )
     .await;
-    assert!(!running.task.is_finished());
+    assert!(!running.is_finished());
     assert!(observer.tls_outcomes().is_empty());
 
     advance(Duration::from_millis(2)).await;
     for _ in 0..8 {
-        if running.task.is_finished() {
+        if running.is_finished() {
             break;
         }
         tokio::task::yield_now().await;
     }
     assert!(
-        running.task.is_finished(),
+        running.is_finished(),
         "the listener must abort a connection that exceeds its grace period"
     );
     assert_eq!(
@@ -613,25 +446,6 @@ async fn grace_timeout_aborts_a_connection_stalled_before_tls() {
             RunnerTransportConnectionEvent::DrainAborted,
         ]
     );
-}
-
-fn raw_hello_request(address: SocketAddr) -> Request<RawBody> {
-    let body = hello_request().canonical_bytes().clone();
-    let body_length = body.len();
-    let mut request = Request::new(Full::new(body).boxed_unsync());
-    *request.method_mut() = Method::POST;
-    *request.version_mut() = Version::HTTP_2;
-    *request.uri_mut() = format!("https://{address}{HANDSHAKE_PATH}")
-        .parse()
-        .expect("hello request URI");
-    request.headers_mut().insert(
-        CONTENT_TYPE,
-        PROTOBUF_CONTENT_TYPE.parse().expect("protobuf media type"),
-    );
-    request
-        .headers_mut()
-        .insert(http::header::CONTENT_LENGTH, body_length.into());
-    request
 }
 
 #[derive(Debug)]

--- a/crates/automata-ci-runner-transport/tests/server_observer.rs
+++ b/crates/automata-ci-runner-transport/tests/server_observer.rs
@@ -1,97 +1,35 @@
 use crate::support;
 
-use std::{
-    convert::Infallible,
-    fmt,
-    net::{Ipv4Addr, SocketAddr},
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{convert::Infallible, sync::Arc, time::Duration};
 
-use automata_ci_auth::machine::{MachineAuthenticationError, MachineIdentityVerifier};
+use automata_ci_auth::machine::MachineAuthenticationError;
 use automata_ci_protocol::ProtocolLimits;
 use automata_ci_runner_transport::{
     HANDSHAKE_PATH, HyperRunnerControlClient, PROTOBUF_CONTENT_TYPE, RunnerControlClient,
-    RunnerControlHandler, RunnerControlServer, RunnerTransportAuthenticationRejection,
-    RunnerTransportByteDirection, RunnerTransportConnectionEvent, RunnerTransportDecodeRejection,
-    RunnerTransportHeadRejection, RunnerTransportObserver, RunnerTransportRequestObservation,
-    RunnerTransportRoute, RunnerTransportTlsOutcome, ServeError, TransportLimits,
+    RunnerTransportAuthenticationRejection, RunnerTransportByteDirection,
+    RunnerTransportDecodeRejection, RunnerTransportHeadRejection,
+    RunnerTransportRequestObservation, RunnerTransportRoute, RunnerTransportTlsOutcome,
+    TransportLimits,
 };
 use bytes::Bytes;
-use http::{Method, Request, StatusCode, Version, header::CONTENT_TYPE};
+use http::{HeaderValue, Method, StatusCode, Version};
 use http_body_util::{BodyExt as _, Channel, Full};
-use tokio::{net::TcpListener, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use support::{
-    HandlerMode, RawBody, RecordingVerifier, TestHandler, TestPki, hello_request, raw_h2_sender,
+    HandlerMode, RecordingTransportObserver, RecordingVerifier, TestHandler, TestPki,
+    hello_request, raw_h2_sender, raw_hello_request, raw_request, spawn_server_with_observer,
 };
-
-#[derive(Default)]
-struct RecordingObserver {
-    connections: Mutex<Vec<RunnerTransportConnectionEvent>>,
-    tls: Mutex<Vec<RunnerTransportTlsOutcome>>,
-    requests: Mutex<Vec<RunnerTransportRequestObservation>>,
-    starts: Mutex<Vec<RunnerTransportRoute>>,
-    finishes: Mutex<Vec<RunnerTransportRoute>>,
-    bytes: Mutex<Vec<(RunnerTransportRoute, RunnerTransportByteDirection, u64)>>,
-}
-
-impl fmt::Debug for RecordingObserver {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("RecordingObserver").finish()
-    }
-}
-
-impl RunnerTransportObserver for RecordingObserver {
-    fn observe_connection(&self, event: RunnerTransportConnectionEvent) {
-        self.connections
-            .lock()
-            .expect("connection lock")
-            .push(event);
-    }
-
-    fn observe_tls(&self, outcome: RunnerTransportTlsOutcome, _duration: Duration) {
-        self.tls.lock().expect("TLS lock").push(outcome);
-    }
-
-    fn observe_request(&self, observation: RunnerTransportRequestObservation, _duration: Duration) {
-        self.requests
-            .lock()
-            .expect("request lock")
-            .push(observation);
-    }
-
-    fn request_started(&self, route: RunnerTransportRoute) {
-        self.starts.lock().expect("start lock").push(route);
-    }
-
-    fn request_finished(&self, route: RunnerTransportRoute) {
-        self.finishes.lock().expect("finish lock").push(route);
-    }
-
-    fn observe_bytes(
-        &self,
-        route: RunnerTransportRoute,
-        direction: RunnerTransportByteDirection,
-        bytes: u64,
-    ) {
-        self.bytes
-            .lock()
-            .expect("byte lock")
-            .push((route, direction, bytes));
-    }
-}
 
 #[tokio::test]
 async fn observer_covers_head_decode_success_and_balanced_in_flight() {
     let pki = TestPki::new();
-    let observer = Arc::new(RecordingObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::Reply);
     let limits = TransportLimits::default()
         .with_body_limits(512, 512)
         .expect("small bounded bodies");
-    let running = spawn_observed(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
@@ -105,7 +43,15 @@ async fn observer_covers_head_decode_success_and_balanced_in_flight() {
             .expect("valid HTTP/2 client");
 
     let (_oversized_sender, oversized_body) = Channel::<Bytes, Infallible>::new(1);
-    let oversized = request(running.address, oversized_body.boxed_unsync(), 513);
+    let oversized = raw_request(
+        running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
+        oversized_body.boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(513_usize.into()),
+    );
     assert_eq!(
         sender
             .send_request(oversized)
@@ -116,10 +62,14 @@ async fn observer_covers_head_decode_success_and_balanced_in_flight() {
     );
 
     let malformed_bytes = Bytes::from_static(&[0xff, 0xff, 0xff]);
-    let malformed = request(
+    let malformed = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         Full::new(malformed_bytes.clone()).boxed_unsync(),
-        malformed_bytes.len(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(malformed_bytes.len().into()),
     );
     assert_eq!(
         sender
@@ -131,10 +81,14 @@ async fn observer_covers_head_decode_success_and_balanced_in_flight() {
     );
 
     let hello_bytes = hello_request().canonical_bytes().clone();
-    let valid = request(
+    let valid = raw_request(
         running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
         Full::new(hello_bytes.clone()).boxed_unsync(),
-        hello_bytes.len(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(hello_bytes.len().into()),
     );
     assert_eq!(
         sender
@@ -152,12 +106,12 @@ async fn observer_covers_head_decode_success_and_balanced_in_flight() {
 }
 
 fn assert_primary_request_observations(
-    observer: &RecordingObserver,
+    observer: &RecordingTransportObserver,
     malformed_length: usize,
     hello_length: usize,
 ) {
     assert_eq!(
-        *observer.requests.lock().expect("request lock"),
+        observer.request_observations(),
         [
             RunnerTransportRequestObservation::HeadRejected {
                 route: RunnerTransportRoute::Handshake,
@@ -173,24 +127,24 @@ fn assert_primary_request_observations(
         ]
     );
     assert_eq!(
-        *observer.starts.lock().expect("start lock"),
+        observer.request_starts(),
         [
             RunnerTransportRoute::Handshake,
             RunnerTransportRoute::Handshake
         ]
     );
     assert_eq!(
-        *observer.finishes.lock().expect("finish lock"),
+        observer.request_finishes(),
         [
             RunnerTransportRoute::Handshake,
             RunnerTransportRoute::Handshake
         ]
     );
     assert_eq!(
-        *observer.tls.lock().expect("TLS lock"),
+        observer.tls_outcomes(),
         [RunnerTransportTlsOutcome::Accepted]
     );
-    let bytes = observer.bytes.lock().expect("byte lock");
+    let bytes = observer.bytes();
     assert!(bytes.contains(&(
         RunnerTransportRoute::Handshake,
         RunnerTransportByteDirection::Request,
@@ -211,9 +165,9 @@ fn assert_primary_request_observations(
 #[tokio::test]
 async fn observer_records_authentication_rejection() {
     let pki = TestPki::new();
-    let auth_observer = Arc::new(RecordingObserver::default());
+    let auth_observer = Arc::new(RecordingTransportObserver::default());
     let auth_handler = TestHandler::new(HandlerMode::Reply);
-    let auth_running = spawn_observed(
+    let auth_running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::rejecting(MachineAuthenticationError::Untrusted),
         auth_handler.clone(),
@@ -227,13 +181,8 @@ async fn observer_records_authentication_rejection() {
     )
     .await
     .expect("valid HTTP/2 client");
-    let body = hello_request().canonical_bytes().clone();
     let response = auth_sender
-        .send_request(request(
-            auth_running.address,
-            Full::new(body.clone()).boxed_unsync(),
-            body.len(),
-        ))
+        .send_request(raw_hello_request(auth_running.address))
         .await
         .expect("authentication response");
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -241,7 +190,7 @@ async fn observer_records_authentication_rejection() {
     auth_connection.abort();
     auth_running.stop().await;
     assert_eq!(
-        *auth_observer.requests.lock().expect("auth request lock"),
+        auth_observer.request_observations(),
         [RunnerTransportRequestObservation::AuthenticationRejected {
             route: RunnerTransportRoute::Handshake,
             reason: RunnerTransportAuthenticationRejection::Untrusted,
@@ -252,8 +201,8 @@ async fn observer_records_authentication_rejection() {
 #[tokio::test]
 async fn observer_records_tls_rejection() {
     let pki = TestPki::new();
-    let tls_observer = Arc::new(RecordingObserver::default());
-    let tls_running = spawn_observed(
+    let tls_observer = Arc::new(RecordingTransportObserver::default());
+    let tls_running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         TestHandler::new(HandlerMode::Reply),
@@ -269,14 +218,9 @@ async fn observer_records_tls_rejection() {
     {
         Err(()) => true,
         Ok((mut sender, connection)) => {
-            let body = hello_request().canonical_bytes().clone();
             let rejected = tokio::time::timeout(
                 Duration::from_secs(1),
-                sender.send_request(request(
-                    tls_running.address,
-                    Full::new(body.clone()).boxed_unsync(),
-                    body.len(),
-                )),
+                sender.send_request(raw_hello_request(tls_running.address)),
             )
             .await
             .expect("TLS rejection request deadline")
@@ -286,19 +230,16 @@ async fn observer_records_tls_rejection() {
         }
     };
     assert!(rejected);
-    tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            if !tls_observer.tls.lock().expect("TLS lock").is_empty() {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("TLS rejection observation");
+    tls_observer
+        .wait_for(
+            RunnerTransportTlsOutcome::Rejected,
+            1,
+            Duration::from_secs(1),
+        )
+        .await;
     tls_running.stop().await;
     assert_eq!(
-        *tls_observer.tls.lock().expect("TLS lock"),
+        tls_observer.tls_outcomes(),
         [RunnerTransportTlsOutcome::Rejected]
     );
 }
@@ -306,7 +247,7 @@ async fn observer_records_tls_rejection() {
 #[tokio::test]
 async fn observer_records_bounded_request_admission_overload() {
     let pki = TestPki::new();
-    let observer = Arc::new(RecordingObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::Delay(Duration::from_millis(100)));
     let limits = TransportLimits::default()
         .with_concurrency_limits(8, 1, 8)
@@ -318,7 +259,7 @@ async fn observer_records_bounded_request_admission_overload() {
             Duration::from_millis(300),
         )
         .expect("short admission timeout");
-    let running = spawn_observed(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
@@ -331,21 +272,11 @@ async fn observer_records_bounded_request_admission_overload() {
             .await
             .expect("valid HTTP/2 client");
     let mut first_sender = sender.clone();
-    let first_body = hello_request().canonical_bytes().clone();
-    let first = request(
-        running.address,
-        Full::new(first_body.clone()).boxed_unsync(),
-        first_body.len(),
-    );
+    let first = raw_hello_request(running.address);
     let first_task = tokio::spawn(async move { first_sender.send_request(first).await });
     handler.wait_until_started().await;
 
-    let second_body = hello_request().canonical_bytes().clone();
-    let second = request(
-        running.address,
-        Full::new(second_body.clone()).boxed_unsync(),
-        second_body.len(),
-    );
+    let second = raw_hello_request(running.address);
     assert_eq!(
         sender
             .send_request(second)
@@ -364,7 +295,7 @@ async fn observer_records_bounded_request_admission_overload() {
     );
     connection.abort();
     running.stop().await;
-    let requests = observer.requests.lock().expect("request lock");
+    let requests = observer.request_observations();
     assert!(requests.contains(&RunnerTransportRequestObservation::AdmissionOverloaded));
     assert!(
         requests.contains(&RunnerTransportRequestObservation::Succeeded {
@@ -376,9 +307,9 @@ async fn observer_records_bounded_request_admission_overload() {
 #[tokio::test]
 async fn dropped_stream_records_cancelled_and_balances_in_flight() {
     let pki = TestPki::new();
-    let observer = Arc::new(RecordingObserver::default());
+    let observer = Arc::new(RecordingTransportObserver::default());
     let handler = TestHandler::new(HandlerMode::WaitForCancellation);
-    let running = spawn_observed(
+    let running = spawn_server_with_observer(
         &pki,
         RecordingVerifier::accepting(),
         handler.clone(),
@@ -405,15 +336,18 @@ async fn dropped_stream_records_cancelled_and_balances_in_flight() {
     handler.wait_until_started().await;
     cancellation.cancel();
     let _ = task.await.expect("client task");
+    observer
+        .wait_for(
+            RunnerTransportRequestObservation::Cancelled {
+                route: RunnerTransportRoute::Handshake,
+            },
+            1,
+            Duration::from_secs(1),
+        )
+        .await;
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
-            if handler.cancellation_seen()
-                && observer.requests.lock().expect("request lock").contains(
-                    &RunnerTransportRequestObservation::Cancelled {
-                        route: RunnerTransportRoute::Handshake,
-                    },
-                )
-            {
+            if handler.cancellation_seen() {
                 break;
             }
             tokio::task::yield_now().await;
@@ -422,71 +356,5 @@ async fn dropped_stream_records_cancelled_and_balances_in_flight() {
     .await
     .expect("server cancellation observation");
     running.stop().await;
-    assert_eq!(
-        *observer.starts.lock().expect("start lock"),
-        *observer.finishes.lock().expect("finish lock")
-    );
-}
-
-struct ObservedServer {
-    address: SocketAddr,
-    shutdown: CancellationToken,
-    task: JoinHandle<Result<(), ServeError>>,
-}
-
-impl ObservedServer {
-    async fn stop(self) {
-        self.shutdown.cancel();
-        self.task
-            .await
-            .expect("server task")
-            .expect("server result");
-    }
-}
-
-async fn spawn_observed(
-    pki: &TestPki,
-    verifier: Arc<dyn MachineIdentityVerifier>,
-    handler: Arc<dyn RunnerControlHandler>,
-    limits: &TransportLimits,
-    observer: Arc<RecordingObserver>,
-) -> ObservedServer {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-        .await
-        .expect("bind observer server");
-    let address = listener.local_addr().expect("observer server address");
-    let server = RunnerControlServer::new(
-        listener,
-        &pki.server_tls(),
-        verifier,
-        handler,
-        ProtocolLimits::default(),
-        *limits,
-    )
-    .expect("observer server")
-    .with_observer(observer);
-    let shutdown = CancellationToken::new();
-    let task = tokio::spawn(server.serve(shutdown.clone()));
-    ObservedServer {
-        address,
-        shutdown,
-        task,
-    }
-}
-
-fn request(address: SocketAddr, body: RawBody, content_length: usize) -> Request<RawBody> {
-    let mut request = Request::new(body);
-    *request.method_mut() = Method::POST;
-    *request.version_mut() = Version::HTTP_2;
-    *request.uri_mut() = format!("https://{address}{HANDSHAKE_PATH}")
-        .parse()
-        .expect("request URI");
-    request.headers_mut().insert(
-        CONTENT_TYPE,
-        PROTOBUF_CONTENT_TYPE.parse().expect("media type"),
-    );
-    request
-        .headers_mut()
-        .insert(http::header::CONTENT_LENGTH, content_length.into());
-    request
+    assert_eq!(observer.request_starts(), observer.request_finishes());
 }

--- a/crates/automata-ci-runner-transport/tests/support/mod.rs
+++ b/crates/automata-ci-runner-transport/tests/support/mod.rs
@@ -30,12 +30,17 @@ use automata_ci_protocol::{
 };
 use automata_ci_runner_transport::{
     ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, ClientTlsConfig,
-    HandlerFuture, HyperRunnerControlClient, PreparedRequest, RunnerControlHandler,
-    RunnerControlServer, ServerTlsConfig, TransportLimits,
+    HANDSHAKE_PATH, HandlerFuture, HyperRunnerControlClient, PROTOBUF_CONTENT_TYPE,
+    PreparedRequest, RunnerControlHandler, RunnerControlServer, RunnerTransportByteDirection,
+    RunnerTransportConnectionEvent, RunnerTransportObserver, RunnerTransportRequestObservation,
+    RunnerTransportRoute, RunnerTransportTlsOutcome, ServerTlsConfig, TransportLimits,
 };
 use bytes::Bytes;
-use http::Uri;
-use http_body_util::combinators::UnsyncBoxBody;
+use http::{
+    HeaderValue, Method, Request, Uri, Version,
+    header::{CONTENT_LENGTH, CONTENT_TYPE},
+};
+use http_body_util::{BodyExt as _, Full, combinators::UnsyncBoxBody};
 use hyper::client::conn::http2::SendRequest;
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use rcgen::{
@@ -51,6 +56,7 @@ use rustls::{
 };
 use tokio::{
     net::{TcpListener, TcpStream},
+    sync::Notify,
     task::JoinHandle,
 };
 use tokio_rustls::TlsConnector;
@@ -60,6 +66,8 @@ pub type RawBody = UnsyncBoxBody<Bytes, Infallible>;
 pub type RawSender = SendRequest<RawBody>;
 type CalendarDate = (i32, u8, u8);
 type Validity = (CalendarDate, CalendarDate);
+
+pub const TEST_WATCHDOG: Duration = Duration::from_secs(5);
 
 pub struct Identity {
     certificates: Vec<Vec<u8>>,
@@ -326,6 +334,172 @@ impl MachineIdentityVerifier for RecordingVerifier {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecordedTransportEvent {
+    Connection(RunnerTransportConnectionEvent),
+    Tls(RunnerTransportTlsOutcome, Duration),
+    Request(RunnerTransportRequestObservation, Duration),
+    RequestStarted(RunnerTransportRoute),
+    RequestFinished(RunnerTransportRoute),
+    Bytes(RunnerTransportRoute, RunnerTransportByteDirection, u64),
+}
+
+pub trait RecordedTransportEventExpectation: Copy + fmt::Debug {
+    fn matches(self, event: &RecordedTransportEvent) -> bool;
+}
+
+impl RecordedTransportEventExpectation for RunnerTransportConnectionEvent {
+    fn matches(self, event: &RecordedTransportEvent) -> bool {
+        matches!(event, RecordedTransportEvent::Connection(observed) if self == *observed)
+    }
+}
+
+impl RecordedTransportEventExpectation for RunnerTransportTlsOutcome {
+    fn matches(self, event: &RecordedTransportEvent) -> bool {
+        matches!(event, RecordedTransportEvent::Tls(observed, _) if self == *observed)
+    }
+}
+
+impl RecordedTransportEventExpectation for RunnerTransportRequestObservation {
+    fn matches(self, event: &RecordedTransportEvent) -> bool {
+        matches!(event, RecordedTransportEvent::Request(observed, _) if self == *observed)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Http2Terminal;
+
+impl RecordedTransportEventExpectation for Http2Terminal {
+    fn matches(self, event: &RecordedTransportEvent) -> bool {
+        matches!(
+            event,
+            RecordedTransportEvent::Connection(
+                RunnerTransportConnectionEvent::Http2Closed
+                    | RunnerTransportConnectionEvent::Http2Error
+            )
+        )
+    }
+}
+
+macro_rules! recorded_values {
+    ($observer:expr, $pattern:pat => $value:expr) => {
+        $observer
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                $pattern => Some($value),
+                _ => None,
+            })
+            .collect()
+    };
+}
+
+#[derive(Debug, Default)]
+pub struct RecordingTransportObserver {
+    events: Mutex<Vec<RecordedTransportEvent>>,
+    changed: Notify,
+}
+
+impl RecordingTransportObserver {
+    pub fn events(&self) -> Vec<RecordedTransportEvent> {
+        self.events.lock().expect("transport event lock").clone()
+    }
+
+    pub fn connection_events(&self) -> Vec<RunnerTransportConnectionEvent> {
+        recorded_values!(self, RecordedTransportEvent::Connection(event) => event)
+    }
+
+    pub fn tls_outcomes(&self) -> Vec<RunnerTransportTlsOutcome> {
+        recorded_values!(self, RecordedTransportEvent::Tls(outcome, _) => outcome)
+    }
+
+    pub fn request_observations(&self) -> Vec<RunnerTransportRequestObservation> {
+        recorded_values!(self, RecordedTransportEvent::Request(observation, _) => observation)
+    }
+
+    pub fn request_starts(&self) -> Vec<RunnerTransportRoute> {
+        recorded_values!(self, RecordedTransportEvent::RequestStarted(route) => route)
+    }
+
+    pub fn request_finishes(&self) -> Vec<RunnerTransportRoute> {
+        recorded_values!(self, RecordedTransportEvent::RequestFinished(route) => route)
+    }
+
+    pub fn bytes(&self) -> Vec<(RunnerTransportRoute, RunnerTransportByteDirection, u64)> {
+        recorded_values!(
+            self,
+            RecordedTransportEvent::Bytes(route, direction, bytes) => (route, direction, bytes)
+        )
+    }
+
+    pub async fn wait_for(
+        &self,
+        expected: impl RecordedTransportEventExpectation,
+        count: usize,
+        watchdog: Duration,
+    ) {
+        tokio::time::timeout(watchdog, async {
+            loop {
+                let changed = self.changed.notified();
+                tokio::pin!(changed);
+                changed.as_mut().enable();
+                let observed = self
+                    .events
+                    .lock()
+                    .expect("transport event lock")
+                    .iter()
+                    .filter(|event| expected.matches(event))
+                    .count();
+                if observed >= count {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("observer did not record {count} {expected:?} events"));
+    }
+
+    fn record(&self, event: RecordedTransportEvent) {
+        self.events
+            .lock()
+            .expect("transport event lock")
+            .push(event);
+        self.changed.notify_waiters();
+    }
+}
+
+impl RunnerTransportObserver for RecordingTransportObserver {
+    fn observe_connection(&self, event: RunnerTransportConnectionEvent) {
+        self.record(RecordedTransportEvent::Connection(event));
+    }
+
+    fn observe_tls(&self, outcome: RunnerTransportTlsOutcome, duration: Duration) {
+        self.record(RecordedTransportEvent::Tls(outcome, duration));
+    }
+
+    fn observe_request(&self, observation: RunnerTransportRequestObservation, duration: Duration) {
+        self.record(RecordedTransportEvent::Request(observation, duration));
+    }
+
+    fn request_started(&self, route: RunnerTransportRoute) {
+        self.record(RecordedTransportEvent::RequestStarted(route));
+    }
+
+    fn request_finished(&self, route: RunnerTransportRoute) {
+        self.record(RecordedTransportEvent::RequestFinished(route));
+    }
+
+    fn observe_bytes(
+        &self,
+        route: RunnerTransportRoute,
+        direction: RunnerTransportByteDirection,
+        bytes: u64,
+    ) {
+        self.record(RecordedTransportEvent::Bytes(route, direction, bytes));
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum HandlerMode {
     Reply,
@@ -547,12 +721,25 @@ pub struct RunningServer {
 }
 
 impl RunningServer {
-    pub async fn stop(self) {
+    pub fn request_shutdown(&self) {
         self.shutdown.cancel();
-        self.task
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+
+    pub async fn finish(self) {
+        tokio::time::timeout(TEST_WATCHDOG, self.task)
             .await
+            .expect("server task watchdog")
             .expect("server task")
             .expect("server serve result");
+    }
+
+    pub async fn stop(self) {
+        self.request_shutdown();
+        self.finish().await;
     }
 }
 
@@ -562,12 +749,32 @@ pub async fn spawn_server(
     handler: Arc<dyn RunnerControlHandler>,
     limits: &TransportLimits,
 ) -> RunningServer {
+    spawn_server_inner(pki, verifier, handler, limits, None).await
+}
+
+pub async fn spawn_server_with_observer(
+    pki: &TestPki,
+    verifier: Arc<dyn MachineIdentityVerifier>,
+    handler: Arc<dyn RunnerControlHandler>,
+    limits: &TransportLimits,
+    observer: Arc<dyn RunnerTransportObserver>,
+) -> RunningServer {
+    spawn_server_inner(pki, verifier, handler, limits, Some(observer)).await
+}
+
+async fn spawn_server_inner(
+    pki: &TestPki,
+    verifier: Arc<dyn MachineIdentityVerifier>,
+    handler: Arc<dyn RunnerControlHandler>,
+    limits: &TransportLimits,
+    observer: Option<Arc<dyn RunnerTransportObserver>>,
+) -> RunningServer {
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
         .await
         .expect("bind test server");
     let address = listener.local_addr().expect("test listener address");
     let tls = pki.server_tls();
-    let server = RunnerControlServer::new(
+    let mut server = RunnerControlServer::new(
         listener,
         &tls,
         verifier,
@@ -576,6 +783,9 @@ pub async fn spawn_server(
         *limits,
     )
     .expect("runner control server");
+    if let Some(observer) = observer {
+        server = server.with_observer(observer);
+    }
     let endpoint: Uri = format!("https://{address}/")
         .parse()
         .expect("test endpoint");
@@ -588,6 +798,44 @@ pub async fn spawn_server(
         shutdown,
         task,
     }
+}
+
+pub fn raw_request(
+    address: SocketAddr,
+    method: Method,
+    path: &str,
+    version: Version,
+    body: RawBody,
+    content_type: Option<HeaderValue>,
+    content_length: Option<HeaderValue>,
+) -> Request<RawBody> {
+    let mut request = Request::new(body);
+    *request.method_mut() = method;
+    *request.version_mut() = version;
+    *request.uri_mut() = format!("https://{address}{path}")
+        .parse()
+        .expect("request URI");
+    if let Some(content_type) = content_type {
+        request.headers_mut().insert(CONTENT_TYPE, content_type);
+    }
+    if let Some(content_length) = content_length {
+        request.headers_mut().insert(CONTENT_LENGTH, content_length);
+    }
+    request
+}
+
+pub fn raw_hello_request(address: SocketAddr) -> Request<RawBody> {
+    let body = hello_request().canonical_bytes().clone();
+    let content_length = body.len();
+    raw_request(
+        address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_2,
+        Full::new(body).boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(content_length.into()),
+    )
 }
 
 pub fn client(

--- a/crates/automata-ci-runner-transport/tests/tls_boundary.rs
+++ b/crates/automata-ci-runner-transport/tests/tls_boundary.rs
@@ -3,13 +3,13 @@ use crate::support;
 use std::time::Duration;
 
 use automata_ci_runner_transport::{HANDSHAKE_PATH, PROTOBUF_CONTENT_TYPE, TransportLimits};
-use http::{Method, Request, StatusCode, header::CONTENT_TYPE};
+use http::{HeaderValue, Method, StatusCode, Version};
 use http_body_util::{BodyExt as _, Full};
 use tokio::time::timeout;
 
 use support::{
     HandlerMode, RecordingVerifier, TestHandler, TestPki, hello_request, raw_h2_sender,
-    spawn_server,
+    raw_request, spawn_server,
 };
 
 #[tokio::test]
@@ -117,21 +117,18 @@ async fn forwarded_certificate_header_cannot_replace_rustls_evidence() {
             .await
             .expect("valid raw h2 client");
     let body = hello_request().canonical_bytes().clone();
-    let mut request = Request::new(Full::new(body.clone()).boxed_unsync());
-    *request.method_mut() = Method::POST;
-    *request.uri_mut() = format!("https://{}{HANDSHAKE_PATH}", running.address)
-        .parse()
-        .expect("request URI");
-    request.headers_mut().insert(
-        CONTENT_TYPE,
-        http::HeaderValue::from_static(PROTOBUF_CONTENT_TYPE),
+    let mut request = raw_request(
+        running.address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_11,
+        Full::new(body.clone()).boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(body.len().into()),
     );
-    request
-        .headers_mut()
-        .insert(http::header::CONTENT_LENGTH, body.len().into());
     request.headers_mut().insert(
         "x-forwarded-client-cert",
-        http::HeaderValue::from_static("forged-certificate"),
+        HeaderValue::from_static("forged-certificate"),
     );
 
     let response = sender.send_request(request).await.expect("h2 response");
@@ -151,18 +148,15 @@ async fn connection_rejected(address: std::net::SocketAddr, config: rustls::Clie
         return true;
     };
     let body = hello_request().canonical_bytes().clone();
-    let mut request = Request::new(Full::new(body.clone()).boxed_unsync());
-    *request.method_mut() = Method::POST;
-    *request.uri_mut() = format!("https://{address}{HANDSHAKE_PATH}")
-        .parse()
-        .expect("request URI");
-    request.headers_mut().insert(
-        CONTENT_TYPE,
-        http::HeaderValue::from_static(PROTOBUF_CONTENT_TYPE),
+    let request = raw_request(
+        address,
+        Method::POST,
+        HANDSHAKE_PATH,
+        Version::HTTP_11,
+        Full::new(body.clone()).boxed_unsync(),
+        Some(HeaderValue::from_static(PROTOBUF_CONTENT_TYPE)),
+        Some(body.len().into()),
     );
-    request
-        .headers_mut()
-        .insert(http::header::CONTENT_LENGTH, body.len().into());
     let rejected = timeout(Duration::from_secs(2), sender.send_request(request))
         .await
         .expect("HTTP attempt deadline")


### PR DESCRIPTION
Closes #354.

## Summary

- replace two local observer implementations with one ordered typed recorder covering every runner-transport server callback
- share observer-aware server lifecycle support while preserving natural completion, explicit shutdown, cancellation, and bounded watchdog behavior
- share explicit raw HTTP request construction without defaulting content length, media type, HTTP version, or security headers
- keep malformed/header-contract, byte-accounting, sync-route, and HTTP/1.1 security evidence at their call sites

This is one subsystem-sized test-support checkpoint: exactly six files, 1,001 changed lines, and 87 net lines removed. It changes no production code, manifests, TLS configuration, certificates, protocol behavior, or files owned by #173.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-runner-transport --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-runner-transport --test runner_transport --all-features` (49/49 passed)
- `CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-runner-transport --all-targets --all-features -- -D warnings`
- independent semantic/static review: no findings