### PR TITLE
test(github-delivery): consolidate typed port fixtures

### DIFF
--- a/crates/automata-ci-github-delivery/tests/delivery_service.rs
+++ b/crates/automata-ci-github-delivery/tests/delivery_service.rs
@@ -9,10 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_auth::secret::SecretString;
-use automata_ci_blob::{
-    BlobDescriptor, BlobKey, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    MediaType, PutBlobOutcome, VerifiedBlob,
-};
+use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
 use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_github_delivery::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubChangedFileSelection,
@@ -49,9 +46,9 @@ use automata_ci_store::{
     ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
     ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
     ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryReceipt,
-    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
     RejectProviderDelivery, RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim,
     RepositoryId as StoreRepositoryId, RetryProviderDelivery, TenantScope,
@@ -67,8 +64,8 @@ use super::subject_evidence::{
     fixture_check_head_sha, fixture_subject_evidence, fixture_subject_evidence_with_head,
 };
 use super::support::{
-    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, ZERO,
-    archive, provider_event_envelope, push_body,
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, ProviderDeliveryLedger, REPOSITORY, REPOSITORY_ID,
+    REPOSITORY_OWNER_ID, VerifiedBlobStore, ZERO, archive, provider_event_envelope, push_body,
 };
 
 const DELIVERY: &str = "delivery-service-1";
@@ -169,34 +166,6 @@ impl GithubDeliveryClock for BlockingClock {
             }
         }
         UnixMillis::new(self.now.load(Ordering::SeqCst))
-    }
-}
-
-#[derive(Debug)]
-struct FixtureBlobStore {
-    descriptor: BlobDescriptor,
-    bytes: Bytes,
-    reads: AtomicUsize,
-}
-
-#[async_trait]
-impl ImmutableBlobStore for FixtureBlobStore {
-    async fn put_if_absent(&self, _payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
-        panic!("the delivery service never writes its authenticated raw object")
-    }
-
-    async fn get_verified(
-        &self,
-        descriptor: &BlobDescriptor,
-        maximum_bytes: u64,
-    ) -> Result<VerifiedBlob, BlobStoreError> {
-        self.reads.fetch_add(1, Ordering::SeqCst);
-        if descriptor != &self.descriptor || descriptor.size() > maximum_bytes {
-            return Err(BlobStoreError::new(BlobStoreErrorKind::Integrity));
-        }
-        let payload = BlobPayload::verify(descriptor.clone(), self.bytes.clone())
-            .map_err(|_| BlobStoreError::new(BlobStoreErrorKind::Integrity))?;
-        Ok(VerifiedBlob::from_payload(payload))
     }
 }
 
