### PR TITLE
fix(ci): backpressure results uploads and stabilize cache keys

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
   SCCACHE_IDLE_TIMEOUT: "0"
   SCCACHE_SERVER_UDS: '\x00automata-sccache'
   TMPDIR: ${{ github.workspace }}/target/task-tmp/ci

--- a/.ci/workflows/pull-request.yml
+++ b/.ci/workflows/pull-request.yml
@@ -16,6 +16,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
   SCCACHE_IDLE_TIMEOUT: "0"
   SCCACHE_SERVER_UDS: '\x00automata-sccache'
   TMPDIR: ${{ github.workspace }}/target/task-tmp/pr

--- a/crates/automata-ci-results-github/Cargo.toml
+++ b/crates/automata-ci-results-github/Cargo.toml
@@ -30,6 +30,7 @@ sha2.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting"] }
+tokio.workspace = true
 url.workspace = true
 uuid.workspace = true
 xmlparser.workspace = true
@@ -43,7 +44,6 @@ automata-ci-protocol-protobuf.workspace = true
 automata-ci-store.workspace = true
 automata-ci-store-postgres = { workspace = true, features = ["test-support"] }
 http-body-util.workspace = true
-tokio.workspace = true
 tower.workspace = true
 
 [lints]

--- a/crates/automata-ci-results-github/src/http.rs
+++ b/crates/automata-ci-results-github/src/http.rs
@@ -1,9 +1,6 @@
 use std::{
     str::FromStr as _,
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, OnceLock},
 };
 
 use automata_ci_core::{JobId, RunId, Sha256Digest};
@@ -19,6 +16,7 @@ use axum::{
 use futures::{StreamExt as _, stream};
 use serde::{Deserialize, Serialize};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use uuid::Uuid;
 
 use crate::{
@@ -43,49 +41,29 @@ const DEFAULT_MIME_TYPE: &str = "application/octet-stream";
 const MAXIMUM_SIGNATURE_BYTES: usize = 256;
 /// Four maximum-size cache blocks bound upload buffering to 512 MiB per process.
 const MAXIMUM_CONCURRENT_RESULTS_UPLOADS: usize = 4;
-const RESULTS_UPLOAD_RETRY_AFTER_SECONDS: &str = "1";
 const RESULTS_UPLOAD_OVERLOAD_BODY: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ServerBusy</Code><Message>The Results upload service is temporarily unavailable.</Message></Error>";
 const X_CONTENT_TYPE_OPTIONS: header::HeaderName =
     header::HeaderName::from_static("x-content-type-options");
 
 #[derive(Debug)]
 pub(crate) struct ResultsUploadAdmission {
-    in_flight: AtomicUsize,
+    permits: Arc<Semaphore>,
 }
 
 impl ResultsUploadAdmission {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
-            in_flight: AtomicUsize::new(0),
+            permits: Arc::new(Semaphore::new(MAXIMUM_CONCURRENT_RESULTS_UPLOADS)),
         }
     }
 
-    fn try_acquire(self: &Arc<Self>) -> Option<ResultsUploadPermit> {
-        self.in_flight
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |in_flight| {
-                (in_flight < MAXIMUM_CONCURRENT_RESULTS_UPLOADS).then_some(in_flight + 1)
-            })
-            .ok()
-            .map(|_| ResultsUploadPermit {
-                admission: Arc::clone(self),
-            })
+    async fn acquire(&self) -> Result<OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        Arc::clone(&self.permits).acquire_owned().await
     }
 
     #[cfg(test)]
     fn in_flight(&self) -> usize {
-        self.in_flight.load(Ordering::Acquire)
-    }
-}
-
-#[derive(Debug)]
-struct ResultsUploadPermit {
-    admission: Arc<ResultsUploadAdmission>,
-}
-
-impl Drop for ResultsUploadPermit {
-    fn drop(&mut self) {
-        let previous = self.admission.in_flight.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "Results upload admission underflow");
+        MAXIMUM_CONCURRENT_RESULTS_UPLOADS - self.permits.available_permits()
     }
 }
 
