### PR TITLE
refactor(auth): centralize runner enrollment tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- `automata-runner enroll` now requires one explicit `--token-source` selector:
+  `file:ABSOLUTE_PATH`, `env:NAME`, or `stdin`. The ambient environment/stdin
+  fallback and former `--token-file` option were removed; enrollment tokens now
+  share one canonical, redacted generation, validation, and digest contract.
 - Job-log visibility now follows the repository publication policy after the
   runner's mandatory secret masker. Public repositories can therefore expose
   redacted logs without exposing readable runtime authority; artifact audience

--- a/crates/automata-ci-auth/src/secret.rs
+++ b/crates/automata-ci-auth/src/secret.rs
@@ -9,6 +9,12 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 const GENERATED_SECRET_BYTES: usize = 32;
 const MAX_SECRET_LENGTH: usize = 65_536;
+const RUNNER_ENROLLMENT_TOKEN_PREFIX: &str = "atm_re_";
+const RUNNER_ENROLLMENT_TOKEN_BYTES: usize = 32;
+const RUNNER_ENROLLMENT_TOKEN_ENCODED_BYTES: usize = 43;
+const RUNNER_ENROLLMENT_TOKEN_DECODE_BUFFER_BYTES: usize =
+    RUNNER_ENROLLMENT_TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
+const RUNNER_ENROLLMENT_TOKEN_DIGEST_DOMAIN: &[u8] = b"automata.runner-enrollment-token.v1\0";
 
 /// An owned UTF-8 secret that is redacted from debug output and zeroized on drop.
 ///
@@ -316,6 +322,95 @@ macro_rules! opaque_token {
 
 opaque_token!(CsrfToken);
 opaque_token!(OAuthState);
+
+/// A canonical one-use runner-enrollment bearer credential.
+///
+/// The plaintext is exactly `atm_re_` followed by the unpadded URL-safe
+/// base64 encoding of 256 bits. The owned allocation is zeroized on drop and
+/// plaintext is available only through [`Self::expose_secret`].
+pub struct RunnerEnrollmentToken(SecretString);
+
+impl RunnerEnrollmentToken {
+    /// Exact UTF-8 byte length of this token.
+    pub const BYTE_LENGTH: usize =
+        RUNNER_ENROLLMENT_TOKEN_PREFIX.len() + RUNNER_ENROLLMENT_TOKEN_ENCODED_BYTES;
+
+    /// Generates a new canonical token from 256 bits of cryptographically
+    /// secure randomness.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the secure random source is unavailable.
+    pub fn generate(random: &dyn SecureRandom) -> Result<Self, RandomnessError> {
+        let mut entropy = Zeroizing::new([0_u8; RUNNER_ENROLLMENT_TOKEN_BYTES]);
+        random.fill(entropy.as_mut())?;
+        let mut token = String::with_capacity(Self::BYTE_LENGTH);
+        token.push_str(RUNNER_ENROLLMENT_TOKEN_PREFIX);
+        URL_SAFE_NO_PAD.encode_string(entropy.as_ref(), &mut token);
+        SecretString::new(token)
+            .map(Self)
+            .map_err(|_| RandomnessError)
+    }
+
+    /// Validates and takes custody of an existing enrollment token.
+    ///
+    /// # Errors
+    ///
+    /// Rejects every value outside the exact current `atm_re_` grammar.
+    pub fn from_secret(secret: SecretString) -> Result<Self, RunnerEnrollmentTokenError> {
+        let Some(encoded) = secret
+            .expose_secret()
+            .strip_prefix(RUNNER_ENROLLMENT_TOKEN_PREFIX)
+            .filter(|encoded| encoded.len() == RUNNER_ENROLLMENT_TOKEN_ENCODED_BYTES)
+        else {
+            return Err(RunnerEnrollmentTokenError);
+        };
+        let mut decoded = Zeroizing::new([0_u8; RUNNER_ENROLLMENT_TOKEN_DECODE_BUFFER_BYTES]);
+        if !matches!(
+            URL_SAFE_NO_PAD.decode_slice(encoded, decoded.as_mut()),
+            Ok(RUNNER_ENROLLMENT_TOKEN_BYTES)
+        ) {
+            return Err(RunnerEnrollmentTokenError);
+        }
+        Ok(Self(secret))
+    }
+
+    /// Exposes the raw credential at an explicit custody boundary.
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        self.0.expose_secret()
+    }
+
+    /// Derives the fixed domain-separated SHA-256 lookup digest.
+    #[must_use]
+    pub fn digest(&self) -> [u8; 32] {
+        let mut digest = Sha256::new();
+        digest.update(RUNNER_ENROLLMENT_TOKEN_DIGEST_DOMAIN);
+        digest.update(self.expose_secret().as_bytes());
+        digest.finalize().into()
+    }
+}
+
+impl<'de> Deserialize<'de> for RunnerEnrollmentToken {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let secret = SecretString::deserialize(deserializer)?;
+        Self::from_secret(secret).map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Debug for RunnerEnrollmentToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RunnerEnrollmentToken([REDACTED])")
+    }
+}
+
+/// Sanitized rejection of a noncanonical runner-enrollment token.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("runner enrollment token is invalid")]
+pub struct RunnerEnrollmentTokenError;
 
 /// Validation failures for persisted opaque credentials.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]

--- a/crates/automata-ci-auth/tests/secret_safety.rs
+++ b/crates/automata-ci-auth/tests/secret_safety.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use automata_ci_auth::{
     github::{GithubTokenResponse, GithubWebCallback},
     human::ProviderCredential,
-    secret::{CsrfToken, PkceVerifier, SecretBytes, SecretString, SharedSensitiveString},
+    secret::{
+        CsrfToken, PkceVerifier, RunnerEnrollmentToken, SecretBytes, SecretString,
+        SharedSensitiveString,
+    },
     vault::{ProviderAccessToken, ProviderRefreshToken, ProviderTokenSet, VersionedProviderTokens},
 };
 use static_assertions::{assert_impl_all, assert_not_impl_any};
@@ -13,6 +16,7 @@ use support::{DeterministicRandom, secret, token_response};
 
 assert_not_impl_any!(SecretString: serde::Serialize, Clone);
 assert_not_impl_any!(SecretBytes: serde::Serialize, Clone);
+assert_not_impl_any!(RunnerEnrollmentToken: serde::Serialize, Clone, std::fmt::Display);
 assert_not_impl_any!(ProviderAccessToken: serde::Serialize, Clone);
 assert_not_impl_any!(ProviderRefreshToken: serde::Serialize, Clone);
 assert_not_impl_any!(ProviderTokenSet: serde::Serialize, Clone);