@@ -927,17 +896,13 @@ struct RecordingRepository {
     template: DeliveryTemplate,
     renewal_behavior: RenewalBehavior,
     terminal_behavior: TerminalBehavior,
+    ledger: ProviderDeliveryLedger,
     claim_calls: Mutex<Vec<ClaimProviderDelivery>>,
     claim_count: AtomicUsize,
     reclaim_enabled: AtomicBool,
     claimed_at: Mutex<Option<UnixMillis>>,
     renewals: Mutex<Vec<RenewProviderDeliveryClaim>>,
     renewal_called: Notify,
-    completions: Mutex<Vec<CompleteProviderDelivery>>,
-    retries: Mutex<Vec<RetryProviderDelivery>>,
-    rejections: Mutex<Vec<RejectProviderDelivery>>,
-    inventory: Mutex<Option<ProviderDeliveryWorkflowInventory>>,
-    progress: Mutex<Vec<ProviderDeliveryWorkflowOutcome>>,
     terminal_entered: Notify,
     terminal_release: CancellationToken,
     renewal_apply_gate: Arc<RenewalApplyGate>,
@@ -945,19 +910,11 @@ struct RecordingRepository {
 
 impl RecordingRepository {
     fn receipt(&self, state: ProviderDeliveryState) -> ProviderDeliveryReceipt {
-        ProviderDeliveryReceipt::from_durable_parts(
-            self.template.delivery_id,
-            state,
-            1,
-            UnixMillis::new(50),
-        )
-        .expect("transition receipt")
+        self.ledger.receipt(self.template.delivery_id, state)
     }
 
     fn transition_count(&self) -> usize {
-        self.completions.lock().expect("completions lock").len()
-            + self.retries.lock().expect("retries lock").len()
-            + self.rejections.lock().expect("rejections lock").len()
+        self.ledger.transition_count()
     }
 }
 
@@ -1039,10 +996,7 @@ impl ProviderDeliveryRepository for RecordingRepository {
         &self,
         request: CompleteProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.completions
-            .lock()
-            .expect("completions lock")
-            .push(request);
+        self.ledger.record_completion(request);
         if self.terminal_behavior == TerminalBehavior::BlockThenSucceed {
             self.terminal_entered.notify_one();
             self.terminal_release.cancelled().await;
@@ -1057,57 +1011,21 @@ impl ProviderDeliveryRepository for RecordingRepository {
         &self,
         request: RegisterProviderDeliveryWorkflowInventory,
     ) -> Result<ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryStoreError> {
-        let mut inventory = self.inventory.lock().expect("inventory lock");
-        match inventory.as_ref() {
-            Some(existing) if existing != request.inventory() => {
-                return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-            }
-            Some(_) => {}
-            None => *inventory = Some(request.inventory().clone()),
-        }
-        ProviderDeliveryWorkflowInventoryReceipt::new(
-            inventory.as_ref().expect("inventory initialized").clone(),
-            self.progress.lock().expect("progress lock").clone(),
-        )
-        .map_err(|_| ProviderDeliveryStoreError::WorkflowProgressRejected)
+        self.ledger.register_workflow_inventory(&request)
     }
 
     async fn record_provider_delivery_workflow_progress(
         &self,
         request: RecordProviderDeliveryWorkflowProgress,
     ) -> Result<ProviderDeliveryWorkflowOutcome, ProviderDeliveryStoreError> {
-        let inventory = self.inventory.lock().expect("inventory lock");
-        let Some(inventory) = inventory.as_ref() else {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        };
-        if inventory.digest() != request.inventory_digest()
-            || !inventory
-                .entries()
-                .iter()
-                .any(|entry| entry.workflow_path() == request.outcome().workflow_path())
-        {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        }
-        let mut progress = self.progress.lock().expect("progress lock");
-        if let Some(existing) = progress
-            .iter()
-            .find(|existing| existing.workflow_path() == request.outcome().workflow_path())
-        {
-            return if existing == request.outcome() {
-                Ok(existing.clone())
-            } else {
-                Err(ProviderDeliveryStoreError::WorkflowProgressRejected)
-            };
-        }
-        progress.push(request.outcome().clone());
-        Ok(request.outcome().clone())
+        self.ledger.record_workflow_progress(&request)
     }
 
     async fn retry_provider_delivery(
         &self,
         request: RetryProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.retries.lock().expect("retries lock").push(request);
+        self.ledger.record_retry(request);
         Ok(self.receipt(ProviderDeliveryState::RetryPending))
     }
 
@@ -1115,10 +1033,7 @@ impl ProviderDeliveryRepository for RecordingRepository {
         &self,
         request: RejectProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.rejections
-            .lock()
-            .expect("rejections lock")
-            .push(request);
+        self.ledger.record_rejection(request);
         if self.terminal_behavior == TerminalBehavior::BlockThenSucceed {
             self.terminal_entered.notify_one();
             self.terminal_release.cancelled().await;
@@ -1275,7 +1190,7 @@ fn database_issued_at(behavior: RenewalBehavior, requested_at: UnixMillis) -> Un
 
 struct Harness {
     service: Arc<GithubDeliveryService>,
-    objects: Arc<FixtureBlobStore>,
+    objects: Arc<VerifiedBlobStore>,
     repository: Arc<RecordingRepository>,
     credentials: Arc<RecordingCredentialProvider>,
     source: Arc<RecordingSourcePort>,
@@ -1304,17 +1219,13 @@ fn blocking_clock_harness(
         template,
         renewal_behavior: RenewalBehavior::NeverReturns,
         terminal_behavior: TerminalBehavior::Succeed,
+        ledger: ProviderDeliveryLedger::new(1, UnixMillis::new(50)),
         claim_calls: Mutex::new(Vec::new()),
         claim_count: AtomicUsize::new(0),
         reclaim_enabled: AtomicBool::new(false),
         claimed_at: Mutex::new(None),
         renewals: Mutex::new(Vec::new()),
         renewal_called: Notify::new(),
-        completions: Mutex::new(Vec::new()),
-        retries: Mutex::new(Vec::new()),
-        rejections: Mutex::new(Vec::new()),
-        inventory: Mutex::new(None),
-        progress: Mutex::new(Vec::new()),
         terminal_entered: Notify::new(),
         terminal_release: CancellationToken::new(),
         renewal_apply_gate,
@@ -1326,11 +1237,7 @@ fn blocking_clock_harness(
     ));
     let worker_id =
         ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
-    let objects = Arc::new(FixtureBlobStore {
-        descriptor,
-        bytes: body,
-        reads: AtomicUsize::new(0),
-    });
+    let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = GithubDeliveryService::new_public_only(
         objects,
         source,
@@ -1430,17 +1337,13 @@ fn harness_with_stored_visibility(
         template,
         renewal_behavior,
         terminal_behavior,
+        ledger: ProviderDeliveryLedger::new(1, UnixMillis::new(50)),
         claim_calls: Mutex::new(Vec::new()),
         claim_count: AtomicUsize::new(0),
         reclaim_enabled: AtomicBool::new(false),
         claimed_at: Mutex::new(None),
         renewals: Mutex::new(Vec::new()),
         renewal_called: Notify::new(),
-        completions: Mutex::new(Vec::new()),
-        retries: Mutex::new(Vec::new()),
-        rejections: Mutex::new(Vec::new()),
-        inventory: Mutex::new(None),
-        progress: Mutex::new(Vec::new()),
         terminal_entered: Notify::new(),
         terminal_release: CancellationToken::new(),
         renewal_apply_gate: renewal_apply_gate.clone(),
@@ -1453,11 +1356,7 @@ fn harness_with_stored_visibility(
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
         ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
-    let objects = Arc::new(FixtureBlobStore {
-        descriptor,
-        bytes: body,
-        reads: AtomicUsize::new(0),
-    });
+    let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = if private_source_enabled {
         GithubDeliveryService::new_with_private_source_credentials(
             objects.clone(),
@@ -1525,17 +1424,13 @@ fn snapshot_processor_harness_with_config(
         template,
         renewal_behavior,
         terminal_behavior: TerminalBehavior::Succeed,
+        ledger: ProviderDeliveryLedger::new(1, UnixMillis::new(50)),
         claim_calls: Mutex::new(Vec::new()),
         claim_count: AtomicUsize::new(0),
         reclaim_enabled: AtomicBool::new(false),
         claimed_at: Mutex::new(None),
         renewals: Mutex::new(Vec::new()),
         renewal_called: Notify::new(),
-        completions: Mutex::new(Vec::new()),
-        retries: Mutex::new(Vec::new()),
-        rejections: Mutex::new(Vec::new()),
-        inventory: Mutex::new(None),
-        progress: Mutex::new(Vec::new()),
         terminal_entered: Notify::new(),
         terminal_release: CancellationToken::new(),
         renewal_apply_gate: renewal_apply_gate.clone(),
@@ -1563,11 +1458,7 @@ fn snapshot_processor_harness_with_config(
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
         ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
-    let objects = Arc::new(FixtureBlobStore {
-        descriptor,
-        bytes: body,
-        reads: AtomicUsize::new(0),
-    });
+    let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = GithubDeliveryService::new_with_private_source_credentials(
         objects.clone(),
         source.clone(),
@@ -1610,17 +1501,13 @@ fn changed_files_renewal_harness(
         template,
         renewal_behavior: RenewalBehavior::BlockCommittedThenSucceed,
         terminal_behavior: TerminalBehavior::Succeed,
+        ledger: ProviderDeliveryLedger::new(1, UnixMillis::new(50)),
         claim_calls: Mutex::new(Vec::new()),
         claim_count: AtomicUsize::new(0),
         reclaim_enabled: AtomicBool::new(false),
         claimed_at: Mutex::new(None),
         renewals: Mutex::new(Vec::new()),
         renewal_called: Notify::new(),
-        completions: Mutex::new(Vec::new()),
-        retries: Mutex::new(Vec::new()),
-        rejections: Mutex::new(Vec::new()),
-        inventory: Mutex::new(None),
-        progress: Mutex::new(Vec::new()),
         terminal_entered: Notify::new(),
         terminal_release: CancellationToken::new(),
         renewal_apply_gate: renewal_apply_gate.clone(),
@@ -1643,11 +1530,7 @@ fn changed_files_renewal_harness(
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
         ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
-    let objects = Arc::new(FixtureBlobStore {
-        descriptor,
-        bytes: body,
-        reads: AtomicUsize::new(0),
-    });
+    let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let changed_files = Arc::new(match first_disposition {
         Some(disposition) => {
             RenewalRacingChangedFiles::new(disposition, renewal_apply_gate.clone())
@@ -1723,11 +1606,7 @@ async fn wait_for_renewal_count(repository: &RecordingRepository, expected: usiz
 }
 
 fn assert_single_skipped_completion(harness: &Harness, fence: u64) {
-    let completions = harness
-        .repository
-        .completions
-        .lock()
-        .expect("completions lock");
+    let completions = harness.repository.ledger.completions();
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].claim().fence(), fence);
     assert_eq!(completions[0].outcomes().len(), 1);
@@ -1737,22 +1616,8 @@ fn assert_single_skipped_completion(harness: &Harness, fence: u64) {
             if reason.as_str() == "github.workflow.event_filters_not_matched"
     ));
     drop(completions);
-    assert!(
-        harness
-            .repository
-            .retries
-            .lock()
-            .expect("retries lock")
-            .is_empty()
-    );
-    assert!(
-        harness
-            .repository
-            .rejections
-            .lock()
-            .expect("rejections lock")
-            .is_empty()
-    );
+    assert!(harness.repository.ledger.retries().is_empty());
+    assert!(harness.repository.ledger.rejections().is_empty());
 }
 
 async fn advance_successful_renewals(
@@ -1940,11 +1805,7 @@ async fn success_uses_one_stable_worker_and_exact_request_scoped_credential() {
         );
     }
     {
-        let completions = harness
-            .repository
-            .completions
-            .lock()
-            .expect("completions lock");
+        let completions = harness.repository.ledger.completions();
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].outcomes().len(), 1);
     }
@@ -2000,7 +1861,7 @@ async fn public_delivery_ignores_retained_private_credentials_and_fetches_anonym
                     .is_empty()
             );
         }
-        assert_eq!(harness.objects.reads.load(Ordering::SeqCst), 1);
+        assert_eq!(harness.objects.read_count(), 1);
         assert_eq!(harness.source.calls.load(Ordering::SeqCst), 1);
         assert!(!harness.source.credential_present.load(Ordering::SeqCst));
         assert!(!harness.source.credential_matched.load(Ordering::SeqCst));
@@ -2031,15 +1892,11 @@ async fn public_only_service_terminally_rejects_private_delivery_without_credent
         outcome,
         GithubDeliveryServiceOutcome::Processed(GithubDeliveryWorkerOutcome::Rejected(_))
     ));
-    assert_eq!(harness.objects.reads.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.objects.read_count(), 1);
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.repository.transition_count(), 1);
-    let rejections = harness
-        .repository
-        .rejections
-        .lock()
-        .expect("rejections lock");
+    let rejections = harness.repository.ledger.rejections();
     assert_eq!(rejections.len(), 1);
     assert_eq!(
         rejections[0].failure_kind().as_str(),
@@ -2068,15 +1925,11 @@ async fn public_only_service_rejects_envelope_visibility_mismatch_before_blob_io
         outcome,
         GithubDeliveryServiceOutcome::Processed(GithubDeliveryWorkerOutcome::Rejected(_))
     ));
-    assert_eq!(harness.objects.reads.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.objects.read_count(), 0);
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.repository.transition_count(), 1);
-    let rejections = harness
-        .repository
-        .rejections
-        .lock()
-        .expect("rejections lock");
+    let rejections = harness.repository.ledger.rejections();
     assert_eq!(rejections.len(), 1);
     assert_eq!(
         rejections[0].failure_kind().as_str(),
@@ -2105,15 +1958,11 @@ async fn public_only_service_rejects_private_envelope_before_anonymous_source() 
         outcome,
         GithubDeliveryServiceOutcome::Processed(GithubDeliveryWorkerOutcome::Rejected(_))
     ));
-    assert_eq!(harness.objects.reads.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.objects.read_count(), 0);
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.repository.transition_count(), 1);
-    let rejections = harness
-        .repository
-        .rejections
-        .lock()
-        .expect("rejections lock");
+    let rejections = harness.repository.ledger.rejections();
     assert_eq!(rejections.len(), 1);
     assert_eq!(
         rejections[0].failure_kind().as_str(),
@@ -2141,23 +1990,12 @@ async fn public_only_service_rejects_private_deletion_before_empty_completion() 
         outcome,
         GithubDeliveryServiceOutcome::Processed(GithubDeliveryWorkerOutcome::Rejected(_))
     ));
-    assert_eq!(harness.objects.reads.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.objects.read_count(), 1);
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.repository.transition_count(), 1);
-    assert!(
-        harness
-            .repository
-            .completions
-            .lock()
-            .expect("completions lock")
-            .is_empty()
-    );
-    let rejections = harness
-        .repository
-        .rejections
-        .lock()
-        .expect("rejections lock");
+    assert!(harness.repository.ledger.completions().is_empty());
+    let rejections = harness.repository.ledger.rejections();
     assert_eq!(rejections.len(), 1);
     assert_eq!(
         rejections[0].failure_kind().as_str(),
@@ -2184,23 +2022,8 @@ async fn public_only_private_rejection_preserves_terminal_fence_loss() {
     ));
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
-    assert_eq!(
-        harness
-            .repository
-            .rejections
-            .lock()
-            .expect("rejections lock")
-            .len(),
-        1
-    );
-    assert!(
-        harness
-            .repository
-            .completions
-            .lock()
-            .expect("completions lock")
-            .is_empty()
-    );
+    assert_eq!(harness.repository.ledger.rejections().len(), 1);
+    assert!(harness.repository.ledger.completions().is_empty());
 }
 
 #[tokio::test]
@@ -2247,11 +2070,7 @@ async fn renewal_during_revision_fetch_discards_stale_source_and_reinvokes() {
     )
     .expect("renewed claim fence");
     drop(renewals);
-    let completions = harness
-        .repository
-        .completions
-        .lock()
-        .expect("completions lock");
+    let completions = harness.repository.ledger.completions();
     assert_eq!(
         completions[0].completed_at(),
         UnixMillis::new(AFTER_INITIAL_EXPIRY)
@@ -2309,11 +2128,7 @@ async fn renewal_during_revision_release_reuses_the_completed_source() {
     assert_eq!(harness.source.calls.load(Ordering::SeqCst), 1);
     assert_eq!(harness.credentials.calls.load(Ordering::SeqCst), 1);
     assert_eq!(harness.credentials.releases.load(Ordering::SeqCst), 1);
-    let completions = harness
-        .repository
-        .completions
-        .lock()
-        .expect("completions lock");
+    let completions = harness.repository.ledger.completions();
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].claim().fence(), 8);
 }
@@ -2542,11 +2357,7 @@ async fn sequential_renewals_rotate_the_latest_terminal_fence() {
     assert_eq!(renewals[1].claim().fence(), 8);
     assert_eq!(renewals[1].observed_at(), UnixMillis::new(RENEWED_NOW + 20));
     drop(renewals);
-    let completions = harness
-        .repository
-        .completions
-        .lock()
-        .expect("completions lock");
+    let completions = harness.repository.ledger.completions();
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].claim().fence(), 9);
 }
