### PR TITLE
refactor(control): split runtime authority decoding

### DIFF
--- a/crates/automata-ci-control/src/runner_control/handler.rs
+++ b/crates/automata-ci-control/src/runner_control/handler.rs
@@ -1503,16 +1503,7 @@ impl DurableRunnerControlHandler {
                 .map_err(|_| app(ApplicationErrorKind::Internal))?;
 
             stage = RunnerRuntimeAuthorityRequestStage::BundleEncoding;
-            let encoded = Zeroizing::new(
-                encode_runtime_authorities(
-                    &authorities,
-                    &job,
-                    offer.lease(),
-                    &self.config.protocol_limits,
-                )
-                .map_err(|_| app(ApplicationErrorKind::Internal))?,
-            );
-            let bundle_digest = sha256(&encoded);
+            let bundle_digest = self.runtime_authority_bundle_digest(&authorities, &job, offer)?;
             if admission
                 .committed_bundle_digest()
                 .is_some_and(|committed| committed != bundle_digest)
@@ -1551,6 +1542,24 @@ impl DurableRunnerControlHandler {
                 .observe_runtime_authority_request_failure(stage, control_failure(error.kind()));
         }
         result
+    }
+
+    fn runtime_authority_bundle_digest(
+        &self,
+        authorities: &JobRuntimeAuthorities,
+        job: &JobIrEnvelope,
+        offer: &AcceptedRuntimeAuthorityOffer,
+    ) -> Result<Sha256Digest, ApplicationError> {
+        let encoded = Zeroizing::new(
+            encode_runtime_authorities(
+                authorities,
+                job,
+                offer.lease(),
+                &self.config.protocol_limits,
+            )
+            .map_err(|_| app(ApplicationErrorKind::Internal))?,
+        );
+        Ok(sha256(&encoded))
     }
 
     async fn issue_runtime_authorities(

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -1887,40 +1887,49 @@ async fn committed_lease_acceptance_replays_after_attempt_expiry() -> TestResult
                 .await?;
         assert_eq!(lifecycle_after_replay, "queued");
 
-        let stale_authorization = AuthorizeRuntimeAuthorityDelivery::new(
-            operation_request(
-                fence,
-                OperationId::new(),
-                RUNTIME_AUTHORITY_REQUEST_KIND,
-                [65; 32],
-            )?,
-            RunnerProtocolVersion::new(RUNTIME_AUTHORITY_PROTOCOL_VERSION)?,
-            authority_binding,
-            database_now(&database).await?,
-        )?;
-        assert!(matches!(
-            database
-                .store()
-                .authorize_runtime_authority_delivery(stale_authorization)
-                .await,
-            Err(StoreError::SessionClosed(session_id)) if session_id == fence.session_id()
-        ));
-        let closed: (Option<i64>, String) = sqlx::query_as(
-            r"
-            SELECT session.disconnected_at_ms, runner.status
-            FROM runner_sessions AS session
-            JOIN runners AS runner ON runner.id = session.runner_id
-            WHERE session.id = $1
-            ",
-        )
-        .bind(fence.session_id().as_uuid())
-        .fetch_one(database.pool())
-        .await?;
-        assert!(closed.0.is_some());
-        assert_eq!(closed.1, "offline");
+        assert_stale_runtime_authority_closes_session(&database, fence, authority_binding).await?;
         Ok(())
     })
     .await
