### PR TITLE
feat(sandbox): bind exact runner custody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   connected-store diagnostics expose no bound state, validated transport is
   one closed security mode, and bucket creation is region-correct, idempotent,
   conflict-reverified, and bounded by one total deadline.
+- Sandbox specifications now require one closed runner-custody variant across
+  every provider; job custody includes a mandatory non-zero durable slot.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ name = "automata-ci-execution"
 version = "0.1.0"
 dependencies = [
  "automata-ci-core",
+ "serde",
  "static_assertions",
  "thiserror",
 ]

--- a/crates/automata-ci-execution/Cargo.toml
+++ b/crates/automata-ci-execution/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [dependencies]
 automata-ci-core.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -34,7 +34,9 @@ mod sandbox;
 mod service;
 mod value;
 
-pub use automata_ci_core::{EnvironmentProfile, EnvironmentProfileId, OperationId, Sha256Digest};
+pub use automata_ci_core::{
+    EnvironmentProfile, EnvironmentProfileId, OperationId, RunnerId, Sha256Digest,
+};
 pub use capability::{ProviderCapabilities, SandboxCapability};
 pub use endpoint::{
     Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentName,
@@ -47,8 +49,8 @@ pub use error::{
     ProviderErrorKind, ProviderStage, ValueError,
 };
 pub use sandbox::{
-    DestroyDisposition, DestroySandbox, SandboxInspection, SandboxProvider, SandboxRecord,
-    SandboxSpec, SandboxState,
+    DestroyDisposition, DestroySandbox, SandboxCustody, SandboxInspection, SandboxProvider,
+    SandboxRecord, SandboxSpec, SandboxState,
 };
 pub use service::{
     ContainerHandle, ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec,

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -1,4 +1,7 @@
-use std::fmt;
+use std::{fmt, num::NonZeroU16};
+
+use automata_ci_core::{JobResourceAllocation, RunnerId};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     Cancellation, EnvironmentProfile, ExecutionEndpoint, NetworkPolicy, OperationId,
@@ -6,7 +9,29 @@ use crate::{
     SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxPrivilegePolicy,
     ServiceContainerBindings, ServiceContainerSpecs, TargetPath,
 };
-use automata_ci_core::JobResourceAllocation;
+
+/// Runner custody coordinates for one sandbox request.
+///
+/// Environment-profile admission runs before a runner session exists and is
+/// therefore deliberately distinct from a job assigned to one durable slot.
+/// Job custody always carries the exact server-correlated, one-based slot
+/// ordinal; providers must not reconstruct it from configured capacity.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SandboxCustody {
+    /// Pre-session lifecycle evidence for one configured runner identity.
+    ProfileAdmission {
+        /// Runner identity whose configured profiles are being admitted.
+        runner_id: RunnerId,
+    },
+    /// One fenced job assigned to an exact stable runner slot.
+    Job {
+        /// Runner identity bound by the accepted lease.
+        runner_id: RunnerId,
+        /// Exact one-based slot from the durable execution request.
+        slot_ordinal: NonZeroU16,
+    },
+}
 
 /// Immutable whole-job sandbox request. The profile is exact and contains no
 /// hosted-label resolution or mutable image reference.
@@ -14,6 +39,7 @@ use automata_ci_core::JobResourceAllocation;
 pub struct SandboxSpec {
     operation_id: OperationId,
     generation: SandboxGeneration,
+    custody: SandboxCustody,
     profile: SandboxEnvironment,
     workspace: TargetPath,
     scratch: Option<TargetPath>,
@@ -33,9 +59,11 @@ impl SandboxSpec {
     /// attested profile, target workspace, network, root-filesystem policy,
     /// and hard resource limits as one request.
     #[must_use]
+    #[allow(clippy::too_many_arguments)] // One constructor binds the complete mandatory sandbox contract.
     pub const fn new(
         operation_id: OperationId,
         generation: SandboxGeneration,
+        custody: SandboxCustody,
         profile: SandboxEnvironment,
         workspace: TargetPath,
         network: NetworkPolicy,
@@ -45,6 +73,7 @@ impl SandboxSpec {
         Self {
             operation_id,
             generation,
+            custody,
             profile,
             workspace,
             scratch: None,
@@ -91,6 +120,12 @@ impl SandboxSpec {
     #[must_use]
     pub const fn generation(&self) -> SandboxGeneration {
         self.generation
+    }
+
+    /// Returns the exact runner and admission-or-job custody coordinates.
+    #[must_use]
+    pub const fn custody(&self) -> SandboxCustody {
+        self.custody
     }
 
     /// Returns the exact content-attested launch environment.
@@ -253,6 +288,7 @@ impl SandboxRecord {
 pub struct SandboxInspection {
     handle: SandboxHandle,
     generation: SandboxGeneration,
+    custody: SandboxCustody,
     profile: EnvironmentProfile,
     state: SandboxState,
 }
@@ -263,12 +299,14 @@ impl SandboxInspection {
     pub const fn new(
         handle: SandboxHandle,
         generation: SandboxGeneration,
+        custody: SandboxCustody,
         profile: EnvironmentProfile,
         state: SandboxState,
     ) -> Self {
         Self {
             handle,
             generation,
+            custody,
             profile,
             state,
         }
@@ -284,6 +322,13 @@ impl SandboxInspection {
     #[must_use]
     pub const fn generation(&self) -> SandboxGeneration {
         self.generation
+    }
+
+    /// Returns the exact runner and admission-or-job custody observed on the
+    /// provider-owned recovery evidence.
+    #[must_use]
+    pub const fn custody(&self) -> SandboxCustody {
+        self.custody
     }
 
     /// Returns the exact environment-profile attestation on the resource.
@@ -305,23 +350,26 @@ pub struct DestroySandbox {
     operation_id: OperationId,
     handle: SandboxHandle,
     generation: SandboxGeneration,
+    custody: SandboxCustody,
 }
 
 impl DestroySandbox {
     /// Creates an exact, idempotently identified destroy request.
     ///
-    /// Both the opaque handle and generation must match the provider-owned
-    /// resource before deletion is allowed.
+    /// The opaque handle, generation, and custody must all match the
+    /// provider-owned resource before deletion is allowed.
     #[must_use]
     pub const fn new(
         operation_id: OperationId,
         handle: SandboxHandle,
         generation: SandboxGeneration,
+        custody: SandboxCustody,
     ) -> Self {
         Self {
             operation_id,
             handle,
             generation,
+            custody,
         }
     }
 
@@ -341,6 +389,12 @@ impl DestroySandbox {
     #[must_use]
     pub const fn generation(&self) -> SandboxGeneration {
         self.generation
+    }
+
+    /// Returns the exact runner custody required before deletion.
+    #[must_use]
+    pub const fn custody(&self) -> SandboxCustody {
+        self.custody
     }
 }
 
@@ -432,9 +486,10 @@ pub trait SandboxProvider: fmt::Debug + Send + Sync {
     }
 
     /// Verifies ownership immediately before exact deletion. Implementations
-    /// must match the request's generation and never use global prune
-    /// operations. A successful return covers subordinate services, networks,
-    /// workspaces, and provider resources owned by that sandbox generation.
+    /// must match the request's generation and custody and never use global
+    /// prune operations. A successful return covers subordinate services,
+    /// networks, workspaces, and provider resources owned by that sandbox
+    /// generation and custody.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -6,11 +6,11 @@ use automata_ci_execution::{
     ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream, ExecutionTermination,
     ImmutableImage, MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES,
     MAX_EXECUTION_OUTPUT_RECORDS, NetworkPolicy, OperationId, ProviderCapabilities, ProviderId,
-    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration,
-    SandboxHandle, SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding,
-    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
-    ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol,
-    Sha256Digest, TargetPath, ValueError,
+    ResourceLimits, RootFilesystemPolicy, RunnerId, SandboxCapability, SandboxCustody,
+    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxPrivilegePolicy, SandboxSpec,
+    ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs,
+    ServiceHealthOverrides, ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding,
+    ServiceTransportProtocol, Sha256Digest, TargetPath, ValueError,
 };
 
 #[test]
@@ -39,6 +39,12 @@ fn profile() -> SandboxEnvironment {
     .expect("profile")
 }
 
+fn custody() -> SandboxCustody {
+    SandboxCustody::ProfileAdmission {
+        runner_id: RunnerId::new(),
+    }
+}
+
 #[test]
 fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
     let image = ImmutableImage::new(IMAGE).expect("immutable image");
@@ -57,6 +63,7 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
     let spec = SandboxSpec::new(
         OperationId::new(),
         SandboxGeneration::new(7).expect("generation"),
+        custody(),
         profile(),
         TargetPath::posix("/__w").expect("workspace"),
         NetworkPolicy::Disabled,
@@ -399,6 +406,7 @@ fn service_requests_are_exact_redacted_and_discovered_by_requested_port() {
     let sandbox = SandboxSpec::new(
         OperationId::new(),
         SandboxGeneration::new(9).expect("generation"),
+        custody(),
         profile(),
         TargetPath::posix("/__w/project").expect("workspace"),
         NetworkPolicy::PrivateEgress,

--- a/crates/automata-ci-job-executor-github/src/container_runtime.rs
+++ b/crates/automata-ci-job-executor-github/src/container_runtime.rs
@@ -144,6 +144,7 @@ pub(super) fn sandbox_spec(
     let mut spec = SandboxSpec::new(
         operation_id,
         generation,
+        request.sandbox_custody(),
         request.environment().clone(),
         workspace.clone(),
         config.network(),

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -4706,7 +4706,8 @@ impl GithubJobExecutor {
         let cancellation = ProviderCancellationBridge(cancellation);
         let generation = SandboxGeneration::new(request.lease().fencing_token().get())
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-        let handle = if let Some(recovered) = request.recovered_sandbox() {
+        let expected_custody = request.sandbox_custody();
+        let (handle, invalid_evidence) = if let Some(recovered) = request.recovered_sandbox() {
             if recovered.provider().as_str() != self.ports.provider.provider_id().as_str() {
                 return Err(ExecutorAdapterError::new(
                     ExecutorAdapterErrorKind::InvalidJob,
@@ -4717,20 +4718,7 @@ impl GithubJobExecutor {
                 recovered.handle().as_str(),
             )
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-            let inspection = self
-                .ports
-                .provider
-                .inspect(&handle, &cancellation)
-                .map_err(|error| map_provider_error(&error))?;
-            if inspection.generation() != generation
-                || inspection.profile() != request.environment().attestation()
-                || inspection.state() != SandboxState::Running
-            {
-                return Err(ExecutorAdapterError::new(
-                    ExecutorAdapterErrorKind::InvalidJob,
-                ));
-            }
-            handle
+            (handle, ExecutorAdapterErrorKind::InvalidJob)
         } else {
             let operation_id = events
                 .begin_provider_operation(ProviderOperationKind::CreateSandbox)
@@ -4764,8 +4752,22 @@ impl GithubJobExecutor {
             events
                 .sandbox_created(operation_id, identity)
                 .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-            record.handle().clone()
+            (record.handle().clone(), ExecutorAdapterErrorKind::Internal)
         };
+        let inspection = self
+            .ports
+            .provider
+            .inspect(&handle, &cancellation)
+            .map_err(|error| map_provider_error(&error))?;
+        if inspection.handle() != &handle
+            || inspection.handle().provider() != self.ports.provider.provider_id()
+            || inspection.generation() != generation
+            || inspection.custody() != expected_custody
+            || inspection.profile() != request.environment().attestation()
+            || inspection.state() != SandboxState::Running
+        {
+            return Err(ExecutorAdapterError::new(invalid_evidence));
+        }
         let services = if service_specs.is_empty() {
             ServiceContainerBindings::empty()
         } else {
@@ -5466,7 +5468,8 @@ impl GithubJobExecutor {
         let operation_id = events
             .begin_provider_operation(ProviderOperationKind::DestroySandbox)
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-        let destroy = DestroySandbox::new(operation_id, handle, generation);
+        let destroy =
+            DestroySandbox::new(operation_id, handle, generation, request.sandbox_custody());
         match self
             .ports
             .provider

--- a/crates/automata-ci-job-executor-github/tests/cancellation_cleanup.rs
+++ b/crates/automata-ci-job-executor-github/tests/cancellation_cleanup.rs
@@ -24,6 +24,7 @@ async fn cancelled_phase_returns_cancelled_and_cleanup_destroys_the_exact_fenced
     let request = fixture.request(run_job("exit 0\n"));
     let session_id = request.session_id();
     let slot = request.slot();
+    let runner_id = request.lease().runner_id();
     let attempt_id = request.lease().attempt_id();
     let guard = request.lease().guard();
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
@@ -37,7 +38,15 @@ async fn cancelled_phase_returns_cancelled_and_cleanup_destroys_the_exact_fenced
     assert!(cancellation.is_cancelled());
     assert_eq!(result.conclusion(), JobConclusion::Cancelled);
     assert_eq!(fixture.events.sandbox(), Some(journal_identity()));
-    let cleanup = CleanupRequest::new(session_id, slot, attempt_id, guard, journal_identity());
+    let cleanup = CleanupRequest::new(
+        runner_id,
+        session_id,
+        slot,
+        attempt_id,
+        guard,
+        journal_identity(),
+    );
+    let expected_custody = cleanup.sandbox_custody();
     fixture
         .executor
         .cleanup(cleanup, events, ExecutionCancellation::new())
@@ -54,6 +63,7 @@ async fn cancelled_phase_returns_cancelled_and_cleanup_destroys_the_exact_fenced
     )
     .expect("valid sandbox handle");
     assert_eq!(destroy_request.handle(), &expected_handle);
+    assert_eq!(destroy_request.custody(), expected_custody);
     assert_eq!(
         destroy_request.generation(),
         SandboxGeneration::new(guard.fencing_token().get()).expect("valid generation")

--- a/crates/automata-ci-job-executor-github/tests/provider_saga.rs
+++ b/crates/automata-ci-job-executor-github/tests/provider_saga.rs
@@ -1,9 +1,9 @@
 mod support;
 
-use std::sync::Arc;
+use std::{num::NonZeroU16, sync::Arc};
 
-use automata_ci_core::JobConclusion;
-use automata_ci_execution::{OperationOutcome, ProviderErrorKind};
+use automata_ci_core::{JobConclusion, RunnerId};
+use automata_ci_execution::{OperationOutcome, ProviderErrorKind, SandboxCustody};
 use automata_ci_runner_journal::{
     ProviderFailureKind, ProviderFailureOutcome, ProviderOperationKind,
 };
@@ -11,7 +11,7 @@ use automata_ci_runner_runtime::{
     CleanupRequest, ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
 };
 
-use support::{Fixture, PhaseResponse, journal_identity, run_job};
+use support::{Fixture, PhaseResponse, journal_identity, recovered_request, run_job};
 
 const PROVIDER_FAILURE_CASES: &[(ProviderErrorKind, ExecutorErrorKind, ProviderFailureKind)] = &[
     (
@@ -163,6 +163,72 @@ async fn sandbox_identity_commit_failure_replays_the_exact_create_intent() {
 }
 
 #[tokio::test]
+async fn fresh_create_requires_exact_post_create_custody_before_attach() {
+    let fixture = Fixture::new(Vec::new(), vec![PhaseResponse::success()]);
+    let request = fixture.request(run_job("true\n"));
+    fixture
+        .provider
+        .set_inspection_custody(SandboxCustody::Job {
+            runner_id: RunnerId::new(),
+            slot_ordinal: NonZeroU16::new(request.slot().get()).expect("non-zero slot"),
+        });
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(request, events, ExecutionCancellation::new())
+        .await
+        .expect_err("fresh create must inspect exact custody before attach");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::Internal);
+    assert_eq!(fixture.provider.counts(), (1, 0, 0));
+    assert_eq!(fixture.provider.inspection_count(), 1);
+    assert_eq!(fixture.events.sandbox(), Some(journal_identity()));
+}
+
+#[tokio::test]
+async fn recovered_sandbox_rejects_wrong_runner_and_slot_custody() {
+    let fixture = Fixture::new(Vec::new(), vec![PhaseResponse::success()]);
+    let request = fixture.request(run_job("true\n"));
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    fixture
+        .executor
+        .execute(
+            request.clone(),
+            events.clone(),
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("initial execution creates exact recoverable sandbox custody");
+
+    for custody in [
+        SandboxCustody::Job {
+            runner_id: RunnerId::new(),
+            slot_ordinal: NonZeroU16::new(request.slot().get()).expect("non-zero slot"),
+        },
+        SandboxCustody::Job {
+            runner_id: request.lease().runner_id(),
+            slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+        },
+    ] {
+        fixture.provider.set_inspection_custody(custody);
+        let error = fixture
+            .executor
+            .execute(
+                recovered_request(&request),
+                events.clone(),
+                ExecutionCancellation::new(),
+            )
+            .await
+            .expect_err("recovery must bind exact runner and slot custody");
+        assert_eq!(error.kind(), ExecutorErrorKind::InvalidJob);
+    }
+
+    assert_eq!(fixture.provider.counts(), (1, 1, 0));
+}
+
+#[tokio::test]
 async fn provider_failure_commit_failure_retains_the_exact_create_intent() {
     let fixture = Fixture::new(Vec::new(), vec![PhaseResponse::success()]);
     fixture.provider.fail_next_create(
@@ -275,6 +341,7 @@ async fn destroy_completion_commit_failure_retains_and_replays_exact_custody() {
     let request = fixture.request(run_job("true\n"));
     let session_id = request.session_id();
     let slot = request.slot();
+    let runner_id = request.lease().runner_id();
     let attempt_id = request.lease().attempt_id();
     let guard = request.lease().guard();
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
@@ -290,7 +357,14 @@ async fn destroy_completion_commit_failure_retains_and_replays_exact_custody() {
         .sandbox()
         .expect("successful creation records exact sandbox custody");
     assert_eq!(retained, journal_identity());
-    let cleanup = CleanupRequest::new(session_id, slot, attempt_id, guard, retained.clone());
+    let cleanup = CleanupRequest::new(
+        runner_id,
+        session_id,
+        slot,
+        attempt_id,
+        guard,
+        retained.clone(),
+    );
 
     fixture.events.fail_next_provider_operation_completed();
     let error = fixture

--- a/crates/automata-ci-job-executor-github/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/run_steps.rs
@@ -3,9 +3,9 @@ mod support;
 use std::{collections::BTreeMap, sync::Arc};
 
 use automata_ci_core::{
-    JobConclusion, JobSecretExposure, StepAnnotationLevel, StepIr, ValueSource,
+    JobConclusion, JobSecretExposure, RunnerId, StepAnnotationLevel, StepIr, ValueSource,
 };
-use automata_ci_execution::{RootFilesystemPolicy, SandboxPrivilegePolicy};
+use automata_ci_execution::{RootFilesystemPolicy, SandboxCustody, SandboxPrivilegePolicy};
 use automata_ci_github_runtime::{CommandFileKind, WorkflowCommandPolicy};
 use automata_ci_runner_runtime::{
     ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
@@ -97,6 +97,8 @@ async fn run_steps_preserve_scripts_and_apply_fresh_command_files_after_exit() {
         )]),
     );
     let request = fixture.request(job);
+    let runner_id = request.lease().runner_id();
+    let slot_ordinal = request.slot().get();
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
 
     let result = fixture
@@ -106,7 +108,7 @@ async fn run_steps_preserve_scripts_and_apply_fresh_command_files_after_exit() {
         .expect("job executes");
 
     assert_eq!(result.conclusion(), JobConclusion::Success);
-    assert_sandbox_spec(&fixture);
+    assert_sandbox_spec(&fixture, runner_id, slot_ordinal);
 
     let state = fixture.endpoint_state.lock().expect("endpoint lock");
     assert_eq!(
@@ -744,7 +746,7 @@ fn conditioned_run_step(id: &str, command: &str, condition: &str) -> StepIr {
     run_step(id, id, command).with_condition(condition)
 }
 
-fn assert_sandbox_spec(fixture: &Fixture) {
+fn assert_sandbox_spec(fixture: &Fixture, runner_id: RunnerId, slot_ordinal: u16) {
     assert_eq!(fixture.provider.counts(), (1, 1, 0));
     let specs = fixture.provider.specs();
     assert_eq!(specs.len(), 1);
@@ -752,6 +754,13 @@ fn assert_sandbox_spec(fixture: &Fixture) {
     assert_eq!(specs[0].privilege(), SandboxPrivilegePolicy::Administrator);
     assert_eq!(specs[0].workspace().as_str(), "/__w/automata/automata");
     assert_eq!(specs[0].scratch(), None);
+    assert!(matches!(
+        specs[0].custody(),
+        SandboxCustody::Job {
+            runner_id: observed_runner,
+            slot_ordinal: observed_slot,
+        } if observed_runner == runner_id && observed_slot.get() == slot_ordinal
+    ));
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/service_containers.rs
+++ b/crates/automata-ci-job-executor-github/tests/service_containers.rs
@@ -55,6 +55,7 @@ async fn service_specs_cross_the_fenced_sandbox_boundary_and_cleanup_with_the_jo
     let request = fixture.request(job);
     let session_id = request.session_id();
     let slot = request.slot();
+    let runner_id = request.lease().runner_id();
     let attempt_id = request.lease().attempt_id();
     let guard = request.lease().guard();
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
@@ -113,7 +114,14 @@ async fn service_specs_cross_the_fenced_sandbox_boundary_and_cleanup_with_the_jo
     assert!(!format!("{sandbox:?}").contains(support::SECRET));
     assert!(!format!("{sandbox:?}").contains("pg_isready"));
 
-    let cleanup = CleanupRequest::new(session_id, slot, attempt_id, guard, journal_identity());
+    let cleanup = CleanupRequest::new(
+        runner_id,
+        session_id,
+        slot,
+        attempt_id,
+        guard,
+        journal_identity(),
+    );
     fixture
         .executor
         .cleanup(cleanup, events, ExecutionCancellation::new())
@@ -129,6 +137,7 @@ async fn cancelled_service_job_retains_exact_sandbox_cleanup_ownership() {
     let request = fixture.request(job);
     let session_id = request.session_id();
     let slot = request.slot();
+    let runner_id = request.lease().runner_id();
     let attempt_id = request.lease().attempt_id();
     let guard = request.lease().guard();
     let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
@@ -147,7 +156,14 @@ async fn cancelled_service_job_retains_exact_sandbox_cleanup_ownership() {
     fixture
         .executor
         .cleanup(
-            CleanupRequest::new(session_id, slot, attempt_id, guard, journal_identity()),
+            CleanupRequest::new(
+                runner_id,
+                session_id,
+                slot,
+                attempt_id,
+                guard,
+                journal_identity(),
+            ),
             events,
             ExecutionCancellation::new(),
         )

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -31,10 +31,10 @@ use automata_ci_execution::{
     ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream,
     ExecutionStage, ExecutionTermination, ImmutableImage, NetworkPolicy, OperationOutcome,
     ProviderCapabilities, ProviderError, ProviderErrorKind, ProviderId, ProviderStage,
-    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration,
-    SandboxHandle, SandboxInspection, SandboxPrivilegePolicy, SandboxProvider, SandboxRecord,
-    SandboxSpec, SandboxState, ServiceContainerBinding, ServiceContainerBindings, ServiceNetwork,
-    ServicePortBinding, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxCustody, SandboxEnvironment,
+    SandboxGeneration, SandboxHandle, SandboxInspection, SandboxPrivilegePolicy, SandboxProvider,
+    SandboxRecord, SandboxSpec, SandboxState, ServiceContainerBinding, ServiceContainerBindings,
+    ServiceNetwork, ServicePortBinding, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
 };
 use automata_ci_expression_github::{
     ExtensionFunctionResult, GithubEvaluationContext, GithubExpressionEvaluator,
@@ -658,6 +658,20 @@ fn execution_request(environment: SandboxEnvironment, job: JobIrEnvelope) -> Exe
         environment,
         JobLifecycle::Preparing,
         None,
+    )
+}
+
+pub fn recovered_request(request: &ExecutionRequest) -> ExecutionRequest {
+    ExecutionRequest::new(
+        request.session_id(),
+        request.slot(),
+        request.lease().clone(),
+        request.job().clone(),
+        request.runtime_authorities().clone(),
+        request.job_content().clone(),
+        request.environment().clone(),
+        request.recovery_lifecycle(),
+        Some(journal_identity()),
     )
 }
 
@@ -1663,9 +1677,11 @@ struct ProviderState {
     pub creates: usize,
     pub create_operations: BTreeSet<OperationId>,
     pub create_failures: VecDeque<ProviderError>,
+    pub inspects: usize,
     pub attaches: usize,
     pub destroy_requests: Vec<DestroySandbox>,
     pub specs: Vec<SandboxSpec>,
+    pub inspection_custody: Option<SandboxCustody>,
 }
 
 impl FakeProvider {
@@ -1732,6 +1748,10 @@ impl FakeProvider {
             .len()
     }
 
+    pub fn inspection_count(&self) -> usize {
+        self.state.lock().expect("provider lock").inspects
+    }
+
     pub fn fail_next_create(&self, kind: ProviderErrorKind, outcome: OperationOutcome) {
         let recovery_handle = (outcome == OperationOutcome::Uncertain).then(|| self.handle.clone());
         self.state
@@ -1756,6 +1776,10 @@ impl FakeProvider {
             .expect("provider lock")
             .destroy_requests
             .clone()
+    }
+
+    pub fn set_inspection_custody(&self, custody: SandboxCustody) {
+        self.state.lock().expect("provider lock").inspection_custody = Some(custody);
     }
 }
 
@@ -1816,9 +1840,16 @@ impl SandboxProvider for FakeProvider {
         handle: &SandboxHandle,
         _cancellation: &dyn Cancellation,
     ) -> Result<SandboxInspection, ProviderError> {
+        let mut state = self.state.lock().expect("provider lock");
+        state.inspects += 1;
+        let custody = state
+            .inspection_custody
+            .unwrap_or_else(|| state.specs.last().expect("created sandbox spec").custody());
+        drop(state);
         Ok(SandboxInspection::new(
             handle.clone(),
             SandboxGeneration::new(7).expect("valid generation"),
+            custody,
             self.environment.attestation().clone(),
             SandboxState::Running,
         ))

--- a/crates/automata-ci-runner-runtime/src/orphan.rs
+++ b/crates/automata-ci-runner-runtime/src/orphan.rs
@@ -222,8 +222,14 @@ impl OrphanRecoveryCoordinator {
                 Arc::clone(&self.content_operations),
             ));
             let signal = ExecutionCancellation::new();
-            let request =
-                CleanupRequest::new(session_id, slot_ordinal, lease.attempt_id(), guard, sandbox);
+            let request = CleanupRequest::new(
+                self.runner_id,
+                session_id,
+                slot_ordinal,
+                lease.attempt_id(),
+                guard,
+                sandbox,
+            );
             let cleanup = self.executor.cleanup(request, events, signal.clone());
             tokio::pin!(cleanup);
             tokio::select! {

--- a/crates/automata-ci-runner-runtime/src/port.rs
+++ b/crates/automata-ci-runner-runtime/src/port.rs
@@ -8,9 +8,9 @@ use std::{
 
 use automata_ci_core::{
     AttemptId, JobIrEnvelope, JobLifecycle, JobResult, Lease, LeaseGuard, LogChannel, OperationId,
-    RunnerSessionId, UnixMillis,
+    RunnerId, RunnerSessionId, UnixMillis,
 };
-use automata_ci_execution::SandboxEnvironment;
+use automata_ci_execution::{SandboxCustody, SandboxEnvironment};
 use automata_ci_protocol::{JobRuntimeAuthorities, ManagedSecretBindingOverlay};
 use automata_ci_protocol::{LeaseRejectionReason, RunnerSlotOrdinal};
 use automata_ci_runner_journal::{
@@ -130,6 +130,12 @@ impl ExecutionRequest {
         self.slot
     }
 
+    /// Returns the exact runner and durable-slot custody for this job.
+    #[must_use]
+    pub fn sandbox_custody(&self) -> SandboxCustody {
+        job_custody(self.lease.runner_id(), self.slot)
+    }
+
     /// Returns the exact fenced lease.
     #[must_use]
     pub const fn lease(&self) -> &Lease {
@@ -221,6 +227,7 @@ impl fmt::Debug for ExecutionRequest {
 /// Immutable input for post-terminal sandbox reconciliation.
 #[derive(Clone, Debug)]
 pub struct CleanupRequest {
+    runner_id: RunnerId,
     session_id: RunnerSessionId,
     slot: RunnerSlotOrdinal,
     attempt_id: AttemptId,
@@ -230,10 +237,11 @@ pub struct CleanupRequest {
 
 impl CleanupRequest {
     /// Constructs post-terminal cleanup work for a sandbox identity retained
-    /// by the durable journal. The caller must supply the same session, slot,
-    /// attempt, and lease guard that own the identity.
+    /// by the durable journal. The caller must supply the same runner,
+    /// session, slot, attempt, and lease guard that own the identity.
     #[must_use]
     pub const fn new(
+        runner_id: RunnerId,
         session_id: RunnerSessionId,
         slot: RunnerSlotOrdinal,
         attempt_id: AttemptId,
@@ -241,6 +249,7 @@ impl CleanupRequest {
         sandbox: SandboxIdentity,
     ) -> Self {
         Self {
+            runner_id,
             session_id,
             slot,
             attempt_id,
@@ -261,6 +270,12 @@ impl CleanupRequest {
         self.slot
     }
 
+    /// Returns the exact runner and durable-slot custody being reconciled.
+    #[must_use]
+    pub fn sandbox_custody(&self) -> SandboxCustody {
+        job_custody(self.runner_id, self.slot)
+    }
+
     /// Returns the attempt identity.
     #[must_use]
     pub const fn attempt_id(&self) -> AttemptId {
@@ -277,6 +292,14 @@ impl CleanupRequest {
     #[must_use]
     pub const fn sandbox(&self) -> &SandboxIdentity {
         &self.sandbox
+    }
+}
+
+fn job_custody(runner_id: RunnerId, slot: RunnerSlotOrdinal) -> SandboxCustody {
+    SandboxCustody::Job {
+        runner_id,
+        slot_ordinal: std::num::NonZeroU16::new(slot.get())
+            .expect("runner slot ordinals are non-zero"),
     }
 }
 

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -3245,6 +3245,7 @@ impl RunnerSessionSupervisor {
         ));
         let signal = ExecutionCancellation::new();
         let request = CleanupRequest::new(
+            self.inner.config.capabilities().runner_id(),
             session.negotiated.session_id(),
             durable.slot(),
             lease.attempt_id(),

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -66,7 +66,8 @@ use super::{
     config::{ObjectStoreTlsTrust, required_podman_state_root},
     metrics::RunnerMetrics,
     profile_admission::{
-        ProfileAdmissionOutcome, ProfileAdmissionPolicy, admit_environment_profiles,
+        ProfileAdmissionError, ProfileAdmissionOutcome, ProfileAdmissionPolicy,
+        admit_environment_profiles,
     },
     spool_crypto::{AES_256_GCM_KEY_BYTES, Aes256GcmContentKeyring, Aes256GcmContentProtector},
     state::{capture_dedicated_runtime_mount, ensure_private_directory},
@@ -741,7 +742,7 @@ fn admit_configured_environment_profiles(
             )
             .map_err(|_| RunnerProductError::ProviderConfiguration)?,
     };
-    let result = admit_environment_profiles(provider, config.environments(), policy, cancellation);
+    let result = admit_runner_profiles(config, provider, policy, cancellation);
     match result {
         Ok(ProfileAdmissionOutcome::Admitted) => {
             info!(
@@ -766,6 +767,21 @@ fn admit_configured_environment_profiles(
             Err(RunnerProductError::EnvironmentProfileAdmission)
         }
     }
+}
+
+fn admit_runner_profiles(
+    config: &RunnerProductConfig,
+    provider: &dyn automata_ci_execution::SandboxProvider,
+    policy: ProfileAdmissionPolicy,
+    cancellation: &crate::podman_probe::ProbeCancellation,
+) -> Result<ProfileAdmissionOutcome, ProfileAdmissionError> {
+    admit_environment_profiles(
+        provider,
+        config.runner_id(),
+        config.environments(),
+        policy,
+        cancellation,
+    )
 }
 
 async fn bind_metrics_listener(

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -3519,8 +3519,8 @@ mod tests {
     use automata_ci_execution::{
         CopyFromRequest, CopyToRequest, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
         ExecutionSignal, NeverCancelled, OperationId, OperationOutcome, ProviderCapabilities,
-        ProviderError, ProviderErrorKind, ProviderId, ProviderStage, SandboxCapability,
-        SandboxGeneration, SandboxHandle, SignalRequest, TargetPath, WaitRequest,
+        ProviderError, ProviderErrorKind, ProviderId, ProviderStage, RunnerId, SandboxCapability,
+        SandboxCustody, SandboxGeneration, SandboxHandle, SignalRequest, TargetPath, WaitRequest,
     };
     use prometheus_client::encoding::prometheus_protobuf;
 
@@ -4361,6 +4361,9 @@ mod tests {
                     OperationId::new(),
                     handle,
                     SandboxGeneration::new(1).expect("generation"),
+                    SandboxCustody::ProfileAdmission {
+                        runner_id: RunnerId::new(),
+                    },
                 ),
                 &NeverCancelled,
             ),

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -5,14 +5,14 @@ use std::{
     time::Duration,
 };
 
-use automata_ci_core::JobResourceAllocation;
+use automata_ci_core::{JobResourceAllocation, RunnerId};
 use automata_ci_execution::{
     Cancellation, CopyToRequest, DestroyDisposition, DestroySandbox, EnvironmentProfile,
     ExecutionArgv, ExecutionCommand, ExecutionError, ExecutionErrorKind, ExecutionStage,
     ExecutionTermination, NetworkPolicy, OperationId, OperationOutcome, ProviderError,
-    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxEnvironment, SandboxGeneration,
-    SandboxHandle, SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, SandboxState, TargetPath,
-    TargetPlatform,
+    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxCustody, SandboxEnvironment,
+    SandboxGeneration, SandboxHandle, SandboxPrivilegePolicy, SandboxProvider, SandboxSpec,
+    SandboxState, TargetPath, TargetPlatform,
 };
 use automata_ci_job_executor_github::{WindowsScriptShell, windows_script_arguments};
 use uuid::Uuid;
@@ -523,6 +523,7 @@ impl Error for ProfileAdmissionError {
 
 pub(super) fn admit_environment_profiles(
     provider: &dyn SandboxProvider,
+    runner_id: RunnerId,
     environments: &BTreeMap<EnvironmentProfile, SandboxEnvironment>,
     policy: ProfileAdmissionPolicy,
     cancellation: &ProbeCancellation,
@@ -539,6 +540,7 @@ pub(super) fn admit_environment_profiles(
     })?;
     let context = ProfileAdmissionContext {
         provider,
+        runner_id,
         policy,
         generation,
         probe_attempt,
@@ -567,6 +569,7 @@ pub(super) fn admit_environment_profiles(
 
 struct ProfileAdmissionContext<'context> {
     provider: &'context dyn SandboxProvider,
+    runner_id: RunnerId,
     policy: ProfileAdmissionPolicy,
     generation: SandboxGeneration,
     probe_attempt: Option<OperationId>,
@@ -575,6 +578,70 @@ struct ProfileAdmissionContext<'context> {
 }
 
 impl ProfileAdmissionContext<'_> {
+    const fn custody(&self) -> SandboxCustody {
+        SandboxCustody::ProfileAdmission {
+            runner_id: self.runner_id,
+        }
+    }
+
+    fn cleanup_after_create_failure(
+        &self,
+        recovery_handle: Option<&SandboxHandle>,
+        operation_id: OperationId,
+        outcome: OperationOutcome,
+    ) -> (ProfileAdmissionCleanupStatus, Option<ProviderError>) {
+        match recovery_handle {
+            Some(handle) => self.cleanup_handle(handle, operation_id),
+            None if outcome == OperationOutcome::KnownNoEffect => {
+                (ProfileAdmissionCleanupStatus::NotRequired, None)
+            }
+            None => (ProfileAdmissionCleanupStatus::Failed, None),
+        }
+    }
+
+    fn cleanup_handle(
+        &self,
+        handle: &SandboxHandle,
+        operation_id: OperationId,
+    ) -> (ProfileAdmissionCleanupStatus, Option<ProviderError>) {
+        match self.destroy_with_reconciliation(handle, operation_id) {
+            Ok(_) => (ProfileAdmissionCleanupStatus::Complete, None),
+            Err(error) => (ProfileAdmissionCleanupStatus::Failed, Some(error)),
+        }
+    }
+
+    fn destroy_with_reconciliation(
+        &self,
+        handle: &SandboxHandle,
+        operation_id: OperationId,
+    ) -> Result<DestroyEvidence, ProviderError> {
+        let request = DestroySandbox::new(
+            operation_id,
+            handle.clone(),
+            self.generation,
+            self.custody(),
+        );
+        match self.provider.destroy(&request, &self.cleanup_cancellation) {
+            Ok(DestroyDisposition::Destroyed) => Ok(DestroyEvidence::Destroyed),
+            Ok(DestroyDisposition::AlreadyAbsent) => Ok(DestroyEvidence::InitiallyAbsent),
+            Err(error)
+                if error.outcome() == OperationOutcome::Uncertain
+                    && error
+                        .recovery_handle()
+                        .is_none_or(|recovery_handle| recovery_handle == handle) =>
+            {
+                match self
+                    .provider
+                    .destroy(&request, &self.cleanup_cancellation)?
+                {
+                    DestroyDisposition::Destroyed => Ok(DestroyEvidence::Destroyed),
+                    DestroyDisposition::AlreadyAbsent => Ok(DestroyEvidence::ReconciledAbsent),
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     fn admit(&self, environment: &SandboxEnvironment) -> Result<(), ProfileAdmissionError> {
         let operation_ids =
             AdmissionOperationIds::for_profile(environment.attestation(), self.probe_attempt);
@@ -601,6 +668,7 @@ impl ProfileAdmissionContext<'_> {
         let mut spec = SandboxSpec::new(
             operation_ids.create,
             self.generation,
+            self.custody(),
             environment.clone(),
             workspace.clone(),
             self.policy.network,
@@ -671,13 +739,10 @@ impl ProfileAdmissionContext<'_> {
             Ok(record) => record,
             Err(error) => {
                 let recovery_handle = error.recovery_handle().cloned();
-                let (cleanup, cleanup_error) = cleanup_after_create_failure(
-                    self.provider,
+                let (cleanup, cleanup_error) = self.cleanup_after_create_failure(
                     recovery_handle.as_ref(),
-                    self.generation,
                     destroy_operation_id,
                     error.outcome(),
-                    &self.cleanup_cancellation,
                 );
                 return Err(ProfileAdmissionError::provider(
                     ProfileAdmissionErrorKind::CreateFailed,
@@ -693,13 +758,8 @@ impl ProfileAdmissionContext<'_> {
             || record.profile() != environment.attestation()
             || record.state() != SandboxState::Running
         {
-            let (cleanup, cleanup_error) = cleanup_handle(
-                self.provider,
-                record.handle(),
-                self.generation,
-                destroy_operation_id,
-                &self.cleanup_cancellation,
-            );
+            let (cleanup, cleanup_error) =
+                self.cleanup_handle(record.handle(), destroy_operation_id);
             return Err(ProfileAdmissionError::evidence(
                 ProfileAdmissionErrorKind::InvalidCreateEvidence,
                 cleanup,
@@ -721,13 +781,8 @@ impl ProfileAdmissionContext<'_> {
         {
             Ok(inspection) => inspection,
             Err(error) => {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    destroy_operation_id,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), destroy_operation_id);
                 return Err(ProfileAdmissionError::provider(
                     ProfileAdmissionErrorKind::InspectFailed,
                     error,
@@ -739,16 +794,12 @@ impl ProfileAdmissionContext<'_> {
         if inspection.handle() != record.handle()
             || inspection.handle().provider() != self.provider.provider_id()
             || inspection.generation() != self.generation
+            || inspection.custody() != self.custody()
             || inspection.profile() != environment.attestation()
             || inspection.state() != SandboxState::Running
         {
-            let (cleanup, cleanup_error) = cleanup_handle(
-                self.provider,
-                record.handle(),
-                self.generation,
-                destroy_operation_id,
-                &self.cleanup_cancellation,
-            );
+            let (cleanup, cleanup_error) =
+                self.cleanup_handle(record.handle(), destroy_operation_id);
             return Err(ProfileAdmissionError::evidence(
                 ProfileAdmissionErrorKind::InvalidInspectionEvidence,
                 cleanup,
@@ -774,13 +825,8 @@ impl ProfileAdmissionContext<'_> {
         {
             Ok(endpoint) => endpoint,
             Err(error) => {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 return Err(ProfileAdmissionError::provider(
                     ProfileAdmissionErrorKind::AttachFailed,
                     error,
@@ -798,13 +844,8 @@ impl ProfileAdmissionContext<'_> {
             .into_iter()
             .all(|capability| endpoint.capabilities().contains(&capability))
         {
-            let (cleanup, cleanup_error) = cleanup_handle(
-                self.provider,
-                record.handle(),
-                self.generation,
-                operation_ids.destroy,
-                &self.cleanup_cancellation,
-            );
+            let (cleanup, cleanup_error) =
+                self.cleanup_handle(record.handle(), operation_ids.destroy);
             return Err(ProfileAdmissionError::evidence(
                 ProfileAdmissionErrorKind::InvalidAttachEvidence,
                 cleanup,
@@ -824,13 +865,8 @@ impl ProfileAdmissionContext<'_> {
                 probe.script_content(execution_operation_id),
             ) else {
                 if script.is_some() || probe.script_name().is_some() {
-                    let (cleanup, cleanup_error) = cleanup_handle(
-                        self.provider,
-                        record.handle(),
-                        self.generation,
-                        operation_ids.destroy,
-                        &self.cleanup_cancellation,
-                    );
+                    let (cleanup, cleanup_error) =
+                        self.cleanup_handle(record.handle(), operation_ids.destroy);
                     return Err(ProfileAdmissionError::evidence(
                         ProfileAdmissionErrorKind::InvalidCopyEvidence,
                         cleanup,
@@ -840,13 +876,8 @@ impl ProfileAdmissionContext<'_> {
                 continue;
             };
             let Ok(request) = CopyToRequest::new(operation_id, script.clone(), content) else {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 return Err(ProfileAdmissionError::evidence(
                     ProfileAdmissionErrorKind::InvalidCopyEvidence,
                     cleanup,
@@ -854,13 +885,8 @@ impl ProfileAdmissionContext<'_> {
                 ));
             };
             if let Err(error) = endpoint.copy_to(&request, &self.provisioning_cancellation) {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 return Err(ProfileAdmissionError::execution(
                     ProfileAdmissionErrorKind::CopyFailed,
                     error,
@@ -877,13 +903,8 @@ impl ProfileAdmissionContext<'_> {
             .zip(operation_ids.exec)
         {
             let Ok(argv) = probe.argv(script.as_ref(), operation_id) else {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 return Err(ProfileAdmissionError::evidence(
                     ProfileAdmissionErrorKind::InvalidExecutionEvidence,
                     cleanup,
@@ -898,13 +919,8 @@ impl ProfileAdmissionContext<'_> {
                 SHELL_PROBE_TIMEOUT,
                 SHELL_PROBE_OUTPUT_BYTES,
             ) else {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 return Err(ProfileAdmissionError::evidence(
                     ProfileAdmissionErrorKind::InvalidExecutionEvidence,
                     cleanup,
@@ -914,13 +930,8 @@ impl ProfileAdmissionContext<'_> {
             let output = match endpoint.exec(&command, &self.provisioning_cancellation) {
                 Ok(output) => output,
                 Err(error) => {
-                    let (cleanup, cleanup_error) = cleanup_handle(
-                        self.provider,
-                        record.handle(),
-                        self.generation,
-                        operation_ids.destroy,
-                        &self.cleanup_cancellation,
-                    );
+                    let (cleanup, cleanup_error) =
+                        self.cleanup_handle(record.handle(), operation_ids.destroy);
                     return Err(ProfileAdmissionError::execution(
                         ProfileAdmissionErrorKind::ExecutionFailed,
                         error,
@@ -934,13 +945,8 @@ impl ProfileAdmissionContext<'_> {
                 || !probe.expected_stdout_matches(operation_id, output.stdout())
                 || !output.stderr().is_empty()
             {
-                let (cleanup, cleanup_error) = cleanup_handle(
-                    self.provider,
-                    record.handle(),
-                    self.generation,
-                    operation_ids.destroy,
-                    &self.cleanup_cancellation,
-                );
+                let (cleanup, cleanup_error) =
+                    self.cleanup_handle(record.handle(), operation_ids.destroy);
                 if output.termination() == ExecutionTermination::Cancelled
                     && self
                         .provisioning_cancellation
@@ -969,13 +975,7 @@ impl ProfileAdmissionContext<'_> {
         record: &automata_ci_execution::SandboxRecord,
         operation_id: OperationId,
     ) -> Result<(), ProfileAdmissionError> {
-        match destroy_with_reconciliation(
-            self.provider,
-            record.handle(),
-            self.generation,
-            operation_id,
-            &self.cleanup_cancellation,
-        ) {
+        match self.destroy_with_reconciliation(record.handle(), operation_id) {
             Ok(DestroyEvidence::Destroyed | DestroyEvidence::ReconciledAbsent) => Ok(()),
             Ok(DestroyEvidence::InitiallyAbsent) => Err(ProfileAdmissionError::evidence(
                 ProfileAdmissionErrorKind::InvalidDestroyEvidence,
@@ -1091,67 +1091,11 @@ fn validate_catalog(
     Ok(())
 }
 
-fn cleanup_after_create_failure(
-    provider: &dyn SandboxProvider,
-    recovery_handle: Option<&SandboxHandle>,
-    generation: SandboxGeneration,
-    operation_id: OperationId,
-    outcome: OperationOutcome,
-    cancellation: &dyn Cancellation,
-) -> (ProfileAdmissionCleanupStatus, Option<ProviderError>) {
-    match recovery_handle {
-        Some(handle) => cleanup_handle(provider, handle, generation, operation_id, cancellation),
-        None if outcome == OperationOutcome::KnownNoEffect => {
-            (ProfileAdmissionCleanupStatus::NotRequired, None)
-        }
-        None => (ProfileAdmissionCleanupStatus::Failed, None),
-    }
-}
-
-fn cleanup_handle(
-    provider: &dyn SandboxProvider,
-    handle: &SandboxHandle,
-    generation: SandboxGeneration,
-    operation_id: OperationId,
-    cancellation: &dyn Cancellation,
-) -> (ProfileAdmissionCleanupStatus, Option<ProviderError>) {
-    match destroy_with_reconciliation(provider, handle, generation, operation_id, cancellation) {
-        Ok(_) => (ProfileAdmissionCleanupStatus::Complete, None),
-        Err(error) => (ProfileAdmissionCleanupStatus::Failed, Some(error)),
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DestroyEvidence {
     Destroyed,
     ReconciledAbsent,
     InitiallyAbsent,
-}
-
-fn destroy_with_reconciliation(
-    provider: &dyn SandboxProvider,
-    handle: &SandboxHandle,
-    generation: SandboxGeneration,
-    operation_id: OperationId,
-    cancellation: &dyn Cancellation,
-) -> Result<DestroyEvidence, ProviderError> {
-    let request = DestroySandbox::new(operation_id, handle.clone(), generation);
-    match provider.destroy(&request, cancellation) {
-        Ok(DestroyDisposition::Destroyed) => Ok(DestroyEvidence::Destroyed),
-        Ok(DestroyDisposition::AlreadyAbsent) => Ok(DestroyEvidence::InitiallyAbsent),
-        Err(error)
-            if error.outcome() == OperationOutcome::Uncertain
-                && error
-                    .recovery_handle()
-                    .is_none_or(|recovery_handle| recovery_handle == handle) =>
-        {
-            match provider.destroy(&request, cancellation)? {
-                DestroyDisposition::Destroyed => Ok(DestroyEvidence::Destroyed),
-                DestroyDisposition::AlreadyAbsent => Ok(DestroyEvidence::ReconciledAbsent),
-            }
-        }
-        Err(error) => Err(error),
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -1246,7 +1190,10 @@ impl Cancellation for CleanupCancellation<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        num::NonZeroU16,
+        sync::{Arc, Mutex},
+    };
 
     use automata_ci_execution::{
         CopyFromRequest, ExecutionEndpoint, ExecutionEnvironment, ExecutionOutput,
@@ -1257,6 +1204,10 @@ mod tests {
 
     use super::*;
 
+    fn runner_id() -> RunnerId {
+        RunnerId::from_uuid(Uuid::from_u128(0x8fe5_8afb_3922_4299_a540_4da9_bfa4_25d6))
+    }
+
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     enum FakeBehavior {
         #[default]
@@ -1264,6 +1215,7 @@ mod tests {
         CreateFailureWithRecovery,
         CreateState(SandboxState),
         InspectState(SandboxState),
+        InspectCustody(SandboxCustody),
         DestroyInitiallyAbsent,
         DestroyUncertainOnce,
         CancelAfterCreate(u8),
@@ -1287,7 +1239,7 @@ mod tests {
     #[derive(Debug)]
     struct FakeState {
         calls: Vec<Call>,
-        resources: BTreeMap<SandboxHandle, (SandboxGeneration, EnvironmentProfile)>,
+        resources: BTreeMap<SandboxHandle, (SandboxGeneration, SandboxCustody, EnvironmentProfile)>,
     }
 
     #[derive(Debug)]
@@ -1365,7 +1317,11 @@ mod tests {
             state.calls.push(Call::Create(Box::new(spec.clone())));
             state.resources.insert(
                 handle.clone(),
-                (spec.generation(), spec.profile().attestation().clone()),
+                (
+                    spec.generation(),
+                    spec.custody(),
+                    spec.profile().attestation().clone(),
+                ),
             );
             drop(state);
             let cancel_after_create = match self.behavior {
@@ -1441,10 +1397,16 @@ mod tests {
                 ));
             }
             let state = self.state.lock().expect("fake state");
-            let (generation, profile) = state.resources.get(handle).expect("owned resource");
+            let (generation, custody, profile) =
+                state.resources.get(handle).expect("owned resource");
+            let custody = match self.behavior {
+                FakeBehavior::InspectCustody(custody) => custody,
+                _ => *custody,
+            };
             Ok(SandboxInspection::new(
                 handle.clone(),
                 *generation,
+                custody,
                 profile.clone(),
                 match self.behavior {
                     FakeBehavior::InspectState(state) => state,
@@ -1822,7 +1784,13 @@ mod tests {
         let profiles = BTreeMap::from([(attestation, environment)]);
 
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, linux_tool_policy(), &signals),
+            admit_environment_profiles(
+                &provider,
+                runner_id(),
+                &profiles,
+                linux_tool_policy(),
+                &signals,
+            ),
             Ok(ProfileAdmissionOutcome::Admitted)
         );
         let calls = provider.calls();
@@ -1944,9 +1912,14 @@ mod tests {
             let (profile, sandbox) = environment("linux-tools", profile_digest(0x57), 0x68);
             let profiles = BTreeMap::from([(profile, sandbox)]);
 
-            let error =
-                admit_environment_profiles(&provider, &profiles, linux_tool_policy(), &signals)
-                    .expect_err("Linux profile tools require the complete sandbox boundary");
+            let error = admit_environment_profiles(
+                &provider,
+                runner_id(),
+                &profiles,
+                linux_tool_policy(),
+                &signals,
+            )
+            .expect_err("Linux profile tools require the complete sandbox boundary");
             assert_eq!(
                 error.kind(),
                 ProfileAdmissionErrorKind::InvalidProviderEvidence
@@ -2008,7 +1981,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, policy(), &signals),
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals),
             Ok(ProfileAdmissionOutcome::Admitted)
         );
         assert_eq!(provider.resource_count(), 0);
@@ -2025,6 +1998,12 @@ mod tests {
             assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Administrator);
             assert_eq!(spec.resources(), policy().resources);
             assert_eq!(spec.generation().get(), ADMISSION_GENERATION);
+            assert_eq!(
+                spec.custody(),
+                SandboxCustody::ProfileAdmission {
+                    runner_id: runner_id(),
+                }
+            );
             let Call::Inspect(inspected) = &calls[1] else {
                 panic!("profile create must be inspected")
             };
@@ -2034,6 +2013,7 @@ mod tests {
             assert!(!cleanup_cancelled);
             assert_eq!(inspected, destroyed.handle());
             assert_eq!(destroyed.generation(), spec.generation());
+            assert_eq!(destroyed.custody(), spec.custody());
             assert_ne!(destroyed.operation_id(), spec.operation_id());
         }
 
@@ -2046,7 +2026,7 @@ mod tests {
             })
             .collect();
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, policy(), &signals),
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals),
             Ok(ProfileAdmissionOutcome::Admitted)
         );
         let second_ids: Vec<_> = provider.calls()[calls.len()..]
@@ -2114,7 +2094,7 @@ mod tests {
         .expect("Hyper-V container admission policy");
 
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, policy, &signals),
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy, &signals),
             Ok(ProfileAdmissionOutcome::Admitted)
         );
         let calls = provider.calls();
@@ -2267,8 +2247,9 @@ mod tests {
             .expect("capabilities with one required boundary omitted");
             let (profiles, policy) = windows_hyperv_fixture();
 
-            let error = admit_environment_profiles(&provider, &profiles, policy, &signals)
-                .expect_err("every isolated boundary must be explicitly advertised");
+            let error =
+                admit_environment_profiles(&provider, runner_id(), &profiles, policy, &signals)
+                    .expect_err("every isolated boundary must be explicitly advertised");
             assert_eq!(
                 error.kind(),
                 ProfileAdmissionErrorKind::InvalidProviderEvidence
@@ -2293,8 +2274,9 @@ mod tests {
             let provider = FakeProvider::new(behavior, signals.clone());
             let (profiles, policy) = windows_hyperv_fixture();
 
-            let error = admit_environment_profiles(&provider, &profiles, policy, &signals)
-                .expect_err("invalid shell evidence must reject admission");
+            let error =
+                admit_environment_profiles(&provider, runner_id(), &profiles, policy, &signals)
+                    .expect_err("invalid shell evidence must reject admission");
             assert_eq!(
                 error.kind(),
                 ProfileAdmissionErrorKind::InvalidExecutionEvidence
@@ -2349,8 +2331,9 @@ mod tests {
         let provider = FakeProvider::new(FakeBehavior::CreateFailureWithRecovery, signals.clone());
         let profiles = BTreeMap::from([environment("linux", profile_digest(0x31), 0x41)]);
 
-        let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-            .expect_err("create failure cannot admit profile");
+        let error =
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals)
+                .expect_err("create failure cannot admit profile");
         assert_eq!(error.kind(), ProfileAdmissionErrorKind::CreateFailed);
         assert_eq!(
             error.cleanup_status(),
@@ -2365,15 +2348,29 @@ mod tests {
 
     #[test]
     fn invalid_create_and_inspection_evidence_are_cleaned() {
+        let expected_runner = runner_id();
         for behavior in [
             FakeBehavior::CreateState(SandboxState::Created),
             FakeBehavior::InspectState(SandboxState::Degraded),
+            FakeBehavior::InspectCustody(SandboxCustody::ProfileAdmission {
+                runner_id: RunnerId::new(),
+            }),
+            FakeBehavior::InspectCustody(SandboxCustody::Job {
+                runner_id: expected_runner,
+                slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+            }),
         ] {
             let signals = ProbeCancellation::default();
             let provider = FakeProvider::new(behavior, signals.clone());
             let profiles = BTreeMap::from([environment("linux", profile_digest(0x51), 0x61)]);
-            let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-                .expect_err("invalid lifecycle evidence cannot admit profile");
+            let error = admit_environment_profiles(
+                &provider,
+                expected_runner,
+                &profiles,
+                policy(),
+                &signals,
+            )
+            .expect_err("invalid lifecycle evidence cannot admit profile");
             assert!(matches!(
                 error.kind(),
                 ProfileAdmissionErrorKind::InvalidCreateEvidence
@@ -2394,7 +2391,7 @@ mod tests {
         let profiles = BTreeMap::from([environment("linux", profile_digest(0x71), 0x81)]);
 
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, policy(), &signals),
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals),
             Ok(ProfileAdmissionOutcome::Cancelled)
         );
         assert_eq!(provider.resource_count(), 0);
@@ -2410,8 +2407,9 @@ mod tests {
         let provider = FakeProvider::new(FakeBehavior::CancelAfterCreate(2), signals.clone());
         let profiles = BTreeMap::from([environment("linux", profile_digest(0x91), 0xa1)]);
 
-        let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-            .expect_err("forced cancellation may interrupt cleanup but cannot hide it");
+        let error =
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals)
+                .expect_err("forced cancellation may interrupt cleanup but cannot hide it");
         assert_eq!(error.kind(), ProfileAdmissionErrorKind::InspectFailed);
         assert_eq!(
             error.cleanup_status(),
@@ -2430,8 +2428,9 @@ mod tests {
         let provider = FakeProvider::new(FakeBehavior::InspectAndDestroyFailure, signals.clone());
         let profiles = BTreeMap::from([environment("linux", profile_digest(0xb1), 0xc1)]);
 
-        let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-            .expect_err("cleanup failure cannot admit profile");
+        let error =
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals)
+                .expect_err("cleanup failure cannot admit profile");
         assert_eq!(error.kind(), ProfileAdmissionErrorKind::InspectFailed);
         assert_eq!(
             error.cleanup_status(),
@@ -2453,8 +2452,9 @@ mod tests {
         let provider = FakeProvider::new(FakeBehavior::DestroyInitiallyAbsent, signals.clone());
         let profiles = BTreeMap::from([environment("linux", profile_digest(0xc1), 0xd1)]);
 
-        let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-            .expect_err("an initially absent destroy target invalidates lifecycle evidence");
+        let error =
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals)
+                .expect_err("an initially absent destroy target invalidates lifecycle evidence");
         assert_eq!(
             error.kind(),
             ProfileAdmissionErrorKind::InvalidDestroyEvidence
@@ -2473,7 +2473,7 @@ mod tests {
         let profiles = BTreeMap::from([environment("linux", profile_digest(0xc7), 0xd7)]);
 
         assert_eq!(
-            admit_environment_profiles(&provider, &profiles, policy(), &signals),
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals),
             Ok(ProfileAdmissionOutcome::Admitted)
         );
         assert_eq!(provider.resource_count(), 0);
@@ -2498,8 +2498,9 @@ mod tests {
             environment("linux", colliding_digest, 0xf1),
         ]);
 
-        let error = admit_environment_profiles(&provider, &profiles, policy(), &signals)
-            .expect_err("colliding replay coordinates must fail before create");
+        let error =
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy(), &signals)
+                .expect_err("colliding replay coordinates must fail before create");
         assert_eq!(error.kind(), ProfileAdmissionErrorKind::InvalidCatalog);
         assert_eq!(
             error.cleanup_status(),

--- a/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
@@ -11,7 +11,7 @@ use automata_ci_sandbox_guest::{
     GuestTermination, MAX_GUEST_FRAME_BYTES, decode_frame, encode_frame,
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::api::{core::v1::Pod, networking::v1::NetworkPolicy};
 use kube::{Api, Client, ResourceExt as _, api::AttachParams};
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
@@ -19,8 +19,10 @@ use tokio::{
 };
 
 use crate::{
-    objects::{GUEST_BINARY, GUEST_SOCKET, MAIN_CONTAINER},
-    provider::{block_on, map_kube_error, pod_state, verify_managed},
+    objects::{GUEST_BINARY, GUEST_SOCKET, MAIN_CONTAINER, network_policy_name},
+    provider::{
+        SandboxObjectIdentity, block_on, map_kube_error, pod_state, verify_required_sandbox_objects,
+    },
 };
 
 const ENDPOINT_CAPABILITIES: [SandboxCapability; 4] = [
@@ -35,6 +37,7 @@ pub(crate) struct KubernetesExecutionEndpoint {
     namespace: String,
     handle: SandboxHandle,
     uid: String,
+    identity: SandboxObjectIdentity,
     operation_timeout: Duration,
 }
 
@@ -44,6 +47,7 @@ impl KubernetesExecutionEndpoint {
         namespace: String,
         handle: SandboxHandle,
         uid: String,
+        identity: SandboxObjectIdentity,
         operation_timeout: Duration,
     ) -> Self {
         Self {
@@ -51,6 +55,7 @@ impl KubernetesExecutionEndpoint {
             namespace,
             handle,
             uid,
+            identity,
             operation_timeout,
         }
     }
@@ -69,8 +74,12 @@ impl KubernetesExecutionEndpoint {
         let frame = encode_frame(request)
             .map_err(|_| execution_error(ExecutionErrorKind::BackendRejected, stage))?;
         let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let policies: Api<NetworkPolicy> = Api::namespaced(self.client.clone(), &self.namespace);
         let name = self.handle.opaque().to_owned();
+        let policy_name = network_policy_name(&name);
+        let namespace = self.namespace.clone();
         let uid = self.uid.clone();
+        let expected_identity = self.identity.clone();
         let operation_timeout = self.operation_timeout;
         let response = block_on(async move {
             let operation = async move {
@@ -78,10 +87,25 @@ impl KubernetesExecutionEndpoint {
                     .await
                     .map_err(|_| automata_ci_execution::ProviderErrorKind::TimedOut)?
                     .map_err(|error| map_kube_error(&error))?;
-                verify_managed(&pod, &name, None)?;
                 if pod.uid().as_deref() != Some(&uid)
                     || pod_state(&pod) != automata_ci_execution::SandboxState::Running
                 {
+                    return Err(automata_ci_execution::ProviderErrorKind::OwnershipMismatch);
+                }
+                let policy = timeout(operation_timeout, policies.get(&policy_name))
+                    .await
+                    .map_err(|_| automata_ci_execution::ProviderErrorKind::TimedOut)?
+                    .map_err(|error| {
+                        let kind = map_kube_error(&error);
+                        if kind == automata_ci_execution::ProviderErrorKind::NotFound {
+                            automata_ci_execution::ProviderErrorKind::InvalidState
+                        } else {
+                            kind
+                        }
+                    })?;
+                let observed_identity =
+                    verify_required_sandbox_objects(&pod, &policy, &name, &namespace)?;
+                if observed_identity != expected_identity {
                     return Err(automata_ci_execution::ProviderErrorKind::OwnershipMismatch);
                 }
                 let params = AttachParams::default()

--- a/crates/automata-ci-sandbox-kubernetes/src/objects.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/objects.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use automata_ci_core::{JobResourceAllocation, ResourceCapacity, Sha256Digest};
 use automata_ci_execution::{
-    ImmutableImage, NetworkPolicy as SandboxNetworkPolicy, RootFilesystemPolicy, SandboxSpec,
+    ImmutableImage, NetworkPolicy as SandboxNetworkPolicy, RootFilesystemPolicy, SandboxCustody,
+    SandboxSpec,
 };
 use k8s_openapi::{
     api::{
@@ -27,6 +28,11 @@ use crate::{
 
 pub(crate) const MANAGED_LABEL: &str = "ci.automata.dev/managed";
 pub(crate) const SANDBOX_LABEL: &str = "ci.automata.dev/sandbox";
+pub(crate) const SCHEMA_LABEL: &str = "ci.automata.dev/sandbox-schema";
+pub(crate) const CUSTODY_KIND_LABEL: &str = "ci.automata.dev/custody-kind";
+pub(crate) const CUSTODY_RUNNER_LABEL: &str = "ci.automata.dev/custody-runner";
+pub(crate) const CUSTODY_SLOT_LABEL: &str = "ci.automata.dev/custody-slot";
+pub(crate) const SANDBOX_SCHEMA: &str = "2";
 pub(crate) const GENERATION_ANNOTATION: &str = "ci.automata.dev/generation";
 pub(crate) const PROFILE_ID_ANNOTATION: &str = "ci.automata.dev/profile-id";
 pub(crate) const PROFILE_DIGEST_ANNOTATION: &str = "ci.automata.dev/profile-digest";
@@ -53,7 +59,7 @@ pub(crate) fn build_objects(
         .image()
         .ok_or_else(|| invalid_configuration(automata_ci_execution::ProviderStage::Validate))?;
     let fingerprint = fingerprint(spec, image, allocation, config);
-    let labels = object_labels(name);
+    let labels = object_labels(name, spec.custody());
     let annotations = object_annotations(spec, &fingerprint);
     let pod = build_pod(
         name,
@@ -112,10 +118,23 @@ fn validated_allocation(
     Ok(allocation)
 }
 
-fn object_labels(name: &str) -> BTreeMap<String, String> {
+fn object_labels(name: &str, custody: SandboxCustody) -> BTreeMap<String, String> {
+    let (kind, runner, slot) = match custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            ("profile-admission", runner_id.to_string(), "0".to_owned())
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => ("job", runner_id.to_string(), slot_ordinal.get().to_string()),
+    };
     BTreeMap::from([
         (MANAGED_LABEL.into(), "true".into()),
         (SANDBOX_LABEL.into(), name.into()),
+        (SCHEMA_LABEL.into(), SANDBOX_SCHEMA.into()),
+        (CUSTODY_KIND_LABEL.into(), kind.into()),
+        (CUSTODY_RUNNER_LABEL.into(), runner),
+        (CUSTODY_SLOT_LABEL.into(), slot),
     ])
 }
 
@@ -359,15 +378,19 @@ fn deny_all_network_policy(
             annotations: Some(annotations),
             ..ObjectMeta::default()
         },
-        spec: Some(NetworkPolicySpec {
-            egress: Some(Vec::new()),
-            ingress: Some(Vec::new()),
-            pod_selector: Some(LabelSelector {
-                match_labels: Some(BTreeMap::from([(SANDBOX_LABEL.into(), name.into())])),
-                ..LabelSelector::default()
-            }),
-            policy_types: Some(vec!["Ingress".into(), "Egress".into()]),
+        spec: Some(deny_all_network_policy_spec(name)),
+    }
+}
+
+pub(crate) fn deny_all_network_policy_spec(name: &str) -> NetworkPolicySpec {
+    NetworkPolicySpec {
+        egress: Some(Vec::new()),
+        ingress: Some(Vec::new()),
+        pod_selector: Some(LabelSelector {
+            match_labels: Some(BTreeMap::from([(SANDBOX_LABEL.into(), name.into())])),
+            ..LabelSelector::default()
         }),
+        policy_types: Some(vec!["Ingress".into(), "Egress".into()]),
     }
 }
 
@@ -421,6 +444,7 @@ fn fingerprint(
     config: &KubernetesSandboxConfig,
 ) -> String {
     let mut digest = Sha256::new();
+    hash_fingerprint_field(&mut digest, b"automata-kubernetes-sandbox-spec-v2");
     let operation_id = spec.operation_id().to_string();
     let generation = spec.generation().get().to_string();
     let profile_digest = spec.profile().attestation().digest().to_string();
@@ -436,6 +460,7 @@ fn fingerprint(
     ] {
         hash_fingerprint_field(&mut digest, value.as_bytes());
     }
+    hash_custody(&mut digest, spec.custody());
     digest.update([spec.network() as u8]);
     digest.update([spec.root_filesystem() as u8]);
     digest.update([spec.privilege() as u8]);
@@ -479,6 +504,23 @@ fn fingerprint(
         digest.update(resources.gpu_count().to_be_bytes());
     }
     Sha256Digest::from_bytes(digest.finalize().into()).to_string()
+}
+
+fn hash_custody(digest: &mut Sha256, custody: SandboxCustody) {
+    match custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            hash_fingerprint_field(digest, b"profile-admission");
+            hash_fingerprint_field(digest, runner_id.as_uuid().as_bytes());
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => {
+            hash_fingerprint_field(digest, b"job");
+            hash_fingerprint_field(digest, runner_id.as_uuid().as_bytes());
+            hash_fingerprint_field(digest, &slot_ordinal.get().to_be_bytes());
+        }
+    }
 }
 
 fn hash_fingerprint_field(digest: &mut Sha256, value: &[u8]) {
@@ -553,6 +595,9 @@ mod tests {
         SandboxSpec::new(
             OperationId::new(),
             SandboxGeneration::new(7).expect("generation"),
+            SandboxCustody::ProfileAdmission {
+                runner_id: automata_ci_core::RunnerId::new(),
+            },
             environment,
             workspace,
             NetworkPolicy::Disabled,
@@ -698,6 +743,7 @@ mod tests {
         let missing_allocation = SandboxSpec::new(
             original.operation_id(),
             original.generation(),
+            original.custody(),
             original.profile().clone(),
             original.workspace().clone(),
             original.network(),
@@ -714,6 +760,7 @@ mod tests {
         let too_small = SandboxSpec::new(
             original.operation_id(),
             original.generation(),
+            original.custody(),
             original.profile().clone(),
             original.workspace().clone(),
             original.network(),
@@ -731,6 +778,7 @@ mod tests {
         let incoherent = SandboxSpec::new(
             original.operation_id(),
             original.generation(),
+            original.custody(),
             original.profile().clone(),
             original.workspace().clone(),
             original.network(),

--- a/crates/automata-ci-sandbox-kubernetes/src/provider.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/provider.rs
@@ -1,10 +1,10 @@
-use std::{future::Future, str::FromStr as _, sync::Arc, time::Instant};
+use std::{future::Future, num::NonZeroU16, str::FromStr as _, sync::Arc, time::Instant};
 
-use automata_ci_core::{EnvironmentProfile, EnvironmentProfileId, Sha256Digest};
+use automata_ci_core::{EnvironmentProfile, EnvironmentProfileId, RunnerId, Sha256Digest};
 use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, OperationOutcome, ProviderCapabilities,
-    ProviderError, ProviderErrorKind, ProviderId, ProviderStage, SandboxCapability, SandboxHandle,
-    SandboxInspection, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
+    ProviderError, ProviderErrorKind, ProviderId, ProviderStage, SandboxCapability, SandboxCustody,
+    SandboxHandle, SandboxInspection, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
 };
 use k8s_openapi::api::{core::v1::Pod, networking::v1::NetworkPolicy};
 use kube::{
@@ -18,8 +18,10 @@ use crate::{
     endpoint::KubernetesExecutionEndpoint,
     invalid_configuration,
     objects::{
-        FINGERPRINT_ANNOTATION, GENERATION_ANNOTATION, MANAGED_LABEL, PROFILE_DIGEST_ANNOTATION,
-        PROFILE_ID_ANNOTATION, SANDBOX_LABEL, build_objects, network_policy_name,
+        CUSTODY_KIND_LABEL, CUSTODY_RUNNER_LABEL, CUSTODY_SLOT_LABEL, FINGERPRINT_ANNOTATION,
+        GENERATION_ANNOTATION, MANAGED_LABEL, PROFILE_DIGEST_ANNOTATION, PROFILE_ID_ANNOTATION,
+        SANDBOX_LABEL, SANDBOX_SCHEMA, SCHEMA_LABEL, build_objects, deny_all_network_policy_spec,
+        network_policy_name,
     },
 };
 
@@ -34,6 +36,14 @@ struct KubernetesInner {
     config: KubernetesSandboxConfig,
     provider_id: ProviderId,
     capabilities: ProviderCapabilities,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct SandboxObjectIdentity {
+    generation: automata_ci_execution::SandboxGeneration,
+    custody: SandboxCustody,
+    profile: EnvironmentProfile,
+    fingerprint: String,
 }
 
 impl KubernetesSandboxProvider {
@@ -174,16 +184,18 @@ impl SandboxProvider for KubernetesSandboxProvider {
         ensure_not_cancelled(cancellation, ProviderStage::Attach)?;
         let pods: Api<Pod> =
             Api::namespaced(self.inner.client.clone(), self.inner.config.namespace());
+        let policies: Api<NetworkPolicy> =
+            Api::namespaced(self.inner.client.clone(), self.inner.config.namespace());
         let name = handle.opaque().to_owned();
+        let namespace = self.inner.config.namespace().to_owned();
         let timeout_duration = self.inner.config.operation_timeout();
-        let pod = block_on(async move {
-            timeout(timeout_duration, pods.get(&name))
-                .await
-                .map_err(|_| ProviderErrorKind::TimedOut)?
-                .map_err(|error| map_kube_error(&error))
+        let (pod, policy) = block_on(async move {
+            get_sandbox_objects(&pods, &policies, &name, timeout_duration).await
         })
         .map_err(|kind| provider_error(kind, ProviderStage::Attach))?;
-        verify_managed(&pod, handle.opaque(), None)
+        let (pod, policy) = require_sandbox_pair(pod, policy, handle.opaque(), &namespace)
+            .map_err(|kind| provider_error(kind, ProviderStage::Attach))?;
+        let identity = verify_required_sandbox_objects(&pod, &policy, handle.opaque(), &namespace)
             .map_err(|kind| provider_error(kind, ProviderStage::Attach))?;
         if pod_state(&pod) != SandboxState::Running {
             return Err(provider_error(
@@ -199,6 +211,7 @@ impl SandboxProvider for KubernetesSandboxProvider {
             self.inner.config.namespace().into(),
             handle.clone(),
             uid,
+            identity,
             self.inner.config.operation_timeout(),
         )))
     }
@@ -212,23 +225,24 @@ impl SandboxProvider for KubernetesSandboxProvider {
         ensure_not_cancelled(cancellation, ProviderStage::Inspect)?;
         let pods: Api<Pod> =
             Api::namespaced(self.inner.client.clone(), self.inner.config.namespace());
+        let policies: Api<NetworkPolicy> =
+            Api::namespaced(self.inner.client.clone(), self.inner.config.namespace());
         let name = handle.opaque().to_owned();
+        let namespace = self.inner.config.namespace().to_owned();
         let timeout_duration = self.inner.config.operation_timeout();
-        let pod = block_on(async move {
-            timeout(timeout_duration, pods.get(&name))
-                .await
-                .map_err(|_| ProviderErrorKind::TimedOut)?
-                .map_err(|error| map_kube_error(&error))
+        let (pod, policy) = block_on(async move {
+            get_sandbox_objects(&pods, &policies, &name, timeout_duration).await
         })
         .map_err(|kind| provider_error(kind, ProviderStage::Inspect))?;
-        verify_managed(&pod, handle.opaque(), None)
+        let (pod, policy) = require_sandbox_pair(pod, policy, handle.opaque(), &namespace)
             .map_err(|kind| provider_error(kind, ProviderStage::Inspect))?;
-        let (generation, profile) =
-            identity_from_pod(&pod).map_err(|kind| provider_error(kind, ProviderStage::Inspect))?;
+        let identity = verify_required_sandbox_objects(&pod, &policy, handle.opaque(), &namespace)
+            .map_err(|kind| provider_error(kind, ProviderStage::Inspect))?;
         Ok(SandboxInspection::new(
             handle.clone(),
-            generation,
-            profile,
+            identity.generation,
+            identity.custody,
+            identity.profile,
             pod_state(&pod),
         ))
     }
@@ -251,18 +265,52 @@ impl SandboxProvider for KubernetesSandboxProvider {
         let name = request.handle().opaque().to_owned();
         let policy_name = network_policy_name(&name);
         let generation = request.generation().get();
+        let custody = request.custody();
+        let namespace = self.inner.config.namespace().to_owned();
         let timeout_duration = self.inner.config.operation_timeout();
         let result = block_on(async move {
+            let started = Instant::now();
+            let pod = timed_get_opt(&pods, &name, remaining(timeout_duration, started)?).await?;
+            let policy = timed_get_opt(
+                &policies,
+                &policy_name,
+                remaining(timeout_duration, started)?,
+            )
+            .await?;
+            let pod_identity = pod
+                .as_ref()
+                .map(|pod| {
+                    let identity = owned_pod_identity(pod, &name, &namespace)?;
+                    if identity.generation.get() != generation || identity.custody != custody {
+                        return Err(ProviderErrorKind::OwnershipMismatch);
+                    }
+                    Ok(identity)
+                })
+                .transpose()?;
+            if let Some(policy) = policy.as_ref() {
+                let policy_identity = owned_policy_identity(policy, &name, &namespace)?;
+                if policy_identity.generation.get() != generation
+                    || policy_identity.custody != custody
+                {
+                    return Err(ProviderErrorKind::OwnershipMismatch);
+                }
+                if pod_identity
+                    .as_ref()
+                    .is_some_and(|pod_identity| pod_identity != &policy_identity)
+                {
+                    return Err(ProviderErrorKind::OwnershipMismatch);
+                }
+            }
             let pod_existed =
-                delete_pod_and_wait(&pods, &name, generation, timeout_duration).await?;
+                delete_pod_and_wait(&pods, &name, pod, remaining(timeout_duration, started)?)
+                    .await?;
             // Network isolation must outlive the exact Pod UID. Kubernetes Pod
             // deletion is asynchronous even after DELETE succeeds.
             let policy_existed = delete_policy_and_wait(
                 &policies,
                 &policy_name,
-                &name,
-                generation,
-                timeout_duration,
+                policy,
+                remaining(timeout_duration, started)?,
             )
             .await?;
             let existed = pod_existed || policy_existed;
@@ -284,17 +332,54 @@ impl SandboxProvider for KubernetesSandboxProvider {
     }
 }
 
+async fn get_sandbox_objects(
+    pods: &Api<Pod>,
+    policies: &Api<NetworkPolicy>,
+    sandbox: &str,
+    deadline: Duration,
+) -> Result<(Option<Pod>, Option<NetworkPolicy>), ProviderErrorKind> {
+    let started = Instant::now();
+    let pod = timed_get_opt(pods, sandbox, remaining(deadline, started)?).await?;
+    let policy = timed_get_opt(
+        policies,
+        &network_policy_name(sandbox),
+        remaining(deadline, started)?,
+    )
+    .await?;
+    Ok((pod, policy))
+}
+
+fn require_sandbox_pair(
+    pod: Option<Pod>,
+    policy: Option<NetworkPolicy>,
+    sandbox: &str,
+    namespace: &str,
+) -> Result<(Pod, NetworkPolicy), ProviderErrorKind> {
+    match (pod, policy) {
+        (Some(pod), Some(policy)) => Ok((pod, policy)),
+        (None, None) => Err(ProviderErrorKind::NotFound),
+        (Some(pod), None) => {
+            owned_pod_identity(&pod, sandbox, namespace)?;
+            Err(ProviderErrorKind::InvalidState)
+        }
+        (None, Some(policy)) => {
+            owned_policy_identity(&policy, sandbox, namespace)?;
+            verify_required_policy_health(&policy, sandbox)?;
+            Err(ProviderErrorKind::InvalidState)
+        }
+    }
+}
+
 async fn delete_pod_and_wait(
     pods: &Api<Pod>,
     name: &str,
-    generation: u64,
+    pod: Option<Pod>,
     deadline: Duration,
 ) -> Result<bool, ProviderErrorKind> {
     let started = Instant::now();
-    let Some(pod) = timed_get_opt(pods, name, remaining(deadline, started)?).await? else {
+    let Some(pod) = pod else {
         return Ok(false);
     };
-    verify_managed(&pod, name, Some(generation))?;
     let uid = pod.uid().ok_or(ProviderErrorKind::BackendRejected)?;
     let resource_version = pod
         .resource_version()
@@ -330,16 +415,13 @@ async fn delete_pod_and_wait(
 async fn delete_policy_and_wait(
     policies: &Api<NetworkPolicy>,
     policy_name: &str,
-    sandbox_name: &str,
-    generation: u64,
+    policy: Option<NetworkPolicy>,
     deadline: Duration,
 ) -> Result<bool, ProviderErrorKind> {
     let started = Instant::now();
-    let Some(policy) = timed_get_opt(policies, policy_name, remaining(deadline, started)?).await?
-    else {
+    let Some(policy) = policy else {
         return Ok(false);
     };
-    verify_managed(&policy, sandbox_name, Some(generation))?;
     let uid = policy.uid().ok_or(ProviderErrorKind::BackendRejected)?;
     let resource_version = policy
         .resource_version()
@@ -465,6 +547,10 @@ fn verify_observed_pod(
 ) -> Result<(), ProviderErrorKind> {
     let name = expected.name_any();
     verify_managed(observed, &name, None)?;
+    if observed.name_any() != name || observed.namespace() != expected.namespace() {
+        return Err(ProviderErrorKind::Conflict);
+    }
+    verify_same_object_identity(observed, expected)?;
     verify_fingerprint(observed, fingerprint)?;
     let observed = observed.spec.as_ref().ok_or(ProviderErrorKind::Conflict)?;
     let expected = expected
@@ -499,6 +585,10 @@ fn verify_observed_policy(
     fingerprint: &str,
 ) -> Result<(), ProviderErrorKind> {
     verify_managed(observed, sandbox, None)?;
+    if observed.name_any() != expected.name_any() || observed.namespace() != expected.namespace() {
+        return Err(ProviderErrorKind::Conflict);
+    }
+    verify_same_object_identity(observed, expected)?;
     verify_fingerprint(observed, fingerprint)?;
     (observed.spec == expected.spec)
         .then_some(())
@@ -573,10 +663,20 @@ pub(crate) fn pod_state(pod: &Pod) -> SandboxState {
     }
 }
 
-fn identity_from_pod(
-    pod: &Pod,
-) -> Result<(automata_ci_execution::SandboxGeneration, EnvironmentProfile), ProviderErrorKind> {
-    let annotations = pod.annotations();
+fn identity_from_object<K>(
+    object: &K,
+) -> Result<
+    (
+        automata_ci_execution::SandboxGeneration,
+        SandboxCustody,
+        EnvironmentProfile,
+    ),
+    ProviderErrorKind,
+>
+where
+    K: Resource,
+{
+    let annotations = ResourceExt::annotations(object);
     let generation = annotations
         .get(GENERATION_ANNOTATION)
         .and_then(|value| value.parse().ok())
@@ -590,7 +690,185 @@ fn identity_from_pod(
         .get(PROFILE_DIGEST_ANNOTATION)
         .and_then(|value| Sha256Digest::from_str(value).ok())
         .ok_or(ProviderErrorKind::OwnershipMismatch)?;
-    Ok((generation, EnvironmentProfile::new(profile_id, digest)))
+    Ok((
+        generation,
+        custody_from_object(object)?,
+        EnvironmentProfile::new(profile_id, digest),
+    ))
+}
+
+fn fingerprint_from_object<K>(object: &K) -> Result<&str, ProviderErrorKind>
+where
+    K: Resource,
+{
+    let value = ResourceExt::annotations(object)
+        .get(FINGERPRINT_ANNOTATION)
+        .map(String::as_str)
+        .ok_or(ProviderErrorKind::OwnershipMismatch)?;
+    let digest = Sha256Digest::from_str(value).map_err(|_| ProviderErrorKind::OwnershipMismatch)?;
+    (digest.to_string() == value)
+        .then_some(value)
+        .ok_or(ProviderErrorKind::OwnershipMismatch)
+}
+
+fn object_identity<K>(object: &K) -> Result<SandboxObjectIdentity, ProviderErrorKind>
+where
+    K: Resource,
+{
+    let (generation, custody, profile) = identity_from_object(object)?;
+    let identity = SandboxObjectIdentity {
+        generation,
+        custody,
+        profile,
+        fingerprint: fingerprint_from_object(object)?.to_owned(),
+    };
+    canonical_identity_encoding(object, &identity)
+        .then_some(identity)
+        .ok_or(ProviderErrorKind::OwnershipMismatch)
+}
+
+fn owned_pod_identity(
+    pod: &Pod,
+    sandbox: &str,
+    namespace: &str,
+) -> Result<SandboxObjectIdentity, ProviderErrorKind> {
+    verify_managed(pod, sandbox, None)?;
+    if pod.name_any() != sandbox || pod.namespace().as_deref() != Some(namespace) {
+        return Err(ProviderErrorKind::OwnershipMismatch);
+    }
+    object_identity(pod)
+}
+
+fn owned_policy_identity(
+    policy: &NetworkPolicy,
+    sandbox: &str,
+    namespace: &str,
+) -> Result<SandboxObjectIdentity, ProviderErrorKind> {
+    verify_managed(policy, sandbox, None)?;
+    if policy.name_any() != network_policy_name(sandbox)
+        || policy.namespace().as_deref() != Some(namespace)
+    {
+        return Err(ProviderErrorKind::OwnershipMismatch);
+    }
+    object_identity(policy)
+}
+
+fn verify_same_object_identity<K>(observed: &K, expected: &K) -> Result<(), ProviderErrorKind>
+where
+    K: Resource,
+{
+    const ANNOTATIONS: [&str; 3] = [
+        GENERATION_ANNOTATION,
+        PROFILE_ID_ANNOTATION,
+        PROFILE_DIGEST_ANNOTATION,
+    ];
+    const LABELS: [&str; 3] = [CUSTODY_KIND_LABEL, CUSTODY_RUNNER_LABEL, CUSTODY_SLOT_LABEL];
+    let observed_annotations = ResourceExt::annotations(observed);
+    let expected_annotations = ResourceExt::annotations(expected);
+    let observed_labels = ResourceExt::labels(observed);
+    let expected_labels = ResourceExt::labels(expected);
+    let exact_encoding = ANNOTATIONS
+        .iter()
+        .all(|key| observed_annotations.get(*key) == expected_annotations.get(*key))
+        && LABELS
+            .iter()
+            .all(|key| observed_labels.get(*key) == expected_labels.get(*key));
+    (identity_from_object(observed)? == identity_from_object(expected)? && exact_encoding)
+        .then_some(())
+        .ok_or(ProviderErrorKind::Conflict)
+}
+
+fn canonical_identity_encoding<K>(object: &K, identity: &SandboxObjectIdentity) -> bool
+where
+    K: Resource,
+{
+    let annotations = ResourceExt::annotations(object);
+    let labels = ResourceExt::labels(object);
+    let generation = identity.generation.get().to_string();
+    let profile_digest = identity.profile.digest().to_string();
+    let (kind, runner_id, slot) = match identity.custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            ("profile-admission", runner_id.to_string(), "0".to_owned())
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => ("job", runner_id.to_string(), slot_ordinal.get().to_string()),
+    };
+    annotations.get(GENERATION_ANNOTATION).map(String::as_str) == Some(generation.as_str())
+        && annotations.get(PROFILE_ID_ANNOTATION).map(String::as_str)
+            == Some(identity.profile.id().as_str())
+        && annotations
+            .get(PROFILE_DIGEST_ANNOTATION)
+            .map(String::as_str)
+            == Some(profile_digest.as_str())
+        && labels.get(CUSTODY_KIND_LABEL).map(String::as_str) == Some(kind)
+        && labels.get(CUSTODY_RUNNER_LABEL).map(String::as_str) == Some(runner_id.as_str())
+        && labels.get(CUSTODY_SLOT_LABEL).map(String::as_str) == Some(slot.as_str())
+}
+
+fn verify_matching_object_identity(
+    observed: &SandboxObjectIdentity,
+    expected: &SandboxObjectIdentity,
+) -> Result<(), ProviderErrorKind> {
+    if observed.generation != expected.generation
+        || observed.custody != expected.custody
+        || observed.profile != expected.profile
+    {
+        return Err(ProviderErrorKind::OwnershipMismatch);
+    }
+    (observed.fingerprint == expected.fingerprint)
+        .then_some(())
+        .ok_or(ProviderErrorKind::Conflict)
+}
+
+fn verify_required_policy_health(
+    policy: &NetworkPolicy,
+    sandbox: &str,
+) -> Result<(), ProviderErrorKind> {
+    (policy.spec.as_ref() == Some(&deny_all_network_policy_spec(sandbox)))
+        .then_some(())
+        .ok_or(ProviderErrorKind::Conflict)
+}
+
+pub(crate) fn verify_required_sandbox_objects(
+    pod: &Pod,
+    policy: &NetworkPolicy,
+    sandbox: &str,
+    namespace: &str,
+) -> Result<SandboxObjectIdentity, ProviderErrorKind> {
+    let pod_identity = owned_pod_identity(pod, sandbox, namespace)?;
+    let policy_identity = owned_policy_identity(policy, sandbox, namespace)?;
+    verify_matching_object_identity(&policy_identity, &pod_identity)?;
+    verify_required_policy_health(policy, sandbox)?;
+    Ok(pod_identity)
+}
+
+fn custody_from_object<K>(object: &K) -> Result<SandboxCustody, ProviderErrorKind>
+where
+    K: Resource,
+{
+    let labels = ResourceExt::labels(object);
+    let runner_id = labels
+        .get(CUSTODY_RUNNER_LABEL)
+        .and_then(|value| RunnerId::from_str(value).ok())
+        .ok_or(ProviderErrorKind::OwnershipMismatch)?;
+    let slot = labels
+        .get(CUSTODY_SLOT_LABEL)
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or(ProviderErrorKind::OwnershipMismatch)?;
+    match labels.get(CUSTODY_KIND_LABEL).map(String::as_str) {
+        Some("profile-admission") if slot == 0 => {
+            Ok(SandboxCustody::ProfileAdmission { runner_id })
+        }
+        Some("job") => NonZeroU16::new(slot)
+            .map(|slot_ordinal| SandboxCustody::Job {
+                runner_id,
+                slot_ordinal,
+            })
+            .ok_or(ProviderErrorKind::OwnershipMismatch),
+        _ => Err(ProviderErrorKind::OwnershipMismatch),
+    }
 }
 
 pub(crate) fn verify_managed<K>(
@@ -606,6 +884,10 @@ where
         .map(String::as_str)
         != Some("true")
         || ResourceExt::labels(object)
+            .get(SCHEMA_LABEL)
+            .map(String::as_str)
+            != Some(SANDBOX_SCHEMA)
+        || ResourceExt::labels(object)
             .get(SANDBOX_LABEL)
             .map(String::as_str)
             != Some(sandbox)
@@ -618,6 +900,7 @@ where
     {
         return Err(ProviderErrorKind::OwnershipMismatch);
     }
+    custody_from_object(object)?;
     Ok(())
 }
 

--- a/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
@@ -44,6 +44,7 @@ use tokio_tungstenite::{
 
 const NAMESPACE: &str = "automata-runners";
 const HANDLE: &str = "a-endpoint-contract-7";
+const FINGERPRINT: &str = "1111111111111111111111111111111111111111111111111111111111111111";
 
 #[derive(Clone, Debug)]
 struct TestCancellation(Arc<AtomicBool>);
@@ -109,6 +110,7 @@ struct ServerState {
     websocket_uris: Vec<String>,
     plain_uris: Vec<String>,
     stale_pod_identity: bool,
+    policy_spec_drift: bool,
     failure: Option<String>,
 }
 
@@ -210,11 +212,26 @@ impl FakeExecServer {
             .len()
     }
 
+    fn plain_uris(&self) -> Vec<String> {
+        self.state
+            .lock()
+            .expect("server state lock")
+            .plain_uris
+            .clone()
+    }
+
     fn make_pod_identity_stale(&self) {
         self.state
             .lock()
             .expect("server state lock")
             .stale_pod_identity = true;
+    }
+
+    fn make_policy_spec_drift(&self) {
+        self.state
+            .lock()
+            .expect("server state lock")
+            .policy_spec_drift = true;
     }
 
     fn assert_finished(&self) {
@@ -277,13 +294,17 @@ async fn handle_plain_http(
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request URI"))?;
-    let stale_pod_identity = {
+    let (stale_pod_identity, policy_spec_drift) = {
         let mut state = state.lock().expect("server state lock");
         state.plain_uris.push(uri.into());
-        state.stale_pod_identity
+        (state.stale_pod_identity, state.policy_spec_drift)
     };
-    let body =
-        serde_json::to_vec(&owned_running_pod(stale_pod_identity)).expect("serialize owned Pod");
+    let resource = if uri.contains("/networkpolicies/") {
+        owned_network_policy(policy_spec_drift)
+    } else {
+        owned_running_pod(stale_pod_identity)
+    };
+    let body = serde_json::to_vec(&resource).expect("serialize owned Kubernetes resource");
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
@@ -351,7 +372,17 @@ fn owned_running_pod(stale_identity: bool) -> serde_json::Value {
             "uid": "endpoint-pod-uid",
             "labels": {
                 "ci.automata.dev/managed": "true",
-                "ci.automata.dev/sandbox": HANDLE
+                "ci.automata.dev/sandbox": HANDLE,
+                "ci.automata.dev/sandbox-schema": "2",
+                "ci.automata.dev/custody-kind": "profile-admission",
+                "ci.automata.dev/custody-runner": "00000000-0000-4000-8000-000000000001",
+                "ci.automata.dev/custody-slot": "0"
+            },
+            "annotations": {
+                "ci.automata.dev/generation": "7",
+                "ci.automata.dev/profile-id": "example.com/linux",
+                "ci.automata.dev/profile-digest": FINGERPRINT,
+                "ci.automata.dev/spec-sha256": FINGERPRINT
             }
         },
         "status": {
@@ -369,6 +400,44 @@ fn owned_running_pod(stale_identity: bool) -> serde_json::Value {
         pod["metadata"]["uid"] = json!("replacement-pod-uid");
     }
     pod
+}
+
+fn owned_network_policy(spec_drift: bool) -> serde_json::Value {
+    let mut policy = json!({
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": format!("{HANDLE}-deny"),
+            "namespace": NAMESPACE,
+            "uid": "endpoint-policy-uid",
+            "labels": {
+                "ci.automata.dev/managed": "true",
+                "ci.automata.dev/sandbox": HANDLE,
+                "ci.automata.dev/sandbox-schema": "2",
+                "ci.automata.dev/custody-kind": "profile-admission",
+                "ci.automata.dev/custody-runner": "00000000-0000-4000-8000-000000000001",
+                "ci.automata.dev/custody-slot": "0"
+            },
+            "annotations": {
+                "ci.automata.dev/generation": "7",
+                "ci.automata.dev/profile-id": "example.com/linux",
+                "ci.automata.dev/profile-digest": FINGERPRINT,
+                "ci.automata.dev/spec-sha256": FINGERPRINT
+            }
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {"ci.automata.dev/sandbox": HANDLE}
+            },
+            "ingress": [],
+            "egress": [],
+            "policyTypes": ["Ingress", "Egress"]
+        }
+    });
+    if spec_drift {
+        policy["spec"]["egress"] = json!([{}]);
+    }
+    policy
 }
 
 fn immutable_image() -> ImmutableImage {
@@ -428,6 +497,19 @@ fn guest_response(value: serde_json::Value) -> GuestResponse {
 fn assert_execution_error(error: ExecutionError, kind: ExecutionErrorKind, stage: ExecutionStage) {
     assert_eq!(error.kind(), kind);
     assert_eq!(error.stage(), stage);
+}
+
+fn assert_required_policy_checks(server: &FakeExecServer, exchange_count: usize) {
+    let plain_uris = server.plain_uris();
+    assert_eq!(plain_uris.len(), 2 * (exchange_count + 1));
+    assert_eq!(
+        plain_uris
+            .iter()
+            .filter(|uri| uri.contains("/networkpolicies/"))
+            .count(),
+        exchange_count + 1,
+        "attach and every endpoint exchange must fetch the required policy"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -532,6 +614,7 @@ async fn exec_and_copy_round_trips_preserve_exact_guest_requests_and_results() {
             && !uri.contains("sensitive-value")
             && !uri.contains("literal%20argument")
     }));
+    assert_required_policy_checks(&server, 3);
     server.assert_finished();
 }
 
@@ -792,6 +875,19 @@ async fn every_exchange_revalidates_pod_identity_and_observes_late_cancellation(
             .copy_to(&copy, &NeverCancelled)
             .expect_err("replacement Pod UID must reject the endpoint"),
         ExecutionErrorKind::OwnershipMismatch,
+        ExecutionStage::CopyTo,
+    );
+    assert!(server.websocket_uris().is_empty());
+    server.assert_finished();
+
+    let server = FakeExecServer::start([]).await;
+    let endpoint = attach_endpoint(&server);
+    server.make_policy_spec_drift();
+    assert_execution_error(
+        endpoint
+            .copy_to(&copy, &NeverCancelled)
+            .expect_err("drifted deny-all policy must reject the endpoint"),
+        ExecutionErrorKind::BackendRejected,
         ExecutionStage::CopyTo,
     );
     assert!(server.websocket_uris().is_empty());

--- a/crates/automata-ci-sandbox-kubernetes/tests/provider.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/provider.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::Infallible,
+    num::NonZeroU16,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -14,9 +15,9 @@ use automata_ci_core::{
 use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, ExecutionArgv, ExecutionEnvironment,
     ImmutableImage, NetworkPolicy, NeverCancelled, OperationOutcome, ProviderError,
-    ProviderErrorKind, ProviderId, ProviderStage, ResourceLimits, RootFilesystemPolicy,
-    SandboxCapability, SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxProvider,
-    SandboxSpec, SandboxState, TargetPath,
+    ProviderErrorKind, ProviderId, ProviderStage, ResourceLimits, RootFilesystemPolicy, RunnerId,
+    SandboxCapability, SandboxCustody, SandboxEnvironment, SandboxGeneration, SandboxHandle,
+    SandboxProvider, SandboxSpec, SandboxState, TargetPath,
 };
 use automata_ci_sandbox_kubernetes::{
     KUBERNETES_PROVIDER_ID, KubernetesSandboxConfig, KubernetesSandboxProvider,
@@ -30,7 +31,13 @@ use tower::service_fn;
 const NAMESPACE: &str = "automata-runners";
 const MANAGED_LABEL: &str = "ci.automata.dev/managed";
 const SANDBOX_LABEL: &str = "ci.automata.dev/sandbox";
+const SCHEMA_LABEL: &str = "ci.automata.dev/sandbox-schema";
+const CUSTODY_KIND_LABEL: &str = "ci.automata.dev/custody-kind";
+const CUSTODY_RUNNER_LABEL: &str = "ci.automata.dev/custody-runner";
+const CUSTODY_SLOT_LABEL: &str = "ci.automata.dev/custody-slot";
 const GENERATION_ANNOTATION: &str = "ci.automata.dev/generation";
+const PROFILE_ID_ANNOTATION: &str = "ci.automata.dev/profile-id";
+const PROFILE_DIGEST_ANNOTATION: &str = "ci.automata.dev/profile-digest";
 const FINGERPRINT_ANNOTATION: &str = "ci.automata.dev/spec-sha256";
 
 #[derive(Clone, Debug)]
@@ -84,6 +91,8 @@ struct FakeState {
     corrupt_policy_fingerprint: bool,
     mutate_pod_create: bool,
     mutate_policy_create: bool,
+    mutate_pod_create_annotation: Option<(String, Value)>,
+    mutate_policy_create_annotation: Option<(String, Value)>,
     pod_view: PodView,
     cancel_after_request: Option<(usize, Arc<AtomicBool>)>,
     next_response: Option<(StatusCode, Vec<u8>)>,
@@ -188,6 +197,14 @@ impl FakeKube {
                 if !is_policy && std::mem::take(&mut state.mutate_pod_create) {
                     resource["spec"]["hostNetwork"] = json!(true);
                 }
+                let annotation_mutation = if is_policy {
+                    state.mutate_policy_create_annotation.take()
+                } else {
+                    state.mutate_pod_create_annotation.take()
+                };
+                if let Some((annotation, value)) = annotation_mutation {
+                    resource["metadata"]["annotations"][annotation] = value;
+                }
                 let conflict = if is_policy {
                     state.policy = Some(resource.clone());
                     std::mem::take(&mut state.conflict_policy_create)
@@ -253,6 +270,26 @@ impl FakeKube {
         self.0.lock().expect("fake state lock").mutate_pod_create = true;
     }
 
+    fn mutate_create_annotation(&self, policy: bool, annotation: &str, value: Value) {
+        let mutation = Some((annotation.to_owned(), value));
+        let mut state = self.0.lock().expect("fake state lock");
+        if policy {
+            state.mutate_policy_create_annotation = mutation;
+        } else {
+            state.mutate_pod_create_annotation = mutation;
+        }
+    }
+
+    fn replace_annotation(&self, policy: bool, annotation: &str, value: Value) {
+        let mut state = self.0.lock().expect("fake state lock");
+        let resource = if policy {
+            state.policy.as_mut().expect("policy exists")
+        } else {
+            state.pod.as_mut().expect("Pod exists")
+        };
+        resource["metadata"]["annotations"][annotation] = value;
+    }
+
     fn cancel_after(&self, request_index: usize, cancellation: &TestCancellation) {
         self.0.lock().expect("fake state lock").cancel_after_request =
             Some((request_index, Arc::clone(&cancellation.0)));
@@ -268,6 +305,73 @@ impl FakeKube {
 
     fn delay_next(&self, delay: Duration) {
         self.0.lock().expect("fake state lock").delay_next = Some(delay);
+    }
+
+    fn replace_custody(&self, kind: &str, runner: RunnerId, slot: u16) {
+        let mut state = self.0.lock().expect("fake state lock");
+        let replace = |resource: &mut Value| {
+            resource["metadata"]["labels"][CUSTODY_KIND_LABEL] = json!(kind);
+            resource["metadata"]["labels"][CUSTODY_RUNNER_LABEL] = json!(runner.to_string());
+            resource["metadata"]["labels"][CUSTODY_SLOT_LABEL] = json!(slot.to_string());
+        };
+        if let Some(resource) = state.pod.as_mut() {
+            replace(resource);
+        }
+        if let Some(resource) = state.policy.as_mut() {
+            replace(resource);
+        }
+    }
+
+    fn replace_schema(&self, schema: &str) {
+        let mut state = self.0.lock().expect("fake state lock");
+        let replace = |resource: &mut Value| {
+            resource["metadata"]["labels"][SCHEMA_LABEL] = json!(schema);
+        };
+        if let Some(resource) = state.pod.as_mut() {
+            replace(resource);
+        }
+        if let Some(resource) = state.policy.as_mut() {
+            replace(resource);
+        }
+    }
+
+    fn remove_policy(&self) {
+        self.0.lock().expect("fake state lock").policy = None;
+    }
+
+    fn remove_pod(&self) {
+        self.0.lock().expect("fake state lock").pod = None;
+    }
+
+    fn replace_policy_identity(&self) {
+        let mut state = self.0.lock().expect("fake state lock");
+        state.policy.as_mut().expect("policy exists")["metadata"]["labels"][SANDBOX_LABEL] =
+            json!("a-different-sandbox-1");
+    }
+
+    fn replace_policy_schema(&self) {
+        let mut state = self.0.lock().expect("fake state lock");
+        state.policy.as_mut().expect("policy exists")["metadata"]["labels"][SCHEMA_LABEL] =
+            json!("1");
+    }
+
+    fn replace_policy_fingerprint(&self) {
+        let mut state = self.0.lock().expect("fake state lock");
+        state.policy.as_mut().expect("policy exists")["metadata"]["annotations"]
+            [FINGERPRINT_ANNOTATION] = json!("ab".repeat(32));
+    }
+
+    fn replace_policy_custody(&self) {
+        let mut state = self.0.lock().expect("fake state lock");
+        let policy = state.policy.as_mut().expect("policy exists");
+        policy["metadata"]["labels"][CUSTODY_KIND_LABEL] = json!("job");
+        policy["metadata"]["labels"][CUSTODY_RUNNER_LABEL] = json!(RunnerId::new().to_string());
+        policy["metadata"]["labels"][CUSTODY_SLOT_LABEL] = json!("9");
+    }
+
+    fn replace_policy_spec(&self) {
+        let mut state = self.0.lock().expect("fake state lock");
+        state.policy.as_mut().expect("policy exists")["spec"]["egress"] = json!([{}]);
     }
 }
 
@@ -357,7 +461,7 @@ fn config() -> KubernetesSandboxConfig {
 fn sandbox_spec() -> SandboxSpec {
     let profile = EnvironmentProfile::new(
         EnvironmentProfileId::new("example.com/linux").expect("profile id"),
-        Sha256Digest::from_bytes([2; 32]),
+        Sha256Digest::from_bytes([0xab; 32]),
     );
     let workspace = TargetPath::posix("/workspace").expect("workspace");
     let environment = SandboxEnvironment::new(
@@ -380,6 +484,10 @@ fn sandbox_spec() -> SandboxSpec {
     SandboxSpec::new(
         OperationId::new(),
         SandboxGeneration::new(7).expect("generation"),
+        SandboxCustody::Job {
+            runner_id: RunnerId::new(),
+            slot_ordinal: NonZeroU16::new(7).expect("non-zero slot"),
+        },
         environment,
         workspace,
         NetworkPolicy::Disabled,
@@ -406,7 +514,12 @@ fn sandbox_handle(spec: &SandboxSpec) -> SandboxHandle {
 }
 
 fn destroy_request(spec: &SandboxSpec) -> DestroySandbox {
-    DestroySandbox::new(OperationId::new(), sandbox_handle(spec), spec.generation())
+    DestroySandbox::new(
+        OperationId::new(),
+        sandbox_handle(spec),
+        spec.generation(),
+        spec.custody(),
+    )
 }
 
 fn test_provider(fake: &FakeKube) -> KubernetesSandboxProvider {
@@ -458,6 +571,7 @@ async fn complete_lifecycle_uses_exact_owned_objects_and_delete_preconditions() 
     assert_eq!(replayed, record);
     assert_eq!(inspection.handle(), &handle);
     assert_eq!(inspection.generation(), spec.generation());
+    assert_eq!(inspection.custody(), spec.custody());
     assert_eq!(inspection.profile(), spec.profile().attestation());
     assert_eq!(inspection.state(), SandboxState::Running);
     assert_eq!(endpoint.handle(), &handle);
@@ -490,6 +604,7 @@ async fn complete_lifecycle_uses_exact_owned_objects_and_delete_preconditions() 
     let pod_body: Value = serde_json::from_slice(&requests[3].body).expect("Pod body");
     assert_eq!(policy_body["metadata"]["labels"][MANAGED_LABEL], "true");
     assert_eq!(policy_body["metadata"]["labels"][SANDBOX_LABEL], name);
+    assert_eq!(policy_body["metadata"]["labels"][SCHEMA_LABEL], "2");
     assert_eq!(
         policy_body["spec"]["policyTypes"],
         json!(["Ingress", "Egress"])
@@ -567,6 +682,65 @@ async fn create_rejects_admission_mutation_of_security_objects() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_and_replay_reject_admission_mutated_generation_and_profile() {
+    let mutations = [
+        ("generation", GENERATION_ANNOTATION, json!("8")),
+        (
+            "generation canonical spelling",
+            GENERATION_ANNOTATION,
+            json!("07"),
+        ),
+        (
+            "profile id",
+            PROFILE_ID_ANNOTATION,
+            json!("example.com/mutated"),
+        ),
+        (
+            "profile digest",
+            PROFILE_DIGEST_ANNOTATION,
+            json!("44".repeat(32)),
+        ),
+        (
+            "profile digest canonical spelling",
+            PROFILE_DIGEST_ANNOTATION,
+            json!("AB".repeat(32)),
+        ),
+    ];
+
+    for policy in [true, false] {
+        for (label, annotation, value) in &mutations {
+            let resource = if policy { "policy" } else { "Pod" };
+            let fake = FakeKube::default();
+            fake.mutate_create_annotation(policy, annotation, value.clone());
+            let error = test_provider(&fake)
+                .create(&sandbox_spec(), &NeverCancelled)
+                .expect_err("admission-mutated identity must reject create");
+            assert_eq!(
+                error.kind(),
+                ProviderErrorKind::Conflict,
+                "{resource} {label}"
+            );
+
+            let fake = FakeKube::default();
+            let provider = test_provider(&fake);
+            let spec = sandbox_spec();
+            provider
+                .create(&spec, &NeverCancelled)
+                .expect("seed exact resources");
+            fake.replace_annotation(policy, annotation, value.clone());
+            let error = provider
+                .create(&spec, &NeverCancelled)
+                .expect_err("mutated stored identity must reject replay");
+            assert_eq!(
+                error.kind(),
+                ProviderErrorKind::Conflict,
+                "{resource} {label}"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn create_recovers_both_create_conflicts_by_verifying_stored_fingerprints() {
     let fake = FakeKube::default();
     fake.conflict_on_create();
@@ -595,6 +769,218 @@ async fn create_recovers_both_create_conflicts_by_verifying_stored_fingerprints(
             Method::GET,
         ]
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_reports_and_revalidates_exact_custody_and_current_schema() {
+    let fake = FakeKube::default();
+    let provider = test_provider(&fake);
+    let spec = sandbox_spec();
+    let handle = sandbox_handle(&spec);
+    provider
+        .create(&spec, &NeverCancelled)
+        .expect("create current Kubernetes resources");
+
+    let wrong_runner = RunnerId::new();
+    fake.replace_custody("job", wrong_runner, 7);
+    assert_eq!(
+        provider
+            .inspect(&handle, &NeverCancelled)
+            .expect("custody is explicit recovery evidence")
+            .custody(),
+        SandboxCustody::Job {
+            runner_id: wrong_runner,
+            slot_ordinal: NonZeroU16::new(7).expect("non-zero slot"),
+        }
+    );
+    let error = provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("replay must reject a wrong runner");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+
+    let SandboxCustody::Job { runner_id, .. } = spec.custody() else {
+        panic!("test spec uses job custody");
+    };
+    fake.replace_custody("job", runner_id, 2);
+    assert_eq!(
+        provider
+            .inspect(&handle, &NeverCancelled)
+            .expect("job slot is explicit recovery evidence")
+            .custody(),
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+        }
+    );
+    let error = provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("replay must reject a wrong slot");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+
+    fake.replace_schema("1");
+    let error = provider
+        .inspect(&handle, &NeverCancelled)
+        .expect_err("schema-1 Kubernetes resources must not recover");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_requires_the_exact_deny_all_policy_evidence() {
+    type PolicyMutationCase = (&'static str, fn(&FakeKube), ProviderErrorKind);
+    let cases: [PolicyMutationCase; 6] = [
+        (
+            "missing",
+            FakeKube::remove_policy,
+            ProviderErrorKind::InvalidState,
+        ),
+        (
+            "identity",
+            FakeKube::replace_policy_identity,
+            ProviderErrorKind::OwnershipMismatch,
+        ),
+        (
+            "schema",
+            FakeKube::replace_policy_schema,
+            ProviderErrorKind::OwnershipMismatch,
+        ),
+        (
+            "fingerprint",
+            FakeKube::replace_policy_fingerprint,
+            ProviderErrorKind::Conflict,
+        ),
+        (
+            "custody",
+            FakeKube::replace_policy_custody,
+            ProviderErrorKind::OwnershipMismatch,
+        ),
+        (
+            "deny-all spec",
+            FakeKube::replace_policy_spec,
+            ProviderErrorKind::Conflict,
+        ),
+    ];
+
+    for (label, mutate, expected_kind) in cases {
+        let fake = FakeKube::default();
+        let provider = test_provider(&fake);
+        let spec = sandbox_spec();
+        let handle = sandbox_handle(&spec);
+        provider
+            .create(&spec, &NeverCancelled)
+            .expect("create exact Kubernetes resources");
+        mutate(&fake);
+
+        let error = provider.inspect(&handle, &NeverCancelled).expect_err(label);
+        assert_eq!(error.kind(), expected_kind, "{label}");
+        assert_eq!(error.stage(), ProviderStage::Inspect, "{label}");
+
+        let error = provider.attach(&handle, &NeverCancelled).expect_err(label);
+        assert_eq!(error.kind(), expected_kind, "{label}");
+        assert_eq!(error.stage(), ProviderStage::Attach, "{label}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inspection_detects_an_owned_policy_only_remnant() {
+    let fake = FakeKube::default();
+    let provider = test_provider(&fake);
+    let spec = sandbox_spec();
+    let handle = sandbox_handle(&spec);
+    provider
+        .create(&spec, &NeverCancelled)
+        .expect("seed exact Kubernetes resources");
+    fake.remove_pod();
+    let before = fake.request_count();
+
+    let error = provider
+        .inspect(&handle, &NeverCancelled)
+        .expect_err("policy-only remnant must not look absent");
+
+    assert_error(
+        &error,
+        ProviderErrorKind::InvalidState,
+        ProviderStage::Inspect,
+        OperationOutcome::KnownNoEffect,
+    );
+    let requests = fake.requests();
+    assert_eq!(requests[before..].len(), 2);
+    assert!(requests[before].uri.contains("/pods/"));
+    assert!(requests[before + 1].uri.contains("/networkpolicies/"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cleanup_uses_policy_ownership_not_current_deny_all_health() {
+    let fake = FakeKube::default();
+    let provider = test_provider(&fake);
+    let spec = sandbox_spec();
+    provider
+        .create(&spec, &NeverCancelled)
+        .expect("seed exact Kubernetes resources");
+    fake.replace_policy_spec();
+
+    assert_eq!(
+        provider
+            .destroy(&destroy_request(&spec), &NeverCancelled)
+            .expect("owned resources remain removable after policy spec drift"),
+        DestroyDisposition::Destroyed
+    );
+
+    let fake = FakeKube::default();
+    let provider = test_provider(&fake);
+    let spec = sandbox_spec();
+    provider
+        .create(&spec, &NeverCancelled)
+        .expect("seed exact Kubernetes resources");
+    fake.replace_policy_identity();
+    let before = fake.request_count();
+    let error = provider
+        .destroy(&destroy_request(&spec), &NeverCancelled)
+        .expect_err("foreign policy identity must reject cleanup before deletion");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert!(
+        fake.requests()[before..]
+            .iter()
+            .all(|request| request.method != Method::DELETE)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_destroy_custody_never_issues_a_delete() {
+    let fake = FakeKube::default();
+    let provider = test_provider(&fake);
+    let spec = sandbox_spec();
+    provider
+        .create(&spec, &NeverCancelled)
+        .expect("create exact Kubernetes resources");
+    let before = fake.request_count();
+    let SandboxCustody::Job { runner_id, .. } = spec.custody() else {
+        panic!("test spec uses job custody");
+    };
+
+    let error = provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                sandbox_handle(&spec),
+                spec.generation(),
+                SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(8).expect("non-zero slot"),
+                },
+            ),
+            &NeverCancelled,
+        )
+        .expect_err("wrong custody must not authorize Kubernetes deletion");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert!(
+        fake.requests()[before..]
+            .iter()
+            .all(|request| request.method != Method::DELETE)
+    );
+
+    provider
+        .destroy(&destroy_request(&spec), &NeverCancelled)
+        .expect("matching custody authorizes cleanup");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/automata-ci-sandbox-macos/src/persistence.rs
+++ b/crates/automata-ci-sandbox-macos/src/persistence.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use automata_ci_execution::{
-    DestroyDisposition, EnvironmentProfile, OperationId, SandboxGeneration,
+    DestroyDisposition, EnvironmentProfile, OperationId, SandboxCustody, SandboxGeneration,
 };
 use rustix::{
     fs::{self, FlockOperation, Mode, OFlags, fchmod, flock, fstat, openat},
@@ -16,13 +16,15 @@ use sha2::{Digest as _, Sha256};
 
 use crate::filesystem::SecureRoot;
 
-const LOCK_FILE_NAME: &str = ".automata-macos-virtualization-v1.lock";
-const JOURNAL_FILE_NAME: &str = ".automata-macos-virtualization-v1.events";
-const LEGACY_STATE_NAMES: [&str; 2] = [
+const LOCK_FILE_NAME: &str = ".automata-macos-virtualization-v2.lock";
+const JOURNAL_FILE_NAME: &str = ".automata-macos-virtualization-v2.events";
+const LEGACY_STATE_NAMES: [&str; 4] = [
+    ".automata-macos-virtualization-v1.lock",
+    ".automata-macos-virtualization-v1.events",
     ".automata-macos-provider-v1.lock",
     ".automata-macos-provider-v1.events",
 ];
-const DURABLE_SCHEMA: u32 = 1;
+const DURABLE_SCHEMA: u32 = 2;
 const MAX_EVENT_BYTES: usize = 64 * 1024;
 const MAX_JOURNAL_BYTES: u64 = 16 * 1024 * 1024;
 const FILE_MODE: Mode = Mode::from_raw_mode(0o600);
@@ -42,6 +44,7 @@ pub(crate) struct DurableCreate {
     pub(crate) operation_id: OperationId,
     pub(crate) fingerprint: [u8; 32],
     pub(crate) handle: String,
+    pub(crate) custody: SandboxCustody,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -50,6 +53,7 @@ pub(crate) struct DurableEntry {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
     pub(crate) workspace: String,
     pub(crate) scratch: String,
     pub(crate) phase: DurableEntryPhase,
@@ -70,6 +74,7 @@ pub(crate) struct DurableDestroyRequest {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -102,6 +107,7 @@ pub(crate) struct DurableTombstone {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
     pub(crate) completed_sequence: u64,
 }
 
@@ -337,18 +343,7 @@ fn apply_event(
     sequence: u64,
 ) -> io::Result<()> {
     match event {
-        DurableEvent::CreateIntent { create, entry } => {
-            if create.handle != entry.handle
-                || entry.phase != DurableEntryPhase::Intent
-                || snapshot.creates.contains_key(&create.operation_id)
-                || snapshot.entries.contains_key(&entry.handle)
-                || snapshot.tombstones.contains_key(&entry.handle)
-            {
-                return Err(invalid());
-            }
-            snapshot.creates.insert(create.operation_id, create.clone());
-            snapshot.entries.insert(entry.handle.clone(), entry.clone());
-        }
+        DurableEvent::CreateIntent { create, entry } => apply_create(snapshot, create, entry)?,
         DurableEvent::CreateReady { handle } => {
             let entry = snapshot.entries.get_mut(handle).ok_or_else(invalid)?;
             if entry.phase != DurableEntryPhase::Intent {
@@ -363,6 +358,7 @@ fn apply_event(
                 .ok_or_else(invalid)?;
             if entry.generation != request.generation
                 || entry.profile != request.profile
+                || entry.custody != request.custody
                 || entry.phase == DurableEntryPhase::Destroying
                 || snapshot
                     .pending_destroys
@@ -392,6 +388,7 @@ fn apply_event(
             if entry.phase != DurableEntryPhase::Destroying
                 || entry.generation != request.generation
                 || entry.profile != request.profile
+                || entry.custody != request.custody
             {
                 return Err(invalid());
             }
@@ -401,6 +398,7 @@ fn apply_event(
                     handle: request.handle.clone(),
                     generation: request.generation,
                     profile: request.profile.clone(),
+                    custody: request.custody,
                     completed_sequence: sequence,
                 },
             );
@@ -420,6 +418,7 @@ fn apply_event(
                 .ok_or_else(invalid)?;
             if tombstone.generation != request.generation
                 || tombstone.profile != request.profile
+                || tombstone.custody != request.custody
                 || snapshot.destroys.contains_key(&request.operation_id)
             {
                 return Err(invalid());
@@ -437,6 +436,25 @@ fn apply_event(
     Ok(())
 }
 
+fn apply_create(
+    snapshot: &mut DurableSnapshot,
+    create: &DurableCreate,
+    entry: &DurableEntry,
+) -> io::Result<()> {
+    if create.handle != entry.handle
+        || create.custody != entry.custody
+        || entry.phase != DurableEntryPhase::Intent
+        || snapshot.creates.contains_key(&create.operation_id)
+        || snapshot.entries.contains_key(&entry.handle)
+        || snapshot.tombstones.contains_key(&entry.handle)
+    {
+        return Err(invalid());
+    }
+    snapshot.creates.insert(create.operation_id, create.clone());
+    snapshot.entries.insert(entry.handle.clone(), entry.clone());
+    Ok(())
+}
+
 pub(crate) fn recovered_generation(value: u64) -> io::Result<SandboxGeneration> {
     SandboxGeneration::new(value).map_err(|_| invalid())
 }
@@ -450,10 +468,13 @@ mod tests {
     use std::{
         fs::{self, OpenOptions},
         io::Write as _,
+        num::NonZeroU16,
         path::PathBuf,
     };
 
-    use automata_ci_execution::{EnvironmentProfileId, Sha256Digest, TargetPath};
+    use automata_ci_execution::{
+        EnvironmentProfileId, RunnerId, SandboxCustody, Sha256Digest, TargetPath,
+    };
 
     use super::*;
 
@@ -471,17 +492,20 @@ mod tests {
         let operation_id = OperationId::new();
         let handle = OperationId::new().to_string();
         let profile = profile();
+        let custody = custody();
         journal
             .append(DurableEvent::CreateIntent {
                 create: DurableCreate {
                     operation_id,
                     fingerprint: [0x33; 32],
                     handle: handle.clone(),
+                    custody,
                 },
                 entry: DurableEntry {
                     handle: handle.clone(),
                     generation: 1,
                     profile,
+                    custody,
                     workspace: "/Users/automata-job/workspaces/job".to_owned(),
                     scratch: "/Users/automata-job/runner/job".to_owned(),
                     phase: DurableEntryPhase::Intent,
@@ -511,6 +535,14 @@ mod tests {
         );
         assert_eq!(
             snapshot
+                .entries
+                .get(&handle)
+                .expect("recovered entry")
+                .custody,
+            custody
+        );
+        assert_eq!(
+            snapshot
                 .creates
                 .get(&operation_id)
                 .expect("recovered create")
@@ -521,18 +553,17 @@ mod tests {
 
     #[test]
     fn legacy_native_state_is_rejected_without_migration() {
-        let fixture = TestRoot::new("legacy");
-        let root = fixture.secure_root();
-        fs::write(
-            fixture.path.join(LEGACY_STATE_NAMES[1]),
-            b"legacy native state\n",
-        )
-        .expect("write legacy marker");
-        assert!(matches!(
-            LifecycleJournal::open(&root),
-            Err(error) if error.kind() == io::ErrorKind::InvalidData
-        ));
-        assert!(!fixture.path.join(JOURNAL_FILE_NAME).exists());
+        for (ordinal, legacy_name) in LEGACY_STATE_NAMES.iter().enumerate() {
+            let fixture = TestRoot::new(&format!("legacy-{ordinal}"));
+            let root = fixture.secure_root();
+            fs::write(fixture.path.join(legacy_name), b"legacy native state\n")
+                .expect("write legacy marker");
+            assert!(matches!(
+                LifecycleJournal::open(&root),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData
+            ));
+            assert!(!fixture.path.join(JOURNAL_FILE_NAME).exists());
+        }
     }
 
     #[test]
@@ -541,6 +572,7 @@ mod tests {
         let root = fixture.secure_root();
         let (mut journal, mut snapshot) = LifecycleJournal::open(&root).expect("initialize WAL");
         let handle = "schema-test-handle".to_owned();
+        let custody = custody();
         journal
             .append_to_snapshot(
                 &mut snapshot,
@@ -549,11 +581,13 @@ mod tests {
                         operation_id: OperationId::new(),
                         fingerprint: [0x51; 32],
                         handle: handle.clone(),
+                        custody,
                     },
                     entry: DurableEntry {
                         handle,
                         generation: 1,
                         profile: profile(),
+                        custody,
                         workspace: "/Users/automata-job/workspaces/schema-test".to_owned(),
                         scratch: "/Users/automata-job/runner/schema-test".to_owned(),
                         phase: DurableEntryPhase::Intent,
@@ -567,14 +601,79 @@ mod tests {
         let current = fs::read_to_string(&journal_path).expect("current WAL");
         let current_schema = format!("\"schema\":{DURABLE_SCHEMA}");
         assert!(current.contains(&current_schema));
-        for schema in [0, DURABLE_SCHEMA.checked_add(1).expect("test schema")] {
+        for schema in [
+            0,
+            DURABLE_SCHEMA - 1,
+            DURABLE_SCHEMA.checked_add(1).expect("test schema"),
+        ] {
             let noncurrent = current.replacen(&current_schema, &format!("\"schema\":{schema}"), 1);
             fs::write(&journal_path, noncurrent).expect("write noncurrent WAL");
-            let error = match LifecycleJournal::open(&root) {
-                Ok(_) => panic!("accepted WAL schema {schema}"),
-                Err(error) => error,
+            let Err(error) = LifecycleJournal::open(&root) else {
+                panic!("accepted WAL schema {schema}");
             };
             assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn lifecycle_reopen_rejects_wrong_runner_and_slot_custody() {
+        let runner_id = RunnerId::new();
+        let expected = SandboxCustody::Job {
+            runner_id,
+            slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+        };
+        for (label, observed) in [
+            (
+                "runner",
+                SandboxCustody::Job {
+                    runner_id: RunnerId::new(),
+                    slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+                },
+            ),
+            (
+                "slot",
+                SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+                },
+            ),
+        ] {
+            let fixture = TestRoot::new(label);
+            let root = fixture.secure_root();
+            let operation_id = OperationId::new();
+            let handle = operation_id.to_string();
+            let event = DurableEvent::CreateIntent {
+                create: DurableCreate {
+                    operation_id,
+                    fingerprint: [0x73; 32],
+                    handle: handle.clone(),
+                    custody: expected,
+                },
+                entry: DurableEntry {
+                    handle,
+                    generation: 1,
+                    profile: profile(),
+                    custody: observed,
+                    workspace: "/Users/automata-job/workspaces/custody".to_owned(),
+                    scratch: "/Users/automata-job/runner/custody".to_owned(),
+                    phase: DurableEntryPhase::Intent,
+                },
+            };
+            let sequence = 1;
+            let mut bytes = serde_json::to_vec(&EventRecord {
+                schema: DURABLE_SCHEMA,
+                sequence,
+                checksum: checksum(sequence, &event).expect("event checksum"),
+                event,
+            })
+            .expect("event record");
+            bytes.push(b'\n');
+            fs::write(fixture.path.join(JOURNAL_FILE_NAME), bytes).expect("write journal");
+
+            assert!(matches!(
+                LifecycleJournal::open(&root),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData
+            ));
         }
     }
 
@@ -583,6 +682,12 @@ mod tests {
             EnvironmentProfileId::new("automata.dev/macos-15-arm64-vm-v1").expect("profile ID"),
             Sha256Digest::from_bytes([0x55; 32]),
         )
+    }
+
+    fn custody() -> SandboxCustody {
+        SandboxCustody::ProfileAdmission {
+            runner_id: RunnerId::new(),
+        }
     }
 
     struct TestRoot {

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -14,9 +14,9 @@ use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, EnvironmentProfile, ExecutionEndpoint,
     NetworkPolicy, OperationId, OperationOutcome, ProviderCapabilities, ProviderError,
     ProviderErrorKind, ProviderId, ProviderStage, ResourceLimits, RootFilesystemPolicy,
-    SandboxCapability, SandboxGeneration, SandboxHandle, SandboxInspection, SandboxLaunch,
-    SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
-    Sha256Digest, TargetPath, TargetPlatform,
+    SandboxCapability, SandboxCustody, SandboxGeneration, SandboxHandle, SandboxInspection,
+    SandboxLaunch, SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec,
+    SandboxState, Sha256Digest, TargetPath, TargetPlatform,
 };
 use serde::de::DeserializeOwned;
 use sha2::{Digest as _, Sha256};
@@ -365,6 +365,7 @@ pub(crate) struct SandboxEntry {
     pub(crate) handle: SandboxHandle,
     pub(crate) generation: SandboxGeneration,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
     pub(crate) workspace: TargetPath,
     pub(crate) scratch: TargetPath,
     pub(crate) operation_lock: Mutex<()>,
@@ -404,6 +405,7 @@ impl SandboxEntry {
         Ok(SandboxInspection::new(
             self.handle.clone(),
             self.generation,
+            self.custody,
             self.profile.clone(),
             self.state().map_err(|()| local(ProviderStage::Inspect))?,
         ))
@@ -447,7 +449,7 @@ impl ProviderInner {
         let fingerprint = spec_fingerprint(spec)?;
         let mut state = self.lock_state(ProviderStage::CreateSandbox)?;
         if let Some(replay) = state.create_operations.get(&spec.operation_id()) {
-            if replay.fingerprint != fingerprint {
+            if replay.fingerprint != fingerprint || replay.custody != spec.custody() {
                 return Err(known(ProviderErrorKind::Conflict, ProviderStage::Validate));
             }
             if let Some(entry) = state.entries.get(&replay.handle).cloned() {
@@ -491,6 +493,7 @@ impl ProviderInner {
             handle: handle.clone(),
             generation: spec.generation(),
             profile: spec.profile().attestation().clone(),
+            custody: spec.custody(),
             workspace: spec.workspace().clone(),
             scratch: scratch.clone(),
             operation_lock: Mutex::new(()),
@@ -504,6 +507,7 @@ impl ProviderInner {
                 operation_id: spec.operation_id(),
                 fingerprint,
                 handle: handle.opaque().to_owned(),
+                custody: spec.custody(),
             },
             entry: durable_entry(&entry, DurableEntryPhase::Intent),
         };
@@ -519,6 +523,7 @@ impl ProviderInner {
             CreateReplay {
                 fingerprint,
                 handle: handle.clone(),
+                custody: spec.custody(),
             },
         );
         state.entries.insert(handle, Arc::clone(&entry));
@@ -567,6 +572,7 @@ impl ProviderInner {
             .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::Inspect))
     }
 
+    #[allow(clippy::too_many_lines)]
     fn destroy(
         &self,
         request: &DestroySandbox,
@@ -614,7 +620,9 @@ impl ProviderInner {
             ));
         }
         if let Some(tombstone) = state.tombstones.get(request.handle()) {
-            if tombstone.generation != request.generation() {
+            if tombstone.generation != request.generation()
+                || tombstone.custody != request.custody()
+            {
                 return Err(known(
                     ProviderErrorKind::OwnershipMismatch,
                     ProviderStage::VerifyOwnership,
@@ -644,7 +652,7 @@ impl ProviderInner {
             .get(request.handle())
             .cloned()
             .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::VerifyOwnership))?;
-        if entry.generation != request.generation() {
+        if entry.generation != request.generation() || entry.custody != request.custody() {
             return Err(known(
                 ProviderErrorKind::OwnershipMismatch,
                 ProviderStage::VerifyOwnership,
@@ -696,6 +704,7 @@ fn complete_destroy(
 ) -> Result<DestroyDisposition, ProviderError> {
     if pending.request.handle() != &entry.handle
         || pending.request.generation() != entry.generation
+        || pending.request.custody() != entry.custody
         || pending.profile != entry.profile
     {
         return Err(invalid_journal());
@@ -741,6 +750,7 @@ fn complete_destroy(
             handle: entry.handle.clone(),
             generation: entry.generation,
             profile: entry.profile.clone(),
+            custody: entry.custody,
         },
     );
     state.destroy_operations.insert(
@@ -766,6 +776,7 @@ struct ProviderState {
 struct CreateReplay {
     fingerprint: [u8; 32],
     handle: SandboxHandle,
+    custody: SandboxCustody,
 }
 
 #[derive(Clone)]
@@ -783,6 +794,7 @@ struct Tombstone {
     handle: SandboxHandle,
     generation: SandboxGeneration,
     profile: EnvironmentProfile,
+    custody: SandboxCustody,
 }
 
 impl Tombstone {
@@ -790,6 +802,7 @@ impl Tombstone {
         SandboxInspection::new(
             self.handle.clone(),
             self.generation,
+            self.custody,
             self.profile.clone(),
             SandboxState::Absent,
         )
@@ -926,7 +939,8 @@ fn validate_spec(
 
 fn spec_fingerprint(spec: &SandboxSpec) -> Result<[u8; 32], ProviderError> {
     let mut digest = Sha256::new();
-    fingerprint_field(&mut digest, b"automata-macos-virtualization-spec-v1");
+    fingerprint_field(&mut digest, b"automata-macos-virtualization-spec-v2");
+    fingerprint_custody(&mut digest, spec.custody());
     fingerprint_field(&mut digest, &spec.generation().get().to_le_bytes());
     fingerprint_field(
         &mut digest,
@@ -971,6 +985,23 @@ fn spec_fingerprint(spec: &SandboxSpec) -> Result<[u8; 32], ProviderError> {
     Ok(digest.finalize().into())
 }
 
+fn fingerprint_custody(digest: &mut Sha256, custody: SandboxCustody) {
+    match custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            fingerprint_field(digest, b"profile-admission");
+            fingerprint_field(digest, runner_id.as_uuid().as_bytes());
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => {
+            fingerprint_field(digest, b"job");
+            fingerprint_field(digest, runner_id.as_uuid().as_bytes());
+            fingerprint_field(digest, &slot_ordinal.get().to_be_bytes());
+        }
+    }
+}
+
 fn fingerprint_field(digest: &mut Sha256, value: &[u8]) {
     digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
     digest.update(value);
@@ -981,6 +1012,7 @@ fn durable_entry(entry: &SandboxEntry, phase: DurableEntryPhase) -> DurableEntry
         handle: entry.handle.opaque().to_owned(),
         generation: entry.generation.get(),
         profile: entry.profile.clone(),
+        custody: entry.custody,
         workspace: entry.workspace.as_str().to_owned(),
         scratch: entry.scratch.as_str().to_owned(),
         phase,
@@ -996,6 +1028,7 @@ fn durable_destroy_request(
         handle: request.handle().opaque().to_owned(),
         generation: request.generation().get(),
         profile: profile.clone(),
+        custody: request.custody(),
     }
 }
 
@@ -1027,7 +1060,17 @@ fn restore_state(
     }
     for durable in snapshot.creates.into_values() {
         let handle = recovered_handle(provider_id, &durable.handle)?;
-        if !(state.entries.contains_key(&handle) || state.tombstones.contains_key(&handle))
+        let observed_custody = state
+            .entries
+            .get(&handle)
+            .map(|entry| entry.custody)
+            .or_else(|| {
+                state
+                    .tombstones
+                    .get(&handle)
+                    .map(|tombstone| tombstone.custody)
+            });
+        if observed_custody != Some(durable.custody)
             || state
                 .create_operations
                 .insert(
@@ -1035,6 +1078,7 @@ fn restore_state(
                     CreateReplay {
                         fingerprint: durable.fingerprint,
                         handle,
+                        custody: durable.custody,
                     },
                 )
                 .is_some()
@@ -1048,6 +1092,7 @@ fn restore_state(
             durable.request.operation_id,
             handle,
             recovered_generation(durable.request.generation).map_err(|_| invalid_journal())?,
+            durable.request.custody,
         );
         if state
             .destroy_operations
@@ -1110,6 +1155,7 @@ fn reconcile_orphans(
                 handle: entry.handle.clone(),
                 generation: entry.generation,
                 profile: entry.profile.clone(),
+                custody: entry.custody,
             };
             journal
                 .append_to_snapshot(
@@ -1146,6 +1192,7 @@ fn restored_tombstone(
         handle: recovered_handle(provider_id, &durable.handle)?,
         generation: recovered_generation(durable.generation).map_err(|_| invalid_journal())?,
         profile: durable.profile,
+        custody: durable.custody,
     })
 }
 

--- a/crates/automata-ci-sandbox-podman/src/naming.rs
+++ b/crates/automata-ci-sandbox-podman/src/naming.rs
@@ -1,14 +1,16 @@
-use std::{fmt::Write as _, str::FromStr as _};
+use std::{fmt::Write as _, num::NonZeroU16, str::FromStr as _};
 
 use automata_ci_execution::{
-    EnvironmentProfile, EnvironmentProfileId, OperationId, ProviderId, SandboxGeneration,
-    SandboxHandle, Sha256Digest,
+    EnvironmentProfile, EnvironmentProfileId, OperationId, ProviderId, RunnerId, SandboxCustody,
+    SandboxGeneration, SandboxHandle, Sha256Digest,
 };
 
 use crate::{PODMAN_PROVIDER_ID, provider_error};
 use sha2::{Digest as _, Sha256};
 
-const HANDLE_VERSION: &str = "p1";
+const HANDLE_VERSION: &str = "p2";
+const RESOURCE_SCHEMA_LABEL_KEY: &str = "io.automata.sandbox-schema";
+const RESOURCE_SCHEMA: &str = "2";
 const OWNER_LABEL_KEY: &str = "io.automata.owner";
 const OWNER_LABEL_VALUE: &str = "automata-runner";
 const SANDBOX_LABEL_KEY: &str = "io.automata.sandbox";
@@ -16,6 +18,9 @@ const GENERATION_LABEL_KEY: &str = "io.automata.generation";
 const PROFILE_LABEL_KEY: &str = "io.automata.profile";
 const PROFILE_DIGEST_LABEL_KEY: &str = "io.automata.profile-sha256";
 const SPEC_LABEL_KEY: &str = "io.automata.spec-sha256";
+const CUSTODY_KIND_LABEL_KEY: &str = "io.automata.custody-kind";
+const CUSTODY_RUNNER_LABEL_KEY: &str = "io.automata.custody-runner";
+const CUSTODY_SLOT_LABEL_KEY: &str = "io.automata.custody-slot";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ResourceNames {
@@ -139,21 +144,36 @@ impl ResourceNames {
         &self,
         profile: &EnvironmentProfile,
         spec_fingerprint: &str,
+        custody: SandboxCustody,
     ) -> Vec<String> {
+        let (custody_kind, custody_runner, custody_slot) = match custody {
+            SandboxCustody::ProfileAdmission { runner_id } => {
+                ("profile-admission", runner_id.to_string(), "0".to_owned())
+            }
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal,
+            } => ("job", runner_id.to_string(), slot_ordinal.get().to_string()),
+        };
         vec![
             format!("{OWNER_LABEL_KEY}={OWNER_LABEL_VALUE}"),
+            format!("{RESOURCE_SCHEMA_LABEL_KEY}={RESOURCE_SCHEMA}"),
             format!("{SANDBOX_LABEL_KEY}={}", self.identifier),
             format!("{GENERATION_LABEL_KEY}={}", self.generation.get()),
             format!("{PROFILE_LABEL_KEY}={}", profile.id().as_str()),
             format!("{PROFILE_DIGEST_LABEL_KEY}={}", profile.digest()),
             format!("{SPEC_LABEL_KEY}={spec_fingerprint}"),
+            format!("{CUSTODY_KIND_LABEL_KEY}={custody_kind}"),
+            format!("{CUSTODY_RUNNER_LABEL_KEY}={custody_runner}"),
+            format!("{CUSTODY_SLOT_LABEL_KEY}={custody_slot}"),
         ]
     }
 
-    pub(crate) fn expected_ownership(&self) -> OwnershipLabels {
+    pub(crate) fn expected_ownership(&self, custody: SandboxCustody) -> OwnershipLabels {
         OwnershipLabels {
             sandbox: self.identifier.clone(),
             generation: self.generation.get().to_string(),
+            custody,
         }
     }
 }
@@ -162,24 +182,29 @@ impl ResourceNames {
 pub(crate) struct OwnershipLabels {
     sandbox: String,
     generation: String,
+    custody: SandboxCustody,
 }
 
 impl OwnershipLabels {
     pub(crate) fn matches(&self, inspection: &InspectedLabels) -> bool {
         inspection.owner == OWNER_LABEL_VALUE
+            && inspection.schema == RESOURCE_SCHEMA
             && inspection.sandbox == self.sandbox
             && inspection.generation == self.generation
+            && inspection.custody == self.custody
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct InspectedLabels {
     owner: String,
+    schema: String,
     sandbox: String,
     generation: String,
     profile: String,
     profile_digest: String,
     spec_fingerprint: String,
+    custody: SandboxCustody,
     state: Option<String>,
 }
 
@@ -188,16 +213,21 @@ impl InspectedLabels {
         let value = std::str::from_utf8(bytes).ok()?;
         let mut lines = value.lines();
         let owner = lines.next()?.to_owned();
+        let schema = lines.next()?.to_owned();
         let sandbox = lines.next()?.to_owned();
         let generation = lines.next()?.to_owned();
         let profile = lines.next()?.to_owned();
         let profile_digest = lines.next()?.to_owned();
         let spec_fingerprint = lines.next()?.to_owned();
+        let custody_kind = lines.next()?;
+        let custody_runner = lines.next()?;
+        let custody_slot = lines.next()?;
         let state = includes_state
             .then(|| lines.next().map(str::to_owned))
             .flatten();
         if lines.next().is_some()
             || owner.len() > 64
+            || schema != RESOURCE_SCHEMA
             || sandbox.len() > 64
             || generation.len() > 32
             || profile.len() > 128
@@ -213,13 +243,25 @@ impl InspectedLabels {
         {
             return None;
         }
+        let runner_id = RunnerId::from_str(custody_runner).ok()?;
+        let slot = custody_slot.parse::<u16>().ok()?;
+        let custody = match custody_kind {
+            "profile-admission" if slot == 0 => SandboxCustody::ProfileAdmission { runner_id },
+            "job" => SandboxCustody::Job {
+                runner_id,
+                slot_ordinal: NonZeroU16::new(slot)?,
+            },
+            _ => return None,
+        };
         Some(Self {
             owner,
+            schema,
             sandbox,
             generation,
             profile,
             profile_digest,
             spec_fingerprint,
+            custody,
             state,
         })
     }
@@ -237,6 +279,10 @@ impl InspectedLabels {
     pub(crate) fn spec_fingerprint(&self) -> &str {
         &self.spec_fingerprint
     }
+
+    pub(crate) const fn custody(&self) -> SandboxCustody {
+        self.custody
+    }
 }
 
 pub(crate) fn label_format(container: bool, include_state: bool) -> String {
@@ -247,11 +293,15 @@ pub(crate) fn label_format(container: bool, include_state: bool) -> String {
     };
     let mut format = format!(
         "{{{{ index {prefix} \"{OWNER_LABEL_KEY}\" }}}}\n\
+         {{{{ index {prefix} \"{RESOURCE_SCHEMA_LABEL_KEY}\" }}}}\n\
          {{{{ index {prefix} \"{SANDBOX_LABEL_KEY}\" }}}}\n\
          {{{{ index {prefix} \"{GENERATION_LABEL_KEY}\" }}}}\n\
          {{{{ index {prefix} \"{PROFILE_LABEL_KEY}\" }}}}\n\
          {{{{ index {prefix} \"{PROFILE_DIGEST_LABEL_KEY}\" }}}}\n\
-         {{{{ index {prefix} \"{SPEC_LABEL_KEY}\" }}}}"
+         {{{{ index {prefix} \"{SPEC_LABEL_KEY}\" }}}}\n\
+         {{{{ index {prefix} \"{CUSTODY_KIND_LABEL_KEY}\" }}}}\n\
+         {{{{ index {prefix} \"{CUSTODY_RUNNER_LABEL_KEY}\" }}}}\n\
+         {{{{ index {prefix} \"{CUSTODY_SLOT_LABEL_KEY}\" }}}}"
     );
     if include_state {
         format.push_str("\n{{.State.Status}}");
@@ -272,7 +322,7 @@ mod tests {
         )
         .handle();
 
-        for version in ["p0", "p2"] {
+        for version in ["p0", "p1", "p3"] {
             let opaque = current.opaque().replacen(HANDLE_VERSION, version, 1);
             let handle = SandboxHandle::new(provider.clone(), opaque).expect("well-formed handle");
             assert!(

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -14,10 +14,10 @@ use automata_ci_execution::{
     Cancellation, ContainerHandle, DestroyDisposition, DestroySandbox, EnvironmentProfile,
     ExecutionEnvironment, NetworkPolicy, NeverCancelled, OperationOutcome, ProviderCapabilities,
     ProviderError, ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy,
-    SandboxCapability, SandboxHandle, SandboxInspection, SandboxPrivilegePolicy, SandboxProvider,
-    SandboxRecord, SandboxSpec, SandboxState, ServiceContainerBinding, ServiceContainerBindings,
-    ServiceContainerSpec, ServiceHealthPolicy, ServiceNetwork, ServicePortBinding,
-    ServiceTransportProtocol,
+    SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection, SandboxPrivilegePolicy,
+    SandboxProvider, SandboxRecord, SandboxSpec, SandboxState, ServiceContainerBinding,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceHealthPolicy, ServiceNetwork,
+    ServicePortBinding, ServiceTransportProtocol,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -433,12 +433,19 @@ impl PodmanInner {
             self.options.service_proxy_image(),
             self.options.buildkit_runtime(),
         );
-        let labels = names.labels(spec.profile().attestation(), &fingerprint);
+        let labels = names.labels(spec.profile().attestation(), &fingerprint, spec.custody());
         let labels = ProvisionLabels {
             arguments: &labels,
             fingerprint: &fingerprint,
+            custody: spec.custody(),
         };
-        self.reject_conflicting_replay(&names, &fingerprint, deadline, cancellation)?;
+        self.reject_conflicting_replay(
+            &names,
+            &fingerprint,
+            spec.custody(),
+            deadline,
+            cancellation,
+        )?;
         let mut service_manifest = self.prepare_service_manifest(spec, &names, &fingerprint)?;
 
         let workspace = self
@@ -520,6 +527,11 @@ impl PodmanInner {
             cancellation,
         )?;
         let inspection = self.inspect_with_deadline(&handle, deadline, cancellation)?;
+        if inspection.custody() != spec.custody() {
+            return Err(provider_error::ownership_mismatch(
+                ProviderStage::VerifyOwnership,
+            ));
+        }
         finish_create(&inspection, handle)
     }
 
@@ -589,6 +601,7 @@ impl PodmanInner {
         let manifest = ServiceManifest::from_specs(
             names,
             fingerprint,
+            spec.custody(),
             resources.pids(),
             spec.services(),
             self.options.service_proxy_image(),
@@ -702,6 +715,7 @@ impl PodmanInner {
                     entry,
                     names,
                     labels.fingerprint,
+                    labels.custody,
                     deadline,
                     cancellation,
                 )?;
@@ -711,6 +725,7 @@ impl PodmanInner {
                     entry,
                     names,
                     labels.fingerprint,
+                    labels.custody,
                     service_cgroup
                         .as_deref()
                         .ok_or_else(|| provider_error::invalid_state(ProviderStage::Start))?,
@@ -720,7 +735,14 @@ impl PodmanInner {
                 )?;
             }
             for entry in manifest.entries() {
-                self.wait_for_service(entry, names, labels.fingerprint, deadline, cancellation)?;
+                self.wait_for_service(
+                    entry,
+                    names,
+                    labels.fingerprint,
+                    labels.custody,
+                    deadline,
+                    cancellation,
+                )?;
             }
             if manifest.port_count() != 0 {
                 self.ensure_service_proxy(
@@ -759,6 +781,7 @@ impl PodmanInner {
                     entry,
                     names,
                     labels.fingerprint,
+                    labels.custody,
                     deadline,
                     cancellation,
                     ProviderStage::VerifyOwnership,
@@ -785,6 +808,7 @@ impl PodmanInner {
                     entry,
                     names,
                     labels.fingerprint,
+                    labels.custody,
                     deadline,
                     cancellation,
                     ProviderStage::VerifyOwnership,
@@ -877,6 +901,7 @@ impl PodmanInner {
             entry,
             names,
             labels.fingerprint,
+            labels.custody,
             deadline,
             cancellation,
             ProviderStage::VerifyOwnership,
@@ -912,6 +937,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
@@ -919,6 +945,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             ProviderStage::Start,
@@ -944,6 +971,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
@@ -966,6 +994,7 @@ impl PodmanInner {
                 entry,
                 names,
                 fingerprint,
+                custody,
                 deadline,
                 cancellation,
                 ProviderStage::Start,
@@ -987,6 +1016,7 @@ impl PodmanInner {
                                 entry,
                                 names,
                                 fingerprint,
+                                custody,
                                 deadline,
                                 cancellation,
                             )?;
@@ -997,6 +1027,7 @@ impl PodmanInner {
                             entry,
                             names,
                             fingerprint,
+                            custody,
                             deadline,
                             cancellation,
                         )?;
@@ -1019,6 +1050,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<Duration, ProviderError> {
@@ -1026,6 +1058,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             ProviderStage::Start,
@@ -1048,6 +1081,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
@@ -1055,6 +1089,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             ProviderStage::Start,
@@ -1075,6 +1110,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         pod_cgroup: &str,
         aggregate_pids: u32,
         deadline: Instant,
@@ -1084,6 +1120,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             ProviderStage::Start,
@@ -1136,11 +1173,13 @@ impl PodmanInner {
         parse_process_id(output.stdout()).ok_or_else(|| provider_error::invalid_state(stage))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn service_readiness(
         &self,
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -1153,7 +1192,7 @@ impl PodmanInner {
         else {
             return Ok(ServiceReadiness::Failed);
         };
-        if !names.expected_ownership().matches(&inspection)
+        if !names.expected_ownership(custody).matches(&inspection)
             || inspection.spec_fingerprint() != fingerprint
         {
             return Err(provider_error::ownership_mismatch(
@@ -1166,7 +1205,7 @@ impl PodmanInner {
             return Ok(ServiceReadiness::Failed);
         };
         if named_container.identifier() != inspection.identifier()
-            || !names.expected_ownership().matches(&named_container)
+            || !names.expected_ownership(custody).matches(&named_container)
             || named_container.spec_fingerprint() != fingerprint
         {
             return Err(provider_error::ownership_mismatch(
@@ -1193,11 +1232,13 @@ impl PodmanInner {
             .ok_or_else(|| provider_error::invalid_state(stage))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn verify_service_for_spec(
         &self,
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -1208,6 +1249,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             stage,
@@ -1221,6 +1263,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -1230,6 +1273,7 @@ impl PodmanInner {
             entry,
             names,
             fingerprint,
+            custody,
             deadline,
             cancellation,
             stage,
@@ -1260,6 +1304,7 @@ impl PodmanInner {
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -1267,7 +1312,7 @@ impl PodmanInner {
         let inspection = self
             .inspect_named_container(token, deadline, cancellation, stage)?
             .ok_or_else(|| provider_error::invalid_state(stage))?;
-        if !names.expected_ownership().matches(&inspection)
+        if !names.expected_ownership(custody).matches(&inspection)
             || inspection.spec_fingerprint() != fingerprint
         {
             return Err(provider_error::ownership_mismatch(
@@ -1278,7 +1323,7 @@ impl PodmanInner {
             .inspect_named_container(entry.container(), deadline, cancellation, stage)?
             .ok_or_else(|| provider_error::invalid_state(stage))?;
         if named_container.identifier() != inspection.identifier()
-            || !names.expected_ownership().matches(&named_container)
+            || !names.expected_ownership(custody).matches(&named_container)
             || named_container.spec_fingerprint() != fingerprint
         {
             return Err(provider_error::ownership_mismatch(
@@ -1381,7 +1426,7 @@ impl PodmanInner {
                 ProviderStage::CreateContainer,
             )?
             .ok_or_else(|| provider_error::invalid_state(ProviderStage::CreateContainer))?;
-        if !names.expected_ownership().matches(&primary)
+        if !names.expected_ownership(labels.custody).matches(&primary)
             || primary.spec_fingerprint() != manifest.fingerprint()
             || primary.state() != Some("running")
         {
@@ -1398,7 +1443,7 @@ impl PodmanInner {
                 ProviderStage::CreateContainer,
             )?
             .ok_or_else(|| provider_error::invalid_state(ProviderStage::CreateContainer))?;
-        if !names.expected_ownership().matches(&pod)
+        if !names.expected_ownership(labels.custody).matches(&pod)
             || pod.spec_fingerprint() != manifest.fingerprint()
         {
             return Err(provider_error::ownership_mismatch(
@@ -1411,6 +1456,7 @@ impl PodmanInner {
             pod.identifier(),
             names,
             manifest.fingerprint(),
+            manifest.custody(),
             deadline,
             cancellation,
             ProviderStage::VerifyOwnership,
@@ -1422,6 +1468,7 @@ impl PodmanInner {
                 &entry,
                 names,
                 manifest.fingerprint(),
+                manifest.custody(),
                 deadline,
                 cancellation,
                 ProviderStage::CreateContainer,
@@ -1534,11 +1581,12 @@ impl PodmanInner {
 
         let proxy = match existing {
             Some(proxy) if proxy.state() == Some("running") => proxy,
-            Some(proxy) => {
-                self.remove_verified_proxy_container(
-                    &proxy,
-                    manifest,
+            Some(_) => {
+                let _removed = self.remove_manifest_containers(
+                    proxy_container_tokens(manifest),
                     names,
+                    manifest.fingerprint(),
+                    manifest.custody(),
                     deadline,
                     cancellation,
                 )?;
@@ -1731,7 +1779,9 @@ impl PodmanInner {
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
     ) -> Result<InspectedServiceContainer, ProviderError> {
-        if !names.expected_ownership().matches(&inspection)
+        if !names
+            .expected_ownership(manifest.custody())
+            .matches(&inspection)
             || inspection.spec_fingerprint() != manifest.fingerprint()
         {
             return Err(provider_error::ownership_mismatch(
@@ -1791,7 +1841,9 @@ impl PodmanInner {
             .inspect_named_container(manifest.proxy_container(), deadline, cancellation, stage)?
             .ok_or_else(|| provider_error::invalid_state(stage))?;
         if stable.identifier() != inspection.identifier()
-            || !names.expected_ownership().matches(&stable)
+            || !names
+                .expected_ownership(manifest.custody())
+                .matches(&stable)
             || stable.spec_fingerprint() != manifest.fingerprint()
         {
             return Err(provider_error::ownership_mismatch(
@@ -1809,6 +1861,7 @@ impl PodmanInner {
         expected_pod: &str,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -1835,7 +1888,7 @@ impl PodmanInner {
             .ok_or_else(|| provider_error::invalid_state(stage))?;
         if actual_pod != Some(expected_pod)
             || stable.identifier() != inspection.identifier()
-            || !names.expected_ownership().matches(&stable)
+            || !names.expected_ownership(custody).matches(&stable)
             || stable.spec_fingerprint() != fingerprint
         {
             return Err(provider_error::ownership_mismatch(
@@ -1912,7 +1965,9 @@ impl PodmanInner {
         let primary = self
             .inspect_named_container(&names.container(), deadline, cancellation, stage)?
             .ok_or_else(|| provider_error::invalid_state(stage))?;
-        if !names.expected_ownership().matches(&primary)
+        if !names
+            .expected_ownership(manifest.custody())
+            .matches(&primary)
             || primary.spec_fingerprint() != manifest.fingerprint()
             || primary.state() != Some("running")
         {
@@ -1923,7 +1978,7 @@ impl PodmanInner {
         let pod = self
             .inspect_resource(ResourceKind::Pod, names, deadline, cancellation, stage)?
             .ok_or_else(|| provider_error::invalid_state(stage))?;
-        if !names.expected_ownership().matches(&pod)
+        if !names.expected_ownership(manifest.custody()).matches(&pod)
             || pod.spec_fingerprint() != manifest.fingerprint()
         {
             return Err(provider_error::ownership_mismatch(
@@ -1936,6 +1991,7 @@ impl PodmanInner {
             pod.identifier(),
             names,
             manifest.fingerprint(),
+            manifest.custody(),
             deadline,
             cancellation,
             ProviderStage::VerifyOwnership,
@@ -2034,6 +2090,7 @@ impl PodmanInner {
                 entry,
                 names,
                 manifest.fingerprint(),
+                manifest.custody(),
                 deadline,
                 cancellation,
                 ProviderStage::Inspect,
@@ -2045,6 +2102,7 @@ impl PodmanInner {
                 entry,
                 names,
                 manifest.fingerprint(),
+                manifest.custody(),
                 deadline,
                 cancellation,
                 ProviderStage::Inspect,
@@ -2078,6 +2136,7 @@ impl PodmanInner {
         self.inspect_with_deadline(handle, self.operation_deadline(), cancellation)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn inspect_with_deadline(
         &self,
         handle: &SandboxHandle,
@@ -2108,12 +2167,27 @@ impl PodmanInner {
         )?;
         let present = [network.as_ref(), pod.as_ref(), container.as_ref()];
         if present.iter().all(Option::is_none) {
+            if let Some(manifest) = self.load_service_manifest(&names, ProviderStage::Inspect)? {
+                let subordinates_present = self.verify_manifest_subordinate_ownership(
+                    &manifest,
+                    &names,
+                    manifest.custody(),
+                    deadline,
+                    cancellation,
+                    ProviderStage::Inspect,
+                )?;
+                if subordinates_present {
+                    return Err(provider_error::invalid_state(ProviderStage::Inspect));
+                }
+            }
             return Err(provider_error::known(
                 ProviderErrorKind::NotFound,
                 ProviderStage::Inspect,
             ));
         }
-        let expected = names.expected_ownership();
+        let labels = [network.as_deref(), pod.as_deref(), container.as_deref()];
+        let custody = consistent_custody(labels)?;
+        let expected = names.expected_ownership(custody);
         if present
             .iter()
             .flatten()
@@ -2121,7 +2195,6 @@ impl PodmanInner {
         {
             return Err(provider_error::ownership_mismatch(ProviderStage::Inspect));
         }
-        let labels = [network.as_deref(), pod.as_deref(), container.as_deref()];
         let profile = consistent_profile(labels)?;
         let core_fingerprint = ensure_consistent_fingerprint(labels)?;
         let workspace = self
@@ -2137,15 +2210,24 @@ impl PodmanInner {
         let manifest = self
             .load_service_manifest(&names, ProviderStage::Inspect)?
             .ok_or_else(|| provider_error::invalid_state(ProviderStage::Inspect))?;
-        if manifest.fingerprint() != core_fingerprint {
+        if manifest.fingerprint() != core_fingerprint || manifest.custody() != custody {
             return Err(provider_error::invalid_state(ProviderStage::Inspect));
         }
+        self.verify_manifest_subordinate_ownership(
+            &manifest,
+            &names,
+            custody,
+            deadline,
+            cancellation,
+            ProviderStage::Inspect,
+        )?;
         if state == SandboxState::Running {
             for entry in manifest.entries() {
                 if self.service_readiness(
                     entry,
                     &names,
                     manifest.fingerprint(),
+                    manifest.custody(),
                     deadline,
                     cancellation,
                     ProviderStage::Inspect,
@@ -2174,11 +2256,13 @@ impl PodmanInner {
         Ok(SandboxInspection::new(
             handle.clone(),
             names.generation(),
+            custody,
             profile,
             state,
         ))
     }
 
+    #[allow(clippy::too_many_lines)]
     fn destroy(
         &self,
         request: &DestroySandbox,
@@ -2192,8 +2276,18 @@ impl PodmanInner {
             ));
         }
         let deadline = self.operation_deadline();
+        let manifest = self.load_service_manifest(&names, ProviderStage::DestroyContainer)?;
+        if !self.verify_destroy_authority(
+            request,
+            &names,
+            manifest.as_ref(),
+            deadline,
+            cancellation,
+        )? {
+            return Ok(DestroyDisposition::AlreadyAbsent);
+        }
         let (manifest, mut removed) =
-            self.remove_services_for_destroy(request, &names, deadline, cancellation)?;
+            self.remove_services_for_destroy(request, &names, manifest, deadline, cancellation)?;
         fence_destroy_result(
             self.stop_job_docker_service(&names),
             removed,
@@ -2207,19 +2301,37 @@ impl PodmanInner {
             )?;
         }
         let primary = fence_destroy_result(
-            self.remove_exact(ResourceKind::Container, &names, deadline, cancellation),
+            self.remove_exact(
+                ResourceKind::Container,
+                &names,
+                request.custody(),
+                deadline,
+                cancellation,
+            ),
             removed,
             request.handle(),
         )?;
         removed |= primary;
         let pod = fence_destroy_result(
-            self.remove_exact(ResourceKind::Pod, &names, deadline, cancellation),
+            self.remove_exact(
+                ResourceKind::Pod,
+                &names,
+                request.custody(),
+                deadline,
+                cancellation,
+            ),
             removed,
             request.handle(),
         )?;
         removed |= pod;
         let network = fence_destroy_result(
-            self.remove_exact(ResourceKind::Network, &names, deadline, cancellation),
+            self.remove_exact(
+                ResourceKind::Network,
+                &names,
+                request.custody(),
+                deadline,
+                cancellation,
+            ),
             removed,
             request.handle(),
         )?;
@@ -2265,10 +2377,10 @@ impl PodmanInner {
         &self,
         request: &DestroySandbox,
         names: &ResourceNames,
+        manifest: Option<ServiceManifest>,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(Option<ServiceManifest>, bool), ProviderError> {
-        let manifest = self.load_service_manifest(names, ProviderStage::DestroyContainer)?;
         let Some(current) = manifest.as_ref() else {
             // A crash may leave any subset of the core sandbox resources after
             // the service manifest has disappeared. The main destroy path
@@ -2280,6 +2392,7 @@ impl PodmanInner {
         self.verify_manifest_core_fingerprint(
             names,
             current.fingerprint(),
+            request.custody(),
             deadline,
             cancellation,
             ProviderStage::DestroyContainer,
@@ -2291,6 +2404,7 @@ impl PodmanInner {
                 entry,
                 names,
                 current.fingerprint(),
+                request.custody(),
                 deadline,
                 cancellation,
             ) {
@@ -2304,6 +2418,103 @@ impl PodmanInner {
         Ok((manifest, removed))
     }
 
+    fn verify_destroy_authority(
+        &self,
+        request: &DestroySandbox,
+        names: &ResourceNames,
+        manifest: Option<&ServiceManifest>,
+        deadline: Instant,
+        cancellation: &dyn Cancellation,
+    ) -> Result<bool, ProviderError> {
+        if manifest.is_some_and(|manifest| manifest.custody() != request.custody()) {
+            return Err(provider_error::ownership_mismatch(
+                ProviderStage::VerifyOwnership,
+            ));
+        }
+        let expected = names.expected_ownership(request.custody());
+        let mut evidence = manifest.is_some();
+        for kind in [
+            ResourceKind::Network,
+            ResourceKind::Pod,
+            ResourceKind::Container,
+        ] {
+            let Some(labels) = self.inspect_resource(
+                kind,
+                names,
+                deadline,
+                cancellation,
+                ProviderStage::VerifyOwnership,
+            )?
+            else {
+                continue;
+            };
+            evidence = true;
+            if !expected.matches(&labels) {
+                return Err(provider_error::ownership_mismatch(
+                    ProviderStage::VerifyOwnership,
+                ));
+            }
+            if manifest.is_some_and(|manifest| labels.spec_fingerprint() != manifest.fingerprint())
+            {
+                return Err(provider_error::invalid_state(
+                    ProviderStage::VerifyOwnership,
+                ));
+            }
+        }
+        if let Some(manifest) = manifest {
+            evidence |= self.verify_manifest_subordinate_ownership(
+                manifest,
+                names,
+                request.custody(),
+                deadline,
+                cancellation,
+                ProviderStage::VerifyOwnership,
+            )?;
+        }
+        let workspace = self
+            .state
+            .workspace_exists(&names.workspace())
+            .map_err(|_| provider_error::local_storage(ProviderStage::VerifyOwnership))?;
+        if !evidence && workspace {
+            return Err(provider_error::ownership_mismatch(
+                ProviderStage::VerifyOwnership,
+            ));
+        }
+        Ok(evidence)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn verify_manifest_subordinate_ownership(
+        &self,
+        manifest: &ServiceManifest,
+        names: &ResourceNames,
+        custody: SandboxCustody,
+        deadline: Instant,
+        cancellation: &dyn Cancellation,
+        stage: ProviderStage,
+    ) -> Result<bool, ProviderError> {
+        if manifest.custody() != custody {
+            return Err(provider_error::ownership_mismatch(stage));
+        }
+        let expected = names.expected_ownership(custody);
+        let mut present = false;
+        for token in manifest_subordinate_tokens(manifest) {
+            let Some(labels) =
+                self.inspect_named_container(&token, deadline, cancellation, stage)?
+            else {
+                continue;
+            };
+            present = true;
+            if !expected.matches(&labels) {
+                return Err(provider_error::ownership_mismatch(stage));
+            }
+            if labels.spec_fingerprint() != manifest.fingerprint() {
+                return Err(provider_error::invalid_state(stage));
+            }
+        }
+        Ok(present)
+    }
+
     #[allow(clippy::single_match_else)]
     fn remove_service_proxy_container(
         &self,
@@ -2312,119 +2523,153 @@ impl PodmanInner {
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<bool, ProviderError> {
-        if manifest.port_count() == 0 {
-            return Ok(false);
-        }
-        let inspection = if manifest.proxy_transition() {
-            match self.inspect_named_container(
-                manifest.proxy_container(),
-                deadline,
-                cancellation,
-                ProviderStage::DestroyContainer,
-            )? {
-                Some(inspection) => inspection,
-                None => return Ok(false),
-            }
-        } else {
-            match manifest.proxy_identifier() {
-                Some(identifier) => match self.inspect_named_container(
-                    identifier,
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )? {
-                    Some(inspection) => inspection,
-                    None => {
-                        if self.named_container_exists(
-                            manifest.proxy_container(),
-                            deadline,
-                            cancellation,
-                            ProviderStage::DestroyContainer,
-                        )? {
-                            return Err(provider_error::ownership_mismatch(
-                                ProviderStage::VerifyOwnership,
-                            ));
-                        }
-                        return Ok(false);
-                    }
-                },
-                None => match self.inspect_named_container(
-                    manifest.proxy_container(),
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )? {
-                    Some(_) => {
-                        return Err(provider_error::ownership_mismatch(
-                            ProviderStage::VerifyOwnership,
-                        ));
-                    }
-                    None => return Ok(false),
-                },
-            }
-        };
-        let inspection = self.verify_service_proxy_container(
-            inspection,
-            manifest,
+        self.remove_manifest_containers(
+            proxy_container_tokens(manifest),
             names,
-            None,
+            manifest.fingerprint(),
+            manifest.custody(),
             deadline,
             cancellation,
-            ProviderStage::DestroyContainer,
-        )?;
-        self.remove_verified_proxy_container(&inspection, manifest, names, deadline, cancellation)
+        )
     }
 
-    fn remove_verified_proxy_container(
+    fn remove_manifest_containers(
         &self,
-        inspection: &InspectedServiceContainer,
-        manifest: &ServiceManifest,
+        tokens: BTreeSet<String>,
         names: &ResourceNames,
+        fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<bool, ProviderError> {
-        let mut arguments = self.base_arguments();
-        arguments.extend(os_args([
-            "rm",
-            "--force",
-            "--ignore",
-            "--time",
-            "0",
-            "--volumes",
-        ]));
-        arguments.push(inspection.identifier().into());
-        self.run_mutation(
-            arguments,
+        let identifiers = self.manifest_container_identifiers(
+            &tokens,
+            names,
+            fingerprint,
+            custody,
             deadline,
             cancellation,
-            ProviderStage::DestroyContainer,
-            names.handle(),
         )?;
-        if self.named_container_exists(
-            inspection.identifier(),
-            deadline,
-            cancellation,
-            ProviderStage::DestroyContainer,
-        )? {
-            return Err(provider_error::uncertain(
-                ProviderErrorKind::BackendRejected,
+        let expected = names.expected_ownership(custody);
+        let mut removed = false;
+        for identifier in identifiers {
+            let inspection = fence_destroy_result(
+                self.inspect_named_container(
+                    &identifier,
+                    deadline,
+                    cancellation,
+                    ProviderStage::DestroyContainer,
+                ),
+                removed,
+                &names.handle(),
+            )?;
+            let Some(inspection) = inspection else {
+                continue;
+            };
+            if inspection.identifier() != identifier
+                || !expected.matches(&inspection)
+                || inspection.spec_fingerprint() != fingerprint
+            {
+                let error = provider_error::ownership_mismatch(ProviderStage::VerifyOwnership);
+                return Err(if removed {
+                    destroy_service_error(&error, names.handle())
+                } else {
+                    error
+                });
+            }
+            let mut arguments = self.base_arguments();
+            arguments.extend(os_args([
+                "rm",
+                "--force",
+                "--ignore",
+                "--time",
+                "0",
+                "--volumes",
+            ]));
+            arguments.push(identifier.clone().into());
+            fence_destroy_result(
+                self.run_mutation(
+                    arguments,
+                    deadline,
+                    cancellation,
+                    ProviderStage::DestroyContainer,
+                    names.handle(),
+                ),
+                removed,
+                &names.handle(),
+            )?;
+            removed = true;
+            if self
+                .named_container_exists(
+                    &identifier,
+                    deadline,
+                    cancellation,
+                    ProviderStage::DestroyContainer,
+                )
+                .map_err(|error| destroy_service_error(&error, names.handle()))?
+            {
+                return Err(provider_error::uncertain(
+                    ProviderErrorKind::BackendRejected,
+                    ProviderStage::DestroyContainer,
+                    names.handle(),
+                ));
+            }
+        }
+        for token in tokens {
+            if self
+                .named_container_exists(
+                    &token,
+                    deadline,
+                    cancellation,
+                    ProviderStage::DestroyContainer,
+                )
+                .map_err(|error| destroy_service_error(&error, names.handle()))?
+            {
+                return Err(provider_error::uncertain(
+                    ProviderErrorKind::OwnershipMismatch,
+                    ProviderStage::VerifyOwnership,
+                    names.handle(),
+                ));
+            }
+        }
+        Ok(removed)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn manifest_container_identifiers(
+        &self,
+        tokens: &BTreeSet<String>,
+        names: &ResourceNames,
+        fingerprint: &str,
+        custody: SandboxCustody,
+        deadline: Instant,
+        cancellation: &dyn Cancellation,
+    ) -> Result<BTreeSet<String>, ProviderError> {
+        let expected = names.expected_ownership(custody);
+        let mut identifiers = BTreeSet::new();
+        for token in tokens {
+            let Some(inspection) = self.inspect_named_container(
+                token,
+                deadline,
+                cancellation,
                 ProviderStage::DestroyContainer,
-                names.handle(),
-            ));
+            )?
+            else {
+                continue;
+            };
+            if !expected.matches(&inspection) {
+                return Err(provider_error::ownership_mismatch(
+                    ProviderStage::VerifyOwnership,
+                ));
+            }
+            if inspection.spec_fingerprint() != fingerprint {
+                return Err(provider_error::invalid_state(
+                    ProviderStage::DestroyContainer,
+                ));
+            }
+            identifiers.insert(inspection.identifier().to_owned());
         }
-        if self.named_container_exists(
-            manifest.proxy_container(),
-            deadline,
-            cancellation,
-            ProviderStage::DestroyContainer,
-        )? {
-            return Err(provider_error::uncertain(
-                ProviderErrorKind::OwnershipMismatch,
-                ProviderStage::VerifyOwnership,
-                names.handle(),
-            ));
-        }
-        Ok(true)
+        Ok(identifiers)
     }
 
     fn remove_exact_workspace(
@@ -2487,6 +2732,7 @@ impl PodmanInner {
         &self,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
@@ -2498,7 +2744,7 @@ impl PodmanInner {
             if let Some(labels) =
                 self.inspect_resource(kind, names, deadline, cancellation, ProviderStage::Inspect)?
             {
-                if !names.expected_ownership().matches(&labels) {
+                if !names.expected_ownership(custody).matches(&labels) {
                     return Err(provider_error::ownership_mismatch(
                         ProviderStage::VerifyOwnership,
                     ));
@@ -2518,6 +2764,7 @@ impl PodmanInner {
         &self,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
         stage: ProviderStage,
@@ -2531,7 +2778,7 @@ impl PodmanInner {
             else {
                 continue;
             };
-            if !names.expected_ownership().matches(&labels) {
+            if !names.expected_ownership(custody).matches(&labels) {
                 return Err(provider_error::ownership_mismatch(
                     ProviderStage::VerifyOwnership,
                 ));
@@ -2563,6 +2810,7 @@ impl PodmanInner {
                 names,
                 spec.profile().attestation(),
                 labels.fingerprint,
+                labels.custody,
                 deadline,
                 cancellation,
             );
@@ -2586,6 +2834,7 @@ impl PodmanInner {
             names,
             spec.profile().attestation(),
             labels.fingerprint,
+            labels.custody,
             deadline,
             cancellation,
         )
@@ -2612,6 +2861,7 @@ impl PodmanInner {
                 names,
                 spec.profile().attestation(),
                 labels.fingerprint,
+                labels.custody,
                 deadline,
                 cancellation,
             )?;
@@ -2667,6 +2917,7 @@ impl PodmanInner {
             names,
             spec.profile().attestation(),
             labels.fingerprint,
+            labels.custody,
             deadline,
             cancellation,
         )?;
@@ -2757,6 +3008,7 @@ impl PodmanInner {
                 names,
                 spec.profile().attestation(),
                 labels.fingerprint,
+                labels.custody,
                 deadline,
                 cancellation,
             );
@@ -2820,6 +3072,7 @@ impl PodmanInner {
             names,
             spec.profile().attestation(),
             labels.fingerprint,
+            labels.custody,
             deadline,
             cancellation,
         )
@@ -3421,12 +3674,14 @@ impl PodmanInner {
         self.verify_buildkit_image_in_engine(job_arguments, runtime.image(), deadline, cancellation)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn verify_owned_for_spec(
         &self,
         kind: ResourceKind,
         names: &ResourceNames,
         profile: &EnvironmentProfile,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<(), ProviderError> {
@@ -3439,7 +3694,7 @@ impl PodmanInner {
                 ProviderStage::VerifyOwnership,
             )?
             .ok_or_else(|| provider_error::invalid_state(ProviderStage::VerifyOwnership))?;
-        if !names.expected_ownership().matches(&labels)
+        if !names.expected_ownership(custody).matches(&labels)
             || labels.profile().as_ref() != Some(profile)
             || labels.spec_fingerprint() != fingerprint
         {
@@ -3515,6 +3770,7 @@ impl PodmanInner {
         &self,
         kind: ResourceKind,
         names: &ResourceNames,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<bool, ProviderError> {
@@ -3523,7 +3779,7 @@ impl PodmanInner {
         else {
             return Ok(false);
         };
-        if !names.expected_ownership().matches(&labels) {
+        if !names.expected_ownership(custody).matches(&labels) {
             return Err(provider_error::ownership_mismatch(
                 ProviderStage::VerifyOwnership,
             ));
@@ -3555,165 +3811,23 @@ impl PodmanInner {
         Ok(true)
     }
 
-    #[allow(clippy::single_match_else, clippy::too_many_lines)]
     fn remove_service_container(
         &self,
         entry: &ServiceManifestEntry,
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         deadline: Instant,
         cancellation: &dyn Cancellation,
     ) -> Result<bool, ProviderError> {
-        let inspection = if entry.transition() {
-            let Some(named_container) = self.inspect_named_container(
-                entry.container(),
-                deadline,
-                cancellation,
-                ProviderStage::DestroyContainer,
-            )?
-            else {
-                return Ok(false);
-            };
-            let pending_matches_name = if let Some(identifier) = entry.identifier() {
-                self.inspect_named_container(
-                    identifier,
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )?
-                .is_some_and(|pending| pending.identifier() == named_container.identifier())
-            } else {
-                false
-            };
-            if pending_matches_name {
-                self.inspect_service_container_base(
-                    entry.identifier().ok_or_else(|| {
-                        provider_error::invalid_state(ProviderStage::DestroyContainer)
-                    })?,
-                    entry,
-                    names,
-                    fingerprint,
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )?
-            } else {
-                self.inspect_service_container(
-                    entry.container(),
-                    entry,
-                    names,
-                    fingerprint,
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )?
-            }
-        } else {
-            match entry.identifier() {
-                Some(identifier) => match self.inspect_named_container(
-                    identifier,
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )? {
-                    Some(inspection) => inspection,
-                    None => {
-                        if self.named_container_exists(
-                            entry.container(),
-                            deadline,
-                            cancellation,
-                            ProviderStage::DestroyContainer,
-                        )? {
-                            return Err(provider_error::ownership_mismatch(
-                                ProviderStage::VerifyOwnership,
-                            ));
-                        }
-                        return Ok(false);
-                    }
-                },
-                None => match self.inspect_named_container(
-                    entry.container(),
-                    deadline,
-                    cancellation,
-                    ProviderStage::DestroyContainer,
-                )? {
-                    Some(_) => {
-                        return Err(provider_error::ownership_mismatch(
-                            ProviderStage::VerifyOwnership,
-                        ));
-                    }
-                    None => return Ok(false),
-                },
-            }
-        };
-        if !names.expected_ownership().matches(&inspection)
-            || inspection.spec_fingerprint() != fingerprint
-        {
-            return Err(provider_error::ownership_mismatch(
-                ProviderStage::VerifyOwnership,
-            ));
-        }
-        let named_container = self
-            .inspect_named_container(
-                entry.container(),
-                deadline,
-                cancellation,
-                ProviderStage::DestroyContainer,
-            )?
-            .ok_or_else(|| provider_error::invalid_state(ProviderStage::DestroyContainer))?;
-        if named_container.identifier() != inspection.identifier() {
-            return Err(provider_error::ownership_mismatch(
-                ProviderStage::VerifyOwnership,
-            ));
-        }
-        let mut arguments = self.base_arguments();
-        arguments.extend(os_args([
-            "rm",
-            "--force",
-            "--ignore",
-            "--time",
-            "0",
-            "--volumes",
-        ]));
-        arguments.push(inspection.identifier().into());
-        self.run_mutation(
-            arguments,
+        self.remove_manifest_containers(
+            service_container_tokens(entry),
+            names,
+            fingerprint,
+            custody,
             deadline,
             cancellation,
-            ProviderStage::DestroyContainer,
-            names.handle(),
-        )?;
-        let still_exists = self
-            .named_container_exists(
-                inspection.identifier(),
-                deadline,
-                cancellation,
-                ProviderStage::DestroyContainer,
-            )
-            .map_err(|error| destroy_service_error(&error, names.handle()))?;
-        if still_exists {
-            return Err(provider_error::uncertain(
-                ProviderErrorKind::BackendRejected,
-                ProviderStage::DestroyContainer,
-                names.handle(),
-            ));
-        }
-        if self
-            .named_container_exists(
-                entry.container(),
-                deadline,
-                cancellation,
-                ProviderStage::DestroyContainer,
-            )
-            .map_err(|error| destroy_service_error(&error, names.handle()))?
-        {
-            return Err(provider_error::uncertain(
-                ProviderErrorKind::OwnershipMismatch,
-                ProviderStage::VerifyOwnership,
-                names.handle(),
-            ));
-        }
-        Ok(true)
+        )
     }
 
     pub(crate) fn run_endpoint(
@@ -4059,6 +4173,7 @@ fn finish_create(
 struct ProvisionLabels<'a> {
     arguments: &'a [String],
     fingerprint: &'a str,
+    custody: SandboxCustody,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -4280,6 +4395,19 @@ fn consistent_profile(
     Ok(profile)
 }
 
+fn consistent_custody(
+    present: [Option<&InspectedLabels>; 3],
+) -> Result<SandboxCustody, ProviderError> {
+    let mut observed = present.iter().flatten().map(|labels| labels.custody());
+    let custody = observed
+        .next()
+        .ok_or_else(|| provider_error::invalid_state(ProviderStage::Inspect))?;
+    if observed.any(|other| other != custody) {
+        return Err(provider_error::ownership_mismatch(ProviderStage::Inspect));
+    }
+    Ok(custody)
+}
+
 fn ensure_consistent_fingerprint(
     present: [Option<&InspectedLabels>; 3],
 ) -> Result<String, ProviderError> {
@@ -4380,6 +4508,8 @@ fn spec_fingerprint(
     buildkit_runtime: Option<&crate::BuildKitRuntime>,
 ) -> String {
     let mut hasher = Sha256::new();
+    hash_field(&mut hasher, b"automata-podman-sandbox-spec-v2");
+    hash_custody(&mut hasher, spec.custody());
     hash_field(&mut hasher, spec.profile().id().as_str().as_bytes());
     hash_field(&mut hasher, spec.profile().digest().as_bytes());
     hash_field(
@@ -4494,6 +4624,23 @@ fn spec_fingerprint(
         hash_service_health(&mut hasher, service.health());
     }
     Sha256Digest::from_bytes(hasher.finalize().into()).to_string()
+}
+
+fn hash_custody(hasher: &mut Sha256, custody: SandboxCustody) {
+    match custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            hash_field(hasher, b"profile-admission");
+            hash_field(hasher, runner_id.as_uuid().as_bytes());
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => {
+            hash_field(hasher, b"job");
+            hash_field(hasher, runner_id.as_uuid().as_bytes());
+            hash_field(hasher, &slot_ordinal.get().to_be_bytes());
+        }
+    }
 }
 
 fn hash_service_health(hasher: &mut Sha256, health: &ServiceHealthPolicy) {
@@ -4875,6 +5022,31 @@ fn create_service_error(error: &ProviderError, handle: SandboxHandle) -> Provide
         OperationOutcome::Uncertain,
         Some(handle),
     )
+}
+
+fn manifest_subordinate_tokens(manifest: &ServiceManifest) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::new();
+    for entry in manifest.entries() {
+        tokens.extend(service_container_tokens(entry));
+    }
+    tokens.extend(proxy_container_tokens(manifest));
+    tokens
+}
+
+fn service_container_tokens(entry: &ServiceManifestEntry) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::from([entry.container().to_owned()]);
+    if let Some(identifier) = entry.identifier() {
+        tokens.insert(identifier.to_owned());
+    }
+    tokens
+}
+
+fn proxy_container_tokens(manifest: &ServiceManifest) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::from([manifest.proxy_container().to_owned()]);
+    if let Some(identifier) = manifest.proxy_identifier() {
+        tokens.insert(identifier.to_owned());
+    }
+    tokens
 }
 
 fn destroy_service_error(error: &ProviderError, handle: SandboxHandle) -> ProviderError {

--- a/crates/automata-ci-sandbox-podman/src/service.rs
+++ b/crates/automata-ci-sandbox-podman/src/service.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeSet;
 
 use automata_ci_core::Sha256Digest;
-use automata_ci_execution::ServiceHealthPolicy;
 use automata_ci_execution::{
     ImmutableImage, ServiceContainerSpecs, ServicePort, ServiceTransportProtocol,
 };
+use automata_ci_execution::{SandboxCustody, ServiceHealthPolicy};
 use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
 
 use crate::naming::ResourceNames;
 
-const MANIFEST_SCHEMA: u64 = 1;
+const MANIFEST_SCHEMA: u64 = 3;
 const MAX_SERVICES: usize = 64;
 const MAX_PORTS_PER_SERVICE: usize = 256;
 const MAX_AGGREGATE_PIDS: u32 = 1_000_000;
@@ -18,6 +18,7 @@ const MAX_AGGREGATE_PIDS: u32 = 1_000_000;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ServiceManifest {
     fingerprint: String,
+    custody: SandboxCustody,
     network: String,
     aggregate_pids: u32,
     proxy_container: String,
@@ -31,6 +32,7 @@ impl ServiceManifest {
     pub(crate) fn from_specs(
         names: &ResourceNames,
         fingerprint: &str,
+        custody: SandboxCustody,
         aggregate_pids: u32,
         specs: &ServiceContainerSpecs,
         proxy_image: Option<&ImmutableImage>,
@@ -71,6 +73,7 @@ impl ServiceManifest {
         };
         Some(Self {
             fingerprint: fingerprint.to_owned(),
+            custody,
             network: names.network(),
             aggregate_pids,
             proxy_container: names.service_proxy(),
@@ -116,6 +119,7 @@ impl ServiceManifest {
             "schema": MANIFEST_SCHEMA,
             "handle": names.handle().opaque(),
             "fingerprint": self.fingerprint,
+            "custody": self.custody,
             "network": self.network,
             "aggregate_pids": self.aggregate_pids,
             "proxy_container": self.proxy_container,
@@ -138,6 +142,7 @@ impl ServiceManifest {
                 "schema",
                 "handle",
                 "fingerprint",
+                "custody",
                 "network",
                 "aggregate_pids",
                 "proxy_container",
@@ -154,6 +159,7 @@ impl ServiceManifest {
             return None;
         }
         let fingerprint = root.get("fingerprint")?.as_str()?.to_owned();
+        let custody = serde_json::from_value(root.get("custody")?.clone()).ok()?;
         let aggregate_pids = u32::try_from(root.get("aggregate_pids")?.as_u64()?).ok()?;
         let proxy_identifier = match root.get("proxy_identifier")? {
             Value::Null => None,
@@ -324,6 +330,7 @@ impl ServiceManifest {
         }
         Some(Self {
             fingerprint,
+            custody,
             network: names.network(),
             aggregate_pids,
             proxy_container: names.service_proxy(),
@@ -336,6 +343,10 @@ impl ServiceManifest {
 
     pub(crate) fn fingerprint(&self) -> &str {
         &self.fingerprint
+    }
+
+    pub(crate) const fn custody(&self) -> SandboxCustody {
+        self.custody
     }
 
     pub(crate) fn network(&self) -> &str {
@@ -504,6 +515,7 @@ impl ServiceManifest {
 
     pub(crate) fn same_request(&self, other: &Self) -> bool {
         self.fingerprint == other.fingerprint
+            && self.custody == other.custody
             && self.network == other.network
             && self.aggregate_pids == other.aggregate_pids
             && self.proxy_container == other.proxy_container
@@ -782,7 +794,7 @@ const fn parse_protocol(value: &str) -> Option<ServiceTransportProtocol> {
 
 #[cfg(test)]
 mod tests {
-    use automata_ci_execution::{OperationId, SandboxGeneration};
+    use automata_ci_execution::{OperationId, RunnerId, SandboxCustody, SandboxGeneration};
 
     use super::*;
 
@@ -796,6 +808,7 @@ mod tests {
             "schema": MANIFEST_SCHEMA,
             "handle": names.handle().opaque(),
             "fingerprint": "0".repeat(64),
+            "custody": SandboxCustody::ProfileAdmission { runner_id: RunnerId::new() },
             "network": names.network(),
             "aggregate_pids": 1,
             "proxy_container": names.service_proxy(),
@@ -807,7 +820,11 @@ mod tests {
         let current = serde_json::to_vec(&manifest).expect("current manifest");
         ServiceManifest::decode(&current, &names).expect("decode current manifest");
 
-        for schema in [0, MANIFEST_SCHEMA.checked_add(1).expect("test schema")] {
+        for schema in [
+            0,
+            MANIFEST_SCHEMA - 1,
+            MANIFEST_SCHEMA.checked_add(1).expect("test schema"),
+        ] {
             manifest["schema"] = json!(schema);
             let bytes = serde_json::to_vec(&manifest).expect("noncurrent manifest");
             assert!(

--- a/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
+++ b/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
@@ -3,6 +3,7 @@
 use crate::support;
 
 use std::{
+    num::NonZeroU16,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -14,9 +15,9 @@ use automata_ci_execution::{
     CopyFromRequest, CopyToRequest, DestroyDisposition, DestroySandbox, EnvironmentName,
     EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
     ExecutionErrorKind, ExecutionSignal, NetworkPolicy, NeverCancelled, OperationId,
-    ProviderErrorKind, RootFilesystemPolicy, SandboxCapability, SandboxGeneration,
-    SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, SandboxState, SignalRequest, TargetPath,
-    WaitRequest,
+    ProviderErrorKind, RootFilesystemPolicy, RunnerId, SandboxCapability, SandboxCustody,
+    SandboxGeneration, SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, SandboxState,
+    SignalRequest, TargetPath, WaitRequest,
 };
 use automata_ci_sandbox_podman::{
     CommandOutput, PodmanCommandExecutor, PodmanHostGatewayAlias, PodmanLaunchTrust,
@@ -24,7 +25,8 @@ use automata_ci_sandbox_podman::{
 };
 
 use support::{
-    Fixture, sample_spec, sample_spec_with, sample_spec_with_digest, test_single_file_tar,
+    Fixture, sample_spec, sample_spec_with, sample_spec_with_digest_and_custody,
+    test_single_file_tar,
 };
 
 #[derive(Debug)]
@@ -151,6 +153,7 @@ fn whole_job_create_replay_exec_and_destroy_are_exact() {
                 OperationId::new(),
                 created.handle().clone(),
                 created.generation(),
+                spec.custody(),
             ),
             &cancellation,
         )
@@ -164,6 +167,7 @@ fn whole_job_create_replay_exec_and_destroy_are_exact() {
                     OperationId::new(),
                     created.handle().clone(),
                     created.generation(),
+                    spec.custody(),
                 ),
                 &cancellation,
             )
@@ -215,7 +219,12 @@ fn create_fails_uncertain_when_the_live_cgroup_can_swap() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy replayed sandbox");
@@ -262,6 +271,7 @@ fn attach_reverifies_and_quarantines_a_running_sandbox() {
                 OperationId::new(),
                 replay.handle().clone(),
                 replay.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -271,9 +281,10 @@ fn attach_reverifies_and_quarantines_a_running_sandbox() {
 #[test]
 fn partial_workspace_cleanup_reopens_and_retries_only_the_exact_user_namespace_target() {
     let fixture = Fixture::new("workspace-cleanup-reopen");
+    let spec = sample_spec(OperationId::new());
     let created = fixture
         .provider
-        .create(&sample_spec(OperationId::new()), &NeverCancelled)
+        .create(&spec, &NeverCancelled)
         .expect("create sandbox");
     let generation = created.generation();
     let handle = created.handle().clone();
@@ -292,7 +303,12 @@ fn partial_workspace_cleanup_reopens_and_retries_only_the_exact_user_namespace_t
     let first = fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle.clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle.clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect_err("injected exact workspace deletion failure");
@@ -337,7 +353,7 @@ fn partial_workspace_cleanup_reopens_and_retries_only_the_exact_user_namespace_t
     .expect("reopen exact provider state");
     let disposition = reopened
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, generation),
+            &DestroySandbox::new(OperationId::new(), handle, generation, spec.custody()),
             &NeverCancelled,
         )
         .expect("replay partial exact cleanup");
@@ -356,9 +372,10 @@ fn partial_workspace_cleanup_reopens_and_retries_only_the_exact_user_namespace_t
 #[test]
 fn workspace_cleanup_rejects_a_swapped_symlink_without_touching_its_target() {
     let fixture = Fixture::new("workspace-cleanup-symlink");
+    let spec = sample_spec(OperationId::new());
     let created = fixture
         .provider
-        .create(&sample_spec(OperationId::new()), &NeverCancelled)
+        .create(&spec, &NeverCancelled)
         .expect("create sandbox");
     let workspace = std::fs::read_dir(fixture.scratch.path().join("workspaces"))
         .expect("workspace root")
@@ -380,6 +397,7 @@ fn workspace_cleanup_rejects_a_swapped_symlink_without_touching_its_target() {
                 OperationId::new(),
                 created.handle().clone(),
                 created.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -387,7 +405,7 @@ fn workspace_cleanup_rejects_a_swapped_symlink_without_touching_its_target() {
     assert_eq!(error.kind(), ProviderErrorKind::LocalStorage);
     assert_eq!(
         error.outcome(),
-        automata_ci_execution::OperationOutcome::Uncertain
+        automata_ci_execution::OperationOutcome::KnownNoEffect
     );
     assert_eq!(
         std::fs::read(outside.join("retained")).expect("outside content survives"),
@@ -581,6 +599,7 @@ fn writable_ephemeral_rootfs_is_explicit_and_retains_isolation_controls() {
     let spec = SandboxSpec::new(
         OperationId::new(),
         SandboxGeneration::new(1).expect("generation"),
+        baseline.custody(),
         baseline.profile().clone(),
         baseline.workspace().clone(),
         NetworkPolicy::PrivateEgress,
@@ -642,6 +661,7 @@ fn writable_ephemeral_rootfs_is_explicit_and_retains_isolation_controls() {
                 OperationId::new(),
                 created.handle().clone(),
                 created.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -684,6 +704,57 @@ fn partial_create_failure_returns_recovery_handle_and_replays() {
 }
 
 #[test]
+fn wrong_destroy_custody_never_removes_owned_resources() {
+    let fixture = Fixture::new("destroy-custody");
+    let spec = sample_spec(OperationId::new());
+    let created = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create sandbox");
+    let before = fixture.fake.commands().len();
+    let SandboxCustody::ProfileAdmission { runner_id } = spec.custody() else {
+        panic!("test spec uses profile-admission custody");
+    };
+
+    let error = fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                created.generation(),
+                SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+                },
+            ),
+            &NeverCancelled,
+        )
+        .expect_err("wrong custody must not authorize deletion");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert!(fixture.fake.commands()[before..].iter().all(|command| {
+        !semantic(command)
+            .iter()
+            .any(|value| value == "rm" || value.ends_with("/rm"))
+    }));
+    assert!(!fixture.fake.is_empty());
+
+    fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                created.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("matching custody authorizes cleanup");
+    assert!(fixture.fake.is_empty());
+}
+
+#[test]
 fn conflicting_spec_and_foreign_ownership_fail_closed() {
     let fixture = Fixture::new("ownership");
     let operation_id = OperationId::new();
@@ -692,10 +763,12 @@ fn conflicting_spec_and_foreign_ownership_fail_closed() {
         .provider
         .create(&first, &NeverCancelled)
         .expect("initial create");
-    let conflicting = sample_spec_with(
+    let conflicting = sample_spec_with_digest_and_custody(
         operation_id,
         "automata.dev/different-profile-v1",
+        [0x11; 32],
         NetworkPolicy::Disabled,
+        first.custody(),
     );
     let error = fixture
         .provider
@@ -712,6 +785,7 @@ fn conflicting_spec_and_foreign_ownership_fail_closed() {
                 OperationId::new(),
                 created.handle().clone(),
                 created.generation(),
+                first.custody(),
             ),
             &NeverCancelled,
         )
@@ -726,6 +800,84 @@ fn conflicting_spec_and_foreign_ownership_fail_closed() {
 }
 
 #[test]
+fn recovery_reports_custody_and_rejects_wrong_runner_slot_and_old_resource_schema() {
+    let fixture = Fixture::new("custody-runner");
+    let spec = sample_spec(OperationId::new());
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create current custody resources");
+    assert_eq!(
+        fixture
+            .provider
+            .inspect(record.handle(), &NeverCancelled)
+            .expect("inspect current custody")
+            .custody(),
+        spec.custody()
+    );
+
+    let wrong_runner = RunnerId::new();
+    fixture
+        .fake
+        .replace_custody("profile-admission", wrong_runner, 0);
+    let wrong_runner = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("recovery must reject custody that differs from durable evidence");
+    assert_eq!(wrong_runner.kind(), ProviderErrorKind::InvalidState);
+    let wrong_runner = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("create replay must reject a wrong runner label");
+    assert_eq!(wrong_runner.kind(), ProviderErrorKind::OwnershipMismatch);
+
+    let fixture = Fixture::new("custody-slot");
+    let baseline = sample_spec(OperationId::new());
+    let runner_id = RunnerId::new();
+    let spec = SandboxSpec::new(
+        baseline.operation_id(),
+        baseline.generation(),
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+        },
+        baseline.profile().clone(),
+        baseline.workspace().clone(),
+        baseline.network(),
+        baseline.root_filesystem(),
+        baseline.resources(),
+    );
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create slot test resources");
+    fixture.fake.replace_custody("job", runner_id, 1);
+    let wrong_slot = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("recovery must reject a slot that differs from durable evidence");
+    assert_eq!(wrong_slot.kind(), ProviderErrorKind::InvalidState);
+    let wrong_slot = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("create replay must reject a wrong slot label");
+    assert_eq!(wrong_slot.kind(), ProviderErrorKind::OwnershipMismatch);
+
+    let fixture = Fixture::new("custody-schema");
+    let spec = sample_spec(OperationId::new());
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create schema test resources");
+    fixture.fake.replace_resource_schema("1");
+    let old_schema = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("schema-1 Podman resources must not recover");
+    assert_eq!(old_schema.kind(), ProviderErrorKind::InvalidState);
+}
+
+#[test]
 fn same_profile_id_with_a_different_attestation_digest_cannot_replay() {
     let fixture = Fixture::new("profile-attestation");
     let operation_id = OperationId::new();
@@ -735,11 +887,12 @@ fn same_profile_id_with_a_different_attestation_digest_cannot_replay() {
         .create(&first, &NeverCancelled)
         .expect("initial create");
 
-    let conflicting = sample_spec_with_digest(
+    let conflicting = sample_spec_with_digest_and_custody(
         operation_id,
         first.profile().id().as_str(),
         [0x22; 32],
         first.network(),
+        first.custody(),
     );
     let error = fixture
         .provider

--- a/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
+++ b/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
@@ -18,10 +18,10 @@ use automata_ci_execution::{
     EnvironmentProfile, EnvironmentProfileId, EnvironmentValue, EnvironmentVariable, ExecutionArgv,
     ExecutionCommand, ExecutionEnvironment, ExecutionErrorKind, ExecutionTermination,
     ImmutableImage, NetworkPolicy, NeverCancelled, OperationId, ProviderErrorKind, ResourceLimits,
-    RootFilesystemPolicy, SandboxEnvironment, SandboxGeneration, SandboxPrivilegePolicy,
-    SandboxProvider, SandboxSpec, ServiceContainerSpec, ServiceContainerSpecs,
-    ServiceHealthOverrides, ServiceHealthPolicy, ServicePort, ServiceTransportProtocol,
-    Sha256Digest, TargetPath,
+    RootFilesystemPolicy, RunnerId, SandboxCustody, SandboxEnvironment, SandboxGeneration,
+    SandboxPrivilegePolicy, SandboxProvider, SandboxSpec, ServiceContainerSpec,
+    ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy, ServicePort,
+    ServiceTransportProtocol, Sha256Digest, TargetPath,
 };
 use automata_ci_sandbox_podman::{
     BuildKitRuntime, CommandRequest, CommandTermination, JobContainerEngine, PodmanBinary,
@@ -105,14 +105,24 @@ fn opt_in_rootless_contract_leaves_no_owned_resources() {
         Err(error) => {
             if let Some(handle) = error.recovery_handle() {
                 let _ignored = provider.destroy(
-                    &DestroySandbox::new(OperationId::new(), handle.clone(), generation),
+                    &DestroySandbox::new(
+                        OperationId::new(),
+                        handle.clone(),
+                        generation,
+                        spec.custody(),
+                    ),
                     &NeverCancelled,
                 );
             }
             panic!("create live sandbox: {error}");
         }
     };
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach live endpoint");
@@ -127,7 +137,12 @@ fn opt_in_rootless_contract_leaves_no_owned_resources() {
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy live sandbox");
@@ -200,7 +215,12 @@ fn opt_in_rootless_services_are_healthy_discoverable_recoverable_and_exactly_rem
         Err(error) => {
             if let Some(handle) = error.recovery_handle() {
                 let _ignored = provider.destroy(
-                    &DestroySandbox::new(OperationId::new(), handle.clone(), generation),
+                    &DestroySandbox::new(
+                        OperationId::new(),
+                        handle.clone(),
+                        generation,
+                        spec.custody(),
+                    ),
                     &NeverCancelled,
                 );
             }
@@ -252,7 +272,7 @@ fn opt_in_rootless_services_are_healthy_discoverable_recoverable_and_exactly_rem
     );
     reopened
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, generation),
+            &DestroySandbox::new(OperationId::new(), handle, generation, spec.custody()),
             &NeverCancelled,
         )
         .expect("destroy live service sandbox");
@@ -289,7 +309,12 @@ fn opt_in_rootless_administrator_is_confined_and_writable() {
     let created = provider
         .create(&spec, &NeverCancelled)
         .expect("create rootless administrator sandbox");
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach live endpoint");
@@ -310,7 +335,12 @@ fn opt_in_rootless_administrator_is_confined_and_writable() {
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy rootless administrator sandbox");
@@ -337,7 +367,12 @@ fn opt_in_hosted_profile_exposes_pinned_libclang_to_bindgen() {
     let created = provider
         .create(&spec, &NeverCancelled)
         .expect("create hosted-profile sandbox");
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach hosted-profile sandbox");
@@ -374,7 +409,12 @@ printf 'libclang-profile-ok\n'
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy hosted-profile sandbox");
@@ -405,7 +445,12 @@ fn opt_in_host_gateway_alias_reaches_local_git_without_a_host_socket() {
     let created = provider
         .create(&spec, &NeverCancelled)
         .expect("create host-alias sandbox");
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach host-alias sandbox");
@@ -431,7 +476,12 @@ fn opt_in_host_gateway_alias_reaches_local_git_without_a_host_socket() {
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy host-alias sandbox");
@@ -460,14 +510,24 @@ fn opt_in_attempt_scoped_docker_api_runs_the_distribution_command_surface() {
         Err(error) => {
             if let Some(handle) = error.recovery_handle() {
                 let _ignored = provider.destroy(
-                    &DestroySandbox::new(OperationId::new(), handle.clone(), generation),
+                    &DestroySandbox::new(
+                        OperationId::new(),
+                        handle.clone(),
+                        generation,
+                        spec.custody(),
+                    ),
                     &NeverCancelled,
                 );
             }
             panic!("create sandbox with attempt-scoped Docker API: {error}");
         }
     };
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach Docker-compatible sandbox");
@@ -490,7 +550,12 @@ fn opt_in_attempt_scoped_docker_api_runs_the_distribution_command_surface() {
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy Docker-compatible sandbox");
@@ -529,14 +594,24 @@ fn opt_in_attempt_scoped_buildx_runs_the_pinned_buildkit_container_driver() {
         Err(error) => {
             if let Some(handle) = error.recovery_handle() {
                 let _ignored = provider.destroy(
-                    &DestroySandbox::new(OperationId::new(), handle.clone(), generation),
+                    &DestroySandbox::new(
+                        OperationId::new(),
+                        handle.clone(),
+                        generation,
+                        spec.custody(),
+                    ),
                     &NeverCancelled,
                 );
             }
             panic!("create sandbox with attempt-scoped BuildKit API: {error}");
         }
     };
-    let mut cleanup = SandboxCleanup::new(provider.clone(), created.handle().clone(), generation);
+    let mut cleanup = SandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        generation,
+        spec.custody(),
+    );
     let endpoint = provider
         .attach(created.handle(), &NeverCancelled)
         .expect("attach BuildKit-compatible sandbox");
@@ -559,7 +634,12 @@ fn opt_in_attempt_scoped_buildx_runs_the_pinned_buildkit_container_driver() {
 
     provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), created.handle().clone(), generation),
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                generation,
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy BuildKit-compatible sandbox");
@@ -846,6 +926,7 @@ struct SandboxCleanup {
     provider: RootlessPodmanProvider,
     handle: Option<automata_ci_execution::SandboxHandle>,
     generation: SandboxGeneration,
+    custody: SandboxCustody,
 }
 
 impl SandboxCleanup {
@@ -853,11 +934,13 @@ impl SandboxCleanup {
         provider: RootlessPodmanProvider,
         handle: automata_ci_execution::SandboxHandle,
         generation: SandboxGeneration,
+        custody: SandboxCustody,
     ) -> Self {
         Self {
             provider,
             handle: Some(handle),
             generation,
+            custody,
         }
     }
 
@@ -870,7 +953,7 @@ impl Drop for SandboxCleanup {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             let _ignored = self.provider.destroy(
-                &DestroySandbox::new(OperationId::new(), handle, self.generation),
+                &DestroySandbox::new(OperationId::new(), handle, self.generation, self.custody),
                 &NeverCancelled,
             );
         }
@@ -944,6 +1027,9 @@ fn live_spec_with_network(
     SandboxSpec::new(
         operation_id,
         generation,
+        SandboxCustody::ProfileAdmission {
+            runner_id: RunnerId::new(),
+        },
         profile,
         TargetPath::posix("/__w").expect("workspace"),
         network,

--- a/crates/automata-ci-sandbox-podman/tests/service_containers.rs
+++ b/crates/automata-ci-sandbox-podman/tests/service_containers.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, fs, path::PathBuf, sync::Arc, time::Duration};
 use automata_ci_execution::{
     DestroyDisposition, DestroySandbox, EnvironmentName, EnvironmentValue, EnvironmentVariable,
     ExecutionEnvironment, ImmutableImage, NeverCancelled, OperationId, OperationOutcome,
-    ProviderErrorKind, SandboxCapability, SandboxProvider, ServiceContainerSpec,
+    ProviderErrorKind, RunnerId, SandboxCapability, SandboxProvider, ServiceContainerSpec,
     ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy, ServicePort,
     ServiceTransportProtocol,
 };
@@ -92,7 +92,7 @@ fn services_use_one_job_network_hardened_argv_and_restart_durable_bindings() {
 
     reopened
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, generation),
+            &DestroySandbox::new(OperationId::new(), handle, generation, spec.custody()),
             &NeverCancelled,
         )
         .expect("destroy services and sandbox");
@@ -105,9 +105,10 @@ fn services_use_one_job_network_hardened_argv_and_restart_durable_bindings() {
 fn podman_normalized_tagged_digest_remains_exactly_owned() {
     let fixture = Fixture::new_with_service_proxy("service-tagged-digest-normalization");
     fixture.fake.normalize_tagged_digest_image_names();
+    let spec = service_spec(OperationId::new());
     let record = fixture
         .provider
-        .create(&service_spec(OperationId::new()), &NeverCancelled)
+        .create(&spec, &NeverCancelled)
         .expect("create services after Podman normalizes tagged digest names");
 
     fixture
@@ -117,6 +118,7 @@ fn podman_normalized_tagged_digest_remains_exactly_owned() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -170,6 +172,7 @@ fn stopped_proxy_is_recreated_with_fresh_logs_and_the_durable_listener_ports() {
                 OperationId::new(),
                 replayed.handle().clone(),
                 replayed.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -203,7 +206,12 @@ fn durable_helper_identity_allows_exact_destroy_after_configuration_is_removed()
     );
     reopened
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, record.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                record.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("manifest-pinned helper identity remains destroyable");
@@ -353,6 +361,7 @@ fn exact_low_tcp_and_udp_ports_are_bound_only_after_the_job_netns_sysctl() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -402,7 +411,12 @@ fn cancellation_during_health_readiness_is_uncertain_and_exactly_recoverable() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("exact recovery destroy");
@@ -432,7 +446,12 @@ fn cancellation_before_first_service_create_is_exactly_recoverable() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("destroy manifest entries whose containers were never created");
@@ -454,7 +473,12 @@ fn created_service_with_unparseable_identifier_is_adopted_only_for_exact_destroy
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("fully verified deterministic service name can be removed by captured ID");
@@ -476,7 +500,12 @@ fn created_service_with_wrong_valid_identifier_recovers_by_the_fenced_name() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("the verified deterministic service name remains exactly recoverable");
@@ -507,7 +536,12 @@ fn proxy_transition_rejects_wrong_argv_after_a_wrong_valid_identifier() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("restored exact proxy command permits fenced recovery");
@@ -536,11 +570,178 @@ fn primary_container_must_remain_in_the_captured_job_pod() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
         .expect("restore exact pod relation before cleanup");
     assert!(fixture.fake.is_empty());
+}
+
+#[test]
+fn service_only_remnants_are_not_reported_absent() {
+    let fixture = Fixture::new_with_service_proxy("service-only-remnants");
+    let spec = service_spec(OperationId::new());
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create service sandbox");
+    fixture.fake.retain_services_only();
+
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("owned service remnants are partial state, not absence");
+    assert_eq!(error.kind(), ProviderErrorKind::InvalidState);
+
+    fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                record.handle().clone(),
+                record.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("exact custody reconciles service-only remnants");
+    assert!(fixture.fake.is_empty());
+}
+
+#[test]
+fn destroy_reconciles_named_and_captured_service_and_proxy_remnants() {
+    type Mutation = (&'static str, fn(&support::FakePodman));
+    let cases: [Mutation; 4] = [
+        (
+            "service-captured-only",
+            support::FakePodman::hide_one_service_name,
+        ),
+        (
+            "service-divergent-name",
+            support::FakePodman::diverge_one_service_name,
+        ),
+        (
+            "proxy-captured-only",
+            support::FakePodman::hide_service_proxy_name,
+        ),
+        (
+            "proxy-divergent-name",
+            support::FakePodman::diverge_service_proxy_name,
+        ),
+    ];
+
+    for (label, mutate) in cases {
+        let fixture = Fixture::new_with_service_proxy(label);
+        let spec = service_spec(OperationId::new());
+        let record = fixture
+            .provider
+            .create(&spec, &NeverCancelled)
+            .expect("create service sandbox");
+        mutate(&fixture.fake);
+
+        fixture
+            .provider
+            .destroy(
+                &DestroySandbox::new(
+                    OperationId::new(),
+                    record.handle().clone(),
+                    record.generation(),
+                    spec.custody(),
+                ),
+                &NeverCancelled,
+            )
+            .unwrap_or_else(|error| panic!("{label}: exact remnants must reconcile: {error}"));
+        assert!(fixture.fake.is_empty(), "{label}");
+        assert!(
+            !service_manifest_path(fixture.scratch.path(), spec.operation_id()).exists(),
+            "{label}: manifest may disappear only after every captured resource"
+        );
+    }
+}
+
+#[test]
+fn recovery_and_destroy_reject_one_service_with_asymmetric_custody() {
+    let fixture = Fixture::new_with_service_proxy("service-asymmetric-custody");
+    let spec = service_spec(OperationId::new());
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create service sandbox");
+    fixture.fake.retain_services_only();
+    fixture
+        .fake
+        .replace_one_service_custody("job", RunnerId::new(), 1);
+
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("one service with different custody must fail recovery");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+
+    let before_destroy = fixture.fake.commands().len();
+    let error = fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                record.handle().clone(),
+                record.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect_err("asymmetric service custody must fence destroy");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_no_removal_after(&fixture.fake, before_destroy);
+    assert!(!fixture.fake.is_empty());
+}
+
+#[test]
+fn recovery_and_destroy_reject_proxy_with_asymmetric_custody() {
+    let fixture = Fixture::new_with_service_proxy("proxy-asymmetric-custody");
+    let spec = service_spec(OperationId::new());
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create service sandbox");
+    fixture
+        .fake
+        .replace_service_proxy_custody("job", RunnerId::new(), 1);
+
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("proxy with different custody must fail recovery");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+
+    let before_destroy = fixture.fake.commands().len();
+    let error = fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                record.handle().clone(),
+                record.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect_err("asymmetric proxy custody must fence destroy");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_no_removal_after(&fixture.fake, before_destroy);
+    assert!(!fixture.fake.is_empty());
+}
+
+fn assert_no_removal_after(fake: &support::FakePodman, command_index: usize) {
+    assert!(
+        fake.commands()[command_index..].iter().all(|command| {
+            !podman_command(command)
+                .iter()
+                .any(|value| *value == "rm" || value.ends_with("/rm"))
+        }),
+        "custody validation must complete before any removal"
+    );
 }
 
 #[test]
@@ -558,7 +759,12 @@ fn cancellation_after_proxy_start_is_uncertain_and_exactly_recoverable() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("exact proxy recovery destroy");
@@ -566,7 +772,7 @@ fn cancellation_after_proxy_start_is_uncertain_and_exactly_recoverable() {
 }
 
 #[test]
-fn cancellation_after_one_service_deletion_retains_the_exact_recovery_fence() {
+fn cancellation_during_destroy_preflight_has_no_effect_and_remains_retryable() {
     let fixture = Fixture::new_with_service_proxy("service-destroy-cancellation");
     let spec = service_spec(OperationId::new());
     let record = fixture
@@ -593,13 +799,14 @@ fn cancellation_after_one_service_deletion_retains_the_exact_recovery_fence() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
-        .expect_err("partial service cleanup cancellation is uncertain");
+        .expect_err("preflight cancellation must stop before service cleanup");
     assert_eq!(error.kind(), ProviderErrorKind::Cancelled);
-    assert_eq!(error.outcome(), OperationOutcome::Uncertain);
-    assert_eq!(error.recovery_handle(), Some(record.handle()));
+    assert_eq!(error.outcome(), OperationOutcome::KnownNoEffect);
+    assert_eq!(error.recovery_handle(), None);
 
     fixture
         .provider
@@ -608,6 +815,7 @@ fn cancellation_after_one_service_deletion_retains_the_exact_recovery_fence() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -726,7 +934,12 @@ fn health_readiness_obeys_the_aggregate_deadline_and_retains_recovery() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("cleanup timed-out services");
@@ -756,6 +969,7 @@ fn provider_drives_healthchecks_inside_its_delegated_cgroup() {
                 OperationId::new(),
                 created.handle().clone(),
                 spec.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -778,7 +992,12 @@ fn override_health_policy_fails_closed_when_backend_omits_the_healthcheck() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("cleanup health-config drift");
@@ -800,7 +1019,12 @@ fn override_health_policy_requires_the_exact_requested_backend_configuration() {
     fixture
         .provider
         .destroy(
-            &DestroySandbox::new(OperationId::new(), handle, spec.generation()),
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle,
+                spec.generation(),
+                spec.custody(),
+            ),
             &NeverCancelled,
         )
         .expect("exact-ID cleanup does not require a healthy workload");
@@ -837,6 +1061,7 @@ fn noncanonical_or_ambiguous_proxy_status_fails_closed() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -876,6 +1101,7 @@ fn stale_service_manifest_fingerprint_is_rejected_before_destroy_mutation() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -896,6 +1122,7 @@ fn stale_service_manifest_fingerprint_is_rejected_before_destroy_mutation() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -906,9 +1133,10 @@ fn stale_service_manifest_fingerprint_is_rejected_before_destroy_mutation() {
 fn destroy_reconciles_owned_core_remnants_without_a_service_manifest() {
     let fixture = Fixture::new_with_service_proxy("service-partial-cleanup");
     let operation_id = OperationId::new();
+    let spec = service_spec(operation_id);
     let record = fixture
         .provider
-        .create(&service_spec(operation_id), &NeverCancelled)
+        .create(&spec, &NeverCancelled)
         .expect("create service sandbox");
     fs::remove_file(service_manifest_path(fixture.scratch.path(), operation_id))
         .expect("simulate manifest cleanup before process crash");
@@ -921,6 +1149,7 @@ fn destroy_reconciles_owned_core_remnants_without_a_service_manifest() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )
@@ -936,6 +1165,7 @@ fn destroy_reconciles_owned_core_remnants_without_a_service_manifest() {
                     OperationId::new(),
                     record.handle().clone(),
                     record.generation(),
+                    spec.custody(),
                 ),
                 &NeverCancelled,
             )
@@ -960,6 +1190,7 @@ fn network_name_replacement_is_never_deleted_after_the_owned_id_is_captured() {
                 OperationId::new(),
                 record.handle().clone(),
                 record.generation(),
+                spec.custody(),
             ),
             &NeverCancelled,
         )

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -15,8 +15,8 @@ use std::{
 
 use automata_ci_execution::{
     EnvironmentProfile, EnvironmentProfileId, ExecutionArgv, ExecutionEnvironment, ImmutableImage,
-    NetworkPolicy, OperationId, ResourceLimits, RootFilesystemPolicy, SandboxEnvironment,
-    SandboxGeneration, SandboxSpec, Sha256Digest, TargetPath,
+    NetworkPolicy, OperationId, ResourceLimits, RootFilesystemPolicy, RunnerId, SandboxCustody,
+    SandboxEnvironment, SandboxGeneration, SandboxSpec, Sha256Digest, TargetPath,
 };
 use automata_ci_sandbox_podman::{
     CommandOutput, CommandRequest, CommandTermination, PodmanBinary, PodmanCommandExecutor,
@@ -24,11 +24,15 @@ use automata_ci_sandbox_podman::{
 };
 
 const OWNER: &str = "io.automata.owner";
+const RESOURCE_SCHEMA: &str = "io.automata.sandbox-schema";
 const SANDBOX: &str = "io.automata.sandbox";
 const GENERATION: &str = "io.automata.generation";
 const PROFILE: &str = "io.automata.profile";
 const PROFILE_DIGEST: &str = "io.automata.profile-sha256";
 const SPEC: &str = "io.automata.spec-sha256";
+const CUSTODY_KIND: &str = "io.automata.custody-kind";
+const CUSTODY_RUNNER: &str = "io.automata.custody-runner";
+const CUSTODY_SLOT: &str = "io.automata.custody-slot";
 const FAKE_INFRA_ID: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
 #[derive(Debug)]
@@ -204,6 +208,61 @@ impl FakePodman {
         }
         for resource in state.containers.values_mut() {
             resource.labels.insert(OWNER.to_owned(), owner.to_owned());
+        }
+    }
+
+    pub(crate) fn replace_custody(&self, kind: &str, runner: RunnerId, slot: u16) {
+        let mut state = self.state.lock().expect("fake lock");
+        if let Some(resource) = state.network.as_mut() {
+            replace_custody_labels(resource, kind, runner, slot);
+        }
+        if let Some(resource) = state.pod.as_mut() {
+            replace_custody_labels(resource, kind, runner, slot);
+        }
+        for resource in state.containers.values_mut() {
+            replace_custody_labels(resource, kind, runner, slot);
+        }
+    }
+
+    pub(crate) fn replace_one_service_custody(&self, kind: &str, runner: RunnerId, slot: u16) {
+        let mut state = self.state.lock().expect("fake lock");
+        let resource = state
+            .containers
+            .values_mut()
+            .find(|resource| {
+                resource.name.starts_with("automata-job-service-")
+                    && !resource.name.starts_with("automata-job-service-proxy-")
+            })
+            .expect("service container exists");
+        replace_custody_labels(resource, kind, runner, slot);
+    }
+
+    pub(crate) fn replace_service_proxy_custody(&self, kind: &str, runner: RunnerId, slot: u16) {
+        let mut state = self.state.lock().expect("fake lock");
+        let resource = state
+            .containers
+            .values_mut()
+            .find(|resource| resource.name.starts_with("automata-job-service-proxy-"))
+            .expect("service proxy exists");
+        replace_custody_labels(resource, kind, runner, slot);
+    }
+
+    pub(crate) fn replace_resource_schema(&self, schema: &str) {
+        let mut state = self.state.lock().expect("fake lock");
+        if let Some(resource) = state.network.as_mut() {
+            resource
+                .labels
+                .insert(RESOURCE_SCHEMA.to_owned(), schema.to_owned());
+        }
+        if let Some(resource) = state.pod.as_mut() {
+            resource
+                .labels
+                .insert(RESOURCE_SCHEMA.to_owned(), schema.to_owned());
+        }
+        for resource in state.containers.values_mut() {
+            resource
+                .labels
+                .insert(RESOURCE_SCHEMA.to_owned(), schema.to_owned());
         }
     }
 
@@ -436,6 +495,56 @@ impl FakePodman {
         state.containers.clear();
     }
 
+    pub(crate) fn retain_services_only(&self) {
+        let mut state = self.state.lock().expect("fake lock");
+        state.network = None;
+        state.pod = None;
+        state
+            .containers
+            .retain(|_, resource| resource.name.starts_with("automata-job-service-"));
+    }
+
+    pub(crate) fn hide_one_service_name(&self) {
+        self.split_container_name(false, false);
+    }
+
+    pub(crate) fn diverge_one_service_name(&self) {
+        self.split_container_name(false, true);
+    }
+
+    pub(crate) fn hide_service_proxy_name(&self) {
+        self.split_container_name(true, false);
+    }
+
+    pub(crate) fn diverge_service_proxy_name(&self) {
+        self.split_container_name(true, true);
+    }
+
+    fn split_container_name(&self, proxy: bool, divergent_name: bool) {
+        let mut state = self.state.lock().expect("fake lock");
+        let name = state
+            .containers
+            .iter()
+            .find_map(|(name, resource)| {
+                let is_proxy = resource.name.starts_with("automata-job-service-proxy-");
+                let is_service = resource.name.starts_with("automata-job-service-") && !is_proxy;
+                ((proxy && is_proxy) || (!proxy && is_service)).then(|| name.clone())
+            })
+            .expect("target service container exists");
+        let original = state
+            .containers
+            .remove(&name)
+            .expect("selected service container exists");
+        let captured_key = format!("captured-remnant-{}", original.identifier);
+        if divergent_name {
+            state.next_container_id = state.next_container_id.saturating_add(1);
+            let mut replacement = original.clone();
+            replacement.identifier = format!("{:064x}", state.next_container_id);
+            state.containers.insert(name, replacement);
+        }
+        state.containers.insert(captured_key, original);
+    }
+
     pub(crate) fn no_swap_verifications(&self) -> u32 {
         self.state.lock().expect("fake lock").no_swap_verifications
     }
@@ -448,6 +557,18 @@ impl FakePodman {
         let state = self.state.lock().expect("fake lock");
         state.network.is_none() && state.pod.is_none() && state.containers.is_empty()
     }
+}
+
+fn replace_custody_labels(resource: &mut Resource, kind: &str, runner: RunnerId, slot: u16) {
+    resource
+        .labels
+        .insert(CUSTODY_KIND.to_owned(), kind.to_owned());
+    resource
+        .labels
+        .insert(CUSTODY_RUNNER.to_owned(), runner.to_string());
+    resource
+        .labels
+        .insert(CUSTODY_SLOT.to_owned(), slot.to_string());
 }
 
 impl PodmanCommandExecutor for FakePodman {
@@ -1367,9 +1488,20 @@ fn option_values<'a>(arguments: &'a [String], option: &'a str) -> impl Iterator<
 }
 
 fn inspect_bytes(resource: &Resource) -> Vec<u8> {
-    let mut values = [OWNER, SANDBOX, GENERATION, PROFILE, PROFILE_DIGEST, SPEC]
-        .map(|key| resource.labels.get(key).cloned().unwrap_or_default())
-        .to_vec();
+    let mut values = [
+        OWNER,
+        RESOURCE_SCHEMA,
+        SANDBOX,
+        GENERATION,
+        PROFILE,
+        PROFILE_DIGEST,
+        SPEC,
+        CUSTODY_KIND,
+        CUSTODY_RUNNER,
+        CUSTODY_SLOT,
+    ]
+    .map(|key| resource.labels.get(key).cloned().unwrap_or_default())
+    .to_vec();
     if let Some(state) = &resource.state {
         values.push(state.clone());
     }
@@ -1487,6 +1619,24 @@ pub(crate) fn sample_spec_with_digest(
     profile_digest: [u8; 32],
     network: NetworkPolicy,
 ) -> SandboxSpec {
+    sample_spec_with_digest_and_custody(
+        operation_id,
+        profile_id,
+        profile_digest,
+        network,
+        SandboxCustody::ProfileAdmission {
+            runner_id: RunnerId::new(),
+        },
+    )
+}
+
+pub(crate) fn sample_spec_with_digest_and_custody(
+    operation_id: OperationId,
+    profile_id: &str,
+    profile_digest: [u8; 32],
+    network: NetworkPolicy,
+    custody: SandboxCustody,
+) -> SandboxSpec {
     let image = ImmutableImage::new(format!(
         "registry.example.invalid/automata/arch@sha256:{}",
         "0".repeat(64)
@@ -1511,6 +1661,7 @@ pub(crate) fn sample_spec_with_digest(
     SandboxSpec::new(
         operation_id,
         SandboxGeneration::new(1).expect("generation"),
+        custody,
         profile,
         TargetPath::posix("/__w").expect("workspace"),
         network,

--- a/crates/automata-ci-sandbox-windows/src/naming.rs
+++ b/crates/automata-ci-sandbox-windows/src/naming.rs
@@ -7,7 +7,7 @@ use automata_ci_execution::{
 
 use crate::{WINDOWS_HYPERV_PROVIDER_ID, error};
 
-const HANDLE_VERSION: &str = "wh1";
+const HANDLE_VERSION: &str = "wh2";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ResourceName {
@@ -125,15 +125,19 @@ mod tests {
                 .generation(),
             generation
         );
-        let noncurrent =
-            SandboxHandle::new(provider.clone(), format!("wh0_{}_41", names.identifier()))
-                .expect("noncurrent handle syntax");
-        assert_eq!(
-            ResourceName::from_handle(&noncurrent, &provider)
-                .expect_err("noncurrent handle version must fail closed")
-                .kind(),
-            ProviderErrorKind::InvalidState
-        );
+        for version in ["wh0", "wh1", "wh3"] {
+            let noncurrent = SandboxHandle::new(
+                provider.clone(),
+                format!("{version}_{}_41", names.identifier()),
+            )
+            .expect("noncurrent handle syntax");
+            assert_eq!(
+                ResourceName::from_handle(&noncurrent, &provider)
+                    .expect_err("noncurrent handle version must fail closed")
+                    .kind(),
+                ProviderErrorKind::InvalidState
+            );
+        }
         let foreign = ProviderId::new("foreign-provider").expect("foreign provider");
         assert_eq!(
             ResourceName::from_handle(&names.handle(), &foreign)

--- a/crates/automata-ci-sandbox-windows/src/persistence.rs
+++ b/crates/automata-ci-sandbox-windows/src/persistence.rs
@@ -6,13 +6,17 @@ use std::{
     path::Path,
 };
 
-use automata_ci_execution::{EnvironmentProfile, OperationId};
+use automata_ci_execution::{EnvironmentProfile, OperationId, SandboxCustody};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-const LOCK_FILE_NAME: &str = ".automata-windows-hyperv-v1.lock";
-const JOURNAL_FILE_NAME: &str = ".automata-windows-hyperv-v1.events";
-const DURABLE_SCHEMA: u32 = 1;
+const LOCK_FILE_NAME: &str = ".automata-windows-hyperv-v2.lock";
+const JOURNAL_FILE_NAME: &str = ".automata-windows-hyperv-v2.events";
+const LEGACY_STATE_NAMES: [&str; 2] = [
+    ".automata-windows-hyperv-v1.lock",
+    ".automata-windows-hyperv-v1.events",
+];
+const DURABLE_SCHEMA: u32 = 2;
 const MAX_EVENT_BYTES: usize = 64 * 1024;
 const MAX_JOURNAL_BYTES: u64 = 256 * 1024 * 1024;
 const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
@@ -33,6 +37,7 @@ pub(crate) struct DurableCreate {
     pub(crate) operation_id: OperationId,
     pub(crate) fingerprint: String,
     pub(crate) handle: String,
+    pub(crate) custody: SandboxCustody,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -41,6 +46,7 @@ pub(crate) struct DurableDestroy {
     pub(crate) operation_id: OperationId,
     pub(crate) handle: String,
     pub(crate) generation: u64,
+    pub(crate) custody: SandboxCustody,
     pub(crate) disposition: DurableDestroyDisposition,
     pub(crate) completed_sequence: u64,
 }
@@ -52,6 +58,7 @@ pub(crate) struct DurableDestroyRequest {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -67,6 +74,7 @@ pub(crate) struct DurableEntry {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
     pub(crate) container: String,
     pub(crate) fingerprint: String,
     pub(crate) phase: DurableEntryPhase,
@@ -86,6 +94,7 @@ pub(crate) struct DurableTombstone {
     pub(crate) handle: String,
     pub(crate) generation: u64,
     pub(crate) profile: EnvironmentProfile,
+    pub(crate) custody: SandboxCustody,
     pub(crate) completed_sequence: u64,
 }
 
@@ -128,6 +137,13 @@ pub(crate) struct LifecycleJournal {
 
 impl LifecycleJournal {
     pub(crate) fn open(root: &Path) -> io::Result<(Self, DurableSnapshot)> {
+        for name in LEGACY_STATE_NAMES {
+            match std::fs::symlink_metadata(root.join(name)) {
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Ok(_) => return Err(io::Error::from(io::ErrorKind::InvalidData)),
+                Err(error) => return Err(error),
+            }
+        }
         let lock = open_exclusive_regular(&root.join(LOCK_FILE_NAME), true, false)?;
         let mut journal = open_exclusive_regular(&root.join(JOURNAL_FILE_NAME), true, false)?;
         if journal.metadata()?.len() > MAX_JOURNAL_BYTES {
@@ -325,6 +341,7 @@ fn apply_create(
 ) -> io::Result<()> {
     if create.handle != entry.handle
         || create.fingerprint != entry.fingerprint
+        || create.custody != entry.custody
         || entry.phase != DurableEntryPhase::Intent
         || snapshot.creates.contains_key(&create.operation_id)
         || snapshot.entries.contains_key(&entry.handle)
@@ -371,6 +388,7 @@ fn apply_destroy_intent(
         )
         || entry.generation != request.generation
         || entry.profile != request.profile
+        || entry.custody != request.custody
     {
         return Err(io::Error::from(io::ErrorKind::InvalidData));
     }
@@ -397,6 +415,7 @@ fn apply_destroy_complete(
     if entry.phase != DurableEntryPhase::Destroying
         || entry.generation != request.generation
         || entry.profile != request.profile
+        || entry.custody != request.custody
         || snapshot.tombstones.contains_key(&request.handle)
     {
         return Err(io::Error::from(io::ErrorKind::InvalidData));
@@ -407,6 +426,7 @@ fn apply_destroy_complete(
             handle: request.handle.clone(),
             generation: request.generation,
             profile: request.profile,
+            custody: request.custody,
             completed_sequence: sequence,
         },
     );
@@ -416,6 +436,7 @@ fn apply_destroy_complete(
             operation_id,
             handle: request.handle,
             generation: request.generation,
+            custody: request.custody,
             disposition: DurableDestroyDisposition::Destroyed,
             completed_sequence: sequence,
         },
@@ -438,6 +459,7 @@ fn apply_destroy_absent(
         || snapshot.destroys.contains_key(&request.operation_id)
         || tombstone.generation != request.generation
         || tombstone.profile != request.profile
+        || tombstone.custody != request.custody
     {
         return Err(io::Error::from(io::ErrorKind::InvalidData));
     }
@@ -447,6 +469,7 @@ fn apply_destroy_absent(
             operation_id: request.operation_id,
             handle: request.handle.clone(),
             generation: request.generation,
+            custody: request.custody,
             disposition: DurableDestroyDisposition::AlreadyAbsent,
             completed_sequence: sequence,
         },
@@ -462,9 +485,11 @@ fn event_checksum(sequence: u64, event: &DurableEvent) -> io::Result<[u8; 32]> {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs, io::Write as _, path::PathBuf};
+    use std::{env, fs, io::Write as _, num::NonZeroU16, path::PathBuf};
 
-    use automata_ci_execution::{EnvironmentProfileId, SandboxGeneration, Sha256Digest};
+    use automata_ci_execution::{
+        EnvironmentProfileId, RunnerId, SandboxCustody, SandboxGeneration, Sha256Digest,
+    };
 
     use super::*;
 
@@ -473,21 +498,85 @@ mod tests {
         let root = TestRoot::new("schema");
         let (journal, _) = LifecycleJournal::open(&root.0).expect("initialize journal");
         drop(journal);
-        let event = create_event();
-        let sequence = 1;
-        let mut bytes = serde_json::to_vec(&EventRecord {
-            schema: DURABLE_SCHEMA.checked_add(1).expect("next schema"),
-            sequence,
-            checksum: event_checksum(sequence, &event).expect("checksum"),
-            event,
-        })
-        .expect("record");
-        bytes.push(b'\n');
-        fs::write(root.0.join(JOURNAL_FILE_NAME), bytes).expect("replace journal");
-        assert!(matches!(
-            LifecycleJournal::open(&root.0),
-            Err(error) if error.kind() == io::ErrorKind::InvalidData
-        ));
+        for schema in [DURABLE_SCHEMA - 1, DURABLE_SCHEMA + 1] {
+            let event = create_event();
+            let sequence = 1;
+            let mut bytes = serde_json::to_vec(&EventRecord {
+                schema,
+                sequence,
+                checksum: event_checksum(sequence, &event).expect("checksum"),
+                event,
+            })
+            .expect("record");
+            bytes.push(b'\n');
+            fs::write(root.0.join(JOURNAL_FILE_NAME), bytes).expect("replace journal");
+            assert!(matches!(
+                LifecycleJournal::open(&root.0),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData
+            ));
+        }
+    }
+
+    #[test]
+    fn prior_generation_state_files_are_rejected_without_migration() {
+        for (ordinal, legacy_name) in LEGACY_STATE_NAMES.iter().enumerate() {
+            let root = TestRoot::new(&format!("legacy-file-{ordinal}"));
+            fs::write(root.0.join(legacy_name), b"schema-1 state\n")
+                .expect("write prior state file");
+            assert!(matches!(
+                LifecycleJournal::open(&root.0),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData
+            ));
+            assert!(!root.0.join(JOURNAL_FILE_NAME).exists());
+        }
+    }
+
+    #[test]
+    fn lifecycle_reopen_rejects_wrong_runner_and_slot_custody() {
+        let runner_id = RunnerId::new();
+        let expected = SandboxCustody::Job {
+            runner_id,
+            slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+        };
+        for (label, observed) in [
+            (
+                "runner",
+                SandboxCustody::Job {
+                    runner_id: RunnerId::new(),
+                    slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+                },
+            ),
+            (
+                "slot",
+                SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+                },
+            ),
+        ] {
+            let root = TestRoot::new(&format!("custody-{label}"));
+            let mut event = create_event();
+            let DurableEvent::CreateIntent { create, entry } = &mut event else {
+                panic!("create fixture event");
+            };
+            create.custody = expected;
+            entry.custody = observed;
+            let sequence = 1;
+            let mut bytes = serde_json::to_vec(&EventRecord {
+                schema: DURABLE_SCHEMA,
+                sequence,
+                checksum: event_checksum(sequence, &event).expect("event checksum"),
+                event,
+            })
+            .expect("event record");
+            bytes.push(b'\n');
+            fs::write(root.0.join(JOURNAL_FILE_NAME), bytes).expect("write journal");
+
+            assert!(matches!(
+                LifecycleJournal::open(&root.0),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData
+            ));
+        }
     }
 
     #[test]
@@ -534,7 +623,7 @@ mod tests {
         let operation_id = OperationId::new();
         let generation = SandboxGeneration::new(1).expect("generation");
         let handle = format!(
-            "wh1_{}_{}",
+            "wh2_{}_{}",
             operation_id.as_uuid().simple(),
             generation.get()
         );
@@ -542,16 +631,21 @@ mod tests {
             EnvironmentProfileId::new("automata.dev/windows-wal-test-v1").expect("profile"),
             Sha256Digest::from_bytes([0x57; 32]),
         );
+        let custody = SandboxCustody::ProfileAdmission {
+            runner_id: RunnerId::new(),
+        };
         DurableEvent::CreateIntent {
             create: DurableCreate {
                 operation_id,
                 fingerprint: "11".repeat(32),
                 handle: handle.clone(),
+                custody,
             },
             entry: DurableEntry {
                 handle,
                 generation: generation.get(),
                 profile,
+                custody,
                 container: format!(
                     "automata-windows-hyperv-{}",
                     operation_id.as_uuid().simple()

--- a/crates/automata-ci-sandbox-windows/src/provider.rs
+++ b/crates/automata-ci-sandbox-windows/src/provider.rs
@@ -4,6 +4,7 @@ use std::{
     fmt,
     fs::{self, File, OpenOptions},
     io::Read as _,
+    num::NonZeroU16,
     os::windows::fs::{MetadataExt as _, OpenOptionsExt as _},
     path::{Component, Path, PathBuf},
     str::FromStr as _,
@@ -14,9 +15,10 @@ use std::{
 use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, EnvironmentProfile, EnvironmentProfileId,
     NeverCancelled, OperationId, OperationOutcome, ProviderCapabilities, ProviderError,
-    ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy, SandboxCapability,
-    SandboxHandle, SandboxInspection, SandboxLaunch, SandboxPrivilegePolicy, SandboxProvider,
-    SandboxRecord, SandboxSpec, SandboxState, Sha256Digest, TargetPath, TargetPlatform,
+    ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy, RunnerId,
+    SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection, SandboxLaunch,
+    SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
+    Sha256Digest, TargetPath, TargetPlatform,
 };
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
@@ -44,6 +46,11 @@ const MAX_PROCESS_LIMIT: u32 = 1_000_000;
 const CONTROL_OUTPUT_BYTES: usize = 1024 * 1024;
 const OWNER_LABEL: &str = "io.automata.owner";
 const OWNER_VALUE: &str = "automata-runner";
+const RESOURCE_SCHEMA_LABEL: &str = "io.automata.sandbox-schema";
+const RESOURCE_SCHEMA: &str = "2";
+const CUSTODY_KIND_LABEL: &str = "io.automata.custody-kind";
+const CUSTODY_RUNNER_LABEL: &str = "io.automata.custody-runner";
+const CUSTODY_SLOT_LABEL: &str = "io.automata.custody-slot";
 const SANDBOX_LABEL: &str = "io.automata.sandbox";
 const GENERATION_LABEL: &str = "io.automata.generation";
 const PROFILE_LABEL: &str = "io.automata.profile";
@@ -399,6 +406,7 @@ impl ProviderInner {
                     handle: entry.handle.clone(),
                     generation: entry.generation,
                     profile: entry.profile.clone(),
+                    custody: entry.custody,
                 };
                 lifecycle
                     .append(&DurableEvent::DestroyIntent {
@@ -522,7 +530,10 @@ impl ProviderInner {
         })?;
         let new_create = if let Some(replay) = lifecycle.snapshot.creates.get(&spec.operation_id())
         {
-            if replay.handle != handle.opaque() || replay.fingerprint != fingerprint {
+            if replay.handle != handle.opaque()
+                || replay.fingerprint != fingerprint
+                || replay.custody != spec.custody()
+            {
                 return Err(error::known(
                     ProviderErrorKind::Conflict,
                     ProviderStage::CreateSandbox,
@@ -531,6 +542,7 @@ impl ProviderInner {
             if let Some(tombstone) = lifecycle.snapshot.tombstones.get(handle.opaque()) {
                 if tombstone.generation != names.generation().get()
                     || tombstone.profile != *spec.profile().attestation()
+                    || tombstone.custody != spec.custody()
                 {
                     return Err(invalid_lifecycle());
                 }
@@ -545,7 +557,13 @@ impl ProviderInner {
                 .entries
                 .get(handle.opaque())
                 .ok_or_else(invalid_lifecycle)?;
-            validate_durable_entry(entry, names, fingerprint, spec.profile().attestation())?;
+            validate_durable_entry(
+                entry,
+                names,
+                fingerprint,
+                spec.profile().attestation(),
+                spec.custody(),
+            )?;
             if entry.phase == DurableEntryPhase::Destroying {
                 return Err(error::known(
                     ProviderErrorKind::Conflict,
@@ -566,11 +584,13 @@ impl ProviderInner {
                     operation_id: spec.operation_id(),
                     fingerprint: fingerprint.to_owned(),
                     handle: handle.opaque().to_owned(),
+                    custody: spec.custody(),
                 },
                 entry: DurableEntry {
                     handle: handle.opaque().to_owned(),
                     generation: names.generation().get(),
                     profile: spec.profile().attestation().clone(),
+                    custody: spec.custody(),
                     container: names.container(),
                     fingerprint: fingerprint.to_owned(),
                     phase: DurableEntryPhase::Intent,
@@ -965,6 +985,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
                 return Ok(SandboxInspection::new(
                     names.handle(),
                     names.generation(),
+                    tombstone.custody,
                     tombstone.profile.clone(),
                     SandboxState::Absent,
                 ));
@@ -981,6 +1002,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
             return Ok(SandboxInspection::new(
                 names.handle(),
                 names.generation(),
+                entry.custody,
                 entry.profile,
                 SandboxState::Degraded,
             ));
@@ -989,6 +1011,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
         Ok(SandboxInspection::new(
             names.handle(),
             names.generation(),
+            entry.custody,
             entry.profile,
             inspection.sandbox_state(),
         ))
@@ -1074,7 +1097,10 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
             )
         })?;
         if let Some(replay) = lifecycle.snapshot.destroys.get(&request.operation_id()) {
-            if replay.handle != handle.opaque() || replay.generation != request.generation().get() {
+            if replay.handle != handle.opaque()
+                || replay.generation != request.generation().get()
+                || replay.custody != request.custody()
+            {
                 return Err(error::known(
                     ProviderErrorKind::Conflict,
                     ProviderStage::DestroySandbox,
@@ -1092,7 +1118,9 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
             .get(&request.operation_id())
             .cloned()
         {
-            if pending.handle != handle.opaque() || pending.generation != request.generation().get()
+            if pending.handle != handle.opaque()
+                || pending.generation != request.generation().get()
+                || pending.custody != request.custody()
             {
                 return Err(error::known(
                     ProviderErrorKind::Conflict,
@@ -1112,7 +1140,9 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
             ));
         } else if let Some(tombstone) = lifecycle.snapshot.tombstones.get(handle.opaque()).cloned()
         {
-            if tombstone.generation != request.generation().get() {
+            if tombstone.generation != request.generation().get()
+                || tombstone.custody != request.custody()
+            {
                 return Err(error::known(
                     ProviderErrorKind::OwnershipMismatch,
                     ProviderStage::VerifyOwnership,
@@ -1123,6 +1153,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
                 handle: handle.opaque().to_owned(),
                 generation: request.generation().get(),
                 profile: tombstone.profile,
+                custody: request.custody(),
             };
             lifecycle
                 .append(&DurableEvent::DestroyAbsent { request: durable })
@@ -1143,7 +1174,8 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
                 .ok_or_else(|| {
                     error::known(ProviderErrorKind::NotFound, ProviderStage::DestroySandbox)
                 })?;
-            if entry.generation != request.generation().get() {
+            if entry.generation != request.generation().get() || entry.custody != request.custody()
+            {
                 return Err(error::known(
                     ProviderErrorKind::OwnershipMismatch,
                     ProviderStage::VerifyOwnership,
@@ -1154,6 +1186,7 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
                 handle: handle.opaque().to_owned(),
                 generation: request.generation().get(),
                 profile: entry.profile,
+                custody: request.custody(),
             };
             lifecycle
                 .append(&DurableEvent::DestroyIntent {
@@ -1175,6 +1208,13 @@ if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 91}
             .get(handle.opaque())
             .cloned()
             .ok_or_else(invalid_lifecycle)?;
+        if entry.generation != pending.generation
+            || entry.profile != pending.profile
+            || entry.custody != pending.custody
+            || pending.custody != request.custody()
+        {
+            return Err(invalid_lifecycle());
+        }
         if let Some(inspection) = self
             .inspect_optional(names, cancellation)
             .map_err(|failure| {
@@ -1422,8 +1462,21 @@ fn expected_labels(
     names: &ResourceName,
     fingerprint: &str,
 ) -> BTreeMap<String, String> {
+    let (custody_kind, custody_runner, custody_slot) = match spec.custody() {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            ("profile-admission", runner_id.to_string(), "0".to_owned())
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => ("job", runner_id.to_string(), slot_ordinal.get().to_string()),
+    };
     BTreeMap::from([
         (OWNER_LABEL.to_owned(), OWNER_VALUE.to_owned()),
+        (RESOURCE_SCHEMA_LABEL.to_owned(), RESOURCE_SCHEMA.to_owned()),
+        (CUSTODY_KIND_LABEL.to_owned(), custody_kind.to_owned()),
+        (CUSTODY_RUNNER_LABEL.to_owned(), custody_runner),
+        (CUSTODY_SLOT_LABEL.to_owned(), custody_slot),
         (SANDBOX_LABEL.to_owned(), names.identifier().to_owned()),
         (
             GENERATION_LABEL.to_owned(),
@@ -1517,8 +1570,17 @@ fn validate_durable_snapshot(
         if operation_id != &create.operation_id
             || names.identifier() != create.operation_id.as_uuid().simple().to_string()
             || !valid_fingerprint(&create.fingerprint)
-            || !(snapshot.entries.contains_key(&create.handle)
-                || snapshot.tombstones.contains_key(&create.handle))
+            || snapshot
+                .entries
+                .get(&create.handle)
+                .map(|entry| entry.custody)
+                .or_else(|| {
+                    snapshot
+                        .tombstones
+                        .get(&create.handle)
+                        .map(|tombstone| tombstone.custody)
+                })
+                != Some(create.custody)
         {
             return Err(invalid_lifecycle());
         }
@@ -1557,6 +1619,7 @@ fn validate_durable_snapshot(
                 entry.phase != DurableEntryPhase::Destroying
                     || entry.generation != pending.generation
                     || entry.profile != pending.profile
+                    || entry.custody != pending.custody
             })
         {
             return Err(invalid_lifecycle());
@@ -1568,7 +1631,10 @@ fn validate_durable_snapshot(
             || snapshot
                 .tombstones
                 .get(&destroy.handle)
-                .is_none_or(|tombstone| tombstone.generation != destroy.generation)
+                .is_none_or(|tombstone| {
+                    tombstone.generation != destroy.generation
+                        || tombstone.custody != destroy.custody
+                })
         {
             return Err(invalid_lifecycle());
         }
@@ -1581,9 +1647,10 @@ fn validate_durable_entry(
     names: &ResourceName,
     fingerprint: &str,
     profile: &EnvironmentProfile,
+    custody: SandboxCustody,
 ) -> Result<(), ProviderError> {
     validate_durable_entry_shape(entry, names)?;
-    if entry.fingerprint != fingerprint || entry.profile != *profile {
+    if entry.fingerprint != fingerprint || entry.profile != *profile || entry.custody != custody {
         return Err(invalid_lifecycle());
     }
     Ok(())
@@ -1624,6 +1691,7 @@ fn validate_durable_inspection(
         .label(CPU_LIMIT_LABEL)
         .and_then(|value| value.parse::<u32>().ok());
     if inspection.profile()? != entry.profile
+        || inspection.custody()? != entry.custody
         || inspection.label(SPEC_DIGEST_LABEL) != Some(entry.fingerprint.as_str())
         || inspection.label(IMAGE_LABEL) != Some(inspection.config.image.as_str())
         || inspection.label(WORKSPACE_LABEL) != Some(inspection.config.working_directory.as_str())
@@ -1775,11 +1843,13 @@ fn validate_owned_shape(
             .is_some_and(|healthcheck| healthcheck.test == ["NONE"])
         && inspection.network_settings.has_no_connectivity()
         && labels.get(OWNER_LABEL).map(String::as_str) == Some(OWNER_VALUE)
+        && labels.get(RESOURCE_SCHEMA_LABEL).map(String::as_str) == Some(RESOURCE_SCHEMA)
         && labels.get(SANDBOX_LABEL).map(String::as_str) == Some(names.identifier())
         && labels.get(GENERATION_LABEL).map(String::as_str)
             == Some(names.generation().get().to_string().as_str())
         && labels.get(HYPERV_LABEL).map(String::as_str) == Some("true")
-        && inspection.process_limit().is_ok();
+        && inspection.process_limit().is_ok()
+        && inspection.custody().is_ok();
     if !owned {
         return Err(error::known(
             ProviderErrorKind::OwnershipMismatch,
@@ -1795,6 +1865,8 @@ fn record(names: &ResourceName, profile: EnvironmentProfile, state: SandboxState
 
 fn spec_fingerprint(spec: &SandboxSpec) -> String {
     let mut hash = Sha256::new();
+    hash_field(&mut hash, b"automata-windows-hyperv-spec-v2");
+    hash_custody(&mut hash, spec.custody());
     for value in [
         spec.profile().id().as_str(),
         &spec.profile().digest().to_string(),
@@ -1837,6 +1909,23 @@ fn spec_fingerprint(spec: &SandboxSpec) -> String {
         hash_field(&mut hash, b"allocation-absent");
     }
     hex_digest(hash.finalize().into())
+}
+
+fn hash_custody(hash: &mut Sha256, custody: SandboxCustody) {
+    match custody {
+        SandboxCustody::ProfileAdmission { runner_id } => {
+            hash_field(hash, b"profile-admission");
+            hash_field(hash, runner_id.as_uuid().as_bytes());
+        }
+        SandboxCustody::Job {
+            runner_id,
+            slot_ordinal,
+        } => {
+            hash_field(hash, b"job");
+            hash_field(hash, runner_id.as_uuid().as_bytes());
+            hash_field(hash, &slot_ordinal.get().to_be_bytes());
+        }
+    }
 }
 
 fn hash_field(hash: &mut Sha256, value: &[u8]) {
@@ -2168,6 +2257,29 @@ impl ContainerInspection {
         }
     }
 
+    fn custody(&self) -> Result<SandboxCustody, ProviderError> {
+        let runner_id = self
+            .label(CUSTODY_RUNNER_LABEL)
+            .and_then(|value| RunnerId::from_str(value).ok())
+            .ok_or_else(ownership_mismatch)?;
+        let slot = self
+            .label(CUSTODY_SLOT_LABEL)
+            .and_then(|value| value.parse::<u16>().ok())
+            .ok_or_else(ownership_mismatch)?;
+        match self.label(CUSTODY_KIND_LABEL) {
+            Some("profile-admission") if slot == 0 => {
+                Ok(SandboxCustody::ProfileAdmission { runner_id })
+            }
+            Some("job") => NonZeroU16::new(slot)
+                .map(|slot_ordinal| SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal,
+                })
+                .ok_or_else(ownership_mismatch),
+            _ => Err(ownership_mismatch()),
+        }
+    }
+
     fn sandbox_state(&self) -> SandboxState {
         match self.state.status.as_str() {
             "created" => SandboxState::Created,
@@ -2188,6 +2300,13 @@ impl ContainerInspection {
                 )
             })
     }
+}
+
+fn ownership_mismatch() -> ProviderError {
+    error::known(
+        ProviderErrorKind::OwnershipMismatch,
+        ProviderStage::VerifyOwnership,
+    )
 }
 
 #[derive(Deserialize)]
@@ -2338,6 +2457,7 @@ mod tests {
     use std::{
         collections::VecDeque,
         env, fs,
+        num::NonZeroU16,
         path::PathBuf,
         sync::{Arc, Mutex},
     };
@@ -2345,7 +2465,7 @@ mod tests {
     use super::*;
     use automata_ci_execution::{
         ExecutionArgv, ExecutionEnvironment, ImmutableImage, NetworkPolicy, ResourceLimits,
-        SandboxEnvironment, SandboxGeneration, SandboxPrivilegePolicy,
+        RunnerId, SandboxEnvironment, SandboxGeneration, SandboxPrivilegePolicy,
     };
     use serde_json::{Value, json};
 
@@ -2402,6 +2522,15 @@ mod tests {
     }
 
     fn hyperv_spec_with_keepalive(arguments: Vec<String>) -> SandboxSpec {
+        hyperv_spec_with_custody(
+            arguments,
+            SandboxCustody::ProfileAdmission {
+                runner_id: RunnerId::new(),
+            },
+        )
+    }
+
+    fn hyperv_spec_with_custody(arguments: Vec<String>, custody: SandboxCustody) -> SandboxSpec {
         let workspace = TargetPath::windows(r"C:\__w").expect("workspace");
         let profile = EnvironmentProfile::new(
             EnvironmentProfileId::new("example.com/windows-hyperv").expect("profile id"),
@@ -2424,6 +2553,7 @@ mod tests {
         SandboxSpec::new(
             OperationId::new(),
             SandboxGeneration::new(3).expect("generation"),
+            custody,
             environment,
             workspace,
             NetworkPolicy::Disabled,
@@ -2584,6 +2714,9 @@ mod tests {
         let generic = SandboxSpec::new(
             OperationId::new(),
             SandboxGeneration::new(4).expect("generation"),
+            SandboxCustody::ProfileAdmission {
+                runner_id: RunnerId::new(),
+            },
             generic_environment,
             workspace,
             NetworkPolicy::Disabled,
@@ -2633,6 +2766,12 @@ mod tests {
                 "/NetworkSettings/Networks/none/IPAddress",
                 json!("10.0.0.2"),
             ),
+            ("/Config/Labels/io.automata.sandbox-schema", json!("1")),
+            (
+                "/Config/Labels/io.automata.custody-runner",
+                json!(RunnerId::new().to_string()),
+            ),
+            ("/Config/Labels/io.automata.custody-slot", json!("1")),
         ] {
             let mut weakened = baseline.clone();
             *weakened
@@ -2673,11 +2812,13 @@ mod tests {
                             operation_id: spec.operation_id(),
                             fingerprint: fingerprint.clone(),
                             handle: names.handle().opaque().to_owned(),
+                            custody: spec.custody(),
                         },
                         entry: DurableEntry {
                             handle: names.handle().opaque().to_owned(),
                             generation: names.generation().get(),
                             profile: spec.profile().attestation().clone(),
+                            custody: spec.custody(),
                             container: names.container(),
                             fingerprint,
                             phase: DurableEntryPhase::Intent,
@@ -2718,6 +2859,80 @@ mod tests {
     }
 
     #[test]
+    fn startup_recovery_rejects_wrong_runner_slot_and_old_resource_schema() {
+        let runner_id = RunnerId::new();
+        for (label, custody, pointer, replacement) in [
+            (
+                "schema",
+                SandboxCustody::ProfileAdmission { runner_id },
+                "/Config/Labels/io.automata.sandbox-schema",
+                json!("1"),
+            ),
+            (
+                "runner",
+                SandboxCustody::ProfileAdmission { runner_id },
+                "/Config/Labels/io.automata.custody-runner",
+                json!(RunnerId::new().to_string()),
+            ),
+            (
+                "slot",
+                SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(2).expect("non-zero slot"),
+                },
+                "/Config/Labels/io.automata.custody-slot",
+                json!("1"),
+            ),
+        ] {
+            let root = TestRoot::new(&format!("recovery-{label}"));
+            let spec = hyperv_spec_with_custody(vec!["keepalive".to_owned()], custody);
+            let names = ResourceName::for_create(spec.operation_id(), spec.generation());
+            let fingerprint = spec_fingerprint(&spec);
+            {
+                let (mut journal, mut snapshot) =
+                    LifecycleJournal::open(&root.path).expect("open lifecycle WAL");
+                journal
+                    .append_to_snapshot(
+                        &mut snapshot,
+                        &DurableEvent::CreateIntent {
+                            create: DurableCreate {
+                                operation_id: spec.operation_id(),
+                                fingerprint: fingerprint.clone(),
+                                handle: names.handle().opaque().to_owned(),
+                                custody: spec.custody(),
+                            },
+                            entry: DurableEntry {
+                                handle: names.handle().opaque().to_owned(),
+                                generation: names.generation().get(),
+                                profile: spec.profile().attestation().clone(),
+                                custody: spec.custody(),
+                                container: names.container(),
+                                fingerprint: fingerprint.clone(),
+                                phase: DurableEntryPhase::Intent,
+                            },
+                        },
+                    )
+                    .expect("persist current create intent");
+            }
+            let mut observed = inspection_value(&spec, &names, &fingerprint);
+            *observed
+                .pointer_mut(pointer)
+                .expect("inspection mutation path") = replacement;
+            let executor = Arc::new(ScriptedExecutor::new([RuntimeCommandOutput::success(
+                serde_json::to_vec(&vec![observed]).expect("inspection JSON"),
+            )]));
+
+            let error = WindowsHyperVContainerProvider::open_with_executor(
+                root.options(),
+                executor.clone(),
+            )
+            .expect_err("startup recovery must bind current schema and exact custody");
+            assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+            executor.assert_drained();
+        }
+    }
+
+    #[test]
     fn startup_completes_the_exact_pending_destroy_operation() {
         let root = TestRoot::new("pending-destroy");
         let spec = hyperv_spec();
@@ -2736,11 +2951,13 @@ mod tests {
                             operation_id: spec.operation_id(),
                             fingerprint: fingerprint.clone(),
                             handle: handle.clone(),
+                            custody: spec.custody(),
                         },
                         entry: DurableEntry {
                             handle: handle.clone(),
                             generation: names.generation().get(),
                             profile: spec.profile().attestation().clone(),
+                            custody: spec.custody(),
                             container: names.container(),
                             fingerprint: fingerprint.clone(),
                             phase: DurableEntryPhase::Intent,
@@ -2765,6 +2982,7 @@ mod tests {
                             handle,
                             generation: names.generation().get(),
                             profile: spec.profile().attestation().clone(),
+                            custody: spec.custody(),
                         },
                     },
                 )
@@ -2782,7 +3000,12 @@ mod tests {
         let provider =
             WindowsHyperVContainerProvider::open_with_executor(root.options(), executor.clone())
                 .expect("startup completes pending cleanup");
-        let request = DestroySandbox::new(destroy_operation, names.handle(), names.generation());
+        let request = DestroySandbox::new(
+            destroy_operation,
+            names.handle(),
+            names.generation(),
+            spec.custody(),
+        );
         assert_eq!(
             provider
                 .destroy(&request, &NeverCancelled)
@@ -2842,10 +3065,37 @@ mod tests {
             .expect("create exact sandbox");
         assert_eq!(record.state(), SandboxState::Running);
 
+        let runtime_calls = executor.calls.lock().expect("calls lock").len();
+        let SandboxCustody::ProfileAdmission { runner_id } = spec.custody() else {
+            panic!("test spec uses profile-admission custody");
+        };
+        let wrong_custody = DestroySandbox::new(
+            OperationId::new(),
+            record.handle().clone(),
+            record.generation(),
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+            },
+        );
+        assert_eq!(
+            provider
+                .destroy(&wrong_custody, &NeverCancelled)
+                .expect_err("wrong custody must not authorize container removal")
+                .kind(),
+            ProviderErrorKind::OwnershipMismatch
+        );
+        assert_eq!(
+            executor.calls.lock().expect("calls lock").len(),
+            runtime_calls,
+            "custody rejection must precede every runtime mutation"
+        );
+
         let destroy = DestroySandbox::new(
             OperationId::new(),
             record.handle().clone(),
             record.generation(),
+            spec.custody(),
         );
         assert_eq!(
             provider
@@ -2863,6 +3113,7 @@ mod tests {
             OperationId::new(),
             record.handle().clone(),
             record.generation(),
+            spec.custody(),
         );
         assert_eq!(
             provider
@@ -2876,13 +3127,11 @@ mod tests {
                 .expect("exact absent replay"),
             DestroyDisposition::AlreadyAbsent
         );
-        assert_eq!(
-            provider
-                .inspect(record.handle(), &NeverCancelled)
-                .expect("inspect tombstone")
-                .state(),
-            SandboxState::Absent
-        );
+        let inspection = provider
+            .inspect(record.handle(), &NeverCancelled)
+            .expect("inspect tombstone");
+        assert_eq!(inspection.state(), SandboxState::Absent);
+        assert_eq!(inspection.custody(), spec.custody());
         assert_eq!(
             provider
                 .create(&spec, &NeverCancelled)


### PR DESCRIPTION
## Outcome

Binds every sandbox lifecycle to exact runner custody and verifies that custody across fresh creation, recovery, attach, execution, inspection, and destruction.

The generic executor now performs an exact post-create inspection before service discovery or attach. Kubernetes treats the Pod and deny-all NetworkPolicy as one required identity and validates canonical generation/profile/custody annotations. Podman reconciles the union of deterministic names and captured IDs for service/proxy remnants, preflights every object before mutation, and cannot report destruction while an exact-ID remnant survives. macOS and Windows persistence move to the same current custody schema.

This is the next self-contained stack layer split from draft #173, on top of the explicit cancellation authority from #357.

## Related issue

Related to #173.

## Trust and compatibility impact

This advances the current sandbox custody/persistence contract with no compatibility aliases or fallback schema. Recovery fails closed on absent, asymmetric, non-canonical, or foreign custody evidence. Destructive operations are authorized by exact handle, generation, custody, and provider-owned fingerprint; wrong custody produces no deletion. Provider cancellation retains the observation-only `Active | Terminate` semantics from #357.

There is no new network protocol, credential surface, or GitHub Actions compatibility behavior.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- affected-package all-target/all-feature locked checks
- full GitHub job-executor suite
- runner-runtime execution/provider recovery suites
- Kubernetes: 4 unit + 23 integration tests
- Podman: 81 unit + 78 integration tests; 7 opt-in live tests ignored
- profile admission: 18 tests
- native strict Clippy with `-D warnings` for every affected package
- direct Windows provider MSVC strict Clippy
- direct macOS provider strict Clippy
- broad aggregate cross lint attempted; the host lacks MSVC `lib.exe` and an Apple-capable C compiler for `ring`, while directly affected platform gates pass
- independent strict semantic review: CLEAN
- final rebase was an exact one-to-one range-diff over a zero-overlap test-only main change

## AI assistance

OpenAI Codex helped extract the custody layer from the larger draft, remediate adversarial recovery findings, run validation, and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
