### PR TITLE
feat(runner): durably linearize endpoint operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "static_assertions",
+ "subtle",
  "tar",
  "thiserror",
  "time",
@@ -900,6 +901,7 @@ name = "automata-ci-runner-journal"
 version = "0.1.0"
 dependencies = [
  "automata-ci-core",
+ "automata-ci-execution",
  "automata-ci-protocol",
  "automata-ci-runner-spool",
  "rustix",
@@ -923,6 +925,7 @@ dependencies = [
  "automata-ci-runner-transport",
  "sha2 0.11.0",
  "static_assertions",
+ "subtle",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -940,6 +943,7 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "static_assertions",
+ "subtle",
  "thiserror",
 ]
 

--- a/crates/automata-ci-execution/src/endpoint.rs
+++ b/crates/automata-ci-execution/src/endpoint.rs
@@ -55,6 +55,23 @@ impl Cancellation for NeverCancelled {
     }
 }
 
+/// Endpoint calls made before the first workflow step.
+const ENDPOINT_JOB_SETUP_OPERATIONS: usize = 2;
+
+/// Maximum endpoint calls made by one admitted literal run step.
+const ENDPOINT_OPERATIONS_PER_RUN_STEP: usize = 15;
+
+/// Hard shared endpoint-operation budget for one admitted job.
+///
+/// The budget admits the current maximum-size run-only job with no dynamically
+/// declared artifact subjects. Composite/action phases and artifact hashing
+/// consume this same non-evicting budget; expansions beyond it fail closed
+/// before the next provider invocation. This is an execution admission bound,
+/// not an independently selected cache size.
+pub const MAX_ENDPOINT_OPERATIONS_PER_JOB: usize = automata_ci_core::MAX_LOGICAL_STEPS
+    * ENDPOINT_OPERATIONS_PER_RUN_STEP
+    + ENDPOINT_JOB_SETUP_OPERATIONS;
+
 /// Validated executable plus literal arguments. No shell command string exists
 /// in the execution contract.
 #[derive(Clone, Eq, PartialEq)]
@@ -900,8 +917,9 @@ pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
     /// [`CopyFromRequest::byte_limit`]. A trusted native provider serving a
     /// `HostFilesystem` capability may resolve the target against the host
     /// only after proving that it remains within the sandbox-owned workspace
-    /// or scratch root. Returned bytes may contain secrets and must not pass
-    /// through durable host-side staging.
+    /// or scratch root. Returned bytes may contain secrets. A durable replay
+    /// layer must protect and authenticate them before storage and may journal
+    /// only their opaque protected-content identity.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -42,7 +42,8 @@ pub use endpoint::{
     Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentName,
     EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEndpoint,
     ExecutionEnvironment, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream,
-    ExecutionSignal, ExecutionTermination, NeverCancelled, SignalRequest, WaitRequest,
+    ExecutionSignal, ExecutionTermination, MAX_ENDPOINT_OPERATIONS_PER_JOB, NeverCancelled,
+    SignalRequest, WaitRequest,
 };
 pub use error::{
     ExecutionError, ExecutionErrorKind, ExecutionStage, OperationOutcome, ProviderError,

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -4782,6 +4782,9 @@ impl GithubJobExecutor {
             .provider
             .attach(&handle, &cancellation)
             .map_err(|error| map_provider_error(&error))?;
+        let endpoint = events
+            .bind_endpoint(self.ports.provider.clone(), inspection, endpoint)
+            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
         Ok(ObtainedSandbox { endpoint, services })
     }
 

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -620,7 +620,7 @@ fn execution_request(environment: SandboxEnvironment, job: JobIrEnvelope) -> Exe
         UnixMillis::new(1_000_000),
     )
     .expect("valid lease");
-    let content = DurableContentRef::after_commit(
+    let content = DurableContentRef::after_public_commit(
         ContentKind::JobIr,
         1,
         Sha256Digest::from_bytes([3; 32]),
@@ -2474,6 +2474,15 @@ impl fmt::Debug for FakeEvents {
 }
 
 impl ExecutionEvents for FakeEvents {
+    fn bind_endpoint(
+        &self,
+        _provider: Arc<dyn SandboxProvider>,
+        _inspection: SandboxInspection,
+        endpoint: Box<dyn ExecutionEndpoint>,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ExecutionEventError> {
+        Ok(endpoint)
+    }
+
     fn transition(
         &self,
         next: JobLifecycle,

--- a/crates/automata-ci-runner-journal/Cargo.toml
+++ b/crates/automata-ci-runner-journal/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [dependencies]
 automata-ci-core.workspace = true
+automata-ci-execution.workspace = true
 automata-ci-protocol.workspace = true
 automata-ci-runner-spool.workspace = true
 rustix.workspace = true

--- a/crates/automata-ci-runner-journal/src/error.rs
+++ b/crates/automata-ci-runner-journal/src/error.rs
@@ -160,6 +160,66 @@ pub enum JournalInvariantError {
     /// A provider operation identity was replayed with different semantics.
     #[error("provider operation identity conflicts with an existing intent")]
     ProviderOperationReplayConflict,
+    /// An endpoint request commitment has the wrong kind or fixed size.
+    #[error("execution-endpoint request commitment is invalid")]
+    InvalidEndpointRequestContent,
+    /// An endpoint result has the wrong kind or violates its object bound.
+    #[error("execution-endpoint result content is invalid")]
+    InvalidEndpointResultContent,
+    /// An endpoint result reservation is zero or exceeds the object ceiling.
+    #[error("execution-endpoint result reservation is invalid")]
+    InvalidEndpointResultReservation,
+    /// The non-evicting per-slot endpoint operation ceiling was reached.
+    #[error("execution-endpoint operation limit reached for this slot")]
+    EndpointOperationLimit,
+    /// The non-evicting per-slot endpoint content-reference ceiling was reached.
+    #[error("execution-endpoint content-reference limit reached for this slot")]
+    EndpointContentRefLimit,
+    /// The aggregate per-slot request commitment and result budget was exhausted.
+    #[error("execution-endpoint content-byte limit reached for this slot")]
+    EndpointContentBytesLimit,
+    /// A prior endpoint operation remains unresolved and fences its successor.
+    #[error("execution-endpoint operation remains unresolved")]
+    EndpointOperationPending,
+    /// A new endpoint operation did not begin in the accepted phase.
+    #[error("execution-endpoint operation must begin in the accepted phase")]
+    EndpointOperationNotAccepted,
+    /// An endpoint operation identity was reused with different semantics.
+    #[error("execution-endpoint operation replay conflicts with durable state")]
+    EndpointOperationReplayConflict,
+    /// The requested endpoint operation does not exist in the durable slot.
+    #[error("execution-endpoint operation is not journaled")]
+    EndpointOperationMissing,
+    /// Backend invocation was attempted after durable cancellation won.
+    #[error("execution-endpoint operation was durably cancelled")]
+    EndpointOperationCancelled,
+    /// The endpoint operation already has a terminal outcome.
+    #[error("execution-endpoint operation is already resolved")]
+    EndpointOperationResolved,
+    /// Cancellation completion was attempted before cancellation won.
+    #[error("execution-endpoint cancellation was not requested")]
+    EndpointCancellationNotRequested,
+    /// Recovery abandonment was attempted from a non-ambiguous phase.
+    #[error("execution-endpoint operation is not abandonable")]
+    EndpointOperationNotAbandonable,
+    /// Recovery cannot abandon an invocation while its sandbox remains owned.
+    #[error("execution-endpoint sandbox is still present")]
+    EndpointSandboxStillPresent,
+    /// Finalization was attempted while endpoint recovery remains pending.
+    #[error("execution-endpoint recovery must finish before finalization")]
+    EndpointRecoveryPending,
+    /// A durable job cancellation closed the slot to new endpoint operations.
+    #[error("execution-endpoint operations are closed for the cancelled slot")]
+    EndpointOperationsClosed,
+    /// A result was offered before backend invocation permission was durable.
+    #[error("execution-endpoint invocation is not durably committed")]
+    EndpointInvocationNotCommitted,
+    /// A result object exceeded the bytes reserved before backend invocation.
+    #[error("execution-endpoint result exceeds its durable reservation")]
+    EndpointResultExceedsReservation,
+    /// A replayed endpoint result disagreed with the durable result identity.
+    #[error("execution-endpoint result conflicts with durable state")]
+    EndpointResultReplayConflict,
     /// Sandbox identity was recorded without the exact pending create intent.
     #[error("sandbox creation has no matching durable provider-operation intent")]
     SandboxWithoutCreateIntent,

--- a/crates/automata-ci-runner-journal/src/file/mod.rs
+++ b/crates/automata-ci-runner-journal/src/file/mod.rs
@@ -18,12 +18,13 @@ use self::{
     platform::PlatformDirectory,
 };
 use crate::{
-    CancellationRecord, CommandDisposition, DurableCommand, DurableContentRef, JournalError,
-    JournalMutationDomain, JournalMutationObservation, JournalMutationOutcome, JournalObserver,
-    JournalSnapshot, LeaseOfferRecord, LogSegmentAcknowledgement, LogSegmentPublication,
-    NoopJournalObserver, OrphanAbandonmentReason, OrphanAuthorityProof, OrphanAuthorityVerifier,
-    OrphanDelivery, OutboundOperationSequence, ProviderFailureOutcome, ProviderOperation,
-    RunnerJournal, SandboxIdentity, SessionBinding, TerminalResultRecord, model::StoredJournal,
+    CancellationRecord, CommandDisposition, DurableCommand, DurableContentRef, EndpointOperation,
+    EndpointResultContentRef, JournalError, JournalMutationDomain, JournalMutationObservation,
+    JournalMutationOutcome, JournalObserver, JournalSnapshot, LeaseOfferRecord,
+    LogSegmentAcknowledgement, LogSegmentPublication, NoopJournalObserver, OrphanAbandonmentReason,
+    OrphanAuthorityProof, OrphanAuthorityVerifier, OrphanDelivery, OutboundOperationSequence,
+    ProviderFailureOutcome, ProviderOperation, RunnerJournal, SandboxIdentity, SessionBinding,
+    TerminalResultRecord, model::StoredJournal,
 };
 
 pub use state_root::StateRoot;
@@ -491,6 +492,79 @@ impl RunnerJournal for FileJournal {
     ) -> Result<JournalSnapshot, JournalError> {
         self.mutate(JournalMutationDomain::Result, |state| {
             state.acknowledge_terminal_result(session_id, slot, guard, operation_id)
+        })
+    }
+
+    fn accept_endpoint_operation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation: EndpointOperation,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.accept_endpoint_operation(session_id, slot, guard, operation)
+        })
+    }
+
+    fn commit_endpoint_invocation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.commit_endpoint_invocation(session_id, slot, guard, operation_id)
+        })
+    }
+
+    fn record_endpoint_cancellation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.record_endpoint_cancellation(session_id, slot, guard, operation_id)
+        })
+    }
+
+    fn complete_endpoint_cancellation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.complete_endpoint_cancellation(session_id, slot, guard, operation_id)
+        })
+    }
+
+    fn abandon_endpoint_operation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.abandon_endpoint_operation(session_id, slot, guard, operation_id)
+        })
+    }
+
+    fn record_endpoint_result(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+        result: EndpointResultContentRef,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::Endpoint, |state| {
+            state.record_endpoint_result(session_id, slot, guard, operation_id, result)
         })
     }
 

--- a/crates/automata-ci-runner-journal/src/journal.rs
+++ b/crates/automata-ci-runner-journal/src/journal.rs
@@ -4,11 +4,12 @@ use automata_ci_core::{
 use automata_ci_protocol::{LeaseRejectionReason, RunnerSlotOrdinal, RuntimeAuthorityGeneration};
 
 use crate::{
-    CancellationRecord, CommandDisposition, DurableCommand, DurableContentRef, JournalError,
-    JournalSnapshot, LeaseOfferRecord, LogSegmentAcknowledgement, LogSegmentPublication,
-    OrphanAbandonmentReason, OrphanAuthorityProof, OrphanAuthorityVerifier, OrphanDelivery,
-    OutboundOperationSequence, ProviderFailureOutcome, ProviderOperation,
-    RuntimeAuthorityDeliveryRecord, SandboxIdentity, SessionBinding, TerminalResultRecord,
+    CancellationRecord, CommandDisposition, DurableCommand, DurableContentRef, EndpointOperation,
+    EndpointResultContentRef, JournalError, JournalSnapshot, LeaseOfferRecord,
+    LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentReason,
+    OrphanAuthorityProof, OrphanAuthorityVerifier, OrphanDelivery, OutboundOperationSequence,
+    ProviderFailureOutcome, ProviderOperation, RuntimeAuthorityDeliveryRecord, SandboxIdentity,
+    SessionBinding, TerminalResultRecord,
 };
 
 /// Backend-neutral, object-safe port for crash-recoverable runner state.
@@ -202,7 +203,8 @@ pub trait RunnerJournal: Send + Sync {
         expires_at: UnixMillis,
     ) -> Result<JournalSnapshot, JournalError>;
 
-    /// Durably records a cancellation command and advances the command cursor.
+    /// Durably records a cancellation command, advances the command cursor,
+    /// and atomically lets cancellation win any unresolved endpoint operation.
     ///
     /// # Errors
     ///
@@ -261,6 +263,98 @@ pub trait RunnerJournal: Send + Sync {
         slot: RunnerSlotOrdinal,
         guard: LeaseGuard,
         operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Accepts one exact endpoint request after its protected commitment is durable.
+    ///
+    /// Capacity, ordering, request-reference, and result-byte reservations are
+    /// checked before this operation can be committed for backend invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] for stale fences, conflicting replay, a pending
+    /// predecessor, exhausted per-slot capacity, or a failed durable commit.
+    fn accept_endpoint_operation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation: EndpointOperation,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Commits permission to expose an accepted operation to the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] for a missing/cancelled operation, stale fence,
+    /// or failed durable commit.
+    fn commit_endpoint_invocation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Lets cancellation win unless an exact result was already durable.
+    ///
+    /// Result-first cancellation is an idempotent no-op. A durable cancellation
+    /// prevents backend invocation and later result adoption.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] for a missing operation, stale fence, or failed
+    /// commit.
+    fn record_endpoint_cancellation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Completes a cancellation only after exact sandbox absence is durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] if cancellation did not previously win, the
+    /// operation is missing, the fence is stale, or persistence fails.
+    fn complete_endpoint_cancellation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Resolves an uncertain invocation after exact sandbox absence is durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] while the sandbox identity remains present, if
+    /// the operation is not ambiguous, the fence is stale, or persistence fails.
+    fn abandon_endpoint_operation(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Adopts a payload-first protected endpoint result after invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] when cancellation already won, invocation was
+    /// not committed, the result exceeds its reservation, replay conflicts, or
+    /// the durable commit fails.
+    fn record_endpoint_result(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+        result: EndpointResultContentRef,
     ) -> Result<JournalSnapshot, JournalError>;
 
     /// Records an idempotent provider mutation intent before the mutation.

