### PR TITLE
fix(windows): keep actions closed without a broker materializer

### DIFF
--- a/crates/automata-ci-job-executor-actions/README.md
+++ b/crates/automata-ci-job-executor-actions/README.md
@@ -108,27 +108,14 @@ generations and no `PATH` probe. The current Ubuntu profile advertises only its
 pinned Node 24 executable. Container-action execution and `runs.plugin` remain
 unsupported.
 
-On an admitted Windows action profile, repository archives are bounded and
-validated before provider mutation. The validator permits only regular files
-and directories under the expected archive root and rejects traversal, links,
-special entries, Windows device names, alternate-stream/illegal characters,
-trailing dots or spaces, non-ASCII names, and case-insensitive collisions. The
-executor refuses a stale destination, creates it inside the job container,
-copies the archive through the sandbox content port, verifies the exact digest
-with the configured hash helper, extracts with the configured `tar.exe`, then
-performs a PowerShell root/reparse-point scan before reading metadata or
-executing an action. Every stage is ordered and fail-closed; archive extraction
-and action hooks never run on the host. JavaScript pre/main/post use only the
-metadata-selected, exact Node-generation path. A missing tar, hash helper,
-Node runtime, digest match, or tree check rejects the job.
-
-Checked-out Windows local actions use the exact configured `pwsh.exe` for their
-JIT metadata probe. The probe receives runner-owned candidate paths through a
-closed internal environment, proves the action directory remains below the job
-workspace, and rejects a reparse point in the workspace path or action tree
-before metadata is copied back. Windows local JavaScript and composite phases
-then use the same exact Node and shell contracts as materialized repository
-actions.
+Windows action steps are rejected during admission before provider mutation,
+and the execution entry point repeats that guard so direct callers cannot
+bypass it. The existing path-based archive and local-action helpers do not
+provide the retained file identity needed across a broker authority boundary.
+Windows JavaScript, composite, repository, local, and Node action capabilities
+therefore remain unavailable until a broker-owned materializer ships with its
+first production provider implementation. Windows shell steps continue to use
+the provider-neutral execution primitives described above.
 
 The control-plane activation boundary anonymously resolves exact-commit public
 repository metadata before Job IR publication and carries the complete

--- a/crates/automata-ci-job-executor-actions/src/executor.rs
+++ b/crates/automata-ci-job-executor-actions/src/executor.rs
@@ -580,6 +580,9 @@ impl ActionsJobExecutor {
         }
         let workspace =
             job_workspace(job, &environment).map_err(|_| AdmissionRejection::InvalidJob)?;
+        if unsupported_windows_action_job(job, workspace.platform()) {
+            return Err(AdmissionRejection::InvalidJob);
+        }
         if self.ports.toolchain.platform() != workspace.platform() {
             return Err(AdmissionRejection::CapabilityChanged);
         }
@@ -703,6 +706,9 @@ impl ActionsJobExecutor {
         events: Arc<dyn ExecutionEvents>,
         cancellation: ExecutionCancellation,
     ) -> Result<JobResult, ExecutorAdapterError> {
+        if unsupported_windows_action_job(request.job(), self.ports.toolchain.platform()) {
+            return Err(invalid_job());
+        }
         // We can safely resume a Preparing saga because no workflow phase has
         // started. Later lifecycle recovery requires durable per-phase state;
         // fail closed instead of replaying arbitrary user code.
@@ -7570,6 +7576,15 @@ fn validate_action_step_admission(
         }
     }
     Ok(())
