### PR TITLE
test(runner): verify durable endpoint recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,8 +939,10 @@ name = "automata-ci-runner-spool"
 version = "0.1.0"
 dependencies = [
  "automata-ci-core",
+ "automata-ci-execution",
  "rustix",
  "serde",
+ "serde_json",
  "sha2 0.11.0",
  "static_assertions",
  "subtle",

--- a/crates/automata-ci-runner-journal/tests/corrupt_data.rs
+++ b/crates/automata-ci-runner-journal/tests/corrupt_data.rs
@@ -129,6 +129,29 @@ fn previous_schema_is_rejected_without_rewrite() {
 }
 
 #[test]
+fn current_schema_requires_endpoint_operation_collection() {
+    let scratch = Scratch::new("missing-endpoint-operations");
+    let fixture = Fixture::new();
+    let root = scratch.state_root();
+    let journal = fixture.open(&scratch);
+    journal.begin_session(fixture.binding()).expect("session");
+    journal
+        .record_lease_offer(fixture.session_id, fixture.offer(1))
+        .expect("offer");
+    drop(journal);
+
+    let path = journal_file(root.as_path());
+    let current = fs::read_to_string(&path).expect("current journal");
+    let missing = current.replacen("\"endpoint_operations\":[],", "", 1);
+    assert_ne!(missing, current, "endpoint collection fixture must apply");
+    fs::write(path, missing).expect("write missing endpoint collection");
+    assert!(matches!(
+        FileJournal::open(root, fixture.runner_id),
+        Err(JournalError::Corrupt)
+    ));
+}
+
+#[test]
 fn current_schema_requires_segment_collection_metadata() {
     let scratch = Scratch::new("missing-log-segments");
     let fixture = Fixture::new();

--- a/crates/automata-ci-runner-journal/tests/endpoint_operations.rs
+++ b/crates/automata-ci-runner-journal/tests/endpoint_operations.rs
@@ -1,0 +1,1127 @@
+use std::{fs, path::Path, sync::Arc};
+
+use automata_ci_core::{JobLifecycle, LeaseGuard, OperationId, UnixMillis};
+use automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB;
+use automata_ci_runner_journal::{
+    CancellationRecord, CommitFault, CommitFaultInjector, CommitStage, ContentKind,
+    EndpointOperation, EndpointOperationKind, EndpointOperationState, EndpointRequestContentRef,
+    EndpointResultContentRef, FileJournal, FileJournalOptions, JournalError, JournalInvariantError,
+    JournalSnapshot, MAX_JOURNAL_BYTES, ProviderName, ProviderOperation, ProviderOperationKind,
+    RunnerJournal, SandboxHandle, SandboxIdentity,
+};
+use automata_ci_runner_spool::endpoint_result_allocation;
+
+use crate::support::{Fixture, Scratch, record_and_ack_runtime_authority, record_and_ack_terminal};
+
+const ENDPOINT_REQUEST_COMMITMENT_BYTES: u64 = 32;
+const MAX_ENDPOINT_RESULT_CONTENT_BYTES: u64 = 17 * 1024 * 1024;
+const MIN_ENDPOINT_RESULT_ALLOCATION_BYTES: u64 = endpoint_result_allocation_or_panic(1);
+const MAX_ENDPOINT_RESULT_ALLOCATION_BYTES: u64 =
+    endpoint_result_allocation_or_panic(MAX_ENDPOINT_RESULT_CONTENT_BYTES);
+const MAX_ENDPOINT_CONTENT_REFS_PER_SLOT: usize = MAX_ENDPOINT_OPERATIONS_PER_JOB * 2;
+const MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT: u64 = ENDPOINT_REQUEST_COMMITMENT_BYTES
+    * MAX_ENDPOINT_OPERATIONS_PER_JOB as u64
+    + MIN_ENDPOINT_RESULT_ALLOCATION_BYTES * (MAX_ENDPOINT_OPERATIONS_PER_JOB as u64 - 1)
+    + MAX_ENDPOINT_RESULT_ALLOCATION_BYTES;
+
+const fn endpoint_result_allocation_or_panic(plaintext_bytes: u64) -> u64 {
+    match endpoint_result_allocation(plaintext_bytes) {
+        Ok(bytes) => bytes,
+        Err(_) => panic!("endpoint result bound must fit the protected spool"),
+    }
+}
+
+fn accepted_operation(
+    operation_id: OperationId,
+    kind: EndpointOperationKind,
+    marker: u8,
+    reservation: u64,
+) -> EndpointOperation {
+    EndpointOperation::accepted(
+        operation_id,
+        kind,
+        EndpointRequestContentRef::new(Fixture::content(ContentKind::EndpointRequest, 32, marker))
+            .expect("valid request commitment"),
+        reservation,
+    )
+    .expect("valid accepted operation")
+}
+
+fn accepted_operation_with_protection_id(
+    operation_id: OperationId,
+    kind: EndpointOperationKind,
+    marker: u8,
+    reservation: u64,
+    protection_id: &str,
+) -> EndpointOperation {
+    EndpointOperation::accepted(
+        operation_id,
+        kind,
+        EndpointRequestContentRef::new(Fixture::content_with_protection_id(
+            ContentKind::EndpointRequest,
+            32,
+            marker,
+            protection_id,
+        ))
+        .expect("valid request commitment"),
+        reservation,
+    )
+    .expect("valid accepted operation")
+}
+
+fn result(marker: u8, size: u64) -> EndpointResultContentRef {
+    EndpointResultContentRef::new(Fixture::content(ContentKind::EndpointResult, size, marker))
+        .expect("valid endpoint result")
+}
+
+fn result_with_protection_id(
+    marker: u8,
+    size: u64,
+    protection_id: &str,
+) -> EndpointResultContentRef {
+    EndpointResultContentRef::new(Fixture::content_with_protection_id(
+        ContentKind::EndpointResult,
+        size,
+        marker,
+        protection_id,
+    ))
+    .expect("valid endpoint result")
+}
+
+fn accepted_journal(label: &str) -> (Scratch, Fixture, FileJournal) {
+    let scratch = Scratch::new(label);
+    let fixture = Fixture::new();
+    let journal = fixture.open(&scratch);
+    journal
+        .begin_session(fixture.binding())
+        .expect("begin session");
+    journal
+        .record_lease_offer(fixture.session_id, fixture.offer(1))
+        .expect("record offer");
+    journal
+        .accept_lease(fixture.session_id, fixture.slot, fixture.lease.guard())
+        .expect("accept offer");
+    (scratch, fixture, journal)
+}
+
+fn accepted_journal_with_sandbox(label: &str) -> (Scratch, Fixture, FileJournal) {
+    let (scratch, fixture, journal) = accepted_journal(label);
+    let guard = fixture.lease.guard();
+    record_and_ack_runtime_authority(&journal, &fixture);
+    journal
+        .transition_lifecycle(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Preparing,
+        )
+        .expect("prepare");
+    let create = OperationId::new();
+    journal
+        .record_provider_intent(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            ProviderOperation::intent(create, ProviderOperationKind::CreateSandbox),
+        )
+        .expect("create intent");
+    journal
+        .record_sandbox_created(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            create,
+            SandboxIdentity::new(
+                ProviderName::new("test-provider").expect("provider"),
+                SandboxHandle::new("generation-7").expect("handle"),
+            ),
+        )
+        .expect("sandbox identity");
+    (scratch, fixture, journal)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FailAt(CommitStage);
+
+impl CommitFaultInjector for FailAt {
+    fn check(&self, stage: CommitStage) -> Result<(), CommitFault> {
+        if stage == self.0 {
+            Err(CommitFault)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn faulting_journal(scratch: &Scratch, fixture: &Fixture, stage: CommitStage) -> FileJournal {
+    FileJournal::open_with_options(
+        scratch.state_root(),
+        fixture.runner_id,
+        FileJournalOptions::new().with_fault_injector(Arc::new(FailAt(stage))),
+    )
+    .expect("open faulting journal")
+}
+
+#[derive(Clone, Copy, Debug)]
+enum EndpointTransition {
+    Accept,
+    CommitInvocation,
+    Cancel,
+    CompleteCancellation,
+    Abandon,
+    Result,
+}
+
+fn apply_transition(
+    journal: &FileJournal,
+    fixture: &Fixture,
+    guard: LeaseGuard,
+    transition: EndpointTransition,
+    operation: EndpointOperation,
+) -> Result<JournalSnapshot, JournalError> {
+    let operation_id = operation.operation_id();
+    match transition {
+        EndpointTransition::Accept => {
+            journal.accept_endpoint_operation(fixture.session_id, fixture.slot, guard, operation)
+        }
+        EndpointTransition::CommitInvocation => journal.commit_endpoint_invocation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+        ),
+        EndpointTransition::Cancel => journal.record_endpoint_cancellation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+        ),
+        EndpointTransition::CompleteCancellation => journal.complete_endpoint_cancellation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+        ),
+        EndpointTransition::Abandon => journal.abandon_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+        ),
+        EndpointTransition::Result => journal.record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+            result(0x71, 64),
+        ),
+    }
+}
+
+fn seed_transition_predecessor(
+    journal: &FileJournal,
+    fixture: &Fixture,
+    transition: EndpointTransition,
+    operation: &EndpointOperation,
+) {
+    let guard = fixture.lease.guard();
+    let operation_id = operation.operation_id();
+    if !matches!(transition, EndpointTransition::Accept) {
+        journal
+            .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, operation.clone())
+            .expect("seed accepted operation");
+    }
+    if matches!(
+        transition,
+        EndpointTransition::Cancel
+            | EndpointTransition::CompleteCancellation
+            | EndpointTransition::Abandon
+            | EndpointTransition::Result
+    ) {
+        journal
+            .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+            .expect("seed invocation commitment");
+    }
+    if matches!(transition, EndpointTransition::CompleteCancellation) {
+        journal
+            .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, operation_id)
+            .expect("seed cancellation request");
+    }
+}
+
+fn assert_recovered_transition_state(
+    transition: EndpointTransition,
+    applied: bool,
+    recovered: &EndpointOperation,
+) {
+    let expected = match (transition, applied) {
+        (EndpointTransition::Accept, _) | (EndpointTransition::CommitInvocation, false) => {
+            EndpointOperationState::Accepted
+        }
+        (EndpointTransition::CommitInvocation, true) | (EndpointTransition::Abandon, false) => {
+            EndpointOperationState::InvocationCommitted
+        }
+        (EndpointTransition::Cancel, true) | (EndpointTransition::CompleteCancellation, false) => {
+            EndpointOperationState::CancellationRequested
+        }
+        (EndpointTransition::Cancel, false) => EndpointOperationState::InvocationCommitted,
+        (EndpointTransition::CompleteCancellation, true) => EndpointOperationState::Cancelled,
+        (EndpointTransition::Abandon, true) => EndpointOperationState::Abandoned,
+        (EndpointTransition::Result, _) => {
+            assert_eq!(recovered.result().is_some(), applied);
+            return;
+        }
+    };
+    assert_eq!(recovered.state(), &expected);
+}
+
+fn assert_transition_recovery(transition: EndpointTransition, stage: CommitStage) {
+    let (scratch, fixture, journal) =
+        accepted_journal(&format!("endpoint-{transition:?}-{stage:?}"));
+    let guard = fixture.lease.guard();
+    let operation = accepted_operation(OperationId::new(), EndpointOperationKind::Exec, 0x70, 128);
+    seed_transition_predecessor(&journal, &fixture, transition, &operation);
+    drop(journal);
+
+    let faulting = faulting_journal(&scratch, &fixture, stage);
+    let mutation = apply_transition(&faulting, &fixture, guard, transition, operation);
+    let applied = matches!(stage, CommitStage::Renamed | CommitStage::DirectorySynced);
+    if applied {
+        assert!(matches!(mutation, Err(JournalError::CommitOutcomeUnknown)));
+    } else {
+        assert!(matches!(
+            mutation,
+            Err(JournalError::InjectedFault(received)) if received == stage
+        ));
+    }
+    drop(faulting);
+
+    let recovered = fixture.open(&scratch).snapshot().expect("recover journal");
+    let operations = recovered
+        .slot(fixture.slot)
+        .expect("durable slot")
+        .endpoint_operations();
+    if matches!(transition, EndpointTransition::Accept) && !applied {
+        assert!(operations.is_empty());
+    } else {
+        assert_recovered_transition_state(
+            transition,
+            applied,
+            operations.first().expect("accepted endpoint operation"),
+        );
+    }
+}
+
+#[test]
+fn every_endpoint_transition_recovers_exactly_at_every_physical_commit_boundary() {
+    let stages = [
+        CommitStage::StagingCreated,
+        CommitStage::DataWritten,
+        CommitStage::FileSynced,
+        CommitStage::Renamed,
+        CommitStage::DirectorySynced,
+    ];
+    for transition in [
+        EndpointTransition::Accept,
+        EndpointTransition::CommitInvocation,
+        EndpointTransition::Cancel,
+        EndpointTransition::CompleteCancellation,
+        EndpointTransition::Abandon,
+        EndpointTransition::Result,
+    ] {
+        for stage in stages {
+            assert_transition_recovery(transition, stage);
+        }
+    }
+}
+
+#[test]
+fn endpoint_operations_linearize_result_and_cancellation_without_eviction() {
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-linearization");
+    let guard = fixture.lease.guard();
+    let first_id = OperationId::new();
+    let first = accepted_operation(first_id, EndpointOperationKind::Exec, 0x10, 128);
+    let accepted = journal
+        .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, first.clone())
+        .expect("accept first endpoint operation");
+    let accepted_revision = accepted.revision();
+    assert_eq!(
+        accepted.slot(fixture.slot).unwrap().endpoint_operations(),
+        std::slice::from_ref(&first)
+    );
+    assert_eq!(
+        journal
+            .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, first)
+            .expect("exact acceptance replay")
+            .revision(),
+        accepted_revision
+    );
+
+    let pending = accepted_operation(
+        OperationId::new(),
+        EndpointOperationKind::CopyFrom,
+        0x11,
+        128,
+    );
+    assert!(matches!(
+        journal.accept_endpoint_operation(fixture.session_id, fixture.slot, guard, pending.clone()),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationPending
+        ))
+    ));
+    assert!(matches!(
+        journal.record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            first_id,
+            result(0x20, 64)
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointInvocationNotCommitted
+        ))
+    ));
+
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, first_id)
+        .expect("commit invocation");
+    let first_result = result(0x21, 64);
+    let completed = journal
+        .record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            first_id,
+            first_result.clone(),
+        )
+        .expect("record exact result");
+    let result_revision = completed.revision();
+    assert_eq!(
+        journal
+            .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, first_id)
+            .expect("result wins later cancellation")
+            .revision(),
+        result_revision
+    );
+
+    let second_id = pending.operation_id();
+    journal
+        .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, pending)
+        .expect("resolved predecessor permits successor");
+    journal
+        .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, second_id)
+        .expect("cancellation wins");
+    assert!(matches!(
+        journal.commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, second_id),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationCancelled
+        ))
+    ));
+    assert!(matches!(
+        journal.record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            second_id,
+            result(0x22, 64)
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationCancelled
+        ))
+    ));
+
+    let snapshot = journal.snapshot().expect("snapshot endpoint ledger");
+    let operations = snapshot.slot(fixture.slot).unwrap().endpoint_operations();
+    assert_eq!(operations.len(), 2);
+    assert_eq!(operations[0].result(), Some(&first_result));
+    assert_eq!(operations[1].state(), &EndpointOperationState::Cancelled);
+    let retained: Vec<_> = snapshot.content_references().collect();
+    assert!(retained.contains(&operations[0].request().content()));
+    assert!(retained.contains(&first_result.content()));
+    assert!(retained.contains(&operations[1].request().content()));
+}
+
+#[test]
+fn acceptance_rejects_an_operation_already_advanced_by_another_journal() {
+    let (_source_scratch, source_fixture, source) =
+        accepted_journal("endpoint-advanced-acceptance-source");
+    let operation_id = OperationId::new();
+    source
+        .accept_endpoint_operation(
+            source_fixture.session_id,
+            source_fixture.slot,
+            source_fixture.lease.guard(),
+            accepted_operation(operation_id, EndpointOperationKind::Wait, 0x17, 64),
+        )
+        .expect("accept source operation");
+    let advanced = source
+        .commit_endpoint_invocation(
+            source_fixture.session_id,
+            source_fixture.slot,
+            source_fixture.lease.guard(),
+            operation_id,
+        )
+        .expect("advance source operation")
+        .slot(source_fixture.slot)
+        .expect("source slot")
+        .endpoint_operations()[0]
+        .clone();
+    assert_eq!(
+        advanced.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+
+    let (_target_scratch, target_fixture, target) =
+        accepted_journal("endpoint-advanced-acceptance-target");
+    assert!(matches!(
+        target.accept_endpoint_operation(
+            target_fixture.session_id,
+            target_fixture.slot,
+            target_fixture.lease.guard(),
+            advanced,
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationNotAccepted
+        ))
+    ));
+    assert!(
+        target
+            .snapshot()
+            .expect("target snapshot")
+            .slot(target_fixture.slot)
+            .expect("target slot")
+            .endpoint_operations()
+            .is_empty()
+    );
+}
+
+#[test]
+fn durable_job_cancellation_atomically_resolves_the_pending_endpoint_race() {
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-job-cancellation");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    let accepted = accepted_operation(operation_id, EndpointOperationKind::Exec, 0x19, 128);
+    journal
+        .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, accepted.clone())
+        .expect("accept endpoint operation");
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("commit invocation");
+    let cancelled = journal
+        .record_cancellation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            CancellationRecord::new(Fixture::command(2), UnixMillis::new(4_000)),
+        )
+        .expect("durably cancel job and endpoint operation");
+    let operation = &cancelled
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::CancellationRequested
+    );
+    assert_eq!(
+        journal
+            .accept_endpoint_operation(fixture.session_id, fixture.slot, guard, accepted)
+            .expect("exact acceptance replay remains idempotent")
+            .revision(),
+        cancelled.revision()
+    );
+    assert!(matches!(
+        journal.record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+            result(0x1a, 64),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationCancelled
+        ))
+    ));
+    assert!(matches!(
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(OperationId::new(), EndpointOperationKind::Wait, 0x1b, 32,),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationsClosed
+        ))
+    ));
+
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-job-result-first");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::Exec, 0x1c, 128),
+        )
+        .expect("accept result-first operation");
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("commit result-first invocation");
+    let expected_result = result(0x1d, 64);
+    journal
+        .record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+            expected_result.clone(),
+        )
+        .expect("result wins");
+    let cancelled = journal
+        .record_cancellation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            CancellationRecord::new(Fixture::command(2), UnixMillis::new(4_000)),
+        )
+        .expect("record later job cancellation");
+    let operation = &cancelled
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(operation.result(), Some(&expected_result));
+    assert!(matches!(
+        operation.state(),
+        EndpointOperationState::Completed { .. }
+    ));
+}
+
+#[test]
+fn unresolved_endpoint_operation_structurally_fences_finalization_and_release() {
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-release");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::Wait, 0x30, 32),
+        )
+        .expect("accept endpoint operation");
+    journal
+        .transition_lifecycle(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Preparing,
+        )
+        .expect("prepare");
+    assert!(matches!(
+        journal.record_terminal_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Failed,
+            Fixture::terminal_result(),
+            Fixture::delivery_time(),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointRecoveryPending
+        ))
+    ));
+    journal
+        .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("resolve operation by cancellation");
+    record_and_ack_terminal(&journal, &fixture, JobLifecycle::Failed);
+    let released = journal
+        .release_slot(fixture.session_id, fixture.slot, guard)
+        .expect("release exact slot");
+    assert!(released.slot(fixture.slot).is_none());
+    assert!(released.content_references().all(|content| {
+        !matches!(
+            content.kind(),
+            ContentKind::EndpointRequest | ContentKind::EndpointResult
+        )
+    }));
+}
+
+#[test]
+fn invoked_cancellation_requires_exact_sandbox_absence() {
+    let (_scratch, fixture, journal) =
+        accepted_journal_with_sandbox("endpoint-cancellation-resolution");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::Exec, 0x35, 128),
+        )
+        .expect("accept operation");
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("commit invocation");
+    assert!(matches!(
+        journal.abandon_endpoint_operation(fixture.session_id, fixture.slot, guard, operation_id),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointSandboxStillPresent
+        ))
+    ));
+    journal
+        .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("request cancellation");
+    assert!(matches!(
+        journal.complete_endpoint_cancellation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointSandboxStillPresent
+        ))
+    ));
+    assert!(matches!(
+        journal.record_terminal_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Failed,
+            Fixture::terminal_result(),
+            Fixture::delivery_time(),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointRecoveryPending
+        ))
+    ));
+    let destroy = OperationId::new();
+    journal
+        .record_provider_intent(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            ProviderOperation::intent(destroy, ProviderOperationKind::DestroySandbox),
+        )
+        .expect("destroy exact generation intent");
+    journal
+        .complete_provider_operation(fixture.session_id, fixture.slot, guard, destroy)
+        .expect("exact generation absent");
+    journal
+        .complete_endpoint_cancellation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("resolve cancellation only after absence proof");
+    record_and_ack_terminal(&journal, &fixture, JobLifecycle::Failed);
+}
+
+#[test]
+fn ambiguous_invocation_abandonment_requires_exact_sandbox_absence() {
+    let (_scratch, fixture, journal) =
+        accepted_journal_with_sandbox("endpoint-abandonment-resolution");
+    let guard = fixture.lease.guard();
+    let ambiguous_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(ambiguous_id, EndpointOperationKind::Wait, 0x36, 32),
+        )
+        .expect("accept ambiguous successor");
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, ambiguous_id)
+        .expect("commit ambiguous invocation");
+    assert!(matches!(
+        journal.abandon_endpoint_operation(fixture.session_id, fixture.slot, guard, ambiguous_id),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointSandboxStillPresent
+        ))
+    ));
+    let destroy = OperationId::new();
+    journal
+        .record_provider_intent(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            ProviderOperation::intent(destroy, ProviderOperationKind::DestroySandbox),
+        )
+        .expect("destroy exact generation intent");
+    journal
+        .complete_provider_operation(fixture.session_id, fixture.slot, guard, destroy)
+        .expect("exact generation absent");
+    journal
+        .abandon_endpoint_operation(fixture.session_id, fixture.slot, guard, ambiguous_id)
+        .expect("resolve ambiguity only after absence proof");
+    record_and_ack_terminal(&journal, &fixture, JobLifecycle::Failed);
+}
+
+#[test]
+fn endpoint_replay_conflicts_and_result_reservations_fail_closed() {
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-conflicts");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::CopyTo, 0x40, 64),
+        )
+        .expect("accept exact operation");
+    assert!(matches!(
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::CopyTo, 0x41, 64),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationReplayConflict
+        ))
+    ));
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("commit invocation");
+    assert!(matches!(
+        journal.record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+            result(0x42, MIN_ENDPOINT_RESULT_ALLOCATION_BYTES),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointResultExceedsReservation
+        ))
+    ));
+}
+
+#[test]
+fn reservation_bounds_are_overflow_safe_and_cancelled_capacity_shrinks_to_retained_bytes() {
+    for invalid in [0, MAX_ENDPOINT_RESULT_CONTENT_BYTES + 1, u64::MAX] {
+        assert_eq!(
+            EndpointOperation::accepted(
+                OperationId::new(),
+                EndpointOperationKind::Exec,
+                EndpointRequestContentRef::new(Fixture::content(
+                    ContentKind::EndpointRequest,
+                    32,
+                    0x48,
+                ))
+                .expect("request commitment"),
+                invalid,
+            ),
+            Err(JournalInvariantError::InvalidEndpointResultReservation)
+        );
+    }
+
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-reservation-shrink");
+    let guard = fixture.lease.guard();
+    let first_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(
+                first_id,
+                EndpointOperationKind::CopyFrom,
+                0x49,
+                MAX_ENDPOINT_RESULT_CONTENT_BYTES,
+            ),
+        )
+        .expect("reserve worst-case output");
+    let cancelled = journal
+        .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, first_id)
+        .expect("cancel before backend invocation");
+    let operation = &cancelled.slot(fixture.slot).unwrap().endpoint_operations()[0];
+    assert_eq!(operation.state(), &EndpointOperationState::Cancelled);
+    assert_eq!(
+        operation
+            .accounted_content_bytes()
+            .expect("bounded retained content"),
+        ENDPOINT_REQUEST_COMMITMENT_BYTES
+    );
+    assert_eq!(operation.accounted_content_refs(), 1);
+
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(
+                OperationId::new(),
+                EndpointOperationKind::CopyFrom,
+                0x4a,
+                MAX_ENDPOINT_RESULT_CONTENT_BYTES,
+            ),
+        )
+        .expect("released reservation admits the successor before any backend call");
+}
+
+#[test]
+fn completed_results_charge_actual_bytes_and_reject_before_the_next_invocation() {
+    let (_scratch, fixture, journal) = accepted_journal("endpoint-byte-capacity");
+    let guard = fixture.lease.guard();
+    let per_full_operation =
+        ENDPOINT_REQUEST_COMMITMENT_BYTES + MAX_ENDPOINT_RESULT_ALLOCATION_BYTES;
+    let full = MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT / per_full_operation;
+    for ordinal in 0..full {
+        let operation_id = OperationId::new();
+        journal
+            .accept_endpoint_operation(
+                fixture.session_id,
+                fixture.slot,
+                guard,
+                accepted_operation(
+                    operation_id,
+                    EndpointOperationKind::Exec,
+                    u8::try_from(ordinal % 251).expect("bounded marker"),
+                    MAX_ENDPOINT_RESULT_CONTENT_BYTES,
+                ),
+            )
+            .expect("reserve full endpoint result object");
+        journal
+            .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+            .expect("commit capacity fixture");
+        journal
+            .record_endpoint_result(
+                fixture.session_id,
+                fixture.slot,
+                guard,
+                operation_id,
+                result(
+                    u8::try_from((ordinal + 1) % 251).expect("bounded marker"),
+                    MAX_ENDPOINT_RESULT_CONTENT_BYTES,
+                ),
+            )
+            .expect("retain full endpoint result object");
+    }
+    let retained_full = full * per_full_operation;
+    let remaining = MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT - retained_full;
+    let per_small_operation =
+        ENDPOINT_REQUEST_COMMITMENT_BYTES + MIN_ENDPOINT_RESULT_ALLOCATION_BYTES;
+    let small = remaining / per_small_operation;
+    for ordinal in 0..small {
+        let operation_id = OperationId::new();
+        journal
+            .accept_endpoint_operation(
+                fixture.session_id,
+                fixture.slot,
+                guard,
+                accepted_operation(
+                    operation_id,
+                    EndpointOperationKind::Exec,
+                    u8::try_from((ordinal + full) % 251).expect("bounded marker"),
+                    1,
+                ),
+            )
+            .expect("reserve minimum endpoint result class");
+        journal
+            .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+            .expect("commit minimum capacity fixture");
+        journal
+            .record_endpoint_result(
+                fixture.session_id,
+                fixture.slot,
+                guard,
+                operation_id,
+                result(
+                    u8::try_from((ordinal + full + 1) % 251).expect("bounded marker"),
+                    1,
+                ),
+            )
+            .expect("retain minimum endpoint result class");
+    }
+    let rejected = OperationId::new();
+    assert!(matches!(
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(rejected, EndpointOperationKind::Wait, 0xfb, 1),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointContentBytesLimit
+        ))
+    ));
+    assert!(matches!(
+        journal.commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, rejected),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationMissing
+        ))
+    ));
+}
+
+#[test]
+fn non_evicting_entry_ceiling_rejects_the_next_operation() {
+    let (scratch, fixture, journal) = accepted_journal("endpoint-entry-capacity");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::Wait, 0x51, 1),
+        )
+        .expect("seed operation");
+    journal
+        .record_endpoint_cancellation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("resolve seed operation");
+    drop(journal);
+    expand_only_endpoint_operation(
+        &scratch.child("state").join("runner-journal.json"),
+        operation_id,
+        MAX_ENDPOINT_OPERATIONS_PER_JOB,
+    );
+    let journal = fixture.open(&scratch);
+    assert_eq!(
+        journal
+            .snapshot()
+            .expect("maximum entry snapshot")
+            .slot(fixture.slot)
+            .unwrap()
+            .endpoint_operations()
+            .len(),
+        MAX_ENDPOINT_OPERATIONS_PER_JOB
+    );
+    let replayed = journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(operation_id, EndpointOperationKind::Wait, 0x51, 1),
+        )
+        .expect("exact replay remains admissible at the entry ceiling");
+    assert_eq!(
+        replayed
+            .slot(fixture.slot)
+            .expect("slot")
+            .endpoint_operations()
+            .len(),
+        MAX_ENDPOINT_OPERATIONS_PER_JOB
+    );
+    assert!(matches!(
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(OperationId::new(), EndpointOperationKind::Wait, 0x52, 1),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationLimit
+        ))
+    ));
+}
+
+#[test]
+fn reference_ceiling_is_aligned_with_the_shared_endpoint_execution_bound() {
+    assert_eq!(
+        MAX_ENDPOINT_CONTENT_REFS_PER_SLOT,
+        MAX_ENDPOINT_OPERATIONS_PER_JOB * 2
+    );
+    let (scratch, fixture, journal) = accepted_journal("endpoint-reference-capacity");
+    let guard = fixture.lease.guard();
+    let operation_id = OperationId::new();
+    let protection_id = "p".repeat(64);
+    journal
+        .accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation_with_protection_id(
+                operation_id,
+                EndpointOperationKind::CopyFrom,
+                0x61,
+                MAX_ENDPOINT_RESULT_CONTENT_BYTES,
+                &protection_id,
+            ),
+        )
+        .expect("seed operation");
+    journal
+        .commit_endpoint_invocation(fixture.session_id, fixture.slot, guard, operation_id)
+        .expect("seed invocation");
+    journal
+        .record_endpoint_result(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            operation_id,
+            result_with_protection_id(0x62, 1, &protection_id),
+        )
+        .expect("seed result");
+    drop(journal);
+    let path = scratch.child("state").join("runner-journal.json");
+    expand_only_endpoint_operation(&path, operation_id, MAX_ENDPOINT_OPERATIONS_PER_JOB);
+    assert!(
+        usize::try_from(fs::metadata(&path).expect("journal metadata").len())
+            .is_ok_and(|bytes| bytes <= MAX_JOURNAL_BYTES),
+        "the maximum admitted current-schema endpoint journal must fit its hard read bound"
+    );
+    let journal = fixture.open(&scratch);
+    assert!(matches!(
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            accepted_operation(OperationId::new(), EndpointOperationKind::Wait, 0x63, 1),
+        ),
+        Err(JournalError::Invariant(
+            JournalInvariantError::EndpointOperationLimit
+        ))
+    ));
+}
+
+fn expand_only_endpoint_operation(path: &Path, original_id: OperationId, count: usize) {
+    let mut journal = fs::read_to_string(path).expect("read canonical journal");
+    let marker = "\"endpoint_operations\":[";
+    let start = journal.find(marker).expect("endpoint operation array") + marker.len();
+    let bytes = journal.as_bytes();
+    assert_eq!(bytes[start], b'{');
+    let mut depth = 0_usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut end = None;
+    for (offset, byte) in bytes[start..].iter().copied().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(start + offset + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let end = end.expect("complete endpoint operation");
+    assert_eq!(journal.as_bytes()[end], b']');
+    let operation = journal[start..end].to_owned();
+    let original_id = original_id.to_string();
+    let expanded = (0..count)
+        .map(|index| {
+            if index == 0 {
+                operation.clone()
+            } else {
+                operation.replacen(&original_id, &OperationId::new().to_string(), 1)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    journal.replace_range(start..end, &expanded);
+    fs::write(path, journal).expect("write expanded canonical journal");
+}

--- a/crates/automata-ci-runner-journal/tests/runner_journal.rs
+++ b/crates/automata-ci-runner-journal/tests/runner_journal.rs
@@ -3,6 +3,7 @@ mod support;
 mod command_dispositions;
 mod corrupt_data;
 mod durable_payloads;
+mod endpoint_operations;
 mod fault_recovery;
 mod journal_contract;
 mod lease_poll_checkpoints;

--- a/crates/automata-ci-runner-runtime/src/endpoint_replay_tests.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_replay_tests.rs
@@ -1,0 +1,1236 @@
+use std::{
+    fmt, fs,
+    num::NonZeroU16,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Barrier, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use automata_ci_core::{
+    AttemptId, EnvironmentProfile, EnvironmentProfileId, FencingToken, JobIrVersion, Lease,
+    LeaseId, OperationId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
+};
+use automata_ci_execution::{
+    Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, DestroyDisposition,
+    DestroySandbox, EnvironmentName, EnvironmentValue, EnvironmentVariable, ExecutionArgv,
+    ExecutionCommand, ExecutionEndpoint, ExecutionEnvironment, ExecutionError, ExecutionErrorKind,
+    ExecutionOutput, ExecutionStage, ProviderCapabilities, ProviderError, ProviderErrorKind,
+    ProviderId, ProviderStage, SandboxCapability, SandboxCustody, SandboxGeneration, SandboxHandle,
+    SandboxInspection, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState, SignalRequest,
+    TargetPath, WaitRequest,
+};
+use automata_ci_protocol::{
+    CommandSequence, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal, RuntimeAuthorityDeliveryBinding,
+    RuntimeAuthorityGeneration,
+};
+use automata_ci_runner_journal::{
+    CommitFault, CommitFaultInjector, CommitStage, ContentKind, DurableCommand, DurableContentRef,
+    EndpointOperationState, FileJournal, FileJournalOptions, JobIrContentRef, LeaseOfferRecord,
+    ProviderName, ProviderOperation, ProviderOperationKind, RunnerJournal,
+    RuntimeAuthorityContentRef, RuntimeAuthorityDeliveryRecord,
+    SandboxHandle as JournalSandboxHandle, SandboxIdentity, SessionBinding, StateRoot,
+};
+use automata_ci_runner_spool::{
+    ContentCommitFault, ContentCommitFaultInjector, ContentCommitStage, ContentCommitmentDomain,
+    ContentProtectionError, ContentProtector, FileSpool, FileSpoolOptions, ProtectionId,
+    SpoolLimits, SpoolRoot, endpoint_result_allocation,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::{content::ContentOperationCoordinator, endpoint_replay::DurableExecutionEndpoint};
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/agent-scratch/endpoint-replay-tests")
+            .join(format!("{label}-{}", OperationId::new()));
+        fs::create_dir_all(&path).expect("create test scratch");
+        Self(fs::canonicalize(path).expect("canonical test scratch"))
+    }
+
+    fn child(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+struct TestProtector {
+    id: ProtectionId,
+    key: [u8; 32],
+}
+
+impl TestProtector {
+    fn new() -> Self {
+        Self {
+            id: ProtectionId::new("endpoint-replay-test-v1").expect("protection id"),
+            key: [0x7c; 32],
+        }
+    }
+
+    fn tag(&self, reference: &DurableContentRef, bytes: &[u8]) -> [u8; 32] {
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(reference.cache_key().as_str().as_bytes());
+        digest.update(bytes);
+        digest.finalize().into()
+    }
+}
+
+impl fmt::Debug for TestProtector {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("TestProtector").finish()
+    }
+}
+
+impl ContentProtector for TestProtector {
+    fn protection_id(&self) -> &ProtectionId {
+        &self.id
+    }
+
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        if protection_id != &self.id {
+            return Err(ContentProtectionError::KeyUnavailable);
+        }
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(domain.separator());
+        digest.update(material_digest);
+        Ok(digest.finalize().into())
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        endpoint_result_allocation(plaintext_bytes).map_err(|_| ContentProtectionError::Failed)
+    }
+
+    fn protect(
+        &self,
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        let mut protected = if let Some(allocation) = reference.endpoint_result_allocation_bytes() {
+            let allocation =
+                usize::try_from(allocation).map_err(|_| ContentProtectionError::Failed)?;
+            let body_bytes = allocation
+                .checked_sub(32)
+                .ok_or(ContentProtectionError::Failed)?;
+            let required = 8_usize
+                .checked_add(plaintext.len())
+                .ok_or(ContentProtectionError::Failed)?;
+            if required > body_bytes {
+                return Err(ContentProtectionError::Failed);
+            }
+            let mut body = Vec::with_capacity(allocation);
+            body.extend_from_slice(
+                &u64::try_from(plaintext.len())
+                    .map_err(|_| ContentProtectionError::Failed)?
+                    .to_be_bytes(),
+            );
+            body.extend(plaintext.iter().map(|byte| byte ^ 0xa5));
+            body.resize(body_bytes, 0);
+            body
+        } else {
+            plaintext.iter().map(|byte| byte ^ 0xa5).collect()
+        };
+        protected.extend_from_slice(&self.tag(reference, &protected));
+        Ok(protected)
+    }
+
+    fn unprotect(
+        &self,
+        reference: &DurableContentRef,
+        protected: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        let split = protected
+            .len()
+            .checked_sub(32)
+            .ok_or(ContentProtectionError::AuthenticationFailed)?;
+        let (ciphertext, tag) = protected.split_at(split);
+        if tag != self.tag(reference, ciphertext) {
+            return Err(ContentProtectionError::AuthenticationFailed);
+        }
+        if reference.endpoint_result_allocation_bytes().is_some() {
+            let length = ciphertext
+                .get(..8)
+                .and_then(|bytes| <[u8; 8]>::try_from(bytes).ok())
+                .map(u64::from_be_bytes)
+                .and_then(|bytes| usize::try_from(bytes).ok())
+                .ok_or(ContentProtectionError::AuthenticationFailed)?;
+            let end = 8_usize
+                .checked_add(length)
+                .filter(|end| *end <= ciphertext.len())
+                .ok_or(ContentProtectionError::AuthenticationFailed)?;
+            if ciphertext[end..].iter().any(|byte| *byte != 0) {
+                return Err(ContentProtectionError::AuthenticationFailed);
+            }
+            return Ok(ciphertext[8..end].iter().map(|byte| byte ^ 0xa5).collect());
+        }
+        Ok(ciphertext.iter().map(|byte| byte ^ 0xa5).collect())
+    }
+}
+
+#[derive(Debug)]
+struct ArmedJournalFault {
+    stage: CommitStage,
+    matching_commits_to_skip: usize,
+}
+
+#[derive(Debug, Default)]
+struct ArmableJournalFault(Mutex<Option<ArmedJournalFault>>);
+
+impl ArmableJournalFault {
+    fn arm(&self, stage: CommitStage) {
+        self.arm_after(stage, 0);
+    }
+
+    fn arm_after(&self, stage: CommitStage, matching_commits_to_skip: usize) {
+        *self.0.lock().expect("journal fault lock") = Some(ArmedJournalFault {
+            stage,
+            matching_commits_to_skip,
+        });
+    }
+}
+
+impl CommitFaultInjector for ArmableJournalFault {
+    fn check(&self, stage: CommitStage) -> Result<(), CommitFault> {
+        let mut armed = self.0.lock().expect("journal fault lock");
+        let Some(fault) = armed.as_mut().filter(|fault| fault.stage == stage) else {
+            return Ok(());
+        };
+        if fault.matching_commits_to_skip > 0 {
+            fault.matching_commits_to_skip -= 1;
+            return Ok(());
+        }
+        *armed = None;
+        Err(CommitFault)
+    }
+}
+
+#[derive(Debug)]
+struct ArmedContentFault {
+    stage: ContentCommitStage,
+    matching_commits_to_skip: usize,
+}
+
+#[derive(Debug, Default)]
+struct ArmableContentFault(Mutex<Option<ArmedContentFault>>);
+
+impl ArmableContentFault {
+    fn arm(&self, stage: ContentCommitStage) {
+        self.arm_after(stage, 0);
+    }
+
+    fn arm_after(&self, stage: ContentCommitStage, matching_commits_to_skip: usize) {
+        *self.0.lock().expect("content fault lock") = Some(ArmedContentFault {
+            stage,
+            matching_commits_to_skip,
+        });
+    }
+}
+
+impl ContentCommitFaultInjector for ArmableContentFault {
+    fn check(&self, stage: ContentCommitStage) -> Result<(), ContentCommitFault> {
+        let mut armed = self.0.lock().expect("content fault lock");
+        let Some(fault) = armed.as_mut().filter(|fault| fault.stage == stage) else {
+            return Ok(());
+        };
+        if fault.matching_commits_to_skip > 0 {
+            fault.matching_commits_to_skip -= 1;
+            return Ok(());
+        }
+        *armed = None;
+        Err(ContentCommitFault)
+    }
+}
+
+#[derive(Debug)]
+struct FakeProvider {
+    id: ProviderId,
+    capabilities: ProviderCapabilities,
+    inspection: Mutex<SandboxInspection>,
+    inspections: AtomicUsize,
+}
+
+impl FakeProvider {
+    fn new(inspection: SandboxInspection) -> Self {
+        let capabilities = vec![
+            SandboxCapability::WholeJob,
+            SandboxCapability::Attach,
+            SandboxCapability::Inspect,
+            SandboxCapability::CopyFrom,
+        ];
+        Self {
+            id: inspection.handle().provider().clone(),
+            capabilities: ProviderCapabilities::new(capabilities).expect("capabilities"),
+            inspection: Mutex::new(inspection),
+            inspections: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl SandboxProvider for FakeProvider {
+    fn provider_id(&self) -> &ProviderId {
+        &self.id
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+
+    fn create(
+        &self,
+        _spec: &SandboxSpec,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<SandboxRecord, ProviderError> {
+        Err(provider_error(ProviderStage::CreateSandbox))
+    }
+
+    fn attach(
+        &self,
+        _handle: &SandboxHandle,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<Box<dyn ExecutionEndpoint>, ProviderError> {
+        Err(provider_error(ProviderStage::Attach))
+    }
+
+    fn inspect(
+        &self,
+        _handle: &SandboxHandle,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<SandboxInspection, ProviderError> {
+        self.inspections.fetch_add(1, Ordering::SeqCst);
+        Ok(self.inspection.lock().expect("inspection lock").clone())
+    }
+
+    fn destroy(
+        &self,
+        _request: &DestroySandbox,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<DestroyDisposition, ProviderError> {
+        Err(provider_error(ProviderStage::DestroySandbox))
+    }
+}
+
+fn provider_error(stage: ProviderStage) -> ProviderError {
+    ProviderError::new(
+        ProviderErrorKind::BackendRejected,
+        stage,
+        automata_ci_execution::OperationOutcome::KnownNoEffect,
+        None,
+    )
+}
+
+#[derive(Debug)]
+struct FakeEndpoint {
+    handle: SandboxHandle,
+    calls: Arc<AtomicUsize>,
+    terminations: Arc<AtomicUsize>,
+}
+
+impl ExecutionEndpoint for FakeEndpoint {
+    fn handle(&self) -> &SandboxHandle {
+        &self.handle
+    }
+
+    fn capabilities(&self) -> &[SandboxCapability] {
+        const CAPABILITIES: &[SandboxCapability] = &[SandboxCapability::CopyFrom];
+        CAPABILITIES
+    }
+
+    fn exec(
+        &self,
+        _request: &ExecutionCommand,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<ExecutionOutput, ExecutionError> {
+        Err(endpoint_error(ExecutionStage::Exec))
+    }
+
+    fn signal(
+        &self,
+        _request: SignalRequest,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        Err(endpoint_error(ExecutionStage::Signal))
+    }
+
+    fn wait(
+        &self,
+        _request: WaitRequest,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<i32, ExecutionError> {
+        Err(endpoint_error(ExecutionStage::Wait))
+    }
+
+    fn copy_to(
+        &self,
+        _request: &CopyToRequest,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<(), ExecutionError> {
+        Err(endpoint_error(ExecutionStage::CopyTo))
+    }
+
+    fn copy_from(
+        &self,
+        _request: &CopyFromRequest,
+        cancellation: &dyn Cancellation,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if cancellation.disposition().requires_termination() {
+            self.terminations.fetch_add(1, Ordering::SeqCst);
+            Err(ExecutionError::new(
+                ExecutionErrorKind::Cancelled,
+                ExecutionStage::CopyFrom,
+            ))
+        } else {
+            Ok(b"protected replay result".to_vec())
+        }
+    }
+}
+
+fn endpoint_error(stage: ExecutionStage) -> ExecutionError {
+    ExecutionError::new(ExecutionErrorKind::UnsupportedCapability, stage)
+}
+
+#[derive(Debug)]
+struct SequencedCancellation {
+    observations: AtomicUsize,
+    trigger_after: usize,
+    disposition: CancellationDisposition,
+}
+
+impl SequencedCancellation {
+    fn after(trigger_after: usize, disposition: CancellationDisposition) -> Self {
+        Self {
+            observations: AtomicUsize::new(0),
+            trigger_after,
+            disposition,
+        }
+    }
+}
+
+impl Cancellation for SequencedCancellation {
+    fn disposition(&self) -> CancellationDisposition {
+        let observation = self.observations.fetch_add(1, Ordering::SeqCst);
+        if observation >= self.trigger_after {
+            self.disposition
+        } else {
+            CancellationDisposition::Active
+        }
+    }
+}
+
+struct Fixture {
+    scratch: Scratch,
+    journal: Arc<FileJournal>,
+    spool: Arc<FileSpool>,
+    coordinator: Arc<ContentOperationCoordinator>,
+    serial: Arc<Mutex<()>>,
+    provider: Arc<FakeProvider>,
+    inspection: SandboxInspection,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+    guard: automata_ci_core::LeaseGuard,
+    calls: Arc<AtomicUsize>,
+    terminations: Arc<AtomicUsize>,
+    journal_fault: Arc<ArmableJournalFault>,
+    spool_fault: Arc<ArmableContentFault>,
+}
+
+fn record_test_runtime_authority(
+    journal: &FileJournal,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+    lease: &Lease,
+    offer: &LeaseOfferRecord,
+) {
+    let content =
+        RuntimeAuthorityContentRef::new(content_ref(ContentKind::RuntimeAuthority, 64, 0x12))
+            .expect("authority content");
+    let digest = content
+        .content()
+        .public_plaintext_sha256()
+        .expect("runtime authority public digest");
+    let generation = RuntimeAuthorityGeneration::new(1).expect("authority generation");
+    let acknowledgement_operation_id = OperationId::new();
+    let authority = RuntimeAuthorityDeliveryRecord::new(
+        RuntimeAuthorityDeliveryBinding::new(
+            lease.attempt_id(),
+            slot,
+            lease.guard(),
+            offer.command().operation_id(),
+            offer.command().sequence(),
+            offer
+                .job_ir()
+                .content()
+                .public_plaintext_sha256()
+                .expect("job IR public digest"),
+            generation,
+        ),
+        OperationId::new(),
+        acknowledgement_operation_id,
+        digest,
+        content,
+    )
+    .expect("authority delivery");
+    journal
+        .record_runtime_authority_delivery(session_id, slot, lease.guard(), authority)
+        .expect("record authority delivery");
+    journal
+        .acknowledge_runtime_authority_delivery(
+            session_id,
+            slot,
+            lease.guard(),
+            generation,
+            digest,
+            acknowledgement_operation_id,
+        )
+        .expect("acknowledge authority delivery");
+}
+
+fn record_test_sandbox(
+    journal: &FileJournal,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+    lease: &Lease,
+) -> SandboxHandle {
+    let provider_id = ProviderId::new("test-provider").expect("provider id");
+    let handle = SandboxHandle::new(provider_id, "sandbox-handle").expect("handle");
+    let create_id = OperationId::new();
+    journal
+        .record_provider_intent(
+            session_id,
+            slot,
+            lease.guard(),
+            ProviderOperation::intent(create_id, ProviderOperationKind::CreateSandbox),
+        )
+        .expect("create intent");
+    journal
+        .record_sandbox_created(
+            session_id,
+            slot,
+            lease.guard(),
+            create_id,
+            SandboxIdentity::new(
+                ProviderName::new(handle.provider().as_str()).expect("journal provider"),
+                JournalSandboxHandle::new(handle.opaque()).expect("journal handle"),
+            ),
+        )
+        .expect("sandbox identity");
+    handle
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        Self::new_with_spool_limits(label, None)
+    }
+
+    fn new_with_spool_limits(label: &str, spool_limits: Option<SpoolLimits>) -> Self {
+        let scratch = Scratch::new(label);
+        let runner_id = RunnerId::new();
+        let session_id = RunnerSessionId::new();
+        let slot = RunnerSlotOrdinal::new(1).expect("slot");
+        let lease = Lease::new(
+            LeaseId::new(),
+            AttemptId::new(),
+            runner_id,
+            FencingToken::new(7).expect("fence"),
+            UnixMillis::new(1_000),
+            UnixMillis::new(10_000),
+        )
+        .expect("lease");
+        let journal_fault = Arc::new(ArmableJournalFault::default());
+        let state_root = StateRoot::explicit(scratch.child("state")).expect("state root");
+        let journal = Arc::new(
+            FileJournal::open_with_options(
+                state_root,
+                runner_id,
+                FileJournalOptions::new().with_fault_injector(journal_fault.clone()),
+            )
+            .expect("journal"),
+        );
+        journal
+            .begin_session(SessionBinding::new(
+                session_id,
+                PROTOCOL_MAX_VERSION,
+                JobIrVersion::current(),
+            ))
+            .expect("session");
+        let offer = LeaseOfferRecord::new(
+            slot,
+            lease.clone(),
+            JobIrContentRef::new(
+                JobIrVersion::current(),
+                content_ref(ContentKind::JobIr, 64, 0x11),
+            )
+            .expect("job content"),
+            DurableCommand::new(
+                CommandSequence::new(1).expect("command"),
+                OperationId::new(),
+                Sha256Digest::from_bytes([0x13; 32]),
+            ),
+        )
+        .expect("offer");
+        journal
+            .record_lease_offer(session_id, offer.clone())
+            .expect("record offer");
+        journal
+            .accept_lease(session_id, slot, lease.guard())
+            .expect("accept offer");
+        record_test_runtime_authority(journal.as_ref(), session_id, slot, &lease, &offer);
+        let handle = record_test_sandbox(journal.as_ref(), session_id, slot, &lease);
+        let profile = EnvironmentProfile::new(
+            EnvironmentProfileId::new("test.provider/linux").expect("profile id"),
+            Sha256Digest::from_bytes([0x44; 32]),
+        );
+        let inspection = SandboxInspection::new(
+            handle,
+            SandboxGeneration::new(lease.fencing_token().get()).expect("generation"),
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal: NonZeroU16::new(slot.get()).expect("slot custody"),
+            },
+            profile,
+            SandboxState::Running,
+        );
+        let provider = Arc::new(FakeProvider::new(inspection.clone()));
+        let spool_fault = Arc::new(ArmableContentFault::default());
+        let spool_root = SpoolRoot::explicit(scratch.child("spool")).expect("spool root");
+        let mut spool_options = FileSpoolOptions::new().with_fault_injector(spool_fault.clone());
+        if let Some(limits) = spool_limits {
+            spool_options = spool_options.with_limits(limits);
+        }
+        let spool = Arc::new(
+            FileSpool::open_with_options(spool_root, Arc::new(TestProtector::new()), spool_options)
+                .expect("spool"),
+        );
+        Self {
+            scratch,
+            journal,
+            spool,
+            coordinator: Arc::new(ContentOperationCoordinator::default()),
+            serial: Arc::new(Mutex::new(())),
+            provider,
+            inspection,
+            session_id,
+            slot,
+            guard: lease.guard(),
+            calls: Arc::new(AtomicUsize::new(0)),
+            terminations: Arc::new(AtomicUsize::new(0)),
+            journal_fault,
+            spool_fault,
+        }
+    }
+
+    fn endpoint(&self) -> DurableExecutionEndpoint {
+        DurableExecutionEndpoint::bind(
+            self.journal.clone(),
+            self.spool.clone(),
+            self.coordinator.clone(),
+            self.serial.clone(),
+            self.session_id,
+            self.slot,
+            self.guard,
+            self.provider.clone(),
+            self.inspection.clone(),
+            Box::new(FakeEndpoint {
+                handle: self.inspection.handle().clone(),
+                calls: self.calls.clone(),
+                terminations: self.terminations.clone(),
+            }),
+        )
+        .expect("bind durable endpoint")
+    }
+
+    fn request(operation_id: OperationId, source: &str) -> CopyFromRequest {
+        CopyFromRequest::new(
+            operation_id,
+            TargetPath::posix(source).expect("source path"),
+            1024,
+        )
+        .expect("copy request")
+    }
+}
+
+fn content_ref(kind: ContentKind, size: u64, marker: u8) -> DurableContentRef {
+    DurableContentRef::after_public_commit(
+        kind,
+        size,
+        Sha256Digest::from_bytes([marker; 32]),
+        ProtectionId::new("endpoint-replay-test-v1").expect("protection id"),
+    )
+    .expect("content ref")
+}
+
+#[test]
+fn completed_result_replays_without_backend_and_result_wins_later_cancellation() {
+    let fixture = Fixture::new("completed");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/result");
+    let first = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect("first result");
+    assert_eq!(first, b"protected replay result");
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+
+    let replay = fixture
+        .endpoint()
+        .copy_from(
+            &request,
+            &SequencedCancellation::after(0, CancellationDisposition::Terminate),
+        )
+        .expect("durable result wins later cancellation");
+    assert_eq!(replay, first);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+
+    let conflict = fixture.endpoint().copy_from(
+        &Fixture::request(operation_id, "/workspace/different"),
+        &automata_ci_execution::NeverCancelled,
+    );
+    assert_eq!(
+        conflict.expect_err("request fingerprint conflict").kind(),
+        ExecutionErrorKind::InvalidState
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn secret_bearing_requests_never_serialize_into_journal_spool_identity_or_debug() {
+    let fixture = Fixture::new("request-secret-redaction");
+    let secret = "pin-0427";
+    let command = ExecutionCommand::new(
+        OperationId::new(),
+        ExecutionArgv::new(
+            TargetPath::posix("/usr/bin/printf").expect("program"),
+            vec![secret.to_owned()],
+        )
+        .expect("argv"),
+        TargetPath::posix("/workspace").expect("working directory"),
+        ExecutionEnvironment::new(vec![EnvironmentVariable::secret(
+            EnvironmentName::new("LOW_ENTROPY_PIN").expect("name"),
+            EnvironmentValue::new(secret).expect("value"),
+        )])
+        .expect("environment"),
+        Duration::from_secs(30),
+        1024,
+    )
+    .expect("command");
+    let error = fixture
+        .endpoint()
+        .exec(&command, &automata_ci_execution::NeverCancelled)
+        .expect_err("fake endpoint reports unsupported exec");
+    assert!(!format!("{command:?}{error:?}").contains(secret));
+
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let request_ref = snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0]
+        .request()
+        .content();
+    let raw_secret_digest: [u8; 32] = Sha256::digest(secret.as_bytes()).into();
+    assert_ne!(
+        request_ref
+            .public_plaintext_sha256()
+            .expect("request commitment public digest")
+            .as_bytes(),
+        raw_secret_digest.as_slice()
+    );
+    let journal_bytes = fs::read(fixture.scratch.child("state").join("runner-journal.json"))
+        .expect("journal bytes");
+    assert!(
+        !journal_bytes
+            .windows(secret.len())
+            .any(|bytes| bytes == secret.as_bytes())
+    );
+    for entry in fs::read_dir(fixture.scratch.child("spool")).expect("spool directory") {
+        let entry = entry.expect("spool entry");
+        if entry.file_type().expect("entry type").is_file() {
+            let bytes = fs::read(entry.path()).expect("spool file");
+            assert!(
+                !bytes
+                    .windows(secret.len())
+                    .any(|part| part == secret.as_bytes())
+            );
+        }
+    }
+}
+
+#[test]
+fn endpoint_result_journal_identity_exposes_neither_plaintext_digest_nor_exact_size() {
+    let fixture = Fixture::new("result-secret-redaction");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/low-entropy-secret");
+    let plaintext = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect("endpoint result");
+    let digest = Sha256Digest::from_bytes(Sha256::digest(&plaintext).into()).to_string();
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let result = snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0]
+        .result()
+        .expect("durable result")
+        .content();
+    assert_eq!(result.public_plaintext_bytes(), None);
+    assert_eq!(result.public_plaintext_sha256(), None);
+    assert_eq!(result.endpoint_result_allocation_bytes(), Some(65_536));
+
+    let debug = format!("{result:?}");
+    let journal = fs::read_to_string(fixture.scratch.child("state").join("runner-journal.json"))
+        .expect("journal bytes");
+    for exposed in [&debug, result.cache_key().as_str()] {
+        assert!(!exposed.contains(&digest));
+        assert!(!exposed.contains("plaintext_sha256"));
+        assert!(!exposed.contains("plaintext_bytes"));
+    }
+    assert!(!journal.contains(&digest));
+    let result_metadata = journal
+        .split_once("\"phase\":\"completed\",\"result\":")
+        .map(|(_, result)| result)
+        .expect("completed result metadata");
+    assert!(!result_metadata.contains("plaintext_sha256"));
+    assert!(!result_metadata.contains("plaintext_bytes"));
+    assert_ne!(
+        result.accounted_bytes(),
+        u64::try_from(plaintext.len()).expect("bounded plaintext")
+    );
+    for entry in fs::read_dir(fixture.scratch.child("spool")).expect("spool directory") {
+        let entry = entry.expect("spool entry");
+        if entry.file_type().expect("entry type").is_file() {
+            let protected = fs::read(entry.path()).expect("spool file");
+            assert!(
+                !protected
+                    .windows(plaintext.len())
+                    .any(|bytes| bytes == plaintext)
+            );
+        }
+    }
+}
+
+#[test]
+fn multiple_bindings_share_one_host_operation_linearization_gate() {
+    let fixture = Fixture::new("multiple-bindings");
+    let request = Fixture::request(OperationId::new(), "/workspace/concurrent");
+    let left = fixture.endpoint();
+    let right = fixture.endpoint();
+    let barrier = Arc::new(Barrier::new(2));
+    let (left_result, right_result) = std::thread::scope(|scope| {
+        let left_request = request.clone();
+        let left_barrier = barrier.clone();
+        let left = scope.spawn(move || {
+            left_barrier.wait();
+            left.copy_from(&left_request, &automata_ci_execution::NeverCancelled)
+        });
+        let right_barrier = barrier.clone();
+        let right = scope.spawn(move || {
+            right_barrier.wait();
+            right.copy_from(&request, &automata_ci_execution::NeverCancelled)
+        });
+        (
+            left.join().expect("left endpoint thread"),
+            right.join().expect("right endpoint thread"),
+        )
+    });
+    assert_eq!(
+        left_result.expect("left result"),
+        b"protected replay result"
+    );
+    assert_eq!(
+        right_result.expect("right result"),
+        b"protected replay result"
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.provider.inspections.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn unresolved_invocation_committed_always_fails_closed() {
+    let fixture = Fixture::new("ambiguous");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/ambiguous");
+    fixture
+        .spool_fault
+        .arm_after(ContentCommitStage::FileSynced, 1);
+    let first = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled);
+    assert_eq!(
+        first
+            .expect_err("result publication leaves ambiguity")
+            .kind(),
+        ExecutionErrorKind::LocalStorage
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    let operation = fixture
+        .journal
+        .snapshot()
+        .expect("snapshot")
+        .slot(fixture.slot)
+        .unwrap()
+        .endpoint_operations()[0]
+        .clone();
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+
+    let replay = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled);
+    assert_eq!(
+        replay
+            .expect_err("unsafe ambiguous replay is fenced")
+            .kind(),
+        ExecutionErrorKind::InvalidState
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.provider.inspections.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn cancellation_cannot_resolve_committed_ambiguity_before_sandbox_absence() {
+    let fixture = Fixture::new("ambiguous-cancellation");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/ambiguous-cancellation");
+    fixture
+        .spool_fault
+        .arm_after(ContentCommitStage::FileSynced, 1);
+    fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("seed invocation-committed ambiguity");
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+
+    let cancelled = fixture.endpoint().copy_from(
+        &request,
+        &SequencedCancellation::after(0, CancellationDisposition::Terminate),
+    );
+    assert_eq!(
+        cancelled
+            .expect_err("recovered ambiguity cannot be completed by a new caller")
+            .kind(),
+        ExecutionErrorKind::InvalidState
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+}
+
+#[test]
+fn termination_is_durable_before_backend_observes_it() {
+    let fixture = Fixture::new("termination");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/cancel");
+    let cancelled = fixture.endpoint().copy_from(
+        &request,
+        &SequencedCancellation::after(2, CancellationDisposition::Terminate),
+    );
+    assert_eq!(
+        cancelled.expect_err("termination wins").kind(),
+        ExecutionErrorKind::Cancelled
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    let snapshot = fixture.journal.snapshot().expect("snapshot cancellation");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::CancellationRequested
+    );
+    assert!(operation.result().is_none());
+    assert_eq!(fixture.terminations.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn pre_invocation_termination_resolves_acceptance_without_backend_exposure() {
+    let fixture = Fixture::new("pre-invocation-termination");
+    let request = Fixture::request(OperationId::new(), "/workspace/pre-invocation-cancel");
+    let cancelled = fixture.endpoint().copy_from(
+        &request,
+        &SequencedCancellation::after(0, CancellationDisposition::Terminate),
+    );
+    assert_eq!(
+        cancelled
+            .expect_err("termination wins before invocation")
+            .kind(),
+        ExecutionErrorKind::Cancelled
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(fixture.provider.inspections.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot cancellation");
+    assert_eq!(
+        snapshot
+            .slot(fixture.slot)
+            .expect("slot")
+            .endpoint_operations()[0]
+            .state(),
+        &EndpointOperationState::Cancelled
+    );
+}
+
+#[test]
+fn request_spool_or_acceptance_fault_never_reaches_the_backend() {
+    let spool_fault = Fixture::new("request-spool-fault");
+    spool_fault.spool_fault.arm(ContentCommitStage::FileSynced);
+    let request = Fixture::request(OperationId::new(), "/workspace/request-spool");
+    let error = spool_fault
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("request content must be durable first");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(spool_fault.calls.load(Ordering::SeqCst), 0);
+    assert!(
+        spool_fault
+            .journal
+            .snapshot()
+            .expect("snapshot")
+            .slot(spool_fault.slot)
+            .expect("slot")
+            .endpoint_operations()
+            .is_empty()
+    );
+
+    let journal_fault = Fixture::new("request-journal-fault");
+    journal_fault.journal_fault.arm(CommitStage::FileSynced);
+    let request = Fixture::request(OperationId::new(), "/workspace/request-journal");
+    let error = journal_fault
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("acceptance must commit before invocation");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(journal_fault.calls.load(Ordering::SeqCst), 0);
+    assert!(
+        journal_fault
+            .journal
+            .snapshot()
+            .expect("snapshot")
+            .slot(journal_fault.slot)
+            .expect("slot")
+            .endpoint_operations()
+            .is_empty()
+    );
+}
+
+#[test]
+fn invocation_commit_fault_never_reaches_the_backend() {
+    let fixture = Fixture::new("invocation-commit-fault");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/invocation");
+    fixture.journal_fault.arm_after(CommitStage::FileSynced, 1);
+    let error = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("invocation commitment must be durable");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(operation.state(), &EndpointOperationState::Accepted);
+}
+
+#[test]
+fn shared_result_capacity_is_reserved_before_provider_inspection_or_backend_invocation() {
+    let limits = SpoolLimits::new(2_048, 67_584, 1, 65_536).expect("bounded one-object spool");
+    let fixture = Fixture::new_with_spool_limits("result-capacity-before-provider", Some(limits));
+    let request = Fixture::request(OperationId::new(), "/workspace/capacity");
+    let error = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("request content consumes the only shared object slot");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.provider.inspections.load(Ordering::SeqCst), 0);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    assert_eq!(
+        snapshot
+            .slot(fixture.slot)
+            .expect("slot")
+            .endpoint_operations()[0]
+            .state(),
+        &EndpointOperationState::Accepted
+    );
+}
+
+#[test]
+fn failed_binding_releases_shared_result_capacity_for_the_exact_accepted_retry() {
+    let limits = SpoolLimits::new(2_048, 67_584, 2, 65_536).expect("bounded two-object spool");
+    let fixture = Fixture::new_with_spool_limits("result-capacity-release", Some(limits));
+    let request = Fixture::request(OperationId::new(), "/workspace/capacity-release");
+    let exited = SandboxInspection::new(
+        fixture.inspection.handle().clone(),
+        fixture.inspection.generation(),
+        fixture.inspection.custody(),
+        fixture.inspection.profile().clone(),
+        SandboxState::Stopped,
+    );
+    *fixture.provider.inspection.lock().expect("inspection lock") = exited;
+    assert_eq!(
+        fixture
+            .endpoint()
+            .copy_from(&request, &automata_ci_execution::NeverCancelled)
+            .expect_err("exited binding")
+            .kind(),
+        ExecutionErrorKind::InvalidState
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+
+    *fixture.provider.inspection.lock().expect("inspection lock") = fixture.inspection.clone();
+    assert_eq!(
+        fixture
+            .endpoint()
+            .copy_from(&request, &automata_ci_execution::NeverCancelled)
+            .expect("exact accepted retry after reservation release"),
+        b"protected replay result"
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.spool.usage().expect("spool usage").0, 2);
+}
+
+#[test]
+fn result_spool_fault_leaves_committed_ambiguity_fenced() {
+    let fixture = Fixture::new("result-spool-fault");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/result-spool");
+    fixture
+        .spool_fault
+        .arm_after(ContentCommitStage::FileSynced, 1);
+    let error = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("result publication fails");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.terminations.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+
+    let replay = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("ambiguous non-replay provider stays fenced");
+    assert_eq!(replay.kind(), ExecutionErrorKind::InvalidState);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn result_journal_fault_preserves_payload_first_ambiguous_state() {
+    let fixture = Fixture::new("result-journal-fault");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/result-journal");
+    fixture.journal_fault.arm_after(CommitStage::FileSynced, 2);
+    let error = fixture
+        .endpoint()
+        .copy_from(&request, &automata_ci_execution::NeverCancelled)
+        .expect_err("result journal adoption fails");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.terminations.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+    assert!(operation.result().is_none());
+    assert_eq!(
+        fixture.spool.usage().expect("spool usage").0,
+        2,
+        "the protected result remains an unreferenced payload-first object"
+    );
+}
+
+#[test]
+fn cancellation_journal_fault_terminates_backend_but_leaves_durable_ambiguity() {
+    let fixture = Fixture::new("cancellation-journal-fault");
+    let operation_id = OperationId::new();
+    let request = Fixture::request(operation_id, "/workspace/cancel-journal");
+    fixture.journal_fault.arm_after(CommitStage::FileSynced, 2);
+    let error = fixture
+        .endpoint()
+        .copy_from(
+            &request,
+            &SequencedCancellation::after(2, CancellationDisposition::Terminate),
+        )
+        .expect_err("cancellation storage failure wins wrapper result");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fixture.terminations.load(Ordering::SeqCst), 1);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    let operation = &snapshot
+        .slot(fixture.slot)
+        .expect("slot")
+        .endpoint_operations()[0];
+    assert_eq!(
+        operation.state(),
+        &EndpointOperationState::InvocationCommitted
+    );
+    assert!(operation.result().is_none());
+}
+
+#[test]
+fn pre_invocation_cancellation_storage_failure_never_reaches_provider_or_backend() {
+    let fixture = Fixture::new("pre-invocation-cancellation-journal-fault");
+    let request = Fixture::request(OperationId::new(), "/workspace/pre-cancel-storage");
+    fixture.journal_fault.arm_after(CommitStage::FileSynced, 1);
+    let error = fixture
+        .endpoint()
+        .copy_from(
+            &request,
+            &SequencedCancellation::after(0, CancellationDisposition::Terminate),
+        )
+        .expect_err("cancellation cannot reach provider before its durable transition");
+    assert_eq!(error.kind(), ExecutionErrorKind::LocalStorage);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(fixture.provider.inspections.load(Ordering::SeqCst), 0);
+    let snapshot = fixture.journal.snapshot().expect("snapshot");
+    assert_eq!(
+        snapshot
+            .slot(fixture.slot)
+            .expect("slot")
+            .endpoint_operations()[0]
+            .state(),
+        &EndpointOperationState::Accepted
+    );
+}

--- a/crates/automata-ci-runner-runtime/src/lib.rs
+++ b/crates/automata-ci-runner-runtime/src/lib.rs
@@ -11,6 +11,8 @@ mod config;
 mod content;
 mod control;
 mod endpoint_replay;
+#[cfg(test)]
+mod endpoint_replay_tests;
 mod endpoint_result;
 mod error;
 mod events;

--- a/crates/automata-ci-runner-runtime/tests/orphan_session_recovery.rs
+++ b/crates/automata-ci-runner-runtime/tests/orphan_session_recovery.rs
@@ -18,7 +18,8 @@ use automata_ci_protocol::{
     ServerToRunner, SessionDisposition, SessionOrphanAuthorization,
 };
 use automata_ci_runner_journal::{
-    LogSegment, LogSegmentPublication, ProviderFailureKind, ProviderFailureOutcome, ProviderName,
+    EndpointOperation, EndpointOperationKind, EndpointRequestContentRef, LogSegment,
+    LogSegmentPublication, ProviderFailureKind, ProviderFailureOutcome, ProviderName,
     ProviderOperation, ProviderOperationKind, RunnerJournal, SandboxHandle, SandboxIdentity,
     TerminalResultRecord,
 };
@@ -31,7 +32,7 @@ use automata_ci_runner_runtime::{
     RuntimeControlFuture, RuntimeControlReply, RuntimeControlRetry, RuntimeOperationOutcome,
     SystemRuntimeIds,
 };
-use automata_ci_runner_spool::{ContentKind, DurableContentStore};
+use automata_ci_runner_spool::{ContentCommitmentDomain, ContentKind, DurableContentStore};
 use automata_ci_runner_transport::PreparedRequest;
 use tokio_util::sync::CancellationToken;
 
@@ -335,6 +336,34 @@ fn seed_terminal_sandbox(
     spool: &dyn DurableContentStore,
     fixture: &support::AcceptedFixture,
 ) {
+    seed_running_sandbox(journal, fixture);
+    seed_undelivered_log(journal, spool, fixture);
+    let guard = fixture.lease.guard();
+    journal
+        .transition_lifecycle(
+            fixture.session_id,
+            fixture.slot,
+            guard,
+            JobLifecycle::Finalizing,
+        )
+        .expect("finalizing");
+    let result = spool
+        .persist(ContentKind::TerminalResult, b"undelivered terminal result")
+        .expect("persist result")
+        .commit_with(|content| {
+            journal.record_terminal_result(
+                fixture.session_id,
+                fixture.slot,
+                guard,
+                JobLifecycle::Failed,
+                TerminalResultRecord::new(OperationId::new(), content.clone())?,
+                UnixMillis::new(10_000),
+            )
+        });
+    assert!(result.is_ok(), "adopt terminal result");
+}
+
+fn seed_running_sandbox(journal: &dyn RunnerJournal, fixture: &support::AcceptedFixture) {
     let guard = fixture.lease.guard();
     journal
         .transition_lifecycle(
@@ -386,29 +415,56 @@ fn seed_terminal_sandbox(
             JobLifecycle::Running,
         )
         .expect("running");
-    seed_undelivered_log(journal, spool, fixture);
-    journal
-        .transition_lifecycle(
+}
+
+fn seed_ambiguous_endpoint(
+    journal: &dyn RunnerJournal,
+    spool: &dyn DurableContentStore,
+    fixture: &support::AcceptedFixture,
+    cancellation_requested: bool,
+) {
+    seed_running_sandbox(journal, fixture);
+    let operation_id = OperationId::new();
+    let commitment = spool
+        .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, &[0x57; 32])
+        .expect("keyed request commitment");
+    let publication = spool
+        .persist(ContentKind::EndpointRequest, commitment.as_bytes())
+        .expect("persist request commitment");
+    let adopted = publication.commit_with(|content| {
+        let request = EndpointRequestContentRef::new(content.clone())?;
+        let operation =
+            EndpointOperation::accepted(operation_id, EndpointOperationKind::Wait, request, 64)?;
+        journal.accept_endpoint_operation(
             fixture.session_id,
             fixture.slot,
-            guard,
-            JobLifecycle::Finalizing,
+            fixture.lease.guard(),
+            operation,
         )
-        .expect("finalizing");
-    let result = spool
-        .persist(ContentKind::TerminalResult, b"undelivered terminal result")
-        .expect("persist result")
-        .commit_with(|content| {
-            journal.record_terminal_result(
+    });
+    if let Err(failure) = adopted {
+        let (error, publication) = failure.into_parts();
+        publication.abort();
+        panic!("accept endpoint operation: {error}");
+    }
+    journal
+        .commit_endpoint_invocation(
+            fixture.session_id,
+            fixture.slot,
+            fixture.lease.guard(),
+            operation_id,
+        )
+        .expect("commit ambiguous invocation");
+    if cancellation_requested {
+        journal
+            .record_endpoint_cancellation(
                 fixture.session_id,
                 fixture.slot,
-                guard,
-                JobLifecycle::Failed,
-                TerminalResultRecord::new(OperationId::new(), content.clone())?,
-                UnixMillis::new(10_000),
+                fixture.lease.guard(),
+                operation_id,
             )
-        });
-    assert!(result.is_ok(), "adopt terminal result");
+            .expect("request ambiguous cancellation");
+    }
 }
 
 fn seed_undelivered_log(
@@ -551,6 +607,58 @@ async fn exact_authority_abandons_two_slots_cleans_sandboxes_and_opens_once() {
     assert_eq!(operations.len(), 4);
     assert_eq!(operations[0].0, ProviderOperationKind::StopSandbox);
     assert_eq!(operations[1].0, ProviderOperationKind::DestroySandbox);
+}
+
+#[tokio::test]
+async fn authorized_orphan_restart_resolves_endpoint_ambiguity_after_exact_cleanup() {
+    for cancellation_requested in [false, true] {
+        let scratch = support::Scratch::new(if cancellation_requested {
+            "orphan-endpoint-cancellation"
+        } else {
+            "orphan-endpoint-abandonment"
+        });
+        let runner_id = RunnerId::new();
+        let old_session;
+        {
+            let (journal, spool) = support::durable_ports(&scratch, runner_id);
+            let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
+            old_session = fixture.session_id;
+            seed_ambiguous_endpoint(
+                journal.as_ref(),
+                spool.as_ref(),
+                &fixture,
+                cancellation_requested,
+            );
+        }
+
+        let (journal, spool) = support::durable_ports(&scratch, runner_id);
+        let shutdown = CancellationToken::new();
+        let client = Arc::new(OrphanControlClient::new(
+            old_session,
+            RunnerSessionId::new(),
+            AuthorityResponse::Exact(OrphanDeliveryPermissions::new(true, true, true)),
+            shutdown.clone(),
+        ));
+        let executor = Arc::new(OrphanExecutor::new(CleanupBehavior::Destroy));
+        runtime(
+            runner_id,
+            client.clone(),
+            journal.clone(),
+            spool,
+            executor.clone(),
+        )
+        .run(shutdown)
+        .await
+        .expect("authorized endpoint recovery and fresh session");
+
+        assert_eq!(client.hello_calls(), 2);
+        assert_released(journal.as_ref());
+        assert_eq!(executor.operations().len(), 1);
+        assert_eq!(
+            executor.operations()[0].0,
+            ProviderOperationKind::DestroySandbox
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
+++ b/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
@@ -15,9 +15,10 @@ use automata_ci_protocol::{
     SUPPORTED_PROTOCOL_RANGE, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_journal::{
-    CommandDisposition, CommandIgnoredReason, ProviderFailureKind, ProviderFailureOutcome,
+    CommandDisposition, CommandIgnoredReason, EndpointOperation, EndpointOperationKind,
+    EndpointRequestContentRef, ProviderFailureKind, ProviderFailureOutcome, ProviderName,
     ProviderOperation, ProviderOperationKind, RunnerJournal, RuntimeAuthorityDeliveryRecord,
-    SessionBinding,
+    SandboxHandle, SandboxIdentity, SessionBinding,
 };
 use automata_ci_runner_runtime::{
     AdmissionRejection, CleanupFuture, CleanupRequest, ExecutionAdmission, ExecutionCancellation,
@@ -27,7 +28,9 @@ use automata_ci_runner_runtime::{
     RuntimeControlErrorKind, RuntimeControlFuture, RuntimeControlReply, RuntimeControlRetry,
     SystemRuntimeIds, TokioRuntimeSleeper,
 };
-use automata_ci_runner_spool::{DurableContentStore, FileSpool};
+use automata_ci_runner_spool::{
+    ContentCommitmentDomain, ContentKind, DurableContentStore, FileSpool,
+};
 use automata_ci_runner_transport::PreparedRequest;
 use tokio_util::sync::CancellationToken;
 
@@ -1435,6 +1438,148 @@ async fn cancellation_timeout_quiesces_executor_before_sandbox_cleanup() {
             .slot(fixture.slot)
             .is_none()
     );
+}
+
+fn seed_ambiguous_endpoint_and_sandbox(
+    journal: &dyn RunnerJournal,
+    spool: &dyn DurableContentStore,
+    fixture: &support::AcceptedFixture,
+    cancellation_requested: bool,
+) -> OperationId {
+    let create = OperationId::new();
+    journal
+        .record_provider_intent(
+            fixture.session_id,
+            fixture.slot,
+            fixture.lease.guard(),
+            ProviderOperation::intent(create, ProviderOperationKind::CreateSandbox),
+        )
+        .expect("seed create intent");
+    journal
+        .record_sandbox_created(
+            fixture.session_id,
+            fixture.slot,
+            fixture.lease.guard(),
+            create,
+            SandboxIdentity::new(
+                ProviderName::new("endpoint-recovery-provider").expect("provider"),
+                SandboxHandle::new("generation-7").expect("sandbox handle"),
+            ),
+        )
+        .expect("seed exact sandbox identity");
+
+    let operation_id = OperationId::new();
+    let request_digest = [0x47; 32];
+    let commitment = spool
+        .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, &request_digest)
+        .expect("keyed request commitment");
+    let publication = spool
+        .persist(ContentKind::EndpointRequest, commitment.as_bytes())
+        .expect("persist request commitment");
+    let adopted = publication.commit_with(|content| {
+        let request = EndpointRequestContentRef::new(content.clone())?;
+        let operation =
+            EndpointOperation::accepted(operation_id, EndpointOperationKind::Wait, request, 64)?;
+        journal.accept_endpoint_operation(
+            fixture.session_id,
+            fixture.slot,
+            fixture.lease.guard(),
+            operation,
+        )
+    });
+    if let Err(failure) = adopted {
+        let (error, publication) = failure.into_parts();
+        publication.abort();
+        panic!("accept endpoint operation: {error}");
+    }
+    journal
+        .commit_endpoint_invocation(
+            fixture.session_id,
+            fixture.slot,
+            fixture.lease.guard(),
+            operation_id,
+        )
+        .expect("seed invocation ambiguity");
+    if cancellation_requested {
+        journal
+            .record_endpoint_cancellation(
+                fixture.session_id,
+                fixture.slot,
+                fixture.lease.guard(),
+                operation_id,
+            )
+            .expect("seed cancellation ambiguity");
+    }
+    operation_id
+}
+
+#[tokio::test]
+async fn restarted_endpoint_ambiguity_is_destroyed_resolved_terminalized_and_released() {
+    for cancellation_requested in [false, true] {
+        let scratch = support::Scratch::new(if cancellation_requested {
+            "endpoint-cancellation-recovery"
+        } else {
+            "endpoint-abandonment-recovery"
+        });
+        let runner_id = RunnerId::new();
+        let (seed_journal, seed_spool) = support::durable_ports(&scratch, runner_id);
+        let fixture =
+            support::seed_accepted_offer(seed_journal.as_ref(), seed_spool.as_ref(), runner_id);
+        seed_ambiguous_endpoint_and_sandbox(
+            seed_journal.as_ref(),
+            seed_spool.as_ref(),
+            &fixture,
+            cancellation_requested,
+        );
+        drop(seed_journal);
+        drop(seed_spool);
+
+        let (journal, spool) = support::durable_ports(&scratch, runner_id);
+        let executor = Arc::new(support::EndpointRecoveryExecutor::default());
+        let client = Arc::new(support::FailureIsolationClient::new(fixture.session_id));
+        let shutdown = CancellationToken::new();
+        let runtime = RunnerSessionSupervisor::new(
+            support::config(runner_id),
+            RunnerRuntimePorts::new(
+                client.clone(),
+                journal.clone(),
+                spool,
+                executor.clone(),
+                Arc::new(support::FixedClock::new(10_000, 50)),
+                Arc::new(support::ImmediateSleeper),
+                Arc::new(SystemRuntimeIds),
+            ),
+        );
+        let task_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move { runtime.run(task_shutdown).await });
+
+        tokio::time::timeout(
+            Duration::from_secs(15),
+            client.wait_for_released_slot_poll(),
+        )
+        .await
+        .expect("recovered endpoint slot reaches durable release");
+        assert_eq!(executor.execute_calls(), 1);
+        assert_eq!(executor.cleanup_calls(), 1);
+        assert_eq!(
+            client.terminal_results(),
+            vec![(fixture.lease.attempt_id(), JobConclusion::Failure)]
+        );
+        assert!(
+            journal
+                .snapshot()
+                .expect("released recovery snapshot")
+                .slot(fixture.slot)
+                .is_none()
+        );
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(15), task)
+            .await
+            .expect("runtime shutdown")
+            .expect("runtime task")
+            .expect("clean shutdown after endpoint recovery");
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -1712,6 +1712,65 @@ pub struct FailureIsolationExecutor {
     survivor_started: AtomicBool,
 }
 
+#[derive(Debug, Default)]
+pub struct EndpointRecoveryExecutor {
+    execute_calls: AtomicUsize,
+    cleanup_calls: AtomicUsize,
+}
+
+impl EndpointRecoveryExecutor {
+    pub fn execute_calls(&self) -> usize {
+        self.execute_calls.load(Ordering::SeqCst)
+    }
+
+    pub fn cleanup_calls(&self) -> usize {
+        self.cleanup_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl JobExecutor for EndpointRecoveryExecutor {
+    fn admit(&self, _job: &JobIrEnvelope) -> Result<ExecutionAdmission, AdmissionRejection> {
+        Ok(ExecutionAdmission::new(sandbox_environment()))
+    }
+
+    fn execute(
+        &self,
+        request: ExecutionRequest,
+        events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> ExecutorFuture<'_> {
+        Box::pin(async move {
+            self.execute_calls.fetch_add(1, Ordering::SeqCst);
+            events
+                .transition(JobLifecycle::Running)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+            Ok(JobResult::new(
+                request.lease().attempt_id(),
+                JobConclusion::Failure,
+                JobSecretExposure::Secretless,
+                UnixMillis::new(10_001),
+            ))
+        })
+    }
+
+    fn cleanup(
+        &self,
+        _request: CleanupRequest,
+        events: Arc<dyn ExecutionEvents>,
+        _cancellation: ExecutionCancellation,
+    ) -> CleanupFuture<'_> {
+        Box::pin(async move {
+            self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+            let destroy = events
+                .begin_provider_operation(ProviderOperationKind::DestroySandbox)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))?;
+            events
+                .provider_operation_completed(destroy)
+                .map_err(|_| ExecutorError::new(ExecutorErrorKind::Internal))
+        })
+    }
+}
+
 pub const FAILURE_ISOLATION_LOG_COUNT: usize = 64;
 
 impl FailureIsolationExecutor {

--- a/crates/automata-ci-runner-spool/Cargo.toml
+++ b/crates/automata-ci-runner-spool/Cargo.toml
@@ -28,4 +28,6 @@ subtle.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+automata-ci-execution.workspace = true
+serde_json.workspace = true
 static_assertions.workspace = true

--- a/crates/automata-ci-runner-spool/tests/endpoint_results.rs
+++ b/crates/automata-ci-runner-spool/tests/endpoint_results.rs
@@ -1,0 +1,292 @@
+use crate::support;
+
+use std::{fs, sync::Arc};
+
+use automata_ci_core::Sha256Digest;
+use automata_ci_runner_spool::{
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentRef, DurableContentStore, FileSpool, FileSpoolOptions, OpaqueContentIdentity,
+    ProtectionId, SpoolError, SpoolInvariantError, SpoolLimits, endpoint_result_allocation,
+};
+use sha2::{Digest as _, Sha256};
+use support::{Scratch, TestProtector, adopt, content_path};
+
+fn protector(marker: u8) -> Arc<TestProtector> {
+    Arc::new(TestProtector::new("endpoint-key", marker))
+}
+
+fn bounded_spool(label: &str, limits: SpoolLimits) -> (Scratch, FileSpool) {
+    let scratch = Scratch::new(label);
+    let spool = FileSpool::open_with_options(
+        scratch.spool_root(),
+        protector(0x71),
+        FileSpoolOptions::new().with_limits(limits),
+    )
+    .expect("open bounded spool");
+    (scratch, spool)
+}
+
+enum PreflightFailure {
+    WrongSize,
+    Unavailable,
+}
+
+struct PreflightProtector {
+    inner: TestProtector,
+    failure: PreflightFailure,
+}
+
+impl ContentProtector for PreflightProtector {
+    fn protection_id(&self) -> &ProtectionId {
+        self.inner.protection_id()
+    }
+
+    fn keyed_commitment(
+        &self,
+        protection_id: &ProtectionId,
+        domain: ContentCommitmentDomain,
+        material_digest: &[u8; 32],
+    ) -> Result<[u8; 32], ContentProtectionError> {
+        self.inner
+            .keyed_commitment(protection_id, domain, material_digest)
+    }
+
+    fn endpoint_result_protected_bytes(
+        &self,
+        plaintext_bytes: u64,
+    ) -> Result<u64, ContentProtectionError> {
+        match self.failure {
+            PreflightFailure::WrongSize => endpoint_result_allocation(plaintext_bytes)
+                .map(|bytes| bytes + 1)
+                .map_err(|_| ContentProtectionError::Failed),
+            PreflightFailure::Unavailable => Err(ContentProtectionError::KeyUnavailable),
+        }
+    }
+
+    fn protect(
+        &self,
+        reference: &DurableContentRef,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        self.inner.protect(reference, plaintext)
+    }
+
+    fn unprotect(
+        &self,
+        reference: &DurableContentRef,
+        protected: &[u8],
+    ) -> Result<Vec<u8>, ContentProtectionError> {
+        self.inner.unprotect(reference, protected)
+    }
+}
+
+#[test]
+fn allocation_classes_are_deterministic_and_hide_exact_lengths() {
+    assert_eq!(endpoint_result_allocation(0).expect("zero"), 64 * 1024);
+    assert_eq!(endpoint_result_allocation(1).expect("one"), 64 * 1024);
+    assert_eq!(
+        endpoint_result_allocation(65_460).expect("last first-class payload"),
+        64 * 1024
+    );
+    assert_eq!(
+        endpoint_result_allocation(65_461).expect("first second-class payload"),
+        128 * 1024
+    );
+    assert!(
+        automata_ci_runner_spool::DurableContentRef::after_endpoint_result_commit(
+            65_537,
+            OpaqueContentIdentity::from_bytes([0x55; 32]),
+            ProtectionId::new("endpoint-key").expect("key ID"),
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn endpoint_result_reference_has_no_plaintext_digest_or_exact_size_oracle() {
+    let scratch = Scratch::new("endpoint-opaque-identity");
+    let spool = FileSpool::open(scratch.spool_root(), protector(0x51)).expect("open spool");
+    let plaintext = b"0427";
+    let reference = adopt(
+        spool
+            .reserve_endpoint_result(plaintext.len().try_into().expect("size"))
+            .expect("reserve")
+            .persist(plaintext)
+            .expect("persist reserved result"),
+    );
+
+    assert_eq!(reference.public_plaintext_bytes(), None);
+    assert_eq!(reference.public_plaintext_sha256(), None);
+    assert_eq!(
+        reference.endpoint_result_allocation_bytes(),
+        Some(64 * 1024)
+    );
+    assert_eq!(reference.accounted_bytes(), 64 * 1024);
+    assert_eq!(spool.load(&reference).expect("open result"), plaintext);
+
+    let plaintext_digest = Sha256Digest::from_bytes(Sha256::digest(plaintext).into()).to_string();
+    let serialized = serde_json::to_string(&reference).expect("serialize current ref");
+    let decoded: automata_ci_runner_spool::DurableContentRef =
+        serde_json::from_str(&serialized).expect("current ref decodes");
+    assert_eq!(decoded, reference);
+    let debug = format!("{reference:?}");
+    for exposed in [&serialized, &debug, reference.cache_key().as_str()] {
+        assert!(!exposed.contains(&plaintext_digest));
+        assert!(!exposed.contains("plaintext_bytes"));
+        assert!(!exposed.contains("plaintext_sha256"));
+    }
+    assert!(!serialized.contains(":4,"));
+
+    for candidate in [b"0000".as_slice(), b"0427", b"9999"] {
+        let digest = Sha256Digest::from_bytes(Sha256::digest(candidate).into()).to_string();
+        assert!(!reference.cache_key().as_str().contains(&digest));
+        assert!(!serialized.contains(&digest));
+    }
+
+    let old_shape = format!(
+        r#"{{"kind":"endpoint_result","size":4,"sha256":"{plaintext_digest}","cache_key":"endpoint-result-old","protection_id":"endpoint-key"}}"#
+    );
+    assert!(
+        serde_json::from_str::<automata_ci_runner_spool::DurableContentRef>(&old_shape).is_err()
+    );
+}
+
+#[test]
+fn same_class_results_have_identical_file_allocation_not_exact_length() {
+    let scratch = Scratch::new("endpoint-padding-class");
+    let root = scratch.spool_root();
+    let spool = FileSpool::open(root.clone(), protector(0x53)).expect("open spool");
+    let short = adopt(
+        spool
+            .reserve_endpoint_result(128)
+            .expect("short reserve")
+            .persist(b"x")
+            .expect("short persist"),
+    );
+    let longer = adopt(
+        spool
+            .reserve_endpoint_result(128)
+            .expect("long reserve")
+            .persist(&[b'y'; 127])
+            .expect("long persist"),
+    );
+    let short_file = fs::metadata(content_path(&root, &short))
+        .expect("short metadata")
+        .len();
+    let longer_file = fs::metadata(content_path(&root, &longer))
+        .expect("long metadata")
+        .len();
+    assert_eq!(short_file, 64 * 1024);
+    assert_eq!(longer_file, short_file);
+    assert_eq!(short.accounted_bytes(), longer.accounted_bytes());
+    assert_ne!(
+        short.endpoint_result_identity(),
+        longer.endpoint_result_identity()
+    );
+}
+
+#[test]
+fn ordinary_persist_cannot_bypass_endpoint_result_reservation() {
+    let scratch = Scratch::new("endpoint-reservation-required");
+    let spool = FileSpool::open(scratch.spool_root(), protector(0x52)).expect("open spool");
+    assert!(matches!(
+        spool.persist(ContentKind::EndpointResult, b"result"),
+        Err(SpoolError::Invariant(
+            SpoolInvariantError::EndpointResultReservationRequired
+        ))
+    ));
+}
+
+#[test]
+fn reservation_preflights_the_active_protector_size_and_availability() {
+    for (label, failure) in [
+        ("endpoint-preflight-size", PreflightFailure::WrongSize),
+        (
+            "endpoint-preflight-unavailable",
+            PreflightFailure::Unavailable,
+        ),
+    ] {
+        let scratch = Scratch::new(label);
+        let spool = FileSpool::open(
+            scratch.spool_root(),
+            Arc::new(PreflightProtector {
+                inner: TestProtector::new("endpoint-preflight", 0x43),
+                failure,
+            }),
+        )
+        .expect("open spool");
+        let Err(error) = spool.reserve_endpoint_result(1) else {
+            panic!("incoherent protection preflight must reject reservation");
+        };
+        assert!(matches!(
+            error,
+            SpoolError::Invariant(SpoolInvariantError::ProtectionOverheadExceeded)
+                | SpoolError::Protection(ContentProtectionError::KeyUnavailable)
+        ));
+        assert_eq!(spool.usage().expect("unchanged usage"), (0, 0));
+    }
+}
+
+#[test]
+fn reservation_blocks_competing_publishers_and_reservations_until_drop() {
+    let limits = SpoolLimits::new(1024, 66_559, 2, 65_535).expect("coherent limits");
+    let (_scratch, spool) = bounded_spool("endpoint-reservation-global", limits);
+    let reservation = spool
+        .reserve_endpoint_result(1)
+        .expect("reserve full byte budget");
+
+    assert!(matches!(
+        spool.persist(ContentKind::JobIr, &[0x42; 1024]),
+        Err(SpoolError::CapacityExhausted)
+    ));
+    assert!(matches!(
+        spool.reserve_endpoint_result(1),
+        Err(SpoolError::CapacityExhausted)
+    ));
+
+    drop(reservation);
+    spool
+        .persist(ContentKind::JobIr, &[0x42; 1024])
+        .expect("drop releases all reserved capacity")
+        .abort();
+}
+
+#[test]
+fn consuming_smaller_class_relinquishes_unused_bytes_atomically() {
+    let limits = SpoolLimits::new(65_536, 131_147, 2, 65_611).expect("coherent limits");
+    let (_scratch, spool) = bounded_spool("endpoint-reservation-consume", limits);
+    let reservation = spool
+        .reserve_endpoint_result(65_461)
+        .expect("reserve second allocation class");
+    let reference = adopt(
+        reservation
+            .persist(b"small actual result")
+            .expect("consume first allocation class"),
+    );
+    assert_eq!(reference.accounted_bytes(), 65_536);
+    assert_eq!(spool.usage().expect("actual usage"), (1, 65_536));
+
+    spool
+        .persist(
+            ContentKind::JobIr,
+            b"fits only after unused reservation is released",
+        )
+        .expect("ordinary publication uses relinquished bytes")
+        .abort();
+}
+
+#[test]
+fn failed_reserved_persist_releases_capacity() {
+    let limits = SpoolLimits::new(1024, 66_559, 1, 65_535).expect("coherent limits");
+    let (_scratch, spool) = bounded_spool("endpoint-reservation-failure", limits);
+    let reservation = spool.reserve_endpoint_result(1).expect("reserve");
+    assert!(matches!(
+        reservation.persist(b"too large"),
+        Err(SpoolError::Invariant(SpoolInvariantError::ObjectTooLarge))
+    ));
+    drop(
+        spool
+            .reserve_endpoint_result(1)
+            .expect("failure releases reservation"),
+    );
+}

--- a/crates/automata-ci-runner-spool/tests/fault_recovery.rs
+++ b/crates/automata-ci-runner-spool/tests/fault_recovery.rs
@@ -97,3 +97,63 @@ fn post_rename_faults_poison_the_handle_and_reopen_recovers_exact_content() {
         assert_eq!(reopened.usage().expect("recovered usage").0, 1);
     }
 }
+
+#[test]
+fn reserved_endpoint_result_faults_release_or_recover_capacity_at_every_commit_boundary() {
+    let payload = b"opaque endpoint result";
+    for stage in [
+        ContentCommitStage::StagingCreated,
+        ContentCommitStage::DataWritten,
+        ContentCommitStage::FileSynced,
+        ContentCommitStage::Renamed,
+        ContentCommitStage::DirectorySynced,
+    ] {
+        let scratch = Scratch::new(&format!("endpoint-result-{stage:?}"));
+        let root = scratch.spool_root();
+        let spool =
+            FileSpool::open_with_options(root.clone(), protector(), options(stage)).expect("open");
+        let error = match spool
+            .reserve_endpoint_result(64)
+            .expect("reserve before provider")
+            .persist(payload)
+        {
+            Err(error) => error,
+            Ok(publication) => {
+                publication.abort();
+                panic!("faulted publication unexpectedly succeeded")
+            }
+        };
+        if matches!(
+            stage,
+            ContentCommitStage::StagingCreated
+                | ContentCommitStage::DataWritten
+                | ContentCommitStage::FileSynced
+        ) {
+            assert!(matches!(
+                error,
+                SpoolError::InjectedFault(received) if received == stage
+            ));
+            assert_eq!(spool.usage().expect("unchanged usage"), (0, 0));
+            drop(
+                spool
+                    .reserve_endpoint_result(64)
+                    .expect("failed persist released reservation"),
+            );
+        } else {
+            assert!(matches!(error, SpoolError::CommitOutcomeUnknown));
+            assert!(matches!(spool.usage(), Err(SpoolError::Poisoned)));
+        }
+        drop(spool);
+
+        let reopened = FileSpool::open(root, protector()).expect("recover spool");
+        let reference = adopt(
+            reopened
+                .reserve_endpoint_result(64)
+                .expect("reserve exact retry")
+                .persist(payload)
+                .expect("retry after reopen"),
+        );
+        assert_eq!(reopened.load(&reference).expect("recover payload"), payload);
+        assert_eq!(reopened.usage().expect("one recovered object").0, 1);
+    }
+}

--- a/crates/automata-ci-runner-spool/tests/key_rotation.rs
+++ b/crates/automata-ci-runner-spool/tests/key_rotation.rs
@@ -86,6 +86,35 @@ fn keyring(active: (&str, u8), decrypt_only: &[(&str, u8)]) -> Arc<TestKeyring> 
     Arc::new(TestKeyring::new(active, decrypt_only))
 }
 
+#[test]
+fn keyed_commitments_replay_with_the_exact_old_key_and_rotate_for_new_requests() {
+    let scratch = Scratch::new("keyed-commitment-rotation");
+    let root = scratch.spool_root();
+    let digest = [0x31; 32];
+    let before =
+        FileSpool::open(root.clone(), keyring(("spool-v1", 0x11), &[])).expect("open old spool");
+    let old = before
+        .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, &digest)
+        .expect("old commitment");
+    drop(before);
+
+    let rotated = FileSpool::open(root, keyring(("spool-v2", 0x22), &[("spool-v1", 0x11)]))
+        .expect("open rotated spool");
+    let replay = rotated
+        .recreate_keyed_commitment(
+            old.protection_id(),
+            ContentCommitmentDomain::EndpointRequest,
+            &digest,
+        )
+        .expect("recreate old commitment");
+    let current = rotated
+        .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, &digest)
+        .expect("create current commitment");
+    assert_eq!(replay, old);
+    assert_ne!(current, old);
+    assert_eq!(current.protection_id().as_str(), "spool-v2");
+}
+
 fn reference(id: &str, plaintext: &[u8]) -> DurableContentRef {
     DurableContentRef::after_public_commit(
         ContentKind::JobIr,
@@ -153,6 +182,41 @@ fn rotation_preserves_old_reads_and_uses_exact_ids_for_remove_and_reconcile() {
         rotated.load(&new_reference),
         Err(SpoolError::ContentMissing)
     ));
+}
+
+#[test]
+fn endpoint_result_opaque_identity_rotates_and_old_exact_key_remains_readable() {
+    let scratch = Scratch::new("endpoint-result-key-rotation");
+    let root = scratch.spool_root();
+    let plaintext = b"low entropy result: 0427";
+    let before =
+        FileSpool::open(root.clone(), keyring(("spool-v1", 0x11), &[])).expect("old spool");
+    let old = adopt(
+        before
+            .reserve_endpoint_result(64)
+            .expect("old reservation")
+            .persist(plaintext)
+            .expect("old result"),
+    );
+    drop(before);
+
+    let rotated = FileSpool::open(root, keyring(("spool-v2", 0x22), &[("spool-v1", 0x11)]))
+        .expect("rotated spool");
+    assert_eq!(rotated.load(&old).expect("old exact key opens"), plaintext);
+    let current = adopt(
+        rotated
+            .reserve_endpoint_result(64)
+            .expect("new reservation")
+            .persist(plaintext)
+            .expect("new result"),
+    );
+    assert_ne!(
+        current.endpoint_result_identity(),
+        old.endpoint_result_identity()
+    );
+    assert_ne!(current.cache_key(), old.cache_key());
+    assert_eq!(current.protection_id().as_str(), "spool-v2");
+    assert_eq!(old.protection_id().as_str(), "spool-v1");
 }
 
 #[test]

--- a/crates/automata-ci-runner-spool/tests/observability.rs
+++ b/crates/automata-ci-runner-spool/tests/observability.rs
@@ -113,6 +113,53 @@ fn operations_protection_reclaim_and_bytes_are_observed_without_identity() {
 }
 
 #[test]
+fn endpoint_result_observation_reports_only_the_padded_allocation_class() {
+    let scratch = Scratch::new("endpoint-result-observability");
+    let observer = Arc::new(CapturingObserver::default());
+    let spool = FileSpool::open_with_options(
+        scratch.spool_root(),
+        protector(),
+        FileSpoolOptions::new().with_observer(observer.clone()),
+    )
+    .expect("open observed spool");
+    let short = adopt(
+        spool
+            .reserve_endpoint_result(128)
+            .expect("reserve short result")
+            .persist(b"x")
+            .expect("persist short result"),
+    );
+    let longer = adopt(
+        spool
+            .reserve_endpoint_result(128)
+            .expect("reserve longer result")
+            .persist(&[b'y'; 128])
+            .expect("persist longer result"),
+    );
+    assert_eq!(spool.load(&short).expect("load short result"), b"x");
+    assert_eq!(
+        spool.load(&longer).expect("load longer result"),
+        [b'y'; 128]
+    );
+
+    let endpoint_bytes: Vec<_> = observer
+        .events()
+        .into_iter()
+        .filter_map(|event| match event {
+            SpoolEvent::ContentBytes {
+                content_kind: ContentKind::EndpointResult,
+                bytes,
+                ..
+            } => Some(bytes),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(endpoint_bytes, vec![65_536; 4]);
+    assert!(!endpoint_bytes.contains(&1));
+    assert!(!endpoint_bytes.contains(&128));
+}
+
+#[test]
 fn capacity_and_typed_failures_are_terminal_and_identifier_free() {
     let scratch = Scratch::new("observability-capacity");
     let observer = Arc::new(CapturingObserver::default());

--- a/crates/automata-ci-runner-spool/tests/runner_spool.rs
+++ b/crates/automata-ci-runner-spool/tests/runner_spool.rs
@@ -1,5 +1,6 @@
 mod support;
 
+mod endpoint_results;
 mod fault_recovery;
 mod key_rotation;
 mod observability;

--- a/crates/automata-ci-runner-spool/tests/spool_contract.rs
+++ b/crates/automata-ci-runner-spool/tests/spool_contract.rs
@@ -2,10 +2,13 @@ use crate::support;
 
 use std::{fs, sync::Arc};
 
+use automata_ci_core::Sha256Digest;
+use automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB;
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, DurableContentStore, FileSpool, FileSpoolOptions,
-    SpoolError, SpoolInvariantError, SpoolLimits,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, DurableContentStore, FileSpool,
+    FileSpoolOptions, SpoolError, SpoolInvariantError, SpoolLimits, endpoint_result_allocation,
 };
+use sha2::{Digest as _, Sha256};
 use static_assertions::assert_obj_safe;
 use support::{Scratch, StaticRetainSet, TestProtector, adopt, content_path};
 
@@ -13,6 +16,55 @@ assert_obj_safe!(DurableContentStore);
 
 fn protector() -> Arc<TestProtector> {
     Arc::new(TestProtector::new("test-aead-v1", 0xa7))
+}
+
+#[test]
+fn default_capacity_holds_every_minimum_class_endpoint_result_admitted_by_one_job() {
+    let admitted_results = u64::try_from(MAX_ENDPOINT_OPERATIONS_PER_JOB).expect("bounded cap");
+    let required = endpoint_result_allocation(1)
+        .expect("one-byte allocation")
+        .checked_mul(admitted_results)
+        .expect("bounded requirement");
+    let limits = SpoolLimits::default();
+    assert!(limits.max_total_bytes() >= required);
+    let required_refs = admitted_results
+        .checked_mul(2)
+        .expect("request and result refs");
+    assert!(u64::from(limits.max_objects()) >= required_refs);
+}
+
+#[test]
+fn plaintext_reference_and_cache_key_cannot_validate_low_entropy_commitment_guesses() {
+    let scratch = Scratch::new("keyed-commitment");
+    let spool = FileSpool::open(scratch.spool_root(), protector()).expect("open spool");
+    let material_digest: [u8; 32] = Sha256::digest(b"0427").into();
+    let commitment = spool
+        .create_keyed_commitment(ContentCommitmentDomain::EndpointRequest, &material_digest)
+        .expect("keyed commitment");
+    assert!(format!("{commitment:?}").contains("[REDACTED]"));
+    assert!(!format!("{commitment:?}").contains("0427"));
+    let reference = adopt(
+        spool
+            .persist(ContentKind::EndpointRequest, commitment.as_bytes())
+            .expect("persist protected commitment"),
+    );
+    for candidate in [b"0000".as_slice(), b"0427", b"9999"] {
+        let candidate_digest: [u8; 32] = Sha256::digest(candidate).into();
+        let vulnerable_reference_digest =
+            Sha256Digest::from_bytes(Sha256::digest(candidate_digest).into());
+        assert_ne!(
+            reference
+                .public_plaintext_sha256()
+                .expect("endpoint commitment is a public content kind"),
+            vulnerable_reference_digest
+        );
+        assert!(
+            !reference
+                .cache_key()
+                .as_str()
+                .contains(&vulnerable_reference_digest.to_string())
+        );
+    }
 }
 
 #[test]
@@ -172,4 +224,33 @@ fn complete_journal_reconciliation_reclaims_payload_first_crash_leftovers() {
         b"journaled JobIR"
     );
     assert_eq!(reopened.usage().expect("stable usage").0, 1);
+}
+
+#[test]
+fn reconciliation_applies_the_object_limit_after_deduplicating_references() {
+    let scratch = Scratch::new("reconcile-duplicate-references");
+    let limits = SpoolLimits::new(1_024, 2_048, 1, 1_024).expect("one-object limits");
+    let spool = FileSpool::open_with_options(
+        scratch.spool_root(),
+        protector(),
+        FileSpoolOptions::new().with_limits(limits),
+    )
+    .expect("open bounded spool");
+    let reference = adopt(
+        spool
+            .persist(ContentKind::JobIr, b"one physical object")
+            .expect("persist object"),
+    );
+
+    spool
+        .reconcile(&StaticRetainSet::new([
+            reference.clone(),
+            reference.clone(),
+        ]))
+        .expect("duplicate logical references retain one physical object");
+    assert_eq!(spool.usage().expect("stable deduplicated usage").0, 1);
+    assert_eq!(
+        spool.load(&reference).expect("retained object"),
+        b"one physical object"
+    );
 }

--- a/crates/automata-ci-runner/src/product/spool_crypto/tests/aes_gcm.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/tests/aes_gcm.rs
@@ -1,6 +1,7 @@
 use automata_ci_core::Sha256Digest;
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, ContentProtector, DurableContentRef, ProtectionId,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentRef, OpaqueContentIdentity, ProtectionId, endpoint_result_allocation,
 };
 use sha2::{Digest as _, Sha256};
 use zeroize::Zeroizing;
@@ -20,6 +21,133 @@ fn make_reference(id: &str, kind: ContentKind, plaintext: &[u8]) -> DurableConte
         ProtectionId::new(id).expect("valid ID"),
     )
     .expect("valid reference")
+}
+
+fn make_endpoint_reference(
+    protector: &Aes256GcmContentProtector,
+    plaintext: &[u8],
+) -> DurableContentRef {
+    const MATERIAL_DOMAIN: &[u8] = b"automata.runner.endpoint-result.material.v1\0";
+    let plaintext_bytes = u64::try_from(plaintext.len()).expect("fixture size");
+    let mut material = Sha256::new();
+    material.update(MATERIAL_DOMAIN);
+    material.update(plaintext_bytes.to_be_bytes());
+    material.update(Sha256::digest(plaintext));
+    let material_digest: [u8; 32] = material.finalize().into();
+    let opaque = protector
+        .keyed_commitment(
+            protector.protection_id(),
+            ContentCommitmentDomain::EndpointResultIdentity,
+            &material_digest,
+        )
+        .expect("opaque identity");
+    DurableContentRef::after_endpoint_result_commit(
+        endpoint_result_allocation(plaintext_bytes).expect("allocation"),
+        OpaqueContentIdentity::from_bytes(opaque),
+        protector.protection_id().clone(),
+    )
+    .expect("endpoint reference")
+}
+
+#[test]
+fn endpoint_commitment_is_a_domain_separated_keyed_prf_and_debug_is_redacted() {
+    let digest = [0x09; 32];
+    let first = make_protector("key-a", 0x42);
+    let same = make_protector("key-a", 0x42);
+    let other = make_protector("key-b", 0x43);
+    let id_a = ProtectionId::new("key-a").expect("key id");
+    let id_b = ProtectionId::new("key-b").expect("key id");
+    let commitment = first
+        .keyed_commitment(&id_a, ContentCommitmentDomain::EndpointRequest, &digest)
+        .expect("commitment");
+    assert_eq!(
+        commitment,
+        same.keyed_commitment(&id_a, ContentCommitmentDomain::EndpointRequest, &digest)
+            .expect("same key commitment")
+    );
+    assert_ne!(
+        commitment,
+        other
+            .keyed_commitment(&id_b, ContentCommitmentDomain::EndpointRequest, &digest)
+            .expect("other key commitment")
+    );
+    assert_ne!(commitment, digest);
+    let result_identity = first
+        .keyed_commitment(
+            &id_a,
+            ContentCommitmentDomain::EndpointResultIdentity,
+            &digest,
+        )
+        .expect("result identity");
+    assert_ne!(result_identity, commitment);
+    assert_ne!(result_identity, digest);
+    assert_eq!(
+        first
+            .keyed_commitment(&id_b, ContentCommitmentDomain::EndpointRequest, &digest)
+            .expect_err("wrong key id"),
+        ContentProtectionError::KeyUnavailable
+    );
+    assert!(!format!("{first:?}").contains("090909"));
+}
+
+#[test]
+fn endpoint_results_round_trip_with_authenticated_padding_classes() {
+    let protector = make_protector("key-a", 0x5a);
+    let short = b"x";
+    let longer = [b'y'; 127];
+    let short_ref = make_endpoint_reference(&protector, short);
+    let longer_ref = make_endpoint_reference(&protector, &longer);
+    let short_protected = protector.protect(&short_ref, short).expect("protect short");
+    let longer_protected = protector
+        .protect(&longer_ref, &longer)
+        .expect("protect longer");
+
+    assert_eq!(
+        protector
+            .endpoint_result_protected_bytes(short.len().try_into().expect("short length"))
+            .expect("preflight short result"),
+        u64::try_from(short_protected.len()).expect("protected length")
+    );
+    assert_eq!(
+        protector
+            .endpoint_result_protected_bytes(longer.len().try_into().expect("longer length"))
+            .expect("preflight longer result"),
+        u64::try_from(longer_protected.len()).expect("protected length")
+    );
+    assert_eq!(short_protected.len(), 64 * 1024);
+    assert_eq!(longer_protected.len(), short_protected.len());
+    assert_eq!(&short_protected[..4], b"ASP2");
+    assert_eq!(
+        protector
+            .unprotect(&short_ref, &short_protected)
+            .expect("open short"),
+        short
+    );
+    assert_eq!(
+        protector
+            .unprotect(&longer_ref, &longer_protected)
+            .expect("open longer"),
+        longer
+    );
+
+    let mut obsolete_header = short_protected.clone();
+    obsolete_header[..4].copy_from_slice(b"ASP1");
+    assert_eq!(
+        protector
+            .unprotect(&short_ref, &obsolete_header)
+            .expect_err("obsolete protection schema must fail closed"),
+        ContentProtectionError::AuthenticationFailed
+    );
+
+    let mut tampered = short_protected;
+    let last = tampered.len() - 1;
+    tampered[last] ^= 0x80;
+    assert_eq!(
+        protector
+            .unprotect(&short_ref, &tampered)
+            .expect_err("authenticated padding rejects tampering"),
+        ContentProtectionError::AuthenticationFailed
+    );
 }
 
 #[test]
@@ -126,6 +254,30 @@ fn runtime_authority_has_a_distinct_authenticated_domain() {
         protector
             .unprotect(&authority, &protected)
             .expect("authority kind authenticates"),
+        plaintext
+    );
+}
+
+#[test]
+fn endpoint_request_and_result_have_distinct_authenticated_domains() {
+    let plaintext = b"endpoint replay bytes";
+    let protector = make_protector("key-a", 0x32);
+    let request = make_reference("key-a", ContentKind::EndpointRequest, plaintext);
+    let result = make_endpoint_reference(&protector, plaintext);
+
+    let protected = protector
+        .protect(&request, plaintext)
+        .expect("protect endpoint request");
+    assert_eq!(
+        protector
+            .unprotect(&result, &protected)
+            .expect_err("request/result substitution rejected"),
+        ContentProtectionError::AuthenticationFailed
+    );
+    assert_eq!(
+        protector
+            .unprotect(&request, &protected)
+            .expect("endpoint request authenticates"),
         plaintext
     );
 }

--- a/crates/automata-ci-runner/src/product/spool_crypto/tests/keyring.rs
+++ b/crates/automata-ci-runner/src/product/spool_crypto/tests/keyring.rs
@@ -1,6 +1,7 @@
 use automata_ci_core::Sha256Digest;
 use automata_ci_runner_spool::{
-    ContentKind, ContentProtectionError, ContentProtector, DurableContentRef, ProtectionId,
+    ContentCommitmentDomain, ContentKind, ContentProtectionError, ContentProtector,
+    DurableContentRef, ProtectionId,
 };
 use sha2::{Digest as _, Sha256};
 use zeroize::Zeroizing;
@@ -46,6 +47,42 @@ fn rotation_reads_exact_old_id_but_all_new_writes_use_active_id() {
             .expect("old key remains readable"),
         old_plaintext
     );
+    let digest = [0x51; 32];
+    let old_commitment = keyring
+        .keyed_commitment(
+            old_reference.protection_id(),
+            ContentCommitmentDomain::EndpointRequest,
+            &digest,
+        )
+        .expect("old exact key commitment");
+    assert_eq!(
+        old_commitment,
+        protector("spool-v1", 0x11)
+            .keyed_commitment(
+                old_reference.protection_id(),
+                ContentCommitmentDomain::EndpointRequest,
+                &digest,
+            )
+            .expect("standalone old commitment")
+    );
+    let old_result_identity = keyring
+        .keyed_commitment(
+            old_reference.protection_id(),
+            ContentCommitmentDomain::EndpointResultIdentity,
+            &digest,
+        )
+        .expect("old exact-key result identity");
+    assert_eq!(
+        old_result_identity,
+        protector("spool-v1", 0x11)
+            .keyed_commitment(
+                old_reference.protection_id(),
+                ContentCommitmentDomain::EndpointResultIdentity,
+                &digest,
+            )
+            .expect("standalone old result identity")
+    );
+    assert_ne!(old_result_identity, old_commitment);
     assert_eq!(
         keyring
             .protect(&old_reference, old_plaintext)


### PR DESCRIPTION
## Outcome

Adds the adversarial verification matrix for the durable endpoint-operation boundary merged in #366, without broadening its production API.

The tests cover every journal transition and physical commit boundary, protected result publication/reconciliation, capacity and key rotation, cancellation/result races, supervisor and orphan recovery, and exact-absence terminalization. A committed ambiguous invocation remains fail-closed as `InvocationCommitted`; there is deliberately no restart-safe provider branch and no guest-v5 or LocalDocker behavior.

This is the tests-only companion PR in the host-replay stack split from draft #173.

## Related issue

Related to #173. Verifies #366.

## Trust and compatibility impact

No production protocol or user-facing behavior is added. The test matrix locks the current-only journal/spool contracts from #366, including rejection of older/corrupt shapes, opaque result identities, pre-invocation capacity reservation, Accepted-only public insertion, unique-object reconciliation, and exact-sandbox-absence recovery.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- runner journal: 80 tests
- runner spool: 28 tests
- runner runtime: 103 tests
- runner library: 123 passed, 1 existing opt-in ignore
- strict affected-package Clippy with `-D warnings`
- locked workspace all-target/all-feature check
- exact one-to-one range-diff after #366 squash
- independent strict review before and after rebase: CLEAN

## AI assistance

OpenAI Codex helped separate the verification matrix from the production replay cycle, remove unimplemented restart-safe scenarios, run validation, and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
