### PR TITLE
feat(runner): admit Windows action runtimes and images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 crates/automata-ci-store-postgres/migrations/*.sql text eol=lf
+images/windows-server-2025-hyperv-candidate/*.json text eol=lf

--- a/crates/automata-ci-action/src/archive.rs
+++ b/crates/automata-ci-action/src/archive.rs
@@ -43,6 +43,270 @@ pub fn inspect_archive(
     inspect_archive_bytes(snapshot.bytes(), subpath, limits)
 }
 
+/// Validates that an already-inspected repository archive can be materialized
+/// into a Windows job workspace without entering an ambiguous NTFS namespace.
+///
+/// This is deliberately narrower than the provider-neutral archive contract.
+/// Windows materialization rejects every link, reparse-capable entry type,
+/// case-insensitive collision, alternate-data-stream separator, reserved DOS
+/// name, trailing space or dot, and non-ASCII member name. The initial Windows
+/// profile therefore fails closed instead of guessing about Unicode
+/// normalization or link-creation privileges.
+///
+/// Callers must invoke this before creating or attaching a sandbox. The
+/// archive is decoded independently so a prepared-action object cannot bypass
+/// the target-platform materialization policy.
+///
+/// # Errors
+///
+/// Returns a bounded archive error for malformed input, unsafe Windows paths,
+/// links or special entries, case-fold collisions, or resource exhaustion.
+pub fn validate_windows_materialization_archive(
+    bytes: &[u8],
+    limits: ActionBundleLimits,
+) -> Result<(), ActionArchiveError> {
+    if u64::try_from(bytes.len())
+        .ok()
+        .is_none_or(|length| length > limits.compressed().maximum_bytes())
+    {
+        return Err(ActionArchiveError::ResourceLimit);
+    }
+    let decoder = MultiGzDecoder::new(Cursor::new(bytes));
+    let mut archive = tar::Archive::new(decoder);
+    let mut root = None::<Vec<u8>>;
+    let mut namespace_paths = BTreeMap::<String, WindowsNamespaceEntry>::new();
+    let mut entry_count = 0_usize;
+    let mut expanded_bytes = 0_u64;
+    let mut path_index_bytes = 0_usize;
+    let mut saw_repository_entry = false;
+    let entries = archive
+        .entries()
+        .map_err(|_| ActionArchiveError::Malformed)?
+        .raw(true);
+    for entry in entries {
+        entry_count = entry_count
+            .checked_add(1)
+            .ok_or(ActionArchiveError::ResourceLimit)?;
+        if entry_count > limits.maximum_entries() {
+            return Err(ActionArchiveError::ResourceLimit);
+        }
+        let mut entry = entry.map_err(|_| ActionArchiveError::Malformed)?;
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_pax_global_extensions() {
+            if saw_repository_entry {
+                return Err(ActionArchiveError::Malformed);
+            }
+            let declared_size = declared_size(&entry)?;
+            expanded_bytes = checked_expanded_size(expanded_bytes, declared_size, limits)?;
+            validate_global_pax(&mut entry, declared_size, limits.maximum_definition_bytes())?;
+            continue;
+        }
+        if entry_type.is_gnu_longname()
+            || entry_type.is_gnu_longlink()
+            || entry_type.is_pax_local_extensions()
+        {
+            return Err(ActionArchiveError::UnsupportedEntry);
+        }
+        saw_repository_entry = true;
+        if !(entry_type.is_dir() || entry_type.is_file()) {
+            return Err(ActionArchiveError::UnsupportedEntry);
+        }
+
+        let path = entry.path_bytes();
+        if path.len() > limits.maximum_entry_path_bytes() {
+            return Err(ActionArchiveError::ResourceLimit);
+        }
+        let components = archive_components(&path)?;
+        if components
+            .iter()
+            .any(|component| !valid_windows_archive_component(component))
+        {
+            return Err(ActionArchiveError::UnsafePath);
+        }
+        let (archive_root, relative) = components
+            .split_first()
+            .ok_or(ActionArchiveError::UnsafePath)?;
+        if let Some(expected_root) = &root {
+            if expected_root != archive_root {
+                return Err(ActionArchiveError::UnsafePath);
+            }
+        } else {
+            root = Some(archive_root.clone());
+        }
+        record_windows_relative_namespace(
+            relative,
+            entry_type.is_dir(),
+            &mut namespace_paths,
+            &mut path_index_bytes,
+            limits,
+        )?;
+
+        let declared_size = declared_size(&entry)?;
+        expanded_bytes = checked_expanded_size(expanded_bytes, declared_size, limits)?;
+        consume_entry(&mut entry, declared_size)?;
+    }
+    let mut decoder = archive.into_inner();
+    let remaining_bytes = limits
+        .maximum_expanded_bytes()
+        .checked_sub(expanded_bytes)
+        .ok_or(ActionArchiveError::ResourceLimit)?;
+    verify_trailing_zeros(&mut decoder, remaining_bytes)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WindowsNamespaceKind {
+    ImplicitDirectory,
+    Directory,
+    File,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WindowsNamespaceEntry {
+    spelling: String,
+    kind: WindowsNamespaceKind,
+}
+
+fn record_windows_relative_namespace(
+    relative: &[Vec<u8>],
+    entry_is_directory: bool,
+    namespace_paths: &mut BTreeMap<String, WindowsNamespaceEntry>,
+    path_index_bytes: &mut usize,
+    limits: ActionBundleLimits,
+) -> Result<(), ActionArchiveError> {
+    let components = relative
+        .iter()
+        .map(|component| std::str::from_utf8(component))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ActionArchiveError::UnsafePath)?;
+    record_windows_namespace_path(
+        namespace_paths,
+        String::new(),
+        String::new(),
+        if components.is_empty() {
+            if entry_is_directory {
+                WindowsNamespaceKind::Directory
+            } else {
+                WindowsNamespaceKind::File
+            }
+        } else {
+            WindowsNamespaceKind::ImplicitDirectory
+        },
+        path_index_bytes,
+        limits,
+    )?;
+    let mut spelling = String::new();
+    let mut folded = String::new();
+    for (index, component) in components.iter().enumerate() {
+        if index > 0 {
+            spelling.push('\\');
+            folded.push('\\');
+        }
+        spelling.push_str(component);
+        folded.push_str(&component.to_ascii_lowercase());
+        record_windows_namespace_path(
+            namespace_paths,
+            folded.clone(),
+            spelling.clone(),
+            if index + 1 != components.len() {
+                WindowsNamespaceKind::ImplicitDirectory
+            } else if entry_is_directory {
+                WindowsNamespaceKind::Directory
+            } else {
+                WindowsNamespaceKind::File
+            },
+            path_index_bytes,
+            limits,
+        )?;
+    }
+    Ok(())
+}
+
+fn record_windows_namespace_path(
+    namespace_paths: &mut BTreeMap<String, WindowsNamespaceEntry>,
+    folded: String,
+    spelling: String,
+    kind: WindowsNamespaceKind,
+    path_index_bytes: &mut usize,
+    limits: ActionBundleLimits,
+) -> Result<(), ActionArchiveError> {
+    if let Some(existing) = namespace_paths.get_mut(&folded) {
+        if existing.spelling != spelling {
+            return Err(ActionArchiveError::DuplicatePath);
+        }
+        return match (existing.kind, kind) {
+            (
+                WindowsNamespaceKind::ImplicitDirectory | WindowsNamespaceKind::Directory,
+                WindowsNamespaceKind::ImplicitDirectory,
+            ) => Ok(()),
+            (WindowsNamespaceKind::ImplicitDirectory, WindowsNamespaceKind::Directory) => {
+                existing.kind = WindowsNamespaceKind::Directory;
+                Ok(())
+            }
+            _ => Err(ActionArchiveError::DuplicatePath),
+        };
+    }
+    *path_index_bytes = path_index_bytes
+        .checked_add(folded.len())
+        .ok_or(ActionArchiveError::ResourceLimit)?;
+    if *path_index_bytes > limits.maximum_path_index_bytes() {
+        return Err(ActionArchiveError::ResourceLimit);
+    }
+    namespace_paths.insert(folded, WindowsNamespaceEntry { spelling, kind });
+    Ok(())
+}
+
+fn valid_windows_archive_component(component: &[u8]) -> bool {
+    if component.is_empty()
+        || !component.is_ascii()
+        || component.ends_with(b" ")
+        || component.ends_with(b".")
+        || component.iter().any(|byte| {
+            byte.is_ascii_control()
+                || matches!(byte, b'<' | b'>' | b':' | b'"' | b'|' | b'?' | b'*')
+        })
+    {
+        return false;
+    }
+    if component == b"." || component == b".." {
+        return false;
+    }
+    if component.starts_with(b".") {
+        return true;
+    }
+    let stem = component
+        .split(|byte| *byte == b'.')
+        .next()
+        .unwrap_or(component);
+    let stem = stem
+        .iter()
+        .rposition(|byte| !matches!(byte, b' ' | b'.'))
+        .map_or(&[][..], |last| &stem[..=last]);
+    if stem.is_empty() || windows_short_name_shaped(stem) {
+        return false;
+    }
+    let upper = stem.iter().map(u8::to_ascii_uppercase).collect::<Vec<_>>();
+    !matches!(
+        upper.as_slice(),
+        b"CON" | b"PRN" | b"AUX" | b"NUL" | b"CLOCK$" | b"CONIN$" | b"CONOUT$"
+    ) && !upper
+        .strip_prefix(b"COM")
+        .or_else(|| upper.strip_prefix(b"LPT"))
+        .is_some_and(|suffix| suffix.len() == 1 && matches!(suffix[0], b'1'..=b'9'))
+}
+
+fn windows_short_name_shaped(stem: &[u8]) -> bool {
+    let Some(tilde) = stem.iter().rposition(|byte| *byte == b'~') else {
+        return false;
+    };
+    let (prefix, suffix) = stem.split_at(tilde);
+    let digits = &suffix[1..];
+    !prefix.is_empty()
+        && prefix.len() <= 6
+        && !digits.is_empty()
+        && matches!(digits[0], b'1'..=b'9')
+        && digits[1..].iter().all(u8::is_ascii_digit)
+}
+
 /// Validates immutable archive bytes and selects one action definition.
 ///
 /// Callers must verify immutable content identity and enforce

--- a/crates/automata-ci-action/src/lib.rs
+++ b/crates/automata-ci-action/src/lib.rs
@@ -17,7 +17,7 @@ mod cache;
 mod model;
 mod resolver;
 
-pub use archive::inspect_archive;
+pub use archive::{inspect_archive, validate_windows_materialization_archive};
 pub use cache::{
     ActionReferenceIndex, ActionReferenceIndexError, ActionReferenceIndexErrorKind,
     ImmutableActionReference, ImmutableActionReferenceError, IndexedActionBundle,

--- a/crates/automata-ci-action/tests/archive_inspection.rs
+++ b/crates/automata-ci-action/tests/archive_inspection.rs
@@ -4,6 +4,7 @@ use std::io::{self, Cursor, Read as _};
 
 use automata_ci_action::{
     ActionArchiveError, ActionBundleLimits, ActionDefinitionKind, ActionSubpath, inspect_archive,
+    validate_windows_materialization_archive,
 };
 use automata_ci_scm::ArchiveLimits;
 use bytes::Bytes;
@@ -471,6 +472,108 @@ fn traversal_links_special_entries_duplicates_and_multiple_roots_are_rejected() 
         .unwrap_err(),
         ActionArchiveError::UnsafePath
     );
+}
+
+#[test]
+fn windows_materialization_rejects_links_ambiguous_names_and_case_collisions() {
+    let valid = build_archive(&[
+        TestEntry::File("root/action.yml", ACTION_DEFINITION),
+        TestEntry::File("root/dist/index.js", b"console.log('ok')"),
+        TestEntry::File("root/.gitignore", b"target"),
+        TestEntry::File("root/.github/workflows/metadata.yml", b"name: metadata"),
+    ]);
+    validate_windows_materialization_archive(&valid, ActionBundleLimits::default())
+        .expect("ordinary ASCII action tree is safe to materialize on Windows");
+    let defaults = ActionBundleLimits::default();
+    let undersized = ActionBundleLimits::new(
+        ArchiveLimits::new(u64::try_from(valid.len() - 1).unwrap()).unwrap(),
+        defaults.maximum_entries(),
+        defaults.maximum_expanded_bytes(),
+        defaults.maximum_definition_bytes(),
+        defaults.maximum_entry_path_bytes(),
+        defaults.maximum_path_index_bytes(),
+    )
+    .unwrap();
+    assert_eq!(
+        validate_windows_materialization_archive(&valid, undersized),
+        Err(ActionArchiveError::ResourceLimit)
+    );
+
+    let link = build_archive(&[
+        TestEntry::File("root/action.yml", ACTION_DEFINITION),
+        TestEntry::Symlink("root/dist/current", "index.js"),
+    ]);
+    assert_eq!(
+        validate_windows_materialization_archive(&link, ActionBundleLimits::default()),
+        Err(ActionArchiveError::UnsupportedEntry)
+    );
+
+    for path in [
+        "root/CON.txt",
+        "root/CON .txt",
+        "root/CONOUT$.txt",
+        "root/LONGFI~1.JS",
+        "root/name:stream",
+        "root/trailing. ",
+        "root/naïve.txt",
+    ] {
+        let archive = build_archive(&[
+            TestEntry::File("root/action.yml", ACTION_DEFINITION),
+            TestEntry::File(path, b"unsafe"),
+        ]);
+        assert_eq!(
+            validate_windows_materialization_archive(&archive, ActionBundleLimits::default()),
+            Err(ActionArchiveError::UnsafePath),
+            "unexpectedly accepted {path}"
+        );
+    }
+
+    let collision = build_archive(&[
+        TestEntry::File("root/action.yml", ACTION_DEFINITION),
+        TestEntry::File("root/dist/Index.js", b"first"),
+        TestEntry::File("root/dist/index.js", b"second"),
+    ]);
+    assert_eq!(
+        validate_windows_materialization_archive(&collision, ActionBundleLimits::default()),
+        Err(ActionArchiveError::DuplicatePath)
+    );
+
+    let prefix_collision = build_archive(&[
+        TestEntry::File("root/Foo/first.js", b"first"),
+        TestEntry::File("root/foo/second.js", b"second"),
+    ]);
+    assert_eq!(
+        validate_windows_materialization_archive(&prefix_collision, ActionBundleLimits::default()),
+        Err(ActionArchiveError::DuplicatePath)
+    );
+
+    for entries in [
+        vec![
+            TestEntry::File("root/action.yml", ACTION_DEFINITION),
+            TestEntry::File("root/dist", b"file"),
+            TestEntry::File("root/dist/index.js", b"child"),
+        ],
+        vec![
+            TestEntry::File("root/action.yml", ACTION_DEFINITION),
+            TestEntry::File("root/dist/index.js", b"child"),
+            TestEntry::File("root/dist", b"file"),
+        ],
+        vec![
+            TestEntry::File("root", b"file"),
+            TestEntry::File("root/action.yml", ACTION_DEFINITION),
+        ],
+        vec![
+            TestEntry::File("root/action.yml", ACTION_DEFINITION),
+            TestEntry::File("root", b"file"),
+        ],
+    ] {
+        let conflict = build_archive(&entries);
+        assert_eq!(
+            validate_windows_materialization_archive(&conflict, ActionBundleLimits::default()),
+            Err(ActionArchiveError::DuplicatePath),
+            "file/directory prefix conflict must be order-independent"
+        );
+    }
 }
 
 #[test]

--- a/crates/automata-ci-control/tests/scheduling_domain_contract.rs
+++ b/crates/automata-ci-control/tests/scheduling_domain_contract.rs
@@ -207,6 +207,42 @@ fn registered_service_container_ceiling_requires_live_observation() {
 }
 
 #[test]
+fn pre_enrollment_admitted_windows_actions_survive_live_capability_intersection() {
+    let runner_id = runner_id(7);
+    let profile = EnvironmentProfile::new(
+        EnvironmentProfileId::new("automata.example/windows-server-2025-hyperv")
+            .expect("profile ID"),
+        Sha256Digest::from_bytes([7; 32]),
+    );
+    let action_features = [
+        RunnerFeature::SHELL_STEPS,
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE12_ACTIONS,
+        RunnerFeature::NODE16_ACTIONS,
+        RunnerFeature::NODE20_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ];
+    let admitted = RunnerCapabilities::new(
+        runner_id,
+        RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+    )
+    .with_features(action_features.clone())
+    .with_environment_profiles([profile]);
+
+    let effective = intersect_runner_capabilities(&admitted, &admitted)
+        .expect("the exact registered and independently observed inventory must intersect");
+
+    for feature in action_features {
+        assert!(
+            effective.features().contains(&feature),
+            "a pre-enrollment admitted and live-observed Windows feature must remain schedulable"
+        );
+    }
+}
+
+#[test]
 fn routing_requirement_json_rejects_unknown_schema_before_admission() {
     let mut encoded =
         serde_json::to_value(RunnerRequirements::default()).expect("requirements must serialize");

--- a/crates/automata-ci-job-executor-github/README.md
+++ b/crates/automata-ci-job-executor-github/README.md
@@ -108,6 +108,28 @@ generations and no `PATH` probe. The current Ubuntu profile advertises only its
 pinned Node 24 executable. Container-action execution and `runs.plugin` remain
 unsupported.
 
+On an admitted Windows action profile, repository archives are bounded and
+validated before provider mutation. The validator permits only regular files
+and directories under the expected archive root and rejects traversal, links,
+special entries, Windows device names, alternate-stream/illegal characters,
+trailing dots or spaces, non-ASCII names, and case-insensitive collisions. The
+executor refuses a stale destination, creates it inside the job container,
+copies the archive through the sandbox content port, verifies the exact digest
+with the configured hash helper, extracts with the configured `tar.exe`, then
+performs a PowerShell root/reparse-point scan before reading metadata or
+executing an action. Every stage is ordered and fail-closed; archive extraction
+and action hooks never run on the host. JavaScript pre/main/post use only the
+metadata-selected, exact Node-generation path. A missing tar, hash helper,
+Node runtime, digest match, or tree check rejects the job.
+
+Checked-out Windows local actions use the exact configured `pwsh.exe` for their
+JIT metadata probe. The probe receives runner-owned candidate paths through a
+closed internal environment, proves the action directory remains below the job
+workspace, and rejects a reparse point in the workspace path or action tree
+before metadata is copied back. Windows local JavaScript and composite phases
+then use the same exact Node and shell contracts as materialized repository
+actions.
+
 The control-plane activation boundary anonymously resolves exact-commit public
 repository metadata before Job IR publication and carries the complete
 statically knowable runtime feature set in `RunnerRequirements`:

--- a/crates/automata-ci-job-executor-github/src/action_content.rs
+++ b/crates/automata-ci-job-executor-github/src/action_content.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use automata_ci_core::OperationId;
 use automata_ci_execution::{
     CopyToRequest, ExecutionArgv, ExecutionCommand, ExecutionEnvironment, TargetPath,
+    TargetPlatform,
 };
 
 use crate::error::{ExecutorAdapterError, ExecutorAdapterErrorKind};
@@ -28,6 +29,50 @@ pub(super) fn prepare_directory_command(
             "--".to_owned(),
             base.as_str().to_owned(),
             extracted.as_str().to_owned(),
+        ],
+    )
+    .map_err(|_| internal())?;
+    ExecutionCommand::new(
+        operation_id,
+        argv,
+        workspace.clone(),
+        ExecutionEnvironment::empty(),
+        timeout,
+        output_limit,
+    )
+    .map_err(|_| internal())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn prepare_windows_directory_command(
+    operation_id: OperationId,
+    pwsh: TargetPath,
+    workspace: &TargetPath,
+    base: &TargetPath,
+    extracted: &TargetPath,
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<ExecutionCommand, ExecutorAdapterError> {
+    if [workspace, base, extracted]
+        .into_iter()
+        .any(|path| path.platform() != TargetPlatform::Windows)
+    {
+        return Err(internal());
+    }
+    let quote = |path: &TargetPath| path.as_str().replace('\'', "''");
+    let script = format!(
+        "$ErrorActionPreference='Stop';$base='{}';$tree='{}';if(Test-Path -LiteralPath $base){{throw 'action directory already exists'}};[System.IO.Directory]::CreateDirectory($tree)|Out-Null",
+        quote(base),
+        quote(extracted),
+    );
+    let argv = ExecutionArgv::new(
+        pwsh,
+        vec![
+            "-NoLogo".to_owned(),
+            "-NoProfile".to_owned(),
+            "-NonInteractive".to_owned(),
+            "-Command".to_owned(),
+            script,
         ],
     )
     .map_err(|_| internal())?;
@@ -71,6 +116,74 @@ pub(super) fn extract_archive_command(
             "--strip-components=1".to_owned(),
             "--no-same-owner".to_owned(),
             "--no-same-permissions".to_owned(),
+        ],
+    )
+    .map_err(|_| internal())?;
+    ExecutionCommand::new(
+        operation_id,
+        argv,
+        workspace.clone(),
+        ExecutionEnvironment::empty(),
+        timeout,
+        output_limit,
+    )
+    .map_err(|_| internal())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn verify_archive_command(
+    operation_id: OperationId,
+    sha256: &ExecutionArgv,
+    workspace: &TargetPath,
+    archive_path: &TargetPath,
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<ExecutionCommand, ExecutorAdapterError> {
+    if sha256.program().platform() != workspace.platform()
+        || archive_path.platform() != workspace.platform()
+    {
+        return Err(internal());
+    }
+    let mut arguments = sha256.arguments().to_vec();
+    arguments.push(archive_path.as_str().to_owned());
+    let argv = ExecutionArgv::new(sha256.program().clone(), arguments).map_err(|_| internal())?;
+    ExecutionCommand::new(
+        operation_id,
+        argv,
+        workspace.clone(),
+        ExecutionEnvironment::empty(),
+        timeout,
+        output_limit,
+    )
+    .map_err(|_| internal())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn verify_windows_tree_command(
+    operation_id: OperationId,
+    pwsh: TargetPath,
+    workspace: &TargetPath,
+    extracted: &TargetPath,
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<ExecutionCommand, ExecutorAdapterError> {
+    if workspace.platform() != TargetPlatform::Windows
+        || extracted.platform() != TargetPlatform::Windows
+    {
+        return Err(internal());
+    }
+    let tree = extracted.as_str().replace('\'', "''");
+    let script = format!(
+        "$ErrorActionPreference='Stop';$tree='{tree}';$root=[System.IO.Path]::GetFullPath($tree).TrimEnd('\\')+'\\';foreach($entry in Get-ChildItem -LiteralPath $tree -Force -Recurse){{$full=[System.IO.Path]::GetFullPath($entry.FullName);if(-not $full.StartsWith($root,[System.StringComparison]::OrdinalIgnoreCase)){{throw 'action path escaped'}};if(($entry.Attributes -band [System.IO.FileAttributes]::ReparsePoint)-ne 0){{throw 'action reparse point'}}}}",
+    );
+    let argv = ExecutionArgv::new(
+        pwsh,
+        vec![
+            "-NoLogo".to_owned(),
+            "-NoProfile".to_owned(),
+            "-NonInteractive".to_owned(),
+            "-Command".to_owned(),
+            script,
         ],
     )
     .map_err(|_| internal())?;

--- a/crates/automata-ci-job-executor-github/src/adapter.rs
+++ b/crates/automata-ci-job-executor-github/src/adapter.rs
@@ -149,6 +149,33 @@ impl StaticGithubToolchain {
         })
     }
 
+    /// Adds the exact archive and SHA-256 tools used to materialize immutable
+    /// repository actions inside a Windows sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate materializer configuration or non-Windows paths.
+    pub fn with_windows_action_materializer(
+        mut self,
+        tar: TargetPath,
+        sha256: TargetPath,
+    ) -> Result<Self, PortError> {
+        if self.platform != TargetPlatform::Windows
+            || self.tar.is_some()
+            || self.sha256.is_some()
+            || !valid_tool(&tar, TargetPlatform::Windows)
+            || !valid_tool(&sha256, TargetPlatform::Windows)
+        {
+            return Err(PortError::new(PortErrorKind::InvalidData));
+        }
+        self.tar = Some(tar);
+        self.sha256 = Some(
+            ExecutionArgv::new(sha256, Vec::<String>::new())
+                .map_err(|_| PortError::new(PortErrorKind::InvalidData))?,
+        );
+        Ok(self)
+    }
+
     /// Creates the required system tool paths for an ARM64 macOS runner profile.
     ///
     /// # Errors

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -90,6 +90,11 @@ const MAX_EVENT_DEPTH: usize = 128;
 const COMPOSITE_ORDINAL_BASE: u32 = 1 << 24;
 const TRUNCATED_OUTPUT_DIAGNOSTIC: &str =
     "command output exceeded the configured capture limit; user output was suppressed";
+const MASKED_SUMMARY_LIMIT_DIAGNOSTIC: &str = "$GITHUB_STEP_SUMMARY content was omitted after secret masking exceeded the retained text limit";
+const STEP_SUMMARY_LIMIT_DIAGNOSTIC: &str =
+    "$GITHUB_STEP_SUMMARY content was omitted after the cumulative step summary limit was reached";
+const JOB_SUMMARY_LIMIT_DIAGNOSTIC: &str =
+    "$GITHUB_STEP_SUMMARY content was omitted after the job attachment limit was reached";
 const LOCAL_ACTION_PROBE_SCRIPT: &str = "# automata-local-action-metadata\nif [ -f \"$1\" ]; then printf yml; elif [ -f \"$2\" ]; then printf yaml; else exit 44; fi";
 const ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\npath=$1\nshift\nif [ ! -f \"$path\" ]; then exit 44; fi\nvalue=$(\"$0\" \"$@\" < \"$path\") || exit $?\ndigest=${value%% *}\nprintf '%s' \"$digest\"";
 const WINDOWS_ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\n$ErrorActionPreference = 'Stop'\n$path = $env:AUTOMATA_INTERNAL_ARTIFACT_PATH\nif (-not [System.IO.File]::Exists($path)) { exit 44 }\n$stream = $null\n$hasher = $null\ntry {\n  $stream = [System.IO.File]::OpenRead($path)\n  $hasher = [System.Security.Cryptography.SHA256]::Create()\n  $bytes = $hasher.ComputeHash($stream)\n  $digest = [System.BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant()\n  [Console]::Out.Write($digest)\n} finally {\n  if ($null -ne $stream) { $stream.Dispose() }\n  if ($null -ne $hasher) { $hasher.Dispose() }\n}";
@@ -5890,6 +5895,7 @@ struct ExecutionAttachments {
     by_step: BTreeMap<String, RetainedStepAttachments>,
     annotation_count: usize,
     aggregate_bytes: usize,
+    summary_budget_exhausted: bool,
 }
 
 impl ExecutionAttachments {
@@ -5902,16 +5908,8 @@ impl ExecutionAttachments {
         command_file_notice: Option<CommandFileNotice>,
         masker: &mut SecretMasker,
     ) -> Result<(), ExecutorAdapterError> {
-        let summary = masked_attachment_text(summary, masker)?;
+        self.record_summary(step_id, summary, command_file_notice, masker)?;
         let retained = self.by_step.entry(step_id.to_owned()).or_default();
-        if !summary.is_empty() {
-            if retained.summary.len().saturating_add(summary.len()) > MAX_STEP_ATTACHMENT_TEXT_BYTES
-            {
-                return Err(resource_exhausted());
-            }
-            charge_attachment_bytes(&mut self.aggregate_bytes, summary.len())?;
-            retained.summary.push_str(&summary);
-        }
 
         for annotation in annotations {
             let properties = annotation
@@ -5983,23 +5981,194 @@ impl ExecutionAttachments {
                 Vec::new(),
             ));
         }
+        Ok(())
+    }
+
+    fn record_summary(
+        &mut self,
+        step_id: &str,
+        summary: &str,
+        command_file_notice: Option<CommandFileNotice>,
+        masker: &mut SecretMasker,
+    ) -> Result<(), ExecutorAdapterError> {
+        if self.summary_budget_exhausted
+            || self
+                .by_step
+                .get(step_id)
+                .is_some_and(|retained| retained.summary_closed)
+        {
+            return Ok(());
+        }
+
         if let Some(CommandFileNotice::SummaryTooLarge { maximum_bytes }) = command_file_notice {
-            let message = format!(
-                "$GITHUB_STEP_SUMMARY upload aborted: content exceeds the {maximum_bytes}-byte limit"
-            );
-            charge_attachment_bytes(&mut self.aggregate_bytes, message.len())?;
-            self.annotation_count = self
-                .annotation_count
-                .checked_add(1)
-                .filter(|count| *count <= MAX_JOB_RESULT_ANNOTATIONS)
-                .ok_or_else(resource_exhausted)?;
-            retained.annotations.push(StepAnnotation::new(
+            self.record_summary_notice(
+                step_id,
+                &format!(
+                    "$GITHUB_STEP_SUMMARY upload aborted: content exceeds the {maximum_bytes}-byte limit"
+                ),
                 StepAnnotationLevel::Error,
-                message,
-                Vec::new(),
+                false,
+                masker,
+            )?;
+            return Ok(());
+        }
+        if summary.is_empty() {
+            return Ok(());
+        }
+
+        // Every source file is capped at one byte beyond the configured 1 MiB
+        // ceiling before it reaches this boundary. Mask replacement can expand
+        // that bounded input by at most three times, so the masking work and
+        // temporary allocation remain bounded even for a one-byte secret.
+        let redacted_bytes = masker.mask(summary.as_bytes())?;
+        if redacted_bytes.len() > MAX_STEP_ATTACHMENT_TEXT_BYTES {
+            self.record_summary_notice(
+                step_id,
+                MASKED_SUMMARY_LIMIT_DIAGNOSTIC,
+                StepAnnotationLevel::Warning,
+                true,
+                masker,
+            )?;
+            return Ok(());
+        }
+        let redacted = String::from_utf8(redacted_bytes)
+            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
+        if redacted.is_empty() {
+            return Ok(());
+        }
+
+        let retained_bytes = self
+            .by_step
+            .get(step_id)
+            .map_or(0, |retained| retained.summary.len());
+        let Some(projected_step_bytes) = retained_bytes.checked_add(redacted.len()) else {
+            self.record_summary_notice(
+                step_id,
+                STEP_SUMMARY_LIMIT_DIAGNOSTIC,
+                StepAnnotationLevel::Warning,
+                true,
+                masker,
+            )?;
+            return Ok(());
+        };
+        if projected_step_bytes > MAX_STEP_ATTACHMENT_TEXT_BYTES {
+            self.record_summary_notice(
+                step_id,
+                STEP_SUMMARY_LIMIT_DIAGNOSTIC,
+                StepAnnotationLevel::Warning,
+                true,
+                masker,
+            )?;
+            return Ok(());
+        }
+
+        if self
+            .aggregate_bytes
+            .checked_add(redacted.len())
+            .is_none_or(|projected| projected > MAX_JOB_RESULT_ATTACHMENT_BYTES)
+        {
+            self.summary_budget_exhausted = true;
+            self.record_summary_notice(
+                step_id,
+                JOB_SUMMARY_LIMIT_DIAGNOSTIC,
+                StepAnnotationLevel::Warning,
+                true,
+                masker,
+            )?;
+            return Ok(());
+        }
+
+        self.aggregate_bytes += redacted.len();
+        self.by_step
+            .entry(step_id.to_owned())
+            .or_default()
+            .summary
+            .push_str(&redacted);
+        Ok(())
+    }
+
+    fn record_summary_notice(
+        &mut self,
+        step_id: &str,
+        message: &str,
+        level: StepAnnotationLevel,
+        close_summary: bool,
+        masker: &mut SecretMasker,
+    ) -> Result<(), ExecutorAdapterError> {
+        let already_noted = {
+            let retained = self.by_step.entry(step_id.to_owned()).or_default();
+            retained.summary_closed |= close_summary;
+            retained.summary_notice_recorded
+        };
+        if already_noted {
+            return Ok(());
+        }
+
+        // Diagnostics are masked too: a dynamically registered short secret
+        // can otherwise coincide with text in this runner-owned message.
+        let message = String::from_utf8(masker.mask(message.as_bytes())?)
+            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
+        if message.len() > MAX_STEP_ATTACHMENT_TEXT_BYTES {
+            return Err(resource_exhausted());
+        }
+        self.make_summary_notice_room(step_id, message.len());
+        let message = if self.aggregate_bytes.saturating_add(message.len())
+            <= MAX_JOB_RESULT_ATTACHMENT_BYTES
+        {
+            message
+        } else {
+            // The structured annotation remains a deterministic indicator even
+            // if unrelated, non-summary attachments left no reclaimable bytes.
+            String::new()
+        };
+        if self.annotation_count >= MAX_JOB_RESULT_ANNOTATIONS {
+            // Summary retention is observational and must never replace the
+            // process result merely because the annotation collection is full.
+            return Ok(());
+        }
+        self.aggregate_bytes += message.len();
+        self.annotation_count += 1;
+        let retained = self.by_step.entry(step_id.to_owned()).or_default();
+        retained.summary_notice_recorded = true;
+        retained
+            .annotations
+            .push(StepAnnotation::new(level, message, Vec::new()));
+        Ok(())
+    }
+
+    fn make_summary_notice_room(&mut self, preferred_step: &str, bytes: usize) {
+        let required = self
+            .aggregate_bytes
+            .saturating_add(bytes)
+            .saturating_sub(MAX_JOB_RESULT_ATTACHMENT_BYTES);
+        if required == 0 {
+            return;
+        }
+
+        let mut remaining = required;
+        if let Some(retained) = self.by_step.get_mut(preferred_step) {
+            remaining = remaining.saturating_sub(truncate_summary_suffix(
+                &mut retained.summary,
+                remaining,
+                &mut self.aggregate_bytes,
             ));
         }
-        Ok(())
+        if remaining == 0 {
+            return;
+        }
+        for (candidate, retained) in self.by_step.iter_mut().rev() {
+            if candidate == preferred_step {
+                continue;
+            }
+            remaining = remaining.saturating_sub(truncate_summary_suffix(
+                &mut retained.summary,
+                remaining,
+                &mut self.aggregate_bytes,
+            ));
+            if remaining == 0 {
+                break;
+            }
+        }
     }
 
     fn take(&mut self, step_id: &str) -> RetainedStepAttachments {
@@ -6011,6 +6180,24 @@ impl ExecutionAttachments {
 struct RetainedStepAttachments {
     summary: String,
     annotations: Vec<StepAnnotation>,
+    summary_closed: bool,
+    summary_notice_recorded: bool,
+}
+
+fn truncate_summary_suffix(
+    summary: &mut String,
+    requested: usize,
+    aggregate_bytes: &mut usize,
+) -> usize {
+    let original = summary.len();
+    let mut retained = original.saturating_sub(requested);
+    while !summary.is_char_boundary(retained) {
+        retained = retained.saturating_sub(1);
+    }
+    summary.truncate(retained);
+    let removed = original - retained;
+    *aggregate_bytes = aggregate_bytes.saturating_sub(removed);
+    removed
 }
 
 fn masked_attachment_text(

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -11,6 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use automata_ci_action::{ActionBundleLimits, validate_windows_materialization_archive};
 use automata_ci_action_github::{GithubActionMetadataDecoder, JavascriptRuntime};
 use automata_ci_core::{
     ActionReference, AttemptId, JOB_RUNTIME_CONTEXT_MEDIA_TYPE, JobAuthorityProfile, JobConclusion,
@@ -96,6 +97,10 @@ const STEP_SUMMARY_LIMIT_DIAGNOSTIC: &str =
 const JOB_SUMMARY_LIMIT_DIAGNOSTIC: &str =
     "$GITHUB_STEP_SUMMARY content was omitted after the job attachment limit was reached";
 const LOCAL_ACTION_PROBE_SCRIPT: &str = "# automata-local-action-metadata\nif [ -f \"$1\" ]; then printf yml; elif [ -f \"$2\" ]; then printf yaml; else exit 44; fi";
+const WINDOWS_LOCAL_ACTION_PROBE_SCRIPT: &str = "# automata-local-action-metadata\n$ErrorActionPreference = 'Stop'\n$root = [System.IO.Path]::GetFullPath($env:AUTOMATA_INTERNAL_LOCAL_ACTION_ROOT).TrimEnd('\\')\n$yml = [System.IO.Path]::GetFullPath($env:AUTOMATA_INTERNAL_LOCAL_ACTION_YML)\n$yaml = [System.IO.Path]::GetFullPath($env:AUTOMATA_INTERNAL_LOCAL_ACTION_YAML)\n$directory = [System.IO.Path]::GetDirectoryName($yml)\nif ($null -eq $directory -or [System.IO.Path]::GetDirectoryName($yaml) -ne $directory) { exit 44 }\n$prefix = $root + '\\'\nif (-not $directory.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) { exit 44 }\n$rootItem = Get-Item -LiteralPath $root -Force\nif (($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { exit 44 }\n$current = $root\n$relative = $directory.Substring($prefix.Length)\nforeach ($segment in ($relative -split '\\\\')) {\n  if ([System.String]::IsNullOrEmpty($segment)) { continue }\n  $current = [System.IO.Path]::Combine($current, $segment)\n  $item = Get-Item -LiteralPath $current -Force\n  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { exit 44 }\n}\n$treePrefix = $directory.TrimEnd('\\') + '\\'\nforeach ($entry in Get-ChildItem -LiteralPath $directory -Force -Recurse) {\n  $full = [System.IO.Path]::GetFullPath($entry.FullName)\n  if (-not $full.StartsWith($treePrefix, [System.StringComparison]::OrdinalIgnoreCase)) { exit 44 }\n  if (($entry.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { exit 44 }\n}\nif ([System.IO.File]::Exists($yml)) { [Console]::Out.Write('yml') } elseif ([System.IO.File]::Exists($yaml)) { [Console]::Out.Write('yaml') } else { exit 44 }";
+const WINDOWS_LOCAL_ACTION_ROOT_ENVIRONMENT: &str = "AUTOMATA_INTERNAL_LOCAL_ACTION_ROOT";
+const WINDOWS_LOCAL_ACTION_YML_ENVIRONMENT: &str = "AUTOMATA_INTERNAL_LOCAL_ACTION_YML";
+const WINDOWS_LOCAL_ACTION_YAML_ENVIRONMENT: &str = "AUTOMATA_INTERNAL_LOCAL_ACTION_YAML";
 const ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\npath=$1\nshift\nif [ ! -f \"$path\" ]; then exit 44; fi\nvalue=$(\"$0\" \"$@\" < \"$path\") || exit $?\ndigest=${value%% *}\nprintf '%s' \"$digest\"";
 const WINDOWS_ARTIFACT_HASH_SCRIPT: &str = "# automata-artifact-sha256\n$ErrorActionPreference = 'Stop'\n$path = $env:AUTOMATA_INTERNAL_ARTIFACT_PATH\nif (-not [System.IO.File]::Exists($path)) { exit 44 }\n$stream = $null\n$hasher = $null\ntry {\n  $stream = [System.IO.File]::OpenRead($path)\n  $hasher = [System.Security.Cryptography.SHA256]::Create()\n  $bytes = $hasher.ComputeHash($stream)\n  $digest = [System.BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant()\n  [Console]::Out.Write($digest)\n} finally {\n  if ($null -ne $stream) { $stream.Dispose() }\n  if ($null -ne $hasher) { $hasher.Dispose() }\n}";
 const WINDOWS_ARTIFACT_PATH_ENVIRONMENT: &str = "AUTOMATA_INTERNAL_ARTIFACT_PATH";
@@ -613,7 +618,7 @@ impl GithubJobExecutor {
             return Err(AdmissionRejection::InvalidJob);
         }
         self.validate_provider_admission(job, &workspace)?;
-        validate_action_step_admission(job, &workspace)?;
+        validate_action_step_admission(job, &workspace, self.ports.toolchain.as_ref())?;
         Ok(environment)
     }
 
@@ -1564,6 +1569,7 @@ impl GithubJobExecutor {
             planner.materials.insert(key, action.clone());
             action
         };
+        self.validate_action_materialization(&action)?;
         self.require_action_runtimes(action.definition())?;
         let slot = preferred_action_slot
             .map_or_else(|| budget.action_slot(), Ok)
@@ -1649,6 +1655,7 @@ impl GithubJobExecutor {
                     planner.materials.insert(key, action.clone());
                     action
                 };
+                self.validate_action_materialization(&action)?;
                 self.require_action_runtimes(action.definition())?;
                 let children = match action.definition().execution() {
                     PreparedActionExecution::Javascript(_) => Vec::new(),
@@ -1690,6 +1697,20 @@ impl GithubJobExecutor {
             planner.leave();
             result
         })
+    }
+
+    fn validate_action_materialization(
+        &self,
+        action: &PreparedAction,
+    ) -> Result<(), ActionLoadError> {
+        if self.ports.toolchain.platform() == TargetPlatform::Windows {
+            validate_windows_materialization_archive(
+                action.archive(),
+                ActionBundleLimits::default(),
+            )
+            .map_err(|_| ActionLoadError::Preparation(ActionPreparationErrorKind::Content))?;
+        }
+        Ok(())
     }
 
     fn require_action_runtimes(
@@ -2983,6 +3004,7 @@ impl GithubJobExecutor {
                     .prepare(ActionPreparationRequest::new(reference))
                     .await
                     .map_err(|error| ActionLoadError::Preparation(error.kind()))?;
+                self.validate_action_materialization(&action)?;
                 self.require_action_runtimes(action.definition())?;
                 let slot = preferred_action_slot
                     .map_or_else(|| budget.action_slot(), Ok)
@@ -3039,17 +3061,13 @@ impl GithubJobExecutor {
             CheckedOutLocalActionPreparer::definition_paths(&paths.workspace, reference)
                 .map_err(|error| ActionLoadError::Preparation(error.kind()))?;
         let phase = budget.phase().map_err(ActionLoadError::Executor)?;
-        let argv = ExecutionArgv::new(
-            required_tool(self.ports.toolchain.sh()).map_err(ActionLoadError::Executor)?,
-            vec![
-                "-c".to_owned(),
-                LOCAL_ACTION_PROBE_SCRIPT.to_owned(),
-                "automata-local-action".to_owned(),
-                candidates.action_yml().as_str().to_owned(),
-                candidates.action_yaml().as_str().to_owned(),
-            ],
+        let (argv, environment) = local_action_probe_invocation(
+            self.ports.toolchain.as_ref(),
+            &paths.workspace,
+            candidates.action_yml(),
+            candidates.action_yaml(),
         )
-        .map_err(|_| ActionLoadError::Executor(invalid_job()))?;
+        .map_err(ActionLoadError::Executor)?;
         let command = ExecutionCommand::new(
             self.ports.operation_ids.operation_id(
                 request.lease().attempt_id(),
@@ -3058,7 +3076,7 @@ impl GithubJobExecutor {
             ),
             argv,
             paths.workspace.clone(),
-            automata_ci_execution::ExecutionEnvironment::empty(),
+            environment,
             self.config.default_step_timeout(),
             64,
         )
@@ -3886,6 +3904,7 @@ impl GithubJobExecutor {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     fn prepare_action_content(
         &self,
         endpoint: &dyn ExecutionEndpoint,
@@ -3897,19 +3916,31 @@ impl GithubJobExecutor {
     ) -> Result<ActionPaths, ExecutorAdapterError> {
         let action_paths = paths.action(index, action.subpath())?;
         let prepare_ordinal = index.checked_add(1).ok_or_else(invalid_job)?;
-        let command = action_content::prepare_directory_command(
-            self.ports.operation_ids.operation_id(
-                attempt_id,
-                OperationPurpose::PrepareDirectory,
-                prepare_ordinal,
-            ),
-            required_tool(self.ports.toolchain.install())?,
-            &paths.workspace,
-            &action_paths.base,
-            &action_paths.extracted,
-            self.config.default_step_timeout(),
-            self.config.maximum_output_bytes(),
-        )?;
+        let prepare_operation = self.ports.operation_ids.operation_id(
+            attempt_id,
+            OperationPurpose::PrepareDirectory,
+            prepare_ordinal,
+        );
+        let command = match paths.workspace.platform() {
+            TargetPlatform::Posix => action_content::prepare_directory_command(
+                prepare_operation,
+                required_tool(self.ports.toolchain.install())?,
+                &paths.workspace,
+                &action_paths.base,
+                &action_paths.extracted,
+                self.config.default_step_timeout(),
+                self.config.maximum_output_bytes(),
+            )?,
+            TargetPlatform::Windows => action_content::prepare_windows_directory_command(
+                prepare_operation,
+                required_tool(self.ports.toolchain.pwsh())?,
+                &paths.workspace,
+                &action_paths.base,
+                &action_paths.extracted,
+                self.config.default_step_timeout(),
+                self.config.maximum_output_bytes(),
+            )?,
+        };
         let output = endpoint
             .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
@@ -3926,6 +3957,38 @@ impl GithubJobExecutor {
         endpoint
             .copy_to(&request, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
+        if paths.workspace.platform() == TargetPlatform::Windows {
+            let sha256 =
+                self.ports.toolchain.sha256().ok_or_else(|| {
+                    ExecutorAdapterError::new(ExecutorAdapterErrorKind::Unsupported)
+                })?;
+            let command = action_content::verify_archive_command(
+                self.ports.operation_ids.operation_id(
+                    attempt_id,
+                    OperationPurpose::VerifyActionArchive,
+                    index,
+                ),
+                sha256,
+                &paths.workspace,
+                &action_paths.archive,
+                self.config.default_step_timeout(),
+                128,
+            )?;
+            let output = endpoint
+                .exec(&command, &CancellationBridge(cancellation))
+                .map_err(map_execution_error)?;
+            require_success(&output)?;
+            let stdout = output
+                .stdout()
+                .strip_suffix(b"\r\n")
+                .or_else(|| output.stdout().strip_suffix(b"\n"))
+                .unwrap_or(output.stdout());
+            if !output.stderr().is_empty()
+                || stdout != action.archive_digest().to_string().as_bytes()
+            {
+                return Err(invalid_job());
+            }
+        }
         let command = action_content::extract_archive_command(
             self.ports.operation_ids.operation_id(
                 attempt_id,
@@ -3943,6 +4006,27 @@ impl GithubJobExecutor {
             .exec(&command, &ProviderCancellationBridge(cancellation))
             .map_err(map_execution_error)?;
         require_success(&output)?;
+        if paths.workspace.platform() == TargetPlatform::Windows {
+            let command = action_content::verify_windows_tree_command(
+                self.ports.operation_ids.operation_id(
+                    attempt_id,
+                    OperationPurpose::VerifyActionTree,
+                    index,
+                ),
+                required_tool(self.ports.toolchain.pwsh())?,
+                &paths.workspace,
+                &action_paths.extracted,
+                self.config.default_step_timeout(),
+                self.config.maximum_output_bytes(),
+            )?;
+            let output = endpoint
+                .exec(&command, &CancellationBridge(cancellation))
+                .map_err(map_execution_error)?;
+            require_success(&output)?;
+            if !output.stdout().is_empty() || !output.stderr().is_empty() {
+                return Err(invalid_job());
+            }
+        }
         Ok(action_paths)
     }
 
@@ -7461,10 +7545,13 @@ const fn conclusion_text(conclusion: JobConclusion) -> &'static str {
 fn validate_action_step_admission(
     job: &JobIrEnvelope,
     workspace: &TargetPath,
+    toolchain: &dyn GithubToolchain,
 ) -> Result<(), AdmissionRejection> {
+    let windows_materializer = workspace.platform() != TargetPlatform::Windows
+        || toolchain.tar().is_some() && toolchain.sha256().is_some();
     for step in job.job().steps() {
         match step.kind() {
-            SemanticStep::Action { .. } if workspace.platform() == TargetPlatform::Windows => {
+            SemanticStep::Action { .. } if !windows_materializer => {
                 return Err(AdmissionRejection::InvalidJob);
             }
             SemanticStep::Action {
@@ -7510,6 +7597,71 @@ fn validate_resource_admission(
     Ok(())
 }
 
+fn local_action_probe_invocation(
+    toolchain: &dyn GithubToolchain,
+    workspace: &TargetPath,
+    primary_metadata: &TargetPath,
+    fallback_metadata: &TargetPath,
+) -> Result<(ExecutionArgv, automata_ci_execution::ExecutionEnvironment), ExecutorAdapterError> {
+    match workspace.platform() {
+        TargetPlatform::Posix => {
+            let argv = ExecutionArgv::new(
+                required_tool(toolchain.sh())?,
+                vec![
+                    "-c".to_owned(),
+                    LOCAL_ACTION_PROBE_SCRIPT.to_owned(),
+                    "automata-local-action".to_owned(),
+                    primary_metadata.as_str().to_owned(),
+                    fallback_metadata.as_str().to_owned(),
+                ],
+            )
+            .map_err(|_| invalid_job())?;
+            Ok((argv, automata_ci_execution::ExecutionEnvironment::empty()))
+        }
+        TargetPlatform::Windows => {
+            if primary_metadata.platform() != TargetPlatform::Windows
+                || fallback_metadata.platform() != TargetPlatform::Windows
+            {
+                return Err(invalid_job());
+            }
+            let argv = ExecutionArgv::new(
+                required_tool(toolchain.pwsh())?,
+                vec![
+                    "-NoLogo".to_owned(),
+                    "-NoProfile".to_owned(),
+                    "-NonInteractive".to_owned(),
+                    "-Command".to_owned(),
+                    WINDOWS_LOCAL_ACTION_PROBE_SCRIPT.to_owned(),
+                ],
+            )
+            .map_err(|_| invalid_job())?;
+            let values = [
+                (WINDOWS_LOCAL_ACTION_ROOT_ENVIRONMENT, workspace.as_str()),
+                (
+                    WINDOWS_LOCAL_ACTION_YML_ENVIRONMENT,
+                    primary_metadata.as_str(),
+                ),
+                (
+                    WINDOWS_LOCAL_ACTION_YAML_ENVIRONMENT,
+                    fallback_metadata.as_str(),
+                ),
+            ]
+            .into_iter()
+            .map(|(name, value)| {
+                Ok(automata_ci_execution::EnvironmentVariable::new(
+                    automata_ci_execution::EnvironmentName::new(name).map_err(|_| invalid_job())?,
+                    automata_ci_execution::EnvironmentValue::new(value)
+                        .map_err(|_| invalid_job())?,
+                ))
+            })
+            .collect::<Result<Vec<_>, ExecutorAdapterError>>()?;
+            let environment = automata_ci_execution::ExecutionEnvironment::new(values)
+                .map_err(|_| resource_exhausted())?;
+            Ok((argv, environment))
+        }
+    }
+}
+
 fn tool_path(path: &TargetPath, platform: TargetPlatform) -> bool {
     path.platform() == platform
         && match platform {
@@ -7552,8 +7704,7 @@ fn valid_toolchain(toolchain: &dyn GithubToolchain) -> bool {
                     && toolchain.powershell().is_some()
                     && toolchain.cmd().is_some()
                     && toolchain.install().is_none()
-                    && toolchain.tar().is_none()
-                    && toolchain.sha256().is_none()
+                    && (toolchain.tar().is_some() == toolchain.sha256().is_some())
             }
         }
 }

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -3975,7 +3975,7 @@ impl GithubJobExecutor {
                 128,
             )?;
             let output = endpoint
-                .exec(&command, &CancellationBridge(cancellation))
+                .exec(&command, &ProviderCancellationBridge(cancellation))
                 .map_err(map_execution_error)?;
             require_success(&output)?;
             let stdout = output
@@ -4020,7 +4020,7 @@ impl GithubJobExecutor {
                 self.config.maximum_output_bytes(),
             )?;
             let output = endpoint
-                .exec(&command, &CancellationBridge(cancellation))
+                .exec(&command, &ProviderCancellationBridge(cancellation))
                 .map_err(map_execution_error)?;
             require_success(&output)?;
             if !output.stdout().is_empty() || !output.stderr().is_empty() {

--- a/crates/automata-ci-job-executor-github/src/executor.rs
+++ b/crates/automata-ci-job-executor-github/src/executor.rs
@@ -5069,6 +5069,7 @@ impl GithubJobExecutor {
                 applied.summary().markdown(),
                 &completed.annotations,
                 applied.notices(),
+                completed.command_file_notice,
                 masker,
             )?;
             Ok((applied.into_next_state(), next_attachments))
@@ -5165,6 +5166,7 @@ impl GithubJobExecutor {
             commands: completed.commands,
             artifacts: completed.artifacts,
             annotations,
+            command_file_notice: completed.command_file_notice,
         })
     }
 
@@ -5232,6 +5234,7 @@ impl GithubJobExecutor {
         cancellation: &dyn ExecutorCancellation,
     ) -> Result<DecodedCommandFiles, ExecutorAdapterError> {
         let mut parsed = Vec::with_capacity(COMMAND_FILE_KINDS.len());
+        let mut command_file_notice = None;
         for (index, (kind, path)) in paths.values.iter().enumerate() {
             if cancellation.is_cancelled() {
                 return Err(ExecutorAdapterError::new(
@@ -5242,10 +5245,17 @@ impl GithubJobExecutor {
                 .checked_mul(5)
                 .and_then(|value| value.checked_add(u32::try_from(index).ok()?))
                 .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-            let limit = if *kind == CommandFileKind::StepSummary {
+            let configured_limit = if *kind == CommandFileKind::StepSummary {
                 self.command_files.limits().maximum_summary_bytes()
             } else {
                 self.command_files.limits().maximum_file_bytes()
+            };
+            let transfer_limit = if *kind == CommandFileKind::StepSummary {
+                configured_limit
+                    .checked_add(1)
+                    .ok_or_else(|| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?
+            } else {
+                configured_limit
             };
             let request = CopyFromRequest::new(
                 self.ports.operation_ids.operation_id(
@@ -5254,25 +5264,42 @@ impl GithubJobExecutor {
                     ordinal,
                 ),
                 path.clone(),
-                limit,
+                transfer_limit,
             )
             .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
-            let bytes =
-                match endpoint.copy_from(&request, &ProviderCancellationBridge(cancellation)) {
-                    Ok(bytes) => bytes,
-                    Err(error)
-                        if *kind == CommandFileKind::StepSummary
-                            && error.kind() == ExecutionErrorKind::NotFound =>
-                    {
-                        Vec::new()
-                    }
-                    Err(error) => return Err(map_execution_error(error)),
-                };
+            let copied = endpoint.copy_from(&request, &ProviderCancellationBridge(cancellation));
             if cancellation.is_cancelled() {
                 return Err(ExecutorAdapterError::new(
                     ExecutorAdapterErrorKind::Cancelled,
                 ));
             }
+            let bytes = match copied {
+                Ok(bytes)
+                    if *kind == CommandFileKind::StepSummary && bytes.len() > configured_limit =>
+                {
+                    command_file_notice = Some(CommandFileNotice::SummaryTooLarge {
+                        maximum_bytes: configured_limit,
+                    });
+                    Vec::new()
+                }
+                Ok(bytes) => bytes,
+                Err(error)
+                    if *kind == CommandFileKind::StepSummary
+                        && error.kind() == ExecutionErrorKind::NotFound =>
+                {
+                    Vec::new()
+                }
+                Err(error)
+                    if *kind == CommandFileKind::StepSummary
+                        && error.kind() == ExecutionErrorKind::OutputLimitExceeded =>
+                {
+                    command_file_notice = Some(CommandFileNotice::SummaryTooLarge {
+                        maximum_bytes: configured_limit,
+                    });
+                    Vec::new()
+                }
+                Err(error) => return Err(map_execution_error(error)),
+            };
             parsed.push(
                 self.command_files
                     .decode(*kind, &bytes, platform)
@@ -5327,6 +5354,7 @@ impl GithubJobExecutor {
         Ok(DecodedCommandFiles {
             commands,
             artifacts,
+            command_file_notice,
         })
     }
 
@@ -5843,11 +5871,18 @@ struct CollectedPhase {
     commands: CompletedStepCommands,
     artifacts: ArtifactDeclarationCommandFile,
     annotations: Vec<automata_ci_github_runtime::Annotation>,
+    command_file_notice: Option<CommandFileNotice>,
 }
 
 struct DecodedCommandFiles {
     commands: CompletedStepCommands,
     artifacts: ArtifactDeclarationCommandFile,
+    command_file_notice: Option<CommandFileNotice>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommandFileNotice {
+    SummaryTooLarge { maximum_bytes: usize },
 }
 
 #[derive(Clone, Default)]
@@ -5864,6 +5899,7 @@ impl ExecutionAttachments {
         summary: &str,
         annotations: &[automata_ci_github_runtime::Annotation],
         notices: &[PhaseApplicationNotice],
+        command_file_notice: Option<CommandFileNotice>,
         masker: &mut SecretMasker,
     ) -> Result<(), ExecutorAdapterError> {
         let summary = masked_attachment_text(summary, masker)?;
@@ -5943,6 +5979,22 @@ impl ExecutionAttachments {
                 .ok_or_else(resource_exhausted)?;
             retained.annotations.push(StepAnnotation::new(
                 StepAnnotationLevel::Notice,
+                message,
+                Vec::new(),
+            ));
+        }
+        if let Some(CommandFileNotice::SummaryTooLarge { maximum_bytes }) = command_file_notice {
+            let message = format!(
+                "$GITHUB_STEP_SUMMARY upload aborted: content exceeds the {maximum_bytes}-byte limit"
+            );
+            charge_attachment_bytes(&mut self.aggregate_bytes, message.len())?;
+            self.annotation_count = self
+                .annotation_count
+                .checked_add(1)
+                .filter(|count| *count <= MAX_JOB_RESULT_ANNOTATIONS)
+                .ok_or_else(resource_exhausted)?;
+            retained.annotations.push(StepAnnotation::new(
+                StepAnnotationLevel::Error,
                 message,
                 Vec::new(),
             ));

--- a/crates/automata-ci-job-executor-github/src/port.rs
+++ b/crates/automata-ci-job-executor-github/src/port.rs
@@ -646,6 +646,10 @@ pub enum OperationPurpose {
     ReadArtifactsFile = 11,
     /// Evaluates one runner-local `hashFiles` call inside the fenced sandbox.
     HashFiles = 12,
+    /// Re-hashes one copied immutable action archive before extraction.
+    VerifyActionArchive = 13,
+    /// Verifies the extracted Windows action tree contains no reparse point.
+    VerifyActionTree = 14,
 }
 
 /// Derives deterministic IDs for retryable endpoint operations.

--- a/crates/automata-ci-job-executor-github/tests/action_pre_job.rs
+++ b/crates/automata-ci-job-executor-github/tests/action_pre_job.rs
@@ -2,7 +2,9 @@ mod support;
 
 use std::sync::Arc;
 
-use automata_ci_core::{JobConclusion, LogChannel};
+use automata_ci_core::{
+    JobConclusion, LogChannel, MAX_STEP_ATTACHMENT_TEXT_BYTES, StepAnnotationLevel,
+};
 use automata_ci_github_runtime::CommandFileKind;
 use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionEvents, JobExecutor};
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
@@ -96,6 +98,53 @@ async fn repository_action_pre_runs_before_every_main_job_step() {
         .nth(2)
         .expect("post command");
     assert_eq!(environment_map(post)["STATE_from_pre"], "yes");
+}
+
+#[tokio::test]
+async fn action_lifecycle_summary_crossing_the_cumulative_limit_is_nonfatal() {
+    const CUMULATIVE_DIAGNOSTIC: &str = "$GITHUB_STEP_SUMMARY content was omitted after the cumulative step summary limit was reached";
+    let half = MAX_STEP_ATTACHMENT_TEXT_BYTES / 2;
+    let fixture = Fixture::new(
+        vec![prepared_node24_action_with_pre()],
+        vec![
+            PhaseResponse::success().with_file(CommandFileKind::StepSummary, vec![b'p'; half]),
+            PhaseResponse::success().with_file(CommandFileKind::StepSummary, vec![b'm'; half]),
+            PhaseResponse::success().with_file(CommandFileKind::StepSummary, vec![b'x']),
+        ],
+    );
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(
+            fixture.request(envelope(vec![action_step("lifecycle", "owner/lifecycle")])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("summary retention must not replace the successful lifecycle result");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let step = &result.steps()[0];
+    assert_eq!(step.conclusion(), JobConclusion::Success);
+    let summary = step
+        .summary_markdown()
+        .expect("the exact-boundary pre and main summaries are retained");
+    assert_eq!(summary.len(), MAX_STEP_ATTACHMENT_TEXT_BYTES);
+    assert!(summary.as_bytes()[..half].iter().all(|byte| *byte == b'p'));
+    assert!(summary.as_bytes()[half..].iter().all(|byte| *byte == b'm'));
+    assert_eq!(step.annotations().len(), 1);
+    assert_eq!(step.annotations()[0].level(), StepAnnotationLevel::Warning);
+    assert_eq!(step.annotations()[0].message(), CUMULATIVE_DIAGNOSTIC);
+
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let phase_commands = state
+        .commands
+        .iter()
+        .filter(|command| command.argv().program().as_str() == "/opt/node24/bin/node")
+        .collect::<Vec<_>>();
+    assert_eq!(phase_commands.len(), 3, "pre, main, and post all execute");
+    assert_fresh_isolated_phase_files(&state, &phase_commands);
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
+++ b/crates/automata-ci-job-executor-github/tests/composite_action_runtime.rs
@@ -7,8 +7,8 @@ use std::{
 
 use automata_ci_action_github::GithubActionMetadataDecoder;
 use automata_ci_core::{
-    ActionReference, JobConclusion, RuntimeBoolean, SemanticStep, Sha256Digest, StepId, StepIr,
-    ValueSource, ValueTemplate,
+    ActionReference, JobConclusion, MAX_STEP_ATTACHMENT_TEXT_BYTES, RuntimeBoolean, SemanticStep,
+    Sha256Digest, StepAnnotationLevel, StepId, StepIr, ValueSource, ValueTemplate,
 };
 use automata_ci_job_executor_github::{
     CheckedOutLocalActionPreparer, LocalActionPreparationRequest, PreparedAction,
@@ -363,6 +363,66 @@ async fn nested_repeated_composite_occurrences_receive_fresh_phase_file_sets() {
         .filter(|command| command.argv().program().as_str() == "/usr/bin/bash")
         .collect::<Vec<_>>();
     assert_eq!(phases.len(), 2);
+    assert_fresh_isolated_phase_files(&state, &phases);
+}
+
+#[tokio::test]
+async fn repeated_composite_summaries_crossing_one_mib_are_diagnostic_only() {
+    const CUMULATIVE_DIAGNOSTIC: &str = "$GITHUB_STEP_SUMMARY content was omitted after the cumulative step summary limit was reached";
+    let fixture = Fixture::new(
+        Vec::new(),
+        vec![
+            PhaseResponse::success().with_file(
+                automata_ci_github_runtime::CommandFileKind::StepSummary,
+                vec![b'c'; MAX_STEP_ATTACHMENT_TEXT_BYTES],
+            ),
+            PhaseResponse::success().with_file(
+                automata_ci_github_runtime::CommandFileKind::StepSummary,
+                vec![b'd'],
+            ),
+        ],
+    );
+    {
+        let mut state = fixture.endpoint_state.lock().expect("endpoint lock");
+        state.files.insert(
+            "/__w/automata/automata/actions/parent/action.yaml".to_owned(),
+            REPEATED_LOCAL_PARENT.as_bytes().to_vec(),
+        );
+        state.files.insert(
+            "/__w/automata/automata/actions/child/action.yml".to_owned(),
+            CHILD_COMPOSITE.as_bytes().to_vec(),
+        );
+    }
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(
+            fixture.request(envelope(vec![local_step("parent", "./actions/parent")])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("composite summary overflow must not fail the parent step");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let step = &result.steps()[0];
+    assert_eq!(step.conclusion(), JobConclusion::Success);
+    assert_eq!(
+        step.summary_markdown().map(str::len),
+        Some(MAX_STEP_ATTACHMENT_TEXT_BYTES)
+    );
+    assert_eq!(step.annotations().len(), 1);
+    assert_eq!(step.annotations()[0].level(), StepAnnotationLevel::Warning);
+    assert_eq!(step.annotations()[0].message(), CUMULATIVE_DIAGNOSTIC);
+
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    let phases = state
+        .commands
+        .iter()
+        .filter(|command| command.argv().program().as_str() == "/usr/bin/bash")
+        .collect::<Vec<_>>();
+    assert_eq!(phases.len(), 2, "both repeated composite children execute");
     assert_fresh_isolated_phase_files(&state, &phases);
 }
 

--- a/crates/automata-ci-job-executor-github/tests/contracts.rs
+++ b/crates/automata-ci-job-executor-github/tests/contracts.rs
@@ -124,7 +124,9 @@ fn extracted_executor_seams_retain_operation_identity_coordinates() {
         "letprepare_ordinal=index.checked_add(1).ok_or_else(invalid_job)?;",
         "OperationPurpose::PrepareDirectory,prepare_ordinal",
         "OperationPurpose::CopyActionArchive,index",
+        "OperationPurpose::VerifyActionArchive,index",
         "OperationPurpose::ExtractActionArchive,index",
+        "OperationPurpose::VerifyActionTree,index",
         "container_runtime::sandbox_spec(&self.config,request,operation_id,generation",
     ] {
         assert!(
@@ -149,7 +151,7 @@ fn extracted_executor_seams_retain_operation_identity_coordinates() {
         action_content
             .matches("ExecutionCommand::new(operation_id,")
             .count(),
-        2
+        5
     );
 
     let container_runtime = include_str!("../src/container_runtime.rs")

--- a/crates/automata-ci-job-executor-github/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/run_steps.rs
@@ -3,8 +3,8 @@ mod support;
 use std::{collections::BTreeMap, sync::Arc};
 
 use automata_ci_core::{
-    JobConclusion, JobSecretExposure, LogGroupKind, RunnerId, StepAnnotationLevel, StepIr,
-    ValueSource,
+    JobConclusion, JobSecretExposure, LogGroupKind, MAX_JOB_RESULT_ATTACHMENT_BYTES,
+    MAX_STEP_ATTACHMENT_TEXT_BYTES, RunnerId, StepAnnotationLevel, StepIr, ValueSource,
 };
 use automata_ci_execution::{RootFilesystemPolicy, SandboxCustody, SandboxPrivilegePolicy};
 use automata_ci_github_runtime::CommandFileKind;
@@ -301,6 +301,166 @@ async fn step_summary_boundary_is_bounded_and_oversized_content_is_diagnostic_on
             summary_requests[0].byte_limit(),
             MAXIMUM_SUMMARY_BYTES + 1,
             "{label}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn secret_mask_expansion_at_the_summary_boundary_is_omitted_without_leaking() {
+    const MASKED_BYTE: u8 = b'e';
+    let retained_source_bytes = MAX_STEP_ATTACHMENT_TEXT_BYTES / 3;
+    let expanded_source_bytes = retained_source_bytes + 1;
+    let fixture = Fixture::secretless(
+        Vec::new(),
+        vec![
+            PhaseResponse::success()
+                .with_stdout("::add-mask::e\n")
+                .with_file(
+                    CommandFileKind::StepSummary,
+                    vec![MASKED_BYTE; retained_source_bytes],
+                ),
+            PhaseResponse::success().with_file(
+                CommandFileKind::StepSummary,
+                vec![MASKED_BYTE; expanded_source_bytes],
+            ),
+        ],
+    );
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(
+            fixture.request(support::envelope(vec![
+                run_step("within-mask-limit", "Within mask limit", "true"),
+                run_step("over-mask-limit", "Over mask limit", "true"),
+            ])),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect("mask expansion is an attachment diagnostic, not a job failure");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let retained = result.steps()[0]
+        .summary_markdown()
+        .expect("the exact in-budget masked summary is retained");
+    assert_eq!(retained.len(), retained_source_bytes * 3);
+    assert!(retained.as_bytes().iter().all(|byte| *byte == b'*'));
+    assert!(result.steps()[0].annotations().is_empty());
+
+    let omitted = &result.steps()[1];
+    assert_eq!(omitted.conclusion(), JobConclusion::Success);
+    assert_eq!(omitted.summary_markdown(), None);
+    assert_eq!(omitted.annotations().len(), 1);
+    assert_eq!(
+        omitted.annotations()[0].level(),
+        StepAnnotationLevel::Warning
+    );
+    assert!(
+        !omitted.annotations()[0]
+            .message()
+            .contains(char::from(MASKED_BYTE)),
+        "the runner-owned indicator is masked against dynamically registered secrets"
+    );
+    assert!(omitted.annotations()[0].message().contains("***"));
+}
+
+#[tokio::test]
+async fn job_summary_aggregate_boundary_is_nonfatal_and_has_one_deterministic_indicator() {
+    const JOB_LIMIT_DIAGNOSTIC: &str =
+        "$GITHUB_STEP_SUMMARY content was omitted after the job attachment limit was reached";
+
+    for step_count in [8_usize, 10] {
+        let responses = (0..step_count)
+            .map(|_| {
+                PhaseResponse::success().with_file(
+                    CommandFileKind::StepSummary,
+                    vec![b's'; MAX_STEP_ATTACHMENT_TEXT_BYTES],
+                )
+            })
+            .collect::<Vec<_>>();
+        let steps = (0..step_count)
+            .map(|index| {
+                let id = format!("summary-{index}");
+                run_step(&id, &id, "true")
+            })
+            .collect::<Vec<_>>();
+        let fixture = Fixture::secretless(Vec::new(), responses);
+        let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+        let result = fixture
+            .executor
+            .execute(
+                fixture.request(support::envelope(steps)),
+                events,
+                ExecutionCancellation::new(),
+            )
+            .await
+            .unwrap_or_else(|error| {
+                panic!("{step_count} valid summaries must not fail the job: {error:?}")
+            });
+
+        assert_eq!(result.conclusion(), JobConclusion::Success, "{step_count}");
+        assert!(
+            result
+                .steps()
+                .iter()
+                .all(|step| step.conclusion() == JobConclusion::Success),
+            "{step_count}"
+        );
+        if step_count == 8 {
+            assert!(result.steps().iter().all(|step| {
+                step.summary_markdown().map(str::len) == Some(MAX_STEP_ATTACHMENT_TEXT_BYTES)
+                    && step.annotations().is_empty()
+            }));
+        } else {
+            assert!(result.steps()[..7].iter().all(|step| {
+                step.summary_markdown().map(str::len) == Some(MAX_STEP_ATTACHMENT_TEXT_BYTES)
+                    && step.annotations().is_empty()
+            }));
+            assert_eq!(
+                result.steps()[7].summary_markdown().map(str::len),
+                Some(MAX_STEP_ATTACHMENT_TEXT_BYTES - JOB_LIMIT_DIAGNOSTIC.len())
+            );
+            assert!(result.steps()[7].annotations().is_empty());
+            assert_eq!(result.steps()[8].summary_markdown(), None);
+            assert_eq!(result.steps()[8].annotations().len(), 1);
+            assert_eq!(
+                result.steps()[8].annotations()[0].level(),
+                StepAnnotationLevel::Warning
+            );
+            assert_eq!(
+                result.steps()[8].annotations()[0].message(),
+                JOB_LIMIT_DIAGNOSTIC
+            );
+            assert_eq!(result.steps()[9].summary_markdown(), None);
+            assert!(result.steps()[9].annotations().is_empty());
+        }
+
+        let attachment_bytes = result
+            .steps()
+            .iter()
+            .map(|step| {
+                step.summary_markdown().map_or(0, str::len)
+                    + step
+                        .annotations()
+                        .iter()
+                        .map(|annotation| annotation.message().len())
+                        .sum::<usize>()
+            })
+            .sum::<usize>();
+        assert_eq!(attachment_bytes, MAX_JOB_RESULT_ATTACHMENT_BYTES);
+        let state = fixture.endpoint_state.lock().expect("endpoint lock");
+        let summary_requests = state
+            .copy_from_requests
+            .iter()
+            .filter(|request| request.source().as_str().ends_with("-summary"))
+            .collect::<Vec<_>>();
+        assert_eq!(summary_requests.len(), step_count);
+        assert!(
+            summary_requests
+                .iter()
+                .all(|request| request.byte_limit() == MAX_STEP_ATTACHMENT_TEXT_BYTES + 1)
         );
     }
 }

--- a/crates/automata-ci-job-executor-github/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-github/tests/run_steps.rs
@@ -227,6 +227,85 @@ async fn summaries_and_structured_annotations_are_masked_and_retained() {
 }
 
 #[tokio::test]
+async fn step_summary_boundary_is_bounded_and_oversized_content_is_diagnostic_only() {
+    const MAXIMUM_SUMMARY_BYTES: usize = 1_024 * 1_024;
+    const OVERSIZED_DIAGNOSTIC: &str =
+        "$GITHUB_STEP_SUMMARY upload aborted: content exceeds the 1048576-byte limit";
+
+    for (label, size, expected_summary_bytes, expects_diagnostic) in [
+        (
+            "exact boundary",
+            MAXIMUM_SUMMARY_BYTES,
+            Some(MAXIMUM_SUMMARY_BYTES),
+            false,
+        ),
+        ("one-byte sentinel", MAXIMUM_SUMMARY_BYTES + 1, None, true),
+        (
+            "endpoint limit rejection",
+            MAXIMUM_SUMMARY_BYTES + 2,
+            None,
+            true,
+        ),
+    ] {
+        let fixture = Fixture::secretless(
+            Vec::new(),
+            vec![
+                PhaseResponse::success().with_file(CommandFileKind::StepSummary, vec![b'x'; size]),
+            ],
+        );
+        let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+        let result = fixture
+            .executor
+            .execute(
+                fixture.request(support::envelope(vec![run_step(
+                    "summary", "Summary", "true",
+                )])),
+                events,
+                ExecutionCancellation::new(),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{label} must not fail the job: {error:?}"));
+
+        assert_eq!(result.conclusion(), JobConclusion::Success, "{label}");
+        let step = &result.steps()[0];
+        assert_eq!(
+            step.summary_markdown().map(str::len),
+            expected_summary_bytes,
+            "{label}"
+        );
+        if expects_diagnostic {
+            assert_eq!(step.annotations().len(), 1, "{label}");
+            assert_eq!(
+                step.annotations()[0].level(),
+                StepAnnotationLevel::Error,
+                "{label}"
+            );
+            assert_eq!(
+                step.annotations()[0].message(),
+                OVERSIZED_DIAGNOSTIC,
+                "{label}"
+            );
+            assert!(step.annotations()[0].properties().is_empty(), "{label}");
+        } else {
+            assert!(step.annotations().is_empty(), "{label}");
+        }
+
+        let state = fixture.endpoint_state.lock().expect("endpoint lock");
+        let summary_requests = state
+            .copy_from_requests
+            .iter()
+            .filter(|request| request.source().as_str().ends_with("-summary"))
+            .collect::<Vec<_>>();
+        assert_eq!(summary_requests.len(), 1, "{label}");
+        assert_eq!(
+            summary_requests[0].byte_limit(),
+            MAXIMUM_SUMMARY_BYTES + 1,
+            "{label}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn phase_files_are_collected_after_failure_timeout_and_cancelled_termination() {
     for (termination, expected, summary) in [
         (

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
+    io::Cursor,
     sync::{
         Arc, Mutex,
         atomic::{AtomicI64, AtomicUsize, Ordering},
@@ -69,7 +70,9 @@ use automata_ci_runner_runtime::{
 use automata_ci_runner_spool::ProtectionId;
 use automata_ci_workflow_github::{GithubConditionCompiler, GithubConditionPhase};
 use bytes::Bytes;
+use flate2::{Compression, write::GzEncoder};
 use sha2::{Digest as _, Sha256};
+use tar::{Builder as TarBuilder, Header as TarHeader};
 
 pub const SECRET: &str = "super-secret-value";
 pub const CONTEXT_SECRET: &str = "context-only-token";
@@ -169,7 +172,7 @@ impl Fixture {
         responses: Vec<PhaseResponse>,
         default_environment: ExecutionEnvironment,
     ) -> Self {
-        Self::with_platform_components_and_timeout(
+        Self::with_platform_components_and_timeout_and_node(
             Vec::new(),
             responses,
             default_environment,
@@ -178,6 +181,21 @@ impl Fixture {
             Arc::new(FakeContexts::windows_secretless()),
             Duration::from_mins(5),
             TargetPlatform::Windows,
+            false,
+        )
+    }
+
+    pub fn windows_actions(actions: Vec<PreparedAction>, responses: Vec<PhaseResponse>) -> Self {
+        Self::with_platform_components_and_timeout_and_node(
+            actions,
+            responses,
+            ExecutionEnvironment::empty(),
+            false,
+            Arc::new(FakeJobContent::default()),
+            Arc::new(FakeContexts::windows_secretless()),
+            Duration::from_mins(5),
+            TargetPlatform::Windows,
+            true,
         )
     }
 
@@ -550,16 +568,33 @@ impl Fixture {
                     toolchain
                 }
             }
-            TargetPlatform::Windows => StaticGithubToolchain::windows(
-                windows_target(r"C:\Program Files\PowerShell\7\pwsh.exe"),
-                windows_target(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"),
-                windows_target(r"C:\Windows\System32\cmd.exe"),
-            )
-            .expect("valid Windows tools")
-            .with_python(windows_target(
-                r"C:\hostedtoolcache\windows\Python\3.13.0\x64\python.exe",
-            ))
-            .expect("valid Windows python"),
+            TargetPlatform::Windows => {
+                let toolchain = StaticGithubToolchain::windows(
+                    windows_target(r"C:\Program Files\PowerShell\7\pwsh.exe"),
+                    windows_target(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"),
+                    windows_target(r"C:\Windows\System32\cmd.exe"),
+                )
+                .expect("valid Windows tools")
+                .with_python(windows_target(
+                    r"C:\hostedtoolcache\windows\Python\3.13.0\x64\python.exe",
+                ))
+                .expect("valid Windows python");
+                if configure_node {
+                    toolchain
+                        .with_windows_action_materializer(
+                            windows_target(r"C:\automata\tools\tar\tar.exe"),
+                            windows_target(r"C:\automata\tools\hash\automata-sha256.exe"),
+                        )
+                        .expect("valid Windows action materializer")
+                        .with_node(
+                            JavascriptRuntime::Node24,
+                            windows_target(r"C:\automata\externals\node24\node.exe"),
+                        )
+                        .expect("valid Windows node")
+                } else {
+                    toolchain
+                }
+            }
         };
         let ports = GithubJobExecutorPorts::new(
             provider.clone(),
@@ -1018,6 +1053,41 @@ pub fn prepared_node24_action() -> PreparedAction {
     prepared_node24_action_with_post_condition("always()")
 }
 
+pub fn prepared_windows_namespace_unsafe_node24_action() -> PreparedAction {
+    let compiler = GithubConditionCompiler::default();
+    let pre_condition = compiler
+        .compile_condition(Some("always()"), GithubConditionPhase::Step)
+        .expect("valid pre condition");
+    let post_condition = compiler
+        .compile_condition(Some("always()"), GithubConditionPhase::Step)
+        .expect("valid post condition");
+    let javascript = PreparedJavascriptAction::new(
+        JavascriptRuntime::Node24,
+        "dist/index.js",
+        None,
+        pre_condition,
+        None,
+        post_condition,
+    )
+    .expect("valid JavaScript action");
+    let archive = test_action_archive(&[
+        (
+            "action.yml",
+            b"runs:\n  using: node24\n  main: dist/index.js\n",
+        ),
+        ("dist/index.js", b"console.log('must not run')\n"),
+        ("CON.txt", b"unsafe Windows namespace entry\n"),
+    ]);
+    let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
+    let definition = PreparedActionDefinition::new(
+        Vec::new(),
+        Vec::new(),
+        PreparedActionExecution::Javascript(Box::new(javascript)),
+    )
+    .expect("valid JavaScript definition");
+    PreparedAction::with_definition(digest, archive, "", definition).expect("valid action")
+}
+
 pub fn prepared_node24_action_with_post_condition(post_condition: &str) -> PreparedAction {
     let compiler = GithubConditionCompiler::default();
     let always = compiler
@@ -1038,7 +1108,13 @@ pub fn prepared_node24_action_with_post_condition(post_condition: &str) -> Prepa
         post_condition,
     )
     .expect("valid JavaScript action");
-    let archive = Bytes::from_static(b"validated-action-archive");
+    let archive = test_action_archive(&[
+        (
+            "action.yml",
+            b"runs:\n  using: node24\n  main: dist/index.js\n",
+        ),
+        ("dist/index.js", b"console.log('main')\n"),
+    ]);
     let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
     let definition = PreparedActionDefinition::new(
         vec![
@@ -1080,7 +1156,15 @@ pub fn prepared_node24_action_with_pre_condition(pre_condition: &str) -> Prepare
         always,
     )
     .expect("valid JavaScript action");
-    let archive = Bytes::from_static(b"validated-pre-action-archive");
+    let archive = test_action_archive(&[
+        (
+            "action.yml",
+            b"runs:\n  using: node24\n  main: dist/main.js\n",
+        ),
+        ("dist/pre.js", b"console.log('pre')\n"),
+        ("dist/main.js", b"console.log('main')\n"),
+        ("dist/post.js", b"console.log('post')\n"),
+    ]);
     let digest = Sha256Digest::from_bytes(Sha256::digest(&archive).into());
     let definition = PreparedActionDefinition::new(
         Vec::new(),
@@ -1089,6 +1173,22 @@ pub fn prepared_node24_action_with_pre_condition(pre_condition: &str) -> Prepare
     )
     .expect("valid JavaScript definition");
     PreparedAction::with_definition(digest, archive, "", definition).expect("valid action")
+}
+
+fn test_action_archive(entries: &[(&str, &[u8])]) -> Bytes {
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut archive = TarBuilder::new(encoder);
+    for (path, bytes) in entries {
+        let mut header = TarHeader::new_gnu();
+        header.set_mode(0o644);
+        header.set_size(u64::try_from(bytes.len()).expect("test entry size"));
+        header.set_cksum();
+        archive
+            .append_data(&mut header, format!("root/{path}"), Cursor::new(*bytes))
+            .expect("append test action entry");
+    }
+    let encoder = archive.into_inner().expect("finish test tar");
+    Bytes::from(encoder.finish().expect("finish test gzip"))
 }
 
 pub fn profile() -> EnvironmentProfile {
@@ -1434,6 +1534,7 @@ impl ExecutionEndpoint for FakeEndpoint {
         &self.capabilities
     }
 
+    #[allow(clippy::too_many_lines)]
     fn exec(
         &self,
         request: &ExecutionCommand,
@@ -1446,7 +1547,57 @@ impl ExecutionEndpoint for FakeEndpoint {
             return execution_output(ExecutionTermination::Cancelled, Vec::new(), false)
                 .map_err(|_| execution_error(ExecutionStage::Exec));
         }
-        if matches!(program, "/usr/bin/install" | "/usr/bin/tar") {
+        if request
+            .argv()
+            .arguments()
+            .iter()
+            .any(|argument| argument.contains("automata-local-action-metadata"))
+        {
+            let arguments = request.argv().arguments();
+            let environment_value = |name: &str| {
+                request
+                    .environment()
+                    .values()
+                    .iter()
+                    .find(|variable| variable.name().as_str() == name)
+                    .map(|variable| variable.value().expose())
+            };
+            let candidates = if program == "/usr/bin/sh" {
+                arguments
+                    .get(3)
+                    .zip(arguments.get(4))
+                    .map(|(preferred, fallback)| (preferred.as_str(), fallback.as_str()))
+            } else if program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe") {
+                environment_value("AUTOMATA_INTERNAL_LOCAL_ACTION_YML")
+                    .zip(environment_value("AUTOMATA_INTERNAL_LOCAL_ACTION_YAML"))
+            } else {
+                None
+            };
+            let selected = candidates.and_then(|(preferred, fallback)| {
+                if state.files.contains_key(preferred) {
+                    Some(b"yml".to_vec())
+                } else if state.files.contains_key(fallback) {
+                    Some(b"yaml".to_vec())
+                } else {
+                    None
+                }
+            });
+            return execution_output(
+                selected
+                    .as_ref()
+                    .map_or(ExecutionTermination::Exited(44), |_| {
+                        ExecutionTermination::Exited(0)
+                    }),
+                selected
+                    .map(|bytes| vec![(ExecutionOutputStream::Stdout, bytes)])
+                    .unwrap_or_default(),
+                false,
+            )
+            .map_err(|_| execution_error(ExecutionStage::Exec));
+        }
+        if matches!(program, "/usr/bin/install" | "/usr/bin/tar")
+            || program.eq_ignore_ascii_case(r"C:\automata\tools\tar\tar.exe")
+        {
             return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
                 .map_err(|_| execution_error(ExecutionStage::Exec));
         }
@@ -1460,35 +1611,36 @@ impl ExecutionEndpoint for FakeEndpoint {
             return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
                 .map_err(|_| execution_error(ExecutionStage::Exec));
         }
-        if program == "/usr/bin/sh"
+        if program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
             && request
                 .argv()
                 .arguments()
-                .get(1)
-                .is_some_and(|argument| argument.contains("automata-local-action-metadata"))
+                .iter()
+                .any(|argument| argument.contains("FileAttributes]::ReparsePoint"))
         {
-            let arguments = request.argv().arguments();
-            let preferred = arguments.get(3).expect("preferred metadata path");
-            let fallback = arguments.get(4).expect("fallback metadata path");
-            let selected = if state.files.contains_key(preferred) {
-                Some(b"yml".to_vec())
-            } else if state.files.contains_key(fallback) {
-                Some(b"yaml".to_vec())
-            } else {
-                None
-            };
-            return execution_output(
-                selected
-                    .as_ref()
-                    .map_or(ExecutionTermination::Exited(44), |_| {
-                        ExecutionTermination::Exited(0)
-                    }),
-                selected
-                    .map(|bytes| vec![(ExecutionOutputStream::Stdout, bytes)])
-                    .unwrap_or_default(),
-                false,
-            )
-            .map_err(|_| execution_error(ExecutionStage::Exec));
+            return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
+                .map_err(|_| execution_error(ExecutionStage::Exec));
+        }
+        if program.eq_ignore_ascii_case(r"C:\automata\tools\hash\automata-sha256.exe") {
+            let archive = request
+                .argv()
+                .arguments()
+                .first()
+                .expect("Windows action archive path");
+            let (termination, output) = state.files.get(archive).map_or_else(
+                || (ExecutionTermination::Exited(44), Vec::new()),
+                |bytes| {
+                    (
+                        ExecutionTermination::Exited(0),
+                        vec![(
+                            ExecutionOutputStream::Stdout,
+                            sha256_hex(bytes).into_bytes(),
+                        )],
+                    )
+                },
+            );
+            return execution_output(termination, output, false)
+                .map_err(|_| execution_error(ExecutionStage::Exec));
         }
         if let Some(output) = artifact_hash_output(request, &state.files) {
             return output;

--- a/crates/automata-ci-job-executor-github/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-github/tests/support/mod.rs
@@ -516,6 +516,7 @@ impl Fixture {
             scripts: Vec::new(),
             copy_from_calls: 0,
             copy_from_calls_since_exec: 0,
+            copy_from_requests: Vec::new(),
             cancellation_before_copy_from: None,
             responses: responses.into(),
         }));
@@ -1335,6 +1336,7 @@ pub struct EndpointState {
     pub scripts: Vec<Vec<u8>>,
     pub copy_from_calls: usize,
     pub copy_from_calls_since_exec: usize,
+    pub copy_from_requests: Vec<CopyFromRequest>,
     cancellation_before_copy_from: Option<ExecutionCancellation>,
     responses: VecDeque<PhaseResponse>,
 }
@@ -1575,17 +1577,23 @@ impl ExecutionEndpoint for FakeEndpoint {
         }
         state.copy_from_calls += 1;
         state.copy_from_calls_since_exec += 1;
+        state.copy_from_requests.push(request.clone());
         if state.missing_files.contains(request.source().as_str()) {
             return Err(ExecutionError::new(
                 ExecutionErrorKind::NotFound,
                 ExecutionStage::CopyFrom,
             ));
         }
-        Ok(state
-            .files
-            .get(request.source().as_str())
-            .cloned()
-            .unwrap_or_default())
+        let Some(bytes) = state.files.get(request.source().as_str()) else {
+            return Ok(Vec::new());
+        };
+        if bytes.len() > request.byte_limit() {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::OutputLimitExceeded,
+                ExecutionStage::CopyFrom,
+            ));
+        }
+        Ok(bytes.clone())
     }
 }
 

--- a/crates/automata-ci-job-executor-github/tests/windows_actions.rs
+++ b/crates/automata-ci-job-executor-github/tests/windows_actions.rs
@@ -1,0 +1,229 @@
+mod support;
+
+use std::sync::Arc;
+
+use automata_ci_core::JobConclusion;
+use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionEvents, JobExecutor};
+
+use support::{
+    Fixture, PhaseResponse, action_step, local_action_step, prepared_node24_action,
+    prepared_windows_namespace_unsafe_node24_action, windows_envelope,
+};
+
+#[tokio::test]
+async fn admitted_windows_javascript_action_is_verified_materialized_and_executed() {
+    let fixture = Fixture::windows_actions(
+        vec![prepared_node24_action()],
+        vec![PhaseResponse::success()],
+    );
+    let job = windows_envelope(vec![action_step("checkout", "actions/example")]);
+    fixture.executor.admit(&job).expect("Windows action admits");
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("verified Windows action executes");
+
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    assert_eq!(
+        result.conclusion(),
+        JobConclusion::Success,
+        "{result:?}; commands={:?}",
+        state.commands
+    );
+    let action_commands = state
+        .commands
+        .iter()
+        .filter(|command| {
+            let program = command.argv().program().as_str();
+            !program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
+                || command.argv().arguments().iter().any(|argument| {
+                    argument.contains("action directory already exists")
+                        || argument.contains("FileAttributes]::ReparsePoint")
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        action_commands
+            .iter()
+            .map(|command| command.argv().program().as_str())
+            .collect::<Vec<_>>(),
+        [
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            r"C:\automata\tools\hash\automata-sha256.exe",
+            r"C:\automata\tools\tar\tar.exe",
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            r"C:\automata\externals\node24\node.exe",
+            r"C:\automata\externals\node24\node.exe",
+        ],
+        "directory creation, archive digest, extraction, reparse scan, main, and post are ordered"
+    );
+    assert!(
+        action_commands[0].argv().arguments()[4].contains("action directory already exists"),
+        "materialization refuses a stale action directory"
+    );
+    assert!(
+        action_commands[3].argv().arguments()[4].contains("FileAttributes]::ReparsePoint"),
+        "the extracted tree is scanned for Windows reparse points"
+    );
+    assert!(
+        action_commands[4].argv().arguments()[0].ends_with(r"\actions\action-0\root\dist\index.js")
+    );
+}
+
+#[tokio::test]
+async fn admitted_windows_local_action_uses_a_reparse_safe_pwsh_probe() {
+    let fixture = Fixture::windows_actions(Vec::new(), vec![PhaseResponse::success()]);
+    fixture
+        .endpoint_state
+        .lock()
+        .expect("endpoint lock")
+        .files
+        .insert(
+            r"D:\a\automata\automata\local-action\action.yml".to_owned(),
+            b"name: Local\nruns:\n  using: node24\n  main: dist/index.js\n".to_vec(),
+        );
+    let job = windows_envelope(vec![local_action_step("local", "./local-action")]);
+    fixture
+        .executor
+        .admit(&job)
+        .expect("Windows local action admits");
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("Windows local action executes");
+
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    assert_eq!(
+        result.conclusion(),
+        JobConclusion::Success,
+        "{result:?}; commands={:?}",
+        state.commands
+    );
+    let probe = state
+        .commands
+        .iter()
+        .find(|command| {
+            command
+                .argv()
+                .arguments()
+                .iter()
+                .any(|argument| argument.contains("automata-local-action-metadata"))
+        })
+        .expect("local metadata probe");
+    assert_eq!(
+        probe.argv().program().as_str(),
+        r"C:\Program Files\PowerShell\7\pwsh.exe"
+    );
+    assert!(
+        probe
+            .argv()
+            .arguments()
+            .iter()
+            .any(|argument| argument.contains("FileAttributes]::ReparsePoint")),
+        "the local action directory and tree are checked for reparse points"
+    );
+    let node = state
+        .commands
+        .iter()
+        .find(|command| {
+            command
+                .argv()
+                .program()
+                .as_str()
+                .eq_ignore_ascii_case(r"C:\automata\externals\node24\node.exe")
+        })
+        .expect("local Node action invocation");
+    assert_eq!(
+        node.argv().arguments()[0],
+        r"D:\a\automata\automata\local-action\dist\index.js"
+    );
+}
+
+#[tokio::test]
+async fn admitted_windows_local_composite_executes_its_pwsh_child() {
+    let fixture = Fixture::windows_actions(Vec::new(), vec![PhaseResponse::success()]);
+    fixture.endpoint_state.lock().expect("endpoint lock").files.insert(
+        r"D:\a\automata\automata\local-composite\action.yml".to_owned(),
+        b"name: Local composite\nruns:\n  using: composite\n  steps:\n    - id: child\n      shell: pwsh\n      run: Write-Output 'windows-composite'\n"
+            .to_vec(),
+    );
+    let job = windows_envelope(vec![local_action_step(
+        "local-composite",
+        "./local-composite",
+    )]);
+    fixture
+        .executor
+        .admit(&job)
+        .expect("Windows local composite admits");
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("Windows local composite executes");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success, "{result:?}");
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    assert!(
+        state.scripts.iter().any(|script| script
+            .windows(b"windows-composite".len())
+            .any(|window| { window == b"windows-composite" })),
+        "the composite child is materialized as a PowerShell script"
+    );
+    assert!(state.commands.iter().any(|command| {
+        command
+            .argv()
+            .program()
+            .as_str()
+            .eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
+            && command
+                .argv()
+                .arguments()
+                .iter()
+                .any(|argument| argument.ends_with(".ps1'"))
+    }));
+}
+
+#[tokio::test]
+async fn nested_repository_action_is_validated_before_windows_materialization() {
+    let fixture = Fixture::windows_actions(
+        vec![prepared_windows_namespace_unsafe_node24_action()],
+        Vec::new(),
+    );
+    fixture.endpoint_state.lock().expect("endpoint lock").files.insert(
+        r"D:\a\automata\automata\local-parent\action.yml".to_owned(),
+        b"name: Local parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/nested@0123456789abcdef0123456789abcdef01234567\n"
+            .to_vec(),
+    );
+    let job = windows_envelope(vec![local_action_step("parent", "./local-parent")]);
+    fixture
+        .executor
+        .admit(&job)
+        .expect("Windows local composite admits");
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect("unsafe nested archive becomes a failed step");
+
+    assert_eq!(result.conclusion(), JobConclusion::Failure, "{result:?}");
+    let state = fixture.endpoint_state.lock().expect("endpoint lock");
+    assert!(
+        state.commands.iter().all(|command| {
+            let program = command.argv().program().as_str();
+            !program.eq_ignore_ascii_case(r"C:\automata\tools\hash\automata-sha256.exe")
+                && !program.eq_ignore_ascii_case(r"C:\automata\tools\tar\tar.exe")
+        }),
+        "the namespace-unsafe nested archive must fail before hash or extraction: {:?}",
+        state.commands
+    );
+}

--- a/crates/automata-ci-runner/README.md
+++ b/crates/automata-ci-runner/README.md
@@ -3,8 +3,8 @@
 The provisioned `automata-runner` command targets Linux and macOS execution
 hosts. Its only Windows execution provider uses Hyper-V-isolated containers;
 the component is implemented, but it
-remains a source-build path without a production enrollment flow, promoted
-runner image, or physical-host release gate. On supported hosts the command
+remains a source-build path without a production-qualified broker deployment,
+promoted runner image, or physical-host release gate. On supported hosts the command
 validates the host and opens an mTLS session to
 the control plane, accepts fenced leases, runs jobs through the configured
 sandbox provider, streams logs, and removes interrupted work.
@@ -96,20 +96,46 @@ image inspection adds it to the live inventory. A missing value
 disables the feature, and an invalid or unavailable configured image stops
 startup. Mutable tags are rejected.
 
-The Windows profile supports PowerShell and `cmd.exe` `run:` steps, plus an
-optional explicitly configured standalone Python interpreter. Startup probes
-each configured interpreter through a copied script before advertising the
-profile. Every `uses:` action, including JavaScript, composite, local,
-repository, and container actions, fails closed. Job containers, service
-containers, administrator profiles, and host-network or host-filesystem policy
-are unsupported.
+The Windows profile always supports exact configured PowerShell and `cmd.exe`
+`run:` steps, plus an optional standalone Python interpreter. Its action-ready
+  component path additionally binds a Windows Server 2025 Server Core image
+  manifest and lock to typed reference records for provenance, SPDX SBOM,
+  patch, and revocation evidence and to exact `tar.exe`, hash-helper, and Node
+  12/16/20/24 paths. Each record binds the native artifact media type and digest;
+  it is not parsed as though it were the referenced native format. Candidate evidence
+without an external Ed25519 promotion envelope remains shell-only. The Windows
+enrollment component defines a receipt contract requiring the same exact
+fresh-container probes before registration and authenticated, short-lived
+receipt retention only through opaque broker custody. The request binds a
+versioned digest of those shared lifecycle, argv, output, and cleanup semantics;
+the broker caller invokes the same helper as runtime admission instead of
+duplicating probe scripts. The restricted-broker
+caller and Windows credential publication are a separate integration gate; until
+they are composed, enrollment remains unavailable rather than registering a
+shell-only or action-ready runner. Only an externally promoted image whose
+ordered config, broker executable, manifest, evidence, and promotion-envelope
+paths and digests receive fresh broker owner/protected-DACL/file-ID/local-volume
+attestation, and whose
+pre-enrollment probes all succeed can register JavaScript, composite,
+repository, local-action, and exact Node-generation capabilities. Startup
+independently repeats admission before reporting the live inventory, so
+registered/live capability intersection retains only abilities proved at both
+boundaries. Missing, stale, tampered, revoked, or mismatched receipt, image,
+tool, or runtime evidence fails closed. Docker
+actions, job containers, service containers, administrator profiles, and
+host-network or host-filesystem policy remain unsupported.
 
 Hosted Windows CI is currently disabled because Automata does not yet operate
 Windows runners. Unit and injected-runtime provider tests do not constitute a
-release gate; there is deliberately no Windows enrollment or static-registration
-fallback. Do not deploy it until secure Windows credential publication, a
-promoted digest-pinned Windows image, and the physical Windows end-to-end gate
-are implemented together.
+release gate; there is deliberately no static-registration or unsigned-receipt
+fallback. The source contract requires broker-owned enrollment-secret and
+admission-receipt custody and writes neither secret to runner-local staging.
+Do not deploy it until that broker is installed under its restricted service
+identity, secure Windows credential publication is qualified, a
+real externally promoted digest-pinned Windows image, and the physical Windows
+end-to-end gate are implemented together. The checked-in candidate image
+contract is deliberately unsigned and is not evidence of a built or tested
+image.
 
 The macOS profile supports Bash and `sh` `run:` steps, plus optional explicitly
 configured Python and PowerShell Core interpreters. Startup probes every

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -163,9 +163,12 @@ or kubelet verification.
 > Unix file-backed TLS custody. `automata-runner run` renews that identity
 > before expiry, durably recovers an interrupted rotation, drains the old
 > runner generation, and reloads the new files itself. The macOS example uses
-> that exact file-backed TLS contract. Windows has no deployment example until
-> native atomic rotation is qualified. There is no manual, static-registration,
-> or alternate-protocol fallback.
+> that exact file-backed TLS contract. The Windows source path requires the
+> restricted broker for active profile admission, opaque receipt and
+> enrollment-secret custody, and final credential publication. Windows has no
+> deployment example until native atomic renewal custody, external image
+> promotion, authenticated placement, and the physical-host gate are qualified.
+> There is no local-secret, manual-registration, or alternate-protocol fallback.
 
 Configure the control plane with the
 [`automata` reference](https://github.com/automata-ci/automata/blob/main/crates/automata-ci/README.md),
@@ -173,15 +176,85 @@ then provision the runner host according to the requirements below.
 
 ## Windows Hyper-V-isolated component boundary
 
-The Hyper-V provider remains exercised by an internal product-schema fixture,
-but no checked-in Windows deployment configuration or `automata-runner run`
-path is published. Native atomic TLS renewal custody, a promoted immutable
-image, authenticated placement evidence, and the physical-host acceptance gate
-must land together before that surface can become current. The component still
-rejects process isolation, networking, host mounts, administrator identity,
-mutable images, and every action other than supported `run:` shells; see the
-[Windows isolation plan](../../../docs/platforms/windows.md). There is no
-environment-backed or static-certificate deployment fallback.
+The internal Windows product fixture is an unprovisionable source-build path for the implemented
+Hyper-V container provider. It requires one absolute SHA-256-pinned container
+runtime executable, one immutable Windows image reference, and the exact guest
+agent path baked into that image. Every job receives a fresh container with
+`--isolation hyperv`, no network, no host mounts, a writable disposable root,
+and `ContainerUser` identity. Configuration rejects every host-network,
+host-filesystem, administrator, native-process, process-isolated-container, or
+mutable-image alternative.
+
+`windows_hyperv.image_contract` also names bounded, no-follow files for the
+exact Windows Server 2025 Server Core manifest, image lock, and typed reference
+records for provenance, SPDX SBOM, patch-report, and revocation artifacts. Each
+reference record has the Automata reference-record media type and binds the
+native artifact's exact media type and digest; the verifier never treats a
+reference record as an in-toto or SPDX document. The manifest and lock digests
+are pinned in runner configuration. All evidence must bind the configured profile,
+base image, output image, guest path, workspace, and exact x86-64 Hyper-V,
+offline, unprivileged policy. The manifest's tool entries must exactly match
+the configured `pwsh.exe`, `powershell.exe`, `cmd.exe`, `tar.exe`,
+`automata-sha256.exe`, and each configured Node 12/16/20/24 executable. Missing,
+malformed, revoked, substituted, or digest-mismatched material stops startup.
+
+The resulting inventory advertises
+`automata.core/windows-hyperv-container@v1` only for `windows_hyperv`. GitHub
+Windows projection requires that exact launch capability together with
+`IsolationLevel::VirtualMachine`; a generic VM advertisement, including the
+macOS VM provider, cannot match. Registered and live-observed capabilities are
+intersected before scheduler matching, and the match is repeated before a
+placement can become a lease.
+
+Without an external promotion envelope the verified candidate's durable
+inventory contains only
+PowerShell and `cmd.exe` shell steps plus command files, with optional support
+for one absolute standalone Python interpreter. A production image may enable
+JavaScript, composite, repository, and local-action capabilities only after a
+canonical Ed25519-signed promotion payload accepts all evidence digests and
+revocation generation. Startup exercises every configured shell, archive,
+hash, Node, and optional Python executable through a copied probe in one fresh
+container. The required Windows enrollment adapter must run the same exact
+profile/tool contract and retain a short-lived authenticated receipt under an
+opaque broker-custody handle. The request binds the shared probe-contract schema
+and digest, and the supplied helper executes the same lifecycle, argv, and
+output checks as startup. This component supplies that request/receipt port;
+the restricted-broker caller and credential-publication integration remain a
+separate deployment gate. Once composed, the enrollment request must use the
+broker-attested ordered host-input set (configuration, executable, manifest,
+lock, evidence records, and promotion envelope), including protected DACL,
+owner, non-reparse, stable file/volume identity, and exact digest proof, and the
+receipt's exact capability set and a staged retry must resolve the identical
+receipt digest and binding. Missing, stale, expired, or tampered custody fails
+closed. The
+`capabilities` command remains a passive shell-only diagnostic and cannot mint
+action authority. Startup independently repeats the probes before opening a
+runtime session, and action/Node features remain schedulable only when the
+registered and live-observed sets agree. There is no `PATH` or Node-generation
+fallback. Docker actions, job
+containers, service containers, and active Podman doctor checks remain
+unsupported. The host state root contains provider ownership and recovery
+metadata only; no runner state or credential path is mounted into a job
+container.
+
+The checked-in runtime digest and the files under
+[`images/windows-server-2025-hyperv-candidate`](../../../images/windows-server-2025-hyperv-candidate/README.md)
+are explicit candidate fixtures, not promoted artifacts. They exercise the
+contract and verifier interfaces but do not claim that an image was built,
+signed, scanned, patched, or run on physical Windows hardware. No promotion
+envelope is checked in. Unit and injected-runtime tests do not prove HCS/HCN
+behavior, patch compatibility, or nested Job Object enforcement. Keep this
+runner out of production until the external image pipeline supplies real
+evidence and signature and the physical-host acceptance gate is published. The
+exact launch requirement also does not by itself satisfy every AUTH-02 and
+broker acceptance requirement.
+
+The internal
+[`runner.windows.product.json`](../tests/fixtures/runner.windows.product.json)
+exists only for schema and component testing. It is not a deployment example
+and must not be copied into production. Follow the
+[Windows isolation plan](../../../docs/platforms/windows.md); no supported
+`automata-runner run` Windows path is published yet.
 
 ## macOS virtual-machine example
 

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -63,7 +63,7 @@ use super::state::RuntimeMountSnapshot;
 use super::{
     ClientTlsMaterialError, ProductStateRootError, RunnerProductConfig, RunnerProductConfigError,
     RunnerProviderConfig, SecretSource, StandardGithubContext,
-    config::{ObjectStoreTlsTrust, required_podman_state_root},
+    config::{ObjectStoreTlsTrust, promoted_windows_runtime_features, required_podman_state_root},
     metrics::RunnerMetrics,
     profile_admission::{
         ProfileAdmissionError, ProfileAdmissionOutcome, ProfileAdmissionPolicy,
@@ -809,13 +809,39 @@ fn build_admitted_runtime_inventory(
     let admission = admit_configured_environment_profiles(config, provider, cancellation);
     after_profile_admission(admission, || {
         revalidate_provider_trust()?;
-        Ok(inventory_for_verified_provider(
-            config.inventory(),
+        admitted_runtime_inventory(
+            config,
             service_proxy_configured,
             buildkit_configured,
             provider.capabilities(),
-        ))
+        )
     })
+}
+
+fn admitted_runtime_inventory(
+    config: &RunnerProductConfig,
+    service_proxy_configured: bool,
+    buildkit_configured: bool,
+    provider: &ProviderCapabilities,
+) -> Result<RunnerCapabilities, RunnerProductError> {
+    let mut inventory = inventory_for_verified_provider(
+        config.inventory(),
+        service_proxy_configured,
+        buildkit_configured,
+        provider,
+    );
+    if config
+        .windows_hyperv()
+        .is_some_and(|windows| windows.image_admission().permits_actions())
+    {
+        inventory = inventory.with_features(promoted_windows_runtime_features(
+            config.executor().toolchain(),
+        ));
+    }
+    inventory
+        .validate()
+        .map_err(|_| RunnerProductError::SandboxProviderInvariant)?;
+    Ok(inventory)
 }
 
 fn after_profile_admission<Inventory>(
@@ -828,6 +854,7 @@ fn after_profile_admission<Inventory>(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn admit_configured_environment_profiles(
     config: &RunnerProductConfig,
     provider: &dyn automata_ci_execution::SandboxProvider,
@@ -849,7 +876,7 @@ fn admit_configured_environment_profiles(
     let toolchain = config.executor().toolchain();
     let policy = match config.provider() {
         RunnerProviderConfig::WindowsHyperV(_) => policy
-            .with_windows_hyperv_shells(
+            .with_windows_hyperv_tools(
                 toolchain
                     .pwsh()
                     .ok_or(RunnerProductError::ProviderConfiguration)?
@@ -863,6 +890,18 @@ fn admit_configured_environment_profiles(
                     .ok_or(RunnerProductError::ProviderConfiguration)?
                     .clone(),
                 toolchain.python().cloned(),
+                toolchain
+                    .tar()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .sha256sum()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain.node12().cloned(),
+                toolchain.node16().cloned(),
+                toolchain.node20().cloned(),
+                toolchain.node24().cloned(),
             )
             .map_err(|_| RunnerProductError::ProviderConfiguration)?,
         RunnerProviderConfig::MacosVirtualization(_) => policy
@@ -1316,6 +1355,7 @@ fn load_s3_private_ca(certificate_source: &SecretSource) -> Result<S3TlsTrust, R
         .map_err(RunnerProductError::ObjectStore)
 }
 
+#[allow(clippy::too_many_lines)]
 fn build_toolchain(
     config: &RunnerProductConfig,
 ) -> Result<StaticGithubToolchain, RunnerProductError> {
@@ -1385,6 +1425,21 @@ fn build_toolchain(
     if let Some(path) = configured.python() {
         toolchain = toolchain.with_python(path.clone())?;
     }
+    let windows_actions = config
+        .windows_hyperv()
+        .is_some_and(|windows| windows.image_admission().permits_actions());
+    if windows_actions {
+        toolchain = toolchain.with_windows_action_materializer(
+            configured
+                .tar()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+            configured
+                .sha256sum()
+                .ok_or(RunnerProductError::ProviderConfiguration)?
+                .clone(),
+        )?;
+    }
     if matches!(
         config.provider(),
         RunnerProviderConfig::Podman(_)
@@ -1401,7 +1456,10 @@ fn build_toolchain(
         (JavascriptRuntime::Node20, configured.node20()),
         (JavascriptRuntime::Node24, configured.node24()),
     ] {
-        if let Some(path) = path {
+        if let Some(path) = path
+            && (!matches!(config.provider(), RunnerProviderConfig::WindowsHyperV(_))
+                || windows_actions)
+        {
             toolchain = toolchain.with_node(runtime, path.clone())?;
         }
     }
@@ -1638,6 +1696,8 @@ mod tests {
     #[cfg(unix)]
     use std::{fs, os::unix::fs::PermissionsExt as _, path::PathBuf};
 
+    #[cfg(target_os = "windows")]
+    use automata_ci_job_executor_github::GithubToolchain as _;
     use automata_ci_metrics::OPENMETRICS_CONTENT_TYPE;
 
     #[cfg(unix)]
@@ -1721,6 +1781,72 @@ mod tests {
         ));
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn unverified_windows_image_cannot_compose_action_tools() {
+        let config = RunnerProductConfig::from_json(include_bytes!(
+            "../../tests/fixtures/runner.windows.product.json"
+        ))
+        .expect("internal Windows product fixture");
+
+        let toolchain = build_toolchain(&config).expect("shell-only Windows toolchain");
+
+        assert!(toolchain.tar().is_none());
+        assert!(toolchain.sha256().is_none());
+        assert!(toolchain.node(JavascriptRuntime::Node24).is_none());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn promoted_windows_features_exist_only_in_post_admission_inventory() {
+        struct InjectedPromotedEvidence;
+
+        impl super::super::windows_image::WindowsImageEvidenceVerifier for InjectedPromotedEvidence {
+            fn verify(
+                &self,
+                _request: &super::super::windows_image::WindowsImageVerificationRequest<'_>,
+            ) -> Result<
+                super::super::windows_image::WindowsImageVerification,
+                super::super::windows_image::WindowsImageVerificationError,
+            > {
+                Ok(
+                    super::super::windows_image::WindowsImageVerification::promoted(
+                        automata_ci_core::Sha256Digest::from_bytes([9; 32]),
+                        automata_ci_core::Sha256Digest::from_bytes([10; 32]),
+                        automata_ci_core::Sha256Digest::from_bytes([11; 32]),
+                    ),
+                )
+            }
+        }
+
+        let config = RunnerProductConfig::from_json(include_bytes!(
+            "../../tests/fixtures/runner.windows.product.json"
+        ))
+        .expect("internal Windows product fixture")
+        .with_verified_windows_image(&InjectedPromotedEvidence)
+        .expect("injected promotion boundary");
+        let provider = ProviderCapabilities::new([SandboxCapability::WholeJob])
+            .expect("provider capabilities");
+
+        assert!(
+            !config
+                .inventory()
+                .features()
+                .contains(&automata_ci_core::RunnerFeature::JAVASCRIPT_ACTIONS),
+            "durable and diagnostic inventory remains pre-admission"
+        );
+        let admitted = admitted_runtime_inventory(&config, false, false, &provider)
+            .expect("post-admission runtime inventory");
+        for feature in [
+            automata_ci_core::RunnerFeature::JAVASCRIPT_ACTIONS,
+            automata_ci_core::RunnerFeature::COMPOSITE_ACTIONS,
+            automata_ci_core::RunnerFeature::REPOSITORY_ACTIONS,
+            automata_ci_core::RunnerFeature::LOCAL_ACTIONS,
+            automata_ci_core::RunnerFeature::NODE24_ACTIONS,
+        ] {
+            assert!(admitted.features().contains(&feature), "missing {feature}");
+        }
+    }
     #[derive(Debug, Default)]
     struct StartupEffects {
         inventories: Cell<u8>,

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -25,6 +25,7 @@ use automata_ci_runner_journal::StateRoot;
 use automata_ci_runner_spool::{ProtectionId, SpoolRoot};
 use http::Uri;
 use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use url::Url;
 
@@ -32,6 +33,11 @@ use super::files::{
     SecretSource, SecureInputError, read_configuration_file, validate_absolute_path,
 };
 use super::spool_crypto::MAX_DECRYPT_ONLY_CONTENT_KEYS;
+use super::windows_image::{
+    FilesystemWindowsImageEvidenceVerifier, RawWindowsImageContractConfig, WindowsImageAdmission,
+    WindowsImageContractConfig, WindowsImageEvidenceVerifier, WindowsImageVerification,
+    WindowsImageVerificationRequest,
+};
 
 /// Current on-disk runner product configuration schema.
 pub const RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION: u16 = 6;
@@ -53,6 +59,8 @@ const MAX_USER_AGENT_BYTES: usize = 256;
 
 /// Fully validated product configuration for one runner process.
 pub struct RunnerProductConfig {
+    configuration_path: Option<PathBuf>,
+    configuration_sha256: Option<Sha256Digest>,
     runner_id: RunnerId,
     control_endpoint: Uri,
     state: StateRoots,
@@ -77,7 +85,10 @@ impl RunnerProductConfig {
     pub fn load(path: &Path) -> Result<Self, RunnerProductConfigError> {
         let bytes = read_configuration_file(path, MAX_RUNNER_CONFIG_BYTES)
             .map_err(RunnerProductConfigError::SecureInput)?;
-        Self::from_json(&bytes)
+        let mut config = Self::from_json(&bytes)?;
+        config.configuration_path = Some(path.to_owned());
+        config.configuration_sha256 = Some(Sha256Digest::from_bytes(Sha256::digest(&bytes).into()));
+        config.with_verified_windows_image(&FilesystemWindowsImageEvidenceVerifier)
     }
 
     /// Parses an already-bounded configuration document. This exists for
@@ -100,6 +111,14 @@ impl RunnerProductConfig {
     #[must_use]
     pub const fn runner_id(&self) -> RunnerId {
         self.runner_id
+    }
+
+    pub(super) fn configuration_path(&self) -> Option<&Path> {
+        self.configuration_path.as_deref()
+    }
+
+    pub(super) const fn configuration_sha256(&self) -> Option<Sha256Digest> {
+        self.configuration_sha256
     }
 
     /// Returns the validated credential-free HTTPS control-plane origin.
@@ -128,8 +147,9 @@ impl RunnerProductConfig {
 
     /// Returns the validated durable registration ceiling for this runner identity.
     ///
-    /// Runtime admission independently reduces configured abilities to the
-    /// capabilities proved by the live provider before opening a session.
+    /// Image promotion and live profile admission may add Windows action
+    /// capabilities only to the ephemeral runtime inventory. They are never
+    /// included in this pre-admission registration or diagnostic surface.
     #[must_use]
     pub const fn inventory(&self) -> &RunnerCapabilities {
         &self.inventory
@@ -230,12 +250,67 @@ impl RunnerProductConfig {
     pub const fn metrics(&self) -> Option<&MetricsProductConfig> {
         self.metrics.as_ref()
     }
+
+    /// Applies one Windows image-evidence verifier before this configuration
+    /// can compose Windows action runtimes after live profile admission.
+    ///
+    /// The configuration is consumed so a failed or weaker re-verification
+    /// cannot leave a previously promoted image admission available to a caller.
+    /// Non-Windows configurations pass through unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized image-evidence error when the verifier rejects the
+    /// exact configured profile, image, paths, tools, or promotion material.
+    pub fn with_verified_windows_image(
+        mut self,
+        verifier: &dyn WindowsImageEvidenceVerifier,
+    ) -> Result<Self, RunnerProductConfigError> {
+        self.apply_windows_image_verification(verifier)?;
+        Ok(self)
+    }
+
+    fn apply_windows_image_verification(
+        &mut self,
+        verifier: &dyn WindowsImageEvidenceVerifier,
+    ) -> Result<(), RunnerProductConfigError> {
+        let RunnerProviderConfig::WindowsHyperV(windows) = &self.provider else {
+            return Ok(());
+        };
+        let (profile, environment) = self
+            .environments
+            .first_key_value()
+            .filter(|_| self.environments.len() == 1)
+            .ok_or(RunnerProductConfigError::InvalidWindowsImage)?;
+        let image = environment
+            .image()
+            .ok_or(RunnerProductConfigError::InvalidWindowsImage)?;
+        let request = WindowsImageVerificationRequest {
+            contract: windows.image_contract(),
+            profile_id: profile.id(),
+            profile_manifest_sha256: profile.digest(),
+            image,
+            workspace: environment.workspace(),
+            guest_agent: windows.guest_agent_path(),
+            toolchain: self.executor.toolchain(),
+        };
+        let verification = verifier
+            .verify(&request)
+            .map_err(|_| RunnerProductConfigError::InvalidWindowsImage)?;
+        let RunnerProviderConfig::WindowsHyperV(windows) = &mut self.provider else {
+            unreachable!("provider was matched above")
+        };
+        windows.image_verification = verification;
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for RunnerProductConfig {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("RunnerProductConfig")
+            .field("configuration_path", &self.configuration_path)
+            .field("configuration_sha256", &self.configuration_sha256)
             .field("runner_id", &self.runner_id)
             .field("control_endpoint", &self.control_endpoint)
             .field("state", &self.state)
@@ -318,6 +393,7 @@ impl StateRoots {
 }
 
 /// Validated execution-provider selection for one runner process.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum RunnerProviderConfig {
     /// Rootless Podman on a dedicated Linux execution host.
@@ -381,6 +457,8 @@ pub struct WindowsHyperVProductConfig {
     runtime_sha256: Sha256Digest,
     guest_agent_path: TargetPath,
     operation_timeout: Duration,
+    image_contract: WindowsImageContractConfig,
+    image_verification: WindowsImageVerification,
 }
 
 impl WindowsHyperVProductConfig {
@@ -406,6 +484,40 @@ impl WindowsHyperVProductConfig {
     #[must_use]
     pub const fn operation_timeout(&self) -> Duration {
         self.operation_timeout
+    }
+
+    /// Returns the digest-bound Server 2025 image evidence contract.
+    #[must_use]
+    pub const fn image_contract(&self) -> &WindowsImageContractConfig {
+        &self.image_contract
+    }
+
+    /// Returns the current image evidence decision.
+    #[must_use]
+    pub const fn image_admission(&self) -> WindowsImageAdmission {
+        self.image_verification.admission()
+    }
+
+    /// Returns the canonical signed-promotion payload digest after verification.
+    #[must_use]
+    pub const fn promotion_payload_sha256(&self) -> Option<Sha256Digest> {
+        self.image_verification.promotion_payload_sha256()
+    }
+
+    /// Returns the digest of the exact verified promotion public key.
+    #[must_use]
+    pub const fn promotion_public_key_sha256(&self) -> Option<Sha256Digest> {
+        self.image_verification.promotion_public_key_sha256()
+    }
+
+    /// Returns the digest of the complete verified promotion envelope.
+    #[must_use]
+    pub const fn promotion_envelope_sha256(&self) -> Option<Sha256Digest> {
+        self.image_verification.promotion_envelope_sha256()
+    }
+
+    pub(super) const fn evidence_digests(&self) -> Option<[Sha256Digest; 4]> {
+        self.image_verification.evidence_digests()
     }
 }
 
@@ -986,6 +1098,9 @@ pub enum RunnerProductConfigError {
     /// Kubernetes adapter policy or operator attestations are invalid.
     #[error("runner Kubernetes configuration is invalid")]
     InvalidKubernetes,
+    /// Windows image evidence is absent, mismatched, revoked, or not trusted.
+    #[error("runner Windows image evidence is invalid")]
+    InvalidWindowsImage,
     /// GitHub executor policy or toolchain paths are invalid.
     #[error("runner executor configuration is invalid")]
     InvalidExecutor,
@@ -1208,6 +1323,8 @@ impl RawRunnerProductConfig {
         }
         let object_store = self.object_store.validate()?;
         Ok(RunnerProductConfig {
+            configuration_path: None,
+            configuration_sha256: None,
             runner_id: self.runner_id,
             control_endpoint,
             state,
@@ -1802,6 +1919,29 @@ fn executor_runtime_features(
     features
 }
 
+pub(super) fn promoted_windows_runtime_features(
+    toolchain: &ToolchainConfig,
+) -> BTreeSet<RunnerFeature> {
+    let mut features = executor_runtime_features(toolchain, ProviderKind::WindowsHyperV);
+    features.extend([
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+    ]);
+    for (available, feature) in [
+        (toolchain.node12().is_some(), RunnerFeature::NODE12_ACTIONS),
+        (toolchain.node16().is_some(), RunnerFeature::NODE16_ACTIONS),
+        (toolchain.node20().is_some(), RunnerFeature::NODE20_ACTIONS),
+        (toolchain.node24().is_some(), RunnerFeature::NODE24_ACTIONS),
+    ] {
+        if available {
+            features.insert(feature);
+            features.insert(RunnerFeature::JAVASCRIPT_ACTIONS);
+        }
+    }
+    features
+}
+
 #[cfg(test)]
 mod runtime_feature_tests {
     use super::*;
@@ -2181,6 +2321,7 @@ struct RawWindowsHyperVProductConfig {
     runtime_sha256: String,
     guest_agent_path: String,
     operation_timeout_seconds: u64,
+    image_contract: RawWindowsImageContractConfig,
 }
 
 impl RawWindowsHyperVProductConfig {
@@ -2215,6 +2356,11 @@ impl RawWindowsHyperVProductConfig {
             runtime_sha256,
             guest_agent_path,
             operation_timeout,
+            image_contract: self
+                .image_contract
+                .validate()
+                .map_err(|_| RunnerProductConfigError::InvalidProvider)?,
+            image_verification: WindowsImageVerification::unverified(),
         })
     }
 }
@@ -2753,6 +2899,7 @@ struct RawToolchainConfig {
 }
 
 impl RawToolchainConfig {
+    #[allow(clippy::too_many_lines)]
     fn validate(
         self,
         provider_kind: ProviderKind,
@@ -2805,11 +2952,33 @@ impl RawToolchainConfig {
                         .python
                         .as_ref()
                         .is_none_or(|path| exact_windows_executable(path, "python.exe"))
+                    && config
+                        .tar
+                        .as_ref()
+                        .is_some_and(|path| exact_windows_executable(path, "tar.exe"))
+                    && config
+                        .sha256sum
+                        .as_ref()
+                        .is_some_and(|path| exact_windows_executable(path, "automata-sha256.exe"))
+                    && [
+                        config.node12.as_ref(),
+                        config.node16.as_ref(),
+                        config.node20.as_ref(),
+                        config.node24.as_ref(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .all(|path| exact_windows_executable(path, "node.exe"))
                     && [
                         config.python.as_ref(),
                         config.pwsh.as_ref(),
                         config.powershell.as_ref(),
                         config.cmd.as_ref(),
+                        config.tar.as_ref(),
+                        config.sha256sum.as_ref(),
+                        config.node12.as_ref(),
+                        config.node16.as_ref(),
+                        config.node20.as_ref(),
                         config.node24.as_ref(),
                     ]
                     .into_iter()
@@ -2821,12 +2990,6 @@ impl RawToolchainConfig {
                             .any(|segment| segment.eq_ignore_ascii_case("WindowsApps"))
                     })
                     && config.install.is_none()
-                    && config.tar.is_none()
-                    && config.sha256sum.is_none()
-                    && config.node12.is_none()
-                    && config.node16.is_none()
-                    && config.node20.is_none()
-                    && config.node24.is_none()
             }
             ProviderKind::MacosVirtualization => {
                 config.bash.is_some()

--- a/crates/automata-ci-runner/src/product/mod.rs
+++ b/crates/automata-ci-runner/src/product/mod.rs
@@ -13,6 +13,8 @@ mod resource_metrics;
 mod spool_crypto;
 mod state;
 mod tls;
+mod windows_enrollment_admission;
+mod windows_image;
 
 pub use composition::{
     RunnerProductError, RunnerShutdown, load_s3_credentials, load_spool_key, load_spool_keyring,
@@ -32,3 +34,16 @@ pub(crate) use files::{
 pub use files::{SecretSource, SecureInputError};
 pub use state::ProductStateRootError;
 pub use tls::ClientTlsMaterialError;
+pub use windows_enrollment_admission::{
+    ValidatedWindowsEnrollmentAdmission, WindowsEnrollmentAdmissionBinding,
+    WindowsEnrollmentAdmissionError, WindowsEnrollmentAdmissionEvidence,
+    WindowsEnrollmentAdmissionHandle, WindowsEnrollmentAdmissionPort,
+    WindowsEnrollmentAdmissionReceipt, WindowsEnrollmentAdmissionRequest, WindowsEnrollmentIntent,
+    WindowsEnrollmentProbePolicy, WindowsHostInputDescriptor, WindowsHostInputKind,
+    current_unix_seconds, probe_windows_enrollment_request, windows_enrollment_admission_request,
+};
+pub use windows_image::{
+    FilesystemWindowsImageEvidenceVerifier, WindowsImageAdmission, WindowsImageContractConfig,
+    WindowsImageEvidenceVerifier, WindowsImagePromotionConfig, WindowsImageVerification,
+    WindowsImageVerificationError, WindowsImageVerificationRequest,
+};

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -15,6 +15,7 @@ use automata_ci_execution::{
     SandboxState, TargetPath, TargetPlatform,
 };
 use automata_ci_job_executor_github::{WindowsScriptShell, windows_script_arguments};
+use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::podman_probe::ProbeCancellation;
@@ -26,6 +27,36 @@ const SHELL_PROBE_OUTPUT_BYTES: usize = 4 * 1024;
 #[cfg(test)]
 const WINDOWS_SHELL_PROBE_COUNT: usize = 3;
 const MAX_SHELL_PROBE_COUNT: usize = 11;
+pub(super) const WINDOWS_PROFILE_PROBE_SCHEMA_VERSION: u16 = 1;
+// This canonical descriptor is the compatibility boundary for the shared
+// enrollment/runtime probe below. Any semantic change to the lifecycle,
+// command construction, or acceptance rules must update this descriptor and
+// increment the schema version so retained enrollment receipts fail closed.
+const WINDOWS_PROFILE_PROBE_CONTRACT_V1: &[u8] = b"automata.windows-profile-probe/v1\n\
+lifecycle=validate-provider-policy,create,inspect-running,attach,copy-script,exec,destroy,inspect-absent\n\
+cleanup=signal-on-cancel,destroy-with-reconciliation,inspect-absent\n\
+pwsh-script=ErrorActionPreference-Stop,Console.Out.Write-exact-operation-marker\n\
+powershell-script=ErrorActionPreference-Stop,Console.Out.Write-exact-operation-marker\n\
+pwsh-argv=-command,dot-source-single-quoted-exact-script-path\n\
+powershell-argv=-command,dot-source-single-quoted-exact-script-path\n\
+cmd-script=echo-off,nul-set-p-exact-operation-marker,exit-B-0\n\
+cmd-argv=/D,/E:ON,/V:OFF,/C,exact-script-path\n\
+python-script=sys.stdout.write-exact-operation-marker,SystemExit-0\n\
+python-argv=exact-script-path\n\
+tar-argv=--version;stdout-prefix=tar (GNU tar) \n\
+sha256-argv=--version;stdout-prefix=automata-sha256 \n\
+node12-argv=--input-type=commonjs,--eval,exact-major-12,exact-operation-marker\n\
+node16-argv=--input-type=commonjs,--eval,exact-major-16,exact-operation-marker\n\
+node20-argv=--input-type=commonjs,--eval,exact-major-20,exact-operation-marker\n\
+node24-argv=--input-type=commonjs,--eval,exact-major-24,exact-operation-marker\n\
+exec=workspace,default-environment,timeout-15-seconds,output-limit-4096\n\
+accept=exit-0,complete-not-truncated,stdout-exact-or-version-prefix,stderr-empty";
+
+pub(super) fn windows_profile_probe_contract_sha256() -> automata_ci_core::Sha256Digest {
+    automata_ci_core::Sha256Digest::from_bytes(
+        Sha256::digest(WINDOWS_PROFILE_PROBE_CONTRACT_V1).into(),
+    )
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ProfileAdmissionPolicy {
@@ -48,7 +79,7 @@ struct ShellProbe {
     program: TargetPath,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum ShellKind {
     Bash,
     Sh,
@@ -206,6 +237,9 @@ impl ShellProbe {
         match self.kind {
             ShellKind::Install => stdout.starts_with(b"install (GNU coreutils) "),
             ShellKind::Tar => stdout.starts_with(b"tar (GNU tar) "),
+            ShellKind::Sha256sum if self.program.platform() == TargetPlatform::Windows => {
+                stdout.starts_with(b"automata-sha256 ")
+            }
             ShellKind::Sha256sum => stdout.starts_with(b"sha256sum (GNU coreutils) "),
             _ => stdout == self.marker(operation_id).as_bytes(),
         }
@@ -315,6 +349,48 @@ impl ProfileAdmissionPolicy {
         Ok(self)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn with_windows_hyperv_tools(
+        self,
+        pwsh: TargetPath,
+        powershell: TargetPath,
+        cmd: TargetPath,
+        python: Option<TargetPath>,
+        tar: TargetPath,
+        sha256: TargetPath,
+        node12: Option<TargetPath>,
+        node16: Option<TargetPath>,
+        node20: Option<TargetPath>,
+        node24: Option<TargetPath>,
+    ) -> Result<Self, ProfileAdmissionError> {
+        let mut policy = self.with_windows_hyperv_shells(pwsh, powershell, cmd, python)?;
+        let probes = &mut policy
+            .shell_probes
+            .as_mut()
+            .ok_or_else(invalid_catalog)?
+            .probes;
+        probes.extend([
+            ShellProbe::new(ShellKind::Tar, tar),
+            ShellProbe::new(ShellKind::Sha256sum, sha256),
+        ]);
+        for (kind, program) in [
+            (ShellKind::Node12, node12),
+            (ShellKind::Node16, node16),
+            (ShellKind::Node20, node20),
+            (ShellKind::Node24, node24),
+        ] {
+            if let Some(program) = program {
+                probes.push(ShellProbe::new(kind, program));
+            }
+        }
+        if probes.len() > MAX_SHELL_PROBE_COUNT
+            || probes.iter().any(|probe| !valid_windows_probe(probe))
+        {
+            return Err(invalid_catalog());
+        }
+        Ok(policy)
+    }
+
     pub(super) fn with_virtualized_macos_shells(
         mut self,
         scratch_root: TargetPath,
@@ -380,6 +456,27 @@ fn valid_linux_probe(probe: &ShellProbe) -> bool {
             basename == "node"
         }
         ShellKind::WindowsPowerShell | ShellKind::Cmd => false,
+    }
+}
+
+fn valid_windows_probe(probe: &ShellProbe) -> bool {
+    if probe.program.platform() != TargetPlatform::Windows {
+        return false;
+    }
+    let Some(basename) = probe.program.as_str().rsplit('\\').next() else {
+        return false;
+    };
+    match probe.kind {
+        ShellKind::Pwsh => basename.eq_ignore_ascii_case("pwsh.exe"),
+        ShellKind::WindowsPowerShell => basename.eq_ignore_ascii_case("powershell.exe"),
+        ShellKind::Cmd => basename.eq_ignore_ascii_case("cmd.exe"),
+        ShellKind::Python => basename.eq_ignore_ascii_case("python.exe"),
+        ShellKind::Tar => basename.eq_ignore_ascii_case("tar.exe"),
+        ShellKind::Sha256sum => basename.eq_ignore_ascii_case("automata-sha256.exe"),
+        ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24 => {
+            basename.eq_ignore_ascii_case("node.exe")
+        }
+        ShellKind::Bash | ShellKind::Sh | ShellKind::Install => false,
     }
 }
 
@@ -1487,11 +1584,14 @@ mod tests {
             Some(ShellKind::Python)
         } else if basename == "install" {
             Some(ShellKind::Install)
-        } else if basename == "tar" {
+        } else if basename.eq_ignore_ascii_case("tar") || basename.eq_ignore_ascii_case("tar.exe") {
             Some(ShellKind::Tar)
-        } else if basename == "sha256sum" {
+        } else if basename.eq_ignore_ascii_case("sha256sum")
+            || basename.eq_ignore_ascii_case("automata-sha256.exe")
+        {
             Some(ShellKind::Sha256sum)
-        } else if basename == "node" {
+        } else if basename.eq_ignore_ascii_case("node") || basename.eq_ignore_ascii_case("node.exe")
+        {
             let evaluation = request.argv().arguments().last()?;
             [
                 ("!== '12'", ShellKind::Node12),
@@ -1545,6 +1645,11 @@ mod tests {
                 match kind {
                     ShellKind::Install => b"install (GNU coreutils) 9.4\n".to_vec(),
                     ShellKind::Tar => b"tar (GNU tar) 1.35\n".to_vec(),
+                    ShellKind::Sha256sum
+                        if request.argv().program().platform() == TargetPlatform::Windows =>
+                    {
+                        b"automata-sha256 1.0.0\n".to_vec()
+                    }
                     ShellKind::Sha256sum => b"sha256sum (GNU coreutils) 9.4\n".to_vec(),
                     _ => ShellProbe::new(kind, request.argv().program().clone())
                         .marker(request.operation_id())
@@ -1999,6 +2104,53 @@ mod tests {
         assert_eq!(
             probes.last().map(|probe| probe.kind),
             Some(ShellKind::Python)
+        );
+    }
+
+    #[test]
+    fn windows_action_tools_and_every_configured_node_generation_are_probed() {
+        let resources = ResourceLimits::new(256 * 1024 * 1024, 1_000, 16).expect("resources");
+        let policy = ProfileAdmissionPolicy::new(
+            NetworkPolicy::Disabled,
+            RootFilesystemPolicy::Writable,
+            SandboxPrivilegePolicy::Unprivileged,
+            resources,
+            resource_allocation(resources),
+        )
+        .with_windows_hyperv_tools(
+            TargetPath::windows(r"C:\Program Files\PowerShell\7\pwsh.exe").expect("pwsh"),
+            TargetPath::windows(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
+                .expect("powershell"),
+            TargetPath::windows(r"C:\Windows\System32\cmd.exe").expect("cmd"),
+            None,
+            TargetPath::windows(r"C:\automata\tools\tar\tar.exe").expect("tar"),
+            TargetPath::windows(r"C:\automata\tools\hash\automata-sha256.exe").expect("hash"),
+            Some(TargetPath::windows(r"C:\automata\externals\node12\node.exe").expect("node12")),
+            Some(TargetPath::windows(r"C:\automata\externals\node16\node.exe").expect("node16")),
+            Some(TargetPath::windows(r"C:\automata\externals\node20\node.exe").expect("node20")),
+            Some(TargetPath::windows(r"C:\automata\externals\node24\node.exe").expect("node24")),
+        )
+        .expect("complete Windows tool policy");
+        let kinds = policy
+            .shell_probes
+            .expect("tool probes")
+            .probes
+            .into_iter()
+            .map(|probe| probe.kind)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            kinds,
+            BTreeSet::from([
+                ShellKind::Pwsh,
+                ShellKind::WindowsPowerShell,
+                ShellKind::Cmd,
+                ShellKind::Tar,
+                ShellKind::Sha256sum,
+                ShellKind::Node12,
+                ShellKind::Node16,
+                ShellKind::Node20,
+                ShellKind::Node24,
+            ])
         );
     }
 

--- a/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
+++ b/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
@@ -542,7 +542,13 @@ pub fn probe_windows_enrollment_request(
     .map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
     let environment = request.environment();
     let environments = BTreeMap::from([(environment.attestation().clone(), environment.clone())]);
-    match admit_environment_profiles(provider, &environments, policy, cancellation) {
+    match admit_environment_profiles(
+        provider,
+        request.binding().runner_id(),
+        &environments,
+        policy,
+        cancellation,
+    ) {
         Ok(ProfileAdmissionOutcome::Admitted) => Ok(()),
         Ok(ProfileAdmissionOutcome::Cancelled) => Err(WindowsEnrollmentAdmissionError::Unavailable),
         Err(_) => Err(WindowsEnrollmentAdmissionError::ProbeFailed),

--- a/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
+++ b/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
@@ -1,0 +1,1558 @@
+use std::{
+    collections::BTreeMap,
+    fmt,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use automata_ci_core::{
+    EnvironmentProfile, JobResourceAllocation, RunnerCapabilities, RunnerId, Sha256Digest,
+};
+use automata_ci_execution::{
+    NetworkPolicy, ResourceLimits, RootFilesystemPolicy, SandboxEnvironment,
+    SandboxPrivilegePolicy, SandboxProvider, TargetPath,
+};
+use automata_ci_sandbox_windows::WINDOWS_HYPERV_PROVIDER_ID;
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{
+    RunnerProductConfig,
+    config::promoted_windows_runtime_features,
+    profile_admission::{
+        ProfileAdmissionOutcome, ProfileAdmissionPolicy, WINDOWS_PROFILE_PROBE_SCHEMA_VERSION,
+        admit_environment_profiles, windows_profile_probe_contract_sha256,
+    },
+};
+
+const MAX_ID_BYTES: usize = 128;
+const MAX_SERVER_ORIGIN_BYTES: usize = 2_048;
+const MAX_RUNNER_NAME_BYTES: usize = 255;
+const MAX_RECEIPT_LIFETIME_SECONDS: u64 = 15 * 60;
+const WINDOWS_HOST_INPUT_KINDS: [WindowsHostInputKind; 9] = [
+    WindowsHostInputKind::Configuration,
+    WindowsHostInputKind::BackendExecutable,
+    WindowsHostInputKind::ImageManifest,
+    WindowsHostInputKind::ImageLock,
+    WindowsHostInputKind::Provenance,
+    WindowsHostInputKind::Sbom,
+    WindowsHostInputKind::PatchReport,
+    WindowsHostInputKind::Revocations,
+    WindowsHostInputKind::PromotionEnvelope,
+];
+
+/// Closed classes of host files independently attested by the Windows broker.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowsHostInputKind {
+    /// The exact runner product configuration document.
+    Configuration,
+    /// The exact restricted broker client/provider executable.
+    BackendExecutable,
+    /// The image manifest.
+    ImageManifest,
+    /// The image lock document.
+    ImageLock,
+    /// The provenance acceptance/reference record.
+    Provenance,
+    /// The SBOM acceptance/reference record.
+    Sbom,
+    /// The patch acceptance/reference record.
+    PatchReport,
+    /// The revocation record.
+    Revocations,
+    /// The externally signed promotion envelope.
+    PromotionEnvelope,
+}
+
+/// Exact host-file identity which broker admission must independently attest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WindowsHostInputDescriptor {
+    kind: WindowsHostInputKind,
+    absolute_path: PathBuf,
+    expected_sha256: Sha256Digest,
+}
+
+impl WindowsHostInputDescriptor {
+    /// Returns the closed semantic input class.
+    #[must_use]
+    pub const fn kind(&self) -> WindowsHostInputKind {
+        self.kind
+    }
+
+    /// Returns the exact local-drive-qualified host path.
+    #[must_use]
+    pub fn absolute_path(&self) -> &Path {
+        &self.absolute_path
+    }
+
+    /// Returns the content digest the broker must reproduce from a stable handle.
+    #[must_use]
+    pub const fn expected_sha256(&self) -> Sha256Digest {
+        self.expected_sha256
+    }
+}
+
+/// Exact one-time enrollment transaction authorized by active admission.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentIntent {
+    operation_id: Uuid,
+    server_origin: String,
+    runner_name: String,
+    enrollment_token_sha256: Sha256Digest,
+    csr_sha256: Sha256Digest,
+}
+
+impl WindowsEnrollmentIntent {
+    /// Creates a secret-free binding for one exact enrollment operation.
+    ///
+    /// The token and private key remain inside broker custody; only the
+    /// one-way token digest and public certificate-request digest cross this
+    /// boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a nil operation, unsafe server origin or runner name, or a zero
+    /// placeholder digest.
+    pub fn new(
+        operation_id: Uuid,
+        server_origin: &reqwest::Url,
+        runner_name: impl Into<String>,
+        enrollment_token_sha256: Sha256Digest,
+        csr_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsEnrollmentAdmissionError> {
+        let runner_name = runner_name.into();
+        let origin = server_origin.as_str();
+        let literal_loopback = server_origin.scheme() == "http"
+            && server_origin
+                .host_str()
+                .and_then(|host| host.parse::<IpAddr>().ok())
+                .is_some_and(|address| address.is_loopback());
+        if operation_id.is_nil()
+            || (server_origin.scheme() != "https" && !literal_loopback)
+            || server_origin.cannot_be_a_base()
+            || server_origin.host().is_none()
+            || server_origin.username() != ""
+            || server_origin.password().is_some()
+            || server_origin.query().is_some()
+            || server_origin.fragment().is_some()
+            || server_origin.path() != "/"
+            || origin.len() > MAX_SERVER_ORIGIN_BYTES
+            || runner_name.is_empty()
+            || runner_name.len() > MAX_RUNNER_NAME_BYTES
+            || runner_name.trim() != runner_name
+            || runner_name.chars().any(char::is_control)
+            || zero_digest(enrollment_token_sha256)
+            || zero_digest(csr_sha256)
+        {
+            return Err(WindowsEnrollmentAdmissionError::InvalidRequest);
+        }
+        Ok(Self {
+            operation_id,
+            server_origin: origin.to_owned(),
+            runner_name,
+            enrollment_token_sha256,
+            csr_sha256,
+        })
+    }
+
+    /// Returns the idempotent enrollment operation identity.
+    #[must_use]
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Returns the exact validated enrollment-server origin.
+    #[must_use]
+    pub fn server_origin(&self) -> &str {
+        &self.server_origin
+    }
+
+    /// Returns the exact registered runner display name.
+    #[must_use]
+    pub fn runner_name(&self) -> &str {
+        &self.runner_name
+    }
+
+    /// Returns the digest of the one-time enrollment token held by the broker.
+    #[must_use]
+    pub const fn enrollment_token_sha256(&self) -> Sha256Digest {
+        self.enrollment_token_sha256
+    }
+
+    /// Returns the digest of the broker-custodied key's certificate request.
+    #[must_use]
+    pub const fn csr_sha256(&self) -> Sha256Digest {
+        self.csr_sha256
+    }
+}
+
+/// Exact configuration and capability binding submitted to active admission.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentAdmissionBinding {
+    runner_id: RunnerId,
+    control_endpoint: String,
+    intent: WindowsEnrollmentIntent,
+    backend_id: String,
+    sandbox_provider_id: String,
+    backend_executable: PathBuf,
+    backend_executable_sha256: Sha256Digest,
+    backend_operation_timeout: Duration,
+    host_inputs: Vec<WindowsHostInputDescriptor>,
+    profile: EnvironmentProfile,
+    image: String,
+    environment: SandboxEnvironment,
+    probe_policy: WindowsEnrollmentProbePolicy,
+    manifest_sha256: Sha256Digest,
+    lock_sha256: Sha256Digest,
+    promotion_key_id: String,
+    promotion_payload_sha256: Sha256Digest,
+    promotion_public_key_sha256: Sha256Digest,
+    promotion_envelope_sha256: Sha256Digest,
+    capabilities: RunnerCapabilities,
+    capabilities_sha256: Sha256Digest,
+}
+
+impl WindowsEnrollmentAdmissionBinding {
+    /// Returns the durable runner identity being admitted.
+    #[must_use]
+    pub const fn runner_id(&self) -> RunnerId {
+        self.runner_id
+    }
+
+    /// Returns the exact control endpoint expected in the enrollment result.
+    #[must_use]
+    pub fn control_endpoint(&self) -> &str {
+        &self.control_endpoint
+    }
+
+    /// Returns the one-time enrollment transaction bound to this receipt.
+    #[must_use]
+    pub const fn intent(&self) -> &WindowsEnrollmentIntent {
+        &self.intent
+    }
+
+    /// Returns the lowercase SHA-256 identity of the exact broker host authority.
+    #[must_use]
+    pub fn backend_id(&self) -> &str {
+        &self.backend_id
+    }
+
+    /// Returns the fixed sandbox-provider identity used by active admission.
+    #[must_use]
+    pub fn sandbox_provider_id(&self) -> &str {
+        &self.sandbox_provider_id
+    }
+
+    /// Returns the exact broker client/provider executable admitted on the host.
+    #[must_use]
+    pub fn backend_executable(&self) -> &Path {
+        &self.backend_executable
+    }
+
+    /// Returns the expected digest of the broker client/provider executable.
+    #[must_use]
+    pub const fn backend_executable_sha256(&self) -> Sha256Digest {
+        self.backend_executable_sha256
+    }
+
+    /// Returns the exact deadline applied to each broker/provider operation.
+    #[must_use]
+    pub const fn backend_operation_timeout(&self) -> Duration {
+        self.backend_operation_timeout
+    }
+
+    /// Returns the fixed ordered host inputs requiring broker ACL/file-ID proof.
+    #[must_use]
+    pub fn host_inputs(&self) -> &[WindowsHostInputDescriptor] {
+        &self.host_inputs
+    }
+
+    /// Returns the exact content-attested environment profile.
+    #[must_use]
+    pub const fn profile(&self) -> &EnvironmentProfile {
+        &self.profile
+    }
+
+    /// Returns the immutable digest-qualified image reference.
+    #[must_use]
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    /// Returns the complete immutable launch material admitted by the receipt.
+    #[must_use]
+    pub const fn environment(&self) -> &SandboxEnvironment {
+        &self.environment
+    }
+
+    /// Returns the exact lifecycle and tool probes admitted by the receipt.
+    #[must_use]
+    pub const fn probe_policy(&self) -> &WindowsEnrollmentProbePolicy {
+        &self.probe_policy
+    }
+
+    /// Returns the exact image-manifest digest.
+    #[must_use]
+    pub const fn manifest_sha256(&self) -> Sha256Digest {
+        self.manifest_sha256
+    }
+
+    /// Returns the exact image-lock digest.
+    #[must_use]
+    pub const fn lock_sha256(&self) -> Sha256Digest {
+        self.lock_sha256
+    }
+
+    /// Returns the verified external promotion-authority key identifier.
+    #[must_use]
+    pub fn promotion_key_id(&self) -> &str {
+        &self.promotion_key_id
+    }
+
+    /// Returns the digest of the canonical signed promotion payload.
+    #[must_use]
+    pub const fn promotion_payload_sha256(&self) -> Sha256Digest {
+        self.promotion_payload_sha256
+    }
+
+    /// Returns the digest of the exact verified promotion public key.
+    #[must_use]
+    pub const fn promotion_public_key_sha256(&self) -> Sha256Digest {
+        self.promotion_public_key_sha256
+    }
+
+    /// Returns the digest of the complete verified promotion envelope.
+    #[must_use]
+    pub const fn promotion_envelope_sha256(&self) -> Sha256Digest {
+        self.promotion_envelope_sha256
+    }
+
+    /// Returns the exact post-admission registration inventory.
+    #[must_use]
+    pub const fn capabilities(&self) -> &RunnerCapabilities {
+        &self.capabilities
+    }
+
+    /// Returns the canonical serialized capability-set digest.
+    #[must_use]
+    pub const fn capabilities_sha256(&self) -> Sha256Digest {
+        self.capabilities_sha256
+    }
+}
+
+/// Exact provider-policy and toolchain inputs which active admission must probe.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentProbePolicy {
+    contract_schema_version: u16,
+    contract_sha256: Sha256Digest,
+    resources: ResourceLimits,
+    allocation: JobResourceAllocation,
+    network: NetworkPolicy,
+    root_filesystem: RootFilesystemPolicy,
+    privilege: SandboxPrivilegePolicy,
+    pwsh: TargetPath,
+    powershell: TargetPath,
+    cmd: TargetPath,
+    python: Option<TargetPath>,
+    tar: TargetPath,
+    sha256: TargetPath,
+    node12: Option<TargetPath>,
+    node16: Option<TargetPath>,
+    node20: Option<TargetPath>,
+    node24: Option<TargetPath>,
+}
+
+impl WindowsEnrollmentProbePolicy {
+    /// Returns the version of the shared lifecycle/tool probe contract.
+    #[must_use]
+    pub const fn contract_schema_version(&self) -> u16 {
+        self.contract_schema_version
+    }
+
+    /// Returns the digest of the exact shared probe semantics.
+    #[must_use]
+    pub const fn contract_sha256(&self) -> Sha256Digest {
+        self.contract_sha256
+    }
+
+    /// Returns the enforced per-sandbox CPU, memory, and process limits.
+    #[must_use]
+    pub const fn resources(&self) -> ResourceLimits {
+        self.resources
+    }
+
+    /// Returns the exact resource request and limit used by the admission sandbox.
+    #[must_use]
+    pub const fn allocation(&self) -> JobResourceAllocation {
+        self.allocation
+    }
+
+    /// Returns the required disabled-network policy.
+    #[must_use]
+    pub const fn network(&self) -> NetworkPolicy {
+        self.network
+    }
+
+    /// Returns the required disposable writable-root policy.
+    #[must_use]
+    pub const fn root_filesystem(&self) -> RootFilesystemPolicy {
+        self.root_filesystem
+    }
+
+    /// Returns the required non-administrator workload identity.
+    #[must_use]
+    pub const fn privilege(&self) -> SandboxPrivilegePolicy {
+        self.privilege
+    }
+
+    /// Returns the exact PowerShell Core executable to probe.
+    #[must_use]
+    pub const fn pwsh(&self) -> &TargetPath {
+        &self.pwsh
+    }
+
+    /// Returns the exact Windows PowerShell executable to probe.
+    #[must_use]
+    pub const fn powershell(&self) -> &TargetPath {
+        &self.powershell
+    }
+
+    /// Returns the exact Windows command interpreter to probe.
+    #[must_use]
+    pub const fn cmd(&self) -> &TargetPath {
+        &self.cmd
+    }
+
+    /// Returns the optional standalone Python executable to probe.
+    #[must_use]
+    pub const fn python(&self) -> Option<&TargetPath> {
+        self.python.as_ref()
+    }
+
+    /// Returns the exact archive executable to probe.
+    #[must_use]
+    pub const fn tar(&self) -> &TargetPath {
+        &self.tar
+    }
+
+    /// Returns the exact SHA-256 helper executable to probe.
+    #[must_use]
+    pub const fn sha256(&self) -> &TargetPath {
+        &self.sha256
+    }
+
+    /// Returns the optional exact Node 12 executable to probe.
+    #[must_use]
+    pub const fn node12(&self) -> Option<&TargetPath> {
+        self.node12.as_ref()
+    }
+
+    /// Returns the optional exact Node 16 executable to probe.
+    #[must_use]
+    pub const fn node16(&self) -> Option<&TargetPath> {
+        self.node16.as_ref()
+    }
+
+    /// Returns the optional exact Node 20 executable to probe.
+    #[must_use]
+    pub const fn node20(&self) -> Option<&TargetPath> {
+        self.node20.as_ref()
+    }
+
+    /// Returns the optional exact Node 24 executable to probe.
+    #[must_use]
+    pub const fn node24(&self) -> Option<&TargetPath> {
+        self.node24.as_ref()
+    }
+}
+
+/// Request passed to the trusted Windows active-admission and custody port.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentAdmissionRequest {
+    binding: WindowsEnrollmentAdmissionBinding,
+}
+
+impl WindowsEnrollmentAdmissionRequest {
+    /// Returns the exact receipt binding to prove and retain.
+    #[must_use]
+    pub const fn binding(&self) -> &WindowsEnrollmentAdmissionBinding {
+        &self.binding
+    }
+
+    /// Returns the immutable environment which must pass a fresh full lifecycle probe.
+    #[must_use]
+    pub const fn environment(&self) -> &SandboxEnvironment {
+        self.binding.environment()
+    }
+
+    /// Returns the exact lifecycle and tool probes required before enrollment.
+    #[must_use]
+    pub const fn probe_policy(&self) -> &WindowsEnrollmentProbePolicy {
+        self.binding.probe_policy()
+    }
+}
+
+/// Executes the shared, versioned lifecycle and tool probe for enrollment.
+///
+/// This is the only probe implementation accepted by the enrollment port. It
+/// uses the same create/inspect/attach/copy/exec/destroy admission path used at
+/// runner startup, including the exact shell scripts, argument vectors, version
+/// prefixes, Node-major checks, output bounds, cleanup, and absence proof.
+///
+/// # Errors
+///
+/// Fails closed if the request names another probe contract or provider, the
+/// probe is cancelled, or any lifecycle, tool, output, or cleanup evidence is
+/// invalid.
+pub fn probe_windows_enrollment_request(
+    request: &WindowsEnrollmentAdmissionRequest,
+    provider: &dyn SandboxProvider,
+    cancellation: &crate::podman_probe::ProbeCancellation,
+) -> Result<(), WindowsEnrollmentAdmissionError> {
+    let probe = request.probe_policy();
+    if probe.contract_schema_version != WINDOWS_PROFILE_PROBE_SCHEMA_VERSION
+        || probe.contract_sha256 != windows_profile_probe_contract_sha256()
+        || provider.provider_id().as_str() != request.binding.sandbox_provider_id
+    {
+        return Err(WindowsEnrollmentAdmissionError::InvalidRequest);
+    }
+    let policy = ProfileAdmissionPolicy::new(
+        probe.network,
+        probe.root_filesystem,
+        probe.privilege,
+        probe.resources,
+        probe.allocation,
+    )
+    .with_windows_hyperv_tools(
+        probe.pwsh.clone(),
+        probe.powershell.clone(),
+        probe.cmd.clone(),
+        probe.python.clone(),
+        probe.tar.clone(),
+        probe.sha256.clone(),
+        probe.node12.clone(),
+        probe.node16.clone(),
+        probe.node20.clone(),
+        probe.node24.clone(),
+    )
+    .map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let environment = request.environment();
+    let environments = BTreeMap::from([(environment.attestation().clone(), environment.clone())]);
+    match admit_environment_profiles(provider, &environments, policy, cancellation) {
+        Ok(ProfileAdmissionOutcome::Admitted) => Ok(()),
+        Ok(ProfileAdmissionOutcome::Cancelled) => Err(WindowsEnrollmentAdmissionError::Unavailable),
+        Err(_) => Err(WindowsEnrollmentAdmissionError::ProbeFailed),
+    }
+}
+
+/// Builds the active-admission request for a promoted Windows image.
+///
+/// A candidate or unverified image returns `None` and retains the shell-only
+/// durable inventory. A promoted image must produce and validate a receipt
+/// before its returned inventory may be sent during enrollment.
+///
+/// # Errors
+///
+/// Rejects missing promotion identity, an invalid broker-host digest, an
+/// ambiguous environment catalog, or an invalid derived capability set.
+pub fn windows_enrollment_admission_request(
+    config: &RunnerProductConfig,
+    backend_id: &str,
+    intent: WindowsEnrollmentIntent,
+) -> Result<Option<WindowsEnrollmentAdmissionRequest>, WindowsEnrollmentAdmissionError> {
+    let Some(windows) = config.windows_hyperv() else {
+        return Ok(None);
+    };
+    if !windows.image_admission().permits_actions() {
+        return Ok(None);
+    }
+    if !valid_backend_id(backend_id) || config.executor().network() != NetworkPolicy::Disabled {
+        return Err(WindowsEnrollmentAdmissionError::InvalidRequest);
+    }
+    let (profile, environment) = config
+        .environments()
+        .first_key_value()
+        .filter(|_| config.environments().len() == 1)
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let image = environment
+        .image()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let promotion = windows
+        .image_contract()
+        .promotion()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let promotion_payload_sha256 = windows
+        .promotion_payload_sha256()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let promotion_public_key_sha256 = windows
+        .promotion_public_key_sha256()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let promotion_envelope_sha256 = windows
+        .promotion_envelope_sha256()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let capabilities = config
+        .inventory()
+        .clone()
+        .with_features(promoted_windows_runtime_features(
+            config.executor().toolchain(),
+        ));
+    capabilities
+        .validate()
+        .map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let capabilities_sha256 = canonical_digest(&capabilities)?;
+    let capacity = config.executor().resource_capacity();
+    let allocation = JobResourceAllocation::new(capacity, capacity)
+        .map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let host_inputs = windows_host_inputs(config)?;
+    Ok(Some(WindowsEnrollmentAdmissionRequest {
+        binding: WindowsEnrollmentAdmissionBinding {
+            runner_id: config.runner_id(),
+            control_endpoint: config.control_endpoint().to_string(),
+            intent,
+            backend_id: backend_id.to_owned(),
+            sandbox_provider_id: WINDOWS_HYPERV_PROVIDER_ID.to_owned(),
+            backend_executable: windows.runtime_executable().to_owned(),
+            backend_executable_sha256: windows.runtime_sha256(),
+            backend_operation_timeout: windows.operation_timeout(),
+            host_inputs,
+            profile: profile.clone(),
+            image: image.reference().to_owned(),
+            environment: environment.clone(),
+            probe_policy: windows_enrollment_probe_policy(config, allocation)?,
+            manifest_sha256: windows.image_contract().manifest_sha256(),
+            lock_sha256: windows.image_contract().lock_sha256(),
+            promotion_key_id: promotion.key_id().to_owned(),
+            promotion_payload_sha256,
+            promotion_public_key_sha256,
+            promotion_envelope_sha256,
+            capabilities,
+            capabilities_sha256,
+        },
+    }))
+}
+
+fn windows_host_inputs(
+    config: &RunnerProductConfig,
+) -> Result<Vec<WindowsHostInputDescriptor>, WindowsEnrollmentAdmissionError> {
+    let windows = config
+        .windows_hyperv()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let contract = windows.image_contract();
+    let promotion = contract
+        .promotion()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let [provenance, sbom, patch_report, revocations] = windows
+        .evidence_digests()
+        .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    let inputs = vec![
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::Configuration,
+            absolute_path: config
+                .configuration_path()
+                .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+                .to_owned(),
+            expected_sha256: config
+                .configuration_sha256()
+                .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?,
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::BackendExecutable,
+            absolute_path: windows.runtime_executable().to_owned(),
+            expected_sha256: windows.runtime_sha256(),
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::ImageManifest,
+            absolute_path: contract.manifest_path().to_owned(),
+            expected_sha256: contract.manifest_sha256(),
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::ImageLock,
+            absolute_path: contract.lock_path().to_owned(),
+            expected_sha256: contract.lock_sha256(),
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::Provenance,
+            absolute_path: contract.provenance_path().to_owned(),
+            expected_sha256: provenance,
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::Sbom,
+            absolute_path: contract.sbom_path().to_owned(),
+            expected_sha256: sbom,
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::PatchReport,
+            absolute_path: contract.patch_report_path().to_owned(),
+            expected_sha256: patch_report,
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::Revocations,
+            absolute_path: contract.revocations_path().to_owned(),
+            expected_sha256: revocations,
+        },
+        WindowsHostInputDescriptor {
+            kind: WindowsHostInputKind::PromotionEnvelope,
+            absolute_path: promotion.envelope_path().to_owned(),
+            expected_sha256: windows
+                .promotion_envelope_sha256()
+                .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?,
+        },
+    ];
+    if !valid_host_inputs(&inputs) {
+        return Err(WindowsEnrollmentAdmissionError::InvalidRequest);
+    }
+    Ok(inputs)
+}
+
+fn valid_host_inputs(inputs: &[WindowsHostInputDescriptor]) -> bool {
+    let unique_paths = inputs
+        .iter()
+        .map(|input| input.absolute_path.as_os_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    unique_paths.len() == inputs.len()
+        && inputs.len() == WINDOWS_HOST_INPUT_KINDS.len()
+        && inputs
+            .iter()
+            .zip(WINDOWS_HOST_INPUT_KINDS)
+            .all(|(input, kind)| input.kind == kind)
+        && !inputs.iter().any(|input| {
+            super::files::validate_absolute_path(&input.absolute_path).is_err()
+                || zero_digest(input.expected_sha256)
+        })
+}
+
+fn windows_enrollment_probe_policy(
+    config: &RunnerProductConfig,
+    allocation: JobResourceAllocation,
+) -> Result<WindowsEnrollmentProbePolicy, WindowsEnrollmentAdmissionError> {
+    let toolchain = config.executor().toolchain();
+    Ok(WindowsEnrollmentProbePolicy {
+        contract_schema_version: WINDOWS_PROFILE_PROBE_SCHEMA_VERSION,
+        contract_sha256: windows_profile_probe_contract_sha256(),
+        resources: config.executor().resources(),
+        allocation,
+        network: config.executor().network(),
+        root_filesystem: config.executor().root_filesystem(),
+        privilege: config.executor().privilege(),
+        pwsh: toolchain
+            .pwsh()
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+            .clone(),
+        powershell: toolchain
+            .powershell()
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+            .clone(),
+        cmd: toolchain
+            .cmd()
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+            .clone(),
+        python: toolchain.python().cloned(),
+        tar: toolchain
+            .tar()
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+            .clone(),
+        sha256: toolchain
+            .sha256sum()
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?
+            .clone(),
+        node12: toolchain.node12().cloned(),
+        node16: toolchain.node16().cloned(),
+        node20: toolchain.node20().cloned(),
+        node24: toolchain.node24().cloned(),
+    })
+}
+
+/// Opaque broker-custody handle retained across an interrupted enrollment.
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct WindowsEnrollmentAdmissionHandle(String);
+
+impl WindowsEnrollmentAdmissionHandle {
+    /// Creates a bounded opaque handle returned by the trusted custody port.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, non-ASCII, or control-bearing values.
+    pub fn new(value: impl Into<String>) -> Result<Self, WindowsEnrollmentAdmissionError> {
+        let value = value.into();
+        if !valid_id(&value) {
+            return Err(WindowsEnrollmentAdmissionError::InvalidReceipt);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the opaque handle for a broker resume or completion call.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for WindowsEnrollmentAdmissionHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WindowsEnrollmentAdmissionHandle")
+            .field("value", &"[OPAQUE]")
+            .finish()
+    }
+}
+
+/// Digests of the independently authenticated evidence consumed by admission.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentAdmissionEvidence {
+    broker_attestation: Sha256Digest,
+    host_input_attestation: Sha256Digest,
+    image_attestation: Sha256Digest,
+    network_attestation: Sha256Digest,
+    authority_receipt: Sha256Digest,
+}
+
+impl WindowsEnrollmentAdmissionEvidence {
+    /// Creates the five exact authenticated evidence digests.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero placeholder digest.
+    pub fn new(
+        broker_attestation_sha256: Sha256Digest,
+        host_input_attestation_sha256: Sha256Digest,
+        image_attestation_sha256: Sha256Digest,
+        network_attestation_sha256: Sha256Digest,
+        authority_receipt_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsEnrollmentAdmissionError> {
+        let digests = [
+            broker_attestation_sha256,
+            host_input_attestation_sha256,
+            image_attestation_sha256,
+            network_attestation_sha256,
+            authority_receipt_sha256,
+        ];
+        if digests.iter().copied().any(zero_digest) {
+            return Err(WindowsEnrollmentAdmissionError::InvalidReceipt);
+        }
+        Ok(Self {
+            broker_attestation: broker_attestation_sha256,
+            host_input_attestation: host_input_attestation_sha256,
+            image_attestation: image_attestation_sha256,
+            network_attestation: network_attestation_sha256,
+            authority_receipt: authority_receipt_sha256,
+        })
+    }
+
+    /// Returns the broker host/profile attestation digest.
+    #[must_use]
+    pub const fn broker_attestation_sha256(self) -> Sha256Digest {
+        self.broker_attestation
+    }
+
+    /// Returns the broker's ordered ACL/file-ID/volume input attestation digest.
+    #[must_use]
+    pub const fn host_input_attestation_sha256(self) -> Sha256Digest {
+        self.host_input_attestation
+    }
+
+    /// Returns the image/tool-probe attestation digest.
+    #[must_use]
+    pub const fn image_attestation_sha256(self) -> Sha256Digest {
+        self.image_attestation
+    }
+
+    /// Returns the disabled-network attestation digest.
+    #[must_use]
+    pub const fn network_attestation_sha256(self) -> Sha256Digest {
+        self.network_attestation
+    }
+
+    /// Returns the authenticated durable receipt digest.
+    #[must_use]
+    pub const fn authority_receipt_sha256(self) -> Sha256Digest {
+        self.authority_receipt
+    }
+}
+
+/// Unvalidated receipt returned from the trusted active-admission port.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsEnrollmentAdmissionReceipt {
+    handle: WindowsEnrollmentAdmissionHandle,
+    binding: WindowsEnrollmentAdmissionBinding,
+    evidence: WindowsEnrollmentAdmissionEvidence,
+    issued_at_unix_seconds: u64,
+    expires_at_unix_seconds: u64,
+}
+
+impl WindowsEnrollmentAdmissionReceipt {
+    /// Creates a receipt returned by an authenticated broker custody adapter.
+    #[must_use]
+    pub const fn new(
+        handle: WindowsEnrollmentAdmissionHandle,
+        binding: WindowsEnrollmentAdmissionBinding,
+        evidence: WindowsEnrollmentAdmissionEvidence,
+        issued_at_unix_seconds: u64,
+        expires_at_unix_seconds: u64,
+    ) -> Self {
+        Self {
+            handle,
+            binding,
+            evidence,
+            issued_at_unix_seconds,
+            expires_at_unix_seconds,
+        }
+    }
+
+    /// Returns the opaque broker-custody handle retained by this receipt.
+    #[must_use]
+    pub const fn handle(&self) -> &WindowsEnrollmentAdmissionHandle {
+        &self.handle
+    }
+
+    /// Returns the complete admission binding authenticated by the authority.
+    #[must_use]
+    pub const fn binding(&self) -> &WindowsEnrollmentAdmissionBinding {
+        &self.binding
+    }
+
+    /// Returns every authenticated evidence digest named by the receipt.
+    #[must_use]
+    pub const fn evidence(&self) -> WindowsEnrollmentAdmissionEvidence {
+        self.evidence
+    }
+
+    /// Returns the authority-controlled receipt issue time.
+    #[must_use]
+    pub const fn issued_at_unix_seconds(&self) -> u64 {
+        self.issued_at_unix_seconds
+    }
+
+    /// Returns the authority-controlled receipt expiry time.
+    #[must_use]
+    pub const fn expires_at_unix_seconds(&self) -> u64 {
+        self.expires_at_unix_seconds
+    }
+
+    /// Validates current bindings and freshness, then exposes enrollment authority.
+    ///
+    /// # Errors
+    ///
+    /// Rejects mismatched, malformed, future-issued, expired, or overlong receipts.
+    pub fn validate(
+        self,
+        request: &WindowsEnrollmentAdmissionRequest,
+        now_unix_seconds: u64,
+    ) -> Result<ValidatedWindowsEnrollmentAdmission, WindowsEnrollmentAdmissionError> {
+        if self.binding != request.binding
+            || canonical_digest(&self.binding.capabilities)? != self.binding.capabilities_sha256
+            || self.binding.capabilities.validate().is_err()
+            || !valid_host_inputs(&self.binding.host_inputs)
+        {
+            return Err(WindowsEnrollmentAdmissionError::Mismatch);
+        }
+        if self.issued_at_unix_seconds > now_unix_seconds {
+            return Err(WindowsEnrollmentAdmissionError::Clock);
+        }
+        let lifetime = self
+            .expires_at_unix_seconds
+            .checked_sub(self.issued_at_unix_seconds)
+            .filter(|lifetime| *lifetime > 0 && *lifetime <= MAX_RECEIPT_LIFETIME_SECONDS)
+            .ok_or(WindowsEnrollmentAdmissionError::InvalidReceipt)?;
+        debug_assert!(lifetime > 0);
+        if now_unix_seconds >= self.expires_at_unix_seconds {
+            return Err(WindowsEnrollmentAdmissionError::Expired);
+        }
+        Ok(ValidatedWindowsEnrollmentAdmission { receipt: self })
+    }
+}
+
+/// Receipt whose exact binding and freshness have been validated for enrollment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidatedWindowsEnrollmentAdmission {
+    receipt: WindowsEnrollmentAdmissionReceipt,
+}
+
+impl ValidatedWindowsEnrollmentAdmission {
+    /// Rechecks freshness and returns the post-admission registration inventory.
+    ///
+    /// Call this immediately before every enrollment send or retry; retaining
+    /// this value never extends the authority's expiry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a clock earlier than issuance or a receipt at or after expiry.
+    pub fn capabilities_at(
+        &self,
+        now_unix_seconds: u64,
+    ) -> Result<&RunnerCapabilities, WindowsEnrollmentAdmissionError> {
+        if now_unix_seconds < self.receipt.issued_at_unix_seconds {
+            return Err(WindowsEnrollmentAdmissionError::Clock);
+        }
+        if now_unix_seconds >= self.receipt.expires_at_unix_seconds {
+            return Err(WindowsEnrollmentAdmissionError::Expired);
+        }
+        Ok(&self.receipt.binding.capabilities)
+    }
+
+    /// Returns the broker custody handle which must be bound to a staged retry.
+    #[must_use]
+    pub const fn handle(&self) -> &WindowsEnrollmentAdmissionHandle {
+        &self.receipt.handle
+    }
+
+    /// Returns the authenticated durable receipt digest for exact retry binding.
+    #[must_use]
+    pub const fn receipt_sha256(&self) -> Sha256Digest {
+        self.receipt.evidence.authority_receipt
+    }
+
+    /// Returns the receipt expiry checked at each use.
+    #[must_use]
+    pub const fn expires_at_unix_seconds(&self) -> u64 {
+        self.receipt.expires_at_unix_seconds
+    }
+
+    /// Returns every independently authenticated evidence digest.
+    #[must_use]
+    pub const fn evidence(&self) -> WindowsEnrollmentAdmissionEvidence {
+        self.receipt.evidence
+    }
+}
+
+/// Trusted active-probe and opaque-custody boundary implemented by the broker lane.
+pub trait WindowsEnrollmentAdmissionPort: Send + Sync {
+    /// Runs fresh broker/image/network admission and durably retains its receipt.
+    /// Implementations must invoke [`probe_windows_enrollment_request`] with the
+    /// exact provider named by the request before minting authority.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed when the authenticated broker or its custody boundary is
+    /// unavailable, or when any required admission evidence cannot be proved.
+    fn issue(
+        &self,
+        request: &WindowsEnrollmentAdmissionRequest,
+    ) -> Result<WindowsEnrollmentAdmissionReceipt, WindowsEnrollmentAdmissionError>;
+
+    /// Reloads and reauthenticates the exact receipt named by a staged handle.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed when custody is absent or the retained receipt does not
+    /// authenticate the current request exactly.
+    fn resume(
+        &self,
+        handle: &WindowsEnrollmentAdmissionHandle,
+        request: &WindowsEnrollmentAdmissionRequest,
+    ) -> Result<WindowsEnrollmentAdmissionReceipt, WindowsEnrollmentAdmissionError>;
+
+    /// Completes broker custody only after enrollment credentials are durable.
+    /// The broker must bind both values, prohibit handle reuse, and retain a
+    /// tombstone so repeating the exact completion after a crash succeeds.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed when the handle/digest pair differs or broker cleanup is
+    /// not durable. An exact already-completed pair returns success.
+    fn complete(
+        &self,
+        handle: &WindowsEnrollmentAdmissionHandle,
+        receipt_sha256: Sha256Digest,
+    ) -> Result<(), WindowsEnrollmentAdmissionError>;
+}
+
+/// Reads a trustworthy wall clock for receipt validation.
+///
+/// # Errors
+///
+/// Fails closed if the clock is before the Unix epoch or does not fit `u64`.
+pub fn current_unix_seconds() -> Result<u64, WindowsEnrollmentAdmissionError> {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| WindowsEnrollmentAdmissionError::Clock)
+}
+
+/// Sanitized pre-enrollment Windows admission failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsEnrollmentAdmissionError {
+    /// The requested configuration or backend identity is invalid.
+    #[error("Windows enrollment admission request is invalid")]
+    InvalidRequest,
+    /// The trusted broker/custody boundary is unavailable.
+    #[error("Windows enrollment admission is unavailable")]
+    Unavailable,
+    /// The active lifecycle or exact tool probe did not prove the contract.
+    #[error("Windows enrollment admission probe failed")]
+    ProbeFailed,
+    /// A returned or resumed receipt violates the closed contract.
+    #[error("Windows enrollment admission receipt is invalid")]
+    InvalidReceipt,
+    /// The receipt does not match the current runner/profile/image/capabilities.
+    #[error("Windows enrollment admission receipt does not match")]
+    Mismatch,
+    /// The receipt expired before it could authorize enrollment.
+    #[error("Windows enrollment admission receipt expired")]
+    Expired,
+    /// The wall clock could not safely validate receipt time.
+    #[error("Windows enrollment admission clock is invalid")]
+    Clock,
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_ID_BYTES
+        && value.is_ascii()
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn valid_backend_id(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn zero_digest(digest: Sha256Digest) -> bool {
+    digest.as_bytes().iter().all(|byte| *byte == 0)
+}
+
+fn canonical_digest<T: Serialize>(
+    value: &T,
+) -> Result<Sha256Digest, WindowsEnrollmentAdmissionError> {
+    let bytes =
+        serde_json::to_vec(value).map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    Ok(Sha256Digest::from_bytes(Sha256::digest(bytes).into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use automata_ci_core::{
+        Architecture, EnvironmentProfileId, OperatingSystem, RunnerFeature, RunnerPlatform,
+    };
+
+    use super::*;
+
+    const NOW: u64 = 1_800_000_000;
+
+    fn test_host_inputs() -> Vec<WindowsHostInputDescriptor> {
+        WINDOWS_HOST_INPUT_KINDS
+            .into_iter()
+            .enumerate()
+            .map(|(index, kind)| WindowsHostInputDescriptor {
+                kind,
+                absolute_path: PathBuf::from(format!(r"C:\trusted\input-{index}.bin")),
+                expected_sha256: Sha256Digest::from_bytes(
+                    [u8::try_from(index).expect("bounded input index") + 20; 32],
+                ),
+            })
+            .collect()
+    }
+
+    fn test_probe_policy(resources: ResourceLimits) -> WindowsEnrollmentProbePolicy {
+        let capacity = automata_ci_core::ResourceCapacity::new(
+            resources.cpu_millis(),
+            resources.memory_bytes(),
+            0,
+            0,
+        );
+        WindowsEnrollmentProbePolicy {
+            contract_schema_version: WINDOWS_PROFILE_PROBE_SCHEMA_VERSION,
+            contract_sha256: windows_profile_probe_contract_sha256(),
+            resources,
+            allocation: JobResourceAllocation::new(capacity, capacity)
+                .expect("resource allocation"),
+            network: NetworkPolicy::Disabled,
+            root_filesystem: RootFilesystemPolicy::Writable,
+            privilege: SandboxPrivilegePolicy::Unprivileged,
+            pwsh: automata_ci_execution::TargetPath::windows(
+                r"C:\Program Files\PowerShell\7\pwsh.exe",
+            )
+            .expect("pwsh"),
+            powershell: automata_ci_execution::TargetPath::windows(
+                r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            )
+            .expect("PowerShell"),
+            cmd: automata_ci_execution::TargetPath::windows(r"C:\Windows\System32\cmd.exe")
+                .expect("cmd"),
+            python: None,
+            tar: automata_ci_execution::TargetPath::windows(r"C:\Windows\System32\tar.exe")
+                .expect("tar"),
+            sha256: automata_ci_execution::TargetPath::windows(
+                r"C:\automata\bin\automata-sha256.exe",
+            )
+            .expect("hash"),
+            node12: None,
+            node16: None,
+            node20: None,
+            node24: Some(
+                automata_ci_execution::TargetPath::windows(
+                    r"C:\automata\externals\node24\node.exe",
+                )
+                .expect("Node 24"),
+            ),
+        }
+    }
+
+    fn request(
+        features: impl IntoIterator<Item = RunnerFeature>,
+    ) -> WindowsEnrollmentAdmissionRequest {
+        let runner_id = RunnerId::new();
+        let profile = EnvironmentProfile::new(
+            EnvironmentProfileId::new("automata.test/windows-2025").expect("profile id"),
+            Sha256Digest::from_bytes([2; 32]),
+        );
+        let capabilities = RunnerCapabilities::new(
+            runner_id,
+            RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+        )
+        .with_features(features)
+        .with_environment_profiles([profile.clone()]);
+        let capabilities_sha256 = canonical_digest(&capabilities).expect("capability digest");
+        let environment = SandboxEnvironment::windows_hyperv_container(
+            profile.clone(),
+            automata_ci_execution::ImmutableImage::new(format!(
+                "registry.example/image@sha256:{}",
+                "1".repeat(64)
+            ))
+            .expect("immutable image"),
+            automata_ci_execution::ExecutionArgv::new(
+                automata_ci_execution::TargetPath::windows(r"C:\guest\agent.exe").expect("guest"),
+                vec!["keepalive".to_owned()],
+            )
+            .expect("keepalive"),
+            automata_ci_execution::TargetPath::windows(r"C:\__w").expect("workspace"),
+            automata_ci_execution::ExecutionEnvironment::empty(),
+        )
+        .expect("environment");
+        let resources =
+            ResourceLimits::new(4 * 1_024 * 1_024 * 1_024, 2_000, 256).expect("resource limits");
+        WindowsEnrollmentAdmissionRequest {
+            binding: WindowsEnrollmentAdmissionBinding {
+                runner_id,
+                control_endpoint: "https://control.example.test/".to_owned(),
+                intent: WindowsEnrollmentIntent::new(
+                    Uuid::from_u128(1),
+                    &reqwest::Url::parse("https://enroll.example.test/")
+                        .expect("enrollment origin"),
+                    "windows-runner",
+                    Sha256Digest::from_bytes([10; 32]),
+                    Sha256Digest::from_bytes([11; 32]),
+                )
+                .expect("enrollment intent"),
+                backend_id: "a".repeat(64),
+                sandbox_provider_id: WINDOWS_HYPERV_PROVIDER_ID.to_owned(),
+                backend_executable: PathBuf::from(r"C:\automata\broker-client.exe"),
+                backend_executable_sha256: Sha256Digest::from_bytes([12; 32]),
+                backend_operation_timeout: Duration::from_mins(2),
+                host_inputs: test_host_inputs(),
+                profile,
+                image: format!("registry.example/image@sha256:{}", "1".repeat(64)),
+                environment,
+                probe_policy: test_probe_policy(resources),
+                manifest_sha256: Sha256Digest::from_bytes([3; 32]),
+                lock_sha256: Sha256Digest::from_bytes([4; 32]),
+                promotion_key_id: "promotion.test/v1".to_owned(),
+                promotion_payload_sha256: Sha256Digest::from_bytes([5; 32]),
+                promotion_public_key_sha256: Sha256Digest::from_bytes([13; 32]),
+                promotion_envelope_sha256: Sha256Digest::from_bytes([14; 32]),
+                capabilities,
+                capabilities_sha256,
+            },
+        }
+    }
+
+    fn receipt(request: &WindowsEnrollmentAdmissionRequest) -> WindowsEnrollmentAdmissionReceipt {
+        WindowsEnrollmentAdmissionReceipt::new(
+            WindowsEnrollmentAdmissionHandle::new("receipt-1").expect("handle"),
+            request.binding.clone(),
+            WindowsEnrollmentAdmissionEvidence::new(
+                Sha256Digest::from_bytes([6; 32]),
+                Sha256Digest::from_bytes([7; 32]),
+                Sha256Digest::from_bytes([8; 32]),
+                Sha256Digest::from_bytes([9; 32]),
+                Sha256Digest::from_bytes([10; 32]),
+            )
+            .expect("evidence"),
+            NOW,
+            NOW + 300,
+        )
+    }
+
+    #[derive(Debug)]
+    struct RestartingPort {
+        state: Mutex<RestartingPortState>,
+    }
+
+    #[derive(Debug, Default)]
+    struct RestartingPortState {
+        retained: Option<WindowsEnrollmentAdmissionReceipt>,
+        completed: Option<(WindowsEnrollmentAdmissionHandle, Sha256Digest)>,
+    }
+
+    impl WindowsEnrollmentAdmissionPort for RestartingPort {
+        fn issue(
+            &self,
+            request: &WindowsEnrollmentAdmissionRequest,
+        ) -> Result<WindowsEnrollmentAdmissionReceipt, WindowsEnrollmentAdmissionError> {
+            let receipt = receipt(request);
+            let mut state = self.state.lock().expect("receipt lock");
+            if state.retained.is_some() || state.completed.is_some() {
+                return Err(WindowsEnrollmentAdmissionError::Mismatch);
+            }
+            state.retained = Some(receipt.clone());
+            Ok(receipt)
+        }
+
+        fn resume(
+            &self,
+            handle: &WindowsEnrollmentAdmissionHandle,
+            _request: &WindowsEnrollmentAdmissionRequest,
+        ) -> Result<WindowsEnrollmentAdmissionReceipt, WindowsEnrollmentAdmissionError> {
+            self.state
+                .lock()
+                .expect("receipt lock")
+                .retained
+                .clone()
+                .filter(|receipt| receipt.handle == *handle)
+                .ok_or(WindowsEnrollmentAdmissionError::Unavailable)
+        }
+
+        fn complete(
+            &self,
+            handle: &WindowsEnrollmentAdmissionHandle,
+            receipt_sha256: Sha256Digest,
+        ) -> Result<(), WindowsEnrollmentAdmissionError> {
+            let mut state = self.state.lock().expect("receipt lock");
+            if state.completed.as_ref() == Some(&(handle.clone(), receipt_sha256)) {
+                return Ok(());
+            }
+            let Some(retained) = state.retained.as_ref() else {
+                return Err(WindowsEnrollmentAdmissionError::Unavailable);
+            };
+            if retained.handle != *handle || retained.evidence.authority_receipt != receipt_sha256 {
+                return Err(WindowsEnrollmentAdmissionError::Mismatch);
+            }
+            let completed = (handle.clone(), receipt_sha256);
+            if state
+                .completed
+                .as_ref()
+                .is_some_and(|prior| prior != &completed)
+            {
+                return Err(WindowsEnrollmentAdmissionError::Unavailable);
+            }
+            state.retained = None;
+            state.completed = Some(completed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn restart_reauthenticates_the_same_broker_custody_receipt() {
+        let request = request([
+            RunnerFeature::SHELL_STEPS,
+            RunnerFeature::JAVASCRIPT_ACTIONS,
+            RunnerFeature::NODE24_ACTIONS,
+        ]);
+        let port = RestartingPort {
+            state: Mutex::new(RestartingPortState::default()),
+        };
+        let issued = port
+            .issue(&request)
+            .expect("issue")
+            .validate(&request, NOW)
+            .expect("validate issued receipt");
+        let resumed = port
+            .resume(issued.handle(), &request)
+            .expect("resume")
+            .validate(&request, NOW + 1)
+            .expect("validate resumed receipt");
+
+        assert_eq!(issued.receipt_sha256(), resumed.receipt_sha256());
+        assert_eq!(
+            issued.capabilities_at(NOW).expect("issued authority"),
+            resumed.capabilities_at(NOW + 1).expect("resumed authority")
+        );
+        assert_eq!(
+            resumed.capabilities_at(NOW + 300),
+            Err(WindowsEnrollmentAdmissionError::Expired),
+            "a previously validated value cannot outlive its receipt"
+        );
+        assert_eq!(
+            port.complete(resumed.handle(), Sha256Digest::from_bytes([99; 32]),),
+            Err(WindowsEnrollmentAdmissionError::Mismatch)
+        );
+        port.complete(resumed.handle(), resumed.receipt_sha256())
+            .expect("complete custody");
+        port.complete(resumed.handle(), resumed.receipt_sha256())
+            .expect("exact completion is idempotent after a crash");
+        assert_eq!(
+            port.resume(resumed.handle(), &request),
+            Err(WindowsEnrollmentAdmissionError::Unavailable)
+        );
+    }
+
+    #[test]
+    fn tamper_capability_superset_and_binding_substitution_fail_closed() {
+        let request = request([RunnerFeature::SHELL_STEPS]);
+        let mut tampered = receipt(&request);
+        tampered.binding.image = format!("registry.example/other@sha256:{}", "a".repeat(64));
+        assert_eq!(
+            tampered.validate(&request, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch)
+        );
+
+        let mut superset = receipt(&request);
+        superset.binding.capabilities = superset.binding.capabilities.clone().with_features([
+            RunnerFeature::SHELL_STEPS,
+            RunnerFeature::JAVASCRIPT_ACTIONS,
+        ]);
+        superset.binding.capabilities_sha256 =
+            canonical_digest(&superset.binding.capabilities).expect("superset digest");
+        assert_eq!(
+            superset.validate(&request, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch)
+        );
+
+        let mut changed_probe = request.clone();
+        changed_probe.binding.probe_policy.node24 = Some(
+            automata_ci_execution::TargetPath::windows(r"C:\substituted\node.exe")
+                .expect("substituted Node"),
+        );
+        assert_eq!(
+            receipt(&request).validate(&changed_probe, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "a custody receipt must not cross an exact tool-probe policy change"
+        );
+
+        let mut changed_probe_contract = request.clone();
+        changed_probe_contract.binding.probe_policy.contract_sha256 =
+            Sha256Digest::from_bytes([76; 32]);
+        assert_eq!(
+            receipt(&request).validate(&changed_probe_contract, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "a probe-semantic change invalidates retained custody"
+        );
+
+        let mut changed_backend = request.clone();
+        changed_backend.binding.backend_executable_sha256 = Sha256Digest::from_bytes([88; 32]);
+        assert_eq!(
+            receipt(&request).validate(&changed_backend, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "backend executable substitution invalidates retained custody"
+        );
+
+        let mut changed_provider = request.clone();
+        changed_provider.binding.sandbox_provider_id = "substituted-provider".to_owned();
+        assert_eq!(
+            receipt(&request).validate(&changed_provider, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "sandbox-provider substitution invalidates retained custody"
+        );
+
+        let mut changed_authority = request.clone();
+        changed_authority.binding.promotion_public_key_sha256 = Sha256Digest::from_bytes([77; 32]);
+        assert_eq!(
+            receipt(&request).validate(&changed_authority, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "promotion trust-anchor rotation invalidates retained custody"
+        );
+
+        let mut changed_transaction = request.clone();
+        changed_transaction.binding.intent.operation_id = Uuid::from_u128(2);
+        assert_eq!(
+            receipt(&request).validate(&changed_transaction, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch),
+            "one receipt cannot authorize a second enrollment operation"
+        );
+    }
+
+    #[test]
+    fn enrollment_intent_rejects_unsafe_origins_names_and_placeholder_digests() {
+        let valid_origin = reqwest::Url::parse("https://enroll.example.test/").expect("origin");
+        assert!(
+            WindowsEnrollmentIntent::new(
+                Uuid::nil(),
+                &valid_origin,
+                "runner",
+                Sha256Digest::from_bytes([1; 32]),
+                Sha256Digest::from_bytes([2; 32]),
+            )
+            .is_err()
+        );
+        for origin in [
+            "http://enroll.example.test/",
+            "https://user@enroll.example.test/",
+            "https://enroll.example.test/path",
+        ] {
+            assert!(
+                WindowsEnrollmentIntent::new(
+                    Uuid::from_u128(1),
+                    &reqwest::Url::parse(origin).expect("test URL"),
+                    "runner",
+                    Sha256Digest::from_bytes([1; 32]),
+                    Sha256Digest::from_bytes([2; 32]),
+                )
+                .is_err(),
+                "unexpectedly accepted {origin}"
+            );
+        }
+        assert!(
+            WindowsEnrollmentIntent::new(
+                Uuid::from_u128(1),
+                &valid_origin,
+                " runner ",
+                Sha256Digest::from_bytes([1; 32]),
+                Sha256Digest::from_bytes([2; 32]),
+            )
+            .is_err()
+        );
+        assert!(
+            WindowsEnrollmentIntent::new(
+                Uuid::from_u128(1),
+                &valid_origin,
+                "runner",
+                Sha256Digest::from_bytes([0; 32]),
+                Sha256Digest::from_bytes([2; 32]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn future_expired_zero_and_overlong_lifetimes_fail_closed() {
+        let request = request([RunnerFeature::SHELL_STEPS]);
+        for (issued, expires, now, expected) in [
+            (
+                NOW + 1,
+                NOW + 10,
+                NOW,
+                WindowsEnrollmentAdmissionError::Clock,
+            ),
+            (
+                NOW,
+                NOW,
+                NOW,
+                WindowsEnrollmentAdmissionError::InvalidReceipt,
+            ),
+            (
+                NOW,
+                NOW + 1,
+                NOW + 1,
+                WindowsEnrollmentAdmissionError::Expired,
+            ),
+            (
+                NOW,
+                NOW + MAX_RECEIPT_LIFETIME_SECONDS + 1,
+                NOW,
+                WindowsEnrollmentAdmissionError::InvalidReceipt,
+            ),
+        ] {
+            let mut receipt = receipt(&request);
+            receipt.issued_at_unix_seconds = issued;
+            receipt.expires_at_unix_seconds = expires;
+            assert_eq!(receipt.validate(&request, now), Err(expected));
+        }
+    }
+}

--- a/crates/automata-ci-runner/src/product/windows_image.rs
+++ b/crates/automata-ci-runner/src/product/windows_image.rs
@@ -1,0 +1,932 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    str::FromStr as _,
+};
+
+use automata_ci_core::{EnvironmentProfileId, Sha256Digest};
+use automata_ci_execution::{ImmutableImage, TargetPath};
+use base64::Engine as _;
+use ring::signature::{ED25519, UnparsedPublicKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use super::{
+    config::ToolchainConfig,
+    files::{read_configuration_file, validate_absolute_path},
+};
+
+const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+const MAX_LOCK_BYTES: usize = 64 * 1024;
+const MAX_EVIDENCE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_PROMOTION_BYTES: usize = 256 * 1024;
+const EVIDENCE_REFERENCE_MEDIA_TYPE: &str =
+    "application/vnd.automata.windows-image-evidence-reference+json";
+const MAX_REVOKED_IMAGES: usize = 4_096;
+
+/// Result of the Windows image-evidence gate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WindowsImageAdmission {
+    /// Configuration has not been loaded through the evidence verifier.
+    Unverified,
+    /// All candidate artifacts are internally consistent, but no external
+    /// promotion authority has accepted them.
+    Candidate,
+    /// Candidate artifacts and an external Ed25519 promotion envelope verify.
+    Promoted,
+}
+
+impl WindowsImageAdmission {
+    /// Reports whether action runtimes may be composed and advertised.
+    #[must_use]
+    pub const fn permits_actions(self) -> bool {
+        matches!(self, Self::Promoted)
+    }
+}
+
+/// Verified image-evidence result retained for later enrollment admission.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WindowsImageVerification {
+    admission: WindowsImageAdmission,
+    provenance_sha256: Option<Sha256Digest>,
+    sbom_sha256: Option<Sha256Digest>,
+    patch_report_sha256: Option<Sha256Digest>,
+    revocations_sha256: Option<Sha256Digest>,
+    promotion_payload_sha256: Option<Sha256Digest>,
+    promotion_public_key_sha256: Option<Sha256Digest>,
+    promotion_envelope_sha256: Option<Sha256Digest>,
+}
+
+impl WindowsImageVerification {
+    /// Creates an unverified result used only before the evidence boundary runs.
+    #[must_use]
+    pub const fn unverified() -> Self {
+        Self {
+            admission: WindowsImageAdmission::Unverified,
+            provenance_sha256: None,
+            sbom_sha256: None,
+            patch_report_sha256: None,
+            revocations_sha256: None,
+            promotion_payload_sha256: None,
+            promotion_public_key_sha256: None,
+            promotion_envelope_sha256: None,
+        }
+    }
+
+    /// Creates a verified candidate which cannot authorize action execution.
+    #[must_use]
+    pub const fn candidate() -> Self {
+        Self {
+            admission: WindowsImageAdmission::Candidate,
+            provenance_sha256: None,
+            sbom_sha256: None,
+            patch_report_sha256: None,
+            revocations_sha256: None,
+            promotion_payload_sha256: None,
+            promotion_public_key_sha256: None,
+            promotion_envelope_sha256: None,
+        }
+    }
+
+    /// Creates a promoted result bound to the canonical signed payload digest.
+    #[must_use]
+    pub const fn promoted(
+        promotion_payload_sha256: Sha256Digest,
+        promotion_public_key_sha256: Sha256Digest,
+        promotion_envelope_sha256: Sha256Digest,
+    ) -> Self {
+        Self {
+            admission: WindowsImageAdmission::Promoted,
+            provenance_sha256: None,
+            sbom_sha256: None,
+            patch_report_sha256: None,
+            revocations_sha256: None,
+            promotion_payload_sha256: Some(promotion_payload_sha256),
+            promotion_public_key_sha256: Some(promotion_public_key_sha256),
+            promotion_envelope_sha256: Some(promotion_envelope_sha256),
+        }
+    }
+
+    /// Returns the coarse image admission state.
+    #[must_use]
+    pub const fn admission(self) -> WindowsImageAdmission {
+        self.admission
+    }
+
+    pub(super) const fn with_evidence_digests(
+        mut self,
+        provenance_sha256: Sha256Digest,
+        sbom_sha256: Sha256Digest,
+        patch_report_sha256: Sha256Digest,
+        revocations_sha256: Sha256Digest,
+    ) -> Self {
+        self.provenance_sha256 = Some(provenance_sha256);
+        self.sbom_sha256 = Some(sbom_sha256);
+        self.patch_report_sha256 = Some(patch_report_sha256);
+        self.revocations_sha256 = Some(revocations_sha256);
+        self
+    }
+
+    pub(super) const fn evidence_digests(self) -> Option<[Sha256Digest; 4]> {
+        match (
+            self.provenance_sha256,
+            self.sbom_sha256,
+            self.patch_report_sha256,
+            self.revocations_sha256,
+        ) {
+            (Some(provenance), Some(sbom), Some(patch_report), Some(revocations)) => {
+                Some([provenance, sbom, patch_report, revocations])
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the digest of the canonical, verified promotion payload.
+    #[must_use]
+    pub const fn promotion_payload_sha256(self) -> Option<Sha256Digest> {
+        self.promotion_payload_sha256
+    }
+
+    /// Returns the digest of the exact verified external promotion public key.
+    #[must_use]
+    pub const fn promotion_public_key_sha256(self) -> Option<Sha256Digest> {
+        self.promotion_public_key_sha256
+    }
+
+    /// Returns the digest of the complete verified promotion envelope.
+    #[must_use]
+    pub const fn promotion_envelope_sha256(self) -> Option<Sha256Digest> {
+        self.promotion_envelope_sha256
+    }
+}
+
+/// Host-side paths and digests for one immutable Windows image contract.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsImageContractConfig {
+    manifest_path: PathBuf,
+    manifest_sha256: Sha256Digest,
+    lock_path: PathBuf,
+    lock_sha256: Sha256Digest,
+    provenance_path: PathBuf,
+    sbom_path: PathBuf,
+    patch_report_path: PathBuf,
+    revocations_path: PathBuf,
+    promotion: Option<WindowsImagePromotionConfig>,
+}
+
+impl WindowsImageContractConfig {
+    /// Returns the candidate image manifest path.
+    #[must_use]
+    pub fn manifest_path(&self) -> &Path {
+        &self.manifest_path
+    }
+
+    /// Returns the exact candidate manifest digest.
+    #[must_use]
+    pub const fn manifest_sha256(&self) -> Sha256Digest {
+        self.manifest_sha256
+    }
+
+    /// Returns the lock document path.
+    #[must_use]
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    /// Returns the exact lock document digest.
+    #[must_use]
+    pub const fn lock_sha256(&self) -> Sha256Digest {
+        self.lock_sha256
+    }
+
+    /// Returns the signed-provenance candidate path.
+    #[must_use]
+    pub fn provenance_path(&self) -> &Path {
+        &self.provenance_path
+    }
+
+    /// Returns the SBOM candidate path.
+    #[must_use]
+    pub fn sbom_path(&self) -> &Path {
+        &self.sbom_path
+    }
+
+    /// Returns the patch-assessment candidate path.
+    #[must_use]
+    pub fn patch_report_path(&self) -> &Path {
+        &self.patch_report_path
+    }
+
+    /// Returns the revocation metadata path.
+    #[must_use]
+    pub fn revocations_path(&self) -> &Path {
+        &self.revocations_path
+    }
+
+    /// Returns the optional external promotion authority configuration.
+    #[must_use]
+    pub const fn promotion(&self) -> Option<&WindowsImagePromotionConfig> {
+        self.promotion.as_ref()
+    }
+}
+
+/// An external promotion envelope and its pinned Ed25519 public key.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsImagePromotionConfig {
+    envelope_path: PathBuf,
+    key_id: String,
+    public_key_base64: String,
+}
+
+impl WindowsImagePromotionConfig {
+    /// Returns the detached promotion envelope path.
+    #[must_use]
+    pub fn envelope_path(&self) -> &Path {
+        &self.envelope_path
+    }
+
+    /// Returns the exact external authority key identifier.
+    #[must_use]
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+/// Exact runner values which the image evidence must bind.
+#[derive(Debug)]
+pub struct WindowsImageVerificationRequest<'a> {
+    pub(crate) contract: &'a WindowsImageContractConfig,
+    pub(crate) profile_id: &'a EnvironmentProfileId,
+    pub(crate) profile_manifest_sha256: Sha256Digest,
+    pub(crate) image: &'a ImmutableImage,
+    pub(crate) workspace: &'a TargetPath,
+    pub(crate) guest_agent: &'a TargetPath,
+    pub(crate) toolchain: &'a ToolchainConfig,
+}
+
+impl WindowsImageVerificationRequest<'_> {
+    /// Returns the configured evidence locations and digest pins.
+    #[must_use]
+    pub const fn contract(&self) -> &WindowsImageContractConfig {
+        self.contract
+    }
+
+    /// Returns the exact environment profile identity.
+    #[must_use]
+    pub const fn profile_id(&self) -> &EnvironmentProfileId {
+        self.profile_id
+    }
+
+    /// Returns the scheduler-visible manifest digest.
+    #[must_use]
+    pub const fn profile_manifest_sha256(&self) -> Sha256Digest {
+        self.profile_manifest_sha256
+    }
+
+    /// Returns the exact immutable output image.
+    #[must_use]
+    pub const fn image(&self) -> &ImmutableImage {
+        self.image
+    }
+
+    /// Returns the exact in-container workspace root.
+    #[must_use]
+    pub const fn workspace(&self) -> &TargetPath {
+        self.workspace
+    }
+
+    /// Returns the exact in-image guest agent.
+    #[must_use]
+    pub const fn guest_agent(&self) -> &TargetPath {
+        self.guest_agent
+    }
+
+    /// Returns the exact configured in-image tools.
+    #[must_use]
+    pub const fn toolchain(&self) -> &ToolchainConfig {
+        self.toolchain
+    }
+}
+
+/// Pluggable image evidence boundary used before Windows capabilities exist.
+pub trait WindowsImageEvidenceVerifier: Send + Sync {
+    /// Verifies every candidate artifact and, when configured, the external
+    /// promotion signature.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on missing, malformed, mismatched, revoked, or incorrectly
+    /// signed material.
+    fn verify(
+        &self,
+        request: &WindowsImageVerificationRequest<'_>,
+    ) -> Result<WindowsImageVerification, WindowsImageVerificationError>;
+}
+
+/// Secure-file implementation of the Windows image evidence boundary.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FilesystemWindowsImageEvidenceVerifier;
+
+/// Sanitized Windows image verification failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsImageVerificationError {
+    /// One or more bounded evidence files could not be securely loaded.
+    #[error("Windows image evidence is unavailable")]
+    Unavailable,
+    /// An evidence document is malformed or violates the closed schema.
+    #[error("Windows image evidence is invalid")]
+    InvalidEvidence,
+    /// A digest, profile, image, tool, or path binding differs.
+    #[error("Windows image evidence does not match runner configuration")]
+    Mismatch,
+    /// The image is present in the accepted revocation metadata.
+    #[error("Windows image is revoked")]
+    Revoked,
+    /// The configured external promotion signature is invalid.
+    #[error("Windows image promotion signature is invalid")]
+    InvalidPromotion,
+}
+
+impl WindowsImageEvidenceVerifier for FilesystemWindowsImageEvidenceVerifier {
+    fn verify(
+        &self,
+        request: &WindowsImageVerificationRequest<'_>,
+    ) -> Result<WindowsImageVerification, WindowsImageVerificationError> {
+        let manifest_bytes = read_evidence(request.contract.manifest_path(), MAX_MANIFEST_BYTES)?;
+        if digest(&manifest_bytes) != request.contract.manifest_sha256() {
+            return Err(WindowsImageVerificationError::Mismatch);
+        }
+        let manifest: ImageManifest = parse(&manifest_bytes)?;
+        validate_manifest(&manifest, request)?;
+
+        let lock_bytes = read_evidence(request.contract.lock_path(), MAX_LOCK_BYTES)?;
+        if digest(&lock_bytes) != request.contract.lock_sha256() {
+            return Err(WindowsImageVerificationError::Mismatch);
+        }
+        let lock: ImageLock = parse(&lock_bytes)?;
+        if lock.schema_version != 1
+            || lock.profile_id != request.profile_id.as_str()
+            || lock.image != request.image.reference()
+            || lock.base_image != manifest.base_image
+            || parse_digest(&lock.manifest_sha256)? != request.contract.manifest_sha256()
+        {
+            return Err(WindowsImageVerificationError::Mismatch);
+        }
+
+        let evidence = [
+            (
+                EvidenceKind::Provenance,
+                request.contract.provenance_path(),
+                &manifest.evidence.provenance,
+            ),
+            (
+                EvidenceKind::Sbom,
+                request.contract.sbom_path(),
+                &manifest.evidence.sbom,
+            ),
+            (
+                EvidenceKind::PatchReport,
+                request.contract.patch_report_path(),
+                &manifest.evidence.patch_report,
+            ),
+            (
+                EvidenceKind::Revocations,
+                request.contract.revocations_path(),
+                &manifest.evidence.revocations,
+            ),
+        ];
+        let mut evidence_digests = BTreeMap::new();
+        let mut revocation_generation = None;
+        for (expected_kind, path, reference) in evidence {
+            let bytes = read_evidence(path, MAX_EVIDENCE_BYTES)?;
+            let actual_digest = digest(&bytes);
+            if parse_digest(&reference.sha256)? != actual_digest
+                || reference.media_type != EVIDENCE_REFERENCE_MEDIA_TYPE
+            {
+                return Err(WindowsImageVerificationError::Mismatch);
+            }
+            let document: EvidenceReferenceDocument = parse(&bytes)?;
+            if let Some(generation) = validate_evidence_reference_document(
+                &document,
+                expected_kind,
+                request.profile_id.as_str(),
+                request.image.reference(),
+            )? {
+                revocation_generation = Some(generation);
+            }
+            evidence_digests.insert(expected_kind, actual_digest);
+        }
+
+        let Some(promotion) = request.contract.promotion() else {
+            return Ok(WindowsImageVerification::candidate().with_evidence_digests(
+                evidence_digests[&EvidenceKind::Provenance],
+                evidence_digests[&EvidenceKind::Sbom],
+                evidence_digests[&EvidenceKind::PatchReport],
+                evidence_digests[&EvidenceKind::Revocations],
+            ));
+        };
+        let promotion_verification = verify_promotion(
+            promotion,
+            request,
+            &manifest,
+            &evidence_digests,
+            revocation_generation.ok_or(WindowsImageVerificationError::InvalidEvidence)?,
+        )?;
+        Ok(WindowsImageVerification::promoted(
+            promotion_verification.payload,
+            promotion_verification.public_key,
+            promotion_verification.envelope,
+        )
+        .with_evidence_digests(
+            evidence_digests[&EvidenceKind::Provenance],
+            evidence_digests[&EvidenceKind::Sbom],
+            evidence_digests[&EvidenceKind::PatchReport],
+            evidence_digests[&EvidenceKind::Revocations],
+        ))
+    }
+}
+
+fn validate_evidence_reference_document(
+    document: &EvidenceReferenceDocument,
+    expected_kind: EvidenceKind,
+    profile_id: &str,
+    image: &str,
+) -> Result<Option<u64>, WindowsImageVerificationError> {
+    if document.schema_version != 1
+        || document.kind != expected_kind
+        || document.candidate_fixture == Some(false)
+        || document.profile_id != profile_id
+        || document.image != image
+        || parse_digest(&document.subject.sha256).is_err()
+        || document.subject.media_type != expected_subject_media_type(expected_kind)
+        || document.statement.is_empty()
+        || document.statement.len() > 4_096
+        || !document.statement.is_ascii()
+    {
+        return Err(WindowsImageVerificationError::Mismatch);
+    }
+    if expected_kind != EvidenceKind::Revocations {
+        if document.generation.is_some() || !document.revoked_images.is_empty() {
+            return Err(WindowsImageVerificationError::InvalidEvidence);
+        }
+        return Ok(None);
+    }
+    let generation = document
+        .generation
+        .filter(|generation| *generation > 0)
+        .ok_or(WindowsImageVerificationError::InvalidEvidence)?;
+    if document.revoked_images.len() > MAX_REVOKED_IMAGES
+        || document
+            .revoked_images
+            .iter()
+            .any(|revoked| ImmutableImage::new(revoked.clone()).is_err())
+    {
+        return Err(WindowsImageVerificationError::InvalidEvidence);
+    }
+    if document
+        .revoked_images
+        .iter()
+        .any(|revoked| revoked == image)
+    {
+        return Err(WindowsImageVerificationError::Revoked);
+    }
+    Ok(Some(generation))
+}
+
+const fn expected_subject_media_type(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Provenance => "application/vnd.in-toto+json",
+        EvidenceKind::Sbom => "application/spdx+json",
+        EvidenceKind::PatchReport => "application/vnd.automata.windows-patch-report+json",
+        EvidenceKind::Revocations => "application/vnd.automata.image-revocations+json",
+    }
+}
+
+fn validate_manifest(
+    manifest: &ImageManifest,
+    request: &WindowsImageVerificationRequest<'_>,
+) -> Result<(), WindowsImageVerificationError> {
+    if manifest.schema_version != 1
+        || manifest.status != "candidate"
+        || manifest.profile_id != request.profile_id.as_str()
+        || manifest.image != request.image.reference()
+        || request.profile_manifest_sha256 != request.contract.manifest_sha256()
+        || manifest.operating_system != "windows-server-2025"
+        || manifest.variant != "server-core"
+        || manifest.architecture != "x86_64"
+        || manifest.isolation != "hyperv-container"
+        || !manifest.network_disabled
+        || !manifest.unprivileged
+        || !manifest.clean_workspace
+        || !manifest
+            .workspace
+            .eq_ignore_ascii_case(request.workspace.as_str())
+        || !manifest
+            .guest_agent
+            .eq_ignore_ascii_case(request.guest_agent.as_str())
+        || ImmutableImage::new(manifest.base_image.clone()).is_err()
+    {
+        return Err(WindowsImageVerificationError::Mismatch);
+    }
+
+    let expected = expected_tools(request.toolchain)?;
+    let mut actual = BTreeMap::new();
+    for tool in &manifest.tools {
+        if tool.version.is_empty()
+            || tool.version.len() > 128
+            || !tool.version.is_ascii()
+            || parse_digest(&tool.sha256).is_err()
+            || actual.insert(tool.kind, tool.path.as_str()).is_some()
+        {
+            return Err(WindowsImageVerificationError::InvalidEvidence);
+        }
+    }
+    if actual.len() != expected.len()
+        || expected.iter().any(|(kind, path)| {
+            actual
+                .get(kind)
+                .is_none_or(|actual| !actual.eq_ignore_ascii_case(path.as_str()))
+        })
+    {
+        return Err(WindowsImageVerificationError::Mismatch);
+    }
+    Ok(())
+}
+
+fn expected_tools(
+    toolchain: &ToolchainConfig,
+) -> Result<BTreeMap<ToolKind, &TargetPath>, WindowsImageVerificationError> {
+    let mut tools = BTreeMap::new();
+    for (kind, path) in [
+        (ToolKind::Pwsh, toolchain.pwsh()),
+        (ToolKind::Powershell, toolchain.powershell()),
+        (ToolKind::Cmd, toolchain.cmd()),
+        (ToolKind::Tar, toolchain.tar()),
+        (ToolKind::Sha256, toolchain.sha256sum()),
+    ] {
+        tools.insert(kind, path.ok_or(WindowsImageVerificationError::Mismatch)?);
+    }
+    for (kind, path) in [
+        (ToolKind::Node12, toolchain.node12()),
+        (ToolKind::Node16, toolchain.node16()),
+        (ToolKind::Node20, toolchain.node20()),
+        (ToolKind::Node24, toolchain.node24()),
+    ] {
+        if let Some(path) = path {
+            tools.insert(kind, path);
+        }
+    }
+    Ok(tools)
+}
+
+fn verify_promotion(
+    promotion: &WindowsImagePromotionConfig,
+    request: &WindowsImageVerificationRequest<'_>,
+    manifest: &ImageManifest,
+    evidence: &BTreeMap<EvidenceKind, Sha256Digest>,
+    revocation_generation: u64,
+) -> Result<PromotionVerification, WindowsImageVerificationError> {
+    let bytes = read_evidence(promotion.envelope_path(), MAX_PROMOTION_BYTES)?;
+    let envelope: PromotionEnvelope = parse(&bytes)?;
+    if envelope.schema_version != 1 || envelope.key_id != promotion.key_id() {
+        return Err(WindowsImageVerificationError::InvalidPromotion);
+    }
+    let decoder = base64::engine::general_purpose::STANDARD;
+    let payload_bytes = decoder
+        .decode(envelope.payload_base64)
+        .map_err(|_| WindowsImageVerificationError::InvalidPromotion)?;
+    let signature = decoder
+        .decode(envelope.signature_base64)
+        .map_err(|_| WindowsImageVerificationError::InvalidPromotion)?;
+    let public_key = decoder
+        .decode(&promotion.public_key_base64)
+        .map_err(|_| WindowsImageVerificationError::InvalidPromotion)?;
+    UnparsedPublicKey::new(&ED25519, &public_key)
+        .verify(&payload_bytes, &signature)
+        .map_err(|_| WindowsImageVerificationError::InvalidPromotion)?;
+    let payload: PromotionPayload = parse(&payload_bytes)?;
+    if serde_json::to_vec(&payload).map_err(|_| WindowsImageVerificationError::InvalidPromotion)?
+        != payload_bytes
+        || payload.schema_version != 1
+        || payload.decision != "promote"
+        || !payload.provenance_accepted
+        || !payload.sbom_accepted
+        || !payload.patch_accepted
+        || !payload.revocations_accepted
+        || payload.profile_id != request.profile_id.as_str()
+        || payload.image != request.image.reference()
+        || payload.base_image != manifest.base_image
+        || parse_digest(&payload.manifest_sha256)? != request.contract.manifest_sha256()
+        || parse_digest(&payload.lock_sha256)? != request.contract.lock_sha256()
+        || parse_digest(&payload.provenance_sha256)? != evidence[&EvidenceKind::Provenance]
+        || parse_digest(&payload.sbom_sha256)? != evidence[&EvidenceKind::Sbom]
+        || parse_digest(&payload.patch_report_sha256)? != evidence[&EvidenceKind::PatchReport]
+        || parse_digest(&payload.revocations_sha256)? != evidence[&EvidenceKind::Revocations]
+        || payload.revocation_generation != revocation_generation
+    {
+        return Err(WindowsImageVerificationError::InvalidPromotion);
+    }
+    Ok(PromotionVerification {
+        payload: digest(&payload_bytes),
+        public_key: digest(&public_key),
+        envelope: digest(&bytes),
+    })
+}
+
+struct PromotionVerification {
+    payload: Sha256Digest,
+    public_key: Sha256Digest,
+    envelope: Sha256Digest,
+}
+
+fn read_evidence(path: &Path, maximum: usize) -> Result<Vec<u8>, WindowsImageVerificationError> {
+    read_configuration_file(path, maximum).map_err(|_| WindowsImageVerificationError::Unavailable)
+}
+
+fn parse<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, WindowsImageVerificationError> {
+    serde_json::from_slice(bytes).map_err(|_| WindowsImageVerificationError::InvalidEvidence)
+}
+
+fn parse_digest(value: &str) -> Result<Sha256Digest, WindowsImageVerificationError> {
+    Sha256Digest::from_str(value).map_err(|_| WindowsImageVerificationError::InvalidEvidence)
+}
+
+fn digest(bytes: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(bytes).into())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImageManifest {
+    schema_version: u16,
+    status: String,
+    profile_id: String,
+    operating_system: String,
+    variant: String,
+    architecture: String,
+    isolation: String,
+    base_image: String,
+    image: String,
+    workspace: String,
+    guest_agent: String,
+    network_disabled: bool,
+    unprivileged: bool,
+    clean_workspace: bool,
+    tools: Vec<ToolRecord>,
+    evidence: EvidenceReferences,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolRecord {
+    kind: ToolKind,
+    path: String,
+    version: String,
+    sha256: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+enum ToolKind {
+    Pwsh,
+    Powershell,
+    Cmd,
+    Tar,
+    Sha256,
+    Node12,
+    Node16,
+    Node20,
+    Node24,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReferences {
+    provenance: EvidenceReference,
+    sbom: EvidenceReference,
+    patch_report: EvidenceReference,
+    revocations: EvidenceReference,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReference {
+    sha256: String,
+    media_type: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImageLock {
+    schema_version: u16,
+    profile_id: String,
+    manifest_sha256: String,
+    base_image: String,
+    image: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceKind {
+    Provenance,
+    Sbom,
+    PatchReport,
+    Revocations,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReferenceDocument {
+    schema_version: u16,
+    kind: EvidenceKind,
+    #[serde(default)]
+    candidate_fixture: Option<bool>,
+    profile_id: String,
+    image: String,
+    subject: EvidenceSubject,
+    statement: String,
+    #[serde(default)]
+    generation: Option<u64>,
+    #[serde(default)]
+    revoked_images: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceSubject {
+    sha256: String,
+    media_type: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PromotionEnvelope {
+    schema_version: u16,
+    key_id: String,
+    payload_base64: String,
+    signature_base64: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+struct PromotionPayload {
+    schema_version: u16,
+    decision: String,
+    profile_id: String,
+    base_image: String,
+    image: String,
+    manifest_sha256: String,
+    lock_sha256: String,
+    provenance_sha256: String,
+    sbom_sha256: String,
+    patch_report_sha256: String,
+    revocations_sha256: String,
+    revocation_generation: u64,
+    provenance_accepted: bool,
+    sbom_accepted: bool,
+    patch_accepted: bool,
+    revocations_accepted: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RawWindowsImageContractConfig {
+    manifest_path: PathBuf,
+    manifest_sha256: String,
+    lock_path: PathBuf,
+    lock_sha256: String,
+    provenance_path: PathBuf,
+    sbom_path: PathBuf,
+    patch_report_path: PathBuf,
+    revocations_path: PathBuf,
+    #[serde(default)]
+    promotion: Option<RawWindowsImagePromotionConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawWindowsImagePromotionConfig {
+    envelope_path: PathBuf,
+    key_id: String,
+    public_key_base64: String,
+}
+
+impl RawWindowsImageContractConfig {
+    pub(super) fn validate(
+        self,
+    ) -> Result<WindowsImageContractConfig, WindowsImageVerificationError> {
+        let paths = [
+            &self.manifest_path,
+            &self.lock_path,
+            &self.provenance_path,
+            &self.sbom_path,
+            &self.patch_report_path,
+            &self.revocations_path,
+        ];
+        if paths
+            .into_iter()
+            .any(|path| validate_absolute_path(path).is_err())
+        {
+            return Err(WindowsImageVerificationError::InvalidEvidence);
+        }
+        let promotion = self
+            .promotion
+            .map(|promotion| {
+                if validate_absolute_path(&promotion.envelope_path).is_err()
+                    || promotion.key_id.is_empty()
+                    || promotion.key_id.len() > 128
+                    || !promotion.key_id.is_ascii()
+                    || promotion.key_id.bytes().any(|byte| byte.is_ascii_control())
+                    || promotion.public_key_base64.is_empty()
+                    || promotion.public_key_base64.len() > 256
+                {
+                    return Err(WindowsImageVerificationError::InvalidEvidence);
+                }
+                Ok(WindowsImagePromotionConfig {
+                    envelope_path: promotion.envelope_path,
+                    key_id: promotion.key_id,
+                    public_key_base64: promotion.public_key_base64,
+                })
+            })
+            .transpose()?;
+        Ok(WindowsImageContractConfig {
+            manifest_path: self.manifest_path,
+            manifest_sha256: parse_digest(&self.manifest_sha256)?,
+            lock_path: self.lock_path,
+            lock_sha256: parse_digest(&self.lock_sha256)?,
+            provenance_path: self.provenance_path,
+            sbom_path: self.sbom_path,
+            patch_report_path: self.patch_report_path,
+            revocations_path: self.revocations_path,
+            promotion,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admission_only_permits_actions_after_external_promotion() {
+        assert!(!WindowsImageAdmission::Unverified.permits_actions());
+        assert!(!WindowsImageAdmission::Candidate.permits_actions());
+        assert!(WindowsImageAdmission::Promoted.permits_actions());
+    }
+
+    #[test]
+    fn promotion_payload_serialization_is_canonical_and_field_ordered() {
+        let payload = PromotionPayload {
+            schema_version: 1,
+            decision: "promote".to_owned(),
+            profile_id: "automata.dev/windows-2025-x64-hyperv-v1".to_owned(),
+            base_image: format!("base@example@sha256:{}", "a".repeat(64)),
+            image: format!("image@example@sha256:{}", "b".repeat(64)),
+            manifest_sha256: "c".repeat(64),
+            lock_sha256: "d".repeat(64),
+            provenance_sha256: "e".repeat(64),
+            sbom_sha256: "f".repeat(64),
+            patch_report_sha256: "1".repeat(64),
+            revocations_sha256: "2".repeat(64),
+            revocation_generation: 1,
+            provenance_accepted: true,
+            sbom_accepted: true,
+            patch_accepted: true,
+            revocations_accepted: true,
+        };
+        let bytes = serde_json::to_vec(&payload).expect("serialize payload");
+        let decoded: PromotionPayload = serde_json::from_slice(&bytes).expect("parse payload");
+        assert_eq!(serde_json::to_vec(&decoded).expect("reserialize"), bytes);
+    }
+
+    #[test]
+    fn production_evidence_reference_does_not_require_a_fixture_marker() {
+        let image = format!("registry.example/image@sha256:{}", "1".repeat(64));
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "kind": "provenance",
+            "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+            "image": image.clone(),
+            "subject": {
+                "sha256": "a".repeat(64),
+                "media_type": "application/vnd.in-toto+json"
+            },
+            "statement": "Externally retained provenance reference."
+        }))
+        .expect("serialize reference");
+        let reference: EvidenceReferenceDocument = parse(&bytes).expect("parse reference");
+
+        assert_eq!(reference.candidate_fixture, None);
+        assert_eq!(
+            validate_evidence_reference_document(
+                &reference,
+                EvidenceKind::Provenance,
+                "automata.dev/windows-2025-x64-hyperv-v1",
+                &image,
+            ),
+            Ok(None)
+        );
+    }
+}

--- a/crates/automata-ci-runner/tests/capabilities_cli.rs
+++ b/crates/automata-ci-runner/tests/capabilities_cli.rs
@@ -25,6 +25,13 @@ const HOST_CONFIG: &str = "config/runner.local-1.example.json";
 static NEXT_EVIDENCE_ROOT: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(windows)]
+fn write_secure_windows_fixture(path: &std::path::Path, bytes: &[u8]) {
+    fs::write(path, bytes).expect("write Windows evidence fixture");
+    automata_ci_windows_file_security::restrict_file_to_current_user_for_test(path)
+        .expect("restrict Windows evidence fixture DACL");
+}
+
+#[cfg(windows)]
 struct WindowsEvidenceFixture {
     root: PathBuf,
     config_path: PathBuf,
@@ -77,7 +84,7 @@ impl WindowsEvidenceFixture {
                 )[..],
             ),
         ] {
-            fs::write(root.join(name), bytes).expect("write Windows evidence fixture");
+            write_secure_windows_fixture(&root.join(name), bytes);
         }
         let mut config: serde_json::Value =
             serde_json::from_slice(include_bytes!("fixtures/runner.windows.product.json"))
@@ -94,11 +101,9 @@ impl WindowsEvidenceFixture {
                 serde_json::json!(root.join(name).to_string_lossy());
         }
         let config_path = root.join("runner.json");
-        fs::write(
-            &config_path,
-            serde_json::to_vec(&config).expect("serialize Windows evidence configuration"),
-        )
-        .expect("write Windows evidence configuration");
+        let config_bytes =
+            serde_json::to_vec(&config).expect("serialize Windows evidence configuration");
+        write_secure_windows_fixture(&config_path, &config_bytes);
         Self { root, config_path }
     }
 }

--- a/crates/automata-ci-runner/tests/capabilities_cli.rs
+++ b/crates/automata-ci-runner/tests/capabilities_cli.rs
@@ -6,18 +6,117 @@ use automata_ci_runner::product::RunnerProductConfig;
 #[cfg(unix)]
 use std::{fs, os::unix::fs::PermissionsExt as _, path::PathBuf};
 
+#[cfg(windows)]
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
 #[cfg(unix)]
 use automata_ci_core::OperationId;
 
 #[cfg(target_os = "macos")]
 const HOST_CONFIG: &str = "config/runner.macos.example.json";
-#[cfg(target_os = "windows")]
-const HOST_CONFIG: &str = "tests/fixtures/runner.windows.product.json";
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const HOST_CONFIG: &str = "config/runner.local-1.example.json";
 
+#[cfg(windows)]
+static NEXT_EVIDENCE_ROOT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(windows)]
+struct WindowsEvidenceFixture {
+    root: PathBuf,
+    config_path: PathBuf,
+}
+
+#[cfg(windows)]
+impl WindowsEvidenceFixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "automata-capabilities-windows-evidence-{}-{}",
+            std::process::id(),
+            NEXT_EVIDENCE_ROOT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&root).expect("create Windows evidence fixture root");
+        for (name, bytes) in [
+            (
+                "manifest.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/manifest.candidate.json"
+                )[..],
+            ),
+            (
+                "image.lock.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/image.lock.candidate.json"
+                )[..],
+            ),
+            (
+                "provenance.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/provenance.candidate.json"
+                )[..],
+            ),
+            (
+                "sbom.spdx.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/sbom.candidate.json"
+                )[..],
+            ),
+            (
+                "patch-report.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/patch-report.candidate.json"
+                )[..],
+            ),
+            (
+                "revocations.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/revocations.candidate.json"
+                )[..],
+            ),
+        ] {
+            fs::write(root.join(name), bytes).expect("write Windows evidence fixture");
+        }
+        let mut config: serde_json::Value =
+            serde_json::from_slice(include_bytes!("fixtures/runner.windows.product.json"))
+                .expect("parse internal Windows product fixture");
+        for (field, name) in [
+            ("manifest_path", "manifest.json"),
+            ("lock_path", "image.lock.json"),
+            ("provenance_path", "provenance.json"),
+            ("sbom_path", "sbom.spdx.json"),
+            ("patch_report_path", "patch-report.json"),
+            ("revocations_path", "revocations.json"),
+        ] {
+            config["windows_hyperv"]["image_contract"][field] =
+                serde_json::json!(root.join(name).to_string_lossy());
+        }
+        let config_path = root.join("runner.json");
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&config).expect("serialize Windows evidence configuration"),
+        )
+        .expect("write Windows evidence configuration");
+        Self { root, config_path }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsEvidenceFixture {
+    fn drop(&mut self) {
+        let _ignored = fs::remove_dir_all(&self.root);
+    }
+}
+
 #[test]
 fn capabilities_command_emits_only_the_canonical_validated_inventory() {
+    #[cfg(windows)]
+    let fixture = WindowsEvidenceFixture::new();
+    #[cfg(windows)]
+    let config_path = fixture.config_path.to_string_lossy().into_owned();
+    #[cfg(not(windows))]
     let config_path = format!("{}/{HOST_CONFIG}", env!("CARGO_MANIFEST_DIR"));
     let secret_sentinel = "capabilities-must-not-read-this-secret";
     let output = Command::new(env!("CARGO_BIN_EXE_automata-runner"))

--- a/crates/automata-ci-runner/tests/fixtures/runner.windows.product.json
+++ b/crates/automata-ci-runner/tests/fixtures/runner.windows.product.json
@@ -49,7 +49,7 @@
     "environment_profiles": [
       {
         "id": "automata.dev/windows-2025-x64-hyperv-v1",
-        "manifest_sha256": "aee9c4c9fb8ad2a8332ca6cf2b0a2e24bc1a61485ef224adef4831093ab5cd6c",
+        "manifest_sha256": "8469373351b458633450cd4f28e24b18fa756832a7917c9d8ae2a82ad6241c23",
         "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
         "keepalive_program": "C:\\automata\\guest\\automata-ci-sandbox-guest.exe",
         "keepalive_arguments": [
@@ -71,7 +71,17 @@
     "runtime_executable": "C:\\Program Files\\Docker\\docker.exe",
     "runtime_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
     "guest_agent_path": "C:\\automata\\guest\\automata-ci-sandbox-guest.exe",
-    "operation_timeout_seconds": 120
+    "operation_timeout_seconds": 120,
+    "image_contract": {
+      "manifest_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\manifest.json",
+          "manifest_sha256": "8469373351b458633450cd4f28e24b18fa756832a7917c9d8ae2a82ad6241c23",
+      "lock_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\image.lock.json",
+          "lock_sha256": "181bc78f2993a8221f0ab4aa6d01f53ef05b02ac1755ffd84c1c0abf0f3c6747",
+      "provenance_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\provenance.json",
+      "sbom_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\sbom.spdx.json",
+      "patch_report_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\patch-report.json",
+      "revocations_path": "C:\\ProgramData\\Automata\\images\\windows-server-2025-hyperv-v1\\revocations.json"
+    }
   },
   "executor": {
     "resources": {
@@ -87,7 +97,7 @@
     "maximum_output_bytes": 16777216,
     "runner_root": "C:\\automata\\runner",
     "home": "C:\\automata\\home",
-    "path": "C:\\Program Files\\PowerShell\\7;C:\\Windows\\System32;C:\\Windows",
+    "path": "C:\\Program Files\\PowerShell\\7;C:\\automata\\tools\\tar;C:\\automata\\tools\\hash;C:\\automata\\externals\\node24;C:\\Windows\\System32;C:\\Windows",
     "temp": "C:\\automata\\temp",
     "tool_cache": "C:\\automata\\toolcache",
     "toolchain": {
@@ -98,11 +108,12 @@
       "powershell": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
       "cmd": "C:\\Windows\\System32\\cmd.exe",
       "install": null,
-      "tar": null,
+      "tar": "C:\\automata\\tools\\tar\\tar.exe",
+      "sha256sum": "C:\\automata\\tools\\hash\\automata-sha256.exe",
       "node12": null,
       "node16": null,
       "node20": null,
-      "node24": null
+      "node24": "C:\\automata\\externals\\node24\\node.exe"
     }
   },
   "object_store": {

--- a/crates/automata-ci-runner/tests/runner_product_config_windows.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_windows.rs
@@ -28,6 +28,12 @@ use serde::Serialize;
 static NEXT_EVIDENCE_ROOT: AtomicUsize = AtomicUsize::new(0);
 const BROKER_HOST_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
+fn write_secure_fixture(path: &Path, bytes: &[u8]) {
+    fs::write(path, bytes).expect("write Windows evidence fixture");
+    automata_ci_windows_file_security::restrict_file_to_current_user_for_test(path)
+        .expect("restrict Windows evidence fixture DACL");
+}
+
 fn assert_admitted_action_features(request: &WindowsEnrollmentAdmissionRequest) {
     for feature in [
         RunnerFeature::JAVASCRIPT_ACTIONS,
@@ -136,7 +142,7 @@ impl EvidenceFixture {
                 )[..],
             ),
         ] {
-            fs::write(root.join(name), bytes).expect("write evidence fixture");
+            write_secure_fixture(&root.join(name), bytes);
         }
         let mut config = baseline();
         for (field, name) in [
@@ -155,11 +161,8 @@ impl EvidenceFixture {
 
     fn write_config(&self, name: &str) -> PathBuf {
         let path = self.root.join(name);
-        fs::write(
-            &path,
-            serde_json::to_vec(&self.config).expect("serialize evidence configuration"),
-        )
-        .expect("write evidence configuration");
+        let bytes = serde_json::to_vec(&self.config).expect("serialize evidence configuration");
+        write_secure_fixture(&path, &bytes);
         path
     }
 }
@@ -227,11 +230,8 @@ fn add_promotion(fixture: &mut EvidenceFixture) {
         "signature_base64": encoder.encode(key.sign(&payload).as_ref())
     });
     let envelope_path = fixture.root.join("promotion.json");
-    fs::write(
-        &envelope_path,
-        serde_json::to_vec(&envelope).expect("serialize promotion envelope"),
-    )
-    .expect("write promotion envelope");
+    let envelope_bytes = serde_json::to_vec(&envelope).expect("serialize promotion envelope");
+    write_secure_fixture(&envelope_path, &envelope_bytes);
     fixture.config["windows_hyperv"]["image_contract"]["promotion"] = serde_json::json!({
         "envelope_path": envelope_path.to_string_lossy(),
         "key_id": "test.windows-image-promotion.v1",
@@ -529,11 +529,9 @@ fn evidence_verification_fails_closed_on_missing_evidence_and_bad_signature() {
             .expect("parse promotion envelope");
     envelope["signature_base64"] =
         serde_json::json!(base64::engine::general_purpose::STANDARD.encode([0_u8; 64]));
-    fs::write(
-        &envelope_path,
-        serde_json::to_vec(&envelope).expect("serialize corrupt promotion envelope"),
-    )
-    .expect("write corrupt promotion envelope");
+    let envelope_bytes =
+        serde_json::to_vec(&envelope).expect("serialize corrupt promotion envelope");
+    write_secure_fixture(&envelope_path, &envelope_bytes);
     assert_eq!(
         RunnerProductConfig::load(&fixture.write_config("bad-signature-runner.json"))
             .expect_err("an invalid promotion signature must fail closed"),

--- a/crates/automata-ci-runner/tests/runner_product_config_windows.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_windows.rs
@@ -1,6 +1,11 @@
 #![cfg(windows)]
 
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use automata_ci_core::{
     Architecture, IsolationLevel, OperatingSystem, RunnerFeature, SandboxFeature,
@@ -8,7 +13,231 @@ use automata_ci_core::{
 use automata_ci_execution::{
     NetworkPolicy, RootFilesystemPolicy, SandboxLaunch, SandboxPrivilegePolicy,
 };
-use automata_ci_runner::product::{RunnerProductConfig, RunnerProductConfigError};
+use automata_ci_runner::product::{
+    RunnerProductConfig, RunnerProductConfigError, WindowsEnrollmentAdmissionRequest,
+    WindowsEnrollmentIntent, WindowsHostInputKind, WindowsImageAdmission,
+    windows_enrollment_admission_request,
+};
+use base64::Engine as _;
+use ring::{
+    rand::SystemRandom,
+    signature::{Ed25519KeyPair, KeyPair as _},
+};
+use serde::Serialize;
+
+static NEXT_EVIDENCE_ROOT: AtomicUsize = AtomicUsize::new(0);
+const BROKER_HOST_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn assert_admitted_action_features(request: &WindowsEnrollmentAdmissionRequest) {
+    for feature in [
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ] {
+        assert!(
+            request
+                .binding()
+                .capabilities()
+                .features()
+                .contains(&feature),
+            "active admission must prove exact registration feature {feature}"
+        );
+    }
+}
+
+fn assert_host_input_contract(request: &WindowsEnrollmentAdmissionRequest, config_path: &Path) {
+    let inputs = request.binding().host_inputs();
+    assert_eq!(
+        inputs
+            .iter()
+            .map(automata_ci_runner::product::WindowsHostInputDescriptor::kind)
+            .collect::<Vec<_>>(),
+        vec![
+            WindowsHostInputKind::Configuration,
+            WindowsHostInputKind::BackendExecutable,
+            WindowsHostInputKind::ImageManifest,
+            WindowsHostInputKind::ImageLock,
+            WindowsHostInputKind::Provenance,
+            WindowsHostInputKind::Sbom,
+            WindowsHostInputKind::PatchReport,
+            WindowsHostInputKind::Revocations,
+            WindowsHostInputKind::PromotionEnvelope,
+        ]
+    );
+    assert_eq!(inputs[0].absolute_path(), config_path);
+    assert!(inputs.iter().all(|input| {
+        input.absolute_path().is_absolute()
+            && input
+                .expected_sha256()
+                .as_bytes()
+                .iter()
+                .any(|byte| *byte != 0)
+    }));
+    assert_eq!(
+        inputs
+            .iter()
+            .map(automata_ci_runner::product::WindowsHostInputDescriptor::absolute_path)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        inputs.len()
+    );
+}
+
+struct EvidenceFixture {
+    root: PathBuf,
+    config: serde_json::Value,
+}
+
+impl EvidenceFixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "automata-windows-image-evidence-{}-{}",
+            std::process::id(),
+            NEXT_EVIDENCE_ROOT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&root).expect("create evidence root");
+        for (name, bytes) in [
+            (
+                "manifest.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/manifest.candidate.json"
+                )[..],
+            ),
+            (
+                "image.lock.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/image.lock.candidate.json"
+                )[..],
+            ),
+            (
+                "provenance.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/provenance.candidate.json"
+                )[..],
+            ),
+            (
+                "sbom.spdx.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/sbom.candidate.json"
+                )[..],
+            ),
+            (
+                "patch-report.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/patch-report.candidate.json"
+                )[..],
+            ),
+            (
+                "revocations.json",
+                &include_bytes!(
+                    "../../../images/windows-server-2025-hyperv-candidate/revocations.candidate.json"
+                )[..],
+            ),
+        ] {
+            fs::write(root.join(name), bytes).expect("write evidence fixture");
+        }
+        let mut config = baseline();
+        for (field, name) in [
+            ("manifest_path", "manifest.json"),
+            ("lock_path", "image.lock.json"),
+            ("provenance_path", "provenance.json"),
+            ("sbom_path", "sbom.spdx.json"),
+            ("patch_report_path", "patch-report.json"),
+            ("revocations_path", "revocations.json"),
+        ] {
+            config["windows_hyperv"]["image_contract"][field] =
+                serde_json::json!(root.join(name).to_string_lossy());
+        }
+        Self { root, config }
+    }
+
+    fn write_config(&self, name: &str) -> PathBuf {
+        let path = self.root.join(name);
+        fs::write(
+            &path,
+            serde_json::to_vec(&self.config).expect("serialize evidence configuration"),
+        )
+        .expect("write evidence configuration");
+        path
+    }
+}
+
+impl Drop for EvidenceFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[derive(Serialize)]
+#[allow(clippy::struct_excessive_bools)]
+struct TestPromotionPayload {
+    schema_version: u16,
+    decision: &'static str,
+    profile_id: &'static str,
+    base_image: String,
+    image: String,
+    manifest_sha256: &'static str,
+    lock_sha256: &'static str,
+    provenance_sha256: &'static str,
+    sbom_sha256: &'static str,
+    patch_report_sha256: &'static str,
+    revocations_sha256: &'static str,
+    revocation_generation: u64,
+    provenance_accepted: bool,
+    sbom_accepted: bool,
+    patch_accepted: bool,
+    revocations_accepted: bool,
+}
+
+fn add_promotion(fixture: &mut EvidenceFixture) {
+    let payload = TestPromotionPayload {
+        schema_version: 1,
+        decision: "promote",
+        profile_id: "automata.dev/windows-2025-x64-hyperv-v1",
+        base_image: format!(
+            "mcr.microsoft.com/windows/servercore@sha256:{}",
+            "0".repeat(64)
+        ),
+        image: format!(
+            "registry.example/automata/windows-runner@sha256:{}",
+            "1".repeat(64)
+        ),
+        manifest_sha256: "8469373351b458633450cd4f28e24b18fa756832a7917c9d8ae2a82ad6241c23",
+        lock_sha256: "181bc78f2993a8221f0ab4aa6d01f53ef05b02ac1755ffd84c1c0abf0f3c6747",
+        provenance_sha256: "8450f524b6efd5cc9017b805dd8803a1079dbc222c23ad4e890994d662f8bb25",
+        sbom_sha256: "280ba2ce2e4ce8767a7392fbc8176e6d98aebaf6e6e4595e49d88eeab6fcb655",
+        patch_report_sha256: "fd34d37ea605013011baa61331834de11ffd476584a4ba9cc2bc09ed0356d9fb",
+        revocations_sha256: "f08001567b8098fe63060a8eeaf12fb2e9dcb4be383c2480f9d887728ed3c223",
+        revocation_generation: 1,
+        provenance_accepted: true,
+        sbom_accepted: true,
+        patch_accepted: true,
+        revocations_accepted: true,
+    };
+    let payload = serde_json::to_vec(&payload).expect("serialize canonical promotion payload");
+    let key = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).expect("generate signing key");
+    let key = Ed25519KeyPair::from_pkcs8(key.as_ref()).expect("decode signing key");
+    let encoder = base64::engine::general_purpose::STANDARD;
+    let envelope = serde_json::json!({
+        "schema_version": 1,
+        "key_id": "test.windows-image-promotion.v1",
+        "payload_base64": encoder.encode(&payload),
+        "signature_base64": encoder.encode(key.sign(&payload).as_ref())
+    });
+    let envelope_path = fixture.root.join("promotion.json");
+    fs::write(
+        &envelope_path,
+        serde_json::to_vec(&envelope).expect("serialize promotion envelope"),
+    )
+    .expect("write promotion envelope");
+    fixture.config["windows_hyperv"]["image_contract"]["promotion"] = serde_json::json!({
+        "envelope_path": envelope_path.to_string_lossy(),
+        "key_id": "test.windows-image-promotion.v1",
+        "public_key_base64": encoder.encode(key.public_key().as_ref())
+    });
+}
 
 fn baseline() -> serde_json::Value {
     serde_json::from_slice(include_bytes!("fixtures/runner.windows.product.json"))
@@ -21,7 +250,19 @@ fn parse(value: &serde_json::Value) -> Result<RunnerProductConfig, RunnerProduct
     )
 }
 
+fn enrollment_intent() -> WindowsEnrollmentIntent {
+    WindowsEnrollmentIntent::new(
+        uuid::Uuid::from_u128(1),
+        &reqwest::Url::parse("https://enroll.example.test/").expect("enrollment origin"),
+        "windows-runner",
+        automata_ci_core::Sha256Digest::from_bytes([41; 32]),
+        automata_ci_core::Sha256Digest::from_bytes([42; 32]),
+    )
+    .expect("enrollment intent")
+}
+
 #[test]
+#[allow(clippy::too_many_lines)]
 fn internal_windows_fixture_selects_only_hyperv_containers() {
     let config = parse(&baseline()).expect("internal Windows product fixture");
     let windows = config.windows_hyperv().expect("Windows Hyper-V provider");
@@ -73,6 +314,10 @@ fn internal_windows_fixture_selects_only_hyperv_containers() {
     assert!(config.executor().toolchain().pwsh().is_some());
     assert!(config.executor().toolchain().powershell().is_some());
     assert!(config.executor().toolchain().cmd().is_some());
+    assert!(config.executor().toolchain().tar().is_some());
+    assert!(config.executor().toolchain().sha256sum().is_some());
+    assert!(config.executor().toolchain().node24().is_some());
+    assert_eq!(windows.image_admission(), WindowsImageAdmission::Unverified);
     for feature in [
         RunnerFeature::SHELL_STEPS,
         RunnerFeature::DEFAULT_WINDOWS_SHELL,
@@ -120,7 +365,180 @@ fn internal_windows_fixture_selects_only_hyperv_containers() {
     );
     assert_eq!(keepalive.arguments(), &["keepalive".to_owned()]);
     assert_eq!(environment.workspace().as_str(), r"C:\__w");
-    assert!(config.executor().toolchain().node24().is_none());
+    assert_eq!(
+        config
+            .executor()
+            .toolchain()
+            .node24()
+            .map(automata_ci_execution::TargetPath::as_str),
+        Some(r"C:\automata\externals\node24\node.exe")
+    );
+}
+
+#[test]
+fn candidate_evidence_is_verified_but_does_not_publish_action_capabilities() {
+    let fixture = EvidenceFixture::new();
+    let config = RunnerProductConfig::load(&fixture.write_config("candidate-runner.json"))
+        .expect("candidate evidence is internally consistent");
+
+    assert_eq!(
+        config
+            .windows_hyperv()
+            .expect("Windows provider")
+            .image_admission(),
+        WindowsImageAdmission::Candidate
+    );
+    for feature in [
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ] {
+        assert!(!config.inventory().features().contains(&feature));
+    }
+    assert!(
+        windows_enrollment_admission_request(&config, BROKER_HOST_ID, enrollment_intent(),)
+            .expect("candidate admission request")
+            .is_none(),
+        "unsigned candidate evidence must not create active enrollment authority"
+    );
+}
+
+#[test]
+fn exact_external_promotion_keeps_actions_pending_for_active_enrollment_admission() {
+    let mut fixture = EvidenceFixture::new();
+    add_promotion(&mut fixture);
+    let config_path = fixture.write_config("promoted-runner.json");
+    let config =
+        RunnerProductConfig::load(&config_path).expect("signed external promotion verifies");
+
+    assert_eq!(
+        config
+            .windows_hyperv()
+            .expect("Windows provider")
+            .image_admission(),
+        WindowsImageAdmission::Promoted
+    );
+    for feature in [
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ] {
+        assert!(
+            !config.inventory().features().contains(&feature),
+            "pre-admission inventory unexpectedly advertised {feature}"
+        );
+    }
+    for feature in [
+        RunnerFeature::NODE12_ACTIONS,
+        RunnerFeature::NODE16_ACTIONS,
+        RunnerFeature::NODE20_ACTIONS,
+    ] {
+        assert!(!config.inventory().features().contains(&feature));
+    }
+
+    let request =
+        windows_enrollment_admission_request(&config, BROKER_HOST_ID, enrollment_intent())
+            .expect("build promoted active-admission request")
+            .expect("a promoted Windows image requires active admission");
+    assert_eq!(request.binding().runner_id(), config.runner_id());
+    assert_eq!(request.binding().backend_id(), BROKER_HOST_ID);
+    assert_eq!(request.binding().sandbox_provider_id(), "windows-hyperv");
+    let windows = config.windows_hyperv().expect("Windows provider");
+    assert_eq!(
+        request.binding().backend_executable(),
+        windows.runtime_executable()
+    );
+    assert_eq!(
+        request.binding().backend_executable_sha256(),
+        windows.runtime_sha256()
+    );
+    assert_eq!(
+        request.binding().promotion_public_key_sha256(),
+        windows
+            .promotion_public_key_sha256()
+            .expect("verified promotion public key")
+    );
+    assert_eq!(
+        request.binding().promotion_envelope_sha256(),
+        windows
+            .promotion_envelope_sha256()
+            .expect("verified promotion envelope")
+    );
+    assert_eq!(
+        request.binding().intent().operation_id(),
+        uuid::Uuid::from_u128(1)
+    );
+    assert_eq!(
+        request.binding().profile(),
+        request.environment().attestation()
+    );
+    assert_eq!(request.probe_policy().contract_schema_version(), 1);
+    assert!(
+        request
+            .probe_policy()
+            .contract_sha256()
+            .as_bytes()
+            .iter()
+            .any(|byte| *byte != 0),
+        "the shared exact probe contract must be digest-bound"
+    );
+    assert_eq!(
+        request.binding().image(),
+        request
+            .environment()
+            .image()
+            .expect("Hyper-V container image")
+            .reference()
+    );
+    assert_admitted_action_features(&request);
+    assert_host_input_contract(&request, &config_path);
+}
+
+#[test]
+fn evidence_verification_rejects_a_same_basename_tool_substitution() {
+    let mut fixture = EvidenceFixture::new();
+    fixture.config["executor"]["toolchain"]["node24"] =
+        serde_json::json!(r"C:\automata\externals\substituted\node.exe");
+
+    assert_eq!(
+        RunnerProductConfig::load(&fixture.write_config("substituted-tool-runner.json"))
+            .expect_err("manifest and configured Node path must agree"),
+        RunnerProductConfigError::InvalidWindowsImage
+    );
+}
+
+#[test]
+fn evidence_verification_fails_closed_on_missing_evidence_and_bad_signature() {
+    let fixture = EvidenceFixture::new();
+    fs::remove_file(fixture.root.join("sbom.spdx.json")).expect("remove SBOM fixture");
+    assert_eq!(
+        RunnerProductConfig::load(&fixture.write_config("missing-sbom-runner.json"))
+            .expect_err("a missing SBOM must fail closed"),
+        RunnerProductConfigError::InvalidWindowsImage
+    );
+
+    let mut fixture = EvidenceFixture::new();
+    add_promotion(&mut fixture);
+    let envelope_path = fixture.root.join("promotion.json");
+    let mut envelope: serde_json::Value =
+        serde_json::from_slice(&fs::read(&envelope_path).expect("read promotion envelope"))
+            .expect("parse promotion envelope");
+    envelope["signature_base64"] =
+        serde_json::json!(base64::engine::general_purpose::STANDARD.encode([0_u8; 64]));
+    fs::write(
+        &envelope_path,
+        serde_json::to_vec(&envelope).expect("serialize corrupt promotion envelope"),
+    )
+    .expect("write corrupt promotion envelope");
+    assert_eq!(
+        RunnerProductConfig::load(&fixture.write_config("bad-signature-runner.json"))
+            .expect_err("an invalid promotion signature must fail closed"),
+        RunnerProductConfigError::InvalidWindowsImage
+    );
 }
 
 #[test]
@@ -261,16 +679,20 @@ fn windows_container_toolchain_and_paths_are_in_image_and_literal() {
     let mut configured_node = baseline();
     configured_node["executor"]["toolchain"]["node24"] =
         serde_json::json!(r"C:\Program Files\nodejs\node.exe");
-    assert_eq!(
-        parse(&configured_node).expect_err("Windows action execution is not advertised"),
-        RunnerProductConfigError::InvalidExecutor
+    let configured_node = parse(&configured_node).expect("literal node.exe is syntactically valid");
+    assert!(
+        !configured_node
+            .inventory()
+            .features()
+            .contains(&RunnerFeature::NODE24_ACTIONS),
+        "configuration parsing alone must not advertise the runtime"
     );
 
-    let mut legacy_node = baseline();
-    legacy_node["executor"]["toolchain"]["node20"] =
-        serde_json::json!(r"C:\Program Files\nodejs\node.exe");
+    let mut invalid_node = baseline();
+    invalid_node["executor"]["toolchain"]["node20"] =
+        serde_json::json!(r"C:\automata\externals\node20\node.cmd");
     assert_eq!(
-        parse(&legacy_node).expect_err("only Node 24 is supported"),
+        parse(&invalid_node).expect_err("every Node generation requires node.exe"),
         RunnerProductConfigError::InvalidExecutor
     );
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -160,6 +160,14 @@ Tasks:
     probes at most one byte beyond the attachment ceiling; either the sentinel
     byte or the endpoint's bounded-output rejection emits the same non-fatal
     diagnostic and omits the complete summary.
+  - [x] Bound retained summaries after masking and across repeated action or
+    composite phases. A phase that would take one step beyond 1 MiB is omitted,
+    the already-retained prefix is preserved, and one masked warning is retained
+    without changing the process conclusion.
+  - [x] Bound the complete job-result attachment set at 8 MiB. The first summary
+    crossing that ceiling closes further summary retention and leaves one
+    deterministic warning; enough previously retained summary suffix is removed
+    to keep that warning inside the durable result budget.
 - [x] Verify summary isolation across pre, main, post, composite, and repeated
   action occurrences.
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -150,13 +150,16 @@ Tasks:
   behavior.
 - [x] Test command-file collection after success, failure, timeout, and
   cancellation.
-- [ ] Aggregate step summaries in completed-step order, define deletion and
+- [x] Aggregate step summaries in completed-step order, define deletion and
   empty-file behavior, and preserve a deterministic truncation indicator.
   - [x] Completed-step ordering plus missing, deleted, and empty summaries are
     defined and covered.
-  - [ ] Match the pinned runner's diagnostic-and-skip behavior for a summary
+  - [x] Match the pinned runner's diagnostic-and-skip behavior for a summary
     larger than 1 MiB across the bounded copy interface. The pinned runner does
-    not truncate the file, so no truncation policy is inferred.
+    not truncate the file, so no truncation policy is inferred. The executor
+    probes at most one byte beyond the attachment ceiling; either the sentinel
+    byte or the endpoint's bounded-output rejection emits the same non-fatal
+    diagnostic and omits the complete summary.
 - [x] Verify summary isolation across pre, main, post, composite, and repeated
   action occurrences.
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -70,10 +70,21 @@ Tasks:
     rejects a source-required feature outside that exact set before runtime or
     Job IR blob publication. Unknown feature identifiers, duplicate or excessive
     sets, historical mappings without the feature-policy section, and Windows
-    profiles that claim action or Node execution fail closed. The current Linux
-    example claims only its configured Bash, `sh`, Python, Node 24, action, and
-    command-file/summary toolchain features; Windows claims no action or Node
-    runtime.
+    profiles that claim action or Node execution without the corresponding
+    accepted profile ceiling fail closed. The current Linux example claims only
+    its configured Bash, `sh`, Python, Node 24, action, and command-file/summary
+    toolchain features. The checked-in Windows candidate remains shell-only.
+  - [x] Windows runner product loading separately verifies a digest-bound
+    Server 2025 manifest/lock, typed digest/media references for provenance,
+    SPDX SBOM, patch and revocation artifacts, and an external Ed25519 promotion
+    envelope. Runner composition adds composite,
+    repository, local-action, JavaScript, and exact Node-generation features
+    only after promotion and successful fresh-sandbox tool probes. An
+    authenticated, short-lived broker-custody receipt contract can carry that
+    exact set into Windows enrollment; the restricted-broker caller remains an
+    integration gate. That caller must make startup independently re-probe
+    before live advertisement. Missing, stale, or mismatched
+    receipt/image/tool/runtime evidence fails closed.
   - [x] Keep temporary placement absence distinct from terminal semantic
     admission. A job that passed its immutable profile ceiling but has no
     currently eligible runner remains durable `NoWork`; admission never derives
@@ -233,6 +244,10 @@ Remaining tasks:
 - [ ] Enforce repository and organization action allowlists and immutable-SHA
   policy.
 - [ ] Verify archive digests, paths, links, and subpath containment.
+  - [x] The Windows component gate rejects traversal, links, special entries,
+    reserved/illegal names, case-insensitive collisions, stale destinations,
+    digest mismatch, and post-extraction reparse escape before action metadata
+    or code, and performs extraction only inside the sandbox.
 - [ ] Cache only immutable action content.
 - [ ] Keep credentials out of logs and durable action metadata.
 

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -38,8 +38,10 @@ startup orphan check are component recovery, but they do not replace a
 restricted management broker, independent watchdog, or real engine/host fault
 evidence. A broker-verifiable signed admission grant, managed egress,
 credential delivery, a signed image factory, and dedicated-host acceptance
-also remain open. Action
-steps, job and service containers, egress, devices, and parallel capacity
+also remain open. The source tree has component support for Windows action
+materialization and JavaScript/composite execution, but the checked-in image
+evidence is an unsigned candidate. It therefore advertises shell-only
+capacity. Job and service containers, egress, devices, and parallel capacity
 remain unsupported.
 
 The detailed
@@ -49,6 +51,29 @@ blocking trust order is `EVT-01` -> `AUTH-02` -> `WIN-ISO-01`. The local
 pre-lease portion of that route is now enforced, but the provider cannot
 advertise support before the signed broker, management/recovery, image, and
 real-host gates pass.
+
+Image admission now verifies a digest-bound Windows Server 2025 Server Core
+manifest and lock together with provenance, SPDX SBOM, patch, and revocation
+metadata. It binds the exact guest/workspace and configured PowerShell, cmd,
+tar, hash-helper, and Node-generation paths. A canonical external Ed25519
+promotion envelope plus successful fresh-container probes are both required
+before runner composition adds JavaScript, composite, repository, local-action,
+or Node-generation features. Candidate, missing, mismatched, revoked, or
+substituted material never gains those features. These are component gates,
+not a signed image factory or physical-host evidence.
+
+Windows enrollment now has a typed pre-enrollment admission contract. Its
+short-lived authenticated receipt binds the runner, broker/provider identity,
+exact enrollment operation, image/profile/promotion trust anchor and probe
+policy, and canonical capability set;
+only an opaque restricted-broker custody handle is durable across retries.
+The production broker caller is a separate integration gate. It must fail
+closed when custody is absent, stale, expired, or mismatched, and runtime startup
+must independently repeat profile/tool admission. Once composed,
+an admitted action/Node feature can exist in both durable registration and live
+observation instead of being removed by their least-authority intersection.
+This interface and its injected tests are not a promoted image or physical-host
+release claim.
 
 Current component placement foundation binds GitHub-projected Windows jobs to
 both VM-grade isolation and the exact
@@ -97,22 +122,33 @@ offline Hyper-V-container gate.
 
 Tasks:
 
-- [ ] Add and probe Node 24, Git, Git Bash, archive extraction, tar/zstd, and
-  optional supported Python.
-- [ ] Publish exact versions, architecture, and paths in a tool manifest.
-- [ ] Withhold individual capabilities when a probe fails.
-- [ ] Replace POSIX `install` and `tar` action extraction with a secure
-  platform-specific materialization port.
-- [ ] Preserve archive digest and subpath provenance.
-- [ ] Reject traversal, links, reparse escape, and overwrite attacks.
-- [ ] Support local metadata reads and idempotent cleanup.
+- [x] Define and probe exact configured `pwsh.exe`, `powershell.exe`,
+  `cmd.exe`, `tar.exe`, Automata SHA-256 helper, and Node 12/16/20/24 paths in
+  a fresh Windows sandbox.
+- [x] Bind exact tool versions, architecture, paths, and digests through the
+  candidate manifest and externally signed promotion interface.
+- [x] Withhold all Windows action and Node capabilities unless image
+  verification and every configured live tool probe succeed.
+- [x] Add a Windows-specific in-sandbox materialization path with exact archive
+  digest verification and subpath provenance.
+- [x] Reject traversal, links, special entries, reserved/illegal Windows names,
+  case-fold collisions, stale destinations, digest mismatch, and reparse-tree
+  escape before metadata or action execution.
+- [x] Support in-sandbox local metadata reads and exact action cleanup phases at
+  the executor component boundary.
+- [ ] Add and qualify Git, Git Bash, zstd, and any optional Python distribution
+  required by the released action profile.
+- [ ] Publish real image/tool versions and digests from the external image
+  factory and pass the physical Windows qualification gate.
 - [ ] Honor reviewed proxy and custom-CA configuration during Git/action source
   access, Results traffic, and startup admission.
 
 Acceptance:
 
-- [ ] Startup proves every advertised tool inside a fresh sandbox.
-- [ ] Missing Node removes action capability without removing plain run steps.
+- [x] Product startup probes every configured action tool inside a fresh
+  sandbox before registration; injected component tests exercise this gate.
+- [x] Candidate or missing Node-generation evidence removes JavaScript and
+  exact Node capabilities without removing plain run steps.
 - [ ] Linux and Windows produce equivalent immutable action trees.
 
 ### WIN-02 — JavaScript and composite actions on Windows
@@ -122,12 +158,16 @@ WIN-ISO-08 managed data/credential boundary, RUN-01, ACT-01.
 
 Tasks:
 
-- [ ] Replace blanket Windows action rejection with granular capabilities.
-- [ ] Execute Node 24 pre, main, and post.
-- [ ] Execute local, repository, composite, and nested-composite actions.
-- [ ] Preserve Windows phase files, environment casing, and CRLF behavior.
+- [x] Replace blanket runner-side Windows action rejection with promotion- and
+  live-admission-gated granular capabilities.
+- [x] Execute metadata-selected Node 12/16/20/24 pre, main, and post through
+  exact configured paths; no generation or `PATH` fallback is allowed.
+- [x] Enable local, repository, composite, and nested-composite executor paths
+  only when their exact runtime capabilities were admitted.
+- [x] Preserve the existing Windows phase-file, environment-casing, and CRLF
+  executor behavior for admitted actions.
 - [ ] Populate action contexts and run cleanup after failure/cancellation.
-- [ ] Keep Docker actions and containers rejected until separately available.
+- [x] Keep Docker actions and containers rejected until separately available.
 
 Acceptance:
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -106,6 +106,49 @@ That provider-foundation pull request did **not** prove or complete:
 - [ ] hostile cross-job, daemon-compromise, crash-transition, or cleanup soak;
 - [ ] Windows Actions compatibility or a production capability claim.
 
+The source tree now also contains an image/action component increment behind
+those release gates:
+
+- a closed, digest-bound Windows Server 2025 Server Core, x86-64,
+  Hyper-V-container profile manifest and image lock;
+- bounded, typed reference interfaces that bind the native media type and
+  digest of provenance, SPDX SBOM, patch, and revocation metadata, plus an
+  optional externally signed Ed25519 promotion
+  envelope that binds every evidence digest and the revocation generation;
+- exact manifest-to-configuration bindings for the guest, workspace,
+  `pwsh.exe`, `powershell.exe`, `cmd.exe`, `tar.exe`, the Automata SHA-256
+  helper, and any configured Node 12/16/20/24 runtime;
+- fresh-sandbox startup probes for all configured Windows action tools; and
+- bounded Windows action-archive validation, in-container digest verification,
+  extraction, reparse-tree inspection, and exact-generation Node execution.
+
+Candidate evidence that is internally consistent but lacks the external
+promotion signature remains shell-only. JavaScript, composite, repository,
+local-action, and Node-generation capabilities are composed only after both
+promotion verification and fresh profile probes succeed. The source-level
+pre-enrollment admission contract binds the runner, broker/provider identity,
+exact enrollment transaction, exact environment and
+resource/tool probe policy, image manifest/lock and signed-promotion identity,
+the versioned digest of the shared lifecycle/tool probe semantics, and canonical
+registration inventory into a short-lived authenticated receipt. The broker
+caller must invoke that shared helper rather than reproduce private probe argv.
+It must also obtain fresh broker proof for the fixed ordered host-input set:
+exact configuration, backend executable, manifest, lock, evidence records, and
+promotion envelope, each bound to content digest, trusted owner, protected and
+non-inherited DACL, non-reparse stable file ID, and approved local volume.
+It requires that only an opaque broker-custody handle cross restart and that the
+runner write no Windows enrollment secret or receipt to local staging. The
+restricted-broker caller remains a separate integration gate. Once composed,
+missing, stale, expired, tampered, or mismatched custody fails closed, and
+runtime startup re-runs the full
+profile probes independently; the receipt never substitutes for live evidence,
+and control-plane registered/live intersection retains only capabilities proved
+twice. Missing,
+mismatched, revoked, or substituted evidence and tools stop startup. The
+checked-in candidate files are contract fixtures: they do not claim a built,
+signed, scanned, patched, or physical-host-tested image, and they do not close
+WIN-ISO-03, WIN-ISO-10, or any production gate.
+
 The current direct CLI boundary is suitable for component development and an
 offline laboratory. It is not the final hostile-workload management boundary.
 A runner identity that can independently access the container-engine named pipe
@@ -351,15 +394,26 @@ Current runner product schema v6 selects exactly one provider. The Windows
 provider requires one or more digest-attested environment profiles with:
 
 - an immutable digest-qualified Windows image reference;
+- a digest-pinned Server 2025 manifest and image lock plus bounded typed
+  reference records for provenance, SPDX SBOM, patch-report, and revocation
+  artifacts;
 - a Windows keepalive executable and literal argument vector;
 - an in-container Windows workspace root;
-- Windows shell paths located in the image; and
+- exact `pwsh.exe`, `powershell.exe`, `cmd.exe`, `tar.exe`, Automata SHA-256
+  helper, and configured Node-generation paths located in the image; and
 - network disabled, writable container root, unprivileged execution, zero GPU,
   and zero claimed ephemeral-disk allocation.
 
-Example values are placeholders, not deployable image or runtime attestations.
-Operators must replace every placeholder digest with evidence from their own
-build and host qualification.
+The optional promotion configuration names an envelope, pinned key identifier,
+and Ed25519 public key. A canonical signed payload must explicitly promote and
+accept provenance, SBOM, patch, and revocation subjects while binding the exact
+profile, manifest, lock, base/output images, all evidence digests, and
+revocation generation. Without it the image remains a candidate and action
+capabilities stay absent.
+
+Example values and the checked-in candidate files are contract fixtures, not
+deployable image or runtime attestations. Operators must replace every
+placeholder digest with evidence from their own build and host qualification.
 
 ### Runtime invocation
 
@@ -547,6 +601,16 @@ The image factory must:
 - publish immutable digests only after security review; and
 - rotate or revoke an image without permitting mutable-tag fallback.
 
+The repository implements the consumer side of that contract: secure bounded
+file loading, exact digest/schema/binding validation, revocation rejection, and
+external Ed25519 promotion verification. The typed records bind external
+artifact digests and native media types; they are not substitutes for parsing
+or producing the referenced in-toto, SPDX, patch, or revocation artifacts. The
+accompanying candidate manifest, lock, and reference records intentionally
+contain placeholder values and no promotion envelope. This is neither the
+image factory nor evidence that any listed tool or image exists; real pipeline
+outputs and dedicated-host qualification remain mandatory.
+
 No host directory or shared mutable tool cache is mounted into the container.
 Source, action content, and outputs cross only through bounded provider-neutral
 copy and result interfaces. Persistent caches and artifacts use their product
@@ -730,6 +794,12 @@ and the broker can mutate only exact generation-bound Automata resources.
 
 ### WIN-ISO-03 — Hermetic Windows image supply chain
 
+- [x] Define a closed candidate manifest/lock schema for one Windows Server
+      2025 Server Core, x86-64, Hyper-V-container profile and exact tools.
+- [x] Add bounded verifier interfaces for manifest, lock, provenance, SPDX
+      SBOM, patch, revocation, and external Ed25519 promotion metadata.
+- [x] Keep checked-in fixtures explicitly candidate-only and withhold action
+      capabilities without a valid external promotion envelope.
 - [ ] Define the exact Server Core host/image compatibility matrix.
 - [ ] Build a digest-pinned image containing guest executable and reviewed
       shells/tools without job-time mutable installation.
@@ -866,12 +936,16 @@ return a Windows host without accepting unknown state.
 **Dependencies:** WIN-01, WIN-02, RUN-01 through RUN-03, ACT-01, and
 WIN-ISO-06 through WIN-ISO-09 as applicable.
 
-- [ ] Run PowerShell 7, Windows PowerShell, cmd, and optional Python with exact
-      Windows argv, encoding, CRLF, environment, working-directory, and exit
-      semantics.
-- [ ] Run Node action pre/main/post and nested composite phases inside the same
-      isolated container.
-- [ ] Materialize actions without host execution or host mounts.
+- [x] Implement exact PowerShell 7, Windows PowerShell, cmd, and optional
+      Python argv, encoding, CRLF, environment, working-directory, and exit
+      semantics at the component boundary.
+- [x] Implement exact-generation Node action pre/main/post and composite phase
+      execution inside the same sandbox at the component boundary.
+- [x] Implement action materialization without host extraction or host mounts,
+      including bounded Windows archive-name/link/collision checks, in-sandbox
+      digest verification, extraction, and reparse-tree validation.
+- [ ] Prove those runtime and materialization paths in the shipped product on a
+      promoted image and dedicated Windows Hyper-V host.
 - [ ] Support only product artifact/cache/source interfaces accepted by their
       packages.
 - [ ] Reject Docker actions, nested job/service containers, devices,

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -820,7 +820,7 @@ for each advertised profile.
 First-PR component scope:
 
 - [x] Add the explicit Windows Hyper-V container launch variant.
-- [x] Keep the current schema-v4 `windows_hyperv` configuration and remove
+- [x] Keep the current schema-v6 `windows_hyperv` configuration and remove
       `windows_native`.
 - [x] Require disabled network, unprivileged workload, writable container root,
       no services, zero GPU, and no ephemeral-disk claim.

--- a/images/windows-server-2025-hyperv-candidate/README.md
+++ b/images/windows-server-2025-hyperv-candidate/README.md
@@ -1,0 +1,17 @@
+# Windows Server 2025 Hyper-V image candidate
+
+This directory is a contract fixture, not a released runner image. Its digest
+values demonstrate the closed manifest, lock, and typed evidence-reference
+interfaces. Each reference binds the expected media type and a placeholder
+digest for external provenance, SBOM, patch, or revocation material. These
+files are not themselves in-toto or SPDX documents and do not assert that an
+image was built, signed, scanned, patched, or exercised on physical Windows
+hardware.
+
+Production promotion requires replacing the candidate values with outputs from
+the Windows image pipeline, deploying the exact files at the configured secure
+paths, and supplying an Ed25519 promotion envelope from an external authority.
+The signed payload must accept all four evidence subjects and bind their exact
+digests, the manifest and lock, both image digests, and the revocation
+generation. Without that envelope the runner can verify this candidate for
+internal consistency but cannot compose or advertise action runtimes.

--- a/images/windows-server-2025-hyperv-candidate/image.lock.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/image.lock.candidate.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "manifest_sha256": "8469373351b458633450cd4f28e24b18fa756832a7917c9d8ae2a82ad6241c23",
+  "base_image": "mcr.microsoft.com/windows/servercore@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/images/windows-server-2025-hyperv-candidate/manifest.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/manifest.candidate.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "status": "candidate",
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "operating_system": "windows-server-2025",
+  "variant": "server-core",
+  "architecture": "x86_64",
+  "isolation": "hyperv-container",
+  "base_image": "mcr.microsoft.com/windows/servercore@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "workspace": "C:\\__w",
+  "guest_agent": "C:\\automata\\guest\\automata-ci-sandbox-guest.exe",
+  "network_disabled": true,
+  "unprivileged": true,
+  "clean_workspace": true,
+  "tools": [
+    {
+      "kind": "pwsh",
+      "path": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+      "version": "candidate-7.x",
+      "sha256": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    {
+      "kind": "powershell",
+      "path": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      "version": "candidate-windows-server-2025",
+      "sha256": "4444444444444444444444444444444444444444444444444444444444444444"
+    },
+    {
+      "kind": "cmd",
+      "path": "C:\\Windows\\System32\\cmd.exe",
+      "version": "candidate-windows-server-2025",
+      "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    {
+      "kind": "tar",
+      "path": "C:\\automata\\tools\\tar\\tar.exe",
+      "version": "candidate-gnu-tar",
+      "sha256": "6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    {
+      "kind": "sha256",
+      "path": "C:\\automata\\tools\\hash\\automata-sha256.exe",
+      "version": "candidate-automata-sha256-v1",
+      "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+    },
+    {
+      "kind": "node24",
+      "path": "C:\\automata\\externals\\node24\\node.exe",
+      "version": "candidate-node-24",
+      "sha256": "8888888888888888888888888888888888888888888888888888888888888888"
+    }
+  ],
+  "evidence": {
+    "provenance": {
+      "sha256": "8450f524b6efd5cc9017b805dd8803a1079dbc222c23ad4e890994d662f8bb25",
+      "media_type": "application/vnd.automata.windows-image-evidence-reference+json"
+    },
+    "sbom": {
+      "sha256": "280ba2ce2e4ce8767a7392fbc8176e6d98aebaf6e6e4595e49d88eeab6fcb655",
+      "media_type": "application/vnd.automata.windows-image-evidence-reference+json"
+    },
+    "patch_report": {
+      "sha256": "fd34d37ea605013011baa61331834de11ffd476584a4ba9cc2bc09ed0356d9fb",
+      "media_type": "application/vnd.automata.windows-image-evidence-reference+json"
+    },
+    "revocations": {
+      "sha256": "f08001567b8098fe63060a8eeaf12fb2e9dcb4be383c2480f9d887728ed3c223",
+      "media_type": "application/vnd.automata.windows-image-evidence-reference+json"
+    }
+  }
+}

--- a/images/windows-server-2025-hyperv-candidate/patch-report.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/patch-report.candidate.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "kind": "patch_report",
+  "candidate_fixture": true,
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "subject": {
+    "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "media_type": "application/vnd.automata.windows-patch-report+json"
+  },
+  "statement": "Candidate patch-metadata interface fixture only; external security acceptance is required for promotion."
+}

--- a/images/windows-server-2025-hyperv-candidate/provenance.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/provenance.candidate.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "kind": "provenance",
+  "candidate_fixture": true,
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "subject": {
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "media_type": "application/vnd.in-toto+json"
+  },
+  "statement": "Candidate provenance interface fixture only; no builder signature or physical image promotion is asserted."
+}

--- a/images/windows-server-2025-hyperv-candidate/revocations.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/revocations.candidate.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "kind": "revocations",
+  "candidate_fixture": true,
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "subject": {
+    "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "media_type": "application/vnd.automata.image-revocations+json"
+  },
+  "statement": "Candidate revocation-metadata interface fixture only; an externally accepted generation is required for promotion.",
+  "generation": 1,
+  "revoked_images": []
+}

--- a/images/windows-server-2025-hyperv-candidate/sbom.candidate.json
+++ b/images/windows-server-2025-hyperv-candidate/sbom.candidate.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "kind": "sbom",
+  "candidate_fixture": true,
+  "profile_id": "automata.dev/windows-2025-x64-hyperv-v1",
+  "image": "registry.example/automata/windows-runner@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "subject": {
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "media_type": "application/spdx+json"
+  },
+  "statement": "Candidate SPDX-interface fixture only; an externally generated image SBOM is required for promotion."
+}


### PR DESCRIPTION
## Status

**Original stack position: 3 of 9.** PR #197 and PR #382 are merged, and this slice is now rebased directly onto `main`.

- Base: `main`
- Base head: `9b9dbc458e38bf3070c219d08439929c68417d4e`
- Head: `991fa21fc942e3d2772f50a8ca88a362b040a430`
- Diff: 37 files, +5,769/-197 (5,966 changed lines)
- Downstream: draft PR #385 remains stacked on this branch and must be rebased after this PR merges.
- Auto-merge is disabled; only the user will merge it.

## What this slice adds

- Windows action-runtime and image-admission contracts in the runner and GitHub executor.
- Exact Windows shell/action capability gating and action-image evidence checks.
- Fail-closed enrollment probes bound to the authenticated runner identity and sandbox-custody coordinate established by PR #382.
- Bounded individual and cumulative step summaries.
- Native Windows action/runtime tests and byte-stable Windows image-evidence fixtures.
- Integration with runner schema 6, certificate-renewal lifecycle, LocalDocker Results transport, `PrivateEgress`, runner binding, and slot ceilings.

This slice admits supported action inputs; it does **not** seal action graphs, build or publish runner images, create Hyper-V sandboxes, or expose a broker service. Production Windows execution remains fail closed.

The rebase preserves `main`'s authority semantics: nested `./...` actions remain caller-workspace local and fail closed before scheduling, while `$/...` is the distinct immutable self-repository form. It also preserves PR #382's verified admission-envelope persistence and replay protections. This PR adds no SQL migration, CI workflow, Cargo/lock, or action-parser change.

## Validation

Exact remote head `991fa21fc942e3d2772f50a8ca88a362b040a430`:

- Unified CI Rust job: passed.
- Unified CI frontend job: passed.
- Unified CI PostgreSQL job: passed.
- Dependabot configuration validation: passed.
- No Windows CI job was created.

Local validation of the patch-identical four-commit slice:

- `git range-diff` reports all four patches unchanged through the final rebase.
- `cargo fmt --all -- --check` from the committed LF snapshot, locked metadata, and `git diff --check`: passed.
- Windows MSVC check and strict Clippy for action, GitHub job executor, Windows sandbox, and runner: passed.
- All-feature action, GitHub job-executor, and Windows-sandbox test suites: passed.
- Runner integration suite: 50/50 passed, including 10/10 Windows product/image-admission tests.
- Scheduling-domain contract suite: 12/12 passed.