+}
+
+fn unsupported_windows_action_job(job: &JobIrEnvelope, platform: TargetPlatform) -> bool {
+    platform == TargetPlatform::Windows
+        && job
+            .job()
+            .steps()
+            .iter()
+            .any(|step| matches!(step.kind(), SemanticStep::Action { .. }))
 }
 
 fn validate_resource_admission(

--- a/crates/automata-ci-job-executor-actions/tests/windows_actions.rs
+++ b/crates/automata-ci-job-executor-actions/tests/windows_actions.rs
@@ -2,228 +2,105 @@ mod support;
 
 use std::sync::Arc;
 
-use automata_ci_core::JobConclusion;
-use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionEvents, JobExecutor};
-
-use support::{
-    Fixture, PhaseResponse, action_step, local_action_step, prepared_node24_action,
-    prepared_windows_namespace_unsafe_node24_action, windows_envelope,
+use automata_ci_runner_runtime::{
+    AdmissionRejection, ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
 };
 
-#[tokio::test]
-async fn admitted_windows_javascript_action_is_verified_materialized_and_executed() {
-    let fixture = Fixture::windows_actions(
-        vec![prepared_node24_action()],
-        vec![PhaseResponse::success()],
-    );
+use support::{Fixture, action_step, local_action_step, windows_envelope};
+
+#[test]
+fn windows_repository_action_is_rejected_before_provider_mutation() {
+    let fixture = Fixture::windows_actions(Vec::new(), Vec::new());
     let job = windows_envelope(vec![action_step("checkout", "actions/example")]);
-    fixture.executor.admit(&job).expect("Windows action admits");
-    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
 
-    let result = fixture
-        .executor
-        .execute(fixture.request(job), events, ExecutionCancellation::new())
-        .await
-        .expect("verified Windows action executes");
-
-    let state = fixture.endpoint_state.lock().expect("endpoint lock");
     assert_eq!(
-        result.conclusion(),
-        JobConclusion::Success,
-        "{result:?}; commands={:?}",
-        state.commands
+        fixture.executor.admit(&job),
+        Err(AdmissionRejection::InvalidJob)
     );
-    let action_commands = state
-        .commands
-        .iter()
-        .filter(|command| {
-            let program = command.argv().program().as_str();
-            !program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
-                || command.argv().arguments().iter().any(|argument| {
-                    argument.contains("action directory already exists")
-                        || argument.contains("FileAttributes]::ReparsePoint")
-                })
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(
-        action_commands
-            .iter()
-            .map(|command| command.argv().program().as_str())
-            .collect::<Vec<_>>(),
-        [
-            r"C:\Program Files\PowerShell\7\pwsh.exe",
-            r"C:\automata\tools\hash\automata-sha256.exe",
-            r"C:\automata\tools\tar\tar.exe",
-            r"C:\Program Files\PowerShell\7\pwsh.exe",
-            r"C:\automata\externals\node24\node.exe",
-            r"C:\automata\externals\node24\node.exe",
-        ],
-        "directory creation, archive digest, extraction, reparse scan, main, and post are ordered"
-    );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
     assert!(
-        action_commands[0].argv().arguments()[4].contains("action directory already exists"),
-        "materialization refuses a stale action directory"
-    );
-    assert!(
-        action_commands[3].argv().arguments()[4].contains("FileAttributes]::ReparsePoint"),
-        "the extracted tree is scanned for Windows reparse points"
-    );
-    assert!(
-        action_commands[4].argv().arguments()[0].ends_with(r"\actions\action-0\root\dist\index.js")
+        fixture
+            .endpoint_state
+            .lock()
+            .expect("endpoint lock")
+            .commands
+            .is_empty()
     );
 }
 
 #[tokio::test]
-async fn admitted_windows_local_action_uses_a_reparse_safe_pwsh_probe() {
-    let fixture = Fixture::windows_actions(Vec::new(), vec![PhaseResponse::success()]);
-    fixture
-        .endpoint_state
-        .lock()
-        .expect("endpoint lock")
-        .files
-        .insert(
-            r"D:\a\automata\automata\local-action\action.yml".to_owned(),
-            b"name: Local\nruns:\n  using: node24\n  main: dist/index.js\n".to_vec(),
-        );
+async fn direct_execute_cannot_bypass_windows_action_admission() {
+    let fixture = Fixture::windows_actions(Vec::new(), Vec::new());
+    let job = windows_envelope(vec![action_step("checkout", "actions/example")]);
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect_err("Windows action execution must fail closed");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::InvalidJob);
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
+    assert!(
+        fixture
+            .endpoint_state
+            .lock()
+            .expect("endpoint lock")
+            .commands
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn direct_execute_trusts_the_windows_toolchain_over_request_environment() {
+    let posix_environment = Fixture::new(Vec::new(), Vec::new()).environment;
+    let mut fixture = Fixture::windows_actions(Vec::new(), Vec::new());
+    fixture.environment = posix_environment;
+    let job = windows_envelope(vec![action_step("checkout", "actions/example")]);
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(fixture.request(job), events, ExecutionCancellation::new())
+        .await
+        .expect_err("the request environment must not weaken the Windows executor gate");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::InvalidJob);
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
+    assert!(
+        fixture
+            .endpoint_state
+            .lock()
+            .expect("endpoint lock")
+            .commands
+            .is_empty()
+    );
+}
+
+#[test]
+fn windows_local_javascript_action_is_rejected_before_provider_mutation() {
+    let fixture = Fixture::windows_actions(Vec::new(), Vec::new());
     let job = windows_envelope(vec![local_action_step("local", "./local-action")]);
-    fixture
-        .executor
-        .admit(&job)
-        .expect("Windows local action admits");
-    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
 
-    let result = fixture
-        .executor
-        .execute(fixture.request(job), events, ExecutionCancellation::new())
-        .await
-        .expect("Windows local action executes");
-
-    let state = fixture.endpoint_state.lock().expect("endpoint lock");
     assert_eq!(
-        result.conclusion(),
-        JobConclusion::Success,
-        "{result:?}; commands={:?}",
-        state.commands
+        fixture.executor.admit(&job),
+        Err(AdmissionRejection::InvalidJob)
     );
-    let probe = state
-        .commands
-        .iter()
-        .find(|command| {
-            command
-                .argv()
-                .arguments()
-                .iter()
-                .any(|argument| argument.contains("automata-local-action-metadata"))
-        })
-        .expect("local metadata probe");
-    assert_eq!(
-        probe.argv().program().as_str(),
-        r"C:\Program Files\PowerShell\7\pwsh.exe"
-    );
-    assert!(
-        probe
-            .argv()
-            .arguments()
-            .iter()
-            .any(|argument| argument.contains("FileAttributes]::ReparsePoint")),
-        "the local action directory and tree are checked for reparse points"
-    );
-    let node = state
-        .commands
-        .iter()
-        .find(|command| {
-            command
-                .argv()
-                .program()
-                .as_str()
-                .eq_ignore_ascii_case(r"C:\automata\externals\node24\node.exe")
-        })
-        .expect("local Node action invocation");
-    assert_eq!(
-        node.argv().arguments()[0],
-        r"D:\a\automata\automata\local-action\dist\index.js"
-    );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
 }
 
-#[tokio::test]
-async fn admitted_windows_local_composite_executes_its_pwsh_child() {
-    let fixture = Fixture::windows_actions(Vec::new(), vec![PhaseResponse::success()]);
-    fixture.endpoint_state.lock().expect("endpoint lock").files.insert(
-        r"D:\a\automata\automata\local-composite\action.yml".to_owned(),
-        b"name: Local composite\nruns:\n  using: composite\n  steps:\n    - id: child\n      shell: pwsh\n      run: Write-Output 'windows-composite'\n"
-            .to_vec(),
-    );
+#[test]
+fn windows_local_composite_action_is_rejected_before_provider_mutation() {
+    let fixture = Fixture::windows_actions(Vec::new(), Vec::new());
     let job = windows_envelope(vec![local_action_step(
         "local-composite",
         "./local-composite",
     )]);
-    fixture
-        .executor
-        .admit(&job)
-        .expect("Windows local composite admits");
-    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
 
-    let result = fixture
-        .executor
-        .execute(fixture.request(job), events, ExecutionCancellation::new())
-        .await
-        .expect("Windows local composite executes");
-
-    assert_eq!(result.conclusion(), JobConclusion::Success, "{result:?}");
-    let state = fixture.endpoint_state.lock().expect("endpoint lock");
-    assert!(
-        state.scripts.iter().any(|script| script
-            .windows(b"windows-composite".len())
-            .any(|window| { window == b"windows-composite" })),
-        "the composite child is materialized as a PowerShell script"
+    assert_eq!(
+        fixture.executor.admit(&job),
+        Err(AdmissionRejection::InvalidJob)
     );
-    assert!(state.commands.iter().any(|command| {
-        command
-            .argv()
-            .program()
-            .as_str()
-            .eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
-            && command
-                .argv()
-                .arguments()
-                .iter()
-                .any(|argument| argument.ends_with(".ps1'"))
-    }));
-}
-
-#[tokio::test]
-async fn nested_repository_action_is_validated_before_windows_materialization() {
-    let fixture = Fixture::windows_actions(
-        vec![prepared_windows_namespace_unsafe_node24_action()],
-        Vec::new(),
-    );
-    fixture.endpoint_state.lock().expect("endpoint lock").files.insert(
-        r"D:\a\automata\automata\local-parent\action.yml".to_owned(),
-        b"name: Local parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/nested@0123456789abcdef0123456789abcdef01234567\n"
-            .to_vec(),
-    );
-    let job = windows_envelope(vec![local_action_step("parent", "./local-parent")]);
-    fixture
-        .executor
-        .admit(&job)
-        .expect("Windows local composite admits");
-    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
-
-    let result = fixture
-        .executor
-        .execute(fixture.request(job), events, ExecutionCancellation::new())
-        .await
-        .expect("unsafe nested archive becomes a failed step");
-
-    assert_eq!(result.conclusion(), JobConclusion::Failure, "{result:?}");
-    let state = fixture.endpoint_state.lock().expect("endpoint lock");
-    assert!(
-        state.commands.iter().all(|command| {
-            let program = command.argv().program().as_str();
-            !program.eq_ignore_ascii_case(r"C:\automata\tools\hash\automata-sha256.exe")
-                && !program.eq_ignore_ascii_case(r"C:\automata\tools\tar\tar.exe")
-        }),
-        "the namespace-unsafe nested archive must fail before hash or extraction: {:?}",
-        state.commands
-    );
+    assert_eq!(fixture.provider.counts(), (0, 0, 0));
 }

--- a/crates/automata-ci-runner/README.md
+++ b/crates/automata-ci-runner/README.md
@@ -96,34 +96,23 @@ image inspection adds it to the live inventory. A missing value
 disables the feature, and an invalid or unavailable configured image stops
 startup. Mutable tags are rejected.
 
-The Windows profile always supports exact configured PowerShell and `cmd.exe`
-`run:` steps, plus an optional standalone Python interpreter. Its action-ready
-  component path additionally binds a Windows Server 2025 Server Core image
-  manifest and lock to typed reference records for provenance, SPDX SBOM,
-  patch, and revocation evidence and to exact `tar.exe`, hash-helper, and Node
-  12/16/20/24 paths. Each record binds the native artifact media type and digest;
-  it is not parsed as though it were the referenced native format. Candidate evidence
-without an external Ed25519 promotion envelope remains shell-only. The Windows
-enrollment component defines a receipt contract requiring the same exact
-fresh-container probes before registration and authenticated, short-lived
-receipt retention only through opaque broker custody. The request binds a
-versioned digest of those shared lifecycle, argv, output, and cleanup semantics;
-the broker caller invokes the same helper as runtime admission instead of
-duplicating probe scripts. The restricted-broker
-caller and Windows credential publication are a separate integration gate; until
-they are composed, enrollment remains unavailable rather than registering a
-shell-only or action-ready runner. Only an externally promoted image whose
-ordered config, broker executable, manifest, evidence, and promotion-envelope
-paths and digests receive fresh broker owner/protected-DACL/file-ID/local-volume
-attestation, and whose
-pre-enrollment probes all succeed can register JavaScript, composite,
-repository, local-action, and exact Node-generation capabilities. Startup
-independently repeats admission before reporting the live inventory, so
-registered/live capability intersection retains only abilities proved at both
-boundaries. Missing, stale, tampered, revoked, or mismatched receipt, image,
-tool, or runtime evidence fails closed. Docker
-actions, job containers, service containers, administrator profiles, and
-host-network or host-filesystem policy remain unsupported.
+The Windows profile supports exact configured PowerShell and `cmd.exe` `run:`
+steps, plus an optional standalone Python interpreter. Its image contract also
+binds a Windows Server 2025 Server Core manifest and lock to provenance, SPDX
+SBOM, patch, revocation, archive-tool, hash-helper, and Node-path evidence.
+Those action artifacts are inputs to a future broker-owned materializer, not
+runtime authority: JavaScript, composite, repository, local, and Node action
+features remain absent from both enrollment and live inventories, even for an
+externally promoted image. The executor rejects every Windows action step
+before provider mutation and repeats the guard at direct execution.
+
+Restricted-broker custody, Windows credential publication, and a
+retained-file-identity materializer remain separate integration gates. Until
+they are implemented together, Windows enrollment stays unavailable rather
+than registering an action-ready runner. Missing, stale, tampered, revoked, or
+mismatched image, tool, or runtime evidence fails closed. Docker actions, job
+containers, service containers, administrator profiles, and host-network or
+host-filesystem policy remain unsupported.
 
 Hosted Windows CI is currently disabled because Automata does not yet operate
 Windows runners. Unit and injected-runtime provider tests do not constitute a

--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -218,32 +218,32 @@ macOS VM provider, cannot match. Registered and live-observed capabilities are
 intersected before scheduler matching, and the match is repeated before a
 placement can become a lease.
 
-Without an external promotion envelope the verified candidate's durable
-inventory contains only
-PowerShell and `cmd.exe` shell steps plus command files, with optional support
-for one absolute standalone Python interpreter. A production image may enable
-JavaScript, composite, repository, and local-action capabilities only after a
-canonical Ed25519-signed promotion payload accepts all evidence digests and
-revocation generation. Startup exercises every configured shell, archive,
-hash, Node, and optional Python executable through a copied probe in one fresh
-container. The required Windows enrollment adapter must run the same exact
-profile/tool contract and retain a short-lived authenticated receipt under an
-opaque broker-custody handle. The request binds the shared probe-contract schema
-and digest, and the supplied helper executes the same lifecycle, argv, and
-output checks as startup. This component supplies that request/receipt port;
-the restricted-broker caller and credential-publication integration remain a
-separate deployment gate. Once composed, the enrollment request must use the
-broker-attested ordered host-input set (configuration, executable, manifest,
-lock, evidence records, and promotion envelope), including protected DACL,
-owner, non-reparse, stable file/volume identity, and exact digest proof, and the
-receipt's exact capability set and a staged retry must resolve the identical
-receipt digest and binding. Missing, stale, expired, or tampered custody fails
-closed. The
+The durable Windows inventory contains only PowerShell and `cmd.exe` shell
+steps plus command files, with optional support for one absolute standalone
+Python interpreter. An externally promoted image remains shell-only: promotion
+qualifies its signed evidence for enrollment but does not authorize JavaScript,
+composite, repository, local-action, or Node runtime capabilities. Those
+features remain unavailable until a broker-owned action materializer ships
+with its first production provider. Startup still exercises every configured
+shell, archive, hash, Node, and optional Python executable through a copied
+probe in one fresh container; evidence and probe success do not make those
+action tools runtime authority. The required Windows enrollment adapter must
+run the same exact profile/tool contract and retain a short-lived authenticated
+receipt under an opaque broker-custody handle. The request binds the shared
+probe-contract schema and digest, and the supplied helper executes the same
+lifecycle, argv, and output checks as startup. This component supplies that
+request/receipt port; the restricted-broker caller and credential-publication
+integration remain a separate deployment gate. Once composed, the enrollment
+request must use the broker-attested ordered host-input set (configuration,
+executable, manifest, lock, evidence records, and promotion envelope),
+including protected DACL, owner, non-reparse, stable file/volume identity,
+and exact digest proof. The receipt's exact capability set and a staged retry
+must resolve the identical receipt digest and binding. Missing, stale, expired,
+or tampered custody fails closed. The
 `capabilities` command remains a passive shell-only diagnostic and cannot mint
 action authority. Startup independently repeats the probes before opening a
-runtime session, and action/Node features remain schedulable only when the
-registered and live-observed sets agree. There is no `PATH` or Node-generation
-fallback. Docker actions, job
+runtime session, and action/Node features are not registered, observed, or
+schedulable. There is no `PATH` or Node-generation fallback. Docker actions, job
 containers, service containers, and active Podman doctor checks remain
 unsupported. The host state root contains provider ownership and recovery
 metadata only; no runner state or credential path is mounted into a job

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -68,7 +68,7 @@ use super::state::RuntimeMountSnapshot;
 use super::{
     ClientTlsMaterialError, ProductStateRootError, RunnerProductConfig, RunnerProductConfigError,
     RunnerProviderConfig, SecretSource, StandardGithubContext,
-    config::{ObjectStoreTlsTrust, promoted_windows_runtime_features, required_podman_state_root},
+    config::{ObjectStoreTlsTrust, required_podman_state_root},
     metrics::RunnerMetrics,
     profile_admission::{
         ProfileAdmissionError, ProfileAdmissionOutcome, ProfileAdmissionPolicy,
@@ -834,20 +834,12 @@ fn admitted_runtime_inventory(
     buildkit_configured: bool,
     provider: &ProviderCapabilities,
 ) -> Result<RunnerCapabilities, RunnerProductError> {
-    let mut inventory = inventory_for_verified_provider(
+    let inventory = inventory_for_verified_provider(
         config.inventory(),
         service_proxy_configured,
         buildkit_configured,
         provider,
     );
-    if config
-        .windows_hyperv()
-        .is_some_and(|windows| windows.image_admission().permits_actions())
-    {
-        inventory = inventory.with_features(promoted_windows_runtime_features(
-            config.executor().toolchain(),
-        ));
-    }
     inventory
         .validate()
         .map_err(|_| RunnerProductError::SandboxProviderInvariant)?;
@@ -1446,21 +1438,6 @@ fn build_toolchain(
     if let Some(path) = configured.python() {
         toolchain = toolchain.with_python(path.clone())?;
     }
-    let windows_actions = config
-        .windows_hyperv()
-        .is_some_and(|windows| windows.image_admission().permits_actions());
-    if windows_actions {
-        toolchain = toolchain.with_windows_action_materializer(
-            configured
-                .tar()
-                .ok_or(RunnerProductError::ProviderConfiguration)?
-                .clone(),
-            configured
-                .sha256sum()
-                .ok_or(RunnerProductError::ProviderConfiguration)?
-                .clone(),
-        )?;
-    }
     if matches!(
         config.provider(),
         RunnerProviderConfig::Podman(_)
@@ -1478,8 +1455,7 @@ fn build_toolchain(
         (JavascriptRuntime::Node24, configured.node24()),
     ] {
         if let Some(path) = path
-            && (!matches!(config.provider(), RunnerProviderConfig::WindowsHyperV(_))
-                || windows_actions)
+            && !matches!(config.provider(), RunnerProviderConfig::WindowsHyperV(_))
         {
             toolchain = toolchain.with_node(runtime, path.clone())?;
         }
@@ -1819,7 +1795,7 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn promoted_windows_features_exist_only_in_post_admission_inventory() {
+    fn promoted_windows_image_remains_shell_only_without_a_broker_materializer() {
         struct InjectedPromotedEvidence;
 
         impl super::super::windows_image::WindowsImageEvidenceVerifier for InjectedPromotedEvidence {
@@ -1865,8 +1841,15 @@ mod tests {
             automata_ci_core::RunnerFeature::LOCAL_ACTIONS,
             automata_ci_core::RunnerFeature::NODE24_ACTIONS,
         ] {
-            assert!(admitted.features().contains(&feature), "missing {feature}");
+            assert!(
+                !admitted.features().contains(&feature),
+                "unsupported Windows action feature escaped admission: {feature}"
+            );
         }
+        let toolchain = build_toolchain(&config).expect("shell-only Windows toolchain");
+        assert!(toolchain.tar().is_none());
+        assert!(toolchain.sha256().is_none());
+        assert!(toolchain.node(JavascriptRuntime::Node24).is_none());
     }
     #[derive(Debug, Default)]
     struct StartupEffects {

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -147,9 +147,10 @@ impl RunnerProductConfig {
 
     /// Returns the validated durable registration ceiling for this runner identity.
     ///
-    /// Image promotion and live profile admission may add Windows action
-    /// capabilities only to the ephemeral runtime inventory. They are never
-    /// included in this pre-admission registration or diagnostic surface.
+    /// Windows image promotion and live profile admission can further restrict
+    /// this ceiling, but they do not add action or Node runtime capabilities.
+    /// Those features remain unavailable until a broker-owned materializer has
+    /// a production provider.
     #[must_use]
     pub const fn inventory(&self) -> &RunnerCapabilities {
         &self.inventory
@@ -252,10 +253,11 @@ impl RunnerProductConfig {
     }
 
     /// Applies one Windows image-evidence verifier before this configuration
-    /// can compose Windows action runtimes after live profile admission.
+    /// can participate in Windows enrollment admission.
     ///
     /// The configuration is consumed so a failed or weaker re-verification
     /// cannot leave a previously promoted image admission available to a caller.
+    /// Promotion does not authorize action or Node runtime capabilities.
     /// Non-Windows configurations pass through unchanged.
     ///
     /// # Errors
@@ -1919,27 +1921,12 @@ fn executor_runtime_features(
     features
 }
 
-pub(super) fn promoted_windows_runtime_features(
+pub(super) fn windows_enrollment_runtime_features(
     toolchain: &ToolchainConfig,
 ) -> BTreeSet<RunnerFeature> {
-    let mut features = executor_runtime_features(toolchain, ProviderKind::WindowsHyperV);
-    features.extend([
-        RunnerFeature::COMPOSITE_ACTIONS,
-        RunnerFeature::REPOSITORY_ACTIONS,
-        RunnerFeature::LOCAL_ACTIONS,
-    ]);
-    for (available, feature) in [
-        (toolchain.node12().is_some(), RunnerFeature::NODE12_ACTIONS),
-        (toolchain.node16().is_some(), RunnerFeature::NODE16_ACTIONS),
-        (toolchain.node20().is_some(), RunnerFeature::NODE20_ACTIONS),
-        (toolchain.node24().is_some(), RunnerFeature::NODE24_ACTIONS),
-    ] {
-        if available {
-            features.insert(feature);
-            features.insert(RunnerFeature::JAVASCRIPT_ACTIONS);
-        }
-    }
-    features
+    // Windows action and Node capabilities remain absent until a broker-owned
+    // materializer ships with its first production provider implementation.
+    executor_runtime_features(toolchain, ProviderKind::WindowsHyperV)
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
+++ b/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use automata_ci_core::{
-    EnvironmentProfile, JobResourceAllocation, RunnerCapabilities, RunnerId, Sha256Digest,
+    EnvironmentProfile, JobResourceAllocation, RunnerCapabilities, RunnerFeature, RunnerId,
+    Sha256Digest,
 };
 use automata_ci_execution::{
     NetworkPolicy, ResourceLimits, RootFilesystemPolicy, SandboxEnvironment,
@@ -21,7 +22,7 @@ use uuid::Uuid;
 
 use super::{
     RunnerProductConfig,
-    config::promoted_windows_runtime_features,
+    config::windows_enrollment_runtime_features,
     profile_admission::{
         ProfileAdmissionOutcome, ProfileAdmissionPolicy, WINDOWS_PROFILE_PROBE_SCHEMA_VERSION,
         admit_environment_profiles, windows_profile_probe_contract_sha256,
@@ -32,6 +33,16 @@ const MAX_ID_BYTES: usize = 128;
 const MAX_SERVER_ORIGIN_BYTES: usize = 2_048;
 const MAX_RUNNER_NAME_BYTES: usize = 255;
 const MAX_RECEIPT_LIFETIME_SECONDS: u64 = 15 * 60;
+const WINDOWS_ACTION_RUNTIME_FEATURES: [RunnerFeature; 8] = [
+    RunnerFeature::JAVASCRIPT_ACTIONS,
+    RunnerFeature::NODE12_ACTIONS,
+    RunnerFeature::NODE16_ACTIONS,
+    RunnerFeature::NODE20_ACTIONS,
+    RunnerFeature::NODE24_ACTIONS,
+    RunnerFeature::COMPOSITE_ACTIONS,
+    RunnerFeature::REPOSITORY_ACTIONS,
+    RunnerFeature::LOCAL_ACTIONS,
+];
 const WINDOWS_HOST_INPUT_KINDS: [WindowsHostInputKind; 9] = [
     WindowsHostInputKind::Configuration,
     WindowsHostInputKind::BackendExecutable,
@@ -573,7 +584,7 @@ pub fn windows_enrollment_admission_request(
     let Some(windows) = config.windows_hyperv() else {
         return Ok(None);
     };
-    if !windows.image_admission().permits_actions() {
+    if !windows.image_admission().is_promoted() {
         return Ok(None);
     }
     if !valid_backend_id(backend_id) || config.executor().network() != NetworkPolicy::Disabled {
@@ -600,15 +611,19 @@ pub fn windows_enrollment_admission_request(
     let promotion_envelope_sha256 = windows
         .promotion_envelope_sha256()
         .ok_or(WindowsEnrollmentAdmissionError::InvalidRequest)?;
-    let capabilities = config
-        .inventory()
-        .clone()
-        .with_features(promoted_windows_runtime_features(
-            config.executor().toolchain(),
-        ));
+    let capabilities =
+        config
+            .inventory()
+            .clone()
+            .with_features(windows_enrollment_runtime_features(
+                config.executor().toolchain(),
+            ));
     capabilities
         .validate()
         .map_err(|_| WindowsEnrollmentAdmissionError::InvalidRequest)?;
+    if has_windows_action_runtime_features(&capabilities) {
+        return Err(WindowsEnrollmentAdmissionError::InvalidRequest);
+    }
     let capabilities_sha256 = canonical_digest(&capabilities)?;
     let capacity = config.executor().resource_capacity();
     let allocation = JobResourceAllocation::new(capacity, capacity)
@@ -951,6 +966,7 @@ impl WindowsEnrollmentAdmissionReceipt {
         if self.binding != request.binding
             || canonical_digest(&self.binding.capabilities)? != self.binding.capabilities_sha256
             || self.binding.capabilities.validate().is_err()
+            || has_windows_action_runtime_features(&self.binding.capabilities)
             || !valid_host_inputs(&self.binding.host_inputs)
         {
             return Err(WindowsEnrollmentAdmissionError::Mismatch);
@@ -969,6 +985,12 @@ impl WindowsEnrollmentAdmissionReceipt {
         }
         Ok(ValidatedWindowsEnrollmentAdmission { receipt: self })
     }
+}
+
+fn has_windows_action_runtime_features(capabilities: &RunnerCapabilities) -> bool {
+    WINDOWS_ACTION_RUNTIME_FEATURES
+        .iter()
+        .any(|feature| capabilities.features().contains(feature))
 }
 
 /// Receipt whose exact binding and freshness have been validated for enrollment.
@@ -1360,11 +1382,7 @@ mod tests {
 
     #[test]
     fn restart_reauthenticates_the_same_broker_custody_receipt() {
-        let request = request([
-            RunnerFeature::SHELL_STEPS,
-            RunnerFeature::JAVASCRIPT_ACTIONS,
-            RunnerFeature::NODE24_ACTIONS,
-        ]);
+        let request = request([RunnerFeature::SHELL_STEPS]);
         let port = RestartingPort {
             state: Mutex::new(RestartingPortState::default()),
         };
@@ -1400,6 +1418,20 @@ mod tests {
         assert_eq!(
             port.resume(resumed.handle(), &request),
             Err(WindowsEnrollmentAdmissionError::Unavailable)
+        );
+    }
+
+    #[test]
+    fn exact_action_capability_receipt_fails_closed() {
+        let request = request([
+            RunnerFeature::SHELL_STEPS,
+            RunnerFeature::JAVASCRIPT_ACTIONS,
+            RunnerFeature::NODE24_ACTIONS,
+        ]);
+
+        assert_eq!(
+            receipt(&request).validate(&request, NOW),
+            Err(WindowsEnrollmentAdmissionError::Mismatch)
         );
     }
 

--- a/crates/automata-ci-runner/src/product/windows_image.rs
+++ b/crates/automata-ci-runner/src/product/windows_image.rs
@@ -38,9 +38,9 @@ pub enum WindowsImageAdmission {
 }
 
 impl WindowsImageAdmission {
-    /// Reports whether action runtimes may be composed and advertised.
+    /// Reports whether the configured image has verified external promotion.
     #[must_use]
-    pub const fn permits_actions(self) -> bool {
+    pub const fn is_promoted(self) -> bool {
         matches!(self, Self::Promoted)
     }
 }
@@ -870,10 +870,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn admission_only_permits_actions_after_external_promotion() {
-        assert!(!WindowsImageAdmission::Unverified.permits_actions());
-        assert!(!WindowsImageAdmission::Candidate.permits_actions());
-        assert!(WindowsImageAdmission::Promoted.permits_actions());
+    fn admission_reports_only_verified_external_promotion() {
+        assert!(!WindowsImageAdmission::Unverified.is_promoted());
+        assert!(!WindowsImageAdmission::Candidate.is_promoted());
+        assert!(WindowsImageAdmission::Promoted.is_promoted());
     }
 
     #[test]

--- a/crates/automata-ci-runner/tests/runner_product_config_windows.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_windows.rs
@@ -34,7 +34,7 @@ fn write_secure_fixture(path: &Path, bytes: &[u8]) {
         .expect("restrict Windows evidence fixture DACL");
 }
 
-fn assert_admitted_action_features(request: &WindowsEnrollmentAdmissionRequest) {
+fn assert_action_features_remain_unadvertised(request: &WindowsEnrollmentAdmissionRequest) {
     for feature in [
         RunnerFeature::JAVASCRIPT_ACTIONS,
         RunnerFeature::COMPOSITE_ACTIONS,
@@ -43,12 +43,12 @@ fn assert_admitted_action_features(request: &WindowsEnrollmentAdmissionRequest) 
         RunnerFeature::NODE24_ACTIONS,
     ] {
         assert!(
-            request
+            !request
                 .binding()
                 .capabilities()
                 .features()
                 .contains(&feature),
-            "active admission must prove exact registration feature {feature}"
+            "unsupported Windows action feature escaped admission: {feature}"
         );
     }
 }
@@ -406,7 +406,7 @@ fn candidate_evidence_is_verified_but_does_not_publish_action_capabilities() {
 }
 
 #[test]
-fn exact_external_promotion_keeps_actions_pending_for_active_enrollment_admission() {
+fn exact_external_promotion_keeps_actions_unadvertised_without_a_broker_materializer() {
     let mut fixture = EvidenceFixture::new();
     add_promotion(&mut fixture);
     let config_path = fixture.write_config("promoted-runner.json");
@@ -494,7 +494,7 @@ fn exact_external_promotion_keeps_actions_pending_for_active_enrollment_admissio
             .expect("Hyper-V container image")
             .reference()
     );
-    assert_admitted_action_features(&request);
+    assert_action_features_remain_unadvertised(&request);
     assert_host_input_contract(&request, &config_path);
 }
 

--- a/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
+++ b/docs/github-actions-parity/github-actions-parity-04-runner-execution.md
@@ -77,14 +77,15 @@ Tasks:
   - [x] Windows runner product loading separately verifies a digest-bound
     Server 2025 manifest/lock, typed digest/media references for provenance,
     SPDX SBOM, patch and revocation artifacts, and an external Ed25519 promotion
-    envelope. Runner composition adds composite,
-    repository, local-action, JavaScript, and exact Node-generation features
-    only after promotion and successful fresh-sandbox tool probes. An
-    authenticated, short-lived broker-custody receipt contract can carry that
-    exact set into Windows enrollment; the restricted-broker caller remains an
-    integration gate. That caller must make startup independently re-probe
-    before live advertisement. Missing, stale, or mismatched
-    receipt/image/tool/runtime evidence fails closed.
+    envelope. Promotion and fresh-sandbox probes qualify image evidence for
+    enrollment only; runner composition and broker-custody receipts remain
+    shell-only and reject action or Node capabilities. Composite, repository,
+    local-action, JavaScript, and Node-generation features stay unavailable
+    until a broker-owned retained-identity materializer ships with its first
+    production provider. The restricted-broker caller remains an integration
+    gate and must make startup independently re-probe before live
+    advertisement. Missing, stale, or mismatched receipt/image/tool/runtime
+    evidence fails closed.
   - [x] Keep temporary placement absence distinct from terminal semantic
     admission. A job that passed its immutable profile ceiling but has no
     currently eligible runner remains durable `NoWork`; admission never derives

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -38,11 +38,11 @@ startup orphan check are component recovery, but they do not replace a
 restricted management broker, independent watchdog, or real engine/host fault
 evidence. A broker-verifiable signed admission grant, managed egress,
 credential delivery, a signed image factory, and dedicated-host acceptance
-also remain open. The source tree has component support for Windows action
-materialization and JavaScript/composite execution, but the checked-in image
-evidence is an unsigned candidate. It therefore advertises shell-only
-capacity. Job and service containers, egress, devices, and parallel capacity
-remain unsupported.
+also remain open. Path-based Windows action helpers exist, but they do not
+retain file identity across the broker authority boundary and are not an
+admitted production materializer. Windows therefore advertises shell-only
+capacity and rejects action steps before provider mutation. Job and service
+containers, egress, devices, and parallel capacity remain unsupported.
 
 The detailed
 [Windows runner isolation plan](../platforms/windows.md) makes one fresh
@@ -56,11 +56,12 @@ Image admission now verifies a digest-bound Windows Server 2025 Server Core
 manifest and lock together with provenance, SPDX SBOM, patch, and revocation
 metadata. It binds the exact guest/workspace and configured PowerShell, cmd,
 tar, hash-helper, and Node-generation paths. A canonical external Ed25519
-promotion envelope plus successful fresh-container probes are both required
-before runner composition adds JavaScript, composite, repository, local-action,
-or Node-generation features. Candidate, missing, mismatched, revoked, or
-substituted material never gains those features. These are component gates,
-not a signed image factory or physical-host evidence.
+promotion envelope and fresh-container probes validate image evidence, but do
+not add JavaScript, composite, repository, local-action, or Node-generation
+features. Those capabilities remain absent until a broker-owned materializer
+ships with a production provider. Candidate, missing, mismatched, revoked, or
+substituted material likewise never gains them. These are component gates, not
+a signed image factory or physical-host evidence.
 
 Windows enrollment now has a typed pre-enrollment admission contract. Its
 short-lived authenticated receipt binds the runner, broker/provider identity,
@@ -69,11 +70,10 @@ policy, and canonical capability set;
 only an opaque restricted-broker custody handle is durable across retries.
 The production broker caller is a separate integration gate. It must fail
 closed when custody is absent, stale, expired, or mismatched, and runtime startup
-must independently repeat profile/tool admission. Once composed,
-an admitted action/Node feature can exist in both durable registration and live
-observation instead of being removed by their least-authority intersection.
-This interface and its injected tests are not a promoted image or physical-host
-release claim.
+must independently repeat profile/tool admission. Action and Node features stay
+out of both durable registration and live observation until retained-identity
+materialization is part of that broker path. This interface and its injected
+tests are not a promoted image or physical-host release claim.
 
 Current component placement foundation binds GitHub-projected Windows jobs to
 both VM-grade isolation and the exact
@@ -127,15 +127,15 @@ Tasks:
   a fresh Windows sandbox.
 - [x] Bind exact tool versions, architecture, paths, and digests through the
   candidate manifest and externally signed promotion interface.
-- [x] Withhold all Windows action and Node capabilities unless image
-  verification and every configured live tool probe succeed.
-- [x] Add a Windows-specific in-sandbox materialization path with exact archive
-  digest verification and subpath provenance.
-- [x] Reject traversal, links, special entries, reserved/illegal Windows names,
+- [x] Withhold all Windows action and Node capabilities until a broker-owned
+  production materializer is available.
+- [ ] Add a broker-owned materialization path that retains archive and tree
+  identity through verification, extraction, metadata reads, and execution.
+- [ ] Reject traversal, links, special entries, reserved/illegal Windows names,
   case-fold collisions, stale destinations, digest mismatch, and reparse-tree
-  escape before metadata or action execution.
-- [x] Support in-sandbox local metadata reads and exact action cleanup phases at
-  the executor component boundary.
+  escape under retained broker handles.
+- [ ] Support broker-mediated local metadata reads and exact action cleanup
+  phases without reopening mutable paths.
 - [ ] Add and qualify Git, Git Bash, zstd, and any optional Python distribution
   required by the released action profile.
 - [ ] Publish real image/tool versions and digests from the external image
@@ -145,10 +145,10 @@ Tasks:
 
 Acceptance:
 
-- [x] Product startup probes every configured action tool inside a fresh
-  sandbox before registration; injected component tests exercise this gate.
-- [x] Candidate or missing Node-generation evidence removes JavaScript and
-  exact Node capabilities without removing plain run steps.
+- [x] Candidate image validation checks configured action-tool evidence without
+  advertising action capabilities.
+- [x] JavaScript and exact Node capabilities remain absent without removing
+  plain run steps.
 - [ ] Linux and Windows produce equivalent immutable action trees.
 
 ### WIN-02 — JavaScript and composite actions on Windows
@@ -158,13 +158,13 @@ WIN-ISO-08 managed data/credential boundary, RUN-01, ACT-01.
 
 Tasks:
 
-- [x] Replace blanket runner-side Windows action rejection with promotion- and
-  live-admission-gated granular capabilities.
-- [x] Execute metadata-selected Node 12/16/20/24 pre, main, and post through
+- [ ] Replace fail-closed Windows action rejection only when broker admission
+  supplies retained materialization authority.
+- [ ] Execute metadata-selected Node 12/16/20/24 pre, main, and post through
   exact configured paths; no generation or `PATH` fallback is allowed.
-- [x] Enable local, repository, composite, and nested-composite executor paths
+- [ ] Enable local, repository, composite, and nested-composite executor paths
   only when their exact runtime capabilities were admitted.
-- [x] Preserve the existing Windows phase-file, environment-casing, and CRLF
+- [ ] Preserve the existing Windows phase-file, environment-casing, and CRLF
   executor behavior for admitted actions.
 - [ ] Populate action contexts and run cleanup after failure/cancellation.
 - [x] Keep Docker actions and containers rejected until separately available.

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -118,14 +118,14 @@ those release gates:
 - exact manifest-to-configuration bindings for the guest, workspace,
   `pwsh.exe`, `powershell.exe`, `cmd.exe`, `tar.exe`, the Automata SHA-256
   helper, and any configured Node 12/16/20/24 runtime;
-- fresh-sandbox startup probes for all configured Windows action tools; and
-- bounded Windows action-archive validation, in-container digest verification,
-  extraction, reparse-tree inspection, and exact-generation Node execution.
+- component probe definitions for configured Windows action tools; and
+- bounded archive-validation helpers for a future broker-owned materializer.
 
 Candidate evidence that is internally consistent but lacks the external
-promotion signature remains shell-only. JavaScript, composite, repository,
-local-action, and Node-generation capabilities are composed only after both
-promotion verification and fresh profile probes succeed. The source-level
+promotion signature remains shell-only. Externally promoted evidence also
+remains shell-only until a broker-owned materializer can retain file identity
+through verification and execution. JavaScript, composite, repository,
+local-action, and Node-generation capabilities are not advertised. The source-level
 pre-enrollment admission contract binds the runner, broker/provider identity,
 exact enrollment transaction, exact environment and
 resource/tool probe policy, image manifest/lock and signed-promotion identity,
@@ -408,8 +408,9 @@ The optional promotion configuration names an envelope, pinned key identifier,
 and Ed25519 public key. A canonical signed payload must explicitly promote and
 accept provenance, SBOM, patch, and revocation subjects while binding the exact
 profile, manifest, lock, base/output images, all evidence digests, and
-revocation generation. Without it the image remains a candidate and action
-capabilities stay absent.
+revocation generation. Promotion qualifies the image evidence for enrollment;
+it does not authorize action or Node capabilities, which stay absent until a
+broker-owned retained-identity materializer has a production provider.
 
 Example values and the checked-in candidate files are contract fixtures, not
 deployable image or runtime attestations. Operators must replace every
@@ -799,7 +800,7 @@ and the broker can mutate only exact generation-bound Automata resources.
 - [x] Add bounded verifier interfaces for manifest, lock, provenance, SPDX
       SBOM, patch, revocation, and external Ed25519 promotion metadata.
 - [x] Keep checked-in fixtures explicitly candidate-only and withhold action
-      capabilities without a valid external promotion envelope.
+      and Node capabilities even after evidence promotion.
 - [ ] Define the exact Server Core host/image compatibility matrix.
 - [ ] Build a digest-pinned image containing guest executable and reviewed
       shells/tools without job-time mutable installation.
@@ -939,11 +940,11 @@ WIN-ISO-06 through WIN-ISO-09 as applicable.
 - [x] Implement exact PowerShell 7, Windows PowerShell, cmd, and optional
       Python argv, encoding, CRLF, environment, working-directory, and exit
       semantics at the component boundary.
-- [x] Implement exact-generation Node action pre/main/post and composite phase
-      execution inside the same sandbox at the component boundary.
-- [x] Implement action materialization without host extraction or host mounts,
-      including bounded Windows archive-name/link/collision checks, in-sandbox
-      digest verification, extraction, and reparse-tree validation.
+- [ ] Implement exact-generation Node action pre/main/post and composite phase
+      execution behind broker-owned retained materialization authority.
+- [ ] Implement action materialization without host extraction or host mounts,
+      retaining file identity across bounded archive checks, digest
+      verification, extraction, metadata reads, and reparse-tree validation.
 - [ ] Prove those runtime and materialization paths in the shipped product on a
       promoted image and dedicated Windows Hyper-V host.
 - [ ] Support only product artifact/cache/source interfaces accepted by their
@@ -953,7 +954,7 @@ WIN-ISO-06 through WIN-ISO-09 as applicable.
       before user code unless separately accepted.
 
 Exit: the exact action-ready profile passes through shipped product processes
-without changing the isolation boundary.
+without changing the isolation boundary or reopening mutable paths.
 
 ### WIN-ISO-11 — Hostile and fault acceptance
 


### PR DESCRIPTION
## Scope

This review follow-up replaces the speculative sealed-action endpoint/graph feature with a narrow fail-closed Windows hardening.

- Base: `main` at `100e16c38b677fb1e1f0ad59c146f8f971d955b0`
- Head: `6aeb4595bfaa9470e23d3bb1b655a301c7cd5e11`
- Diff: 13 files, +265/-393 (658 changed lines)
- SQL migrations: none
- Workflow/CI changes: none

## What changed

- Removed the PR-owned Windows archive/graph contract from the neutral execution endpoint, Job IR, protobuf, journal/replay, metrics, workflow publication, and protocol surfaces. No provider-neutral endpoint budget or speculative production API remains in this PR.
- Reject every Windows `SemanticStep::Action` during executor admission before provider mutation.
- Repeat the same guard at direct execution, keyed from the trusted executor toolchain rather than the caller-supplied request environment. A regression covers a forged POSIX request environment and proves no provider or endpoint work occurs.
- Keep production Windows runner composition shell-only: it installs neither an action materializer nor Node runtimes, even for an externally promoted image.
- Treat image promotion as evidence eligibility for enrollment, not action authority. Windows enrollment request construction and receipt validation explicitly reject JavaScript, Node 12/16/20/24, composite, repository, and local-action capabilities.
- Update runner and platform documentation so broker-owned retained-file-identity materialization is an explicit future gate that must ship with its first production provider.

This resolves the review concern without adding a contract that no production provider can fulfill. Existing path-oriented test-support seams inherited from `main` are unreachable for Windows action jobs through both admission and direct execution.

## CI policy

This PR adds no workflow or CI-script changes. Automata has no Windows CI runners, so there is no Windows job or Windows aggregate gate. Validation on GitHub uses the unified Linux checks inherited from `main`.

## Validation at this exact head

- Exact LF committed-tree `cargo fmt --all -- --check`: passed.
- Locked Cargo metadata and `git diff --check`: passed.
- Full `automata-ci-job-executor-actions` all-feature test suite: passed.
- Windows action fail-closed regressions: 5/5 passed.
- Strict all-target/all-feature executor Clippy with `-D warnings`: passed.
- Runner runtime-feature tests: 2/2 passed.
- Runner composition tests: 12/12 passed.
- Windows enrollment admission tests: 5/5 passed.
- Windows product-config integration tests: 10/10 passed.
- Independent semantic and final-scope audits: no remaining blocker.
- Remote unified CI: Frontend, Rust, and PostgreSQL passed; no Windows job exists.

Only the user will merge this PR. Auto-merge remains disabled.