### PR TITLE
fix(web): publish runner-redacted public logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- Job-log visibility now follows the repository publication policy after the
+  runner's mandatory secret masker. Public repositories can therefore expose
+  redacted logs without exposing readable runtime authority; artifact audience
+  remains independently constrained.
 - Sandbox cancellation now crosses provider boundaries as an explicit
   `Active | Terminate` disposition. `Terminate` authorizes provider-specific
   termination handling when an adapter reaches a cancellation checkpoint; it

--- a/crates/automata-ci-postgres/tests/store/security/secrets_output_safety.rs
+++ b/crates/automata-ci-postgres/tests/store/security/secrets_output_safety.rs
@@ -685,7 +685,8 @@ async fn public_output_is_allowed_only_with_a_compatible_safety_snapshot() -> Te
             "workflow_runs_publication_snapshot_immutable",
         );
 
-        let unsafe_attempt = sqlx::query(
+        let readable_attempt = Uuid::new_v4();
+        sqlx::query(
             r"
             INSERT INTO job_attempts (
                 id, job_id, attempt_number, lifecycle, fencing_token,
@@ -699,12 +700,10 @@ async fn public_output_is_allowed_only_with_a_compatible_safety_snapshot() -> Te
             )
             ",
         )
-        .bind(Uuid::new_v4())
+        .bind(readable_attempt)
         .bind(public_job)
         .execute(database.pool())
-        .await
-        .expect_err("readable-secret attempt resources remain private");
-        assert_constraint(&unsafe_attempt, "job_attempts_exposure_safety");
+        .await?;
 
         let attempt = Uuid::new_v4();
         sqlx::query(
@@ -715,32 +714,12 @@ async fn public_output_is_allowed_only_with_a_compatible_safety_snapshot() -> Te
                 raw_log_disposition, requested_log_visibility,
                 effective_log_visibility, output_safety_reason, classified_at_ms
             ) VALUES (
-                $1, $2, 1, 'succeeded', 7, 1, 2, 'secretless',
+                $1, $2, 2, 'succeeded', 8, 1, 2, 'secretless',
                 'persist', 'public', 'public', 'repository_policy', 1
             )
             ",
         )
         .bind(attempt)
-        .bind(public_job)
-        .execute(database.pool())
-        .await?;
-
-        let readable_attempt = Uuid::new_v4();
-        sqlx::query(
-            r"
-            INSERT INTO job_attempts (
-                id, job_id, attempt_number, lifecycle, fencing_token,
-                queued_at_ms, changed_at_ms, secret_exposure_class,
-                raw_log_disposition, requested_log_visibility,
-                effective_log_visibility, output_safety_reason, classified_at_ms
-            ) VALUES (
-                $1, $2, 2, 'succeeded', 8, 1, 2, 'readable_secret',
-                'persist', 'public', 'private',
-                'secret_exposure', 1
-            )
-            ",
-        )
-        .bind(readable_attempt)
         .bind(public_job)
         .execute(database.pool())
         .await?;
@@ -809,7 +788,7 @@ async fn public_output_is_allowed_only_with_a_compatible_safety_snapshot() -> Te
                 requested_visibility, effective_visibility,
                 publication_safety_reason
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, 7, 'public-artifact', 7,
+                $1, $2, $3, $4, $5, $6, 8, 'public-artifact', 7,
                 'application/octet-stream', 1, 'secretless',
                 'public', 'public', 'repository_policy'
             ) RETURNING id
@@ -877,12 +856,12 @@ async fn public_output_is_allowed_only_with_a_compatible_safety_snapshot() -> Te
                 output_safety_reason
             ) VALUES (
                 $1, $2, $3, $4, $5, $6, $7, 1, $8, 7, 1, 2,
-                'secretless', 'persist', 'public', 'public', 'repository_policy'
+                'readable_secret', 'persist', 'public', 'public', 'repository_policy'
             )
             ",
         )
         .bind(stream)