@@ -71,6 +75,60 @@ fn csrf_tokens_are_unpredictable_length_and_constant_time_comparable() {
     assert!(!format!("{token:?}").contains(token.expose_secret()));
     assert!(CsrfToken::from_generated_secret(secret(token.expose_secret())).is_ok());
     assert!(CsrfToken::from_generated_secret(secret("too-short")).is_err());
+}
+
+#[test]
+fn runner_enrollment_token_has_one_redacted_canonical_representation() {
+    let token = RunnerEnrollmentToken::generate(&DeterministicRandom::new(7))
+        .expect("runner enrollment token");
+    assert_eq!(
+        token.expose_secret(),
+        "atm_re_BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc"
+    );
+    assert_eq!(
+        token.expose_secret().len(),
+        RunnerEnrollmentToken::BYTE_LENGTH
+    );
+    assert_eq!(
+        token.digest(),
+        [
+            0x9b, 0xd4, 0x7e, 0xbc, 0x44, 0x56, 0xa0, 0xe2, 0x09, 0xf9, 0x9f, 0x3d, 0xf5, 0xa7,
+            0xb2, 0x8a, 0x1d, 0xa7, 0x65, 0x83, 0x24, 0x81, 0x68, 0x61, 0xaf, 0xd2, 0xcd, 0x50,
+            0x00, 0xcc, 0xf2, 0x6b,
+        ]
+    );
+    assert_eq!(format!("{token:?}"), "RunnerEnrollmentToken([REDACTED])");
+    assert!(!format!("{token:?}").contains(token.expose_secret()));
+
+    let restored: RunnerEnrollmentToken =
+        serde_json::from_str(&format!("\"{}\"", token.expose_secret()))
+            .expect("canonical persisted token");
+    assert_eq!(restored.expose_secret(), token.expose_secret());
+}
+
+#[test]
+fn runner_enrollment_token_parser_rejects_every_noncanonical_shape_without_echoing_it() {
+    let canonical = RunnerEnrollmentToken::generate(&DeterministicRandom::new(7))
+        .expect("runner enrollment token");
+    for invalid in [
+        "plain-secret".to_owned(),
+        format!("{}A", canonical.expose_secret()),
+        format!("{}\n", canonical.expose_secret()),
+        canonical.expose_secret().replace("atm_re_", "ATM_RE_"),
+        canonical
+            .expose_secret()
+            .strip_suffix('c')
+            .expect("suffix")
+            .to_owned()
+            + "d",
+    ] {
+        let document = serde_json::to_string(&invalid).expect("test JSON");
+        let error = serde_json::from_str::<RunnerEnrollmentToken>(&document)
+            .expect_err("noncanonical token");
+        let rendered = format!("{error:?}");
+        assert!(!rendered.contains(&invalid));
+        assert!(rendered.contains("runner enrollment token is invalid"));
+    }
 }
 
 #[test]

--- a/crates/automata-ci-runner/Cargo.toml
+++ b/crates/automata-ci-runner/Cargo.toml
@@ -50,7 +50,6 @@ automata-ci-sandbox-windows.workspace = true
 automata-ci-scm.workspace = true
 automata-ci-workflow-github.workspace = true
 axum.workspace = true
-base64.workspace = true
 bytes.workspace = true
 clap.workspace = true
 http.workspace = true
@@ -87,6 +86,7 @@ automata-ci-build-support.workspace = true
 [dev-dependencies]
 automata-ci-auth.workspace = true
 automata-ci-protocol-protobuf.workspace = true
+base64.workspace = true
 flate2.workspace = true
 rcgen.workspace = true
 static_assertions.workspace = true

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -455,11 +455,14 @@ directory root-owned or group-writable. Never enroll as root or as an operator
 account and then copy the private key into place.
 
 Mint a separate one-use token and run `automata-runner enroll` as the exact
-service account for each configuration. Start the services only after every
-enrollment succeeds. If an enrollment is interrupted, repeat the same command
-as the same account with the same server, configuration, and runner name and
-with standard input from `/dev/null`. The private stage retains the original
-token and key; do not mint a replacement token or delete the stage.
+service account for each configuration, selecting exactly one explicit
+`--token-source file:PATH`, `--token-source env:NAME`, or
+`--token-source stdin`. Start the services only after every enrollment succeeds.
+If an enrollment is interrupted, repeat the exact command as the same account
+with the same server, configuration, runner name, and source selector. The
+private stage retains the original token and key and is loaded before the source;
+an explicit stdin retry may therefore use `/dev/null`. Do not mint a replacement
+token or delete the stage.
 
 Use owner-only file sources or the process supervisor's private credential
 facility. Do not place secret values in the JSON file, shell history, service

--- a/crates/automata-ci-runner/src/cli.rs
+++ b/crates/automata-ci-runner/src/cli.rs
@@ -1,6 +1,8 @@
-use std::path::PathBuf;
+use std::{convert::Infallible, fmt, path::PathBuf, str::FromStr};
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, error::ErrorKind};
+
+use crate::product::{validate_absolute_path, validate_environment_name};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -9,9 +11,57 @@ use clap::{Args, Parser, Subcommand};
     long_version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("AUTOMATA_BUILD_GIT_SHA"), ")"),
     about = "Automata runner for Linux, Windows, and isolated macOS execution hosts"
 )]