@@ -2614,14 +2425,7 @@ async fn stale_processor_failure_waits_for_renewal_and_is_reinvoked() {
     assert_eq!(snapshots[0].claim().fence(), 7);
     assert_eq!(snapshots[1].claim().fence(), 8);
     assert_eq!(harness.repository.transition_count(), 1);
-    assert!(
-        harness
-            .repository
-            .rejections
-            .lock()
-            .expect("rejections lock")
-            .is_empty()
-    );
+    assert!(harness.repository.ledger.rejections().is_empty());
 }
 
 #[tokio::test]
@@ -3492,14 +3296,10 @@ async fn credential_authority_failures_have_closed_retry_or_terminal_outcomes() 
         assert_eq!(outcome.receipt().state(), expected_state);
         assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
         if expected_state == ProviderDeliveryState::RetryPending {
-            let retries = harness.repository.retries.lock().expect("retries lock");
+            let retries = harness.repository.ledger.retries();
             assert_eq!(retries[0].failure_kind().as_str(), expected_kind);
         } else {
-            let rejections = harness
-                .repository
-                .rejections
-                .lock()
-                .expect("rejections lock");
+            let rejections = harness.repository.ledger.rejections();
             assert_eq!(rejections[0].failure_kind().as_str(), expected_kind);
         }
     }
@@ -3538,11 +3338,7 @@ async fn credential_identity_and_expiry_mismatch_reject_before_source_io() {
             ))
         );
         assert_eq!(harness.source.calls.load(Ordering::SeqCst), 0);
-        let rejections = harness
-            .repository
-            .rejections
-            .lock()
-            .expect("rejections lock");
+        let rejections = harness.repository.ledger.rejections();
         assert_eq!(
             rejections[0].failure_kind().as_str(),
             "github.repository_source.credential_invalid"
@@ -3563,15 +3359,7 @@ async fn terminal_fence_loss_is_reported_as_nonfatal_claim_loss() {
         run_once(harness.service, CancellationToken::new()).await,
         Err(GithubDeliveryServiceError::ClaimLost)
     ));