@@ -99,7 +77,10 @@ pub(crate) async fn admit_results_upload(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    let Some(_permit) = admission.try_acquire() else {
+    // Waiting here applies bounded, FIFO backpressure before Axum starts buffering
+    // another request body. Cache traffic therefore cannot turn a valid artifact
+    // upload into a transient protocol failure when the shared memory budget is full.
+    let Ok(_permit) = admission.acquire().await else {
         return results_upload_overloaded();
     };
     next.run(request).await
@@ -108,10 +89,7 @@ pub(crate) async fn admit_results_upload(
 fn results_upload_overloaded() -> Response {
     let mut response = (
         StatusCode::SERVICE_UNAVAILABLE,
-        [
-            (header::CONTENT_TYPE, "application/xml; charset=utf-8"),
-            (header::RETRY_AFTER, RESULTS_UPLOAD_RETRY_AFTER_SECONDS),
-        ],
+        [(header::CONTENT_TYPE, "application/xml; charset=utf-8")],
         RESULTS_UPLOAD_OVERLOAD_BODY,
     )
         .into_response();
@@ -997,7 +975,6 @@ mod tests {
     use std::{convert::Infallible, sync::Mutex, time::Duration};
 
     use axum::{body::Bytes, routing::put};
-    use http_body_util::BodyExt as _;
     use tower::ServiceExt as _;
 
     use super::*;
@@ -1053,7 +1030,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn artifact_and_cache_uploads_share_budget_and_cancelled_request_releases_it() {
+    async fn artifact_and_cache_uploads_share_fifo_backpressure_and_release_cancelled_requests() {
         let artifact_admission = results_upload_admission();
         let cache_admission = results_upload_admission();
         assert!(Arc::ptr_eq(&artifact_admission, &cache_admission));
@@ -1087,32 +1064,22 @@ mod tests {
         }
         wait_for_uploads(&artifact_admission, MAXIMUM_CONCURRENT_RESULTS_UPLOADS).await;
 
-        let rejected = tokio::time::timeout(
-            Duration::from_secs(1),
+        let queued = tokio::spawn(
             router
                 .clone()
                 .oneshot(pending_upload(ARTIFACT_UPLOAD_TEST_PATH)),
-        )
-        .await
-        .expect("overload response must not wait for request body")
-        .expect("overload response");
-        assert_eq!(rejected.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(rejected.headers()[header::RETRY_AFTER], "1");
-        assert_eq!(rejected.headers()[header::CACHE_CONTROL], "no-store");
-        assert_eq!(rejected.headers()[X_CONTENT_TYPE_OPTIONS], "nosniff");
-        let body = rejected
-            .into_body()
-            .collect()
-            .await
-            .expect("overload body")
-            .to_bytes();
-        assert_eq!(body.as_ref(), RESULTS_UPLOAD_OVERLOAD_BODY.as_bytes());
-        assert_eq!(
-            *observer.completed.lock().expect("completed observations"),
-            vec![(
-                ResultsHttpRoute::Upload,
-                crate::ResultsHttpStatusClass::ServerError,
-            )]
+        );
+        tokio::task::yield_now().await;
+        assert!(
+            !queued.is_finished(),
+            "the fifth upload must wait for capacity"
+        );
+        assert!(
+            observer
+                .completed
+                .lock()
+                .expect("completed observations")
+                .is_empty()
         );
 
         let cancelled = requests.remove(0);
@@ -1123,17 +1090,14 @@ mod tests {
                 .expect_err("admitted upload must be cancelled")
                 .is_cancelled()
         );
-        wait_for_uploads(&artifact_admission, MAXIMUM_CONCURRENT_RESULTS_UPLOADS - 1).await;
-
-        let replacement = tokio::spawn(router.oneshot(pending_upload(CACHE_UPLOAD_TEST_PATH)));
         wait_for_uploads(&artifact_admission, MAXIMUM_CONCURRENT_RESULTS_UPLOADS).await;
 
         for request in requests {
             request.abort();
             let _ = request.await;
         }
-        replacement.abort();
-        let _ = replacement.await;
+        queued.abort();
+        let _ = queued.await;
         wait_for_uploads(&artifact_admission, 0).await;
     }
 }

--- a/crates/automata-ci/src/app/github_auth.rs
+++ b/crates/automata-ci/src/app/github_auth.rs
@@ -3024,6 +3024,7 @@ mod tests {
         let (setup_app, setup_probe) = setup_begin_harness_with_admission(admission);
 
         let mut invalid_origin = browser_begin_request();
+        invalid_origin.headers_mut().remove(SEC_FETCH_SITE);
         invalid_origin
             .headers_mut()
             .insert(ORIGIN, HeaderValue::from_static("https://attacker.example"));

--- a/crates/automata-ci/src/server/github_oidc.rs
+++ b/crates/automata-ci/src/server/github_oidc.rs
@@ -816,10 +816,13 @@ mod tests {
 
     use automata_ci_control::runner_control::RuntimeAuthorityIssueRequest;
     use automata_ci_core::{
-        AttemptId, FencingToken, JobContentReference, JobExecutionContext, JobId,
-        JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest, JobSource, Lease, LeaseId,
-        PermissionLevel, RunId, RunValueTemplates, RunnerId, RunnerRequirements, RunnerSessionId,
-        RuntimeBoolean, SemanticStep, ShellTemplate, StepId, StepIr, ValueTemplate, WorkflowId,
+        AttemptId, FencingToken, JobAuthorityProfile, JobContentReference, JobExecutionContext,
+        JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobPermissionRequest, JobSource, Lease,
+        LeaseId, PermissionLevel, RunId, RunValueTemplates, RunnerId, RunnerRequirements,
+        RunnerSessionId, RuntimeBoolean, SemanticStep, ShellTemplate, StepId, StepIr,
+        TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
+        TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
+        ValueTemplate, WorkflowId,
     };
     use automata_ci_oidc_github::{
         AuthorizedOidcIssuance, OidcAuthorityId, OidcRepositoryError, ReserveOidcIssuance,
@@ -1326,6 +1329,8 @@ norlX3KEHNe7cTke5cP4OA==";
                 )],
             )
             .with_permission_request(permission)
+            .with_trust_snapshot(trusted_push_snapshot())
+            .with_authority_profile(JobAuthorityProfile::Standard)
             .with_timeout_seconds(120);
             let execution = JobExecutionContext::new(
                 "CI",
@@ -1405,6 +1410,33 @@ norlX3KEHNe7cTke5cP4OA==";
             )
             .expect("runtime authority request")
         }
+    }
+
+    fn trusted_push_snapshot() -> TrustSnapshot {
+        let repository =
+            TrustRepositoryEvidence::new("90210", "731").expect("stable repository trust evidence");
+        TrustPolicy::current()
+            .evaluate(
+                TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
+                    .with_original_actor(
+                        TrustActorEvidence::new(
+                            "4242",
+                            TrustActorKind::User,
+                            TrustAutomationKind::None,
+                        )
+                        .expect("stable actor trust evidence"),
+                    )
+                    .with_repositories(repository.clone(), repository)
+                    .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
+                    .with_revisions(
+                        "0123456789abcdef0123456789abcdef01234567",
+                        "0123456789abcdef0123456789abcdef01234567",
+                        "0123456789abcdef0123456789abcdef01234567",
+                    )
+                    .with_fork(false)
+                    .with_token_recursion(TrustTokenRecursion::Suppressed),
+            )
+            .expect("complete same-repository trust snapshot")
     }
 
     fn current_policy() -> GithubOidcCurrentPolicy {
@@ -1663,8 +1695,22 @@ norlX3KEHNe7cTke5cP4OA==";
         assert_eq!(authorities.as_slice().len(), 1);
         assert_eq!(authorities.as_slice()[0].name().as_str(), "github-results");
 
-        let provider_entitled =
+        let provider_without_authority =
             RuntimeFixture::new("github", JobPermissionRequest::mapping([]), "push");
+        let authorities = composite
+            .issue(provider_without_authority.request())
+            .await
+            .expect("an explicit empty permission mapping keeps only Results");
+        assert_eq!(authorities.as_slice().len(), 1);
+
+        let provider_entitled = RuntimeFixture::new(
+            "github",
+            JobPermissionRequest::mapping([automata_ci_core::JobPermissionGrant::new(
+                "contents",
+                PermissionLevel::Read,
+            )]),
+            "push",
+        );
         assert_eq!(
             composite.issue(provider_entitled.request()).await,
             Err(ControlPortError::Unavailable)

--- a/scripts/ci/tests/rust-build-cache.test.py
+++ b/scripts/ci/tests/rust-build-cache.test.py
@@ -48,6 +48,9 @@ def main() -> None:
     assert workflow.count('SCCACHE_IDLE_TIMEOUT: "0"') == 1, (
         "the job-scoped sccache server must survive until post-job statistics"
     )
+    assert workflow.count("SCCACHE_BASEDIRS: ${{ github.workspace }}") == 1, (
+        "sccache must normalize each ephemeral checkout to a stable source path"
+    )
     for job in RUST_JOBS:
         body = job_body(workflow, job)
         assert "RUSTC_WRAPPER: sccache" in body, f"{job} lost the rustc wrapper"


### PR DESCRIPTION
## Summary
- queue Results artifact/cache uploads at the shared bounded memory gate instead of returning `503 ServerBusy` under normal cache contention
- repair current trust-aware auth/OIDC fixtures that made the coverage gate fail deterministically
- normalize ephemeral checkout roots in sccache keys for cross-run and cross-host hits

## Evidence
- `cargo test -p automata-ci --lib` (514 passed)
- `cargo test -p automata-ci-results-github --all-targets`
- `cargo clippy -p automata-ci -p automata-ci-results-github --all-targets --all-features --locked -- -D warnings`
- `python3 scripts/ci/tests/rust-build-cache.test.py`
- `actionlint .ci/workflows/*.yml`
