### PR TITLE
fix(ci): bound exact results acceptance explicitly

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
           cargo test --locked -p automata-ci-results-github --test cache_http --all-features -- --ignored --test-threads=1
 
       - name: Run exact clients across PostgreSQL and production object storage
+        timeout-minutes: 10
         run: >-
           cargo test --locked -p automata-ci-results-github --test exact_client_real_store
           --all-features exact_clients_cross_real_http_postgres_and_object_storage


### PR DESCRIPTION
## Summary

- give the real PostgreSQL/object-store Results acceptance step an explicit 10-minute timeout
- retain the runner’s fast 60-second default for ordinary steps
- keep the enclosing job bounded at 60 minutes

The current main run proved this step was cancelled at exactly the default 60-second boundary rather than failing an assertion.

## Validation

- `target/ci-tools/actionlint .ci/workflows/*.yml`
- `cargo test --locked -p automata-ci-workflow-github --test workflow_github --all-features logical -- --nocapture` (14 passed)
- `git diff --check`