### PR TITLE
refactor(auth): separate runner enrollment authority

### DIFF
--- a/crates/automata-ci-auth-postgres/src/lib.rs
+++ b/crates/automata-ci-auth-postgres/src/lib.rs
@@ -22,7 +22,7 @@ pub use github_mapping_management::PostgresGithubMappingManagementRepository;
 pub use github_membership::PostgresGithubMembershipRepository;
 pub use installation::PostgresInstallationRepository;
 pub use login::PostgresLoginTransactionRepository;
-pub use management::PostgresHumanRbacManagementRepository;
+pub use management::{PostgresHumanRbacManagementRepository, PostgresRunnerEnrollmentRepository};
 pub use provider_tokens::PostgresProviderTokenVault;
 pub use request_auth::PostgresRequestAuthenticationResolver;
 pub use session::PostgresHumanSessionRepository;

--- a/crates/automata-ci-auth-postgres/src/management.rs
+++ b/crates/automata-ci-auth-postgres/src/management.rs
@@ -45,9 +45,9 @@ mod runner_enrollment;
 
 pub use runner_enrollment::{
     ConsumeRunnerEnrollment, CreateRunnerEnrollmentToken, MAX_RUNNER_CERTIFICATE_LIFETIME_SECONDS,
-    MIN_RUNNER_CERTIFICATE_REMAINING_LIFETIME_SECONDS, PrepareRunnerEnrollment,
-    PreparedRunnerEnrollment, RunnerEnrollmentConsumeOutcome, RunnerEnrollmentPrepareOutcome,
-    RunnerEnrollmentTokenRecord,
+    MIN_RUNNER_CERTIFICATE_REMAINING_LIFETIME_SECONDS, PostgresRunnerEnrollmentRepository,
+    PrepareRunnerEnrollment, PreparedRunnerEnrollment, RunnerEnrollmentConsumeOutcome,
+    RunnerEnrollmentPrepareOutcome, RunnerEnrollmentTokenRecord,
 };
 
 const ACTION_ROLE_CREATE: &str = "rbac.role.create";

--- a/crates/automata-ci-auth-postgres/src/management/runner_enrollment.rs
+++ b/crates/automata-ci-auth-postgres/src/management/runner_enrollment.rs
@@ -1,14 +1,15 @@
+use std::fmt;
+
 use automata_ci_auth::management::{
     ManagementActor, ManagementMutationOutcome, ManagementRepositoryError,
 };
 use automata_ci_core::{MAX_REGISTERED_RUNNERS, RunnerCapabilities, RunnerGroup};
-use sqlx::{FromRow, Postgres, Transaction};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use super::{
-    AuditDescriptor, AuthorizedActor, MutationAuthorization, PostgresHumanRbacManagementRepository,
-    authorize_mutation, closed_authorization, commit, database_time_milliseconds, finish_applied,
-    map_database_error,
+    AuditDescriptor, AuthorizedActor, MutationAuthorization, authorize_mutation,
+    closed_authorization, commit, database_time_milliseconds, finish_applied, map_database_error,
 };
 
 const ACTION_TOKEN_CREATE: &str = "runner.enrollment_token.create";
@@ -21,6 +22,32 @@ const RUNNER_ENROLLMENT_CREATE_LOCK_SALT: i64 = 0x454e_524f_4c4c_4d54;
 const MAX_NAME_BYTES: usize = 255;
 const MAX_GROUP_CHARACTERS: usize = 256;
 const MAX_REDEEM_RESPONSE_BYTES: usize = 512 * 1_024;
+
+/// `PostgreSQL` adapter for one-time runner enrollment creation and redemption.
+///
+/// Human token creation reauthorizes its session and RBAC grant inside the
+/// transaction. Redemption is authorized solely by possession of the opaque
+/// one-time token.
+#[derive(Clone)]
+pub struct PostgresRunnerEnrollmentRepository {
+    pool: PgPool,
+}
+
+impl PostgresRunnerEnrollmentRepository {
+    /// Binds runner enrollment to one `PostgreSQL` pool.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl fmt::Debug for PostgresRunnerEnrollmentRepository {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresRunnerEnrollmentRepository")
+            .finish_non_exhaustive()
+    }
+}
 
 /// Maximum lifetime used by the control-plane certificate profile. A leaf is
 /// shorter when its issuing CA expires first.
