### PR TITLE
refactor(guest): centralize response protocol access

### DIFF
--- a/crates/automata-ci-sandbox-guest/src/lib.rs
+++ b/crates/automata-ci-sandbox-guest/src/lib.rs
@@ -393,6 +393,22 @@ pub enum GuestResponse {
     },
 }
 
+impl GuestResponse {
+    /// Returns the protocol version carried by this response.
+    #[must_use]
+    pub const fn protocol(&self) -> u16 {
+        match self {
+            Self::Ready { protocol }
+            | Self::Hello { protocol, .. }
+            | Self::Configured { protocol }
+            | Self::Exec { protocol, .. }
+            | Self::WriteFile { protocol }
+            | Self::ReadFile { protocol, .. }
+            | Self::Rejected { protocol, .. } => *protocol,
+        }
+    }
+}
+
 impl fmt::Debug for GuestResponse {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
@@ -185,9 +185,9 @@ impl KubernetesExecutionEndpoint {
         if cancellation.disposition().requires_termination() {
             return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
         }
-        let response = decode_frame(&response)
+        let response: GuestResponse = decode_frame(&response)
             .map_err(|_| execution_error(ExecutionErrorKind::BackendRejected, stage))?;
-        if response_protocol(&response) != GUEST_PROTOCOL_VERSION {
+        if response.protocol() != GUEST_PROTOCOL_VERSION {
             return Err(execution_error(ExecutionErrorKind::BackendRejected, stage));
         }
         Ok(response)
@@ -420,18 +420,6 @@ fn copy_from_result(response: GuestResponse, byte_limit: usize) -> Result<Vec<u8
             Ok(content)
         }
         response => Err(response_error(&response, ExecutionStage::CopyFrom)),
-    }
-}
-
-const fn response_protocol(response: &GuestResponse) -> u16 {
-    match response {
-        GuestResponse::Ready { protocol }
-        | GuestResponse::Hello { protocol, .. }
-        | GuestResponse::Configured { protocol }
-        | GuestResponse::Exec { protocol, .. }
-        | GuestResponse::WriteFile { protocol }
-        | GuestResponse::ReadFile { protocol, .. }
-        | GuestResponse::Rejected { protocol, .. } => *protocol,
     }
 }
 

--- a/crates/automata-ci-sandbox-macos/src/vm.rs
+++ b/crates/automata-ci-sandbox-macos/src/vm.rs
@@ -237,7 +237,7 @@ impl VmProcess {
         })?;
         let response: GuestResponse = decode_frame(&frame)
             .map_err(|_| execution_error(ExecutionErrorKind::BackendRejected, stage))?;
-        if response_protocol(&response) != GUEST_PROTOCOL_VERSION {
+        if response.protocol() != GUEST_PROTOCOL_VERSION {
             return Err(execution_error(ExecutionErrorKind::BackendRejected, stage));
         }
         Ok(response)
@@ -397,18 +397,6 @@ fn framed_payload(frame: &[u8], maximum: usize) -> io::Result<&[u8]> {
         return Err(invalid_data());
     }
     Ok(&frame[4..])
-}
-
-const fn response_protocol(response: &GuestResponse) -> u16 {
-    match response {
-        GuestResponse::Ready { protocol }
-        | GuestResponse::Hello { protocol, .. }
-        | GuestResponse::Configured { protocol }
-        | GuestResponse::Exec { protocol, .. }
-        | GuestResponse::WriteFile { protocol }
-        | GuestResponse::ReadFile { protocol, .. }
-        | GuestResponse::Rejected { protocol, .. } => *protocol,
-    }
 }
 
 fn duration_millis(duration: Duration) -> io::Result<u64> {


### PR DESCRIPTION
## Outcome

Centralizes current guest-response protocol extraction in one exhaustive `GuestResponse::protocol()` method and consumes it from the Kubernetes and macOS endpoints.

The two duplicate provider helpers are removed. Future response variants must update the central exhaustive match at compile time.

This is a fully consumed micro-slice extracted from draft #173. It deliberately contains no LocalDocker, guest schema v4/v5, replay cache, or capacity behavior.

## Related issue

Related to #173.

## Trust and compatibility impact

None beyond deduplicating the existing closed response-kind check. Wire bytes, schemas, capabilities, and provider behavior are unchanged; wrong-protocol responses continue to fail closed.

## Verification

- guest, Kubernetes, and macOS all-target/all-feature tests
- native strict Clippy with `-D warnings`
- aarch64-apple-darwin all-target check and library strict Clippy
- fmt and diff checks
- independent strict review: CLEAN

## AI assistance

OpenAI Codex helped isolate this consumed cleanup from the blocked guest-protocol work and perform an independent strict review. Every submitted change was reviewed and verified.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
