### PR TITLE
fix(execution): require canonical immutable images

### DIFF
--- a/crates/automata-ci-execution/src/value.rs
+++ b/crates/automata-ci-execution/src/value.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt,
+    net::Ipv6Addr,
     num::{NonZeroU32, NonZeroU64},
     str::FromStr as _,
 };
@@ -12,6 +13,8 @@ use crate::{
 };
 
 const MAX_IDENTIFIER_BYTES: usize = 64;
+// Distribution limits the remote-name path, excluding the registry, to 255 bytes.
+const MAX_DOCKER_REMOTE_NAME_BYTES: usize = 255;
 const MAX_TARGET_PATH_BYTES: usize = 4_096;
 const MAX_MEMORY_BYTES: u64 = 1024 * 1024 * 1024 * 1024;
 const MIN_MEMORY_BYTES: u64 = 16 * 1024 * 1024;
@@ -139,12 +142,13 @@ pub struct ImmutableImage {
 }
 
 impl ImmutableImage {
-    /// Parses `registry/repository@sha256:<64 lowercase hex>`.
+    /// Parses a canonical `registry/repository@sha256:<64 lowercase hex>`.
     ///
     /// # Errors
     ///
-    /// Rejects mutable tags, uppercase/non-hex digests, whitespace, and
-    /// oversized or ambiguous references.
+    /// Rejects mutable tags, non-canonical registry or Docker repository
+    /// names, uppercase/non-hex digests, whitespace, and oversized or
+    /// ambiguous references.
     pub fn new(reference: impl Into<String>) -> Result<Self, ValueError> {
         let reference = reference.into();
         if reference.is_empty()
@@ -159,13 +163,7 @@ impl ImmutableImage {
             .ok_or(ValueError::InvalidImmutableImage)?;
         if repository.is_empty()
             || repository.contains('@')
-            || !repository.contains('/')
-            || repository
-                .split('/')
-                .any(|component| component.is_empty() || matches!(component, "." | ".."))
-            || !repository
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || b"./:_-".contains(&byte))
+            || !valid_registry_qualified_repository(repository)
             || digest.len() != 64
             || !digest
                 .bytes()
@@ -189,6 +187,112 @@ impl ImmutableImage {
     pub const fn digest(&self) -> Sha256Digest {
         self.digest
     }
+}
+
+fn valid_registry_qualified_repository(repository: &str) -> bool {
+    let Some((registry, repository_name)) = repository.split_once('/') else {
+        return false;
+    };
+    valid_registry(registry)
+        && !repository_name.is_empty()
+        && repository_name.len() <= MAX_DOCKER_REMOTE_NAME_BYTES
+        && repository_name.split('/').all(valid_repository_component)
+}
+
+fn valid_registry(value: &str) -> bool {
+    if let Some(rest) = value.strip_prefix('[') {
+        let Some((address, port)) = rest.split_once(']') else {
+            return false;
+        };
+        if !address
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b':')
+        {
+            return false;
+        }
+        let Ok(address_value) = Ipv6Addr::from_str(address) else {
+            return false;
+        };
+        return address_value.to_ipv4_mapped().is_none()
+            && address_value.to_string() == address
+            && (port.is_empty() || port.strip_prefix(':').is_some_and(valid_canonical_port));
+    }
+
+    let (host, port) = match value.rsplit_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (value, None),
+    };
+    if host.is_empty()
+        || host.len() > 253
+        || !host.is_ascii()
+        || host.bytes().any(|byte| byte.is_ascii_uppercase())
+        || port.is_some_and(|port| !valid_canonical_port(port))
+    {
+        return false;
+    }
+    let explicitly_registry_qualified = host == "localhost" || host.contains('.') || port.is_some();
+    explicitly_registry_qualified
+        && host.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        })
+}
+
+fn valid_canonical_port(value: &str) -> bool {
+    value
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .is_some_and(|port| port.to_string() == value)
+}
+
+fn valid_repository_component(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let run_start = offset;
+        while offset < bytes.len()
+            && (bytes[offset].is_ascii_lowercase() || bytes[offset].is_ascii_digit())
+        {
+            offset += 1;
+        }
+        if offset == run_start {
+            return false;
+        }
+        if offset == bytes.len() {
+            return true;
+        }
+        match bytes[offset] {
+            b'.' => offset += 1,
+            b'_' => {
+                offset += 1;
+                if bytes.get(offset) == Some(&b'_') {
+                    offset += 1;
+                }
+            }
+            b'-' => {
+                while bytes.get(offset) == Some(&b'-') {
+                    offset += 1;
+                }
+            }
+            _ => return false,
+        }
+    }
+    false
 }
 
 impl fmt::Debug for ImmutableImage {

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -59,6 +59,36 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
         ),
         Err(ValueError::InvalidImmutableImage)
     ));
