### PR TITLE
docs: link public Automata CI dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ workflows. It accepts authenticated GitHub events, plans work from
 `.ci/workflows/`, schedules fenced job attempts, and executes them through an
 isolated runner provider on infrastructure you control.
 
+Public CI runs and runner-redacted logs for this repository are available on
+the [Automata CI dashboard](https://ci.automata-ci.com/automata-ci/automata/actions).
+
 > [!WARNING]
 > Automata is pre-1.0 software for development and evaluation. No public
 > release has been published, and the complete production composition has not


### PR DESCRIPTION
## Outcome

Links the repository README directly to its public Automata CI runs and runner-redacted logs.

## Verification

- `git diff --check`
- dashboard and active anonymous job pages return HTTP 200

## AI assistance

OpenAI Codex prepared and verified this documentation update.