### PR TITLE
refactor(credential-github): share supervised custody

### DIFF
--- a/crates/automata-ci-credential-github/src/authority_coordinator.rs
+++ b/crates/automata-ci-credential-github/src/authority_coordinator.rs
@@ -1,11 +1,4 @@
-use std::{
-    fmt,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::{fmt, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use automata_ci_core::{
@@ -35,14 +28,13 @@ use automata_ci_store::{
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
-use tokio::{
-    runtime::Handle,
-    sync::{OwnedSemaphorePermit, oneshot},
-};
+use tokio::{runtime::Handle, sync::oneshot};
 
 use crate::{
     GithubAppCredentialBroker, GithubInstallationTokenMintOutcome,
-    GithubInstallationTokenRevocationCandidate, config::whole_milliseconds,
+    GithubInstallationTokenRevocationCandidate,
+    config::whole_milliseconds,
+    supervised_custody::{Entry, Reservation, SupervisedCustody},
 };
 
 const INSTALLATION_TOKEN_FRAME_DOMAIN: &[u8] = b"automata-ci/github-installation-token/v1\0";
@@ -456,14 +448,9 @@ pub enum GithubRuntimeAuthorityCommitSupervisorError {
 /// evidence and must reconcile to `indeterminate` without another mint.
 pub struct GithubRuntimeAuthorityCommitSupervisor {
     repository: Arc<dyn GithubRuntimeAuthorityRepository>,
-    runtime: Handle,
     retry_interval: Duration,
-    permits: Arc<tokio::sync::Semaphore>,
-    outstanding: Arc<AtomicUsize>,
-    pending: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-    protected_custody: Arc<Mutex<Vec<Arc<SupervisedProtectedCommit>>>>,
-    unprotected_custody: Arc<Mutex<Vec<Arc<SupervisedUnprotectedCandidate>>>>,
+    protected_custody: SupervisedCustody<PendingGithubRuntimeAuthorityCommit>,
+    unprotected_custody: SupervisedCustody<UnprotectedGithubRuntimeAuthorityCandidate>,
 }
 
 impl GithubRuntimeAuthorityCommitSupervisor {
@@ -485,32 +472,19 @@ impl GithubRuntimeAuthorityCommitSupervisor {
         if retry_interval.is_zero() || retry_interval > MAX_PENDING_COMMIT_RETRY_DELAY {
             return Err(GithubRuntimeAuthorityCommitSupervisorError::InvalidRetryInterval);
         }
+        let protected_custody = SupervisedCustody::new(runtime, capacity);
+        let unprotected_custody = protected_custody.linked(capacity);
         Ok(Self {
             repository,
-            runtime,
             retry_interval,
-            permits: Arc::new(tokio::sync::Semaphore::new(capacity)),
-            outstanding: Arc::new(AtomicUsize::new(0)),
-            pending: Arc::new(AtomicUsize::new(0)),
-            drained: Arc::new(tokio::sync::Notify::new()),
-            protected_custody: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
-            unprotected_custody: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
+            protected_custody,
+            unprotected_custody,
         })
     }
 
     pub(crate) fn try_reserve(&self) -> Option<GithubRuntimeAuthorityCommitReservation> {
         self.redrive_retained();
-        self.outstanding.fetch_add(1, Ordering::AcqRel);
-        let Ok(permit) = Arc::clone(&self.permits).try_acquire_owned() else {
-            self.outstanding.fetch_sub(1, Ordering::AcqRel);
-            self.drained.notify_waiters();
-            return None;
-        };
-        Some(GithubRuntimeAuthorityCommitReservation {
-            _permit: permit,
-            outstanding: Arc::clone(&self.outstanding),
-            drained: Arc::clone(&self.drained),
-        })
+        self.protected_custody.try_reserve()
     }
 
     pub(crate) fn supervise(
@@ -518,21 +492,7 @@ impl GithubRuntimeAuthorityCommitSupervisor {
         reservation: GithubRuntimeAuthorityCommitReservation,
         pending: PendingGithubRuntimeAuthorityCommit,
     ) -> oneshot::Receiver<GithubRuntimeAuthorityReceipt> {
-        let custody = Arc::new(SupervisedProtectedCommit {
-            _reservation: reservation,
-            _pending_observation: SupervisorPendingObservation::new(
-                Arc::clone(&self.pending),
-                Arc::clone(&self.drained),
-            ),
-            pending,
-            task_abort: Mutex::new(None),
-            driver_active: Arc::new(AtomicBool::new(false)),
-            removed: AtomicBool::new(false),
-        });
-        self.protected_custody
-            .lock()
-            .expect("runtime-authority protected custody lock")
-            .push(Arc::clone(&custody));
+        let custody = self.protected_custody.retain(reservation, pending);
 
         let (result_sender, result_receiver) = oneshot::channel();
         let started = self.start_protected_driver(&custody, Some(result_sender));
@@ -542,52 +502,27 @@ impl GithubRuntimeAuthorityCommitSupervisor {
 
     fn start_protected_driver(
         &self,
-        custody: &Arc<SupervisedProtectedCommit>,
+        custody: &Arc<Entry<PendingGithubRuntimeAuthorityCommit>>,
         result_sender: Option<oneshot::Sender<GithubRuntimeAuthorityReceipt>>,
     ) -> bool {
-        if custody.removed.load(Ordering::Acquire) {
-            return false;
-        }
-        if custody
-            .driver_active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return false;
-        }
-        if custody.removed.load(Ordering::Acquire) {
-            custody.driver_active.store(false, Ordering::Release);
-            self.drained.notify_waiters();
-            return false;
-        }
         let repository = Arc::clone(&self.repository);
-        let retained = Arc::clone(&self.protected_custody);
-        let task_custody = Arc::clone(custody);
         let retry_interval = self.retry_interval;
-        let driver_active = SupervisorDriverObservation {
-            active: Arc::clone(&custody.driver_active),
-            drained: Arc::clone(&self.drained),
-        };
-        let task = self.runtime.spawn(async move {
-            let _driver_active = driver_active;
-            let receipt = loop {
-                match task_custody.pending.replay(repository.as_ref()).await {
-                    Ok(receipt) => break receipt,
-                    Err(_) => tokio::time::sleep(retry_interval).await,
+        self.protected_custody.start_driver(
+            custody,
+            move |custody| async move {
+                loop {
+                    match custody.value().replay(repository.as_ref()).await {
+                        Ok(receipt) => break receipt,
+                        Err(_) => tokio::time::sleep(retry_interval).await,
+                    }
                 }
-            };
-            task_custody.removed.store(true, Ordering::Release);
-            drop(take_supervised_custody(&retained, &task_custody));
-            drop(task_custody);
-            if let Some(result_sender) = result_sender {
-                let _ = result_sender.send(receipt);
-            }
-        });
-        *custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority protected task lock") = Some(task.abort_handle());
-        true
+            },
+            move |receipt| {
+                if let Some(result_sender) = result_sender {
+                    let _ = result_sender.send(receipt);
+                }
+            },
+        )
     }
 
     fn retain_unprotected(
@@ -595,170 +530,90 @@ impl GithubRuntimeAuthorityCommitSupervisor {
         reservation: GithubRuntimeAuthorityCommitReservation,
         custody: UnprotectedGithubRuntimeAuthorityCandidate,
     ) {
-        let custody = Arc::new(SupervisedUnprotectedCandidate {
-            _reservation: reservation,
-            _pending_observation: SupervisorPendingObservation::new(
-                Arc::clone(&self.pending),
-                Arc::clone(&self.drained),
-            ),
-            custody,
-            task_abort: Mutex::new(None),
-            driver_active: Arc::new(AtomicBool::new(false)),
-            removed: AtomicBool::new(false),
-        });
-        self.unprotected_custody
-            .lock()
-            .expect("runtime-authority unprotected custody lock")
-            .push(Arc::clone(&custody));
+        let custody = self.unprotected_custody.retain(reservation, custody);
 
         let started = self.start_unprotected_driver(&custody);
         assert!(started, "new unprotected custody starts one driver");
     }
 
-    fn start_unprotected_driver(&self, custody: &Arc<SupervisedUnprotectedCandidate>) -> bool {
-        if custody.removed.load(Ordering::Acquire) {
-            return false;
-        }
-        if custody
-            .driver_active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return false;
-        }
-        if custody.removed.load(Ordering::Acquire) {
-            custody.driver_active.store(false, Ordering::Release);
-            self.drained.notify_waiters();
-            return false;
-        }
+    fn start_unprotected_driver(
+        &self,
+        custody: &Arc<Entry<UnprotectedGithubRuntimeAuthorityCandidate>>,
+    ) -> bool {
         let repository = Arc::clone(&self.repository);
-        let retained = Arc::clone(&self.unprotected_custody);
-        let task_custody = Arc::clone(custody);
         let retry_interval = self.retry_interval;
-        let driver_active = SupervisorDriverObservation {
-            active: Arc::clone(&custody.driver_active),
-            drained: Arc::clone(&self.drained),
-        };
-        let task = self.runtime.spawn(async move {
-            let _driver_active = driver_active;
-            let request = AuthenticateGithubRuntimeAuthorityUnprotectedErasure::new(
-                &task_custody.custody.claim,
-            );
-            let expected_key = task_custody.custody.claim.identity().key();
-            let earliest_erasure = task_custody.custody.claim.identity().conservative_expiry();
-            loop {
-                if let Ok(Some(receipt)) = repository
-                    .authenticate_github_runtime_authority_unprotected_erasure(request.clone())
-                    .await
-                    && receipt.key() == expected_key
-                    && receipt.state() == GithubRuntimeAuthorityState::Revoked
-                    && receipt.updated_at() >= earliest_erasure
-                    && receipt.terminal_reason()
-                        == Some(GithubRuntimeAuthorityTerminalReason::IndeterminateAuthorityExpired)
-                {
-                    break;
+        self.unprotected_custody.start_driver(
+            custody,
+            move |custody| async move {
+                let request = AuthenticateGithubRuntimeAuthorityUnprotectedErasure::new(
+                    &custody.value().claim,
+                );
+                let expected_key = custody.value().claim.identity().key();
+                let earliest_erasure = custody.value().claim.identity().conservative_expiry();
+                loop {
+                    if let Ok(Some(receipt)) = repository
+                        .authenticate_github_runtime_authority_unprotected_erasure(request.clone())
+                        .await
+                        && receipt.key() == expected_key
+                        && receipt.state() == GithubRuntimeAuthorityState::Revoked
+                        && receipt.updated_at() >= earliest_erasure
+                        && receipt.terminal_reason()
+                            == Some(
+                                GithubRuntimeAuthorityTerminalReason::IndeterminateAuthorityExpired,
+                            )
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(retry_interval).await;
                 }
-                tokio::time::sleep(retry_interval).await;
-            }
-            task_custody.removed.store(true, Ordering::Release);
-            drop(take_supervised_custody(&retained, &task_custody));
-            drop(task_custody);
-        });
-        *custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority unprotected task lock") = Some(task.abort_handle());
-        true
+            },
+            |()| {},
+        )
     }
 
     fn redrive_retained(&self) {
-        let protected = self
-            .protected_custody
-            .lock()
-            .expect("runtime-authority protected custody lock")
-            .clone();
-        for custody in protected {
+        for custody in self.protected_custody.retained() {
             let _ = self.start_protected_driver(&custody, None);
         }
-        let unprotected = self
-            .unprotected_custody
-            .lock()
-            .expect("runtime-authority unprotected custody lock")
-            .clone();
-        for custody in unprotected {
+        for custody in self.unprotected_custody.retained() {
             let _ = self.start_unprotected_driver(&custody);
         }
     }
 
     #[cfg(test)]
     fn abort_protected_task(&self) -> bool {
-        let custody = self
-            .protected_custody
-            .lock()
-            .expect("runtime-authority protected custody lock")
+        self.protected_custody
+            .retained()
             .first()
-            .cloned();
-        let Some(custody) = custody else {
-            return false;
-        };
-        let task = custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority protected task lock")
-            .clone();
-        task.is_some_and(|task| {
-            task.abort();
-            true
-        })
+            .is_some_and(|custody| custody.abort_driver())
     }
 
     #[cfg(test)]
     fn abort_unprotected_task(&self) -> bool {
-        let custody = self
-            .unprotected_custody
-            .lock()
-            .expect("runtime-authority unprotected custody lock")
+        self.unprotected_custody
+            .retained()
             .first()
-            .cloned();
-        let Some(custody) = custody else {
-            return false;
-        };
-        let task = custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority unprotected task lock")
-            .clone();
-        task.is_some_and(|task| {
-            task.abort();
-            true
-        })
+            .is_some_and(|custody| custody.abort_driver())
     }
 
     /// Returns the number of protected or unprotected candidates under custody.
     #[must_use]
     pub fn pending_count(&self) -> usize {
-        self.pending.load(Ordering::Acquire)
+        self.protected_custody.pending()
     }
 
     /// Closes admission for new provider-mint candidates during shutdown.
     /// Already-supervised candidates retain their permits and custody.
     pub fn close(&self) {
-        self.permits.close();
+        self.protected_custody.close();
     }
 
     /// Waits until every supervised protected commit is durably confirmed.
     /// Process wall time can never authorize loss of pending custody.
     pub async fn wait_for_idle(&self) {
-        loop {
-            let notified = self.drained.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-            self.redrive_retained();
-            if self.outstanding.load(Ordering::Acquire) == 0 {
-                return;
-            }
-            notified.await;
-        }
+        self.protected_custody
+            .wait_for_idle(|| self.redrive_retained())
+            .await;
     }
 
     /// Waits up to `timeout` for all supervised protected commits to confirm.
@@ -777,98 +632,22 @@ impl fmt::Debug for GithubRuntimeAuthorityCommitSupervisor {
             .debug_struct("GithubRuntimeAuthorityCommitSupervisor")
             .field("repository", &"[AUTHORITY REPOSITORY]")
             .field("retry_interval", &self.retry_interval)
-            .field("outstanding", &self.outstanding.load(Ordering::Acquire))
-            .field("available_capacity", &self.permits.available_permits())
+            .field("outstanding", &self.protected_custody.outstanding())
+            .field("available_capacity", &self.protected_custody.available())
             .field("pending", &self.pending_count())
             .field(
                 "protected_custody",
-                &self
-                    .protected_custody
-                    .lock()
-                    .expect("runtime-authority protected custody lock")
-                    .len(),
+                &self.protected_custody.retained_count(),
             )
             .field(
                 "unprotected_custody",
-                &self
-                    .unprotected_custody
-                    .lock()
-                    .expect("runtime-authority unprotected custody lock")
-                    .len(),
+                &self.unprotected_custody.retained_count(),
             )
             .finish_non_exhaustive()
     }
 }
 
-struct SupervisedProtectedCommit {
-    _reservation: GithubRuntimeAuthorityCommitReservation,
-    _pending_observation: SupervisorPendingObservation,
-    pending: PendingGithubRuntimeAuthorityCommit,
-    task_abort: Mutex<Option<tokio::task::AbortHandle>>,
-    driver_active: Arc<AtomicBool>,
-    removed: AtomicBool,
-}
-
-struct SupervisedUnprotectedCandidate {
-    _reservation: GithubRuntimeAuthorityCommitReservation,
-    _pending_observation: SupervisorPendingObservation,
-    custody: UnprotectedGithubRuntimeAuthorityCandidate,
-    task_abort: Mutex<Option<tokio::task::AbortHandle>>,
-    driver_active: Arc<AtomicBool>,
-    removed: AtomicBool,
-}
-
-struct SupervisorDriverObservation {
-    active: Arc<AtomicBool>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl Drop for SupervisorDriverObservation {
-    fn drop(&mut self) {
-        self.active.store(false, Ordering::Release);
-        self.drained.notify_waiters();
-    }
-}
-
-fn take_supervised_custody<T>(retained: &Mutex<Vec<Arc<T>>>, target: &Arc<T>) -> Option<Arc<T>> {
-    let mut retained = retained.lock().expect("runtime-authority custody lock");
-    let position = retained
-        .iter()
-        .position(|entry| Arc::ptr_eq(entry, target))?;
-    Some(retained.swap_remove(position))
-}
-
-pub(crate) struct GithubRuntimeAuthorityCommitReservation {
-    _permit: OwnedSemaphorePermit,
-    outstanding: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl Drop for GithubRuntimeAuthorityCommitReservation {
-    fn drop(&mut self) {
-        self.outstanding.fetch_sub(1, Ordering::AcqRel);
-        self.drained.notify_waiters();
-    }
-}
-
-struct SupervisorPendingObservation {
-    count: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl SupervisorPendingObservation {
-    fn new(count: Arc<AtomicUsize>, drained: Arc<tokio::sync::Notify>) -> Self {
-        count.fetch_add(1, Ordering::AcqRel);
-        Self { count, drained }
-    }
-}
-
-impl Drop for SupervisorPendingObservation {
-    fn drop(&mut self) {
-        self.count.fetch_sub(1, Ordering::AcqRel);
-        self.drained.notify_waiters();
-    }
-}
+pub(crate) type GithubRuntimeAuthorityCommitReservation = Reservation;
 
 /// Result of one bounded coordinator pass.
 #[must_use]
@@ -3016,8 +2795,7 @@ mod tests {
         let stale_custody = harness
             .supervisor
             .protected_custody
-            .lock()
-            .expect("runtime-authority protected custody lock")
+            .retained()
             .first()
             .cloned()
             .expect("protected custody retained before confirmation");
@@ -3031,9 +2809,7 @@ mod tests {
             GithubRuntimeAuthorityCoordinationOutcome::Transitioned(_)
         ));
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !stale_custody.removed.load(Ordering::Acquire)
-                || stale_custody.driver_active.load(Ordering::Acquire)
-            {
+            while !stale_custody.is_removed() || stale_custody.is_driver_active() {
                 tokio::task::yield_now().await;
             }
         })
@@ -3187,17 +2963,14 @@ mod tests {
         gate.wait_until_entered().await;
         let stale_custody = supervisor
             .unprotected_custody
-            .lock()
-            .expect("runtime-authority unprotected custody lock")
+            .retained()
             .first()
             .cloned()
             .expect("unprotected custody retained before erasure confirmation");
         repository.authenticate_unprotected_erasure();
         gate.release();
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !stale_custody.removed.load(Ordering::Acquire)
-                || stale_custody.driver_active.load(Ordering::Acquire)
-            {
+            while !stale_custody.is_removed() || stale_custody.is_driver_active() {
                 tokio::task::yield_now().await;
             }
         })

--- a/crates/automata-ci-credential-github/src/lib.rs
+++ b/crates/automata-ci-credential-github/src/lib.rs
@@ -27,6 +27,7 @@ mod runtime_authority;
 mod runtime_authority_lifecycle;
 mod server_service_authority;
 mod signer;
+mod supervised_custody;
 
 pub use adapter::{GithubAppBrokerConstructionError, GithubAppCredentialBroker};
 pub use authority_coordinator::{

--- a/crates/automata-ci-credential-github/src/runtime_authority_lifecycle.rs
+++ b/crates/automata-ci-credential-github/src/runtime_authority_lifecycle.rs
@@ -1,14 +1,6 @@
 //! Bounded reconciliation and revocation for protected GitHub job authority.
 
-use std::{
-    collections::BTreeMap,
-    fmt,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt, sync::Arc, time::Duration};
 
 use automata_ci_auth::secret::SecretString;
 use automata_ci_core::UnixMillis;
@@ -30,16 +22,15 @@ use automata_ci_store::{
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
-use tokio::{
-    runtime::Handle,
-    sync::{OwnedSemaphorePermit, oneshot},
-};
+use tokio::{runtime::Handle, sync::oneshot};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     GithubAppCredentialBroker, GithubInstallationTokenRevocationCandidate,
     GithubInstallationTokenRevocationFailureKind, GithubInstallationTokenRevocationOutcome,
-    GithubRuntimeAuthorityCoordinatorClock, config::whole_milliseconds,
+    GithubRuntimeAuthorityCoordinatorClock,
+    config::whole_milliseconds,
+    supervised_custody::{Entry, Reservation, SupervisedCustody},
 };
 
 const INSTALLATION_TOKEN_FRAME_DOMAIN: &[u8] = b"automata-ci/github-installation-token/v1\0";
@@ -326,13 +317,8 @@ pub enum GithubRuntimeAuthorityLifecycleSupervisorError {
 /// Bounded independent custody for exact post-provider lifecycle mutations.
 pub struct GithubRuntimeAuthorityLifecycleSupervisor {
     repository: Arc<dyn GithubRuntimeAuthorityRepository>,
-    runtime: Handle,
     retry_interval: Duration,
-    permits: Arc<tokio::sync::Semaphore>,
-    outstanding: Arc<AtomicUsize>,
-    pending: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-    custody: Arc<Mutex<Vec<Arc<SupervisedLifecycleCommit>>>>,
+    custody: SupervisedCustody<PendingGithubRuntimeAuthorityLifecycleCommit>,
 }
 
 impl GithubRuntimeAuthorityLifecycleSupervisor {
@@ -356,29 +342,14 @@ impl GithubRuntimeAuthorityLifecycleSupervisor {
         }
         Ok(Self {
             repository,
-            runtime,
             retry_interval,
-            permits: Arc::new(tokio::sync::Semaphore::new(capacity)),
-            outstanding: Arc::new(AtomicUsize::new(0)),
-            pending: Arc::new(AtomicUsize::new(0)),
-            drained: Arc::new(tokio::sync::Notify::new()),
-            custody: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
+            custody: SupervisedCustody::new(runtime, capacity),
         })
     }
 
     fn try_reserve(&self) -> Option<LifecycleCommitReservation> {
         self.redrive_retained();
-        self.outstanding.fetch_add(1, Ordering::AcqRel);
-        let Ok(permit) = Arc::clone(&self.permits).try_acquire_owned() else {
-            self.outstanding.fetch_sub(1, Ordering::AcqRel);
-            self.drained.notify_waiters();
-            return None;
-        };
-        Some(LifecycleCommitReservation {
-            _permit: permit,
-            outstanding: Arc::clone(&self.outstanding),
-            drained: Arc::clone(&self.drained),
-        })
+        self.custody.try_reserve()
     }
 
     fn supervise(
@@ -386,21 +357,7 @@ impl GithubRuntimeAuthorityLifecycleSupervisor {
         reservation: LifecycleCommitReservation,
         pending_commit: PendingGithubRuntimeAuthorityLifecycleCommit,
     ) -> oneshot::Receiver<GithubRuntimeAuthorityReceipt> {
-        let custody = Arc::new(SupervisedLifecycleCommit {
-            _reservation: reservation,
-            _pending_observation: LifecyclePendingObservation::new(
-                Arc::clone(&self.pending),
-                Arc::clone(&self.drained),
-            ),
-            pending: pending_commit,
-            task_abort: Mutex::new(None),
-            driver_active: Arc::new(AtomicBool::new(false)),
-            removed: AtomicBool::new(false),
-        });
-        self.custody
-            .lock()
-            .expect("runtime-authority lifecycle custody lock")
-            .push(Arc::clone(&custody));
+        let custody = self.custody.retain(reservation, pending_commit);
 
         let (result_sender, result_receiver) = oneshot::channel();
         let started = self.start_driver(&custody, Some(result_sender));
@@ -410,112 +367,59 @@ impl GithubRuntimeAuthorityLifecycleSupervisor {
 
     fn start_driver(
         &self,
-        custody: &Arc<SupervisedLifecycleCommit>,
+        custody: &Arc<Entry<PendingGithubRuntimeAuthorityLifecycleCommit>>,
         result_sender: Option<oneshot::Sender<GithubRuntimeAuthorityReceipt>>,
     ) -> bool {
-        if custody.removed.load(Ordering::Acquire) {
-            return false;
-        }
-        if custody
-            .driver_active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return false;
-        }
-        if custody.removed.load(Ordering::Acquire) {
-            custody.driver_active.store(false, Ordering::Release);
-            self.drained.notify_waiters();
-            return false;
-        }
         let repository = Arc::clone(&self.repository);
-        let retained = Arc::clone(&self.custody);
-        let task_custody = Arc::clone(custody);
         let retry_interval = self.retry_interval;
-        let driver_active = LifecycleDriverObservation {
-            active: Arc::clone(&custody.driver_active),
-            drained: Arc::clone(&self.drained),
-        };
-        let task = self.runtime.spawn(async move {
-            let _driver_active = driver_active;
-            let receipt = loop {
-                match task_custody.pending.replay(repository.as_ref()).await {
-                    Ok(receipt) => break receipt,
-                    Err(_) => tokio::time::sleep(retry_interval).await,
+        self.custody.start_driver(
+            custody,
+            move |custody| async move {
+                loop {
+                    match custody.value().replay(repository.as_ref()).await {
+                        Ok(receipt) => break receipt,
+                        Err(_) => tokio::time::sleep(retry_interval).await,
+                    }
                 }
-            };
-            task_custody.removed.store(true, Ordering::Release);
-            drop(take_lifecycle_custody(&retained, &task_custody));
-            drop(task_custody);
-            if let Some(result_sender) = result_sender {
-                let _ = result_sender.send(receipt);
-            }
-        });
-        *custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority lifecycle task lock") = Some(task.abort_handle());
-        true
+            },
+            move |receipt| {
+                if let Some(result_sender) = result_sender {
+                    let _ = result_sender.send(receipt);
+                }
+            },
+        )
     }
 
     fn redrive_retained(&self) {
-        let custody = self
-            .custody
-            .lock()
-            .expect("runtime-authority lifecycle custody lock")
-            .clone();
-        for custody in custody {
+        for custody in self.custody.retained() {
             let _ = self.start_driver(&custody, None);
         }
     }
 
     #[cfg(test)]
     fn abort_pending_task(&self) -> bool {
-        let custody = self
-            .custody
-            .lock()
-            .expect("runtime-authority lifecycle custody lock")
+        self.custody
+            .retained()
             .first()
-            .cloned();
-        let Some(custody) = custody else {
-            return false;
-        };
-        let task = custody
-            .task_abort
-            .lock()
-            .expect("runtime-authority lifecycle task lock")
-            .clone();
-        task.is_some_and(|task| {
-            task.abort();
-            true
-        })
+            .is_some_and(|custody| custody.abort_driver())
     }
 
     /// Returns the number of exact lifecycle mutations under independent custody.
     #[must_use]
     pub fn pending_count(&self) -> usize {
-        self.pending.load(Ordering::Acquire)
+        self.custody.pending()
     }
 
     /// Closes admission for new provider-side lifecycle work during shutdown.
     /// Already-supervised mutations retain their permits and custody.
     pub fn close(&self) {
-        self.permits.close();
+        self.custody.close();
     }
 
     /// Waits until every supervised lifecycle mutation commits. Process wall
     /// time can never authorize loss of pending custody.
     pub async fn wait_for_idle(&self) {
-        loop {
-            let notified = self.drained.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-            self.redrive_retained();
-            if self.outstanding.load(Ordering::Acquire) == 0 {
-                return;
-            }
-            notified.await;
-        }
+        self.custody.wait_for_idle(|| self.redrive_retained()).await;
     }
 
     /// Waits up to `timeout` for all currently supervised mutations to commit.
@@ -534,86 +438,15 @@ impl fmt::Debug for GithubRuntimeAuthorityLifecycleSupervisor {
             .debug_struct("GithubRuntimeAuthorityLifecycleSupervisor")
             .field("repository", &"[AUTHORITY REPOSITORY]")
             .field("retry_interval", &self.retry_interval)
-            .field("outstanding", &self.outstanding.load(Ordering::Acquire))
+            .field("outstanding", &self.custody.outstanding())
             .field("pending", &self.pending_count())
-            .field("available_capacity", &self.permits.available_permits())
-            .field(
-                "retained_custody",
-                &self
-                    .custody
-                    .lock()
-                    .expect("runtime-authority lifecycle custody lock")
-                    .len(),
-            )
+            .field("available_capacity", &self.custody.available())
+            .field("retained_custody", &self.custody.retained_count())
             .finish_non_exhaustive()
     }
 }
 
-struct SupervisedLifecycleCommit {
-    _reservation: LifecycleCommitReservation,
-    _pending_observation: LifecyclePendingObservation,
-    pending: PendingGithubRuntimeAuthorityLifecycleCommit,
-    task_abort: Mutex<Option<tokio::task::AbortHandle>>,
-    driver_active: Arc<AtomicBool>,
-    removed: AtomicBool,
-}
-
-struct LifecycleDriverObservation {
-    active: Arc<AtomicBool>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl Drop for LifecycleDriverObservation {
-    fn drop(&mut self) {
-        self.active.store(false, Ordering::Release);
-        self.drained.notify_waiters();
-    }
-}
-
-fn take_lifecycle_custody(
-    retained: &Mutex<Vec<Arc<SupervisedLifecycleCommit>>>,
-    target: &Arc<SupervisedLifecycleCommit>,
-) -> Option<Arc<SupervisedLifecycleCommit>> {
-    let mut retained = retained
-        .lock()
-        .expect("runtime-authority lifecycle custody lock");
-    let position = retained
-        .iter()
-        .position(|entry| Arc::ptr_eq(entry, target))?;
-    Some(retained.swap_remove(position))
-}
-
-struct LifecycleCommitReservation {
-    _permit: OwnedSemaphorePermit,
-    outstanding: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl Drop for LifecycleCommitReservation {
-    fn drop(&mut self) {
-        self.outstanding.fetch_sub(1, Ordering::AcqRel);
-        self.drained.notify_waiters();
-    }
-}
-
-struct LifecyclePendingObservation {
-    count: Arc<AtomicUsize>,
-    drained: Arc<tokio::sync::Notify>,
-}
-
-impl LifecyclePendingObservation {
-    fn new(count: Arc<AtomicUsize>, drained: Arc<tokio::sync::Notify>) -> Self {
-        count.fetch_add(1, Ordering::AcqRel);
-        Self { count, drained }
-    }
-}
-
-impl Drop for LifecyclePendingObservation {
-    fn drop(&mut self) {
-        self.count.fetch_sub(1, Ordering::AcqRel);
-        self.drained.notify_waiters();
-    }
-}
+type LifecycleCommitReservation = Reservation;
 
 /// Result of one bounded reconcile-and-revoke maintenance step.
 #[derive(Debug)]
@@ -1343,17 +1176,14 @@ mod tests {
         repository.assert_exact_mutation_attempts(&expected, 1);
         let stale_custody = supervisor
             .custody
-            .lock()
-            .expect("runtime-authority lifecycle custody lock")
+            .retained()
             .first()
             .cloned()
             .expect("lifecycle custody retained before confirmation");
         gate.release();
         result.await.expect("confirmed lifecycle mutation");
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !stale_custody.removed.load(Ordering::Acquire)
-                || stale_custody.driver_active.load(Ordering::Acquire)
-            {
+            while !stale_custody.is_removed() || stale_custody.is_driver_active() {
                 tokio::task::yield_now().await;
             }
         })

--- a/crates/automata-ci-credential-github/src/supervised_custody.rs
+++ b/crates/automata-ci-credential-github/src/supervised_custody.rs
@@ -1,0 +1,324 @@
+use std::{
+    future::Future,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+use tokio::{
+    runtime::Handle,
+    sync::{Notify, OwnedSemaphorePermit, Semaphore},
+    task::AbortHandle,
+};
+
+pub(crate) struct SupervisedCustody<T> {
+    shared: Arc<Shared>,
+    retained: Arc<Mutex<Vec<Arc<Entry<T>>>>>,
+}
+
+impl<T> SupervisedCustody<T> {
+    pub(crate) fn new(runtime: Handle, capacity: usize) -> Self {
+        Self {
+            shared: Arc::new(Shared {
+                runtime,
+                permits: Arc::new(Semaphore::new(capacity)),
+                outstanding: AtomicUsize::new(0),
+                pending: AtomicUsize::new(0),
+                drained: Arc::new(Notify::new()),
+            }),
+            retained: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
+        }
+    }
+
+    pub(crate) fn linked<U>(&self, capacity: usize) -> SupervisedCustody<U> {
+        SupervisedCustody {
+            shared: Arc::clone(&self.shared),
+            retained: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
+        }
+    }
+
+    pub(crate) fn try_reserve(&self) -> Option<Reservation> {
+        self.shared.outstanding.fetch_add(1, Ordering::AcqRel);
+        let Ok(permit) = Arc::clone(&self.shared.permits).try_acquire_owned() else {
+            self.shared.outstanding.fetch_sub(1, Ordering::AcqRel);
+            self.shared.drained.notify_waiters();
+            return None;
+        };
+        Some(Reservation {
+            _permit: permit,
+            shared: Arc::clone(&self.shared),
+        })
+    }
+
+    pub(crate) fn retain(&self, reservation: Reservation, value: T) -> Arc<Entry<T>> {
+        assert!(
+            Arc::ptr_eq(&self.shared, &reservation.shared),
+            "reservation belongs to the supervised custody core"
+        );
+        let entry = Arc::new(Entry {
+            reservation,
+            _pending: PendingObservation::new(Arc::clone(&self.shared)),
+            value,
+            task_abort: Mutex::new(None),
+            driver_active: Arc::new(AtomicBool::new(false)),
+            removed: AtomicBool::new(false),
+        });
+        self.retained
+            .lock()
+            .expect("supervised custody lock")
+            .push(Arc::clone(&entry));
+        entry
+    }
+
+    pub(crate) fn start_driver<R, Drive, DriveFuture, Complete>(
+        &self,
+        entry: &Arc<Entry<T>>,
+        drive: Drive,
+        complete: Complete,
+    ) -> bool
+    where
+        T: Send + Sync + 'static,
+        R: Send + 'static,
+        Drive: FnOnce(Arc<Entry<T>>) -> DriveFuture + Send + 'static,
+        DriveFuture: Future<Output = R> + Send + 'static,
+        Complete: FnOnce(R) + Send + 'static,
+    {
+        assert!(
+            Arc::ptr_eq(&self.shared, &entry.reservation.shared),
+            "entry belongs to the supervised custody core"
+        );
+        if entry.removed.load(Ordering::Acquire) {
+            return false;
+        }
+        if entry
+            .driver_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        if entry.removed.load(Ordering::Acquire) {
+            entry.driver_active.store(false, Ordering::Release);
+            self.shared.drained.notify_waiters();
+            return false;
+        }
+
+        let retained = Arc::clone(&self.retained);
+        let task_entry = Arc::clone(entry);
+        let driver_active = DriverObservation {
+            active: Arc::clone(&entry.driver_active),
+            drained: Arc::clone(&self.shared.drained),
+        };
+        let task = self.shared.runtime.spawn(async move {
+            let _driver_active = driver_active;
+            let result = drive(Arc::clone(&task_entry)).await;
+            task_entry.removed.store(true, Ordering::Release);
+            drop(take_retained(&retained, &task_entry));
+            drop(task_entry);
+            complete(result);
+        });
+        *entry.task_abort.lock().expect("supervised driver lock") = Some(task.abort_handle());
+        true
+    }
+
+    pub(crate) fn retained(&self) -> Vec<Arc<Entry<T>>> {
+        self.retained
+            .lock()
+            .expect("supervised custody lock")
+            .clone()
+    }
+
+    pub(crate) fn retained_count(&self) -> usize {
+        self.retained.lock().expect("supervised custody lock").len()
+    }
+
+    pub(crate) fn pending(&self) -> usize {
+        self.shared.pending.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn outstanding(&self) -> usize {
+        self.shared.outstanding.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn available(&self) -> usize {
+        self.shared.permits.available_permits()
+    }
+
+    pub(crate) fn close(&self) {
+        self.shared.permits.close();
+    }
+
+    pub(crate) async fn wait_for_idle(&self, mut redrive: impl FnMut()) {
+        loop {
+            let notified = self.shared.drained.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            redrive();
+            if self.outstanding() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+pub(crate) struct Entry<T> {
+    reservation: Reservation,
+    _pending: PendingObservation,
+    value: T,
+    task_abort: Mutex<Option<AbortHandle>>,
+    driver_active: Arc<AtomicBool>,
+    removed: AtomicBool,
+}
+
+impl<T> Entry<T> {
+    pub(crate) const fn value(&self) -> &T {
+        &self.value
+    }
+
+    #[cfg(test)]
+    pub(crate) fn abort_driver(&self) -> bool {
+        let task = self
+            .task_abort
+            .lock()
+            .expect("supervised driver lock")
+            .clone();
+        task.is_some_and(|task| {
+            task.abort();
+            true
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_removed(&self) -> bool {
+        self.removed.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_driver_active(&self) -> bool {
+        self.driver_active.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct Reservation {
+    _permit: OwnedSemaphorePermit,
+    shared: Arc<Shared>,
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.shared.outstanding.fetch_sub(1, Ordering::AcqRel);
+        self.shared.drained.notify_waiters();
+    }
+}
+
+struct Shared {
+    runtime: Handle,
+    permits: Arc<Semaphore>,
+    outstanding: AtomicUsize,
+    pending: AtomicUsize,
+    drained: Arc<Notify>,
+}
+
+struct PendingObservation {
+    shared: Arc<Shared>,
+}
+
+impl PendingObservation {
+    fn new(shared: Arc<Shared>) -> Self {
+        shared.pending.fetch_add(1, Ordering::AcqRel);
+        Self { shared }
+    }
+}
+
+impl Drop for PendingObservation {
+    fn drop(&mut self) {
+        self.shared.pending.fetch_sub(1, Ordering::AcqRel);
+        self.shared.drained.notify_waiters();
+    }
+}
+
+struct DriverObservation {
+    active: Arc<AtomicBool>,
+    drained: Arc<Notify>,
+}
+
+impl Drop for DriverObservation {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::Release);
+        self.drained.notify_waiters();
+    }
+}
+
+fn take_retained<T>(
+    retained: &Mutex<Vec<Arc<Entry<T>>>>,
+    target: &Arc<Entry<T>>,
+) -> Option<Arc<Entry<T>>> {
+    let mut retained = retained.lock().expect("supervised custody lock");
+    let position = retained
+        .iter()
+        .position(|entry| Arc::ptr_eq(entry, target))?;
+    Some(retained.swap_remove(position))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    async fn wait_for_driver(entry: &Entry<()>, active: bool) {
+        for _ in 0..100 {
+            if entry.is_driver_active() == active {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("driver activity did not converge");
+    }
+
+    #[tokio::test]
+    async fn aborted_driver_retains_custody_for_redrive() {
+        let custody = SupervisedCustody::new(Handle::current(), 1);
+        let entry = custody.retain(custody.try_reserve().expect("reservation"), ());
+        assert!(custody.start_driver(&entry, |_| std::future::pending(), |()| {}));
+        wait_for_driver(&entry, true).await;
+        assert!(entry.abort_driver());
+        wait_for_driver(&entry, false).await;
+        assert_eq!((custody.pending(), custody.outstanding()), (1, 1));
+        assert_eq!(custody.retained_count(), 1);
+
+        assert!(custody.start_driver(&entry, |_| async {}, |()| {}));
+        drop(entry);
+        custody.wait_for_idle(|| {}).await;
+        assert_eq!((custody.pending(), custody.outstanding()), (0, 0));
+        assert_eq!(custody.retained_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn linked_typed_ledgers_share_one_bounded_core() {
+        let left = SupervisedCustody::<u8>::new(Handle::current(), 1);
+        let right = left.linked::<u16>(1);
+        let reservation = left.try_reserve().expect("shared reservation");
+        assert!(right.try_reserve().is_none());
+        let _entry = right.retain(reservation, 7);
+        assert_eq!((left.outstanding(), right.outstanding()), (1, 1));
+        assert_eq!((left.pending(), right.pending()), (1, 1));
+        assert_eq!((left.available(), right.available()), (0, 0));
+        assert_eq!((left.retained_count(), right.retained_count()), (0, 1));
+    }
+
+    #[tokio::test]
+    async fn foreign_reservation_is_rejected_without_counter_drift() {
+        let local = SupervisedCustody::<()>::new(Handle::current(), 1);
+        let foreign = SupervisedCustody::<()>::new(Handle::current(), 1);
+        let reservation = foreign.try_reserve().expect("foreign reservation");
+        let rejected = catch_unwind(AssertUnwindSafe(|| local.retain(reservation, ())));
+        assert!(rejected.is_err());
+        assert_eq!((local.pending(), local.outstanding()), (0, 0));
+        assert_eq!((foreign.pending(), foreign.outstanding()), (0, 0));
+        assert_eq!((local.available(), foreign.available()), (1, 1));
+        assert_eq!((local.retained_count(), foreign.retained_count()), (0, 0));
+    }
+}


### PR DESCRIPTION
Closes #371.

## Summary

- introduce one private typed `SupervisedCustody<T>` core for bounded retained work, driver ownership, abort recovery, and idle waiting
- link protected and unprotected authority custody over shared capacity, counters, and wakeups while keeping distinct typed retained ledgers
- keep runtime-authority lifecycle custody independent and leave repository/authority/receipt/retry policy in the existing adapters
- preserve protected-before-unprotected redrive ordering, stale-entry accounting, driver CAS/removal fences, and the pin-and-enable no-lost-wakeup loop
- add focused primitive coverage for abort/redrive, linked capacity/accounting, and foreign-reservation rejection

This is one four-file subsystem checkpoint: 962 changed lines, with 72 net lines removed. No public API or re-export changes.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo check --locked -p automata-ci-credential-github --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo test --locked -p automata-ci-credential-github --all-features` (85 passed)
- `CARGO_BUILD_JOBS=1 cargo clippy --locked -p automata-ci-credential-github --all-targets --all-features -- -D warnings`

The final patch received independent API/semantic and concurrency reviews.