+    for invalid in [
+        "library/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "Registry.Example/library/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/Team/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example:05000/team/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team//alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team/alpine_@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team/alpine___edge@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team/alpine..edge@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team/alpine:stable@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ] {
+        assert_eq!(
+            ImmutableImage::new(invalid),
+            Err(ValueError::InvalidImmutableImage),
+            "invalid image reference was accepted: {invalid}"
+        );
+    }
+    for valid in [
+        "localhost/team/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "localhost:5000/team/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "registry.example/team/a_b/a__b.c--d@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "[2001:db8::1]:5000/team/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ] {
+        assert_eq!(
+            ImmutableImage::new(valid)
+                .expect("valid registry-qualified immutable image")
+                .reference(),
+            valid
+        );
+    }
 
     let spec = SandboxSpec::new(
         OperationId::new(),
@@ -93,6 +123,47 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
         IMAGE
     );
     assert_eq!(spec.resources().cpu_millis(), 2_000);
+}
+
+#[test]
+fn immutable_image_enforces_docker_name_boundary_and_canonical_ipv6() {
+    const DIGEST: &str = "@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    let maximum_remote_name = "a".repeat(255);
+    let maximum_reference = format!("r.io/{maximum_remote_name}{DIGEST}");
+    assert_eq!(
+        ImmutableImage::new(&maximum_reference)
+            .expect("255-byte Docker remote name")
+            .reference(),
+        maximum_reference
+    );
+
+    let overlong_remote_name = "a".repeat(256);
+    assert_eq!(
+        ImmutableImage::new(format!("r.io/{overlong_remote_name}{DIGEST}")),
+        Err(ValueError::InvalidImmutableImage)
+    );
+
+    let canonical = format!("[2001:db8::1]/team/alpine{DIGEST}");
+    assert_eq!(
+        ImmutableImage::new(&canonical)
+            .expect("canonical bracketed IPv6 registry")
+            .reference(),
+        canonical
+    );
+    for alias in [
+        "[2001:DB8::1]",
+        "[2001:0db8:0000:0000:0000:0000:0000:0001]",
+        "[::192.0.2.1]",
+        "[::ffff:192.0.2.1]",
+        "[::ffff:c000:201]",
+    ] {
+        assert_eq!(
+            ImmutableImage::new(format!("{alias}/team/alpine{DIGEST}")),
+            Err(ValueError::InvalidImmutableImage),
+            "noncanonical IPv6 registry alias was accepted: {alias}"
+        );
+    }
 }
 
 #[test]

--- a/crates/automata-ci-sandbox-podman/tests/service_containers.rs
+++ b/crates/automata-ci-sandbox-podman/tests/service_containers.rs
@@ -102,31 +102,6 @@ fn services_use_one_job_network_hardened_argv_and_restart_durable_bindings() {
 }
 
 #[test]