-        .bind(attempt)
+        .bind(readable_attempt)
         .bind(fence.session_id().as_uuid())
         .bind(Uuid::new_v4())
         .bind(fence.runner_id().as_uuid())
@@ -2109,7 +2088,7 @@ async fn create_public_run_and_job(pool: &PgPool, seed: &SeedData) -> TestResult
             event_media_type, plan_digest, plan_object_key, plan_size_bytes,
             plan_media_type, plan_schema, workflow_name, head_sha, status,
             2, 2, 2, 'public', 'public', 'public', 'public',
-            'repository_policy', 1, runner_requirements_schema
+            'repository_policy', 2, runner_requirements_schema
         FROM workflow_runs
         WHERE id = $2
         ",

--- a/crates/automata-ci-store-postgres/migrations/0044_publish_runner_redacted_logs.sql
+++ b/crates/automata-ci-store-postgres/migrations/0044_publish_runner_redacted_logs.sql
@@ -1,0 +1,80 @@
+-- Runner log segments contain only bytes produced after the mandatory secret
+-- masker. Publication schema 2 therefore applies the repository's requested
+-- log audience exactly; readable runtime authority still narrows artifacts.
+
+ALTER TABLE workflow_runs DISABLE TRIGGER USER;
+ALTER TABLE job_attempts DISABLE TRIGGER USER;
+ALTER TABLE attempt_log_streams DISABLE TRIGGER USER;
+ALTER TABLE workflow_artifacts DISABLE TRIGGER USER;
+
+ALTER TABLE workflow_runs
+    DROP CONSTRAINT workflow_runs_publication_safety_schema;
+ALTER TABLE job_attempts
+    DROP CONSTRAINT job_attempts_exposure_safety,
+    DROP CONSTRAINT job_attempts_output_safety_reason_code,
+    DROP CONSTRAINT job_attempts_output_safety_schema;
+ALTER TABLE attempt_log_streams
+    DROP CONSTRAINT attempt_log_streams_exposure_safety,
+    DROP CONSTRAINT attempt_log_streams_output_safety_reason_code,
+    DROP CONSTRAINT attempt_log_streams_output_safety_schema;
+ALTER TABLE workflow_artifacts
+    DROP CONSTRAINT workflow_artifacts_publication_safety_schema;
+
+ALTER TABLE workflow_runs
+    ALTER COLUMN publication_safety_schema SET DEFAULT 2;
+ALTER TABLE job_attempts
+    ALTER COLUMN output_safety_schema SET DEFAULT 2;
+ALTER TABLE attempt_log_streams
+    ALTER COLUMN output_safety_schema SET DEFAULT 2;
+ALTER TABLE workflow_artifacts
+    ALTER COLUMN publication_safety_schema SET DEFAULT 2;
+
+UPDATE workflow_runs
+SET publication_safety_schema = 2;
+
+UPDATE job_attempts
+SET effective_log_visibility = requested_log_visibility,
+    output_safety_reason = 'repository_policy',
+    output_safety_schema = 2;
+
+UPDATE attempt_log_streams
+SET effective_visibility = requested_visibility,
+    output_safety_reason = 'repository_policy',
+    output_safety_schema = 2;
+
+UPDATE workflow_artifacts
+SET publication_safety_schema = 2;
+
+ALTER TABLE workflow_runs
+    ADD CONSTRAINT workflow_runs_publication_safety_schema
+    CHECK (publication_safety_schema = 2);
+ALTER TABLE job_attempts
+    ADD CONSTRAINT job_attempts_exposure_safety
+    CHECK (
+        output_safety_schema = 2
+        AND raw_log_disposition = 'persist'
+        AND effective_log_visibility = requested_log_visibility
+    ),
+    ADD CONSTRAINT job_attempts_output_safety_reason_code
+    CHECK (output_safety_reason = 'repository_policy'),
+    ADD CONSTRAINT job_attempts_output_safety_schema
+    CHECK (output_safety_schema = 2);
+ALTER TABLE attempt_log_streams
+    ADD CONSTRAINT attempt_log_streams_exposure_safety
+    CHECK (
+        output_safety_schema = 2
+        AND raw_log_disposition = 'persist'
+        AND effective_visibility = requested_visibility
+    ),
+    ADD CONSTRAINT attempt_log_streams_output_safety_reason_code
+    CHECK (output_safety_reason = 'repository_policy'),
+    ADD CONSTRAINT attempt_log_streams_output_safety_schema
+    CHECK (output_safety_schema = 2);
+ALTER TABLE workflow_artifacts
+    ADD CONSTRAINT workflow_artifacts_publication_safety_schema
+    CHECK (publication_safety_schema = 2);
+
+ALTER TABLE workflow_runs ENABLE TRIGGER USER;
+ALTER TABLE job_attempts ENABLE TRIGGER USER;
+ALTER TABLE attempt_log_streams ENABLE TRIGGER USER;
+ALTER TABLE workflow_artifacts ENABLE TRIGGER USER;