--- a/crates/automata-ci-runner-journal/src/lib.rs
+++ b/crates/automata-ci-runner-journal/src/lib.rs
@@ -25,15 +25,17 @@ pub use file::{
 pub use journal::RunnerJournal;
 pub use model::{
     CancellationRecord, CommandDisposition, CommandIgnoredReason, CommandTombstone, DurableCommand,
-    JobIrContentRef, JournalSnapshot, LeaseOfferRecord, LeaseOfferStatus, LeasePollCheckpoint,
-    LeaseRejectionRecord, LogDeliveryCursor, LogSegment, LogSegmentAcknowledgement,
-    LogSegmentPublication, OrphanAbandonmentPermissions, OrphanAbandonmentReason,
-    OrphanAuthorityError, OrphanAuthorityGrant, OrphanAuthorityProof, OrphanAuthorityVerifier,
-    OrphanClaim, OrphanDelivery, OrphanRecord, OutboundOperationCursor, OutboundOperationSequence,
-    PendingDeliveryTimestamps, ProviderFailureKind, ProviderFailureOutcome, ProviderName,
-    ProviderOperation, ProviderOperationKind, ProviderOperationOutcome, RuntimeAuthorityContentRef,
-    RuntimeAuthorityDeliveryRecord, SandboxHandle, SandboxIdentity, SessionBinding,
-    SessionSnapshot, SlotSnapshot, TerminalResultRecord,
+    EndpointOperation, EndpointOperationKind, EndpointOperationState, EndpointRequestContentRef,
+    EndpointResultContentRef, JobIrContentRef, JournalSnapshot, LeaseOfferRecord, LeaseOfferStatus,
+    LeasePollCheckpoint, LeaseRejectionRecord, LogDeliveryCursor, LogSegment,
+    LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentPermissions,
+    OrphanAbandonmentReason, OrphanAuthorityError, OrphanAuthorityGrant, OrphanAuthorityProof,
+    OrphanAuthorityVerifier, OrphanClaim, OrphanDelivery, OrphanRecord, OutboundOperationCursor,
+    OutboundOperationSequence, PendingDeliveryTimestamps, ProviderFailureKind,
+    ProviderFailureOutcome, ProviderName, ProviderOperation, ProviderOperationKind,
+    ProviderOperationOutcome, RuntimeAuthorityContentRef, RuntimeAuthorityDeliveryRecord,
+    SandboxHandle, SandboxIdentity, SessionBinding, SessionSnapshot, SlotSnapshot,
+    TerminalResultRecord,
 };
 pub use observer::{
     JournalMutationDomain, JournalMutationObservation, JournalMutationOutcome, JournalObserver,
@@ -44,7 +46,7 @@ pub use observer::{
 ///
 /// Obsolete or future schemas fail closed rather than being interpreted by
 /// compatibility readers.
-pub const RUNNER_JOURNAL_SCHEMA_VERSION: u16 = 2;
+pub const RUNNER_JOURNAL_SCHEMA_VERSION: u16 = 5;
 
 /// Largest delivery enqueue timestamp accepted by the durable journal.
 ///
@@ -61,6 +63,43 @@ pub const MAX_JOURNALED_SLOTS: usize = 256;
 
 /// Maximum recent provider operations retained for exact replay.
 pub const MAX_PROVIDER_OPERATIONS_PER_SLOT: usize = 32;
+
+/// Maximum protected execution-endpoint request/result references per slot.
+pub(crate) const MAX_ENDPOINT_CONTENT_REFS_PER_SLOT: usize =
+    automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB * 2;
+
+/// Maximum protected result object for one execution-endpoint operation.
+pub(crate) const MAX_ENDPOINT_RESULT_CONTENT_BYTES: u64 = 17 * 1024 * 1024;
+
+/// Exact protected request commitment retained for every endpoint operation.
+pub(crate) const ENDPOINT_REQUEST_COMMITMENT_BYTES: u64 = 32;
+
+/// Smallest opaque protected allocation retained by an endpoint result.
+pub(crate) const MIN_ENDPOINT_RESULT_ALLOCATION_BYTES: u64 = endpoint_result_allocation_or_panic(1);
+
+/// Largest opaque protected allocation retained by an endpoint result.
+pub(crate) const MAX_ENDPOINT_RESULT_ALLOCATION_BYTES: u64 =
+    endpoint_result_allocation_or_panic(MAX_ENDPOINT_RESULT_CONTENT_BYTES);
+
+/// Maximum aggregate endpoint content charged to one slot.
+///
+/// This admits the maximum shared endpoint-operation count when every retained
+/// result is in the smallest protected allocation class, while still reserving
+/// the largest result class for the sole operation allowed to be in flight.
+/// Larger cumulative retained output fails closed before a successor backend
+/// invocation.
+pub(crate) const MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT: u64 = ENDPOINT_REQUEST_COMMITMENT_BYTES
+    * automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB as u64
+    + MIN_ENDPOINT_RESULT_ALLOCATION_BYTES
+        * (automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB as u64 - 1)
+    + MAX_ENDPOINT_RESULT_ALLOCATION_BYTES;
+
+const fn endpoint_result_allocation_or_panic(plaintext_bytes: u64) -> u64 {
+    match automata_ci_runner_spool::endpoint_result_allocation(plaintext_bytes) {
+        Ok(bytes) => bytes,
+        Err(_) => panic!("endpoint result bound must fit the protected spool"),
+    }
+}
 
 /// Maximum recent server-command digest tombstones retained per session.
 pub const MAX_COMMAND_TOMBSTONES: usize = 256;

--- a/crates/automata-ci-runner-journal/src/model/command.rs
+++ b/crates/automata-ci-runner-journal/src/model/command.rs
@@ -312,7 +312,7 @@ impl RuntimeAuthorityDeliveryRecord {
     pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
         self.content.validate()?;
         if self.binding.generation().get() == 0
-            || self.content.content().sha256() != self.bundle_digest
+            || self.content.content().public_plaintext_sha256() != Some(self.bundle_digest)
         {
             return Err(JournalInvariantError::InvalidRuntimeAuthorityDelivery);
         }

--- a/crates/automata-ci-runner-journal/src/model/content.rs
+++ b/crates/automata-ci-runner-journal/src/model/content.rs
@@ -54,8 +54,8 @@ impl RuntimeAuthorityContentRef {
 
     pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
         if self.0.kind() != ContentKind::RuntimeAuthority
-            || self.0.size() == 0
-            || self.0.size() > MAX_RUNTIME_AUTHORITY_CONTENT_BYTES
+            || self.0.accounted_bytes() == 0
+            || self.0.accounted_bytes() > MAX_RUNTIME_AUTHORITY_CONTENT_BYTES
         {
             return Err(JournalInvariantError::InvalidRuntimeAuthorityContent);
         }
@@ -93,8 +93,8 @@ impl JobIrContentRef {
 
     pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
         if self.content.kind() != ContentKind::JobIr
-            || self.content.size() == 0
-            || self.content.size() > MAX_JOB_IR_CONTENT_BYTES
+            || self.content.accounted_bytes() == 0
+            || self.content.accounted_bytes() > MAX_JOB_IR_CONTENT_BYTES
         {
             return Err(JournalInvariantError::InvalidJobIrContent);
         }
@@ -160,8 +160,8 @@ impl TerminalResultRecord {
 
     pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
         if self.content.kind() != ContentKind::TerminalResult
-            || self.content.size() == 0
-            || terminal_result_content_bytes_rejection(self.content.size()).is_some()
+            || self.content.accounted_bytes() == 0
+            || terminal_result_content_bytes_rejection(self.content.accounted_bytes()).is_some()
         {
             return Err(JournalInvariantError::InvalidTerminalResultContent);
         }

--- a/crates/automata-ci-runner-journal/src/model/cursor.rs
+++ b/crates/automata-ci-runner-journal/src/model/cursor.rs
@@ -194,12 +194,12 @@ impl LogSegment {
             .checked_sub(self.first_sequence.get())
             .and_then(|span| span.checked_add(1))
             .ok_or(JournalInvariantError::InvalidLogSegment)?;
-        if self.content.size() == 0
+        if self.content.accounted_bytes() == 0
             || self.frame_count == 0
             || usize::try_from(self.frame_count).unwrap_or(usize::MAX) > MAX_LOG_SEGMENT_FRAMES
             || u64::from(self.frame_count) != expected_frames
             || self.payload_bytes > MAX_LOG_SPOOL_CONTENT_BYTES
-            || self.payload_bytes > self.content.size()
+            || self.payload_bytes > self.content.accounted_bytes()
             || (self.end_of_stream && !self.sealed)
         {
             return Err(JournalInvariantError::InvalidLogSegment);
@@ -400,7 +400,7 @@ impl LogDeliveryCursor {
     #[must_use]
     pub fn backlog_content_bytes(&self) -> u64 {
         self.segments.iter().fold(0_u64, |total, segment| {
-            total.saturating_add(segment.content().size())
+            total.saturating_add(segment.content().accounted_bytes())
         })
     }
 
@@ -442,14 +442,14 @@ impl LogDeliveryCursor {
                 || candidate.last_sequence() != expected_last
                 || candidate.frame_count() != current.frame_count().saturating_add(1)
                 || candidate.payload_bytes() < current.payload_bytes()
-                || candidate.content().size() <= current.content().size()
+                || candidate.content().accounted_bytes() <= current.content().accounted_bytes()
             {
                 return Err(JournalInvariantError::InvalidLogSegment);
             }
             let retained = self
                 .backlog_content_bytes()
-                .checked_sub(current.content().size())
-                .and_then(|bytes| bytes.checked_add(candidate.content().size()))
+                .checked_sub(current.content().accounted_bytes())
+                .and_then(|bytes| bytes.checked_add(candidate.content().accounted_bytes()))
                 .ok_or(JournalInvariantError::LogBacklogLimit)?;
             if retained > MAX_LOG_SPOOL_CONTENT_BYTES {
                 return Err(JournalInvariantError::LogBacklogLimit);
@@ -473,7 +473,7 @@ impl LogDeliveryCursor {
             }
             let retained = self
                 .backlog_content_bytes()
-                .checked_add(candidate.content().size())
+                .checked_add(candidate.content().accounted_bytes())
                 .ok_or(JournalInvariantError::LogBacklogLimit)?;
             if retained > MAX_LOG_SPOOL_CONTENT_BYTES {
                 return Err(JournalInvariantError::LogBacklogLimit);
@@ -572,7 +572,7 @@ impl LogDeliveryCursor {
                 .checked_next()
                 .map_err(|_| JournalInvariantError::DecodedStateInvalid)?;
             total = total
-                .checked_add(segment.content().size())
+                .checked_add(segment.content().accounted_bytes())
                 .ok_or(JournalInvariantError::DecodedStateInvalid)?;
         }
         if total > MAX_LOG_SPOOL_CONTENT_BYTES {
@@ -606,7 +606,9 @@ impl LogDeliveryCursor {
 }
 
 fn validate_log_content(content: &DurableContentRef) -> Result<(), JournalInvariantError> {
-    if content.kind() != ContentKind::LogSpool || content.size() > MAX_LOG_SPOOL_CONTENT_BYTES {
+    if content.kind() != ContentKind::LogSpool
+        || content.accounted_bytes() > MAX_LOG_SPOOL_CONTENT_BYTES
+    {
         Err(JournalInvariantError::InvalidLogSpoolContent)
     } else {
         Ok(())
@@ -622,7 +624,7 @@ mod tests {
     use crate::{JournalInvariantError, MAX_LOG_SEGMENTS_PER_SLOT, MAX_LOG_SPOOL_CONTENT_BYTES};
 
     fn content(size: u64, marker: u8) -> DurableContentRef {
-        DurableContentRef::after_commit(
+        DurableContentRef::after_public_commit(
             ContentKind::LogSpool,
             size,
             Sha256Digest::from_bytes([marker; 32]),

--- a/crates/automata-ci-runner-journal/src/model/endpoint.rs
+++ b/crates/automata-ci-runner-journal/src/model/endpoint.rs
@@ -1,0 +1,356 @@
+use automata_ci_core::OperationId;
+use automata_ci_runner_spool::{ContentKind, DurableContentRef, endpoint_result_allocation};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ENDPOINT_REQUEST_COMMITMENT_BYTES, JournalInvariantError, MAX_ENDPOINT_RESULT_ALLOCATION_BYTES,
+    MAX_ENDPOINT_RESULT_CONTENT_BYTES, MIN_ENDPOINT_RESULT_ALLOCATION_BYTES,
+};
+
+/// Closed execution-endpoint operation domain retained for exact replay.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EndpointOperationKind {
+    /// Executes one literal argv request.
+    Exec,
+    /// Delivers one portable signal.
+    Signal,
+    /// Waits for the sandbox's primary workload.
+    Wait,
+    /// Copies bounded bytes into the sandbox.
+    CopyTo,
+    /// Copies bounded bytes out of the sandbox.
+    CopyFrom,
+}
+
+/// Protected fixed-size commitment to an exact endpoint request.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct EndpointRequestContentRef(DurableContentRef);
+
+impl EndpointRequestContentRef {
+    /// Binds an already durable request commitment.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a reference with the wrong semantic kind or byte length.
+    pub fn new(content: DurableContentRef) -> Result<Self, JournalInvariantError> {
+        let value = Self(content);
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the protected immutable content identity.
+    #[must_use]
+    pub const fn content(&self) -> &DurableContentRef {
+        &self.0
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
+        if self.0.kind() != ContentKind::EndpointRequest
+            || self.0.public_plaintext_bytes() != Some(ENDPOINT_REQUEST_COMMITMENT_BYTES)
+        {
+            return Err(JournalInvariantError::InvalidEndpointRequestContent);
+        }
+        Ok(())
+    }
+}
+
+/// Protected exact result of one endpoint operation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct EndpointResultContentRef(DurableContentRef);
+
+impl EndpointResultContentRef {
+    /// Binds an already durable endpoint result.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a reference with the wrong kind or protected allocation class.
+    pub fn new(content: DurableContentRef) -> Result<Self, JournalInvariantError> {
+        let value = Self(content);
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the protected immutable content identity.
+    #[must_use]
+    pub const fn content(&self) -> &DurableContentRef {
+        &self.0
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
+        let allocation = self.0.endpoint_result_allocation_bytes();
+        if self.0.kind() != ContentKind::EndpointResult
+            || allocation.is_none_or(|bytes| {
+                !(MIN_ENDPOINT_RESULT_ALLOCATION_BYTES..=MAX_ENDPOINT_RESULT_ALLOCATION_BYTES)
+                    .contains(&bytes)
+            })
+        {
+            return Err(JournalInvariantError::InvalidEndpointResultContent);
+        }
+        Ok(())
+    }
+}
+
+/// Non-evicting linearization record for one exact endpoint operation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EndpointOperation {
+    #[serde(rename = "id")]
+    operation_id: OperationId,
+    kind: EndpointOperationKind,
+    request: EndpointRequestContentRef,
+    #[serde(rename = "reservation")]
+    reserved_result_bytes: u64,
+    state: EndpointOperationState,
+}
+
+/// Closed durable phase/outcome of one execution-endpoint operation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "phase", deny_unknown_fields)]
+pub enum EndpointOperationState {
+    /// The exact request is accepted, but no backend call is permitted yet.
+    Accepted,
+    /// Permission to expose the exact request to the backend is durable.
+    InvocationCommitted,
+    /// Termination won the durable race, but backend quiescence is not proven.
+    CancellationRequested,
+    /// Cancellation is complete after the exact sandbox was proven absent.
+    Cancelled,
+    /// Recovery proved the exact sandbox generation absent after ambiguity.
+    Abandoned,
+    /// The exact protected result won the operation's durable race.
+    Completed {
+        /// Payload-first protected result bytes.
+        result: EndpointResultContentRef,
+    },
+}
+
+impl EndpointOperation {
+    /// Creates an accepted operation from a payload-first request commitment.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid content or an empty/oversized result reservation.
+    pub fn accepted(
+        operation_id: OperationId,
+        kind: EndpointOperationKind,
+        request: EndpointRequestContentRef,
+        reserved_result_bytes: u64,
+    ) -> Result<Self, JournalInvariantError> {
+        request.validate()?;
+        if reserved_result_bytes == 0 || reserved_result_bytes > MAX_ENDPOINT_RESULT_CONTENT_BYTES {
+            return Err(JournalInvariantError::InvalidEndpointResultReservation);
+        }
+        Ok(Self {
+            operation_id,
+            kind,
+            request,
+            reserved_result_bytes,
+            state: EndpointOperationState::Accepted,
+        })
+    }
+
+    /// Returns the stable endpoint operation identity.
+    #[must_use]
+    pub const fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Returns the closed endpoint operation kind.
+    #[must_use]
+    pub const fn kind(&self) -> EndpointOperationKind {
+        self.kind
+    }
+
+    /// Returns the protected exact-request commitment.
+    #[must_use]
+    pub const fn request(&self) -> &EndpointRequestContentRef {
+        &self.request
+    }
+
+    /// Returns the result capacity reserved before the backend may run.
+    #[must_use]
+    pub const fn reserved_result_bytes(&self) -> u64 {
+        self.reserved_result_bytes
+    }
+
+    /// Returns the closed durable phase/outcome.
+    #[must_use]
+    pub const fn state(&self) -> &EndpointOperationState {
+        &self.state
+    }
+
+    /// Reports whether recovery must complete before finalization is legal.
+    #[must_use]
+    pub const fn is_recovery_pending(&self) -> bool {
+        matches!(
+            self.state,
+            EndpointOperationState::Accepted
+                | EndpointOperationState::InvocationCommitted
+                | EndpointOperationState::CancellationRequested
+        )
+    }
+
+    /// Returns the exact protected result when result publication won.
+    #[must_use]
+    pub const fn result(&self) -> Option<&EndpointResultContentRef> {
+        match &self.state {
+            EndpointOperationState::Completed { result } => Some(result),
+            _ => None,
+        }
+    }
+
+    /// Returns bytes charged against the per-slot retained-content budget.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an incoherent result allocation or arithmetic overflow.
+    pub fn accounted_content_bytes(&self) -> Result<u64, JournalInvariantError> {
+        let result_bytes = match &self.state {
+            EndpointOperationState::Accepted
+            | EndpointOperationState::InvocationCommitted
+            | EndpointOperationState::CancellationRequested => {
+                endpoint_result_allocation(self.reserved_result_bytes)
+                    .map_err(|_| JournalInvariantError::InvalidEndpointResultReservation)?
+            }
+            EndpointOperationState::Completed { result } => result
+                .content()
+                .endpoint_result_allocation_bytes()
+                .ok_or(JournalInvariantError::InvalidEndpointResultContent)?,
+            EndpointOperationState::Cancelled | EndpointOperationState::Abandoned => 0,
+        };
+        ENDPOINT_REQUEST_COMMITMENT_BYTES
+            .checked_add(result_bytes)
+            .ok_or(JournalInvariantError::DecodedStateInvalid)
+    }
+
+    /// Returns protected references charged against the per-slot reference budget.
+    #[must_use]
+    pub const fn accounted_content_refs(&self) -> usize {
+        match self.state {
+            EndpointOperationState::Accepted
+            | EndpointOperationState::InvocationCommitted
+            | EndpointOperationState::CancellationRequested
+            | EndpointOperationState::Completed { .. } => 2,
+            EndpointOperationState::Cancelled | EndpointOperationState::Abandoned => 1,
+        }
+    }
+
+    pub(crate) fn matches_acceptance(&self, candidate: &Self) -> bool {
+        self.operation_id == candidate.operation_id
+            && self.kind == candidate.kind
+            && self.request == candidate.request
+            && self.reserved_result_bytes == candidate.reserved_result_bytes
+    }
+
+    pub(crate) fn commit_invocation(&mut self) -> Result<bool, JournalInvariantError> {
+        match self.state {
+            EndpointOperationState::Accepted => {
+                self.state = EndpointOperationState::InvocationCommitted;
+                Ok(true)
+            }
+            EndpointOperationState::InvocationCommitted => Ok(false),
+            EndpointOperationState::CancellationRequested | EndpointOperationState::Cancelled => {
+                Err(JournalInvariantError::EndpointOperationCancelled)
+            }
+            EndpointOperationState::Abandoned | EndpointOperationState::Completed { .. } => {
+                Err(JournalInvariantError::EndpointOperationResolved)
+            }
+        }
+    }
+
+    pub(crate) fn request_cancellation(&mut self) -> bool {
+        match self.state {
+            EndpointOperationState::Accepted => {
+                self.state = EndpointOperationState::Cancelled;
+                true
+            }
+            EndpointOperationState::InvocationCommitted => {
+                self.state = EndpointOperationState::CancellationRequested;
+                true
+            }
+            EndpointOperationState::CancellationRequested
+            | EndpointOperationState::Cancelled
+            | EndpointOperationState::Abandoned
+            | EndpointOperationState::Completed { .. } => false,
+        }
+    }
+
+    pub(crate) fn complete_cancellation(&mut self) -> Result<bool, JournalInvariantError> {
+        match self.state {
+            EndpointOperationState::CancellationRequested => {
+                self.state = EndpointOperationState::Cancelled;
+                Ok(true)
+            }
+            EndpointOperationState::Cancelled => Ok(false),
+            _ => Err(JournalInvariantError::EndpointCancellationNotRequested),
+        }
+    }
+
+    pub(crate) fn abandon(&mut self) -> Result<bool, JournalInvariantError> {
+        match self.state {
+            EndpointOperationState::InvocationCommitted
+            | EndpointOperationState::CancellationRequested => {
+                self.state = EndpointOperationState::Abandoned;
+                Ok(true)
+            }
+            EndpointOperationState::Abandoned => Ok(false),
+            _ => Err(JournalInvariantError::EndpointOperationNotAbandonable),
+        }
+    }
+
+    pub(crate) fn record_result(
+        &mut self,
+        result: EndpointResultContentRef,
+    ) -> Result<bool, JournalInvariantError> {
+        result.validate()?;
+        let reserved_allocation = endpoint_result_allocation(self.reserved_result_bytes)
+            .map_err(|_| JournalInvariantError::InvalidEndpointResultReservation)?;
+        if result.content().accounted_bytes() > reserved_allocation {
+            return Err(JournalInvariantError::EndpointResultExceedsReservation);
+        }
+        match &self.state {
+            EndpointOperationState::InvocationCommitted => {
+                self.state = EndpointOperationState::Completed { result };
+                Ok(true)
+            }
+            EndpointOperationState::Completed { result: existing } if existing == &result => {
+                Ok(false)
+            }
+            EndpointOperationState::Completed { .. } => {
+                Err(JournalInvariantError::EndpointResultReplayConflict)
+            }
+            EndpointOperationState::CancellationRequested
+            | EndpointOperationState::Cancelled
+            | EndpointOperationState::Abandoned => {
+                Err(JournalInvariantError::EndpointOperationCancelled)
+            }
+            EndpointOperationState::Accepted => {
+                Err(JournalInvariantError::EndpointInvocationNotCommitted)
+            }
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), JournalInvariantError> {
+        self.request.validate()?;
+        if self.reserved_result_bytes == 0
+            || self.reserved_result_bytes > MAX_ENDPOINT_RESULT_CONTENT_BYTES
+        {
+            return Err(JournalInvariantError::DecodedStateInvalid);
+        }
+        if let EndpointOperationState::Completed { result } = &self.state {
+            result.validate()?;
+            let reserved_allocation = endpoint_result_allocation(self.reserved_result_bytes)
+                .map_err(|_| JournalInvariantError::DecodedStateInvalid)?;
+            if result.content().accounted_bytes() > reserved_allocation {
+                return Err(JournalInvariantError::DecodedStateInvalid);
+            }
+        }
+        self.accounted_content_bytes()?
+            .checked_sub(ENDPOINT_REQUEST_COMMITMENT_BYTES)
+            .ok_or(JournalInvariantError::DecodedStateInvalid)?;
+        Ok(())
+    }
+}

--- a/crates/automata-ci-runner-journal/src/model/mod.rs
+++ b/crates/automata-ci-runner-journal/src/model/mod.rs
@@ -1,6 +1,7 @@
 mod command;
 mod content;
 mod cursor;
+mod endpoint;
 mod orphan;
 mod provider;
 mod state;
@@ -14,6 +15,10 @@ pub use content::{JobIrContentRef, RuntimeAuthorityContentRef, TerminalResultRec
 pub use cursor::{
     LogDeliveryCursor, LogSegment, LogSegmentAcknowledgement, LogSegmentPublication,
     OutboundOperationCursor, OutboundOperationSequence,
+};
+pub use endpoint::{
+    EndpointOperation, EndpointOperationKind, EndpointOperationState, EndpointRequestContentRef,
+    EndpointResultContentRef,
 };
 pub use orphan::{
     OrphanAbandonmentPermissions, OrphanAbandonmentReason, OrphanAuthorityError,

--- a/crates/automata-ci-runner-journal/src/model/state.rs
+++ b/crates/automata-ci-runner-journal/src/model/state.rs
@@ -4,6 +4,7 @@ use automata_ci_core::{
     JobIrVersion, JobIrVersionRange, JobLifecycle, LeaseGuard, LogStreamId, OperationId, RunnerId,
     RunnerSessionId, UnixMillis,
 };
+use automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB;
 use automata_ci_protocol::{
     CommandCursor, CommandSequence, LeaseRejectionReason, ProtocolVersion, RunnerSlotOrdinal,
     SUPPORTED_PROTOCOL_RANGE,
@@ -13,16 +14,17 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     CancellationRecord, CommandDisposition, CommandTombstone, DiskSchemaVersion, DurableCommand,
-    LeaseOfferRecord, LeaseRejectionRecord, LogDeliveryCursor, LogSegment,
-    LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentReason,
-    OrphanAuthorityGrant, OrphanDelivery, OrphanRecord, OutboundOperationCursor,
-    OutboundOperationSequence, ProviderFailureOutcome, ProviderOperation, ProviderOperationKind,
-    ProviderOperationOutcome, RuntimeAuthorityDeliveryRecord, SandboxIdentity,
-    TerminalResultRecord,
+    EndpointOperation, EndpointOperationState, EndpointResultContentRef, LeaseOfferRecord,
+    LeaseRejectionRecord, LogDeliveryCursor, LogSegment, LogSegmentAcknowledgement,
+    LogSegmentPublication, OrphanAbandonmentReason, OrphanAuthorityGrant, OrphanDelivery,
+    OrphanRecord, OutboundOperationCursor, OutboundOperationSequence, ProviderFailureOutcome,
+    ProviderOperation, ProviderOperationKind, ProviderOperationOutcome,
+    RuntimeAuthorityDeliveryRecord, SandboxIdentity, TerminalResultRecord,
 };
 use crate::{
-    JournalInvariantError, MAX_COMMAND_TOMBSTONES, MAX_JOURNALED_SLOTS,
-    MAX_PROVIDER_OPERATIONS_PER_SLOT, RUNNER_JOURNAL_SCHEMA_VERSION,
+    JournalInvariantError, MAX_COMMAND_TOMBSTONES, MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT,
+    MAX_ENDPOINT_CONTENT_REFS_PER_SLOT, MAX_JOURNALED_SLOTS, MAX_PROVIDER_OPERATIONS_PER_SLOT,
+    RUNNER_JOURNAL_SCHEMA_VERSION,
 };
 
 /// Whether a durably recorded offer is awaiting or has received local
@@ -215,6 +217,7 @@ pub struct SlotSnapshot {
     terminal_result_enqueued_at: Option<UnixMillis>,
     provider_checkpoint: ProviderRecoveryState,
     provider_operations: Vec<ProviderOperation>,
+    endpoint_operations: Vec<EndpointOperation>,
     sandbox: Option<SandboxIdentity>,
     outbound_operations: OutboundOperationCursor,
     log_delivery: Option<LogDeliveryCursor>,
@@ -298,6 +301,7 @@ impl SlotSnapshot {
             terminal_result_enqueued_at: None,
             provider_checkpoint: ProviderRecoveryState::default(),
             provider_operations: Vec::new(),
+            endpoint_operations: Vec::new(),
             sandbox: None,
             outbound_operations: OutboundOperationCursor::initial(),
             log_delivery: None,
@@ -372,6 +376,20 @@ impl SlotSnapshot {
         &self.provider_operations
     }
 
+    /// Returns every non-evicting endpoint operation in acceptance order.
+    #[must_use]
+    pub fn endpoint_operations(&self) -> &[EndpointOperation] {
+        &self.endpoint_operations
+    }
+
+    /// Returns the sole endpoint operation that still requires recovery.
+    #[must_use]
+    pub fn endpoint_recovery_pending(&self) -> Option<&EndpointOperation> {
+        self.endpoint_operations
+            .last()
+            .filter(|operation| operation.is_recovery_pending())
+    }
+
     /// Returns the recoverable provider and opaque sandbox identity, if live.
     #[must_use]
     pub const fn sandbox(&self) -> Option<&SandboxIdentity> {
@@ -428,6 +446,7 @@ impl SlotSnapshot {
         if self.provider_operations.len() > MAX_PROVIDER_OPERATIONS_PER_SLOT {
             return Err(JournalInvariantError::DecodedCollectionLimit);
         }
+        self.validate_endpoint_operations()?;
         self.validate_provider_state()?;
         let rejection_consistent = matches!(
             (self.offer_status, self.rejection.as_ref()),
@@ -477,7 +496,7 @@ impl SlotSnapshot {
         if let Some(orphan) = self.orphan
             && (orphan.session_id() != session.session_id()
                 || orphan.guard() != self.guard()
-                || !self.lifecycle.is_terminal()
+                || (!self.lifecycle.is_terminal() && self.endpoint_recovery_pending().is_none())
                 || (orphan.is_abandoned(OrphanDelivery::TerminalResult)
                     && self.terminal_result.is_none())
                 || (orphan.is_abandoned(OrphanDelivery::LogStream) && self.log_delivery.is_none())
@@ -519,11 +538,55 @@ impl SlotSnapshot {
             || binding.guard() != self.offer.lease().guard()
             || binding.offer_operation_id() != self.offer.command().operation_id()
             || binding.offer_sequence() != self.offer.command().sequence()
-            || binding.job_ir_digest() != self.offer.job_ir().content().sha256()
+            || self.offer.job_ir().content().public_plaintext_sha256()
+                != Some(binding.job_ir_digest())
         {
             return Err(JournalInvariantError::InvalidRuntimeAuthorityDelivery);
         }
         Ok(())
+    }
+
+    fn validate_endpoint_operations(&self) -> Result<(), JournalInvariantError> {
+        if self.endpoint_operations.len() > MAX_ENDPOINT_OPERATIONS_PER_JOB {
+            return Err(JournalInvariantError::DecodedCollectionLimit);
+        }
+        if !self.endpoint_operations.is_empty() && self.offer_status != LeaseOfferStatus::Accepted {
+            return Err(JournalInvariantError::DecodedStateInvalid);
+        }
+        let mut ids = HashSet::with_capacity(self.endpoint_operations.len());
+        let mut content_bytes = 0_u64;
+        let mut content_refs = 0_usize;
+        for (index, operation) in self.endpoint_operations.iter().enumerate() {
+            operation.validate()?;
+            content_refs = content_refs
+                .checked_add(operation.accounted_content_refs())
+                .ok_or(JournalInvariantError::DecodedStateInvalid)?;
+            content_bytes = content_bytes
+                .checked_add(operation.accounted_content_bytes()?)
+                .ok_or(JournalInvariantError::DecodedStateInvalid)?;
+            if !ids.insert(operation.operation_id())
+                || operation.is_recovery_pending() && index + 1 != self.endpoint_operations.len()
+            {
+                return Err(JournalInvariantError::DecodedStateInvalid);
+            }
+        }
+        if content_refs > MAX_ENDPOINT_CONTENT_REFS_PER_SLOT
+            || content_bytes > MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT
+            || (self.lifecycle == JobLifecycle::Finalizing || self.lifecycle.is_terminal())
+                && self.endpoint_recovery_pending().is_some()
+        {
+            return Err(JournalInvariantError::DecodedCollectionLimit);
+        }
+        Ok(())
+    }
+
+    fn terminalize_orphan_after_endpoint_resolution(&mut self) {
+        if self.orphan.is_some()
+            && !self.lifecycle.is_terminal()
+            && self.endpoint_recovery_pending().is_none()
+        {
+            self.lifecycle = JobLifecycle::Lost;
+        }
     }
 
     fn validate_delivery_timestamps(&self) -> Result<(), JournalInvariantError> {
@@ -813,6 +876,10 @@ impl JournalSnapshot {
                         .iter()
                         .flat_map(|delivery| delivery.segments().iter().map(LogSegment::content)),
                 )
+                .chain(slot.endpoint_operations.iter().flat_map(|operation| {
+                    std::iter::once(operation.request().content())
+                        .chain(operation.result().map(EndpointResultContentRef::content))
+                }))
         })
     }
 }
@@ -1201,7 +1268,8 @@ impl StoredJournal {
             || binding.guard() != slot.offer.lease().guard()
             || binding.offer_operation_id() != slot.offer.command().operation_id()
             || binding.offer_sequence() != slot.offer.command().sequence()
-            || binding.job_ir_digest() != slot.offer.job_ir().content().sha256()
+            || slot.offer.job_ir().content().public_plaintext_sha256()
+                != Some(binding.job_ir_digest())
         {
             return Err(JournalInvariantError::InvalidRuntimeAuthorityDelivery);
         }
@@ -1352,6 +1420,13 @@ impl StoredJournal {
         }
         self.slots[index].cancellation = Some(cancellation);
         self.slots[index].lifecycle = JobLifecycle::Cancelling;
+        if let Some(operation) = self.slots[index]
+            .endpoint_operations
+            .last_mut()
+            .filter(|operation| operation.is_recovery_pending())
+        {
+            operation.request_cancellation();
+        }
         Ok(true)
     }
 
@@ -1374,6 +1449,9 @@ impl StoredJournal {
         }
         if next.is_terminal() {
             return Err(JournalInvariantError::TerminalResultRequired);
+        }
+        if next == JobLifecycle::Finalizing && slot.endpoint_recovery_pending().is_some() {
+            return Err(JournalInvariantError::EndpointRecoveryPending);
         }
         slot.lifecycle
             .validate_transition(next)
@@ -1404,6 +1482,9 @@ impl StoredJournal {
         }
         if !terminal.is_terminal() {
             return Err(JournalInvariantError::InvalidLifecycleTransition);
+        }
+        if slot.endpoint_recovery_pending().is_some() {
+            return Err(JournalInvariantError::EndpointRecoveryPending);
         }
         if let Some(existing) = &slot.terminal_result {
             return if existing.matches_unacknowledged(&result) && slot.lifecycle == terminal {
@@ -1442,6 +1523,169 @@ impl StoredJournal {
         }
         result.acknowledge();
         Ok(true)
+    }
+
+    pub(crate) fn accept_endpoint_operation(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation: EndpointOperation,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        if slot.offer_status != LeaseOfferStatus::Accepted {
+            return Err(JournalInvariantError::OfferNotAccepted);
+        }
+        if slot.lifecycle.is_terminal() {
+            return Err(JournalInvariantError::LeaseTerminal);
+        }
+        if slot.orphan.is_some() {
+            return Err(JournalInvariantError::OrphanNotAuthorized);
+        }
+        operation.validate()?;
+        if !matches!(operation.state(), EndpointOperationState::Accepted) {
+            return Err(JournalInvariantError::EndpointOperationNotAccepted);
+        }
+        if let Some(existing) = slot
+            .endpoint_operations
+            .iter()
+            .find(|existing| existing.operation_id() == operation.operation_id())
+        {
+            return if existing.matches_acceptance(&operation) {
+                Ok(false)
+            } else {
+                Err(JournalInvariantError::EndpointOperationReplayConflict)
+            };
+        }
+        if slot.cancellation.is_some() {
+            return Err(JournalInvariantError::EndpointOperationsClosed);
+        }
+        if slot
+            .endpoint_operations
+            .last()
+            .is_some_and(EndpointOperation::is_recovery_pending)
+        {
+            return Err(JournalInvariantError::EndpointOperationPending);
+        }
+        if slot.endpoint_operations.len() >= MAX_ENDPOINT_OPERATIONS_PER_JOB {
+            return Err(JournalInvariantError::EndpointOperationLimit);
+        }
+        let prospective_refs = slot
+            .endpoint_operations
+            .iter()
+            .try_fold(operation.accounted_content_refs(), |refs, current| {
+                refs.checked_add(current.accounted_content_refs())
+            })
+            .ok_or(JournalInvariantError::EndpointContentRefLimit)?;
+        if prospective_refs > MAX_ENDPOINT_CONTENT_REFS_PER_SLOT {
+            return Err(JournalInvariantError::EndpointContentRefLimit);
+        }
+        let content_bytes = slot.endpoint_operations.iter().try_fold(
+            operation.accounted_content_bytes()?,
+            |total, current| {
+                total
+                    .checked_add(current.accounted_content_bytes()?)
+                    .ok_or(JournalInvariantError::EndpointContentBytesLimit)
+            },
+        )?;
+        if content_bytes > MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT {
+            return Err(JournalInvariantError::EndpointContentBytesLimit);
+        }
+        slot.endpoint_operations.push(operation);
+        Ok(true)
+    }
+
+    pub(crate) fn commit_endpoint_invocation(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        let operation = slot
+            .endpoint_operations
+            .iter_mut()
+            .find(|operation| operation.operation_id() == operation_id)
+            .ok_or(JournalInvariantError::EndpointOperationMissing)?;
+        operation.commit_invocation()
+    }
+
+    pub(crate) fn record_endpoint_cancellation(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        let changed = slot
+            .endpoint_operations
+            .iter_mut()
+            .find(|operation| operation.operation_id() == operation_id)
+            .ok_or(JournalInvariantError::EndpointOperationMissing)?
+            .request_cancellation();
+        slot.terminalize_orphan_after_endpoint_resolution();
+        Ok(changed)
+    }
+
+    pub(crate) fn complete_endpoint_cancellation(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        if slot.sandbox.is_some() {
+            return Err(JournalInvariantError::EndpointSandboxStillPresent);
+        }
+        let changed = slot
+            .endpoint_operations
+            .iter_mut()
+            .find(|operation| operation.operation_id() == operation_id)
+            .ok_or(JournalInvariantError::EndpointOperationMissing)?
+            .complete_cancellation()?;
+        slot.terminalize_orphan_after_endpoint_resolution();
+        Ok(changed)
+    }
+
+    pub(crate) fn abandon_endpoint_operation(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        if slot.sandbox.is_some() {
+            return Err(JournalInvariantError::EndpointSandboxStillPresent);
+        }
+        let changed = slot
+            .endpoint_operations
+            .iter_mut()
+            .find(|operation| operation.operation_id() == operation_id)
+            .ok_or(JournalInvariantError::EndpointOperationMissing)?
+            .abandon()?;
+        slot.terminalize_orphan_after_endpoint_resolution();
+        Ok(changed)
+    }
+
+    pub(crate) fn record_endpoint_result(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+        result: EndpointResultContentRef,
+    ) -> Result<bool, JournalInvariantError> {
+        let slot = self.slot_mut(session_id, slot, guard)?;
+        let operation = slot
+            .endpoint_operations
+            .iter_mut()
+            .find(|operation| operation.operation_id() == operation_id)
+            .ok_or(JournalInvariantError::EndpointOperationMissing)?;
+        operation.record_result(result)
     }
 
     pub(crate) fn record_provider_intent(
@@ -1739,7 +1983,9 @@ impl StoredJournal {
             };
         }
         self.slots[index].orphan = Some(OrphanRecord::from_grant(grant));
-        if !self.slots[index].lifecycle.is_terminal() {
+        if !self.slots[index].lifecycle.is_terminal()
+            && self.slots[index].endpoint_recovery_pending().is_none()
+        {
             self.slots[index].lifecycle = JobLifecycle::Lost;
         }
         Ok(true)
@@ -1788,6 +2034,10 @@ impl StoredJournal {
                 .last()
                 .is_some_and(|operation| operation.is_pending())
             || self.slots[index].sandbox.is_some()
+            || self.slots[index]
+                .endpoint_operations
+                .iter()
+                .any(EndpointOperation::is_recovery_pending)
         {
             return Err(JournalInvariantError::SlotNotTerminal);
         }

--- a/crates/automata-ci-runner-journal/src/observer.rs
+++ b/crates/automata-ci-runner-journal/src/observer.rs
@@ -20,6 +20,8 @@ pub enum JournalMutationDomain {
     Result,
     /// Provider mutation intent or recovery outcome.
     Provider,
+    /// Execution-endpoint acceptance, invocation, result, or cancellation.
+    Endpoint,
     /// Runner-to-control-plane operation cursor state.
     Outbound,
     /// Durable log stream, segment, seal, or acknowledgement state.

--- a/crates/automata-ci-runner-journal/tests/durable_payloads.rs
+++ b/crates/automata-ci-runner-journal/tests/durable_payloads.rs
@@ -412,7 +412,7 @@ fn payload_fsync_precedes_offer_cursor_and_exact_session_negotiation_survives_re
     assert_eq!(durable_offer.job_ir().version(), JobIrVersion::current());
     assert_eq!(durable_offer.job_ir().content(), &job_content);
     assert_eq!(
-        durable_offer.job_ir().content().size(),
+        durable_offer.job_ir().content().accounted_bytes(),
         job_bytes.len() as u64
     );
     drop(journal);

--- a/crates/automata-ci-runner-journal/tests/limits_and_untrusted.rs
+++ b/crates/automata-ci-runner-journal/tests/limits_and_untrusted.rs
@@ -25,7 +25,7 @@ const _: () = {
 };
 
 fn reference(kind: ContentKind, size: u64) -> DurableContentRef {
-    DurableContentRef::after_commit(
+    DurableContentRef::after_public_commit(
         kind,
         size,
         Sha256Digest::from_bytes([0x99; 32]),

--- a/crates/automata-ci-runner-journal/tests/support/mod.rs
+++ b/crates/automata-ci-runner-journal/tests/support/mod.rs
@@ -18,8 +18,10 @@ use automata_ci_runner_journal::{
     LogSegment, LogSegmentPublication, RunnerJournal, RuntimeAuthorityContentRef,
     RuntimeAuthorityDeliveryRecord, SessionBinding, StateRoot, TerminalResultRecord,
 };
-use automata_ci_runner_spool::ProtectionId;
-use automata_ci_runner_spool::{ContentProtectionError, ContentProtector, SpoolRoot};
+use automata_ci_runner_spool::{
+    ContentCommitmentDomain, ContentProtectionError, ContentProtector, OpaqueContentIdentity,
+    ProtectionId, SpoolRoot, endpoint_result_allocation,
+};
 use sha2::{Digest as _, Sha256};
 
 pub struct Scratch {
@@ -88,6 +90,29 @@ impl fmt::Debug for TestProtector {
 impl ContentProtector for TestProtector {
     fn protection_id(&self) -> &ProtectionId {
         &self.id
+    }
+
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        if protection_id != &self.id {
+            return Err(ContentProtectionError::KeyUnavailable);
+        }
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(domain.separator());
+        digest.update(material_digest);
+        Ok(digest.finalize().into())
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        _plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        Err(ContentProtectionError::Failed)
     }
 
     fn protect(
@@ -198,13 +223,32 @@ impl Fixture {
     }
 
     pub fn content(kind: ContentKind, size: u64, marker: u8) -> DurableContentRef {
-        DurableContentRef::after_commit(
-            kind,
-            size,
-            Sha256Digest::from_bytes([marker; 32]),
-            ProtectionId::new("test-aead-key-v1").expect("valid protection identifier"),
-        )
-        .expect("valid durable content reference")
+        Self::content_with_protection_id(kind, size, marker, "test-aead-key-v1")
+    }
+
+    pub fn content_with_protection_id(
+        kind: ContentKind,
+        size: u64,
+        marker: u8,
+        protection_id: &str,
+    ) -> DurableContentRef {
+        let protection_id = ProtectionId::new(protection_id).expect("valid protection identifier");
+        if kind == ContentKind::EndpointResult {
+            DurableContentRef::after_endpoint_result_commit(
+                endpoint_result_allocation(size).expect("bounded endpoint result allocation"),
+                OpaqueContentIdentity::from_bytes([marker; 32]),
+                protection_id,
+            )
+            .expect("valid opaque endpoint-result reference")
+        } else {
+            DurableContentRef::after_public_commit(
+                kind,
+                size,
+                Sha256Digest::from_bytes([marker; 32]),
+                protection_id,
+            )
+            .expect("valid public durable content reference")
+        }
     }
 
     pub fn runtime_authority() -> RuntimeAuthorityContentRef {
@@ -231,12 +275,19 @@ impl Fixture {
                 self.lease.guard(),
                 offer.command().operation_id(),
                 offer.command().sequence(),
-                offer.job_ir().content().sha256(),
+                offer
+                    .job_ir()
+                    .content()
+                    .public_plaintext_sha256()
+                    .expect("job IR has a public digest"),
                 INITIAL_RUNTIME_AUTHORITY_GENERATION,
             ),
             OperationId::new(),
             OperationId::new(),
-            content.content().sha256(),
+            content
+                .content()
+                .public_plaintext_sha256()
+                .expect("runtime authority has a public digest"),
             content,
         )
         .expect("valid runtime-authority delivery")

--- a/crates/automata-ci-runner-runtime/Cargo.toml
+++ b/crates/automata-ci-runner-runtime/Cargo.toml
@@ -28,6 +28,7 @@ automata-ci-runner-journal.workspace = true
 automata-ci-runner-spool.workspace = true
 automata-ci-runner-transport.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/automata-ci-runner-runtime/src/content.rs
+++ b/crates/automata-ci-runner-runtime/src/content.rs
@@ -1,7 +1,9 @@
 use std::sync::{Mutex, PoisonError};
 
 use automata_ci_runner_journal::{JournalContentRetainSet, RunnerJournal};
-use automata_ci_runner_spool::{DurableContentStore, SpoolError};
+use automata_ci_runner_spool::{
+    DurableContentStore, EndpointResultCapacityReservation, SpoolError,
+};
 
 pub(crate) trait CapacityReclaimError: Sized {
     fn is_capacity_exhausted(&self) -> bool;
@@ -56,5 +58,25 @@ impl ContentOperationCoordinator {
             }
             outcome => outcome,
         })
+    }
+
+    /// Reserves shared protected capacity for an endpoint result before any
+    /// backend invocation, reconciling journal-unreferenced payloads before one
+    /// exact retry on exhaustion.
+    pub(crate) fn reserve_endpoint_result<'store>(
+        &self,
+        journal: &dyn RunnerJournal,
+        spool: &'store dyn DurableContentStore,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'store> + 'store>, SpoolError> {
+        self.run(
+            || match spool.reserve_endpoint_result(maximum_plaintext_bytes) {
+                Err(SpoolError::CapacityExhausted) => {
+                    spool.reconcile(&JournalContentRetainSet::new(journal))?;
+                    spool.reserve_endpoint_result(maximum_plaintext_bytes)
+                }
+                outcome => outcome,
+            },
+        )
     }
 }

--- a/crates/automata-ci-runner-runtime/src/endpoint_replay.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_replay.rs
@@ -1,0 +1,800 @@
+use std::{
+    fmt,
+    num::NonZeroU16,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use automata_ci_core::{LeaseGuard, OperationId, RunnerSessionId};
+use automata_ci_execution::{
+    Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, ExecutionCommand,
+    ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionSignal,
+    ExecutionStage, SandboxCapability, SandboxCustody, SandboxInspection, SandboxProvider,
+    SandboxState, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+};
+use automata_ci_protocol::RunnerSlotOrdinal;
+use automata_ci_runner_journal::{
+    EndpointOperation, EndpointOperationKind, EndpointOperationState, EndpointRequestContentRef,
+    EndpointResultContentRef, JournalError, JournalInvariantError, RUNNER_JOURNAL_SCHEMA_VERSION,
+    RunnerJournal,
+};
+use automata_ci_runner_spool::{
+    ContentCommitmentDomain, ContentKind, DurableContentStore, EndpointResultCapacityReservation,
+    KeyedContentCommitment,
+};
+use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
+use zeroize::Zeroizing;
+
+use crate::{ExecutionEventError, content::ContentOperationCoordinator, endpoint_result};
+
+const ENDPOINT_REPLAY_SCHEMA_VERSION: u16 = 2;
+const FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/runner/endpoint-request";
+
+pub(crate) struct DurableExecutionEndpoint {
+    journal: Arc<dyn RunnerJournal>,
+    spool: Arc<dyn DurableContentStore>,
+    content_operations: Arc<ContentOperationCoordinator>,
+    serial: Arc<Mutex<()>>,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+    guard: LeaseGuard,
+    provider: Arc<dyn SandboxProvider>,
+    inspection: SandboxInspection,
+    inner: Box<dyn ExecutionEndpoint>,
+}
+
+enum PreparedOperation {
+    Replay(Vec<u8>),
+    Invoke,
+}
+
+impl DurableExecutionEndpoint {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn bind(
+        journal: Arc<dyn RunnerJournal>,
+        spool: Arc<dyn DurableContentStore>,
+        content_operations: Arc<ContentOperationCoordinator>,
+        serial: Arc<Mutex<()>>,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        provider: Arc<dyn SandboxProvider>,
+        inspection: SandboxInspection,
+        inner: Box<dyn ExecutionEndpoint>,
+    ) -> Result<Self, ExecutionEventError> {
+        let snapshot = journal.snapshot().map_err(ExecutionEventError::Journal)?;
+        let durable_slot = snapshot
+            .slot(slot)
+            .ok_or(ExecutionEventError::InvalidEvent)?;
+        let durable_sandbox = durable_slot
+            .sandbox()
+            .ok_or(ExecutionEventError::InvalidEvent)?;
+        let expected_slot = NonZeroU16::new(slot.get()).ok_or(ExecutionEventError::InvalidEvent)?;
+        let exact = snapshot
+            .session()
+            .is_some_and(|session| session.session_id() == session_id)
+            && durable_slot.offer().lease().guard() == guard
+            && inspection.handle() == inner.handle()
+            && inspection.handle().provider() == provider.provider_id()
+            && provider.provider_id() == inner.handle().provider()
+            && inspection.generation().get() == guard.fencing_token().get()
+            && inspection.state() == SandboxState::Running
+            && inspection.custody()
+                == (SandboxCustody::Job {
+                    runner_id: snapshot.runner_id(),
+                    slot_ordinal: expected_slot,
+                })
+            && durable_sandbox.provider().as_str() == provider.provider_id().as_str()
+            && durable_sandbox.handle().as_str() == inspection.handle().opaque();
+        if !exact {
+            return Err(ExecutionEventError::InvalidEvent);
+        }
+        Ok(Self {
+            journal,
+            spool,
+            content_operations,
+            serial,
+            session_id,
+            slot,
+            guard,
+            provider,
+            inspection,
+            inner,
+        })
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        clippy::too_many_arguments,
+        reason = "the endpoint boundary owns and zeroizes each request digest on every exit"
+    )]
+    fn run<T>(
+        &self,
+        operation_id: OperationId,
+        kind: EndpointOperationKind,
+        request_digest: Zeroizing<[u8; 32]>,
+        reservation: u64,
+        stage: ExecutionStage,
+        cancellation: &dyn Cancellation,
+        invoke: impl FnOnce(&dyn Cancellation) -> Result<T, ExecutionError>,
+        encode: impl FnOnce(&Result<T, ExecutionError>) -> Result<Vec<u8>, ()>,
+        decode: impl FnOnce(&[u8]) -> Result<Result<T, ExecutionError>, ()>,
+    ) -> Result<T, ExecutionError> {
+        let _serial = self
+            .serial
+            .lock()
+            .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+        let prepared = self.prepare(operation_id, kind, &request_digest, reservation, stage)?;
+        if let PreparedOperation::Replay(bytes) = prepared {
+            return decode(&bytes)
+                .map_err(|()| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+        }
+        let PreparedOperation::Invoke = prepared else {
+            unreachable!("replay returned above")
+        };
+        if self.linearize_pre_invocation_cancellation(operation_id, stage, cancellation)? {
+            return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+        }
+        let result_capacity = self
+            .content_operations
+            .reserve_endpoint_result(self.journal.as_ref(), self.spool.as_ref(), reservation)
+            .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+        let binding_cancellation = LinearizedCancellation::new(
+            cancellation,
+            self.journal.as_ref(),
+            self.session_id,
+            self.slot,
+            self.guard,
+            operation_id,
+        );
+        let binding = self.verify_live_binding(stage, &binding_cancellation);
+        if binding_cancellation.storage_failed() {
+            return Err(execution_error(ExecutionErrorKind::LocalStorage, stage));
+        }
+        if binding_cancellation.cancellation_won()
+            || self.linearize_pre_invocation_cancellation(operation_id, stage, cancellation)?
+        {
+            return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+        }
+        binding?;
+        if let Err(error) = self.journal.commit_endpoint_invocation(
+            self.session_id,
+            self.slot,
+            self.guard,
+            operation_id,
+        ) {
+            let kind = if matches!(
+                error,
+                JournalError::Invariant(JournalInvariantError::EndpointOperationCancelled)
+            ) {
+                ExecutionErrorKind::Cancelled
+            } else {
+                ExecutionErrorKind::LocalStorage
+            };
+            return Err(execution_error(kind, stage));
+        }
+        let observed = LinearizedCancellation::new(
+            cancellation,
+            self.journal.as_ref(),
+            self.session_id,
+            self.slot,
+            self.guard,
+            operation_id,
+        );
+        let result = invoke(&observed);
+        if observed.storage_failed() {
+            return Err(execution_error(ExecutionErrorKind::LocalStorage, stage));
+        }
+        if observed.cancellation_won() {
+            return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+        }
+        if self.linearize_returned_cancellation(operation_id, stage, cancellation)? {
+            return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+        }
+        let encoded = encode(&result)
+            .map_err(|()| execution_error(ExecutionErrorKind::InvalidState, stage))?;
+        if u64::try_from(encoded.len()).map_or(true, |bytes| bytes > reservation) {
+            return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
+        }
+        self.publish_result(operation_id, &encoded, result_capacity, stage)?;
+        result
+    }
+
+    fn prepare(
+        &self,
+        operation_id: OperationId,
+        kind: EndpointOperationKind,
+        request_digest: &[u8; 32],
+        reservation: u64,
+        stage: ExecutionStage,
+    ) -> Result<PreparedOperation, ExecutionError> {
+        let snapshot = self
+            .journal
+            .snapshot()
+            .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+        let slot = snapshot
+            .slot(self.slot)
+            .ok_or_else(|| execution_error(ExecutionErrorKind::InvalidState, stage))?;
+        if let Some(operation) = slot
+            .endpoint_operations()
+            .iter()
+            .find(|operation| operation.operation_id() == operation_id)
+        {
+            if operation.kind() != kind || operation.reserved_result_bytes() != reservation {
+                return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
+            }
+            let expected = self
+                .spool
+                .recreate_keyed_commitment(
+                    operation.request().content().protection_id(),
+                    ContentCommitmentDomain::EndpointRequest,
+                    request_digest,
+                )
+                .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+            let stored = self
+                .spool
+                .load(operation.request().content())
+                .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+            if !bool::from(stored.as_slice().ct_eq(expected.as_bytes().as_slice())) {
+                return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
+            }
+            match operation.state() {
+                EndpointOperationState::Accepted => {
+                    return Ok(PreparedOperation::Invoke);
+                }
+                EndpointOperationState::CancellationRequested
+                | EndpointOperationState::Cancelled => {
+                    return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+                }
+                EndpointOperationState::InvocationCommitted | EndpointOperationState::Abandoned => {
+                    return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
+                }
+                EndpointOperationState::Completed { result } => {
+                    let bytes = self
+                        .spool
+                        .load(result.content())
+                        .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+                    return Ok(PreparedOperation::Replay(bytes));
+                }
+            }
+        }
+        let commitment = self
+            .spool
+            .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, request_digest)
+            .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+        self.publish_request(operation_id, kind, &commitment, reservation)
+            .map_err(|error| map_event_error(&error, stage))?;
+        Ok(PreparedOperation::Invoke)
+    }
+
+    fn publish_request(
+        &self,
+        operation_id: OperationId,
+        kind: EndpointOperationKind,
+        commitment: &KeyedContentCommitment,
+        reservation: u64,
+    ) -> Result<(), ExecutionEventError> {
+        self.content_operations.publish_reclaiming_capacity(
+            self.journal.as_ref(),
+            self.spool.as_ref(),
+            || {
+                let publication = self
+                    .spool
+                    .persist(ContentKind::EndpointRequest, commitment.as_bytes())
+                    .map_err(ExecutionEventError::Spool)?;
+                match publication.commit_with(|content| {
+                    if content.protection_id() != commitment.protection_id() {
+                        return Err(JournalError::Invariant(
+                            JournalInvariantError::InvalidEndpointRequestContent,
+                        ));
+                    }
+                    let request = EndpointRequestContentRef::new(content.clone())?;
+                    let operation =
+                        EndpointOperation::accepted(operation_id, kind, request, reservation)?;
+                    self.journal.accept_endpoint_operation(
+                        self.session_id,
+                        self.slot,
+                        self.guard,
+                        operation,
+                    )
+                }) {
+                    Ok(_) => Ok(()),
+                    Err(failure) => {
+                        let (error, publication) = failure.into_parts();
+                        publication.abort();
+                        Err(ExecutionEventError::Journal(error))
+                    }
+                }
+            },
+        )
+    }
+
+    fn publish_result(
+        &self,
+        operation_id: OperationId,
+        encoded: &[u8],
+        capacity: Box<dyn EndpointResultCapacityReservation<'_> + '_>,
+        stage: ExecutionStage,
+    ) -> Result<(), ExecutionError> {
+        let committed = self.content_operations.run(|| {
+            let publication = capacity
+                .persist(encoded)
+                .map_err(ExecutionEventError::Spool)?;
+            match publication.commit_with(|content| {
+                let result = EndpointResultContentRef::new(content.clone())?;
+                self.journal.record_endpoint_result(
+                    self.session_id,
+                    self.slot,
+                    self.guard,
+                    operation_id,
+                    result,
+                )
+            }) {
+                Ok(_) => Ok(()),
+                Err(failure) => {
+                    let (error, publication) = failure.into_parts();
+                    publication.abort();
+                    Err(ExecutionEventError::Journal(error))
+                }
+            }
+        });
+        match committed {
+            Ok(()) => Ok(()),
+            Err(ExecutionEventError::Journal(JournalError::Invariant(
+                JournalInvariantError::EndpointOperationCancelled,
+            ))) => Err(execution_error(ExecutionErrorKind::Cancelled, stage)),
+            Err(_) => Err(execution_error(ExecutionErrorKind::LocalStorage, stage)),
+        }
+    }
+
+    fn linearize_pre_invocation_cancellation(
+        &self,
+        operation_id: OperationId,
+        stage: ExecutionStage,
+        cancellation: &dyn Cancellation,
+    ) -> Result<bool, ExecutionError> {
+        match cancellation.disposition() {
+            CancellationDisposition::Active => Ok(false),
+            CancellationDisposition::Terminate => {
+                let snapshot = self
+                    .journal
+                    .record_endpoint_cancellation(
+                        self.session_id,
+                        self.slot,
+                        self.guard,
+                        operation_id,
+                    )
+                    .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+                let operation = snapshot
+                    .slot(self.slot)
+                    .and_then(|slot| {
+                        slot.endpoint_operations()
+                            .iter()
+                            .find(|operation| operation.operation_id() == operation_id)
+                    })
+                    .ok_or_else(|| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+                match operation.state() {
+                    EndpointOperationState::CancellationRequested => Ok(true),
+                    EndpointOperationState::Cancelled | EndpointOperationState::Abandoned => {
+                        Ok(true)
+                    }
+                    EndpointOperationState::Completed { .. } => Ok(false),
+                    EndpointOperationState::Accepted
+                    | EndpointOperationState::InvocationCommitted => {
+                        Err(execution_error(ExecutionErrorKind::LocalStorage, stage))
+                    }
+                }
+            }
+        }
+    }
+
+    fn linearize_returned_cancellation(
+        &self,
+        operation_id: OperationId,
+        stage: ExecutionStage,
+        cancellation: &dyn Cancellation,
+    ) -> Result<bool, ExecutionError> {
+        match cancellation.disposition() {
+            CancellationDisposition::Active => Ok(false),
+            CancellationDisposition::Terminate => {
+                let snapshot = self
+                    .journal
+                    .record_endpoint_cancellation(
+                        self.session_id,
+                        self.slot,
+                        self.guard,
+                        operation_id,
+                    )
+                    .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+                let operation = snapshot
+                    .slot(self.slot)
+                    .and_then(|slot| {
+                        slot.endpoint_operations()
+                            .iter()
+                            .find(|operation| operation.operation_id() == operation_id)
+                    })
+                    .ok_or_else(|| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+                match operation.state() {
+                    EndpointOperationState::CancellationRequested => Ok(true),
+                    EndpointOperationState::Cancelled | EndpointOperationState::Abandoned => {
+                        Ok(true)
+                    }
+                    EndpointOperationState::Completed { .. } => Ok(false),
+                    EndpointOperationState::Accepted
+                    | EndpointOperationState::InvocationCommitted => {
+                        Err(execution_error(ExecutionErrorKind::LocalStorage, stage))
+                    }
+                }
+            }
+        }
+    }
+
+    fn verify_live_binding(
+        &self,
+        stage: ExecutionStage,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        let current = self
+            .provider
+            .inspect(self.inspection.handle(), cancellation)
+            .map_err(|_| execution_error(ExecutionErrorKind::InvalidState, stage))?;
+        if current.handle() != self.inspection.handle()
+            || current.generation() != self.inspection.generation()
+            || current.custody() != self.inspection.custody()
+            || current.profile() != self.inspection.profile()
+            || current.state() != SandboxState::Running
+        {
+            return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
+        }
+        Ok(())
+    }
+
+    fn fingerprint(&self, kind: EndpointOperationKind, operation_id: OperationId) -> Fingerprint {
+        let mut fingerprint = Fingerprint::new();
+        fingerprint.bytes(FINGERPRINT_DOMAIN);
+        fingerprint.u16(RUNNER_JOURNAL_SCHEMA_VERSION);
+        fingerprint.u16(ENDPOINT_REPLAY_SCHEMA_VERSION);
+        fingerprint.text(self.inspection.handle().provider().as_str());
+        fingerprint.text(self.inspection.handle().opaque());
+        fingerprint.u64(self.inspection.generation().get());
+        match self.inspection.custody() {
+            SandboxCustody::ProfileAdmission { runner_id } => {
+                fingerprint.byte(0);
+                fingerprint.bytes(runner_id.as_uuid().as_bytes());
+            }
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal,
+            } => {
+                fingerprint.byte(1);
+                fingerprint.bytes(runner_id.as_uuid().as_bytes());
+                fingerprint.u16(slot_ordinal.get());
+            }
+        }
+        fingerprint.text(self.inspection.profile().id().as_str());
+        fingerprint.bytes(self.inspection.profile().digest().as_bytes());
+        fingerprint.byte(operation_kind_tag(kind));
+        fingerprint.bytes(operation_id.as_uuid().as_bytes());
+        fingerprint
+    }
+}
+
+impl fmt::Debug for DurableExecutionEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DurableExecutionEndpoint")
+            .field("session_id", &self.session_id)
+            .field("slot", &self.slot)
+            .field("guard", &self.guard)
+            .field("provider", &self.provider.provider_id())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ExecutionEndpoint for DurableExecutionEndpoint {
+    fn handle(&self) -> &automata_ci_execution::SandboxHandle {
+        self.inner.handle()
+    }
+
+    fn capabilities(&self) -> &[SandboxCapability] {
+        self.inner.capabilities()
+    }
+
+    fn exec(
+        &self,
+        request: &ExecutionCommand,
+        cancellation: &dyn Cancellation,
+    ) -> Result<ExecutionOutput, ExecutionError> {
+        let mut fingerprint = self.fingerprint(EndpointOperationKind::Exec, request.operation_id());
+        fingerprint.target_path(request.argv().program());
+        fingerprint.usize(request.argv().arguments().len());
+        for argument in request.argv().arguments() {
+            fingerprint.text(argument);
+        }
+        fingerprint.target_path(request.working_directory());
+        fingerprint.usize(request.environment().values().len());
+        for variable in request.environment().values() {
+            fingerprint.text(variable.name().as_str());
+            fingerprint.text(variable.value().expose());
+            fingerprint.byte(u8::from(variable.is_secret()));
+        }
+        fingerprint.duration(request.timeout());
+        fingerprint.usize(request.output_limit());
+        let request_digest = fingerprint.finish();
+        let reservation = endpoint_result::exec_reservation(request).ok_or_else(|| {
+            execution_error(ExecutionErrorKind::InvalidState, ExecutionStage::Exec)
+        })?;
+        self.run(
+            request.operation_id(),
+            EndpointOperationKind::Exec,
+            request_digest,
+            reservation,
+            ExecutionStage::Exec,
+            cancellation,
+            |observed| self.inner.exec(request, observed),
+            |result| endpoint_result::encode_exec(result, request),
+            |encoded| endpoint_result::decode_exec(encoded, request),
+        )
+    }
+
+    fn signal(
+        &self,
+        request: SignalRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        let mut fingerprint =
+            self.fingerprint(EndpointOperationKind::Signal, request.operation_id());
+        fingerprint.byte(match request.signal() {
+            ExecutionSignal::Interrupt => 0,
+            ExecutionSignal::Terminate => 1,
+            ExecutionSignal::Kill => 2,
+        });
+        self.run(
+            request.operation_id(),
+            EndpointOperationKind::Signal,
+            fingerprint.finish(),
+            endpoint_result::small_reservation(),
+            ExecutionStage::Signal,
+            cancellation,
+            |observed| self.inner.signal(request, observed),
+            |result| endpoint_result::encode_unit(1, ExecutionStage::Signal, *result),
+            |encoded| endpoint_result::decode_unit(encoded, 1, ExecutionStage::Signal),
+        )
+    }
+
+    fn wait(
+        &self,
+        request: WaitRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<i32, ExecutionError> {
+        let mut fingerprint = self.fingerprint(EndpointOperationKind::Wait, request.operation_id());
+        fingerprint.duration(request.timeout());
+        self.run(
+            request.operation_id(),
+            EndpointOperationKind::Wait,
+            fingerprint.finish(),
+            endpoint_result::small_reservation(),
+            ExecutionStage::Wait,
+            cancellation,
+            |observed| self.inner.wait(request, observed),
+            |result| endpoint_result::encode_wait(*result),
+            endpoint_result::decode_wait,
+        )
+    }
+
+    fn copy_to(
+        &self,
+        request: &CopyToRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        let mut fingerprint =
+            self.fingerprint(EndpointOperationKind::CopyTo, request.operation_id());
+        fingerprint.target_path(request.target());
+        fingerprint.usize(request.content().len());
+        let payload_digest = Zeroizing::new(<[u8; 32]>::from(Sha256::digest(request.content())));
+        fingerprint.bytes(payload_digest.as_slice());
+        self.run(
+            request.operation_id(),
+            EndpointOperationKind::CopyTo,
+            fingerprint.finish(),
+            endpoint_result::small_reservation(),
+            ExecutionStage::CopyTo,
+            cancellation,
+            |observed| self.inner.copy_to(request, observed),
+            |result| endpoint_result::encode_unit(3, ExecutionStage::CopyTo, *result),
+            |encoded| endpoint_result::decode_unit(encoded, 3, ExecutionStage::CopyTo),
+        )
+    }
+
+    fn copy_from(
+        &self,
+        request: &CopyFromRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let mut fingerprint =
+            self.fingerprint(EndpointOperationKind::CopyFrom, request.operation_id());
+        fingerprint.target_path(request.source());
+        fingerprint.usize(request.byte_limit());
+        let reservation = endpoint_result::copy_from_reservation(request).ok_or_else(|| {
+            execution_error(ExecutionErrorKind::InvalidState, ExecutionStage::CopyFrom)
+        })?;
+        self.run(
+            request.operation_id(),
+            EndpointOperationKind::CopyFrom,
+            fingerprint.finish(),
+            reservation,
+            ExecutionStage::CopyFrom,
+            cancellation,
+            |observed| self.inner.copy_from(request, observed),
+            |result| endpoint_result::encode_bytes(result, request),
+            |encoded| endpoint_result::decode_bytes(encoded, request),
+        )
+    }
+}
+
+struct LinearizedCancellation<'a> {
+    source: &'a dyn Cancellation,
+    journal: &'a dyn RunnerJournal,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+    guard: LeaseGuard,
+    operation_id: OperationId,
+    cancellation_won: AtomicBool,
+    storage_failed: AtomicBool,
+}
+
+impl<'a> LinearizedCancellation<'a> {
+    fn new(
+        source: &'a dyn Cancellation,
+        journal: &'a dyn RunnerJournal,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        operation_id: OperationId,
+    ) -> Self {
+        Self {
+            source,
+            journal,
+            session_id,
+            slot,
+            guard,
+            operation_id,
+            cancellation_won: AtomicBool::new(false),
+            storage_failed: AtomicBool::new(false),
+        }
+    }
+
+    fn cancellation_won(&self) -> bool {
+        self.cancellation_won.load(Ordering::Acquire)
+    }
+
+    fn storage_failed(&self) -> bool {
+        self.storage_failed.load(Ordering::Acquire)
+    }
+}
+
+impl Cancellation for LinearizedCancellation<'_> {
+    fn disposition(&self) -> CancellationDisposition {
+        match self.source.disposition() {
+            CancellationDisposition::Active => CancellationDisposition::Active,
+            CancellationDisposition::Terminate => {
+                if self.cancellation_won.load(Ordering::Acquire)
+                    || self.storage_failed.load(Ordering::Acquire)
+                {
+                    return CancellationDisposition::Terminate;
+                }
+                let committed = self.journal.record_endpoint_cancellation(
+                    self.session_id,
+                    self.slot,
+                    self.guard,
+                    self.operation_id,
+                );
+                if let Ok(snapshot) = committed {
+                    let cancelled = snapshot.slot(self.slot).and_then(|slot| {
+                        slot.endpoint_operations()
+                            .iter()
+                            .find(|operation| operation.operation_id() == self.operation_id)
+                    });
+                    if cancelled.is_some_and(|operation| {
+                        matches!(
+                            operation.state(),
+                            EndpointOperationState::CancellationRequested
+                                | EndpointOperationState::Cancelled
+                        )
+                    }) {
+                        self.cancellation_won.store(true, Ordering::Release);
+                        CancellationDisposition::Terminate
+                    } else {
+                        CancellationDisposition::Active
+                    }
+                } else {
+                    self.storage_failed.store(true, Ordering::Release);
+                    // Durable cancellation could not be recorded. Terminate
+                    // backend work so the caller reaches fail-closed recovery,
+                    // but leave the invocation unresolved for exact sandbox
+                    // destruction rather than claiming durable quiescence.
+                    CancellationDisposition::Terminate
+                }
+            }
+        }
+    }
+}
+
+struct Fingerprint(Sha256);
+
+impl Fingerprint {
+    fn new() -> Self {
+        Self(Sha256::new())
+    }
+
+    fn byte(&mut self, value: u8) {
+        self.0.update([value]);
+    }
+
+    fn u16(&mut self, value: u16) {
+        self.0.update(value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.0.update(value.to_be_bytes());
+    }
+
+    fn usize(&mut self, value: usize) {
+        self.u64(u64::try_from(value).expect("execution request bounds fit u64"));
+    }
+
+    fn bytes(&mut self, value: &[u8]) {
+        self.usize(value.len());
+        self.0.update(value);
+    }
+
+    fn text(&mut self, value: &str) {
+        self.bytes(value.as_bytes());
+    }
+
+    fn duration(&mut self, value: Duration) {
+        self.u64(value.as_secs());
+        self.0.update(value.subsec_nanos().to_be_bytes());
+    }
+
+    fn target_path(&mut self, value: &TargetPath) {
+        self.byte(match value.platform() {
+            TargetPlatform::Posix => 0,
+            TargetPlatform::Windows => 1,
+        });
+        self.text(value.as_str());
+    }
+
+    fn finish(self) -> Zeroizing<[u8; 32]> {
+        Zeroizing::new(self.0.finalize().into())
+    }
+}
+
+const fn operation_kind_tag(kind: EndpointOperationKind) -> u8 {
+    match kind {
+        EndpointOperationKind::Exec => 0,
+        EndpointOperationKind::Signal => 1,
+        EndpointOperationKind::Wait => 2,
+        EndpointOperationKind::CopyTo => 3,
+        EndpointOperationKind::CopyFrom => 4,
+    }
+}
+
+const fn execution_error(kind: ExecutionErrorKind, stage: ExecutionStage) -> ExecutionError {
+    ExecutionError::new(kind, stage)
+}
+
+fn map_event_error(error: &ExecutionEventError, stage: ExecutionStage) -> ExecutionError {
+    let kind = match error {
+        ExecutionEventError::Journal(JournalError::Invariant(_))
+        | ExecutionEventError::InvalidEvent => ExecutionErrorKind::InvalidState,
+        ExecutionEventError::Journal(_) | ExecutionEventError::Spool(_) => {
+            ExecutionErrorKind::LocalStorage
+        }
+    };
+    execution_error(kind, stage)
+}

--- a/crates/automata-ci-runner-runtime/src/endpoint_result.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_result.rs
@@ -1,0 +1,504 @@
+use automata_ci_execution::{
+    CopyFromRequest, ExecutionCommand, ExecutionError, ExecutionErrorKind, ExecutionOutput,
+    ExecutionOutputRecord, ExecutionOutputStream, ExecutionStage, ExecutionTermination,
+    MAX_EXECUTION_OUTPUT_RECORDS,
+};
+
+const MAGIC: &[u8; 8] = b"AERES001";
+const STATUS_SUCCESS: u8 = 0;
+const STATUS_ERROR: u8 = 1;
+const EXEC_RECORD_OVERHEAD_BYTES: usize = 6;
+const EXEC_FIXED_OVERHEAD_BYTES: usize = MAGIC.len() + 16;
+
+pub(crate) fn exec_reservation(request: &ExecutionCommand) -> Option<u64> {
+    request
+        .output_limit()
+        .checked_add(MAX_EXECUTION_OUTPUT_RECORDS.checked_mul(EXEC_RECORD_OVERHEAD_BYTES)?)
+        .and_then(|value| value.checked_add(EXEC_FIXED_OVERHEAD_BYTES))
+        .and_then(|value| u64::try_from(value).ok())
+}
+
+pub(crate) fn copy_from_reservation(request: &CopyFromRequest) -> Option<u64> {
+    request
+        .byte_limit()
+        .checked_add(MAGIC.len() + 8)
+        .and_then(|value| u64::try_from(value).ok())
+}
+
+pub(crate) const fn small_reservation() -> u64 {
+    32
+}
+
+pub(crate) fn encode_exec(
+    result: &Result<ExecutionOutput, ExecutionError>,
+    request: &ExecutionCommand,
+) -> Result<Vec<u8>, ()> {
+    let mut encoded = header(0);
+    match result {
+        Ok(output) => {
+            let output_bytes = output
+                .stdout()
+                .len()
+                .checked_add(output.stderr().len())
+                .ok_or(())?;
+            if output_bytes > request.output_limit()
+                || output.records().len() > MAX_EXECUTION_OUTPUT_RECORDS
+            {
+                return Err(());
+            }
+            encoded.push(STATUS_SUCCESS);
+            encode_termination(&mut encoded, output.termination());
+            encoded.push(u8::from(output.was_truncated()));
+            put_u32(&mut encoded, output.records().len())?;
+            for record in output.records() {
+                encoded.push(match record.stream() {
+                    ExecutionOutputStream::Stdout => 0,
+                    ExecutionOutputStream::Stderr => 1,
+                });
+                encoded.push(u8::from(record.is_end_of_stream()));
+                put_bytes(&mut encoded, record.bytes())?;
+            }
+        }
+        Err(error) => encode_error(&mut encoded, *error, ExecutionStage::Exec)?,
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_exec(
+    encoded: &[u8],
+    request: &ExecutionCommand,
+) -> Result<Result<ExecutionOutput, ExecutionError>, ()> {
+    let mut reader = Reader::new(encoded, 0)?;
+    match reader.byte()? {
+        STATUS_SUCCESS => {
+            let termination = decode_termination(&mut reader)?;
+            let truncated = reader.boolean()?;
+            let count = reader.length()?;
+            if count > MAX_EXECUTION_OUTPUT_RECORDS {
+                return Err(());
+            }
+            let mut records = Vec::with_capacity(count);
+            let mut output_bytes = 0_usize;
+            for _ in 0..count {
+                let stream = match reader.byte()? {
+                    0 => ExecutionOutputStream::Stdout,
+                    1 => ExecutionOutputStream::Stderr,
+                    _ => return Err(()),
+                };
+                let end_of_stream = reader.boolean()?;
+                let bytes = reader.bytes()?;
+                output_bytes = output_bytes.checked_add(bytes.len()).ok_or(())?;
+                if output_bytes > request.output_limit() {
+                    return Err(());
+                }
+                let record = if end_of_stream {
+                    if !bytes.is_empty() {
+                        return Err(());
+                    }
+                    ExecutionOutputRecord::end_of_stream(stream)
+                } else {
+                    ExecutionOutputRecord::data(stream, bytes.to_vec()).map_err(|_| ())?
+                };
+                records.push(record);
+            }
+            reader.finish()?;
+            ExecutionOutput::new(termination, records, truncated)
+                .map(Ok)
+                .map_err(|_| ())
+        }
+        STATUS_ERROR => decode_error(&mut reader, ExecutionStage::Exec).map(Err),
+        _ => Err(()),
+    }
+}
+
+pub(crate) fn encode_unit(
+    kind: u8,
+    stage: ExecutionStage,
+    result: Result<(), ExecutionError>,
+) -> Result<Vec<u8>, ()> {
+    let mut encoded = header(kind);
+    match result {
+        Ok(()) => encoded.push(STATUS_SUCCESS),
+        Err(error) => encode_error(&mut encoded, error, stage)?,
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_unit(
+    encoded: &[u8],
+    kind: u8,
+    stage: ExecutionStage,
+) -> Result<Result<(), ExecutionError>, ()> {
+    let mut reader = Reader::new(encoded, kind)?;
+    match reader.byte()? {
+        STATUS_SUCCESS => {
+            reader.finish()?;
+            Ok(Ok(()))
+        }
+        STATUS_ERROR => decode_error(&mut reader, stage).map(Err),
+        _ => Err(()),
+    }
+}
+
+pub(crate) fn encode_wait(result: Result<i32, ExecutionError>) -> Result<Vec<u8>, ()> {
+    let mut encoded = header(2);
+    match result {
+        Ok(status) => {
+            encoded.push(STATUS_SUCCESS);
+            encoded.extend_from_slice(&status.to_be_bytes());
+        }
+        Err(error) => encode_error(&mut encoded, error, ExecutionStage::Wait)?,
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_wait(encoded: &[u8]) -> Result<Result<i32, ExecutionError>, ()> {
+    let mut reader = Reader::new(encoded, 2)?;
+    match reader.byte()? {
+        STATUS_SUCCESS => {
+            let status = i32::from_be_bytes(reader.array()?);
+            reader.finish()?;
+            Ok(Ok(status))
+        }
+        STATUS_ERROR => decode_error(&mut reader, ExecutionStage::Wait).map(Err),
+        _ => Err(()),
+    }
+}
+
+pub(crate) fn encode_bytes(
+    result: &Result<Vec<u8>, ExecutionError>,
+    request: &CopyFromRequest,
+) -> Result<Vec<u8>, ()> {
+    let mut encoded = header(4);
+    match result {
+        Ok(bytes) => {
+            if bytes.len() > request.byte_limit() {
+                return Err(());
+            }
+            encoded.push(STATUS_SUCCESS);
+            put_bytes(&mut encoded, bytes)?;
+        }
+        Err(error) => encode_error(&mut encoded, *error, ExecutionStage::CopyFrom)?,
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_bytes(
+    encoded: &[u8],
+    request: &CopyFromRequest,
+) -> Result<Result<Vec<u8>, ExecutionError>, ()> {
+    let mut reader = Reader::new(encoded, 4)?;
+    match reader.byte()? {
+        STATUS_SUCCESS => {
+            let bytes = reader.bytes()?;
+            if bytes.len() > request.byte_limit() {
+                return Err(());
+            }
+            let bytes = bytes.to_vec();
+            reader.finish()?;
+            Ok(Ok(bytes))
+        }
+        STATUS_ERROR => decode_error(&mut reader, ExecutionStage::CopyFrom).map(Err),
+        _ => Err(()),
+    }
+}
+
+fn header(kind: u8) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(MAGIC.len() + 16);
+    encoded.extend_from_slice(MAGIC);
+    encoded.push(kind);
+    encoded
+}
+
+fn encode_error(
+    encoded: &mut Vec<u8>,
+    error: ExecutionError,
+    expected_stage: ExecutionStage,
+) -> Result<(), ()> {
+    if error.stage() != expected_stage {
+        return Err(());
+    }
+    encoded.push(STATUS_ERROR);
+    encoded.push(error_kind_tag(error.kind()));
+    encoded.push(stage_tag(error.stage()));
+    Ok(())
+}
+
+fn decode_error(
+    reader: &mut Reader<'_>,
+    expected_stage: ExecutionStage,
+) -> Result<ExecutionError, ()> {
+    let kind = decode_error_kind(reader.byte()?)?;
+    let stage = decode_stage(reader.byte()?)?;
+    if stage != expected_stage {
+        return Err(());
+    }
+    reader.finish()?;
+    Ok(ExecutionError::new(kind, stage))
+}
+
+const fn error_kind_tag(kind: ExecutionErrorKind) -> u8 {
+    match kind {
+        ExecutionErrorKind::UnsupportedCapability => 0,
+        ExecutionErrorKind::InvalidEnvironment => 1,
+        ExecutionErrorKind::Cancelled => 2,
+        ExecutionErrorKind::TimedOut => 3,
+        ExecutionErrorKind::NotFound => 4,
+        ExecutionErrorKind::OwnershipMismatch => 5,
+        ExecutionErrorKind::InvalidState => 6,
+        ExecutionErrorKind::OutputLimitExceeded => 7,
+        ExecutionErrorKind::BackendRejected => 8,
+        ExecutionErrorKind::LocalStorage => 9,
+    }
+}
+
+const fn decode_error_kind(tag: u8) -> Result<ExecutionErrorKind, ()> {
+    match tag {
+        0 => Ok(ExecutionErrorKind::UnsupportedCapability),
+        1 => Ok(ExecutionErrorKind::InvalidEnvironment),
+        2 => Ok(ExecutionErrorKind::Cancelled),
+        3 => Ok(ExecutionErrorKind::TimedOut),
+        4 => Ok(ExecutionErrorKind::NotFound),
+        5 => Ok(ExecutionErrorKind::OwnershipMismatch),
+        6 => Ok(ExecutionErrorKind::InvalidState),
+        7 => Ok(ExecutionErrorKind::OutputLimitExceeded),
+        8 => Ok(ExecutionErrorKind::BackendRejected),
+        9 => Ok(ExecutionErrorKind::LocalStorage),
+        _ => Err(()),
+    }
+}
+
+const fn stage_tag(stage: ExecutionStage) -> u8 {
+    match stage {
+        ExecutionStage::Exec => 0,
+        ExecutionStage::Signal => 1,
+        ExecutionStage::Wait => 2,
+        ExecutionStage::CopyTo => 3,
+        ExecutionStage::CopyFrom => 4,
+    }
+}
+
+const fn decode_stage(tag: u8) -> Result<ExecutionStage, ()> {
+    match tag {
+        0 => Ok(ExecutionStage::Exec),
+        1 => Ok(ExecutionStage::Signal),
+        2 => Ok(ExecutionStage::Wait),
+        3 => Ok(ExecutionStage::CopyTo),
+        4 => Ok(ExecutionStage::CopyFrom),
+        _ => Err(()),
+    }
+}
+
+fn encode_termination(encoded: &mut Vec<u8>, termination: ExecutionTermination) {
+    match termination {
+        ExecutionTermination::Exited(status) => {
+            encoded.push(0);
+            encoded.extend_from_slice(&status.to_be_bytes());
+        }
+        ExecutionTermination::Signalled => encoded.push(1),
+        ExecutionTermination::TimedOut => encoded.push(2),
+        ExecutionTermination::Cancelled => encoded.push(3),
+    }
+}
+
+fn decode_termination(reader: &mut Reader<'_>) -> Result<ExecutionTermination, ()> {
+    match reader.byte()? {
+        0 => Ok(ExecutionTermination::Exited(i32::from_be_bytes(
+            reader.array()?,
+        ))),
+        1 => Ok(ExecutionTermination::Signalled),
+        2 => Ok(ExecutionTermination::TimedOut),
+        3 => Ok(ExecutionTermination::Cancelled),
+        _ => Err(()),
+    }
+}
+
+fn put_u32(encoded: &mut Vec<u8>, value: usize) -> Result<(), ()> {
+    let value = u32::try_from(value).map_err(|_| ())?;
+    encoded.extend_from_slice(&value.to_be_bytes());
+    Ok(())
+}
+
+fn put_bytes(encoded: &mut Vec<u8>, bytes: &[u8]) -> Result<(), ()> {
+    put_u32(encoded, bytes.len())?;
+    encoded.extend_from_slice(bytes);
+    Ok(())
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8], kind: u8) -> Result<Self, ()> {
+        let mut reader = Self { bytes, offset: 0 };
+        if reader.take(MAGIC.len())? != MAGIC || reader.byte()? != kind {
+            return Err(());
+        }
+        Ok(reader)
+    }
+
+    fn byte(&mut self) -> Result<u8, ()> {
+        Ok(*self.take(1)?.first().ok_or(())?)
+    }
+
+    fn boolean(&mut self) -> Result<bool, ()> {
+        match self.byte()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(()),
+        }
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ()> {
+        self.take(N)?.try_into().map_err(|_| ())
+    }
+
+    fn length(&mut self) -> Result<usize, ()> {
+        usize::try_from(u32::from_be_bytes(self.array()?)).map_err(|_| ())
+    }
+
+    fn bytes(&mut self) -> Result<&'a [u8], ()> {
+        let length = self.length()?;
+        self.take(length)
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ()> {
+        let end = self.offset.checked_add(length).ok_or(())?;
+        let bytes = self.bytes.get(self.offset..end).ok_or(())?;
+        self.offset = end;
+        Ok(bytes)
+    }
+
+    fn finish(&self) -> Result<(), ()> {
+        (self.offset == self.bytes.len()).then_some(()).ok_or(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use automata_ci_core::OperationId;
+    use automata_ci_execution::{
+        CopyFromRequest, ExecutionArgv, ExecutionEnvironment, ExecutionOutputRecord,
+        ExecutionOutputStream, TargetPath,
+    };
+
+    use super::*;
+
+    fn command(output_limit: usize) -> ExecutionCommand {
+        ExecutionCommand::new(
+            OperationId::new(),
+            ExecutionArgv::new(
+                TargetPath::posix("/bin/printf").expect("program"),
+                vec!["value".to_owned()],
+            )
+            .expect("argv"),
+            TargetPath::posix("/workspace").expect("working directory"),
+            ExecutionEnvironment::empty(),
+            Duration::from_secs(30),
+            output_limit,
+        )
+        .expect("command")
+    }
+
+    fn output(termination: ExecutionTermination) -> ExecutionOutput {
+        ExecutionOutput::new(
+            termination,
+            vec![
+                ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, b"out".to_vec())
+                    .expect("stdout"),
+                ExecutionOutputRecord::data(ExecutionOutputStream::Stderr, b"err".to_vec())
+                    .expect("stderr"),
+                ExecutionOutputRecord::end_of_stream(ExecutionOutputStream::Stdout),
+                ExecutionOutputRecord::end_of_stream(ExecutionOutputStream::Stderr),
+            ],
+            false,
+        )
+        .expect("output")
+    }
+
+    #[test]
+    fn exec_codec_round_trips_every_termination_without_plain_schema_fallbacks() {
+        let request = command(1024);
+        for termination in [
+            ExecutionTermination::Exited(23),
+            ExecutionTermination::Signalled,
+            ExecutionTermination::TimedOut,
+            ExecutionTermination::Cancelled,
+        ] {
+            let expected = output(termination);
+            let encoded = encode_exec(&Ok(expected.clone()), &request).expect("encode");
+            let decoded = decode_exec(&encoded, &request).expect("decode");
+            assert_eq!(decoded, Ok(expected));
+        }
+    }
+
+    #[test]
+    fn error_codec_round_trips_the_closed_error_domain() {
+        for kind in [
+            ExecutionErrorKind::UnsupportedCapability,
+            ExecutionErrorKind::InvalidEnvironment,
+            ExecutionErrorKind::Cancelled,
+            ExecutionErrorKind::TimedOut,
+            ExecutionErrorKind::NotFound,
+            ExecutionErrorKind::OwnershipMismatch,
+            ExecutionErrorKind::InvalidState,
+            ExecutionErrorKind::OutputLimitExceeded,
+            ExecutionErrorKind::BackendRejected,
+            ExecutionErrorKind::LocalStorage,
+        ] {
+            let expected = ExecutionError::new(kind, ExecutionStage::Signal);
+            let encoded = encode_unit(1, ExecutionStage::Signal, Err(expected)).expect("encode");
+            assert_eq!(
+                decode_unit(&encoded, 1, ExecutionStage::Signal).expect("decode"),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn wait_and_copy_from_codecs_round_trip_and_reapply_request_bounds() {
+        let wait = encode_wait(Ok(-9)).expect("encode wait");
+        assert_eq!(decode_wait(&wait).expect("decode wait"), Ok(-9));
+
+        let request = CopyFromRequest::new(
+            OperationId::new(),
+            TargetPath::posix("/workspace/value").expect("source"),
+            3,
+        )
+        .expect("copy request");
+        let encoded = encode_bytes(&Ok(b"abc".to_vec()), &request).expect("encode bytes");
+        assert_eq!(
+            decode_bytes(&encoded, &request).expect("decode bytes"),
+            Ok(b"abc".to_vec())
+        );
+        assert!(encode_bytes(&Ok(b"abcd".to_vec()), &request).is_err());
+    }
+
+    #[test]
+    fn codec_rejects_wrong_kind_trailing_data_and_narrower_replay_limit() {
+        let request = command(16);
+        let mut encoded = encode_exec(&Ok(output(ExecutionTermination::Exited(0))), &request)
+            .expect("encode exec");
+        encoded[MAGIC.len()] = 4;
+        assert!(decode_exec(&encoded, &request).is_err());
+
+        let mut encoded = encode_wait(Ok(0)).expect("encode wait");
+        encoded.push(0);
+        assert!(decode_wait(&encoded).is_err());
+
+        let broad = CopyFromRequest::new(
+            OperationId::new(),
+            TargetPath::posix("/workspace/value").expect("source"),
+            4,
+        )
+        .expect("broad request");
+        let narrow = CopyFromRequest::new(broad.operation_id(), broad.source().clone(), 3)
+            .expect("narrow request");
+        let encoded = encode_bytes(&Ok(b"abcd".to_vec()), &broad).expect("encode broad bytes");
+        assert!(decode_bytes(&encoded, &narrow).is_err());
+    }
+}

--- a/crates/automata-ci-runner-runtime/src/events.rs
+++ b/crates/automata-ci-runner-runtime/src/events.rs
@@ -4,6 +4,7 @@ use automata_ci_core::{
     AttemptId, JobLifecycle, LeaseGuard, LogChannel, LogFrame, LogSequence, LogStreamId,
     OperationId,
 };
+use automata_ci_execution::{ExecutionEndpoint, SandboxInspection, SandboxProvider};
 use automata_ci_protocol::{
     LogBatch, MessageHeader, NegotiatedSession, ProtocolLimits, RunnerSlotOrdinal, RunnerToServer,
 };
@@ -442,6 +443,27 @@ impl fmt::Debug for DurableExecutionEvents {
 }
 
 impl ExecutionEvents for DurableExecutionEvents {
+    fn bind_endpoint(
+        &self,
+        provider: Arc<dyn SandboxProvider>,
+        inspection: SandboxInspection,
+        endpoint: Box<dyn ExecutionEndpoint>,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ExecutionEventError> {
+        crate::endpoint_replay::DurableExecutionEndpoint::bind(
+            self.journal.clone(),
+            self.spool.clone(),
+            self.content_operations.clone(),
+            self.serial.clone(),
+            self.session.session_id(),
+            self.slot,
+            self.guard,
+            provider,
+            inspection,
+            endpoint,
+        )
+        .map(|endpoint| Box::new(endpoint) as Box<dyn ExecutionEndpoint>)
+    }
+
     fn transition(&self, next: JobLifecycle) -> Result<(), ExecutionEventError> {
         if next.is_terminal() {
             return Err(ExecutionEventError::InvalidEvent);

--- a/crates/automata-ci-runner-runtime/src/lib.rs
+++ b/crates/automata-ci-runner-runtime/src/lib.rs
@@ -10,6 +10,8 @@
 mod config;
 mod content;
 mod control;
+mod endpoint_replay;
+mod endpoint_result;
 mod error;
 mod events;
 mod observer;

--- a/crates/automata-ci-runner-runtime/src/orphan.rs
+++ b/crates/automata-ci-runner-runtime/src/orphan.rs
@@ -1,13 +1,14 @@
 use std::{fmt, sync::Arc};
 
-use automata_ci_core::{OperationId, RunnerId, RunnerSessionId, Sha256Digest};
+use automata_ci_core::{LeaseGuard, OperationId, RunnerId, RunnerSessionId, Sha256Digest};
 use automata_ci_protocol::{
-    HandshakeErrorCode, NegotiatedSession, ProtocolLimits, ServerToRunner, SessionDisposition,
+    HandshakeErrorCode, NegotiatedSession, ProtocolLimits, RunnerSlotOrdinal, ServerToRunner,
+    SessionDisposition,
 };
 use automata_ci_runner_journal::{
-    JournalContentRetainSet, OrphanAbandonmentPermissions, OrphanAbandonmentReason,
-    OrphanAuthorityError, OrphanAuthorityGrant, OrphanAuthorityProof, OrphanAuthorityVerifier,
-    OrphanClaim, OrphanDelivery, RunnerJournal, SlotSnapshot,
+    EndpointOperationState, JournalContentRetainSet, OrphanAbandonmentPermissions,
+    OrphanAbandonmentReason, OrphanAuthorityError, OrphanAuthorityGrant, OrphanAuthorityProof,
+    OrphanAuthorityVerifier, OrphanClaim, OrphanDelivery, RunnerJournal, SlotSnapshot,
 };
 use automata_ci_runner_spool::DurableContentStore;
 use sha2::{Digest as _, Sha256};
@@ -249,8 +250,61 @@ impl OrphanRecoveryCoordinator {
             }
         }
 
+        self.resolve_endpoint_recovery_after_sandbox_absence(session_id, slot_ordinal, guard)?;
+
         self.journal.release_slot(session_id, slot_ordinal, guard)?;
         Ok(())
+    }
+
+    fn resolve_endpoint_recovery_after_sandbox_absence(
+        &self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+    ) -> Result<(), RunnerRuntimeError> {
+        loop {
+            let snapshot = self.journal.snapshot()?;
+            let durable = snapshot
+                .slot(slot)
+                .ok_or(RunnerRuntimeError::ExecutorContract)?;
+            if durable.offer().lease().guard() != guard || durable.sandbox().is_some() {
+                return Err(RunnerRuntimeError::ExecutorContract);
+            }
+            let Some(operation) = durable.endpoint_recovery_pending() else {
+                return Ok(());
+            };
+            match operation.state() {
+                EndpointOperationState::Accepted => {
+                    self.journal.record_endpoint_cancellation(
+                        session_id,
+                        slot,
+                        guard,
+                        operation.operation_id(),
+                    )?;
+                }
+                EndpointOperationState::InvocationCommitted => {
+                    self.journal.abandon_endpoint_operation(
+                        session_id,
+                        slot,
+                        guard,
+                        operation.operation_id(),
+                    )?;
+                }
+                EndpointOperationState::CancellationRequested => {
+                    self.journal.complete_endpoint_cancellation(
+                        session_id,
+                        slot,
+                        guard,
+                        operation.operation_id(),
+                    )?;
+                }
+                EndpointOperationState::Cancelled
+                | EndpointOperationState::Abandoned
+                | EndpointOperationState::Completed { .. } => {
+                    return Err(RunnerRuntimeError::ExecutorContract);
+                }
+            }
+        }
     }
 }
 

--- a/crates/automata-ci-runner-runtime/src/outbox.rs
+++ b/crates/automata-ci-runner-runtime/src/outbox.rs
@@ -233,7 +233,7 @@ mod tests {
         }
 
         fn segment(encoded: &[u8], last: u64, frame_count: u32, end_of_stream: bool) -> LogSegment {
-            let content = DurableContentRef::after_commit(
+            let content = DurableContentRef::after_public_commit(
                 ContentKind::LogSpool,
                 u64::try_from(encoded.len()).expect("encoded size"),
                 Sha256Digest::from_bytes([0xa5; 32]),

--- a/crates/automata-ci-runner-runtime/src/port.rs
+++ b/crates/automata-ci-runner-runtime/src/port.rs
@@ -10,7 +10,9 @@ use automata_ci_core::{
     AttemptId, JobIrEnvelope, JobLifecycle, JobResult, Lease, LeaseGuard, LogChannel, OperationId,
     RunnerId, RunnerSessionId, UnixMillis,
 };
-use automata_ci_execution::{SandboxCustody, SandboxEnvironment};
+use automata_ci_execution::{
+    ExecutionEndpoint, SandboxCustody, SandboxEnvironment, SandboxInspection, SandboxProvider,
+};
 use automata_ci_protocol::{JobRuntimeAuthorities, ManagedSecretBindingOverlay};
 use automata_ci_protocol::{LeaseRejectionReason, RunnerSlotOrdinal};
 use automata_ci_runner_journal::{
@@ -437,6 +439,22 @@ impl CapacityReclaimError for ExecutionEventError {
 
 /// Narrow callback surface for durable executor progress and provider sagas.
 pub trait ExecutionEvents: fmt::Debug + Send + Sync {
+    /// Installs durable endpoint replay on one freshly inspected attachment.
+    ///
+    /// The inspection must bind the endpoint handle to the exact live sandbox
+    /// generation, custody, and current environment-profile attestation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutionEventError`] when attachment evidence conflicts with
+    /// the durable slot or the replay boundary cannot be constructed.
+    fn bind_endpoint(
+        &self,
+        provider: Arc<dyn SandboxProvider>,
+        inspection: SandboxInspection,
+        endpoint: Box<dyn ExecutionEndpoint>,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ExecutionEventError>;
+
     /// Commits a non-terminal lifecycle transition.
     ///
     /// # Errors

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -23,11 +23,12 @@ use automata_ci_protocol_protobuf::{
     encode_runtime_authorities,
 };
 use automata_ci_runner_journal::{
-    CancellationRecord, CommandDisposition, CommandIgnoredReason, DurableCommand, JobIrContentRef,
-    JournalContentRetainSet, JournalInvariantError, LeaseOfferRecord, LeaseOfferStatus,
-    LeasePollCheckpoint, LogSegmentAcknowledgement, ProviderOperationKind, RunnerJournal,
-    RuntimeAuthorityContentRef, RuntimeAuthorityDeliveryRecord,
-    SessionBinding as JournalSessionBinding, SlotSnapshot, TerminalResultRecord,
+    CancellationRecord, CommandDisposition, CommandIgnoredReason, DurableCommand,
+    EndpointOperationState, JobIrContentRef, JournalContentRetainSet, JournalInvariantError,
+    LeaseOfferRecord, LeaseOfferStatus, LeasePollCheckpoint, LogSegmentAcknowledgement,
+    ProviderOperationKind, RunnerJournal, RuntimeAuthorityContentRef,
+    RuntimeAuthorityDeliveryRecord, SessionBinding as JournalSessionBinding, SlotSnapshot,
+    TerminalResultRecord,
 };
 use automata_ci_runner_spool::{ContentKind, DurableContentStore};
 use automata_ci_runner_transport::PreparedRequest;
@@ -518,7 +519,7 @@ impl RunnerSessionSupervisor {
         );
         if let Some(sandbox) = durable.sandbox().cloned()
             && let Err(_error) = self
-                .cleanup_terminal_sandbox(session, &durable, sandbox, cancellation.clone())
+                .cleanup_sandbox(session, &durable, sandbox, cancellation.clone())
                 .await
         {
             warn!(
@@ -1205,13 +1206,19 @@ impl RunnerSessionSupervisor {
             return self.inner.ports.journal.snapshot().map_err(Into::into);
         }
         let job = self.load_job(durable)?;
+        let job_ir_digest = durable
+            .offer()
+            .job_ir()
+            .content()
+            .public_plaintext_sha256()
+            .ok_or(RunnerRuntimeError::InvalidDurablePayload)?;
         let binding = RuntimeAuthorityDeliveryBinding::new(
             durable.offer().lease().attempt_id(),
             durable.slot(),
             durable.offer().lease().guard(),
             durable.offer().command().operation_id(),
             durable.offer().command().sequence(),
-            durable.offer().job_ir().content().sha256(),
+            job_ir_digest,
             INITIAL_RUNTIME_AUTHORITY_GENERATION,
         );
         if durable.runtime_authority_delivery().is_none() {
@@ -1268,11 +1275,11 @@ impl RunnerSessionSupervisor {
         let request_operation_id = self.stable_runtime_authority_operation_id(
             durable,
             StableIdDomain::RuntimeAuthorityRequest,
-        );
+        )?;
         let acknowledgement_operation_id = self.stable_runtime_authority_operation_id(
             durable,
             StableIdDomain::RuntimeAuthorityAcknowledgement,
-        );
+        )?;
         let request = RuntimeAuthorityRequest::new(
             Self::request_header(session, request_operation_id),
             binding,
@@ -1454,7 +1461,7 @@ impl RunnerSessionSupervisor {
         &self,
         durable: &SlotSnapshot,
         domain: StableIdDomain,
-    ) -> OperationId {
+    ) -> Result<OperationId, RunnerRuntimeError> {
         let binding = durable.offer();
         let mut identity = binding
             .command()
@@ -1466,9 +1473,16 @@ impl RunnerSessionSupervisor {
         identity.extend_from_slice(binding.lease().attempt_id().as_uuid().as_bytes());
         identity.extend_from_slice(binding.lease().lease_id().as_uuid().as_bytes());
         identity.extend_from_slice(&binding.lease().fencing_token().get().to_be_bytes());
-        identity.extend_from_slice(binding.job_ir().content().sha256().as_bytes());
+        identity.extend_from_slice(
+            binding
+                .job_ir()
+                .content()
+                .public_plaintext_sha256()
+                .ok_or(RunnerRuntimeError::InvalidDurablePayload)?
+                .as_bytes(),
+        );
         identity.extend_from_slice(&INITIAL_RUNTIME_AUTHORITY_GENERATION.get().to_be_bytes());
-        self.inner.ports.ids.stable_operation_id(domain, &identity)
+        Ok(self.inner.ports.ids.stable_operation_id(domain, &identity))
     }
 
     async fn send_until_operation_ack(
@@ -1519,7 +1533,11 @@ impl RunnerSessionSupervisor {
     fn load_job(&self, durable: &SlotSnapshot) -> Result<JobIrEnvelope, RunnerRuntimeError> {
         let content = durable.offer().job_ir().content();
         let encoded = self.inner.ports.spool.load(content)?;
-        if encoded.len() != usize::try_from(content.size()).unwrap_or(usize::MAX) {
+        if content
+            .public_plaintext_bytes()
+            .and_then(|bytes| usize::try_from(bytes).ok())
+            != Some(encoded.len())
+        {
             return Err(RunnerRuntimeError::InvalidDurablePayload);
         }
         let job = decode_job_ir(&encoded, self.inner.config.protocol_limits())
@@ -1541,7 +1559,11 @@ impl RunnerSessionSupervisor {
             .ok_or(RunnerRuntimeError::InvalidDurablePayload)?;
         let content = delivery.content().content();
         let encoded = Zeroizing::new(self.inner.ports.spool.load(content)?);
-        if encoded.len() != usize::try_from(content.size()).unwrap_or(usize::MAX) {
+        if content
+            .public_plaintext_bytes()
+            .and_then(|bytes| usize::try_from(bytes).ok())
+            != Some(encoded.len())
+        {
             return Err(RunnerRuntimeError::InvalidDurablePayload);
         }
         decode_runtime_authorities(
@@ -1981,6 +2003,13 @@ impl RunnerSessionSupervisor {
         });
         let conclusion = RuntimeJobConclusion::from(result.conclusion());
         let finished = async {
+            self.resolve_endpoint_recovery_before_terminal(
+                session,
+                durable.slot(),
+                lease.guard(),
+                cancellation.clone(),
+            )
+            .await?;
             let finalization_lifecycle = self.finalization_heartbeat_lifecycle(durable.slot())?;
             self.commit_terminal_result(session, durable.slot(), lease.guard(), result)?;
             self.observe(RunnerRuntimeEvent::JobCompleted {
@@ -2038,6 +2067,13 @@ impl RunnerSessionSupervisor {
             JobSecretExposure::Secretless,
             self.inner.ports.clock.wall_now(),
         );
+        self.resolve_endpoint_recovery_before_terminal(
+            session,
+            durable.slot(),
+            durable.offer().lease().guard(),
+            cancellation.clone(),
+        )
+        .await?;
         self.commit_terminal_result(
             session,
             durable.slot(),
@@ -2072,6 +2108,13 @@ impl RunnerSessionSupervisor {
             JobSecretExposure::Secretless,
             self.inner.ports.clock.wall_now(),
         );
+        self.resolve_endpoint_recovery_before_terminal(
+            session,
+            durable.slot(),
+            durable.offer().lease().guard(),
+            cancellation.clone(),
+        )
+        .await?;
         self.commit_terminal_result(
             session,
             durable.slot(),
@@ -2809,6 +2852,84 @@ impl RunnerSessionSupervisor {
         Ok(())
     }
 
+    async fn resolve_endpoint_recovery_before_terminal(
+        &self,
+        session: RuntimeSession,
+        slot: RunnerSlotOrdinal,
+        guard: LeaseGuard,
+        cancellation: CancellationToken,
+    ) -> Result<(), RunnerRuntimeError> {
+        loop {
+            let snapshot = self.inner.ports.journal.snapshot()?;
+            let durable = snapshot
+                .slot(slot)
+                .cloned()
+                .ok_or(RunnerRuntimeError::ExecutorContract)?;
+            if durable.offer().lease().guard() != guard {
+                return Err(RunnerRuntimeError::RecoveryIdentityMismatch {
+                    attempt_id: durable.offer().lease().attempt_id(),
+                    guard,
+                    session_id: session.negotiated.session_id(),
+                    slot,
+                });
+            }
+            let Some(operation) = durable.endpoint_recovery_pending() else {
+                return Ok(());
+            };
+            let operation_id = operation.operation_id();
+            match operation.state() {
+                EndpointOperationState::Accepted => {
+                    self.inner.ports.journal.record_endpoint_cancellation(
+                        session.negotiated.session_id(),
+                        slot,
+                        guard,
+                        operation_id,
+                    )?;
+                }
+                EndpointOperationState::InvocationCommitted
+                | EndpointOperationState::CancellationRequested => {
+                    let cancellation_requested = matches!(
+                        operation.state(),
+                        EndpointOperationState::CancellationRequested
+                    );
+                    if durable.sandbox().is_some() {
+                        self.reconcile_sandbox_absence(session, slot, guard, cancellation.clone())
+                            .await?;
+                    }
+                    let proven = self.inner.ports.journal.snapshot()?;
+                    let proven_slot = proven
+                        .slot(slot)
+                        .ok_or(RunnerRuntimeError::ExecutorContract)?;
+                    if proven_slot.offer().lease().guard() != guard
+                        || proven_slot.sandbox().is_some()
+                    {
+                        return Err(RunnerRuntimeError::ExecutorContract);
+                    }
+                    if cancellation_requested {
+                        self.inner.ports.journal.complete_endpoint_cancellation(
+                            session.negotiated.session_id(),
+                            slot,
+                            guard,
+                            operation_id,
+                        )?;
+                    } else {
+                        self.inner.ports.journal.abandon_endpoint_operation(
+                            session.negotiated.session_id(),
+                            slot,
+                            guard,
+                            operation_id,
+                        )?;
+                    }
+                }
+                EndpointOperationState::Cancelled
+                | EndpointOperationState::Abandoned
+                | EndpointOperationState::Completed { .. } => {
+                    return Err(RunnerRuntimeError::ExecutorContract);
+                }
+            }
+        }
+    }
+
     async fn finish_terminal_slot(
         &self,
         session: RuntimeSession,
@@ -2951,7 +3072,7 @@ impl RunnerSessionSupervisor {
             .cloned()
             .ok_or(RunnerRuntimeError::ExecutorContract)?;
         if current.sandbox().is_some() {
-            self.reconcile_terminal_sandbox(session, slot, guard, cancellation.clone())
+            self.reconcile_sandbox_absence(session, slot, guard, cancellation.clone())
                 .await?;
             current = self
                 .inner
@@ -2979,7 +3100,7 @@ impl RunnerSessionSupervisor {
         Ok(())
     }
 
-    async fn reconcile_terminal_sandbox(
+    async fn reconcile_sandbox_absence(
         &self,
         session: RuntimeSession,
         slot: RunnerSlotOrdinal,
@@ -3006,7 +3127,7 @@ impl RunnerSessionSupervisor {
                 return Ok(());
             };
             match self
-                .cleanup_terminal_sandbox(session, &current, sandbox, cancellation.clone())
+                .cleanup_sandbox(session, &current, sandbox, cancellation.clone())
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -3026,7 +3147,7 @@ impl RunnerSessionSupervisor {
                         .filter(|operation| operation.is_pending())
                         .map(|operation| operation.operation_id());
                     warn!(
-                        stage = "terminal_cleanup",
+                        stage = "sandbox_cleanup",
                         runner_id = %self.inner.config.capabilities().runner_id(),
                         session_id = %session.negotiated.session_id(),
                         attempt_id = %current.offer().lease().attempt_id(),
@@ -3200,7 +3321,7 @@ impl RunnerSessionSupervisor {
         Ok(())
     }
 
-    async fn cleanup_terminal_sandbox(
+    async fn cleanup_sandbox(
         &self,
         session: RuntimeSession,
         durable: &SlotSnapshot,
@@ -3209,7 +3330,7 @@ impl RunnerSessionSupervisor {
     ) -> Result<(), RunnerRuntimeError> {
         let started = self.inner.ports.clock.monotonic_now();
         let result = self
-            .cleanup_terminal_sandbox_inner(session, durable, sandbox, cancellation)
+            .cleanup_sandbox_inner(session, durable, sandbox, cancellation)
             .await;
         let outcome = match &result {
             Ok(()) => RuntimeOperationOutcome::Success,
@@ -3223,7 +3344,7 @@ impl RunnerSessionSupervisor {
         result
     }
 
-    async fn cleanup_terminal_sandbox_inner(
+    async fn cleanup_sandbox_inner(
         &self,
         session: RuntimeSession,
         durable: &SlotSnapshot,

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -51,9 +51,10 @@ use automata_ci_runner_runtime::{
     RuntimeControlRetry, RuntimeSleeper, SleepFuture,
 };
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, ContentProtector, DurableContentPublication,
-    DurableContentRef, DurableContentStore, FileSpool, ProtectionId, RetainedContentError,
-    RetainedContentSource, SpoolError, SpoolRoot,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentPublication, DurableContentRef, DurableContentStore,
+    EndpointResultCapacityReservation, FileSpool, KeyedContentCommitment, ProtectionId,
+    RetainedContentError, RetainedContentSource, SpoolError, SpoolRoot, endpoint_result_allocation,
 };
 use automata_ci_runner_transport::PreparedRequest;
 use sha2::{Digest as _, Sha256};
@@ -143,6 +144,31 @@ impl AckCapacitySpool {
 }
 
 impl DurableContentStore for AckCapacitySpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -202,6 +228,31 @@ impl TerminalCapacityProbeSpool {
 }
 
 impl DurableContentStore for TerminalCapacityProbeSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -288,6 +339,31 @@ impl NestedOfferCapacityProbeSpool {
 }
 
 impl DurableContentStore for NestedOfferCapacityProbeSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -376,6 +452,31 @@ impl BlockingEosSpool {
 }
 
 impl DurableContentStore for BlockingEosSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -472,6 +573,31 @@ impl BlockingSegmentLoadSpool {
 }
 
 impl DurableContentStore for BlockingSegmentLoadSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -545,18 +671,67 @@ impl ContentProtector for TestProtector {
         &self.id
     }
 
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        if protection_id != &self.id {
+            return Err(ContentProtectionError::KeyUnavailable);
+        }
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(domain.separator());
+        digest.update(material_digest);
+        Ok(digest.finalize().into())
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        endpoint_result_allocation(plaintext_bytes).map_err(|_| ContentProtectionError::Failed)
+    }
+
     fn protect(
         &self,
         reference: &DurableContentRef,
         plaintext: &[u8],
     ) -> Result<Vec<u8>, ContentProtectionError> {
-        let mut protected = Vec::with_capacity(plaintext.len() + 32);
-        protected.extend(
+        let mut protected = if let Some(allocation) = reference.endpoint_result_allocation_bytes() {
+            let allocation =
+                usize::try_from(allocation).map_err(|_| ContentProtectionError::Failed)?;
+            let body_bytes = allocation
+                .checked_sub(32)
+                .ok_or(ContentProtectionError::Failed)?;
+            let required = 8_usize
+                .checked_add(plaintext.len())
+                .ok_or(ContentProtectionError::Failed)?;
+            if required > body_bytes {
+                return Err(ContentProtectionError::Failed);
+            }
+            let mut body = Vec::with_capacity(allocation);
+            body.extend_from_slice(
+                &u64::try_from(plaintext.len())
+                    .map_err(|_| ContentProtectionError::Failed)?
+                    .to_be_bytes(),
+            );
+            body.extend(
+                plaintext
+                    .iter()
+                    .enumerate()
+                    .map(|(index, byte)| byte ^ self.key[index % self.key.len()]),
+            );
+            body.resize(body_bytes, 0);
+            body
+        } else {
             plaintext
                 .iter()
                 .enumerate()
-                .map(|(index, byte)| byte ^ self.key[index % self.key.len()]),
-        );
+                .map(|(index, byte)| byte ^ self.key[index % self.key.len()])
+                .collect()
+        };
         protected.extend_from_slice(&self.tag(reference, &protected));
         Ok(protected)
     }
@@ -574,6 +749,24 @@ impl ContentProtector for TestProtector {
         if protected[tag_offset..] != self.tag(reference, ciphertext) {
             return Err(ContentProtectionError::AuthenticationFailed);
         }
+        let ciphertext = if reference.endpoint_result_allocation_bytes().is_some() {
+            let length = ciphertext
+                .get(..8)
+                .and_then(|bytes| <[u8; 8]>::try_from(bytes).ok())
+                .map(u64::from_be_bytes)
+                .and_then(|bytes| usize::try_from(bytes).ok())
+                .ok_or(ContentProtectionError::AuthenticationFailed)?;
+            let end = 8_usize
+                .checked_add(length)
+                .filter(|end| *end <= ciphertext.len())
+                .ok_or(ContentProtectionError::AuthenticationFailed)?;
+            if ciphertext[end..].iter().any(|byte| *byte != 0) {
+                return Err(ContentProtectionError::AuthenticationFailed);
+            }
+            &ciphertext[8..end]
+        } else {
+            ciphertext
+        };
         Ok(ciphertext
             .iter()
             .enumerate()
@@ -843,6 +1036,31 @@ impl ContentRaceSpool {
 }
 
 impl DurableContentStore for ContentRaceSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner.create_keyed_commitment(domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.inner
+            .recreate_keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        self.inner.reserve_endpoint_result(maximum_plaintext_bytes)
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -5729,7 +5947,11 @@ fn record_test_authority_delivery_with_expiries_and_acknowledgement(
                 fixture.lease.guard(),
                 offer.command().operation_id(),
                 offer.command().sequence(),
-                offer.job_ir().content().sha256(),
+                offer
+                    .job_ir()
+                    .content()
+                    .public_plaintext_sha256()
+                    .expect("job IR public digest"),
                 INITIAL_RUNTIME_AUTHORITY_GENERATION,
             ),
             request_operation_id,

--- a/crates/automata-ci-runner-spool/Cargo.toml
+++ b/crates/automata-ci-runner-spool/Cargo.toml
@@ -24,6 +24,7 @@ automata-ci-core.workspace = true
 rustix.workspace = true
 serde.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/automata-ci-runner-spool/src/error.rs
+++ b/crates/automata-ci-runner-spool/src/error.rs
@@ -33,6 +33,9 @@ pub enum SpoolInvariantError {
     /// A cache key was malformed or inconsistent with its content receipt.
     #[error("content cache key is invalid or does not match its content identity")]
     InvalidCacheKey,
+    /// Content kind and its current-only identity representation disagree.
+    #[error("content identity is invalid for its semantic kind")]
+    InvalidContentIdentity,
     /// Plaintext exceeds either the configured or global per-object bound.
     #[error("content exceeds the hard object-size limit")]
     ObjectTooLarge,
@@ -42,9 +45,12 @@ pub enum SpoolInvariantError {
     /// Protected output expanded beyond the configured per-object allowance.
     #[error("protected content exceeds the configured expansion limit")]
     ProtectionOverheadExceeded,
-    /// Opened plaintext does not match the size and digest in its durable receipt.
-    #[error("content bytes do not match their durable size or SHA-256 identity")]
+    /// Opened plaintext does not match its kind-specific durable identity.
+    #[error("content bytes do not match their durable identity")]
     ContentMismatch,
+    /// Endpoint results must consume capacity reserved before provider invocation.
+    #[error("endpoint-result persistence requires a live capacity reservation")]
+    EndpointResultReservationRequired,
 }
 
 /// Secret-free error returned by a content-protection adapter.

--- a/crates/automata-ci-runner-spool/src/lib.rs
+++ b/crates/automata-ci-runner-spool/src/lib.rs
@@ -22,7 +22,11 @@ mod store;
 pub use error::{
     ContentProtectionError, RetainedContentError, SpoolError, SpoolInvariantError, SpoolRootError,
 };
-pub use model::{ContentCacheKey, ContentKind, DurableContentRef, ProtectionId, SpoolLimits};
+pub use model::{
+    ContentCacheKey, ContentCommitmentDomain, ContentKind, DurableContentRef,
+    KeyedContentCommitment, OpaqueContentIdentity, ProtectionId, SpoolLimits,
+    endpoint_result_allocation,
+};
 pub use observer::{
     NoopSpoolObserver, SpoolCapacityResource, SpoolEvent, SpoolFailureKind, SpoolObserver,
     SpoolOperation, SpoolOperationOutcome, SpoolProtectionOperation, SpoolProtectionOutcome,
@@ -30,8 +34,8 @@ pub use observer::{
 pub use root::SpoolRoot;
 pub use store::{
     ContentCommitFault, ContentCommitFaultInjector, ContentCommitStage, ContentProtector,
-    DurableContentPublication, DurableContentStore, FileSpool, FileSpoolOptions,
-    NoContentCommitFaults, PublicationCommitFailure, RetainedContentSource,
+    DurableContentPublication, DurableContentStore, EndpointResultCapacityReservation, FileSpool,
+    FileSpoolOptions, NoContentCommitFaults, PublicationCommitFailure, RetainedContentSource,
 };
 
 /// Hard upper bound for one plaintext object accepted by any adapter.

--- a/crates/automata-ci-runner-spool/src/model.rs
+++ b/crates/automata-ci-runner-spool/src/model.rs
@@ -9,6 +9,99 @@ use crate::{
 
 const MAX_PROTECTION_ID_BYTES: usize = 64;
 const MAX_CACHE_KEY_BYTES: usize = 192;
+const ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES: u64 = 64 * 1024;
+const ENDPOINT_RESULT_PROTECTED_ENVELOPE_BYTES: u64 = 76;
+
+/// Returns the current padded protected allocation charged for an endpoint result.
+///
+/// The class includes the authenticated exact-length/digest envelope and the
+/// protection nonce/tag overhead, rounded to a fixed 64-KiB boundary. It is a
+/// capacity ceiling, never an exact plaintext length.
+///
+/// # Errors
+///
+/// Rejects plaintext beyond the global object bound or arithmetic overflow.
+pub const fn endpoint_result_allocation(plaintext_bytes: u64) -> Result<u64, SpoolInvariantError> {
+    if plaintext_bytes > MAX_CONTENT_OBJECT_BYTES {
+        return Err(SpoolInvariantError::ObjectTooLarge);
+    }
+    let Some(required) = plaintext_bytes.checked_add(ENDPOINT_RESULT_PROTECTED_ENVELOPE_BYTES)
+    else {
+        return Err(SpoolInvariantError::ObjectTooLarge);
+    };
+    let Some(rounded) = required.checked_add(ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES - 1) else {
+        return Err(SpoolInvariantError::ObjectTooLarge);
+    };
+    let rounded = rounded / ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES;
+    match rounded.checked_mul(ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES) {
+        Some(allocation) => Ok(allocation),
+        None => Err(SpoolInvariantError::ObjectTooLarge),
+    }
+}
+
+const fn valid_endpoint_result_allocation(allocation_bytes: u64) -> bool {
+    allocation_bytes >= ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES
+        && allocation_bytes.is_multiple_of(ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES)
+        && allocation_bytes <= MAX_CONTENT_OBJECT_BYTES + ENDPOINT_RESULT_ALLOCATION_GRANULE_BYTES
+}
+
+/// Closed domain for commitments computed by the protected-content authority.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContentCommitmentDomain {
+    /// Exact execution-endpoint request replay identity.
+    EndpointRequest,
+    /// Opaque durable identity for an execution-endpoint result.
+    EndpointResultIdentity,
+}
+
+impl ContentCommitmentDomain {
+    /// Returns the fixed cryptographic domain separator.
+    #[must_use]
+    pub const fn separator(self) -> &'static [u8] {
+        match self {
+            Self::EndpointRequest => b"automata.runner.endpoint-request.commitment.v1\0",
+            Self::EndpointResultIdentity => b"automata.runner.endpoint-result.identity.v1\0",
+        }
+    }
+}
+
+/// Keyed, fixed-size commitment produced by an exact spool protection key.
+#[derive(Clone, Eq, PartialEq)]
+pub struct KeyedContentCommitment {
+    protection_id: ProtectionId,
+    bytes: [u8; 32],
+}
+
+impl KeyedContentCommitment {
+    pub(crate) const fn new(protection_id: ProtectionId, bytes: [u8; 32]) -> Self {
+        Self {
+            protection_id,
+            bytes,
+        }
+    }
+
+    /// Returns the exact non-secret protection-key identifier used.
+    #[must_use]
+    pub const fn protection_id(&self) -> &ProtectionId {
+        &self.protection_id
+    }
+
+    /// Borrows commitment bytes for protected persistence or constant-time comparison.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+}
+
+impl fmt::Debug for KeyedContentCommitment {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("KeyedContentCommitment")
+            .field("protection_id", &self.protection_id)
+            .field("bytes", &"[REDACTED]")
+            .finish()
+    }
+}
 
 /// Semantic role of immutable recovery content.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -22,6 +115,10 @@ pub enum ContentKind {
     TerminalResult,
     /// Buffered log content awaiting replay or upload.
     LogSpool,
+    /// Fixed-size commitment to one exact execution-endpoint request.
+    EndpointRequest,
+    /// Protected replay result from one execution-endpoint operation.
+    EndpointResult,
 }
 
 impl ContentKind {
@@ -31,7 +128,62 @@ impl ContentKind {
             Self::RuntimeAuthority => "runtime-authority",
             Self::TerminalResult => "terminal-result",
             Self::LogSpool => "log-spool",
+            Self::EndpointRequest => "endpoint-request",
+            Self::EndpointResult => "endpoint-result",
         }
+    }
+}
+
+/// Protection-keyed, fixed-size identity for one endpoint result.
+///
+/// The bytes are safe to persist but intentionally hidden from debug output.
+/// They cannot be recomputed from a low-entropy result without the exact spool
+/// protection key.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OpaqueContentIdentity(Sha256Digest);
+
+impl OpaqueContentIdentity {
+    /// Wraps an identity produced by the protected-content authority.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(Sha256Digest::from_bytes(bytes))
+    }
+
+    /// Borrows the opaque identity bytes for authenticated protection.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+impl fmt::Debug for OpaqueContentIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OpaqueContentIdentity([REDACTED])")
+    }
+}
+
+impl fmt::Display for OpaqueContentIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+impl Serialize for OpaqueContentIdentity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for OpaqueContentIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let digest = Sha256Digest::deserialize(deserializer)?;
+        Ok(Self(digest))
     }
 }
 
@@ -101,17 +253,37 @@ impl<'de> Deserialize<'de> for ProtectionId {
 pub struct ContentCacheKey(String);
 
 impl ContentCacheKey {
-    fn derive(
+    fn derive_public(
         kind: ContentKind,
         digest: Sha256Digest,
         size: u64,
         protection_id: &ProtectionId,
     ) -> Result<Self, SpoolInvariantError> {
+        if kind == ContentKind::EndpointResult {
+            return Err(SpoolInvariantError::InvalidContentIdentity);
+        }
         let value = format!(
             "{}-{}-{digest}-{size}",
             kind.cache_prefix(),
             protection_id.as_str()
         );
+        Self::validated(value)
+    }
+
+    fn derive_endpoint_result(
+        identity: OpaqueContentIdentity,
+        protected_allocation_bytes: u64,
+        protection_id: &ProtectionId,
+    ) -> Result<Self, SpoolInvariantError> {
+        let value = format!(
+            "{}-{}-{identity}-{protected_allocation_bytes}",
+            ContentKind::EndpointResult.cache_prefix(),
+            protection_id.as_str()
+        );
+        Self::validated(value)
+    }
+
+    fn validated(value: String) -> Result<Self, SpoolInvariantError> {
         if value.len() <= MAX_CACHE_KEY_BYTES
             && value
                 .bytes()
@@ -172,38 +344,153 @@ impl<'de> Deserialize<'de> for ContentCacheKey {
     }
 }
 
+/// Kind-specific durable identity that never exposes endpoint-result plaintext
+/// size or digest.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum DurableContentIdentity {
+    Public {
+        plaintext_bytes: u64,
+        plaintext_sha256: Sha256Digest,
+    },
+    EndpointResult {
+        protected_allocation_bytes: u64,
+        opaque_identity: OpaqueContentIdentity,
+    },
+}
+
 /// Immutable identity of protected content already committed by an adapter.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DurableContentRef {
     kind: ContentKind,
-    size: u64,
-    sha256: Sha256Digest,
+    identity: DurableContentIdentity,
     cache_key: ContentCacheKey,
     protection_id: ProtectionId,
 }
 
+impl fmt::Debug for DurableContentRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = formatter.debug_struct("DurableContentRef");
+        debug.field("kind", &self.kind);
+        match &self.identity {
+            DurableContentIdentity::Public {
+                plaintext_bytes,
+                plaintext_sha256,
+            } => {
+                debug
+                    .field("plaintext_bytes", plaintext_bytes)
+                    .field("plaintext_sha256", plaintext_sha256);
+            }
+            DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                ..
+            } => {
+                debug
+                    .field("protected_allocation_bytes", protected_allocation_bytes)
+                    .field("opaque_identity", &"[REDACTED]");
+            }
+        }
+        debug
+            .field("cache_key", &self.cache_key)
+            .field("protection_id", &self.protection_id)
+            .finish()
+    }
+}
+
 impl DurableContentRef {
+    fn derive_cache_key(
+        kind: ContentKind,
+        identity: &DurableContentIdentity,
+        protection_id: &ProtectionId,
+    ) -> Result<ContentCacheKey, SpoolInvariantError> {
+        match *identity {
+            DurableContentIdentity::Public {
+                plaintext_bytes,
+                plaintext_sha256,
+            } if kind != ContentKind::EndpointResult
+                && plaintext_bytes <= MAX_CONTENT_OBJECT_BYTES =>
+            {
+                ContentCacheKey::derive_public(
+                    kind,
+                    plaintext_sha256,
+                    plaintext_bytes,
+                    protection_id,
+                )
+            }
+            DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                opaque_identity,
+            } if kind == ContentKind::EndpointResult
+                && valid_endpoint_result_allocation(protected_allocation_bytes) =>
+            {
+                ContentCacheKey::derive_endpoint_result(
+                    opaque_identity,
+                    protected_allocation_bytes,
+                    protection_id,
+                )
+            }
+            _ => Err(SpoolInvariantError::InvalidContentIdentity),
+        }
+    }
+
     /// Constructs the durable receipt returned by a storage adapter only after
     /// it has synchronized the verified bytes and directory metadata.
     ///
     /// # Errors
     ///
     /// Rejects content beyond the hard object bound.
-    pub fn after_commit(
+    pub fn after_public_commit(
         kind: ContentKind,
-        size: u64,
-        sha256: Sha256Digest,
+        plaintext_bytes: u64,
+        plaintext_sha256: Sha256Digest,
         protection_id: ProtectionId,
     ) -> Result<Self, SpoolInvariantError> {
-        if size > MAX_CONTENT_OBJECT_BYTES {
+        if kind == ContentKind::EndpointResult {
+            return Err(SpoolInvariantError::InvalidContentIdentity);
+        }
+        if plaintext_bytes > MAX_CONTENT_OBJECT_BYTES {
             return Err(SpoolInvariantError::ObjectTooLarge);
         }
-        let cache_key = ContentCacheKey::derive(kind, sha256, size, &protection_id)?;
+        let cache_key = ContentCacheKey::derive_public(
+            kind,
+            plaintext_sha256,
+            plaintext_bytes,
+            &protection_id,
+        )?;
         Ok(Self {
             kind,
-            size,
-            sha256,
+            identity: DurableContentIdentity::Public {
+                plaintext_bytes,
+                plaintext_sha256,
+            },
+            cache_key,
+            protection_id,
+        })
+    }
+
+    /// Constructs a receipt for an endpoint result after protected publication.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero or globally oversized padded allocation class.
+    pub fn after_endpoint_result_commit(
+        protected_allocation_bytes: u64,
+        opaque_identity: OpaqueContentIdentity,
+        protection_id: ProtectionId,
+    ) -> Result<Self, SpoolInvariantError> {
+        if !valid_endpoint_result_allocation(protected_allocation_bytes) {
+            return Err(SpoolInvariantError::InvalidContentIdentity);
+        }
+        let cache_key = ContentCacheKey::derive_endpoint_result(
+            opaque_identity,
+            protected_allocation_bytes,
+            &protection_id,
+        )?;
+        Ok(Self {
+            kind: ContentKind::EndpointResult,
+            identity: DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                opaque_identity,
+            },
             cache_key,
             protection_id,
         })
@@ -215,16 +502,66 @@ impl DurableContentRef {
         self.kind
     }
 
-    /// Returns the exact plaintext byte length included in this identity.
+    /// Returns capacity-accounted bytes for this object.
+    ///
+    /// Public kinds return exact plaintext bytes. Endpoint results return only
+    /// their deterministic padded protected allocation class.
     #[must_use]
-    pub const fn size(&self) -> u64 {
-        self.size
+    pub const fn accounted_bytes(&self) -> u64 {
+        match self.identity {
+            DurableContentIdentity::Public {
+                plaintext_bytes, ..
+            } => plaintext_bytes,
+            DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                ..
+            } => protected_allocation_bytes,
+        }
     }
 
-    /// Returns the SHA-256 digest of the plaintext content.
+    /// Returns exact plaintext bytes only for a public content kind.
     #[must_use]
-    pub const fn sha256(&self) -> Sha256Digest {
-        self.sha256
+    pub const fn public_plaintext_bytes(&self) -> Option<u64> {
+        match self.identity {
+            DurableContentIdentity::Public {
+                plaintext_bytes, ..
+            } => Some(plaintext_bytes),
+            DurableContentIdentity::EndpointResult { .. } => None,
+        }
+    }
+
+    /// Returns the plaintext SHA-256 identity only for a public content kind.
+    #[must_use]
+    pub const fn public_plaintext_sha256(&self) -> Option<Sha256Digest> {
+        match self.identity {
+            DurableContentIdentity::Public {
+                plaintext_sha256, ..
+            } => Some(plaintext_sha256),
+            DurableContentIdentity::EndpointResult { .. } => None,
+        }
+    }
+
+    /// Returns the padded protected allocation only for an endpoint result.
+    #[must_use]
+    pub const fn endpoint_result_allocation_bytes(&self) -> Option<u64> {
+        match self.identity {
+            DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                ..
+            } => Some(protected_allocation_bytes),
+            DurableContentIdentity::Public { .. } => None,
+        }
+    }
+
+    /// Returns the protection-keyed identity only for an endpoint result.
+    #[must_use]
+    pub const fn endpoint_result_identity(&self) -> Option<&OpaqueContentIdentity> {
+        match &self.identity {
+            DurableContentIdentity::EndpointResult {
+                opaque_identity, ..
+            } => Some(opaque_identity),
+            DurableContentIdentity::Public { .. } => None,
+        }
     }
 
     /// Returns the deterministic local filename key for this identity.
@@ -240,9 +577,8 @@ impl DurableContentRef {
     }
 
     pub(crate) fn validate(&self) -> Result<(), SpoolInvariantError> {
-        let expected =
-            ContentCacheKey::derive(self.kind, self.sha256, self.size, &self.protection_id)?;
-        if self.size <= MAX_CONTENT_OBJECT_BYTES && self.cache_key == expected {
+        let expected = Self::derive_cache_key(self.kind, &self.identity, &self.protection_id)?;
+        if self.cache_key == expected {
             Ok(())
         } else {
             Err(SpoolInvariantError::InvalidCacheKey)
@@ -250,14 +586,46 @@ impl DurableContentRef {
     }
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DurableContentRefSerialize<'a> {
+    Public(ContentKind, u64, Sha256Digest, &'a ProtectionId),
+    Result(u64, &'a OpaqueContentIdentity, &'a ProtectionId),
+}
+
+impl Serialize for DurableContentRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match &self.identity {
+            DurableContentIdentity::Public {
+                plaintext_bytes,
+                plaintext_sha256,
+            } => DurableContentRefSerialize::Public(
+                self.kind,
+                *plaintext_bytes,
+                *plaintext_sha256,
+                &self.protection_id,
+            ),
+            DurableContentIdentity::EndpointResult {
+                protected_allocation_bytes,
+                opaque_identity,
+            } => DurableContentRefSerialize::Result(
+                *protected_allocation_bytes,
+                opaque_identity,
+                &self.protection_id,
+            ),
+        };
+        value.serialize(serializer)
+    }
+}
+
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct DurableContentRefData {
-    kind: ContentKind,
-    size: u64,
-    sha256: Sha256Digest,
-    cache_key: ContentCacheKey,
-    protection_id: ProtectionId,
+#[serde(rename_all = "snake_case")]
+enum DurableContentRefData {
+    Public(ContentKind, u64, Sha256Digest, ProtectionId),
+    Result(u64, OpaqueContentIdentity, ProtectionId),
 }
 
 impl<'de> Deserialize<'de> for DurableContentRef {
@@ -265,16 +633,15 @@ impl<'de> Deserialize<'de> for DurableContentRef {
     where
         D: Deserializer<'de>,
     {
-        let value = DurableContentRefData::deserialize(deserializer)?;
-        let reference = Self {
-            kind: value.kind,
-            size: value.size,
-            sha256: value.sha256,
-            cache_key: value.cache_key,
-            protection_id: value.protection_id,
-        };
-        reference.validate().map_err(serde::de::Error::custom)?;
-        Ok(reference)
+        match DurableContentRefData::deserialize(deserializer)? {
+            DurableContentRefData::Public(kind, bytes, digest, protection_id) => {
+                Self::after_public_commit(kind, bytes, digest, protection_id)
+            }
+            DurableContentRefData::Result(allocation, identity, protection_id) => {
+                Self::after_endpoint_result_commit(allocation, identity, protection_id)
+            }
+        }
+        .map_err(serde::de::Error::custom)
     }
 }
 
@@ -352,8 +719,8 @@ impl Default for SpoolLimits {
     fn default() -> Self {
         Self {
             object_bytes: MAX_CONTENT_OBJECT_BYTES,
-            total_bytes: 1024 * 1024 * 1024,
-            objects: 4_096,
+            total_bytes: MAX_CONTENT_SPOOL_BYTES,
+            objects: MAX_CONTENT_OBJECTS,
             protection_overhead_bytes: 1024 * 1024,
         }
     }

--- a/crates/automata-ci-runner-spool/src/observer.rs
+++ b/crates/automata-ci-runner-spool/src/observer.rs
@@ -29,6 +29,8 @@ pub enum SpoolOperationOutcome {
 /// Closed cryptographic operation domain.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SpoolProtectionOperation {
+    /// Compute a domain-separated keyed commitment without exposing its key.
+    Commitment,
     /// Convert plaintext to authenticated protected bytes before storage.
     Protect,
     /// Authenticate protected bytes and recover plaintext after reading.
@@ -134,13 +136,14 @@ pub enum SpoolEvent {
         /// Local elapsed time spent in the operation.
         duration: Duration,
     },
-    /// Plaintext bytes successfully persisted, loaded, or removed.
+    /// Logical protected-content bytes successfully persisted, loaded, or removed.
     ContentBytes {
         /// Operation that accounted the bytes.
         operation: SpoolOperation,
         /// Semantic role of the accounted content.
         content_kind: ContentKind,
-        /// Plaintext byte count; never the bytes themselves.
+        /// Exact plaintext bytes for public kinds, or the opaque padded
+        /// allocation class for an endpoint result; never the bytes themselves.
         bytes: u64,
     },
     /// One protection-adapter invocation completed.

--- a/crates/automata-ci-runner-spool/src/platform/windows.rs
+++ b/crates/automata-ci-runner-spool/src/platform/windows.rs
@@ -530,7 +530,7 @@ mod tests {
             PlatformDirectory::open(&root),
             Err(SpoolError::AlreadyLocked)
         ));
-        let reference = DurableContentRef::after_commit(
+        let reference = DurableContentRef::after_public_commit(
             ContentKind::LogSpool,
             7,
             Sha256Digest::from_bytes([7; 32]),

--- a/crates/automata-ci-runner-spool/src/store.rs
+++ b/crates/automata-ci-runner-spool/src/store.rs
@@ -7,9 +7,11 @@ use std::{
 
 use automata_ci_core::Sha256Digest;
 use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
 
 use crate::{
-    ContentKind, ContentProtectionError, DurableContentRef, NoopSpoolObserver, ProtectionId,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, DurableContentRef,
+    KeyedContentCommitment, NoopSpoolObserver, OpaqueContentIdentity, ProtectionId,
     RetainedContentError, SpoolCapacityResource, SpoolError, SpoolEvent, SpoolFailureKind,
     SpoolInvariantError, SpoolLimits, SpoolObserver, SpoolOperation, SpoolOperationOutcome,
     SpoolProtectionOperation, SpoolProtectionOutcome, SpoolRoot,
@@ -74,6 +76,40 @@ pub trait ContentProtector: Send + Sync {
     fn supports_protection_id(&self, protection_id: &ProtectionId) -> bool {
         protection_id == self.protection_id()
     }
+
+    /// Computes a domain-separated PRF commitment with the exact named key.
+    ///
+    /// The implementation must use secret key material unavailable to a reader
+    /// of spool files or journal metadata. Errors must not contain commitment
+    /// input or key material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContentProtectionError`] when the exact key is unavailable or
+    /// the protected commitment operation fails.
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError>;
+
+    /// Returns the exact encoded bytes this protector will produce for an
+    /// endpoint result of `plaintext_bytes` under its active key.
+    ///
+    /// Implementations must apply the current opaque padded-allocation
+    /// contract. This is a protection-authority preflight: success promises
+    /// that [`Self::protect`] will emit exactly the returned byte count for the
+    /// matching endpoint-result reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContentProtectionError`] when the active protection authority
+    /// is unavailable or the plaintext length cannot be protected.
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError>;
 
     /// Protects plaintext before any filesystem write.
     ///
@@ -234,6 +270,26 @@ pub struct PublicationCommitFailure<'a, E> {
     publication: DurableContentPublication<'a>,
 }
 
+/// Capacity reserved globally before invoking one endpoint operation.
+///
+/// The reservation owns one object slot and the protected allocation class for
+/// the declared maximum result. Dropping it releases both. Endpoint results can
+/// only be published by consuming this value.
+#[must_use = "endpoint-result capacity must be consumed or released"]
+pub trait EndpointResultCapacityReservation<'store>: Send {
+    /// Protects and durably publishes the result while atomically consuming the
+    /// reserved capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoolError`] for an oversized result, protection, commit, or
+    /// poisoned-store failure. Every failure releases the reservation.
+    fn persist(
+        self: Box<Self>,
+        plaintext: &[u8],
+    ) -> Result<DurableContentPublication<'store>, SpoolError>;
+}
+
 impl<E> fmt::Debug for PublicationCommitFailure<'_, E> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -253,6 +309,44 @@ impl<'a, E> PublicationCommitFailure<'a, E> {
 
 /// Object-safe protected content-store port.
 pub trait DurableContentStore: Send + Sync {
+    /// Computes a new commitment under the active protection key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoolError`] when the protection authority is unavailable.
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError>;
+
+    /// Recomputes a commitment under the exact key named by durable state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoolError`] when that exact key is unavailable or protection fails.
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError>;
+
+    /// Reserves global capacity for one endpoint result before provider invocation.
+    ///
+    /// The reservation accounts for one object and the deterministic padded
+    /// protected allocation of `maximum_plaintext_bytes`. It blocks every
+    /// competing publisher or reservation that would consume that capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpoolError`] for an invalid maximum, unavailable protection
+    /// authority, exhausted capacity, or poisoned store.
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError>;
+
     /// Protects, verifies, and durably commits immutable content.
     ///
     /// A successful return occurs only after file and directory synchronization.
@@ -369,6 +463,8 @@ impl fmt::Debug for FileSpoolOptions {
 #[derive(Clone, Copy, Debug, Default)]
 struct MemoryState {
     usage: SpoolUsage,
+    reserved_objects: u32,
+    reserved_protected_bytes: u64,
     poisoned: bool,
 }
 
@@ -385,6 +481,191 @@ pub struct FileSpool {
     memory: Mutex<MemoryState>,
     publications: PublicationGate,
     options: FileSpoolOptions,
+}
+
+struct FileEndpointResultReservation<'store> {
+    spool: &'store FileSpool,
+    maximum_plaintext_bytes: u64,
+    reserved_protected_bytes: u64,
+    active: bool,
+}
+
+impl fmt::Debug for FileEndpointResultReservation<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EndpointResultCapacityReservation")
+            .field("maximum_plaintext_bytes", &self.maximum_plaintext_bytes)
+            .field("reserved_protected_bytes", &self.reserved_protected_bytes)
+            .field("state", &if self.active { "reserved" } else { "consumed" })
+            .finish()
+    }
+}
+
+impl<'store> FileEndpointResultReservation<'store> {
+    fn release(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut memory = self
+            .spool
+            .memory
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        match (
+            memory.reserved_objects.checked_sub(1),
+            memory
+                .reserved_protected_bytes
+                .checked_sub(self.reserved_protected_bytes),
+        ) {
+            (Some(objects), Some(bytes)) => {
+                memory.reserved_objects = objects;
+                memory.reserved_protected_bytes = bytes;
+            }
+            _ => memory.poisoned = true,
+        }
+        self.active = false;
+    }
+
+    fn persist_inner(
+        &mut self,
+        plaintext: &[u8],
+        operation: SpoolOperation,
+    ) -> Result<DurableContentPublication<'store>, SpoolError> {
+        let protection_id = self.spool.protector.protection_id();
+        let reference = self
+            .spool
+            .endpoint_result_reference_for(protection_id, plaintext)?;
+        let actual_allocation = reference
+            .endpoint_result_allocation_bytes()
+            .ok_or(SpoolInvariantError::InvalidContentIdentity)?;
+        if actual_allocation > self.reserved_protected_bytes {
+            return Err(SpoolError::CapacityExhausted);
+        }
+        let permit = self.spool.publications.begin()?;
+        let mut memory = self.spool.memory.lock().map_err(|_| SpoolError::Poisoned)?;
+        if memory.poisoned {
+            return Err(SpoolError::Poisoned);
+        }
+        if let Some(existing) = self.spool.load_protected(&reference)? {
+            self.spool.open_and_verify(&reference, &existing)?;
+            let reserved_objects = memory
+                .reserved_objects
+                .checked_sub(1)
+                .ok_or(SpoolError::Poisoned)?;
+            let reserved_protected_bytes = memory
+                .reserved_protected_bytes
+                .checked_sub(self.reserved_protected_bytes)
+                .ok_or(SpoolError::Poisoned)?;
+            memory.reserved_objects = reserved_objects;
+            memory.reserved_protected_bytes = reserved_protected_bytes;
+            self.active = false;
+            return Ok(DurableContentPublication { reference, permit });
+        }
+        let protected = self.spool.protector.protect(&reference, plaintext);
+        self.spool.options.observer.observe(SpoolEvent::Protection {
+            operation: SpoolProtectionOperation::Protect,
+            outcome: if protected.is_ok() {
+                SpoolProtectionOutcome::Success
+            } else {
+                SpoolProtectionOutcome::Error
+            },
+        });
+        let protected = protected?;
+        let protected_bytes = u64::try_from(protected.len())
+            .map_err(|_| SpoolInvariantError::ProtectionOverheadExceeded)?;
+        self.spool
+            .validate_protected_size(&reference, protected_bytes)?;
+        if protected_bytes > self.reserved_protected_bytes {
+            return Err(SpoolError::CapacityExhausted);
+        }
+        let reserved_objects = memory
+            .reserved_objects
+            .checked_sub(1)
+            .ok_or(SpoolError::Poisoned)?;
+        let reserved_bytes = memory
+            .reserved_protected_bytes
+            .checked_sub(self.reserved_protected_bytes)
+            .ok_or(SpoolError::Poisoned)?;
+        let objects = memory
+            .usage
+            .objects
+            .checked_add(1)
+            .ok_or(SpoolError::Poisoned)?;
+        let usage_bytes = memory
+            .usage
+            .protected_bytes
+            .checked_add(protected_bytes)
+            .ok_or(SpoolError::Poisoned)?;
+        match self.spool.directory.commit(
+            &reference,
+            &protected,
+            self.spool.options.fault_injector.as_ref(),
+        ) {
+            Ok(()) => {
+                memory.reserved_objects = reserved_objects;
+                memory.reserved_protected_bytes = reserved_bytes;
+                memory.usage.objects = objects;
+                memory.usage.protected_bytes = usage_bytes;
+                self.active = false;
+                Ok(DurableContentPublication { reference, permit })
+            }
+            Err(failure) if failure.renamed() => {
+                memory.poisoned = true;
+                self.spool
+                    .options
+                    .observer
+                    .observe(SpoolEvent::Poisoned { operation });
+                Err(SpoolError::CommitOutcomeUnknown)
+            }
+            Err(failure) => Err(failure.into_public()),
+        }
+    }
+}
+
+impl Drop for FileEndpointResultReservation<'_> {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl<'store> EndpointResultCapacityReservation<'store> for FileEndpointResultReservation<'store> {
+    fn persist(
+        mut self: Box<Self>,
+        plaintext: &[u8],
+    ) -> Result<DurableContentPublication<'store>, SpoolError> {
+        let plaintext_bytes =
+            u64::try_from(plaintext.len()).map_err(|_| SpoolInvariantError::ObjectTooLarge)?;
+        if plaintext_bytes > self.maximum_plaintext_bytes {
+            return Err(SpoolInvariantError::ObjectTooLarge.into());
+        }
+        let observed_bytes = crate::endpoint_result_allocation(plaintext_bytes)?;
+
+        let operation = SpoolOperation::Persist;
+        let started = Instant::now();
+        self.spool
+            .options
+            .observer
+            .observe(SpoolEvent::OperationStarted { operation });
+        let result = self.persist_inner(plaintext, operation);
+        if result.is_ok() {
+            self.spool
+                .options
+                .observer
+                .observe(SpoolEvent::ContentBytes {
+                    operation,
+                    content_kind: ContentKind::EndpointResult,
+                    bytes: observed_bytes,
+                });
+        }
+        self.spool.observe_completion(
+            operation,
+            Some(ContentKind::EndpointResult),
+            SpoolOperationOutcome::Success,
+            started,
+            &result,
+        );
+        result
+    }
 }
 
 impl fmt::Debug for FileSpool {
@@ -430,6 +711,8 @@ impl FileSpool {
             protector,
             memory: Mutex::new(MemoryState {
                 usage,
+                reserved_objects: 0,
+                reserved_protected_bytes: 0,
                 poisoned: false,
             }),
             publications: PublicationGate::default(),
@@ -462,7 +745,7 @@ impl FileSpool {
         Ok((memory.usage.objects, memory.usage.protected_bytes))
     }
 
-    fn reference_for(
+    fn public_reference_for(
         &self,
         kind: ContentKind,
         plaintext: &[u8],
@@ -476,13 +759,54 @@ impl FileSpool {
             return Err(SpoolInvariantError::ObjectTooLarge.into());
         }
         let digest = Sha256Digest::from_bytes(Sha256::digest(plaintext).into());
-        DurableContentRef::after_commit(kind, size, digest, self.protector.protection_id().clone())
-            .map_err(Into::into)
+        DurableContentRef::after_public_commit(
+            kind,
+            size,
+            digest,
+            self.protector.protection_id().clone(),
+        )
+        .map_err(Into::into)
+    }
+
+    fn endpoint_result_reference_for(
+        &self,
+        protection_id: &ProtectionId,
+        plaintext: &[u8],
+    ) -> Result<DurableContentRef, SpoolError> {
+        const MATERIAL_DOMAIN: &[u8] = b"automata.runner.endpoint-result.material.v1\0";
+        let plaintext_bytes =
+            u64::try_from(plaintext.len()).map_err(|_| SpoolInvariantError::ObjectTooLarge)?;
+        if plaintext_bytes > self.options.limits.max_object_bytes() {
+            return Err(SpoolInvariantError::ObjectTooLarge.into());
+        }
+        let plaintext_sha256: [u8; 32] = Sha256::digest(plaintext).into();
+        let mut material = Sha256::new();
+        material.update(MATERIAL_DOMAIN);
+        material.update(plaintext_bytes.to_be_bytes());
+        material.update(plaintext_sha256);
+        let material_digest: [u8; 32] = material.finalize().into();
+        let opaque = self.protector.keyed_commitment(
+            protection_id,
+            ContentCommitmentDomain::EndpointResultIdentity,
+            &material_digest,
+        )?;
+        let protected_allocation_bytes = crate::endpoint_result_allocation(plaintext_bytes)?;
+        DurableContentRef::after_endpoint_result_commit(
+            protected_allocation_bytes,
+            OpaqueContentIdentity::from_bytes(opaque),
+            protection_id.clone(),
+        )
+        .map_err(Into::into)
     }
 
     fn load_protected(&self, reference: &DurableContentRef) -> Result<Option<Vec<u8>>, SpoolError> {
-        if reference.size() > self.options.limits.max_object_bytes() {
-            return Err(SpoolInvariantError::ObjectTooLarge.into());
+        match (
+            reference.public_plaintext_bytes(),
+            reference.endpoint_result_allocation_bytes(),
+        ) {
+            (Some(bytes), None) if bytes <= self.options.limits.max_object_bytes() => {}
+            (None, Some(bytes)) if bytes <= self.options.limits.max_encoded_object_bytes() => {}
+            _ => return Err(SpoolInvariantError::ObjectTooLarge.into()),
         }
         if !self
             .protector
@@ -509,18 +833,27 @@ impl FileSpool {
             },
         });
         let plaintext = plaintext?;
-        verify_plaintext(reference, &plaintext)?;
+        self.verify_plaintext(reference, &plaintext)?;
         Ok(plaintext)
     }
 
-    fn capacity_after(&self, usage: SpoolUsage, protected_bytes: u64) -> Result<(), SpoolError> {
-        let objects = usage
+    fn capacity_after(
+        &self,
+        memory: &MemoryState,
+        additional_objects: u32,
+        additional_protected_bytes: u64,
+    ) -> Result<(), SpoolError> {
+        let objects = memory
+            .usage
             .objects
-            .checked_add(1)
+            .checked_add(memory.reserved_objects)
+            .and_then(|objects| objects.checked_add(additional_objects))
             .ok_or(SpoolError::CapacityExhausted)?;
-        let bytes = usage
+        let bytes = memory
+            .usage
             .protected_bytes
-            .checked_add(protected_bytes)
+            .checked_add(memory.reserved_protected_bytes)
+            .and_then(|bytes| bytes.checked_add(additional_protected_bytes))
             .ok_or(SpoolError::CapacityExhausted)?;
         if objects > self.options.limits.max_objects() {
             self.options.observer.observe(SpoolEvent::CapacityRejected {
@@ -535,6 +868,65 @@ impl FileSpool {
             return Err(SpoolError::CapacityExhausted);
         }
         Ok(())
+    }
+
+    fn validate_protected_size(
+        &self,
+        reference: &DurableContentRef,
+        protected_bytes: u64,
+    ) -> Result<(), SpoolError> {
+        let allowed = match (
+            reference.public_plaintext_bytes(),
+            reference.endpoint_result_allocation_bytes(),
+        ) {
+            (Some(plaintext_bytes), None) => plaintext_bytes
+                .checked_add(self.options.limits.max_protection_overhead_bytes())
+                .is_some_and(|maximum| protected_bytes <= maximum),
+            (None, Some(allocation_bytes)) => protected_bytes == allocation_bytes,
+            _ => false,
+        } && protected_bytes <= self.options.limits.max_encoded_object_bytes();
+        if allowed {
+            Ok(())
+        } else {
+            Err(SpoolInvariantError::ProtectionOverheadExceeded.into())
+        }
+    }
+
+    fn verify_plaintext(
+        &self,
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<(), SpoolError> {
+        if let (Some(expected_bytes), Some(expected_digest)) = (
+            reference.public_plaintext_bytes(),
+            reference.public_plaintext_sha256(),
+        ) {
+            let size = u64::try_from(plaintext.len()).unwrap_or(u64::MAX);
+            let digest = Sha256Digest::from_bytes(Sha256::digest(plaintext).into());
+            return if size == expected_bytes && digest == expected_digest {
+                Ok(())
+            } else {
+                Err(SpoolInvariantError::ContentMismatch.into())
+            };
+        }
+        let expected = self.endpoint_result_reference_for(reference.protection_id(), plaintext)?;
+        let expected_identity = expected
+            .endpoint_result_identity()
+            .ok_or(SpoolInvariantError::InvalidContentIdentity)?;
+        let actual_identity = reference
+            .endpoint_result_identity()
+            .ok_or(SpoolInvariantError::InvalidContentIdentity)?;
+        if bool::from(
+            expected_identity
+                .as_bytes()
+                .ct_eq(actual_identity.as_bytes()),
+        ) && expected.endpoint_result_allocation_bytes()
+            == reference.endpoint_result_allocation_bytes()
+        {
+            Ok(())
+        } else {
+            Err(SpoolInvariantError::ContentMismatch.into())
+        }
     }
 
     fn observe_completion<T>(
@@ -565,6 +957,88 @@ impl FileSpool {
 }
 
 impl DurableContentStore for FileSpool {
+    fn create_keyed_commitment(
+        &self,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        self.recreate_keyed_commitment(self.protector.protection_id(), domain, material_digest)
+    }
+
+    fn recreate_keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<KeyedContentCommitment, SpoolError> {
+        if !self.protector.supports_protection_id(protection_id) {
+            return Err(ContentProtectionError::KeyUnavailable.into());
+        }
+        let commitment = self
+            .protector
+            .keyed_commitment(protection_id, domain, material_digest);
+        self.options.observer.observe(SpoolEvent::Protection {
+            operation: SpoolProtectionOperation::Commitment,
+            outcome: if commitment.is_ok() {
+                SpoolProtectionOutcome::Success
+            } else {
+                SpoolProtectionOutcome::Error
+            },
+        });
+        Ok(KeyedContentCommitment::new(
+            protection_id.clone(),
+            commitment?,
+        ))
+    }
+
+    fn reserve_endpoint_result(
+        &self,
+        maximum_plaintext_bytes: u64,
+    ) -> Result<Box<dyn EndpointResultCapacityReservation<'_> + '_>, SpoolError> {
+        if maximum_plaintext_bytes > self.options.limits.max_object_bytes() {
+            self.options.observer.observe(SpoolEvent::CapacityRejected {
+                resource: SpoolCapacityResource::ObjectBytes,
+            });
+            return Err(SpoolInvariantError::ObjectTooLarge.into());
+        }
+        let protected_bytes = crate::endpoint_result_allocation(maximum_plaintext_bytes)?;
+        let protector_bytes = self
+            .protector
+            .endpoint_result_protected_bytes(maximum_plaintext_bytes)?;
+        if protector_bytes != protected_bytes {
+            return Err(SpoolInvariantError::ProtectionOverheadExceeded.into());
+        }
+        let maximum_encoded = maximum_plaintext_bytes
+            .checked_add(self.options.limits.max_protection_overhead_bytes())
+            .ok_or(SpoolInvariantError::ProtectionOverheadExceeded)?;
+        if protected_bytes > maximum_encoded
+            || protected_bytes > self.options.limits.max_encoded_object_bytes()
+        {
+            return Err(SpoolInvariantError::ProtectionOverheadExceeded.into());
+        }
+        let mut memory = self.memory.lock().map_err(|_| SpoolError::Poisoned)?;
+        if memory.poisoned {
+            return Err(SpoolError::Poisoned);
+        }
+        self.capacity_after(&memory, 1, protected_bytes)?;
+        let reserved_objects = memory
+            .reserved_objects
+            .checked_add(1)
+            .ok_or(SpoolError::CapacityExhausted)?;
+        let reserved_protected_bytes = memory
+            .reserved_protected_bytes
+            .checked_add(protected_bytes)
+            .ok_or(SpoolError::CapacityExhausted)?;
+        memory.reserved_objects = reserved_objects;
+        memory.reserved_protected_bytes = reserved_protected_bytes;
+        Ok(Box::new(FileEndpointResultReservation {
+            spool: self,
+            maximum_plaintext_bytes,
+            reserved_protected_bytes: protected_bytes,
+            active: true,
+        }))
+    }
+
     fn persist(
         &self,
         kind: ContentKind,
@@ -576,7 +1050,10 @@ impl DurableContentStore for FileSpool {
             .observer
             .observe(SpoolEvent::OperationStarted { operation });
         let result = (|| {
-            let reference = self.reference_for(kind, plaintext)?;
+            if kind == ContentKind::EndpointResult {
+                return Err(SpoolInvariantError::EndpointResultReservationRequired.into());
+            }
+            let reference = self.public_reference_for(kind, plaintext)?;
             let permit = self.publications.begin()?;
             let mut memory = self.memory.lock().map_err(|_| SpoolError::Poisoned)?;
             if memory.poisoned {
@@ -598,23 +1075,26 @@ impl DurableContentStore for FileSpool {
             let protected = protected?;
             let protected_bytes = u64::try_from(protected.len())
                 .map_err(|_| SpoolInvariantError::ProtectionOverheadExceeded)?;
-            let allowed = reference
-                .size()
-                .checked_add(self.options.limits.max_protection_overhead_bytes())
-                .is_some_and(|maximum| protected_bytes <= maximum)
-                && protected_bytes <= self.options.limits.max_encoded_object_bytes();
-            if !allowed {
-                return Err(SpoolInvariantError::ProtectionOverheadExceeded.into());
-            }
-            self.capacity_after(memory.usage, protected_bytes)?;
+            self.validate_protected_size(&reference, protected_bytes)?;
+            self.capacity_after(&memory, 1, protected_bytes)?;
+            let next_objects = memory
+                .usage
+                .objects
+                .checked_add(1)
+                .ok_or(SpoolError::CapacityExhausted)?;
+            let next_protected_bytes = memory
+                .usage
+                .protected_bytes
+                .checked_add(protected_bytes)
+                .ok_or(SpoolError::CapacityExhausted)?;
             match self.directory.commit(
                 &reference,
                 &protected,
                 self.options.fault_injector.as_ref(),
             ) {
                 Ok(()) => {
-                    memory.usage.objects += 1;
-                    memory.usage.protected_bytes += protected_bytes;
+                    memory.usage.objects = next_objects;
+                    memory.usage.protected_bytes = next_protected_bytes;
                     Ok(DurableContentPublication { reference, permit })
                 }
                 Err(failure) if failure.renamed() => {
@@ -665,7 +1145,11 @@ impl DurableContentStore for FileSpool {
             self.options.observer.observe(SpoolEvent::ContentBytes {
                 operation,
                 content_kind: reference.kind(),
-                bytes: u64::try_from(plaintext.len()).unwrap_or(u64::MAX),
+                bytes: if reference.kind() == ContentKind::EndpointResult {
+                    reference.accounted_bytes()
+                } else {
+                    u64::try_from(plaintext.len()).unwrap_or(u64::MAX)
+                },
             });
         }
         self.observe_completion(
@@ -699,6 +1183,16 @@ impl DurableContentStore for FileSpool {
             };
             self.open_and_verify(reference, &protected)?;
             let protected_bytes = u64::try_from(protected.len()).unwrap_or(u64::MAX);
+            let next_objects = memory
+                .usage
+                .objects
+                .checked_sub(1)
+                .ok_or(SpoolError::Poisoned)?;
+            let next_protected_bytes = memory
+                .usage
+                .protected_bytes
+                .checked_sub(protected_bytes)
+                .ok_or(SpoolError::Poisoned)?;
             match self.directory.remove(reference) {
                 Ok(false) => return Ok(false),
                 Ok(true) => {}
@@ -713,23 +1207,15 @@ impl DurableContentStore for FileSpool {
                 }
                 Err(failure) => return Err(failure.into_public()),
             }
-            memory.usage.objects = memory
-                .usage
-                .objects
-                .checked_sub(1)
-                .ok_or(SpoolError::Poisoned)?;
-            memory.usage.protected_bytes = memory
-                .usage
-                .protected_bytes
-                .checked_sub(protected_bytes)
-                .ok_or(SpoolError::Poisoned)?;
+            memory.usage.objects = next_objects;
+            memory.usage.protected_bytes = next_protected_bytes;
             Ok(true)
         })();
         if matches!(result, Ok(true)) {
             self.options.observer.observe(SpoolEvent::ContentBytes {
                 operation,
                 content_kind: reference.kind(),
-                bytes: reference.size(),
+                bytes: reference.accounted_bytes(),
             });
         }
         let successful_outcome = if matches!(result, Ok(false)) {
@@ -759,28 +1245,31 @@ impl DurableContentStore for FileSpool {
                 return Err(SpoolError::PublicationsInFlight);
             }
             let retained = retained.retained_content()?;
-            if retained.len()
-                > usize::try_from(self.options.limits.max_objects()).unwrap_or(usize::MAX)
-            {
-                self.options.observer.observe(SpoolEvent::CapacityRejected {
-                    resource: SpoolCapacityResource::ObjectCount,
-                });
-                return Err(SpoolError::CapacityExhausted);
-            }
+            let maximum_objects =
+                usize::try_from(self.options.limits.max_objects()).unwrap_or(usize::MAX);
             let mut memory = self.memory.lock().map_err(|_| SpoolError::Poisoned)?;
             if memory.poisoned {
                 return Err(SpoolError::Poisoned);
             }
             let previous = memory.usage;
-            let mut retained_names = HashSet::with_capacity(retained.len());
+            let mut retained_names = HashSet::with_capacity(retained.len().min(maximum_objects));
             for reference in retained {
                 reference.validate()?;
+                let retained_name = format!("{}.blob", reference.cache_key().as_str()).into_bytes();
+                if retained_names.contains(&retained_name) {
+                    continue;
+                }
+                if retained_names.len() >= maximum_objects {
+                    self.options.observer.observe(SpoolEvent::CapacityRejected {
+                        resource: SpoolCapacityResource::ObjectCount,
+                    });
+                    return Err(SpoolError::CapacityExhausted);
+                }
                 let protected = self
                     .load_protected(&reference)?
                     .ok_or(SpoolError::ContentMissing)?;
                 self.open_and_verify(&reference, &protected)?;
-                retained_names
-                    .insert(format!("{}.blob", reference.cache_key().as_str()).into_bytes());
+                retained_names.insert(retained_name);
             }
             match self
                 .directory
@@ -814,15 +1303,5 @@ impl DurableContentStore for FileSpool {
             &result,
         );
         result
-    }
-}
-
-fn verify_plaintext(reference: &DurableContentRef, plaintext: &[u8]) -> Result<(), SpoolError> {
-    let size = u64::try_from(plaintext.len()).unwrap_or(u64::MAX);
-    let digest = Sha256Digest::from_bytes(Sha256::digest(plaintext).into());
-    if size == reference.size() && digest == reference.sha256() {
-        Ok(())
-    } else {
-        Err(SpoolInvariantError::ContentMismatch.into())
     }
 }

--- a/crates/automata-ci-runner-spool/tests/key_rotation.rs
+++ b/crates/automata-ci-runner-spool/tests/key_rotation.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use automata_ci_core::Sha256Digest;
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, ContentProtector, DurableContentRef, DurableContentStore,
-    FileSpool, ProtectionId, SpoolError,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentRef, DurableContentStore, FileSpool, ProtectionId, SpoolError,
 };
 use sha2::{Digest as _, Sha256};
 use support::{Scratch, StaticRetainSet, TestProtector, adopt};
@@ -45,6 +45,24 @@ impl ContentProtector for TestKeyring {
         self.exact(protection_id).is_some()
     }
 
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        self.exact(protection_id)
+            .ok_or(ContentProtectionError::KeyUnavailable)?
+            .keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        self.active.endpoint_result_protected_bytes(plaintext_bytes)
+    }
+
     fn protect(
         &self,
         reference: &DurableContentRef,
@@ -69,7 +87,7 @@ fn keyring(active: (&str, u8), decrypt_only: &[(&str, u8)]) -> Arc<TestKeyring> 
 }
 
 fn reference(id: &str, plaintext: &[u8]) -> DurableContentRef {
-    DurableContentRef::after_commit(
+    DurableContentRef::after_public_commit(
         ContentKind::JobIr,
         u64::try_from(plaintext.len()).expect("fixture size"),
         Sha256Digest::from_bytes(Sha256::digest(plaintext).into()),

--- a/crates/automata-ci-runner-spool/tests/path_security.rs
+++ b/crates/automata-ci-runner-spool/tests/path_security.rs
@@ -77,7 +77,7 @@ fn roots_and_content_are_owner_only_and_symlinks_are_never_followed() {
     drop(spool);
 
     let digest = Sha256Digest::from_bytes(Sha256::digest(b"other content").into());
-    let malicious_ref = DurableContentRef::after_commit(
+    let malicious_ref = DurableContentRef::after_public_commit(
         ContentKind::JobIr,
         13,
         digest,

--- a/crates/automata-ci-runner-spool/tests/support/mod.rs
+++ b/crates/automata-ci-runner-spool/tests/support/mod.rs
@@ -7,8 +7,9 @@ use std::{
 
 use automata_ci_core::OperationId;
 use automata_ci_runner_spool::{
-    ContentProtectionError, ContentProtector, DurableContentPublication, DurableContentRef,
-    ProtectionId, RetainedContentError, RetainedContentSource, SpoolRoot,
+    ContentCommitmentDomain, ContentProtectionError, ContentProtector, DurableContentPublication,
+    DurableContentRef, ProtectionId, RetainedContentError, RetainedContentSource, SpoolRoot,
+    endpoint_result_allocation,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -65,6 +66,36 @@ impl TestProtector {
         digest.update(ciphertext);
         digest.finalize().into()
     }
+
+    fn protected_plaintext(
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        let Some(allocation) = reference.endpoint_result_allocation_bytes() else {
+            return Ok(plaintext.to_vec());
+        };
+        let inner_bytes = allocation
+            .checked_sub(32)
+            .and_then(|bytes| usize::try_from(bytes).ok())
+            .ok_or(ContentProtectionError::Failed)?;
+        let required = 44_usize
+            .checked_add(plaintext.len())
+            .ok_or(ContentProtectionError::Failed)?;
+        if required > inner_bytes {
+            return Err(ContentProtectionError::Failed);
+        }
+        let mut inner = Vec::with_capacity(inner_bytes);
+        inner.extend_from_slice(b"EPR1");
+        inner.extend_from_slice(
+            &u64::try_from(plaintext.len())
+                .map_err(|_| ContentProtectionError::Failed)?
+                .to_be_bytes(),
+        );
+        inner.extend_from_slice(&Sha256::digest(plaintext));
+        inner.extend_from_slice(plaintext);
+        inner.resize(inner_bytes, 0);
+        Ok(inner)
+    }
 }
 
 impl fmt::Debug for TestProtector {
@@ -82,20 +113,43 @@ impl ContentProtector for TestProtector {
         &self.id
     }
 
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        if protection_id != &self.id {
+            return Err(ContentProtectionError::KeyUnavailable);
+        }
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(domain.separator());
+        digest.update(material_digest);
+        Ok(digest.finalize().into())
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        endpoint_result_allocation(plaintext_bytes).map_err(|_| ContentProtectionError::Failed)
+    }
+
     fn protect(
         &self,
         reference: &DurableContentRef,
         plaintext: &[u8],
     ) -> Result<Vec<u8>, ContentProtectionError> {
-        let mut protected = Vec::with_capacity(plaintext.len() + 36);
-        protected.extend_from_slice(b"ATP1");
+        let inner = Self::protected_plaintext(reference, plaintext)?;
+        let mut protected = Vec::with_capacity(inner.len() + 32);
         protected.extend(
-            plaintext
+            inner
                 .iter()
                 .enumerate()
                 .map(|(index, byte)| byte ^ self.key[index % self.key.len()]),
         );
-        let tag = self.tag(reference, &protected[4..]);
+        let tag = self.tag(reference, &protected);
         protected.extend_from_slice(&tag);
         Ok(protected)
     }
@@ -105,19 +159,44 @@ impl ContentProtector for TestProtector {
         reference: &DurableContentRef,
         protected: &[u8],
     ) -> Result<Vec<u8>, ContentProtectionError> {
-        if protected.len() < 36 || &protected[..4] != b"ATP1" {
+        if protected.len() < 32 {
             return Err(ContentProtectionError::AuthenticationFailed);
         }
         let tag_offset = protected.len() - 32;
-        let ciphertext = &protected[4..tag_offset];
+        let ciphertext = &protected[..tag_offset];
         if protected[tag_offset..] != self.tag(reference, ciphertext) {
             return Err(ContentProtectionError::AuthenticationFailed);
         }
-        Ok(ciphertext
+        let inner: Vec<u8> = ciphertext
             .iter()
             .enumerate()
             .map(|(index, byte)| byte ^ self.key[index % self.key.len()])
-            .collect())
+            .collect();
+        if reference.kind() != automata_ci_runner_spool::ContentKind::EndpointResult {
+            return Ok(inner);
+        }
+        if inner.len() < 44 || &inner[..4] != b"EPR1" {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        let plaintext_bytes = u64::from_be_bytes(
+            inner[4..12]
+                .try_into()
+                .map_err(|_| ContentProtectionError::AuthenticationFailed)?,
+        );
+        let plaintext_length = usize::try_from(plaintext_bytes)
+            .map_err(|_| ContentProtectionError::AuthenticationFailed)?;
+        let end = 44_usize
+            .checked_add(plaintext_length)
+            .filter(|end| *end <= inner.len())
+            .ok_or(ContentProtectionError::AuthenticationFailed)?;
+        if inner[end..].iter().any(|byte| *byte != 0) {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        let plaintext = inner[44..end].to_vec();
+        if Sha256::digest(&plaintext).as_slice() != &inner[12..44] {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        Ok(plaintext)
     }
 }
 

--- a/crates/automata-ci-runner/Cargo.toml
+++ b/crates/automata-ci-runner/Cargo.toml
@@ -63,6 +63,7 @@ rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util"] }
 tokio-util.workspace = true

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -239,6 +239,7 @@ const fn journal_domain_label(domain: JournalMutationDomain) -> &'static str {
         JournalMutationDomain::Lifecycle => "lifecycle",
         JournalMutationDomain::Result => "result",
         JournalMutationDomain::Provider => "provider",
+        JournalMutationDomain::Endpoint => "endpoint",
         JournalMutationDomain::Outbound => "outbound",
         JournalMutationDomain::Log => "log",
         JournalMutationDomain::Orphan => "orphan",
@@ -1876,6 +1877,8 @@ const fn content_kind_label(value: ContentKind) -> &'static str {
         ContentKind::RuntimeAuthority => "runtime_authority",
         ContentKind::TerminalResult => "terminal_result",
         ContentKind::LogSpool => "log_spool",
+        ContentKind::EndpointRequest => "endpoint_request",
+        ContentKind::EndpointResult => "endpoint_result",
     }
 }
 
@@ -1898,6 +1901,7 @@ const fn spool_failure_label(value: SpoolFailureKind) -> &'static str {
 
 const fn protection_operation_label(value: SpoolProtectionOperation) -> &'static str {
     match value {
+        SpoolProtectionOperation::Commitment => "commitment",
         SpoolProtectionOperation::Protect => "protect",
         SpoolProtectionOperation::Unprotect => "unprotect",
     }

--- a/crates/automata-ci-runner/src/product/spool_crypto/aes_gcm.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/aes_gcm.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, ContentProtector, DurableContentRef,
-    MAX_CONTENT_OBJECT_BYTES, ProtectionId,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentRef, MAX_CONTENT_OBJECT_BYTES, ProtectionId, endpoint_result_allocation,
 };
 use ring::{
     aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey},
+    hmac,
     rand::{SecureRandom as _, SystemRandom},
 };
 use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
 use zeroize::Zeroizing;
 
 use super::error::ContentProtectorConfigurationError;
@@ -17,9 +19,13 @@ use super::error::ContentProtectorConfigurationError;
 pub(in crate::product) const AES_256_GCM_KEY_BYTES: usize = 32;
 const NONCE_BYTES: usize = 12;
 const TAG_BYTES: usize = 16;
-const HEADER: &[u8; 4] = b"ASP1";
+const HEADER: &[u8; 4] = b"ASP2";
 const ENCODED_OVERHEAD: usize = HEADER.len() + NONCE_BYTES + TAG_BYTES;
-const AAD_DOMAIN: &[u8] = b"automata.runner.spool.aes256gcm.v1\0";
+const ENDPOINT_RESULT_ENVELOPE_HEADER: &[u8; 4] = b"EPR1";
+const ENDPOINT_RESULT_ENVELOPE_BYTES: usize = ENDPOINT_RESULT_ENVELOPE_HEADER.len() + 8 + 32;
+const ENDPOINT_RESULT_MATERIAL_DOMAIN: &[u8] = b"automata.runner.endpoint-result.material.v1\0";
+const AAD_DOMAIN: &[u8] = b"automata.runner.spool.aes256gcm.v2\0";
+const COMMITMENT_KEY_DOMAIN: &[u8] = b"automata.runner.spool.commitment-key.v1\0";
 
 /// AES-256-GCM implementation of the runner spool protection boundary.
 ///
@@ -29,6 +35,7 @@ const AAD_DOMAIN: &[u8] = b"automata.runner.spool.aes256gcm.v1\0";
 pub(in crate::product) struct Aes256GcmContentProtector {
     id: ProtectionId,
     key: LessSafeKey,
+    commitment_key: hmac::Key,
     random: SystemRandom,
 }
 
@@ -53,6 +60,9 @@ impl Aes256GcmContentProtector {
         if key_material.len() != AES_256_GCM_KEY_BYTES {
             return Err(ContentProtectorConfigurationError::InvalidKeyLength);
         }
+        let root_key = hmac::Key::new(hmac::HMAC_SHA256, &key_material);
+        let derived = hmac::sign(&root_key, COMMITMENT_KEY_DOMAIN);
+        let commitment_key = hmac::Key::new(hmac::HMAC_SHA256, derived.as_ref());
         let key = UnboundKey::new(&AES_256_GCM, &key_material)
             .map(LessSafeKey::new)
             .map_err(|_| ContentProtectorConfigurationError::InvalidKey)?;
@@ -60,12 +70,21 @@ impl Aes256GcmContentProtector {
         Ok(Self {
             id,
             key,
+            commitment_key,
             random: SystemRandom::new(),
         })
     }
 
     fn matching_reference(&self, reference: &DurableContentRef) -> bool {
-        reference.protection_id() == &self.id && reference.size() <= MAX_CONTENT_OBJECT_BYTES
+        reference.protection_id() == &self.id
+            && match (
+                reference.public_plaintext_bytes(),
+                reference.endpoint_result_allocation_bytes(),
+            ) {
+                (Some(bytes), None) => bytes <= MAX_CONTENT_OBJECT_BYTES,
+                (None, Some(bytes)) => bytes > 0,
+                _ => false,
+            }
     }
 
     fn associated_data(reference: &DurableContentRef) -> Vec<u8> {
@@ -80,9 +99,27 @@ impl Aes256GcmContentProtector {
             ContentKind::TerminalResult => 2,
             ContentKind::LogSpool => 3,
             ContentKind::RuntimeAuthority => 4,
+            ContentKind::EndpointRequest => 5,
+            ContentKind::EndpointResult => 6,
         });
-        data.extend_from_slice(&reference.size().to_be_bytes());
-        data.extend_from_slice(reference.sha256().as_bytes());
+        match (
+            reference.public_plaintext_bytes(),
+            reference.public_plaintext_sha256(),
+            reference.endpoint_result_allocation_bytes(),
+            reference.endpoint_result_identity(),
+        ) {
+            (Some(bytes), Some(digest), None, None) => {
+                data.push(1);
+                data.extend_from_slice(&bytes.to_be_bytes());
+                data.extend_from_slice(digest.as_bytes());
+            }
+            (None, None, Some(allocation), Some(identity)) => {
+                data.push(2);
+                data.extend_from_slice(&allocation.to_be_bytes());
+                data.extend_from_slice(identity.as_bytes());
+            }
+            _ => unreachable!("validated durable content identities are kind coherent"),
+        }
         let cache_length =
             u16::try_from(cache_key.len()).expect("cache keys are bounded below u16");
         data.extend_from_slice(&cache_length.to_be_bytes());
@@ -94,9 +131,120 @@ impl Aes256GcmContentProtector {
         data
     }
 
-    fn plaintext_matches(reference: &DurableContentRef, plaintext: &[u8]) -> bool {
-        u64::try_from(plaintext.len()) == Ok(reference.size())
-            && Sha256::digest(plaintext).as_slice() == reference.sha256().as_bytes()
+    fn endpoint_result_material_digest(
+        plaintext: &[u8],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        let plaintext_bytes =
+            u64::try_from(plaintext.len()).map_err(|_| ContentProtectionError::Failed)?;
+        let plaintext_sha256: [u8; 32] = Sha256::digest(plaintext).into();
+        let mut material = Sha256::new();
+        material.update(ENDPOINT_RESULT_MATERIAL_DOMAIN);
+        material.update(plaintext_bytes.to_be_bytes());
+        material.update(plaintext_sha256);
+        Ok(material.finalize().into())
+    }
+
+    fn plaintext_matches(
+        &self,
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<bool, ContentProtectionError> {
+        if let (Some(bytes), Some(digest)) = (
+            reference.public_plaintext_bytes(),
+            reference.public_plaintext_sha256(),
+        ) {
+            return Ok(u64::try_from(plaintext.len()) == Ok(bytes)
+                && Sha256::digest(plaintext).as_slice() == digest.as_bytes());
+        }
+        let plaintext_bytes =
+            u64::try_from(plaintext.len()).map_err(|_| ContentProtectionError::Failed)?;
+        let allocation = endpoint_result_allocation(plaintext_bytes)
+            .map_err(|_| ContentProtectionError::Failed)?;
+        if reference.endpoint_result_allocation_bytes() != Some(allocation) {
+            return Ok(false);
+        }
+        let material = Self::endpoint_result_material_digest(plaintext)?;
+        let expected = self.keyed_commitment(
+            &self.id,
+            ContentCommitmentDomain::EndpointResultIdentity,
+            &material,
+        )?;
+        let Some(actual) = reference.endpoint_result_identity() else {
+            return Ok(false);
+        };
+        Ok(bool::from(expected.ct_eq(actual.as_bytes())))
+    }
+
+    fn protected_plaintext(
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        if reference.kind() != ContentKind::EndpointResult {
+            return Ok(plaintext.to_vec());
+        }
+        let allocation = reference
+            .endpoint_result_allocation_bytes()
+            .ok_or(ContentProtectionError::Failed)?;
+        let protected_plaintext_bytes = allocation
+            .checked_sub(u64::try_from(ENCODED_OVERHEAD).expect("fixed overhead fits u64"))
+            .and_then(|bytes| usize::try_from(bytes).ok())
+            .ok_or(ContentProtectionError::Failed)?;
+        let required = ENDPOINT_RESULT_ENVELOPE_BYTES
+            .checked_add(plaintext.len())
+            .ok_or(ContentProtectionError::Failed)?;
+        if required > protected_plaintext_bytes {
+            return Err(ContentProtectionError::Failed);
+        }
+        let mut enveloped = Vec::with_capacity(protected_plaintext_bytes);
+        enveloped.extend_from_slice(ENDPOINT_RESULT_ENVELOPE_HEADER);
+        enveloped.extend_from_slice(
+            &u64::try_from(plaintext.len())
+                .map_err(|_| ContentProtectionError::Failed)?
+                .to_be_bytes(),
+        );
+        enveloped.extend_from_slice(&Sha256::digest(plaintext));
+        enveloped.extend_from_slice(plaintext);
+        enveloped.resize(protected_plaintext_bytes, 0);
+        Ok(enveloped)
+    }
+
+    fn open_endpoint_result(
+        &self,
+        reference: &DurableContentRef,
+        enveloped: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        if enveloped.len() < ENDPOINT_RESULT_ENVELOPE_BYTES
+            || &enveloped[..ENDPOINT_RESULT_ENVELOPE_HEADER.len()]
+                != ENDPOINT_RESULT_ENVELOPE_HEADER
+        {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        let length_offset = ENDPOINT_RESULT_ENVELOPE_HEADER.len();
+        let digest_offset = length_offset + 8;
+        let payload_offset = digest_offset + 32;
+        let plaintext_bytes = u64::from_be_bytes(
+            enveloped[length_offset..digest_offset]
+                .try_into()
+                .map_err(|_| ContentProtectionError::AuthenticationFailed)?,
+        );
+        let plaintext_length = usize::try_from(plaintext_bytes)
+            .map_err(|_| ContentProtectionError::AuthenticationFailed)?;
+        let payload_end = payload_offset
+            .checked_add(plaintext_length)
+            .filter(|end| *end <= enveloped.len())
+            .ok_or(ContentProtectionError::AuthenticationFailed)?;
+        if enveloped[payload_end..].iter().any(|byte| *byte != 0) {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        let plaintext = enveloped[payload_offset..payload_end].to_vec();
+        if Sha256::digest(&plaintext).as_slice() != &enveloped[digest_offset..payload_offset]
+            || !self
+                .plaintext_matches(reference, &plaintext)
+                .map_err(|_| ContentProtectionError::AuthenticationFailed)?
+        {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        Ok(plaintext)
     }
 }
 
@@ -116,6 +264,32 @@ impl ContentProtector for Aes256GcmContentProtector {
         &self.id
     }
 
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        if protection_id != &self.id {
+            return Err(ContentProtectionError::KeyUnavailable);
+        }
+        let mut context = hmac::Context::with_key(&self.commitment_key);
+        context.update(domain.separator());
+        context.update(material_digest);
+        let signature = context.sign();
+        signature
+            .as_ref()
+            .try_into()
+            .map_err(|_| ContentProtectionError::Failed)
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        endpoint_result_allocation(plaintext_bytes).map_err(|_| ContentProtectionError::Failed)
+    }
+
     fn protect(
         &self,
         reference: &DurableContentRef,
@@ -124,10 +298,11 @@ impl ContentProtector for Aes256GcmContentProtector {
         if !self.matching_reference(reference) {
             return Err(ContentProtectionError::KeyUnavailable);
         }
-        if !Self::plaintext_matches(reference, plaintext) {
+        if !self.plaintext_matches(reference, plaintext)? {
             return Err(ContentProtectionError::Failed);
         }
-        let capacity = plaintext
+        let mut ciphertext = Self::protected_plaintext(reference, plaintext)?;
+        let capacity = ciphertext
             .len()
             .checked_add(ENCODED_OVERHEAD)
             .ok_or(ContentProtectionError::Failed)?;
@@ -136,7 +311,6 @@ impl ContentProtector for Aes256GcmContentProtector {
             .fill(&mut nonce_bytes)
             .map_err(|_| ContentProtectionError::Failed)?;
         let nonce = Nonce::assume_unique_for_key(nonce_bytes);
-        let mut ciphertext = plaintext.to_vec();
         self.key
             .seal_in_place_append_tag(
                 nonce,
@@ -159,13 +333,18 @@ impl ContentProtector for Aes256GcmContentProtector {
         if !self.matching_reference(reference) {
             return Err(ContentProtectionError::KeyUnavailable);
         }
-        let expected_length = reference
-            .size()
-            .checked_add(
-                u64::try_from(ENCODED_OVERHEAD)
-                    .expect("the fixed protection overhead always fits u64"),
-            )
-            .ok_or(ContentProtectionError::AuthenticationFailed)?;
+        let expected_length = match reference.endpoint_result_allocation_bytes() {
+            Some(allocation) => allocation,
+            None => reference
+                .public_plaintext_bytes()
+                .and_then(|bytes| {
+                    bytes.checked_add(
+                        u64::try_from(ENCODED_OVERHEAD)
+                            .expect("the fixed protection overhead always fits u64"),
+                    )
+                })
+                .ok_or(ContentProtectionError::AuthenticationFailed)?,
+        };
         if u64::try_from(protected.len()) != Ok(expected_length)
             || &protected[..HEADER.len()] != HEADER
         {
@@ -184,9 +363,15 @@ impl ContentProtector for Aes256GcmContentProtector {
                 &mut ciphertext,
             )
             .map_err(|_| ContentProtectionError::AuthenticationFailed)?;
-        let plaintext_length = plaintext.len();
-        ciphertext.truncate(plaintext_length);
-        if !Self::plaintext_matches(reference, &ciphertext) {
+        let opened_length = plaintext.len();
+        ciphertext.truncate(opened_length);
+        if reference.kind() == ContentKind::EndpointResult {
+            return self.open_endpoint_result(reference, &ciphertext);
+        }
+        if !self
+            .plaintext_matches(reference, &ciphertext)
+            .map_err(|_| ContentProtectionError::AuthenticationFailed)?
+        {
             return Err(ContentProtectionError::AuthenticationFailed);
         }
         Ok(ciphertext)

--- a/crates/automata-ci-runner/src/product/spool_crypto/keyring.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/keyring.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, fmt};
 
 use automata_ci_runner_spool::{
-    ContentProtectionError, ContentProtector, DurableContentRef, ProtectionId,
+    ContentCommitmentDomain, ContentProtectionError, ContentProtector, DurableContentRef,
+    ProtectionId,
 };
 
 use super::{aes_gcm::Aes256GcmContentProtector, error::ContentProtectorConfigurationError};
@@ -95,6 +96,23 @@ impl ContentProtector for Aes256GcmContentKeyring {
     fn supports_protection_id(&self, protection_id: &ProtectionId) -> bool {
         protection_id == self.active.protection_id()
             || self.decrypt_only.contains_key(protection_id)
+    }
+
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        self.protector_for(protection_id)?
+            .keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        self.active.endpoint_result_protected_bytes(plaintext_bytes)
     }
 
     fn protect(

--- a/crates/automata-ci-runner/src/product/spool_crypto/tests/aes_gcm.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/tests/aes_gcm.rs
@@ -13,7 +13,7 @@ fn make_protector(id: &str, marker: u8) -> Aes256GcmContentProtector {
 }
 
 fn make_reference(id: &str, kind: ContentKind, plaintext: &[u8]) -> DurableContentRef {
-    DurableContentRef::after_commit(
+    DurableContentRef::after_public_commit(
         kind,
         u64::try_from(plaintext.len()).expect("fixture size"),
         Sha256Digest::from_bytes(Sha256::digest(plaintext).into()),
@@ -34,7 +34,7 @@ fn round_trips_with_fresh_nonces_and_no_plaintext_debug() {
         .expect("protect again");
     assert_ne!(first, second, "each object protection uses a fresh nonce");
     assert_eq!(first.len(), plaintext.len() + 32);
-    assert_eq!(&first[..4], b"ASP1");
+    assert_eq!(&first[..4], b"ASP2");
     assert!(
         !first
             .windows(plaintext.len())
@@ -49,32 +49,6 @@ fn round_trips_with_fresh_nonces_and_no_plaintext_debug() {
     let debug = format!("{protector:?}");
     assert!(debug.contains("REDACTED"));
     assert!(!debug.contains("424242"));
-}
-
-#[test]
-fn decrypts_fixed_legacy_asp1_ciphertext() {
-    // Models the former standalone adapter's ASP1 output for nonce
-    // 000102030405060708090a0b. The vector was independently generated with
-    // Python cryptography and cross-checked with Node/OpenSSL AES-GCM.
-    const LEGACY_PROTECTED: [u8; 79] = [
-        0x41, 0x53, 0x50, 0x31, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-        0x0b, 0x77, 0xab, 0xff, 0xb3, 0xd4, 0x5e, 0xd2, 0x79, 0xf8, 0x65, 0x2b, 0x65, 0xb4, 0xaf,
-        0x22, 0x1b, 0x42, 0xfc, 0xb7, 0x06, 0xcf, 0x28, 0x86, 0xc9, 0x64, 0xf0, 0x54, 0x4f, 0xba,
-        0x67, 0xd8, 0x91, 0x27, 0xd2, 0xfd, 0xcb, 0x07, 0x55, 0x02, 0x94, 0x8b, 0x01, 0x63, 0x61,
-        0x66, 0xe0, 0xb9, 0xb0, 0x6e, 0x74, 0x03, 0x51, 0x5f, 0x1f, 0xa4, 0x1a, 0x22, 0x11, 0xc7,
-        0x47, 0x95, 0x18, 0xb6,
-    ];
-
-    let plaintext = b"runner recovery payload with sensitive material";
-    let reference = make_reference("key-2026-08", ContentKind::JobIr, plaintext);
-    let protector = make_protector("key-2026-08", 0x42);
-
-    assert_eq!(
-        protector
-            .unprotect(&reference, &LEGACY_PROTECTED)
-            .expect("legacy ciphertext authenticates"),
-        plaintext
-    );
 }
 
 #[test]

--- a/crates/automata-ci-runner/src/product/spool_crypto/tests/keyring.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/tests/keyring.rs
@@ -16,7 +16,7 @@ fn protector(id: &str, marker: u8) -> Aes256GcmContentProtector {
 }
 
 fn reference(id: &str, plaintext: &[u8]) -> DurableContentRef {
-    DurableContentRef::after_commit(
+    DurableContentRef::after_public_commit(
         ContentKind::RuntimeAuthority,
         u64::try_from(plaintext.len()).expect("fixture size"),
         Sha256Digest::from_bytes(Sha256::digest(plaintext).into()),


### PR DESCRIPTION
## Outcome

Makes runner endpoint operations crash-safe across the journal, protected spool, runtime, and GitHub executor boundary.

Each endpoint call is accepted durably before invocation, commits its exact request identity, and publishes its result payload-first into protected storage before the journal points at it. Cancellation and result publication are first-writer transitions. The supervisor and orphan paths refuse terminalization or slot release while endpoint recovery is pending.

A committed invocation with an ambiguous outcome always fails closed until the exact sandbox is destroyed and proven absent. No provider advertises speculative restart-safe replay, and this PR deliberately contains no guest-v5 or LocalDocker behavior.

This is the production half of the durable-host-replay stack split from draft #173. A separate tests-only PR carries the large adversarial crash/recovery matrix.

## Related issue

Related to #173. Depends conceptually on the custody boundary merged in #363.

## Trust and compatibility impact

The runner journal and protected-spool schemas advance as current-only contracts; older shapes are rejected rather than migrated or aliased. Endpoint request commitments and result references expose only protection-keyed opaque identities and protected allocation classes. Capacity is reserved before provider invocation and reconciled over unique physical objects.

Only `MAX_ENDPOINT_OPERATIONS_PER_JOB` remains public. Component capacity constants and journal internals are crate-private. Synthetically deserialized advanced endpoint phases cannot enter through public acceptance. `InvocationCommitted` recovery is unconditionally fail-closed until exact sandbox absence.

There is no guest protocol, LocalDocker, credential, or GitHub Actions syntax change in this PR.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- strict Clippy with `-D warnings` across the affected execution, journal, spool, runtime, executor, and runner crates
- focused journal, protected-spool, runner-runtime, executor, and runner tests
- Windows MSVC strict Clippy for the changed spool library
- broader Windows journal/runtime cross-check attempted; host lacks MSVC `lib.exe` while the directly changed Windows spool boundary passes
- exact one-to-one range-diffs across custody and current-main rebases
- independent strict semantic review and re-review: CLEAN

## AI assistance

OpenAI Codex helped extract the consumed production cycle from the larger draft, remove unconsumed replay capability branches, run validation, and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