-fn podman_normalized_tagged_digest_remains_exactly_owned() {
-    let fixture = Fixture::new_with_service_proxy("service-tagged-digest-normalization");
-    fixture.fake.normalize_tagged_digest_image_names();
-    let spec = service_spec(OperationId::new());
-    let record = fixture
-        .provider
-        .create(&spec, &NeverCancelled)
-        .expect("create services after Podman normalizes tagged digest names");
-
-    fixture
-        .provider
-        .destroy(
-            &DestroySandbox::new(
-                OperationId::new(),
-                record.handle().clone(),
-                record.generation(),
-                spec.custody(),
-            ),
-            &NeverCancelled,
-        )
-        .expect("normalized immutable image remains safely destroyable");
-    assert!(fixture.fake.is_empty());
-}
-
-#[test]
 fn stopped_proxy_is_recreated_with_fresh_logs_and_the_durable_listener_ports() {
     let fixture = Fixture::new_with_service_proxy("service-proxy-restart");
     let spec = service_spec(OperationId::new());
@@ -1260,7 +1235,7 @@ fn service_spec_with_database_variable(
 
 fn service_image(byte: u8) -> ImmutableImage {
     ImmutableImage::new(format!(
-        "registry.example.invalid/synthetic/service:stable@sha256:{}",
+        "registry.example.invalid/synthetic/service@sha256:{}",
         format!("{byte:02x}").repeat(32)
     ))
     .expect("immutable service image")

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -129,7 +129,6 @@ struct FakeState {
     wrong_proxy_identifier_once: bool,
     drift_health_configuration_once: bool,
     replace_network_before_remove: bool,
-    normalize_tagged_digest_image_names: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -156,13 +155,6 @@ impl std::fmt::Debug for FakePodman {
 impl FakePodman {
     pub(crate) fn commands(&self) -> Vec<Vec<String>> {
         self.state.lock().expect("fake lock").commands.clone()
-    }
-
-    pub(crate) fn normalize_tagged_digest_image_names(&self) {
-        self.state
-            .lock()
-            .expect("fake lock")
-            .normalize_tagged_digest_image_names = true;
     }
 
     pub(crate) fn fail_once(&self, command: &[&str]) {
@@ -1180,9 +1172,6 @@ fn create_fake_container(state: &mut FakeState, arguments: &[String]) -> Command
         .find(|value| value.contains("@sha256:"))
         .cloned()
         .unwrap_or_default();
-    if state.normalize_tagged_digest_image_names {
-        resource.image_name = podman_normalized_digest_reference(&resource.image_name);
-    }
     if arguments.iter().any(|value| value == "--network-alias") {
         state.next_service_address = state.next_service_address.max(10).saturating_add(1);
         resource.network_address = Some(format!("10.89.0.{}", state.next_service_address));
@@ -1276,18 +1265,6 @@ fn create_fake_container(state: &mut FakeState, arguments: &[String]) -> Command
     } else {
         CommandOutput::success(format!("{identifier}\n").into_bytes())
     }
-}
-
-fn podman_normalized_digest_reference(reference: &str) -> String {
-    let Some((name, digest)) = reference.rsplit_once('@') else {
-        return reference.to_owned();
-    };
-    let final_slash = name.rfind('/');
-    let repository = match name.rfind(':') {
-        Some(tag) if final_slash.is_none_or(|slash| tag > slash) => &name[..tag],
-        _ => name,
-    };
-    format!("{repository}@{digest}")
 }
 
 fn execute_fake_copy(


### PR DESCRIPTION
## Outcome

Makes `ImmutableImage` accept one canonical digest-pinned Docker/distribution reference for each image identity.

The parser now enforces the primary distribution remote-name grammar and its exact 255-byte repository-path limit, canonical registry/port spelling, and canonical bracketed IPv6. Dotted IPv4-mapped IPv6 and other aliases are rejected, so equivalent registries cannot produce distinct desired bytes or fingerprints.

Obsolete Podman test scaffolding for tagged-plus-digest input is removed; production Podman normalization compatibility remains unchanged and covered.

This is a small, fully consumed slice extracted from draft #173. It contains no LocalDocker or desired-spec surface.

## Related issue

Related to #173.

## Trust and compatibility impact

Image references that Docker rejects, or accepts only through non-canonical aliases, now fail before provider mutation. Valid canonical digest-pinned references retain their existing behavior. There is no wire, storage, credential, or GitHub Actions syntax change.

## Verification

- execution tests: 17/17
- Podman: 81 unit + 77 integration tests; 7 opt-in live tests ignored
- runner product config: 21/21
- full GitHub executor suite
- affected strict Clippy with `-D warnings`
- locked workspace all-target/all-feature check
- execution cross-checks on Windows GNU, Apple ARM64, and Linux musl
- fmt and diff checks
- wasm32 check attempted; current main is blocked in `uuid` because no randomness feature is configured
- independent strict review and exact rebase rereview: CLEAN

## AI assistance

OpenAI Codex helped extract and validate this slice from the larger draft and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