-    assert_eq!(
-        harness
-            .repository
-            .completions
-            .lock()
-            .expect("completions lock")
-            .len(),
-        1
-    );
+    assert_eq!(harness.repository.ledger.completions().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/automata-ci-github-delivery/tests/support/mod.rs
+++ b/crates/automata-ci-github-delivery/tests/support/mod.rs
@@ -1,6 +1,17 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
-use automata_ci_blob::BlobDescriptor;
+use async_trait::async_trait;
+use automata_ci_blob::{
+    BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
+    PutBlobOutcome, VerifiedBlob,
+};
+use automata_ci_core::UnixMillis;
 use automata_ci_github::{
     GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE,
     GithubRepositoryVisibility as GithubRepositoryVisibilityFact, GithubSealedEventEnvelopeV1,
@@ -8,7 +19,14 @@ use automata_ci_github::{
     rehydrate_stored_authenticated_github_webhook,
 };
 use automata_ci_github_delivery::GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE;
-use automata_ci_store::{ProviderDeliveryEventEnvelope, ProviderRepositoryVisibility};
+use automata_ci_store::{
+    CompleteProviderDelivery, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
+    ProviderDeliveryReceipt, ProviderDeliveryState, ProviderDeliveryStoreError,
+    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryReceipt,
+    ProviderDeliveryWorkflowOutcome, ProviderRepositoryVisibility,
+    RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
+    RejectProviderDelivery, RetryProviderDelivery,
+};
 use bytes::Bytes;
 use flate2::{Compression, write::GzEncoder};
 use tar::{Builder, EntryType, Header};
@@ -21,6 +39,195 @@ pub(super) const REPOSITORY: &str = "private-repository";
 pub(super) const REPOSITORY_ID: u64 = 9_001;
 pub(super) const REPOSITORY_OWNER_ID: u64 = 8_001;
 pub(super) const INSTALLATION_ID: u64 = 4_242;
+
+#[derive(Debug)]
+pub(super) struct ProviderDeliveryLedger {
+    attempts: u16,
+    accepted_at: UnixMillis,
+    completions: Mutex<Vec<CompleteProviderDelivery>>,
+    retries: Mutex<Vec<RetryProviderDelivery>>,
+    rejections: Mutex<Vec<RejectProviderDelivery>>,
+    inventory: Mutex<Option<ProviderDeliveryWorkflowInventory>>,
+    progress: Mutex<Vec<ProviderDeliveryWorkflowOutcome>>,
+}
+
+impl ProviderDeliveryLedger {
+    pub(super) fn new(attempts: u16, accepted_at: UnixMillis) -> Self {
+        Self {
+            attempts,
+            accepted_at,
+            completions: Mutex::new(Vec::new()),
+            retries: Mutex::new(Vec::new()),
+            rejections: Mutex::new(Vec::new()),
+            inventory: Mutex::new(None),
+            progress: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn receipt(
+        &self,
+        delivery_id: ProviderDeliveryId,
+        state: ProviderDeliveryState,
+    ) -> ProviderDeliveryReceipt {
+        ProviderDeliveryReceipt::from_durable_parts(
+            delivery_id,
+            state,
+            self.attempts,
+            self.accepted_at,
+        )
+        .expect("transition receipt")
+    }
+
+    pub(super) fn record_completion(&self, request: CompleteProviderDelivery) {
+        self.completions
+            .lock()
+            .expect("completions lock")
+            .push(request);
+    }
+
+    pub(super) fn record_retry(&self, request: RetryProviderDelivery) {
+        self.retries.lock().expect("retries lock").push(request);
+    }
+
+    pub(super) fn record_rejection(&self, request: RejectProviderDelivery) {
+        self.rejections
+            .lock()
+            .expect("rejections lock")
+            .push(request);
+    }
+
+    pub(super) fn completions(&self) -> Vec<CompleteProviderDelivery> {
+        self.completions.lock().expect("completions lock").clone()
+    }
+
+    pub(super) fn retries(&self) -> Vec<RetryProviderDelivery> {
+        self.retries.lock().expect("retries lock").clone()
+    }
+
+    pub(super) fn rejections(&self) -> Vec<RejectProviderDelivery> {
+        self.rejections.lock().expect("rejections lock").clone()
+    }
+
+    pub(super) fn progress(&self) -> Vec<ProviderDeliveryWorkflowOutcome> {
+        self.progress.lock().expect("progress lock").clone()
+    }
+
+    pub(super) fn transition_count(&self) -> usize {
+        self.completions.lock().expect("completions lock").len()
+            + self.retries.lock().expect("retries lock").len()
+            + self.rejections.lock().expect("rejections lock").len()
+    }
+
+    pub(super) fn register_workflow_inventory(
+        &self,
+        request: &RegisterProviderDeliveryWorkflowInventory,
+    ) -> Result<ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryStoreError> {
+        let mut inventory = self.inventory.lock().expect("inventory lock");
+        match inventory.as_ref() {
+            Some(existing) if existing != request.inventory() => {
+                return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
+            }
+            Some(_) => {}
+            None => *inventory = Some(request.inventory().clone()),
+        }
+        ProviderDeliveryWorkflowInventoryReceipt::new(
+            inventory.as_ref().expect("inventory initialized").clone(),
+            self.progress.lock().expect("progress lock").clone(),
+        )
+        .map_err(|_| ProviderDeliveryStoreError::WorkflowProgressRejected)
+    }
+
+    pub(super) fn record_workflow_progress(
+        &self,
+        request: &RecordProviderDeliveryWorkflowProgress,
+    ) -> Result<ProviderDeliveryWorkflowOutcome, ProviderDeliveryStoreError> {
+        let inventory = self.inventory.lock().expect("inventory lock");
+        let Some(inventory) = inventory.as_ref() else {
+            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
+        };
+        if inventory.digest() != request.inventory_digest()
+            || !inventory
+                .entries()
+                .iter()
+                .any(|entry| entry.workflow_path() == request.outcome().workflow_path())
+        {
+            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
+        }
+        let mut progress = self.progress.lock().expect("progress lock");
+        if let Some(existing) = progress
+            .iter()
+            .find(|existing| existing.workflow_path() == request.outcome().workflow_path())
+        {
+            return if existing == request.outcome() {
+                Ok(existing.clone())
+            } else {
+                Err(ProviderDeliveryStoreError::WorkflowProgressRejected)
+            };
+        }
+        progress.push(request.outcome().clone());
+        Ok(request.outcome().clone())
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct VerifiedBlobStore {
+    descriptor: BlobDescriptor,
+    bytes: Bytes,
+    failure: Option<BlobStoreErrorKind>,
+    reads: AtomicUsize,
+}
+
+impl VerifiedBlobStore {
+    pub(super) fn exact(descriptor: BlobDescriptor, bytes: Bytes) -> Self {
+        Self {
+            descriptor,
+            bytes,
+            failure: None,
+            reads: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn failing(
+        descriptor: BlobDescriptor,
+        bytes: Bytes,
+        failure: BlobStoreErrorKind,
+    ) -> Self {
+        Self {
+            descriptor,
+            bytes,
+            failure: Some(failure),
+            reads: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn read_count(&self) -> usize {
+        self.reads.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ImmutableBlobStore for VerifiedBlobStore {
+    async fn put_if_absent(&self, _payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
+        panic!("the verified blob fixture is read-only")
+    }
+
+    async fn get_verified(
+        &self,
+        descriptor: &BlobDescriptor,
+        maximum_bytes: u64,
+    ) -> Result<VerifiedBlob, BlobStoreError> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        if let Some(failure) = self.failure {
+            return Err(BlobStoreError::new(failure));
+        }
+        if descriptor != &self.descriptor || descriptor.size() > maximum_bytes {
+            return Err(BlobStoreError::new(BlobStoreErrorKind::Integrity));
+        }
+        let payload = BlobPayload::verify(descriptor.clone(), self.bytes.clone())
+            .map_err(|_| BlobStoreError::new(BlobStoreErrorKind::Integrity))?;
+        Ok(VerifiedBlob::from_payload(payload))
+    }
+}
 
 pub(super) fn archive<T: AsRef<[u8]>>(files: BTreeMap<&str, T>) -> Bytes {
     let encoder = GzEncoder::new(Vec::new(), Compression::default());

--- a/crates/automata-ci-github-delivery/tests/worker.rs
+++ b/crates/automata-ci-github-delivery/tests/worker.rs
@@ -1,17 +1,11 @@
 use std::{
     collections::BTreeMap,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
 use automata_ci_auth::secret::SecretString;
-use automata_ci_blob::{
-    BlobDescriptor, BlobKey, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    MediaType, PutBlobOutcome, VerifiedBlob,
-};
+use automata_ci_blob::{BlobDescriptor, BlobKey, BlobStoreErrorKind, MediaType};
 use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_github::{GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX, GithubPushRefKind};
 use automata_ci_github_delivery::{
@@ -44,9 +38,9 @@ use automata_ci_store::{
     ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind, ProviderDeliveryId,
     ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRepository,
     ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryReceipt,
-    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
     RejectProviderDelivery, RepositoryId as StoreRepositoryId, ResolveGithubRepositoryDispatch,
     RetryProviderDelivery, TenantScope,
@@ -61,8 +55,8 @@ use super::subject_evidence::{
     fixture_subject_evidence, fixture_subject_evidence_with_head,
 };
 use super::support::{
-    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, ZERO,
-    archive, provider_event_envelope, push_body,
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, ProviderDeliveryLedger, REPOSITORY, REPOSITORY_ID,
+    REPOSITORY_OWNER_ID, VerifiedBlobStore, ZERO, archive, provider_event_envelope, push_body,
 };
 
 const STALE_MERGE: &str = "89abcdef0123456789abcdef0123456789abcdef";
@@ -75,62 +69,6 @@ struct FixedClock(UnixMillis);
 impl GithubDeliveryClock for FixedClock {
     fn now(&self) -> UnixMillis {
         self.0
-    }
-}
-
-#[derive(Debug)]
-struct FixtureBlobStore {
-    descriptor: BlobDescriptor,
-    bytes: Bytes,
-    failure: Option<BlobStoreErrorKind>,
-    reads: AtomicUsize,
-}
-
-impl FixtureBlobStore {
-    fn exact(descriptor: BlobDescriptor, bytes: Bytes) -> Self {
-        Self {
-            descriptor,
-            bytes,
-            failure: None,
-            reads: AtomicUsize::new(0),
-        }
-    }
-
-    fn failing(descriptor: BlobDescriptor, bytes: Bytes, failure: BlobStoreErrorKind) -> Self {
-        Self {
-            descriptor,
-            bytes,
-            failure: Some(failure),
-            reads: AtomicUsize::new(0),
-        }
-    }
-
-    fn read_count(&self) -> usize {
-        self.reads.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl ImmutableBlobStore for FixtureBlobStore {
-    async fn put_if_absent(&self, _payload: BlobPayload) -> Result<PutBlobOutcome, BlobStoreError> {
-        panic!("the delivery worker never writes raw objects")
-    }
-
-    async fn get_verified(
-        &self,
-        descriptor: &BlobDescriptor,
-        maximum_bytes: u64,
-    ) -> Result<VerifiedBlob, BlobStoreError> {
-        self.reads.fetch_add(1, Ordering::SeqCst);
-        if let Some(failure) = self.failure {
-            return Err(BlobStoreError::new(failure));
-        }
-        if descriptor != &self.descriptor || descriptor.size() > maximum_bytes {
-            return Err(BlobStoreError::new(BlobStoreErrorKind::Integrity));
-        }
-        let payload = BlobPayload::verify(descriptor.clone(), self.bytes.clone())
-            .map_err(|_| BlobStoreError::new(BlobStoreErrorKind::Integrity))?;
-        Ok(VerifiedBlob::from_payload(payload))
     }
 }
 
@@ -415,54 +353,40 @@ impl GithubDeliveryWorkflowProcessor for RecordingProcessor {
 
 #[derive(Debug)]
 struct RecordingDeliveries {
-    claimed_receipt: ProviderDeliveryReceipt,
+    claimed_delivery_id: ProviderDeliveryId,
+    ledger: ProviderDeliveryLedger,
     reject_completion_outcome_run: bool,
-    completions: Mutex<Vec<CompleteProviderDelivery>>,
-    retries: Mutex<Vec<RetryProviderDelivery>>,
-    rejections: Mutex<Vec<RejectProviderDelivery>>,
-    inventory: Mutex<Option<ProviderDeliveryWorkflowInventory>>,
-    progress: Mutex<Vec<ProviderDeliveryWorkflowOutcome>>,
 }
 
 impl RecordingDeliveries {
     fn new(claimed_receipt: ProviderDeliveryReceipt) -> Self {
         Self {
-            claimed_receipt,
+            claimed_delivery_id: claimed_receipt.id(),
+            ledger: ProviderDeliveryLedger::new(
+                claimed_receipt.attempts(),
+                claimed_receipt.accepted_at(),
+            ),
             reject_completion_outcome_run: false,
-            completions: Mutex::new(Vec::new()),
-            retries: Mutex::new(Vec::new()),
-            rejections: Mutex::new(Vec::new()),
-            inventory: Mutex::new(None),
-            progress: Mutex::new(Vec::new()),
         }
     }
 
     fn rejecting_completion_outcome_run(claimed_receipt: ProviderDeliveryReceipt) -> Self {
         Self {
-            claimed_receipt,
+            claimed_delivery_id: claimed_receipt.id(),
+            ledger: ProviderDeliveryLedger::new(
+                claimed_receipt.attempts(),
+                claimed_receipt.accepted_at(),
+            ),
             reject_completion_outcome_run: true,
-            completions: Mutex::new(Vec::new()),
-            retries: Mutex::new(Vec::new()),
-            rejections: Mutex::new(Vec::new()),
-            inventory: Mutex::new(None),
-            progress: Mutex::new(Vec::new()),
         }
     }
 
     fn receipt(&self, state: ProviderDeliveryState) -> ProviderDeliveryReceipt {
-        ProviderDeliveryReceipt::from_durable_parts(
-            self.claimed_receipt.id(),
-            state,
-            self.claimed_receipt.attempts(),
-            self.claimed_receipt.accepted_at(),
-        )
-        .expect("transition receipt")
+        self.ledger.receipt(self.claimed_delivery_id, state)
     }
 
     fn transition_count(&self) -> usize {
-        self.completions.lock().expect("completions lock").len()
-            + self.retries.lock().expect("retries lock").len()
-            + self.rejections.lock().expect("rejections lock").len()
+        self.ledger.transition_count()
     }
 }
 
@@ -486,10 +410,7 @@ impl ProviderDeliveryRepository for RecordingDeliveries {
         &self,
         request: CompleteProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.completions
-            .lock()
-            .expect("completions lock")
-            .push(request);
+        self.ledger.record_completion(request);
         if self.reject_completion_outcome_run {
             return Err(ProviderDeliveryStoreError::OutcomeRunRejected);
         }
@@ -500,63 +421,27 @@ impl ProviderDeliveryRepository for RecordingDeliveries {
         &self,
         request: RegisterProviderDeliveryWorkflowInventory,
     ) -> Result<ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryStoreError> {
-        if request.claim().delivery_id() != self.claimed_receipt.id() {
+        if request.claim().delivery_id() != self.claimed_delivery_id {
             return Err(ProviderDeliveryStoreError::ClaimRejected);
         }
-        let mut inventory = self.inventory.lock().expect("inventory lock");
-        match inventory.as_ref() {
-            Some(existing) if existing != request.inventory() => {
-                return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-            }
-            Some(_) => {}
-            None => *inventory = Some(request.inventory().clone()),
-        }
-        ProviderDeliveryWorkflowInventoryReceipt::new(
-            inventory.as_ref().expect("inventory initialized").clone(),
-            self.progress.lock().expect("progress lock").clone(),
-        )
-        .map_err(|_| ProviderDeliveryStoreError::WorkflowProgressRejected)
+        self.ledger.register_workflow_inventory(&request)
     }
 
     async fn record_provider_delivery_workflow_progress(
         &self,
         request: RecordProviderDeliveryWorkflowProgress,
     ) -> Result<ProviderDeliveryWorkflowOutcome, ProviderDeliveryStoreError> {
-        if request.claim().delivery_id() != self.claimed_receipt.id() {
+        if request.claim().delivery_id() != self.claimed_delivery_id {
             return Err(ProviderDeliveryStoreError::ClaimRejected);
         }
-        let inventory = self.inventory.lock().expect("inventory lock");
-        let Some(inventory) = inventory.as_ref() else {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        };
-        if inventory.digest() != request.inventory_digest()
-            || !inventory
-                .entries()
-                .iter()
-                .any(|entry| entry.workflow_path() == request.outcome().workflow_path())
-        {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        }
-        let mut progress = self.progress.lock().expect("progress lock");
-        if let Some(existing) = progress
-            .iter()
-            .find(|existing| existing.workflow_path() == request.outcome().workflow_path())
-        {
-            return if existing == request.outcome() {
-                Ok(existing.clone())
-            } else {
-                Err(ProviderDeliveryStoreError::WorkflowProgressRejected)
-            };
-        }
-        progress.push(request.outcome().clone());
-        Ok(request.outcome().clone())
+        self.ledger.record_workflow_progress(&request)
     }
 
     async fn retry_provider_delivery(
         &self,
         request: RetryProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.retries.lock().expect("retries lock").push(request);
+        self.ledger.record_retry(request);
         Ok(self.receipt(ProviderDeliveryState::RetryPending))
     }
 
@@ -564,10 +449,7 @@ impl ProviderDeliveryRepository for RecordingDeliveries {
         &self,
         request: RejectProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        self.rejections
-            .lock()
-            .expect("rejections lock")
-            .push(request);
+        self.ledger.record_rejection(request);
         Ok(self.receipt(ProviderDeliveryState::Rejected))
     }
 }
@@ -1183,7 +1065,7 @@ fn worker(
     processor: Arc<RecordingProcessor>,
     deliveries: Arc<RecordingDeliveries>,
     config: GithubDeliveryWorkerConfig,
-) -> (GithubDeliveryWorker, Arc<FixtureBlobStore>) {
+) -> (GithubDeliveryWorker, Arc<VerifiedBlobStore>) {
     let subject_evidence =
         FixtureSubjectEvidence::from_claimed(&fixture.claimed, fixture.check_head_sha);
     worker_with_evidence(
@@ -1203,8 +1085,8 @@ fn worker_with_evidence(
     deliveries: Arc<RecordingDeliveries>,
     config: GithubDeliveryWorkerConfig,
     subject_evidence: FixtureSubjectEvidence,
-) -> (GithubDeliveryWorker, Arc<FixtureBlobStore>) {
-    let objects = Arc::new(FixtureBlobStore::exact(
+) -> (GithubDeliveryWorker, Arc<VerifiedBlobStore>) {
+    let objects = Arc::new(VerifiedBlobStore::exact(
         fixture.descriptor.clone(),
         fixture.body.clone(),
     ));
@@ -1228,8 +1110,8 @@ fn repository_dispatch_worker(
     processor: Arc<RecordingProcessor>,
     deliveries: Arc<RecordingDeliveries>,
     evidence: Arc<RecordingRepositoryDispatchEvidence>,
-) -> (GithubDeliveryWorker, Arc<FixtureBlobStore>) {
-    let objects = Arc::new(FixtureBlobStore::exact(
+) -> (GithubDeliveryWorker, Arc<VerifiedBlobStore>) {
+    let objects = Arc::new(VerifiedBlobStore::exact(
         fixture.descriptor.clone(),
         fixture.body.clone(),
     ));
@@ -1339,7 +1221,7 @@ async fn exact_source_and_all_direct_workflows_complete_deterministically() {
             && !observation.debug.contains(OWNER)
     }));
 
-    let completions = deliveries.completions.lock().expect("completions lock");
+    let completions = deliveries.ledger.completions();
     assert_eq!(completions.len(), 2);
     assert_eq!(completions[0], completions[1]);
     let outcomes = completions[0].outcomes();
@@ -1401,14 +1283,8 @@ async fn all_direct_retry_resumes_after_durable_per_workflow_progress() {
         matches!(first, GithubDeliveryWorkerOutcome::RetryScheduled(_)),
         "unexpected first outcome: {first:?}"
     );
-    assert!(
-        deliveries
-            .completions
-            .lock()
-            .expect("completions lock")
-            .is_empty()
-    );
-    assert_eq!(deliveries.progress.lock().expect("progress lock").len(), 1);
+    assert!(deliveries.ledger.completions().is_empty());
+    assert_eq!(deliveries.ledger.progress().len(), 1);
 
     let second = worker
         .process_claimed(
@@ -1435,9 +1311,9 @@ async fn all_direct_retry_resumes_after_durable_per_workflow_progress() {
             ".ci/workflows/b.yaml",
         ]
     );
-    assert_eq!(deliveries.retries.lock().expect("retries lock").len(), 1);
-    assert_eq!(deliveries.progress.lock().expect("progress lock").len(), 3);
-    let completions = deliveries.completions.lock().expect("completions lock");
+    assert_eq!(deliveries.ledger.retries().len(), 1);
+    assert_eq!(deliveries.ledger.progress().len(), 3);
+    let completions = deliveries.ledger.completions();
     assert_eq!(completions.len(), 1);
     assert_eq!(
         completions[0]
@@ -1690,14 +1566,8 @@ async fn repository_dispatch_resolution_failure_creates_no_check_or_workflow() {
     assert_eq!(evidence.resolution_count(), 0);
     assert!(!evidence.has_resolved_evidence());
     assert!(processor.event_observations().is_empty());
-    assert!(
-        deliveries
-            .completions
-            .lock()
-            .expect("completions lock")
-            .is_empty()
-    );
-    assert_eq!(deliveries.retries.lock().expect("retries lock").len(), 1);
+    assert!(deliveries.ledger.completions().is_empty());
+    assert_eq!(deliveries.ledger.retries().len(), 1);
 }
 
 #[tokio::test]
@@ -1729,7 +1599,7 @@ async fn no_direct_workflows_completes_with_an_empty_outcome_set() {
 
     assert!(matches!(outcome, GithubDeliveryWorkerOutcome::Completed(_)));
     assert!(processor.observations().is_empty());
-    let completions = deliveries.completions.lock().expect("completions lock");
+    let completions = deliveries.ledger.completions();
     assert_eq!(completions.len(), 1);
     let outcomes = completions[0].outcomes();
     assert!(outcomes.is_empty());
@@ -1750,7 +1620,7 @@ async fn historical_manifest_evidence_survives_a_later_manifest_rotation() {
         historical.0.private_source_authority(),
         rotated_current.0.private_source_authority()
     );
-    let objects = Arc::new(FixtureBlobStore::exact(
+    let objects = Arc::new(VerifiedBlobStore::exact(
         fixture.descriptor.clone(),
         fixture.body.clone(),
     ));
@@ -1922,9 +1792,7 @@ async fn pinned_manifest_exceeding_a_local_ceiling_rejects_before_source_io() {
     assert!(source.observations().is_empty());
     assert!(processor.observations().is_empty());
     assert_eq!(
-        deliveries.rejections.lock().expect("rejections lock")[0]
-            .failure_kind()
-            .as_str(),
+        deliveries.ledger.rejections()[0].failure_kind().as_str(),
         "github.subject_evidence.mismatch"
     );
 }
@@ -1958,7 +1826,7 @@ async fn deleted_pinned_branch_completes_without_source_authority_or_processing(
     assert!(matches!(outcome, GithubDeliveryWorkerOutcome::Completed(_)));
     assert!(source.observations().is_empty());
     assert!(processor.observations().is_empty());
-    let completions = deliveries.completions.lock().expect("completions lock");
+    let completions = deliveries.ledger.completions();
     assert_eq!(completions.len(), 1);
     assert!(completions[0].outcomes().is_empty());
 }
@@ -2031,7 +1899,7 @@ async fn private_live_ref_rejects_public_authority_before_provider_io() {
 #[tokio::test]
 async fn rehydrated_push_head_must_match_the_pinned_check_before_source_io() {
     let fixture = claimed_fixture("refs/heads/main", false, 1);
-    let objects = Arc::new(FixtureBlobStore::exact(
+    let objects = Arc::new(VerifiedBlobStore::exact(
         fixture.descriptor.clone(),
         fixture.body.clone(),
     ));
@@ -2073,9 +1941,7 @@ async fn rehydrated_push_head_must_match_the_pinned_check_before_source_io() {
     assert!(processor.observations().is_empty());
     assert_eq!(deliveries.transition_count(), 1);
     assert_eq!(
-        deliveries.rejections.lock().expect("rejections lock")[0]
-            .failure_kind()
-            .as_str(),
+        deliveries.ledger.rejections()[0].failure_kind().as_str(),
         "github.subject_evidence.mismatch"
     );
 }
@@ -2174,9 +2040,7 @@ async fn invalid_or_rebound_event_envelopes_reject_before_blob_or_source_io() {
             _ => unreachable!("closed test cases"),
         };
         assert_eq!(
-            deliveries.rejections.lock().expect("rejections lock")[0]
-                .failure_kind()
-                .as_str(),
+            deliveries.ledger.rejections()[0].failure_kind().as_str(),
             expected_kind,
             "case {case}",
         );
@@ -2198,7 +2062,7 @@ async fn immutable_object_failures_are_durably_classified_before_source_io() {
         ),
     ] {
         let fixture = claimed_fixture("refs/heads/main", false, 1);
-        let objects = Arc::new(FixtureBlobStore::failing(
+        let objects = Arc::new(VerifiedBlobStore::failing(
             fixture.descriptor.clone(),
             fixture.body.clone(),
             failure,
@@ -2237,10 +2101,10 @@ async fn immutable_object_failures_are_durably_classified_before_source_io() {
         assert_eq!(outcome.receipt().state(), expected_state);
         assert!(source.observations().is_empty());
         if expected_state == ProviderDeliveryState::Rejected {
-            let rejections = deliveries.rejections.lock().expect("rejections lock");
+            let rejections = deliveries.ledger.rejections();
             assert_eq!(rejections[0].failure_kind().as_str(), expected_kind);
         } else {
-            let retries = deliveries.retries.lock().expect("retries lock");
+            let retries = deliveries.ledger.retries();
             assert_eq!(retries[0].failure_kind().as_str(), expected_kind);
             assert_eq!(retries[0].retry_at(), UnixMillis::new(1_734));
         }
@@ -2277,7 +2141,7 @@ async fn source_rate_limit_and_processor_prerequisite_never_commit_partial_paths
         GithubDeliveryWorkerOutcome::RetryScheduled(_)
     ));
     {
-        let retries = deliveries.retries.lock().expect("retries lock");
+        let retries = deliveries.ledger.retries();
         assert_eq!(retries[0].retry_at(), UnixMillis::new(9_500));
     }
 
@@ -2354,23 +2218,11 @@ async fn rejected_admitted_run_reuses_the_owned_terminal_operation() {
 
     assert!(matches!(outcome, GithubDeliveryWorkerOutcome::Rejected(_)));
     assert_eq!(
-        deliveries.rejections.lock().expect("rejections lock")[0]
-            .failure_kind()
-            .as_str(),
+        deliveries.ledger.rejections()[0].failure_kind().as_str(),
         "github.workflow.invalid_admitted_run"
     );
-    assert_eq!(
-        deliveries
-            .completions
-            .lock()
-            .expect("completions lock")
-            .len(),
-        1
-    );
-    assert_eq!(
-        deliveries.rejections.lock().expect("rejections lock").len(),
-        1
-    );
+    assert_eq!(deliveries.ledger.completions().len(), 1);
+    assert_eq!(deliveries.ledger.rejections().len(), 1);
 }
 
 #[test]
@@ -2393,7 +2245,7 @@ fn configuration_rejects_unrepresentable_outcome_and_provider_bounds() {
         repository_source(archive(BTreeMap::<&str, Vec<u8>>::new())),
     ));
     let result = GithubDeliveryWorker::new(
-        Arc::new(FixtureBlobStore::exact(fixture.descriptor, fixture.body)),
+        Arc::new(VerifiedBlobStore::exact(fixture.descriptor, fixture.body)),
         source,
         Arc::new(RecordingProcessor::returning(skipped())),
         Arc::new(RecordingDeliveries::new(fixture.receipt)),

--- a/crates/automata-ci-github-delivery/tests/workflow_processor.rs
+++ b/crates/automata-ci-github-delivery/tests/workflow_processor.rs
@@ -45,9 +45,9 @@ use automata_ci_store::{
     ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
     ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
     ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
-    ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryReceipt,
-    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
+    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
     RejectProviderDelivery, RepositoryId as StoreRepositoryId, RetryProviderDelivery, TenantScope,
     WorkflowAdmissionIdempotency,
@@ -59,8 +59,8 @@ use uuid::Uuid;
 
 use super::subject_evidence::fixture_subject_evidence;
 use super::support::{
-    AFTER, BEFORE, INSTALLATION_ID, OWNER, REPOSITORY, REPOSITORY_ID, REPOSITORY_OWNER_ID, archive,
-    provider_event_envelope, push_body,
+    AFTER, BEFORE, INSTALLATION_ID, OWNER, ProviderDeliveryLedger, REPOSITORY, REPOSITORY_ID,
+    REPOSITORY_OWNER_ID, archive, provider_event_envelope, push_body,
 };
 
 const DELIVERY: &str = "delivery-workflow-processor-1";
@@ -174,21 +174,24 @@ impl LogicalWorkflowAdmissionRepository for LogicalAdmissions {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct DeliveryOutcomes {
-    completions: Mutex<Vec<CompleteProviderDelivery>>,
-    retries: Mutex<Vec<RetryProviderDelivery>>,
-    inventory: Mutex<Option<ProviderDeliveryWorkflowInventory>>,
-    progress: Mutex<Vec<ProviderDeliveryWorkflowOutcome>>,
+    ledger: ProviderDeliveryLedger,
 }
 
 impl DeliveryOutcomes {
+    fn new(attempts: u16, accepted_at: UnixMillis) -> Self {
+        Self {
+            ledger: ProviderDeliveryLedger::new(attempts, accepted_at),
+        }
+    }
+
     fn completions(&self) -> Vec<CompleteProviderDelivery> {
-        self.completions.lock().expect("completions lock").clone()
+        self.ledger.completions()
     }
 
     fn retry_count(&self) -> usize {
-        self.retries.lock().expect("retries lock").len()
+        self.ledger.retries().len()
     }
 }
 
@@ -212,11 +215,11 @@ impl ProviderDeliveryRepository for DeliveryOutcomes {
         &self,
         request: CompleteProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        let receipt = transition_receipt(request.claim(), ProviderDeliveryState::Completed);
-        self.completions
-            .lock()
-            .expect("completions lock")
-            .push(request);
+        let receipt = self.ledger.receipt(
+            request.claim().delivery_id(),
+            ProviderDeliveryState::Completed,
+        );
+        self.ledger.record_completion(request);
         Ok(receipt)
     }
 
@@ -224,58 +227,25 @@ impl ProviderDeliveryRepository for DeliveryOutcomes {
         &self,
         request: RegisterProviderDeliveryWorkflowInventory,
     ) -> Result<ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryStoreError> {
-        let mut inventory = self.inventory.lock().expect("inventory lock");
-        match inventory.as_ref() {
-            Some(existing) if existing != request.inventory() => {
-                return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-            }
-            Some(_) => {}
-            None => *inventory = Some(request.inventory().clone()),
-        }
-        ProviderDeliveryWorkflowInventoryReceipt::new(
-            inventory.as_ref().expect("inventory initialized").clone(),
-            self.progress.lock().expect("progress lock").clone(),
-        )
-        .map_err(|_| ProviderDeliveryStoreError::WorkflowProgressRejected)
+        self.ledger.register_workflow_inventory(&request)
     }
 
     async fn record_provider_delivery_workflow_progress(
         &self,
         request: RecordProviderDeliveryWorkflowProgress,
     ) -> Result<ProviderDeliveryWorkflowOutcome, ProviderDeliveryStoreError> {
-        let inventory = self.inventory.lock().expect("inventory lock");
-        let Some(inventory) = inventory.as_ref() else {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        };
-        if inventory.digest() != request.inventory_digest()
-            || !inventory
-                .entries()
-                .iter()
-                .any(|entry| entry.workflow_path() == request.outcome().workflow_path())
-        {
-            return Err(ProviderDeliveryStoreError::WorkflowProgressRejected);
-        }
-        let mut progress = self.progress.lock().expect("progress lock");
-        if let Some(existing) = progress
-            .iter()
-            .find(|existing| existing.workflow_path() == request.outcome().workflow_path())
-        {
-            return if existing == request.outcome() {
-                Ok(existing.clone())
-            } else {
-                Err(ProviderDeliveryStoreError::WorkflowProgressRejected)
-            };
-        }
-        progress.push(request.outcome().clone());
-        Ok(request.outcome().clone())
+        self.ledger.record_workflow_progress(&request)
     }
 
     async fn retry_provider_delivery(
         &self,
         request: RetryProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        let receipt = transition_receipt(request.claim(), ProviderDeliveryState::RetryPending);
-        self.retries.lock().expect("retries lock").push(request);
+        let receipt = self.ledger.receipt(
+            request.claim().delivery_id(),
+            ProviderDeliveryState::RetryPending,
+        );
+        self.ledger.record_retry(request);
         Ok(receipt)
     }
 
@@ -283,8 +253,8 @@ impl ProviderDeliveryRepository for DeliveryOutcomes {
         &self,
         request: RejectProviderDelivery,
     ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryStoreError> {
-        Ok(transition_receipt(
-            request.claim(),
+        Ok(self.ledger.receipt(
+            request.claim().delivery_id(),
             ProviderDeliveryState::Rejected,
         ))
     }
@@ -372,14 +342,6 @@ impl GithubSubjectEvidenceRepository for FixtureSubjectEvidence {
     ) -> Result<GithubWorkflowRunSubjectEvidence, GithubSubjectEvidenceStoreError> {
         panic!("run evidence is outside the processor test")
     }
-}
-
-fn transition_receipt(
-    claim: ProviderDeliveryClaimFence,
-    state: ProviderDeliveryState,
-) -> ProviderDeliveryReceipt {
-    ProviderDeliveryReceipt::from_durable_parts(claim.delivery_id(), state, 1, UnixMillis::new(50))
-        .expect("transition receipt")
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -675,7 +637,7 @@ async fn harness_with_visibility(
         ArchiveFormat::TarGzip,
         archive(files),
     );
-    let deliveries = Arc::new(DeliveryOutcomes::default());
+    let deliveries = Arc::new(DeliveryOutcomes::new(1, UnixMillis::new(50)));
     let credentials = Arc::new(DiffCredentials::default());
     let subject_evidence = Arc::new(FixtureSubjectEvidence::from_claimed(&claimed));
     let worker = GithubDeliveryWorker::new(
@@ -752,7 +714,7 @@ async fn pull_request_harness_with_visibility(
         ArchiveFormat::TarGzip,
         archive(files),
     );
-    let deliveries = Arc::new(DeliveryOutcomes::default());
+    let deliveries = Arc::new(DeliveryOutcomes::new(1, UnixMillis::new(50)));
     let credentials = Arc::new(DiffCredentials::default());
     let subject_evidence = Arc::new(FixtureSubjectEvidence::authenticated_event(
         &claimed,


### PR DESCRIPTION
Closes #362.

## Summary

- consolidate duplicated provider-delivery transition, inventory, progress, and receipt recording behind one typed policy-free ledger
- preserve the three distinct repository fakes, their delivery-ID sources, claim/error gates, and adapter-specific receipt-versus-record ordering
- consolidate duplicate immutable verified-blob stores with explicit exact and failing constructors
- retain worker-local claim checks, inventory replay/conflict behavior, blob integrity checks, and all security/protocol evidence at call sites

This is one subsystem-sized test-support checkpoint: exactly four files, 879 changed lines, and 191 net lines removed. It changes no production code, manifests, subject evidence, protocol, credentials, clocks, renewals, or files owned by open PRs.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-github-delivery --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-github-delivery --all-features --test github_delivery` (107/107 passed)
- `CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-github-delivery --all-targets --all-features -- -D warnings`
- independent semantic/static review: no findings