--- a/crates/automata-ci-store-postgres/src/g1.rs
+++ b/crates/automata-ci-store-postgres/src/g1.rs
@@ -2892,12 +2892,9 @@ fn runner_log_safety_is_consistent(safety: &DurableRunnerLogSafety) -> bool {
                 safety.requested_visibility.as_str(),
                 safety.effective_visibility.as_str(),
             ),
-            ("private", "private")
-                | ("authenticated", "private" | "authenticated")
-                | ("public", "private" | "authenticated" | "public")
+            ("private", "private") | ("authenticated", "authenticated") | ("public", "public")
         )
-        && (safety.secret_exposure != SecretExposureClass::ReadableSecret
-            || safety.effective_visibility == "private")
+        && safety.reason == "repository_policy"
 }
 
 #[cfg(test)]
@@ -2916,7 +2913,7 @@ mod runner_log_safety_tests {
             schema: automata_ci_store::HUMAN_OUTPUT_PUBLICATION_SAFETY_SCHEMA,
         };
         assert!(runner_log_safety_is_consistent(&safety));
-        for schema in [0, 2] {
+        for schema in [0, 1, 3] {
             safety.schema = schema;
             assert!(!runner_log_safety_is_consistent(&safety));
         }

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -119,11 +119,11 @@ fn pg_bigint(value: u64) -> i64 {
 ///
 /// Standard execution requires a Results runtime authority, and the GitHub
 /// execution context exposes its bearer to user code as
-/// `ACTIONS_RUNTIME_TOKEN`. Standard attempts are
-/// therefore readable-secret. Only a fully validated credential-free `JobIR` may
-/// admit a secretless logical attempt. Attempts persist runner-redacted logs,
-/// while readable-secret attempts retain a private visibility ceiling. Retries
-/// must reproduce the canonical snapshot exactly.
+/// `ACTIONS_RUNTIME_TOKEN`. Standard attempts are therefore readable-secret.
+/// Only a fully validated credential-free `JobIR` may admit a secretless
+/// logical attempt. Attempts persist only runner-redacted logs, whose immutable
+/// audience exactly follows repository policy. Retries must reproduce the
+/// canonical snapshot exactly.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct CurrentAttemptOutputSafety {
     secret_exposure: SecretExposureClass,
@@ -172,12 +172,9 @@ impl CurrentAttemptOutputSafety {
             output_safety_schema,
         };
         (valid_raw_log_policy(secret_exposure, raw_log_disposition, output_safety_schema)
-            && snapshot.effective_log_visibility <= snapshot.requested_log_visibility
-            && (!matches!(
-                snapshot.secret_exposure,
-                SecretExposureClass::ReadableSecret
-            ) || matches!(snapshot.effective_log_visibility, OutputVisibility::Private)))
-        .then_some(snapshot)
+            && snapshot.effective_log_visibility == snapshot.requested_log_visibility
+            && snapshot.output_safety_reason == "repository_policy")
+            .then_some(snapshot)
     }
 
     pub(crate) const fn secret_exposure_class(self) -> &'static str {