@@ -283,7 +310,7 @@ impl EnrollmentRow {
     }
 }
 
-impl PostgresHumanRbacManagementRepository {
+impl PostgresRunnerEnrollmentRepository {
     /// Creates an audited one-time token record after checking `runners:enroll`.
     ///
     /// # Errors

--- a/crates/automata-ci-postgres/tests/auth/management.rs
+++ b/crates/automata-ci-postgres/tests/auth/management.rs
@@ -23,7 +23,7 @@ use automata_ci_auth::{
     time::UnixTimestamp,
 };
 use automata_ci_auth_postgres::{
-    PostgresHumanRbacManagementRepository,
+    PostgresHumanRbacManagementRepository, PostgresRunnerEnrollmentRepository,
     management::{
         ConsumeRunnerEnrollment, CreateRunnerEnrollmentToken,
         MAX_RUNNER_CERTIFICATE_LIFETIME_SECONDS, MIN_RUNNER_CERTIFICATE_REMAINING_LIFETIME_SECONDS,
@@ -3208,7 +3208,7 @@ async fn runner_enrollment_is_authorized_scoped_atomic_and_one_use() -> TestResu
         let session_id = Uuid::new_v4();
         let authority_revision =
             seed_session(pool, "runner-enrollment", manager, session_id).await?;
-        let repository = PostgresHumanRbacManagementRepository::new(pool.clone());
+        let repository = PostgresRunnerEnrollmentRepository::new(pool.clone());
         let token_sha256 = [7_u8; 32];
         let enrollment_id = Uuid::new_v4();
         let issued = repository

--- a/crates/automata-ci/src/app/human_auth_middleware.rs
+++ b/crates/automata-ci/src/app/human_auth_middleware.rs
@@ -212,7 +212,6 @@ fn request_surface(path: &str) -> HumanRequestSurface {
                 | "/api/v1/auth/device/poll"
                 | "/api/v1/setup/device"
                 | "/api/v1/setup/device/poll"
-                | "/api/v1/runner-enrollments/redeem"
         )
     {
         HumanRequestSurface::Bypass
@@ -1025,6 +1024,10 @@ mod tests {
             HumanRequestSurface::Cli
         );
         assert_eq!(request_surface("/api/v1/users"), HumanRequestSurface::Cli);
+        assert_eq!(
+            request_surface(crate::app::runner_enrollment_api::RUNNER_ENROLLMENT_REDEEM_PATH),
+            HumanRequestSurface::Cli
+        );
         assert_eq!(request_surface("/api/v1"), HumanRequestSurface::Cli);
         assert_eq!(
             request_surface("/api/v1/local/future-route"),

--- a/crates/automata-ci/src/app/runner_enrollment_api.rs
+++ b/crates/automata-ci/src/app/runner_enrollment_api.rs
@@ -1,4 +1,4 @@
-//! One-time runner enrollment over the human HTTPS listener.
+//! One-time runner enrollment over the control-plane HTTPS listener.
 
 use std::{fmt, sync::Arc, time::Duration};
 
@@ -13,7 +13,7 @@ use automata_ci_auth::{
 };
 use automata_ci_auth_postgres::management::{
     ConsumeRunnerEnrollment, CreateRunnerEnrollmentToken, MAX_RUNNER_CERTIFICATE_LIFETIME_SECONDS,
-    MIN_RUNNER_CERTIFICATE_REMAINING_LIFETIME_SECONDS, PostgresHumanRbacManagementRepository,
+    MIN_RUNNER_CERTIFICATE_REMAINING_LIFETIME_SECONDS, PostgresRunnerEnrollmentRepository,
     PrepareRunnerEnrollment, PreparedRunnerEnrollment, RunnerEnrollmentConsumeOutcome,
     RunnerEnrollmentPrepareOutcome,
 };
@@ -316,27 +316,39 @@ fn server_root_authority(
 pub(crate) struct RunnerCertificateIssuerError;
 
 #[derive(Clone)]
-struct RunnerEnrollmentApiState {
-    repository: Arc<PostgresHumanRbacManagementRepository>,
-    issuer: Arc<RunnerCertificateIssuer>,
+struct RunnerEnrollmentCreateApiState {
+    repository: Arc<PostgresRunnerEnrollmentRepository>,
     clock: Arc<dyn Clock>,
+}
+
+#[derive(Clone)]
+struct RunnerEnrollmentRedeemApiState {
+    repository: Arc<PostgresRunnerEnrollmentRepository>,
+    issuer: Arc<RunnerCertificateIssuer>,
     capability_readiness: RunnerCapabilityReadiness,
     redemptions: Arc<tokio::sync::Semaphore>,
 }
 
-pub(crate) fn runner_enrollment_api_router(
-    repository: Arc<PostgresHumanRbacManagementRepository>,
-    issuer: Arc<RunnerCertificateIssuer>,
+pub(crate) fn runner_enrollment_create_router(
+    repository: Arc<PostgresRunnerEnrollmentRepository>,
     clock: Arc<dyn Clock>,
-    capability_readiness: RunnerCapabilityReadiness,
 ) -> Router {
     Router::new()
         .route(RUNNER_ENROLLMENTS_PATH, post(create_enrollment))
+        .with_state(RunnerEnrollmentCreateApiState { repository, clock })
+        .layer(axum::middleware::from_fn(super::api_security::no_store))
+}
+
+pub(crate) fn runner_enrollment_redeem_router(
+    repository: Arc<PostgresRunnerEnrollmentRepository>,
+    issuer: Arc<RunnerCertificateIssuer>,
+    capability_readiness: RunnerCapabilityReadiness,
+) -> Router {
+    Router::new()
         .route(RUNNER_ENROLLMENT_REDEEM_PATH, post(redeem_enrollment))
-        .with_state(RunnerEnrollmentApiState {
+        .with_state(RunnerEnrollmentRedeemApiState {
             repository,
             issuer,
-            clock,
             capability_readiness,
             redemptions: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REDEMPTIONS)),
         })
@@ -344,7 +356,7 @@ pub(crate) fn runner_enrollment_api_router(
 }
 
 async fn create_enrollment(
-    State(state): State<RunnerEnrollmentApiState>,
+    State(state): State<RunnerEnrollmentCreateApiState>,
     request: Request,
 ) -> Response {
     let actor = match actor_from_request(&state, &request) {
@@ -401,7 +413,7 @@ async fn create_enrollment(
 }
 
 async fn redeem_enrollment(
-    State(state): State<RunnerEnrollmentApiState>,
+    State(state): State<RunnerEnrollmentRedeemApiState>,
     request: Request,
 ) -> Response {
     let Ok(_permit) = state.redemptions.try_acquire() else {
@@ -541,7 +553,7 @@ fn decide_enrollment_preparation(
 }
 
 fn actor_from_request(
-    state: &RunnerEnrollmentApiState,
+    state: &RunnerEnrollmentCreateApiState,
     request: &Request,
 ) -> Result<ManagementActor, ApiError> {
     let snapshot = request

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -14,6 +14,7 @@ use automata_ci_auth::{
 };
 use automata_ci_auth_postgres::{
     PostgresDelegatedActorResolver, PostgresHumanRbacManagementRepository,
+    PostgresRunnerEnrollmentRepository,
 };
 use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType};
 use automata_ci_blob_s3::S3BlobStoreConfigError;
@@ -139,7 +140,9 @@ use crate::app::{
         OperationalRepositorySecretWebData, RepositorySecretWebData,
         repository_secret_browser_router,
     },
-    runner_enrollment_api::{RunnerCertificateIssuer, runner_enrollment_api_router},
+    runner_enrollment_api::{
+        RunnerCertificateIssuer, runner_enrollment_create_router, runner_enrollment_redeem_router,
+    },
     secret_api::{RepositorySecretApiBackend, repository_secret_api_router},
     web::{
         LiveWebData, ManagementRbacWebData, RbacWebData, RequestContext, SetupPageAvailability,
@@ -195,6 +198,7 @@ pub(crate) struct ProductionComponents {
     pub(crate) secret_mutation_recovery_loop: Option<SecretMutationRecoveryLoop>,
     pub(crate) state_sampler: ControlPlaneStateSampler,
     pub(crate) human_api: Router,
+    pub(crate) runner_enrollment_redeem_api: Router,
     pub(crate) delegated_actor_api: Option<Router>,
     pub(crate) live_log_stream_api: Router,
     pub(crate) log_commit_listener: Option<PostgresLogCommitListener>,
@@ -227,6 +231,10 @@ impl fmt::Debug for ProductionComponents {
             )
             .field("state_sampler", &self.state_sampler)
             .field("human_api", &self.human_api)
+            .field(
+                "runner_enrollment_redeem_api",
+                &self.runner_enrollment_redeem_api,
+            )
             .field("delegated_actor_api", &self.delegated_actor_api)
             .field("live_log_stream_api", &self.live_log_stream_api)
             .field("log_commit_listener", &self.log_commit_listener)
@@ -368,6 +376,35 @@ impl ProductionComponents {
             RunnerCapabilityReadiness::unavailable()
         };
         verify_runner_capability_readiness(store.as_ref(), capability_readiness).await?;
+        let (runner_enrollment_repository, runner_enrollment_redeem_api) =
+            match config.runner_public_authority.as_ref() {
+                Some(authority) => {
+                    let client_ca = config.load_client_ca_pem()?;
+                    let client_ca_key = config.load_client_ca_private_key_pem()?;
+                    let server_ca = config.load_runner_server_ca_pem()?;
+                    let server_certificate = config.load_server_certificate_pem()?;
+                    let issuer = Arc::new(
+                        RunnerCertificateIssuer::from_pem(
+                            &client_ca,
+                            &client_ca_key,
+                            &server_ca,
+                            &server_certificate,
+                            format!("https://{authority}/"),
+                        )
+                        .map_err(|_| ServerCompositionError::InvalidRunnerEnrollment)?,
+                    );
+                    let repository = Arc::new(PostgresRunnerEnrollmentRepository::new(
+                        store.postgres_pool().clone(),
+                    ));
+                    let router = runner_enrollment_redeem_router(
+                        Arc::clone(&repository),
+                        issuer,
+                        capability_readiness,
+                    );
+                    (Some(repository), router)
+                }
+                None => (None, Router::new()),
+            };
         let state_repository: Arc<dyn ControlPlaneStateRepository> = store.clone();
         let state_sampler = metrics.state_sampler(state_repository);
 
@@ -468,8 +505,8 @@ impl ProductionComponents {
             secret_management.as_ref(),
             repository_secret_web.clone(),
             fallback_tenant,
-            capability_readiness,
             Arc::clone(&live_log_service),
+            runner_enrollment_repository,
         )
         .await?;
         let managed_secret_tenant =
@@ -674,6 +711,7 @@ impl ProductionComponents {
             secret_mutation_recovery_loop,
             state_sampler,
             human_api: human.router,
+            runner_enrollment_redeem_api,
             delegated_actor_api,
             live_log_stream_api,
             log_commit_listener: Some(log_commit_listener),
@@ -1517,8 +1555,8 @@ async fn build_human_api(
     secret_management: Option<&SecretManagementComposition>,
     repository_secret_web: Option<Arc<dyn RepositorySecretWebData>>,
     fallback_tenant: TenantId,
-    capability_readiness: RunnerCapabilityReadiness,
     live_log_service: Arc<LiveLogService>,
+    runner_enrollment_repository: Option<Arc<PostgresRunnerEnrollmentRepository>>,
 ) -> Result<HumanApiComposition, ServerCompositionError> {
     let deployment_token = config.load_conformance_export_token()?;
     let mut router = match deployment_token.as_deref() {
@@ -1539,28 +1577,6 @@ async fn build_human_api(
         None => Router::new(),
     };
 
-    let enrollment_issuer = if config.human_auth().is_some() {
-        let client_ca = config.load_client_ca_pem()?;
-        let client_ca_key = config.load_client_ca_private_key_pem()?;
-        let server_ca = config.load_runner_server_ca_pem()?;
-        let server_certificate = config.load_server_certificate_pem()?;
-        let authority = config
-            .runner_public_authority
-            .as_ref()
-            .ok_or(ServerCompositionError::InvalidRunnerEnrollment)?;
-        Some(Arc::new(
-            RunnerCertificateIssuer::from_pem(
-                &client_ca,
-                &client_ca_key,
-                &server_ca,
-                &server_certificate,
-                format!("https://{authority}/"),
-            )
-            .map_err(|_| ServerCompositionError::InvalidRunnerEnrollment)?,
-        ))
-    } else {
-        None
-    };
     let Some(config) = config.human_auth() else {
         return Ok(HumanApiComposition {
             router,
@@ -1676,11 +1692,9 @@ async fn build_human_api(
     let management = Arc::new(PostgresHumanRbacManagementRepository::new(
         store.postgres_pool().clone(),
     ));
-    router = router.merge(runner_enrollment_api_router(
-        Arc::clone(&management),
-        enrollment_issuer.ok_or(ServerCompositionError::InvalidRunnerEnrollment)?,
+    router = router.merge(runner_enrollment_create_router(
+        runner_enrollment_repository.ok_or(ServerCompositionError::InvalidRunnerEnrollment)?,
         Arc::clone(runtime.clock()),
-        capability_readiness,
     ));
     let management_api_repository: Arc<
         dyn automata_ci_auth::management::HumanRbacManagementRepository,

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -222,6 +222,9 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
                 )),
                 None => router,
             };
+            // One-time enrollment possession is the complete authentication
+            // boundary and must not depend on a configured human identity provider.
+            let router = router.merge(components.runner_enrollment_redeem_api.clone());
             // Live transports authenticate only the one-time, origin-bound
             // ticket and must remain outside browser/CLI session parsing.
             let router = router.merge(components.live_log_stream_api.clone());


### PR DESCRIPTION
## Outcome

Separates the production runner-enrollment repository and authentication boundaries without adding the dormant deployment/bootstrap authority from draft #173.

`PostgresRunnerEnrollmentRepository` now owns the existing create/prepare/consume methods. The create router remains under human session/RBAC middleware and requires `AuthenticatedRequestSnapshot`; the redeem router is composed outside human middleware and remains authenticated solely by possession of the opaque enrollment token. Both routes retain `no-store`, and issuer/redeem composition exists only when exact runner authority and certificate material are configured.

This small consumed boundary is the prerequisite for the separately stacked certificate-renewal feature.

## Related issue

Related to #173.

## Trust and compatibility impact

There is no SQL, migration, token grammar, HTTP path, or compatibility change. Existing human-created enrollment and one-use redemption keep their behavior while repository ownership and middleware placement become structurally explicit.

No installation/deployment/bootstrap APIs, schema, aliases, or test-only public surface are included.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- locked workspace all-target/all-feature check
- strict workspace Clippy with `-D warnings`
- `automata-ci-auth-postgres`: 18/18
- runner enrollment unit/API tests: 8/8 plus focused middleware coverage
- PostgreSQL enrollment integration target compiles; live case is opt-in when `AUTOMATA_TEST_DATABASE_URL` is available
- full service suite attempted; only five known unrelated mainline GitHub auth/OIDC fixture failures remain
- independent strict review and exact-current rebase review: CLEAN

## AI assistance

OpenAI Codex helped isolate the consumed ownership/authentication boundary from the dormant deployment bootstrap work, run validation, and perform independent strict reviews. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
