### PR TITLE
fix(web): render public runner-redacted logs

### DIFF
--- a/crates/automata-ci/src/app/web/live.rs
+++ b/crates/automata-ci/src/app/web/live.rs
@@ -1317,10 +1317,6 @@ fn log_stream_safety_is_valid(stream: &automata_ci_store::HumanLogStream) -> boo
     automata_ci_store::human_output_publication_safety_schema_is_current(i32::from(
         stream.publication.safety_schema,
     )) && stream.raw_log_disposition == HumanRawLogDisposition::Persist
-        && (!matches!(
-            stream.publication.secret_exposure,
-            SecretExposureClass::ReadableSecret
-        ) || stream.publication.effective_visibility == OutputVisibility::Private)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -4435,6 +4431,25 @@ mod tests {
             stream.publication.safety_schema = schema;
             assert!(!log_stream_safety_is_valid(&stream));
         }
+    }
+
+    #[test]
+    fn log_stream_reader_accepts_public_runner_redacted_logs() {
+        let run_id = RunId::new();
+        let run = fixture_run(run_id, OutputVisibility::Public);
+        let (_, stream) = fixture_job_detail(
+            run,
+            JobId::new(),
+            AttemptId::new(),
+            HumanRawLogDisposition::Persist,
+            fixture_output_publication(
+                OutputVisibility::Public,
+                SecretExposureClass::ReadableSecret,
+                "repository_policy",
+            ),
+        );
+
+        assert!(log_stream_safety_is_valid(&stream));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- remove the obsolete exposure-based narrowing from the schema-2 runner-redacted log reader
- accept public logs for public repositories while preserving the exact safety-schema and persist-only checks
- add a regression test for public logs from jobs with readable runtime authority

## Verification
- cargo fmt --check
- cargo test -p automata-ci app::web::live::tests --lib (39 passed)
- cargo clippy -p automata-ci --lib -- -D warnings
- reproduced production failure as HTTP 500 with requested=public, effective=public, schema 2 and readable_secret; this closes that stale reader invariant