@@ -226,23 +223,12 @@ impl CurrentAttemptOutputSafety {
         requested_log_visibility: &str,
     ) -> Option<Self> {
         let requested_log_visibility = parse_output_visibility(requested_log_visibility)?;
-        let readable_secret = matches!(secret_exposure, SecretExposureClass::ReadableSecret);
         Some(Self {
             secret_exposure,
             raw_log_disposition: "persist",
             requested_log_visibility,
-            effective_log_visibility: if readable_secret {
-                OutputVisibility::Private
-            } else {
-                requested_log_visibility
-            },
-            output_safety_reason: if readable_secret
-                && !matches!(requested_log_visibility, OutputVisibility::Private)
-            {
-                "secret_exposure"
-            } else {
-                "repository_policy"
-            },
+            effective_log_visibility: requested_log_visibility,
+            output_safety_reason: "repository_policy",
             output_safety_schema: automata_ci_store::HUMAN_OUTPUT_PUBLICATION_SAFETY_SCHEMA,
         })
     }
@@ -311,20 +297,16 @@ mod attempt_output_safety_tests {
     use super::CurrentAttemptOutputSafety;
 
     #[test]
-    fn current_readable_snapshot_closes_every_requested_audience() {
-        for (requested, reason) in [
-            ("private", "repository_policy"),
-            ("authenticated", "secret_exposure"),
-            ("public", "secret_exposure"),
-        ] {
+    fn current_readable_snapshot_publishes_only_to_the_requested_audience() {
+        for requested in ["private", "authenticated", "public"] {
             let snapshot = CurrentAttemptOutputSafety::readable(requested)
-                .expect("closed publication audience");
+                .expect("exact publication audience");
             assert_eq!(snapshot.secret_exposure_class(), "readable_secret");
             assert_eq!(snapshot.raw_log_disposition(), "persist");
             assert_eq!(snapshot.requested_log_visibility(), requested);
-            assert_eq!(snapshot.effective_log_visibility(), "private");
-            assert_eq!(snapshot.output_safety_reason(), reason);
-            assert_eq!(snapshot.output_safety_schema(), 1);
+            assert_eq!(snapshot.effective_log_visibility(), requested);
+            assert_eq!(snapshot.output_safety_reason(), "repository_policy");
+            assert_eq!(snapshot.output_safety_schema(), 2);
         }
         assert!(CurrentAttemptOutputSafety::readable("unknown").is_none());
 
@@ -347,18 +329,18 @@ mod attempt_output_safety_tests {
             "public",
             "public",
             "repository_policy",
-            1,
+            2,
         )
         .expect("canonical secretless snapshot");
         assert_eq!(secretless.secret_exposure_class(), "secretless");
-        assert_eq!(secretless.output_safety_schema(), 1);
+        assert_eq!(secretless.output_safety_schema(), 2);
         let current = CurrentAttemptOutputSafety::from_durable(
             "readable_secret",
             "persist",
             "public",
-            "private",
-            "secret_exposure",
-            1,
+            "public",
+            "repository_policy",
+            2,
         )
         .expect("current readable-secret snapshot");
         assert!(current.supports_current_authority_profile());
@@ -367,9 +349,9 @@ mod attempt_output_safety_tests {
                 "readable_secret",
                 "persist",
                 "public",
-                "private",
-                "secret_exposure",
-                2,
+                "public",
+                "repository_policy",
+                1,
             )
             .is_none()
         );
@@ -380,7 +362,7 @@ mod attempt_output_safety_tests {
                 "public",
                 "private",
                 "secret_exposure",
-                1,
+                2,
             )
             .is_none()
         );
@@ -391,7 +373,7 @@ mod attempt_output_safety_tests {
                 "private",
                 "public",
                 "repository_policy",
-                1,
+                2,
             )
             .is_none()
         );

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -177,6 +177,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0043_terminalize_expired_active_leases.sql",
         "b4caf908ce785d736293e16c864320e9ea098e3cc76843539e91339f85c859f1482f57609ed865060e43aad0183c0ce1",
     ),