-pub(crate) struct Cli {
+struct ParsedCli {
     #[command(subcommand)]
     pub(crate) command: Command,
+}
+
+#[derive(Debug)]
+pub(crate) struct Cli {
+    pub(crate) command: Command,
+}
+
+impl CommandFactory for Cli {
+    fn command() -> clap::Command {
+        ParsedCli::command()
+    }
+
+    fn command_for_update() -> clap::Command {
+        ParsedCli::command_for_update()
+    }
+}
+
+impl FromArgMatches for Cli {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        let parsed = ParsedCli::from_arg_matches(matches)?;
+        validate_command(&parsed.command)?;
+        Ok(Self {
+            command: parsed.command,
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl Parser for Cli {}
+
+fn validate_command(command: &Command) -> Result<(), clap::Error> {
+    if matches!(
+        command,
+        Command::Enroll(EnrollArgs {
+            token_source: EnrollmentTokenSource::Invalid,
+            ..
+        })
+    ) {
+        return Err(clap::Error::raw(
+            ErrorKind::InvalidValue,
+            "runner enrollment token source must be file:PATH, env:NAME, or stdin",
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Subcommand)]
@@ -40,10 +90,60 @@ pub(crate) struct EnrollArgs {
     /// Human-readable runner name, unique within its tenant.
     #[arg(long, value_name = "NAME")]
     pub(crate) name: String,
-    /// Owner-only file containing the one-time token. If omitted, the token is read from
-    /// `AUTOMATA_RUNNER_ENROLLMENT_TOKEN` or redirected stdin, in that order.
-    #[arg(long, value_name = "PATH")]
-    pub(crate) token_file: Option<PathBuf>,
+    /// Explicit one-time token source. File input must be absolute and owner-only; stdin must reach EOF.
+    #[arg(long, value_name = "file:PATH|env:NAME|stdin")]
+    pub(crate) token_source: EnrollmentTokenSource,
+}
+
+#[derive(Clone)]
+pub(crate) enum EnrollmentTokenSource {
+    File(PathBuf),
+    Environment(String),
+    Stdin,
+    Invalid,
+}
+
+impl FromStr for EnrollmentTokenSource {
+    type Err = Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let source = if value == "stdin" {
+            Self::Stdin
+        } else if let Some(path) = value.strip_prefix("file:") {
+            let path = PathBuf::from(path);
+            if validate_absolute_path(&path).is_ok() {
+                Self::File(path)
+            } else {
+                Self::Invalid
+            }
+        } else if let Some(name) = value.strip_prefix("env:") {
+            let name = name.to_owned();
+            if validate_environment_name(&name).is_ok() {
+                Self::Environment(name)
+            } else {
+                Self::Invalid
+            }
+        } else {
+            Self::Invalid
+        };
+        Ok(source)
+    }
+}
+
+impl fmt::Debug for EnrollmentTokenSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::File(_) => "file",
+            Self::Environment(_) => "environment",
+            Self::Stdin => "stdin",
+            Self::Invalid => "invalid",
+        };
+        formatter
+            .debug_struct("EnrollmentTokenSource")
+            .field("kind", &kind)
+            .field("reference", &"[REDACTED]")
+            .finish()
+    }
 }
 
 #[derive(Debug, Args)]
@@ -90,9 +190,9 @@ pub(crate) struct InternalProbeHttpArgs {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser as _;
+    use clap::{CommandFactory as _, Parser as _, error::ErrorKind};
 
-    use super::{Cli, Command};
+    use super::{Cli, Command, EnrollmentTokenSource};
 
     #[test]
     fn run_accepts_only_a_configuration_path() {
@@ -149,7 +249,8 @@ mod tests {
     }
 
     #[test]
-    fn enroll_accepts_safe_token_sources_but_no_inline_token() {
+    fn enroll_requires_one_explicit_redacted_token_source() {
+        let marker = "private-enrollment-source-marker";
         let cli = Cli::try_parse_from([
             "automata-runner",
             "enroll",
@@ -159,22 +260,47 @@ mod tests {
             "https://ci.example.test",
             "--name",
             "linux-amd64-1",
-            "--token-file",
-            "/run/secrets/automata-enrollment-token",
+            "--token-source",
+            &format!("file:/run/secrets/{marker}"),
         ])
         .expect("enroll CLI must parse");
         let Command::Enroll(args) = cli.command else {
             panic!("enroll command expected");
         };
         assert_eq!(args.name, "linux-amd64-1");
-        assert_eq!(
-            args.token_file.as_deref(),
-            Some(std::path::Path::new(
-                "/run/secrets/automata-enrollment-token"
-            ))
-        );
+        assert!(matches!(&args.token_source, EnrollmentTokenSource::File(_)));
+        let rendered = format!("{:?}", args.token_source);
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(!rendered.contains(marker));
 
-        let error = Cli::try_parse_from([
+        for (source, reference) in [
+            (
+                "env:PRIVATE_ENROLLMENT_SOURCE_MARKER",
+                Some("PRIVATE_ENROLLMENT_SOURCE_MARKER"),
+            ),
+            ("stdin", None),
+        ] {
+            let cli = Cli::try_parse_from([
+                "automata-runner",
+                "enroll",
+                "--config",
+                "/var/lib/automata/runner.json",
+                "--server",
+                "https://ci.example.test",
+                "--name",
+                "linux-amd64-1",
+                "--token-source",
+                source,
+            ])
+            .expect("each explicit token source must parse");
+            let rendered = format!("{cli:?}");
+            assert!(rendered.contains("[REDACTED]"));
+            if let Some(reference) = reference {
+                assert!(!rendered.contains(reference));
+            }
+        }
+
+        let omitted = Cli::try_parse_from([
             "automata-runner",
             "enroll",
             "--config",
@@ -183,11 +309,63 @@ mod tests {
             "https://ci.example.test",
             "--name",
             "linux-amd64-1",
-            "--token",
-            "must-not-enter-argv",
         ])
-        .expect_err("inline enrollment tokens must not be accepted");
-        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+        .expect_err("the token source must be required");
+        assert_eq!(omitted.kind(), ErrorKind::MissingRequiredArgument);
+
+        for removed in ["--token", "--token-file"] {
+            let error = Cli::try_parse_from([
+                "automata-runner",
+                "enroll",
+                "--config",
+                "/var/lib/automata/runner.json",
+                "--server",
+                "https://ci.example.test",
+                "--name",
+                "linux-amd64-1",
+                removed,
+                marker,
+            ])
+            .expect_err("removed token arguments must not be accepted");
+            assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+            assert!(!error.to_string().contains(marker));
+        }
+
+        for invalid_source in [
+            marker.to_owned(),
+            format!("file:relative-{marker}"),
+            format!("env:lowercase_{marker}"),
+        ] {
+            let invalid = Cli::try_parse_from([
+                "automata-runner",
+                "enroll",
+                "--config",
+                "/var/lib/automata/runner.json",
+                "--server",
+                "https://ci.example.test",
+                "--name",
+                "linux-amd64-1",
+                "--token-source",
+                invalid_source.as_str(),
+            ])
+            .expect_err("invalid token sources must fail without being retained");
+            assert_eq!(invalid.kind(), ErrorKind::InvalidValue);
+            assert!(!invalid.to_string().contains(&invalid_source));
+        }
+    }
+
+    #[test]
+    fn enroll_help_exposes_only_the_current_explicit_source_contract() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("enroll")
+            .expect("enroll command")
+            .render_long_help()
+            .to_string();
+        assert!(help.contains("--token-source"));
+        assert!(help.contains("file:PATH|env:NAME|stdin"));
+        assert!(!help.contains("--token-file"));
+        assert!(!help.contains("AUTOMATA_RUNNER_ENROLLMENT_TOKEN"));
     }
 
     #[test]

--- a/crates/automata-ci-runner/src/enrollment.rs
+++ b/crates/automata-ci-runner/src/enrollment.rs
@@ -1,12 +1,12 @@
 //! Secure runner-side enrollment and local TLS credential custody.
 
 use std::{
-    io::Read as _,
+    io::Read,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context as _, Result, bail};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use automata_ci_auth::secret::{RunnerEnrollmentToken, SecretString};
 use bytes::Bytes;
 use reqwest::{Client, StatusCode, Url, header, redirect::Policy};
 use serde::{Deserialize, Serialize};
@@ -20,16 +20,11 @@ use custody::CredentialDestinations;
 use transport::read_bounded_response;
 
 use crate::{
-    cli::EnrollArgs,
-    product::{RunnerProductConfig, SecretSource},
+    cli::{EnrollArgs, EnrollmentTokenSource},
+    product::{RunnerProductConfig, ScalarLineEnding, SecretSource, normalize_scalar_bytes},
 };
 
 const REDEEM_PATH: &str = "/api/v1/runner-enrollments/redeem";
-const TOKEN_PREFIX: &str = "atm_re_";
-const TOKEN_BYTES: usize = 32;
-const TOKEN_ENCODED_BYTES: usize = 43;
-const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
-const MAX_TOKEN_BYTES: usize = TOKEN_PREFIX.len() + TOKEN_ENCODED_BYTES;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -49,7 +44,7 @@ pub(super) async fn enroll(args: &EnrollArgs) -> Result<()> {
         .context("runner enrollment endpoint is invalid")?;
     let body = RedeemRequest {
         operation_id: stage.operation_id,
-        token: stage.token.as_str(),
+        token: stage.token.expose_secret(),
         runner_name: &stage.runner_name,
         capabilities: &stage.capabilities,
         csr_pem: &stage.csr_pem,
@@ -114,36 +109,56 @@ fn validate_staged_response(staged: &[u8], replayed: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn load_token(args: &EnrollArgs) -> Result<Zeroizing<String>> {
-    let bytes = if let Some(path) = &args.token_file {
-        SecretSource::File { path: path.clone() }
-            .read_scalar(MAX_TOKEN_BYTES)
-            .context("runner enrollment token file is unavailable")?
-    } else if std::env::var_os("AUTOMATA_RUNNER_ENROLLMENT_TOKEN").is_some() {
-        SecretSource::Environment {
-            name: "AUTOMATA_RUNNER_ENROLLMENT_TOKEN".to_owned(),
+fn load_token(args: &EnrollArgs) -> Result<RunnerEnrollmentToken> {
+    let bytes = match &args.token_source {
+        EnrollmentTokenSource::File(path) => SecretSource::File { path: path.clone() }
+            .read_scalar(RunnerEnrollmentToken::BYTE_LENGTH)
+            .context("runner enrollment token file is unavailable")?,
+        EnrollmentTokenSource::Environment(name) => {
+            SecretSource::Environment { name: name.clone() }
+                .read_scalar(RunnerEnrollmentToken::BYTE_LENGTH)
+                .context("runner enrollment token environment value is unavailable")?
         }
-        .read_scalar(MAX_TOKEN_BYTES)
-        .context("runner enrollment token environment value is unavailable")?
-    } else {
-        let mut bytes = Zeroizing::new(Vec::new());
-        std::io::stdin()
-            .take(u64::try_from(MAX_TOKEN_BYTES + 2).expect("token bound fits u64"))
-            .read_to_end(&mut bytes)
-            .context("runner enrollment token could not be read from stdin")?;
-        while bytes
-            .last()
-            .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
-        {
-            bytes.pop();
+        EnrollmentTokenSource::Stdin => {
+            let stdin = std::io::stdin();
+            read_stdin_token(&mut stdin.lock())?
         }
-        bytes
+        EnrollmentTokenSource::Invalid => bail!("runner enrollment token source is invalid"),
     };
-    let token = String::from_utf8(Vec::from(bytes.as_slice()))
-        .map(Zeroizing::new)
-        .context("runner enrollment token is invalid")?;
-    validate_token(token.as_str())?;
-    Ok(token)
+    parse_token(bytes)
+}
+
+fn read_stdin_token(reader: &mut dyn Read) -> Result<Zeroizing<Vec<u8>>> {
+    let framed_limit = RunnerEnrollmentToken::BYTE_LENGTH
+        .checked_add(2)
+        .expect("token framing bound fits usize");
+    let proof_limit = framed_limit
+        .checked_add(1)
+        .expect("token overflow probe bound fits usize");
+    let mut bytes = Zeroizing::new(Vec::with_capacity(proof_limit));
+    reader
+        .take(u64::try_from(proof_limit).expect("token overflow probe bound fits u64"))
+        .read_to_end(&mut bytes)
+        .context("runner enrollment token could not be read from stdin")?;
+    normalize_scalar_bytes(
+        &mut bytes,
+        RunnerEnrollmentToken::BYTE_LENGTH,
+        ScalarLineEnding::OptionalSingle,
+    )
+    .context("runner enrollment token stdin value is invalid")?;
+    Ok(bytes)
+}
+
+fn parse_token(mut bytes: Zeroizing<Vec<u8>>) -> Result<RunnerEnrollmentToken> {
+    let token = match String::from_utf8(std::mem::take(&mut *bytes)) {
+        Ok(token) => token,
+        Err(error) => {
+            let _invalid = Zeroizing::new(error.into_bytes());
+            bail!("runner enrollment token is invalid");
+        }
+    };
+    let secret = SecretString::new(token).context("runner enrollment token is invalid")?;
+    RunnerEnrollmentToken::from_secret(secret).context("runner enrollment token is invalid")
 }
 
 fn enrollment_origin(value: &str) -> Result<Url> {
@@ -205,23 +220,6 @@ fn current_unix_time_seconds() -> Result<i64> {
     i64::try_from(seconds).context("runner enrollment system time is out of range")
 }
 
-fn validate_token(value: &str) -> Result<()> {
-    let Some(encoded) = value
-        .strip_prefix(TOKEN_PREFIX)
-        .filter(|encoded| encoded.len() == TOKEN_ENCODED_BYTES)
-    else {
-        bail!("runner enrollment token is invalid");
-    };
-    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
-    if !matches!(
-        URL_SAFE_NO_PAD.decode_slice(encoded, &mut *decoded),
-        Ok(TOKEN_BYTES)
-    ) {
-        bail!("runner enrollment token is invalid");
-    }
-    Ok(())
-}
-
 #[derive(Serialize)]
 struct RedeemRequest<'a> {
     operation_id: Uuid,
@@ -244,9 +242,11 @@ struct RedeemResponse {
 
 #[cfg(test)]
 mod tests {
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use std::io::Cursor;
 
-    use super::{TOKEN_PREFIX, enrollment_origin, validate_staged_response, validate_token};
+    use super::{enrollment_origin, parse_token, read_stdin_token, validate_staged_response};
+
+    const CANONICAL_TOKEN: &str = "atm_re_BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc";
 
     #[test]
     fn enrollment_origin_requires_tls_except_for_literal_loopback() {
@@ -259,17 +259,29 @@ mod tests {
     }
 
     #[test]
-    fn enrollment_token_requires_the_one_canonical_generated_shape() {
-        let token = format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode([7_u8; 32]));
-        validate_token(&token).expect("canonical token");
-        assert!(validate_token("plain-secret").is_err());
-        assert!(validate_token(&format!("{token}A")).is_err());
-        assert!(validate_token(&format!("{token}\n")).is_err());
-    }
-
-    #[test]
     fn staged_response_requires_a_byte_exact_replay() {
         validate_staged_response(b"exact", b"exact").expect("exact replay");
         assert!(validate_staged_response(b"staged", b"different").is_err());
+    }
+
+    #[test]
+    fn stdin_token_requires_eof_and_one_exact_optional_line_ending() {
+        for input in [
+            CANONICAL_TOKEN.as_bytes().to_vec(),
+            format!("{CANONICAL_TOKEN}\n").into_bytes(),
+            format!("{CANONICAL_TOKEN}\r\n").into_bytes(),
+        ] {
+            let bytes = read_stdin_token(&mut Cursor::new(input)).expect("canonical stdin token");
+            let token = parse_token(bytes).expect("canonical enrollment token");
+            assert_eq!(token.expose_secret(), CANONICAL_TOKEN);
+        }
+
+        for suffix in ["\r", "\n\n", "\r\r", "\r\n\n", "\r\ntrailing"] {
+            let input = format!("{CANONICAL_TOKEN}{suffix}").into_bytes();
+            assert!(
+                read_stdin_token(&mut Cursor::new(input)).is_err(),
+                "invalid stdin suffix {suffix:?} must fail"
+            );
+        }
     }
 }

--- a/crates/automata-ci-runner/src/enrollment/custody.rs
+++ b/crates/automata-ci-runner/src/enrollment/custody.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, bail};
+use automata_ci_auth::secret::RunnerEnrollmentToken;
 use rcgen::{
     CertificateParams, CertificateSigningRequestParams, DistinguishedName, DnType, KeyPair,
     PKCS_ECDSA_P256_SHA256, PublicKeyData as _,
@@ -21,7 +22,7 @@ use uuid::Uuid;
 use x509_parser::parse_x509_certificate;
 use zeroize::Zeroizing;
 
-use super::{RedeemResponse, transport::MAX_RESPONSE_BYTES, validate_token};
+use super::{RedeemResponse, transport::MAX_RESPONSE_BYTES};
 use crate::product::{RunnerProductConfig, SecretSource};
 
 const MAX_STAGE_BYTES: usize = 1024 * 1_024;
@@ -120,7 +121,7 @@ impl CredentialDestinations {
         config: &RunnerProductConfig,
         origin: &Url,
         runner_name: &str,
-        token: Zeroizing<String>,
+        token: RunnerEnrollmentToken,
     ) -> Result<EnrollmentStage> {
         self.require_absent()?;
         let stage = EnrollmentStage::new(config, origin, runner_name, token)?;
@@ -180,11 +181,8 @@ pub(super) struct EnrollmentStage {
     pub(super) runner_name: String,
     pub(super) capabilities: automata_ci_core::RunnerCapabilities,
     pub(super) csr_pem: String,
-    #[serde(
-        deserialize_with = "deserialize_zeroizing",
-        serialize_with = "serialize_zeroizing"
-    )]
-    pub(super) token: Zeroizing<String>,
+    #[serde(serialize_with = "serialize_runner_enrollment_token")]
+    pub(super) token: RunnerEnrollmentToken,
     #[serde(
         deserialize_with = "deserialize_zeroizing",
         serialize_with = "serialize_zeroizing"
@@ -204,9 +202,8 @@ impl EnrollmentStage {
         config: &RunnerProductConfig,
         origin: &Url,
         runner_name: &str,
-        token: Zeroizing<String>,
+        token: RunnerEnrollmentToken,
     ) -> Result<Self> {
-        validate_token(token.as_str())?;
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
             .context("runner enrollment could not generate the local private key")?;
         let mut distinguished_name = DistinguishedName::new();
@@ -244,7 +241,6 @@ impl EnrollmentStage {
         {
             bail!("runner enrollment request stage does not match this invocation");
         }
-        validate_token(self.token.as_str())?;
         let key = KeyPair::from_pem(self.private_key_pem.as_str())
             .context("runner enrollment request stage has an invalid private key")?;
         let csr = CertificateSigningRequestParams::from_pem(&self.csr_pem)
@@ -385,6 +381,16 @@ where
     S: serde::Serializer,
 {
     serializer.serialize_str(value.as_str())
+}
+
+fn serialize_runner_enrollment_token<S>(
+    value: &RunnerEnrollmentToken,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(value.expose_secret())
 }
 
 fn deserialize_zeroizing<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
@@ -821,6 +827,7 @@ mod tests {
     #[cfg(unix)]
     use std::fs::{self, File};
 
+    use automata_ci_auth::secret::{RandomnessError, RunnerEnrollmentToken, SecureRandom};
     use automata_ci_core::{
         Architecture, OperatingSystem, RunnerCapabilities, RunnerId, RunnerPlatform,
     };
@@ -843,6 +850,15 @@ mod tests {
     use crate::enrollment::RedeemResponse;
     #[cfg(target_os = "linux")]
     use crate::product::RunnerProductConfig;
+
+    struct FixedRandom;
+
+    impl SecureRandom for FixedRandom {
+        fn fill(&self, destination: &mut [u8]) -> Result<(), RandomnessError> {
+            destination.fill(7);
+            Ok(())
+        }
+    }
 
     #[cfg(target_os = "linux")]
     fn product_config(root: &std::path::Path, runner_id: Uuid) -> RunnerProductConfig {
@@ -1042,7 +1058,7 @@ mod tests {
                 RunnerPlatform::new(OperatingSystem::Linux, Architecture::X86_64),
             ),
             csr_pem: csr_pem.clone(),
-            token: zeroize::Zeroizing::new("atm_re_staged-secret".to_owned()),
+            token: RunnerEnrollmentToken::generate(&FixedRandom).expect("runner token"),
             private_key_pem: zeroize::Zeroizing::new(private_key_pem.clone()),
         };
         let encoded = serde_json::to_vec(&stage).expect("stage JSON");
@@ -1056,12 +1072,18 @@ mod tests {
         let decoded: EnrollmentStage = serde_json::from_slice(&encoded).expect("staged request");
         assert_eq!(decoded.operation_id, operation_id);
         assert_eq!(decoded.csr_pem, csr_pem);
-        assert_eq!(decoded.token.as_str(), "atm_re_staged-secret");
+        assert_eq!(
+            decoded.token.expose_secret(),
+            RunnerEnrollmentToken::generate(&FixedRandom)
+                .expect("runner token")
+                .expose_secret()
+        );
         assert_eq!(decoded.private_key_pem.as_str(), private_key_pem);
     }
 
     #[test]
     fn request_stage_reader_rejects_noncurrent_schema_versions() {
+        let token = RunnerEnrollmentToken::generate(&FixedRandom).expect("runner token");
         let mut document = serde_json::json!({
             "schema": STAGE_SCHEMA,
             "operation_id": Uuid::new_v4(),
@@ -1072,7 +1094,7 @@ mod tests {
                 RunnerPlatform::new(OperatingSystem::Linux, Architecture::X86_64),
             ),
             "csr_pem": "unused by schema validation",
-            "token": "unused by schema validation",
+            "token": token.expose_secret(),
             "private_key_pem": "unused by schema validation",
         });
         document["schema"] = serde_json::json!(STAGE_SCHEMA + 1);

--- a/crates/automata-ci-runner/src/product/files.rs
+++ b/crates/automata-ci-runner/src/product/files.rs
@@ -22,6 +22,12 @@ const KEYCHAIN_SKIP_AUTHENTICATED_ITEMS: bool = true;
 #[cfg(target_os = "macos")]
 const KEYCHAIN_DISABLE_INTERACTION: bool = true;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ScalarLineEnding {
+    Forbidden,
+    OptionalSingle,
+}
+
 /// A secret-bearing input location. Secret bytes are never accepted directly
 /// in process arguments or in the runner configuration document.
 #[derive(Clone, Deserialize, Eq, PartialEq)]
@@ -117,23 +123,47 @@ impl SecretSource {
             Self::Environment { .. } | Self::MacosKeychain { .. } => maximum_bytes,
         };
         let mut bytes = self.read(input_limit)?;
-        if matches!(self, Self::File { .. }) {
-            if bytes.ends_with(b"\r\n") {
-                let scalar_len = bytes.len() - 2;
-                bytes.truncate(scalar_len);
-            } else if bytes.ends_with(b"\n") {
-                let scalar_len = bytes.len() - 1;
-                bytes.truncate(scalar_len);
-            }
-        }
-        if bytes.is_empty() || bytes.len() > maximum_bytes {
-            return Err(SecureInputError::InvalidSize);
-        }
-        if bytes.iter().any(|byte| matches!(byte, b'\r' | b'\n')) {
-            return Err(SecureInputError::InvalidEncoding);
-        }
+        let line_ending = if matches!(self, Self::File { .. }) {
+            ScalarLineEnding::OptionalSingle
+        } else {
+            ScalarLineEnding::Forbidden
+        };
+        normalize_scalar_bytes(&mut bytes, maximum_bytes, line_ending)?;
         Ok(bytes)
     }
+}
+
+pub(crate) fn normalize_scalar_bytes(
+    bytes: &mut Vec<u8>,
+    maximum_bytes: usize,
+    line_ending: ScalarLineEnding,
+) -> Result<(), SecureInputError> {
+    if maximum_bytes == 0 {
+        return Err(SecureInputError::InvalidLimit);
+    }
+    let framed_limit = match line_ending {
+        ScalarLineEnding::Forbidden => maximum_bytes,
+        ScalarLineEnding::OptionalSingle => maximum_bytes
+            .checked_add(2)
+            .ok_or(SecureInputError::InvalidLimit)?,
+    };
+    if bytes.len() > framed_limit {
+        return Err(SecureInputError::InvalidSize);
+    }
+    if line_ending == ScalarLineEnding::OptionalSingle {
+        if bytes.ends_with(b"\r\n") {
+            bytes.truncate(bytes.len() - 2);
+        } else if bytes.ends_with(b"\n") {
+            bytes.truncate(bytes.len() - 1);
+        }
+    }
+    if bytes.is_empty() || bytes.len() > maximum_bytes {
+        return Err(SecureInputError::InvalidSize);
+    }
+    if bytes.iter().any(|byte| matches!(byte, b'\r' | b'\n')) {
+        return Err(SecureInputError::InvalidEncoding);
+    }
+    Ok(())
 }
 
 impl fmt::Debug for SecretSource {
@@ -261,7 +291,7 @@ pub(crate) fn validate_absolute_path(path: &Path) -> Result<(), SecureInputError
     Ok(())
 }
 
-fn validate_environment_name(name: &str) -> Result<(), SecureInputError> {
+pub(crate) fn validate_environment_name(name: &str) -> Result<(), SecureInputError> {
     let valid = !name.is_empty()
         && name.len() <= 128
         && name
@@ -548,6 +578,48 @@ fn read_file(
     _trust: FileTrust,
 ) -> Result<Vec<u8>, SecureInputError> {
     Err(SecureInputError::UnsupportedPlatform)
+}
+
+#[cfg(test)]
+mod scalar_tests {
+    use super::{ScalarLineEnding, SecureInputError, normalize_scalar_bytes};
+
+    #[test]
+    fn exact_scalars_reject_every_line_ending() {
+        for mut bytes in [b"value\n".to_vec(), b"value\r\n".to_vec()] {
+            assert_eq!(
+                normalize_scalar_bytes(&mut bytes, 5, ScalarLineEnding::Forbidden),
+                Err(SecureInputError::InvalidSize)
+            );
+        }
+        let mut exact = b"value".to_vec();
+        normalize_scalar_bytes(&mut exact, 5, ScalarLineEnding::Forbidden).expect("exact scalar");
+        assert_eq!(exact, b"value");
+    }
+
+    #[test]
+    fn line_terminated_scalars_accept_only_one_lf_or_crlf() {
+        for mut bytes in [
+            b"value".to_vec(),
+            b"value\n".to_vec(),
+            b"value\r\n".to_vec(),
+        ] {
+            normalize_scalar_bytes(&mut bytes, 5, ScalarLineEnding::OptionalSingle)
+                .expect("optional single line ending");
+            assert_eq!(bytes, b"value");
+        }
+        for mut bytes in [
+            b"value\r".to_vec(),
+            b"value\n\n".to_vec(),
+            b"value\r\r".to_vec(),
+            b"value\r\n\n".to_vec(),
+            b"value\r\nextra".to_vec(),
+        ] {
+            assert!(
+                normalize_scalar_bytes(&mut bytes, 5, ScalarLineEnding::OptionalSingle).is_err()
+            );
+        }
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/automata-ci-runner/src/product/mod.rs
+++ b/crates/automata-ci-runner/src/product/mod.rs
@@ -25,6 +25,9 @@ pub use config::{
     WindowsHyperVProductConfig,
 };
 pub use context::StandardGithubContext;
+pub(crate) use files::{
+    ScalarLineEnding, normalize_scalar_bytes, validate_absolute_path, validate_environment_name,
+};
 pub use files::{SecretSource, SecureInputError};
 pub use state::ProductStateRootError;
 pub use tls::ClientTlsMaterialError;

--- a/crates/automata-ci/src/app/runner_enrollment_api.rs
+++ b/crates/automata-ci/src/app/runner_enrollment_api.rs
@@ -7,6 +7,7 @@ use automata_ci_auth::{
         ManagementActor, ManagementMutationOutcome, ManagementRepositoryError, ManagementRevision,
     },
     request_auth::AuthenticatedRequestSnapshot,
+    secret::{RunnerEnrollmentToken, SecretString},
     session::SessionKind,
     time::Clock,
 };
@@ -26,7 +27,6 @@ use axum::{
     response::{IntoResponse, Response},
     routing::post,
 };
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use futures::StreamExt as _;
 use rcgen::{
     CertificateSigningRequestParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
@@ -47,11 +47,6 @@ use zeroize::Zeroizing;
 pub(crate) const RUNNER_ENROLLMENTS_PATH: &str = "/api/v1/runner-enrollments";
 pub(crate) const RUNNER_ENROLLMENT_REDEEM_PATH: &str = "/api/v1/runner-enrollments/redeem";
 
-const TOKEN_PREFIX: &str = "atm_re_";
-const TOKEN_BYTES: usize = 32;
-const TOKEN_ENCODED_BYTES: usize = 43;
-const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
-const TOKEN_DOMAIN: &[u8] = b"automata.runner-enrollment-token.v1\0";
 const REDEEM_REQUEST_DOMAIN: &[u8] = b"automata.runner-enrollment-request.v1\0";
 const MAX_REQUEST_BYTES: usize = 384 * 1_024;
 const INITIAL_REQUEST_CAPACITY_BYTES: usize = 8 * 1_024;
@@ -371,14 +366,13 @@ async fn create_enrollment(
     let Ok(runner_group) = RunnerGroup::new(&document.runner_group) else {
         return ApiError::InvalidRequest.into_response();
     };
-    let token_sha256 = match token_digest(document.token.as_bytes()) {
-        Ok(digest) => digest,
-        Err(error) => return error.into_response(),
+    let Ok(token) = RunnerEnrollmentToken::from_secret(document.token) else {
+        return ApiError::EnrollmentRejected.into_response();
     };
     let request = CreateRunnerEnrollmentToken {
         actor,
         enrollment_id: document.operation_id,
-        token_sha256,
+        token_sha256: token.digest(),
         runner_group: runner_group.as_str().to_owned(),
         lifetime_ms: i64::try_from(document.expires_in_seconds)
             .ok()
@@ -420,18 +414,17 @@ async fn redeem_enrollment(
     if !valid_redeem_document(&document) {
         return ApiError::InvalidRequest.into_response();
     }
-    let token_sha256 = match token_digest(document.token.as_bytes()) {
-        Ok(digest) => digest,
-        Err(error) => return error.into_response(),
-    };
     let request_sha256 = match redeem_request_digest(&document) {
         Ok(digest) => digest,
         Err(error) => return error.into_response(),
     };
+    let Ok(token) = RunnerEnrollmentToken::from_secret(document.token) else {
+        return ApiError::EnrollmentRejected.into_response();
+    };
     let outcome = match state
         .repository
         .prepare_runner_enrollment(PrepareRunnerEnrollment {
-            token_sha256,
+            token_sha256: token.digest(),
             operation_id: document.operation_id,
             request_sha256,
         })
@@ -480,7 +473,7 @@ async fn redeem_enrollment(
         return ApiError::Internal.into_response();
     }
     let consume = ConsumeRunnerEnrollment {
-        token_sha256,
+        token_sha256: token.digest(),
         operation_id: document.operation_id,
         request_sha256,
         runner_id,
@@ -617,26 +610,6 @@ fn is_json_content_type(headers: &HeaderMap) -> bool {
         })
 }
 
-fn token_digest(token: &[u8]) -> Result<[u8; 32], ApiError> {
-    let encoded = token
-        .strip_prefix(TOKEN_PREFIX.as_bytes())
-        .ok_or(ApiError::EnrollmentRejected)?;
-    if encoded.len() != TOKEN_ENCODED_BYTES {
-        return Err(ApiError::EnrollmentRejected);
-    }
-    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
-    let decoded_length = URL_SAFE_NO_PAD
-        .decode_slice(encoded, &mut *decoded)
-        .map_err(|_| ApiError::EnrollmentRejected)?;
-    if decoded_length != TOKEN_BYTES {
-        return Err(ApiError::EnrollmentRejected);
-    }
-    let mut digest = Sha256::new();
-    digest.update(TOKEN_DOMAIN);
-    digest.update(token);
-    Ok(digest.finalize().into())
-}
-
 fn redeem_request_digest(document: &RedeemEnrollmentDocument) -> Result<[u8; 32], ApiError> {
     let receipt = RedeemRequestReceipt {
         operation_id: document.operation_id,
@@ -672,8 +645,7 @@ fn exact_json_response(status: StatusCode, body: Vec<u8>) -> Response {
 #[serde(deny_unknown_fields)]
 struct CreateEnrollmentDocument {
     operation_id: Uuid,
-    #[serde(deserialize_with = "deserialize_zeroizing")]
-    token: Zeroizing<String>,
+    token: SecretString,
     runner_group: String,
     expires_in_seconds: u64,
 }
@@ -686,19 +658,11 @@ struct CreateEnrollmentResponse<'a> {
     redeem_url: &'a str,
 }
 
-fn deserialize_zeroizing<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(Zeroizing::new)
-}
-
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RedeemEnrollmentDocument {
     operation_id: Uuid,
-    #[serde(deserialize_with = "deserialize_zeroizing")]
-    token: Zeroizing<String>,
+    token: SecretString,
     runner_name: String,
     capabilities: RunnerCapabilities,
     csr_pem: String,
@@ -835,17 +799,6 @@ mod tests {
     }
 
     #[test]
-    fn token_hash_is_domain_separated_and_exact() {
-        let token = format!(
-            "{TOKEN_PREFIX}{}",
-            URL_SAFE_NO_PAD.encode([7_u8; TOKEN_BYTES])
-        );
-        let digest = token_digest(token.as_bytes()).expect("valid enrollment token");
-        assert_ne!(digest, Sha256::digest(token.as_bytes()).as_slice());
-        assert!(token_digest(b"plain-secret").is_err());
-    }
-
-    #[test]
     fn token_create_response_never_echoes_the_client_generated_secret() {
         let response = CreateEnrollmentResponse {
             enrollment_id: Uuid::new_v4(),
@@ -871,13 +824,13 @@ mod tests {
         );
         let mut document = RedeemEnrollmentDocument {
             operation_id,
-            token: Zeroizing::new("first-secret".to_owned()),
+            token: SecretString::new("first-secret").expect("bounded secret"),
             runner_name: "runner-one".to_owned(),
             capabilities,
             csr_pem: "csr".to_owned(),
         };
         let first = redeem_request_digest(&document).expect("request digest");
-        document.token = Zeroizing::new("different-secret".to_owned());
+        document.token = SecretString::new("different-secret").expect("bounded secret");
         assert_eq!(
             redeem_request_digest(&document).expect("request digest"),
             first

--- a/crates/automata-ci/src/cli/runner.rs
+++ b/crates/automata-ci/src/cli/runner.rs
@@ -3,9 +3,11 @@
 use std::io::Write as _;
 
 use anyhow::{Context as _, Result, bail};
-use automata_ci_auth::session_credential::SessionCredential;
+use automata_ci_auth::{
+    secret::{RunnerEnrollmentToken, SystemSecureRandom},
+    session_credential::SessionCredential,
+};
 use automata_ci_core::RunnerGroup;
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use bytes::Bytes;
 use reqwest::{Client, StatusCode, header};
 use serde::{Deserialize, Serialize};
@@ -19,10 +21,6 @@ use super::{
 };
 
 const ENROLLMENTS_PATH: &str = "/api/v1/runner-enrollments";
-const TOKEN_PREFIX: &str = "atm_re_";
-const TOKEN_BYTES: usize = 32;
-const TOKEN_ENCODED_BYTES: usize = 43;
-const TOKEN_DECODE_BUFFER_BYTES: usize = TOKEN_ENCODED_BYTES.div_ceil(4) * 3;
 const CREATE_ATTEMPTS: usize = 3;
 
 pub(crate) async fn execute_runner_command(
@@ -77,7 +75,7 @@ async fn create_token(
     let pending = load_or_create_pending(process_lock, group, expires_in_seconds)?;
     let body = CreateTokenRequest {
         operation_id: pending.operation_id,
-        token: pending.token.as_str(),
+        token: pending.token.expose_secret(),
         runner_group: group,
         expires_in_seconds,
     };
@@ -113,7 +111,6 @@ fn load_or_create_pending(
             || pending.operation_id.is_nil()
             || pending.runner_group != runner_group
             || pending.expires_in_seconds != expires_in_seconds
-            || !valid_generated_token(pending.token.as_str())
         {
             bail!("runner enrollment token receipt does not match this request");
         }
@@ -122,7 +119,8 @@ fn load_or_create_pending(
     let pending = PendingTokenCreate {
         schema: 1,
         operation_id: Uuid::new_v4(),
-        token: generate_token()?,
+        token: RunnerEnrollmentToken::generate(&SystemSecureRandom)
+            .context("runner enrollment token entropy is unavailable")?,
         runner_group: runner_group.to_owned(),
         expires_in_seconds,
     };
@@ -186,37 +184,12 @@ async fn send(
         .context("runner enrollment token request failed")
 }
 
-fn generate_token() -> Result<Zeroizing<String>> {
-    let mut entropy = Zeroizing::new([0_u8; TOKEN_BYTES]);
-    getrandom::fill(&mut *entropy).context("runner enrollment token entropy is unavailable")?;
-    let mut token = Zeroizing::new(String::with_capacity(
-        TOKEN_PREFIX.len() + TOKEN_ENCODED_BYTES,
-    ));
-    token.push_str(TOKEN_PREFIX);
-    URL_SAFE_NO_PAD.encode_string(entropy.as_slice(), &mut token);
-    Ok(token)
-}
-
-fn valid_generated_token(token: &str) -> bool {
-    let Some(encoded) = token
-        .strip_prefix(TOKEN_PREFIX)
-        .filter(|encoded| encoded.len() == TOKEN_ENCODED_BYTES)
-    else {
-        return false;
-    };
-    let mut decoded = Zeroizing::new([0_u8; TOKEN_DECODE_BUFFER_BYTES]);
-    matches!(
-        URL_SAFE_NO_PAD.decode_slice(encoded, &mut *decoded),
-        Ok(TOKEN_BYTES)
-    )
-}
-
 fn print_token(output: OutputFormat, issued: &IssuedToken) -> Result<()> {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
     match output {
         OutputFormat::Table => {
-            writeln!(stdout, "token\t{}", issued.token.as_str())?;
+            writeln!(stdout, "token\t{}", issued.token.expose_secret())?;
             writeln!(stdout, "runner_group\t{}", issued.runner_group)?;
             writeln!(stdout, "expires_at_ms\t{}", issued.expires_at_ms)?;
         }
@@ -225,7 +198,7 @@ fn print_token(output: OutputFormat, issued: &IssuedToken) -> Result<()> {
                 &mut stdout,
                 &IssuedTokenOutput {
                     enrollment_id: issued.enrollment_id,
-                    token: issued.token.as_str(),
+                    token: issued.token.expose_secret(),
                     runner_group: &issued.runner_group,
                     expires_at_ms: issued.expires_at_ms,
                 },
@@ -260,32 +233,25 @@ struct CreateTokenResponse {
 struct PendingTokenCreate {
     schema: u8,
     operation_id: Uuid,
-    #[serde(
-        deserialize_with = "deserialize_zeroizing",
-        serialize_with = "serialize_zeroizing"
-    )]
-    token: Zeroizing<String>,
+    #[serde(serialize_with = "serialize_runner_enrollment_token")]
+    token: RunnerEnrollmentToken,
     runner_group: String,
     expires_in_seconds: u64,
 }
 
-fn serialize_zeroizing<S>(value: &Zeroizing<String>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_runner_enrollment_token<S>(
+    value: &RunnerEnrollmentToken,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(value.as_str())
-}
-
-fn deserialize_zeroizing<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(Zeroizing::new)
+    serializer.serialize_str(value.expose_secret())
 }
 
 struct IssuedToken {
     enrollment_id: Uuid,
-    token: Zeroizing<String>,
+    token: RunnerEnrollmentToken,
     runner_group: String,
     expires_at_ms: i64,
 }
@@ -296,19 +262,4 @@ struct IssuedTokenOutput<'a> {
     token: &'a str,
     runner_group: &'a str,
     expires_at_ms: i64,
-}
-
-#[cfg(test)]
-mod tests {
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-
-    use super::{TOKEN_PREFIX, valid_generated_token};
-
-    #[test]
-    fn pending_token_validation_accepts_only_the_canonical_secret_shape() {
-        let token = format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode([7_u8; 32]));
-        assert!(valid_generated_token(&token));
-        assert!(!valid_generated_token("plain-secret"));
-        assert!(!valid_generated_token(&format!("{token}A")));
-    }
 }

--- a/docs/runner-control-plane-security-and-enrollment.md
+++ b/docs/runner-control-plane-security-and-enrollment.md
@@ -37,8 +37,10 @@ are independent of transport TLS.
    The server stores and returns only non-secret metadata; token plaintext stays in the operator
    process and is never echoed by the API.
 3. The token is transferred once through a protected operator channel. It is never accepted in
-   runner argv. `automata-runner enroll` reads an owner-only file, a dedicated environment value,
-   or redirected stdin.
+   runner argv. `automata-runner enroll` requires one explicit `--token-source`: an owner-only
+   `file:PATH`, a named `env:NAME`, or `stdin`. There is no ambient source, precedence chain, or
+   fallback. File and stdin framing accept only the canonical token, that token plus one LF, or
+   that token plus one CRLF; environment values must contain exactly the canonical token.
 4. The runner loads its strict configuration, generates an ECDSA P-256 key locally, and sends
    only a signed CSR, canonical capabilities, runner name, stable operation ID, and token to the
    human HTTPS listener. It durably stages the operation, one-time token, and local key in one


### PR DESCRIPTION
## Outcome

Moves runner enrollment-token generation, parsing, redaction, and domain-separated hashing behind one shared `RunnerEnrollmentToken` authority in `automata-ci-auth`.

Management CLI, enrollment API, and runner enrollment now consume the same exact grammar. Runner enrollment requires an explicit `--token-source=file:ABS_PATH|env:NAME|stdin`; there is no ambient file→environment→stdin fallback or legacy alias. File and stdin framing accept only exact token bytes, one LF, or one CRLF and prove EOF, so truncated or trailing input cannot normalize into a valid token.

The runner's `base64` dependency becomes test-only. The dormant local bootstrap command is deliberately excluded from this PR.

This is another fully consumed slice split from draft #173.

## Related issue

Related to #173.

## Trust and compatibility impact

The token remains a CSPRNG-generated, bounded, redacted secret with the existing domain-separated digest. Debug and error surfaces do not expose token bytes or source references. CLI source selection is intentionally current-only and explicit; old ambient/default behavior is removed rather than aliased.

There is no enrollment wire-protocol or database-schema change.

## Verification

- full `automata-ci-auth` tests
- full runner all-target/all-feature tests
- control-plane enrollment API tests
- locked workspace all-target/all-feature check
- strict native Clippy with `-D warnings` for auth, runner, and automata
- Windows GNU runner all-target/all-feature check; only pre-existing target-only warnings remain
- fmt and diff checks
- broad `automata-ci` all-feature suite attempted; five unrelated fixture failures reproduce on the exact main parent, while every affected token test passes
- independent strict review: CLEAN

## AI assistance

OpenAI Codex helped extract the shared token boundary from the larger draft, close framing and fallback findings, run validation, and perform an independent strict review. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