+}
+
+async fn assert_stale_runtime_authority_closes_session(
+    database: &TestDatabase,
+    fence: automata_ci_store::RunnerSessionFence,
+    authority_binding: RuntimeAuthorityDeliveryBinding,
+) -> TestResult {
+    let stale_authorization = AuthorizeRuntimeAuthorityDelivery::new(
+        operation_request(
+            fence,
+            OperationId::new(),
+            RUNTIME_AUTHORITY_REQUEST_KIND,
+            [65; 32],
+        )?,
+        RunnerProtocolVersion::new(RUNTIME_AUTHORITY_PROTOCOL_VERSION)?,
+        authority_binding,
+        database_now(database).await?,
+    )?;
+    assert!(matches!(
+        database
+            .store()
+            .authorize_runtime_authority_delivery(stale_authorization)
+            .await,
+        Err(StoreError::SessionClosed(session_id)) if session_id == fence.session_id()
+    ));
+    let closed: (Option<i64>, String) = sqlx::query_as(
+        r"
+        SELECT session.disconnected_at_ms, runner.status
+        FROM runner_sessions AS session
+        JOIN runners AS runner ON runner.id = session.runner_id
+        WHERE session.id = $1
+        ",
+    )
+    .bind(fence.session_id().as_uuid())
+    .fetch_one(database.pool())
+    .await?;
+    assert!(closed.0.is_some());
+    assert_eq!(closed.1, "offline");
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/automata-ci-store-postgres/src/g1.rs
+++ b/crates/automata-ci-store-postgres/src/g1.rs
@@ -5197,12 +5197,18 @@ async fn load_lease_offer_publication_by_command(
     Ok(publication)
 }
 
-#[allow(clippy::too_many_lines)] // One snapshot query closes every offer field under the same lock.
-async fn load_runtime_authority_offer_by_command(
+#[derive(Debug)]
+struct DecodedRuntimeAuthorityCommand {
+    request_kind: RunnerOperationKind,
+    operation_id: OperationId,
+    sequence: CommandSequence,
+    created_at: UnixMillis,
+}
+
+async fn query_runtime_authority_offer_by_command(
     transaction: &mut Transaction<'_, Postgres>,
     identity: LeaseOfferCommandIdentity,
-) -> Result<Option<AcceptedRuntimeAuthorityOffer>, StoreError> {
-    let session = identity.session();
+) -> Result<Option<sqlx::postgres::PgRow>, StoreError> {
     let rows = sqlx::query(
         r"
         SELECT publication.request_operation_id, publication.runner_id,
@@ -5233,21 +5239,24 @@ async fn load_runtime_authority_offer_by_command(
         FOR UPDATE OF publication, command
         ",
     )
-    .bind(session.session_id().as_uuid())
+    .bind(identity.session().session_id().as_uuid())
     .bind(sequence_i64(identity.sequence())?)
     .fetch_all(&mut **transaction)
     .await
     .map_err(operation_error)?;
-    let [row] = rows.as_slice() else {
-        return if rows.is_empty() {
-            Ok(None)
-        } else {
-            Err(StoreError::corrupt_data(
-                "multiple runtime-authority offers reference one command",
-            ))
-        };
-    };
+    match rows.len() {
+        0 => Ok(None),
+        1 => Ok(rows.into_iter().next()),
+        _ => Err(StoreError::corrupt_data(
+            "multiple runtime-authority offers reference one command",
+        )),
+    }
+}
 
+fn validate_runtime_authority_offer_session(
+    row: &sqlx::postgres::PgRow,
+    session: RunnerSessionFence,
+) -> Result<(), StoreError> {
     let publication_runner_id =
         RunnerId::from_uuid(row.try_get("runner_id").map_err(operation_error)?);
     let publication_epoch = decode_epoch(
@@ -5269,19 +5278,26 @@ async fn load_runtime_authority_offer_by_command(
         row.try_get("command_runner_generation")
             .map_err(operation_error)?,
     )?;
-    if publication_runner_id != session.runner_id()
-        || publication_epoch != session.session_epoch()
-        || publication_generation != session.runner_generation()
-        || command_session_id != session.session_id().as_uuid()
-        || command_runner_id != session.runner_id()
-        || command_epoch != session.session_epoch()
-        || command_generation != session.runner_generation()
+    if publication_runner_id == session.runner_id()
+        && publication_epoch == session.session_epoch()
+        && publication_generation == session.runner_generation()
+        && command_session_id == session.session_id().as_uuid()
+        && command_runner_id == session.runner_id()
+        && command_epoch == session.session_epoch()
+        && command_generation == session.runner_generation()
     {
-        return Err(StoreError::corrupt_data(
+        Ok(())
+    } else {
+        Err(StoreError::corrupt_data(
             "runtime-authority offer has a mismatched session fence",
-        ));
+        ))
     }
+}
 
+fn decode_runtime_authority_command(
+    row: &sqlx::postgres::PgRow,
+    identity: LeaseOfferCommandIdentity,
+) -> Result<DecodedRuntimeAuthorityCommand, StoreError> {
     let request_kind = RunnerOperationKind::new(
         row.try_get::<String, _>("operation_kind")
             .map_err(operation_error)?,
@@ -5289,29 +5305,27 @@ async fn load_runtime_authority_offer_by_command(
     .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
     let command_kind: String = row.try_get("command_kind").map_err(operation_error)?;
     let command_schema = decode_schema(row.try_get("command_schema").map_err(operation_error)?)?;
-    let _command_digest =
-        decode_sha256_digest(row.try_get("command_digest").map_err(operation_error)?)
-            .map_err(|error| StoreError::corrupt_data(error.clone()))?;
+    decode_sha256_digest(row.try_get("command_digest").map_err(operation_error)?)
+        .map_err(|error| StoreError::corrupt_data(error.clone()))?;
     if request_kind.as_str() != LEASE_RPC_OPERATION_KIND
         || !is_lease_offer_command_kind(&command_kind)
+        || command_schema.get() != LEASE_OFFER_COMMAND_SCHEMA
     {
         return Err(StoreError::corrupt_data(
             "runtime-authority offer has invalid command metadata",
         ));
     }
-
-    let command_operation_id = OperationId::from_uuid(
+    let operation_id = OperationId::from_uuid(
         row.try_get("command_operation_id")
             .map_err(operation_error)?,
     );
-    let command_sequence =
-        decode_sequence(row.try_get("command_sequence").map_err(operation_error)?)?;
-    if command_operation_id != identity.operation_id() || command_sequence != identity.sequence() {
+    let sequence = decode_sequence(row.try_get("command_sequence").map_err(operation_error)?)?;
+    if operation_id != identity.operation_id() || sequence != identity.sequence() {
         return Err(StoreError::corrupt_data(
             "runtime-authority offer resolved a different command identity",
         ));
     }
-    let command_created_at = UnixMillis::new(
+    let created_at = UnixMillis::new(
         row.try_get("command_created_at_ms")
             .map_err(operation_error)?,
     );
@@ -5319,12 +5333,29 @@ async fn load_runtime_authority_offer_by_command(
         row.try_get("publication_created_at_ms")
             .map_err(operation_error)?,
     );
-    if command_created_at != publication_created_at {
+    if created_at != publication_created_at {
         return Err(StoreError::corrupt_data(
             "runtime-authority publication and command creation times disagree",
         ));
     }
+    Ok(DecodedRuntimeAuthorityCommand {
+        request_kind,
+        operation_id,
+        sequence,
+        created_at,
+    })
+}
 
+async fn load_runtime_authority_offer_by_command(
+    transaction: &mut Transaction<'_, Postgres>,
+    identity: LeaseOfferCommandIdentity,
+) -> Result<Option<AcceptedRuntimeAuthorityOffer>, StoreError> {
+    let Some(row) = query_runtime_authority_offer_by_command(transaction, identity).await? else {
+        return Ok(None);
+    };
+    let session = identity.session();
+    validate_runtime_authority_offer_session(&row, session)?;
+    let command = decode_runtime_authority_command(&row, identity)?;
     let request_operation_id = OperationId::from_uuid(
         row.try_get("request_operation_id")
             .map_err(operation_error)?,
@@ -5332,13 +5363,15 @@ async fn load_runtime_authority_offer_by_command(
     let request_digest =
         decode_sha256_digest(row.try_get("request_digest").map_err(operation_error)?)
             .map_err(|error| StoreError::corrupt_data(error.clone()))?;
-    let request =
-        RunnerOperationRequest::new(session, request_operation_id, request_kind, request_digest);
+    let request = RunnerOperationRequest::new(
+        session,
+        request_operation_id,
+        command.request_kind,
+        request_digest,
+    );
     let protocol_version =
         decode_protocol(row.try_get("protocol_version").map_err(operation_error)?)?;
-    if command_schema.get() != LEASE_OFFER_COMMAND_SCHEMA
-        || protocol_version.get() != LEASE_OFFER_COMMAND_SCHEMA
-    {
+    if protocol_version.get() != LEASE_OFFER_COMMAND_SCHEMA {
         return Err(StoreError::corrupt_data(
             "runtime-authority offer has invalid protocol metadata",
         ));
@@ -5357,8 +5390,8 @@ async fn load_runtime_authority_offer_by_command(
     .ok()
     .and_then(|value| FencingToken::new(value).ok())
     .ok_or_else(|| StoreError::corrupt_data("invalid runtime-authority fencing token"))?;
-    let lease = decode_lease_offer_lease(row, session.runner_id(), fencing)?;
-    let job_ir = decode_lease_offer_job_ir(row)?;
+    let lease = decode_lease_offer_lease(&row, session.runner_id(), fencing)?;
+    let job_ir = decode_lease_offer_job_ir(&row)?;
     let offer_valid_until = UnixMillis::new(
         row.try_get("offer_valid_until_ms")
             .map_err(operation_error)?,
@@ -5371,9 +5404,9 @@ async fn load_runtime_authority_offer_by_command(
         job_ir,
         offer_valid_until,
         RuntimeAuthorityOfferCommand::new(
-            command_operation_id,
-            command_sequence,
-            command_created_at,
+            command.operation_id,
+            command.sequence,
+            command.created_at,
         ),
     )
     .map(Some)


### PR DESCRIPTION
## Summary

- extract runtime-authority bundle encoding/digest into one private zeroizing helper
- split PostgreSQL lease-offer session and command decoding without changing the locked query or fail-closed validation
- keep the exact stale-authorization and session-close assertions in the focused PostgreSQL fixture

## Scope

This is a three-file cleanup stacked directly on the merged certificate-renewal authority. It adds no public API, schema, migration, compatibility path, or LocalDocker/bootstrap behavior.

## Verification

- independent exact-range review: CLEAN
- `cargo fmt --all -- --check` and `git diff --check`
- strict Clippy for control/store-postgres/postgres targets
- selected package tests (197 passed; expected ignored integration cases unchanged)
- four focused live PostgreSQL 18 locking/replay/fence tests
- full workspace all-target/all-feature check and strict Clippy passed during reconstruction