+    (
+        "0044_publish_runner_redacted_logs.sql",
+        "c507be6b296266570b3a3d35708c95376ebb1fd07f8bcbbf1bf40ef1d4bbcf058dfbde58e4c02992100a8d13d27e17fc",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store/src/web.rs
+++ b/crates/automata-ci-store/src/web.rs
@@ -563,8 +563,8 @@ pub struct HumanTerminalResult {
     pub committed_at: UnixMillis,
 }
 
-/// Immutable output-safety evidence for a log stream or artifact.
-pub const HUMAN_OUTPUT_PUBLICATION_SAFETY_SCHEMA: i32 = 1;
+/// Immutable output-safety evidence for a runner-redacted log stream or artifact.
+pub const HUMAN_OUTPUT_PUBLICATION_SAFETY_SCHEMA: i32 = 2;
 
 /// Returns whether an output-safety schema is the exact schema accepted by this build.
 #[must_use]
@@ -579,7 +579,7 @@ pub struct HumanOutputPublication {
     pub secret_exposure: SecretExposureClass,
     /// Audience originally requested for this output kind.
     pub requested_visibility: OutputVisibility,
-    /// Immutable audience after exposure-driven narrowing.
+    /// Immutable audience after output-kind publication policy is applied.
     pub effective_visibility: OutputVisibility,
     /// Closed machine reason supporting the effective audience.
     pub safety_reason: String,

--- a/crates/automata-ci/src/app/web/live.rs
+++ b/crates/automata-ci/src/app/web/live.rs
@@ -3595,7 +3595,7 @@ mod tests {
                 requested_log_visibility: OutputVisibility::Public,
                 requested_artifact_visibility: OutputVisibility::Public,
                 safety_reason: "secretless".to_owned(),
-                safety_schema: 1,
+                safety_schema: 2,
             },
         }
     }
@@ -4431,7 +4431,7 @@ mod tests {
             ),
         );
         assert!(log_stream_safety_is_valid(&stream));
-        for schema in [0, 2] {
+        for schema in [0, 1, 3] {
             stream.publication.safety_schema = schema;
             assert!(!log_stream_safety_is_valid(&stream));
         }
@@ -4871,7 +4871,7 @@ mod tests {
                 requested_log_visibility: OutputVisibility::Public,
                 requested_artifact_visibility: OutputVisibility::Public,
                 safety_reason: "secretless".to_owned(),
-                safety_schema: 1,
+                safety_schema: 2,
             },
         };
         let mapped = map_run(&run).expect("unsafe optional copy is omitted");
@@ -5123,7 +5123,7 @@ mod tests {
                     requested_visibility: artifact_visibility,
                     effective_visibility: artifact_visibility,
                     safety_reason: "fixture".to_owned(),
-                    safety_schema: 1,
+                    safety_schema: 2,
                 },
             };
             let manifest = ArtifactManifest {


### PR DESCRIPTION
## Summary
- make persisted runner-redacted log visibility exactly follow repository publication policy
- keep artifact publication independently constrained by its existing exposure policy
- migrate existing runs, attempts, and streams to the closed publication-safety schema 2
- remove the obsolete exposure-narrowing branch instead of carrying compatibility behavior

## Verification
- cargo fmt --check
- automata-ci-store web tests (5 passed)
- automata-ci-store-postgres unit tests (49 passed)
- frozen migration-layout tests (6 passed)
- Automata live web tests (38 passed)
- disposable PostgreSQL 18 public-output safety integration contract
- targeted clippy for web/store/store-postgres/PostgreSQL integration with -D warnings
- git diff --check