### PR TITLE
feat(windows): bind broker authority through lease extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "automata-ci-store",
  "automata-ci-workload-oidc",
  "flate2",
+ "ring",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/automata-ci-control/Cargo.toml
+++ b/crates/automata-ci-control/Cargo.toml
@@ -36,6 +36,7 @@ automata-ci-store.workspace = true
 flate2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+ring.workspace = true
 sha2.workspace = true
 subtle.workspace = true
 thiserror.workspace = true

--- a/crates/automata-ci-control/README.md
+++ b/crates/automata-ci-control/README.md
@@ -9,6 +9,15 @@ validated runner capabilities to deterministic placement decisions. Its
 application services compose those decisions with durable ports and versioned
 runner messages.
 
+Runner lease-authority integrations cross one provider-neutral extension
+boundary. Every canonical poll contribution is accepted before scheduling and
+its exact bundle digest is acknowledged in the durable poll response. Offer
+evidence is bounded, canonical, and retained in the durable command; after
+acceptance, the matching extension prepares a sandbox authorization whose
+commit is atomic with delivery of the complete runtime-authority bundle.
+Unknown or unconfigured authorities fail closed. Provider-specific admission,
+renewal, issuance, and one-use storage remain inside their adapter module.
+
 First-party repository adapters use the feature-gated, documentation-hidden
 `adapter-spi` trust boundary. That module is not a supported general-purpose
 API.

--- a/crates/automata-ci-control/README.md
+++ b/crates/automata-ci-control/README.md
@@ -12,7 +12,8 @@ runner messages.
 Runner lease-authority integrations cross one provider-neutral extension
 boundary. Every canonical poll contribution is accepted before scheduling and
 its exact bundle digest is acknowledged in the durable poll response. Offer
-evidence is bounded, canonical, and retained in the durable command; after
+evidence is canonical, retained in the durable command, and limited to an
+8 MiB encoded budget that leaves capacity for the rest of that command; after
 acceptance, the matching extension prepares a sandbox authorization whose
 commit is atomic with delivery of the complete runtime-authority bundle.
 Unknown or unconfigured authorities fail closed. Provider-specific admission,

--- a/crates/automata-ci-control/src/adapter_spi.rs
+++ b/crates/automata-ci-control/src/adapter_spi.rs
@@ -120,18 +120,6 @@ pub fn rebase_try_claim_attempt(
     request.rebased(observed_at, expires_at)
 }
 
-/// Re-derives provider-specific placement authority from one locked current candidate.
-///
-/// First-party adapters call this after their authoritative clock rebase and
-/// immediately before transitioning the attempt out of `queued`.
-#[must_use]
-pub fn try_claim_attempt_matches_runnable(
-    request: &crate::lease::TryClaimAttempt,
-    candidate: &crate::lease::RunnableAttempt,
-) -> bool {
-    request.placement_matches(candidate)
-}
-
 /// Inspects the cursor embedded in a terminal no-work request.
 #[must_use]
 pub const fn no_work_lease_request_cursor(

--- a/crates/automata-ci-control/src/lease/mod.rs
+++ b/crates/automata-ci-control/src/lease/mod.rs
@@ -28,6 +28,7 @@ pub mod routing;
 mod runnable;
 mod service;
 
+pub use automata_ci_protocol::LeaseAuthorityPollContributions;
 pub use config::{LeasePollConfig, LeaseTimeToLive, LeaseTimeToLiveError};
 pub use error::{CapabilityDocument, LeasePollError, LeasePollInvariant, RequestCorrelationError};
 pub(crate) use observer::NoopLeasePollObserver;
@@ -38,7 +39,7 @@ pub use operation::{
     BeginLeaseRequest, BegunLeaseRequest, ClaimCommandError, ClaimRejection, ClaimedAttempt,
     CompleteLeaseRequest, LeaseOfferCompletionError, LeaseRequestCompletion, LeaseRequestKey,
     LeaseRequestKeyError, NoWorkLeaseRequest, RevokedLeaseOfferFallback, TryClaimAttempt,
-    TryClaimOutcome, TryClaimReceipt, WindowsHyperVPlacementGrant, WindowsPlacementGrantError,
+    TryClaimOutcome, TryClaimReceipt,
 };
 pub use port::{
     LeaseClock, LeaseIdGenerator, LeasePollRepository, RandomLeaseIdGenerator, RunnableAttemptGate,

--- a/crates/automata-ci-control/src/lease/operation.rs
+++ b/crates/automata-ci-control/src/lease/operation.rs
@@ -1,9 +1,7 @@
 //! Idempotent lease-poll operation values and durable claim outcomes.
 
-use automata_ci_core::{
-    Architecture, AttemptId, EnvironmentProfile, IsolationLevel, JobLifecycle, Lease, LeaseId,
-    OperatingSystem, OperationId, SandboxFeature, TrustSourceClass, UnixMillis,
-};
+use automata_ci_core::{AttemptId, JobLifecycle, Lease, LeaseId, OperationId, UnixMillis};
+use automata_ci_protocol::LeaseAuthorityPollContributions;
 use automata_ci_store::{
     AttemptAssignment, AttemptAssignmentError, DocumentSchema, JobIrMetadata,
     LeaseOfferCommandIdentity, RunnerOperationResponse, RunnerSessionFence, Sha256Digest,
@@ -12,11 +10,22 @@ use automata_ci_store::{
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
-use super::runnable::{AuthenticatedPlacementTrust, RunnableAttempt, RunnableCursorAdvance};
+use super::runnable::{RunnableAttempt, RunnableCursorAdvance};
 
 const LEASE_REQUEST_DIGEST_DOMAIN: &[u8] = b"automata.store.lease-request.v2\0";
-const WINDOWS_PLACEMENT_GRANT_DIGEST_DOMAIN: &[u8] =
-    b"automata.control.windows-hyperv-placement-grant.v1\0";
+const LEASE_POLL_DECISION_REQUEST_DIGEST_DOMAIN: &[u8] =
+    b"automata.control.lease-poll-decision-request.v3\0";
+
+pub(super) fn lease_poll_decision_request_digest(
+    request_key: LeaseRequestKey,
+    authority_contributions: &LeaseAuthorityPollContributions,
+) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(LEASE_POLL_DECISION_REQUEST_DIGEST_DOMAIN);
+    digest.update(request_key.request_digest().as_bytes());
+    digest.update(authority_contributions.sha256_digest().as_bytes());
+    Sha256Digest::from_bytes(digest.finalize().into())
+}
 
 /// Canonical identity of one runner lease poll before scheduling selects work.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -110,6 +119,16 @@ impl LeaseRequestKey {
             None => digest.update([0]),
         }
         Sha256Digest::from_bytes(digest.finalize().into())
+    }
+
+    /// Computes the canonical durable decision digest for this request and its
+    /// exact provider-neutral authority contribution bundle.
+    #[must_use]
+    pub fn decision_request_digest(
+        self,
+        authority_contributions: &LeaseAuthorityPollContributions,
+    ) -> Sha256Digest {
+        lease_poll_decision_request_digest(self, authority_contributions)
     }
 }
 
@@ -532,215 +551,7 @@ pub struct TryClaimAttempt {
     observed_at: UnixMillis,
     expires_at: UnixMillis,
     cursor: RunnableCursorAdvance,
-    windows_placement_grant: Option<WindowsHyperVPlacementGrant>,
-}
-
-/// Server-only one-use authority for one exact Windows Hyper-V placement.
-///
-/// The value is neither serialized nor accepted from a runner. It binds the
-/// authenticated trust root and immutable job plan to one poll operation,
-/// runner generation/session/slot, proposed lease, exact image-profile
-/// manifest, and half-open validity interval. A first-party durable adapter
-/// re-derives it from locked current state immediately before leasing.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WindowsHyperVPlacementGrant {
-    attempt_id: AttemptId,
-    job_id: automata_ci_core::JobId,
-    run_id: automata_ci_core::RunId,
-    operation_id: OperationId,
-    session: RunnerSessionFence,
-    slot: StableRunnerSlot,
-    lease_id: LeaseId,
-    job_ir: JobIrMetadata,
-    trust: AuthenticatedPlacementTrust,
-    environment_profile: EnvironmentProfile,
-    issued_at: UnixMillis,
-    expires_at: UnixMillis,
-    binding_digest: Sha256Digest,
-}
-
-impl WindowsHyperVPlacementGrant {
-    fn for_candidate(
-        request_key: LeaseRequestKey,
-        lease_id: LeaseId,
-        issued_at: UnixMillis,
-        expires_at: UnixMillis,
-        candidate: &RunnableAttempt,
-    ) -> Result<Option<Self>, WindowsPlacementGrantError> {
-        let requirements = candidate.requirements();
-        if requirements.operating_system() != Some(&OperatingSystem::Windows) {
-            return Ok(None);
-        }
-        if requirements.minimum_isolation() < IsolationLevel::VirtualMachine
-            || !requirements
-                .sandbox_features()
-                .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
-        {
-            return Err(WindowsPlacementGrantError::InexactIsolation);
-        }
-        if requirements.architecture() != Some(&Architecture::X86_64) {
-            return Err(WindowsPlacementGrantError::UnsupportedArchitecture);
-        }
-        let environment_profile = requirements
-            .environment_profile()
-            .cloned()
-            .ok_or(WindowsPlacementGrantError::MissingEnvironmentProfile)?;
-        let trust = candidate
-            .placement_trust()
-            .cloned()
-            .ok_or(WindowsPlacementGrantError::MissingAuthenticatedTrust)?;
-        if !trust.evidence_complete() || trust.source() == TrustSourceClass::Incomplete {
-            return Err(WindowsPlacementGrantError::IncompleteAuthenticatedTrust);
-        }
-        if expires_at <= issued_at {
-            return Err(WindowsPlacementGrantError::InvalidValidityInterval);
-        }
-        let mut grant = Self {
-            attempt_id: candidate.attempt_id(),
-            job_id: candidate.job_id(),
-            run_id: candidate.run_id(),
-            operation_id: request_key.operation_id(),
-            session: request_key.session(),
-            slot: request_key.slot(),
-            lease_id,
-            job_ir: candidate.job_ir().clone(),
-            trust,
-            environment_profile,
-            issued_at,
-            expires_at,
-            binding_digest: Sha256Digest::from_bytes([0; 32]),
-        };
-        grant.binding_digest = grant.compute_binding_digest();
-        Ok(Some(grant))
-    }
-
-    #[cfg(feature = "adapter-spi")]
-    fn rebased(
-        &self,
-        issued_at: UnixMillis,
-        expires_at: UnixMillis,
-    ) -> Result<Self, WindowsPlacementGrantError> {
-        if expires_at <= issued_at {
-            return Err(WindowsPlacementGrantError::InvalidValidityInterval);
-        }
-        let mut grant = self.clone();
-        grant.issued_at = issued_at;
-        grant.expires_at = expires_at;
-        grant.binding_digest = grant.compute_binding_digest();
-        Ok(grant)
-    }
-
-    fn compute_binding_digest(&self) -> Sha256Digest {
-        fn field(digest: &mut Sha256, value: &[u8]) {
-            digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_be_bytes());
-            digest.update(value);
-        }
-
-        let mut digest = Sha256::new();
-        digest.update(WINDOWS_PLACEMENT_GRANT_DIGEST_DOMAIN);
-        digest.update(self.attempt_id.as_uuid().as_bytes());
-        digest.update(self.job_id.as_uuid().as_bytes());
-        digest.update(self.run_id.as_uuid().as_bytes());
-        digest.update(self.operation_id.as_uuid().as_bytes());
-        digest.update(self.session.runner_id().as_uuid().as_bytes());
-        digest.update(self.session.session_id().as_uuid().as_bytes());
-        digest.update(self.session.runner_generation().get().to_be_bytes());
-        digest.update(self.session.session_epoch().get().to_be_bytes());
-        digest.update(self.slot.ordinal().to_be_bytes());
-        digest.update(self.lease_id.as_uuid().as_bytes());
-        digest.update(self.job_ir.version().get().to_be_bytes());
-        digest.update(self.job_ir.encoded_size().to_be_bytes());
-        digest.update(self.job_ir.digest().as_bytes());
-        field(&mut digest, self.job_ir.object_key().as_str().as_bytes());
-        digest.update(self.trust.snapshot_schema().to_be_bytes());
-        digest.update(self.trust.policy_revision().get().to_be_bytes());
-        digest.update(self.trust.policy_digest().as_bytes());
-        digest.update(self.trust.snapshot_digest().as_bytes());
-        digest.update(match self.trust.authority_profile() {
-            automata_ci_core::JobAuthorityProfile::Standard => [0],
-            automata_ci_core::JobAuthorityProfile::CredentialFree => [1],
-        });
-        digest.update(self.trust.requirements_digest().as_bytes());
-        field(
-            &mut digest,
-            self.environment_profile.id().as_str().as_bytes(),
-        );
-        digest.update(self.environment_profile.digest().as_bytes());
-        digest.update(self.issued_at.get().to_be_bytes());
-        digest.update(self.expires_at.get().to_be_bytes());
-        Sha256Digest::from_bytes(digest.finalize().into())
-    }
-
-    /// Returns the exact attempt authorized by this one-use value.
-    #[must_use]
-    pub const fn attempt_id(&self) -> AttemptId {
-        self.attempt_id
-    }
-
-    /// Returns the exact poll operation authorized by this one-use value.
-    #[must_use]
-    pub const fn operation_id(&self) -> OperationId {
-        self.operation_id
-    }
-
-    /// Returns the exact runner generation/session bound into this value.
-    #[must_use]
-    pub const fn session(&self) -> RunnerSessionFence {
-        self.session
-    }
-
-    /// Returns the exact stable slot bound into this value.
-    #[must_use]
-    pub const fn slot(&self) -> StableRunnerSlot {
-        self.slot
-    }
-
-    /// Returns the exact proposed lease identity.
-    #[must_use]
-    pub const fn lease_id(&self) -> LeaseId {
-        self.lease_id
-    }
-
-    /// Returns the immutable content-attested Windows environment profile.
-    #[must_use]
-    pub const fn environment_profile(&self) -> &EnvironmentProfile {
-        &self.environment_profile
-    }
-
-    /// Returns the exclusive authority horizon.
-    #[must_use]
-    pub const fn expires_at(&self) -> UnixMillis {
-        self.expires_at
-    }
-
-    /// Returns the canonical domain-separated binding digest.
-    #[must_use]
-    pub const fn binding_digest(&self) -> Sha256Digest {
-        self.binding_digest
-    }
-}
-
-/// Closed local reasons that prevent a Windows candidate becoming a lease.
-#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum WindowsPlacementGrantError {
-    /// The candidate does not require the exact Hyper-V-container boundary.
-    #[error("Windows placement does not require exact Hyper-V-container isolation")]
-    InexactIsolation,
-    /// Wave 1 admits only native Windows AMD64 profiles.
-    #[error("Windows placement architecture is unsupported")]
-    UnsupportedArchitecture,
-    /// No immutable profile-manifest digest was selected.
-    #[error("Windows placement is missing an exact environment profile")]
-    MissingEnvironmentProfile,
-    /// The durable run has no authenticated trust/materialization lineage.
-    #[error("Windows placement is missing authenticated trust evidence")]
-    MissingAuthenticatedTrust,
-    /// Authenticated facts were incomplete and therefore cannot authorize execution.
-    #[error("Windows placement trust evidence is incomplete")]
-    IncompleteAuthenticatedTrust,
-    /// The proposed grant has an empty or reversed validity interval.
-    #[error("Windows placement grant validity interval is invalid")]
-    InvalidValidityInterval,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl TryClaimAttempt {
@@ -756,6 +567,7 @@ impl TryClaimAttempt {
         observed_at: UnixMillis,
         expires_at: UnixMillis,
         cursor: RunnableCursorAdvance,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<Self, ClaimCommandError> {
         if expires_at <= observed_at {
             return Err(ClaimCommandError::InvalidLeaseInterval);
@@ -775,17 +587,15 @@ impl TryClaimAttempt {
             observed_at,
             expires_at,
             cursor,
-            windows_placement_grant: None,
+            authority_contributions,
         })
     }
 
-    /// Creates a claim and derives any mandatory Windows placement authority.
+    /// Creates a claim for one exact durable runnable candidate.
     ///
     /// # Errors
     ///
-    /// Rejects cursor/attempt disagreement or a Windows candidate without
-    /// complete authenticated trust, an exact AMD64 environment profile, and
-    /// the non-fallback Hyper-V-container requirement.
+    /// Rejects cursor/attempt disagreement or an invalid lease interval.
     pub fn for_candidate(
         request_key: LeaseRequestKey,
         candidate: &RunnableAttempt,
@@ -793,24 +603,17 @@ impl TryClaimAttempt {
         observed_at: UnixMillis,
         expires_at: UnixMillis,
         cursor: RunnableCursorAdvance,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<Self, ClaimCommandError> {
-        let mut request = Self::new(
+        Self::new(
             request_key,
             candidate.attempt_id(),
             lease_id,
             observed_at,
             expires_at,
             cursor,
-        )?;
-        request.windows_placement_grant = WindowsHyperVPlacementGrant::for_candidate(
-            request_key,
-            lease_id,
-            observed_at,
-            expires_at,
-            candidate,
+            authority_contributions,
         )
-        .map_err(ClaimCommandError::InvalidWindowsPlacementGrant)?;
-        Ok(request)
     }
 
     /// Returns the claim operation identity.
@@ -861,16 +664,16 @@ impl TryClaimAttempt {
         self.request_key
     }
 
-    /// Returns the canonical pre-scheduling lease-request digest.
+    /// Returns the canonical claim-request digest, including exact authority contributions.
     #[must_use]
     pub fn request_digest(&self) -> Sha256Digest {
-        self.request_key.request_digest()
+        lease_poll_decision_request_digest(self.request_key, &self.authority_contributions)
     }
 
-    /// Returns a server-only Windows placement grant when this is a Windows claim.
+    /// Returns the exact bounded authority contributions admitted with this poll.
     #[must_use]
-    pub const fn windows_placement_grant(&self) -> Option<&WindowsHyperVPlacementGrant> {
-        self.windows_placement_grant.as_ref()
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
     }
 
     #[cfg(feature = "adapter-spi")]
@@ -879,33 +682,15 @@ impl TryClaimAttempt {
         observed_at: UnixMillis,
         expires_at: UnixMillis,
     ) -> Result<Self, ClaimCommandError> {
-        let mut request = Self::new(
+        Self::new(
             self.request_key,
             self.attempt_id,
             self.lease_id,
             observed_at,
             expires_at,
             self.cursor,
-        )?;
-        request.windows_placement_grant = self
-            .windows_placement_grant
-            .as_ref()
-            .map(|grant| grant.rebased(observed_at, expires_at))
-            .transpose()
-            .map_err(ClaimCommandError::InvalidWindowsPlacementGrant)?;
-        Ok(request)
-    }
-
-    #[cfg(feature = "adapter-spi")]
-    pub(crate) fn placement_matches(&self, candidate: &RunnableAttempt) -> bool {
-        WindowsHyperVPlacementGrant::for_candidate(
-            self.request_key,
-            self.lease_id,
-            self.observed_at,
-            self.expires_at,
-            candidate,
+            self.authority_contributions.clone(),
         )
-        .is_ok_and(|expected| expected.as_ref() == self.windows_placement_grant.as_ref())
     }
 
     /// Returns the opaque authoritative scan cursor used by an adapter.
@@ -922,6 +707,7 @@ pub struct NoWorkLeaseRequest {
     request_key: LeaseRequestKey,
     observed_at: UnixMillis,
     cursor: RunnableCursorAdvance,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl NoWorkLeaseRequest {
@@ -934,6 +720,7 @@ impl NoWorkLeaseRequest {
         request_key: LeaseRequestKey,
         observed_at: UnixMillis,
         cursor: RunnableCursorAdvance,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<Self, ClaimCommandError> {
         if cursor.session() != request_key.session() || cursor.slot() != request_key.slot() {
             return Err(ClaimCommandError::CursorMismatch);
@@ -942,6 +729,7 @@ impl NoWorkLeaseRequest {
             request_key,
             observed_at,
             cursor,
+            authority_contributions,
         })
     }
 
@@ -955,6 +743,18 @@ impl NoWorkLeaseRequest {
     #[must_use]
     pub const fn observed_at(&self) -> UnixMillis {
         self.observed_at
+    }
+
+    /// Returns the canonical poll-decision digest, including exact authority contributions.
+    #[must_use]
+    pub fn request_digest(&self) -> Sha256Digest {
+        lease_poll_decision_request_digest(self.request_key, &self.authority_contributions)
+    }
+
+    /// Returns the exact bounded authority contributions admitted with this poll.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
     }
 
     /// Returns the opaque authoritative scan cursor used by an adapter.
@@ -974,9 +774,6 @@ pub enum ClaimCommandError {
     /// The cursor proof belongs to another request, slot, or attempt.
     #[error("queue cursor proof does not match the lease request")]
     CursorMismatch,
-    /// Mandatory Windows placement evidence is missing or invalid.
-    #[error("invalid Windows Hyper-V placement grant: {0}")]
-    InvalidWindowsPlacementGrant(WindowsPlacementGrantError),
 }
 
 /// Successfully fenced claim and its stable connection assignment.
@@ -985,6 +782,7 @@ pub struct ClaimedAttempt {
     lease: Lease,
     assignment: AttemptAssignment,
     job_ir: JobIrMetadata,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl ClaimedAttempt {
@@ -997,12 +795,14 @@ impl ClaimedAttempt {
         lease: Lease,
         assignment: AttemptAssignment,
         job_ir: JobIrMetadata,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<Self, AttemptAssignmentError> {
         assignment.validate_lease(&lease)?;
         Ok(Self {
             lease,
             assignment,
             job_ir,
+            authority_contributions,
         })
     }
 
@@ -1022,6 +822,12 @@ impl ClaimedAttempt {
     #[must_use]
     pub const fn job_ir(&self) -> &JobIrMetadata {
         &self.job_ir
+    }
+
+    /// Returns the exact bounded authority contributions admitted with the claim.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
     }
 }
 
@@ -1079,6 +885,7 @@ impl TryClaimOutcome {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TryClaimReceipt {
     request_key: LeaseRequestKey,
+    request_digest: Sha256Digest,
     outcome: TryClaimOutcome,
     replayed: bool,
 }
@@ -1088,11 +895,13 @@ impl TryClaimReceipt {
     #[must_use]
     pub const fn new(
         request_key: LeaseRequestKey,
+        request_digest: Sha256Digest,
         outcome: TryClaimOutcome,
         replayed: bool,
     ) -> Self {
         Self {
             request_key,
+            request_digest,
             outcome,
             replayed,
         }
@@ -1112,8 +921,8 @@ impl TryClaimReceipt {
 
     /// Returns the canonical lease-request digest.
     #[must_use]
-    pub fn request_digest(&self) -> Sha256Digest {
-        self.request_key.request_digest()
+    pub const fn request_digest(&self) -> Sha256Digest {
+        self.request_digest
     }
 
     /// Returns the canonical lease-request key.

--- a/crates/automata-ci-control/src/lease/repository.rs
+++ b/crates/automata-ci-control/src/lease/repository.rs
@@ -4,6 +4,7 @@ use crate::lease::{
     TryClaimReceipt,
 };
 use async_trait::async_trait;
+use automata_ci_protocol::LeaseAuthorityPollContributions;
 use automata_ci_store::StoreError;
 
 /// Bounded exact-response ledger for lease-request chains.
@@ -30,6 +31,7 @@ pub trait RunnerClaimRepository: Send + Sync {
     async fn lookup_lease_request(
         &self,
         request: LeaseRequestKey,
+        authority_contributions: &LeaseAuthorityPollContributions,
     ) -> Result<Option<TryClaimReceipt>, StoreError>;
 
     /// Claims one scheduler-selected candidate and records the answer in the

--- a/crates/automata-ci-control/src/lease/runnable.rs
+++ b/crates/automata-ci-control/src/lease/runnable.rs
@@ -3,9 +3,8 @@
 use std::num::{NonZeroU16, NonZeroU64};
 
 use automata_ci_core::{
-    Architecture, AttemptId, IsolationLevel, JobAuthorityProfile, JobId, OperatingSystem, RunId,
-    RunnerRequirements, SandboxFeature, Sha256Digest, TrustAuthorityDecision, TrustSnapshot,
-    TrustSourceClass, UnixMillis,
+    AttemptId, JobAuthorityProfile, JobId, RunId, RunnerRequirements, Sha256Digest,
+    TrustAuthorityDecision, TrustSnapshot, TrustSourceClass, UnixMillis,
 };
 use automata_ci_store::{JobIrMetadata, RunnerSessionFence, StableRunnerSlot};
 use sha2::{Digest as _, Sha256};
@@ -379,27 +378,6 @@ impl RunnableAttempt {
     #[must_use]
     pub const fn placement_trust(&self) -> Option<&AuthenticatedPlacementTrust> {
         self.placement_trust.as_ref()
-    }
-
-    /// Reports whether a Windows candidate has the complete local authority
-    /// inputs required before it may reach scheduling.
-    ///
-    /// Non-Windows candidates do not use the Windows-specific grant.
-    #[must_use]
-    pub fn windows_placement_is_authorizable(&self) -> bool {
-        if self.requirements.operating_system() != Some(&OperatingSystem::Windows) {
-            return true;
-        }
-        self.requirements.minimum_isolation() >= IsolationLevel::VirtualMachine
-            && self
-                .requirements
-                .sandbox_features()
-                .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
-            && self.requirements.architecture() == Some(&Architecture::X86_64)
-            && self.requirements.environment_profile().is_some()
-            && self.placement_trust.as_ref().is_some_and(|trust| {
-                trust.evidence_complete() && trust.source() != TrustSourceClass::Incomplete
-            })
     }
 }
 

--- a/crates/automata-ci-control/src/lease/service.rs
+++ b/crates/automata-ci-control/src/lease/service.rs
@@ -15,7 +15,9 @@ use crate::scheduling::{
 use automata_ci_core::{
     JobIrVersion, Lease, RunnerCapabilities, RunnerGroup, RunnerLabel, UnixMillis,
 };
-use automata_ci_protocol::{LeaseRequest, ProtocolVersion, RunnerSlotOrdinal};
+use automata_ci_protocol::{
+    LeaseAuthorityPollContributions, LeaseRequest, ProtocolVersion, RunnerSlotOrdinal,
+};
 use automata_ci_store::{JobIrMetadata, RoutingDocument, RunnerSessionFence, StableRunnerSlot};
 
 use super::{
@@ -79,23 +81,26 @@ impl AuthenticatedRunnerSession {
 pub struct ClaimedLeasePoll {
     lease: Lease,
     slot: RunnerSlotOrdinal,
-    job_ir: JobIrMetadata,
+    job_ir: Box<JobIrMetadata>,
+    authority_contributions: LeaseAuthorityPollContributions,
     replayed: bool,
 }
 
 impl ClaimedLeasePoll {
     /// Reconstitutes one exact claimed poll from a trusted scheduling adapter.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         lease: Lease,
         slot: RunnerSlotOrdinal,
         job_ir: JobIrMetadata,
+        authority_contributions: LeaseAuthorityPollContributions,
         replayed: bool,
     ) -> Self {
         Self {
             lease,
             slot,
-            job_ir,
+            job_ir: Box::new(job_ir),
+            authority_contributions,
             replayed,
         }
     }
@@ -116,6 +121,12 @@ impl ClaimedLeasePoll {
     #[must_use]
     pub const fn job_ir(&self) -> &JobIrMetadata {
         &self.job_ir
+    }
+
+    /// Returns the exact bounded authority contributions admitted with this claim.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
     }
 
     /// Reports whether a durable terminal receipt was replayed.
@@ -258,10 +269,10 @@ impl<'a> LeasePollService<'a> {
 
         if let Some(receipt) = self
             .repository
-            .lookup_lease_request(poll.request_key)
+            .lookup_lease_request(poll.request_key, &poll.authority_contributions)
             .await?
         {
-            return Self::receipt_outcome(poll, &receipt, None, true);
+            return Self::receipt_outcome(&poll, &receipt, None, true);
         }
 
         let observed_at = self.clock.now();
@@ -269,7 +280,7 @@ impl<'a> LeasePollService<'a> {
             .repository
             .routing_for_session(poll.request_key.session())
             .await?;
-        ensure_routing_context(&routing, poll)?;
+        ensure_routing_context(&routing, &poll)?;
         let registered = decode_capabilities(
             routing.registered_capabilities(),
             CapabilityDocument::Registered,
@@ -321,7 +332,7 @@ impl<'a> LeasePollService<'a> {
         match self.scheduler.decide(input) {
             PlacementDecision::Place(placement) => {
                 self.claim(
-                    poll,
+                    &poll,
                     availability == RunnerSlotAvailability::Available
                         && slot_is_effectively_available,
                     observed_at,
@@ -339,11 +350,12 @@ impl<'a> LeasePollService<'a> {
                             poll.request_key,
                             observed_at,
                             page.no_work_advance(),
+                            poll.authority_contributions.clone(),
                         )
                         .map_err(LeasePollError::InvalidClaim)?,
                     )
                     .await?;
-                Self::receipt_outcome(poll, &receipt, None, false)
+                Self::receipt_outcome(&poll, &receipt, None, false)
             }
         }
     }
@@ -355,9 +367,6 @@ impl<'a> LeasePollService<'a> {
     ) -> Result<Vec<RunnableCandidate>, LeasePollError> {
         let mut eligible = Vec::with_capacity(candidates.len());
         for candidate in candidates {
-            if !candidate.windows_placement_authorized {
-                continue;
-            }
             let disposition = if let Some(gate) = self.attempt_gate {
                 gate.evaluate(candidate.candidate.attempt_id(), observed_at)
                     .await?
@@ -373,7 +382,7 @@ impl<'a> LeasePollService<'a> {
 
     async fn claim(
         &self,
-        poll: ValidatedLeasePoll,
+        poll: &ValidatedLeasePoll,
         slot_is_available: bool,
         observed_at: UnixMillis,
         placement: Placement,
@@ -421,6 +430,7 @@ impl<'a> LeasePollService<'a> {
             expires_at,
             page.claim_advance(placement.attempt_id())
                 .map_err(LeasePollError::InvalidRunnableScan)?,
+            poll.authority_contributions.clone(),
         )
         .map_err(LeasePollError::InvalidClaim)?;
         let receipt = self.repository.try_claim(claim).await?;
@@ -443,13 +453,17 @@ impl<'a> LeasePollService<'a> {
     }
 
     fn receipt_outcome(
-        poll: ValidatedLeasePoll,
+        poll: &ValidatedLeasePoll,
         receipt: &TryClaimReceipt,
         selected: Option<(automata_ci_core::AttemptId, automata_ci_core::JobId)>,
         found_before_scheduling: bool,
     ) -> Result<LeasePollOutcome, LeasePollError> {
         if receipt.request_key() != poll.request_key
-            || receipt.request_digest() != poll.request_key.request_digest()
+            || receipt.request_digest()
+                != super::operation::lease_poll_decision_request_digest(
+                    poll.request_key,
+                    &poll.authority_contributions,
+                )
         {
             return Err(LeasePollInvariant::ReceiptRequestMismatch.into());
         }
@@ -473,12 +487,16 @@ impl<'a> LeasePollService<'a> {
                 if claimed.job_ir().version() != poll.job_ir_version {
                     return Err(LeasePollInvariant::ReceiptJobIrVersionMismatch.into());
                 }
+                if claimed.authority_contributions() != &poll.authority_contributions {
+                    return Err(LeasePollInvariant::ReceiptRequestMismatch.into());
+                }
                 let slot = RunnerSlotOrdinal::new(request_key.slot().ordinal())
                     .map_err(|_| LeasePollInvariant::ReceiptAssignmentMismatch)?;
                 Ok(LeasePollOutcome::Claimed(ClaimedLeasePoll::new(
                     claimed.lease().clone(),
                     slot,
                     claimed.job_ir().clone(),
+                    claimed.authority_contributions().clone(),
                     replayed,
                 )))
             }
@@ -546,10 +564,11 @@ const fn observe_failure(error: &LeasePollError) -> LeasePollFailure {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct ValidatedLeasePoll {
     request_key: LeaseRequestKey,
     job_ir_version: JobIrVersion,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl ValidatedLeasePoll {
@@ -590,18 +609,18 @@ impl ValidatedLeasePoll {
         Ok(Self {
             request_key,
             job_ir_version: authenticated.job_ir_version,
+            authority_contributions: request.authority_contributions().clone(),
         })
     }
 }
 
 struct ApplicationCandidate {
     candidate: RunnableCandidate,
-    windows_placement_authorized: bool,
 }
 
 fn ensure_routing_context(
     routing: &RunnerRoutingSnapshot,
-    expected: ValidatedLeasePoll,
+    expected: &ValidatedLeasePoll,
 ) -> Result<(), LeasePollError> {
     if routing.fence() != expected.request_key.session() {
         return Err(LeasePollInvariant::RoutingFenceMismatch.into());
@@ -706,6 +725,5 @@ fn candidate_from_durable(
             durable.queued_at(),
             routing,
         ),
-        windows_placement_authorized: durable.windows_placement_is_authorizable(),
     })
 }

--- a/crates/automata-ci-control/src/runner_control/durable.rs
+++ b/crates/automata-ci-control/src/runner_control/durable.rs
@@ -5,7 +5,10 @@ use automata_ci_core::{
     AttemptId, JobConclusion, JobIrVersion, JobLifecycle, Lease, LeaseGuard, LogSequence,
     LogStreamId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
 };
-use automata_ci_protocol::{INITIAL_RUNTIME_AUTHORITY_GENERATION, RuntimeAuthorityDeliveryBinding};
+use automata_ci_protocol::{
+    INITIAL_RUNTIME_AUTHORITY_GENERATION, LeaseAuthorityPollContributions,
+    RuntimeAuthorityDeliveryBinding,
+};
 use automata_ci_store::{
     AcknowledgeRunnerCommands, CommandCursor, CommandSequence, DocumentSchema,
     DurableRunnerCommand, EnqueueRunnerCommand, JobIrMetadata, LeaseOfferCommandIdentity,
@@ -14,6 +17,11 @@ use automata_ci_store::{
     RunnerSessionFence, StableRunnerSlot, StoreError,
 };
 use thiserror::Error;
+
+use super::{
+    lease_authority::LeaseAuthorityEvidenceSet,
+    port::{durable_lease_authority_evidence, durable_managed_secret_bindings},
+};
 
 const MAX_UNCOMPRESSED_RUNNER_LOG_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_DURABLE_LOG_SEQUENCE: u64 = 9_223_372_036_854_775_807;
@@ -78,6 +86,9 @@ pub struct AcceptedRuntimeAuthorityOffer {
     job_ir: JobIrMetadata,
     offer_valid_until: UnixMillis,
     command: RuntimeAuthorityOfferCommand,
+    lease_authority_evidence: LeaseAuthorityEvidenceSet,
+    managed_secret_bindings_empty: bool,
+    command_projection_valid: bool,
 }
 
 impl AcceptedRuntimeAuthorityOffer {
@@ -104,6 +115,9 @@ impl AcceptedRuntimeAuthorityOffer {
             job_ir,
             offer_valid_until,
             command,
+            lease_authority_evidence: LeaseAuthorityEvidenceSet::empty(),
+            managed_secret_bindings_empty: true,
+            command_projection_valid: true,
         })
     }
 
@@ -147,6 +161,26 @@ impl AcceptedRuntimeAuthorityOffer {
     #[must_use]
     pub const fn command(&self) -> RuntimeAuthorityOfferCommand {
         self.command
+    }
+
+    /// Returns canonical provider-neutral authority evidence retained before
+    /// the encrypted lease-offer payload is erased.
+    #[must_use]
+    pub const fn lease_authority_evidence(&self) -> &LeaseAuthorityEvidenceSet {
+        &self.lease_authority_evidence
+    }
+
+    /// Reports whether the retained offer carried no managed-secret bindings.
+    #[must_use]
+    pub const fn managed_secret_bindings_empty(&self) -> bool {
+        self.managed_secret_bindings_empty
+    }
+
+    /// Reports whether every value-free security projection was decoded from
+    /// the exact durable command before its payload was erased.
+    #[must_use]
+    pub const fn command_projection_valid(&self) -> bool {
+        self.command_projection_valid
     }
 }
 
@@ -205,6 +239,7 @@ pub struct LeaseOfferClaim {
     slot: StableRunnerSlot,
     lease: Lease,
     job_ir: JobIrMetadata,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl LeaseOfferClaim {
@@ -218,6 +253,7 @@ impl LeaseOfferClaim {
         slot: StableRunnerSlot,
         lease: Lease,
         job_ir: JobIrMetadata,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<Self, RunnerControlValueError> {
         if lease.runner_id() != request.session().runner_id() {
             return Err(RunnerControlValueError::LeaseRunnerMismatch);
@@ -231,6 +267,7 @@ impl LeaseOfferClaim {
             slot,
             lease,
             job_ir,
+            authority_contributions,
         })
     }
 
@@ -263,6 +300,13 @@ impl LeaseOfferClaim {
     pub const fn job_ir(&self) -> &JobIrMetadata {
         &self.job_ir
     }
+
+    /// Returns the exact provider-neutral contribution bundle accepted with
+    /// the lease request and bound by its durable claim receipt.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
+    }
 }
 
 /// Durable state of one exact claimed lease poll before authority issuance.
@@ -289,19 +333,28 @@ impl PublishLeaseOffer {
     ///
     /// # Errors
     /// Returns an error for a cross-session command or a lease owned by another runner.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         request: RunnerOperationRequest,
         protocol_version: RunnerProtocolVersion,
         slot: StableRunnerSlot,
         lease: Lease,
         job_ir: JobIrMetadata,
+        authority_contributions: LeaseAuthorityPollContributions,
         offer_valid_until: UnixMillis,
         command: EnqueueRunnerCommand,
     ) -> Result<Self, RunnerControlValueError> {
         if request.session() != command.session() {
             return Err(RunnerControlValueError::SessionMismatch);
         }
-        let claim = LeaseOfferClaim::new(request, protocol_version, slot, lease, job_ir)?;
+        let claim = LeaseOfferClaim::new(
+            request,
+            protocol_version,
+            slot,
+            lease,
+            job_ir,
+            authority_contributions,
+        )?;
         validate_offer_validity_horizon(claim.lease(), command.created_at(), offer_valid_until)?;
         Ok(Self {
             claim,
@@ -344,6 +397,13 @@ impl PublishLeaseOffer {
     #[must_use]
     pub const fn job_ir(&self) -> &JobIrMetadata {
         self.claim.job_ir()
+    }
+
+    /// Returns the exact provider-neutral contribution bundle bound by the
+    /// claim receipt being consumed by this publication.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        self.claim.authority_contributions()
     }
 
     /// Returns the exclusive horizon shared by the lease and every delivered runtime authority.
@@ -449,6 +509,14 @@ impl PublishedLeaseOffer {
 
 impl From<PublishedLeaseOffer> for AcceptedRuntimeAuthorityOffer {
     fn from(offer: PublishedLeaseOffer) -> Self {
+        let (lease_authority_evidence, managed_secret_bindings_empty, command_projection_valid) =
+            match (
+                durable_lease_authority_evidence(&offer.command),
+                durable_managed_secret_bindings(&offer.command),
+            ) {
+                (Ok(evidence), Ok(bindings)) => (evidence, bindings.bindings().is_empty(), true),
+                _ => (LeaseAuthorityEvidenceSet::empty(), false, false),
+            };
         let command = RuntimeAuthorityOfferCommand::new(
             offer.command.request().operation_id(),
             offer.command.sequence(),
@@ -462,6 +530,9 @@ impl From<PublishedLeaseOffer> for AcceptedRuntimeAuthorityOffer {
             job_ir: offer.job_ir,
             offer_valid_until: offer.offer_valid_until,
             command,
+            lease_authority_evidence,
+            managed_secret_bindings_empty,
+            command_projection_valid,
         }
     }
 }

--- a/crates/automata-ci-control/src/runner_control/handler.rs
+++ b/crates/automata-ci-control/src/runner_control/handler.rs
@@ -13,17 +13,18 @@ use automata_ci_blob::{
 };
 use automata_ci_core::{
     JobAuthorityProfile, JobIrEnvelope, JobIrVersionRange, JobLifecycle, LogAck, OperationId,
-    Sha256Digest, TrustSecretAuthority, UnixMillis,
+    SandboxAuthorizations, Sha256Digest, TrustSecretAuthority, UnixMillis,
 };
 use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandSequence, ErrorMessage, HandshakeErrorCode,
     HandshakeRejected, JobRuntimeAuthorities, LeaseDisposition, LeaseHeartbeat, LeaseOffer,
-    LeaseRenewal, LogAckMessage, ManagedSecretBindingOverlay, MessageHeader, NegotiatedSession,
-    NoWork, OperationAck, OrphanDeliveryPermissions, ProtocolLimits, RemoteErrorCode, RunnerHello,
-    RunnerToServer, RuntimeAuthorityAck, RuntimeAuthorityGrant, RuntimeAuthorityRequest,
-    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
-    SessionDisposition, SessionOrphanAuthorization, SessionResume, ValidatedRunnerToServer,
-    negotiate_job_ir, negotiate_protocol,
+    LeasePollOutcome as ProtocolLeasePollOutcome, LeasePollResponse, LeaseRenewal, LogAckMessage,
+    ManagedSecretBindingOverlay, MessageHeader, NegotiatedSession, OperationAck,
+    OrphanDeliveryPermissions, ProtocolLimits, RemoteErrorCode, RunnerHello, RunnerToServer,
+    RuntimeAuthorityAck, RuntimeAuthorityGrant, RuntimeAuthorityRequest, SUPPORTED_PROTOCOL_RANGE,
+    ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
+    SessionOrphanAuthorization, SessionResume, ValidatedRunnerToServer, negotiate_job_ir,
+    negotiate_protocol,
 };
 use automata_ci_protocol_protobuf::{
     decode_server_frame as decode_server_protobuf, encode_runtime_authorities, encode_server_frame,
@@ -52,6 +53,9 @@ use super::durable::{
     CommitLeaseResponse, CommitRunnerLogSegment, CommitRunnerTerminalResult,
     CommitRuntimeAuthorityDelivery, LeaseResponseAction, RunnerControlTransactionRepository,
     RunnerLogAdmissionRequest, RuntimeAuthorityDeliveryRepository,
+};
+use super::lease_authority::{
+    LeaseAuthorityExtensionRegistry, LeaseAuthorityOfferRequest, LeaseAuthorityPollAcceptance,
 };
 use super::observer::NoopRunnerControlObserver;
 use super::port::{
@@ -365,6 +369,7 @@ pub struct RunnerControlPorts {
     durability: RunnerDurabilityPorts,
     runtime_authorities: Option<Arc<dyn RuntimeAuthorityIssuer>>,
     managed_secret_bindings: Option<Arc<dyn ManagedSecretBindingIssuer>>,
+    lease_authority_extensions: LeaseAuthorityExtensionRegistry,
     clock: Arc<dyn LeaseClock>,
     ids: Arc<dyn ControlIdGenerator>,
 }
@@ -391,6 +396,7 @@ impl RunnerControlPorts {
             durability,
             runtime_authorities: None,
             managed_secret_bindings: None,
+            lease_authority_extensions: LeaseAuthorityExtensionRegistry::empty(),
             clock,
             ids,
         }
@@ -416,6 +422,16 @@ impl RunnerControlPorts {
         issuer: Arc<dyn ManagedSecretBindingIssuer>,
     ) -> Self {
         self.managed_secret_bindings = Some(issuer);
+        self
+    }
+
+    /// Installs the canonical provider-neutral lease-authority extensions.
+    #[must_use]
+    pub fn with_lease_authority_extensions(
+        mut self,
+        extensions: LeaseAuthorityExtensionRegistry,
+    ) -> Self {
+        self.lease_authority_extensions = extensions;
         self
     }
 }
@@ -1005,8 +1021,21 @@ impl DurableRunnerControlHandler {
             if let Some(completion) = admission.completion() {
                 stage = RunnerLeaseRequestStage::CompletedRequestReplay;
                 return self
-                    .resolve_lease_request_completion(fence, request.header(), completion)
+                    .resolve_lease_request_completion(fence, request, completion)
                     .await;
+            }
+
+            if !request.authority_contributions().as_slice().is_empty() {
+                stage = RunnerLeaseRequestStage::LeaseAuthorityAcceptance;
+                Self::not_cancelled(cancellation)?;
+                self.ports
+                    .lease_authority_extensions
+                    .accept_poll_contributions(
+                        LeaseAuthorityPollAcceptance::new(fence, self.ports.clock.now()),
+                        request.authority_contributions(),
+                    )
+                    .await
+                    .map_err(port_application_error)?;
             }
 
             stage = RunnerLeaseRequestStage::PrePollCommandReplay;
@@ -1016,9 +1045,8 @@ impl DurableRunnerControlHandler {
             {
                 PendingCommand::Found(command) => {
                     stage = RunnerLeaseRequestStage::DurableCompletion;
-                    return self
-                        .complete_lease_request(begin, request.header(), command)
-                        .await;
+                    let response = self.wrap_lease_poll_command(request, command)?;
+                    return self.complete_lease_request(begin, request, response).await;
                 }
                 PendingCommand::Empty => {}
                 PendingCommand::Saturated => {
@@ -1044,7 +1072,7 @@ impl DurableRunnerControlHandler {
                 .map_err(lease_poll_application_error)?;
             let response = match outcome {
                 LeasePollOutcome::NoWork { .. } | LeasePollOutcome::Rejected { .. } => {
-                    self.no_work_response(request.header())
+                    self.no_work_response(request)
                 }
                 LeasePollOutcome::Claimed(claimed) => {
                     stage = RunnerLeaseRequestStage::OfferBuild;
@@ -1072,14 +1100,15 @@ impl DurableRunnerControlHandler {
                     return Err(app(ApplicationErrorKind::Unavailable));
                 }
             };
+            let actual_response = self.wrap_lease_poll_command(request, actual_response)?;
 
             stage = RunnerLeaseRequestStage::ResponseValidation;
             let actual_response = self
-                .validate_lease_offer_response(fence, request.header(), actual_response, None, true)
+                .validate_lease_offer_response(fence, request, actual_response, None, true)
                 .await?;
 
             stage = RunnerLeaseRequestStage::DurableCompletion;
-            self.complete_lease_request(begin, request.header(), actual_response)
+            self.complete_lease_request(begin, request, actual_response)
                 .await
         }
         .await;
@@ -1106,22 +1135,27 @@ impl DurableRunnerControlHandler {
     async fn complete_lease_request(
         &self,
         begin: BeginLeaseRequest,
-        header: MessageHeader,
+        request: &automata_ci_protocol::LeaseRequest,
         response: ServerToRunner,
     ) -> Result<ServerToRunner, ApplicationError> {
         let durable = self.durable_response(&response)?;
-        let completion = if let ServerToRunner::LeaseOffer(offer) = &response {
+        let completion = if let ServerToRunner::LeasePollResponse(poll) = &response
+            && let ProtocolLeasePollOutcome::LeaseOffer(offer) = poll.outcome()
+        {
             let sequence = StoreCommandSequence::new(offer.header().sequence().get())
                 .map_err(|_| app(ApplicationErrorKind::Internal))?;
             let revoked_message =
-                self.revoked_offer_no_work_response(header, offer.header().operation_id());
-            let ServerToRunner::NoWork(no_work) = &revoked_message else {
+                self.revoked_offer_no_work_response(request, offer.header().operation_id());
+            let ServerToRunner::LeasePollResponse(no_work) = &revoked_message else {
+                return Err(app(ApplicationErrorKind::Internal));
+            };
+            let ProtocolLeasePollOutcome::NoWork { retry_after_millis } = no_work.outcome() else {
                 return Err(app(ApplicationErrorKind::Internal));
             };
             let revoked_response = self.durable_response(&revoked_message)?;
             let revoked_fallback = RevokedLeaseOfferFallback::new(
                 no_work.header().operation_id(),
-                no_work.retry_after_millis(),
+                *retry_after_millis,
                 revoked_response.schema(),
                 revoked_response.digest(),
             )
@@ -1152,37 +1186,31 @@ impl DurableRunnerControlHandler {
             Ok(completed) => completed,
             Err(error) => return Err(store_application_error(error)),
         };
-        self.resolve_lease_request_completion(begin.request_key().session(), header, &completed)
+        self.resolve_lease_request_completion(begin.request_key().session(), request, &completed)
             .await
     }
 
     async fn resolve_lease_request_completion(
         &self,
         fence: RunnerSessionFence,
-        request_header: MessageHeader,
+        request: &automata_ci_protocol::LeaseRequest,
         completion: &LeaseRequestCompletion,
     ) -> Result<ServerToRunner, ApplicationError> {
         match completion {
             LeaseRequestCompletion::Response(response) => {
                 let response =
-                    decode_receipt(response, request_header, &self.config.protocol_limits)?;
-                self.validate_lease_offer_response(fence, request_header, response, None, false)
+                    decode_receipt(response, request.header(), &self.config.protocol_limits)?;
+                self.validate_lease_offer_response(fence, request, response, None, false)
                     .await
             }
             LeaseRequestCompletion::LiveLeaseOffer { response, fallback } => {
                 let response =
-                    decode_receipt(response, request_header, &self.config.protocol_limits)?;
-                self.validate_lease_offer_response(
-                    fence,
-                    request_header,
-                    response,
-                    Some(*fallback),
-                    false,
-                )
-                .await
+                    decode_receipt(response, request.header(), &self.config.protocol_limits)?;
+                self.validate_lease_offer_response(fence, request, response, Some(*fallback), false)
+                    .await
             }
             LeaseRequestCompletion::RevokedLeaseOffer { fallback, .. } => {
-                self.revoked_offer_no_work_from_fallback(request_header, *fallback)
+                self.revoked_offer_no_work_from_fallback(request, *fallback)
             }
         }
     }
@@ -1190,23 +1218,28 @@ impl DurableRunnerControlHandler {
     async fn validate_lease_offer_response(
         &self,
         fence: RunnerSessionFence,
-        request_header: MessageHeader,
+        request: &automata_ci_protocol::LeaseRequest,
         response: ServerToRunner,
         revoked_fallback: Option<RevokedLeaseOfferFallback>,
         allow_store_revocation_resolution: bool,
     ) -> Result<ServerToRunner, ApplicationError> {
-        let (operation_id, sequence, revoked_offer_operation_id) = match &response {
-            ServerToRunner::LeaseOffer(offer) => (
+        let ServerToRunner::LeasePollResponse(poll) = &response else {
+            return Err(app(ApplicationErrorKind::Internal));
+        };
+        poll.validate_for(request)
+            .map_err(|_| app(ApplicationErrorKind::Internal))?;
+        let (operation_id, sequence, revoked_offer_operation_id) = match poll.outcome() {
+            ProtocolLeasePollOutcome::LeaseOffer(offer) => (
                 offer.header().operation_id(),
                 offer.header().sequence(),
                 Some(offer.header().operation_id()),
             ),
-            ServerToRunner::CancelJob(cancel) => (
+            ProtocolLeasePollOutcome::CancelJob(cancel) => (
                 cancel.header().operation_id(),
                 cancel.header().sequence(),
                 None,
             ),
-            _ => return Ok(response),
+            ProtocolLeasePollOutcome::NoWork { .. } => return Ok(response),
         };
         let resolved = self
             .ports
@@ -1221,7 +1254,7 @@ impl DurableRunnerControlHandler {
                 return if revoked_offer_operation_id.is_some()
                     && let Some(fallback) = revoked_fallback
                 {
-                    self.revoked_offer_no_work_from_fallback(request_header, fallback)
+                    self.revoked_offer_no_work_from_fallback(request, fallback)
                 } else if revoked_offer_operation_id.is_some() && allow_store_revocation_resolution
                 {
                     // This is a newly built offer, not a replay. Preserve its typed offer
@@ -1239,11 +1272,20 @@ impl DurableRunnerControlHandler {
         };
         let durable = decode_durable_server_command(
             &command,
-            request_header.protocol_version(),
+            request.header().protocol_version(),
             &self.config.protocol_limits,
         )
         .map_err(port_application_error)?;
-        if durable != response {
+        let durable_matches = match (durable, poll.outcome()) {
+            (ServerToRunner::LeaseOffer(durable), ProtocolLeasePollOutcome::LeaseOffer(actual)) => {
+                durable == *actual
+            }
+            (ServerToRunner::CancelJob(durable), ProtocolLeasePollOutcome::CancelJob(actual)) => {
+                durable == *actual
+            }
+            _ => false,
+        };
+        if !durable_matches {
             return Err(app(ApplicationErrorKind::Internal));
         }
         Ok(response)
@@ -1302,6 +1344,7 @@ impl DurableRunnerControlHandler {
             claimed.slot(),
             claimed.lease().clone(),
             metadata.clone(),
+            claimed.authority_contributions().clone(),
         );
         *stage = RunnerLeaseRequestStage::OfferClaimInspection;
         let claim_status = self
@@ -1330,7 +1373,7 @@ impl DurableRunnerControlHandler {
             LeaseOfferClaimStatus::ClaimSuperseded => {
                 self.observer
                     .observe_lease_offer(LeaseOfferObservation::Superseded);
-                return Ok(self.no_work_response(request.header()));
+                return Ok(self.no_work_response(request));
             }
             LeaseOfferClaimStatus::Current => {}
         }
@@ -1351,6 +1394,12 @@ impl DurableRunnerControlHandler {
         )
         .map_err(|_| app(ApplicationErrorKind::Internal))?;
         Self::not_cancelled(cancellation)?;
+        let lease_authority_evidence = self
+            .ports
+            .lease_authority_extensions
+            .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(fence, &claimed, &job))
+            .await
+            .map_err(port_application_error)?;
         let authority_slot = StableRunnerSlot::new(claim.slot().get())
             .map_err(|_| app(ApplicationErrorKind::Internal))?;
         *stage = RunnerLeaseRequestStage::OfferRuntimeAuthorityRequest;
@@ -1398,6 +1447,7 @@ impl DurableRunnerControlHandler {
             .and_then(|command| {
                 command.with_managed_secret_bindings(managed_secret_bindings.clone())
             })
+            .and_then(|command| command.with_lease_authority_evidence(lease_authority_evidence))
             .map_err(|_| app(ApplicationErrorKind::Internal))?;
         *stage = RunnerLeaseRequestStage::OfferCommandPublication;
         let publication = self
@@ -1410,7 +1460,7 @@ impl DurableRunnerControlHandler {
         let LeaseOfferPublishOutcome::Published(published) = publication else {
             self.observer
                 .observe_lease_offer(LeaseOfferObservation::Superseded);
-            return Ok(self.no_work_response(request.header()));
+            return Ok(self.no_work_response(request));
         };
         self.observer
             .observe_lease_offer(if published.was_replayed() {
@@ -1495,8 +1545,33 @@ impl DurableRunnerControlHandler {
 
             stage = RunnerRuntimeAuthorityRequestStage::AuthorityIssue;
             let offer = admission.offer();
-            let authorities = self.issue_runtime_authorities(&job, offer).await?;
-
+            if !offer.command_projection_valid() {
+                return Err(app(ApplicationErrorKind::Unavailable));
+            }
+            let credential_authorities = self.issue_runtime_authorities(&job, offer).await?;
+            if !credential_authorities
+                .sandbox_authorizations()
+                .as_slice()
+                .is_empty()
+            {
+                return Err(app(ApplicationErrorKind::Internal));
+            }
+            let prepared = self
+                .ports
+                .lease_authority_extensions
+                .prepare_sandbox_authorization(offer.lease_authority_evidence(), &job, &admission)
+                .await
+                .map_err(port_application_error)?;
+            let sandbox_authorizations =
+                LeaseAuthorityExtensionRegistry::authorizations(prepared.as_deref())
+                    .map_err(port_application_error)?;
+            let authorities = JobRuntimeAuthorities::new(
+                credential_authorities.as_slice().to_vec(),
+                sandbox_authorizations,
+                &job,
+                offer.lease(),
+            )
+            .map_err(|_| app(ApplicationErrorKind::Internal))?;
             stage = RunnerRuntimeAuthorityRequestStage::AuthorityValidation;
             authorities
                 .validate_for(&job, offer.lease())
@@ -1521,20 +1596,20 @@ impl DurableRunnerControlHandler {
             Self::not_cancelled(cancellation)?;
 
             stage = RunnerRuntimeAuthorityRequestStage::DurableCommit;
-            self.ports
-                .durability
-                .runtime_authority_deliveries
-                .commit_runtime_authority_delivery(commit)
-                .await
-                .map_err(store_application_error)?;
-            Ok(ServerToRunner::RuntimeAuthorityGrant(Box::new(
-                RuntimeAuthorityGrant::new(
-                    self.reply_header(request.header()),
-                    request.binding(),
-                    bundle_digest,
-                    authorities,
-                ),
-            )))
+            if let Some(prepared) = prepared {
+                prepared
+                    .commit(commit)
+                    .await
+                    .map_err(port_application_error)?;
+            } else {
+                self.ports
+                    .durability
+                    .runtime_authority_deliveries
+                    .commit_runtime_authority_delivery(commit)
+                    .await
+                    .map_err(store_application_error)?;
+            }
+            Ok(self.runtime_authority_response(request, bundle_digest, authorities))
         }
         .await;
         if let Err(error) = &result {
@@ -1562,6 +1637,21 @@ impl DurableRunnerControlHandler {
         Ok(sha256(&encoded))
     }
 
+    fn runtime_authority_response(
+        &self,
+        request: &RuntimeAuthorityRequest,
+        bundle_digest: Sha256Digest,
+        authorities: JobRuntimeAuthorities,
+    ) -> ServerToRunner {
+        let grant = RuntimeAuthorityGrant::new(
+            self.reply_header(request.header()),
+            request.binding(),
+            bundle_digest,
+            authorities,
+        );
+        ServerToRunner::RuntimeAuthorityGrant(Box::new(grant))
+    }
+
     async fn issue_runtime_authorities(
         &self,
         job: &JobIrEnvelope,
@@ -1584,8 +1674,13 @@ impl DurableRunnerControlHandler {
             | (
                 JobAuthorityProfile::Standard,
                 automata_ci_core::TrustPermissionAuthority::DenyAll,
-            ) => JobRuntimeAuthorities::new(Vec::new(), job, offer.lease())
-                .map_err(|_| app(ApplicationErrorKind::Internal)),
+            ) => JobRuntimeAuthorities::new(
+                Vec::new(),
+                SandboxAuthorizations::empty(),
+                job,
+                offer.lease(),
+            )
+            .map_err(|_| app(ApplicationErrorKind::Internal)),
             (JobAuthorityProfile::Standard, _) => self
                 .ports
                 .runtime_authorities
@@ -2164,52 +2259,82 @@ impl DurableRunnerControlHandler {
         )
     }
 
-    fn no_work_response(&self, request: MessageHeader) -> ServerToRunner {
-        ServerToRunner::NoWork(NoWork::new(
-            self.reply_header(request),
+    fn no_work_response(&self, request: &automata_ci_protocol::LeaseRequest) -> ServerToRunner {
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+            self.reply_header(request.header()),
+            request.authority_contributions().sha256_digest(),
             self.config.no_work_retry_after_millis,
-        ))
+        )))
+    }
+
+    fn wrap_lease_poll_command(
+        &self,
+        request: &automata_ci_protocol::LeaseRequest,
+        response: ServerToRunner,
+    ) -> Result<ServerToRunner, ApplicationError> {
+        let response = match response {
+            ServerToRunner::LeasePollResponse(response) => {
+                response
+                    .validate_for(request)
+                    .map_err(|_| app(ApplicationErrorKind::Internal))?;
+                return Ok(ServerToRunner::LeasePollResponse(response));
+            }
+            ServerToRunner::LeaseOffer(offer) => LeasePollResponse::lease_offer(
+                self.reply_header(request.header()),
+                request.authority_contributions().sha256_digest(),
+                *offer,
+            ),
+            ServerToRunner::CancelJob(cancel) => LeasePollResponse::cancel_job(
+                self.reply_header(request.header()),
+                request.authority_contributions().sha256_digest(),
+                cancel,
+            ),
+            _ => return Err(app(ApplicationErrorKind::Internal)),
+        };
+        Ok(ServerToRunner::LeasePollResponse(Box::new(response)))
     }
 
     fn revoked_offer_no_work_response(
         &self,
-        request: MessageHeader,
+        request: &automata_ci_protocol::LeaseRequest,
         offer_operation_id: OperationId,
     ) -> ServerToRunner {
         let mut digest = Sha256::new();
         digest.update(b"automata.runner.revoked-lease-offer-no-work.v1");
         digest.update(offer_operation_id.as_uuid().as_bytes());
-        digest.update(request.operation_id().as_uuid().as_bytes());
+        digest.update(request.header().operation_id().as_uuid().as_bytes());
         let digest = Sha256Digest::from_bytes(digest.finalize().into());
         let encoded_operation_id = digest.to_string();
         let operation_id: OperationId = encoded_operation_id[..32]
             .parse()
             .expect("a SHA-256 prefix is a valid UUID representation");
-        ServerToRunner::NoWork(NoWork::new(
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
             MessageHeader::reply(
-                request.protocol_version(),
-                request.session_id(),
+                request.header().protocol_version(),
+                request.header().session_id(),
                 operation_id,
-                request.operation_id(),
+                request.header().operation_id(),
             ),
+            request.authority_contributions().sha256_digest(),
             self.config.no_work_retry_after_millis,
-        ))
+        )))
     }
 
     fn revoked_offer_no_work_from_fallback(
         &self,
-        request: MessageHeader,
+        request: &automata_ci_protocol::LeaseRequest,
         fallback: RevokedLeaseOfferFallback,
     ) -> Result<ServerToRunner, ApplicationError> {
-        let response = ServerToRunner::NoWork(NoWork::new(
+        let response = ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
             MessageHeader::reply(
-                request.protocol_version(),
-                request.session_id(),
+                request.header().protocol_version(),
+                request.header().session_id(),
                 fallback.response_operation_id(),
-                request.operation_id(),
+                request.header().operation_id(),
             ),
+            request.authority_contributions().sha256_digest(),
             fallback.retry_after_millis(),
-        ));
+        )));
         let canonical = self.durable_response(&response)?;
         if canonical.schema() != fallback.response_schema()
             || canonical.digest() != fallback.response_digest()
@@ -2438,6 +2563,9 @@ fn decode_operation_receipt(
 
 fn response_correlates(response: &ServerToRunner, request: MessageHeader) -> bool {
     match response {
+        ServerToRunner::LeasePollResponse(value) => {
+            value.header().validate_reply_for(request).is_ok()
+        }
         ServerToRunner::LeaseOffer(value) => value
             .header()
             .validate_for(request.protocol_version(), request.session_id())
@@ -2452,7 +2580,6 @@ fn response_correlates(response: &ServerToRunner, request: MessageHeader) -> boo
         ServerToRunner::LeaseRenewal(value) => value.header().validate_reply_for(request).is_ok(),
         ServerToRunner::LogAck(value) => value.header().validate_reply_for(request).is_ok(),
         ServerToRunner::OperationAck(value) => value.header().validate_reply_for(request).is_ok(),
-        ServerToRunner::NoWork(value) => value.header().validate_reply_for(request).is_ok(),
         ServerToRunner::Error(value) => value.header().validate_reply_for(request).is_ok(),
         ServerToRunner::Hello(_) | ServerToRunner::HandshakeRejected(_) => false,
     }

--- a/crates/automata-ci-control/src/runner_control/lease_authority.rs
+++ b/crates/automata-ci-control/src/runner_control/lease_authority.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{collections::BTreeMap, fmt, io, sync::Arc};
 
 use async_trait::async_trait;
 use automata_ci_core::{
@@ -27,6 +27,12 @@ use super::{
 pub const LEASE_AUTHORITY_EVIDENCE_SCHEMA_VERSION: u16 = 1;
 /// Maximum number of independent authority extensions retained by one offer.
 pub const MAX_LEASE_AUTHORITY_EVIDENCE: usize = MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS;
+/// Maximum encoded bytes reserved for authority evidence in one durable offer.
+///
+/// This is deliberately below the 16 MiB durable command ceiling so evidence
+/// cannot consume the entire command budget needed by the verified `JobIR`,
+/// lease, and secret-binding metadata.
+pub const MAX_DURABLE_LEASE_AUTHORITY_EVIDENCE_BYTES: usize = 8 * 1024 * 1024;
 
 /// One bounded, value-free provider-owned authority projection.
 #[derive(Clone, Eq, PartialEq)]
@@ -44,6 +50,14 @@ struct LeaseAuthorityEvidenceDocument {
     payload_schema_version: u16,
     payload_sha256: Sha256Digest,
     payload: Box<[u8]>,
+}
+
+#[derive(Serialize)]
+struct LeaseAuthorityEvidenceDocumentRef<'a> {
+    name: &'a LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: &'a [u8],
 }
 
 impl LeaseAuthorityEvidence {
@@ -134,11 +148,11 @@ impl Serialize for LeaseAuthorityEvidence {
     where
         S: serde::Serializer,
     {
-        LeaseAuthorityEvidenceDocument {
-            name: self.name.clone(),
+        LeaseAuthorityEvidenceDocumentRef {
+            name: &self.name,
             payload_schema_version: self.payload_schema_version,
             payload_sha256: self.payload_sha256,
-            payload: self.payload.clone(),
+            payload: &self.payload,
         }
         .serialize(serializer)
     }
@@ -172,6 +186,12 @@ pub struct LeaseAuthorityEvidenceSet {
 struct LeaseAuthorityEvidenceSetDocument {
     schema_version: u16,
     evidence: Vec<LeaseAuthorityEvidence>,
+}
+
+#[derive(Serialize)]
+struct LeaseAuthorityEvidenceSetDocumentRef<'a> {
+    schema_version: u16,
+    evidence: &'a [LeaseAuthorityEvidence],
 }
 
 impl LeaseAuthorityEvidenceSet {
@@ -232,6 +252,18 @@ impl LeaseAuthorityEvidenceSet {
             }
             previous = Some(evidence.name());
         }
+        let document = LeaseAuthorityEvidenceSetDocumentRef {
+            schema_version: self.schema_version,
+            evidence: &self.evidence,
+        };
+        if serde_json::to_writer(
+            EncodedSizeWriter::new(MAX_DURABLE_LEASE_AUTHORITY_EVIDENCE_BYTES),
+            &document,
+        )
+        .is_err()
+        {
+            return Err(LeaseAuthorityEvidenceError::EncodedPayloadTooLarge);
+        }
         Ok(())
     }
 }
@@ -247,9 +279,9 @@ impl Serialize for LeaseAuthorityEvidenceSet {
     where
         S: serde::Serializer,
     {
-        LeaseAuthorityEvidenceSetDocument {
+        LeaseAuthorityEvidenceSetDocumentRef {
             schema_version: self.schema_version,
-            evidence: self.evidence.clone(),
+            evidence: &self.evidence,
         }
         .serialize(serializer)
     }
@@ -288,9 +320,90 @@ pub enum LeaseAuthorityEvidenceError {
     /// The evidence set exceeds its hard entry limit.
     #[error("lease authority evidence count is invalid")]
     InvalidCount,
+    /// The canonical durable JSON representation exceeds its reserved budget.
+    #[error("lease authority evidence exceeds its durable encoded-byte budget")]
+    EncodedPayloadTooLarge,
     /// Evidence is duplicated or not in canonical namespace order.
     #[error("lease authority evidence is not in canonical order")]
     NonCanonicalOrder,
+}
+
+struct EncodedSizeWriter {
+    remaining: usize,
+}
+
+impl EncodedSizeWriter {
+    const fn new(maximum: usize) -> Self {
+        Self { remaining: maximum }
+    }
+}
+
+impl io::Write for EncodedSizeWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > self.remaining {
+            return Err(io::Error::other(
+                "encoded evidence exceeds its durable budget",
+            ));
+        }
+        self.remaining -= bytes.len();
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn maximal_evidence(name: &str, byte: u8) -> LeaseAuthorityEvidence {
+        LeaseAuthorityEvidence::new(
+            LeaseAuthorityName::new(name).expect("authority name"),
+            1,
+            vec![byte; MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES],
+        )
+        .expect("maximal evidence")
+    }
+
+    #[test]
+    fn one_maximal_evidence_payload_always_fits_the_durable_budget() {
+        for byte in [0, u8::MAX] {
+            let set = LeaseAuthorityEvidenceSet::new(vec![maximal_evidence("extension", byte)])
+                .expect("one maximal evidence payload");
+            assert!(
+                serde_json::to_vec(&set).expect("encoded evidence").len()
+                    <= MAX_DURABLE_LEASE_AUTHORITY_EVIDENCE_BYTES
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_durable_evidence_budget_rejects_wire_valid_amplification() {
+        let within_budget = LeaseAuthorityEvidenceSet::new(vec![
+            maximal_evidence("extension-1", 0),
+            maximal_evidence("extension-2", 0),
+            maximal_evidence("extension-3", 0),
+        ])
+        .expect("three zero-filled payloads fit the encoded budget");
+        assert!(
+            serde_json::to_vec(&within_budget)
+                .expect("encoded evidence")
+                .len()
+                <= MAX_DURABLE_LEASE_AUTHORITY_EVIDENCE_BYTES
+        );
+
+        assert_eq!(
+            LeaseAuthorityEvidenceSet::new(vec![
+                maximal_evidence("extension-1", 0),
+                maximal_evidence("extension-2", 0),
+                maximal_evidence("extension-3", 0),
+                maximal_evidence("extension-4", 0),
+            ]),
+            Err(LeaseAuthorityEvidenceError::EncodedPayloadTooLarge)
+        );
+    }
 }
 
 /// Trusted server context for accepting one runner poll contribution.

--- a/crates/automata-ci-control/src/runner_control/lease_authority.rs
+++ b/crates/automata-ci-control/src/runner_control/lease_authority.rs
@@ -1,0 +1,558 @@
+use std::{collections::BTreeMap, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use automata_ci_core::{
+    JobIrEnvelope, SandboxAuthorization, SandboxAuthorizations, Sha256Digest, UnixMillis,
+};
+use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollContribution, LeaseAuthorityPollContributions,
+    MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS, MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES,
+};
+use automata_ci_store::RunnerSessionFence;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::lease::ClaimedLeasePoll;
+
+use super::{
+    durable::{
+        CommitRuntimeAuthorityDelivery, RuntimeAuthorityDeliveryAdmission,
+        RuntimeAuthorityDeliveryDisposition,
+    },
+    port::ControlPortError,
+};
+
+/// Schema of the provider-neutral evidence set retained with a lease offer.
+pub const LEASE_AUTHORITY_EVIDENCE_SCHEMA_VERSION: u16 = 1;
+/// Maximum number of independent authority extensions retained by one offer.
+pub const MAX_LEASE_AUTHORITY_EVIDENCE: usize = MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS;
+
+/// One bounded, value-free provider-owned authority projection.
+#[derive(Clone, Eq, PartialEq)]
+pub struct LeaseAuthorityEvidence {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseAuthorityEvidenceDocument {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+impl LeaseAuthorityEvidence {
+    /// Creates durable evidence and commits to its exact provider-owned bytes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects schema zero or an empty or oversized payload.
+    pub fn new(
+        name: LeaseAuthorityName,
+        payload_schema_version: u16,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, LeaseAuthorityEvidenceError> {
+        let payload = payload.into();
+        let payload_sha256 = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        Self::from_parts(name, payload_schema_version, payload_sha256, payload)
+    }
+
+    /// Rehydrates exact durable evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid bounds or a substituted payload digest.
+    pub fn from_parts(
+        name: LeaseAuthorityName,
+        payload_schema_version: u16,
+        payload_sha256: Sha256Digest,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, LeaseAuthorityEvidenceError> {
+        let payload = payload.into();
+        if payload_schema_version == 0 {
+            return Err(LeaseAuthorityEvidenceError::ZeroPayloadSchema);
+        }
+        if payload.is_empty() || payload.len() > MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES {
+            return Err(LeaseAuthorityEvidenceError::InvalidPayloadSize);
+        }
+        let actual = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        if actual != payload_sha256 {
+            return Err(LeaseAuthorityEvidenceError::PayloadDigestMismatch);
+        }
+        Ok(Self {
+            name,
+            payload_schema_version,
+            payload_sha256,
+            payload,
+        })
+    }
+
+    /// Returns the owning extension namespace.
+    #[must_use]
+    pub const fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    /// Returns the provider-owned evidence schema.
+    #[must_use]
+    pub const fn payload_schema_version(&self) -> u16 {
+        self.payload_schema_version
+    }
+
+    /// Returns the digest of the exact evidence bytes.
+    #[must_use]
+    pub const fn payload_sha256(&self) -> Sha256Digest {
+        self.payload_sha256
+    }
+
+    /// Returns the exact provider-owned evidence bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+impl fmt::Debug for LeaseAuthorityEvidence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LeaseAuthorityEvidence")
+            .field("name", &self.name)
+            .field("payload_schema_version", &self.payload_schema_version)
+            .field("payload_sha256", &self.payload_sha256)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
+}
+
+impl Serialize for LeaseAuthorityEvidence {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        LeaseAuthorityEvidenceDocument {
+            name: self.name.clone(),
+            payload_schema_version: self.payload_schema_version,
+            payload_sha256: self.payload_sha256,
+            payload: self.payload.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LeaseAuthorityEvidence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = LeaseAuthorityEvidenceDocument::deserialize(deserializer)?;
+        Self::from_parts(
+            value.name,
+            value.payload_schema_version,
+            value.payload_sha256,
+            value.payload,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Canonically ordered durable authority evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LeaseAuthorityEvidenceSet {
+    schema_version: u16,
+    evidence: Vec<LeaseAuthorityEvidence>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseAuthorityEvidenceSetDocument {
+    schema_version: u16,
+    evidence: Vec<LeaseAuthorityEvidence>,
+}
+
+impl LeaseAuthorityEvidenceSet {
+    /// Creates a canonical evidence set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized, duplicate, or noncanonically ordered evidence.
+    pub fn new(evidence: Vec<LeaseAuthorityEvidence>) -> Result<Self, LeaseAuthorityEvidenceError> {
+        let value = Self {
+            schema_version: LEASE_AUTHORITY_EVIDENCE_SCHEMA_VERSION,
+            evidence,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Creates an explicit empty set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            schema_version: LEASE_AUTHORITY_EVIDENCE_SCHEMA_VERSION,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// Returns the evidence in canonical namespace order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[LeaseAuthorityEvidence] {
+        &self.evidence
+    }
+
+    /// Finds evidence owned by one exact extension.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&LeaseAuthorityEvidence> {
+        self.evidence
+            .binary_search_by(|evidence| evidence.name().as_str().cmp(name))
+            .ok()
+            .map(|index| &self.evidence[index])
+    }
+
+    /// Validates the durable schema and canonical ordering.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unsupported schema, excessive entries, duplicates, or disorder.
+    pub fn validate(&self) -> Result<(), LeaseAuthorityEvidenceError> {
+        if self.schema_version != LEASE_AUTHORITY_EVIDENCE_SCHEMA_VERSION {
+            return Err(LeaseAuthorityEvidenceError::UnsupportedSchema);
+        }
+        if self.evidence.len() > MAX_LEASE_AUTHORITY_EVIDENCE {
+            return Err(LeaseAuthorityEvidenceError::InvalidCount);
+        }
+        let mut previous: Option<&LeaseAuthorityName> = None;
+        for evidence in &self.evidence {
+            if previous.is_some_and(|name| name >= evidence.name()) {
+                return Err(LeaseAuthorityEvidenceError::NonCanonicalOrder);
+            }
+            previous = Some(evidence.name());
+        }
+        Ok(())
+    }
+}
+
+impl Default for LeaseAuthorityEvidenceSet {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl Serialize for LeaseAuthorityEvidenceSet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        LeaseAuthorityEvidenceSetDocument {
+            schema_version: self.schema_version,
+            evidence: self.evidence.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LeaseAuthorityEvidenceSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = LeaseAuthorityEvidenceSetDocument::deserialize(deserializer)?;
+        let set = Self {
+            schema_version: value.schema_version,
+            evidence: value.evidence,
+        };
+        set.validate().map_err(serde::de::Error::custom)?;
+        Ok(set)
+    }
+}
+
+/// Invalid durable lease-authority evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum LeaseAuthorityEvidenceError {
+    /// Provider-owned schema zero is reserved.
+    #[error("lease authority evidence payload schema must be nonzero")]
+    ZeroPayloadSchema,
+    /// The evidence payload is empty or above its hard bound.
+    #[error("lease authority evidence payload size is invalid")]
+    InvalidPayloadSize,
+    /// The exact evidence payload does not match its digest.
+    #[error("lease authority evidence payload digest does not match")]
+    PayloadDigestMismatch,
+    /// The evidence-set schema is unsupported.
+    #[error("lease authority evidence schema is unsupported")]
+    UnsupportedSchema,
+    /// The evidence set exceeds its hard entry limit.
+    #[error("lease authority evidence count is invalid")]
+    InvalidCount,
+    /// Evidence is duplicated or not in canonical namespace order.
+    #[error("lease authority evidence is not in canonical order")]
+    NonCanonicalOrder,
+}
+
+/// Trusted server context for accepting one runner poll contribution.
+#[derive(Clone, Copy, Debug)]
+pub struct LeaseAuthorityPollAcceptance {
+    session: RunnerSessionFence,
+    observed_at: UnixMillis,
+}
+
+impl LeaseAuthorityPollAcceptance {
+    /// Creates an acceptance context after durable request admission.
+    #[must_use]
+    pub const fn new(session: RunnerSessionFence, observed_at: UnixMillis) -> Self {
+        Self {
+            session,
+            observed_at,
+        }
+    }
+
+    /// Returns the exact authenticated session fence.
+    #[must_use]
+    pub const fn session(self) -> RunnerSessionFence {
+        self.session
+    }
+
+    /// Returns trusted server time for freshness verification.
+    #[must_use]
+    pub const fn observed_at(self) -> UnixMillis {
+        self.observed_at
+    }
+}
+
+/// Verified offer inputs from which extensions may retain value-free evidence.
+#[derive(Clone, Copy, Debug)]
+pub struct LeaseAuthorityOfferRequest<'a> {
+    session: RunnerSessionFence,
+    claimed: &'a ClaimedLeasePoll,
+    job: &'a JobIrEnvelope,
+}
+
+impl<'a> LeaseAuthorityOfferRequest<'a> {
+    /// Creates an offer-evidence request.
+    #[must_use]
+    pub const fn new(
+        session: RunnerSessionFence,
+        claimed: &'a ClaimedLeasePoll,
+        job: &'a JobIrEnvelope,
+    ) -> Self {
+        Self {
+            session,
+            claimed,
+            job,
+        }
+    }
+
+    /// Returns the exact authenticated session.
+    #[must_use]
+    pub const fn session(self) -> RunnerSessionFence {
+        self.session
+    }
+
+    /// Returns the exact durable scheduler claim.
+    #[must_use]
+    pub const fn claimed(self) -> &'a ClaimedLeasePoll {
+        self.claimed
+    }
+
+    /// Returns the verified immutable job.
+    #[must_use]
+    pub const fn job(self) -> &'a JobIrEnvelope {
+        self.job
+    }
+}
+
+/// Prepared provider authorization whose commit owns the specialized atomic path.
+#[async_trait]
+pub trait PreparedSandboxAuthorization: fmt::Debug + Send {
+    /// Returns the exact generic authorization to protect for the runner.
+    fn authorization(&self) -> &SandboxAuthorization;
+
+    /// Atomically commits delivery through the provider-owned durable boundary.
+    async fn commit(
+        self: Box<Self>,
+        delivery: CommitRuntimeAuthorityDelivery,
+    ) -> Result<RuntimeAuthorityDeliveryDisposition, ControlPortError>;
+}
+
+/// Provider-neutral extension lifecycle for lease-bound sandbox authority.
+#[async_trait]
+pub trait LeaseAuthorityExtension: fmt::Debug + Send + Sync {
+    /// Returns the stable namespace owned by this extension.
+    fn name(&self) -> &LeaseAuthorityName;
+
+    /// Verifies and durably accepts one exact poll contribution.
+    async fn accept_poll_contribution(
+        &self,
+        context: LeaseAuthorityPollAcceptance,
+        contribution: &LeaseAuthorityPollContribution,
+    ) -> Result<(), ControlPortError>;
+
+    /// Produces bounded value-free evidence for a claimed offer when applicable.
+    async fn prepare_offer_evidence(
+        &self,
+        request: LeaseAuthorityOfferRequest<'_>,
+    ) -> Result<Option<LeaseAuthorityEvidence>, ControlPortError>;
+
+    /// Prepares the exact sandbox authorization and its atomic commit object.
+    async fn prepare_sandbox_authorization(
+        &self,
+        evidence: &LeaseAuthorityEvidence,
+        job: &JobIrEnvelope,
+        admission: &RuntimeAuthorityDeliveryAdmission,
+    ) -> Result<Box<dyn PreparedSandboxAuthorization>, ControlPortError>;
+}
+
+/// Canonical registry for independently owned lease-authority extensions.
+#[derive(Default)]
+pub struct LeaseAuthorityExtensionRegistry {
+    extensions: BTreeMap<LeaseAuthorityName, Arc<dyn LeaseAuthorityExtension>>,
+}
+
+impl fmt::Debug for LeaseAuthorityExtensionRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LeaseAuthorityExtensionRegistry")
+            .field("names", &self.extensions.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl LeaseAuthorityExtensionRegistry {
+    /// Creates an explicit empty registry.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            extensions: BTreeMap::new(),
+        }
+    }
+
+    /// Creates a canonical registry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate namespaces or an excessive extension count.
+    pub fn new(
+        extensions: Vec<Arc<dyn LeaseAuthorityExtension>>,
+    ) -> Result<Self, LeaseAuthorityRegistryError> {
+        if extensions.len() > MAX_LEASE_AUTHORITY_EVIDENCE {
+            return Err(LeaseAuthorityRegistryError::InvalidCount);
+        }
+        let mut by_name = BTreeMap::new();
+        for extension in extensions {
+            let name = extension.name().clone();
+            if by_name.insert(name, extension).is_some() {
+                return Err(LeaseAuthorityRegistryError::DuplicateName);
+            }
+        }
+        Ok(Self {
+            extensions: by_name,
+        })
+    }
+
+    /// Accepts every contribution before any scheduling side effect.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed for an unregistered namespace or adapter rejection.
+    pub async fn accept_poll_contributions(
+        &self,
+        context: LeaseAuthorityPollAcceptance,
+        contributions: &LeaseAuthorityPollContributions,
+    ) -> Result<(), ControlPortError> {
+        for contribution in contributions.as_slice() {
+            let extension = self
+                .extensions
+                .get(contribution.name())
+                .ok_or(ControlPortError::Conflict)?;
+            extension
+                .accept_poll_contribution(context, contribution)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Collects canonical durable evidence from all configured extensions.
+    ///
+    /// # Errors
+    ///
+    /// Rejects namespace substitution or invalid evidence.
+    pub async fn prepare_offer_evidence(
+        &self,
+        request: LeaseAuthorityOfferRequest<'_>,
+    ) -> Result<LeaseAuthorityEvidenceSet, ControlPortError> {
+        let mut evidence = Vec::new();
+        for (name, extension) in &self.extensions {
+            if let Some(value) = extension.prepare_offer_evidence(request).await? {
+                if value.name() != name {
+                    return Err(ControlPortError::Corrupt);
+                }
+                evidence.push(value);
+            }
+        }
+        LeaseAuthorityEvidenceSet::new(evidence).map_err(|_| ControlPortError::Corrupt)
+    }
+
+    /// Prepares at most one sandbox-provider authorization for an accepted offer.
+    ///
+    /// A job has exactly one sandbox provider. Multiple prepared authorization
+    /// commits could not be atomic across independent repositories and therefore
+    /// fail closed.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unknown durable evidence, extension failures, or more than one
+    /// prepared sandbox authorization.
+    pub async fn prepare_sandbox_authorization(
+        &self,
+        evidence: &LeaseAuthorityEvidenceSet,
+        job: &JobIrEnvelope,
+        admission: &RuntimeAuthorityDeliveryAdmission,
+    ) -> Result<Option<Box<dyn PreparedSandboxAuthorization>>, ControlPortError> {
+        let mut prepared = None;
+        for value in evidence.as_slice() {
+            let extension = self
+                .extensions
+                .get(value.name())
+                .ok_or(ControlPortError::Unavailable)?;
+            let candidate = extension
+                .prepare_sandbox_authorization(value, job, admission)
+                .await?;
+            if candidate.authorization().name().as_str() != value.name().as_str() {
+                return Err(ControlPortError::Corrupt);
+            }
+            if prepared.replace(candidate).is_some() {
+                return Err(ControlPortError::Corrupt);
+            }
+        }
+        Ok(prepared)
+    }
+
+    /// Builds the canonical generic authorization set for a prepared object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an authorization that violates the core canonical set bounds.
+    pub fn authorizations(
+        prepared: Option<&dyn PreparedSandboxAuthorization>,
+    ) -> Result<SandboxAuthorizations, ControlPortError> {
+        let values = prepared
+            .map(|prepared| vec![prepared.authorization().clone()])
+            .unwrap_or_default();
+        SandboxAuthorizations::new(values).map_err(|_| ControlPortError::Corrupt)
+    }
+}
+
+/// Invalid extension registry composition.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum LeaseAuthorityRegistryError {
+    /// Too many independent extensions were configured.
+    #[error("lease authority extension count is invalid")]
+    InvalidCount,
+    /// More than one extension owns the same namespace.
+    #[error("lease authority extension namespace is duplicated")]
+    DuplicateName,
+}

--- a/crates/automata-ci-control/src/runner_control/mod.rs
+++ b/crates/automata-ci-control/src/runner_control/mod.rs
@@ -19,11 +19,13 @@ pub mod capability_admission;
 /// Durable models and repositories for authenticated runner-control operations.
 pub mod durable;
 mod handler;
+mod lease_authority;
 mod observer;
 mod port;
 /// Durable runner sessions, operation receipts, and command delivery repositories.
 pub mod repository;
 mod verify;
+mod windows_lease_authority;
 
 pub use automata_ci_protocol::{
     INITIAL_RUNTIME_AUTHORITY_GENERATION, RuntimeAuthorityDeliveryBinding,
@@ -39,6 +41,11 @@ pub use handler::{
     MAX_LEASE_DURATION_MILLIS, MAX_NO_WORK_RETRY_AFTER_MILLIS, RunnerControlConfig,
     RunnerControlConfigError, RunnerControlPorts, RunnerDurabilityPorts, RunnerIdentityPorts,
     RunnerLeasePorts,
+};
+pub use lease_authority::{
+    LeaseAuthorityEvidence, LeaseAuthorityEvidenceError, LeaseAuthorityEvidenceSet,
+    LeaseAuthorityExtension, LeaseAuthorityExtensionRegistry, LeaseAuthorityOfferRequest,
+    LeaseAuthorityPollAcceptance, LeaseAuthorityRegistryError, PreparedSandboxAuthorization,
 };
 pub use observer::{
     LeaseOfferObservation, RunnerControlFailure, RunnerControlMessageKind,
@@ -58,3 +65,13 @@ pub use port::{
     StoreRunnerSessionFenceResolver,
 };
 pub use verify::{JobIrBlobError, verify_job_ir_blob};
+pub use windows_lease_authority::{
+    AuthorizeWindowsHyperVBrokerGrant, CommitWindowsHyperVBrokerGrantDelivery,
+    CommitWindowsHyperVPlacementRenewal, Ed25519WindowsHyperVBrokerGrantIssuer,
+    WindowsHyperVBrokerGrantAuthorizationRepository, WindowsHyperVBrokerGrantIssuanceAuthorization,
+    WindowsHyperVBrokerGrantIssueRequest, WindowsHyperVBrokerGrantIssuer,
+    WindowsHyperVBrokerGrantIssuerError, WindowsHyperVBrokerGrantProposal,
+    WindowsHyperVCurrentAdmission, WindowsHyperVCurrentAdmissionReader,
+    WindowsHyperVLeaseAuthorityExtension, WindowsHyperVPlacementEvidence,
+    WindowsHyperVPlacementRenewalDisposition, WindowsHyperVPlacementRenewalRepository,
+};

--- a/crates/automata-ci-control/src/runner_control/observer.rs
+++ b/crates/automata-ci-control/src/runner_control/observer.rs
@@ -89,6 +89,9 @@ pub enum RunnerLeaseRequestStage {
     SessionHeartbeat,
     /// Resolution of an already-completed request.
     CompletedRequestReplay,
+    /// Verification and durable acceptance of canonical lease-authority poll
+    /// contributions before scheduling.
+    LeaseAuthorityAcceptance,
     /// Durable command replay before polling for work.
     PrePollCommandReplay,
     /// Scheduler polling and attempt claim.

--- a/crates/automata-ci-control/src/runner_control/port.rs
+++ b/crates/automata-ci-control/src/runner_control/port.rs
@@ -708,6 +708,9 @@ pub enum LeaseOfferCommandError {
     /// Lease-authority evidence does not match the exact claim and `JobIR`.
     #[error("lease-offer authority evidence is invalid")]
     InvalidLeaseAuthorityEvidence,
+    /// The complete durable command representation exceeds its storage budget.
+    #[error("lease-offer durable command payload is invalid")]
+    InvalidDurablePayload,
     /// The command was created outside the lease validity interval.
     #[error("lease-offer creation time is outside its validity interval")]
     InvalidCreationTime,
@@ -739,14 +742,16 @@ impl LeaseOfferCommand {
             return Err(LeaseOfferCommandError::InvalidCreationTime);
         }
         let offer_valid_until = claim.lease().expires_at();
-        Ok(Self {
+        let command = Self {
             managed_secret_bindings: ManagedSecretBindingOverlay::empty(claim.lease()),
             lease_authority_evidence: LeaseAuthorityEvidenceSet::empty(),
             claim,
             job,
             offer_valid_until,
             created_at,
-        })
+        };
+        encode_lease_offer_command_payload(&command)?;
+        Ok(command)
     }
 
     /// Retains value-free evidence for post-accept provider authorization.
@@ -763,6 +768,7 @@ impl LeaseOfferCommand {
             .validate()
             .map_err(|_| LeaseOfferCommandError::InvalidLeaseAuthorityEvidence)?;
         self.lease_authority_evidence = evidence;
+        encode_lease_offer_command_payload(&self)?;
         Ok(self)
     }
 
@@ -779,6 +785,7 @@ impl LeaseOfferCommand {
             .validate_for(self.claim.lease())
             .map_err(|_| LeaseOfferCommandError::InvalidManagedSecretBindings)?;
         self.managed_secret_bindings = overlay;
+        encode_lease_offer_command_payload(&self)?;
         Ok(self)
     }
 
@@ -1191,24 +1198,8 @@ impl LeaseOfferCommandPublisher for StoreLeaseOfferCommandPublisher {
         let (store_claim, request_kind) = store_lease_offer_claim(&claim)?;
         let command_kind = RunnerOperationKind::new(LEASE_OFFER_COMMAND_KIND)
             .map_err(|_| ControlPortError::Corrupt)?;
-        let schema = DocumentSchema::new(LEASE_OFFER_COMMAND_SCHEMA)
-            .map_err(|_| ControlPortError::Corrupt)?;
-        let mut payload = Zeroizing::new(Vec::new());
-        serde_json::to_writer(
-            &mut *payload,
-            &LeaseOfferCommandPayloadRef {
-                job: command.job(),
-                lease: command.lease(),
-                managed_secret_bindings: command.managed_secret_bindings(),
-                lease_authority_evidence: command.lease_authority_evidence(),
-                protocol_version: command.protocol_version().get(),
-                schema: LEASE_OFFER_COMMAND_SCHEMA,
-                slot: command.slot().get(),
-            },
-        )
-        .map_err(|_| ControlPortError::Corrupt)?;
-        let payload = RunnerCommandPayload::new(schema, std::mem::take(&mut *payload))
-            .map_err(|_| ControlPortError::Corrupt)?;
+        let payload =
+            encode_lease_offer_command_payload(&command).map_err(|_| ControlPortError::Corrupt)?;
         let durable_command = EnqueueRunnerCommand::new(
             command.session(),
             self.ids.next_operation_id(),
@@ -1251,6 +1242,29 @@ impl LeaseOfferCommandPublisher for StoreLeaseOfferCommandPublisher {
             published.was_replayed(),
         )))
     }
+}
+
+fn encode_lease_offer_command_payload(
+    command: &LeaseOfferCommand,
+) -> Result<RunnerCommandPayload, LeaseOfferCommandError> {
+    let schema = DocumentSchema::new(LEASE_OFFER_COMMAND_SCHEMA)
+        .map_err(|_| LeaseOfferCommandError::InvalidDurablePayload)?;
+    let mut payload = Zeroizing::new(Vec::new());
+    serde_json::to_writer(
+        &mut *payload,
+        &LeaseOfferCommandPayloadRef {
+            job: command.job(),
+            lease: command.lease(),
+            managed_secret_bindings: command.managed_secret_bindings(),
+            lease_authority_evidence: command.lease_authority_evidence(),
+            protocol_version: command.protocol_version().get(),
+            schema: LEASE_OFFER_COMMAND_SCHEMA,
+            slot: command.slot().get(),
+        },
+    )
+    .map_err(|_| LeaseOfferCommandError::InvalidDurablePayload)?;
+    RunnerCommandPayload::new(schema, std::mem::take(&mut *payload))
+        .map_err(|_| LeaseOfferCommandError::InvalidDurablePayload)
 }
 
 pub(crate) fn decode_durable_server_command(

--- a/crates/automata-ci-control/src/runner_control/port.rs
+++ b/crates/automata-ci-control/src/runner_control/port.rs
@@ -15,13 +15,13 @@ use automata_ci_blob::{
     BlobDescriptor, BlobKey, BlobStoreErrorKind, ImmutableBlobStore, MediaType,
 };
 use automata_ci_core::{
-    JobIrEnvelope, JobIrVersion, Lease, OperationId, RunnerId, RunnerSessionId, Sha256Digest,
-    UnixMillis,
+    JobIrEnvelope, JobIrVersion, Lease, OperationId, RunnerId, RunnerSessionId,
+    SandboxAuthorizations, Sha256Digest, UnixMillis,
 };
 use automata_ci_protocol::{
-    CancelJob, CommandSequence, JobRuntimeAuthorities, LeaseOffer, LeaseRequest,
-    MAX_CONFIGURABLE_FRAME_BYTES, ManagedSecretBindingOverlay, ProtocolLimits, ProtocolVersion,
-    RunnerSlotOrdinal, ServerCommandHeader, ServerToRunner,
+    CancelJob, CommandSequence, JobRuntimeAuthorities, LeaseAuthorityPollContributions, LeaseOffer,
+    LeaseRequest, MAX_CONFIGURABLE_FRAME_BYTES, ManagedSecretBindingOverlay, ProtocolLimits,
+    ProtocolVersion, RunnerSlotOrdinal, ServerCommandHeader, ServerToRunner,
 };
 use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_store::{
@@ -40,19 +40,21 @@ use super::durable::{
     LeaseOfferClaimStatus as StoreLeaseOfferClaimStatus, PublishLeaseOffer, PublishedLeaseOffer,
     RunnerLeaseOfferRepository,
 };
+use super::lease_authority::LeaseAuthorityEvidenceSet;
 
 /// Immutable media type used for standalone protobuf `JobIR` objects.
 pub const JOB_IR_PROTOBUF_MEDIA_TYPE: &str = "application/vnd.automata.job-ir.protobuf";
 
 const LEASE_REQUEST_KIND: &str = "automata.runner.lease-request.v1";
-const LEASE_OFFER_COMMAND_KIND: &str = "automata.runner.lease-offer.v2";
-const LEASE_OFFER_COMMAND_SCHEMA: u16 = 2;
+const LEASE_OFFER_COMMAND_KIND: &str = "automata.runner.lease-offer.v3";
+const LEASE_OFFER_COMMAND_SCHEMA: u16 = 3;
 
 #[derive(serde::Serialize)]
 struct LeaseOfferCommandPayloadRef<'a> {
     job: &'a JobIrEnvelope,
     lease: &'a Lease,
     managed_secret_bindings: &'a ManagedSecretBindingOverlay,
+    lease_authority_evidence: &'a LeaseAuthorityEvidenceSet,
     protocol_version: u16,
     schema: u16,
     slot: u16,
@@ -64,6 +66,7 @@ struct DurableLeaseOfferCommandPayload {
     job: JobIrEnvelope,
     lease: Lease,
     managed_secret_bindings: ManagedSecretBindingOverlay,
+    lease_authority_evidence: LeaseAuthorityEvidenceSet,
     protocol_version: u16,
     schema: u16,
     slot: u16,
@@ -442,6 +445,9 @@ impl RuntimeAuthorityIssuer for CompositeRuntimeAuthorityIssuer {
             bundle
                 .validate_for(request.job(), request.lease())
                 .map_err(|_| ControlPortError::Corrupt)?;
+            if !bundle.sandbox_authorizations().as_slice().is_empty() {
+                return Err(ControlPortError::Corrupt);
+            }
             authorities.extend(bundle.as_slice().iter().cloned());
             if authorities.len() > automata_ci_protocol::MAX_RUNTIME_AUTHORITIES {
                 return Err(ControlPortError::Corrupt);
@@ -454,14 +460,22 @@ impl RuntimeAuthorityIssuer for CompositeRuntimeAuthorityIssuer {
             bundle
                 .validate_for(request.job(), request.lease())
                 .map_err(|_| ControlPortError::Corrupt)?;
+            if !bundle.sandbox_authorizations().as_slice().is_empty() {
+                return Err(ControlPortError::Corrupt);
+            }
             authorities.extend(bundle.as_slice().iter().cloned());
             if authorities.len() > automata_ci_protocol::MAX_RUNTIME_AUTHORITIES {
                 return Err(ControlPortError::Corrupt);
             }
         }
         authorities.sort_by(|left, right| left.name().cmp(right.name()));
-        JobRuntimeAuthorities::new(authorities, request.job(), request.lease())
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            authorities,
+            SandboxAuthorizations::empty(),
+            request.job(),
+            request.lease(),
+        )
+        .map_err(|_| ControlPortError::Corrupt)
     }
 }
 
@@ -575,6 +589,7 @@ pub struct LeaseOfferClaim {
     slot: RunnerSlotOrdinal,
     lease: automata_ci_core::Lease,
     job_ir_metadata: JobIrMetadata,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl LeaseOfferClaim {
@@ -589,6 +604,7 @@ impl LeaseOfferClaim {
         slot: RunnerSlotOrdinal,
         lease: automata_ci_core::Lease,
         job_ir_metadata: JobIrMetadata,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Self {
         Self {
             session,
@@ -598,6 +614,7 @@ impl LeaseOfferClaim {
             slot,
             lease,
             job_ir_metadata,
+            authority_contributions,
         }
     }
 
@@ -642,6 +659,13 @@ impl LeaseOfferClaim {
     pub const fn job_ir_metadata(&self) -> &JobIrMetadata {
         &self.job_ir_metadata
     }
+
+    /// Returns the exact provider-neutral contribution bundle accepted with
+    /// the lease request and bound by its durable claim receipt.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
+    }
 }
 
 /// Recovery state of one exact claimed lease poll.
@@ -661,6 +685,7 @@ pub struct LeaseOfferCommand {
     claim: LeaseOfferClaim,
     job: JobIrEnvelope,
     managed_secret_bindings: ManagedSecretBindingOverlay,
+    lease_authority_evidence: LeaseAuthorityEvidenceSet,
     offer_valid_until: UnixMillis,
     created_at: UnixMillis,
 }
@@ -680,6 +705,9 @@ pub enum LeaseOfferCommandError {
     /// Secret-binding metadata is not bound to the exact leased attempt.
     #[error("lease-offer managed-secret bindings are invalid")]
     InvalidManagedSecretBindings,
+    /// Lease-authority evidence does not match the exact claim and `JobIR`.
+    #[error("lease-offer authority evidence is invalid")]
+    InvalidLeaseAuthorityEvidence,
     /// The command was created outside the lease validity interval.
     #[error("lease-offer creation time is outside its validity interval")]
     InvalidCreationTime,
@@ -713,11 +741,29 @@ impl LeaseOfferCommand {
         let offer_valid_until = claim.lease().expires_at();
         Ok(Self {
             managed_secret_bindings: ManagedSecretBindingOverlay::empty(claim.lease()),
+            lease_authority_evidence: LeaseAuthorityEvidenceSet::empty(),
             claim,
             job,
             offer_valid_until,
             created_at,
         })
+    }
+
+    /// Retains value-free evidence for post-accept provider authorization.
+    ///
+    /// # Errors
+    ///
+    /// Rejects every cross-binding disagreement with the durable claim,
+    /// verified `JobIR`, environment profile, session, slot, or lease fence.
+    pub fn with_lease_authority_evidence(
+        mut self,
+        evidence: LeaseAuthorityEvidenceSet,
+    ) -> Result<Self, LeaseOfferCommandError> {
+        evidence
+            .validate()
+            .map_err(|_| LeaseOfferCommandError::InvalidLeaseAuthorityEvidence)?;
+        self.lease_authority_evidence = evidence;
+        Ok(self)
     }
 
     /// Replaces the empty default with the exact lease-scoped binding overlay.
@@ -771,6 +817,12 @@ impl LeaseOfferCommand {
     pub const fn job_ir_metadata(&self) -> &JobIrMetadata {
         self.claim.job_ir_metadata()
     }
+    /// Returns the exact provider-neutral contribution bundle accepted with
+    /// the lease request and bound by its durable claim receipt.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        self.claim.authority_contributions()
+    }
     /// Returns the validated `JobIR` envelope.
     #[must_use]
     pub const fn job(&self) -> &JobIrEnvelope {
@@ -780,6 +832,11 @@ impl LeaseOfferCommand {
     #[must_use]
     pub const fn managed_secret_bindings(&self) -> &ManagedSecretBindingOverlay {
         &self.managed_secret_bindings
+    }
+    /// Returns server-retained evidence for post-accept provider authorization.
+    #[must_use]
+    pub const fn lease_authority_evidence(&self) -> &LeaseAuthorityEvidenceSet {
+        &self.lease_authority_evidence
     }
     /// Returns the exclusive minimum of the lease and runtime-authority expiries.
     #[must_use]
@@ -918,6 +975,7 @@ fn store_lease_offer_claim(
         slot,
         claim.lease().clone(),
         claim.job_ir_metadata().clone(),
+        claim.authority_contributions().clone(),
     )
     .map_err(|_| ControlPortError::Corrupt)?;
     Ok((store_claim, request_kind))
@@ -941,52 +999,54 @@ fn published_claim_matches(
 
 fn durable_lease_offer_payload_matches(published: &PublishedLeaseOffer) -> bool {
     let command = published.command().request();
-    if command.session() != published.request().session() {
+    if command.session() != published.request().session()
+        || command.kind().as_str() != LEASE_OFFER_COMMAND_KIND
+        || command.payload().schema().get() != LEASE_OFFER_COMMAND_SCHEMA
+    {
         return false;
     }
-    match (command.kind().as_str(), command.payload().schema().get()) {
-        (LEASE_OFFER_COMMAND_KIND, LEASE_OFFER_COMMAND_SCHEMA) => {
-            let Ok(payload) = serde_json::from_slice::<DurableLeaseOfferCommandPayload>(
-                command.payload().bytes(),
-            ) else {
-                return false;
-            };
-            let mut canonical = Zeroizing::new(Vec::new());
-            if serde_json::to_writer(
-                &mut *canonical,
-                &LeaseOfferCommandPayloadRef {
-                    job: &payload.job,
-                    lease: &payload.lease,
-                    managed_secret_bindings: &payload.managed_secret_bindings,
-                    protocol_version: payload.protocol_version,
-                    schema: payload.schema,
-                    slot: payload.slot,
-                },
-            )
-            .is_err()
-                || canonical.as_slice() != command.payload().bytes()
-            {
-                return false;
-            }
-            durable_payload_matches(
-                published,
-                &payload.job,
-                &payload.lease,
-                &payload.managed_secret_bindings,
-                payload.protocol_version,
-                payload.schema,
-                payload.slot,
-            )
-        }
-        _ => false,
+    let Ok(payload) =
+        serde_json::from_slice::<DurableLeaseOfferCommandPayload>(command.payload().bytes())
+    else {
+        return false;
+    };
+    let mut canonical = Zeroizing::new(Vec::new());
+    if serde_json::to_writer(
+        &mut *canonical,
+        &LeaseOfferCommandPayloadRef {
+            job: &payload.job,
+            lease: &payload.lease,
+            managed_secret_bindings: &payload.managed_secret_bindings,
+            lease_authority_evidence: &payload.lease_authority_evidence,
+            protocol_version: payload.protocol_version,
+            schema: payload.schema,
+            slot: payload.slot,
+        },
+    )
+    .is_err()
+        || canonical.as_slice() != command.payload().bytes()
+    {
+        return false;
     }
+    durable_payload_matches(
+        published,
+        &payload.job,
+        &payload.lease,
+        &payload.managed_secret_bindings,
+        &payload.lease_authority_evidence,
+        payload.protocol_version,
+        payload.schema,
+        payload.slot,
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn durable_payload_matches(
     published: &PublishedLeaseOffer,
     job: &JobIrEnvelope,
     lease: &Lease,
     managed_secret_bindings: &ManagedSecretBindingOverlay,
+    lease_authority_evidence: &LeaseAuthorityEvidenceSet,
     protocol_version: u16,
     schema: u16,
     slot: u16,
@@ -1001,6 +1061,9 @@ fn durable_payload_matches(
     if validate_lease_offer_payload(job, lease, managed_secret_bindings, published.job_ir())
         .is_err()
     {
+        return false;
+    }
+    if lease_authority_evidence.validate().is_err() {
         return false;
     }
     let created_at = published.command().request().created_at();
@@ -1123,6 +1186,7 @@ impl LeaseOfferCommandPublisher for StoreLeaseOfferCommandPublisher {
             command.slot(),
             command.lease().clone(),
             command.job_ir_metadata().clone(),
+            command.authority_contributions().clone(),
         );
         let (store_claim, request_kind) = store_lease_offer_claim(&claim)?;
         let command_kind = RunnerOperationKind::new(LEASE_OFFER_COMMAND_KIND)
@@ -1136,6 +1200,7 @@ impl LeaseOfferCommandPublisher for StoreLeaseOfferCommandPublisher {
                 job: command.job(),
                 lease: command.lease(),
                 managed_secret_bindings: command.managed_secret_bindings(),
+                lease_authority_evidence: command.lease_authority_evidence(),
                 protocol_version: command.protocol_version().get(),
                 schema: LEASE_OFFER_COMMAND_SCHEMA,
                 slot: command.slot().get(),
@@ -1157,6 +1222,7 @@ impl LeaseOfferCommandPublisher for StoreLeaseOfferCommandPublisher {
             store_claim.slot(),
             store_claim.lease().clone(),
             store_claim.job_ir().clone(),
+            store_claim.authority_contributions().clone(),
             command.offer_valid_until(),
             durable_command,
         )
@@ -1216,6 +1282,7 @@ pub(crate) fn decode_durable_server_command(
                     .managed_secret_bindings
                     .validate_for(&payload.lease)
                     .is_err()
+                || payload.lease_authority_evidence.validate().is_err()
             {
                 return Err(ControlPortError::Corrupt);
             }
@@ -1249,6 +1316,41 @@ pub(crate) fn decode_durable_server_command(
         .validate(limits)
         .map_err(|_| ControlPortError::Corrupt)?;
     Ok(message)
+}
+
+/// Loads the server-retained lease-authority evidence from an exact durable offer.
+///
+/// This value is deliberately omitted from [`LeaseOffer`] and becomes
+/// runner-visible only through the accepted runtime-authority delivery path.
+pub(crate) fn durable_lease_authority_evidence(
+    command: &DurableRunnerCommand,
+) -> Result<LeaseAuthorityEvidenceSet, ControlPortError> {
+    if command.request().kind().as_str() != LEASE_OFFER_COMMAND_KIND
+        || command.request().payload().schema().get() != LEASE_OFFER_COMMAND_SCHEMA
+    {
+        return Err(ControlPortError::Corrupt);
+    }
+    let payload: DurableLeaseOfferCommandPayload =
+        serde_json::from_slice(command.request().payload().bytes())
+            .map_err(|_| ControlPortError::Corrupt)?;
+    Ok(payload.lease_authority_evidence)
+}
+
+/// Loads the exact value-free managed-secret overlay committed to a durable
+/// lease offer. This is rechecked before any post-accept sandbox authorization
+/// is minted so a substituted durable command cannot reach an issuer.
+pub(crate) fn durable_managed_secret_bindings(
+    command: &DurableRunnerCommand,
+) -> Result<ManagedSecretBindingOverlay, ControlPortError> {
+    if command.request().kind().as_str() != LEASE_OFFER_COMMAND_KIND
+        || command.request().payload().schema().get() != LEASE_OFFER_COMMAND_SCHEMA
+    {
+        return Err(ControlPortError::Corrupt);
+    }
+    let payload: DurableLeaseOfferCommandPayload =
+        serde_json::from_slice(command.request().payload().bytes())
+            .map_err(|_| ControlPortError::Corrupt)?;
+    Ok(payload.managed_secret_bindings)
 }
 
 pub(crate) fn is_durable_lease_offer_command(command: &DurableRunnerCommand) -> bool {

--- a/crates/automata-ci-control/src/runner_control/windows_lease_authority.rs
+++ b/crates/automata-ci-control/src/runner_control/windows_lease_authority.rs
@@ -1,0 +1,2193 @@
+use std::{collections::BTreeMap, fmt, str::FromStr as _, sync::Arc};
+
+use async_trait::async_trait;
+use automata_ci_core::{
+    Architecture, EnvironmentProfile, IsolationLevel, JobAuthorityProfile, JobIrEnvelope, Lease,
+    OperatingSystem, RunnerId, SandboxAuthorization, SandboxAuthorizationName, SandboxFeature,
+    Sha256Digest, TrustSourceClass, UnixMillis, WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4,
+    WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME, WindowsHyperVBrokerGrant,
+    WindowsHyperVBrokerGrantClaims,
+};
+use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollContribution, VerifiedWindowsRunnerPlacementRenewal,
+    WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION, WindowsRunnerAdmissionTrustStore,
+    WindowsRunnerPlacementRenewalEnvelope, verify_windows_runner_placement_renewal,
+};
+use automata_ci_protocol_protobuf::{
+    decode_windows_runner_placement_renewal_payload, encode_windows_hyperv_broker_grant_payload,
+};
+use automata_ci_store::{JobIrMetadata, RunnerOperationRequest, RunnerSessionFence};
+use ring::signature::{Ed25519KeyPair, KeyPair as _};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+use super::{
+    durable::{
+        AcceptedRuntimeAuthorityOffer, CommitRuntimeAuthorityDelivery,
+        RuntimeAuthorityDeliveryAdmission, RuntimeAuthorityDeliveryDisposition,
+    },
+    lease_authority::{
+        LeaseAuthorityEvidence, LeaseAuthorityExtension, LeaseAuthorityOfferRequest,
+        LeaseAuthorityPollAcceptance, PreparedSandboxAuthorization,
+    },
+    port::ControlPortError,
+};
+
+const WINDOWS_PLACEMENT_EVIDENCE_DIGEST_DOMAIN: &[u8] =
+    b"automata.control.windows-hyperv-placement-evidence.v3\0";
+const WINDOWS_PLACEMENT_TRUST_DIGEST_DOMAIN: &[u8] =
+    b"automata.control.windows-hyperv-placement-trust.v1\0";
+
+/// Value-free server-retained evidence needed to mint a broker capability
+/// only after the exact offer has been durably accepted.
+#[derive(Clone, Debug, serde::Deserialize, Eq, PartialEq, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsHyperVPlacementEvidence {
+    placement_binding_digest: Sha256Digest,
+    trust_binding_digest: Sha256Digest,
+    broker_host_id: Sha256Digest,
+    environment_profile: EnvironmentProfile,
+    profile_contract_sha256: Sha256Digest,
+    sandbox_pids_limit: u32,
+    placement_valid_until: UnixMillis,
+    poll_contributions_sha256: Sha256Digest,
+    placement_renewal_serial: u64,
+    placement_renewal_envelope_sha256: Sha256Digest,
+}
+
+impl WindowsHyperVPlacementEvidence {
+    fn from_offer_request(
+        request: LeaseAuthorityOfferRequest<'_>,
+        verified: &VerifiedWindowsRunnerPlacementRenewal,
+    ) -> Result<Self, ControlPortError> {
+        let claimed = request.claimed();
+        let claims = verified.claims();
+        let broker = claims.binding().broker_profile();
+        let broker_host_id = Sha256Digest::from_str(broker.broker_host_id())
+            .map_err(|_| ControlPortError::Corrupt)?;
+        let placement_valid_until = UnixMillis::new(
+            i64::try_from(claims.validity().expires_at_unix_millis())
+                .map_err(|_| ControlPortError::Corrupt)?,
+        );
+        Self::from_coordinates(
+            request.session(),
+            claimed.lease(),
+            claimed.slot().get(),
+            claimed.job_ir(),
+            request.job(),
+            broker_host_id,
+            claims.evidence().broker().profile_contract_sha256(),
+            broker.sandbox_pids_limit(),
+            placement_valid_until,
+            claimed.authority_contributions().sha256_digest(),
+            claims.renewal_serial(),
+            verified.envelope_sha256(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_coordinates(
+        session: RunnerSessionFence,
+        lease: &Lease,
+        slot: u16,
+        metadata: &JobIrMetadata,
+        job: &JobIrEnvelope,
+        broker_host_id: Sha256Digest,
+        profile_contract_sha256: Sha256Digest,
+        sandbox_pids_limit: u32,
+        placement_valid_until: UnixMillis,
+        poll_contributions_sha256: Sha256Digest,
+        placement_renewal_serial: u64,
+        placement_renewal_envelope_sha256: Sha256Digest,
+    ) -> Result<Self, ControlPortError> {
+        let planned = job.job();
+        let requirements = planned.requirements();
+        if lease.runner_id() != session.runner_id()
+            || lease.expires_at() <= lease.issued_at()
+            || metadata.version() != job.version()
+            || metadata.job_id() != planned.job_id()
+            || metadata.run_id() != planned.run_id()
+            || requirements.operating_system() != Some(&OperatingSystem::Windows)
+            || requirements.minimum_isolation() < IsolationLevel::VirtualMachine
+            || !requirements
+                .sandbox_features()
+                .contains(&SandboxFeature::WINDOWS_HYPERV_CONTAINER)
+            || requirements.architecture() != Some(&Architecture::X86_64)
+            || !windows_job_is_offline_credential_free(job)
+            || broker_host_id.as_bytes().iter().all(|byte| *byte == 0)
+            || profile_contract_sha256
+                .as_bytes()
+                .iter()
+                .all(|byte| *byte == 0)
+            || sandbox_pids_limit == 0
+            || placement_valid_until < lease.expires_at()
+            || placement_renewal_serial == 0
+            || placement_renewal_envelope_sha256
+                .as_bytes()
+                .iter()
+                .all(|byte| *byte == 0)
+        {
+            return Err(ControlPortError::Unavailable);
+        }
+        let environment_profile = requirements
+            .environment_profile()
+            .cloned()
+            .ok_or(ControlPortError::Unavailable)?;
+        let trust_binding_digest = windows_trust_binding_digest(job)?;
+        let mut evidence = Self {
+            placement_binding_digest: Sha256Digest::from_bytes([0; 32]),
+            trust_binding_digest,
+            broker_host_id,
+            environment_profile,
+            profile_contract_sha256,
+            sandbox_pids_limit,
+            placement_valid_until,
+            poll_contributions_sha256,
+            placement_renewal_serial,
+            placement_renewal_envelope_sha256,
+        };
+        evidence.placement_binding_digest =
+            evidence.compute_binding_digest(session, lease, slot, metadata);
+        Ok(evidence)
+    }
+
+    fn compute_binding_digest(
+        &self,
+        session: RunnerSessionFence,
+        lease: &Lease,
+        slot: u16,
+        metadata: &JobIrMetadata,
+    ) -> Sha256Digest {
+        fn field(digest: &mut Sha256, value: &[u8]) {
+            digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_be_bytes());
+            digest.update(value);
+        }
+
+        let mut digest = Sha256::new();
+        digest.update(WINDOWS_PLACEMENT_EVIDENCE_DIGEST_DOMAIN);
+        digest.update(lease.attempt_id().as_uuid().as_bytes());
+        digest.update(metadata.job_id().as_uuid().as_bytes());
+        digest.update(metadata.run_id().as_uuid().as_bytes());
+        digest.update(session.runner_id().as_uuid().as_bytes());
+        digest.update(session.session_id().as_uuid().as_bytes());
+        digest.update(session.runner_generation().get().to_be_bytes());
+        digest.update(session.session_epoch().get().to_be_bytes());
+        digest.update(slot.to_be_bytes());
+        digest.update(lease.lease_id().as_uuid().as_bytes());
+        digest.update(lease.fencing_token().get().to_be_bytes());
+        digest.update(metadata.version().get().to_be_bytes());
+        digest.update(metadata.encoded_size().to_be_bytes());
+        digest.update(metadata.digest().as_bytes());
+        field(&mut digest, metadata.object_key().as_str().as_bytes());
+        digest.update(self.trust_binding_digest.as_bytes());
+        digest.update(self.broker_host_id.as_bytes());
+        field(
+            &mut digest,
+            self.environment_profile.id().as_str().as_bytes(),
+        );
+        digest.update(self.environment_profile.digest().as_bytes());
+        digest.update(self.profile_contract_sha256.as_bytes());
+        digest.update(self.sandbox_pids_limit.to_be_bytes());
+        digest.update(self.placement_valid_until.get().to_be_bytes());
+        digest.update(lease.issued_at().get().to_be_bytes());
+        digest.update(lease.expires_at().get().to_be_bytes());
+        digest.update(self.poll_contributions_sha256.as_bytes());
+        digest.update(self.placement_renewal_serial.to_be_bytes());
+        digest.update(self.placement_renewal_envelope_sha256.as_bytes());
+        Sha256Digest::from_bytes(digest.finalize().into())
+    }
+
+    /// Returns the digest of the original locked placement decision.
+    #[must_use]
+    pub const fn placement_binding_digest(&self) -> Sha256Digest {
+        self.placement_binding_digest
+    }
+
+    /// Returns the authenticated trust/requirements binding.
+    #[must_use]
+    pub const fn trust_binding_digest(&self) -> Sha256Digest {
+        self.trust_binding_digest
+    }
+
+    /// Returns the exact broker host authenticated by the accepted renewal.
+    #[must_use]
+    pub const fn broker_host_id(&self) -> Sha256Digest {
+        self.broker_host_id
+    }
+
+    /// Returns the exact content-attested environment profile.
+    #[must_use]
+    pub const fn environment_profile(&self) -> &EnvironmentProfile {
+        &self.environment_profile
+    }
+
+    /// Returns the exact broker-minted launch contract authenticated by the renewal.
+    #[must_use]
+    pub const fn profile_contract_sha256(&self) -> Sha256Digest {
+        self.profile_contract_sha256
+    }
+
+    /// Returns the exact hard process ceiling authenticated by the renewal.
+    #[must_use]
+    pub const fn sandbox_pids_limit(&self) -> u32 {
+        self.sandbox_pids_limit
+    }
+
+    /// Returns the exact exclusive freshness horizon authenticated by the renewal.
+    #[must_use]
+    pub const fn placement_valid_until(&self) -> UnixMillis {
+        self.placement_valid_until
+    }
+
+    /// Returns the exact broker-durable serial of the accepted placement renewal.
+    #[must_use]
+    pub const fn placement_renewal_serial(&self) -> u64 {
+        self.placement_renewal_serial
+    }
+
+    /// Returns the digest of the exact accepted placement-renewal envelope.
+    #[must_use]
+    pub const fn placement_renewal_envelope_sha256(&self) -> Sha256Digest {
+        self.placement_renewal_envelope_sha256
+    }
+
+    fn is_valid_for_offer(
+        &self,
+        job: &JobIrEnvelope,
+        offer: &AcceptedRuntimeAuthorityOffer,
+    ) -> Result<bool, ControlPortError> {
+        let expected = Self::from_coordinates(
+            offer.request().session(),
+            offer.lease(),
+            offer.slot().ordinal(),
+            offer.job_ir(),
+            job,
+            self.broker_host_id,
+            self.profile_contract_sha256,
+            self.sandbox_pids_limit,
+            self.placement_valid_until,
+            self.poll_contributions_sha256,
+            self.placement_renewal_serial,
+            self.placement_renewal_envelope_sha256,
+        )?;
+        Ok(self == &expected)
+    }
+}
+
+fn windows_trust_binding_digest(job: &JobIrEnvelope) -> Result<Sha256Digest, ControlPortError> {
+    let planned = job.job();
+    let snapshot = planned.trust_snapshot();
+    if snapshot.is_construction_placeholder()
+        || !snapshot.evidence_complete()
+        || snapshot.source_class() == TrustSourceClass::Incomplete
+    {
+        return Err(ControlPortError::Unavailable);
+    }
+    let requirements = serde_json::to_value(planned.requirements())
+        .and_then(|value| serde_json::to_vec(&value))
+        .map_err(|_| ControlPortError::Corrupt)?;
+    let requirements_digest = Sha256Digest::from_bytes(Sha256::digest(requirements).into());
+    let encoded = serde_json::to_vec(&(
+        snapshot.schema(),
+        snapshot.policy_revision(),
+        snapshot.policy_digest(),
+        snapshot.digest(),
+        snapshot.source_class(),
+        snapshot.authority(),
+        snapshot.evidence_complete(),
+        planned.authority_profile(),
+        requirements_digest,
+    ))
+    .map_err(|_| ControlPortError::Corrupt)?;
+    let mut digest = Sha256::new();
+    digest.update(WINDOWS_PLACEMENT_TRUST_DIGEST_DOMAIN);
+    digest.update(
+        u64::try_from(encoded.len())
+            .unwrap_or(u64::MAX)
+            .to_be_bytes(),
+    );
+    digest.update(encoded);
+    Ok(Sha256Digest::from_bytes(digest.finalize().into()))
+}
+
+/// Server-side issuer for the value-free capability consumed by a restricted
+/// Windows host broker.
+pub trait WindowsHyperVBrokerGrantIssuer: fmt::Debug + Send + Sync {
+    /// Builds the exact unsigned proposal for transactional durable admission.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized configuration or contract failure when the current
+    /// admission, accepted offer, or durable `JobIR` do not bind exactly.
+    fn propose(
+        &self,
+        request: &WindowsHyperVBrokerGrantIssueRequest<'_>,
+    ) -> Result<WindowsHyperVBrokerGrantProposal, ControlPortError>;
+
+    /// Signs only a proposal carrying a store-minted one-use authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized configuration or signing failure when the runner
+    /// has no exact host mapping or the placement cannot be signed.
+    fn issue(
+        &self,
+        authorization: &WindowsHyperVBrokerGrantIssuanceAuthorization,
+    ) -> Result<WindowsHyperVBrokerGrant, ControlPortError>;
+}
+
+/// Current server-verified Windows placement admission.
+///
+/// This is deliberately not the short-lived enrollment receipt. Implementations
+/// return this value only while the latest broker-signed, independently
+/// refreshed host/input/promotion evidence remains fresh and equal to the
+/// durable revocation/serial high-water state. Mutable runner inventory or
+/// configuration is not an authority source for this record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsHyperVCurrentAdmission {
+    runner_id: RunnerId,
+    renewal_serial: u64,
+    renewal_envelope_sha256: Sha256Digest,
+    broker_host_id: Sha256Digest,
+    environment_profile: EnvironmentProfile,
+    profile_contract_sha256: Sha256Digest,
+    sandbox_pids_limit: u32,
+    placement_valid_until: UnixMillis,
+}
+
+impl WindowsHyperVCurrentAdmission {
+    /// Constructs a current admission returned by a server-owned durable store.
+    ///
+    /// # Errors
+    ///
+    /// Rejects nil identities, zero digests/process limits, or an already
+    /// expired record.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        runner_id: RunnerId,
+        renewal_serial: u64,
+        renewal_envelope_sha256: Sha256Digest,
+        broker_host_id: Sha256Digest,
+        environment_profile: EnvironmentProfile,
+        profile_contract_sha256: Sha256Digest,
+        sandbox_pids_limit: u32,
+        placement_valid_until: UnixMillis,
+        observed_at: UnixMillis,
+    ) -> Result<Self, ControlPortError> {
+        if runner_id.as_uuid().is_nil()
+            || renewal_serial == 0
+            || [
+                renewal_envelope_sha256,
+                broker_host_id,
+                environment_profile.digest(),
+                profile_contract_sha256,
+            ]
+            .iter()
+            .any(|digest| digest.as_bytes().iter().all(|byte| *byte == 0))
+            || sandbox_pids_limit == 0
+            || placement_valid_until <= observed_at
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            runner_id,
+            renewal_serial,
+            renewal_envelope_sha256,
+            broker_host_id,
+            environment_profile,
+            profile_contract_sha256,
+            sandbox_pids_limit,
+            placement_valid_until,
+        })
+    }
+
+    /// Returns the admitted runner.
+    #[must_use]
+    pub const fn runner_id(&self) -> RunnerId {
+        self.runner_id
+    }
+
+    /// Returns the exact broker-durable serial of the current placement renewal.
+    #[must_use]
+    pub const fn renewal_serial(&self) -> u64 {
+        self.renewal_serial
+    }
+
+    /// Returns the digest of the exact current placement-renewal envelope.
+    #[must_use]
+    pub const fn renewal_envelope_sha256(&self) -> Sha256Digest {
+        self.renewal_envelope_sha256
+    }
+
+    /// Returns the exact broker host bound by the signed enrollment receipt.
+    #[must_use]
+    pub const fn broker_host_id(&self) -> Sha256Digest {
+        self.broker_host_id
+    }
+
+    /// Returns the exact admitted environment profile.
+    #[must_use]
+    pub const fn environment_profile(&self) -> &EnvironmentProfile {
+        &self.environment_profile
+    }
+
+    /// Returns the broker-minted durable launch contract identity.
+    #[must_use]
+    pub const fn profile_contract_sha256(&self) -> Sha256Digest {
+        self.profile_contract_sha256
+    }
+
+    /// Returns the broker-admitted hard process ceiling.
+    #[must_use]
+    pub const fn sandbox_pids_limit(&self) -> u32 {
+        self.sandbox_pids_limit
+    }
+
+    /// Returns the exclusive placement-admission freshness horizon.
+    ///
+    /// This horizon is bounded by the latest broker host/input observation and
+    /// signed image-promotion expiry. It must never be populated from the
+    /// one-time enrollment receipt expiry.
+    #[must_use]
+    pub const fn placement_valid_until(&self) -> UnixMillis {
+        self.placement_valid_until
+    }
+}
+
+/// Reads the current signed Windows placement admission from durable state.
+///
+/// Implementations atomically choose the latest broker-signed renewal, require
+/// its promotion serial and revocation generation to equal current server
+/// high-water marks, sample database time only after locking the exact session,
+/// require that time before the independently attested placement horizon, and
+/// return `None` after expiry or revocation. The immutable enrollment receipt
+/// is not a renewable placement record.
+#[async_trait]
+pub trait WindowsHyperVCurrentAdmissionReader: fmt::Debug + Send + Sync {
+    /// Resolves the sole Windows placement authority for an exact runner/profile.
+    async fn current(
+        &self,
+        session: RunnerSessionFence,
+        environment_profile: &EnvironmentProfile,
+    ) -> Result<Option<WindowsHyperVCurrentAdmission>, ControlPortError>;
+}
+
+/// Exact authenticated-session request to advance a Windows placement head.
+///
+/// Signature verification performed by the handler is deliberately only a
+/// fail-fast check. The durable implementation must verify the raw envelope
+/// again with its own configured trust store after locking renewal head,
+/// promotion/revocation high-water, runner, and the exact session fence. It
+/// samples database time only after those locks.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitWindowsHyperVPlacementRenewal {
+    session: RunnerSessionFence,
+    envelope: WindowsRunnerPlacementRenewalEnvelope,
+    verified: VerifiedWindowsRunnerPlacementRenewal,
+}
+
+impl CommitWindowsHyperVPlacementRenewal {
+    /// Constructs one structurally and cryptographically fail-fast-verified
+    /// renewal for an exact authenticated session.
+    ///
+    /// # Errors
+    ///
+    /// Rejects runner, envelope-digest, or network-policy substitution.
+    pub fn new(
+        session: RunnerSessionFence,
+        envelope: WindowsRunnerPlacementRenewalEnvelope,
+        verified: VerifiedWindowsRunnerPlacementRenewal,
+    ) -> Result<Self, ControlPortError> {
+        let claims = verified.claims();
+        if claims.runner_id() != session.runner_id()
+            || claims.binding().transaction().runner_id() != session.runner_id()
+            || !claims.binding().broker_profile().network_disabled()
+            || verified.envelope_sha256() != envelope.envelope_sha256()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            session,
+            envelope,
+            verified,
+        })
+    }
+
+    /// Returns the exact authenticated runner-session fence.
+    #[must_use]
+    pub const fn session(&self) -> RunnerSessionFence {
+        self.session
+    }
+
+    /// Returns the complete untrusted wire envelope for independent durable
+    /// verification and byte-exact replay comparison.
+    #[must_use]
+    pub const fn envelope(&self) -> &WindowsRunnerPlacementRenewalEnvelope {
+        &self.envelope
+    }
+
+    /// Returns the handler's fail-fast verification result.
+    #[must_use]
+    pub const fn fail_fast_verified(&self) -> &VerifiedWindowsRunnerPlacementRenewal {
+        &self.verified
+    }
+}
+
+/// Whether an exact placement renewal advanced the durable head or replayed it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WindowsHyperVPlacementRenewalDisposition {
+    /// The exact next serial was appended and made current.
+    Committed,
+    /// The same runner, serial, envelope, and nonce were already current.
+    Replayed,
+}
+
+/// Atomic durable Windows placement-renewal boundary.
+///
+/// A new envelope is valid only at exactly `current_serial + 1`. Repeating the
+/// same runner/serial/envelope/nonce is idempotent; a lower serial, a gap, or an
+/// equal serial with different bytes is a conflict. The implementation must
+/// append the verified renewal and advance its current pointer in one
+/// transaction. The signed exclusive placement horizon is at most fifteen
+/// minutes and never exceeds promotion expiry.
+#[async_trait]
+pub trait WindowsHyperVPlacementRenewalRepository: fmt::Debug + Send + Sync {
+    /// Independently verifies and atomically commits one renewal.
+    async fn commit(
+        &self,
+        request: CommitWindowsHyperVPlacementRenewal,
+    ) -> Result<WindowsHyperVPlacementRenewalDisposition, ControlPortError>;
+}
+
+/// Exact accepted-offer evidence passed to the server-owned broker signer.
+pub struct WindowsHyperVBrokerGrantIssueRequest<'a> {
+    placement: &'a WindowsHyperVPlacementEvidence,
+    admission: &'a WindowsHyperVCurrentAdmission,
+    offer: &'a AcceptedRuntimeAuthorityOffer,
+    job: &'a JobIrEnvelope,
+    post_accept_request: &'a RunnerOperationRequest,
+}
+
+impl fmt::Debug for WindowsHyperVBrokerGrantIssueRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WindowsHyperVBrokerGrantIssueRequest")
+            .field(
+                "placement_binding_digest",
+                &self.placement.placement_binding_digest(),
+            )
+            .field(
+                "profile_contract_sha256",
+                &self.admission.profile_contract_sha256(),
+            )
+            .field("offer_operation_id", &self.offer.command().operation_id())
+            .field(
+                "post_accept_operation_id",
+                &self.post_accept_request.operation_id(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> WindowsHyperVBrokerGrantIssueRequest<'a> {
+    /// Constructs issuance input only after the durable store authorized the
+    /// post-accept delivery for this exact offer.
+    ///
+    /// # Errors
+    ///
+    /// Rejects any session, lease, `JobIR`, environment, or request mismatch.
+    pub fn new(
+        placement: &'a WindowsHyperVPlacementEvidence,
+        admission: &'a WindowsHyperVCurrentAdmission,
+        offer: &'a AcceptedRuntimeAuthorityOffer,
+        job: &'a JobIrEnvelope,
+        post_accept_request: &'a RunnerOperationRequest,
+    ) -> Result<Self, ControlPortError> {
+        if post_accept_request.session() != offer.request().session()
+            || post_accept_request.kind().as_str() != "automata.runner.runtime-authority-request.v2"
+            || job.version() != offer.job_ir().version()
+            || job.job().job_id() != offer.job_ir().job_id()
+            || job.job().run_id() != offer.job_ir().run_id()
+            || job.job().requirements().resource_allocation().is_none()
+            || job.job().requirements().environment_profile()
+                != Some(placement.environment_profile())
+            || admission.runner_id() != offer.lease().runner_id()
+            || admission.broker_host_id() != placement.broker_host_id()
+            || admission.environment_profile() != placement.environment_profile()
+            || admission.profile_contract_sha256() != placement.profile_contract_sha256()
+            || admission.sandbox_pids_limit() != placement.sandbox_pids_limit()
+            || admission.placement_valid_until() != placement.placement_valid_until()
+            || admission.renewal_serial() != placement.placement_renewal_serial()
+            || admission.renewal_envelope_sha256() != placement.placement_renewal_envelope_sha256()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            placement,
+            admission,
+            offer,
+            job,
+            post_accept_request,
+        })
+    }
+
+    /// Returns the server-retained placement evidence.
+    #[must_use]
+    pub const fn placement(&self) -> &WindowsHyperVPlacementEvidence {
+        self.placement
+    }
+
+    /// Returns the current durable signed runner admission.
+    #[must_use]
+    pub const fn admission(&self) -> &WindowsHyperVCurrentAdmission {
+        self.admission
+    }
+
+    /// Returns the exact accepted durable offer.
+    #[must_use]
+    pub const fn offer(&self) -> &AcceptedRuntimeAuthorityOffer {
+        self.offer
+    }
+
+    /// Returns the verified immutable `JobIR`.
+    #[must_use]
+    pub const fn job(&self) -> &JobIrEnvelope {
+        self.job
+    }
+
+    /// Returns the post-accept request admitted by durable state.
+    #[must_use]
+    pub const fn post_accept_request(&self) -> &RunnerOperationRequest {
+        self.post_accept_request
+    }
+
+    fn proposal(
+        &self,
+        key_id: Sha256Digest,
+        host_id: Sha256Digest,
+    ) -> Result<WindowsHyperVBrokerGrantProposal, ControlPortError> {
+        let offer = self.offer();
+        let lease = offer.lease();
+        let session = offer.request().session();
+        let metadata = offer.job_ir();
+        let object_key_digest = {
+            let mut digest = Sha256::new();
+            digest.update(b"automata.windows-hyperv-job-ir-object-key.v1\0");
+            digest.update(metadata.object_key().as_str().as_bytes());
+            Sha256Digest::from_bytes(digest.finalize().into())
+        };
+        let resource_allocation = self
+            .job()
+            .job()
+            .requirements()
+            .resource_allocation()
+            .ok_or(ControlPortError::Corrupt)?;
+        let claims = WindowsHyperVBrokerGrantClaims::new(
+            host_id,
+            self.placement().placement_binding_digest(),
+            lease.attempt_id(),
+            metadata.job_id(),
+            metadata.run_id(),
+            offer.request().operation_id(),
+            offer.command().operation_id(),
+            offer.command().sequence().get(),
+            self.post_accept_request().operation_id(),
+            self.post_accept_request().request_digest(),
+            session.runner_id(),
+            session.session_id(),
+            session.runner_generation().get(),
+            session.session_epoch().get(),
+            offer.slot().ordinal(),
+            lease.lease_id(),
+            lease.fencing_token(),
+            metadata.version(),
+            metadata.encoded_size(),
+            metadata.digest(),
+            object_key_digest,
+            resource_allocation,
+            self.admission().sandbox_pids_limit(),
+            self.placement().trust_binding_digest(),
+            self.placement().environment_profile().clone(),
+            self.admission().profile_contract_sha256(),
+            lease.issued_at(),
+            lease.expires_at(),
+        )
+        .map_err(|_| ControlPortError::Corrupt)?;
+        Ok(WindowsHyperVBrokerGrantProposal::new(
+            key_id,
+            claims,
+            self.placement().placement_renewal_serial(),
+            self.placement().placement_renewal_envelope_sha256(),
+        ))
+    }
+}
+
+/// Exact unsigned Windows broker grant proposed for transactional admission.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsHyperVBrokerGrantProposal {
+    key_id: Sha256Digest,
+    claims: WindowsHyperVBrokerGrantClaims,
+    signing_payload_sha256: Sha256Digest,
+    renewal_serial: u64,
+    renewal_envelope_sha256: Sha256Digest,
+}
+
+impl WindowsHyperVBrokerGrantProposal {
+    fn new(
+        key_id: Sha256Digest,
+        claims: WindowsHyperVBrokerGrantClaims,
+        renewal_serial: u64,
+        renewal_envelope_sha256: Sha256Digest,
+    ) -> Self {
+        let payload = WindowsHyperVBrokerGrant::signing_bytes_for(key_id, &claims);
+        let signing_payload_sha256 = Sha256Digest::from_bytes(Sha256::digest(payload).into());
+        Self {
+            key_id,
+            claims,
+            signing_payload_sha256,
+            renewal_serial,
+            renewal_envelope_sha256,
+        }
+    }
+
+    /// Returns the exact signing-key identity.
+    #[must_use]
+    pub const fn key_id(&self) -> Sha256Digest {
+        self.key_id
+    }
+
+    /// Returns every proposed value-free grant claim.
+    #[must_use]
+    pub const fn claims(&self) -> &WindowsHyperVBrokerGrantClaims {
+        &self.claims
+    }
+
+    /// Returns the commitment reserved by the transactional store.
+    #[must_use]
+    pub const fn signing_payload_sha256(&self) -> Sha256Digest {
+        self.signing_payload_sha256
+    }
+
+    /// Returns the exact broker-durable renewal serial which produced the placement binding.
+    #[must_use]
+    pub const fn renewal_serial(&self) -> u64 {
+        self.renewal_serial
+    }
+
+    /// Returns the exact renewal-envelope digest which produced the placement binding.
+    #[must_use]
+    pub const fn renewal_envelope_sha256(&self) -> Sha256Digest {
+        self.renewal_envelope_sha256
+    }
+}
+
+/// Store request which must revalidate a current renewal, exact session, and
+/// accepted offer under one lock order before grant signing can occur.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorizeWindowsHyperVBrokerGrant {
+    delivery: RuntimeAuthorityDeliveryAdmission,
+    admission: WindowsHyperVCurrentAdmission,
+    proposal: WindowsHyperVBrokerGrantProposal,
+}
+
+impl AuthorizeWindowsHyperVBrokerGrant {
+    /// Binds a proposal to the exact durable post-accept delivery admission.
+    ///
+    /// # Errors
+    ///
+    /// Rejects session, offer, runner, or post-accept request substitution.
+    pub fn new(
+        delivery: RuntimeAuthorityDeliveryAdmission,
+        admission: WindowsHyperVCurrentAdmission,
+        proposal: WindowsHyperVBrokerGrantProposal,
+    ) -> Result<Self, ControlPortError> {
+        let offer = delivery.offer();
+        let claims = proposal.claims();
+        if claims.runner_id() != offer.lease().runner_id()
+            || claims.runner_session_id() != offer.request().session().session_id()
+            || claims.runner_generation() != offer.request().session().runner_generation().get()
+            || claims.session_epoch() != offer.request().session().session_epoch().get()
+            || claims.accepted_offer_operation_id() != offer.command().operation_id()
+            || claims.post_accept_operation_id() != delivery.request().request().operation_id()
+            || claims.post_accept_request_digest() != delivery.request().request().request_digest()
+            || claims.runner_id() != admission.runner_id()
+            || claims.host_id() != admission.broker_host_id()
+            || claims.environment_profile() != admission.environment_profile()
+            || claims.profile_contract_sha256() != admission.profile_contract_sha256()
+            || claims.sandbox_pids_limit() != admission.sandbox_pids_limit()
+            || claims.expires_at() > admission.placement_valid_until()
+            || proposal.renewal_serial() != admission.renewal_serial()
+            || proposal.renewal_envelope_sha256() != admission.renewal_envelope_sha256()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            delivery,
+            admission,
+            proposal,
+        })
+    }
+
+    /// Returns the exact accepted runtime-authority delivery.
+    #[must_use]
+    pub const fn delivery(&self) -> &RuntimeAuthorityDeliveryAdmission {
+        &self.delivery
+    }
+
+    /// Returns the server-owned current admission revalidated transactionally.
+    #[must_use]
+    pub const fn admission(&self) -> &WindowsHyperVCurrentAdmission {
+        &self.admission
+    }
+
+    /// Returns the exact unsigned grant payload.
+    #[must_use]
+    pub const fn proposal(&self) -> &WindowsHyperVBrokerGrantProposal {
+        &self.proposal
+    }
+}
+
+/// One-use grant reservation minted only by the transactional durable port.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsHyperVBrokerGrantIssuanceAuthorization {
+    request: AuthorizeWindowsHyperVBrokerGrant,
+    reservation_nonce: Sha256Digest,
+    authorized_at: UnixMillis,
+    valid_until: UnixMillis,
+}
+
+impl WindowsHyperVBrokerGrantIssuanceAuthorization {
+    /// Constructs a durable reservation after the store completed all locks
+    /// and sampled its own clock.
+    ///
+    /// # Errors
+    ///
+    /// Rejects placeholder or out-of-horizon reservations.
+    pub fn new(
+        request: AuthorizeWindowsHyperVBrokerGrant,
+        reservation_nonce: Sha256Digest,
+        authorized_at: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<Self, ControlPortError> {
+        let claims = request.proposal().claims();
+        if reservation_nonce.as_bytes().iter().all(|byte| *byte == 0)
+            || authorized_at < claims.issued_at()
+            || authorized_at >= valid_until
+            || valid_until > claims.expires_at()
+            || valid_until > request.delivery().offer().offer_valid_until()
+            || valid_until > request.admission().placement_valid_until()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            request,
+            reservation_nonce,
+            authorized_at,
+            valid_until,
+        })
+    }
+
+    /// Returns the exact durable reservation request.
+    #[must_use]
+    pub const fn request(&self) -> &AuthorizeWindowsHyperVBrokerGrant {
+        &self.request
+    }
+
+    /// Returns the one-use durable reservation identity.
+    #[must_use]
+    pub const fn reservation_nonce(&self) -> Sha256Digest {
+        self.reservation_nonce
+    }
+
+    /// Returns the database time sampled after all authorization locks.
+    #[must_use]
+    pub const fn authorized_at(&self) -> UnixMillis {
+        self.authorized_at
+    }
+
+    /// Returns the exclusive reservation horizon.
+    #[must_use]
+    pub const fn valid_until(&self) -> UnixMillis {
+        self.valid_until
+    }
+}
+
+/// Exact atomic commit consuming a Windows grant reservation together with its
+/// metadata-only runtime-authority delivery.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitWindowsHyperVBrokerGrantDelivery {
+    authorization: WindowsHyperVBrokerGrantIssuanceAuthorization,
+    delivery: CommitRuntimeAuthorityDelivery,
+    grant_digest: Sha256Digest,
+}
+
+impl CommitWindowsHyperVBrokerGrantDelivery {
+    /// Binds the signed grant and normal delivery commit to one reservation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a delivery, proposal, key, claims, digest, or horizon mismatch.
+    pub fn new(
+        authorization: WindowsHyperVBrokerGrantIssuanceAuthorization,
+        delivery: CommitRuntimeAuthorityDelivery,
+        grant: &WindowsHyperVBrokerGrant,
+    ) -> Result<Self, ControlPortError> {
+        if delivery.admission() != authorization.request().delivery()
+            || grant.key_id() != authorization.request().proposal().key_id()
+            || grant.claims() != authorization.request().proposal().claims()
+            || delivery.committed_at() < authorization.authorized_at()
+            || delivery.committed_at() >= authorization.valid_until()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        Ok(Self {
+            authorization,
+            delivery,
+            grant_digest: grant.digest(),
+        })
+    }
+
+    /// Returns the exact one-use reservation to consume.
+    #[must_use]
+    pub const fn authorization(&self) -> &WindowsHyperVBrokerGrantIssuanceAuthorization {
+        &self.authorization
+    }
+
+    /// Returns the metadata-only runtime-authority delivery commit.
+    #[must_use]
+    pub const fn delivery(&self) -> &CommitRuntimeAuthorityDelivery {
+        &self.delivery
+    }
+
+    /// Returns the digest of the exact signed grant delivered to the runner.
+    #[must_use]
+    pub const fn grant_digest(&self) -> Sha256Digest {
+        self.grant_digest
+    }
+}
+
+/// Transactional store boundary for post-accept Windows grant delivery.
+///
+/// `authorize` locks renewal head, promotion/revocation high-water, runner,
+/// exact session, and accepted offer in that order, samples database time, and
+/// requires the current renewal serial and envelope digest to equal the exact
+/// admission carried by the proposal before atomically persisting a one-use
+/// reservation. Any head, high-water, or session transition must serialize
+/// against live reservations.
+/// `commit` atomically consumes that reservation while committing the normal
+/// runtime-authority delivery digest. A detached current read is never grant
+/// authority.
+#[async_trait]
+pub trait WindowsHyperVBrokerGrantAuthorizationRepository: fmt::Debug + Send + Sync {
+    /// Reserves one exact unsigned grant after all current-state checks.
+    async fn authorize(
+        &self,
+        request: AuthorizeWindowsHyperVBrokerGrant,
+    ) -> Result<WindowsHyperVBrokerGrantIssuanceAuthorization, ControlPortError>;
+
+    /// Atomically consumes the exact reservation and commits delivery.
+    async fn commit(
+        &self,
+        request: CommitWindowsHyperVBrokerGrantDelivery,
+    ) -> Result<RuntimeAuthorityDeliveryDisposition, ControlPortError>;
+}
+
+/// Deterministic Ed25519 issuer backed by a server-owned signing seed and an
+/// explicit runner-to-host registry.
+pub struct Ed25519WindowsHyperVBrokerGrantIssuer {
+    signing_seed: Zeroizing<[u8; 32]>,
+    public_key: [u8; 32],
+    key_id: Sha256Digest,
+    hosts: BTreeMap<RunnerId, Sha256Digest>,
+}
+
+impl fmt::Debug for Ed25519WindowsHyperVBrokerGrantIssuer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Ed25519WindowsHyperVBrokerGrantIssuer")
+            .field("key_id", &self.key_id)
+            .field("mapped_runners", &self.hosts.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Ed25519WindowsHyperVBrokerGrantIssuer {
+    /// Creates an issuer from an exact 32-byte server secret and an explicit
+    /// durable runner-to-broker-host mapping.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty map, nil runner identity, zero host digest, or invalid
+    /// Ed25519 seed.
+    pub fn new(
+        signing_seed: Zeroizing<[u8; 32]>,
+        hosts: BTreeMap<RunnerId, Sha256Digest>,
+    ) -> Result<Self, WindowsHyperVBrokerGrantIssuerError> {
+        if hosts.is_empty() {
+            return Err(WindowsHyperVBrokerGrantIssuerError::EmptyHostMap);
+        }
+        if hosts.iter().any(|(runner, host)| {
+            runner.as_uuid().is_nil() || host.as_bytes().iter().all(|byte| *byte == 0)
+        }) {
+            return Err(WindowsHyperVBrokerGrantIssuerError::InvalidHostMap);
+        }
+        let key_pair = Ed25519KeyPair::from_seed_unchecked(signing_seed.as_ref())
+            .map_err(|_| WindowsHyperVBrokerGrantIssuerError::InvalidSigningSeed)?;
+        let public_key = key_pair
+            .public_key()
+            .as_ref()
+            .try_into()
+            .map_err(|_| WindowsHyperVBrokerGrantIssuerError::InvalidSigningSeed)?;
+        let key_id = Sha256Digest::from_bytes(Sha256::digest(public_key).into());
+        Ok(Self {
+            signing_seed,
+            public_key,
+            key_id,
+            hosts,
+        })
+    }
+
+    /// Returns the public verification key installed on broker hosts.
+    #[must_use]
+    pub fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+
+    /// Returns the digest used to select this verification key.
+    #[must_use]
+    pub const fn key_id(&self) -> Sha256Digest {
+        self.key_id
+    }
+}
+
+impl WindowsHyperVBrokerGrantIssuer for Ed25519WindowsHyperVBrokerGrantIssuer {
+    fn propose(
+        &self,
+        request: &WindowsHyperVBrokerGrantIssueRequest<'_>,
+    ) -> Result<WindowsHyperVBrokerGrantProposal, ControlPortError> {
+        let runner_id = request.offer().lease().runner_id();
+        let host_id = self
+            .hosts
+            .get(&runner_id)
+            .copied()
+            .ok_or(ControlPortError::Corrupt)?;
+        if request.admission().broker_host_id() != host_id {
+            return Err(ControlPortError::Corrupt);
+        }
+        request.proposal(self.key_id, host_id)
+    }
+
+    fn issue(
+        &self,
+        authorization: &WindowsHyperVBrokerGrantIssuanceAuthorization,
+    ) -> Result<WindowsHyperVBrokerGrant, ControlPortError> {
+        let proposal = authorization.request().proposal();
+        let claims = proposal.claims();
+        let expected_host_id = self
+            .hosts
+            .get(&claims.runner_id())
+            .copied()
+            .ok_or(ControlPortError::Corrupt)?;
+        if proposal.key_id() != self.key_id || claims.host_id() != expected_host_id {
+            return Err(ControlPortError::Corrupt);
+        }
+        let key_pair = Ed25519KeyPair::from_seed_unchecked(self.signing_seed.as_ref())
+            .map_err(|_| ControlPortError::Corrupt)?;
+        let signing_bytes = WindowsHyperVBrokerGrant::signing_bytes_for(self.key_id, claims);
+        if Sha256Digest::from_bytes(Sha256::digest(&signing_bytes).into())
+            != proposal.signing_payload_sha256()
+        {
+            return Err(ControlPortError::Corrupt);
+        }
+        let signature = key_pair.sign(&signing_bytes);
+        WindowsHyperVBrokerGrant::new(self.key_id, claims.clone(), signature.as_ref())
+            .map_err(|_| ControlPortError::Corrupt)
+    }
+}
+
+/// Invalid configuration of the Ed25519 Windows broker grant issuer.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsHyperVBrokerGrantIssuerError {
+    /// No restricted host mapping was configured.
+    #[error("Windows Hyper-V broker host map cannot be empty")]
+    EmptyHostMap,
+    /// A runner identity or host digest used a zero sentinel.
+    #[error("Windows Hyper-V broker host map contains an invalid identity")]
+    InvalidHostMap,
+    /// The server signing seed could not initialize an Ed25519 key.
+    #[error("Windows Hyper-V broker signing seed is invalid")]
+    InvalidSigningSeed,
+}
+
+const WINDOWS_HYPERV_EVIDENCE_SCHEMA_VERSION: u16 = 3;
+
+/// Windows Hyper-V implementation of the provider-neutral lease-authority lifecycle.
+pub struct WindowsHyperVLeaseAuthorityExtension {
+    name: LeaseAuthorityName,
+    broker_grants: Arc<dyn WindowsHyperVBrokerGrantIssuer>,
+    grant_authorizations: Arc<dyn WindowsHyperVBrokerGrantAuthorizationRepository>,
+    current_admissions: Arc<dyn WindowsHyperVCurrentAdmissionReader>,
+    placement_renewals: Arc<dyn WindowsHyperVPlacementRenewalRepository>,
+    admission_trust: Arc<dyn WindowsRunnerAdmissionTrustStore>,
+}
+
+impl fmt::Debug for WindowsHyperVLeaseAuthorityExtension {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WindowsHyperVLeaseAuthorityExtension")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WindowsHyperVLeaseAuthorityExtension {
+    /// Composes every Windows-specific authority dependency behind one extension.
+    ///
+    /// # Errors
+    ///
+    /// Returns a corrupt configuration error if the canonical namespace cannot
+    /// be constructed.
+    pub fn new(
+        broker_grants: Arc<dyn WindowsHyperVBrokerGrantIssuer>,
+        grant_authorizations: Arc<dyn WindowsHyperVBrokerGrantAuthorizationRepository>,
+        current_admissions: Arc<dyn WindowsHyperVCurrentAdmissionReader>,
+        placement_renewals: Arc<dyn WindowsHyperVPlacementRenewalRepository>,
+        admission_trust: Arc<dyn WindowsRunnerAdmissionTrustStore>,
+    ) -> Result<Self, ControlPortError> {
+        let name = LeaseAuthorityName::new(WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME)
+            .map_err(|_| ControlPortError::Corrupt)?;
+        Ok(Self {
+            name,
+            broker_grants,
+            grant_authorizations,
+            current_admissions,
+            placement_renewals,
+            admission_trust,
+        })
+    }
+}
+
+#[async_trait]
+impl LeaseAuthorityExtension for WindowsHyperVLeaseAuthorityExtension {
+    fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    async fn accept_poll_contribution(
+        &self,
+        context: LeaseAuthorityPollAcceptance,
+        contribution: &LeaseAuthorityPollContribution,
+    ) -> Result<(), ControlPortError> {
+        if contribution.name() != &self.name
+            || contribution.payload_schema_version()
+                != WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION
+        {
+            return Err(ControlPortError::Conflict);
+        }
+        let envelope = decode_windows_runner_placement_renewal_payload(contribution.payload())
+            .map_err(|_| ControlPortError::Conflict)?;
+        let now =
+            u64::try_from(context.observed_at().get()).map_err(|_| ControlPortError::Corrupt)?;
+        let verified =
+            verify_windows_runner_placement_renewal(&envelope, self.admission_trust.as_ref(), now)
+                .map_err(|_| ControlPortError::Conflict)?;
+        let commit =
+            CommitWindowsHyperVPlacementRenewal::new(context.session(), envelope, verified)?;
+        self.placement_renewals.commit(commit).await?;
+        Ok(())
+    }
+
+    async fn prepare_offer_evidence(
+        &self,
+        request: LeaseAuthorityOfferRequest<'_>,
+    ) -> Result<Option<LeaseAuthorityEvidence>, ControlPortError> {
+        let contribution = request
+            .claimed()
+            .authority_contributions()
+            .get(self.name.as_str());
+        let windows_job = request.job().job().requirements().operating_system()
+            == Some(&OperatingSystem::Windows);
+        if !windows_job {
+            return if contribution.is_none() {
+                Ok(None)
+            } else {
+                Err(ControlPortError::Conflict)
+            };
+        }
+        let contribution = contribution.ok_or(ControlPortError::Unavailable)?;
+        if contribution.payload_schema_version() != WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION
+        {
+            return Err(ControlPortError::Conflict);
+        }
+        let envelope = decode_windows_runner_placement_renewal_payload(contribution.payload())
+            .map_err(|_| ControlPortError::Conflict)?;
+        let observed_at = u64::try_from(request.claimed().lease().issued_at().get())
+            .map_err(|_| ControlPortError::Corrupt)?;
+        let verified = verify_windows_runner_placement_renewal(
+            &envelope,
+            self.admission_trust.as_ref(),
+            observed_at,
+        )
+        .map_err(|_| ControlPortError::Conflict)?;
+        let evidence = WindowsHyperVPlacementEvidence::from_offer_request(request, &verified)?;
+        let claims = verified.claims();
+        let broker = claims.binding().broker_profile();
+        if claims.runner_id() != request.session().runner_id()
+            || claims.binding().transaction().runner_id() != request.session().runner_id()
+            || broker.profile() != evidence.environment_profile()
+            || !broker.network_disabled()
+        {
+            return Err(ControlPortError::Unavailable);
+        }
+        let current = self
+            .current_admissions
+            .current(request.session(), evidence.environment_profile())
+            .await?
+            .ok_or(ControlPortError::Unavailable)?;
+        if current.runner_id() != request.claimed().lease().runner_id()
+            || current.broker_host_id() != evidence.broker_host_id()
+            || current.environment_profile() != evidence.environment_profile()
+            || current.profile_contract_sha256() != evidence.profile_contract_sha256()
+            || current.sandbox_pids_limit() != evidence.sandbox_pids_limit()
+            || current.placement_valid_until() != evidence.placement_valid_until()
+            || current.renewal_serial() != evidence.placement_renewal_serial()
+            || current.renewal_envelope_sha256() != evidence.placement_renewal_envelope_sha256()
+        {
+            return Err(ControlPortError::Unavailable);
+        }
+        let payload = serde_json::to_vec(&evidence).map_err(|_| ControlPortError::Corrupt)?;
+        LeaseAuthorityEvidence::new(
+            self.name.clone(),
+            WINDOWS_HYPERV_EVIDENCE_SCHEMA_VERSION,
+            payload,
+        )
+        .map(Some)
+        .map_err(|_| ControlPortError::Corrupt)
+    }
+
+    async fn prepare_sandbox_authorization(
+        &self,
+        evidence: &LeaseAuthorityEvidence,
+        job: &JobIrEnvelope,
+        delivery: &RuntimeAuthorityDeliveryAdmission,
+    ) -> Result<Box<dyn PreparedSandboxAuthorization>, ControlPortError> {
+        if evidence.name() != &self.name
+            || evidence.payload_schema_version() != WINDOWS_HYPERV_EVIDENCE_SCHEMA_VERSION
+            || !windows_job_is_offline_credential_free(job)
+            || !delivery.offer().command_projection_valid()
+            || !delivery.offer().managed_secret_bindings_empty()
+        {
+            return Err(ControlPortError::Unavailable);
+        }
+        let placement: WindowsHyperVPlacementEvidence =
+            serde_json::from_slice(evidence.payload()).map_err(|_| ControlPortError::Corrupt)?;
+        let canonical = serde_json::to_vec(&placement).map_err(|_| ControlPortError::Corrupt)?;
+        if canonical.as_slice() != evidence.payload() {
+            return Err(ControlPortError::Corrupt);
+        }
+        let offer = delivery.offer();
+        if !placement.is_valid_for_offer(job, offer)? {
+            return Err(ControlPortError::Corrupt);
+        }
+        let current = self
+            .current_admissions
+            .current(offer.request().session(), placement.environment_profile())
+            .await?
+            .ok_or(ControlPortError::Unavailable)?;
+        if current.runner_id() != offer.lease().runner_id()
+            || current.broker_host_id() != placement.broker_host_id()
+            || current.environment_profile() != placement.environment_profile()
+            || current.profile_contract_sha256() != placement.profile_contract_sha256()
+            || current.sandbox_pids_limit() != placement.sandbox_pids_limit()
+            || current.placement_valid_until() != placement.placement_valid_until()
+            || current.renewal_serial() != placement.placement_renewal_serial()
+            || current.renewal_envelope_sha256() != placement.placement_renewal_envelope_sha256()
+        {
+            return Err(ControlPortError::Unavailable);
+        }
+        let issuance = WindowsHyperVBrokerGrantIssueRequest::new(
+            &placement,
+            &current,
+            offer,
+            job,
+            delivery.request().request(),
+        )?;
+        let proposal = self.broker_grants.propose(&issuance)?;
+        let request = AuthorizeWindowsHyperVBrokerGrant::new(delivery.clone(), current, proposal)?;
+        let reservation = self.grant_authorizations.authorize(request).await?;
+        let grant = self.broker_grants.issue(&reservation)?;
+        let payload = encode_windows_hyperv_broker_grant_payload(&grant);
+        let authorization = SandboxAuthorization::new(
+            SandboxAuthorizationName::new(WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME)
+                .map_err(|_| ControlPortError::Corrupt)?,
+            WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4,
+            payload,
+        )
+        .map_err(|_| ControlPortError::Corrupt)?;
+        Ok(Box::new(PreparedWindowsHyperVAuthorization {
+            authorization,
+            grant,
+            reservation,
+            repository: Arc::clone(&self.grant_authorizations),
+        }))
+    }
+}
+
+struct PreparedWindowsHyperVAuthorization {
+    authorization: SandboxAuthorization,
+    grant: WindowsHyperVBrokerGrant,
+    reservation: WindowsHyperVBrokerGrantIssuanceAuthorization,
+    repository: Arc<dyn WindowsHyperVBrokerGrantAuthorizationRepository>,
+}
+
+impl fmt::Debug for PreparedWindowsHyperVAuthorization {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedWindowsHyperVAuthorization")
+            .field("authorization", &self.authorization)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl PreparedSandboxAuthorization for PreparedWindowsHyperVAuthorization {
+    fn authorization(&self) -> &SandboxAuthorization {
+        &self.authorization
+    }
+
+    async fn commit(
+        self: Box<Self>,
+        delivery: CommitRuntimeAuthorityDelivery,
+    ) -> Result<RuntimeAuthorityDeliveryDisposition, ControlPortError> {
+        let commit =
+            CommitWindowsHyperVBrokerGrantDelivery::new(self.reservation, delivery, &self.grant)?;
+        self.repository.commit(commit).await
+    }
+}
+
+fn windows_job_is_offline_credential_free(job: &JobIrEnvelope) -> bool {
+    let job = job.job();
+    job.requirements().operating_system() == Some(&OperatingSystem::Windows)
+        && job.authority_profile() == JobAuthorityProfile::CredentialFree
+        && job
+            .permission_request()
+            .grants()
+            .is_some_and(<[_]>::is_empty)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use automata_ci_core::{
+        AttemptId, EnvironmentProfileId, FencingToken, GitObjectId, JobContentReference,
+        JobExecutionContext, JobId, JobInstanceIdentity, JobIr, JobPermissionRequest,
+        JobResourceAllocation, JobSource, LeaseId, OperationId, ResourceCapacity, RunId,
+        RunValueTemplates, RunnerCapabilities, RunnerFeature, RunnerPlatform, RunnerRequirements,
+        RunnerSessionId, RuntimeBoolean, SandboxCapabilities, SemanticStep, ShellTemplate, StepId,
+        StepIr, TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind,
+        TrustEvidence, TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot,
+        TrustTokenRecursion, ValueTemplate, WorkflowId,
+    };
+    use automata_ci_protocol::{
+        CommandSequence as ProtocolCommandSequence, INITIAL_RUNTIME_AUTHORITY_GENERATION,
+        LeaseAuthorityPollContributions, ProtocolLimits, RunnerSlotOrdinal,
+        RuntimeAuthorityDeliveryBinding, WINDOWS_RUNNER_ADMISSION_PROVIDER_ID,
+        WindowsAdmissionImage, WindowsAdmissionValidity, WindowsAuthorityAdmissionEvidence,
+        WindowsBrokerAdmissionEvidence, WindowsBrokerProfileBinding,
+        WindowsEnrollmentTransactionBinding, WindowsImagePromotionBinding,
+        WindowsPromotionValidity, WindowsRunnerAdmissionBinding, WindowsRunnerAdmissionEvidence,
+        WindowsRunnerAdmissionTrustAnchor, WindowsRunnerPlacementRenewalClaims,
+    };
+    use automata_ci_protocol_protobuf::{
+        decode_windows_hyperv_broker_grant_payload, encode_job_ir,
+        encode_windows_runner_placement_renewal_payload,
+    };
+    use automata_ci_store::{
+        CommandSequence as StoreCommandSequence, JobIrMetadata, ObjectKey, RunnerGeneration,
+        RunnerOperationKind, RunnerProtocolVersion, SessionEpoch, StableRunnerSlot,
+    };
+
+    use crate::{
+        lease::ClaimedLeasePoll,
+        runner_control::durable::{
+            AuthorizeRuntimeAuthorityDelivery, RuntimeAuthorityOfferCommand,
+        },
+    };
+
+    use super::*;
+
+    const NOW: u64 = 1_800_000_000_000;
+
+    fn digest(byte: u8) -> Sha256Digest {
+        Sha256Digest::from_bytes([byte; 32])
+    }
+
+    #[derive(Debug)]
+    struct TrustStore(BTreeMap<String, WindowsRunnerAdmissionTrustAnchor>);
+
+    impl WindowsRunnerAdmissionTrustStore for TrustStore {
+        fn admission_trust_anchor(
+            &self,
+            issuer_key_id: &str,
+        ) -> Option<WindowsRunnerAdmissionTrustAnchor> {
+            self.0.get(issuer_key_id).cloned()
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RenewalRepository {
+        commits: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl WindowsHyperVPlacementRenewalRepository for RenewalRepository {
+        async fn commit(
+            &self,
+            _request: CommitWindowsHyperVPlacementRenewal,
+        ) -> Result<WindowsHyperVPlacementRenewalDisposition, ControlPortError> {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+            Ok(WindowsHyperVPlacementRenewalDisposition::Committed)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CurrentAdmissions(Mutex<WindowsHyperVCurrentAdmission>);
+
+    impl CurrentAdmissions {
+        fn new(current: WindowsHyperVCurrentAdmission) -> Self {
+            Self(Mutex::new(current))
+        }
+
+        fn replace(&self, current: WindowsHyperVCurrentAdmission) {
+            *self.0.lock().expect("current admission") = current;
+        }
+
+        fn snapshot(&self) -> WindowsHyperVCurrentAdmission {
+            self.0.lock().expect("current admission").clone()
+        }
+    }
+
+    #[async_trait]
+    impl WindowsHyperVCurrentAdmissionReader for CurrentAdmissions {
+        async fn current(
+            &self,
+            session: RunnerSessionFence,
+            environment_profile: &EnvironmentProfile,
+        ) -> Result<Option<WindowsHyperVCurrentAdmission>, ControlPortError> {
+            let current = self.snapshot();
+            Ok((current.runner_id() == session.runner_id()
+                && current.environment_profile() == environment_profile)
+                .then_some(current))
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct GrantRepository {
+        authorizations: AtomicUsize,
+        commits: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl WindowsHyperVBrokerGrantAuthorizationRepository for GrantRepository {
+        async fn authorize(
+            &self,
+            request: AuthorizeWindowsHyperVBrokerGrant,
+        ) -> Result<WindowsHyperVBrokerGrantIssuanceAuthorization, ControlPortError> {
+            self.authorizations.fetch_add(1, Ordering::SeqCst);
+            let issued_at = request.proposal().claims().issued_at().get();
+            let valid_until = request.proposal().claims().expires_at();
+            WindowsHyperVBrokerGrantIssuanceAuthorization::new(
+                request,
+                digest(0x40),
+                UnixMillis::new(issued_at + 200),
+                valid_until,
+            )
+        }
+
+        async fn commit(
+            &self,
+            _request: CommitWindowsHyperVBrokerGrantDelivery,
+        ) -> Result<RuntimeAuthorityDeliveryDisposition, ControlPortError> {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+            Ok(RuntimeAuthorityDeliveryDisposition::Committed)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingIssuer {
+        inner: Ed25519WindowsHyperVBrokerGrantIssuer,
+        proposals: AtomicUsize,
+        issues: AtomicUsize,
+    }
+
+    impl WindowsHyperVBrokerGrantIssuer for CountingIssuer {
+        fn propose(
+            &self,
+            request: &WindowsHyperVBrokerGrantIssueRequest<'_>,
+        ) -> Result<WindowsHyperVBrokerGrantProposal, ControlPortError> {
+            self.proposals.fetch_add(1, Ordering::SeqCst);
+            self.inner.propose(request)
+        }
+
+        fn issue(
+            &self,
+            authorization: &WindowsHyperVBrokerGrantIssuanceAuthorization,
+        ) -> Result<WindowsHyperVBrokerGrant, ControlPortError> {
+            self.issues.fetch_add(1, Ordering::SeqCst);
+            self.inner.issue(authorization)
+        }
+    }
+
+    struct ContractFixture {
+        extension: WindowsHyperVLeaseAuthorityExtension,
+        renewal_repository: Arc<RenewalRepository>,
+        grant_repository: Arc<GrantRepository>,
+        current_admissions: Arc<CurrentAdmissions>,
+        issuer: Arc<CountingIssuer>,
+        session: RunnerSessionFence,
+        contribution: LeaseAuthorityPollContribution,
+        claimed: ClaimedLeasePoll,
+        job: JobIrEnvelope,
+    }
+
+    fn trusted_snapshot() -> TrustSnapshot {
+        TrustPolicy::current()
+            .evaluate(
+                TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::Push)
+                    .with_original_actor(
+                        TrustActorEvidence::new(
+                            "windows-contract",
+                            TrustActorKind::User,
+                            TrustAutomationKind::None,
+                        )
+                        .expect("actor evidence"),
+                    )
+                    .with_repositories(
+                        TrustRepositoryEvidence::new("42", "7").expect("source repository"),
+                        TrustRepositoryEvidence::new("42", "7").expect("target repository"),
+                    )
+                    .with_refs("refs/heads/main", "refs/heads/main", "refs/heads/main")
+                    .with_revisions("source-sha", "target-sha", "execution-sha")
+                    .with_fork(false)
+                    .with_token_recursion(TrustTokenRecursion::Suppressed),
+            )
+            .expect("complete trust snapshot")
+    }
+
+    fn windows_job(profile: EnvironmentProfile) -> JobIrEnvelope {
+        let capacity = ResourceCapacity::new(1_000, 1 << 30, 1 << 30, 0);
+        let requirements = RunnerRequirements::default()
+            .with_windows_hyperv_container()
+            .with_architecture(Architecture::X86_64)
+            .with_environment_profile(profile)
+            .with_resource_allocation(
+                JobResourceAllocation::new(capacity, capacity).expect("resource allocation"),
+            );
+        JobIrEnvelope::new(
+            WorkflowId::new(),
+            JobSource::new(
+                "github",
+                "automata-ci/automata",
+                GitObjectId::from_provider_hex("0123456789abcdef0123456789abcdef01234567")
+                    .expect("revision"),
+                ".github/workflows/windows.yml",
+                "push",
+            ),
+            JobExecutionContext::new(
+                "Windows",
+                "refs/heads/main",
+                "C:\\__w\\automata\\automata",
+                JobContentReference::new("events/push.json", digest(0x71), 2, "application/json"),
+                JobContentReference::new(
+                    "contexts/windows.pb",
+                    digest(0x72),
+                    2,
+                    "application/vnd.automata.job-runtime-context.protobuf",
+                ),
+            ),
+            JobIr::new(
+                JobId::new(),
+                RunId::new(),
+                "windows-contract",
+                requirements,
+                JobInstanceIdentity::new("windows-contract", 0, 1, digest(0x73))
+                    .expect("job instance"),
+                false,
+                vec![StepIr::new(
+                    StepId::new("test").expect("step ID"),
+                    ValueTemplate::literal("Test").expect("step name"),
+                    RuntimeBoolean::literal(false),
+                    SemanticStep::run(RunValueTemplates::new(
+                        ValueTemplate::literal("cargo test").expect("command"),
+                        ShellTemplate::default_shell(),
+                    )),
+                )],
+            )
+            .with_trust_snapshot(trusted_snapshot())
+            .with_authority_profile(JobAuthorityProfile::CredentialFree)
+            .with_permission_request(JobPermissionRequest::mapping([])),
+        )
+    }
+
+    fn renewal_binding(
+        runner_id: RunnerId,
+        broker_host_id: &str,
+        profile: EnvironmentProfile,
+    ) -> WindowsRunnerAdmissionBinding {
+        let capabilities = RunnerCapabilities::new(
+            runner_id,
+            RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+        )
+        .with_sandbox(SandboxCapabilities::new(
+            IsolationLevel::VirtualMachine,
+            [SandboxFeature::WINDOWS_HYPERV_CONTAINER],
+        ))
+        .with_features([RunnerFeature::SHELL_STEPS])
+        .with_environment_profiles([profile.clone()]);
+        let transaction = WindowsEnrollmentTransactionBinding::new(
+            runner_id,
+            OperationId::new(),
+            "https://control.example.test/",
+            "https://enroll.example.test/",
+            digest(1),
+            digest(2),
+            digest(3),
+        )
+        .expect("transaction binding");
+        let image_digest = digest(5);
+        let image = WindowsAdmissionImage::new(
+            format!("registry.example.test/automata/windows@sha256:{image_digest}"),
+            image_digest,
+        )
+        .expect("image");
+        let broker_profile = WindowsBrokerProfileBinding::new(
+            broker_host_id,
+            WINDOWS_RUNNER_ADMISSION_PROVIDER_ID,
+            digest(6),
+            profile,
+            image,
+            digest(7),
+            true,
+            false,
+            64,
+        )
+        .expect("broker profile");
+        let promotion = WindowsImagePromotionBinding::new(
+            "production.windows.v1",
+            "promotion-key-v1",
+            digest(8),
+            digest(9),
+            41,
+            19,
+            WindowsPromotionValidity::new(NOW - 60_000, NOW + 600_000).expect("promotion validity"),
+        )
+        .expect("promotion");
+        WindowsRunnerAdmissionBinding::new(transaction, broker_profile, promotion, capabilities)
+            .expect("admission binding")
+    }
+
+    fn renewal_evidence() -> WindowsRunnerAdmissionEvidence {
+        let broker = WindowsBrokerAdmissionEvidence::new(
+            digest(10),
+            digest(11),
+            digest(12),
+            digest(13),
+            digest(14),
+        )
+        .expect("broker evidence");
+        let authority =
+            WindowsAuthorityAdmissionEvidence::new(digest(15), digest(16), digest(17), digest(18))
+                .expect("authority evidence");
+        WindowsRunnerAdmissionEvidence::new(broker, authority)
+    }
+
+    fn signed_renewal(
+        runner_id: RunnerId,
+        broker_host: &str,
+        profile: EnvironmentProfile,
+        renewal_serial: u64,
+        nonce: Sha256Digest,
+        renewal_key: &Ed25519KeyPair,
+    ) -> WindowsRunnerPlacementRenewalEnvelope {
+        let issuer = "broker-admission-v1";
+        let claims = WindowsRunnerPlacementRenewalClaims::new(
+            issuer,
+            runner_id,
+            renewal_serial,
+            nonce,
+            digest(21),
+            renewal_binding(runner_id, broker_host, profile),
+            renewal_evidence(),
+            WindowsAdmissionValidity::new(NOW - 1_000, NOW + 60_000).expect("renewal validity"),
+        )
+        .expect("renewal claims");
+        WindowsRunnerPlacementRenewalEnvelope::new(
+            issuer,
+            claims.canonical_bytes().expect("canonical claims"),
+            renewal_key
+                .sign(&claims.signing_bytes().expect("signing bytes"))
+                .as_ref()
+                .to_vec(),
+        )
+        .expect("renewal envelope")
+    }
+
+    fn renewal_trust_store(
+        renewal_key: &Ed25519KeyPair,
+        broker_host: String,
+        profile: EnvironmentProfile,
+    ) -> TrustStore {
+        let anchor = WindowsRunnerAdmissionTrustAnchor::new(
+            renewal_key
+                .public_key()
+                .as_ref()
+                .try_into()
+                .expect("public key"),
+            broker_host,
+            profile,
+            "production.windows.v1",
+        )
+        .expect("trust anchor");
+        TrustStore(BTreeMap::from([("broker-admission-v1".to_owned(), anchor)]))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn fixture() -> ContractFixture {
+        let runner_id = RunnerId::new();
+        let session = RunnerSessionFence::new(
+            RunnerSessionId::new(),
+            runner_id,
+            RunnerGeneration::new(7).expect("runner generation"),
+            SessionEpoch::new(11).expect("session epoch"),
+        );
+        let profile = EnvironmentProfile::new(
+            EnvironmentProfileId::new("automata.example/windows-server-2025").expect("profile ID"),
+            digest(4),
+        );
+        let broker_host_id = digest(0xaa);
+        let broker_host = broker_host_id.to_string();
+        let renewal_key =
+            Ed25519KeyPair::from_seed_unchecked(&[0x25; 32]).expect("renewal signing key");
+        let envelope = signed_renewal(
+            runner_id,
+            &broker_host,
+            profile.clone(),
+            7,
+            digest(20),
+            &renewal_key,
+        );
+        let renewal_envelope_sha256 = envelope.envelope_sha256();
+        let contribution = LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new(WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME)
+                .expect("Windows namespace"),
+            WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION,
+            encode_windows_runner_placement_renewal_payload(&envelope),
+        )
+        .expect("poll contribution");
+        let contributions = LeaseAuthorityPollContributions::new(vec![contribution.clone()])
+            .expect("contribution bundle");
+        let job = windows_job(profile.clone());
+        let encoded = encode_job_ir(&job, &ProtocolLimits::default()).expect("encoded JobIR");
+        let metadata = JobIrMetadata::new(
+            job.job().job_id(),
+            job.job().run_id(),
+            job.version(),
+            u64::try_from(encoded.len()).expect("encoded size"),
+            Sha256Digest::from_bytes(Sha256::digest(&encoded).into()),
+            ObjectKey::new("job-ir/windows-contract.pb").expect("object key"),
+        )
+        .expect("JobIR metadata");
+        let lease = Lease::new(
+            LeaseId::new(),
+            AttemptId::new(),
+            runner_id,
+            FencingToken::new(5).expect("fencing token"),
+            UnixMillis::new(i64::try_from(NOW).expect("now")),
+            UnixMillis::new(i64::try_from(NOW + 30_000).expect("lease expiry")),
+        )
+        .expect("lease");
+        let claimed = ClaimedLeasePoll::new(
+            lease,
+            RunnerSlotOrdinal::new(1).expect("slot"),
+            metadata,
+            contributions,
+            true,
+        );
+        let trust_store = renewal_trust_store(&renewal_key, broker_host, profile.clone());
+        let current = WindowsHyperVCurrentAdmission::new(
+            runner_id,
+            7,
+            renewal_envelope_sha256,
+            broker_host_id,
+            profile,
+            digest(14),
+            64,
+            UnixMillis::new(i64::try_from(NOW + 60_000).expect("renewal expiry")),
+            UnixMillis::new(i64::try_from(NOW).expect("observed at")),
+        )
+        .expect("current admission");
+        let current_admissions = Arc::new(CurrentAdmissions::new(current));
+        let renewal_repository = Arc::new(RenewalRepository::default());
+        let grant_repository = Arc::new(GrantRepository::default());
+        let issuer = Arc::new(CountingIssuer {
+            inner: Ed25519WindowsHyperVBrokerGrantIssuer::new(
+                Zeroizing::new([0x35; 32]),
+                BTreeMap::from([(runner_id, broker_host_id)]),
+            )
+            .expect("broker grant issuer"),
+            proposals: AtomicUsize::new(0),
+            issues: AtomicUsize::new(0),
+        });
+        let extension = WindowsHyperVLeaseAuthorityExtension::new(
+            issuer.clone(),
+            grant_repository.clone(),
+            current_admissions.clone(),
+            renewal_repository.clone(),
+            Arc::new(trust_store),
+        )
+        .expect("Windows authority extension");
+        ContractFixture {
+            extension,
+            renewal_repository,
+            grant_repository,
+            current_admissions,
+            issuer,
+            session,
+            contribution,
+            claimed,
+            job,
+        }
+    }
+
+    fn next_identical_projection_admission(
+        previous: &WindowsHyperVCurrentAdmission,
+    ) -> WindowsHyperVCurrentAdmission {
+        let renewal_key =
+            Ed25519KeyPair::from_seed_unchecked(&[0x25; 32]).expect("renewal signing key");
+        let newer_envelope = signed_renewal(
+            previous.runner_id(),
+            &previous.broker_host_id().to_string(),
+            previous.environment_profile().clone(),
+            previous.renewal_serial() + 1,
+            digest(0x22),
+            &renewal_key,
+        );
+        WindowsHyperVCurrentAdmission::new(
+            previous.runner_id(),
+            previous.renewal_serial() + 1,
+            newer_envelope.envelope_sha256(),
+            previous.broker_host_id(),
+            previous.environment_profile().clone(),
+            previous.profile_contract_sha256(),
+            previous.sandbox_pids_limit(),
+            previous.placement_valid_until(),
+            UnixMillis::new(i64::try_from(NOW).expect("observed at")),
+        )
+        .expect("newer current admission")
+    }
+
+    fn delivery(fixture: &ContractFixture) -> RuntimeAuthorityDeliveryAdmission {
+        let lease = fixture.claimed.lease();
+        let metadata = fixture.claimed.job_ir();
+        let protocol = RunnerProtocolVersion::new(3).expect("protocol");
+        let offer_operation_id = OperationId::new();
+        let sequence = 1;
+        let accepted = AcceptedRuntimeAuthorityOffer::new(
+            RunnerOperationRequest::new(
+                fixture.session,
+                OperationId::new(),
+                RunnerOperationKind::new("automata.runner.lease-request.v2")
+                    .expect("lease request kind"),
+                digest(0x31),
+            ),
+            protocol,
+            StableRunnerSlot::new(fixture.claimed.slot().get()).expect("stable slot"),
+            lease.clone(),
+            metadata.clone(),
+            lease.expires_at(),
+            RuntimeAuthorityOfferCommand::new(
+                offer_operation_id,
+                StoreCommandSequence::new(sequence).expect("store command sequence"),
+                UnixMillis::new(i64::try_from(NOW + 100).expect("command time")),
+            ),
+        )
+        .expect("accepted offer");
+        let binding = RuntimeAuthorityDeliveryBinding::new(
+            lease.attempt_id(),
+            fixture.claimed.slot(),
+            lease.guard(),
+            offer_operation_id,
+            ProtocolCommandSequence::new(sequence).expect("protocol command sequence"),
+            metadata.digest(),
+            INITIAL_RUNTIME_AUTHORITY_GENERATION,
+        );
+        let authorization = AuthorizeRuntimeAuthorityDelivery::new(
+            RunnerOperationRequest::new(
+                fixture.session,
+                OperationId::new(),
+                RunnerOperationKind::new("automata.runner.runtime-authority-request.v2")
+                    .expect("authority request kind"),
+                digest(0x32),
+            ),
+            protocol,
+            binding,
+            UnixMillis::new(i64::try_from(NOW + 150).expect("authorization time")),
+        )
+        .expect("delivery authorization");
+        RuntimeAuthorityDeliveryAdmission::new(authorization, accepted, None)
+            .expect("delivery admission")
+    }
+
+    #[tokio::test]
+    async fn accepted_renewal_survives_replayed_generic_claim_and_commits_specialized_delivery() {
+        let fixture = fixture();
+        fixture
+            .extension
+            .accept_poll_contribution(
+                LeaseAuthorityPollAcceptance::new(
+                    fixture.session,
+                    UnixMillis::new(i64::try_from(NOW).expect("observed at")),
+                ),
+                &fixture.contribution,
+            )
+            .await
+            .expect("accepted renewal");
+        assert_eq!(fixture.renewal_repository.commits.load(Ordering::SeqCst), 1);
+        assert!(fixture.claimed.was_replayed());
+        assert_eq!(
+            fixture
+                .claimed
+                .authority_contributions()
+                .get(WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME),
+            Some(&fixture.contribution)
+        );
+
+        let evidence = fixture
+            .extension
+            .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                fixture.session,
+                &fixture.claimed,
+                &fixture.job,
+            ))
+            .await
+            .expect("offer evidence")
+            .expect("Windows evidence");
+        let delivery = delivery(&fixture);
+        let prepared = fixture
+            .extension
+            .prepare_sandbox_authorization(&evidence, &fixture.job, &delivery)
+            .await
+            .expect("prepared authorization");
+        assert_eq!(
+            prepared.authorization().name().as_str(),
+            WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME
+        );
+        let grant = decode_windows_hyperv_broker_grant_payload(prepared.authorization().payload())
+            .expect("canonical Windows grant");
+        assert_eq!(
+            grant.claims().lease_id(),
+            fixture.claimed.lease().lease_id()
+        );
+        assert_eq!(
+            fixture
+                .grant_repository
+                .authorizations
+                .load(Ordering::SeqCst),
+            1
+        );
+        let commit = CommitRuntimeAuthorityDelivery::new(
+            delivery,
+            digest(0x51),
+            UnixMillis::new(i64::try_from(NOW + 500).expect("commit time")),
+        )
+        .expect("generic delivery commit");
+        assert_eq!(
+            prepared.commit(commit).await.expect("specialized commit"),
+            RuntimeAuthorityDeliveryDisposition::Committed
+        );
+        assert_eq!(fixture.grant_repository.commits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn identical_projection_newer_renewal_rejects_stale_evidence_before_reservation() {
+        let fixture = fixture();
+        let evidence = fixture
+            .extension
+            .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                fixture.session,
+                &fixture.claimed,
+                &fixture.job,
+            ))
+            .await
+            .expect("offer evidence")
+            .expect("Windows evidence");
+
+        let previous = fixture.current_admissions.snapshot();
+        let newer = next_identical_projection_admission(&previous);
+        assert_eq!(newer.broker_host_id(), previous.broker_host_id());
+        assert_eq!(newer.environment_profile(), previous.environment_profile());
+        assert_eq!(
+            newer.profile_contract_sha256(),
+            previous.profile_contract_sha256()
+        );
+        assert_eq!(newer.sandbox_pids_limit(), previous.sandbox_pids_limit());
+        assert_eq!(
+            newer.placement_valid_until(),
+            previous.placement_valid_until()
+        );
+        assert_ne!(newer.renewal_serial(), previous.renewal_serial());
+        assert_ne!(
+            newer.renewal_envelope_sha256(),
+            previous.renewal_envelope_sha256()
+        );
+        fixture.current_admissions.replace(newer);
+
+        let error = fixture
+            .extension
+            .prepare_sandbox_authorization(&evidence, &fixture.job, &delivery(&fixture))
+            .await
+            .expect_err("stale renewal evidence must fail closed");
+        assert_eq!(error, ControlPortError::Unavailable);
+        assert_eq!(
+            fixture
+                .grant_repository
+                .authorizations
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(fixture.issuer.proposals.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.issuer.issues.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn identical_projection_newer_renewal_rejects_stale_claim_at_offer() {
+        let fixture = fixture();
+        let previous = fixture.current_admissions.snapshot();
+        fixture
+            .current_admissions
+            .replace(next_identical_projection_admission(&previous));
+
+        let error = fixture
+            .extension
+            .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                fixture.session,
+                &fixture.claimed,
+                &fixture.job,
+            ))
+            .await
+            .expect_err("stale claimed renewal must fail closed");
+        assert_eq!(error, ControlPortError::Unavailable);
+        assert_eq!(
+            fixture
+                .grant_repository
+                .authorizations
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(fixture.issuer.proposals.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.issuer.issues.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn authorize_rejects_stale_proposal_against_identical_newer_renewal() {
+        let fixture = fixture();
+        let evidence = fixture
+            .extension
+            .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                fixture.session,
+                &fixture.claimed,
+                &fixture.job,
+            ))
+            .await
+            .expect("offer evidence")
+            .expect("Windows evidence");
+        let placement: WindowsHyperVPlacementEvidence =
+            serde_json::from_slice(evidence.payload()).expect("placement evidence");
+        let delivery = delivery(&fixture);
+        let previous = fixture.current_admissions.snapshot();
+        let issuance = WindowsHyperVBrokerGrantIssueRequest::new(
+            &placement,
+            &previous,
+            delivery.offer(),
+            &fixture.job,
+            delivery.request().request(),
+        )
+        .expect("grant issue request");
+        let proposal = fixture.issuer.propose(&issuance).expect("grant proposal");
+        assert_eq!(proposal.renewal_serial(), previous.renewal_serial());
+        assert_eq!(
+            proposal.renewal_envelope_sha256(),
+            previous.renewal_envelope_sha256()
+        );
+
+        let newer = next_identical_projection_admission(&previous);
+        assert_eq!(
+            AuthorizeWindowsHyperVBrokerGrant::new(delivery, newer, proposal)
+                .expect_err("stale proposal must fail before durable reservation"),
+            ControlPortError::Corrupt
+        );
+        assert_eq!(
+            fixture
+                .grant_repository
+                .authorizations
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(fixture.issuer.proposals.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.issuer.issues.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_or_substituted_windows_contribution_fails_closed() {
+        let fixture = fixture();
+        let missing = ClaimedLeasePoll::new(
+            fixture.claimed.lease().clone(),
+            fixture.claimed.slot(),
+            fixture.claimed.job_ir().clone(),
+            LeaseAuthorityPollContributions::empty(),
+            true,
+        );
+        assert_eq!(
+            fixture
+                .extension
+                .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                    fixture.session,
+                    &missing,
+                    &fixture.job,
+                ))
+                .await,
+            Err(ControlPortError::Unavailable)
+        );
+
+        let substituted = LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new("automata.test.substituted-windows")
+                .expect("substituted namespace"),
+            fixture.contribution.payload_schema_version(),
+            fixture.contribution.payload().to_vec(),
+        )
+        .expect("substituted contribution");
+        let substituted = ClaimedLeasePoll::new(
+            fixture.claimed.lease().clone(),
+            fixture.claimed.slot(),
+            fixture.claimed.job_ir().clone(),
+            LeaseAuthorityPollContributions::new(vec![substituted]).expect("substituted bundle"),
+            true,
+        );
+        assert_eq!(
+            fixture
+                .extension
+                .prepare_offer_evidence(LeaseAuthorityOfferRequest::new(
+                    fixture.session,
+                    &substituted,
+                    &fixture.job,
+                ))
+                .await,
+            Err(ControlPortError::Unavailable)
+        );
+    }
+}

--- a/crates/automata-ci-control/src/workload_oidc/runtime_authority.rs
+++ b/crates/automata-ci-control/src/workload_oidc/runtime_authority.rs
@@ -417,9 +417,14 @@ impl OptionalRuntimeAuthorityIssuer for WorkloadOidcRuntimeAuthorityIssuer {
             expires_at,
         )
         .map_err(|_| ControlPortError::Corrupt)?;
-        JobRuntimeAuthorities::new(vec![authority], job, lease)
-            .map(Some)
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            job,
+            lease,
+        )
+        .map(Some)
+        .map_err(|_| ControlPortError::Corrupt)
     }
 }
 

--- a/crates/automata-ci-control/tests/lease_poll.rs
+++ b/crates/automata-ci-control/tests/lease_poll.rs
@@ -7,7 +7,7 @@ use automata_ci_control::lease::{
     LeasePollRepository, LeasePollService, LeaseRequestKey, LeaseTimeToLive, NoWorkLeaseRequest,
     RunnableAttempt, RunnableAttemptError, RunnableAttemptGate, RunnableAttemptGateDisposition,
     RunnableScanLimit, RunnableScanPage, RunnableScanRequest, TryClaimAttempt, TryClaimOutcome,
-    TryClaimReceipt, WindowsHyperVPlacementGrant,
+    TryClaimReceipt,
     repository::{RunnableAttemptRepository, RunnerClaimRepository},
     routing::{
         RunnerGroupId, RunnerRoutingRepository, RunnerRoutingSnapshot, RunnerSlotAvailability,
@@ -24,11 +24,43 @@ use automata_ci_core::{
     TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy,
     TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion, UnixMillis,
 };
-use automata_ci_protocol::{LeaseRequest, MessageHeader, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal};
+use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollContribution, LeaseAuthorityPollContributions,
+    LeaseRequest, MessageHeader, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal,
+};
 use automata_ci_store::{
     AttemptAssignment, JobIrMetadata, ObjectKey, RoutingDocument, RoutingLabel, RunnerGeneration,
     RunnerSessionFence, RunnerSlotCount, SessionEpoch, StableRunnerSlot, StoreError,
 };
+
+fn empty_lease_request(header: MessageHeader, slot: RunnerSlotOrdinal) -> LeaseRequest {
+    LeaseRequest::first(header, slot, LeaseAuthorityPollContributions::empty())
+}
+
+fn successor_lease_request(
+    header: MessageHeader,
+    slot: RunnerSlotOrdinal,
+    predecessor: OperationId,
+) -> LeaseRequest {
+    LeaseRequest::successor(
+        header,
+        slot,
+        predecessor,
+        LeaseAuthorityPollContributions::empty(),
+    )
+}
+
+fn test_authority_contributions(payload: u8) -> LeaseAuthorityPollContributions {
+    LeaseAuthorityPollContributions::new(vec![
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new("automata.test.authority").expect("authority name"),
+            1,
+            vec![payload],
+        )
+        .expect("authority contribution"),
+    ])
+    .expect("authority contribution bundle")
+}
 
 #[derive(Debug)]
 struct FixedClock(UnixMillis);
@@ -109,7 +141,7 @@ struct FakeRepository {
     availability: RunnerSlotAvailability,
     candidates: Vec<RunnableAttempt>,
     metadata: JobIrMetadata,
-    windows_grants: Mutex<Vec<Option<WindowsHyperVPlacementGrant>>>,
+    authority_contributions: Mutex<Vec<LeaseAuthorityPollContributions>>,
 }
 
 impl FakeRepository {
@@ -127,6 +159,7 @@ impl RunnerClaimRepository for FakeRepository {
     async fn lookup_lease_request(
         &self,
         request: LeaseRequestKey,
+        _authority_contributions: &LeaseAuthorityPollContributions,
     ) -> Result<Option<TryClaimReceipt>, StoreError> {
         self.called("lookup");
         self.lease_keys
@@ -138,10 +171,12 @@ impl RunnerClaimRepository for FakeRepository {
 
     async fn try_claim(&self, request: TryClaimAttempt) -> Result<TryClaimReceipt, StoreError> {
         self.called("claim");
-        self.windows_grants
+        self.authority_contributions
             .lock()
-            .expect("Windows grant observations")
-            .push(request.windows_placement_grant().cloned());
+            .expect("authority contribution observations")
+            .push(request.authority_contributions().clone());
+        let request_digest = request.request_digest();
+        let authority_contributions = request.authority_contributions().clone();
         let lease = Lease::new(
             request.lease_id(),
             request.attempt_id(),
@@ -155,10 +190,12 @@ impl RunnerClaimRepository for FakeRepository {
             lease,
             AttemptAssignment::new(request.session(), request.slot()),
             self.metadata.clone(),
+            authority_contributions,
         )
         .expect("fake assignment");
         Ok(TryClaimReceipt::new(
             request.request_key(),
+            request_digest,
             TryClaimOutcome::Claimed(Box::new(claimed)),
             false,
         ))
@@ -169,8 +206,10 @@ impl RunnerClaimRepository for FakeRepository {
         request: NoWorkLeaseRequest,
     ) -> Result<TryClaimReceipt, StoreError> {
         self.called("no_work");
+        let request_digest = request.request_digest();
         Ok(TryClaimReceipt::new(
             request.request_key(),
+            request_digest,
             TryClaimOutcome::NoWork,
             false,
         ))
@@ -330,7 +369,7 @@ fn fixture(availability: RunnerSlotAvailability, with_candidates: bool) -> Fixtu
         Vec::new()
     };
     let operation_id = OperationId::new();
-    let request = LeaseRequest::first(
+    let request = empty_lease_request(
         MessageHeader::request(PROTOCOL_MAX_VERSION, fence.session_id(), operation_id),
         RunnerSlotOrdinal::new(1).expect("slot"),
     );
@@ -344,7 +383,7 @@ fn fixture(availability: RunnerSlotAvailability, with_candidates: bool) -> Fixtu
             availability,
             candidates,
             metadata,
-            windows_grants: Mutex::new(Vec::new()),
+            authority_contributions: Mutex::new(Vec::new()),
         },
         authenticated: AuthenticatedRunnerSession::new(
             fence,
@@ -504,10 +543,11 @@ fn capability_document(capabilities: &RunnerCapabilities) -> RoutingDocument {
         .expect("routing document")
 }
 
-fn windows_claim_request(
+fn claim_request(
     fixture: &Fixture,
     candidate: &RunnableAttempt,
     operation_id: OperationId,
+    authority_contributions: LeaseAuthorityPollContributions,
 ) -> TryClaimAttempt {
     let page = RunnableScanPage::try_new(
         fixture.authenticated.fence(),
@@ -531,8 +571,9 @@ fn windows_claim_request(
         UnixMillis::new(1_500),
         page.claim_advance(candidate.attempt_id())
             .expect("claim cursor"),
+        authority_contributions,
     )
-    .expect("Windows claim")
+    .expect("claim")
 }
 
 fn service(fixture: &Fixture) -> LeasePollService<'_> {
@@ -603,59 +644,45 @@ async fn temporarily_no_eligible_runner_for_admitted_features_remains_no_work() 
 }
 
 #[tokio::test]
-async fn windows_claim_carries_one_use_trust_profile_and_generation_binding() {
-    let fixture = windows_fixture(true);
+async fn claim_carries_exact_provider_neutral_authority_contributions() {
+    let mut fixture = windows_fixture(true);
+    let authority_contributions = test_authority_contributions(0x41);
+    fixture.request = LeaseRequest::first(
+        fixture.request.header(),
+        fixture.request.slot(),
+        authority_contributions.clone(),
+    );
 
     let outcome = service(&fixture)
         .poll(fixture.authenticated, &fixture.request)
         .await
-        .expect("authenticated Windows placement succeeds");
+        .expect("provider-neutral authority contribution is admitted");
 
     let LeasePollOutcome::Claimed(claimed) = outcome else {
-        panic!("authenticated exact-profile Windows work must be claimed");
+        panic!("matching work must be claimed");
     };
-    let grants = fixture
+    assert_eq!(claimed.authority_contributions(), &authority_contributions);
+    let recorded = fixture
         .repository
-        .windows_grants
+        .authority_contributions
         .lock()
-        .expect("Windows grant observations");
-    let grant = grants[0].as_ref().expect("Windows placement grant");
-    assert_eq!(grant.attempt_id(), claimed.lease().attempt_id());
-    assert_eq!(
-        grant.operation_id(),
-        fixture.request.header().operation_id()
-    );
-    assert_eq!(grant.session(), fixture.authenticated.fence());
-    assert_eq!(grant.lease_id(), fixture.lease_id);
-    assert_eq!(grant.expires_at(), UnixMillis::new(1_500));
-    assert_eq!(
-        grant.environment_profile().id().as_str(),
-        "automata.test/windows-2025"
-    );
-    assert_ne!(grant.binding_digest(), Sha256Digest::from_bytes([0; 32]));
+        .expect("authority contribution observations");
+    assert_eq!(recorded.as_slice(), [authority_contributions]);
 }
 
 #[tokio::test]
-async fn windows_candidate_without_authenticated_trust_is_no_work_before_claim() {
+async fn generic_lease_does_not_interpret_provider_specific_windows_trust() {
     let fixture = windows_fixture(false);
 
     let outcome = service(&fixture)
         .poll(fixture.authenticated, &fixture.request)
         .await
-        .expect("missing Windows trust is a fail-closed no-work result");
+        .expect("generic lease service does not own provider admission");
 
-    assert_eq!(outcome, LeasePollOutcome::NoWork { replayed: false });
+    assert!(matches!(outcome, LeasePollOutcome::Claimed(_)));
     assert_eq!(
         fixture.repository.calls(),
-        ["lookup", "routing", "availability", "scan", "no_work"]
-    );
-    assert!(
-        fixture
-            .repository
-            .windows_grants
-            .lock()
-            .expect("Windows grant observations")
-            .is_empty()
+        ["lookup", "routing", "availability", "scan", "claim"]
     );
 }
 
@@ -684,61 +711,37 @@ async fn unavailable_service_container_requirement_never_creates_a_lease() {
 }
 
 #[test]
-fn windows_grant_changes_across_operations_and_trust_snapshots() {
+fn claim_digest_binds_operation_and_exact_authority_contribution_bundle() {
     let fixture = windows_fixture(true);
     let candidate = &fixture.repository.candidates[0];
-    let first = windows_claim_request(&fixture, candidate, OperationId::new());
-    let second = windows_claim_request(&fixture, candidate, OperationId::new());
-    assert_ne!(
-        first
-            .windows_placement_grant()
-            .expect("first Windows grant")
-            .binding_digest(),
-        second
-            .windows_placement_grant()
-            .expect("second Windows grant")
-            .binding_digest()
+    let operation_id = OperationId::new();
+    let first = claim_request(
+        &fixture,
+        candidate,
+        operation_id,
+        test_authority_contributions(0x41),
     );
-
-    let changed_trust = AuthenticatedPlacementTrust::try_new(
-        &trusted_snapshot("actor-2"),
-        JobAuthorityProfile::Standard,
-        candidate.requirements(),
-    )
-    .expect("changed placement trust");
-    let changed_candidate = RunnableAttempt::try_new(
-        candidate.attempt_id(),
-        candidate.job_id(),
-        candidate.run_id(),
-        candidate.queued_at(),
-        candidate.requirements().clone(),
-        candidate.job_ir().clone(),
-        Some(changed_trust),
-    )
-    .expect("changed candidate");
-    let changed = windows_claim_request(&fixture, &changed_candidate, first.operation_id());
-    assert_ne!(
-        first
-            .windows_placement_grant()
-            .expect("first Windows grant")
-            .binding_digest(),
-        changed
-            .windows_placement_grant()
-            .expect("changed Windows grant")
-            .binding_digest()
+    let changed_operation = claim_request(
+        &fixture,
+        candidate,
+        OperationId::new(),
+        test_authority_contributions(0x41),
     );
-    #[cfg(feature = "adapter-spi")]
-    {
-        assert!(
-            automata_ci_control::adapter_spi::try_claim_attempt_matches_runnable(&first, candidate)
-        );
-        assert!(
-            !automata_ci_control::adapter_spi::try_claim_attempt_matches_runnable(
-                &first,
-                &changed_candidate,
-            )
-        );
-    }
+    let changed_contribution = claim_request(
+        &fixture,
+        candidate,
+        operation_id,
+        test_authority_contributions(0x42),
+    );
+    assert_ne!(first.request_digest(), changed_operation.request_digest());
+    assert_ne!(
+        first.request_digest(),
+        changed_contribution.request_digest()
+    );
+    assert_eq!(
+        first.authority_contributions(),
+        &test_authority_contributions(0x41)
+    );
 }
 
 #[test]
@@ -840,7 +843,7 @@ async fn configured_slot_beyond_negotiated_capacity_is_no_work_not_corrupt_state
         JobIrVersion::current(),
     )
     .expect("routing snapshot");
-    fixture.request = LeaseRequest::first(
+    fixture.request = empty_lease_request(
         fixture.request.header(),
         RunnerSlotOrdinal::new(2).expect("second slot"),
     );
@@ -865,7 +868,13 @@ async fn exact_no_work_retry_returns_before_every_scheduling_read() {
         fixture.request.header().operation_id(),
         StableRunnerSlot::new(fixture.request.slot().get()).expect("slot"),
     );
-    fixture.repository.lookup = Some(TryClaimReceipt::new(key, TryClaimOutcome::NoWork, false));
+    let request_digest = key.decision_request_digest(fixture.request.authority_contributions());
+    fixture.repository.lookup = Some(TryClaimReceipt::new(
+        key,
+        request_digest,
+        TryClaimOutcome::NoWork,
+        false,
+    ));
 
     let outcome = service(&fixture)
         .poll(fixture.authenticated, &fixture.request)
@@ -880,7 +889,7 @@ async fn exact_no_work_retry_returns_before_every_scheduling_read() {
 async fn protocol_successor_is_carried_into_the_durable_key_and_digest() {
     let mut fixture = fixture(RunnerSlotAvailability::Available, false);
     let predecessor = OperationId::new();
-    fixture.request = LeaseRequest::successor(
+    fixture.request = successor_lease_request(
         fixture.request.header(),
         fixture.request.slot(),
         predecessor,
@@ -928,10 +937,16 @@ async fn exact_claim_retry_uses_self_contained_receipt_and_never_reschedules() {
         fixture.authenticated.fence(),
         StableRunnerSlot::new(1).expect("slot"),
     );
-    let claimed = ClaimedAttempt::try_new(lease, assignment, fixture.repository.metadata.clone())
-        .expect("claimed attempt");
+    let claimed = ClaimedAttempt::try_new(
+        lease,
+        assignment,
+        fixture.repository.metadata.clone(),
+        fixture.request.authority_contributions().clone(),
+    )
+    .expect("claimed attempt");
     fixture.repository.lookup = Some(TryClaimReceipt::new(
         key,
+        key.decision_request_digest(fixture.request.authority_contributions()),
         TryClaimOutcome::Claimed(Box::new(claimed)),
         false,
     ));
@@ -982,10 +997,12 @@ async fn observer_separates_physical_replay_from_one_new_claim_transition() {
             StableRunnerSlot::new(1).expect("slot"),
         ),
         replay.repository.metadata.clone(),
+        replay.request.authority_contributions().clone(),
     )
     .expect("claimed attempt");
     replay.repository.lookup = Some(TryClaimReceipt::new(
         key,
+        key.decision_request_digest(replay.request.authority_contributions()),
         TryClaimOutcome::Claimed(Box::new(claimed)),
         false,
     ));

--- a/crates/automata-ci-control/tests/runner_control_handler_security.rs
+++ b/crates/automata-ci-control/tests/runner_control_handler_security.rs
@@ -4,6 +4,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
+use async_trait::async_trait;
 use automata_ci_auth::{
     authorization::SecretExposureClass,
     machine::{AuthenticatedMachine, ExternalRunnerIdentity},
@@ -17,17 +18,21 @@ use automata_ci_control::lease::{
     RevokedLeaseOfferFallback,
 };
 use automata_ci_control::runner_control::durable::{
-    LeaseResponseAction, PublishedLeaseOffer, RunnerControlValueError,
+    CommitRuntimeAuthorityDelivery, LeaseResponseAction, PublishedLeaseOffer,
+    RunnerControlValueError, RuntimeAuthorityDeliveryDisposition,
 };
 use automata_ci_control::runner_control::{
     AuthorizeRuntimeAuthorityDelivery, AuthorizedRunnerRegistration, ControlPortError,
-    DesiredRunnerState, DurableRunnerControlHandler, LeaseOfferClaimStatus, LeaseOfferObservation,
-    LeaseOfferPublishOutcome, LeaseOfferReplayResolution, PublishedCommand, RunnerControlConfig,
-    RunnerControlFailure, RunnerControlMessageKind, RunnerControlMessageOutcome,
-    RunnerControlObserver, RunnerControlPorts, RunnerDurabilityPorts, RunnerDurableDisposition,
-    RunnerDurableMessageKind, RunnerHandshakeOutcome, RunnerHandshakeRejection,
-    RunnerIdentityPorts, RunnerLeasePorts, RunnerLeaseRequestStage,
-    RuntimeAuthorityDeliveryAdmission, repository::RunnerCommandOutbox as _,
+    DesiredRunnerState, DurableRunnerControlHandler, LeaseAuthorityEvidence,
+    LeaseAuthorityEvidenceSet, LeaseAuthorityExtension, LeaseAuthorityExtensionRegistry,
+    LeaseAuthorityOfferRequest, LeaseAuthorityPollAcceptance, LeaseOfferClaimStatus,
+    LeaseOfferObservation, LeaseOfferPublishOutcome, LeaseOfferReplayResolution,
+    PreparedSandboxAuthorization, PublishedCommand, RunnerControlConfig, RunnerControlFailure,
+    RunnerControlMessageKind, RunnerControlMessageOutcome, RunnerControlObserver,
+    RunnerControlPorts, RunnerDurabilityPorts, RunnerDurableDisposition, RunnerDurableMessageKind,
+    RunnerHandshakeOutcome, RunnerHandshakeRejection, RunnerIdentityPorts, RunnerLeasePorts,
+    RunnerLeaseRequestStage, RuntimeAuthorityDeliveryAdmission,
+    repository::RunnerCommandOutbox as _,
 };
 use automata_ci_core::{
     Architecture, AttemptId, FencingToken, JobAuthorityProfile, JobConclusion, JobId,
@@ -35,21 +40,26 @@ use automata_ci_core::{
     JobPermissionRequest, JobResult, JobSecretExposure, JobSource, Lease, LeaseGuard, LeaseId,
     LogFrame, LogSequence, LogStreamId, OperatingSystem, OperationId, RunId, RunValueTemplates,
     RunnerCapabilities, RunnerGroup, RunnerId, RunnerLabel, RunnerPlatform, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, SecretBinding, SemanticStep, Sha256Digest, ShellTemplate,
-    StepId, StepIr, UnixMillis, ValueTemplate, WorkflowId,
+    RunnerSessionId, RuntimeBoolean, SandboxAuthorization, SandboxAuthorizationName,
+    SandboxAuthorizations, SecretBinding, SemanticStep, Sha256Digest, ShellTemplate, StepId,
+    StepIr, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandSequence, HandshakeErrorCode,
     INITIAL_RUNTIME_AUTHORITY_GENERATION, JobRuntimeAuthorities, JobRuntimeAuthority,
-    JobStateUpdate, LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeaseRejectionReason,
-    LeaseRequest, LeaseResponse, LogBatch, ManagedSecretBindingOverlay, MessageHeader, NoWork,
+    JobStateUpdate, LeaseAuthorityName, LeaseAuthorityPollContribution,
+    LeaseAuthorityPollContributions, LeaseDisposition, LeaseHeartbeat, LeaseOffer,
+    LeasePollOutcome as ProtocolLeasePollOutcome, LeasePollResponse, LeaseRejectionReason,
+    LeaseRequest, LeaseResponse, LogBatch, ManagedSecretBindingOverlay, MessageHeader,
     ProtocolLimits, ProtocolRange, ProtocolVersion, RemoteErrorCode, RunnerHello,
     RunnerSlotOrdinal, RunnerToServer, RuntimeAuthorityAck, RuntimeAuthorityCredential,
     RuntimeAuthorityDeliveryBinding, RuntimeAuthorityEndpoint, RuntimeAuthorityGeneration,
     RuntimeAuthorityName, RuntimeAuthorityRequest, SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader,
     ServerToRunner, SessionDisposition, SessionResume, ValidatedRunnerToServer,
 };
-use automata_ci_protocol_protobuf::{encode_job_ir, encode_runner_frame, encode_server_frame};
+use automata_ci_protocol_protobuf::{
+    encode_job_ir, encode_runner_frame, encode_runtime_authorities, encode_server_frame,
+};
 use automata_ci_runner_transport::ApplicationErrorKind;
 use automata_ci_store::{
     CommandCursor as StoreCommandCursor, CommandReplayDisposition,
@@ -67,6 +77,96 @@ use super::runner_control_support::{
     Receipts, Resolver, Sessions, Transactions,
 };
 
+fn empty_lease_request(header: MessageHeader, slot: RunnerSlotOrdinal) -> LeaseRequest {
+    LeaseRequest::first(header, slot, LeaseAuthorityPollContributions::empty())
+}
+
+fn successor_lease_request(
+    header: MessageHeader,
+    slot: RunnerSlotOrdinal,
+    predecessor: OperationId,
+) -> LeaseRequest {
+    LeaseRequest::successor(
+        header,
+        slot,
+        predecessor,
+        LeaseAuthorityPollContributions::empty(),
+    )
+}
+
+#[derive(Clone, Copy)]
+struct TestNoWork {
+    header: MessageHeader,
+    retry_after_millis: u32,
+}
+
+impl TestNoWork {
+    const fn header(self) -> MessageHeader {
+        self.header
+    }
+
+    const fn retry_after_millis(self) -> u32 {
+        self.retry_after_millis
+    }
+}
+
+fn no_work_view(response: &ServerToRunner) -> TestNoWork {
+    let ServerToRunner::LeasePollResponse(response) = response else {
+        panic!("expected a lease-poll response")
+    };
+    let ProtocolLeasePollOutcome::NoWork { retry_after_millis } = response.outcome() else {
+        panic!("expected a no-work lease-poll outcome")
+    };
+    TestNoWork {
+        header: response.header(),
+        retry_after_millis: *retry_after_millis,
+    }
+}
+
+fn is_no_work(response: &ServerToRunner) -> bool {
+    matches!(
+        response,
+        ServerToRunner::LeasePollResponse(response)
+            if matches!(response.outcome(), ProtocolLeasePollOutcome::NoWork { .. })
+    )
+}
+
+fn lease_offer_view(response: &ServerToRunner) -> &LeaseOffer {
+    let ServerToRunner::LeasePollResponse(response) = response else {
+        panic!("expected a lease-poll response")
+    };
+    let ProtocolLeasePollOutcome::LeaseOffer(offer) = response.outcome() else {
+        panic!("expected a lease-offer outcome")
+    };
+    offer
+}
+
+fn is_lease_offer(response: &ServerToRunner) -> bool {
+    matches!(
+        response,
+        ServerToRunner::LeasePollResponse(response)
+            if matches!(response.outcome(), ProtocolLeasePollOutcome::LeaseOffer(_))
+    )
+}
+
+fn cancel_view(response: &ServerToRunner) -> &automata_ci_protocol::CancelJob {
+    let ServerToRunner::LeasePollResponse(response) = response else {
+        panic!("expected a lease-poll response")
+    };
+    let ProtocolLeasePollOutcome::CancelJob(cancel) = response.outcome() else {
+        panic!("expected a cancel outcome")
+    };
+    cancel
+}
+
+fn is_cancel(response: &ServerToRunner) -> bool {
+    matches!(
+        response,
+        ServerToRunner::LeasePollResponse(response)
+            if matches!(response.outcome(), ProtocolLeasePollOutcome::CancelJob(_))
+    )
+}
+
 struct Harness {
     handler: DurableRunnerControlHandler,
     observer: Arc<RecordingRunnerControlObserver>,
@@ -81,6 +181,110 @@ struct Harness {
     transactions: Arc<Transactions>,
     receipts: Arc<Receipts>,
     commands: Arc<Commands>,
+}
+
+#[derive(Debug)]
+struct TestLeaseAuthorityExtension {
+    name: LeaseAuthorityName,
+    evidence: LeaseAuthorityEvidence,
+    authorization: SandboxAuthorization,
+    accepted: AtomicUsize,
+    offers: AtomicUsize,
+    prepared: AtomicUsize,
+    committed: Arc<AtomicUsize>,
+    committed_digest: Arc<Mutex<Option<Sha256Digest>>>,
+}
+
+impl TestLeaseAuthorityExtension {
+    fn new() -> Self {
+        let name = LeaseAuthorityName::new("test-sandbox").expect("authority name");
+        let evidence =
+            LeaseAuthorityEvidence::new(name.clone(), 1, vec![0x31; 32]).expect("evidence");
+        let authorization = SandboxAuthorization::new(
+            SandboxAuthorizationName::new("test-sandbox").expect("authorization name"),
+            1,
+            vec![0x42; 32],
+        )
+        .expect("authorization");
+        Self {
+            name,
+            evidence,
+            authorization,
+            accepted: AtomicUsize::new(0),
+            offers: AtomicUsize::new(0),
+            prepared: AtomicUsize::new(0),
+            committed: Arc::new(AtomicUsize::new(0)),
+            committed_digest: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl LeaseAuthorityExtension for TestLeaseAuthorityExtension {
+    fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    async fn accept_poll_contribution(
+        &self,
+        _context: LeaseAuthorityPollAcceptance,
+        contribution: &LeaseAuthorityPollContribution,
+    ) -> Result<(), ControlPortError> {
+        if contribution.name() != &self.name {
+            return Err(ControlPortError::Conflict);
+        }
+        self.accepted.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn prepare_offer_evidence(
+        &self,
+        _request: LeaseAuthorityOfferRequest<'_>,
+    ) -> Result<Option<LeaseAuthorityEvidence>, ControlPortError> {
+        self.offers.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(self.evidence.clone()))
+    }
+
+    async fn prepare_sandbox_authorization(
+        &self,
+        evidence: &LeaseAuthorityEvidence,
+        _job: &JobIrEnvelope,
+        _admission: &RuntimeAuthorityDeliveryAdmission,
+    ) -> Result<Box<dyn PreparedSandboxAuthorization>, ControlPortError> {
+        if evidence != &self.evidence {
+            return Err(ControlPortError::Corrupt);
+        }
+        self.prepared.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::new(TestPreparedSandboxAuthorization {
+            authorization: self.authorization.clone(),
+            committed: Arc::clone(&self.committed),
+            committed_digest: Arc::clone(&self.committed_digest),
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct TestPreparedSandboxAuthorization {
+    authorization: SandboxAuthorization,
+    committed: Arc<AtomicUsize>,
+    committed_digest: Arc<Mutex<Option<Sha256Digest>>>,
+}
+
+#[async_trait]
+impl PreparedSandboxAuthorization for TestPreparedSandboxAuthorization {
+    fn authorization(&self) -> &SandboxAuthorization {
+        &self.authorization
+    }
+
+    async fn commit(
+        self: Box<Self>,
+        delivery: CommitRuntimeAuthorityDelivery,
+    ) -> Result<RuntimeAuthorityDeliveryDisposition, ControlPortError> {
+        self.committed.fetch_add(1, Ordering::SeqCst);
+        *self.committed_digest.lock().expect("committed digest lock") =
+            Some(delivery.bundle_digest());
+        Ok(RuntimeAuthorityDeliveryDisposition::Committed)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -489,7 +693,7 @@ fn claimed_credential_free_job() -> JobIrEnvelope {
 
 fn claimed_runtime_authorities(job: &JobIrEnvelope, lease: &Lease) -> JobRuntimeAuthorities {
     if job.job().authority_profile() == JobAuthorityProfile::CredentialFree {
-        return JobRuntimeAuthorities::new(Vec::new(), job, lease)
+        return JobRuntimeAuthorities::new(Vec::new(), SandboxAuthorizations::empty(), job, lease)
             .expect("credential-free runtime authorities");
     }
     let authority = JobRuntimeAuthority::new(
@@ -504,7 +708,8 @@ fn claimed_runtime_authorities(job: &JobIrEnvelope, lease: &Lease) -> JobRuntime
         UnixMillis::new(9_000),
     )
     .expect("runtime authority");
-    JobRuntimeAuthorities::new(vec![authority], job, lease).expect("runtime authorities")
+    JobRuntimeAuthorities::new(vec![authority], SandboxAuthorizations::empty(), job, lease)
+        .expect("runtime authorities")
 }
 
 fn test_offer_command(
@@ -535,12 +740,71 @@ fn test_offer_command_with_bindings(
     lease: &Lease,
     managed_secret_bindings: &ManagedSecretBindingOverlay,
 ) -> DurableRunnerCommand {
+    test_offer_command_with_projection(
+        fence,
+        operation_id,
+        sequence,
+        slot,
+        job,
+        lease,
+        managed_secret_bindings,
+        &LeaseAuthorityEvidenceSet::empty(),
+    )
+}
+
+fn handler_with_extensions(
+    harness: &Harness,
+    extensions: LeaseAuthorityExtensionRegistry,
+) -> DurableRunnerControlHandler {
+    let ports = RunnerControlPorts::new(
+        RunnerIdentityPorts::new(
+            harness.authorizer.clone(),
+            harness.resolver.clone(),
+            harness.sessions.clone(),
+        ),
+        RunnerLeasePorts::new(
+            harness.poller.clone(),
+            harness.objects.clone(),
+            harness.publisher.clone(),
+        ),
+        RunnerDurabilityPorts::new(
+            harness.ingress_objects.clone(),
+            harness.transactions.clone(),
+            harness.receipts.clone(),
+            harness.receipts.clone(),
+            harness.commands.clone(),
+            harness.transactions.clone(),
+        ),
+        Arc::new(Clock(UnixMillis::new(2_000))),
+        Arc::new(Ids),
+    )
+    .with_runtime_authority_issuer(harness.authority_issuer.clone())
+    .with_lease_authority_extensions(extensions);
+    DurableRunnerControlHandler::new(
+        ports,
+        RunnerControlConfig::new(15_000, 60_000, 1_750, ProtocolLimits::default())
+            .expect("test policy"),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn test_offer_command_with_projection(
+    fence: RunnerSessionFence,
+    operation_id: OperationId,
+    sequence: CommandSequence,
+    slot: RunnerSlotOrdinal,
+    job: &JobIrEnvelope,
+    lease: &Lease,
+    managed_secret_bindings: &ManagedSecretBindingOverlay,
+    lease_authority_evidence: &LeaseAuthorityEvidenceSet,
+) -> DurableRunnerCommand {
     let payload = serde_json::to_vec(&serde_json::json!({
         "job": job,
         "lease": lease,
         "managed_secret_bindings": managed_secret_bindings,
+        "lease_authority_evidence": lease_authority_evidence,
         "protocol_version": SUPPORTED_PROTOCOL_RANGE.max().get(),
-        "schema": 2,
+        "schema": 3,
         "slot": slot.get(),
     }))
     .expect("offer payload");
@@ -548,8 +812,8 @@ fn test_offer_command_with_bindings(
         EnqueueRunnerCommand::new(
             fence,
             operation_id,
-            RunnerOperationKind::new("automata.runner.lease-offer.v2").expect("offer kind"),
-            RunnerCommandPayload::new(DocumentSchema::new(2).expect("schema"), payload)
+            RunnerOperationKind::new("automata.runner.lease-offer.v3").expect("offer kind"),
+            RunnerCommandPayload::new(DocumentSchema::new(3).expect("schema"), payload)
                 .expect("offer payload"),
             UnixMillis::new(2_000),
         ),
@@ -560,6 +824,7 @@ fn test_offer_command_with_bindings(
 
 fn test_offer_response(
     fence: RunnerSessionFence,
+    request_operation_id: OperationId,
     operation_id: OperationId,
     sequence: CommandSequence,
     slot: RunnerSlotOrdinal,
@@ -580,7 +845,16 @@ fn test_offer_response(
     )
     .with_managed_secret_bindings(empty_overlay)
     .expect("canonical managed-secret overlay");
-    ServerToRunner::LeaseOffer(Box::new(offer))
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::lease_offer(
+        MessageHeader::reply(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            fence.session_id(),
+            operation_id,
+            request_operation_id,
+        ),
+        LeaseAuthorityPollContributions::empty().sha256_digest(),
+        offer,
+    )))
 }
 
 struct RuntimeAuthorityExchangeFixture {
@@ -595,6 +869,22 @@ fn install_runtime_authority_exchange(
     fence: RunnerSessionFence,
     runner_id: RunnerId,
     job: JobIrEnvelope,
+) -> RuntimeAuthorityExchangeFixture {
+    install_runtime_authority_exchange_with_evidence(
+        harness,
+        fence,
+        runner_id,
+        job,
+        &LeaseAuthorityEvidenceSet::empty(),
+    )
+}
+
+fn install_runtime_authority_exchange_with_evidence(
+    harness: &Harness,
+    fence: RunnerSessionFence,
+    runner_id: RunnerId,
+    job: JobIrEnvelope,
+    lease_authority_evidence: &LeaseAuthorityEvidenceSet,
 ) -> RuntimeAuthorityExchangeFixture {
     let encoded = encode_job_ir(&job, &ProtocolLimits::default()).expect("JobIR");
     let metadata = JobIrMetadata::new(
@@ -618,13 +908,15 @@ fn install_runtime_authority_exchange(
     let slot = RunnerSlotOrdinal::new(1).expect("slot");
     let offer_operation_id = OperationId::new();
     let offer_sequence = CommandSequence::new(1).expect("sequence");
-    let command = test_offer_command(
+    let command = test_offer_command_with_projection(
         fence,
         offer_operation_id,
         offer_sequence,
         slot,
         &job,
         &lease,
+        &ManagedSecretBindingOverlay::empty(&lease),
+        lease_authority_evidence,
     );
     let offer_request = RunnerOperationRequest::new(
         fence,
@@ -1018,14 +1310,17 @@ fn revoked_test_completion(
     let response_operation_id: OperationId = encoded_operation_id[..32]
         .parse()
         .expect("digest prefix operation ID");
-    let durable = durable_test_response(&ServerToRunner::NoWork(NoWork::new(
-        MessageHeader::reply(
-            request.protocol_version(),
-            request.session_id(),
-            response_operation_id,
-            request.operation_id(),
+    let durable = durable_test_response(&ServerToRunner::LeasePollResponse(Box::new(
+        LeasePollResponse::no_work(
+            MessageHeader::reply(
+                request.protocol_version(),
+                request.session_id(),
+                response_operation_id,
+                request.operation_id(),
+            ),
+            LeaseAuthorityPollContributions::empty().sha256_digest(),
+            retry_after_millis,
         ),
-        retry_after_millis,
     )));
     let fallback = RevokedLeaseOfferFallback::new(
         response_operation_id,
@@ -1104,7 +1399,7 @@ async fn observer_records_only_reachable_handshake_and_transport_message_outcome
     );
 
     let (transport, identity, _runner_id, _generation) = harness(DesiredRunnerState::Active);
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             RunnerSessionId::new(),
@@ -1191,6 +1486,7 @@ async fn retryable_claim_offer_failures_leave_the_current_poll_head_incomplete()
                 lease.clone(),
                 slot,
                 metadata.clone(),
+                LeaseAuthorityPollContributions::empty(),
                 false,
             )));
         *harness.objects.bytes.lock().expect("object bytes lock") = Some(encoded);
@@ -1215,7 +1511,7 @@ async fn retryable_claim_offer_failures_leave_the_current_poll_head_incomplete()
                 .expect("publication result lock") = Some(Err(ControlPortError::Unavailable));
         }
 
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -1342,7 +1638,7 @@ async fn durable_offer_replays_decode_their_exact_secret_overlay_shape() {
             .push(command.clone());
         *harness.publisher.replay.lock().expect("offer replay lock") =
             Some(Ok(LeaseOfferReplayResolution::Published(command)));
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -1351,10 +1647,8 @@ async fn durable_offer_replays_decode_their_exact_secret_overlay_shape() {
             slot,
         ));
 
-        let ServerToRunner::LeaseOffer(replayed) = exchange(&harness, &identity, &request).await
-        else {
-            panic!("canonical durable lease offer");
-        };
+        let response = exchange(&harness, &identity, &request).await;
+        let replayed = lease_offer_view(&response);
         if include_binding {
             assert_eq!(replayed.managed_secret_bindings(), Some(&overlay));
         } else {
@@ -1419,7 +1713,7 @@ async fn pending_offer_replay_requires_two_way_publication_provenance() {
                 .expect("commands lock")
                 .push(pending);
         }
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -1481,7 +1775,7 @@ async fn exact_pending_offer_provenance_completes_without_rebuilding_work() {
         .push(command.clone());
     *harness.publisher.replay.lock().expect("offer replay lock") =
         Some(Ok(LeaseOfferReplayResolution::Published(command)));
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1490,9 +1784,8 @@ async fn exact_pending_offer_provenance_completes_without_rebuilding_work() {
         slot,
     ));
 
-    assert!(matches!(
-        exchange(&harness, &identity, &request).await,
-        ServerToRunner::LeaseOffer(_)
+    assert!(is_lease_offer(
+        &exchange(&harness, &identity, &request).await
     ));
     assert_eq!(harness.publisher.replays.load(Ordering::SeqCst), 2);
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 0);
@@ -1537,9 +1830,14 @@ async fn post_publication_offer_revocation_commits_no_work_before_admitting_succ
         UnixMillis::new(10_000),
     )
     .expect("lease");
-    *harness.poller.outcome.lock().expect("poll outcome lock") = Some(LeasePollOutcome::Claimed(
-        ClaimedLeasePoll::new(lease.clone(), slot, metadata, false),
-    ));
+    *harness.poller.outcome.lock().expect("poll outcome lock") =
+        Some(LeasePollOutcome::Claimed(ClaimedLeasePoll::new(
+            lease.clone(),
+            slot,
+            metadata,
+            LeaseAuthorityPollContributions::empty(),
+            false,
+        )));
     *harness.objects.bytes.lock().expect("object bytes lock") = Some(encoded);
     *harness
         .authority_issuer
@@ -1577,7 +1875,7 @@ async fn post_publication_offer_revocation_commits_no_work_before_admitting_succ
         .revoke_lease_completion
         .store(true, Ordering::SeqCst);
     let request_operation_id = OperationId::new();
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1587,9 +1885,7 @@ async fn post_publication_offer_revocation_commits_no_work_before_admitting_succ
     ));
 
     let first = exchange(&harness, &identity, &request).await;
-    let ServerToRunner::NoWork(no_work) = &first else {
-        panic!("receipt-completion revocation must return no work")
-    };
+    let no_work = no_work_view(&first);
     assert_eq!(no_work.header().in_reply_to(), Some(request_operation_id));
     assert_eq!(exchange(&harness, &identity, &request).await, first);
     assert_eq!(harness.publisher.replays.load(Ordering::SeqCst), 1);
@@ -1626,7 +1922,7 @@ async fn post_publication_offer_revocation_commits_no_work_before_admitting_succ
     *harness.poller.outcome.lock().expect("poll outcome lock") =
         Some(LeasePollOutcome::NoWork { replayed: false });
     let successor_operation_id = OperationId::new();
-    let successor = RunnerToServer::LeaseRequest(LeaseRequest::successor(
+    let successor = RunnerToServer::LeaseRequest(successor_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1637,7 +1933,7 @@ async fn post_publication_offer_revocation_commits_no_work_before_admitting_succ
     ));
     assert!(matches!(
         exchange(&harness, &identity, &successor).await,
-        ServerToRunner::NoWork(_)
+        response if is_no_work(&response)
     ));
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 2);
     assert_eq!(harness.receipts.lease_completions.load(Ordering::SeqCst), 2);
@@ -1698,7 +1994,7 @@ async fn revoked_pending_offer_requires_a_retry_before_later_work_or_polling() {
                 resolutions.push_back(Ok(LeaseOfferReplayResolution::NotPublished));
             }
         }
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -1732,14 +2028,8 @@ async fn revoked_pending_offer_requires_a_retry_before_later_work_or_polling() {
             .expect("commands lock")
             .retain(|command| command.sequence().get() != 1);
         let response = exchange(&harness, &identity, &request).await;
-        assert_eq!(
-            matches!(&response, ServerToRunner::CancelJob(_)),
-            has_later_command
-        );
-        assert_eq!(
-            matches!(&response, ServerToRunner::NoWork(_)),
-            !has_later_command
-        );
+        assert_eq!(is_cancel(&response), has_later_command);
+        assert_eq!(is_no_work(&response), !has_later_command);
         assert_eq!(
             harness.poller.calls.load(Ordering::SeqCst),
             usize::from(!has_later_command)
@@ -1762,7 +2052,7 @@ async fn saturated_replay_page_is_retryable_without_polling_or_completing() {
         .lock()
         .expect("command replay disposition lock")
         .push_back(CommandReplayDisposition::Saturated);
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1790,9 +2080,7 @@ async fn saturated_replay_page_is_retryable_without_polling_or_completing() {
 
     let (_, _, later_sequence) = install_cancel_command(&harness, fence).await;
     let response = exchange(&harness, &identity, &request).await;
-    let ServerToRunner::CancelJob(cancel) = response else {
-        panic!("the retry must reach the later durable command")
-    };
+    let cancel = cancel_view(&response);
     assert_eq!(cancel.header().sequence(), later_sequence);
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.receipts.lease_completions.load(Ordering::SeqCst), 1);
@@ -1811,7 +2099,7 @@ async fn post_poll_saturation_does_not_complete_the_lease_request() {
             CommandReplayDisposition::Exhausted,
             CommandReplayDisposition::Saturated,
         ]);
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1876,7 +2164,7 @@ async fn resolver_revocation_never_scans_a_second_command_in_the_same_exchange()
     }
     let (_, _, later_sequence) = install_cancel_command(&harness, fence).await;
     assert_eq!(later_sequence.get(), 2);
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1900,9 +2188,7 @@ async fn resolver_revocation_never_scans_a_second_command_in_the_same_exchange()
         .expect("commands lock")
         .retain(|command| command.sequence().get() == later_sequence.get());
     let response = exchange(&harness, &identity, &request).await;
-    let ServerToRunner::CancelJob(cancel) = response else {
-        panic!("the retry must reach the later durable command")
-    };
+    let cancel = cancel_view(&response);
     assert_eq!(cancel.header().sequence(), later_sequence);
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 0);
     assert_eq!(harness.receipts.lease_completions.load(Ordering::SeqCst), 1);
@@ -1935,9 +2221,14 @@ async fn credential_free_offer_bypasses_every_runtime_authority_issuer() {
     )
     .expect("lease");
     let slot = RunnerSlotOrdinal::new(1).expect("slot");
-    *harness.poller.outcome.lock().expect("poll outcome lock") = Some(LeasePollOutcome::Claimed(
-        ClaimedLeasePoll::new(lease.clone(), slot, metadata, false),
-    ));
+    *harness.poller.outcome.lock().expect("poll outcome lock") =
+        Some(LeasePollOutcome::Claimed(ClaimedLeasePoll::new(
+            lease.clone(),
+            slot,
+            metadata,
+            LeaseAuthorityPollContributions::empty(),
+            false,
+        )));
     *harness.objects.bytes.lock().expect("object bytes lock") = Some(encoded);
     *harness
         .publisher
@@ -1965,7 +2256,7 @@ async fn credential_free_offer_bypasses_every_runtime_authority_issuer() {
             &empty_overlay,
         )),
     ));
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -1986,9 +2277,7 @@ async fn credential_free_offer_bypasses_every_runtime_authority_issuer() {
                 harness.publisher.publications.load(Ordering::SeqCst),
             )
         });
-    let ServerToRunner::LeaseOffer(offer) = response else {
-        panic!("credential-free poll must return an offer")
-    };
+    let offer = lease_offer_view(&response);
     assert_eq!(
         offer.job().job().authority_profile(),
         JobAuthorityProfile::CredentialFree
@@ -2052,9 +2341,14 @@ async fn observer_distinguishes_published_replayed_and_superseded_lease_offers()
         )
         .expect("lease");
         let slot = RunnerSlotOrdinal::new(1).expect("slot");
-        *harness.poller.outcome.lock().expect("poll outcome lock") = Some(
-            LeasePollOutcome::Claimed(ClaimedLeasePoll::new(lease.clone(), slot, metadata, false)),
-        );
+        *harness.poller.outcome.lock().expect("poll outcome lock") =
+            Some(LeasePollOutcome::Claimed(ClaimedLeasePoll::new(
+                lease.clone(),
+                slot,
+                metadata,
+                LeaseAuthorityPollContributions::empty(),
+                false,
+            )));
         *harness.objects.bytes.lock().expect("object bytes lock") = Some(encoded);
         *harness
             .authority_issuer
@@ -2112,7 +2406,7 @@ async fn observer_distinguishes_published_replayed_and_superseded_lease_offers()
             }
         }
 
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -2122,7 +2416,7 @@ async fn observer_distinguishes_published_replayed_and_superseded_lease_offers()
         ));
         let response = exchange(&harness, &identity, &request).await;
         assert_eq!(
-            matches!(response, ServerToRunner::LeaseOffer(_)),
+            is_lease_offer(&response),
             !matches!(scenario, ObservedOfferScenario::Superseded)
         );
         assert_eq!(
@@ -2147,7 +2441,7 @@ async fn persisted_offer_fallback_survives_retry_policy_restart_on_both_replay_p
         let fence = install_session(&harness, runner_id, generation);
         let slot = RunnerSlotOrdinal::new(1).expect("slot");
         let request_operation_id = OperationId::new();
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -2184,12 +2478,10 @@ async fn persisted_offer_fallback_survives_retry_policy_restart_on_both_replay_p
         let first_handler = handler_with_retry(&harness, 1_750);
         let first = exchange_with_handler(&first_handler, &identity, &request).await;
         if revoke_at_completion {
-            let ServerToRunner::NoWork(no_work) = &first else {
-                panic!("revoked completion must return its persisted no-work fallback")
-            };
+            let no_work = no_work_view(&first);
             assert_eq!(no_work.retry_after_millis(), 1_750);
         } else {
-            assert!(matches!(first, ServerToRunner::LeaseOffer(_)));
+            assert!(is_lease_offer(&first));
             *harness.publisher.replay.lock().expect("offer replay lock") =
                 Some(Ok(LeaseOfferReplayResolution::Revoked));
         }
@@ -2207,9 +2499,7 @@ async fn persisted_offer_fallback_survives_retry_policy_restart_on_both_replay_p
 
         let restarted_handler = handler_with_retry(&harness, 9_250);
         let replay = exchange_with_handler(&restarted_handler, &identity, &request).await;
-        let ServerToRunner::NoWork(no_work) = &replay else {
-            panic!("revoked offer replay must return persisted no work")
-        };
+        let no_work = no_work_view(&replay);
         assert_eq!(no_work.retry_after_millis(), 1_750);
         assert_eq!(
             no_work.header().operation_id(),
@@ -2233,7 +2523,7 @@ async fn revoked_completed_and_race_winner_offers_replay_as_no_work() {
         let fence = install_session(&harness, runner_id, generation);
         let slot = RunnerSlotOrdinal::new(1).expect("slot");
         let request_operation_id = OperationId::new();
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -2287,9 +2577,7 @@ async fn revoked_completed_and_race_winner_offers_replay_as_no_work() {
             });
         let second = exchange(&harness, &identity, &request).await;
         assert_eq!(first, second);
-        let ServerToRunner::NoWork(no_work) = first else {
-            panic!("a revoked durable offer must replay as no work")
-        };
+        let no_work = no_work_view(&first);
         assert_ne!(no_work.header().operation_id(), offer_operation_id);
         assert_eq!(no_work.header().in_reply_to(), Some(request_operation_id));
         assert_eq!(harness.publisher.replays.load(Ordering::SeqCst), 0);
@@ -2318,7 +2606,7 @@ async fn exact_completed_and_race_winner_offer_provenance_replays() {
         let fence = install_session(&harness, runner_id, generation);
         let slot = RunnerSlotOrdinal::new(1).expect("slot");
         let request_operation_id = OperationId::new();
-        let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        let request = RunnerToServer::LeaseRequest(empty_lease_request(
             MessageHeader::request(
                 SUPPORTED_PROTOCOL_RANGE.max(),
                 fence.session_id(),
@@ -2351,6 +2639,7 @@ async fn exact_completed_and_race_winner_offer_provenance_replays() {
         let command = test_offer_command(fence, server_operation_id, sequence, slot, &job, &lease);
         let response = durable_test_response(&test_offer_response(
             fence,
+            request_operation_id,
             server_operation_id,
             sequence,
             slot,
@@ -2375,9 +2664,8 @@ async fn exact_completed_and_race_winner_offer_provenance_replays() {
                 .expect("completion winner lock") = Some(completion);
         }
 
-        assert!(matches!(
-            exchange(&harness, &identity, &request).await,
-            ServerToRunner::LeaseOffer(_)
+        assert!(is_lease_offer(
+            &exchange(&harness, &identity, &request).await
         ));
         assert_eq!(harness.publisher.replays.load(Ordering::SeqCst), 1);
         assert_eq!(
@@ -2599,7 +2887,7 @@ async fn resumed_sync_replays_cancel_exactly_before_poll_until_cumulative_ack() 
     ));
 
     let poll_operation = OperationId::new();
-    let poll = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let poll = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -2610,13 +2898,10 @@ async fn resumed_sync_replays_cancel_exactly_before_poll_until_cumulative_ack() 
     let first = exchange(&harness, &identity, &poll).await;
     let replay = exchange(&harness, &identity, &poll).await;
     assert_eq!(first, replay);
-    assert!(matches!(
-        first,
-        ServerToRunner::CancelJob(ref cancel)
-            if cancel.attempt_id() == attempt_id
-                && cancel.guard() == guard
-                && cancel.header().sequence() == sequence
-    ));
+    let cancel = cancel_view(&first);
+    assert_eq!(cancel.attempt_id(), attempt_id);
+    assert_eq!(cancel.guard(), guard);
+    assert_eq!(cancel.header().sequence(), sequence);
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 0);
 
     let acknowledgement = RunnerToServer::CommandAck(CommandAck::new(
@@ -2637,7 +2922,7 @@ async fn resumed_sync_replays_cancel_exactly_before_poll_until_cumulative_ack() 
     );
     record_test_command_cursor(&harness, sequence);
 
-    let successor = RunnerToServer::LeaseRequest(LeaseRequest::successor(
+    let successor = RunnerToServer::LeaseRequest(successor_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -2648,7 +2933,7 @@ async fn resumed_sync_replays_cancel_exactly_before_poll_until_cumulative_ack() 
     ));
     assert!(matches!(
         exchange(&harness, &identity, &successor).await,
-        ServerToRunner::NoWork(_)
+        response if is_no_work(&response)
     ));
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 1);
 }
@@ -3227,7 +3512,7 @@ async fn cancellation_short_circuits_before_authorization_or_mutation() {
 async fn every_sync_rejects_a_different_authenticated_machine() {
     let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
     let fence = install_session(&harness, runner_id, generation);
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3256,7 +3541,7 @@ async fn every_sync_rejects_a_different_authenticated_machine() {
 async fn sync_fences_cross_session_and_cross_protocol_claims() {
     let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
     let fence = install_session(&harness, runner_id, generation);
-    let cross_session = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let cross_session = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             RunnerSessionId::new(),
@@ -3282,7 +3567,7 @@ async fn sync_fences_cross_session_and_cross_protocol_claims() {
     );
 
     *harness.sessions.snapshot.lock().expect("session lock") = Some(snapshot(fence, 1));
-    let cross_protocol = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let cross_protocol = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3327,7 +3612,7 @@ async fn closed_or_disabled_session_cannot_refresh_liveness_through_a_lease_poll
         )
         .expect("closed snapshot"),
     );
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3353,7 +3638,7 @@ async fn closed_or_disabled_session_cannot_refresh_liveness_through_a_lease_poll
 
     let (disabled, identity, runner_id, generation) = harness(DesiredRunnerState::Disabled);
     let fence = install_session(&disabled, runner_id, generation);
-    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let request = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3387,7 +3672,7 @@ async fn transport_sync_correlates_only_an_authenticated_stale_session() {
         RunnerSessionId::new(),
         OperationId::new(),
     );
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         request_header,
         RunnerSlotOrdinal::new(1).expect("slot"),
     ));
@@ -3445,7 +3730,7 @@ async fn transport_sync_correlates_only_an_authenticated_stale_session() {
 
     let (conflict, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
     let fence = install_session(&conflict, runner_id, generation);
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3494,7 +3779,7 @@ async fn transport_sync_correlates_only_an_authenticated_stale_session() {
 async fn lease_poll_no_work_is_correlated_receipted_and_replayed() {
     let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
     let fence = install_session(&harness, runner_id, generation);
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3526,7 +3811,14 @@ async fn lease_poll_no_work_is_correlated_receipted_and_replayed() {
         .await
         .expect("replayed no work");
     assert_eq!(first, second);
-    assert!(matches!(first, ServerToRunner::NoWork(_)));
+    assert!(is_no_work(&first));
+    let ServerToRunner::LeasePollResponse(poll) = &first else {
+        panic!("no-work must use the explicit lease-poll wrapper")
+    };
+    assert_eq!(
+        poll.accepted_contributions_sha256(),
+        LeaseAuthorityPollContributions::empty().sha256_digest()
+    );
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 1);
     assert_eq!(harness.receipts.lease_completions.load(Ordering::SeqCst), 1);
     assert_eq!(harness.sessions.heartbeats.load(Ordering::SeqCst), 2);
@@ -3561,12 +3853,154 @@ async fn lease_poll_no_work_is_correlated_receipted_and_replayed() {
 }
 
 #[tokio::test]
+async fn unknown_lease_authority_contribution_fails_before_scheduling() {
+    let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
+    let fence = install_session(&harness, runner_id, generation);
+    let contribution = LeaseAuthorityPollContribution::new(
+        LeaseAuthorityName::new("unknown-provider").expect("authority name"),
+        1,
+        vec![7; 32],
+    )
+    .expect("contribution");
+    let contributions =
+        LeaseAuthorityPollContributions::new(vec![contribution]).expect("contributions");
+    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        MessageHeader::request(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            fence.session_id(),
+            OperationId::new(),
+        ),
+        RunnerSlotOrdinal::new(1).expect("slot"),
+        contributions,
+    ));
+    let error = exchange_result(&harness, &identity, &message)
+        .await
+        .expect_err("an unregistered extension must fail closed");
+    assert_eq!(error.kind(), ApplicationErrorKind::Conflict);
+    assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.objects.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.publisher.publications.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn accepted_lease_authority_contributions_are_echoed_exactly_and_replayed() {
+    let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
+    let fence = install_session(&harness, runner_id, generation);
+    let extension = Arc::new(TestLeaseAuthorityExtension::new());
+    let contribution =
+        LeaseAuthorityPollContribution::new(extension.name.clone(), 1, vec![0x19; 32])
+            .expect("contribution");
+    let contributions =
+        LeaseAuthorityPollContributions::new(vec![contribution]).expect("contributions");
+    let accepted_digest = contributions.sha256_digest();
+    let request = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        MessageHeader::request(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            fence.session_id(),
+            OperationId::new(),
+        ),
+        RunnerSlotOrdinal::new(1).expect("slot"),
+        contributions,
+    ));
+    let extension_port: Arc<dyn LeaseAuthorityExtension> = extension.clone();
+    let registry =
+        LeaseAuthorityExtensionRegistry::new(vec![extension_port]).expect("extension registry");
+    let handler = handler_with_extensions(&harness, registry);
+
+    let first = exchange_with_handler(&handler, &identity, &request).await;
+    let replay = exchange_with_handler(&handler, &identity, &request).await;
+
+    assert_eq!(first, replay, "replay must preserve the exact wrapper");
+    let ServerToRunner::LeasePollResponse(response) = first else {
+        panic!("lease polling must use the explicit response wrapper")
+    };
+    assert_eq!(response.accepted_contributions_sha256(), accepted_digest);
+    assert!(matches!(
+        response.outcome(),
+        ProtocolLeasePollOutcome::NoWork { .. }
+    ));
+    assert_eq!(extension.accepted.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(harness.receipts.lease_completions.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn durable_authority_evidence_propagates_to_one_atomic_sandbox_authorization_commit() {
+    let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
+    let fence = install_session(&harness, runner_id, generation);
+    let extension = Arc::new(TestLeaseAuthorityExtension::new());
+    let evidence =
+        LeaseAuthorityEvidenceSet::new(vec![extension.evidence.clone()]).expect("evidence set");
+    let fixture = install_runtime_authority_exchange_with_evidence(
+        &harness,
+        fence,
+        runner_id,
+        claimed_credential_free_job(),
+        &evidence,
+    );
+    let retained = harness
+        .transactions
+        .runtime_authority_admission
+        .lock()
+        .expect("runtime-authority admission lock")
+        .as_ref()
+        .expect("runtime-authority admission")
+        .offer()
+        .lease_authority_evidence()
+        .clone();
+    assert_eq!(retained, evidence);
+
+    let extension_port: Arc<dyn LeaseAuthorityExtension> = extension.clone();
+    let registry =
+        LeaseAuthorityExtensionRegistry::new(vec![extension_port]).expect("extension registry");
+    let handler = handler_with_extensions(&harness, registry);
+    let response = exchange_with_handler(&handler, &identity, &fixture.request).await;
+    let ServerToRunner::RuntimeAuthorityGrant(grant) = response else {
+        panic!("post-accept request must return a runtime-authority grant")
+    };
+    assert_eq!(
+        grant.authorities().sandbox_authorizations().as_slice(),
+        std::slice::from_ref(&extension.authorization)
+    );
+    let canonical_bundle = encode_runtime_authorities(
+        grant.authorities(),
+        &fixture.job,
+        &fixture.lease,
+        &ProtocolLimits::default(),
+    )
+    .expect("canonical complete runtime-authority bundle");
+    assert_eq!(
+        grant.bundle_digest(),
+        Sha256Digest::from_bytes(Sha256::digest(canonical_bundle).into()),
+        "the protected digest covers the whole bundle including sandbox authorization",
+    );
+    assert_eq!(extension.prepared.load(Ordering::SeqCst), 1);
+    assert_eq!(extension.committed.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *extension
+            .committed_digest
+            .lock()
+            .expect("committed digest lock"),
+        Some(grant.bundle_digest())
+    );
+    assert!(
+        harness
+            .transactions
+            .runtime_authority_commits
+            .lock()
+            .expect("generic delivery commits lock")
+            .is_empty(),
+        "the prepared provider commit owns the atomic delivery path"
+    );
+}
+
+#[tokio::test]
 async fn lease_poll_successors_require_the_exact_completed_head_before_liveness_or_polling() {
     let (harness, identity, runner_id, generation) = harness(DesiredRunnerState::Active);
     let fence = install_session(&harness, runner_id, generation);
     let slot = RunnerSlotOrdinal::new(1).expect("slot");
     let first_operation = OperationId::new();
-    let first = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let first = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3576,10 +4010,10 @@ async fn lease_poll_successors_require_the_exact_completed_head_before_liveness_
     ));
     assert!(matches!(
         exchange(&harness, &identity, &first).await,
-        ServerToRunner::NoWork(_)
+        response if is_no_work(&response)
     ));
 
-    let missing_predecessor = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let missing_predecessor = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3587,7 +4021,7 @@ async fn lease_poll_successors_require_the_exact_completed_head_before_liveness_
         ),
         slot,
     ));
-    let wrong_predecessor = RunnerToServer::LeaseRequest(LeaseRequest::successor(
+    let wrong_predecessor = RunnerToServer::LeaseRequest(successor_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3606,7 +4040,7 @@ async fn lease_poll_successors_require_the_exact_completed_head_before_liveness_
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 1);
 
     let successor_operation = OperationId::new();
-    let successor = RunnerToServer::LeaseRequest(LeaseRequest::successor(
+    let successor = RunnerToServer::LeaseRequest(successor_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),
@@ -3616,7 +4050,7 @@ async fn lease_poll_successors_require_the_exact_completed_head_before_liveness_
         first_operation,
     ));
     let response = exchange(&harness, &identity, &successor).await;
-    assert!(matches!(response, ServerToRunner::NoWork(_)));
+    assert!(is_no_work(&response));
     assert_eq!(exchange(&harness, &identity, &successor).await, response);
     assert_eq!(harness.sessions.heartbeats.load(Ordering::SeqCst), 3);
     assert_eq!(harness.poller.calls.load(Ordering::SeqCst), 2);
@@ -3638,7 +4072,7 @@ async fn lease_poll_fails_closed_when_fenced_liveness_refresh_is_rejected() {
         .sessions
         .reject_heartbeats
         .store(true, Ordering::SeqCst);
-    let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
+    let message = RunnerToServer::LeaseRequest(empty_lease_request(
         MessageHeader::request(
             SUPPORTED_PROTOCOL_RANGE.max(),
             fence.session_id(),

--- a/crates/automata-ci-control/tests/runner_control_runtime_authority_composite.rs
+++ b/crates/automata-ci-control/tests/runner_control_runtime_authority_composite.rs
@@ -192,9 +192,13 @@ async fn optional_oversized_merge_fails_closed() {
             .expect("authority")
         })
         .collect::<Vec<_>>();
-    let optional_bundle =
-        JobRuntimeAuthorities::new(optional_authorities, request.job(), request.lease())
-            .expect("maximum-sized optional bundle");
+    let optional_bundle = JobRuntimeAuthorities::new(
+        optional_authorities,
+        automata_ci_core::SandboxAuthorizations::empty(),
+        request.job(),
+        request.lease(),
+    )
+    .expect("maximum-sized optional bundle");
     let required: Arc<dyn RuntimeAuthorityIssuer> =
         Arc::new(DerivedIssuer::new("required", "required-token"));
     let optional: Arc<dyn OptionalRuntimeAuthorityIssuer> =
@@ -405,8 +409,13 @@ impl RuntimeAuthorityIssuer for DerivedIssuer {
             request.lease().expires_at(),
         )
         .map_err(|_| ControlPortError::Corrupt)?;
-        JobRuntimeAuthorities::new(vec![authority], request.job(), request.lease())
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            request.job(),
+            request.lease(),
+        )
+        .map_err(|_| ControlPortError::Corrupt)
     }
 }
 

--- a/crates/automata-ci-control/tests/runner_control_store_adapters.rs
+++ b/crates/automata-ci-control/tests/runner_control_store_adapters.rs
@@ -6,7 +6,8 @@ use std::sync::{
 use async_trait::async_trait;
 use automata_ci_control::cancellation::CANCEL_JOB_COMMAND_KIND;
 use automata_ci_control::runner_control::{
-    ControlIdGenerator, ControlPortError, LeaseOfferClaim as ControlLeaseOfferClaim,
+    ControlIdGenerator, ControlPortError, LeaseAuthorityEvidence, LeaseAuthorityEvidenceSet,
+    LeaseOfferClaim as ControlLeaseOfferClaim,
     LeaseOfferClaimStatus as ControlLeaseOfferClaimStatus, LeaseOfferCommand,
     LeaseOfferCommandError, LeaseOfferCommandPublisher as _, LeaseOfferPublishOutcome,
     LeaseOfferReplayResolution, RunnerSessionFenceResolver as _, StoreLeaseOfferCommandPublisher,
@@ -24,6 +25,7 @@ use automata_ci_core::{
     UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollContribution, LeaseAuthorityPollContributions,
     ManagedSecretBindingOverlay, ProtocolLimits, ProtocolVersion, RunnerSlotOrdinal,
 };
 use automata_ci_protocol_protobuf::encode_job_ir;
@@ -273,6 +275,7 @@ impl RunnerLeaseOfferRepository for MismatchedPublishedLeaseOffer {
             "job": self.job,
             "lease": self.lease,
             "managed_secret_bindings": ManagedSecretBindingOverlay::empty(&self.lease),
+            "lease_authority_evidence": LeaseAuthorityEvidenceSet::empty(),
             "protocol_version": request.protocol_version().get(),
             "schema": self.inner_schema,
             "slot": self.slot,
@@ -287,7 +290,7 @@ impl RunnerLeaseOfferRepository for MismatchedPublishedLeaseOffer {
         let command = EnqueueRunnerCommand::new(
             request.request().session(),
             OperationId::new(),
-            RunnerOperationKind::new("automata.runner.lease-offer.v2").expect("command kind"),
+            RunnerOperationKind::new("automata.runner.lease-offer.v3").expect("command kind"),
             RunnerCommandPayload::new(
                 DocumentSchema::new(self.outer_schema).expect("schema"),
                 payload,
@@ -417,6 +420,7 @@ impl LeaseOfferCommandFixture {
                 self.slot,
                 self.lease.clone(),
                 metadata,
+                LeaseAuthorityPollContributions::empty(),
             ),
             self.job.clone(),
             created_at,
@@ -519,6 +523,24 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
         )],
     )
     .expect("managed-secret overlay");
+    let lease_authority_evidence = LeaseAuthorityEvidenceSet::new(vec![
+        LeaseAuthorityEvidence::new(
+            LeaseAuthorityName::new("test-sandbox").expect("authority name"),
+            7,
+            vec![0x6d; 32],
+        )
+        .expect("lease-authority evidence"),
+    ])
+    .expect("lease-authority evidence set");
+    let authority_contributions = LeaseAuthorityPollContributions::new(vec![
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new("test-sandbox").expect("authority name"),
+            3,
+            vec![0x5a; 32],
+        )
+        .expect("lease-authority contribution"),
+    ])
+    .expect("lease-authority contributions");
     let repository = Arc::new(LeaseOffers::default());
     let publisher = StoreLeaseOfferCommandPublisher::new(
         repository.clone(),
@@ -535,6 +557,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
         RunnerSlotOrdinal::new(2).expect("slot"),
         lease.clone(),
         metadata.clone(),
+        authority_contributions.clone(),
     );
     assert_eq!(
         publisher.inspect(claim.clone()).await.expect("inspection"),
@@ -545,6 +568,9 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
             LeaseOfferCommand::try_new(claim.clone(), job.clone(), UnixMillis::new(20))
                 .and_then(|command| {
                     command.with_managed_secret_bindings(managed_secret_bindings.clone())
+                })
+                .and_then(|command| {
+                    command.with_lease_authority_evidence(lease_authority_evidence.clone())
                 })
                 .expect("valid lease-offer command"),
         )
@@ -655,6 +681,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
         assert_eq!(request.slot().get(), 2);
         assert_eq!(request.lease(), &lease);
         assert_eq!(request.job_ir(), &metadata);
+        assert_eq!(request.authority_contributions(), &authority_contributions);
         assert_eq!(request.offer_valid_until(), lease.expires_at());
         for invalid_horizon in [lease.issued_at(), UnixMillis::new(101)] {
             assert_eq!(
@@ -664,6 +691,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
                     request.slot(),
                     request.lease().clone(),
                     request.job_ir().clone(),
+                    request.authority_contributions().clone(),
                     invalid_horizon,
                     request.command().clone(),
                 )
@@ -685,6 +713,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
                 request.slot(),
                 request.lease().clone(),
                 request.job_ir().clone(),
+                request.authority_contributions().clone(),
                 request.offer_valid_until(),
                 early_command,
             )
@@ -695,11 +724,11 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
         assert_eq!(request.command().operation_id(), server_operation_id);
         assert_eq!(
             request.command().kind().as_str(),
-            "automata.runner.lease-offer.v2"
+            "automata.runner.lease-offer.v3"
         );
         let body: serde_json::Value =
             serde_json::from_slice(request.command().payload().bytes()).expect("offer JSON");
-        assert_eq!(body["schema"], 2);
+        assert_eq!(body["schema"], 3);
         assert_eq!(body["protocol_version"], 2);
         assert_eq!(body["slot"], 2);
         assert_eq!(
@@ -712,6 +741,10 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
             serde_json::to_value(&managed_secret_bindings).expect("managed-secret overlay JSON")
         );
         assert_eq!(
+            body["lease_authority_evidence"],
+            serde_json::to_value(&lease_authority_evidence).expect("lease-authority evidence JSON")
+        );
+        assert_eq!(
             body.as_object()
                 .expect("offer object")
                 .keys()
@@ -720,6 +753,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
             [
                 "job",
                 "lease",
+                "lease_authority_evidence",
                 "managed_secret_bindings",
                 "protocol_version",
                 "schema",
@@ -779,6 +813,7 @@ async fn durable_offer_adapter_publishes_exact_typed_body_and_identity() {
         RunnerSlotOrdinal::new(2).expect("slot"),
         lease.clone(),
         metadata.clone(),
+        LeaseAuthorityPollContributions::empty(),
     );
     assert_eq!(
         superseded
@@ -849,6 +884,7 @@ async fn lease_offer_adapter_maps_only_draining_races_to_unavailable() {
         RunnerSlotOrdinal::new(2).expect("slot"),
         lease.clone(),
         metadata.clone(),
+        LeaseAuthorityPollContributions::empty(),
     );
     let command = LeaseOfferCommand::try_new(claim.clone(), job.clone(), UnixMillis::new(20))
         .expect("valid lease-offer command");
@@ -922,6 +958,7 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
         RunnerSlotOrdinal::new(2).expect("slot"),
         lease.clone(),
         metadata,
+        LeaseAuthorityPollContributions::empty(),
     );
     let mismatched_job = job();
     let same_identity_mismatched_job = JobIrEnvelope::new(
@@ -962,8 +999,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 3,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: false,
         },
@@ -972,8 +1009,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: false,
         },
@@ -982,8 +1019,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: false,
         },
@@ -992,8 +1029,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: mismatched_lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: false,
         },
@@ -1002,8 +1039,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: true,
             nested_extra_field: false,
         },
@@ -1012,8 +1049,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 2,
+            outer_schema: 3,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: true,
         },
@@ -1022,8 +1059,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 1,
-            inner_schema: 2,
+            outer_schema: 2,
+            inner_schema: 3,
             extra_field: false,
             nested_extra_field: false,
         },
@@ -1032,7 +1069,7 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
+            outer_schema: 3,
             inner_schema: 0,
             extra_field: false,
             nested_extra_field: false,
@@ -1042,8 +1079,8 @@ async fn recovered_offer_payload_rejects_noncurrent_schema_and_mismatched_column
             lease: lease.clone(),
             slot: 2,
             created_at: UnixMillis::new(20),
-            outer_schema: 2,
-            inner_schema: 1,
+            outer_schema: 3,
+            inner_schema: 2,
             extra_field: false,
             nested_extra_field: false,
         },

--- a/crates/automata-ci-control/tests/workload_oidc_runtime_authority.rs
+++ b/crates/automata-ci-control/tests/workload_oidc_runtime_authority.rs
@@ -715,8 +715,13 @@ impl RuntimeAuthorityIssuer for RequiredAuthorityIssuer {
             request.lease().expires_at(),
         )
         .map_err(|_| ControlPortError::Corrupt)?;
-        JobRuntimeAuthorities::new(vec![authority], request.job(), request.lease())
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            request.job(),
+            request.lease(),
+        )
+        .map_err(|_| ControlPortError::Corrupt)
     }
 }
 

--- a/crates/automata-ci-core/src/execution/authorization.rs
+++ b/crates/automata-ci-core/src/execution/authorization.rs
@@ -1,0 +1,371 @@
+//! Provider-neutral, job-bound sandbox authorizations.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::Sha256Digest;
+
+/// Current schema for a job-bound sandbox-authorization bundle.
+pub const SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION: u16 = 1;
+/// Maximum number of independent sandbox authorizations carried by one job.
+pub const MAX_SANDBOX_AUTHORIZATIONS: usize = 16;
+/// Maximum UTF-8 bytes in one sandbox-authorization namespace.
+pub const MAX_SANDBOX_AUTHORIZATION_NAME_BYTES: usize = 128;
+/// Maximum bytes in one provider-owned sandbox-authorization payload.
+pub const MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+/// Canonical provider-owned namespace for one sandbox authorization.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct SandboxAuthorizationName(String);
+
+impl SandboxAuthorizationName {
+    /// Validates a lowercase portable authorization namespace.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, path-like, or noncanonical names.
+    pub fn new(value: impl Into<String>) -> Result<Self, SandboxAuthorizationError> {
+        let value = value.into();
+        let mut bytes = value.bytes();
+        let valid_first = bytes.next().is_some_and(|byte| byte.is_ascii_lowercase());
+        let valid_rest = bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+        });
+        if value.len() <= MAX_SANDBOX_AUTHORIZATION_NAME_BYTES && valid_first && valid_rest {
+            Ok(Self(value))
+        } else {
+            Err(SandboxAuthorizationError::InvalidName)
+        }
+    }
+
+    /// Returns the canonical provider namespace.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<SandboxAuthorizationName> for String {
+    fn from(value: SandboxAuthorizationName) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<String> for SandboxAuthorizationName {
+    type Error = SandboxAuthorizationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SandboxAuthorizationDocument {
+    name: SandboxAuthorizationName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+/// One bounded provider-owned authorization carried through generic execution.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(
+    try_from = "SandboxAuthorizationDocument",
+    into = "SandboxAuthorizationDocument"
+)]
+pub struct SandboxAuthorization {
+    name: SandboxAuthorizationName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+impl SandboxAuthorization {
+    /// Creates an authorization and commits to its exact payload bytes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects schema zero, an empty payload, or a payload above the hard bound.
+    pub fn new(
+        name: SandboxAuthorizationName,
+        payload_schema_version: u16,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, SandboxAuthorizationError> {
+        let payload = payload.into();
+        let payload_sha256 = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        Self::from_parts(name, payload_schema_version, payload_sha256, payload)
+    }
+
+    /// Rehydrates an authorization at a durable or transport boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid bounds or a digest that does not match the exact payload.
+    pub fn from_parts(
+        name: SandboxAuthorizationName,
+        payload_schema_version: u16,
+        payload_sha256: Sha256Digest,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, SandboxAuthorizationError> {
+        let payload = payload.into();
+        if payload_schema_version == 0 {
+            return Err(SandboxAuthorizationError::ZeroPayloadSchema);
+        }
+        if payload.is_empty() || payload.len() > MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES {
+            return Err(SandboxAuthorizationError::InvalidPayloadSize);
+        }
+        let actual = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        if actual != payload_sha256 {
+            return Err(SandboxAuthorizationError::PayloadDigestMismatch);
+        }
+        Ok(Self {
+            name,
+            payload_schema_version,
+            payload_sha256,
+            payload,
+        })
+    }
+
+    /// Returns the provider-owned authorization namespace.
+    #[must_use]
+    pub const fn name(&self) -> &SandboxAuthorizationName {
+        &self.name
+    }
+
+    /// Returns the provider-owned payload schema.
+    #[must_use]
+    pub const fn payload_schema_version(&self) -> u16 {
+        self.payload_schema_version
+    }
+
+    /// Returns the digest of the exact payload bytes.
+    #[must_use]
+    pub const fn payload_sha256(&self) -> Sha256Digest {
+        self.payload_sha256
+    }
+
+    /// Returns the exact provider-owned payload bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+impl fmt::Debug for SandboxAuthorization {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SandboxAuthorization")
+            .field("name", &self.name)
+            .field("payload_schema_version", &self.payload_schema_version)
+            .field("payload_sha256", &self.payload_sha256)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
+}
+
+impl From<SandboxAuthorization> for SandboxAuthorizationDocument {
+    fn from(value: SandboxAuthorization) -> Self {
+        Self {
+            name: value.name,
+            payload_schema_version: value.payload_schema_version,
+            payload_sha256: value.payload_sha256,
+            payload: value.payload,
+        }
+    }
+}
+
+impl TryFrom<SandboxAuthorizationDocument> for SandboxAuthorization {
+    type Error = SandboxAuthorizationError;
+
+    fn try_from(value: SandboxAuthorizationDocument) -> Result<Self, Self::Error> {
+        Self::from_parts(
+            value.name,
+            value.payload_schema_version,
+            value.payload_sha256,
+            value.payload,
+        )
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SandboxAuthorizationsDocument {
+    schema_version: u16,
+    authorizations: Vec<SandboxAuthorization>,
+}
+
+/// Canonically ordered provider-owned sandbox authorizations.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(
+    try_from = "SandboxAuthorizationsDocument",
+    into = "SandboxAuthorizationsDocument"
+)]
+pub struct SandboxAuthorizations {
+    schema_version: u16,
+    authorizations: Vec<SandboxAuthorization>,
+}
+
+impl SandboxAuthorizations {
+    /// Creates an explicit canonical authorization set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized, duplicate, or noncanonically ordered entries.
+    pub fn new(
+        authorizations: Vec<SandboxAuthorization>,
+    ) -> Result<Self, SandboxAuthorizationError> {
+        let authorizations = Self {
+            schema_version: SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION,
+            authorizations,
+        };
+        authorizations.validate()?;
+        Ok(authorizations)
+    }
+
+    /// Returns an explicit empty authorization set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            schema_version: SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION,
+            authorizations: Vec::new(),
+        }
+    }
+
+    /// Returns the bundle schema.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns entries in canonical namespace order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[SandboxAuthorization] {
+        &self.authorizations
+    }
+
+    /// Finds one exact authorization namespace.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&SandboxAuthorization> {
+        self.authorizations
+            .binary_search_by(|authorization| authorization.name().as_str().cmp(name))
+            .ok()
+            .map(|index| &self.authorizations[index])
+    }
+
+    /// Validates schema, bounds, and canonical ordering.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsupported schema or invalid authorization structure.
+    pub fn validate(&self) -> Result<(), SandboxAuthorizationError> {
+        if self.schema_version != SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION {
+            return Err(SandboxAuthorizationError::UnsupportedSchema);
+        }
+        if self.authorizations.len() > MAX_SANDBOX_AUTHORIZATIONS {
+            return Err(SandboxAuthorizationError::InvalidCount);
+        }
+        let mut previous: Option<&SandboxAuthorizationName> = None;
+        for authorization in &self.authorizations {
+            if previous.is_some_and(|name| name >= authorization.name()) {
+                return Err(SandboxAuthorizationError::NonCanonicalOrder);
+            }
+            previous = Some(authorization.name());
+        }
+        Ok(())
+    }
+}
+
+impl Default for SandboxAuthorizations {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<SandboxAuthorizations> for SandboxAuthorizationsDocument {
+    fn from(value: SandboxAuthorizations) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            authorizations: value.authorizations,
+        }
+    }
+}
+
+impl TryFrom<SandboxAuthorizationsDocument> for SandboxAuthorizations {
+    type Error = SandboxAuthorizationError;
+
+    fn try_from(value: SandboxAuthorizationsDocument) -> Result<Self, Self::Error> {
+        if value.schema_version != SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION {
+            return Err(SandboxAuthorizationError::UnsupportedSchema);
+        }
+        Self::new(value.authorizations)
+    }
+}
+
+/// Invalid provider-neutral sandbox-authorization material.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum SandboxAuthorizationError {
+    /// The namespace is empty, oversized, path-like, or noncanonical.
+    #[error("sandbox authorization name is invalid")]
+    InvalidName,
+    /// Payload schema zero is reserved.
+    #[error("sandbox authorization payload schema must be nonzero")]
+    ZeroPayloadSchema,
+    /// Payload is empty or above the hard bound.
+    #[error("sandbox authorization payload size is invalid")]
+    InvalidPayloadSize,
+    /// Payload bytes disagree with their claimed digest.
+    #[error("sandbox authorization payload digest does not match")]
+    PayloadDigestMismatch,
+    /// The bundle schema is unsupported.
+    #[error("sandbox authorization bundle schema is unsupported")]
+    UnsupportedSchema,
+    /// The bundle contains too many entries.
+    #[error("sandbox authorization count is invalid")]
+    InvalidCount,
+    /// Entries are not strictly ordered by unique namespace.
+    #[error("sandbox authorizations are not in canonical order")]
+    NonCanonicalOrder,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn payload(name: &str, byte: u8) -> SandboxAuthorization {
+        SandboxAuthorization::new(
+            SandboxAuthorizationName::new(name).expect("name"),
+            1,
+            vec![byte; 32],
+        )
+        .expect("authorization")
+    }
+
+    #[test]
+    fn authorization_rejects_payload_substitution_and_redacts_debug() {
+        let exact = payload("example.authorization", 0x5a);
+        let debug = format!("{exact:?}");
+        assert!(!debug.contains(&"5a".repeat(16)));
+        assert!(matches!(
+            SandboxAuthorization::from_parts(
+                exact.name().clone(),
+                exact.payload_schema_version(),
+                exact.payload_sha256(),
+                vec![0x6b; 32]
+            ),
+            Err(SandboxAuthorizationError::PayloadDigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn bundle_rejects_noncanonical_entries_and_defaults_to_explicit_empty() {
+        assert!(matches!(
+            SandboxAuthorizations::new(vec![payload("zulu", 1), payload("alpha", 2)]),
+            Err(SandboxAuthorizationError::NonCanonicalOrder)
+        ));
+        assert!(SandboxAuthorizations::default().as_slice().is_empty());
+    }
+}

--- a/crates/automata-ci-core/src/execution/mod.rs
+++ b/crates/automata-ci-core/src/execution/mod.rs
@@ -1,9 +1,20 @@
 //! Job-attempt lifecycle, leases, and fencing.
 
 mod attempt;
+mod authorization;
 mod lease;
 mod lifecycle;
+mod windows;
 
 pub use attempt::{AttemptStateError, FenceError, JobAttemptState};
+pub use authorization::{
+    MAX_SANDBOX_AUTHORIZATION_NAME_BYTES, MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES,
+    MAX_SANDBOX_AUTHORIZATIONS, SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION, SandboxAuthorization,
+    SandboxAuthorizationError, SandboxAuthorizationName, SandboxAuthorizations,
+};
 pub use lease::{Lease, LeaseError, LeaseGuard};
 pub use lifecycle::{JobLifecycle, TransitionError};
+pub use windows::{
+    WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4, WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME,
+    WindowsHyperVBrokerGrant, WindowsHyperVBrokerGrantClaims, WindowsHyperVBrokerGrantError,
+};

--- a/crates/automata-ci-core/src/execution/windows.rs
+++ b/crates/automata-ci-core/src/execution/windows.rs
@@ -1,0 +1,738 @@
+//! Value-free authority carried from Windows placement to the restricted host broker.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    AttemptId, EnvironmentProfile, FencingToken, JobId, JobIrVersion, JobResourceAllocation,
+    LeaseId, OperationId, RunId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
+};
+
+/// Current schema for a signed Windows Hyper-V broker grant.
+pub const WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4: u16 = 4;
+/// Provider-neutral sandbox-authorization namespace owned by the Windows Hyper-V adapter.
+pub const WINDOWS_HYPERV_SANDBOX_AUTHORIZATION_NAME: &str = "windows-hyperv";
+/// Exact Ed25519 signature size accepted by the broker contract.
+pub const WINDOWS_HYPERV_BROKER_GRANT_SIGNATURE_BYTES: usize = 64;
+
+const SIGNING_DOMAIN: &[u8] = b"automata.windows-hyperv-broker-grant.v4\0";
+const DIGEST_DOMAIN: &[u8] = b"automata.windows-hyperv-broker-grant-digest.v4\0";
+const SANDBOX_SPEC_DOMAIN: &[u8] = b"automata.windows-hyperv-sandbox-spec.v4\0";
+const WINDOWS_HYPERV_PROVIDER_ID: &[u8] = b"windows-hyperv";
+
+/// Immutable, value-free claims authorizing one exact Windows Hyper-V placement.
+///
+/// The claims deliberately contain no credential material, runtime command line,
+/// host path, container-engine endpoint, or caller-selected HCS document. The
+/// placement digest is derived by the control plane from its server-only grant;
+/// the restricted broker verifies the signature and consumes it once.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsHyperVBrokerGrantClaims {
+    host_id: Sha256Digest,
+    placement_binding_digest: Sha256Digest,
+    attempt_id: AttemptId,
+    job_id: JobId,
+    run_id: RunId,
+    poll_operation_id: OperationId,
+    accepted_offer_operation_id: OperationId,
+    accepted_offer_sequence: u64,
+    post_accept_operation_id: OperationId,
+    post_accept_request_digest: Sha256Digest,
+    runner_id: RunnerId,
+    runner_session_id: RunnerSessionId,
+    runner_generation: u64,
+    session_epoch: u64,
+    slot: u16,
+    lease_id: LeaseId,
+    fencing_token: FencingToken,
+    job_ir_version: JobIrVersion,
+    job_ir_encoded_size: u64,
+    job_ir_digest: Sha256Digest,
+    job_ir_object_key_digest: Sha256Digest,
+    job_resource_allocation: JobResourceAllocation,
+    sandbox_pids_limit: u32,
+    trust_binding_digest: Sha256Digest,
+    environment_profile: EnvironmentProfile,
+    profile_contract_sha256: Sha256Digest,
+    sandbox_spec_sha256: Sha256Digest,
+    issued_at: UnixMillis,
+    expires_at: UnixMillis,
+}
+
+impl WindowsHyperVBrokerGrantClaims {
+    /// Builds and validates the complete metadata binding for one placement.
+    ///
+    /// # Errors
+    ///
+    /// Rejects nil identities, zero counters, empty `JobIR`, zero security
+    /// digests, or a non-positive validity interval.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        host_id: Sha256Digest,
+        placement_binding_digest: Sha256Digest,
+        attempt_id: AttemptId,
+        job_id: JobId,
+        run_id: RunId,
+        poll_operation_id: OperationId,
+        accepted_offer_operation_id: OperationId,
+        accepted_offer_sequence: u64,
+        post_accept_operation_id: OperationId,
+        post_accept_request_digest: Sha256Digest,
+        runner_id: RunnerId,
+        runner_session_id: RunnerSessionId,
+        runner_generation: u64,
+        session_epoch: u64,
+        slot: u16,
+        lease_id: LeaseId,
+        fencing_token: FencingToken,
+        job_ir_version: JobIrVersion,
+        job_ir_encoded_size: u64,
+        job_ir_digest: Sha256Digest,
+        job_ir_object_key_digest: Sha256Digest,
+        job_resource_allocation: JobResourceAllocation,
+        sandbox_pids_limit: u32,
+        trust_binding_digest: Sha256Digest,
+        environment_profile: EnvironmentProfile,
+        profile_contract_sha256: Sha256Digest,
+        issued_at: UnixMillis,
+        expires_at: UnixMillis,
+    ) -> Result<Self, WindowsHyperVBrokerGrantError> {
+        let mut claims = Self {
+            host_id,
+            placement_binding_digest,
+            attempt_id,
+            job_id,
+            run_id,
+            poll_operation_id,
+            accepted_offer_operation_id,
+            accepted_offer_sequence,
+            post_accept_operation_id,
+            post_accept_request_digest,
+            runner_id,
+            runner_session_id,
+            runner_generation,
+            session_epoch,
+            slot,
+            lease_id,
+            fencing_token,
+            job_ir_version,
+            job_ir_encoded_size,
+            job_ir_digest,
+            job_ir_object_key_digest,
+            job_resource_allocation,
+            sandbox_pids_limit,
+            trust_binding_digest,
+            environment_profile,
+            profile_contract_sha256,
+            sandbox_spec_sha256: Sha256Digest::from_bytes([0; 32]),
+            issued_at,
+            expires_at,
+        };
+        claims.sandbox_spec_sha256 = claims.compute_sandbox_spec_sha256();
+        claims.validate()?;
+        Ok(claims)
+    }
+
+    /// Validates claims after deserialization or before signing.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first violated invariant.
+    pub fn validate(&self) -> Result<(), WindowsHyperVBrokerGrantError> {
+        if self.attempt_id.as_uuid().is_nil()
+            || self.job_id.as_uuid().is_nil()
+            || self.run_id.as_uuid().is_nil()
+            || self.poll_operation_id.as_uuid().is_nil()
+            || self.accepted_offer_operation_id.as_uuid().is_nil()
+            || self.post_accept_operation_id.as_uuid().is_nil()
+            || self.runner_id.as_uuid().is_nil()
+            || self.runner_session_id.as_uuid().is_nil()
+            || self.lease_id.as_uuid().is_nil()
+        {
+            return Err(WindowsHyperVBrokerGrantError::NilIdentity);
+        }
+        if self.runner_generation == 0
+            || self.session_epoch == 0
+            || self.slot == 0
+            || self.accepted_offer_sequence == 0
+        {
+            return Err(WindowsHyperVBrokerGrantError::ZeroFence);
+        }
+        if self.job_ir_encoded_size == 0 {
+            return Err(WindowsHyperVBrokerGrantError::EmptyJobIr);
+        }
+        if [
+            self.host_id,
+            self.placement_binding_digest,
+            self.post_accept_request_digest,
+            self.job_ir_digest,
+            self.job_ir_object_key_digest,
+            self.trust_binding_digest,
+            self.environment_profile.digest(),
+            self.profile_contract_sha256,
+            self.sandbox_spec_sha256,
+        ]
+        .iter()
+        .any(is_zero_digest)
+        {
+            return Err(WindowsHyperVBrokerGrantError::ZeroDigest);
+        }
+        if self.sandbox_pids_limit == 0 {
+            return Err(WindowsHyperVBrokerGrantError::ZeroProcessLimit);
+        }
+        if self.sandbox_spec_sha256 != self.compute_sandbox_spec_sha256() {
+            return Err(WindowsHyperVBrokerGrantError::SandboxSpecBindingMismatch);
+        }
+        if self.expires_at <= self.issued_at {
+            return Err(WindowsHyperVBrokerGrantError::InvalidValidityInterval);
+        }
+        Ok(())
+    }
+
+    /// Returns the stable identity of the only host allowed to consume the grant.
+    #[must_use]
+    pub const fn host_id(&self) -> Sha256Digest {
+        self.host_id
+    }
+
+    /// Returns the digest of the original server-only placement grant.
+    #[must_use]
+    pub const fn placement_binding_digest(&self) -> Sha256Digest {
+        self.placement_binding_digest
+    }
+
+    /// Returns the authorized attempt identity.
+    #[must_use]
+    pub const fn attempt_id(&self) -> AttemptId {
+        self.attempt_id
+    }
+
+    /// Returns the authorized job identity.
+    #[must_use]
+    pub const fn job_id(&self) -> JobId {
+        self.job_id
+    }
+
+    /// Returns the authorized workflow-run identity.
+    #[must_use]
+    pub const fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    /// Returns the lease-poll operation that selected the placement.
+    #[must_use]
+    pub const fn poll_operation_id(&self) -> OperationId {
+        self.poll_operation_id
+    }
+
+    /// Returns the durable offer command admitted by the acceptance transaction.
+    #[must_use]
+    pub const fn accepted_offer_operation_id(&self) -> OperationId {
+        self.accepted_offer_operation_id
+    }
+
+    /// Returns the nonzero durable sequence of the accepted offer command.
+    #[must_use]
+    pub const fn accepted_offer_sequence(&self) -> u64 {
+        self.accepted_offer_sequence
+    }
+
+    /// Returns the exact post-accept delivery request that caused issuance.
+    #[must_use]
+    pub const fn post_accept_operation_id(&self) -> OperationId {
+        self.post_accept_operation_id
+    }
+
+    /// Returns the canonical digest of that post-accept request.
+    #[must_use]
+    pub const fn post_accept_request_digest(&self) -> Sha256Digest {
+        self.post_accept_request_digest
+    }
+
+    /// Returns the authorized runner identity.
+    #[must_use]
+    pub const fn runner_id(&self) -> RunnerId {
+        self.runner_id
+    }
+
+    /// Returns the authorized runner-session identity.
+    #[must_use]
+    pub const fn runner_session_id(&self) -> RunnerSessionId {
+        self.runner_session_id
+    }
+
+    /// Returns the registered-runner generation fence.
+    #[must_use]
+    pub const fn runner_generation(&self) -> u64 {
+        self.runner_generation
+    }
+
+    /// Returns the authenticated session epoch fence.
+    #[must_use]
+    pub const fn session_epoch(&self) -> u64 {
+        self.session_epoch
+    }
+
+    /// Returns the one-based stable runner slot.
+    #[must_use]
+    pub const fn slot(&self) -> u16 {
+        self.slot
+    }
+
+    /// Returns the authorized lease identity.
+    #[must_use]
+    pub const fn lease_id(&self) -> LeaseId {
+        self.lease_id
+    }
+
+    /// Returns the durable lease fencing token.
+    #[must_use]
+    pub const fn fencing_token(&self) -> FencingToken {
+        self.fencing_token
+    }
+
+    /// Returns the exact `JobIR` schema version.
+    #[must_use]
+    pub const fn job_ir_version(&self) -> JobIrVersion {
+        self.job_ir_version
+    }
+
+    /// Returns the exact encoded `JobIR` byte length.
+    #[must_use]
+    pub const fn job_ir_encoded_size(&self) -> u64 {
+        self.job_ir_encoded_size
+    }
+
+    /// Returns the exact `JobIR` content digest.
+    #[must_use]
+    pub const fn job_ir_digest(&self) -> Sha256Digest {
+        self.job_ir_digest
+    }
+
+    /// Returns a digest of the credential-free durable `JobIR` object key.
+    #[must_use]
+    pub const fn job_ir_object_key_digest(&self) -> Sha256Digest {
+        self.job_ir_object_key_digest
+    }
+
+    /// Returns the exact server-verified request and hard-limit allocation.
+    #[must_use]
+    pub const fn job_resource_allocation(&self) -> JobResourceAllocation {
+        self.job_resource_allocation
+    }
+
+    /// Returns the exact hard process ceiling admitted for this sandbox.
+    #[must_use]
+    pub const fn sandbox_pids_limit(&self) -> u32 {
+        self.sandbox_pids_limit
+    }
+
+    /// Returns the digest binding authenticated trust and requirements evidence.
+    #[must_use]
+    pub const fn trust_binding_digest(&self) -> Sha256Digest {
+        self.trust_binding_digest
+    }
+
+    /// Returns the exact server-attested environment profile.
+    #[must_use]
+    pub const fn environment_profile(&self) -> &EnvironmentProfile {
+        &self.environment_profile
+    }
+
+    /// Returns the broker-minted durable launch/profile contract identity.
+    #[must_use]
+    pub const fn profile_contract_sha256(&self) -> Sha256Digest {
+        self.profile_contract_sha256
+    }
+
+    /// Returns the canonical signed authorization for the exact sandbox spec.
+    #[must_use]
+    pub const fn sandbox_spec_sha256(&self) -> Sha256Digest {
+        self.sandbox_spec_sha256
+    }
+
+    /// Verifies the dynamic typed sandbox fields covered by the signed spec binding.
+    ///
+    /// The immutable image/argv/workspace/default-environment fields are
+    /// resolved independently by the broker from `profile_contract_sha256`.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn authorizes_sandbox_spec(
+        &self,
+        profile_contract_sha256: Sha256Digest,
+        generation: u64,
+        allocation: JobResourceAllocation,
+        pids_limit: u32,
+        network_disabled: bool,
+    ) -> bool {
+        profile_contract_sha256 == self.profile_contract_sha256
+            && generation == self.fencing_token.get()
+            && allocation == self.job_resource_allocation
+            && pids_limit == self.sandbox_pids_limit
+            && network_disabled
+            && self.sandbox_spec_sha256 == self.compute_sandbox_spec_sha256()
+    }
+
+    /// Returns the inclusive issue time.
+    #[must_use]
+    pub const fn issued_at(&self) -> UnixMillis {
+        self.issued_at
+    }
+
+    /// Returns the exclusive expiry time.
+    #[must_use]
+    pub const fn expires_at(&self) -> UnixMillis {
+        self.expires_at
+    }
+
+    /// Reports whether the grant is valid at `now` under `[issued, expires)` semantics.
+    #[must_use]
+    pub const fn is_valid_at(&self, now: UnixMillis) -> bool {
+        now.get() >= self.issued_at.get() && now.get() < self.expires_at.get()
+    }
+
+    fn append_signing_fields(&self, bytes: &mut Vec<u8>) {
+        field(bytes, self.host_id.as_bytes());
+        field(bytes, self.placement_binding_digest.as_bytes());
+        field(bytes, self.attempt_id.as_uuid().as_bytes());
+        field(bytes, self.job_id.as_uuid().as_bytes());
+        field(bytes, self.run_id.as_uuid().as_bytes());
+        field(bytes, self.poll_operation_id.as_uuid().as_bytes());
+        field(bytes, self.accepted_offer_operation_id.as_uuid().as_bytes());
+        field(bytes, &self.accepted_offer_sequence.to_be_bytes());
+        field(bytes, self.post_accept_operation_id.as_uuid().as_bytes());
+        field(bytes, self.post_accept_request_digest.as_bytes());
+        field(bytes, self.runner_id.as_uuid().as_bytes());
+        field(bytes, self.runner_session_id.as_uuid().as_bytes());
+        field(bytes, &self.runner_generation.to_be_bytes());
+        field(bytes, &self.session_epoch.to_be_bytes());
+        field(bytes, &self.slot.to_be_bytes());
+        field(bytes, self.lease_id.as_uuid().as_bytes());
+        field(bytes, &self.fencing_token.get().to_be_bytes());
+        field(bytes, &self.job_ir_version.get().to_be_bytes());
+        field(bytes, &self.job_ir_encoded_size.to_be_bytes());
+        field(bytes, self.job_ir_digest.as_bytes());
+        field(bytes, self.job_ir_object_key_digest.as_bytes());
+        for capacity in [
+            self.job_resource_allocation.requests(),
+            self.job_resource_allocation.limits(),
+        ] {
+            field(bytes, &capacity.cpu_millis().to_be_bytes());
+            field(bytes, &capacity.memory_bytes().to_be_bytes());
+            field(bytes, &capacity.ephemeral_disk_bytes().to_be_bytes());
+            field(bytes, &capacity.gpu_count().to_be_bytes());
+        }
+        field(bytes, &self.sandbox_pids_limit.to_be_bytes());
+        field(bytes, self.trust_binding_digest.as_bytes());
+        field(bytes, self.environment_profile.id().as_str().as_bytes());
+        field(bytes, self.environment_profile.digest().as_bytes());
+        field(bytes, self.profile_contract_sha256.as_bytes());
+        field(bytes, self.sandbox_spec_sha256.as_bytes());
+        field(bytes, &self.issued_at.get().to_be_bytes());
+        field(bytes, &self.expires_at.get().to_be_bytes());
+    }
+
+    fn compute_sandbox_spec_sha256(&self) -> Sha256Digest {
+        let mut bytes = Vec::with_capacity(640);
+        bytes.extend_from_slice(SANDBOX_SPEC_DOMAIN);
+        field(&mut bytes, WINDOWS_HYPERV_PROVIDER_ID);
+        field(&mut bytes, &[1]);
+        field(&mut bytes, self.host_id.as_bytes());
+        field(&mut bytes, self.placement_binding_digest.as_bytes());
+        field(&mut bytes, self.profile_contract_sha256.as_bytes());
+        field(&mut bytes, self.post_accept_request_digest.as_bytes());
+        field(&mut bytes, self.runner_id.as_uuid().as_bytes());
+        field(&mut bytes, self.runner_session_id.as_uuid().as_bytes());
+        field(&mut bytes, &self.runner_generation.to_be_bytes());
+        field(&mut bytes, &self.session_epoch.to_be_bytes());
+        field(&mut bytes, &self.slot.to_be_bytes());
+        field(&mut bytes, self.attempt_id.as_uuid().as_bytes());
+        field(&mut bytes, self.job_id.as_uuid().as_bytes());
+        field(&mut bytes, self.run_id.as_uuid().as_bytes());
+        field(&mut bytes, self.lease_id.as_uuid().as_bytes());
+        field(&mut bytes, &self.fencing_token.get().to_be_bytes());
+        field(&mut bytes, &self.job_ir_version.get().to_be_bytes());
+        field(&mut bytes, &self.job_ir_encoded_size.to_be_bytes());
+        field(&mut bytes, self.job_ir_digest.as_bytes());
+        field(&mut bytes, self.job_ir_object_key_digest.as_bytes());
+        field(&mut bytes, self.trust_binding_digest.as_bytes());
+        field(
+            &mut bytes,
+            self.environment_profile.id().as_str().as_bytes(),
+        );
+        field(&mut bytes, self.environment_profile.digest().as_bytes());
+        for capacity in [
+            self.job_resource_allocation.requests(),
+            self.job_resource_allocation.limits(),
+        ] {
+            field(&mut bytes, &capacity.cpu_millis().to_be_bytes());
+            field(&mut bytes, &capacity.memory_bytes().to_be_bytes());
+            field(&mut bytes, &capacity.ephemeral_disk_bytes().to_be_bytes());
+            field(&mut bytes, &capacity.gpu_count().to_be_bytes());
+        }
+        field(&mut bytes, &self.sandbox_pids_limit.to_be_bytes());
+        Sha256Digest::from_bytes(Sha256::digest(bytes).into())
+    }
+}
+
+/// Versioned signed envelope consumed only by the restricted Windows host broker.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsHyperVBrokerGrant {
+    schema: u16,
+    key_id: Sha256Digest,
+    claims: WindowsHyperVBrokerGrantClaims,
+    signature: Box<[u8]>,
+}
+
+impl WindowsHyperVBrokerGrant {
+    /// Builds a current signed envelope from an issuer-produced signature.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed claims, a zero key identifier, or any signature that
+    /// is not exactly the Ed25519 signature length.
+    pub fn new(
+        key_id: Sha256Digest,
+        claims: WindowsHyperVBrokerGrantClaims,
+        signature: impl Into<Box<[u8]>>,
+    ) -> Result<Self, WindowsHyperVBrokerGrantError> {
+        Self::from_parts(
+            WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4,
+            key_id,
+            claims,
+            signature,
+        )
+    }
+
+    /// Rehydrates a versioned grant at a protocol or durable boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsupported schema or any malformed envelope field.
+    pub fn from_parts(
+        schema: u16,
+        key_id: Sha256Digest,
+        claims: WindowsHyperVBrokerGrantClaims,
+        signature: impl Into<Box<[u8]>>,
+    ) -> Result<Self, WindowsHyperVBrokerGrantError> {
+        if schema != WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4 {
+            return Err(WindowsHyperVBrokerGrantError::UnsupportedSchema(schema));
+        }
+        if is_zero_digest(&key_id) {
+            return Err(WindowsHyperVBrokerGrantError::ZeroKeyId);
+        }
+        claims.validate()?;
+        let signature = signature.into();
+        if signature.len() != WINDOWS_HYPERV_BROKER_GRANT_SIGNATURE_BYTES {
+            return Err(WindowsHyperVBrokerGrantError::InvalidSignatureLength {
+                received: signature.len(),
+            });
+        }
+        Ok(Self {
+            schema,
+            key_id,
+            claims,
+            signature,
+        })
+    }
+
+    /// Returns the envelope schema.
+    #[must_use]
+    pub const fn schema(&self) -> u16 {
+        self.schema
+    }
+
+    /// Returns the issuer verification-key identifier.
+    #[must_use]
+    pub const fn key_id(&self) -> Sha256Digest {
+        self.key_id
+    }
+
+    /// Returns the signed metadata claims.
+    #[must_use]
+    pub const fn claims(&self) -> &WindowsHyperVBrokerGrantClaims {
+        &self.claims
+    }
+
+    /// Returns the exact detached Ed25519 signature bytes.
+    #[must_use]
+    pub fn signature(&self) -> &[u8] {
+        &self.signature
+    }
+
+    /// Returns the exact domain-separated bytes an issuer signs and a broker verifies.
+    #[must_use]
+    pub fn signing_bytes_for(
+        key_id: Sha256Digest,
+        claims: &WindowsHyperVBrokerGrantClaims,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(640);
+        bytes.extend_from_slice(SIGNING_DOMAIN);
+        field(
+            &mut bytes,
+            &WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4.to_be_bytes(),
+        );
+        field(&mut bytes, key_id.as_bytes());
+        claims.append_signing_fields(&mut bytes);
+        bytes
+    }
+
+    /// Returns the exact bytes covered by this envelope's signature.
+    #[must_use]
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        Self::signing_bytes_for(self.key_id, &self.claims)
+    }
+
+    /// Computes the stable one-use ledger identity of the complete envelope.
+    #[must_use]
+    pub fn digest(&self) -> Sha256Digest {
+        let signing_bytes = self.signing_bytes();
+        let mut digest = Sha256::new();
+        digest.update(DIGEST_DOMAIN);
+        digest.update((signing_bytes.len() as u64).to_be_bytes());
+        digest.update(signing_bytes);
+        digest.update((self.signature.len() as u64).to_be_bytes());
+        digest.update(&self.signature);
+        Sha256Digest::from_bytes(digest.finalize().into())
+    }
+}
+
+fn field(bytes: &mut Vec<u8>, value: &[u8]) {
+    bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(value);
+}
+
+fn is_zero_digest(digest: &Sha256Digest) -> bool {
+    digest.as_bytes().iter().all(|byte| *byte == 0)
+}
+
+/// Invalid signed Windows broker grant metadata or envelope.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsHyperVBrokerGrantError {
+    /// A UUID identity was nil.
+    #[error("Windows Hyper-V broker grant identities cannot be nil")]
+    NilIdentity,
+    /// A generation, epoch, or stable slot fence was zero.
+    #[error("Windows Hyper-V broker grant fences must be positive")]
+    ZeroFence,
+    /// The selected `JobIR` had no encoded content.
+    #[error("Windows Hyper-V broker grant cannot bind an empty JobIR")]
+    EmptyJobIr,
+    /// The admitted sandbox process ceiling was zero.
+    #[error("Windows Hyper-V broker grant process limit must be positive")]
+    ZeroProcessLimit,
+    /// A security-relevant content digest was the all-zero sentinel.
+    #[error("Windows Hyper-V broker grant digests cannot use the zero sentinel")]
+    ZeroDigest,
+    /// The stored exact-spec binding did not match the remaining claims.
+    #[error("Windows Hyper-V broker sandbox-spec binding is inconsistent")]
+    SandboxSpecBindingMismatch,
+    /// The validity interval was empty or negative.
+    #[error("Windows Hyper-V broker grant expiry must be after issuance")]
+    InvalidValidityInterval,
+    /// The envelope schema is not supported by this build.
+    #[error("unsupported Windows Hyper-V broker grant schema {0}")]
+    UnsupportedSchema(u16),
+    /// The verification-key identity was the all-zero sentinel.
+    #[error("Windows Hyper-V broker verification-key identity cannot be zero")]
+    ZeroKeyId,
+    /// The detached signature did not have the exact Ed25519 size.
+    #[error(
+        "Windows Hyper-V broker grant signature must contain exactly {WINDOWS_HYPERV_BROKER_GRANT_SIGNATURE_BYTES} bytes; received {received}"
+    )]
+    InvalidSignatureLength {
+        /// Actual signature byte length.
+        received: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EnvironmentProfileId, ResourceCapacity};
+
+    fn claims() -> WindowsHyperVBrokerGrantClaims {
+        let capacity = ResourceCapacity::new(2_000, 2 * 1024 * 1024 * 1024, 0, 0);
+        WindowsHyperVBrokerGrantClaims::new(
+            Sha256Digest::from_bytes([1; 32]),
+            Sha256Digest::from_bytes([2; 32]),
+            AttemptId::new(),
+            JobId::new(),
+            RunId::new(),
+            OperationId::new(),
+            OperationId::new(),
+            1,
+            OperationId::new(),
+            Sha256Digest::from_bytes([3; 32]),
+            RunnerId::new(),
+            RunnerSessionId::new(),
+            1,
+            1,
+            1,
+            LeaseId::new(),
+            FencingToken::new(1).expect("fencing token"),
+            JobIrVersion::current(),
+            128,
+            Sha256Digest::from_bytes([4; 32]),
+            Sha256Digest::from_bytes([5; 32]),
+            JobResourceAllocation::new(capacity, capacity).expect("allocation"),
+            64,
+            Sha256Digest::from_bytes([6; 32]),
+            EnvironmentProfile::new(
+                EnvironmentProfileId::new("example.test/windows").expect("profile id"),
+                Sha256Digest::from_bytes([7; 32]),
+            ),
+            Sha256Digest::from_bytes([8; 32]),
+            UnixMillis::new(100),
+            UnixMillis::new(200),
+        )
+        .expect("claims")
+    }
+
+    #[test]
+    fn v4_signing_and_sandbox_binding_commit_to_exact_placement() {
+        let key_id = Sha256Digest::from_bytes([9; 32]);
+        let exact = claims();
+        let mut substituted = exact.clone();
+        substituted.sandbox_pids_limit += 1;
+        substituted.sandbox_spec_sha256 = substituted.compute_sandbox_spec_sha256();
+        let mut another_create_request = exact.clone();
+        another_create_request.post_accept_operation_id = OperationId::new();
+
+        assert_ne!(
+            exact.sandbox_spec_sha256(),
+            substituted.sandbox_spec_sha256()
+        );
+        assert_eq!(
+            exact.sandbox_spec_sha256(),
+            another_create_request.sandbox_spec_sha256(),
+            "a retry's operation identity is not part of the sandbox spec"
+        );
+        assert_ne!(
+            WindowsHyperVBrokerGrant::signing_bytes_for(key_id, &exact),
+            WindowsHyperVBrokerGrant::signing_bytes_for(key_id, &substituted)
+        );
+        assert_ne!(
+            WindowsHyperVBrokerGrant::signing_bytes_for(key_id, &exact),
+            WindowsHyperVBrokerGrant::signing_bytes_for(key_id, &another_create_request),
+            "the signed issuance evidence still commits to its request identity"
+        );
+        assert!(exact.authorizes_sandbox_spec(
+            exact.profile_contract_sha256(),
+            exact.fencing_token().get(),
+            exact.job_resource_allocation(),
+            exact.sandbox_pids_limit(),
+            true,
+        ));
+        assert!(!exact.authorizes_sandbox_spec(
+            exact.profile_contract_sha256(),
+            exact.fencing_token().get(),
+            exact.job_resource_allocation(),
+            exact.sandbox_pids_limit() + 1,
+            true,
+        ));
+    }
+}

--- a/crates/automata-ci-credential-github/src/authority_issuer.rs
+++ b/crates/automata-ci-credential-github/src/authority_issuer.rs
@@ -431,8 +431,13 @@ impl GithubRepositoryRuntimeAuthorityIssuer {
             expires_at,
         )
         .map_err(|_| ControlPortError::Corrupt)?;
-        JobRuntimeAuthorities::new(vec![authority], request.job(), request.lease())
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            request.job(),
+            request.lease(),
+        )
+        .map_err(|_| ControlPortError::Corrupt)
     }
 
     async fn quarantine(

--- a/crates/automata-ci-execution/README.md
+++ b/crates/automata-ci-execution/README.md
@@ -11,6 +11,15 @@ a separate side channel from general sandbox networking: a provider must
 enforce the supplied scheme, host, and port set and must not infer broader
 egress authority from it.
 
+`SandboxAuthorizations` carries a canonical bounded set of opaque,
+provider-owned authorization payloads from a leased execution request into
+the exact `SandboxSpec`. A provider must consume only its own namespace and
+payload schema before mutation; providers without such a boundary reject a
+nonempty set instead of ignoring it. `SandboxExecutionBinding` accompanies a
+job authorization with the exact session, run, job, attempt, lease, accepted
+offer, and immutable `JobIR` identity so a restricted adapter can reject an
+authorization substituted from another execution.
+
 The Podman, Kubernetes, macOS Virtualization.framework, and Windows Hyper-V
 sandbox adapters implement `SandboxProvider` directly. Providers that
 advertise service-container support return the complete healthy discovery view

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -42,7 +42,10 @@ mod service;
 mod value;
 
 pub use automata_ci_core::{
-    EnvironmentProfile, EnvironmentProfileId, OperationId, RunnerId, Sha256Digest,
+    AttemptId, EnvironmentProfile, EnvironmentProfileId, FencingToken, JobId, JobIrVersion,
+    JobResourceAllocation, LeaseGuard, LeaseId, OperationId, ResourceCapacity, RunId, RunnerId,
+    RunnerSessionId, SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION, SandboxAuthorization,
+    SandboxAuthorizationError, SandboxAuthorizationName, SandboxAuthorizations, Sha256Digest,
 };
 pub use capability::{ProviderCapabilities, SandboxCapability};
 pub use endpoint::{
@@ -61,8 +64,8 @@ pub use runtime_service::{
     MAX_RUNTIME_SERVICE_ROUTES, RuntimeServiceProtocol, RuntimeServiceRoute, RuntimeServiceRoutes,
 };
 pub use sandbox::{
-    DestroyDisposition, DestroySandbox, SandboxCustody, SandboxInspection, SandboxProvider,
-    SandboxRecord, SandboxSpec, SandboxState,
+    DestroyDisposition, DestroySandbox, SandboxCustody, SandboxExecutionBinding, SandboxInspection,
+    SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
 };
 pub use service::{
     ContainerHandle, ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec,

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -1,13 +1,20 @@
-use std::{fmt, num::NonZeroU16};
+use std::{
+    fmt,
+    num::{NonZeroU16, NonZeroU64},
+};
 
-use automata_ci_core::{JobResourceAllocation, RunnerId};
+use automata_ci_core::{
+    AttemptId, JobId, JobIrVersion, JobResourceAllocation, LeaseGuard, RunId, RunnerId,
+    RunnerSessionId, Sha256Digest,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     Cancellation, EnvironmentProfile, ExecutionEndpoint, NetworkPolicy, OperationId,
     ProviderCapabilities, ProviderError, ProviderId, ResourceLimits, RootFilesystemPolicy,
-    RuntimeServiceRoutes, SandboxEnvironment, SandboxGeneration, SandboxHandle,
-    SandboxPrivilegePolicy, ServiceContainerBindings, ServiceContainerSpecs, TargetPath,
+    RuntimeServiceRoutes, SandboxAuthorizations, SandboxEnvironment, SandboxGeneration,
+    SandboxHandle, SandboxPrivilegePolicy, ServiceContainerBindings, ServiceContainerSpecs,
+    TargetPath,
 };
 
 /// Runner custody coordinates for one sandbox request.
@@ -33,6 +40,108 @@ pub enum SandboxCustody {
     },
 }
 
+/// Exact provider-neutral execution coordinates for one job sandbox.
+///
+/// This value lets a restricted provider adapter correlate an opaque signed
+/// authorization with the job, lease, session, accepted offer, and immutable
+/// `JobIR` that the runner is actually executing. Profile-admission sandboxes
+/// have no execution binding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SandboxExecutionBinding {
+    runner_session_id: RunnerSessionId,
+    run_id: RunId,
+    job_id: JobId,
+    attempt_id: AttemptId,
+    guard: LeaseGuard,
+    accepted_offer_operation_id: OperationId,
+    accepted_offer_sequence: NonZeroU64,
+    job_ir_version: JobIrVersion,
+    job_ir_digest: Sha256Digest,
+}
+
+impl SandboxExecutionBinding {
+    /// Creates the complete execution binding for an accepted job offer.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)] // The boundary deliberately binds every independent identity.
+    pub const fn new(
+        runner_session_id: RunnerSessionId,
+        run_id: RunId,
+        job_id: JobId,
+        attempt_id: AttemptId,
+        guard: LeaseGuard,
+        accepted_offer_operation_id: OperationId,
+        accepted_offer_sequence: NonZeroU64,
+        job_ir_version: JobIrVersion,
+        job_ir_digest: Sha256Digest,
+    ) -> Self {
+        Self {
+            runner_session_id,
+            run_id,
+            job_id,
+            attempt_id,
+            guard,
+            accepted_offer_operation_id,
+            accepted_offer_sequence,
+            job_ir_version,
+            job_ir_digest,
+        }
+    }
+
+    /// Returns the authenticated runner-session identity.
+    #[must_use]
+    pub const fn runner_session_id(self) -> RunnerSessionId {
+        self.runner_session_id
+    }
+
+    /// Returns the workflow-run identity.
+    #[must_use]
+    pub const fn run_id(self) -> RunId {
+        self.run_id
+    }
+
+    /// Returns the logical job identity.
+    #[must_use]
+    pub const fn job_id(self) -> JobId {
+        self.job_id
+    }
+
+    /// Returns the exact attempt identity.
+    #[must_use]
+    pub const fn attempt_id(self) -> AttemptId {
+        self.attempt_id
+    }
+
+    /// Returns the exact lease identity and fencing token.
+    #[must_use]
+    pub const fn guard(self) -> LeaseGuard {
+        self.guard
+    }
+
+    /// Returns the accepted lease-offer operation identity.
+    #[must_use]
+    pub const fn accepted_offer_operation_id(self) -> OperationId {
+        self.accepted_offer_operation_id
+    }
+
+    /// Returns the accepted lease-offer command sequence.
+    #[must_use]
+    pub const fn accepted_offer_sequence(self) -> NonZeroU64 {
+        self.accepted_offer_sequence
+    }
+
+    /// Returns the immutable `JobIR` schema version.
+    #[must_use]
+    pub const fn job_ir_version(self) -> JobIrVersion {
+        self.job_ir_version
+    }
+
+    /// Returns the immutable canonical `JobIR` digest.
+    #[must_use]
+    pub const fn job_ir_digest(self) -> Sha256Digest {
+        self.job_ir_digest
+    }
+}
+
 /// Immutable whole-job sandbox request. The profile is exact and contains no
 /// hosted-label resolution or mutable image reference.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -50,6 +159,8 @@ pub struct SandboxSpec {
     resource_allocation: Option<JobResourceAllocation>,
     services: ServiceContainerSpecs,
     runtime_service_routes: RuntimeServiceRoutes,
+    sandbox_authorizations: SandboxAuthorizations,
+    execution_binding: Option<SandboxExecutionBinding>,
 }
 
 impl SandboxSpec {
@@ -85,6 +196,8 @@ impl SandboxSpec {
             resource_allocation: None,
             services: ServiceContainerSpecs::empty(),
             runtime_service_routes: RuntimeServiceRoutes::empty(),
+            sandbox_authorizations: SandboxAuthorizations::empty(),
+            execution_binding: None,
         }
     }
 
@@ -229,6 +342,35 @@ impl SandboxSpec {
     #[must_use]
     pub const fn runtime_service_routes(&self) -> &RuntimeServiceRoutes {
         &self.runtime_service_routes
+    }
+
+    /// Attaches the exact provider-owned authorizations delivered for this job.
+    #[must_use]
+    pub fn with_sandbox_authorizations(
+        mut self,
+        sandbox_authorizations: SandboxAuthorizations,
+    ) -> Self {
+        self.sandbox_authorizations = sandbox_authorizations;
+        self
+    }
+
+    /// Returns the complete canonical authorization set for provider admission.
+    #[must_use]
+    pub const fn sandbox_authorizations(&self) -> &SandboxAuthorizations {
+        &self.sandbox_authorizations
+    }
+
+    /// Attaches the exact accepted-job identity visible to provider adapters.
+    #[must_use]
+    pub const fn with_execution_binding(mut self, binding: SandboxExecutionBinding) -> Self {
+        self.execution_binding = Some(binding);
+        self
+    }
+
+    /// Returns the accepted-job identity, absent for profile admission.
+    #[must_use]
+    pub const fn execution_binding(&self) -> Option<SandboxExecutionBinding> {
+        self.execution_binding
     }
 }
 
@@ -440,7 +582,9 @@ pub trait SandboxProvider: fmt::Debug + Send + Sync {
     /// fail closed. A successful replay returns the same generation-fenced
     /// resource rather than creating another sandbox. Providers which do not
     /// advertise [`crate::SandboxCapability::RuntimeServiceProxy`] must reject
-    /// a nonempty [`SandboxSpec::runtime_service_routes`] request.
+    /// a nonempty [`SandboxSpec::runtime_service_routes`] request. Providers
+    /// without an exact authorization consumer must likewise reject nonempty
+    /// [`SandboxSpec::sandbox_authorizations`] before mutation.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -7,11 +7,12 @@ use automata_ci_execution::{
     ImmutableImage, MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES,
     MAX_EXECUTION_OUTPUT_RECORDS, NetworkPolicy, OperationId, ProviderCapabilities, ProviderId,
     ResourceLimits, RootFilesystemPolicy, RunnerId, RuntimeServiceProtocol, RuntimeServiceRoute,
-    RuntimeServiceRoutes, SandboxCapability, SandboxCustody, SandboxEnvironment, SandboxGeneration,
-    SandboxHandle, SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding,
-    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
-    ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol,
-    Sha256Digest, TargetPath, ValueError,
+    RuntimeServiceRoutes, SandboxAuthorization, SandboxAuthorizationName, SandboxAuthorizations,
+    SandboxCapability, SandboxCustody, SandboxEnvironment, SandboxGeneration, SandboxHandle,
+    SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding, ServiceContainerBindings,
+    ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy,
+    ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol, Sha256Digest,
+    TargetPath, ValueError,
 };
 use url::Url;
 
@@ -140,6 +141,19 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
     );
     assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Unprivileged);
     assert!(spec.runtime_service_routes().is_empty());
+    assert!(spec.sandbox_authorizations().as_slice().is_empty());
+    let authorization = SandboxAuthorization::new(
+        SandboxAuthorizationName::new("example.provider").expect("authorization name"),
+        3,
+        b"opaque-authorization".to_vec(),
+    )
+    .expect("authorization");
+    let authorizations =
+        SandboxAuthorizations::new(vec![authorization]).expect("authorization set");
+    let authorized = spec
+        .clone()
+        .with_sandbox_authorizations(authorizations.clone());
+    assert_eq!(authorized.sandbox_authorizations(), &authorizations);
     let administrative = spec
         .clone()
         .with_privilege(SandboxPrivilegePolicy::Administrator);

--- a/crates/automata-ci-job-executor-actions/README.md
+++ b/crates/automata-ci-job-executor-actions/README.md
@@ -100,6 +100,11 @@ scheme/host/port routes on `SandboxSpec`. Credentials remain in the execution
 context and never enter the provider route contract. Providers without that
 capability receive no routes.
 
+The executor also copies the leased request's exact canonical
+`SandboxAuthorizations` set into `SandboxSpec` without interpreting provider
+payloads. Provider adapters remain responsible for fail-closed namespace,
+schema, policy-binding, and one-use consumption.
+
 ## Action metadata and runtime contract
 
 Repository action metadata is recursively prepared and cached after runtime

--- a/crates/automata-ci-job-executor-actions/src/container_runtime.rs
+++ b/crates/automata-ci-job-executor-actions/src/container_runtime.rs
@@ -154,6 +154,8 @@ pub(super) fn sandbox_spec(
     )
     .with_privilege(config.privilege())
     .with_services(service_specs.clone())
+    .with_sandbox_authorizations(request.sandbox_authorizations().clone())
+    .with_execution_binding(request.sandbox_execution_binding())
     .with_resource_allocation(
         request
             .job()

--- a/crates/automata-ci-job-executor-actions/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-actions/tests/run_steps.rs
@@ -7,7 +7,10 @@ use automata_ci_core::{
     JobConclusion, JobSecretExposure, LogGroupKind, MAX_JOB_RESULT_ATTACHMENT_BYTES,
     MAX_STEP_ATTACHMENT_TEXT_BYTES, RunnerId, StepAnnotationLevel, StepIr, ValueSource,
 };
-use automata_ci_execution::{RootFilesystemPolicy, SandboxCustody, SandboxPrivilegePolicy};
+use automata_ci_execution::{
+    RootFilesystemPolicy, SandboxAuthorization, SandboxAuthorizationName, SandboxAuthorizations,
+    SandboxCustody, SandboxPrivilegePolicy,
+};
 use automata_ci_runner_runtime::{
     ExecutionCancellation, ExecutionEvents, ExecutorErrorKind, JobExecutor,
 };
@@ -76,6 +79,37 @@ async fn credential_free_execution_has_no_authority_or_secret_and_emits_public_o
             "unexpected {forbidden}"
         );
     }
+}
+
+#[tokio::test]
+async fn sandbox_authorizations_reach_the_provider_as_the_exact_canonical_set() {
+    let fixture = Fixture::secretless(Vec::new(), vec![PhaseResponse::success()]);
+    let authorization = SandboxAuthorization::new(
+        SandboxAuthorizationName::new("example.provider").expect("authorization name"),
+        7,
+        b"opaque-provider-payload".to_vec(),
+    )
+    .expect("authorization");
+    let authorizations =
+        SandboxAuthorizations::new(vec![authorization]).expect("canonical authorization set");
+    let request = fixture.request_with_sandbox_authorizations(
+        credential_free_envelope(vec![run_step("authorized", "Authorized", "true")]),
+        authorizations.clone(),
+    );
+    let execution_binding = request.sandbox_execution_binding();
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(request, events, ExecutionCancellation::new())
+        .await
+        .expect("job executes");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let specs = fixture.provider.specs();
+    assert_eq!(specs.len(), 1);
+    assert_eq!(specs[0].sandbox_authorizations(), &authorizations);
+    assert_eq!(specs[0].execution_binding(), Some(execution_binding));
 }
 
 #[tokio::test]
@@ -933,6 +967,7 @@ fn assert_sandbox_spec(fixture: &Fixture, runner_id: RunnerId, slot_ordinal: u16
     assert_eq!(specs[0].privilege(), SandboxPrivilegePolicy::Administrator);
     assert_eq!(specs[0].workspace().as_str(), "/__w/automata/automata");
     assert_eq!(specs[0].scratch(), None);
+    assert!(specs[0].sandbox_authorizations().as_slice().is_empty());
     assert!(matches!(
         specs[0].custody(),
         SandboxCustody::Job {

--- a/crates/automata-ci-job-executor-actions/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-actions/tests/support/mod.rs
@@ -36,10 +36,11 @@ use automata_ci_execution::{
     ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream,
     ExecutionStage, ExecutionTermination, ImmutableImage, NetworkPolicy, OperationOutcome,
     ProviderCapabilities, ProviderError, ProviderErrorKind, ProviderId, ProviderStage,
-    ResourceLimits, RootFilesystemPolicy, SandboxCapability, SandboxCustody, SandboxEnvironment,
-    SandboxGeneration, SandboxHandle, SandboxInspection, SandboxPrivilegePolicy, SandboxProvider,
-    SandboxRecord, SandboxSpec, SandboxState, ServiceContainerBinding, ServiceContainerBindings,
-    ServiceNetwork, ServicePortBinding, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+    ResourceLimits, RootFilesystemPolicy, SandboxAuthorizations, SandboxCapability, SandboxCustody,
+    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxInspection,
+    SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
+    ServiceContainerBinding, ServiceContainerBindings, ServiceNetwork, ServicePortBinding,
+    SignalRequest, TargetPath, TargetPlatform, WaitRequest,
 };
 use automata_ci_expression_actions::{
     ExtensionFunctionResult, GithubEvaluationContext, GithubExpressionEvaluator,
@@ -55,8 +56,9 @@ use automata_ci_job_executor_actions::{
     SecretCustodyAcknowledger, SecretPort, StaticActionsToolchain,
 };
 use automata_ci_protocol::{
-    JobRuntimeAuthorities, JobRuntimeAuthority, ProtocolLimits, RunnerSlotOrdinal,
-    RuntimeAuthorityCredential, RuntimeAuthorityEndpoint, RuntimeAuthorityName,
+    CommandSequence, JobRuntimeAuthorities, JobRuntimeAuthority, ProtocolLimits, RunnerSlotOrdinal,
+    RuntimeAuthorityCredential, RuntimeAuthorityDeliveryBinding, RuntimeAuthorityEndpoint,
+    RuntimeAuthorityGeneration, RuntimeAuthorityName,
 };
 use automata_ci_protocol_protobuf::encode_job_runtime_context;
 use automata_ci_runner_journal::{
@@ -687,11 +689,27 @@ impl Fixture {
     }
 
     pub fn request(&self, job: JobIrEnvelope) -> ExecutionRequest {
-        execution_request(self.environment.clone(), job)
+        execution_request(
+            self.environment.clone(),
+            job,
+            SandboxAuthorizations::empty(),
+        )
+    }
+
+    pub fn request_with_sandbox_authorizations(
+        &self,
+        job: JobIrEnvelope,
+        sandbox_authorizations: SandboxAuthorizations,
+    ) -> ExecutionRequest {
+        execution_request(self.environment.clone(), job, sandbox_authorizations)
     }
 }
 
-fn execution_request(environment: SandboxEnvironment, job: JobIrEnvelope) -> ExecutionRequest {
+fn execution_request(
+    environment: SandboxEnvironment,
+    job: JobIrEnvelope,
+    sandbox_authorizations: SandboxAuthorizations,
+) -> ExecutionRequest {
     let attempt_id = AttemptId::new();
     let lease = Lease::new(
         LeaseId::new(),
@@ -709,6 +727,19 @@ fn execution_request(environment: SandboxEnvironment, job: JobIrEnvelope) -> Exe
         ProtectionId::new("tests").expect("valid protection"),
     )
     .expect("valid content");
+    let session_id = RunnerSessionId::new();
+    let slot = RunnerSlotOrdinal::new(1).expect("valid slot");
+    let authority_binding = RuntimeAuthorityDeliveryBinding::new(
+        lease.attempt_id(),
+        slot,
+        lease.guard(),
+        OperationId::new(),
+        CommandSequence::new(1).expect("valid offer sequence"),
+        content
+            .public_plaintext_sha256()
+            .expect("JobIR content is public"),
+        RuntimeAuthorityGeneration::new(1).expect("valid authority generation"),
+    );
     let authorities = match job.job().authority_profile() {
         JobAuthorityProfile::Standard => {
             let authority = JobRuntimeAuthority::new(
@@ -724,23 +755,27 @@ fn execution_request(environment: SandboxEnvironment, job: JobIrEnvelope) -> Exe
                 UnixMillis::new(1_000_000),
             )
             .expect("valid authority");
-            JobRuntimeAuthorities::new(vec![authority], &job, &lease)
+            JobRuntimeAuthorities::new(vec![authority], sandbox_authorizations, &job, &lease)
                 .expect("valid standard authority bundle")
         }
-        JobAuthorityProfile::CredentialFree => JobRuntimeAuthorities::new(Vec::new(), &job, &lease)
-            .expect("valid credential-free authority bundle"),
+        JobAuthorityProfile::CredentialFree => {
+            JobRuntimeAuthorities::new(Vec::new(), sandbox_authorizations, &job, &lease)
+                .expect("valid credential-free authority bundle")
+        }
     };
     ExecutionRequest::new(
-        RunnerSessionId::new(),
-        RunnerSlotOrdinal::new(1).expect("valid slot"),
+        session_id,
+        slot,
         lease,
         job,
         authorities,
+        authority_binding,
         content,
         environment,
         JobLifecycle::Preparing,
         None,
     )
+    .expect("valid execution request")
 }
 
 pub fn recovered_request(request: &ExecutionRequest) -> ExecutionRequest {
@@ -750,11 +785,13 @@ pub fn recovered_request(request: &ExecutionRequest) -> ExecutionRequest {
         request.lease().clone(),
         request.job().clone(),
         request.runtime_authorities().clone(),
+        request.runtime_authority_delivery_binding(),
         request.job_content().clone(),
         request.environment().clone(),
         request.recovery_lifecycle(),
         Some(journal_identity()),
     )
+    .expect("valid recovered execution request")
 }
 
 pub fn run_job(command: &str) -> JobIrEnvelope {

--- a/crates/automata-ci-local/src/local_docker/mod.rs
+++ b/crates/automata-ci-local/src/local_docker/mod.rs
@@ -2614,6 +2614,7 @@ fn validate_spec(spec: &SandboxSpec, runner_id: RunnerId) -> Result<(), Provider
         || workspace_conflicts_with_control
         || spec.scratch().is_some()
         || !spec.services().is_empty()
+        || !spec.sandbox_authorizations().as_slice().is_empty()
         || !spec.runtime_service_routes().is_empty()
         || spec.network() != NetworkPolicy::PrivateEgress
         || spec.root_filesystem() != RootFilesystemPolicy::Writable

--- a/crates/automata-ci-local/src/local_docker/tests.rs
+++ b/crates/automata-ci-local/src/local_docker/tests.rs
@@ -16,7 +16,8 @@ use automata_ci_execution::{
     Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentProfile,
     EnvironmentProfileId, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
     ExecutionErrorKind, ExecutionTermination, NeverCancelled, ResourceLimits, RootFilesystemPolicy,
-    SandboxCustody, SandboxGeneration, SandboxProvider, SandboxState, TargetPath,
+    SandboxAuthorization, SandboxAuthorizationName, SandboxAuthorizations, SandboxCustody,
+    SandboxGeneration, SandboxProvider, SandboxState, TargetPath,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestRequest, GuestResponse, decode_frame, encode_frame,
@@ -1194,6 +1195,25 @@ fn verified_results_transport(installation: &Installation) -> VerifiedResultsTra
 
 fn sandbox_spec() -> SandboxSpec {
     sandbox_spec_with_resources(ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits"))
+}
+
+#[test]
+fn local_docker_rejects_sandbox_authorizations_at_validation() {
+    let authorization = SandboxAuthorization::new(
+        SandboxAuthorizationName::new("another-provider").expect("authorization name"),
+        1,
+        b"opaque-authority".to_vec(),
+    )
+    .expect("authorization");
+    let spec = sandbox_spec().with_sandbox_authorizations(
+        SandboxAuthorizations::new(vec![authorization]).expect("authorization set"),
+    );
+
+    let error = validate_spec(&spec, RunnerId::from_uuid(Uuid::from_u128(2)))
+        .expect_err("local Docker cannot consume the authorization");
+
+    assert_eq!(error.kind(), ProviderErrorKind::UnsupportedCapability);
+    assert_eq!(error.stage(), ProviderStage::Validate);
 }
 
 fn sandbox_spec_with_resources(resources: ResourceLimits) -> SandboxSpec {

--- a/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
+++ b/crates/automata-ci-postgres/tests/store/execution/runner_control.rs
@@ -42,6 +42,7 @@ use automata_ci_core::{
 };
 use automata_ci_protocol::{
     CommandSequence as ProtocolCommandSequence, INITIAL_RUNTIME_AUTHORITY_GENERATION,
+    LeaseAuthorityName, LeaseAuthorityPollContribution, LeaseAuthorityPollContributions,
     RunnerSlotOrdinal, RuntimeAuthorityDeliveryBinding,
 };
 use automata_ci_store::{
@@ -59,8 +60,8 @@ use crate::support::{
 };
 
 const LEASE_REQUEST_KIND: &str = "automata.runner.lease-request.v1";
-const LEASE_OFFER_KIND: &str = "automata.runner.lease-offer.v2";
-const RUNTIME_AUTHORITY_PROTOCOL_VERSION: u16 = 2;
+const LEASE_OFFER_KIND: &str = "automata.runner.lease-offer.v3";
+const RUNTIME_AUTHORITY_PROTOCOL_VERSION: u16 = 3;
 const RUNTIME_AUTHORITY_REQUEST_KIND: &str = "automata.runner.runtime-authority-request.v2";
 const RUNTIME_AUTHORITY_ACK_KIND: &str = "automata.runner.runtime-authority-ack.v2";
 const ACTIVE_LEASE_DURATION_MILLIS: i64 = 300_000;
@@ -79,7 +80,7 @@ async fn expired_unpublished_claim_becomes_one_terminal_replay_without_maintenan
 
         let first = database
             .store()
-            .lookup_lease_request(request)
+            .lookup_lease_request(request, &LeaseAuthorityPollContributions::empty())
             .await?
             .expect("the admitted request retains one terminal receipt");
         assert!(matches!(
@@ -90,7 +91,7 @@ async fn expired_unpublished_claim_becomes_one_terminal_replay_without_maintenan
 
         let second = database
             .store()
-            .lookup_lease_request(request)
+            .lookup_lease_request(request, &LeaseAuthorityPollContributions::empty())
             .await?
             .expect("the terminal receipt replays exactly");
         assert_eq!(second.outcome(), first.outcome());
@@ -190,7 +191,7 @@ async fn superseded_unpublished_claim_becomes_one_terminal_replay() -> TestResul
 
         let first = database
             .store()
-            .lookup_lease_request(request)
+            .lookup_lease_request(request, &LeaseAuthorityPollContributions::empty())
             .await?
             .expect("the admitted request retains one terminal receipt");
         assert!(matches!(
@@ -201,7 +202,7 @@ async fn superseded_unpublished_claim_becomes_one_terminal_replay() -> TestResul
 
         let second = database
             .store()
-            .lookup_lease_request(request)
+            .lookup_lease_request(request, &LeaseAuthorityPollContributions::empty())
             .await?
             .expect("the terminal receipt replays exactly");
         assert_eq!(second.outcome(), first.outcome());
@@ -258,6 +259,7 @@ async fn lease_request_chains_bound_retry_state_per_live_slot() -> TestResult {
                         key,
                         observed_at,
                         page.no_work_advance(),
+                        LeaseAuthorityPollContributions::empty(),
                     )?)
                     .await?;
                 assert!(matches!(receipt.outcome(), TryClaimOutcome::NoWork));
@@ -382,8 +384,12 @@ async fn lease_request_drop_retry_predecessor_and_late_handler_are_fenced() -> T
                 UnixMillis::new(10),
             ))
             .await?;
-        let no_work =
-            NoWorkLeaseRequest::new(first_key, UnixMillis::new(10), page.no_work_advance())?;
+        let no_work = NoWorkLeaseRequest::new(
+            first_key,
+            UnixMillis::new(10),
+            page.no_work_advance(),
+            LeaseAuthorityPollContributions::empty(),
+        )?;
         database.store().record_no_work(no_work.clone()).await?;
 
         let dropped_retry = database.store().begin_lease_request(first_begin).await?;
@@ -391,7 +397,7 @@ async fn lease_request_drop_retry_predecessor_and_late_handler_are_fenced() -> T
         assert!(
             database
                 .store()
-                .lookup_lease_request(first_key)
+                .lookup_lease_request(first_key, &LeaseAuthorityPollContributions::empty())
                 .await?
                 .expect("semantic receipt")
                 .was_replayed()
@@ -549,6 +555,7 @@ async fn lease_request_rpc_failpoint_recovers_without_losing_head_or_semantic_re
                 key,
                 UnixMillis::new(10),
                 page.no_work_advance(),
+                LeaseAuthorityPollContributions::empty(),
             )?)
             .await?;
 
@@ -971,6 +978,75 @@ async fn lease_offer_publication_is_atomic_concurrent_and_exactly_replayed() -> 
             database.store().publish_lease_offer(stale).await,
             Err(StoreError::SessionFenceRejected(id)) if id == fence.session_id()
         ));
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
+async fn lease_offer_publication_rejects_authority_contribution_substitution_without_writes()
+-> TestResult {
+    run_with_database(|database| async move {
+        let accepted = lease_authority_contributions("test-sandbox", 0x31)?;
+        let substituted = lease_authority_contributions("test-sandbox", 0x32)?;
+        let (seed, lease, metadata, slot, request_operation_id, request_digest) =
+            active_lease_with_duration_protocol_and_authority(
+                &database,
+                ACTIVE_LEASE_DURATION_MILLIS,
+                Some(RUNTIME_AUTHORITY_PROTOCOL_VERSION),
+                accepted.clone(),
+            )
+            .await?;
+        let fence = seed.session_fences[0];
+        let exact = runtime_authority_offer_with_contributions(
+            fence,
+            &lease,
+            &metadata,
+            slot,
+            request_operation_id,
+            request_digest,
+            accepted,
+            OperationId::new(),
+        )?;
+        database.store().publish_lease_offer(exact).await?;
+        let published_state = offer_state(&database, fence.session_id()).await?;
+        assert_eq!(published_state, (1, 1, 1));
+
+        let conflicting = runtime_authority_offer_with_contributions(
+            fence,
+            &lease,
+            &metadata,
+            slot,
+            request_operation_id,
+            request_digest,
+            substituted,
+            OperationId::new(),
+        )?;
+        assert!(matches!(
+            database
+                .store()
+                .inspect_lease_offer_claim(conflicting.claim().clone())
+                .await,
+            Err(StoreError::OperationConflict { operation_id, .. })
+                if operation_id == request_operation_id
+        ));
+        assert_eq!(
+            offer_state(&database, fence.session_id()).await?,
+            published_state,
+            "a substituted inspection must not mutate the published offer or outbox"
+        );
+
+        assert!(matches!(
+            database.store().publish_lease_offer(conflicting).await,
+            Err(StoreError::OperationConflict { operation_id, .. })
+                if operation_id == request_operation_id
+        ));
+        assert_eq!(
+            offer_state(&database, fence.session_id()).await?,
+            published_state,
+            "a substituted publication retry must not append an offer or outbox command"
+        );
         Ok(())
     })
     .await
@@ -1957,7 +2033,7 @@ async fn runtime_authority_delivery_is_post_accept_value_free_exact_and_replayab
                 command_operation_id,
             )?)
             .await
-            .map_err(|error| std::io::Error::other(format!("publish v2 offer: {error}")))?;
+            .map_err(|error| std::io::Error::other(format!("publish v3 offer: {error}")))?;
         let binding = RuntimeAuthorityDeliveryBinding::new(
             lease.attempt_id(),
             RunnerSlotOrdinal::new(slot.ordinal())?,
@@ -2754,6 +2830,29 @@ async fn active_lease_with_duration_and_protocol(
     OperationId,
     Sha256Digest,
 )> {
+    active_lease_with_duration_protocol_and_authority(
+        database,
+        duration_millis,
+        protocol_version,
+        LeaseAuthorityPollContributions::empty(),
+    )
+    .await
+}
+
+async fn active_lease_with_duration_protocol_and_authority(
+    database: &TestDatabase,
+    duration_millis: i64,
+    protocol_version: Option<u16>,
+    authority_contributions: LeaseAuthorityPollContributions,
+) -> TestResult<(
+    SeedData,
+    Lease,
+    JobIrMetadata,
+    StableRunnerSlot,
+    OperationId,
+    Sha256Digest,
+)> {
+    let expected_authority_contributions = authority_contributions.clone();
     let seed = seed_control_plane(database.pool(), 1).await?;
     if let Some(protocol_version) = protocol_version {
         let updated = sqlx::query("UPDATE runner_sessions SET protocol_version = $2 WHERE id = $1")
@@ -2808,11 +2907,17 @@ async fn active_lease_with_duration_and_protocol(
             observed_at,
             expires_at,
             page.claim_advance(attempt_id)?,
+            authority_contributions,
         )?)
         .await?;
     let TryClaimOutcome::Claimed(claimed) = receipt.outcome() else {
         panic!("fixture attempt was not claimed");
     };
+    assert_eq!(
+        claimed.authority_contributions(),
+        &expected_authority_contributions,
+        "the durable claim must replay the exact accepted authority contributions"
+    );
     Ok((
         seed,
         claimed.lease().clone(),
@@ -2855,6 +2960,7 @@ fn offer(
         slot,
         lease.clone(),
         metadata.clone(),
+        LeaseAuthorityPollContributions::empty(),
         lease.expires_at(),
         command,
     )?)
@@ -2870,6 +2976,29 @@ fn runtime_authority_offer(
     request_digest: Sha256Digest,
     command_operation_id: OperationId,
 ) -> TestResult<PublishLeaseOffer> {
+    runtime_authority_offer_with_contributions(
+        fence,
+        lease,
+        metadata,
+        slot,
+        request_operation_id,
+        request_digest,
+        LeaseAuthorityPollContributions::empty(),
+        command_operation_id,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn runtime_authority_offer_with_contributions(
+    fence: automata_ci_store::RunnerSessionFence,
+    lease: &Lease,
+    metadata: &JobIrMetadata,
+    slot: StableRunnerSlot,
+    request_operation_id: OperationId,
+    request_digest: Sha256Digest,
+    authority_contributions: LeaseAuthorityPollContributions,
+    command_operation_id: OperationId,
+) -> TestResult<PublishLeaseOffer> {
     let request = RunnerOperationRequest::new(
         fence,
         request_operation_id,
@@ -2879,7 +3008,7 @@ fn runtime_authority_offer(
     let command = EnqueueRunnerCommand::new(
         fence,
         command_operation_id,
-        RunnerOperationKind::new("automata.runner.lease-offer.v2")?,
+        RunnerOperationKind::new(LEASE_OFFER_KIND)?,
         RunnerCommandPayload::new(
             DocumentSchema::new(RUNTIME_AUTHORITY_PROTOCOL_VERSION)?,
             b"value-free lease offer body".to_vec(),
@@ -2892,9 +3021,23 @@ fn runtime_authority_offer(
         slot,
         lease.clone(),
         metadata.clone(),
+        authority_contributions,
         lease.expires_at(),
         command,
     )?)
+}
+
+fn lease_authority_contributions(
+    name: &str,
+    payload_byte: u8,
+) -> TestResult<LeaseAuthorityPollContributions> {
+    Ok(LeaseAuthorityPollContributions::new(vec![
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new(name)?,
+            1,
+            vec![payload_byte; 32],
+        )?,
+    ])?)
 }
 
 fn operation_request(
@@ -3118,6 +3261,7 @@ async fn install_completed_no_work_head(
             key,
             observed_at,
             page.no_work_advance(),
+            LeaseAuthorityPollContributions::empty(),
         )?)
         .await?;
     database

--- a/crates/automata-ci-protocol-protobuf/proto/automata/runner/v1/runner.proto
+++ b/crates/automata-ci-protocol-protobuf/proto/automata/runner/v1/runner.proto
@@ -26,6 +26,8 @@ message RunnerFrame {
 }
 
 message ServerFrame {
+  reserved 8;
+  reserved "no_work";
   oneof payload {
     ServerHello hello = 1;
     HandshakeRejected handshake_rejected = 2;
@@ -34,9 +36,9 @@ message ServerFrame {
     CancelJob cancel_job = 5;
     LogAckMessage log_ack = 6;
     OperationAck operation_ack = 7;
-    NoWork no_work = 8;
     ErrorMessage error = 9;
     RuntimeAuthorityGrant runtime_authority_grant = 10;
+    LeasePollResponse lease_poll_response = 11;
   }
 }
 
@@ -236,10 +238,46 @@ message RunnerRequirements {
 }
 
 message LeaseRequest {
+  reserved 4;
+  reserved "windows_placement_renewal";
   MessageHeader header = 1;
   uint32 slot = 2;
   // Present on every successor and absent only on the first request for a slot.
   optional bytes acknowledges_operation_id = 3;
+  // Required even when empty. The server must acknowledge this bundle's exact
+  // canonical digest before the runner adopts a poll outcome.
+  LeaseAuthorityPollContributions authority_contributions = 5;
+}
+
+message LeaseAuthorityPollContribution {
+  string name = 1;
+  uint32 payload_schema_version = 2;
+  bytes payload_sha256 = 3;
+  bytes payload = 4;
+}
+
+message LeaseAuthorityPollContributions {
+  uint32 schema_version = 1;
+  // Canonical set: strictly ascending and duplicate-free by name.
+  repeated LeaseAuthorityPollContribution contributions = 2;
+  bytes sha256_digest = 3;
+}
+
+message LeasePollResponse {
+  MessageHeader header = 1;
+  bytes accepted_contributions_sha256 = 2;
+  oneof outcome {
+    uint32 no_work_retry_after_millis = 3;
+    LeaseOffer lease_offer = 4;
+    CancelJob cancel_job = 5;
+  }
+}
+
+message WindowsRunnerPlacementRenewalEnvelope {
+  uint32 schema_version = 1;
+  string issuer_key_id = 2;
+  bytes signed_payload = 3;
+  bytes authenticator = 4;
 }
 
 message Lease {
@@ -278,7 +316,50 @@ message LeaseOffer {
   Lease lease = 3;
   JobIrEnvelope job = 4;
   reserved 5;
+  reserved "windows_hyperv_broker_grant";
   ManagedSecretBindingOverlay managed_secret_bindings = 6;
+}
+
+// Signed, value-free authority for one exact restricted host placement. It
+// contains no credential, engine endpoint, host path, command, or HCS document.
+message WindowsHyperVBrokerGrant {
+  uint32 schema = 1;
+  bytes key_id_sha256 = 2;
+  WindowsHyperVBrokerGrantClaims claims = 3;
+  bytes ed25519_signature = 4;
+}
+
+message WindowsHyperVBrokerGrantClaims {
+  bytes host_id_sha256 = 1;
+  bytes placement_binding_sha256 = 2;
+  bytes attempt_id = 3;
+  bytes job_id = 4;
+  bytes run_id = 5;
+  bytes poll_operation_id = 6;
+  bytes runner_id = 7;
+  bytes runner_session_id = 8;
+  uint64 runner_generation = 9;
+  uint64 session_epoch = 10;
+  uint32 slot = 11;
+  bytes lease_id = 12;
+  uint64 fencing_token = 13;
+  uint32 job_ir_version = 14;
+  uint64 job_ir_encoded_size = 15;
+  bytes job_ir_sha256 = 16;
+  bytes job_ir_object_key_sha256 = 17;
+  bytes trust_binding_sha256 = 18;
+  string environment_profile_id = 19;
+  bytes environment_profile_sha256 = 20;
+  int64 issued_at_unix_millis = 21;
+  int64 expires_at_unix_millis = 22;
+  bytes accepted_offer_operation_id = 23;
+  uint64 accepted_offer_sequence = 24;
+  bytes post_accept_operation_id = 25;
+  bytes post_accept_request_sha256 = 26;
+  JobResourceAllocation job_resource_allocation = 27;
+  bytes profile_contract_sha256 = 28;
+  uint32 sandbox_pids_limit = 29;
+  bytes sandbox_spec_sha256 = 30;
 }
 
 message ManagedSecretBindingOverlayEntry {
@@ -326,6 +407,20 @@ message JobRuntimeAuthorities {
   uint32 schema_version = 1;
   // Canonical map: strictly ascending and duplicate-free by authority name.
   repeated JobRuntimeAuthority authorities = 2;
+  SandboxAuthorizations sandbox_authorizations = 3;
+}
+
+message SandboxAuthorization {
+  string name = 1;
+  uint32 payload_schema_version = 2;
+  bytes payload_sha256 = 3;
+  bytes payload = 4;
+}
+
+message SandboxAuthorizations {
+  uint32 schema_version = 1;
+  // Canonical set: strictly ascending and duplicate-free by name.
+  repeated SandboxAuthorization authorizations = 2;
 }
 
 message LeaseResponse {
@@ -815,6 +910,8 @@ message RuntimeAuthorityRequest {
 }
 
 message RuntimeAuthorityGrant {
+  reserved 5;
+  reserved "windows_hyperv_broker_grant";
   MessageHeader header = 1;
   RuntimeAuthorityDeliveryBinding binding = 2;
   bytes bundle_sha256 = 3;
@@ -990,11 +1087,6 @@ message CommandAck {
 
 message OperationAck {
   MessageHeader header = 1;
-}
-
-message NoWork {
-  MessageHeader header = 1;
-  uint32 retry_after_millis = 2;
 }
 
 enum RemoteErrorCode {

--- a/crates/automata-ci-protocol-protobuf/src/decode.rs
+++ b/crates/automata-ci-protocol-protobuf/src/decode.rs
@@ -100,6 +100,66 @@ pub fn decode_runtime_authorities(
     runtime_authorities(value, job, lease, limits)
 }
 
+/// Canonically decodes one provider-owned Windows runner placement renewal payload.
+///
+/// This standalone payload is bounded by the generic lease-authority payload
+/// ceiling and rejects unknown, reordered, or otherwise noncanonical protobuf
+/// encodings before returning the domain envelope.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for empty, oversized, malformed, noncanonical, or
+/// invalid renewal bytes.
+pub fn decode_windows_runner_placement_renewal_payload(
+    encoded: &[u8],
+) -> Result<protocol::WindowsRunnerPlacementRenewalEnvelope, DecodeError> {
+    check_intrinsic_payload_size(encoded, protocol::MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES)?;
+    let value = wire::WindowsRunnerPlacementRenewalEnvelope::decode(encoded)
+        .map_err(DecodeError::MalformedProtobuf)?;
+    if value.encode_to_vec() != encoded {
+        return Err(DecodeError::NonCanonicalValue {
+            field: "windows_runner_placement_renewal_payload",
+        });
+    }
+    windows_placement_renewal(value)
+}
+
+/// Canonically decodes one provider-owned Windows Hyper-V sandbox grant payload.
+///
+/// This standalone payload is bounded by the generic sandbox-authorization
+/// payload ceiling and rejects protobuf aliases before returning the grant.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for empty, oversized, malformed, noncanonical, or
+/// invalid grant bytes.
+pub fn decode_windows_hyperv_broker_grant_payload(
+    encoded: &[u8],
+) -> Result<core::WindowsHyperVBrokerGrant, DecodeError> {
+    check_intrinsic_payload_size(encoded, core::MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES)?;
+    let value =
+        wire::WindowsHyperVBrokerGrant::decode(encoded).map_err(DecodeError::MalformedProtobuf)?;
+    if value.encode_to_vec() != encoded {
+        return Err(DecodeError::NonCanonicalValue {
+            field: "windows_hyperv_broker_grant_payload",
+        });
+    }
+    windows_hyperv_broker_grant(value)
+}
+
+fn check_intrinsic_payload_size(encoded: &[u8], maximum: usize) -> Result<(), DecodeError> {
+    if encoded.is_empty() {
+        return Err(DecodeError::EmptyFrame);
+    }
+    if encoded.len() > maximum {
+        return Err(DecodeError::FrameTooLarge {
+            size: encoded.len(),
+            maximum,
+        });
+    }
+    Ok(())
+}
+
 fn check_frame_size(frame: &[u8], limits: &protocol::ProtocolLimits) -> Result<(), DecodeError> {
     if frame.is_empty() {
         return Err(DecodeError::EmptyFrame);
@@ -122,7 +182,7 @@ fn runner_frame(
 
     match required_variant(frame.payload, "runner_frame.payload")? {
         Payload::Hello(value) => runner_hello(value, limits).map(Domain::Hello),
-        Payload::LeaseRequest(value) => lease_request(value).map(Domain::LeaseRequest),
+        Payload::LeaseRequest(value) => lease_request(value, limits).map(Domain::LeaseRequest),
         Payload::LeaseResponse(value) => lease_response(value).map(Domain::LeaseResponse),
         Payload::RuntimeAuthorityRequest(value) => {
             runtime_authority_request(value).map(Domain::RuntimeAuthorityRequest)
@@ -150,6 +210,9 @@ fn server_frame(
         Payload::HandshakeRejected(value) => {
             handshake_rejected(value).map(Domain::HandshakeRejected)
         }
+        Payload::LeasePollResponse(value) => {
+            lease_poll_response(value, limits).map(|item| Domain::LeasePollResponse(Box::new(item)))
+        }
         Payload::LeaseOffer(value) => {
             lease_offer(value, limits).map(|item| Domain::LeaseOffer(Box::new(item)))
         }
@@ -159,7 +222,6 @@ fn server_frame(
         Payload::CancelJob(value) => cancel_job(value).map(Domain::CancelJob),
         Payload::LogAck(value) => log_ack_message(value).map(Domain::LogAck),
         Payload::OperationAck(value) => operation_ack(value).map(Domain::OperationAck),
-        Payload::NoWork(value) => no_work(value).map(Domain::NoWork),
         Payload::Error(value) => error_message(value, limits).map(Domain::Error),
     }
 }
@@ -885,22 +947,149 @@ fn decode_groups(
         .collect()
 }
 
-fn lease_request(value: wire::LeaseRequest) -> Result<protocol::LeaseRequest, DecodeError> {
+fn lease_request(
+    value: wire::LeaseRequest,
+    limits: &protocol::ProtocolLimits,
+) -> Result<protocol::LeaseRequest, DecodeError> {
     let header = message_header(required(value.header, "lease_request.header")?)?;
     let slot = runner_slot(value.slot, "lease_request.slot")?;
-    value.acknowledges_operation_id.map_or_else(
-        || Ok(protocol::LeaseRequest::first(header, slot)),
-        |operation_id| {
-            Ok(protocol::LeaseRequest::successor(
-                header,
-                slot,
-                core::OperationId::from_uuid(uuid(
-                    operation_id,
-                    "lease_request.acknowledges_operation_id",
-                )?),
-            ))
-        },
+    let authority_contributions = lease_authority_poll_contributions(
+        required(
+            value.authority_contributions,
+            "lease_request.authority_contributions",
+        )?,
+        limits,
+    )?;
+    match value.acknowledges_operation_id {
+        None => Ok(protocol::LeaseRequest::first(
+            header,
+            slot,
+            authority_contributions,
+        )),
+        Some(operation_id) => Ok(protocol::LeaseRequest::successor(
+            header,
+            slot,
+            core::OperationId::from_uuid(uuid(
+                operation_id,
+                "lease_request.acknowledges_operation_id",
+            )?),
+            authority_contributions,
+        )),
+    }
+}
+
+fn lease_authority_poll_contributions(
+    value: wire::LeaseAuthorityPollContributions,
+    limits: &protocol::ProtocolLimits,
+) -> Result<protocol::LeaseAuthorityPollContributions, DecodeError> {
+    check_schema(
+        value.schema_version,
+        protocol::LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+        "lease_authority_poll_contributions.schema_version",
+    )?;
+    check_collection(
+        value.contributions.len(),
+        protocol::MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS.min(limits.max_collection_items()),
+        "lease_authority_poll_contributions.contributions",
+    )?;
+    ensure_order(
+        value
+            .contributions
+            .windows(2)
+            .map(|pair| pair[0].name.cmp(&pair[1].name)),
+        "lease_authority_poll_contributions.contributions",
+    )?;
+    let contributions = value
+        .contributions
+        .into_iter()
+        .map(lease_authority_poll_contribution)
+        .collect::<Result<Vec<_>, _>>()?;
+    protocol::LeaseAuthorityPollContributions::from_parts(
+        narrow_u16(
+            value.schema_version,
+            "lease_authority_poll_contributions.schema_version",
+        )?,
+        contributions,
+        sha256_digest(
+            value.sha256_digest,
+            "lease_authority_poll_contributions.sha256_digest",
+        )?,
     )
+    .map_err(|_| DecodeError::InvalidValue {
+        field: "lease_authority_poll_contributions",
+    })
+}
+
+fn lease_authority_poll_contribution(
+    value: wire::LeaseAuthorityPollContribution,
+) -> Result<protocol::LeaseAuthorityPollContribution, DecodeError> {
+    protocol::LeaseAuthorityPollContribution::from_parts(
+        protocol::LeaseAuthorityName::new(value.name).map_err(|_| DecodeError::InvalidValue {
+            field: "lease_authority_poll_contribution.name",
+        })?,
+        narrow_u16(
+            value.payload_schema_version,
+            "lease_authority_poll_contribution.payload_schema_version",
+        )?,
+        sha256_digest(
+            value.payload_sha256,
+            "lease_authority_poll_contribution.payload_sha256",
+        )?,
+        value.payload,
+    )
+    .map_err(|_| DecodeError::InvalidValue {
+        field: "lease_authority_poll_contribution",
+    })
+}
+
+fn lease_poll_response(
+    value: wire::LeasePollResponse,
+    limits: &protocol::ProtocolLimits,
+) -> Result<protocol::LeasePollResponse, DecodeError> {
+    use wire::lease_poll_response::Outcome;
+
+    let header = message_header(required(value.header, "lease_poll_response.header")?)?;
+    let accepted = sha256_digest(
+        value.accepted_contributions_sha256,
+        "lease_poll_response.accepted_contributions_sha256",
+    )?;
+    match required_variant(value.outcome, "lease_poll_response.outcome")? {
+        Outcome::NoWorkRetryAfterMillis(retry_after_millis) => Ok(
+            protocol::LeasePollResponse::no_work(header, accepted, retry_after_millis),
+        ),
+        Outcome::LeaseOffer(offer) => Ok(protocol::LeasePollResponse::lease_offer(
+            header,
+            accepted,
+            lease_offer(offer, limits)?,
+        )),
+        Outcome::CancelJob(cancel) => Ok(protocol::LeasePollResponse::cancel_job(
+            header,
+            accepted,
+            cancel_job(cancel)?,
+        )),
+    }
+}
+
+fn windows_placement_renewal(
+    value: wire::WindowsRunnerPlacementRenewalEnvelope,
+) -> Result<protocol::WindowsRunnerPlacementRenewalEnvelope, DecodeError> {
+    let schema_version =
+        u16::try_from(value.schema_version).map_err(|_| DecodeError::IntegerOutOfRange {
+            field: "windows_runner_placement_renewal_payload.schema_version",
+        })?;
+    if schema_version != protocol::WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION {
+        return Err(DecodeError::InvalidValue {
+            field: "windows_runner_placement_renewal_payload.schema_version",
+        });
+    }
+    protocol::WindowsRunnerPlacementRenewalEnvelope::new(
+        value.issuer_key_id,
+        value.signed_payload,
+        value.authenticator,
+    )
+    .map_err(|_| DecodeError::InvalidValue {
+        field: "windows_runner_placement_renewal_payload",
+    })
 }
 
 fn lease_offer(
@@ -915,17 +1104,161 @@ fn lease_offer(
         .managed_secret_bindings
         .map(|overlay| managed_secret_binding_overlay(overlay, &lease, limits))
         .transpose()?;
-    let offer = protocol::LeaseOffer::new(header, slot, lease, job);
-    match managed_secret_bindings {
-        Some(overlay) => {
+    let mut offer = protocol::LeaseOffer::new(header, slot, lease, job);
+    if let Some(overlay) = managed_secret_bindings {
+        offer =
             offer
                 .with_managed_secret_bindings(overlay)
                 .map_err(|_| DecodeError::InvalidValue {
                     field: "lease_offer.managed_secret_bindings",
-                })
-        }
-        None => Ok(offer),
+                })?;
     }
+    Ok(offer)
+}
+
+fn windows_hyperv_broker_grant(
+    value: wire::WindowsHyperVBrokerGrant,
+) -> Result<core::WindowsHyperVBrokerGrant, DecodeError> {
+    let schema = u16::try_from(value.schema).map_err(|_| DecodeError::IntegerOutOfRange {
+        field: "windows_hyperv_broker_grant.schema",
+    })?;
+    let key_id = sha256_digest(
+        value.key_id_sha256,
+        "windows_hyperv_broker_grant.key_id_sha256",
+    )?;
+    let claims = windows_hyperv_broker_grant_claims(required(
+        value.claims,
+        "windows_hyperv_broker_grant.claims",
+    )?)?;
+    core::WindowsHyperVBrokerGrant::from_parts(schema, key_id, claims, value.ed25519_signature)
+        .map_err(|_| DecodeError::InvalidValue {
+            field: "windows_hyperv_broker_grant",
+        })
+}
+
+#[allow(clippy::too_many_lines)]
+pub(crate) fn windows_hyperv_broker_grant_claims(
+    value: wire::WindowsHyperVBrokerGrantClaims,
+) -> Result<core::WindowsHyperVBrokerGrantClaims, DecodeError> {
+    let slot = u16::try_from(value.slot).map_err(|_| DecodeError::IntegerOutOfRange {
+        field: "windows_hyperv_broker_grant.claims.slot",
+    })?;
+    let job_ir_version =
+        u16::try_from(value.job_ir_version).map_err(|_| DecodeError::IntegerOutOfRange {
+            field: "windows_hyperv_broker_grant.claims.job_ir_version",
+        })?;
+    let profile_id =
+        core::EnvironmentProfileId::new(value.environment_profile_id).map_err(|_| {
+            DecodeError::InvalidValue {
+                field: "windows_hyperv_broker_grant.claims.environment_profile_id",
+            }
+        })?;
+    let profile = core::EnvironmentProfile::new(
+        profile_id,
+        sha256_digest(
+            value.environment_profile_sha256,
+            "windows_hyperv_broker_grant.claims.environment_profile_sha256",
+        )?,
+    );
+    let job_resource_allocation = decode_resource_allocation(required(
+        value.job_resource_allocation,
+        "windows_hyperv_broker_grant.claims.job_resource_allocation",
+    )?)?;
+    let expected_sandbox_spec_sha256 = sha256_digest(
+        value.sandbox_spec_sha256,
+        "windows_hyperv_broker_grant.claims.sandbox_spec_sha256",
+    )?;
+    let claims = core::WindowsHyperVBrokerGrantClaims::new(
+        sha256_digest(
+            value.host_id_sha256,
+            "windows_hyperv_broker_grant.claims.host_id_sha256",
+        )?,
+        sha256_digest(
+            value.placement_binding_sha256,
+            "windows_hyperv_broker_grant.claims.placement_binding_sha256",
+        )?,
+        core::AttemptId::from_uuid(uuid(
+            value.attempt_id,
+            "windows_hyperv_broker_grant.claims.attempt_id",
+        )?),
+        core::JobId::from_uuid(uuid(
+            value.job_id,
+            "windows_hyperv_broker_grant.claims.job_id",
+        )?),
+        core::RunId::from_uuid(uuid(
+            value.run_id,
+            "windows_hyperv_broker_grant.claims.run_id",
+        )?),
+        core::OperationId::from_uuid(uuid(
+            value.poll_operation_id,
+            "windows_hyperv_broker_grant.claims.poll_operation_id",
+        )?),
+        core::OperationId::from_uuid(uuid(
+            value.accepted_offer_operation_id,
+            "windows_hyperv_broker_grant.claims.accepted_offer_operation_id",
+        )?),
+        value.accepted_offer_sequence,
+        core::OperationId::from_uuid(uuid(
+            value.post_accept_operation_id,
+            "windows_hyperv_broker_grant.claims.post_accept_operation_id",
+        )?),
+        sha256_digest(
+            value.post_accept_request_sha256,
+            "windows_hyperv_broker_grant.claims.post_accept_request_sha256",
+        )?,
+        core::RunnerId::from_uuid(uuid(
+            value.runner_id,
+            "windows_hyperv_broker_grant.claims.runner_id",
+        )?),
+        core::RunnerSessionId::from_uuid(uuid(
+            value.runner_session_id,
+            "windows_hyperv_broker_grant.claims.runner_session_id",
+        )?),
+        value.runner_generation,
+        value.session_epoch,
+        slot,
+        core::LeaseId::from_uuid(uuid(
+            value.lease_id,
+            "windows_hyperv_broker_grant.claims.lease_id",
+        )?),
+        core::FencingToken::new(value.fencing_token).map_err(|_| DecodeError::InvalidValue {
+            field: "windows_hyperv_broker_grant.claims.fencing_token",
+        })?,
+        core::JobIrVersion::new(job_ir_version).map_err(|_| DecodeError::InvalidValue {
+            field: "windows_hyperv_broker_grant.claims.job_ir_version",
+        })?,
+        value.job_ir_encoded_size,
+        sha256_digest(
+            value.job_ir_sha256,
+            "windows_hyperv_broker_grant.claims.job_ir_sha256",
+        )?,
+        sha256_digest(
+            value.job_ir_object_key_sha256,
+            "windows_hyperv_broker_grant.claims.job_ir_object_key_sha256",
+        )?,
+        job_resource_allocation,
+        value.sandbox_pids_limit,
+        sha256_digest(
+            value.trust_binding_sha256,
+            "windows_hyperv_broker_grant.claims.trust_binding_sha256",
+        )?,
+        profile,
+        sha256_digest(
+            value.profile_contract_sha256,
+            "windows_hyperv_broker_grant.claims.profile_contract_sha256",
+        )?,
+        core::UnixMillis::new(value.issued_at_unix_millis),
+        core::UnixMillis::new(value.expires_at_unix_millis),
+    )
+    .map_err(|_| DecodeError::InvalidValue {
+        field: "windows_hyperv_broker_grant.claims",
+    })?;
+    if claims.sandbox_spec_sha256() != expected_sandbox_spec_sha256 {
+        return Err(DecodeError::InvalidValue {
+            field: "windows_hyperv_broker_grant.claims.sandbox_spec_sha256",
+        });
+    }
+    Ok(claims)
 }
 
 fn runtime_authority_delivery_binding(
@@ -1109,11 +1442,18 @@ fn runtime_authorities(
         .into_iter()
         .map(runtime_authority)
         .collect::<Result<Vec<_>, _>>()?;
-    protocol::JobRuntimeAuthorities::new(authorities, job, lease).map_err(|_| {
-        DecodeError::InvalidValue {
+    let sandbox_authorizations = sandbox_authorizations(
+        required(
+            value.sandbox_authorizations,
+            "runtime_authorities.sandbox_authorizations",
+        )?,
+        limits,
+    )?;
+    protocol::JobRuntimeAuthorities::new(authorities, sandbox_authorizations, job, lease).map_err(
+        |_| DecodeError::InvalidValue {
             field: "runtime_authorities",
-        }
-    })
+        },
+    )
 }
 
 fn runtime_authorities_unbound(
@@ -1135,10 +1475,67 @@ fn runtime_authorities_unbound(
         .into_iter()
         .map(runtime_authority)
         .collect::<Result<Vec<_>, _>>()?;
-    protocol::JobRuntimeAuthorities::from_unbound(authorities).map_err(|_| {
-        DecodeError::InvalidValue {
+    let sandbox_authorizations = sandbox_authorizations(
+        required(
+            value.sandbox_authorizations,
+            "runtime_authorities.sandbox_authorizations",
+        )?,
+        limits,
+    )?;
+    protocol::JobRuntimeAuthorities::from_unbound(authorities, sandbox_authorizations).map_err(
+        |_| DecodeError::InvalidValue {
             field: "runtime_authorities",
-        }
+        },
+    )
+}
+
+fn sandbox_authorizations(
+    value: wire::SandboxAuthorizations,
+    limits: &protocol::ProtocolLimits,
+) -> Result<core::SandboxAuthorizations, DecodeError> {
+    check_schema(
+        value.schema_version,
+        core::SANDBOX_AUTHORIZATIONS_SCHEMA_VERSION,
+        "sandbox_authorizations.schema_version",
+    )?;
+    check_collection(
+        value.authorizations.len(),
+        core::MAX_SANDBOX_AUTHORIZATIONS.min(limits.max_collection_items()),
+        "sandbox_authorizations.authorizations",
+    )?;
+    ensure_order(
+        value
+            .authorizations
+            .windows(2)
+            .map(|pair| pair[0].name.cmp(&pair[1].name)),
+        "sandbox_authorizations.authorizations",
+    )?;
+    let authorizations = value
+        .authorizations
+        .into_iter()
+        .map(sandbox_authorization)
+        .collect::<Result<Vec<_>, _>>()?;
+    core::SandboxAuthorizations::new(authorizations).map_err(|_| DecodeError::InvalidValue {
+        field: "sandbox_authorizations",
+    })
+}
+
+fn sandbox_authorization(
+    value: wire::SandboxAuthorization,
+) -> Result<core::SandboxAuthorization, DecodeError> {
+    core::SandboxAuthorization::from_parts(
+        core::SandboxAuthorizationName::new(value.name).map_err(|_| DecodeError::InvalidValue {
+            field: "sandbox_authorization.name",
+        })?,
+        narrow_u16(
+            value.payload_schema_version,
+            "sandbox_authorization.payload_schema_version",
+        )?,
+        sha256_digest(value.payload_sha256, "sandbox_authorization.payload_sha256")?,
+        value.payload,
+    )
+    .map_err(|_| DecodeError::InvalidValue {
+        field: "sandbox_authorization",
     })
 }
 
@@ -2676,13 +3073,6 @@ fn operation_ack(value: wire::OperationAck) -> Result<protocol::OperationAck, De
     )?)?))
 }
 
-fn no_work(value: wire::NoWork) -> Result<protocol::NoWork, DecodeError> {
-    Ok(protocol::NoWork::new(
-        message_header(required(value.header, "no_work.header")?)?,
-        value.retry_after_millis,
-    ))
-}
-
 fn error_message(
     value: wire::ErrorMessage,
     limits: &protocol::ProtocolLimits,
@@ -2745,6 +3135,13 @@ fn runner_slot(
 
 fn fencing_token(value: u64, field: &'static str) -> Result<core::FencingToken, DecodeError> {
     core::FencingToken::new(value).map_err(|_| DecodeError::InvalidValue { field })
+}
+
+fn sha256_digest(value: Vec<u8>, field: &'static str) -> Result<core::Sha256Digest, DecodeError> {
+    let bytes = value
+        .try_into()
+        .map_err(|_| DecodeError::InvalidValue { field })?;
+    Ok(core::Sha256Digest::from_bytes(bytes))
 }
 
 fn uuid(value: impl AsRef<[u8]>, field: &'static str) -> Result<Uuid, DecodeError> {

--- a/crates/automata-ci-protocol-protobuf/src/encode.rs
+++ b/crates/automata-ci-protocol-protobuf/src/encode.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use automata_ci_core as core;
 use automata_ci_protocol as protocol;
+use prost::Message as _;
 use uuid::Uuid;
 use zeroize::Zeroize as _;
 
@@ -111,6 +112,29 @@ pub fn encode_runtime_authorities(
     encoded
 }
 
+/// Canonically encodes one provider-owned Windows runner placement renewal payload.
+///
+/// The domain envelope enforces its own hard byte bounds. The returned bytes
+/// are suitable for [`protocol::LeaseAuthorityPollContribution::new`] and do
+/// not depend on runner-frame transport limits.
+#[must_use]
+pub fn encode_windows_runner_placement_renewal_payload(
+    renewal: &protocol::WindowsRunnerPlacementRenewalEnvelope,
+) -> Vec<u8> {
+    windows_placement_renewal(renewal).encode_to_vec()
+}
+
+/// Canonically encodes one provider-owned Windows Hyper-V sandbox grant payload.
+///
+/// The grant shape is intrinsically bounded. The returned exact protobuf bytes
+/// are suitable for [`core::SandboxAuthorization::new`].
+#[must_use]
+pub fn encode_windows_hyperv_broker_grant_payload(
+    grant: &core::WindowsHyperVBrokerGrant,
+) -> Vec<u8> {
+    windows_hyperv_broker_grant(grant).encode_to_vec()
+}
+
 fn encode_message<M: prost::Message>(
     message: &M,
     limits: &protocol::ProtocolLimits,
@@ -157,6 +181,7 @@ fn server_frame(message: &protocol::ServerToRunner) -> wire::ServerFrame {
     let payload = match message {
         Domain::Hello(value) => Payload::Hello(server_hello(value)),
         Domain::HandshakeRejected(value) => Payload::HandshakeRejected(handshake_rejected(value)),
+        Domain::LeasePollResponse(value) => Payload::LeasePollResponse(lease_poll_response(value)),
         Domain::LeaseOffer(value) => Payload::LeaseOffer(lease_offer(value)),
         Domain::RuntimeAuthorityGrant(value) => {
             Payload::RuntimeAuthorityGrant(runtime_authority_grant(value))
@@ -165,7 +190,6 @@ fn server_frame(message: &protocol::ServerToRunner) -> wire::ServerFrame {
         Domain::CancelJob(value) => Payload::CancelJob(cancel_job(value)),
         Domain::LogAck(value) => Payload::LogAck(log_ack_message(value)),
         Domain::OperationAck(value) => Payload::OperationAck(operation_ack(*value)),
-        Domain::NoWork(value) => Payload::NoWork(no_work(value)),
         Domain::Error(value) => Payload::Error(error_message(value)),
     };
     wire::ServerFrame {
@@ -474,6 +498,63 @@ fn lease_request(value: &protocol::LeaseRequest) -> wire::LeaseRequest {
         acknowledges_operation_id: value
             .acknowledges_operation_id()
             .map(|operation_id| uuid_bytes(operation_id.as_uuid())),
+        authority_contributions: Some(lease_authority_poll_contributions(
+            value.authority_contributions(),
+        )),
+    }
+}
+
+fn lease_authority_poll_contributions(
+    value: &protocol::LeaseAuthorityPollContributions,
+) -> wire::LeaseAuthorityPollContributions {
+    wire::LeaseAuthorityPollContributions {
+        schema_version: u32::from(value.schema_version()),
+        contributions: value
+            .as_slice()
+            .iter()
+            .map(lease_authority_poll_contribution)
+            .collect(),
+        sha256_digest: value.sha256_digest().as_bytes().to_vec(),
+    }
+}
+
+fn lease_authority_poll_contribution(
+    value: &protocol::LeaseAuthorityPollContribution,
+) -> wire::LeaseAuthorityPollContribution {
+    wire::LeaseAuthorityPollContribution {
+        name: value.name().as_str().to_owned(),
+        payload_schema_version: u32::from(value.payload_schema_version()),
+        payload_sha256: value.payload_sha256().as_bytes().to_vec(),
+        payload: value.payload().to_vec(),
+    }
+}
+
+fn lease_poll_response(value: &protocol::LeasePollResponse) -> wire::LeasePollResponse {
+    use protocol::LeasePollOutcome as Domain;
+    use wire::lease_poll_response::Outcome;
+
+    let outcome = match value.outcome() {
+        Domain::NoWork { retry_after_millis } => {
+            Outcome::NoWorkRetryAfterMillis(*retry_after_millis)
+        }
+        Domain::LeaseOffer(offer) => Outcome::LeaseOffer(lease_offer(offer)),
+        Domain::CancelJob(cancel) => Outcome::CancelJob(cancel_job(cancel)),
+    };
+    wire::LeasePollResponse {
+        header: Some(message_header(value.header())),
+        accepted_contributions_sha256: value.accepted_contributions_sha256().as_bytes().to_vec(),
+        outcome: Some(outcome),
+    }
+}
+
+fn windows_placement_renewal(
+    value: &protocol::WindowsRunnerPlacementRenewalEnvelope,
+) -> wire::WindowsRunnerPlacementRenewalEnvelope {
+    wire::WindowsRunnerPlacementRenewalEnvelope {
+        schema_version: u32::from(value.schema_version()),
+        issuer_key_id: value.issuer_key_id().to_owned(),
+        signed_payload: value.signed_payload().to_vec(),
+        authenticator: value.authenticator().to_vec(),
     }
 }
 
@@ -486,6 +567,54 @@ fn lease_offer(value: &protocol::LeaseOffer) -> wire::LeaseOffer {
         managed_secret_bindings: value
             .managed_secret_bindings()
             .map(managed_secret_binding_overlay),
+    }
+}
+
+fn windows_hyperv_broker_grant(
+    value: &core::WindowsHyperVBrokerGrant,
+) -> wire::WindowsHyperVBrokerGrant {
+    wire::WindowsHyperVBrokerGrant {
+        schema: u32::from(value.schema()),
+        key_id_sha256: value.key_id().as_bytes().to_vec(),
+        claims: Some(windows_hyperv_broker_grant_claims(value.claims())),
+        ed25519_signature: value.signature().to_vec(),
+    }
+}
+
+fn windows_hyperv_broker_grant_claims(
+    value: &core::WindowsHyperVBrokerGrantClaims,
+) -> wire::WindowsHyperVBrokerGrantClaims {
+    wire::WindowsHyperVBrokerGrantClaims {
+        host_id_sha256: value.host_id().as_bytes().to_vec(),
+        placement_binding_sha256: value.placement_binding_digest().as_bytes().to_vec(),
+        attempt_id: uuid_bytes(value.attempt_id().as_uuid()),
+        job_id: uuid_bytes(value.job_id().as_uuid()),
+        run_id: uuid_bytes(value.run_id().as_uuid()),
+        poll_operation_id: uuid_bytes(value.poll_operation_id().as_uuid()),
+        runner_id: uuid_bytes(value.runner_id().as_uuid()),
+        runner_session_id: uuid_bytes(value.runner_session_id().as_uuid()),
+        runner_generation: value.runner_generation(),
+        session_epoch: value.session_epoch(),
+        slot: u32::from(value.slot()),
+        lease_id: uuid_bytes(value.lease_id().as_uuid()),
+        fencing_token: value.fencing_token().get(),
+        job_ir_version: u32::from(value.job_ir_version().get()),
+        job_ir_encoded_size: value.job_ir_encoded_size(),
+        job_ir_sha256: value.job_ir_digest().as_bytes().to_vec(),
+        job_ir_object_key_sha256: value.job_ir_object_key_digest().as_bytes().to_vec(),
+        trust_binding_sha256: value.trust_binding_digest().as_bytes().to_vec(),
+        environment_profile_id: value.environment_profile().id().as_str().to_owned(),
+        environment_profile_sha256: value.environment_profile().digest().as_bytes().to_vec(),
+        issued_at_unix_millis: value.issued_at().get(),
+        expires_at_unix_millis: value.expires_at().get(),
+        accepted_offer_operation_id: uuid_bytes(value.accepted_offer_operation_id().as_uuid()),
+        accepted_offer_sequence: value.accepted_offer_sequence(),
+        post_accept_operation_id: uuid_bytes(value.post_accept_operation_id().as_uuid()),
+        post_accept_request_sha256: value.post_accept_request_digest().as_bytes().to_vec(),
+        job_resource_allocation: Some(job_resource_allocation(value.job_resource_allocation())),
+        profile_contract_sha256: value.profile_contract_sha256().as_bytes().to_vec(),
+        sandbox_pids_limit: value.sandbox_pids_limit(),
+        sandbox_spec_sha256: value.sandbox_spec_sha256().as_bytes().to_vec(),
     }
 }
 
@@ -558,6 +687,23 @@ fn runtime_authorities(value: &protocol::JobRuntimeAuthorities) -> wire::JobRunt
     wire::JobRuntimeAuthorities {
         schema_version: u32::from(value.schema_version()),
         authorities: value.as_slice().iter().map(runtime_authority).collect(),
+        sandbox_authorizations: Some(sandbox_authorizations(value.sandbox_authorizations())),
+    }
+}
+
+fn sandbox_authorizations(value: &core::SandboxAuthorizations) -> wire::SandboxAuthorizations {
+    wire::SandboxAuthorizations {
+        schema_version: u32::from(value.schema_version()),
+        authorizations: value.as_slice().iter().map(sandbox_authorization).collect(),
+    }
+}
+
+fn sandbox_authorization(value: &core::SandboxAuthorization) -> wire::SandboxAuthorization {
+    wire::SandboxAuthorization {
+        name: value.name().as_str().to_owned(),
+        payload_schema_version: u32::from(value.payload_schema_version()),
+        payload_sha256: value.payload_sha256().as_bytes().to_vec(),
+        payload: value.payload().to_vec(),
     }
 }
 
@@ -597,6 +743,11 @@ fn zeroize_server_authorities(frame: &mut wire::ServerFrame) {
 fn zeroize_runtime_authorities(authorities: &mut wire::JobRuntimeAuthorities) {
     for authority in &mut authorities.authorities {
         authority.credential.zeroize();
+    }
+    if let Some(authorizations) = authorities.sandbox_authorizations.as_mut() {
+        for authorization in &mut authorizations.authorizations {
+            authorization.payload.zeroize();
+        }
     }
 }
 
@@ -1418,13 +1569,6 @@ fn operation_ack(value: protocol::OperationAck) -> wire::OperationAck {
     }
 }
 
-fn no_work(value: &protocol::NoWork) -> wire::NoWork {
-    wire::NoWork {
-        header: Some(message_header(value.header())),
-        retry_after_millis: value.retry_after_millis(),
-    }
-}
-
 fn error_message(value: &protocol::ErrorMessage) -> wire::ErrorMessage {
     wire::ErrorMessage {
         header: Some(message_header(value.header())),
@@ -1467,4 +1611,102 @@ const fn remote_error_code(value: protocol::RemoteErrorCode) -> i32 {
 
 fn uuid_bytes(value: Uuid) -> Vec<u8> {
     value.as_bytes().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DecodeError,
+        decode::{
+            decode_windows_hyperv_broker_grant_payload,
+            windows_hyperv_broker_grant_claims as decode_claims,
+        },
+    };
+
+    fn claims() -> core::WindowsHyperVBrokerGrantClaims {
+        let capacity = core::ResourceCapacity::new(2_000, 2 * 1024 * 1024 * 1024, 0, 0);
+        core::WindowsHyperVBrokerGrantClaims::new(
+            core::Sha256Digest::from_bytes([1; 32]),
+            core::Sha256Digest::from_bytes([2; 32]),
+            core::AttemptId::new(),
+            core::JobId::new(),
+            core::RunId::new(),
+            core::OperationId::new(),
+            core::OperationId::new(),
+            1,
+            core::OperationId::new(),
+            core::Sha256Digest::from_bytes([3; 32]),
+            core::RunnerId::new(),
+            core::RunnerSessionId::new(),
+            1,
+            1,
+            1,
+            core::LeaseId::new(),
+            core::FencingToken::new(1).expect("fencing token"),
+            core::JobIrVersion::current(),
+            128,
+            core::Sha256Digest::from_bytes([4; 32]),
+            core::Sha256Digest::from_bytes([5; 32]),
+            core::JobResourceAllocation::new(capacity, capacity).expect("allocation"),
+            64,
+            core::Sha256Digest::from_bytes([6; 32]),
+            core::EnvironmentProfile::new(
+                core::EnvironmentProfileId::new("example.test/windows").expect("profile id"),
+                core::Sha256Digest::from_bytes([7; 32]),
+            ),
+            core::Sha256Digest::from_bytes([8; 32]),
+            core::UnixMillis::new(100),
+            core::UnixMillis::new(200),
+        )
+        .expect("claims")
+    }
+
+    #[test]
+    fn sandbox_spec_binding_roundtrips_and_mutation_fails_closed() {
+        let expected = claims();
+        let wire = windows_hyperv_broker_grant_claims(&expected);
+        assert_eq!(decode_claims(wire).expect("roundtrip"), expected);
+
+        let mut mutated = windows_hyperv_broker_grant_claims(&expected);
+        mutated.sandbox_pids_limit += 1;
+        assert!(matches!(
+            decode_claims(mutated),
+            Err(DecodeError::InvalidValue {
+                field: "windows_hyperv_broker_grant.claims.sandbox_spec_sha256"
+            })
+        ));
+    }
+
+    #[test]
+    fn broker_grant_payload_codec_is_canonical_and_intrinsically_bounded() {
+        let grant = core::WindowsHyperVBrokerGrant::new(
+            core::Sha256Digest::from_bytes([9; 32]),
+            claims(),
+            vec![0xa5; 64],
+        )
+        .expect("grant");
+        let encoded = encode_windows_hyperv_broker_grant_payload(&grant);
+        assert_eq!(
+            decode_windows_hyperv_broker_grant_payload(&encoded).expect("canonical payload"),
+            grant
+        );
+
+        let mut aliased = encoded;
+        aliased.extend_from_slice(&[0xf8, 0x01, 0x00]);
+        assert!(matches!(
+            decode_windows_hyperv_broker_grant_payload(&aliased),
+            Err(DecodeError::NonCanonicalValue {
+                field: "windows_hyperv_broker_grant_payload"
+            })
+        ));
+
+        let oversized = vec![0; core::MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES + 1];
+        assert!(matches!(
+            decode_windows_hyperv_broker_grant_payload(&oversized),
+            Err(DecodeError::FrameTooLarge { size, maximum })
+                if size == core::MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES + 1
+                    && maximum == core::MAX_SANDBOX_AUTHORIZATION_PAYLOAD_BYTES
+        ));
+    }
 }

--- a/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
+++ b/crates/automata-ci-protocol-protobuf/src/generated/automata.runner.v1.rs
@@ -34,7 +34,7 @@ pub mod runner_frame {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServerFrame {
-    #[prost(oneof = "server_frame::Payload", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    #[prost(oneof = "server_frame::Payload", tags = "1, 2, 3, 4, 5, 6, 7, 9, 10, 11")]
     pub payload: ::core::option::Option<server_frame::Payload>,
 }
 /// Nested message and enum types in `ServerFrame`.
@@ -55,12 +55,12 @@ pub mod server_frame {
         LogAck(super::LogAckMessage),
         #[prost(message, tag = "7")]
         OperationAck(super::OperationAck),
-        #[prost(message, tag = "8")]
-        NoWork(super::NoWork),
         #[prost(message, tag = "9")]
         Error(super::ErrorMessage),
         #[prost(message, tag = "10")]
         RuntimeAuthorityGrant(super::RuntimeAuthorityGrant),
+        #[prost(message, tag = "11")]
+        LeasePollResponse(super::LeasePollResponse),
     }
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
@@ -339,7 +339,7 @@ pub struct RunnerRequirements {
     #[prost(message, optional, tag = "12")]
     pub resource_allocation: ::core::option::Option<JobResourceAllocation>,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeaseRequest {
     #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<MessageHeader>,
@@ -348,6 +348,63 @@ pub struct LeaseRequest {
     /// Present on every successor and absent only on the first request for a slot.
     #[prost(bytes = "vec", optional, tag = "3")]
     pub acknowledges_operation_id: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    /// Required even when empty. The server must acknowledge this bundle's exact
+    /// canonical digest before the runner adopts a poll outcome.
+    #[prost(message, optional, tag = "5")]
+    pub authority_contributions: ::core::option::Option<LeaseAuthorityPollContributions>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LeaseAuthorityPollContribution {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub payload_schema_version: u32,
+    #[prost(bytes = "vec", tag = "3")]
+    pub payload_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LeaseAuthorityPollContributions {
+    #[prost(uint32, tag = "1")]
+    pub schema_version: u32,
+    /// Canonical set: strictly ascending and duplicate-free by name.
+    #[prost(message, repeated, tag = "2")]
+    pub contributions: ::prost::alloc::vec::Vec<LeaseAuthorityPollContribution>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub sha256_digest: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LeasePollResponse {
+    #[prost(message, optional, tag = "1")]
+    pub header: ::core::option::Option<MessageHeader>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub accepted_contributions_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof = "lease_poll_response::Outcome", tags = "3, 4, 5")]
+    pub outcome: ::core::option::Option<lease_poll_response::Outcome>,
+}
+/// Nested message and enum types in `LeasePollResponse`.
+pub mod lease_poll_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Outcome {
+        #[prost(uint32, tag = "3")]
+        NoWorkRetryAfterMillis(u32),
+        #[prost(message, tag = "4")]
+        LeaseOffer(super::LeaseOffer),
+        #[prost(message, tag = "5")]
+        CancelJob(super::CancelJob),
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WindowsRunnerPlacementRenewalEnvelope {
+    #[prost(uint32, tag = "1")]
+    pub schema_version: u32,
+    #[prost(string, tag = "2")]
+    pub issuer_key_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "3")]
+    pub signed_payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub authenticator: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Lease {
@@ -400,6 +457,82 @@ pub struct LeaseOffer {
     pub job: ::core::option::Option<JobIrEnvelope>,
     #[prost(message, optional, tag = "6")]
     pub managed_secret_bindings: ::core::option::Option<ManagedSecretBindingOverlay>,
+}
+/// Signed, value-free authority for one exact restricted host placement. It
+/// contains no credential, engine endpoint, host path, command, or HCS document.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WindowsHyperVBrokerGrant {
+    #[prost(uint32, tag = "1")]
+    pub schema: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub key_id_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub claims: ::core::option::Option<WindowsHyperVBrokerGrantClaims>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub ed25519_signature: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WindowsHyperVBrokerGrantClaims {
+    #[prost(bytes = "vec", tag = "1")]
+    pub host_id_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub placement_binding_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub attempt_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub job_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub run_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    pub poll_operation_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub runner_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "8")]
+    pub runner_session_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "9")]
+    pub runner_generation: u64,
+    #[prost(uint64, tag = "10")]
+    pub session_epoch: u64,
+    #[prost(uint32, tag = "11")]
+    pub slot: u32,
+    #[prost(bytes = "vec", tag = "12")]
+    pub lease_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "13")]
+    pub fencing_token: u64,
+    #[prost(uint32, tag = "14")]
+    pub job_ir_version: u32,
+    #[prost(uint64, tag = "15")]
+    pub job_ir_encoded_size: u64,
+    #[prost(bytes = "vec", tag = "16")]
+    pub job_ir_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "17")]
+    pub job_ir_object_key_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "18")]
+    pub trust_binding_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "19")]
+    pub environment_profile_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "20")]
+    pub environment_profile_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(int64, tag = "21")]
+    pub issued_at_unix_millis: i64,
+    #[prost(int64, tag = "22")]
+    pub expires_at_unix_millis: i64,
+    #[prost(bytes = "vec", tag = "23")]
+    pub accepted_offer_operation_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "24")]
+    pub accepted_offer_sequence: u64,
+    #[prost(bytes = "vec", tag = "25")]
+    pub post_accept_operation_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "26")]
+    pub post_accept_request_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "27")]
+    pub job_resource_allocation: ::core::option::Option<JobResourceAllocation>,
+    #[prost(bytes = "vec", tag = "28")]
+    pub profile_contract_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "29")]
+    pub sandbox_pids_limit: u32,
+    #[prost(bytes = "vec", tag = "30")]
+    pub sandbox_spec_sha256: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ManagedSecretBindingOverlayEntry {
@@ -461,6 +594,27 @@ pub struct JobRuntimeAuthorities {
     /// Canonical map: strictly ascending and duplicate-free by authority name.
     #[prost(message, repeated, tag = "2")]
     pub authorities: ::prost::alloc::vec::Vec<JobRuntimeAuthority>,
+    #[prost(message, optional, tag = "3")]
+    pub sandbox_authorizations: ::core::option::Option<SandboxAuthorizations>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SandboxAuthorization {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub payload_schema_version: u32,
+    #[prost(bytes = "vec", tag = "3")]
+    pub payload_sha256: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SandboxAuthorizations {
+    #[prost(uint32, tag = "1")]
+    pub schema_version: u32,
+    /// Canonical set: strictly ascending and duplicate-free by name.
+    #[prost(message, repeated, tag = "2")]
+    pub authorizations: ::prost::alloc::vec::Vec<SandboxAuthorization>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LeaseResponse {
@@ -1364,13 +1518,6 @@ pub struct CommandAck {
 pub struct OperationAck {
     #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<MessageHeader>,
-}
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct NoWork {
-    #[prost(message, optional, tag = "1")]
-    pub header: ::core::option::Option<MessageHeader>,
-    #[prost(uint32, tag = "2")]
-    pub retry_after_millis: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ErrorMessage {

--- a/crates/automata-ci-protocol-protobuf/src/lib.rs
+++ b/crates/automata-ci-protocol-protobuf/src/lib.rs
@@ -28,11 +28,13 @@ mod wire {
 
 pub use decode::{
     decode_job_ir, decode_job_runtime_context, decode_runner_frame, decode_runtime_authorities,
-    decode_server_frame,
+    decode_server_frame, decode_windows_hyperv_broker_grant_payload,
+    decode_windows_runner_placement_renewal_payload,
 };
 pub use encode::{
     encode_job_ir, encode_job_runtime_context, encode_runner_frame, encode_runtime_authorities,
-    encode_server_frame,
+    encode_server_frame, encode_windows_hyperv_broker_grant_payload,
+    encode_windows_runner_placement_renewal_payload,
 };
 pub use error::{DecodeError, EncodeError};
 

--- a/crates/automata-ci-protocol-protobuf/tests/boundary.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/boundary.rs
@@ -5,8 +5,9 @@ use automata_ci_core::{
     RunnerSessionId,
 };
 use automata_ci_protocol::{
-    CommandAck, CommandCursor, LeaseOffer, LeaseRequest, MessageHeader, MessageValidationError,
-    ProtocolLimits, RunnerToServer, SUPPORTED_PROTOCOL_RANGE, ServerToRunner,
+    CommandAck, CommandCursor, LeaseAuthorityPollContributions, LeaseOffer, LeaseRequest,
+    MessageHeader, MessageValidationError, ProtocolLimits, RunnerToServer,
+    SUPPORTED_PROTOCOL_RANGE, ServerToRunner,
 };
 use automata_ci_protocol_protobuf::{
     DecodeError, EncodeError, decode_job_ir, decode_runner_frame, decode_server_frame,
@@ -36,6 +37,15 @@ fn wire_guard() -> fixture_wire::LeaseGuard {
     fixture_wire::LeaseGuard {
         lease_id: Uuid::from_u128(4).as_bytes().to_vec(),
         fencing_token: 1,
+    }
+}
+
+fn wire_empty_authority_contributions() -> fixture_wire::LeaseAuthorityPollContributions {
+    let empty = LeaseAuthorityPollContributions::default();
+    fixture_wire::LeaseAuthorityPollContributions {
+        schema_version: u32::from(empty.schema_version()),
+        contributions: Vec::new(),
+        sha256_digest: empty.sha256_digest().as_bytes().to_vec(),
     }
 }
 
@@ -532,6 +542,7 @@ fn missing_or_unknown_required_oneofs_are_rejected() {
                 header: None,
                 slot: 1,
                 acknowledges_operation_id: None,
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -555,6 +566,47 @@ fn missing_or_unknown_required_oneofs_are_rejected() {
             field: "runtime_authority_grant.authorities"
         })
     ));
+
+    let message = common::runner_messages()
+        .into_iter()
+        .find_map(|(name, message)| (name == "lease_request").then_some(message))
+        .expect("lease request fixture");
+    let encoded =
+        encode_runner_frame(&message, &ProtocolLimits::default()).expect("encode fixture");
+    let mut frame = fixture_wire::RunnerFrame::decode(encoded.as_slice()).expect("wire fixture");
+    let Some(fixture_wire::runner_frame::Payload::LeaseRequest(request)) = frame.payload.as_mut()
+    else {
+        panic!("lease request fixture shape");
+    };
+    request.authority_contributions = None;
+    assert!(matches!(
+        decode_runner_frame(&encode(&frame), &ProtocolLimits::default()),
+        Err(DecodeError::MissingField {
+            field: "lease_request.authority_contributions"
+        })
+    ));
+}
+
+#[test]
+fn protected_authority_bundle_requires_provider_neutral_sandbox_authorizations() {
+    let mut frame = fixture_runtime_authority_grant();
+    let Some(fixture_wire::server_frame::Payload::RuntimeAuthorityGrant(grant)) =
+        frame.payload.as_mut()
+    else {
+        panic!("runtime-authority grant fixture shape");
+    };
+    grant
+        .authorities
+        .as_mut()
+        .expect("authorities")
+        .sandbox_authorizations = None;
+
+    assert!(matches!(
+        decode_server_frame(&encode(&frame), &ProtocolLimits::default()),
+        Err(DecodeError::MissingField {
+            field: "runtime_authorities.sandbox_authorizations"
+        })
+    ));
 }
 
 #[test]
@@ -567,6 +619,7 @@ fn uuid_fields_require_exactly_sixteen_bytes_without_echoing_contents() {
                 header: Some(header),
                 slot: 1,
                 acknowledges_operation_id: None,
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -589,6 +642,7 @@ fn uuid_fields_require_exactly_sixteen_bytes_without_echoing_contents() {
                 header: Some(wire_header(false)),
                 slot: 1,
                 acknowledges_operation_id: Some(acknowledgement),
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -614,6 +668,7 @@ fn lease_request_self_acknowledgement_is_rejected_after_wire_conversion() {
                 header: Some(header),
                 slot: 1,
                 acknowledges_operation_id: Some(operation_id),
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -1131,6 +1186,7 @@ fn only_the_current_protocol_is_accepted() {
                 header: Some(wire_header(false)),
                 slot: 1,
                 acknowledges_operation_id: None,
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -1164,6 +1220,7 @@ fn message_job_ir_and_requirements_schema_skew_are_rejected_without_reconstructi
                 header: Some(wire_header(false)),
                 slot: 1,
                 acknowledges_operation_id: None,
+                authority_contributions: Some(wire_empty_authority_contributions()),
             },
         )),
     };
@@ -1244,6 +1301,7 @@ fn encoding_applies_domain_validation_and_size_budget() {
     let valid = RunnerToServer::LeaseRequest(LeaseRequest::first(
         common::request_header(90),
         common::slot(),
+        LeaseAuthorityPollContributions::default(),
     ));
     let tiny = ProtocolLimits::new(1, 1, 1, 1, 1).expect("coherent tiny limits");
     assert!(matches!(

--- a/crates/automata-ci-protocol-protobuf/tests/common/mod.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/common/mod.rs
@@ -12,20 +12,22 @@ use automata_ci_core::{
     LogFrame, LogSequence, LogStreamId, MountSource, OperatingSystem, OperationId,
     ResourceCapacity, RunId, RunValueTemplates, RunnerCapabilities, RunnerFeature, RunnerGroup,
     RunnerId, RunnerLabel, RunnerPlatform, RunnerRequirements, RunnerSessionId, RuntimeBoolean,
-    RuntimePositiveInteger, RuntimeTimeoutTemplate, SandboxCapabilities, SandboxFeature,
-    SecretBinding, SemanticStep, Sha256Digest, ShellTemplate, StepAnnotation, StepAnnotationLevel,
-    StepAnnotationProperty, StepId, StepIr, StepResult, TransportProtocol, TrustActorEvidence,
-    TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind,
-    TrustPolicy, TrustRepositoryEvidence, TrustTokenRecursion, UnixMillis, ValueSource,
-    ValueTemplate, VolumeMount, WorkflowId,
+    RuntimePositiveInteger, RuntimeTimeoutTemplate, SandboxAuthorization, SandboxAuthorizationName,
+    SandboxAuthorizations, SandboxCapabilities, SandboxFeature, SecretBinding, SemanticStep,
+    Sha256Digest, ShellTemplate, StepAnnotation, StepAnnotationLevel, StepAnnotationProperty,
+    StepId, StepIr, StepResult, TransportProtocol, TrustActorEvidence, TrustActorKind,
+    TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy,
+    TrustRepositoryEvidence, TrustTokenRecursion, UnixMillis, ValueSource, ValueTemplate,
+    VolumeMount, WorkflowId,
 };
 use automata_ci_protocol::{
     CancelJob, CommandAck, CommandCursor, CommandSequence, ErrorMessage, HandshakeErrorCode,
     HandshakeRejected, INITIAL_RUNTIME_AUTHORITY_GENERATION, JobResultMessage,
-    JobRuntimeAuthorities, JobRuntimeAuthority, JobStateUpdate, LeaseDisposition, LeaseHeartbeat,
-    LeaseOffer, LeaseRejectionReason, LeaseRenewal, LeaseRequest, LeaseResponse, LogAckMessage,
-    LogBatch, ManagedSecretBindingOverlay, MessageHeader, NegotiatedSession, NoWork, OperationAck,
-    RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer, RuntimeAuthorityAck,
+    JobRuntimeAuthorities, JobRuntimeAuthority, JobStateUpdate, LeaseAuthorityPollContributions,
+    LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeasePollResponse, LeaseRejectionReason,
+    LeaseRenewal, LeaseRequest, LeaseResponse, LogAckMessage, LogBatch,
+    ManagedSecretBindingOverlay, MessageHeader, NegotiatedSession, OperationAck, RemoteErrorCode,
+    RunnerHello, RunnerSlotOrdinal, RunnerToServer, RuntimeAuthorityAck,
     RuntimeAuthorityCredential, RuntimeAuthorityDeliveryBinding, RuntimeAuthorityEndpoint,
     RuntimeAuthorityGrant, RuntimeAuthorityName, RuntimeAuthorityRequest, SUPPORTED_PROTOCOL_RANGE,
     ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
@@ -60,6 +62,7 @@ pub fn runner_messages() -> Vec<(&'static str, RunnerToServer)> {
                 request_header(12),
                 slot(),
                 operation_id(11),
+                LeaseAuthorityPollContributions::default(),
             )),
         ),
         (
@@ -203,8 +206,12 @@ pub fn server_messages() -> Vec<(&'static str, ServerToRunner)> {
             ServerToRunner::OperationAck(OperationAck::new(reply_header(61, 62))),
         ),
         (
-            "no_work",
-            ServerToRunner::NoWork(NoWork::new(reply_header(63, 64), 1_250)),
+            "lease_poll_response_no_work",
+            ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+                reply_header(63, 64),
+                LeaseAuthorityPollContributions::default().sha256_digest(),
+                1_250,
+            ))),
         ),
         (
             "error",
@@ -666,7 +673,17 @@ pub fn runtime_authorities(job: &JobIrEnvelope, lease: &Lease) -> JobRuntimeAuth
         UnixMillis::new(1_700_003_600_000),
     )
     .expect("valid runtime authority");
-    JobRuntimeAuthorities::new(vec![authority], job, lease).expect("valid authority bundle")
+    let sandbox_authorizations = SandboxAuthorizations::new(vec![
+        SandboxAuthorization::new(
+            SandboxAuthorizationName::new("windows-hyperv").expect("authorization name"),
+            automata_ci_core::WINDOWS_HYPERV_BROKER_GRANT_SCHEMA_V4,
+            vec![0xa5; 64],
+        )
+        .expect("sandbox authorization"),
+    ])
+    .expect("sandbox authorizations");
+    JobRuntimeAuthorities::new(vec![authority], sandbox_authorizations, job, lease)
+        .expect("valid authority bundle")
 }
 
 fn job_result(attempt: AttemptId) -> JobResult {

--- a/crates/automata-ci-protocol-protobuf/tests/job_ir.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/job_ir.rs
@@ -6,11 +6,11 @@ use automata_ci_core::{
     JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobOutputDefinition, JobPermissionGrant,
     JobPermissionRequest, JobSource, Lease, LeaseId, OperationId, OutputSensitivity,
     PermissionLevel, RunId, RunIdAlias, RunValueTemplates, RunnerId, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, RuntimePositiveInteger, RuntimeTimeoutTemplate, SemanticStep,
-    Sha256Digest, ShellTemplate, StepId, StepIr, TrustActorEvidence, TrustActorKind,
-    TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy,
-    TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion, UnixMillis, ValueSource,
-    ValueTemplate, ValueTemplateSegment, WorkflowId,
+    RunnerSessionId, RuntimeBoolean, RuntimePositiveInteger, RuntimeTimeoutTemplate,
+    SandboxAuthorizations, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
+    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
+    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustSnapshot, TrustTokenRecursion,
+    UnixMillis, ValueSource, ValueTemplate, ValueTemplateSegment, WorkflowId,
 };
 use automata_ci_protocol::{
     CommandSequence, JobRuntimeAuthorities, LeaseOffer, MessageValidationError, ProtocolLimits,
@@ -487,7 +487,8 @@ fn credential_free_offer_round_trips_without_pre_accept_authority_material() {
         UnixMillis::new(10_000),
     )
     .expect("lease");
-    JobRuntimeAuthorities::new(Vec::new(), &job, &lease).expect("empty authority bundle");
+    JobRuntimeAuthorities::new(Vec::new(), SandboxAuthorizations::default(), &job, &lease)
+        .expect("empty authority bundle");
     let message = ServerToRunner::LeaseOffer(Box::new(LeaseOffer::new(
         ServerCommandHeader::new(
             SUPPORTED_PROTOCOL_RANGE.max(),

--- a/crates/automata-ci-protocol-protobuf/tests/roundtrip.rs
+++ b/crates/automata-ci-protocol-protobuf/tests/roundtrip.rs
@@ -4,7 +4,10 @@ use automata_ci_core::{
     IsolationLevel, JobResourceAllocation, OperatingSystem, OperationId, ResourceCapacity,
     RunnerRequirements, SandboxFeature,
 };
-use automata_ci_protocol::{LeaseRequest, ProtocolLimits, RunnerToServer, ServerToRunner};
+use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollContribution, LeaseAuthorityPollContributions,
+    LeasePollResponse, LeaseRequest, ProtocolLimits, RunnerToServer, ServerToRunner,
+};
 use automata_ci_protocol_protobuf::{
     PROTOBUF_PACKAGE, decode_job_ir, decode_runner_frame, decode_server_frame, encode_job_ir,
     encode_runner_frame, encode_server_frame,
@@ -25,15 +28,26 @@ fn every_runner_envelope_variant_round_trips_losslessly() {
 fn first_and_successor_lease_requests_round_trip_with_exact_chain_position() {
     let limits = ProtocolLimits::default();
     let acknowledged = OperationId::new();
+    let contributions = LeaseAuthorityPollContributions::new(vec![
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new("windows-hyperv").expect("authority name"),
+            2,
+            vec![0x5a; 64],
+        )
+        .expect("poll contribution"),
+    ])
+    .expect("contribution bundle");
     let messages = [
         RunnerToServer::LeaseRequest(LeaseRequest::first(
             common::request_header(101),
             common::slot(),
+            LeaseAuthorityPollContributions::default(),
         )),
         RunnerToServer::LeaseRequest(LeaseRequest::successor(
             common::request_header(102),
             common::slot(),
             acknowledged,
+            contributions,
         )),
     ];
 
@@ -41,6 +55,51 @@ fn first_and_successor_lease_requests_round_trip_with_exact_chain_position() {
         let encoded = encode_runner_frame(&message, &limits).expect("encode lease request");
         let decoded = decode_runner_frame(&encoded, &limits)
             .expect("decode lease request")
+            .into_message();
+        assert_eq!(decoded, message);
+    }
+}
+
+#[test]
+fn every_correlated_poll_outcome_round_trips_inside_its_receipt() {
+    let limits = ProtocolLimits::default();
+    let accepted = LeaseAuthorityPollContributions::default().sha256_digest();
+    let offer = common::server_messages()
+        .into_iter()
+        .find_map(|(_, message)| match message {
+            ServerToRunner::LeaseOffer(offer) => Some(*offer),
+            _ => None,
+        })
+        .expect("lease offer fixture");
+    let cancel = common::server_messages()
+        .into_iter()
+        .find_map(|(_, message)| match message {
+            ServerToRunner::CancelJob(cancel) => Some(cancel),
+            _ => None,
+        })
+        .expect("cancel fixture");
+    let messages = [
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+            common::reply_header(201, 101),
+            accepted,
+            1_000,
+        ))),
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::lease_offer(
+            common::reply_header(202, 102),
+            accepted,
+            offer,
+        ))),
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::cancel_job(
+            common::reply_header(203, 103),
+            accepted,
+            cancel,
+        ))),
+    ];
+
+    for message in messages {
+        let encoded = encode_server_frame(&message, &limits).expect("encode poll response");
+        let decoded = decode_server_frame(&encoded, &limits)
+            .expect("decode poll response")
             .into_message();
         assert_eq!(decoded, message);
     }

--- a/crates/automata-ci-protocol/README.md
+++ b/crates/automata-ci-protocol/README.md
@@ -8,6 +8,18 @@ format; production framing is supplied by the separately versioned
 Control-plane and runner application layers depend on these messages without
 depending on a particular HTTP or serialization implementation.
 
+Runner protocol 3 requires every `LeaseRequest` to carry a canonical
+`LeaseAuthorityPollContributions` bundle, including the canonical empty bundle.
+A result for that poll is accepted only through a correlated
+`LeasePollResponse` whose accepted digest matches the exact contribution
+bundle. The provider-owned poll payloads remain opaque to this generic layer.
+
+After lease acceptance, protected `JobRuntimeAuthorities` schema 2 carries both
+credential authorities and canonical provider-owned `SandboxAuthorizations`.
+These post-accept authorizations are distinct from poll contributions and do
+not add provider-specific fields to the generic lease protocol.
+
 - [Protocol documentation](https://github.com/automata-ci/automata/blob/main/docs/architecture.md)
+- [Runtime-authority delivery](https://github.com/automata-ci/automata/blob/main/docs/runtime-authority-delivery.md)
 - API documentation: run `cargo doc -p automata-ci-protocol --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-protocol/src/lib.rs
+++ b/crates/automata-ci-protocol/src/lib.rs
@@ -9,10 +9,12 @@
 pub mod message;
 pub mod negotiation;
 pub mod windows_admission;
+pub mod windows_admission_renewal;
 
 pub use message::*;
 pub use negotiation::*;
 pub use windows_admission::*;
+pub use windows_admission_renewal::*;
 
 /// Current schema version for the message structs in this crate.
 ///

--- a/crates/automata-ci-protocol/src/message/authority.rs
+++ b/crates/automata-ci-protocol/src/message/authority.rs
@@ -5,14 +5,15 @@ use std::{fmt, sync::Arc};
 use automata_ci_auth::secret::SecretString;
 use automata_ci_core::{
     AttemptId, FencingToken, JobAuthorityProfile, JobId, JobIrEnvelope, Lease, LeaseGuard,
-    OperationId, RunId, Sha256Digest, TrustPermissionAuthority, UnixMillis,
+    OperationId, RunId, SandboxAuthorizationError, SandboxAuthorizations, Sha256Digest,
+    TrustPermissionAuthority, UnixMillis,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use url::{Host, Url};
 
 /// Schema of the protected runtime-authority bundle.
-pub const RUNTIME_AUTHORITY_SCHEMA_VERSION: u16 = 1;
+pub const RUNTIME_AUTHORITY_SCHEMA_VERSION: u16 = 2;
 /// Maximum number of independent authorities carried by one job.
 pub const MAX_RUNTIME_AUTHORITIES: usize = 16;
 /// Maximum UTF-8 bytes in one authority name.
@@ -443,6 +444,7 @@ impl JobRuntimeAuthority {
 pub struct JobRuntimeAuthorities {
     schema_version: u16,
     authorities: Vec<JobRuntimeAuthority>,
+    sandbox_authorizations: SandboxAuthorizations,
 }
 
 impl JobRuntimeAuthorities {
@@ -457,10 +459,12 @@ impl JobRuntimeAuthorities {
     /// Rejects oversized, duplicate, or non-canonical material.
     pub fn from_unbound(
         authorities: Vec<JobRuntimeAuthority>,
+        sandbox_authorizations: SandboxAuthorizations,
     ) -> Result<Self, RuntimeAuthorityError> {
         let bundle = Self {
             schema_version: RUNTIME_AUTHORITY_SCHEMA_VERSION,
             authorities,
+            sandbox_authorizations,
         };
         bundle.validate_structure()?;
         Ok(bundle)
@@ -476,12 +480,14 @@ impl JobRuntimeAuthorities {
     /// or execution-mismatched material is rejected in every case.
     pub fn new(
         authorities: Vec<JobRuntimeAuthority>,
+        sandbox_authorizations: SandboxAuthorizations,
         job: &JobIrEnvelope,
         lease: &Lease,
     ) -> Result<Self, RuntimeAuthorityError> {
         let bundle = Self {
             schema_version: RUNTIME_AUTHORITY_SCHEMA_VERSION,
             authorities,
+            sandbox_authorizations,
         };
         bundle.validate_for(job, lease)?;
         Ok(bundle)
@@ -506,6 +512,12 @@ impl JobRuntimeAuthorities {
             .binary_search_by(|authority| authority.name().as_str().cmp(name))
             .ok()
             .map(|index| &self.authorities[index])
+    }
+
+    /// Returns provider-owned sandbox authorizations carried in this protected object.
+    #[must_use]
+    pub const fn sandbox_authorizations(&self) -> &SandboxAuthorizations {
+        &self.sandbox_authorizations
     }
 
     /// Validates schema, canonical order, bounds, and execution binding.
@@ -544,6 +556,7 @@ impl JobRuntimeAuthorities {
         if self.schema_version != RUNTIME_AUTHORITY_SCHEMA_VERSION {
             return Err(RuntimeAuthorityError::UnsupportedSchema);
         }
+        self.sandbox_authorizations.validate()?;
         if self.authorities.len() > MAX_RUNTIME_AUTHORITIES {
             return Err(RuntimeAuthorityError::InvalidCount);
         }
@@ -588,6 +601,9 @@ pub enum RuntimeAuthorityError {
     /// Cleartext delivery binding contradicts `JobIR` or lease identity.
     #[error("runtime authority execution binding does not match the lease offer")]
     ExecutionBindingMismatch,
+    /// Provider-owned sandbox authorizations are structurally invalid.
+    #[error(transparent)]
+    SandboxAuthorization(#[from] SandboxAuthorizationError),
 }
 
 /// First and only initial runtime-authority delivery generation.
@@ -853,7 +869,8 @@ impl RuntimeAuthorityGrant {
         }
         self.authorities
             .validate_for(job, lease)
-            .map_err(|_| RuntimeAuthorityDeliveryError::InvalidAuthorities)
+            .map_err(|_| RuntimeAuthorityDeliveryError::InvalidAuthorities)?;
+        Ok(())
     }
 }
 

--- a/crates/automata-ci-protocol/src/message/envelope.rs
+++ b/crates/automata-ci-protocol/src/message/envelope.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     CancelJob, CommandAck, ErrorMessage, HandshakeRejected, JobResultMessage, JobStateUpdate,
-    LeaseHeartbeat, LeaseOffer, LeaseRenewal, LeaseRequest, LeaseResponse, LogAckMessage, LogBatch,
-    NoWork, OperationAck, ProtocolLimits, RunnerHello, RuntimeAuthorityAck, RuntimeAuthorityGrant,
-    RuntimeAuthorityRequest, ServerHello,
+    LeaseHeartbeat, LeaseOffer, LeasePollResponse, LeaseRenewal, LeaseRequest, LeaseResponse,
+    LogAckMessage, LogBatch, OperationAck, ProtocolLimits, RunnerHello, RuntimeAuthorityAck,
+    RuntimeAuthorityGrant, RuntimeAuthorityRequest, ServerHello,
     validation::{validate_runner_message, validate_server_message},
 };
 
@@ -64,6 +64,8 @@ pub enum ServerToRunner {
     Hello(ServerHello),
     /// Rejects a pre-negotiation hello with a stable reason code.
     HandshakeRejected(HandshakeRejected),
+    /// Returns one explicitly acknowledged lease-poll result.
+    LeasePollResponse(Box<LeasePollResponse>),
     /// Offers one immutable job and lease fence without credential values.
     LeaseOffer(Box<LeaseOffer>),
     /// Delivers one exact post-accept runtime-authority generation.
@@ -76,8 +78,6 @@ pub enum ServerToRunner {
     LogAck(LogAckMessage),
     /// Confirms an idempotent runner operation with no richer response.
     OperationAck(OperationAck),
-    /// Directs an idle slot to back off before polling again.
-    NoWork(NoWork),
     /// Reports a typed, sanitized remote failure.
     Error(ErrorMessage),
 }

--- a/crates/automata-ci-protocol/src/message/error.rs
+++ b/crates/automata-ci-protocol/src/message/error.rs
@@ -6,38 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use super::MessageHeader;
 
-/// Poll response indicating that no compatible work is currently available.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct NoWork {
-    header: MessageHeader,
-    retry_after_millis: u32,
-}
-
-impl NoWork {
-    /// Creates a correlated idle response with a server-selected backoff.
-    ///
-    /// Envelope validation rejects a zero delay.
-    #[must_use]
-    pub const fn new(header: MessageHeader, retry_after_millis: u32) -> Self {
-        Self {
-            header,
-            retry_after_millis,
-        }
-    }
-
-    #[must_use]
-    /// Returns the response header correlated to the lease request.
-    pub const fn header(&self) -> MessageHeader {
-        self.header
-    }
-
-    #[must_use]
-    /// Returns the minimum delay before this slot should poll again.
-    pub const fn retry_after_millis(&self) -> u32 {
-        self.retry_after_millis
-    }
-}
-
 /// Stable remote error codes; callers must not parse the human message.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/automata-ci-protocol/src/message/lease.rs
+++ b/crates/automata-ci-protocol/src/message/lease.rs
@@ -2,29 +2,36 @@
 
 use automata_ci_core::{
     AttemptId, FencingToken, JobIrEnvelope, JobLifecycle, Lease, LeaseGuard, LeaseId, OperationId,
-    UnixMillis,
+    Sha256Digest, UnixMillis,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 
-use super::MessageValidationError;
+use super::{CancelJob, LeaseAuthorityPollContributions, MessageValidationError};
 use super::{MessageHeader, RunnerSlotOrdinal, ServerCommandHeader};
 
 /// Runner request for at most one assignment to one stable slot.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LeaseRequest {
     header: MessageHeader,
     slot: RunnerSlotOrdinal,
     acknowledges_operation_id: Option<OperationId>,
+    authority_contributions: LeaseAuthorityPollContributions,
 }
 
 impl LeaseRequest {
     /// Creates the first lease request in a slot's request chain.
     #[must_use]
-    pub const fn first(header: MessageHeader, slot: RunnerSlotOrdinal) -> Self {
+    pub const fn first(
+        header: MessageHeader,
+        slot: RunnerSlotOrdinal,
+        authority_contributions: LeaseAuthorityPollContributions,
+    ) -> Self {
         Self {
             header,
             slot,
             acknowledges_operation_id: None,
+            authority_contributions,
         }
     }
 
@@ -35,11 +42,13 @@ impl LeaseRequest {
         header: MessageHeader,
         slot: RunnerSlotOrdinal,
         acknowledges_operation_id: OperationId,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Self {
         Self {
             header,
             slot,
             acknowledges_operation_id: Some(acknowledges_operation_id),
+            authority_contributions,
         }
     }
 
@@ -62,6 +71,12 @@ impl LeaseRequest {
         self.acknowledges_operation_id
     }
 
+    /// Returns the exact provider-neutral authority contributions carried by this poll.
+    #[must_use]
+    pub const fn authority_contributions(&self) -> &LeaseAuthorityPollContributions {
+        &self.authority_contributions
+    }
+
     /// Validates locally provable lease-request invariants.
     ///
     /// # Errors
@@ -79,9 +94,133 @@ impl LeaseRequest {
     }
 }
 
+/// Successful result of one lease poll after its authority contributions are durable.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LeasePollResponse {
+    header: MessageHeader,
+    accepted_contributions_sha256: Sha256Digest,
+    outcome: LeasePollOutcome,
+}
+
+impl LeasePollResponse {
+    /// Creates a correlated no-work response with a positive backoff.
+    #[must_use]
+    pub const fn no_work(
+        header: MessageHeader,
+        accepted_contributions_sha256: Sha256Digest,
+        retry_after_millis: u32,
+    ) -> Self {
+        Self {
+            header,
+            accepted_contributions_sha256,
+            outcome: LeasePollOutcome::NoWork { retry_after_millis },
+        }
+    }
+
+    /// Creates a correlated response carrying one durable lease offer command.
+    #[must_use]
+    pub fn lease_offer(
+        header: MessageHeader,
+        accepted_contributions_sha256: Sha256Digest,
+        offer: LeaseOffer,
+    ) -> Self {
+        Self {
+            header,
+            accepted_contributions_sha256,
+            outcome: LeasePollOutcome::LeaseOffer(Box::new(offer)),
+        }
+    }
+
+    /// Creates a correlated response carrying one durable cancellation command.
+    #[must_use]
+    pub const fn cancel_job(
+        header: MessageHeader,
+        accepted_contributions_sha256: Sha256Digest,
+        cancel: CancelJob,
+    ) -> Self {
+        Self {
+            header,
+            accepted_contributions_sha256,
+            outcome: LeasePollOutcome::CancelJob(cancel),
+        }
+    }
+
+    /// Returns the response header correlated to the lease request.
+    #[must_use]
+    pub const fn header(&self) -> MessageHeader {
+        self.header
+    }
+
+    /// Returns the exact contribution-bundle digest durably accepted by the server.
+    #[must_use]
+    pub const fn accepted_contributions_sha256(&self) -> Sha256Digest {
+        self.accepted_contributions_sha256
+    }
+
+    /// Returns the poll result.
+    #[must_use]
+    pub const fn outcome(&self) -> &LeasePollOutcome {
+        &self.outcome
+    }
+
+    /// Validates locally provable response invariants.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an invalid reply header, zero backoff, or mismatched nested command session.
+    pub fn validate(&self) -> Result<(), MessageValidationError> {
+        self.header.validate_reply()?;
+        match &self.outcome {
+            LeasePollOutcome::NoWork { retry_after_millis } if *retry_after_millis == 0 => {
+                Err(MessageValidationError::ZeroValue("retry_after_millis"))
+            }
+            LeasePollOutcome::NoWork { .. } => Ok(()),
+            LeasePollOutcome::LeaseOffer(offer) => offer
+                .header()
+                .validate_for(self.header.protocol_version(), self.header.session_id()),
+            LeasePollOutcome::CancelJob(cancel) => cancel
+                .header()
+                .validate_for(self.header.protocol_version(), self.header.session_id()),
+        }
+    }
+
+    /// Validates correlation and exact contribution acceptance for one request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a response to another request, an unequal accepted digest, or
+    /// any invalid nested outcome. A durable command may be replayed on a
+    /// concurrent slot exchange, so the nested offer's stable slot is not
+    /// required to match the poll carrier's slot.
+    pub fn validate_for(&self, request: &LeaseRequest) -> Result<(), MessageValidationError> {
+        self.validate()?;
+        self.header.validate_reply_for(request.header())?;
+        if self.accepted_contributions_sha256 != request.authority_contributions().sha256_digest() {
+            return Err(MessageValidationError::LeaseAuthorityAcceptanceMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Outcome nested inside one explicitly correlated lease-poll response.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum LeasePollOutcome {
+    /// No compatible work is available; wait at least this many milliseconds.
+    NoWork {
+        /// Server-selected positive retry delay.
+        retry_after_millis: u32,
+    },
+    /// One durable job assignment command.
+    LeaseOffer(Box<LeaseOffer>),
+    /// One durable cancellation command.
+    CancelJob(CancelJob),
+}
+
 /// Server offer containing an immutable job and its exclusive lease.
 ///
-/// Runtime credentials are deliberately absent. Protocol v2 delivers them
+/// Runtime credentials are deliberately absent. Protocol v3 delivers them
 /// only after the runner has durably accepted this exact offer.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/automata-ci-protocol/src/message/lease_authority.rs
+++ b/crates/automata-ci-protocol/src/message/lease_authority.rs
@@ -1,0 +1,558 @@
+//! Provider-neutral authority contributions attached to a lease poll.
+
+use std::fmt;
+
+use automata_ci_core::Sha256Digest;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+/// Current schema of the canonical lease-authority contribution bundle.
+pub const LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION: u16 = 1;
+/// Maximum number of independent extensions contributing to one poll.
+pub const MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS: usize = 16;
+/// Maximum UTF-8 bytes in one lease-authority namespace.
+pub const MAX_LEASE_AUTHORITY_NAME_BYTES: usize = 128;
+/// Maximum bytes in one provider-owned contribution payload.
+pub const MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+const CONTRIBUTIONS_DIGEST_DOMAIN: &[u8] = b"automata.lease-authority-poll-contributions.v1\0";
+
+/// Canonical namespace owned by one lease-authority extension.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct LeaseAuthorityName(String);
+
+impl LeaseAuthorityName {
+    /// Validates a lowercase portable extension namespace.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, path-like, or noncanonical names.
+    pub fn new(value: impl Into<String>) -> Result<Self, LeaseAuthorityPollContributionError> {
+        let value = value.into();
+        let mut bytes = value.bytes();
+        let valid_first = bytes.next().is_some_and(|byte| byte.is_ascii_lowercase());
+        let valid_rest = bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+        });
+        if value.len() <= MAX_LEASE_AUTHORITY_NAME_BYTES && valid_first && valid_rest {
+            Ok(Self(value))
+        } else {
+            Err(LeaseAuthorityPollContributionError::InvalidName)
+        }
+    }
+
+    /// Returns the canonical extension namespace.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<LeaseAuthorityName> for String {
+    fn from(value: LeaseAuthorityName) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<String> for LeaseAuthorityName {
+    type Error = LeaseAuthorityPollContributionError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseAuthorityPollContributionDocument {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+/// One bounded, provider-owned lease-poll contribution.
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(
+    try_from = "LeaseAuthorityPollContributionDocument",
+    into = "LeaseAuthorityPollContributionDocument"
+)]
+pub struct LeaseAuthorityPollContribution {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+    payload: Box<[u8]>,
+}
+
+impl LeaseAuthorityPollContribution {
+    /// Creates a contribution and commits to its exact payload bytes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects schema zero, an empty payload, or a payload above the hard bound.
+    pub fn new(
+        name: LeaseAuthorityName,
+        payload_schema_version: u16,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, LeaseAuthorityPollContributionError> {
+        let payload = payload.into();
+        let payload_sha256 = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        Self::from_parts(name, payload_schema_version, payload_sha256, payload)
+    }
+
+    /// Rehydrates one contribution at a transport boundary.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid bounds or a digest that does not match the payload.
+    pub fn from_parts(
+        name: LeaseAuthorityName,
+        payload_schema_version: u16,
+        payload_sha256: Sha256Digest,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, LeaseAuthorityPollContributionError> {
+        let payload = payload.into();
+        if payload_schema_version == 0 {
+            return Err(LeaseAuthorityPollContributionError::ZeroPayloadSchema);
+        }
+        if payload.is_empty() || payload.len() > MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES {
+            return Err(LeaseAuthorityPollContributionError::InvalidPayloadSize);
+        }
+        let actual = Sha256Digest::from_bytes(Sha256::digest(&payload).into());
+        if actual != payload_sha256 {
+            return Err(LeaseAuthorityPollContributionError::PayloadDigestMismatch);
+        }
+        Ok(Self {
+            name,
+            payload_schema_version,
+            payload_sha256,
+            payload,
+        })
+    }
+
+    /// Returns the extension namespace.
+    #[must_use]
+    pub const fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    /// Returns the provider-owned payload schema.
+    #[must_use]
+    pub const fn payload_schema_version(&self) -> u16 {
+        self.payload_schema_version
+    }
+
+    /// Returns the digest of the exact payload bytes.
+    #[must_use]
+    pub const fn payload_sha256(&self) -> Sha256Digest {
+        self.payload_sha256
+    }
+
+    /// Returns the exact provider-owned payload.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+impl fmt::Debug for LeaseAuthorityPollContribution {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LeaseAuthorityPollContribution")
+            .field("name", &self.name)
+            .field("payload_schema_version", &self.payload_schema_version)
+            .field("payload_sha256", &self.payload_sha256)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
+}
+
+impl From<LeaseAuthorityPollContribution> for LeaseAuthorityPollContributionDocument {
+    fn from(value: LeaseAuthorityPollContribution) -> Self {
+        Self {
+            name: value.name,
+            payload_schema_version: value.payload_schema_version,
+            payload_sha256: value.payload_sha256,
+            payload: value.payload,
+        }
+    }
+}
+
+impl TryFrom<LeaseAuthorityPollContributionDocument> for LeaseAuthorityPollContribution {
+    type Error = LeaseAuthorityPollContributionError;
+
+    fn try_from(value: LeaseAuthorityPollContributionDocument) -> Result<Self, Self::Error> {
+        Self::from_parts(
+            value.name,
+            value.payload_schema_version,
+            value.payload_sha256,
+            value.payload,
+        )
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseAuthorityPollReceiptDocument {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+}
+
+/// Value-free identity of one contribution durably accepted by control.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(
+    try_from = "LeaseAuthorityPollReceiptDocument",
+    into = "LeaseAuthorityPollReceiptDocument"
+)]
+pub struct LeaseAuthorityPollReceipt {
+    name: LeaseAuthorityName,
+    payload_schema_version: u16,
+    payload_sha256: Sha256Digest,
+}
+
+impl LeaseAuthorityPollReceipt {
+    /// Creates the exact acknowledgement identity for one accepted contribution.
+    #[must_use]
+    pub fn for_contribution(contribution: &LeaseAuthorityPollContribution) -> Self {
+        Self {
+            name: contribution.name().clone(),
+            payload_schema_version: contribution.payload_schema_version(),
+            payload_sha256: contribution.payload_sha256(),
+        }
+    }
+
+    /// Rehydrates one value-free acknowledgement identity.
+    ///
+    /// # Errors
+    ///
+    /// Rejects reserved payload schema zero.
+    pub fn from_parts(
+        name: LeaseAuthorityName,
+        payload_schema_version: u16,
+        payload_sha256: Sha256Digest,
+    ) -> Result<Self, LeaseAuthorityPollContributionError> {
+        if payload_schema_version == 0 {
+            return Err(LeaseAuthorityPollContributionError::ZeroPayloadSchema);
+        }
+        Ok(Self {
+            name,
+            payload_schema_version,
+            payload_sha256,
+        })
+    }
+
+    /// Returns the extension namespace.
+    #[must_use]
+    pub const fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    /// Returns the accepted provider-owned payload schema.
+    #[must_use]
+    pub const fn payload_schema_version(&self) -> u16 {
+        self.payload_schema_version
+    }
+
+    /// Returns the digest of the exact accepted payload bytes.
+    #[must_use]
+    pub const fn payload_sha256(&self) -> Sha256Digest {
+        self.payload_sha256
+    }
+}
+
+impl From<LeaseAuthorityPollReceipt> for LeaseAuthorityPollReceiptDocument {
+    fn from(value: LeaseAuthorityPollReceipt) -> Self {
+        Self {
+            name: value.name,
+            payload_schema_version: value.payload_schema_version,
+            payload_sha256: value.payload_sha256,
+        }
+    }
+}
+
+impl TryFrom<LeaseAuthorityPollReceiptDocument> for LeaseAuthorityPollReceipt {
+    type Error = LeaseAuthorityPollContributionError;
+
+    fn try_from(value: LeaseAuthorityPollReceiptDocument) -> Result<Self, Self::Error> {
+        Self::from_parts(
+            value.name,
+            value.payload_schema_version,
+            value.payload_sha256,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseAuthorityPollContributionsDocument {
+    schema_version: u16,
+    contributions: Vec<LeaseAuthorityPollContribution>,
+    sha256_digest: Sha256Digest,
+}
+
+/// Canonical contribution bundle which a server must explicitly acknowledge.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(
+    try_from = "LeaseAuthorityPollContributionsDocument",
+    into = "LeaseAuthorityPollContributionsDocument"
+)]
+pub struct LeaseAuthorityPollContributions {
+    schema_version: u16,
+    contributions: Vec<LeaseAuthorityPollContribution>,
+    sha256_digest: Sha256Digest,
+}
+
+impl LeaseAuthorityPollContributions {
+    /// Creates a canonical contribution bundle.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized, duplicate, or noncanonically ordered entries.
+    pub fn new(
+        contributions: Vec<LeaseAuthorityPollContribution>,
+    ) -> Result<Self, LeaseAuthorityPollContributionError> {
+        let sha256_digest = contributions_digest(
+            LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+            &contributions,
+        );
+        Self::from_parts(
+            LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+            contributions,
+            sha256_digest,
+        )
+    }
+
+    /// Creates the canonical empty contribution bundle.
+    #[must_use]
+    pub fn empty() -> Self {
+        let contributions = Vec::new();
+        let sha256_digest = contributions_digest(
+            LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+            &contributions,
+        );
+        Self {
+            schema_version: LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+            contributions,
+            sha256_digest,
+        }
+    }
+
+    /// Rehydrates a bundle with its claimed canonical digest.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unsupported schema, invalid ordering, or digest substitution.
+    pub fn from_parts(
+        schema_version: u16,
+        contributions: Vec<LeaseAuthorityPollContribution>,
+        sha256_digest: Sha256Digest,
+    ) -> Result<Self, LeaseAuthorityPollContributionError> {
+        if schema_version != LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION {
+            return Err(LeaseAuthorityPollContributionError::UnsupportedSchema);
+        }
+        if contributions.len() > MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS {
+            return Err(LeaseAuthorityPollContributionError::InvalidCount);
+        }
+        let mut previous: Option<&LeaseAuthorityName> = None;
+        for contribution in &contributions {
+            if previous.is_some_and(|name| name >= contribution.name()) {
+                return Err(LeaseAuthorityPollContributionError::NonCanonicalOrder);
+            }
+            previous = Some(contribution.name());
+        }
+        if contributions_digest(schema_version, &contributions) != sha256_digest {
+            return Err(LeaseAuthorityPollContributionError::BundleDigestMismatch);
+        }
+        Ok(Self {
+            schema_version,
+            contributions,
+            sha256_digest,
+        })
+    }
+
+    /// Returns the bundle schema.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns contributions in canonical namespace order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[LeaseAuthorityPollContribution] {
+        &self.contributions
+    }
+
+    /// Finds one exact extension namespace.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&LeaseAuthorityPollContribution> {
+        self.contributions
+            .binary_search_by(|contribution| contribution.name().as_str().cmp(name))
+            .ok()
+            .map(|index| &self.contributions[index])
+    }
+
+    /// Returns the canonical digest a successful poll response must echo.
+    #[must_use]
+    pub const fn sha256_digest(&self) -> Sha256Digest {
+        self.sha256_digest
+    }
+}
+
+impl Default for LeaseAuthorityPollContributions {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<LeaseAuthorityPollContributions> for LeaseAuthorityPollContributionsDocument {
+    fn from(value: LeaseAuthorityPollContributions) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            contributions: value.contributions,
+            sha256_digest: value.sha256_digest,
+        }
+    }
+}
+
+impl TryFrom<LeaseAuthorityPollContributionsDocument> for LeaseAuthorityPollContributions {
+    type Error = LeaseAuthorityPollContributionError;
+
+    fn try_from(value: LeaseAuthorityPollContributionsDocument) -> Result<Self, Self::Error> {
+        Self::from_parts(
+            value.schema_version,
+            value.contributions,
+            value.sha256_digest,
+        )
+    }
+}
+
+fn contributions_digest(
+    schema_version: u16,
+    contributions: &[LeaseAuthorityPollContribution],
+) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(CONTRIBUTIONS_DIGEST_DOMAIN);
+    digest.update(schema_version.to_be_bytes());
+    digest.update(
+        u32::try_from(contributions.len())
+            .unwrap_or(u32::MAX)
+            .to_be_bytes(),
+    );
+    for contribution in contributions {
+        update_bytes(&mut digest, contribution.name().as_str().as_bytes());
+        digest.update(contribution.payload_schema_version().to_be_bytes());
+        digest.update(contribution.payload_sha256().as_bytes());
+        update_bytes(&mut digest, contribution.payload());
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}
+
+fn update_bytes(digest: &mut Sha256, value: &[u8]) {
+    digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_be_bytes());
+    digest.update(value);
+}
+
+/// Invalid provider-neutral lease-authority contribution material.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum LeaseAuthorityPollContributionError {
+    /// The extension namespace is empty, oversized, path-like, or noncanonical.
+    #[error("lease authority name is invalid")]
+    InvalidName,
+    /// Payload schema zero is reserved.
+    #[error("lease authority payload schema must be nonzero")]
+    ZeroPayloadSchema,
+    /// Payload is empty or above the hard bound.
+    #[error("lease authority contribution payload size is invalid")]
+    InvalidPayloadSize,
+    /// Payload bytes disagree with their claimed digest.
+    #[error("lease authority contribution payload digest does not match")]
+    PayloadDigestMismatch,
+    /// The contribution bundle schema is unsupported.
+    #[error("lease authority contribution bundle schema is unsupported")]
+    UnsupportedSchema,
+    /// The contribution bundle contains too many entries.
+    #[error("lease authority contribution count is invalid")]
+    InvalidCount,
+    /// Contributions are not strictly ordered by unique namespace.
+    #[error("lease authority contributions are not in canonical order")]
+    NonCanonicalOrder,
+    /// The claimed canonical bundle digest is incorrect.
+    #[error("lease authority contribution bundle digest does not match")]
+    BundleDigestMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contribution(name: &str, byte: u8) -> LeaseAuthorityPollContribution {
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new(name).expect("name"),
+            1,
+            vec![byte; 32],
+        )
+        .expect("contribution")
+    }
+
+    #[test]
+    fn exact_bundle_digest_commits_to_payload_and_order() {
+        let first = contribution("alpha", 1);
+        let second = contribution("zulu", 2);
+        let bundle = LeaseAuthorityPollContributions::new(vec![first.clone(), second.clone()])
+            .expect("bundle");
+        assert_eq!(
+            bundle.sha256_digest().to_string(),
+            "77cbaccb7a406d175fe88ff86e4efa43ab63ab597d7ee1196d7602388eb6687e"
+        );
+        assert_ne!(
+            bundle.sha256_digest(),
+            LeaseAuthorityPollContributions::empty().sha256_digest()
+        );
+        assert!(matches!(
+            LeaseAuthorityPollContributions::from_parts(
+                bundle.schema_version(),
+                vec![second, first],
+                bundle.sha256_digest(),
+            ),
+            Err(LeaseAuthorityPollContributionError::NonCanonicalOrder)
+        ));
+    }
+
+    #[test]
+    fn payload_and_bundle_digest_substitution_fail_closed() {
+        let exact = contribution("alpha", 1);
+        assert!(matches!(
+            LeaseAuthorityPollContribution::from_parts(
+                exact.name().clone(),
+                exact.payload_schema_version(),
+                exact.payload_sha256(),
+                vec![2; 32],
+            ),
+            Err(LeaseAuthorityPollContributionError::PayloadDigestMismatch)
+        ));
+        assert!(matches!(
+            LeaseAuthorityPollContributions::from_parts(
+                LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION,
+                vec![exact],
+                Sha256Digest::from_bytes([0x5a; 32]),
+            ),
+            Err(LeaseAuthorityPollContributionError::BundleDigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn receipt_identity_includes_payload_schema() {
+        let exact = contribution("alpha", 1);
+        let receipt = LeaseAuthorityPollReceipt::for_contribution(&exact);
+        let another_schema = LeaseAuthorityPollReceipt::from_parts(
+            exact.name().clone(),
+            exact.payload_schema_version() + 1,
+            exact.payload_sha256(),
+        )
+        .expect("receipt");
+        assert_ne!(receipt, another_schema);
+    }
+}

--- a/crates/automata-ci-protocol/src/message/mod.rs
+++ b/crates/automata-ci-protocol/src/message/mod.rs
@@ -9,6 +9,7 @@ mod execution;
 mod handshake;
 mod header;
 mod lease;
+mod lease_authority;
 mod limits;
 mod log;
 mod managed_secret;
@@ -19,7 +20,7 @@ pub use authority::*;
 pub use codec::{ValidatedRunnerToServer, ValidatedServerToRunner};
 pub use control::{CommandAck, OperationAck};
 pub use envelope::{RunnerToServer, ServerToRunner};
-pub use error::{ErrorMessage, NoWork, RemoteErrorCode};
+pub use error::{ErrorMessage, RemoteErrorCode};
 pub use execution::{CancelJob, JobResultMessage, JobStateUpdate};
 pub use handshake::{
     HandshakeErrorCode, HandshakeRejected, NegotiatedSession, OrphanDeliveryPermissions,
@@ -27,8 +28,14 @@ pub use handshake::{
 };
 pub use header::MessageHeader;
 pub use lease::{
-    LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeaseRejectionReason, LeaseRenewal, LeaseRequest,
-    LeaseResponse,
+    LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeasePollOutcome, LeasePollResponse,
+    LeaseRejectionReason, LeaseRenewal, LeaseRequest, LeaseResponse,
+};
+pub use lease_authority::{
+    LEASE_AUTHORITY_POLL_CONTRIBUTIONS_SCHEMA_VERSION, LeaseAuthorityName,
+    LeaseAuthorityPollContribution, LeaseAuthorityPollContributionError,
+    LeaseAuthorityPollContributions, LeaseAuthorityPollReceipt, MAX_LEASE_AUTHORITY_NAME_BYTES,
+    MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS, MAX_LEASE_AUTHORITY_POLL_PAYLOAD_BYTES,
 };
 pub use limits::{MAX_CONFIGURABLE_FRAME_BYTES, ProtocolLimits, ProtocolLimitsError};
 pub use log::{LogAckMessage, LogBatch};

--- a/crates/automata-ci-protocol/src/message/validation.rs
+++ b/crates/automata-ci-protocol/src/message/validation.rs
@@ -11,7 +11,8 @@ use automata_ci_core::{
 use thiserror::Error;
 
 use super::{
-    ErrorMessage, LogBatch, ProtocolLimits, RunnerSlotOrdinal, RunnerToServer, ServerToRunner,
+    CancelJob, ErrorMessage, LeaseOffer, LeasePollOutcome, LogBatch, ProtocolLimits,
+    RunnerSlotOrdinal, RunnerToServer, ServerToRunner,
 };
 use crate::{MESSAGE_SCHEMA_VERSION, ProtocolRange, ProtocolRangeError, ProtocolVersion};
 
@@ -37,7 +38,22 @@ pub(super) fn validate_runner_message(
             hello.validate()?;
             validate_capabilities(hello.runner(), limits)
         }
-        RunnerToServer::LeaseRequest(request) => request.validate(),
+        RunnerToServer::LeaseRequest(request) => {
+            request.validate()?;
+            validate_collection(
+                "lease authority contributions",
+                request.authority_contributions().as_slice().len(),
+                limits.max_collection_items(),
+            )?;
+            for contribution in request.authority_contributions().as_slice() {
+                validate_nonempty_text(
+                    "lease authority name",
+                    contribution.name().as_str(),
+                    limits,
+                )?;
+            }
+            Ok(())
+        }
         RunnerToServer::LeaseResponse(response) => response.header().validate_request(),
         RunnerToServer::RuntimeAuthorityRequest(request) => request.validate(),
         RunnerToServer::RuntimeAuthorityAck(acknowledgement) => acknowledgement.validate(),
@@ -75,36 +91,71 @@ pub(super) fn validate_server_message(
             rejection.validate()?;
             validate_control_text("handshake rejection message", rejection.message(), limits)
         }
-        ServerToRunner::LeaseOffer(offer) => {
-            offer.header().validate()?;
-            offer.lease().validate()?;
-            validate_job(offer.job(), limits)?;
-            if let Some(overlay) = offer.managed_secret_bindings() {
-                overlay.validate_for(offer.lease())?;
+        ServerToRunner::LeasePollResponse(response) => {
+            response.validate()?;
+            match response.outcome() {
+                LeasePollOutcome::NoWork { .. } => Ok(()),
+                LeasePollOutcome::LeaseOffer(offer) => validate_lease_offer(offer, limits),
+                LeasePollOutcome::CancelJob(cancel) => validate_cancel_job(cancel, limits),
+            }
+        }
+        ServerToRunner::LeaseOffer(offer) => validate_lease_offer(offer, limits),
+        ServerToRunner::RuntimeAuthorityGrant(grant) => {
+            grant.validate()?;
+            validate_collection(
+                "runtime authorities",
+                grant.authorities().as_slice().len(),
+                limits.max_collection_items(),
+            )?;
+            validate_collection(
+                "sandbox authorizations",
+                grant
+                    .authorities()
+                    .sandbox_authorizations()
+                    .as_slice()
+                    .len(),
+                limits.max_collection_items(),
+            )?;
+            for authorization in grant.authorities().sandbox_authorizations().as_slice() {
+                validate_nonempty_text(
+                    "sandbox authorization name",
+                    authorization.name().as_str(),
+                    limits,
+                )?;
             }
             Ok(())
         }
-        ServerToRunner::RuntimeAuthorityGrant(grant) => grant.validate(),
         ServerToRunner::LeaseRenewal(renewal) => renewal.header().validate_reply(),
-        ServerToRunner::CancelJob(cancel) => {
-            cancel.header().validate()?;
-            validate_control_text("cancellation reason", cancel.reason(), limits)
-        }
+        ServerToRunner::CancelJob(cancel) => validate_cancel_job(cancel, limits),
         ServerToRunner::LogAck(acknowledgement) => {
             acknowledgement.header().validate_reply()?;
             acknowledgement.ack().validate()?;
             Ok(())
         }
         ServerToRunner::OperationAck(acknowledgement) => acknowledgement.header().validate_reply(),
-        ServerToRunner::NoWork(no_work) => {
-            no_work.header().validate_reply()?;
-            if no_work.retry_after_millis() == 0 {
-                return Err(MessageValidationError::ZeroValue("retry_after_millis"));
-            }
-            Ok(())
-        }
         ServerToRunner::Error(error) => validate_error(error, limits),
     }
+}
+
+fn validate_lease_offer(
+    offer: &LeaseOffer,
+    limits: &ProtocolLimits,
+) -> Result<(), MessageValidationError> {
+    offer.header().validate()?;
+    offer.lease().validate()?;
+    validate_job(offer.job(), limits)?;
+    if let Some(overlay) = offer.managed_secret_bindings() {
+        overlay.validate_for(offer.lease())?;
+    }
+    Ok(())
+}
+
+fn validate_cancel_job(
+    cancel: &CancelJob,
+    limits: &ProtocolLimits,
+) -> Result<(), MessageValidationError> {
+    cancel.header().validate()?;
+    validate_control_text("cancellation reason", cancel.reason(), limits)
 }
 
 /// Validates a standalone durable `JobIR` envelope with transport resource limits.
@@ -789,6 +840,9 @@ pub enum MessageValidationError {
         /// Self-referential lease-request operation identity.
         operation_id: OperationId,
     },
+    /// A lease-poll response acknowledged a different contribution bundle.
+    #[error("lease authority contribution acceptance does not match the request")]
+    LeaseAuthorityAcceptanceMismatch,
     /// A server response omits the request operation it answers.
     #[error("server response headers must carry request correlation")]
     MissingResponseCorrelation,
@@ -924,6 +978,9 @@ pub enum MessageValidationError {
     /// Runtime-authority delivery metadata is invalid or conflicting.
     #[error(transparent)]
     RuntimeAuthorityDelivery(#[from] super::RuntimeAuthorityDeliveryError),
+    /// Lease-authority contribution material violates its bounded canonical contract.
+    #[error(transparent)]
+    LeaseAuthorityPollContribution(#[from] super::LeaseAuthorityPollContributionError),
     /// A managed-secret overlay violates canonical form, digest, or lease binding.
     #[error(transparent)]
     ManagedSecretBindingOverlay(#[from] super::ManagedSecretBindingOverlayError),

--- a/crates/automata-ci-protocol/src/negotiation.rs
+++ b/crates/automata-ci-protocol/src/negotiation.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use automata_ci_core::{JobIrVersion, JobIrVersionRange};
 
 /// Lowest protocol version spoken by this build.
-pub const PROTOCOL_MIN_VERSION: ProtocolVersion = ProtocolVersion(2);
+pub const PROTOCOL_MIN_VERSION: ProtocolVersion = ProtocolVersion(3);
 /// Highest protocol version spoken by this build.
-pub const PROTOCOL_MAX_VERSION: ProtocolVersion = ProtocolVersion(2);
+pub const PROTOCOL_MAX_VERSION: ProtocolVersion = ProtocolVersion(3);
 /// Complete supported range for this build.
 pub const SUPPORTED_PROTOCOL_RANGE: ProtocolRange = ProtocolRange {
     min: PROTOCOL_MIN_VERSION,

--- a/crates/automata-ci-protocol/src/windows_admission.rs
+++ b/crates/automata-ci-protocol/src/windows_admission.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use url::Url;
 
 /// Schema version of the canonical Windows admission payload and envelope.
-pub const WINDOWS_RUNNER_ADMISSION_SCHEMA_VERSION: u16 = 1;
+pub const WINDOWS_RUNNER_ADMISSION_SCHEMA_VERSION: u16 = 2;
 /// Fixed sandbox provider authorized by this receipt contract.
 pub const WINDOWS_RUNNER_ADMISSION_PROVIDER_ID: &str = "windows-hyperv";
 
@@ -34,7 +34,7 @@ const MAX_ADMISSION_LIFETIME_MILLIS: u64 = 15 * 60 * 1_000;
 const MAX_PROMOTION_LIFETIME_MILLIS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const ED25519_PUBLIC_KEY_BYTES: usize = 32;
 const ED25519_SIGNATURE_BYTES: usize = 64;
-const RECEIPT_DIGEST_DOMAIN: &[u8] = b"automata.windows-runner-admission-envelope.v1\0";
+const RECEIPT_DIGEST_DOMAIN: &[u8] = b"automata.windows-runner-admission-envelope.v2\0";
 
 /// Exact enrollment transaction named by the broker admission.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -234,6 +234,7 @@ pub struct WindowsBrokerProfileBinding {
     probe_contract_sha256: Sha256Digest,
     network_disabled: bool,
     sealed_action_trees: bool,
+    sandbox_pids_limit: u32,
 }
 
 #[derive(Deserialize)]
@@ -247,6 +248,7 @@ struct UncheckedWindowsBrokerProfileBinding {
     probe_contract_sha256: Sha256Digest,
     network_disabled: bool,
     sealed_action_trees: bool,
+    sandbox_pids_limit: u32,
 }
 
 impl<'de> Deserialize<'de> for WindowsBrokerProfileBinding {
@@ -264,6 +266,7 @@ impl<'de> Deserialize<'de> for WindowsBrokerProfileBinding {
             value.probe_contract_sha256,
             value.network_disabled,
             value.sealed_action_trees,
+            value.sandbox_pids_limit,
         )
         .map_err(D::Error::custom)
     }
@@ -286,6 +289,7 @@ impl WindowsBrokerProfileBinding {
         probe_contract_sha256: Sha256Digest,
         network_disabled: bool,
         sealed_action_trees: bool,
+        sandbox_pids_limit: u32,
     ) -> Result<Self, WindowsRunnerAdmissionError> {
         let broker_host_id = broker_host_id.into();
         let sandbox_provider_id = sandbox_provider_id.into();
@@ -295,6 +299,7 @@ impl WindowsBrokerProfileBinding {
             || zero_digest(profile.digest())
             || zero_digest(probe_contract_sha256)
             || !network_disabled
+            || sandbox_pids_limit == 0
         {
             return Err(WindowsRunnerAdmissionError::InvalidBrokerProfile);
         }
@@ -307,6 +312,7 @@ impl WindowsBrokerProfileBinding {
             probe_contract_sha256,
             network_disabled,
             sealed_action_trees,
+            sandbox_pids_limit,
         })
     }
 
@@ -357,6 +363,14 @@ impl WindowsBrokerProfileBinding {
     #[must_use]
     pub const fn sealed_action_trees(&self) -> bool {
         self.sealed_action_trees
+    }
+
+    /// Returns the broker-admitted hard process ceiling authenticated by the
+    /// receipt. Placement grants must copy this value from the current durable
+    /// admission rather than mutable runner inventory.
+    #[must_use]
+    pub const fn sandbox_pids_limit(&self) -> u32 {
+        self.sandbox_pids_limit
     }
 }
 
@@ -1201,6 +1215,16 @@ impl WindowsRunnerAdmissionEnvelope {
         &self.authenticator
     }
 
+    /// Returns the domain-separated digest of this complete signed envelope.
+    ///
+    /// This is a transport commitment only. It does not verify the signature
+    /// or authorize capabilities; callers must still use
+    /// [`verify_windows_runner_admission`] for that purpose.
+    #[must_use]
+    pub fn envelope_sha256(&self) -> Sha256Digest {
+        envelope_digest(self)
+    }
+
     /// Decodes the already canonical, structurally validated claims.
     ///
     /// # Errors
@@ -1360,7 +1384,7 @@ pub fn verify_windows_runner_admission(
     validate_current_window(claims.validity, now_unix_millis)?;
     validate_current_promotion(claims.binding.promotion.validity, now_unix_millis)?;
     Ok(VerifiedWindowsRunnerAdmission {
-        envelope_sha256: envelope_digest(envelope),
+        envelope_sha256: envelope.envelope_sha256(),
         claims,
         envelope: envelope.clone(),
     })
@@ -1682,6 +1706,7 @@ mod tests {
             digest(7),
             true,
             true,
+            64,
         )
         .expect("broker profile");
         let promotion = WindowsImagePromotionBinding::new(

--- a/crates/automata-ci-protocol/src/windows_admission_renewal.rs
+++ b/crates/automata-ci-protocol/src/windows_admission_renewal.rs
@@ -1,0 +1,821 @@
+//! Domain-separated Windows placement-admission renewals.
+//!
+//! Enrollment receipts authorize one enrollment transaction and expire within
+//! fifteen minutes. They are never reused as long-lived placement authority.
+//! This module defines a distinct broker-signed renewal which can travel only
+//! from an authenticated runner to control with a lease poll. Control must
+//! still atomically consume its nonce, enforce the exact next serial, compare
+//! promotion/revocation high-water state, and update its durable current head.
+
+use automata_ci_core::{RunnerId, Sha256Digest};
+use ring::signature;
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    WindowsAdmissionValidity, WindowsRunnerAdmissionBinding, WindowsRunnerAdmissionEvidence,
+    WindowsRunnerAdmissionTrustStore,
+};
+
+/// Current schema for a broker-signed placement renewal.
+pub const WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION: u16 = 2;
+
+const MAX_CANONICAL_PAYLOAD_BYTES: usize = 512 * 1024;
+const MAX_ID_BYTES: usize = 128;
+const ED25519_SIGNATURE_BYTES: usize = 64;
+const SIGNING_DOMAIN: &[u8] = b"automata.windows-runner-placement-renewal.signature.v2\0";
+const ENVELOPE_DIGEST_DOMAIN: &[u8] = b"automata.windows-runner-placement-renewal-envelope.v2\0";
+
+/// Canonical claims for one independently refreshed placement admission.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WindowsRunnerPlacementRenewalClaims {
+    schema_version: u16,
+    issuer_key_id: String,
+    runner_id: RunnerId,
+    renewal_serial: u64,
+    nonce: Sha256Digest,
+    enrollment_envelope_sha256: Sha256Digest,
+    binding: WindowsRunnerAdmissionBinding,
+    evidence: WindowsRunnerAdmissionEvidence,
+    validity: WindowsAdmissionValidity,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedWindowsRunnerPlacementRenewalClaims {
+    schema_version: u16,
+    issuer_key_id: String,
+    runner_id: RunnerId,
+    renewal_serial: u64,
+    nonce: Sha256Digest,
+    enrollment_envelope_sha256: Sha256Digest,
+    binding: WindowsRunnerAdmissionBinding,
+    evidence: WindowsRunnerAdmissionEvidence,
+    validity: WindowsAdmissionValidity,
+}
+
+impl<'de> Deserialize<'de> for WindowsRunnerPlacementRenewalClaims {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = UncheckedWindowsRunnerPlacementRenewalClaims::deserialize(deserializer)?;
+        if value.schema_version != WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION {
+            return Err(D::Error::custom(
+                WindowsRunnerPlacementRenewalError::UnsupportedSchema,
+            ));
+        }
+        Self::new(
+            value.issuer_key_id,
+            value.runner_id,
+            value.renewal_serial,
+            value.nonce,
+            value.enrollment_envelope_sha256,
+            value.binding,
+            value.evidence,
+            value.validity,
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+impl WindowsRunnerPlacementRenewalClaims {
+    /// Creates one exact renewal proposal ready for broker signing.
+    ///
+    /// # Errors
+    ///
+    /// Rejects placeholder identity/commitments, a zero serial, a runner
+    /// substitution, a non-disabled network profile, or a horizon beyond the
+    /// signed promotion expiry.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        issuer_key_id: impl Into<String>,
+        runner_id: RunnerId,
+        renewal_serial: u64,
+        nonce: Sha256Digest,
+        enrollment_envelope_sha256: Sha256Digest,
+        binding: WindowsRunnerAdmissionBinding,
+        evidence: WindowsRunnerAdmissionEvidence,
+        validity: WindowsAdmissionValidity,
+    ) -> Result<Self, WindowsRunnerPlacementRenewalError> {
+        let issuer_key_id = issuer_key_id.into();
+        let broker_profile = binding.broker_profile();
+        let promotion = binding.promotion();
+        if !valid_id(&issuer_key_id)
+            || runner_id.as_uuid().is_nil()
+            || renewal_serial == 0
+            || zero_digest(nonce)
+            || zero_digest(enrollment_envelope_sha256)
+            || binding.transaction().runner_id() != runner_id
+            || !broker_profile.network_disabled()
+            || validity.expires_at_unix_millis() > promotion.validity().expires_at_unix_millis()
+        {
+            return Err(WindowsRunnerPlacementRenewalError::InvalidClaims);
+        }
+        Ok(Self {
+            schema_version: WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION,
+            issuer_key_id,
+            runner_id,
+            renewal_serial,
+            nonce,
+            enrollment_envelope_sha256,
+            binding,
+            evidence,
+            validity,
+        })
+    }
+
+    /// Returns the renewal schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns the broker signing-key identifier.
+    #[must_use]
+    pub fn issuer_key_id(&self) -> &str {
+        &self.issuer_key_id
+    }
+
+    /// Returns the exact enrolled runner.
+    #[must_use]
+    pub const fn runner_id(&self) -> RunnerId {
+        self.runner_id
+    }
+
+    /// Returns the broker-durable contiguous renewal serial.
+    #[must_use]
+    pub const fn renewal_serial(&self) -> u64 {
+        self.renewal_serial
+    }
+
+    /// Returns the one-use renewal nonce.
+    #[must_use]
+    pub const fn nonce(&self) -> Sha256Digest {
+        self.nonce
+    }
+
+    /// Returns the original verified enrollment-envelope commitment.
+    #[must_use]
+    pub const fn enrollment_envelope_sha256(&self) -> Sha256Digest {
+        self.enrollment_envelope_sha256
+    }
+
+    /// Returns the exact enrolled broker/profile/promotion/capability binding.
+    #[must_use]
+    pub const fn binding(&self) -> &WindowsRunnerAdmissionBinding {
+        &self.binding
+    }
+
+    /// Returns the freshly observed evidence digests.
+    #[must_use]
+    pub const fn evidence(&self) -> WindowsRunnerAdmissionEvidence {
+        self.evidence
+    }
+
+    /// Returns the exclusive placement horizon, bounded to fifteen minutes.
+    #[must_use]
+    pub const fn validity(&self) -> WindowsAdmissionValidity {
+        self.validity
+    }
+
+    /// Returns the canonical payload stored in the signed envelope.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails or exceeds the fixed bound.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, WindowsRunnerPlacementRenewalError> {
+        let bytes = serde_json::to_vec(self)
+            .map_err(|_| WindowsRunnerPlacementRenewalError::InvalidCanonicalPayload)?;
+        if bytes.is_empty() || bytes.len() > MAX_CANONICAL_PAYLOAD_BYTES {
+            return Err(WindowsRunnerPlacementRenewalError::PayloadTooLarge);
+        }
+        Ok(bytes)
+    }
+
+    /// Returns the domain-separated bytes which the broker must sign.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the canonical payload cannot be produced.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, WindowsRunnerPlacementRenewalError> {
+        let payload = self.canonical_bytes()?;
+        Ok(signing_bytes(&payload))
+    }
+}
+
+/// Untrusted transport envelope for one Windows placement renewal.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WindowsRunnerPlacementRenewalEnvelope {
+    schema_version: u16,
+    issuer_key_id: String,
+    signed_payload: Vec<u8>,
+    authenticator: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedWindowsRunnerPlacementRenewalEnvelope {
+    schema_version: u16,
+    issuer_key_id: String,
+    signed_payload: Vec<u8>,
+    authenticator: Vec<u8>,
+}
+
+impl<'de> Deserialize<'de> for WindowsRunnerPlacementRenewalEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = UncheckedWindowsRunnerPlacementRenewalEnvelope::deserialize(deserializer)?;
+        if value.schema_version != WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION {
+            return Err(D::Error::custom(
+                WindowsRunnerPlacementRenewalError::UnsupportedSchema,
+            ));
+        }
+        Self::new(
+            value.issuer_key_id,
+            value.signed_payload,
+            value.authenticator,
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+impl WindowsRunnerPlacementRenewalEnvelope {
+    /// Wraps canonical renewal claims and one Ed25519 authenticator.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a noncanonical issuer/payload, issuer substitution, oversized
+    /// payload, or a non-Ed25519 authenticator length.
+    pub fn new(
+        issuer_key_id: impl Into<String>,
+        signed_payload: Vec<u8>,
+        authenticator: Vec<u8>,
+    ) -> Result<Self, WindowsRunnerPlacementRenewalError> {
+        let issuer_key_id = issuer_key_id.into();
+        if !valid_id(&issuer_key_id) {
+            return Err(WindowsRunnerPlacementRenewalError::InvalidIssuer);
+        }
+        if signed_payload.is_empty() || signed_payload.len() > MAX_CANONICAL_PAYLOAD_BYTES {
+            return Err(WindowsRunnerPlacementRenewalError::PayloadTooLarge);
+        }
+        if authenticator.len() != ED25519_SIGNATURE_BYTES {
+            return Err(WindowsRunnerPlacementRenewalError::InvalidAuthenticator);
+        }
+        let claims: WindowsRunnerPlacementRenewalClaims =
+            serde_json::from_slice(&signed_payload)
+                .map_err(|_| WindowsRunnerPlacementRenewalError::InvalidCanonicalPayload)?;
+        if claims.canonical_bytes()? != signed_payload {
+            return Err(WindowsRunnerPlacementRenewalError::NonCanonicalPayload);
+        }
+        if claims.issuer_key_id() != issuer_key_id {
+            return Err(WindowsRunnerPlacementRenewalError::IssuerMismatch);
+        }
+        Ok(Self {
+            schema_version: WINDOWS_RUNNER_PLACEMENT_RENEWAL_SCHEMA_VERSION,
+            issuer_key_id,
+            signed_payload,
+            authenticator,
+        })
+    }
+
+    /// Returns the renewal envelope schema.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns the independently selected issuer key ID.
+    #[must_use]
+    pub fn issuer_key_id(&self) -> &str {
+        &self.issuer_key_id
+    }
+
+    /// Returns the canonical signed claims payload.
+    #[must_use]
+    pub fn signed_payload(&self) -> &[u8] {
+        &self.signed_payload
+    }
+
+    /// Returns the raw Ed25519 signature.
+    #[must_use]
+    pub fn authenticator(&self) -> &[u8] {
+        &self.authenticator
+    }
+
+    /// Returns the domain-separated complete-envelope commitment.
+    #[must_use]
+    pub fn envelope_sha256(&self) -> Sha256Digest {
+        envelope_digest(self)
+    }
+
+    /// Decodes the structurally validated canonical claims.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an in-memory envelope was corrupted.
+    pub fn claims(
+        &self,
+    ) -> Result<WindowsRunnerPlacementRenewalClaims, WindowsRunnerPlacementRenewalError> {
+        serde_json::from_slice(&self.signed_payload)
+            .map_err(|_| WindowsRunnerPlacementRenewalError::InvalidCanonicalPayload)
+    }
+}
+
+/// Server-verified placement renewal.
+///
+/// This type is not sufficient by itself for placement. Control must commit it
+/// atomically with nonce/serial/high-water checks before its current-admission
+/// reader may expose the new head.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedWindowsRunnerPlacementRenewal {
+    claims: WindowsRunnerPlacementRenewalClaims,
+    envelope_sha256: Sha256Digest,
+}
+
+impl VerifiedWindowsRunnerPlacementRenewal {
+    /// Returns the authenticated renewal claims.
+    #[must_use]
+    pub const fn claims(&self) -> &WindowsRunnerPlacementRenewalClaims {
+        &self.claims
+    }
+
+    /// Returns the complete signed-envelope commitment.
+    #[must_use]
+    pub const fn envelope_sha256(&self) -> Sha256Digest {
+        self.envelope_sha256
+    }
+}
+
+/// Verifies one renewal against the server-owned scoped broker trust store.
+///
+/// # Errors
+///
+/// Rejects unknown/scoped-substituted issuers, invalid signatures,
+/// noncanonical claims, future/expired horizons, or expired promotion proof.
+pub fn verify_windows_runner_placement_renewal(
+    envelope: &WindowsRunnerPlacementRenewalEnvelope,
+    trust_store: &dyn WindowsRunnerAdmissionTrustStore,
+    now_unix_millis: u64,
+) -> Result<VerifiedWindowsRunnerPlacementRenewal, WindowsRunnerPlacementRenewalError> {
+    let claims = envelope.claims()?;
+    if claims.issuer_key_id() != envelope.issuer_key_id() {
+        return Err(WindowsRunnerPlacementRenewalError::IssuerMismatch);
+    }
+    let anchor = trust_store
+        .admission_trust_anchor(envelope.issuer_key_id())
+        .ok_or(WindowsRunnerPlacementRenewalError::UnknownIssuer)?;
+    let broker = claims.binding().broker_profile();
+    let promotion = claims.binding().promotion();
+    if broker.broker_host_id() != anchor.broker_host_id()
+        || broker.profile() != anchor.profile()
+        || promotion.trust_bundle_id() != anchor.promotion_trust_bundle_id()
+    {
+        return Err(WindowsRunnerPlacementRenewalError::TrustScopeMismatch);
+    }
+    signature::UnparsedPublicKey::new(&signature::ED25519, anchor.ed25519_public_key())
+        .verify(
+            &signing_bytes(envelope.signed_payload()),
+            envelope.authenticator(),
+        )
+        .map_err(|_| WindowsRunnerPlacementRenewalError::InvalidSignature)?;
+    let validity = claims.validity();
+    if validity.issued_at_unix_millis() > now_unix_millis {
+        return Err(WindowsRunnerPlacementRenewalError::NotYetValid);
+    }
+    if now_unix_millis >= validity.expires_at_unix_millis() {
+        return Err(WindowsRunnerPlacementRenewalError::Expired);
+    }
+    let promotion_validity = promotion.validity();
+    if promotion_validity.issued_at_unix_millis() > now_unix_millis {
+        return Err(WindowsRunnerPlacementRenewalError::NotYetValid);
+    }
+    if now_unix_millis >= promotion_validity.expires_at_unix_millis() {
+        return Err(WindowsRunnerPlacementRenewalError::PromotionExpired);
+    }
+    Ok(VerifiedWindowsRunnerPlacementRenewal {
+        envelope_sha256: envelope.envelope_sha256(),
+        claims,
+    })
+}
+
+/// Fail-closed renewal validation failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsRunnerPlacementRenewalError {
+    /// The message uses an unsupported schema.
+    #[error("unsupported Windows placement-renewal schema")]
+    UnsupportedSchema,
+    /// A signed claim or nested binding is invalid.
+    #[error("invalid Windows placement-renewal claims")]
+    InvalidClaims,
+    /// The issuer key ID is malformed.
+    #[error("invalid Windows placement-renewal issuer")]
+    InvalidIssuer,
+    /// Payload bytes are missing or exceed the fixed budget.
+    #[error("Windows placement-renewal payload is too large")]
+    PayloadTooLarge,
+    /// The payload cannot be decoded canonically.
+    #[error("invalid Windows placement-renewal canonical payload")]
+    InvalidCanonicalPayload,
+    /// Decoded payload bytes are not the unique canonical representation.
+    #[error("noncanonical Windows placement-renewal payload")]
+    NonCanonicalPayload,
+    /// Envelope and claims name different issuers.
+    #[error("Windows placement-renewal issuer mismatch")]
+    IssuerMismatch,
+    /// The authenticator is not exactly one Ed25519 signature.
+    #[error("invalid Windows placement-renewal authenticator")]
+    InvalidAuthenticator,
+    /// The server does not trust this issuer.
+    #[error("unknown Windows placement-renewal issuer")]
+    UnknownIssuer,
+    /// The issuer is trusted for a different host/profile/trust bundle.
+    #[error("Windows placement-renewal trust scope mismatch")]
+    TrustScopeMismatch,
+    /// Signature verification failed.
+    #[error("invalid Windows placement-renewal signature")]
+    InvalidSignature,
+    /// The broker issue time is in the future.
+    #[error("Windows placement renewal is not yet valid")]
+    NotYetValid,
+    /// The exclusive placement horizon passed.
+    #[error("Windows placement renewal expired")]
+    Expired,
+    /// The signed image promotion expired.
+    #[error("Windows placement renewal promotion expired")]
+    PromotionExpired,
+}
+
+fn signing_bytes(payload: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(SIGNING_DOMAIN.len() + 8 + payload.len());
+    bytes.extend_from_slice(SIGNING_DOMAIN);
+    bytes.extend_from_slice(&(payload.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn envelope_digest(envelope: &WindowsRunnerPlacementRenewalEnvelope) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(ENVELOPE_DIGEST_DOMAIN);
+    for field in [
+        envelope.issuer_key_id().as_bytes(),
+        envelope.signed_payload(),
+        envelope.authenticator(),
+    ] {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}
+
+fn valid_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (3..=MAX_ID_BYTES).contains(&bytes.len())
+        && bytes[0].is_ascii_lowercase()
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(byte))
+}
+
+fn zero_digest(value: Sha256Digest) -> bool {
+    value.as_bytes().iter().all(|byte| *byte == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use automata_ci_core::{
+        Architecture, EnvironmentProfile, EnvironmentProfileId, IsolationLevel, OperatingSystem,
+        OperationId, RunnerCapabilities, RunnerFeature, RunnerPlatform, SandboxCapabilities,
+        SandboxFeature,
+    };
+    use ring::{
+        rand::SystemRandom,
+        signature::{Ed25519KeyPair, KeyPair as _},
+    };
+
+    use super::*;
+    use crate::{
+        WINDOWS_RUNNER_ADMISSION_PROVIDER_ID, WindowsAdmissionImage,
+        WindowsAuthorityAdmissionEvidence, WindowsBrokerAdmissionEvidence,
+        WindowsBrokerProfileBinding, WindowsEnrollmentTransactionBinding,
+        WindowsImagePromotionBinding, WindowsPromotionValidity, WindowsRunnerAdmissionTrustAnchor,
+    };
+
+    const NOW: u64 = 1_800_000_000_000;
+
+    #[derive(Debug)]
+    struct TrustStore(BTreeMap<String, WindowsRunnerAdmissionTrustAnchor>);
+
+    impl WindowsRunnerAdmissionTrustStore for TrustStore {
+        fn admission_trust_anchor(
+            &self,
+            issuer_key_id: &str,
+        ) -> Option<WindowsRunnerAdmissionTrustAnchor> {
+            self.0.get(issuer_key_id).cloned()
+        }
+    }
+
+    fn digest(byte: u8) -> Sha256Digest {
+        Sha256Digest::from_bytes([byte; 32])
+    }
+
+    fn key_pair() -> Ed25519KeyPair {
+        let document = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).expect("generate key");
+        Ed25519KeyPair::from_pkcs8(document.as_ref()).expect("parse key")
+    }
+
+    fn binding(runner_id: RunnerId, broker_host_id: &str) -> WindowsRunnerAdmissionBinding {
+        let profile = EnvironmentProfile::new(
+            EnvironmentProfileId::new("automata.example/windows-server-2025").expect("profile ID"),
+            digest(4),
+        );
+        let capabilities = RunnerCapabilities::new(
+            runner_id,
+            RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+        )
+        .with_sandbox(SandboxCapabilities::new(
+            IsolationLevel::VirtualMachine,
+            [SandboxFeature::WINDOWS_HYPERV_CONTAINER],
+        ))
+        .with_features([RunnerFeature::SHELL_STEPS])
+        .with_environment_profiles([profile.clone()]);
+        let transaction = WindowsEnrollmentTransactionBinding::new(
+            runner_id,
+            OperationId::new(),
+            "https://control.example.test/",
+            "https://enroll.example.test/",
+            digest(1),
+            digest(2),
+            digest(3),
+        )
+        .expect("transaction");
+        let image_digest = digest(5);
+        let image = WindowsAdmissionImage::new(
+            format!("registry.example.test/automata/windows@sha256:{image_digest}"),
+            image_digest,
+        )
+        .expect("image");
+        let broker_profile = WindowsBrokerProfileBinding::new(
+            broker_host_id,
+            WINDOWS_RUNNER_ADMISSION_PROVIDER_ID,
+            digest(6),
+            profile,
+            image,
+            digest(7),
+            true,
+            false,
+            64,
+        )
+        .expect("broker profile");
+        let promotion = WindowsImagePromotionBinding::new(
+            "production.windows.v1",
+            "promotion-key-v1",
+            digest(8),
+            digest(9),
+            41,
+            19,
+            WindowsPromotionValidity::new(NOW - 60_000, NOW + 3_600_000)
+                .expect("promotion validity"),
+        )
+        .expect("promotion");
+        WindowsRunnerAdmissionBinding::new(transaction, broker_profile, promotion, capabilities)
+            .expect("binding")
+    }
+
+    fn evidence() -> WindowsRunnerAdmissionEvidence {
+        let broker = WindowsBrokerAdmissionEvidence::new(
+            digest(10),
+            digest(11),
+            digest(12),
+            digest(13),
+            digest(14),
+        )
+        .expect("broker evidence");
+        let authority =
+            WindowsAuthorityAdmissionEvidence::new(digest(15), digest(16), digest(17), digest(18))
+                .expect("authority evidence");
+        WindowsRunnerAdmissionEvidence::new(broker, authority)
+    }
+
+    fn claims(
+        issuer: &str,
+        runner_id: RunnerId,
+        broker_host_id: &str,
+        serial: u64,
+        issued_at: u64,
+        expires_at: u64,
+    ) -> WindowsRunnerPlacementRenewalClaims {
+        WindowsRunnerPlacementRenewalClaims::new(
+            issuer,
+            runner_id,
+            serial,
+            digest(20),
+            digest(21),
+            binding(runner_id, broker_host_id),
+            evidence(),
+            WindowsAdmissionValidity::new(issued_at, expires_at).expect("validity"),
+        )
+        .expect("claims")
+    }
+
+    fn signed(
+        issuer: &str,
+        key_pair: &Ed25519KeyPair,
+        claims: &WindowsRunnerPlacementRenewalClaims,
+    ) -> WindowsRunnerPlacementRenewalEnvelope {
+        let payload = claims.canonical_bytes().expect("canonical claims");
+        WindowsRunnerPlacementRenewalEnvelope::new(
+            issuer,
+            payload,
+            key_pair
+                .sign(&claims.signing_bytes().expect("signing bytes"))
+                .as_ref()
+                .to_vec(),
+        )
+        .expect("envelope")
+    }
+
+    fn trust_store(issuer: &str, key_pair: &Ed25519KeyPair, broker_host_id: &str) -> TrustStore {
+        let anchor = WindowsRunnerAdmissionTrustAnchor::new(
+            key_pair
+                .public_key()
+                .as_ref()
+                .try_into()
+                .expect("public key"),
+            broker_host_id,
+            EnvironmentProfile::new(
+                EnvironmentProfileId::new("automata.example/windows-server-2025")
+                    .expect("profile ID"),
+                digest(4),
+            ),
+            "production.windows.v1",
+        )
+        .expect("anchor");
+        TrustStore(BTreeMap::from([(issuer.to_owned(), anchor)]))
+    }
+
+    #[test]
+    fn verifies_exact_scoped_contiguous_renewal_envelope() {
+        let issuer = "broker-admission-v1";
+        let host = "a".repeat(64);
+        let runner_id = RunnerId::new();
+        let key_pair = key_pair();
+        let claims = claims(issuer, runner_id, &host, 7, NOW - 1_000, NOW + 60_000);
+        let envelope = signed(issuer, &key_pair, &claims);
+        let verified = verify_windows_runner_placement_renewal(
+            &envelope,
+            &trust_store(issuer, &key_pair, &host),
+            NOW,
+        )
+        .expect("verified renewal");
+
+        assert_eq!(verified.claims(), &claims);
+        assert_eq!(verified.claims().runner_id(), runner_id);
+        assert_eq!(verified.claims().renewal_serial(), 7);
+        assert_eq!(verified.envelope_sha256(), envelope.envelope_sha256());
+        let encoded = serde_json::to_vec(&envelope).expect("serialize");
+        assert_eq!(
+            serde_json::from_slice::<WindowsRunnerPlacementRenewalEnvelope>(&encoded)
+                .expect("deserialize"),
+            envelope
+        );
+    }
+
+    #[test]
+    fn signature_scope_and_enrollment_commitment_substitution_fail_closed() {
+        let issuer = "broker-admission-v1";
+        let host = "a".repeat(64);
+        let runner_id = RunnerId::new();
+        let key_pair = key_pair();
+        let claims = claims(issuer, runner_id, &host, 1, NOW - 1_000, NOW + 60_000);
+        let envelope = signed(issuer, &key_pair, &claims);
+        let trust = trust_store(issuer, &key_pair, &host);
+
+        let forged = WindowsRunnerPlacementRenewalEnvelope::new(
+            issuer,
+            envelope.signed_payload().to_vec(),
+            vec![0x5a; ED25519_SIGNATURE_BYTES],
+        )
+        .expect("structural envelope");
+        assert_eq!(
+            verify_windows_runner_placement_renewal(&forged, &trust, NOW),
+            Err(WindowsRunnerPlacementRenewalError::InvalidSignature)
+        );
+        assert_eq!(
+            verify_windows_runner_placement_renewal(
+                &envelope,
+                &trust_store(issuer, &key_pair, &"b".repeat(64)),
+                NOW,
+            ),
+            Err(WindowsRunnerPlacementRenewalError::TrustScopeMismatch)
+        );
+
+        let substituted = WindowsRunnerPlacementRenewalClaims::new(
+            issuer,
+            runner_id,
+            1,
+            claims.nonce(),
+            digest(22),
+            claims.binding().clone(),
+            claims.evidence(),
+            claims.validity(),
+        )
+        .expect("substituted claims");
+        let payload = substituted.canonical_bytes().expect("payload");
+        let substituted = WindowsRunnerPlacementRenewalEnvelope::new(
+            issuer,
+            payload,
+            envelope.authenticator().to_vec(),
+        )
+        .expect("structural envelope");
+        assert_eq!(
+            verify_windows_runner_placement_renewal(&substituted, &trust, NOW),
+            Err(WindowsRunnerPlacementRenewalError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn future_expired_unknown_and_noncanonical_renewals_are_rejected() {
+        let issuer = "broker-admission-v1";
+        let host = "a".repeat(64);
+        let runner_id = RunnerId::new();
+        let key_pair = key_pair();
+        let future_claims = claims(issuer, runner_id, &host, 1, NOW + 1, NOW + 60_001);
+        let future = signed(issuer, &key_pair, &future_claims);
+        let trust = trust_store(issuer, &key_pair, &host);
+        assert_eq!(
+            verify_windows_runner_placement_renewal(&future, &trust, NOW),
+            Err(WindowsRunnerPlacementRenewalError::NotYetValid)
+        );
+
+        let expired_claims = claims(issuer, runner_id, &host, 1, NOW - 60_000, NOW);
+        let expired = signed(issuer, &key_pair, &expired_claims);
+        assert_eq!(
+            verify_windows_runner_placement_renewal(&expired, &trust, NOW),
+            Err(WindowsRunnerPlacementRenewalError::Expired)
+        );
+        assert_eq!(
+            verify_windows_runner_placement_renewal(&expired, &TrustStore(BTreeMap::new()), NOW,),
+            Err(WindowsRunnerPlacementRenewalError::UnknownIssuer)
+        );
+
+        let mut noncanonical = b" \n".to_vec();
+        noncanonical.extend(future_claims.canonical_bytes().expect("claims"));
+        assert_eq!(
+            WindowsRunnerPlacementRenewalEnvelope::new(
+                issuer,
+                noncanonical,
+                vec![0x5a; ED25519_SIGNATURE_BYTES],
+            ),
+            Err(WindowsRunnerPlacementRenewalError::NonCanonicalPayload)
+        );
+        let mut outer = serde_json::to_value(future).expect("value");
+        outer["future_field"] = serde_json::json!(true);
+        let error = serde_json::from_value::<WindowsRunnerPlacementRenewalEnvelope>(outer)
+            .expect_err("unknown envelope fields must be rejected");
+        assert_eq!(error.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    fn zero_serial_and_horizon_past_promotion_are_invalid_claims() {
+        let issuer = "broker-admission-v1";
+        let host = "a".repeat(64);
+        let runner_id = RunnerId::new();
+        let exact = claims(issuer, runner_id, &host, 1, NOW - 1_000, NOW + 60_000);
+        assert_eq!(
+            WindowsRunnerPlacementRenewalClaims::new(
+                issuer,
+                runner_id,
+                0,
+                exact.nonce(),
+                exact.enrollment_envelope_sha256(),
+                exact.binding().clone(),
+                exact.evidence(),
+                exact.validity(),
+            ),
+            Err(WindowsRunnerPlacementRenewalError::InvalidClaims)
+        );
+        let mut binding = serde_json::to_value(exact.binding()).expect("binding value");
+        binding["promotion"]["validity"]["expires_at_unix_millis"] = serde_json::json!(NOW + 500);
+        let binding: WindowsRunnerAdmissionBinding =
+            serde_json::from_value(binding).expect("short promotion binding");
+        assert_eq!(
+            WindowsRunnerPlacementRenewalClaims::new(
+                issuer,
+                runner_id,
+                2,
+                exact.nonce(),
+                exact.enrollment_envelope_sha256(),
+                binding,
+                exact.evidence(),
+                WindowsAdmissionValidity::new(NOW, NOW + 1_000).expect("validity"),
+            ),
+            Err(WindowsRunnerPlacementRenewalError::InvalidClaims)
+        );
+    }
+}

--- a/crates/automata-ci-protocol/tests/capability_version_skew.rs
+++ b/crates/automata-ci-protocol/tests/capability_version_skew.rs
@@ -3,8 +3,8 @@ use automata_ci_core::{
     IsolationLevel, JobId, JobInstanceIdentity, JobIr, JobIrEnvelope, JobIrVersionRange, JobSource,
     Lease, LeaseId, OperatingSystem, OperationId, RequirementMismatch, RunId, RunValueTemplates,
     RunnerCapabilities, RunnerFeature, RunnerId, RunnerPlatform, RunnerRequirements,
-    RuntimeBoolean, SandboxCapabilities, SandboxFeature, Sha256Digest, ShellTemplate, StepId,
-    StepIr, UnixMillis, ValueTemplate, WorkflowId,
+    RuntimeBoolean, SandboxAuthorizations, SandboxCapabilities, SandboxFeature, Sha256Digest,
+    ShellTemplate, StepId, StepIr, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
     CommandSequence, JobRuntimeAuthorities, JobRuntimeAuthority, LeaseOffer,
@@ -259,8 +259,13 @@ fn runtime_authority_bundle_rejects_forward_schema() {
         UnixMillis::new(3_600_010),
     )
     .expect("runtime authority");
-    let authorities = JobRuntimeAuthorities::new(vec![authority], offer.job(), offer.lease())
-        .expect("runtime authorities");
+    let authorities = JobRuntimeAuthorities::new(
+        vec![authority],
+        SandboxAuthorizations::default(),
+        offer.job(),
+        offer.lease(),
+    )
+    .expect("runtime authorities");
     let mut value = serde_json::to_value(authorities).expect("serialize authority bundle");
     value["schema_version"] = serde_json::json!(
         RUNTIME_AUTHORITY_SCHEMA_VERSION

--- a/crates/automata-ci-protocol/tests/codec_boundary.rs
+++ b/crates/automata-ci-protocol/tests/codec_boundary.rs
@@ -7,21 +7,21 @@ use automata_ci_core::{
     JobSecretExposure, JobSource, Lease, LeaseGuard, LeaseId, LogAck, LogChannel, LogFrame,
     LogSequence, LogStreamId, OperatingSystem, OperationId, PermissionLevel, RunId,
     RunValueTemplates, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
-    RunnerSessionId, RuntimeBoolean, SandboxCapabilities, Sha256Digest, ShellTemplate, StepId,
-    StepIr, StepResult, TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind,
-    TrustEvidence, TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustTokenRecursion,
-    UnixMillis, ValueTemplate, WorkflowId,
+    RunnerSessionId, RuntimeBoolean, SandboxAuthorizations, SandboxCapabilities, Sha256Digest,
+    ShellTemplate, StepId, StepIr, StepResult, TrustActorEvidence, TrustActorKind,
+    TrustAutomationKind, TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy,
+    TrustRepositoryEvidence, TrustTokenRecursion, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
     CancelJob, CommandAck, CommandCursor, CommandSequence, ErrorMessage, HandshakeErrorCode,
     HandshakeRejected, JobResultMessage, JobRuntimeAuthorities, JobRuntimeAuthority,
-    JobStateUpdate, LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeaseRenewal, LeaseRequest,
-    LeaseResponse, LogAckMessage, LogBatch, MAX_CONFIGURABLE_FRAME_BYTES, MessageHeader,
-    MessageValidationError, NegotiatedSession, NoWork, OperationAck, ProtocolLimits,
-    ProtocolLimitsError, RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer,
-    RuntimeAuthorityCredential, RuntimeAuthorityEndpoint, RuntimeAuthorityName,
-    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
-    SessionDisposition, ValidatedRunnerToServer, ValidatedServerToRunner,
+    JobStateUpdate, LeaseAuthorityPollContributions, LeaseDisposition, LeaseHeartbeat, LeaseOffer,
+    LeasePollResponse, LeaseRenewal, LeaseRequest, LeaseResponse, LogAckMessage, LogBatch,
+    MAX_CONFIGURABLE_FRAME_BYTES, MessageHeader, MessageValidationError, NegotiatedSession,
+    OperationAck, ProtocolLimits, ProtocolLimitsError, RemoteErrorCode, RunnerHello,
+    RunnerSlotOrdinal, RunnerToServer, RuntimeAuthorityCredential, RuntimeAuthorityEndpoint,
+    RuntimeAuthorityName, SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming,
+    ServerToRunner, SessionDisposition, ValidatedRunnerToServer, ValidatedServerToRunner,
 };
 
 fn header() -> MessageHeader {
@@ -171,7 +171,12 @@ fn authority_bundle_emptiness_must_match_the_immutable_job_profile() {
     let lease = lease(attempt_id, runner_id);
     let standard = job_envelope(RunnerRequirements::default());
     assert!(matches!(
-        JobRuntimeAuthorities::new(Vec::new(), &standard, &lease),
+        JobRuntimeAuthorities::new(
+            Vec::new(),
+            SandboxAuthorizations::default(),
+            &standard,
+            &lease,
+        ),
         Err(automata_ci_protocol::RuntimeAuthorityError::AuthorityProfileMismatch)
     ));
 
@@ -194,11 +199,21 @@ fn authority_bundle_emptiness_must_match_the_immutable_job_profile() {
     )
     .expect("authority");
     assert!(matches!(
-        JobRuntimeAuthorities::new(vec![authority], &credential_free, &lease),
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            SandboxAuthorizations::default(),
+            &credential_free,
+            &lease,
+        ),
         Err(automata_ci_protocol::RuntimeAuthorityError::AuthorityProfileMismatch)
     ));
-    JobRuntimeAuthorities::new(Vec::new(), &credential_free, &lease)
-        .expect("credential-free empty authority bundle");
+    JobRuntimeAuthorities::new(
+        Vec::new(),
+        SandboxAuthorizations::default(),
+        &credential_free,
+        &lease,
+    )
+    .expect("credential-free empty authority bundle");
     let offer = LeaseOffer::new(command_header(), slot(), lease, credential_free);
     ValidatedServerToRunner::new(
         ServerToRunner::LeaseOffer(Box::new(offer)),
@@ -286,7 +301,11 @@ fn every_runner_envelope_variant_passes_the_validated_boundary() {
             runner_capabilities(),
             UnixMillis::new(1),
         )),
-        RunnerToServer::LeaseRequest(LeaseRequest::first(header(), slot())),
+        RunnerToServer::LeaseRequest(LeaseRequest::first(
+            header(),
+            slot(),
+            LeaseAuthorityPollContributions::default(),
+        )),
         RunnerToServer::LeaseResponse(LeaseResponse::new(
             header(),
             attempt_id,
@@ -383,7 +402,11 @@ fn every_server_envelope_variant_passes_the_validated_boundary() {
             LogAck::new(stream_id, Some(LogSequence::new(0))),
         )),
         ServerToRunner::OperationAck(OperationAck::new(reply_header())),
-        ServerToRunner::NoWork(NoWork::new(reply_header(), 1_000)),
+        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+            reply_header(),
+            LeaseAuthorityPollContributions::default().sha256_digest(),
+            1_000,
+        ))),
         ServerToRunner::Error(ErrorMessage::new(
             reply_header(),
             RemoteErrorCode::RetryLater,
@@ -427,7 +450,11 @@ fn unvalidated_message_cannot_enter_the_validated_handler_boundary() {
         OperationId::new(),
         OperationId::new(),
     );
-    let raw = RunnerToServer::LeaseRequest(LeaseRequest::first(invalid_header, slot()));
+    let raw = RunnerToServer::LeaseRequest(LeaseRequest::first(
+        invalid_header,
+        slot(),
+        LeaseAuthorityPollContributions::default(),
+    ));
 
     assert!(matches!(
         ValidatedRunnerToServer::try_from(raw),

--- a/crates/automata-ci-protocol/tests/lease_correlation.rs
+++ b/crates/automata-ci-protocol/tests/lease_correlation.rs
@@ -5,9 +5,10 @@ use automata_ci_core::{
     ShellTemplate, StepId, StepIr, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_protocol::{
-    CommandSequence, LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeaseRenewal, LeaseResponse,
-    MessageHeader, MessageValidationError, RunnerSlotOrdinal, SUPPORTED_PROTOCOL_RANGE,
-    ServerCommandHeader,
+    CommandSequence, LeaseAuthorityName, LeaseAuthorityPollContribution,
+    LeaseAuthorityPollContributions, LeaseDisposition, LeaseHeartbeat, LeaseOffer,
+    LeasePollResponse, LeaseRenewal, LeaseRequest, LeaseResponse, MessageHeader,
+    MessageValidationError, RunnerSlotOrdinal, SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader,
 };
 
 fn slot(ordinal: u16) -> RunnerSlotOrdinal {
@@ -171,4 +172,77 @@ fn renewal_must_correlate_to_the_exact_heartbeat_operation() {
         wrong_attempt.validate_for(&heartbeat),
         Err(MessageValidationError::AttemptCorrelationMismatch { .. }),
     ));
+}
+
+#[test]
+fn poll_response_requires_exact_contribution_acceptance_but_allows_cross_slot_replay() {
+    let session_id = RunnerSessionId::new();
+    let poll_operation_id = OperationId::new();
+    let contributions = LeaseAuthorityPollContributions::new(vec![
+        LeaseAuthorityPollContribution::new(
+            LeaseAuthorityName::new("windows-hyperv").expect("authority name"),
+            1,
+            vec![0x5a; 32],
+        )
+        .expect("poll contribution"),
+    ])
+    .expect("contribution bundle");
+    let request = LeaseRequest::first(
+        MessageHeader::request(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            session_id,
+            poll_operation_id,
+        ),
+        slot(1),
+        contributions.clone(),
+    );
+    let reply = MessageHeader::reply(
+        SUPPORTED_PROTOCOL_RANGE.max(),
+        session_id,
+        OperationId::new(),
+        poll_operation_id,
+    );
+    let offer = LeaseOffer::new(
+        ServerCommandHeader::new(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            session_id,
+            OperationId::new(),
+            CommandSequence::new(7).expect("command sequence"),
+        ),
+        slot(2),
+        lease(AttemptId::new(), RunnerId::new()),
+        job(),
+    );
+    let response = LeasePollResponse::lease_offer(reply, contributions.sha256_digest(), offer);
+    assert_eq!(response.validate_for(&request), Ok(()));
+
+    let wrong_digest = LeasePollResponse::no_work(
+        reply,
+        LeaseAuthorityPollContributions::default().sha256_digest(),
+        1_000,
+    );
+    assert!(matches!(
+        wrong_digest.validate_for(&request),
+        Err(MessageValidationError::LeaseAuthorityAcceptanceMismatch)
+    ));
+
+    let wrong_operation_id = OperationId::new();
+    let wrong_correlation_id = OperationId::new();
+    let wrong_reply = LeasePollResponse::no_work(
+        MessageHeader::reply(
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            session_id,
+            wrong_operation_id,
+            wrong_correlation_id,
+        ),
+        contributions.sha256_digest(),
+        1_000,
+    );
+    assert_eq!(
+        wrong_reply.validate_for(&request),
+        Err(MessageValidationError::ResponseOperationMismatch {
+            expected: request.header().operation_id(),
+            received: wrong_correlation_id,
+        })
+    );
 }

--- a/crates/automata-ci-protocol/tests/protocol_negotiation.rs
+++ b/crates/automata-ci-protocol/tests/protocol_negotiation.rs
@@ -29,12 +29,12 @@ fn disjoint_ranges_return_typed_error() {
 }
 
 #[test]
-fn current_protocol_is_exactly_v2_and_rejects_legacy_and_forward_skew() {
-    assert_eq!(PROTOCOL_MIN_VERSION, version(2));
-    assert_eq!(PROTOCOL_MAX_VERSION, version(2));
-    assert_eq!(SUPPORTED_PROTOCOL_RANGE, range(2, 2));
+fn current_protocol_is_exactly_v3_and_rejects_legacy_and_forward_skew() {
+    assert_eq!(PROTOCOL_MIN_VERSION, version(3));
+    assert_eq!(PROTOCOL_MAX_VERSION, version(3));
+    assert_eq!(SUPPORTED_PROTOCOL_RANGE, range(3, 3));
 
-    let legacy = range(1, 1);
+    let legacy = range(2, 2);
     assert_eq!(
         negotiate_protocol(SUPPORTED_PROTOCOL_RANGE, legacy),
         Err(ProtocolNegotiationError::NoCommonVersion {
@@ -43,7 +43,7 @@ fn current_protocol_is_exactly_v2_and_rejects_legacy_and_forward_skew() {
         })
     );
 
-    let unsupported = range(3, 3);
+    let unsupported = range(4, 4);
     assert_eq!(
         negotiate_protocol(SUPPORTED_PROTOCOL_RANGE, unsupported),
         Err(ProtocolNegotiationError::NoCommonVersion {

--- a/crates/automata-ci-protocol/tests/session_replay.rs
+++ b/crates/automata-ci-protocol/tests/session_replay.rs
@@ -4,9 +4,10 @@ use automata_ci_core::{
 };
 use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandCursorError, CommandSequence, CommandSequenceError,
-    LeaseRequest, MessageHeader, MessageValidationError, NegotiatedSession, ProtocolLimits,
-    RunnerHello, RunnerSlotOrdinal, RunnerToServer, SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader,
-    ServerHello, ServerTiming, SessionDisposition, SessionResume, ValidatedRunnerToServer,
+    LeaseAuthorityPollContributions, LeaseRequest, MessageHeader, MessageValidationError,
+    NegotiatedSession, ProtocolLimits, RunnerHello, RunnerSlotOrdinal, RunnerToServer,
+    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, SessionDisposition,
+    SessionResume, ValidatedRunnerToServer,
 };
 
 fn capabilities() -> RunnerCapabilities {
@@ -212,6 +213,7 @@ fn lease_request_constructors_make_chain_position_explicit_and_reject_self_ackno
     let first = LeaseRequest::first(
         MessageHeader::request(protocol, session_id, first_operation_id),
         slot,
+        LeaseAuthorityPollContributions::default(),
     );
     assert_eq!(first.acknowledges_operation_id(), None);
     assert_eq!(first.validate(), Ok(()));
@@ -220,6 +222,7 @@ fn lease_request_constructors_make_chain_position_explicit_and_reject_self_ackno
         MessageHeader::request(protocol, session_id, OperationId::new()),
         slot,
         first_operation_id,
+        LeaseAuthorityPollContributions::default(),
     );
     assert_eq!(
         successor.acknowledges_operation_id(),
@@ -232,6 +235,7 @@ fn lease_request_constructors_make_chain_position_explicit_and_reject_self_ackno
         MessageHeader::request(protocol, session_id, self_operation_id),
         slot,
         self_operation_id,
+        LeaseAuthorityPollContributions::default(),
     ));
     assert_eq!(
         ValidatedRunnerToServer::try_from(self_acknowledgement),
@@ -251,6 +255,7 @@ fn first_lease_poll_validates_chain_origin_for_one_authenticated_slot() {
     let message = RunnerToServer::LeaseRequest(LeaseRequest::first(
         header,
         RunnerSlotOrdinal::new(2).expect("slot two"),
+        LeaseAuthorityPollContributions::default(),
     ));
     let validated = ValidatedRunnerToServer::new(message, &ProtocolLimits::default())
         .expect("validate first lease poll");

--- a/crates/automata-ci-runner-journal/README.md
+++ b/crates/automata-ci-runner-journal/README.md
@@ -5,6 +5,10 @@ a bounded, canonical local format. It records semantic identifiers, immutable
 digests, operation intentions, and recovery cursors without retaining transport
 frames, provider credentials, or job payload bytes.
 
+A lease-poll response is one journal transaction: its nested command effect,
+carrier-slot successor, and pending provider-neutral authority receipts either
+all survive a crash or none do, even when the command targets another slot.
+
 `automata-ci-runner-runtime` uses the journal together with
 `automata-ci-runner-spool` to reconcile interrupted work.
 

--- a/crates/automata-ci-runner-journal/src/error.rs
+++ b/crates/automata-ci-runner-journal/src/error.rs
@@ -60,6 +60,9 @@ pub enum JournalInvariantError {
     /// A proposed lease-poll identity is already bound to another checkpoint.
     #[error("lease-poll operation identity conflicts with another durable checkpoint")]
     LeasePollOperationConflict,
+    /// Source acknowledgement did not match the exact durably accepted contribution identities.
+    #[error("lease-authority acknowledgement receipts do not match the durable checkpoint")]
+    LeaseAuthorityReceiptMismatch,
     /// No durable lease occupies the requested stable slot.
     #[error("runner slot ordinal {0:?} is not journaled")]
     SlotNotFound(RunnerSlotOrdinal),

--- a/crates/automata-ci-runner-journal/src/file/mod.rs
+++ b/crates/automata-ci-runner-journal/src/file/mod.rs
@@ -311,15 +311,24 @@ impl RunnerJournal for FileJournal {
         })
     }
 
-    fn advance_lease_poll(
+    fn complete_lease_poll(
+        &self,
+        session_id: RunnerSessionId,
+        completion: crate::LeasePollCompletion,
+    ) -> Result<JournalSnapshot, JournalError> {
+        self.mutate(JournalMutationDomain::LeasePoll, |state| {
+            state.complete_lease_poll(session_id, completion)
+        })
+    }
+
+    fn acknowledge_lease_authority_receipts(
         &self,
         session_id: RunnerSessionId,
         slot: RunnerSlotOrdinal,
-        expected_current: OperationId,
-        successor_operation_id: OperationId,
+        expected: &[automata_ci_protocol::LeaseAuthorityPollReceipt],
     ) -> Result<JournalSnapshot, JournalError> {
         self.mutate(JournalMutationDomain::LeasePoll, |state| {
-            state.advance_lease_poll(session_id, slot, expected_current, successor_operation_id)
+            state.acknowledge_lease_authority_receipts(session_id, slot, expected)
         })
     }
 

--- a/crates/automata-ci-runner-journal/src/journal.rs
+++ b/crates/automata-ci-runner-journal/src/journal.rs
@@ -1,11 +1,13 @@
 use automata_ci_core::{
     JobLifecycle, LeaseGuard, LogStreamId, OperationId, RunnerSessionId, Sha256Digest, UnixMillis,
 };
-use automata_ci_protocol::{LeaseRejectionReason, RunnerSlotOrdinal, RuntimeAuthorityGeneration};
+use automata_ci_protocol::{
+    LeaseAuthorityPollReceipt, LeaseRejectionReason, RunnerSlotOrdinal, RuntimeAuthorityGeneration,
+};
 
 use crate::{
     CancellationRecord, CommandDisposition, DurableCommand, DurableContentRef, EndpointOperation,
-    EndpointResultContentRef, JournalError, JournalSnapshot, LeaseOfferRecord,
+    EndpointResultContentRef, JournalError, JournalSnapshot, LeaseOfferRecord, LeasePollCompletion,
     LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentReason,
     OrphanAuthorityProof, OrphanAuthorityVerifier, OrphanDelivery, OutboundOperationSequence,
     ProviderFailureOutcome, ProviderOperation, RuntimeAuthorityDeliveryRecord, SandboxIdentity,
@@ -52,23 +54,36 @@ pub trait RunnerJournal: Send + Sync {
         operation_id: OperationId,
     ) -> Result<JournalSnapshot, JournalError>;
 
-    /// Durably replaces a completed current lease request with its exact
-    /// successor, which acknowledges `expected_current`.
+    /// Atomically commits one complete lease-poll result.
     ///
-    /// The mutation is compare-and-swap fenced. Replaying it after the same
-    /// predecessor was already advanced is a no-op and returns the actual
-    /// durable successor, even if the caller generated a different candidate.
+    /// A nested command disposition and its application effect, when present,
+    /// become durable in the same physical commit as the carrier poll's exact
+    /// successor and pending authority receipts. Commands may target a slot
+    /// other than the carrier. Exact replay after an uncertain commit is a
+    /// no-op that returns the already durable state.
     ///
     /// # Errors
     ///
     /// Returns [`JournalError`] for a missing or unrelated checkpoint, stale
-    /// session, operation-identity conflict, or failed commit.
-    fn advance_lease_poll(
+    /// or conflicting command, operation-identity conflict, or failed commit.
+    fn complete_lease_poll(
+        &self,
+        session_id: RunnerSessionId,
+        completion: LeasePollCompletion,
+    ) -> Result<JournalSnapshot, JournalError>;
+
+    /// Clears the exact accepted contribution receipts after every source has
+    /// durably acknowledged them. Repeating an already completed clear is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] for a stale session, missing checkpoint,
+    /// substituted receipt set, or failed commit.
+    fn acknowledge_lease_authority_receipts(
         &self,
         session_id: RunnerSessionId,
         slot: RunnerSlotOrdinal,
-        expected_current: OperationId,
-        successor_operation_id: OperationId,
+        expected: &[LeaseAuthorityPollReceipt],
     ) -> Result<JournalSnapshot, JournalError>;
 
     /// Atomically records a generic command disposition and advances the

--- a/crates/automata-ci-runner-journal/src/lib.rs
+++ b/crates/automata-ci-runner-journal/src/lib.rs
@@ -27,15 +27,15 @@ pub use model::{
     CancellationRecord, CommandDisposition, CommandIgnoredReason, CommandTombstone, DurableCommand,
     EndpointOperation, EndpointOperationKind, EndpointOperationState, EndpointRequestContentRef,
     EndpointResultContentRef, JobIrContentRef, JournalSnapshot, LeaseOfferRecord, LeaseOfferStatus,
-    LeasePollCheckpoint, LeaseRejectionRecord, LogDeliveryCursor, LogSegment,
-    LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentPermissions,
-    OrphanAbandonmentReason, OrphanAuthorityError, OrphanAuthorityGrant, OrphanAuthorityProof,
-    OrphanAuthorityVerifier, OrphanClaim, OrphanDelivery, OrphanRecord, OutboundOperationCursor,
-    OutboundOperationSequence, PendingDeliveryTimestamps, ProviderFailureKind,
-    ProviderFailureOutcome, ProviderName, ProviderOperation, ProviderOperationKind,
-    ProviderOperationOutcome, RuntimeAuthorityContentRef, RuntimeAuthorityDeliveryRecord,
-    SandboxHandle, SandboxIdentity, SessionBinding, SessionSnapshot, SlotSnapshot,
-    TerminalResultRecord,
+    LeasePollCheckpoint, LeasePollCommandRecord, LeasePollCompletion, LeaseRejectionRecord,
+    LogDeliveryCursor, LogSegment, LogSegmentAcknowledgement, LogSegmentPublication,
+    OrphanAbandonmentPermissions, OrphanAbandonmentReason, OrphanAuthorityError,
+    OrphanAuthorityGrant, OrphanAuthorityProof, OrphanAuthorityVerifier, OrphanClaim,
+    OrphanDelivery, OrphanRecord, OutboundOperationCursor, OutboundOperationSequence,
+    PendingDeliveryTimestamps, ProviderFailureKind, ProviderFailureOutcome, ProviderName,
+    ProviderOperation, ProviderOperationKind, ProviderOperationOutcome, RuntimeAuthorityContentRef,
+    RuntimeAuthorityDeliveryRecord, SandboxHandle, SandboxIdentity, SessionBinding,
+    SessionSnapshot, SlotSnapshot, TerminalResultRecord,
 };
 pub use observer::{
     JournalMutationDomain, JournalMutationObservation, JournalMutationOutcome, JournalObserver,
@@ -46,7 +46,7 @@ pub use observer::{
 ///
 /// Obsolete or future schemas fail closed rather than being interpreted by
 /// compatibility readers.
-pub const RUNNER_JOURNAL_SCHEMA_VERSION: u16 = 5;
+pub const RUNNER_JOURNAL_SCHEMA_VERSION: u16 = 6;
 
 /// Largest delivery enqueue timestamp accepted by the durable journal.
 ///

--- a/crates/automata-ci-runner-journal/src/model/command.rs
+++ b/crates/automata-ci-runner-journal/src/model/command.rs
@@ -1,4 +1,4 @@
-use automata_ci_core::{Lease, OperationId, Sha256Digest, UnixMillis};
+use automata_ci_core::{Lease, LeaseGuard, OperationId, Sha256Digest, UnixMillis};
 use automata_ci_protocol::{
     CommandSequence, LeaseRejectionReason, ManagedSecretBindingOverlay, RunnerSlotOrdinal,
     RuntimeAuthorityDeliveryBinding, RuntimeAuthorityGeneration,
@@ -73,6 +73,38 @@ pub enum CommandDisposition {
     Applied,
     /// The cursor advanced with a durable reason and no application effect.
     Ignored(CommandIgnoredReason),
+}
+
+/// Semantic command effect committed atomically with one lease-poll successor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LeasePollCommandRecord {
+    /// The poll returned no durable command.
+    NoCommand,
+    /// The exact command effect is already durable and must only be verified.
+    Recorded {
+        /// Stable command identity expected in the durable replay window.
+        command: DurableCommand,
+        /// Exact disposition already committed for the command.
+        disposition: CommandDisposition,
+    },
+    /// A new command is intentionally ignored with no application effect.
+    Ignored {
+        /// Stable identity of the command being retired.
+        command: DurableCommand,
+        /// Durable reason the command has no application effect.
+        reason: CommandIgnoredReason,
+    },
+    /// A new lease offer and its applied command disposition.
+    LeaseOffer(Box<LeaseOfferRecord>),
+    /// A new cancellation and its applied command disposition.
+    Cancellation {
+        /// Stable slot containing the cancellation target.
+        slot: RunnerSlotOrdinal,
+        /// Exact lease fence named by the cancellation.
+        guard: LeaseGuard,
+        /// Durable cancellation record.
+        cancellation: CancellationRecord,
+    },
 }
 
 /// Bounded exact-replay tombstone for a durable command.

--- a/crates/automata-ci-runner-journal/src/model/mod.rs
+++ b/crates/automata-ci-runner-journal/src/model/mod.rs
@@ -9,7 +9,7 @@ mod value;
 
 pub use command::{
     CancellationRecord, CommandDisposition, CommandIgnoredReason, CommandTombstone, DurableCommand,
-    LeaseOfferRecord, LeaseRejectionRecord, RuntimeAuthorityDeliveryRecord,
+    LeaseOfferRecord, LeasePollCommandRecord, LeaseRejectionRecord, RuntimeAuthorityDeliveryRecord,
 };
 pub use content::{JobIrContentRef, RuntimeAuthorityContentRef, TerminalResultRecord};
 pub use cursor::{
@@ -31,7 +31,7 @@ pub use provider::{
 };
 pub(crate) use state::StoredJournal;
 pub use state::{
-    JournalSnapshot, LeaseOfferStatus, LeasePollCheckpoint, PendingDeliveryTimestamps,
-    SessionBinding, SessionSnapshot, SlotSnapshot,
+    JournalSnapshot, LeaseOfferStatus, LeasePollCheckpoint, LeasePollCompletion,
+    PendingDeliveryTimestamps, SessionBinding, SessionSnapshot, SlotSnapshot,
 };
 pub(crate) use value::DiskSchemaVersion;

--- a/crates/automata-ci-runner-journal/src/model/state.rs
+++ b/crates/automata-ci-runner-journal/src/model/state.rs
@@ -6,7 +6,8 @@ use automata_ci_core::{
 };
 use automata_ci_execution::MAX_ENDPOINT_OPERATIONS_PER_JOB;
 use automata_ci_protocol::{
-    CommandCursor, CommandSequence, LeaseRejectionReason, ProtocolVersion, RunnerSlotOrdinal,
+    CommandCursor, CommandSequence, LeaseAuthorityPollReceipt, LeaseRejectionReason,
+    MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS, ProtocolVersion, RunnerSlotOrdinal,
     SUPPORTED_PROTOCOL_RANGE,
 };
 use automata_ci_runner_spool::DurableContentRef;
@@ -15,11 +16,12 @@ use serde::{Deserialize, Serialize};
 use super::{
     CancellationRecord, CommandDisposition, CommandTombstone, DiskSchemaVersion, DurableCommand,
     EndpointOperation, EndpointOperationState, EndpointResultContentRef, LeaseOfferRecord,
-    LeaseRejectionRecord, LogDeliveryCursor, LogSegment, LogSegmentAcknowledgement,
-    LogSegmentPublication, OrphanAbandonmentReason, OrphanAuthorityGrant, OrphanDelivery,
-    OrphanRecord, OutboundOperationCursor, OutboundOperationSequence, ProviderFailureOutcome,
-    ProviderOperation, ProviderOperationKind, ProviderOperationOutcome,
-    RuntimeAuthorityDeliveryRecord, SandboxIdentity, TerminalResultRecord,
+    LeasePollCommandRecord, LeaseRejectionRecord, LogDeliveryCursor, LogSegment,
+    LogSegmentAcknowledgement, LogSegmentPublication, OrphanAbandonmentReason,
+    OrphanAuthorityGrant, OrphanDelivery, OrphanRecord, OutboundOperationCursor,
+    OutboundOperationSequence, ProviderFailureOutcome, ProviderOperation, ProviderOperationKind,
+    ProviderOperationOutcome, RuntimeAuthorityDeliveryRecord, SandboxIdentity,
+    TerminalResultRecord,
 };
 use crate::{
     JournalInvariantError, MAX_COMMAND_TOMBSTONES, MAX_ENDPOINT_CONTENT_BYTES_PER_SLOT,
@@ -165,12 +167,13 @@ impl SessionSnapshot {
 
 /// Crash-durable identity of the exact lease request currently owned by one
 /// stable runner slot.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LeasePollCheckpoint {
     slot: RunnerSlotOrdinal,
     current_operation_id: OperationId,
     acknowledges_operation_id: Option<OperationId>,
+    pending_authority_receipts: Vec<LeaseAuthorityPollReceipt>,
 }
 
 impl LeasePollCheckpoint {
@@ -179,6 +182,7 @@ impl LeasePollCheckpoint {
             slot,
             current_operation_id,
             acknowledges_operation_id: None,
+            pending_authority_receipts: Vec::new(),
         }
     }
 
@@ -190,14 +194,51 @@ impl LeasePollCheckpoint {
 
     /// Returns the exact request operation that recovery must replay.
     #[must_use]
-    pub const fn current_operation_id(self) -> OperationId {
+    pub const fn current_operation_id(&self) -> OperationId {
         self.current_operation_id
     }
 
     /// Returns the predecessor acknowledged by the current request, if any.
     #[must_use]
-    pub const fn acknowledges_operation_id(self) -> Option<OperationId> {
+    pub const fn acknowledges_operation_id(&self) -> Option<OperationId> {
         self.acknowledges_operation_id
+    }
+
+    /// Returns accepted contribution identities awaiting durable source acknowledgement.
+    #[must_use]
+    pub fn pending_authority_receipts(&self) -> &[LeaseAuthorityPollReceipt] {
+        &self.pending_authority_receipts
+    }
+}
+
+/// One complete lease-poll result prepared for a single atomic journal commit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LeasePollCompletion {
+    poll_slot: RunnerSlotOrdinal,
+    expected_current: OperationId,
+    successor_operation_id: OperationId,
+    pending_authority_receipts: Vec<LeaseAuthorityPollReceipt>,
+    command: LeasePollCommandRecord,
+}
+
+impl LeasePollCompletion {
+    /// Binds a nested command effect and accepted authority receipts to the
+    /// exact carrier poll and its proposed successor.
+    #[must_use]
+    pub fn new(
+        poll_slot: RunnerSlotOrdinal,
+        expected_current: OperationId,
+        successor_operation_id: OperationId,
+        pending_authority_receipts: Vec<LeaseAuthorityPollReceipt>,
+        command: LeasePollCommandRecord,
+    ) -> Self {
+        Self {
+            poll_slot,
+            expected_current,
+            successor_operation_id,
+            pending_authority_receipts,
+            command,
+        }
     }
 }
 
@@ -704,6 +745,7 @@ fn validate_session(session: &SessionSnapshot) -> Result<(), JournalInvariantErr
         {
             return Err(JournalInvariantError::DecodedStateInvalid);
         }
+        validate_authority_receipts(checkpoint.pending_authority_receipts())?;
         previous_slot = Some(checkpoint.slot());
     }
     Ok(())
@@ -1034,13 +1076,63 @@ impl StoredJournal {
         }
     }
 
-    pub(crate) fn advance_lease_poll(
+    pub(crate) fn complete_lease_poll(
+        &mut self,
+        session_id: RunnerSessionId,
+        completion: LeasePollCompletion,
+    ) -> Result<bool, JournalInvariantError> {
+        let LeasePollCompletion {
+            poll_slot,
+            expected_current,
+            successor_operation_id,
+            pending_authority_receipts,
+            command,
+        } = completion;
+        validate_authority_receipts(&pending_authority_receipts)?;
+        let checkpoint_changed = self.advance_lease_poll(
+            session_id,
+            poll_slot,
+            expected_current,
+            successor_operation_id,
+            pending_authority_receipts,
+        )?;
+        let command_changed = match command {
+            LeasePollCommandRecord::NoCommand => false,
+            LeasePollCommandRecord::Recorded {
+                command,
+                disposition,
+            } => {
+                self.verify_recorded_command(session_id, command, disposition)?;
+                false
+            }
+            LeasePollCommandRecord::Ignored { command, reason } => self
+                .record_command_disposition(
+                    session_id,
+                    command,
+                    CommandDisposition::Ignored(reason),
+                )?,
+            LeasePollCommandRecord::LeaseOffer(offer) => self.record_offer(session_id, *offer)?,
+            LeasePollCommandRecord::Cancellation {
+                slot,
+                guard,
+                cancellation,
+            } => self.record_cancellation(session_id, slot, guard, cancellation)?,
+        };
+        if !checkpoint_changed && command_changed {
+            return Err(JournalInvariantError::CommandReplayConflict);
+        }
+        Ok(command_changed || checkpoint_changed)
+    }
+
+    fn advance_lease_poll(
         &mut self,
         session_id: RunnerSessionId,
         slot: RunnerSlotOrdinal,
         expected_current: OperationId,
         successor_operation_id: OperationId,
+        pending_authority_receipts: Vec<LeaseAuthorityPollReceipt>,
     ) -> Result<bool, JournalInvariantError> {
+        validate_authority_receipts(&pending_authority_receipts)?;
         self.require_session(session_id)?;
         let session = self
             .session
@@ -1050,10 +1142,16 @@ impl StoredJournal {
             .lease_poll_checkpoints
             .binary_search_by_key(&slot, LeasePollCheckpoint::slot)
             .map_err(|_| JournalInvariantError::LeasePollCheckpointMissing(slot))?;
-        let checkpoint = session.lease_poll_checkpoints[index];
+        let checkpoint = &session.lease_poll_checkpoints[index];
         if checkpoint.current_operation_id() != expected_current {
             return if checkpoint.acknowledges_operation_id() == Some(expected_current) {
-                Ok(false)
+                if checkpoint.pending_authority_receipts.is_empty()
+                    || checkpoint.pending_authority_receipts == pending_authority_receipts
+                {
+                    Ok(false)
+                } else {
+                    Err(JournalInvariantError::LeaseAuthorityReceiptMismatch)
+                }
             } else {
                 Err(JournalInvariantError::LeasePollCheckpointMismatch {
                     expected: expected_current,
@@ -1068,7 +1166,35 @@ impl StoredJournal {
             slot,
             current_operation_id: successor_operation_id,
             acknowledges_operation_id: Some(expected_current),
+            pending_authority_receipts,
         };
+        Ok(true)
+    }
+
+    pub(crate) fn acknowledge_lease_authority_receipts(
+        &mut self,
+        session_id: RunnerSessionId,
+        slot: RunnerSlotOrdinal,
+        expected: &[LeaseAuthorityPollReceipt],
+    ) -> Result<bool, JournalInvariantError> {
+        self.require_session(session_id)?;
+        validate_authority_receipts(expected)?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or(JournalInvariantError::NoSession)?;
+        let checkpoint = session
+            .lease_poll_checkpoints
+            .binary_search_by_key(&slot, LeasePollCheckpoint::slot)
+            .map(|index| &mut session.lease_poll_checkpoints[index])
+            .map_err(|_| JournalInvariantError::LeasePollCheckpointMissing(slot))?;
+        if checkpoint.pending_authority_receipts.is_empty() {
+            return Ok(false);
+        }
+        if checkpoint.pending_authority_receipts != expected {
+            return Err(JournalInvariantError::LeaseAuthorityReceiptMismatch);
+        }
+        checkpoint.pending_authority_receipts.clear();
         Ok(true)
     }
 
@@ -1171,6 +1297,34 @@ impl StoredJournal {
         disposition: CommandDisposition,
     ) -> Result<bool, JournalInvariantError> {
         self.commit_command(session_id, command, disposition)
+    }
+
+    fn verify_recorded_command(
+        &self,
+        session_id: RunnerSessionId,
+        command: DurableCommand,
+        disposition: CommandDisposition,
+    ) -> Result<(), JournalInvariantError> {
+        self.require_session(session_id)?;
+        let session = self
+            .session
+            .as_ref()
+            .ok_or(JournalInvariantError::NoSession)?;
+        let Some(cursor) = session.command_cursor().acknowledged_through() else {
+            return Err(JournalInvariantError::CommandReplayConflict);
+        };
+        if command.sequence() > cursor {
+            return Err(JournalInvariantError::CommandReplayConflict);
+        }
+        let tombstone = session
+            .command_tombstones
+            .iter()
+            .find(|tombstone| tombstone.command().sequence() == command.sequence())
+            .ok_or(JournalInvariantError::CommandReplayOutsideWindow)?;
+        if tombstone.command() != command || tombstone.disposition() != disposition {
+            return Err(JournalInvariantError::CommandReplayConflict);
+        }
+        Ok(())
     }
 
     fn slot_index(&self, slot: RunnerSlotOrdinal) -> Result<usize, JournalInvariantError> {
@@ -2108,4 +2262,20 @@ fn lease_poll_operation_is_used(session: &SessionSnapshot, operation_id: Operati
         checkpoint.current_operation_id() == operation_id
             || checkpoint.acknowledges_operation_id() == Some(operation_id)
     })
+}
+
+fn validate_authority_receipts(
+    receipts: &[LeaseAuthorityPollReceipt],
+) -> Result<(), JournalInvariantError> {
+    if receipts.len() > MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS
+        || receipts
+            .windows(2)
+            .any(|pair| pair[0].name() >= pair[1].name())
+        || receipts
+            .iter()
+            .any(|receipt| receipt.payload_schema_version() == 0)
+    {
+        return Err(JournalInvariantError::DecodedStateInvalid);
+    }
+    Ok(())
 }

--- a/crates/automata-ci-runner-journal/tests/lease_poll_checkpoints.rs
+++ b/crates/automata-ci-runner-journal/tests/lease_poll_checkpoints.rs
@@ -2,11 +2,14 @@ use super::support;
 
 use std::sync::Arc;
 
-use automata_ci_core::{JobIrVersion, JobLifecycle, OperationId, RunnerSessionId};
-use automata_ci_protocol::{PROTOCOL_MAX_VERSION, RunnerSlotOrdinal};
+use automata_ci_core::{JobIrVersion, JobLifecycle, OperationId, RunnerSessionId, Sha256Digest};
+use automata_ci_protocol::{
+    LeaseAuthorityName, LeaseAuthorityPollReceipt, PROTOCOL_MAX_VERSION, RunnerSlotOrdinal,
+};
 use automata_ci_runner_journal::{
     CommitFault, CommitFaultInjector, CommitStage, FileJournal, FileJournalOptions, JournalError,
-    JournalInvariantError, RunnerJournal, SessionBinding,
+    JournalInvariantError, JournalSnapshot, LeaseOfferRecord, LeasePollCommandRecord,
+    LeasePollCompletion, RunnerJournal, SessionBinding,
 };
 use support::{Fixture, Scratch, record_and_ack_terminal};
 
@@ -31,13 +34,61 @@ fn checkpoint(
     journal: &dyn RunnerJournal,
     slot: RunnerSlotOrdinal,
 ) -> automata_ci_runner_journal::LeasePollCheckpoint {
-    *journal
+    journal
         .snapshot()
         .expect("snapshot")
         .session()
         .expect("session")
         .lease_poll_checkpoint(slot)
         .expect("lease-poll checkpoint")
+        .clone()
+}
+
+fn authority_receipt(name: &str, digest_byte: u8) -> LeaseAuthorityPollReceipt {
+    LeaseAuthorityPollReceipt::from_parts(
+        LeaseAuthorityName::new(name).expect("authority name"),
+        1,
+        Sha256Digest::from_bytes([digest_byte; 32]),
+    )
+    .expect("authority receipt")
+}
+
+fn assert_fault_recovery(
+    recovered: &JournalSnapshot,
+    fixture: &Fixture,
+    carrier: RunnerSlotOrdinal,
+    operations: (OperationId, OperationId),
+    receipt: &LeaseAuthorityPollReceipt,
+    offer: &LeaseOfferRecord,
+    committed: bool,
+) {
+    let (predecessor, successor) = operations;
+    let recovered_checkpoint = recovered
+        .session()
+        .expect("session")
+        .lease_poll_checkpoint(carrier)
+        .expect("carrier checkpoint");
+    assert_eq!(recovered.slot(fixture.slot).is_some(), committed);
+    assert_eq!(
+        recovered_checkpoint.current_operation_id(),
+        if committed { successor } else { predecessor }
+    );
+    assert_eq!(
+        recovered_checkpoint.pending_authority_receipts(),
+        if committed {
+            std::slice::from_ref(receipt)
+        } else {
+            &[]
+        }
+    );
+    assert_eq!(
+        recovered
+            .session()
+            .expect("session")
+            .command_cursor()
+            .acknowledged_through(),
+        committed.then_some(offer.command().sequence())
+    );
 }
 
 #[test]
@@ -68,26 +119,58 @@ fn prepare_resume_advance_and_new_session_preserve_exact_chain() {
     );
 
     let successor = OperationId::new();
+    let pending_authority_receipts = vec![authority_receipt("test-authority", 0x44)];
     journal
-        .advance_lease_poll(fixture.session_id, fixture.slot, first, successor)
+        .complete_lease_poll(
+            fixture.session_id,
+            LeasePollCompletion::new(
+                fixture.slot,
+                first,
+                successor,
+                pending_authority_receipts.clone(),
+                LeasePollCommandRecord::NoCommand,
+            ),
+        )
         .expect("advance poll");
     let durable = checkpoint(&journal, fixture.slot);
     assert_eq!(durable.current_operation_id(), successor);
     assert_eq!(durable.acknowledges_operation_id(), Some(first));
+    assert_eq!(
+        durable.pending_authority_receipts(),
+        pending_authority_receipts
+    );
 
     let discarded_replay_successor = OperationId::new();
     journal
-        .advance_lease_poll(
+        .complete_lease_poll(
             fixture.session_id,
-            fixture.slot,
-            first,
-            discarded_replay_successor,
+            LeasePollCompletion::new(
+                fixture.slot,
+                first,
+                discarded_replay_successor,
+                pending_authority_receipts.clone(),
+                LeasePollCommandRecord::NoCommand,
+            ),
         )
         .expect("replay completed advance");
     assert_eq!(
         checkpoint(&journal, fixture.slot),
         durable,
         "a recovery retry returns the already durable successor"
+    );
+
+    journal
+        .acknowledge_lease_authority_receipts(
+            fixture.session_id,
+            fixture.slot,
+            &pending_authority_receipts,
+        )
+        .expect("acknowledge durable authority receipts");
+    assert!(
+        checkpoint(&journal, fixture.slot)
+            .pending_authority_receipts()
+            .is_empty(),
+        "source acknowledgement clears the exact durable receipt set"
     );
 
     let fresh_session = RunnerSessionId::new();
@@ -107,6 +190,159 @@ fn prepare_resume_advance_and_new_session_preserve_exact_chain() {
             .lease_poll_checkpoints()
             .is_empty(),
         "a genuinely new session cannot acknowledge an old-session poll"
+    );
+}
+
+#[test]
+fn cross_slot_poll_command_and_receipts_recover_as_one_commit() {
+    for (stage, committed) in [
+        (CommitStage::FileSynced, false),
+        (CommitStage::Renamed, true),
+    ] {
+        let scratch = Scratch::new(&format!("lease-poll-cross-slot-{stage:?}"));
+        let fixture = Fixture::new();
+        let carrier = RunnerSlotOrdinal::new(2).expect("carrier slot");
+        let journal = fixture.open(&scratch);
+        journal.begin_session(fixture.binding()).expect("session");
+        let predecessor = OperationId::new();
+        journal
+            .prepare_lease_poll(fixture.session_id, carrier, predecessor)
+            .expect("prepare carrier poll");
+        drop(journal);
+
+        let offer = fixture.offer(1);
+        let receipt = authority_receipt("test-authority", 0x55);
+        let first_successor = OperationId::new();
+        let faulting =
+            FileJournal::open_with_options(scratch.state_root(), fixture.runner_id, options(stage))
+                .expect("faulting journal");
+        let result = faulting.complete_lease_poll(
+            fixture.session_id,
+            LeasePollCompletion::new(
+                carrier,
+                predecessor,
+                first_successor,
+                vec![receipt.clone()],
+                LeasePollCommandRecord::LeaseOffer(Box::new(offer.clone())),
+            ),
+        );
+        if committed {
+            assert!(matches!(result, Err(JournalError::CommitOutcomeUnknown)));
+        } else {
+            assert!(
+                matches!(result, Err(JournalError::InjectedFault(received)) if received == stage)
+            );
+        }
+        drop(faulting);
+
+        let reopened = fixture.open(&scratch);
+        let recovered = reopened.snapshot().expect("recovered snapshot");
+        assert_fault_recovery(
+            &recovered,
+            &fixture,
+            carrier,
+            (predecessor, first_successor),
+            &receipt,
+            &offer,
+            committed,
+        );
+
+        let replay_successor = OperationId::new();
+        reopened
+            .complete_lease_poll(
+                fixture.session_id,
+                LeasePollCompletion::new(
+                    carrier,
+                    predecessor,
+                    replay_successor,
+                    vec![receipt.clone()],
+                    LeasePollCommandRecord::LeaseOffer(Box::new(offer.clone())),
+                ),
+            )
+            .expect("recover exact atomic poll completion");
+        let completed = reopened.snapshot().expect("completed snapshot");
+        assert_eq!(
+            completed.slot(fixture.slot).expect("target offer").offer(),
+            &offer
+        );
+        let completed_checkpoint = completed
+            .session()
+            .expect("session")
+            .lease_poll_checkpoint(carrier)
+            .expect("carrier checkpoint");
+        assert_eq!(
+            completed_checkpoint.current_operation_id(),
+            if committed {
+                first_successor
+            } else {
+                replay_successor
+            },
+            "an exact uncertain replay retains the already committed successor"
+        );
+        assert_eq!(
+            completed_checkpoint.acknowledges_operation_id(),
+            Some(predecessor)
+        );
+        assert_eq!(
+            completed_checkpoint.pending_authority_receipts(),
+            std::slice::from_ref(&receipt)
+        );
+    }
+}
+
+#[test]
+fn retired_poll_cannot_introduce_a_new_command() {
+    let scratch = Scratch::new("lease-poll-retired-command");
+    let fixture = Fixture::new();
+    let journal = fixture.open(&scratch);
+    journal.begin_session(fixture.binding()).expect("session");
+    let predecessor = OperationId::new();
+    journal
+        .prepare_lease_poll(fixture.session_id, fixture.slot, predecessor)
+        .expect("prepare poll");
+    let receipt = authority_receipt("test-authority", 0x66);
+    journal
+        .complete_lease_poll(
+            fixture.session_id,
+            LeasePollCompletion::new(
+                fixture.slot,
+                predecessor,
+                OperationId::new(),
+                vec![receipt.clone()],
+                LeasePollCommandRecord::NoCommand,
+            ),
+        )
+        .expect("complete poll without a command");
+    journal
+        .acknowledge_lease_authority_receipts(
+            fixture.session_id,
+            fixture.slot,
+            std::slice::from_ref(&receipt),
+        )
+        .expect("clear poll receipt");
+    let before_replay = journal.snapshot().expect("snapshot before stale replay");
+
+    let result = journal.complete_lease_poll(
+        fixture.session_id,
+        LeasePollCompletion::new(
+            fixture.slot,
+            predecessor,
+            OperationId::new(),
+            Vec::new(),
+            LeasePollCommandRecord::LeaseOffer(Box::new(fixture.offer(1))),
+        ),
+    );
+
+    assert!(matches!(
+        result,
+        Err(JournalError::Invariant(
+            JournalInvariantError::CommandReplayConflict
+        ))
+    ));
+    assert_eq!(
+        journal.snapshot().expect("snapshot after stale replay"),
+        before_replay,
+        "a retired poll cannot advance the command cursor or create a slot"
     );
 }
 
@@ -194,10 +430,11 @@ fn checkpoint_commits_recover_on_both_sides_of_atomic_rename() {
             .session()
             .expect("session")
             .lease_poll_checkpoint(fixture.slot)
-            .copied();
+            .cloned();
         assert_eq!(
             recovered_checkpoint
-                .map(automata_ci_runner_journal::LeasePollCheckpoint::current_operation_id,),
+                .as_ref()
+                .map(automata_ci_runner_journal::LeasePollCheckpoint::current_operation_id),
             committed.then_some(operation_id)
         );
     }

--- a/crates/automata-ci-runner-results/README.md
+++ b/crates/automata-ci-runner-results/README.md
@@ -109,7 +109,7 @@ URLs use separate protocol domains and derived keys. Every metadata mutation
 rechecks the attempt lifecycle and fence.
 
 `RunnerResultsRuntimeAuthorityIssuer` creates the JWT only after the runner
-durably accepts the exact lease offer. Runner protocol v2 delivers the
+durably accepts the exact lease offer. Runner protocol v3 delivers the
 per-attempt authority bundle through the separate post-accept exchange; the
 lease offer and its persisted outbox payload contain no credential values. The
 runner protects the bundle before acknowledging custody and injects it into

--- a/crates/automata-ci-runner-results/src/runtime_authority.rs
+++ b/crates/automata-ci-runner-results/src/runtime_authority.rs
@@ -80,8 +80,13 @@ impl RuntimeAuthorityIssuer for RunnerResultsRuntimeAuthorityIssuer {
         let trust = request.job().job().trust_snapshot().authority();
         match (trust.results(), trust.cache()) {
             (TrustResultsAuthority::Denied, TrustCacheAuthority::Denied) => {
-                return JobRuntimeAuthorities::new(Vec::new(), request.job(), request.lease())
-                    .map_err(|_| ControlPortError::Corrupt);
+                return JobRuntimeAuthorities::new(
+                    Vec::new(),
+                    automata_ci_core::SandboxAuthorizations::empty(),
+                    request.job(),
+                    request.lease(),
+                )
+                .map_err(|_| ControlPortError::Corrupt);
             }
             (TrustResultsAuthority::Standard, TrustCacheAuthority::ReadWrite)
             | (TrustResultsAuthority::Untrusted, TrustCacheAuthority::ReadOnly) => {}
@@ -145,8 +150,13 @@ impl RuntimeAuthorityIssuer for RunnerResultsRuntimeAuthorityIssuer {
             expires_at,
         )
         .map_err(|_| ControlPortError::Corrupt)?;
-        JobRuntimeAuthorities::new(vec![authority], job, lease)
-            .map_err(|_| ControlPortError::Corrupt)
+        JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            job,
+            lease,
+        )
+        .map_err(|_| ControlPortError::Corrupt)
     }
 }
 

--- a/crates/automata-ci-runner-runtime/README.md
+++ b/crates/automata-ci-runner-runtime/README.md
@@ -8,6 +8,22 @@ remains behind an explicit `JobExecutor` port.
 The `automata-runner` executable assembles this runtime with durable local
 state, transport, a job executor, and the selected isolation provider.
 
+For protocol-3 polling, the runtime snapshots registered provider-neutral
+authority extensions into one canonical contribution bundle and retries the
+same prepared request. It validates the correlated response and exact accepted
+bundle digest before mutation. One journal commit records the nested command
+effect, the carrier poll's successor, and its accepted-contribution receipts,
+including when the command targets another slot. Pending receipts globally
+fence slot processing after recovery; the command acknowledgement is flushed
+before extension sources are acknowledged. Invalid or uncorrelated responses
+advance neither checkpoint nor source acknowledgement.
+
+The runtime treats both poll-contribution payloads and post-accept sandbox
+authorizations as opaque provider-owned data. Provider adapters and restricted
+consumers validate their own namespace and schema at the relevant mutation
+boundary.
+
 - [Runner documentation](https://github.com/automata-ci/automata/tree/main/docs)
+- [Runtime-authority delivery](https://github.com/automata-ci/automata/blob/main/docs/runtime-authority-delivery.md)
 - API documentation: run `cargo doc -p automata-ci-runner-runtime --open` from a source checkout.
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-runner-runtime/src/error.rs
+++ b/crates/automata-ci-runner-runtime/src/error.rs
@@ -55,6 +55,9 @@ pub enum RunnerRuntimeError {
     /// Protected payload storage failed.
     #[error("runner protected content operation failed")]
     Spool(#[source] SpoolError),
+    /// A runner-side lease-authority extension failed closed.
+    #[error("lease authority extension failed")]
+    LeaseAuthority(#[source] crate::LeaseAuthorityExtensionError),
     /// A standalone or durable protobuf payload was invalid.
     #[error("runner durable protobuf payload is invalid")]
     InvalidDurablePayload,

--- a/crates/automata-ci-runner-runtime/src/lib.rs
+++ b/crates/automata-ci-runner-runtime/src/lib.rs
@@ -42,7 +42,9 @@ pub use observer::{
 pub use port::{
     AdmissionRejection, CleanupFuture, CleanupRequest, ExecutionAdmission, ExecutionCancellation,
     ExecutionCancellationReason, ExecutionEventError, ExecutionEvents, ExecutionRequest,
-    ExecutorError, ExecutorErrorKind, ExecutorFuture, JobExecutor, LogEvent, RuntimeClock,
+    ExecutorError, ExecutorErrorKind, ExecutorFuture, JobExecutor,
+    LeaseAuthorityAcknowledgementFuture, LeaseAuthorityExtension, LeaseAuthorityExtensionError,
+    LeaseAuthorityExtensionRegistry, LeaseAuthorityPollFuture, LogEvent, RuntimeClock,
     RuntimeIdSource, RuntimeSleeper, SleepFuture, StableIdDomain, SystemRuntimeClock,
     SystemRuntimeIds, TokioRuntimeSleeper,
 };

--- a/crates/automata-ci-runner-runtime/src/port.rs
+++ b/crates/automata-ci-runner-runtime/src/port.rs
@@ -11,9 +11,15 @@ use automata_ci_core::{
     LogChannel, LogGroup, LogGroupId, OperationId, RunnerId, RunnerSessionId, UnixMillis,
 };
 use automata_ci_execution::{
-    ExecutionEndpoint, SandboxCustody, SandboxEnvironment, SandboxInspection, SandboxProvider,
+    ExecutionEndpoint, SandboxCustody, SandboxEnvironment, SandboxExecutionBinding,
+    SandboxInspection, SandboxProvider,
 };
-use automata_ci_protocol::{JobRuntimeAuthorities, ManagedSecretBindingOverlay};
+use automata_ci_protocol::{
+    JobRuntimeAuthorities, LeaseAuthorityName, LeaseAuthorityPollContribution,
+    LeaseAuthorityPollContributions, LeaseAuthorityPollReceipt,
+    MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS, ManagedSecretBindingOverlay,
+    RuntimeAuthorityDeliveryBinding,
+};
 use automata_ci_protocol::{LeaseRejectionReason, RunnerSlotOrdinal};
 use automata_ci_runner_journal::{
     DurableContentRef, ProviderFailureOutcome, ProviderOperationKind, SandboxIdentity,
@@ -79,6 +85,8 @@ pub struct ExecutionRequest {
     lease: Lease,
     job: JobIrEnvelope,
     runtime_authorities: JobRuntimeAuthorities,
+    authority_binding: RuntimeAuthorityDeliveryBinding,
+    sandbox_execution_binding: SandboxExecutionBinding,
     managed_secret_bindings: Option<ManagedSecretBindingOverlay>,
     job_content: DurableContentRef,
     environment: SandboxEnvironment,
@@ -94,30 +102,64 @@ impl ExecutionRequest {
     /// Alternate supervisors must preserve those trust-boundary invariants;
     /// the executor independently validates correlations it can observe.
     #[allow(clippy::too_many_arguments)]
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Rejects an authority delivery binding that does not match the exact
+    /// slot, lease, `JobIR`, or protected runtime-authority bundle.
     pub fn new(
         session_id: RunnerSessionId,
         slot: RunnerSlotOrdinal,
         lease: Lease,
         job: JobIrEnvelope,
         runtime_authorities: JobRuntimeAuthorities,
+        authority_binding: RuntimeAuthorityDeliveryBinding,
         job_content: DurableContentRef,
         environment: SandboxEnvironment,
         recovery_lifecycle: JobLifecycle,
         recovered_sandbox: Option<SandboxIdentity>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ExecutorError> {
+        runtime_authorities
+            .validate_for(&job, &lease)
+            .map_err(|_| ExecutorError::new(ExecutorErrorKind::InvalidJob))?;
+        let job_ir_digest = job_content
+            .public_plaintext_sha256()
+            .ok_or_else(|| ExecutorError::new(ExecutorErrorKind::InvalidJob))?;
+        if authority_binding.attempt_id() != lease.attempt_id()
+            || authority_binding.slot() != slot
+            || authority_binding.guard() != lease.guard()
+            || authority_binding.job_ir_digest() != job_ir_digest
+        {
+            return Err(ExecutorError::new(ExecutorErrorKind::InvalidJob));
+        }
+        let accepted_offer_sequence =
+            std::num::NonZeroU64::new(authority_binding.offer_sequence().get())
+                .ok_or_else(|| ExecutorError::new(ExecutorErrorKind::InvalidJob))?;
+        let sandbox_execution_binding = SandboxExecutionBinding::new(
+            session_id,
+            job.job().run_id(),
+            job.job().job_id(),
+            lease.attempt_id(),
+            lease.guard(),
+            authority_binding.offer_operation_id(),
+            accepted_offer_sequence,
+            job.version(),
+            job_ir_digest,
+        );
+        Ok(Self {
             session_id,
             slot,
             lease,
             job,
             runtime_authorities,
+            authority_binding,
+            sandbox_execution_binding,
             managed_secret_bindings: None,
             job_content,
             environment,
             recovery_lifecycle,
             recovered_sandbox,
-        }
+        })
     }
 
     /// Returns the durable runner session.
@@ -150,7 +192,7 @@ impl ExecutionRequest {
         &self.job
     }
 
-    /// Returns exact server-issued authority protected before lease acceptance.
+    /// Returns exact server-issued authority protected after lease acceptance and before execution.
     #[must_use]
     pub const fn runtime_authorities(&self) -> &JobRuntimeAuthorities {
         &self.runtime_authorities
@@ -176,6 +218,24 @@ impl ExecutionRequest {
     #[must_use]
     pub const fn managed_secret_bindings(&self) -> Option<&ManagedSecretBindingOverlay> {
         self.managed_secret_bindings.as_ref()
+    }
+
+    /// Returns the exact sandbox authorizations from the protected authority bundle.
+    #[must_use]
+    pub const fn sandbox_authorizations(&self) -> &automata_ci_core::SandboxAuthorizations {
+        self.runtime_authorities.sandbox_authorizations()
+    }
+
+    /// Returns the exact job, lease, session, offer, and `JobIR` binding.
+    #[must_use]
+    pub const fn sandbox_execution_binding(&self) -> SandboxExecutionBinding {
+        self.sandbox_execution_binding
+    }
+
+    /// Returns the exact post-accept delivery coordinates used for recovery.
+    #[must_use]
+    pub const fn runtime_authority_delivery_binding(&self) -> RuntimeAuthorityDeliveryBinding {
+        self.authority_binding
     }
 
     /// Returns the durable protected `JobIR` content identity.
@@ -219,6 +279,11 @@ impl fmt::Debug for ExecutionRequest {
                     .as_ref()
                     .map_or(0, |overlay| overlay.bindings().len()),
             )
+            .field(
+                "sandbox_authorizations",
+                self.runtime_authorities.sandbox_authorizations(),
+            )
+            .field("sandbox_execution_binding", &self.sandbox_execution_binding)
             .field("environment", &self.environment)
             .field("recovery_lifecycle", &self.recovery_lifecycle)
             .field("recovered_sandbox", &self.recovered_sandbox)
@@ -638,6 +703,177 @@ pub trait RuntimeClock: fmt::Debug + Send + Sync {
     fn wall_now(&self) -> UnixMillis;
     /// Returns process-local monotonic time used for leases and deadlines.
     fn monotonic_now(&self) -> MonotonicMillis;
+}
+
+/// Future returned by one durable lease-authority extension.
+pub type LeaseAuthorityPollFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<LeaseAuthorityPollContribution, LeaseAuthorityExtensionError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Future returned after control durably accepts one exact contribution.
+pub type LeaseAuthorityAcknowledgementFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), LeaseAuthorityExtensionError>> + Send + 'a>>;
+
+/// Runner-side durable source for one namespaced lease-authority extension.
+///
+/// Implementations retain the exact current contribution across restart and
+/// replay it until [`Self::acknowledge`] succeeds. Multiple slots may observe
+/// the same retained contribution concurrently, so an exact repeated or stale
+/// acknowledgement must be idempotent while a substituted digest fails closed.
+pub trait LeaseAuthorityExtension: fmt::Debug + Send + Sync {
+    /// Returns the extension's stable protocol namespace.
+    fn name(&self) -> &LeaseAuthorityName;
+
+    /// Returns the current retained contribution or durably refreshes it.
+    fn current_or_refresh(
+        &self,
+        observed_at: UnixMillis,
+        cancellation: CancellationToken,
+    ) -> LeaseAuthorityPollFuture<'_>;
+
+    /// Durably acknowledges control acceptance of one exact contribution identity.
+    ///
+    /// The extension must continue replaying that contribution until this
+    /// succeeds. Exact repeated acknowledgements are idempotent.
+    fn acknowledge(
+        &self,
+        receipt: LeaseAuthorityPollReceipt,
+        cancellation: CancellationToken,
+    ) -> LeaseAuthorityAcknowledgementFuture<'_>;
+}
+
+/// Canonical registry of runner-side lease-authority extensions.
+#[derive(Clone, Default)]
+pub struct LeaseAuthorityExtensionRegistry {
+    extensions: Arc<[Arc<dyn LeaseAuthorityExtension>]>,
+}
+
+impl LeaseAuthorityExtensionRegistry {
+    /// Builds a canonical registry ordered by extension namespace.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate namespaces or more extensions than the protocol can
+    /// carry in one poll.
+    pub fn new(
+        mut extensions: Vec<Arc<dyn LeaseAuthorityExtension>>,
+    ) -> Result<Self, LeaseAuthorityExtensionError> {
+        if extensions.len() > MAX_LEASE_AUTHORITY_POLL_CONTRIBUTIONS {
+            return Err(LeaseAuthorityExtensionError::TooManyExtensions);
+        }
+        extensions.sort_by(|left, right| left.name().cmp(right.name()));
+        if extensions
+            .windows(2)
+            .any(|pair| pair[0].name() == pair[1].name())
+        {
+            return Err(LeaseAuthorityExtensionError::DuplicateName);
+        }
+        Ok(Self {
+            extensions: extensions.into(),
+        })
+    }
+
+    /// Returns an empty registry for runners with no lease-authority adapter.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of registered extension namespaces.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.extensions.len()
+    }
+
+    /// Returns whether no lease-authority extensions are installed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.extensions.is_empty()
+    }
+
+    pub(crate) async fn current_or_refresh(
+        &self,
+        observed_at: UnixMillis,
+        cancellation: CancellationToken,
+    ) -> Result<LeaseAuthorityPollContributions, LeaseAuthorityExtensionError> {
+        let mut contributions = Vec::with_capacity(self.extensions.len());
+        for extension in self.extensions.iter() {
+            let contribution = extension
+                .current_or_refresh(observed_at, cancellation.clone())
+                .await?;
+            if contribution.name() != extension.name() {
+                return Err(LeaseAuthorityExtensionError::ContributionNameMismatch);
+            }
+            contributions.push(contribution);
+        }
+        LeaseAuthorityPollContributions::new(contributions)
+            .map_err(|_| LeaseAuthorityExtensionError::InvalidContributionSet)
+    }
+
+    pub(crate) async fn acknowledge(
+        &self,
+        receipts: &[LeaseAuthorityPollReceipt],
+        cancellation: CancellationToken,
+    ) -> Result<(), LeaseAuthorityExtensionError> {
+        if receipts.len() != self.extensions.len() {
+            return Err(LeaseAuthorityExtensionError::InvalidContributionSet);
+        }
+        for (extension, receipt) in self.extensions.iter().zip(receipts.iter()) {
+            if receipt.name() != extension.name() {
+                return Err(LeaseAuthorityExtensionError::ContributionNameMismatch);
+            }
+            extension
+                .acknowledge(receipt.clone(), cancellation.clone())
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for LeaseAuthorityExtensionRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LeaseAuthorityExtensionRegistry")
+            .field(
+                "names",
+                &self
+                    .extensions
+                    .iter()
+                    .map(|extension| extension.name().as_str())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+/// Value-free failure from runner-side lease-authority extension plumbing.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum LeaseAuthorityExtensionError {
+    /// An adapter or its durable custody is temporarily unavailable.
+    #[error("lease authority extension is unavailable")]
+    Unavailable,
+    /// Retained adapter state violated its extension contract.
+    #[error("lease authority extension state is invalid")]
+    InvalidState,
+    /// Local shutdown cancelled extension work.
+    #[error("lease authority extension work was cancelled")]
+    Cancelled,
+    /// Two adapters claimed the same canonical namespace.
+    #[error("lease authority extension namespace is duplicated")]
+    DuplicateName,
+    /// The registry exceeds the protocol's fixed contribution budget.
+    #[error("too many lease authority extensions are registered")]
+    TooManyExtensions,
+    /// An adapter returned a contribution under another namespace.
+    #[error("lease authority contribution namespace does not match its extension")]
+    ContributionNameMismatch,
+    /// Adapter contributions could not form one canonical protocol bundle.
+    #[error("lease authority contribution set is invalid")]
+    InvalidContributionSet,
 }
 
 /// Production runtime clock.

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -12,7 +12,8 @@ use automata_ci_core::{
 };
 use automata_ci_protocol::{
     CancelJob, CommandAck, ErrorMessage, HandshakeErrorCode, INITIAL_RUNTIME_AUTHORITY_GENERATION,
-    JobRuntimeAuthorities, LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeaseRejectionReason,
+    JobRuntimeAuthorities, LeaseAuthorityPollContributions, LeaseAuthorityPollReceipt,
+    LeaseDisposition, LeaseHeartbeat, LeaseOffer, LeasePollOutcome, LeaseRejectionReason,
     LeaseRequest, LeaseResponse, LogBatch, MessageHeader, NegotiatedSession, OperationAck,
     RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer, RuntimeAuthorityAck,
     RuntimeAuthorityDeliveryBinding, RuntimeAuthorityRequest, SUPPORTED_PROTOCOL_RANGE,
@@ -25,10 +26,10 @@ use automata_ci_protocol_protobuf::{
 use automata_ci_runner_journal::{
     CancellationRecord, CommandDisposition, CommandIgnoredReason, DurableCommand,
     EndpointOperationState, JobIrContentRef, JournalContentRetainSet, JournalInvariantError,
-    LeaseOfferRecord, LeaseOfferStatus, LeasePollCheckpoint, LogSegmentAcknowledgement,
-    ProviderOperationKind, RunnerJournal, RuntimeAuthorityContentRef,
-    RuntimeAuthorityDeliveryRecord, SessionBinding as JournalSessionBinding, SlotSnapshot,
-    TerminalResultRecord,
+    LeaseOfferRecord, LeaseOfferStatus, LeasePollCheckpoint, LeasePollCommandRecord,
+    LeasePollCompletion, LogSegmentAcknowledgement, ProviderOperationKind, RunnerJournal,
+    RuntimeAuthorityContentRef, RuntimeAuthorityDeliveryRecord,
+    SessionBinding as JournalSessionBinding, SlotSnapshot, TerminalResultRecord,
 };
 use automata_ci_runner_spool::{ContentKind, DurableContentStore};
 use automata_ci_runner_transport::PreparedRequest;
@@ -45,15 +46,16 @@ use crate::outbox::validate_log_segment_records;
 use crate::retry::{exchange_exact, sleep_or_shutdown};
 use crate::{
     AdmissionRejection, CleanupRequest, ExecutionCancellation, ExecutionCancellationReason,
-    ExecutionEvents, ExecutionRequest, ExecutorErrorKind, JobExecutor, LeaseWatchdog,
-    MonotonicMillis, NoopRunnerRuntimeObserver, RemotePhase, RunnerRuntimeConfig,
-    RunnerRuntimeControlClient, RunnerRuntimeError, RunnerRuntimeEvent, RunnerRuntimeObserver,
-    RuntimeCancellationReason, RuntimeClock, RuntimeCommandKind, RuntimeCommandOutcome,
-    RuntimeControlReply, RuntimeExchangeKind, RuntimeIdSource, RuntimeInfrastructureFailure,
-    RuntimeJobConclusion, RuntimeJobStartMode, RuntimeLeaseDisposition, RuntimeLeasePollOutcome,
-    RuntimeOperationOutcome, RuntimeReconnectReason, RuntimeRemoteErrorDisposition,
-    RuntimeRemoteErrorKind, RuntimeRetryCause, RuntimeSessionMode, RuntimeSessionOutcome,
-    RuntimeSleeper, RuntimeTerminalResultStage, StableIdDomain,
+    ExecutionEvents, ExecutionRequest, ExecutorErrorKind, JobExecutor,
+    LeaseAuthorityExtensionRegistry, LeaseWatchdog, MonotonicMillis, NoopRunnerRuntimeObserver,
+    RemotePhase, RunnerRuntimeConfig, RunnerRuntimeControlClient, RunnerRuntimeError,
+    RunnerRuntimeEvent, RunnerRuntimeObserver, RuntimeCancellationReason, RuntimeClock,
+    RuntimeCommandKind, RuntimeCommandOutcome, RuntimeControlReply, RuntimeExchangeKind,
+    RuntimeIdSource, RuntimeInfrastructureFailure, RuntimeJobConclusion, RuntimeJobStartMode,
+    RuntimeLeaseDisposition, RuntimeLeasePollOutcome, RuntimeOperationOutcome,
+    RuntimeReconnectReason, RuntimeRemoteErrorDisposition, RuntimeRemoteErrorKind,
+    RuntimeRetryCause, RuntimeSessionMode, RuntimeSessionOutcome, RuntimeSleeper,
+    RuntimeTerminalResultStage, StableIdDomain,
 };
 
 /// Dependency-injected boundaries used by [`RunnerSessionSupervisor`].
@@ -66,6 +68,7 @@ pub struct RunnerRuntimePorts {
     sleeper: Arc<dyn RuntimeSleeper>,
     ids: Arc<dyn RuntimeIdSource>,
     observer: Arc<dyn RunnerRuntimeObserver>,
+    lease_authorities: LeaseAuthorityExtensionRegistry,
 }
 
 impl RunnerRuntimePorts {
@@ -90,6 +93,7 @@ impl RunnerRuntimePorts {
             sleeper,
             ids,
             observer: Arc::new(NoopRunnerRuntimeObserver),
+            lease_authorities: LeaseAuthorityExtensionRegistry::empty(),
         }
     }
 
@@ -97,6 +101,16 @@ impl RunnerRuntimePorts {
     #[must_use]
     pub fn with_observer(mut self, observer: Arc<dyn RunnerRuntimeObserver>) -> Self {
         self.observer = observer;
+        self
+    }
+
+    /// Installs the canonical provider-neutral lease-authority extension registry.
+    #[must_use]
+    pub fn with_lease_authority_extensions(
+        mut self,
+        extensions: LeaseAuthorityExtensionRegistry,
+    ) -> Self {
+        self.lease_authorities = extensions;
         self
     }
 }
@@ -113,6 +127,7 @@ impl fmt::Debug for RunnerRuntimePorts {
             .field("sleeper", &"configured")
             .field("ids", &"configured")
             .field("observer", &"configured")
+            .field("lease_authorities", &self.lease_authorities)
             .finish()
     }
 }
@@ -468,6 +483,24 @@ impl RunnerSessionSupervisor {
                 return Err(RunnerRuntimeError::Shutdown);
             }
             let snapshot = self.inner.ports.journal.snapshot()?;
+            let durable_session = snapshot.session().ok_or(RunnerRuntimeError::StaleSession)?;
+            if durable_session.session_id() != session.negotiated.session_id() {
+                return Err(RunnerRuntimeError::StaleSession);
+            }
+            if let Some(checkpoint) = durable_session
+                .lease_poll_checkpoints()
+                .iter()
+                .find(|checkpoint| !checkpoint.pending_authority_receipts().is_empty())
+            {
+                self.drain_lease_authority_receipts(
+                    session,
+                    checkpoint.slot(),
+                    checkpoint.pending_authority_receipts().to_vec(),
+                    cancellation.clone(),
+                )
+                .await?;
+                continue;
+            }
             let Some(durable) = snapshot.slot(slot).cloned() else {
                 self.poll_slot(session, slot, cancellation.clone()).await?;
                 continue;
@@ -543,43 +576,44 @@ impl RunnerSessionSupervisor {
         cancellation: CancellationToken,
     ) -> Result<(), RunnerRuntimeError> {
         let started = self.inner.ports.clock.monotonic_now();
-        let (checkpoint, prepared) = self.prepare_lease_poll(session, slot)?;
+        let authority_contributions = self
+            .inner
+            .ports
+            .lease_authorities
+            .current_or_refresh(self.inner.ports.clock.wall_now(), cancellation.clone())
+            .await
+            .map_err(RunnerRuntimeError::LeaseAuthority)?;
+        let (checkpoint, prepared) =
+            self.prepare_lease_poll(session, slot, authority_contributions.clone())?;
         loop {
             let reply = self.exchange(&prepared, cancellation.clone()).await?;
             match reply.message().message() {
-                ServerToRunner::NoWork(no_work) => {
-                    self.advance_lease_poll(session, slot, checkpoint.current_operation_id())?;
-                    self.observe(RunnerRuntimeEvent::LeasePoll {
-                        outcome: RuntimeLeasePollOutcome::NoWork,
-                        duration: self.elapsed_since(started),
-                    });
-                    let delay = Duration::from_millis(u64::from(no_work.retry_after_millis()))
-                        .min(self.inner.config.limits().idle_delay_ceiling());
-                    sleep_or_shutdown(&self.inner.ports.sleeper, delay, &cancellation).await?;
-                    return Ok(());
-                }
-                ServerToRunner::LeaseOffer(_) => {
-                    self.process_command(session, &reply, cancellation.clone())
-                        .await?;
-                    self.advance_lease_poll(session, slot, checkpoint.current_operation_id())?;
-                    self.flush_command_ack(session, cancellation.clone())
-                        .await?;
-                    self.observe(RunnerRuntimeEvent::LeasePoll {
-                        outcome: RuntimeLeasePollOutcome::LeaseOffer,
-                        duration: self.elapsed_since(started),
-                    });
-                    return Ok(());
-                }
-                ServerToRunner::CancelJob(_) => {
-                    self.process_command(session, &reply, cancellation.clone())
-                        .await?;
-                    self.advance_lease_poll(session, slot, checkpoint.current_operation_id())?;
-                    self.flush_command_ack(session, cancellation.clone())
+                ServerToRunner::LeasePollResponse(response) => {
+                    let RunnerToServer::LeaseRequest(request) = prepared.message() else {
+                        return Err(RunnerRuntimeError::ExecutorContract);
+                    };
+                    response
+                        .validate_for(request)
+                        .map_err(|_| RunnerRuntimeError::UnexpectedSyncResponse)?;
+                    let (outcome, retry_after_millis) = self
+                        .complete_lease_poll_response(
+                            session,
+                            slot,
+                            checkpoint,
+                            &authority_contributions,
+                            response.outcome(),
+                            cancellation.clone(),
+                        )
                         .await?;
                     self.observe(RunnerRuntimeEvent::LeasePoll {
-                        outcome: RuntimeLeasePollOutcome::Cancellation,
+                        outcome,
                         duration: self.elapsed_since(started),
                     });
+                    if let Some(retry_after_millis) = retry_after_millis {
+                        let delay = Duration::from_millis(u64::from(retry_after_millis))
+                            .min(self.inner.config.limits().idle_delay_ceiling());
+                        sleep_or_shutdown(&self.inner.ports.sleeper, delay, &cancellation).await?;
+                    }
                     return Ok(());
                 }
                 ServerToRunner::Error(error) => {
@@ -596,10 +630,97 @@ impl RunnerSessionSupervisor {
         }
     }
 
+    async fn complete_lease_poll_response(
+        &self,
+        session: RuntimeSession,
+        slot: RunnerSlotOrdinal,
+        checkpoint: LeasePollCheckpoint,
+        authority_contributions: &LeaseAuthorityPollContributions,
+        outcome: &LeasePollOutcome,
+        cancellation: CancellationToken,
+    ) -> Result<(RuntimeLeasePollOutcome, Option<u32>), RunnerRuntimeError> {
+        let receipts = authority_contributions
+            .as_slice()
+            .iter()
+            .map(LeaseAuthorityPollReceipt::for_contribution)
+            .collect::<Vec<_>>();
+        let completion = PendingLeasePollCompletion {
+            slot,
+            expected_current: checkpoint.current_operation_id(),
+            successor_operation_id: self.inner.ports.ids.fresh_operation_id(),
+            pending_authority_receipts: receipts.clone(),
+        };
+        let (runtime_outcome, retry_after_millis) = match outcome {
+            LeasePollOutcome::NoWork { retry_after_millis } => {
+                self.inner.ports.journal.complete_lease_poll(
+                    session.negotiated.session_id(),
+                    completion.record(LeasePollCommandRecord::NoCommand),
+                )?;
+                (RuntimeLeasePollOutcome::NoWork, Some(*retry_after_millis))
+            }
+            LeasePollOutcome::LeaseOffer(_) => {
+                self.process_lease_poll_command(session, outcome, completion, cancellation.clone())
+                    .await?;
+                (RuntimeLeasePollOutcome::LeaseOffer, None)
+            }
+            LeasePollOutcome::CancelJob(_) => {
+                self.process_lease_poll_command(session, outcome, completion, cancellation.clone())
+                    .await?;
+                (RuntimeLeasePollOutcome::Cancellation, None)
+            }
+        };
+        if !matches!(outcome, LeasePollOutcome::NoWork { .. }) {
+            self.flush_command_ack(session, cancellation.clone())
+                .await?;
+        }
+        self.inner
+            .ports
+            .lease_authorities
+            .acknowledge(&receipts, cancellation)
+            .await
+            .map_err(RunnerRuntimeError::LeaseAuthority)?;
+        self.inner
+            .ports
+            .journal
+            .acknowledge_lease_authority_receipts(
+                session.negotiated.session_id(),
+                slot,
+                &receipts,
+            )?;
+        Ok((runtime_outcome, retry_after_millis))
+    }
+
+    async fn drain_lease_authority_receipts(
+        &self,
+        session: RuntimeSession,
+        slot: RunnerSlotOrdinal,
+        receipts: Vec<LeaseAuthorityPollReceipt>,
+        cancellation: CancellationToken,
+    ) -> Result<(), RunnerRuntimeError> {
+        self.flush_command_ack(session, cancellation.clone())
+            .await?;
+        self.inner
+            .ports
+            .lease_authorities
+            .acknowledge(&receipts, cancellation)
+            .await
+            .map_err(RunnerRuntimeError::LeaseAuthority)?;
+        self.inner
+            .ports
+            .journal
+            .acknowledge_lease_authority_receipts(
+                session.negotiated.session_id(),
+                slot,
+                &receipts,
+            )?;
+        Ok(())
+    }
+
     fn prepare_lease_poll(
         &self,
         session: RuntimeSession,
         slot: RunnerSlotOrdinal,
+        authority_contributions: LeaseAuthorityPollContributions,
     ) -> Result<(LeasePollCheckpoint, PreparedRequest), RunnerRuntimeError> {
         let snapshot = self.inner.ports.journal.prepare_lease_poll(
             session.negotiated.session_id(),
@@ -610,13 +731,16 @@ impl RunnerSessionSupervisor {
         if durable_session.session_id() != session.negotiated.session_id() {
             return Err(RunnerRuntimeError::StaleSession);
         }
-        let checkpoint = *durable_session
+        let checkpoint = durable_session
             .lease_poll_checkpoint(slot)
+            .cloned()
             .ok_or(RunnerRuntimeError::ExecutorContract)?;
         let header = Self::request_header(session, checkpoint.current_operation_id());
         let request = match checkpoint.acknowledges_operation_id() {
-            Some(predecessor) => LeaseRequest::successor(header, slot, predecessor),
-            None => LeaseRequest::first(header, slot),
+            Some(predecessor) => {
+                LeaseRequest::successor(header, slot, predecessor, authority_contributions)
+            }
+            None => LeaseRequest::first(header, slot, authority_contributions),
         };
         let prepared = PreparedRequest::for_session(
             RunnerToServer::LeaseRequest(request),
@@ -624,21 +748,6 @@ impl RunnerSessionSupervisor {
             self.inner.config.protocol_limits(),
         )?;
         Ok((checkpoint, prepared))
-    }
-
-    fn advance_lease_poll(
-        &self,
-        session: RuntimeSession,
-        slot: RunnerSlotOrdinal,
-        expected_current: OperationId,
-    ) -> Result<(), RunnerRuntimeError> {
-        self.inner.ports.journal.advance_lease_poll(
-            session.negotiated.session_id(),
-            slot,
-            expected_current,
-            self.inner.ports.ids.fresh_operation_id(),
-        )?;
-        Ok(())
     }
 
     async fn process_command(
@@ -674,6 +783,48 @@ impl RunnerSessionSupervisor {
             ServerToRunner::CancelJob(cancel) => {
                 self.record_cancellation(session, cancel, reply.canonical_bytes())
             }
+            _ => Err(RunnerRuntimeError::UnexpectedSyncResponse),
+        }
+    }
+
+    async fn process_lease_poll_command(
+        &self,
+        session: RuntimeSession,
+        outcome: &LeasePollOutcome,
+        completion: PendingLeasePollCompletion,
+        cancellation: CancellationToken,
+    ) -> Result<(), RunnerRuntimeError> {
+        let message = match outcome {
+            LeasePollOutcome::LeaseOffer(offer) => ServerToRunner::LeaseOffer(offer.clone()),
+            LeasePollOutcome::CancelJob(cancel) => ServerToRunner::CancelJob(cancel.clone()),
+            LeasePollOutcome::NoWork { .. } => {
+                return Err(RunnerRuntimeError::UnexpectedSyncResponse);
+            }
+        };
+        let reply = RuntimeControlReply::from_message(message, self.inner.config.protocol_limits())
+            .map_err(|_| RunnerRuntimeError::InvalidDurablePayload)?;
+        let header = match reply.message().message() {
+            ServerToRunner::LeaseOffer(offer) => offer.header(),
+            ServerToRunner::CancelJob(cancel) => cancel.header(),
+            _ => return Err(RunnerRuntimeError::UnexpectedSyncResponse),
+        };
+        self.await_command_turn(header.session_id(), header.sequence(), &cancellation)
+            .await?;
+        let _record_guard = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => return Err(RunnerRuntimeError::Shutdown),
+            guard = self.inner.command_record_lock.lock() => guard,
+        };
+        match reply.message().message() {
+            ServerToRunner::LeaseOffer(offer) => {
+                self.record_lease_poll_offer(session, offer, reply.canonical_bytes(), completion)
+            }
+            ServerToRunner::CancelJob(cancel) => self.record_lease_poll_cancellation(
+                session,
+                cancel,
+                reply.canonical_bytes(),
+                completion,
+            ),
             _ => Err(RunnerRuntimeError::UnexpectedSyncResponse),
         }
     }
@@ -778,6 +929,144 @@ impl RunnerSessionSupervisor {
             },
         });
         Ok(())
+    }
+
+    fn record_lease_poll_offer(
+        &self,
+        session: RuntimeSession,
+        offer: &LeaseOffer,
+        canonical: &[u8],
+        completion: PendingLeasePollCompletion,
+    ) -> Result<(), RunnerRuntimeError> {
+        let header = offer.header();
+        let command = durable_command(header, canonical);
+        if let Some(disposition) =
+            self.replayed_command_disposition(header.session_id(), command)?
+        {
+            self.inner.ports.journal.complete_lease_poll(
+                header.session_id(),
+                completion.record(LeasePollCommandRecord::Recorded {
+                    command,
+                    disposition,
+                }),
+            )?;
+            self.observe(RunnerRuntimeEvent::Command {
+                kind: RuntimeCommandKind::LeaseOffer,
+                outcome: RuntimeCommandOutcome::Replayed,
+            });
+            return Ok(());
+        }
+        if offer.slot().get() > self.inner.config.capabilities().max_parallel_jobs() {
+            self.inner.ports.journal.complete_lease_poll(
+                header.session_id(),
+                completion.record(LeasePollCommandRecord::Ignored {
+                    command,
+                    reason: CommandIgnoredReason::InvalidCommand,
+                }),
+            )?;
+            self.observe(RunnerRuntimeEvent::Command {
+                kind: RuntimeCommandKind::LeaseOffer,
+                outcome: RuntimeCommandOutcome::IgnoredInvalid,
+            });
+            return Ok(());
+        }
+        let snapshot = self.inner.ports.journal.snapshot()?;
+        if let Some(existing) = snapshot.slot(offer.slot())
+            && existing.offer().command() != command
+        {
+            self.inner.ports.journal.complete_lease_poll(
+                header.session_id(),
+                completion.record(LeasePollCommandRecord::Ignored {
+                    command,
+                    reason: CommandIgnoredReason::SlotUnavailable,
+                }),
+            )?;
+            self.observe(RunnerRuntimeEvent::Command {
+                kind: RuntimeCommandKind::LeaseOffer,
+                outcome: RuntimeCommandOutcome::IgnoredSlotUnavailable,
+            });
+            return Ok(());
+        }
+        let encoded_job = encode_job_ir(offer.job(), self.inner.config.protocol_limits())
+            .map_err(|_| RunnerRuntimeError::InvalidDurablePayload)?;
+        let (durable, expected_job_ir) = self.publish_lease_poll_offer_content(
+            session,
+            offer,
+            command,
+            &encoded_job,
+            &completion,
+        )?;
+        match durable.slot(offer.slot()) {
+            Some(slot)
+                if slot.offer().job_ir() == &expected_job_ir
+                    && slot.offer().managed_secret_bindings()
+                        == offer.managed_secret_bindings() => {}
+            Some(_) | None => return Err(RunnerRuntimeError::CommandReplayConflict),
+        }
+        self.observe(RunnerRuntimeEvent::Command {
+            kind: RuntimeCommandKind::LeaseOffer,
+            outcome: RuntimeCommandOutcome::Applied,
+        });
+        Ok(())
+    }
+
+    fn publish_lease_poll_offer_content(
+        &self,
+        session: RuntimeSession,
+        offer: &LeaseOffer,
+        command: DurableCommand,
+        encoded_job: &[u8],
+        completion: &PendingLeasePollCompletion,
+    ) -> Result<(automata_ci_runner_journal::JournalSnapshot, JobIrContentRef), RunnerRuntimeError>
+    {
+        self.inner.content_operations.publish_reclaiming_capacity(
+            self.inner.ports.journal.as_ref(),
+            self.inner.ports.spool.as_ref(),
+            || {
+                let job_publication = self
+                    .inner
+                    .ports
+                    .spool
+                    .persist(ContentKind::JobIr, encoded_job)
+                    .map_err(RunnerRuntimeError::from)?;
+                let completion = completion.clone();
+                let committed = job_publication.commit_with(|job_content| {
+                    let job_ir = JobIrContentRef::new(
+                        session.negotiated.selected_job_ir(),
+                        job_content.clone(),
+                    )
+                    .map_err(automata_ci_runner_journal::JournalError::Invariant)?;
+                    let mut record = LeaseOfferRecord::new(
+                        offer.slot(),
+                        offer.lease().clone(),
+                        job_ir.clone(),
+                        command,
+                    )
+                    .map_err(automata_ci_runner_journal::JournalError::Invariant)?;
+                    if let Some(overlay) = offer.managed_secret_bindings() {
+                        record = record
+                            .with_managed_secret_bindings(overlay.clone())
+                            .map_err(automata_ci_runner_journal::JournalError::Invariant)?;
+                    }
+                    self.inner
+                        .ports
+                        .journal
+                        .complete_lease_poll(
+                            offer.header().session_id(),
+                            completion.record(LeasePollCommandRecord::LeaseOffer(Box::new(record))),
+                        )
+                        .map(|snapshot| (snapshot, job_ir))
+                });
+                match committed {
+                    Ok(committed) => Ok::<_, RunnerRuntimeError>(committed),
+                    Err(failure) => {
+                        let (error, publication) = failure.into_parts();
+                        publication.abort();
+                        Err(error.into())
+                    }
+                }
+            },
+        )
     }
 
     fn publish_lease_offer_content(
@@ -900,6 +1189,81 @@ impl RunnerSessionSupervisor {
             slot,
             cancel.guard(),
             CancellationRecord::new(command, cancel.requested_at()),
+        )?;
+        self.observe(RunnerRuntimeEvent::Command {
+            kind: RuntimeCommandKind::Cancellation,
+            outcome: RuntimeCommandOutcome::Applied,
+        });
+        if let Some(signal) = self
+            .inner
+            .executions
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&cancel.attempt_id())
+            .cloned()
+        {
+            signal.signal(ExecutionCancellationReason::ServerRequest);
+            self.observe(RunnerRuntimeEvent::Cancellation {
+                reason: RuntimeCancellationReason::ServerRequest,
+            });
+        }
+        Ok(())
+    }
+
+    fn record_lease_poll_cancellation(
+        &self,
+        _session: RuntimeSession,
+        cancel: &CancelJob,
+        canonical: &[u8],
+        completion: PendingLeasePollCompletion,
+    ) -> Result<(), RunnerRuntimeError> {
+        let header = cancel.header();
+        let command = durable_command(header, canonical);
+        if let Some(disposition) =
+            self.replayed_command_disposition(header.session_id(), command)?
+        {
+            self.inner.ports.journal.complete_lease_poll(
+                header.session_id(),
+                completion.record(LeasePollCommandRecord::Recorded {
+                    command,
+                    disposition,
+                }),
+            )?;
+            self.observe(RunnerRuntimeEvent::Command {
+                kind: RuntimeCommandKind::Cancellation,
+                outcome: RuntimeCommandOutcome::Replayed,
+            });
+            return Ok(());
+        }
+        let snapshot = self.inner.ports.journal.snapshot()?;
+        let target = snapshot.slots().iter().find(|slot| {
+            slot.offer().lease().attempt_id() == cancel.attempt_id()
+                && slot.offer().lease().guard() == cancel.guard()
+                && !slot.lifecycle().is_terminal()
+                && slot.offer_status() != LeaseOfferStatus::Rejected
+        });
+        let Some(target) = target else {
+            self.inner.ports.journal.complete_lease_poll(
+                header.session_id(),
+                completion.record(LeasePollCommandRecord::Ignored {
+                    command,
+                    reason: CommandIgnoredReason::StaleLease,
+                }),
+            )?;
+            self.observe(RunnerRuntimeEvent::Command {
+                kind: RuntimeCommandKind::Cancellation,
+                outcome: RuntimeCommandOutcome::IgnoredStaleLease,
+            });
+            return Ok(());
+        };
+        let slot = target.slot();
+        self.inner.ports.journal.complete_lease_poll(
+            header.session_id(),
+            completion.record(LeasePollCommandRecord::Cancellation {
+                slot,
+                guard: cancel.guard(),
+                cancellation: CancellationRecord::new(command, cancel.requested_at()),
+            }),
         )?;
         self.observe(RunnerRuntimeEvent::Command {
             kind: RuntimeCommandKind::Cancellation,
@@ -1312,7 +1676,6 @@ impl RunnerSessionSupervisor {
                     }
                     return self.persist_runtime_authority_delivery(
                         session,
-                        durable,
                         binding,
                         request_operation_id,
                         acknowledgement_operation_id,
@@ -1406,11 +1769,9 @@ impl RunnerSessionSupervisor {
             .is_some_and(|slot| slot.cancellation().is_some()))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn persist_runtime_authority_delivery(
         &self,
         session: RuntimeSession,
-        durable: &SlotSnapshot,
         binding: RuntimeAuthorityDeliveryBinding,
         request_operation_id: OperationId,
         acknowledgement_operation_id: OperationId,
@@ -1439,8 +1800,8 @@ impl RunnerSessionSupervisor {
                     .map_err(automata_ci_runner_journal::JournalError::Invariant)?;
                     self.inner.ports.journal.record_runtime_authority_delivery(
                         session.negotiated.session_id(),
-                        durable.slot(),
-                        durable.offer().lease().guard(),
+                        binding.slot(),
+                        binding.guard(),
                         delivery,
                     )?;
                     Ok(())
@@ -1787,17 +2148,24 @@ impl RunnerSessionSupervisor {
             authority_expired.clone(),
             watchdog_stop.clone(),
         );
+        let authority_binding = durable
+            .runtime_authority_delivery()
+            .filter(|delivery| delivery.is_acknowledged())
+            .ok_or(RunnerRuntimeError::InvalidDurablePayload)?
+            .binding();
         let mut request = ExecutionRequest::new(
             session.negotiated.session_id(),
             durable.slot(),
             lease.clone(),
             job,
             runtime_authorities,
+            authority_binding,
             durable.offer().job_ir().content().clone(),
             environment,
             durable.lifecycle(),
             durable.sandbox().cloned(),
-        );
+        )
+        .map_err(|_| RunnerRuntimeError::InvalidDurablePayload)?;
         if let Some(overlay) = durable.offer().managed_secret_bindings() {
             request = request
                 .with_managed_secret_bindings(overlay.clone())
@@ -3571,6 +3939,26 @@ fn executor_join_result(
         Ok(Ok(result)) => Ok(result),
         Ok(Err(error)) => Err(ExecutorFailure::Adapter(error.kind())),
         Err(_) => Err(ExecutorFailure::TaskTerminated),
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PendingLeasePollCompletion {
+    slot: RunnerSlotOrdinal,
+    expected_current: OperationId,
+    successor_operation_id: OperationId,
+    pending_authority_receipts: Vec<LeaseAuthorityPollReceipt>,
+}
+
+impl PendingLeasePollCompletion {
+    fn record(self, command: LeasePollCommandRecord) -> LeasePollCompletion {
+        LeasePollCompletion::new(
+            self.slot,
+            self.expected_current,
+            self.successor_operation_id,
+            self.pending_authority_receipts,
+            command,
+        )
     }
 }
 

--- a/crates/automata-ci-runner-runtime/tests/lease_poll_chaining.rs
+++ b/crates/automata-ci-runner-runtime/tests/lease_poll_chaining.rs
@@ -1,29 +1,38 @@
 use super::support;
 
 use std::{
-    collections::BTreeMap,
-    sync::{Arc, Mutex, PoisonError},
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        Arc, Mutex, PoisonError,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use automata_ci_core::{
-    AttemptId, FencingToken, Lease, LeaseId, OperationId, RunnerId, RunnerSessionId, UnixMillis,
+    AttemptId, FencingToken, Lease, LeaseId, OperationId, RunnerId, RunnerSessionId, Sha256Digest,
+    UnixMillis,
 };
 use automata_ci_protocol::{
-    CancelJob, CommandCursor, CommandSequence, ErrorMessage, LeaseOffer, MessageHeader,
-    NegotiatedSession, NoWork, OperationAck, RemoteErrorCode, RunnerSlotOrdinal, RunnerToServer,
-    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
-    SessionDisposition,
+    CancelJob, CommandCursor, CommandSequence, ErrorMessage, LeaseAuthorityName,
+    LeaseAuthorityPollContribution, LeaseAuthorityPollContributions, LeaseAuthorityPollReceipt,
+    LeaseOffer, LeasePollResponse, LeaseRequest, MessageHeader, NegotiatedSession, OperationAck,
+    RemoteErrorCode, RunnerSlotOrdinal, RunnerToServer, SUPPORTED_PROTOCOL_RANGE,
+    ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
+use automata_ci_protocol_protobuf::encode_job_ir;
 use automata_ci_runner_journal::{
-    CommitFault, CommitFaultInjector, CommitStage, FileJournal, FileJournalOptions, JournalError,
+    CommitFault, CommitFaultInjector, CommitStage, DurableCommand, FileJournal, FileJournalOptions,
+    JobIrContentRef, JournalError, LeaseOfferRecord, LeasePollCommandRecord, LeasePollCompletion,
     RunnerJournal, SessionBinding,
 };
 use automata_ci_runner_runtime::{
-    RunnerRuntimeControlClient, RunnerRuntimeError, RunnerRuntimePorts, RunnerSessionSupervisor,
-    RuntimeControlError, RuntimeControlErrorKind, RuntimeControlFuture, RuntimeControlReply,
-    RuntimeControlRetry, SystemRuntimeIds,
+    LeaseAuthorityAcknowledgementFuture, LeaseAuthorityExtension, LeaseAuthorityExtensionError,
+    LeaseAuthorityExtensionRegistry, LeaseAuthorityPollFuture, RunnerRuntimeControlClient,
+    RunnerRuntimeError, RunnerRuntimePorts, RunnerSessionSupervisor, RuntimeControlError,
+    RuntimeControlErrorKind, RuntimeControlFuture, RuntimeControlReply, RuntimeControlRetry,
+    SystemRuntimeIds,
 };
-use automata_ci_runner_spool::FileSpool;
+use automata_ci_runner_spool::{ContentKind, DurableContentStore, FileSpool};
 use automata_ci_runner_transport::PreparedRequest;
 use tokio_util::sync::CancellationToken;
 
@@ -32,6 +41,7 @@ struct PollObservation {
     slot: RunnerSlotOrdinal,
     operation_id: OperationId,
     acknowledges_operation_id: Option<OperationId>,
+    authority_contributions: LeaseAuthorityPollContributions,
     canonical_bytes: Vec<u8>,
 }
 
@@ -44,8 +54,204 @@ impl PollObservation {
             slot: poll.slot(),
             operation_id: poll.header().operation_id(),
             acknowledges_operation_id: poll.acknowledges_operation_id(),
+            authority_contributions: poll.authority_contributions().clone(),
             canonical_bytes: request.canonical_bytes().to_vec(),
         }
+    }
+}
+
+#[derive(Debug)]
+struct RotatingAuthorityExtension {
+    name: LeaseAuthorityName,
+    contributions: [LeaseAuthorityPollContribution; 2],
+    state: Mutex<RotatingAuthorityState>,
+}
+
+#[derive(Debug, Default)]
+struct RotatingAuthorityState {
+    current: usize,
+    acknowledgement_failures_remaining: usize,
+    acknowledged: BTreeSet<LeaseAuthorityPollReceipt>,
+    acknowledgement_attempts: Vec<LeaseAuthorityPollReceipt>,
+    acknowledgements: Vec<LeaseAuthorityPollReceipt>,
+}
+
+impl RotatingAuthorityExtension {
+    fn new() -> Self {
+        Self::named("test.placement")
+    }
+
+    fn named(namespace: &str) -> Self {
+        let name = LeaseAuthorityName::new(namespace).expect("authority name");
+        Self {
+            contributions: [
+                authority_contribution(name.clone(), 1),
+                authority_contribution(name.clone(), 2),
+            ],
+            name,
+            state: Mutex::new(RotatingAuthorityState::default()),
+        }
+    }
+
+    fn acknowledgements(&self) -> Vec<Sha256Digest> {
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .acknowledgements
+            .iter()
+            .map(LeaseAuthorityPollReceipt::payload_sha256)
+            .collect()
+    }
+
+    fn acknowledgement_attempts(&self) -> Vec<Sha256Digest> {
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .acknowledgement_attempts
+            .iter()
+            .map(LeaseAuthorityPollReceipt::payload_sha256)
+            .collect()
+    }
+
+    fn assert_acknowledgements(&self, expected: &[Sha256Digest]) {
+        assert_eq!(self.acknowledgements(), expected);
+    }
+
+    fn fail_next_acknowledgement(&self) {
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .acknowledgement_failures_remaining = 1;
+    }
+}
+
+impl LeaseAuthorityExtension for RotatingAuthorityExtension {
+    fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    fn current_or_refresh(
+        &self,
+        _observed_at: UnixMillis,
+        cancellation: CancellationToken,
+    ) -> LeaseAuthorityPollFuture<'_> {
+        Box::pin(async move {
+            if cancellation.is_cancelled() {
+                return Err(LeaseAuthorityExtensionError::Cancelled);
+            }
+            let current = self
+                .state
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .current;
+            Ok(self.contributions[current].clone())
+        })
+    }
+
+    fn acknowledge(
+        &self,
+        receipt: LeaseAuthorityPollReceipt,
+        _cancellation: CancellationToken,
+    ) -> LeaseAuthorityAcknowledgementFuture<'_> {
+        Box::pin(async move {
+            let index = self
+                .contributions
+                .iter()
+                .position(|contribution| {
+                    LeaseAuthorityPollReceipt::for_contribution(contribution) == receipt
+                })
+                .ok_or(LeaseAuthorityExtensionError::InvalidState)?;
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            if index > state.current {
+                return Err(LeaseAuthorityExtensionError::InvalidState);
+            }
+            state.acknowledgement_attempts.push(receipt.clone());
+            if state.acknowledgement_failures_remaining > 0 {
+                state.acknowledgement_failures_remaining -= 1;
+                return Err(LeaseAuthorityExtensionError::Unavailable);
+            }
+            if state.acknowledged.insert(receipt.clone()) {
+                state.acknowledgements.push(receipt);
+                if index == state.current && state.current + 1 < self.contributions.len() {
+                    state.current += 1;
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+fn authority_contribution(name: LeaseAuthorityName, serial: u8) -> LeaseAuthorityPollContribution {
+    LeaseAuthorityPollContribution::new(name, 1, vec![serial; 32]).expect("authority contribution")
+}
+
+#[derive(Debug)]
+struct BlockingAuthorityExtension {
+    name: LeaseAuthorityName,
+    contribution: LeaseAuthorityPollContribution,
+    acknowledgement_calls: AtomicUsize,
+    acknowledgement_calls_changed: tokio::sync::Notify,
+    acknowledgement_release: tokio::sync::Semaphore,
+}
+
+impl BlockingAuthorityExtension {
+    fn new() -> Self {
+        let name = LeaseAuthorityName::new("test.blocking").expect("authority name");
+        Self {
+            contribution: authority_contribution(name.clone(), 0x33),
+            name,
+            acknowledgement_calls: AtomicUsize::new(0),
+            acknowledgement_calls_changed: tokio::sync::Notify::new(),
+            acknowledgement_release: tokio::sync::Semaphore::new(0),
+        }
+    }
+
+    async fn wait_for_acknowledgement_calls(&self, expected: usize) {
+        loop {
+            let changed = self.acknowledgement_calls_changed.notified();
+            if self.acknowledgement_calls.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            changed.await;
+        }
+    }
+
+    fn release_acknowledgements(&self, permits: usize) {
+        self.acknowledgement_release.add_permits(permits);
+    }
+}
+
+impl LeaseAuthorityExtension for BlockingAuthorityExtension {
+    fn name(&self) -> &LeaseAuthorityName {
+        &self.name
+    }
+
+    fn current_or_refresh(
+        &self,
+        _observed_at: UnixMillis,
+        _cancellation: CancellationToken,
+    ) -> LeaseAuthorityPollFuture<'_> {
+        Box::pin(async { Ok(self.contribution.clone()) })
+    }
+
+    fn acknowledge(
+        &self,
+        receipt: LeaseAuthorityPollReceipt,
+        _cancellation: CancellationToken,
+    ) -> LeaseAuthorityAcknowledgementFuture<'_> {
+        Box::pin(async move {
+            if receipt != LeaseAuthorityPollReceipt::for_contribution(&self.contribution) {
+                return Err(LeaseAuthorityExtensionError::InvalidState);
+            }
+            self.acknowledgement_calls.fetch_add(1, Ordering::SeqCst);
+            self.acknowledgement_calls_changed.notify_waiters();
+            self.acknowledgement_release
+                .acquire()
+                .await
+                .map_err(|_| LeaseAuthorityExtensionError::Unavailable)?
+                .forget();
+            Err(LeaseAuthorityExtensionError::Unavailable)
+        })
     }
 }
 
@@ -62,6 +268,8 @@ struct NoWorkClient {
     shutdown: Option<CancellationToken>,
     slots: u16,
     successes_per_slot: usize,
+    accepted_contributions_override: Option<Sha256Digest>,
+    invalid_poll_response: bool,
     state: Mutex<NoWorkState>,
 }
 
@@ -78,6 +286,8 @@ impl NoWorkClient {
             shutdown,
             slots,
             successes_per_slot,
+            accepted_contributions_override: None,
+            invalid_poll_response: false,
             state: Mutex::new(NoWorkState {
                 retryable_errors_remaining: retryable_errors,
                 ..NoWorkState::default()
@@ -91,6 +301,16 @@ impl NoWorkClient {
             .unwrap_or_else(PoisonError::into_inner)
             .observations
             .clone()
+    }
+
+    fn with_accepted_contributions_override(mut self, digest: Sha256Digest) -> Self {
+        self.accepted_contributions_override = Some(digest);
+        self
+    }
+
+    fn with_invalid_poll_response(mut self) -> Self {
+        self.invalid_poll_response = true;
+        self
     }
 
     fn hello(&self, hello: &automata_ci_protocol::RunnerHello) -> ServerToRunner {
@@ -145,6 +365,9 @@ impl RunnerRuntimeControlClient for NoWorkClient {
                             (false, complete)
                         }
                     };
+                    if self.invalid_poll_response {
+                        return Err(invalid_control_response());
+                    }
                     if should_shutdown && let Some(shutdown) = &self.shutdown {
                         shutdown.cancel();
                     }
@@ -156,7 +379,14 @@ impl RunnerRuntimeControlClient for NoWorkClient {
                             true,
                         ))
                     } else {
-                        ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                        let accepted = self
+                            .accepted_contributions_override
+                            .unwrap_or_else(|| poll.authority_contributions().sha256_digest());
+                        ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+                            reply_header(poll.header()),
+                            accepted,
+                            1,
+                        )))
                     }
                 }
                 _ => return Err(invalid_control_response()),
@@ -291,18 +521,27 @@ impl RunnerRuntimeControlClient for OfferClient {
     ) -> RuntimeControlFuture<'a> {
         Box::pin(async move {
             let response = match request.message() {
-                RunnerToServer::Hello(hello) => ServerToRunner::Hello(ServerHello::new(
-                    OperationId::new(),
-                    hello.operation_id(),
-                    NegotiatedSession::new(
-                        SUPPORTED_PROTOCOL_RANGE.max(),
-                        automata_ci_core::JobIrVersion::current(),
-                        self.session_id,
-                        SessionDisposition::Opened,
-                        CommandCursor::initial(),
-                    ),
-                    ServerTiming::new(UnixMillis::new(10_000), 1_000, 30_000),
-                )),
+                RunnerToServer::Hello(hello) => {
+                    let (disposition, cursor) = hello.resume().map_or(
+                        (SessionDisposition::Opened, CommandCursor::initial()),
+                        |resume| {
+                            assert_eq!(resume.session_id(), self.session_id);
+                            (SessionDisposition::Resumed, resume.command_cursor())
+                        },
+                    );
+                    ServerToRunner::Hello(ServerHello::new(
+                        OperationId::new(),
+                        hello.operation_id(),
+                        NegotiatedSession::new(
+                            SUPPORTED_PROTOCOL_RANGE.max(),
+                            automata_ci_core::JobIrVersion::current(),
+                            self.session_id,
+                            disposition,
+                            cursor,
+                        ),
+                        ServerTiming::new(UnixMillis::new(10_000), 1_000, 30_000),
+                    ))
+                }
                 RunnerToServer::LeaseRequest(poll) => {
                     let is_initial = !self
                         .state
@@ -311,16 +550,14 @@ impl RunnerRuntimeControlClient for OfferClient {
                         .initial_polls
                         .contains_key(&poll.slot());
                     if is_initial {
-                        ServerToRunner::LeaseOffer(Box::new(
-                            self.offer_for_initial_poll(request).await,
-                        ))
+                        lease_poll_offer(poll, self.offer_for_initial_poll(request).await)
                     } else {
                         self.state
                             .lock()
                             .unwrap_or_else(PoisonError::into_inner)
                             .polls
                             .push(PollObservation::from_request(request));
-                        ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                        lease_poll_no_work(poll, 1)
                     }
                 }
                 RunnerToServer::CommandAck(ack) => {
@@ -342,6 +579,7 @@ struct CancelClient {
     session_id: RunnerSessionId,
     shutdown: CancellationToken,
     cancellation: CancelJob,
+    direct_poll_response: bool,
     poll: Mutex<Option<PollObservation>>,
 }
 
@@ -371,8 +609,14 @@ impl CancelClient {
                 "stale scripted cancellation",
                 UnixMillis::new(10_001),
             ),
+            direct_poll_response: false,
             poll: Mutex::new(None),
         }
+    }
+
+    fn with_direct_poll_response(mut self) -> Self {
+        self.direct_poll_response = true;
+        self
     }
 
     fn poll(&self) -> PollObservation {
@@ -404,17 +648,87 @@ impl RunnerRuntimeControlClient for CancelClient {
                     ),
                     ServerTiming::new(UnixMillis::new(10_000), 1_000, 30_000),
                 )),
-                RunnerToServer::LeaseRequest(_) => {
+                RunnerToServer::LeaseRequest(poll_request) => {
                     let mut poll = self.poll.lock().unwrap_or_else(PoisonError::into_inner);
                     if poll.is_some() {
                         return Err(invalid_control_response());
                     }
                     *poll = Some(PollObservation::from_request(request));
-                    ServerToRunner::CancelJob(self.cancellation.clone())
+                    if self.direct_poll_response {
+                        ServerToRunner::CancelJob(self.cancellation.clone())
+                    } else {
+                        lease_poll_cancel(poll_request, self.cancellation.clone())
+                    }
                 }
                 RunnerToServer::CommandAck(ack) => {
                     self.shutdown.cancel();
                     ServerToRunner::OperationAck(OperationAck::new(reply_header(ack.header())))
+                }
+                _ => return Err(invalid_control_response()),
+            };
+            reply(response)
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ReceiptGateClient {
+    session_id: RunnerSessionId,
+    lease_response_seen: AtomicBool,
+    lease_response_changed: tokio::sync::Notify,
+}
+
+impl ReceiptGateClient {
+    fn new(session_id: RunnerSessionId) -> Self {
+        Self {
+            session_id,
+            lease_response_seen: AtomicBool::new(false),
+            lease_response_changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    async fn wait_for_lease_response(&self) {
+        loop {
+            let changed = self.lease_response_changed.notified();
+            if self.lease_response_seen.load(Ordering::SeqCst) {
+                return;
+            }
+            changed.await;
+        }
+    }
+}
+
+impl RunnerRuntimeControlClient for ReceiptGateClient {
+    fn exchange<'a>(
+        &'a self,
+        request: &'a PreparedRequest,
+        _cancellation: CancellationToken,
+    ) -> RuntimeControlFuture<'a> {
+        Box::pin(async move {
+            let response = match request.message() {
+                RunnerToServer::Hello(hello) => {
+                    let resume = hello.resume().expect("journaled session must resume");
+                    assert_eq!(resume.session_id(), self.session_id);
+                    ServerToRunner::Hello(ServerHello::new(
+                        OperationId::new(),
+                        hello.operation_id(),
+                        NegotiatedSession::new(
+                            SUPPORTED_PROTOCOL_RANGE.max(),
+                            automata_ci_core::JobIrVersion::current(),
+                            self.session_id,
+                            SessionDisposition::Resumed,
+                            resume.command_cursor(),
+                        ),
+                        ServerTiming::new(UnixMillis::new(10_000), 1_000, 30_000),
+                    ))
+                }
+                RunnerToServer::CommandAck(ack) => {
+                    ServerToRunner::OperationAck(OperationAck::new(reply_header(ack.header())))
+                }
+                RunnerToServer::LeaseResponse(response) => {
+                    self.lease_response_seen.store(true, Ordering::SeqCst);
+                    self.lease_response_changed.notify_waiters();
+                    ServerToRunner::OperationAck(OperationAck::new(reply_header(response.header())))
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -445,6 +759,30 @@ fn reply_header(request: MessageHeader) -> MessageHeader {
     )
 }
 
+fn lease_poll_no_work(request: &LeaseRequest, retry_after_millis: u32) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        retry_after_millis,
+    )))
+}
+
+fn lease_poll_offer(request: &LeaseRequest, offer: LeaseOffer) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::lease_offer(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        offer,
+    )))
+}
+
+fn lease_poll_cancel(request: &LeaseRequest, cancel: CancelJob) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::cancel_job(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        cancel,
+    )))
+}
+
 fn invalid_control_response() -> RuntimeControlError {
     RuntimeControlError::new(
         RuntimeControlErrorKind::InvalidResponse,
@@ -464,21 +802,48 @@ fn runtime(
     journal: Arc<dyn RunnerJournal>,
     spool: Arc<FileSpool>,
 ) -> RunnerSessionSupervisor {
+    runtime_with_authority(runner_id, slots, client, journal, spool, None)
+}
+
+fn runtime_with_authority(
+    runner_id: RunnerId,
+    slots: u16,
+    client: Arc<dyn RunnerRuntimeControlClient>,
+    journal: Arc<dyn RunnerJournal>,
+    spool: Arc<FileSpool>,
+    extension: Option<Arc<dyn LeaseAuthorityExtension>>,
+) -> RunnerSessionSupervisor {
+    let extensions = extension.map_or_else(LeaseAuthorityExtensionRegistry::empty, |extension| {
+        LeaseAuthorityExtensionRegistry::new(vec![extension]).expect("authority registry")
+    });
+    runtime_with_authority_registry(runner_id, slots, client, journal, spool, extensions)
+}
+
+fn runtime_with_authority_registry(
+    runner_id: RunnerId,
+    slots: u16,
+    client: Arc<dyn RunnerRuntimeControlClient>,
+    journal: Arc<dyn RunnerJournal>,
+    spool: Arc<FileSpool>,
+    extensions: LeaseAuthorityExtensionRegistry,
+) -> RunnerSessionSupervisor {
+    let ports = RunnerRuntimePorts::new(
+        client,
+        journal,
+        spool,
+        Arc::new(support::NeverExecutor),
+        Arc::new(support::FixedClock::new(10_000, 50)),
+        Arc::new(support::ImmediateSleeper),
+        Arc::new(SystemRuntimeIds),
+    )
+    .with_lease_authority_extensions(extensions);
     RunnerSessionSupervisor::new(
         support::config_with_slots_and_retry(
             runner_id,
             slots,
             automata_ci_runner_runtime::RetryPolicy::default(),
         ),
-        RunnerRuntimePorts::new(
-            client,
-            journal,
-            spool,
-            Arc::new(support::NeverExecutor),
-            Arc::new(support::FixedClock::new(10_000, 50)),
-            Arc::new(support::ImmediateSleeper),
-            Arc::new(SystemRuntimeIds),
-        ),
+        ports,
     )
 }
 
@@ -487,6 +852,7 @@ async fn run_one_successful_no_work(
     session_id: RunnerSessionId,
     journal: Arc<dyn RunnerJournal>,
     spool: Arc<FileSpool>,
+    extension: Arc<dyn LeaseAuthorityExtension>,
 ) -> Vec<PollObservation> {
     let shutdown = CancellationToken::new();
     let client = Arc::new(NoWorkClient::new(
@@ -496,11 +862,61 @@ async fn run_one_successful_no_work(
         0,
         Some(shutdown.clone()),
     ));
-    runtime(runner_id, 1, client.clone(), journal, spool)
-        .run(shutdown)
-        .await
-        .expect("one successful no-work response");
+    runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal,
+        spool,
+        Some(extension),
+    )
+    .run(shutdown)
+    .await
+    .expect("one successful no-work response");
     client.observations()
+}
+
+fn seed_lease_poll(
+    journal: &dyn RunnerJournal,
+    session_id: RunnerSessionId,
+    slot: RunnerSlotOrdinal,
+) -> OperationId {
+    journal
+        .begin_session(SessionBinding::new(
+            session_id,
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            automata_ci_core::JobIrVersion::current(),
+        ))
+        .expect("seed session");
+    let operation_id = OperationId::new();
+    journal
+        .prepare_lease_poll(session_id, slot, operation_id)
+        .expect("durable checkpoint before first send");
+    operation_id
+}
+
+fn assert_failed_authority_poll(
+    client: &NoWorkClient,
+    operation_id: OperationId,
+    payload_sha256: Sha256Digest,
+    source: &RotatingAuthorityExtension,
+) -> Vec<PollObservation> {
+    let poll = client.observations();
+    assert_eq!(poll.len(), 1);
+    assert_eq!(poll[0].operation_id, operation_id);
+    assert_eq!(poll[0].acknowledges_operation_id, None);
+    assert_eq!(
+        poll[0]
+            .authority_contributions
+            .get("test.placement")
+            .map(LeaseAuthorityPollContribution::payload_sha256),
+        Some(payload_sha256)
+    );
+    assert!(
+        source.acknowledgements().is_empty(),
+        "the authority must not rotate before the poll successor is durable"
+    );
+    poll
 }
 
 #[tokio::test]
@@ -547,7 +963,7 @@ async fn no_work_forms_unique_per_slot_successor_chains() {
             .session()
             .expect("session")
             .lease_poll_checkpoint(slot)
-            .copied()
+            .cloned()
             .expect("checkpoint");
         assert_eq!(
             checkpoint.acknowledges_operation_id(),
@@ -565,6 +981,8 @@ async fn retryable_protocol_errors_reuse_current_exact_request() {
     let runner_id = RunnerId::new();
     let session_id = RunnerSessionId::new();
     let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let first_payload_sha256 = authority_source.contributions[0].payload_sha256();
     let shutdown = CancellationToken::new();
     let client = Arc::new(NoWorkClient::new(
         session_id,
@@ -574,10 +992,17 @@ async fn retryable_protocol_errors_reuse_current_exact_request() {
         Some(shutdown.clone()),
     ));
 
-    runtime(runner_id, 1, client.clone(), journal.clone(), spool)
-        .run(shutdown)
-        .await
-        .expect("retryable errors preserve the poll");
+    runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(shutdown)
+    .await
+    .expect("retryable errors preserve the poll");
 
     let observations = client.observations();
     assert_eq!(observations.len(), 3);
@@ -598,6 +1023,7 @@ async fn retryable_protocol_errors_reuse_current_exact_request() {
             .acknowledges_operation_id(),
         Some(observations[0].operation_id)
     );
+    authority_source.assert_acknowledgements(&[first_payload_sha256]);
 }
 
 #[tokio::test]
@@ -606,18 +1032,11 @@ async fn crashes_before_send_after_response_and_after_rotate_reconstruct_exact_p
     let runner_id = RunnerId::new();
     let session_id = RunnerSessionId::new();
     let slot = RunnerSlotOrdinal::new(1).expect("slot");
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let first_payload_sha256 = authority_source.contributions[0].payload_sha256();
+    let second_payload_sha256 = authority_source.contributions[1].payload_sha256();
     let (journal, spool) = support::durable_ports(&scratch, runner_id);
-    journal
-        .begin_session(SessionBinding::new(
-            session_id,
-            SUPPORTED_PROTOCOL_RANGE.max(),
-            automata_ci_core::JobIrVersion::current(),
-        ))
-        .expect("seed session");
-    let before_send_operation = OperationId::new();
-    journal
-        .prepare_lease_poll(session_id, slot, before_send_operation)
-        .expect("durable checkpoint before first send");
+    let before_send_operation = seed_lease_poll(journal.as_ref(), session_id, slot);
     drop(journal);
 
     let faulting = Arc::new(
@@ -630,12 +1049,13 @@ async fn crashes_before_send_after_response_and_after_rotate_reconstruct_exact_p
         .expect("faulting journal"),
     );
     let first_client = Arc::new(NoWorkClient::new(session_id, 1, 1, 0, None));
-    let first_runtime = runtime(
+    let first_runtime = runtime_with_authority(
         runner_id,
         1,
         first_client.clone(),
         faulting.clone(),
         spool.clone(),
+        Some(authority_source.clone()),
     );
     let error = first_runtime
         .run(CancellationToken::new())
@@ -645,30 +1065,39 @@ async fn crashes_before_send_after_response_and_after_rotate_reconstruct_exact_p
         error,
         RunnerRuntimeError::Journal(JournalError::InjectedFault(CommitStage::FileSynced))
     ));
-    let first_poll = first_client.observations();
-    assert_eq!(first_poll.len(), 1);
-    assert_eq!(first_poll[0].operation_id, before_send_operation);
-    assert_eq!(first_poll[0].acknowledges_operation_id, None);
+    let first_poll = assert_failed_authority_poll(
+        first_client.as_ref(),
+        before_send_operation,
+        first_payload_sha256,
+        authority_source.as_ref(),
+    );
     drop(first_runtime);
     drop(faulting);
 
     let retry_journal = Arc::new(
         FileJournal::open(scratch.journal_root(), runner_id).expect("reopen after failed rotation"),
     );
-    let retried_poll =
-        run_one_successful_no_work(runner_id, session_id, retry_journal.clone(), spool.clone())
-            .await;
+    let retried_poll = run_one_successful_no_work(
+        runner_id,
+        session_id,
+        retry_journal.clone(),
+        spool.clone(),
+        authority_source.clone(),
+    )
+    .await;
     assert_eq!(
         retried_poll, first_poll,
         "operation and canonical bytes retry exactly"
     );
-    let rotated = *retry_journal
+    authority_source.assert_acknowledgements(&[first_payload_sha256]);
+    let rotated = retry_journal
         .snapshot()
         .expect("rotated snapshot")
         .session()
         .expect("session")
         .lease_poll_checkpoint(slot)
-        .expect("rotated checkpoint");
+        .expect("rotated checkpoint")
+        .clone();
     assert_ne!(rotated.current_operation_id(), before_send_operation);
     assert_eq!(
         rotated.acknowledges_operation_id(),
@@ -680,12 +1109,249 @@ async fn crashes_before_send_after_response_and_after_rotate_reconstruct_exact_p
         FileJournal::open(scratch.journal_root(), runner_id)
             .expect("reopen after durable rotation"),
     );
-    let resumed = run_one_successful_no_work(runner_id, session_id, resumed_journal, spool).await;
+    let resumed = run_one_successful_no_work(
+        runner_id,
+        session_id,
+        resumed_journal,
+        spool,
+        authority_source.clone(),
+    )
+    .await;
     assert_eq!(resumed.len(), 1);
     assert_eq!(resumed[0].operation_id, rotated.current_operation_id());
     assert_eq!(
         resumed[0].acknowledges_operation_id,
         rotated.acknowledges_operation_id()
+    );
+    assert_eq!(
+        resumed[0]
+            .authority_contributions
+            .get("test.placement")
+            .map(LeaseAuthorityPollContribution::payload_sha256),
+        Some(second_payload_sha256)
+    );
+    authority_source.assert_acknowledgements(&[first_payload_sha256, second_payload_sha256]);
+}
+
+#[tokio::test]
+async fn accepted_offer_receipt_is_recovered_before_the_durable_slot_runs() {
+    let scratch = support::Scratch::new("lease-poll-authority-ack-recovery");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let slot = RunnerSlotOrdinal::new(1).expect("slot");
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    authority_source.fail_next_acknowledgement();
+    let receipt = LeaseAuthorityPollReceipt::for_contribution(&authority_source.contributions[0]);
+    let shutdown = CancellationToken::new();
+    let client = Arc::new(OfferClient::new(
+        runner_id,
+        session_id,
+        OfferDelivery::Direct,
+        shutdown.clone(),
+    ));
+
+    let first_runtime = runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool.clone(),
+        Some(authority_source.clone()),
+    );
+    let error = first_runtime
+        .run(shutdown.clone())
+        .await
+        .expect_err("extension acknowledgement fails after the offer is durable");
+    assert!(matches!(
+        error,
+        RunnerRuntimeError::LeaseAuthority(LeaseAuthorityExtensionError::Unavailable)
+    ));
+    let snapshot = journal.snapshot().expect("failed-ack snapshot");
+    assert!(
+        snapshot.slot(slot).is_some(),
+        "the accepted offer remains durable while its receipt is pending"
+    );
+    assert_eq!(
+        snapshot
+            .session()
+            .expect("session")
+            .lease_poll_checkpoint(slot)
+            .expect("checkpoint")
+            .pending_authority_receipts(),
+        std::slice::from_ref(&receipt)
+    );
+    assert!(authority_source.acknowledgements().is_empty());
+    drop(first_runtime);
+    drop(journal);
+
+    let reopened = Arc::new(
+        FileJournal::open(scratch.journal_root(), runner_id)
+            .expect("reopen with a pending authority receipt"),
+    );
+    runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        reopened.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(shutdown)
+    .await
+    .expect("restart drains the receipt before processing the durable offer");
+
+    assert_eq!(
+        client.observations().len(),
+        1,
+        "restart drains the receipt before issuing another lease poll"
+    );
+    assert_eq!(
+        authority_source.acknowledgement_attempts(),
+        vec![receipt.payload_sha256(), receipt.payload_sha256()]
+    );
+    authority_source.assert_acknowledgements(&[receipt.payload_sha256()]);
+    let recovered = reopened.snapshot().expect("recovered snapshot");
+    assert!(
+        recovered
+            .session()
+            .expect("session")
+            .lease_poll_checkpoint(slot)
+            .expect("checkpoint")
+            .pending_authority_receipts()
+            .is_empty(),
+        "the receipt is cleared only after the extension acknowledges it"
+    );
+}
+
+fn assert_cross_slot_receipt_remains_pending(
+    journal: &dyn RunnerJournal,
+    target_slot: RunnerSlotOrdinal,
+    carrier_slot: RunnerSlotOrdinal,
+    receipt: &LeaseAuthorityPollReceipt,
+) {
+    let snapshot = journal.snapshot().expect("gated snapshot");
+    assert_eq!(
+        snapshot
+            .slot(target_slot)
+            .expect("target offer")
+            .offer_status(),
+        automata_ci_runner_journal::LeaseOfferStatus::Recorded
+    );
+    assert_eq!(
+        snapshot
+            .session()
+            .expect("session")
+            .lease_poll_checkpoint(carrier_slot)
+            .expect("carrier checkpoint")
+            .pending_authority_receipts(),
+        std::slice::from_ref(receipt)
+    );
+}
+
+#[tokio::test]
+async fn cross_slot_pending_receipt_gates_target_offer_after_restart() {
+    let scratch = support::Scratch::new("lease-poll-cross-slot-receipt-gate");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let target_slot = RunnerSlotOrdinal::new(1).expect("target slot");
+    let carrier_slot = RunnerSlotOrdinal::new(2).expect("carrier slot");
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    journal
+        .begin_session(SessionBinding::new(
+            session_id,
+            SUPPORTED_PROTOCOL_RANGE.max(),
+            automata_ci_core::JobIrVersion::current(),
+        ))
+        .expect("seed session");
+    let carrier_operation = OperationId::new();
+    journal
+        .prepare_lease_poll(session_id, carrier_slot, carrier_operation)
+        .expect("seed carrier poll");
+
+    let authority_source = Arc::new(BlockingAuthorityExtension::new());
+    let receipt = LeaseAuthorityPollReceipt::for_contribution(&authority_source.contribution);
+    let lease = Lease::new(
+        LeaseId::new(),
+        AttemptId::new(),
+        runner_id,
+        FencingToken::new(7).expect("fencing token"),
+        UnixMillis::new(9_000),
+        UnixMillis::new(40_000),
+    )
+    .expect("lease");
+    let job = support::minimal_job();
+    let encoded_job = encode_job_ir(&job, &automata_ci_protocol::ProtocolLimits::default())
+        .expect("encode JobIR");
+    let command = DurableCommand::new(
+        CommandSequence::new(1).expect("command sequence"),
+        OperationId::new(),
+        Sha256Digest::from_bytes([0x66; 32]),
+    );
+    {
+        let publication = spool
+            .persist(ContentKind::JobIr, &encoded_job)
+            .expect("persist JobIR");
+        let adopted = publication.commit_with(|content| {
+            let job_ir = JobIrContentRef::new(job.version(), content.clone())?;
+            let offer = LeaseOfferRecord::new(target_slot, lease.clone(), job_ir, command)?;
+            journal.complete_lease_poll(
+                session_id,
+                LeasePollCompletion::new(
+                    carrier_slot,
+                    carrier_operation,
+                    OperationId::new(),
+                    vec![receipt.clone()],
+                    LeasePollCommandRecord::LeaseOffer(Box::new(offer)),
+                ),
+            )
+        });
+        if let Err(failure) = adopted {
+            let (error, publication) = failure.into_parts();
+            publication.abort();
+            panic!("seed atomic cross-slot response: {error}");
+        }
+    }
+
+    let client = Arc::new(ReceiptGateClient::new(session_id));
+    let supervisor = runtime_with_authority(
+        runner_id,
+        2,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    );
+    let mut runtime_task =
+        tokio::spawn(async move { supervisor.run(CancellationToken::new()).await });
+    tokio::select! {
+        () = authority_source.wait_for_acknowledgement_calls(2) => {}
+        () = client.wait_for_lease_response() => {
+            panic!("target offer ran before its cross-slot authority receipt was acknowledged")
+        }
+        result = &mut runtime_task => {
+            panic!("runtime stopped before both slot loops observed the receipt: {result:?}")
+        }
+    }
+    assert!(
+        !client.lease_response_seen.load(Ordering::SeqCst),
+        "neither slot may process the target while the carrier receipt is pending"
+    );
+    authority_source.release_acknowledgements(2);
+    let error = runtime_task
+        .await
+        .expect("runtime task")
+        .expect_err("blocked authority acknowledgement fails the resumed session");
+    assert!(matches!(
+        error,
+        RunnerRuntimeError::LeaseAuthority(LeaseAuthorityExtensionError::Unavailable)
+    ));
+
+    assert_cross_slot_receipt_remains_pending(
+        journal.as_ref(),
+        target_slot,
+        carrier_slot,
+        &receipt,
     );
 }
 
@@ -696,6 +1362,8 @@ async fn direct_and_cross_slot_offer_responses_retire_their_carrier_polls() {
         let runner_id = RunnerId::new();
         let session_id = RunnerSessionId::new();
         let (journal, spool) = support::durable_ports(&scratch, runner_id);
+        let authority_source = Arc::new(RotatingAuthorityExtension::new());
+        let first_payload_sha256 = authority_source.contributions[0].payload_sha256();
         let shutdown = CancellationToken::new();
         let client = Arc::new(OfferClient::new(
             runner_id,
@@ -705,10 +1373,17 @@ async fn direct_and_cross_slot_offer_responses_retire_their_carrier_polls() {
         ));
         let slots = client.slots();
 
-        runtime(runner_id, slots, client.clone(), journal.clone(), spool)
-            .run(shutdown)
-            .await
-            .expect("offer command is durable before poll retirement");
+        runtime_with_authority(
+            runner_id,
+            slots,
+            client.clone(),
+            journal.clone(),
+            spool,
+            Some(authority_source.clone()),
+        )
+        .run(shutdown)
+        .await
+        .expect("offer command is durable before poll retirement");
 
         let observations = client.observations();
         assert!(observations.len() >= usize::from(slots));
@@ -742,6 +1417,19 @@ async fn direct_and_cross_slot_offer_responses_retire_their_carrier_polls() {
                 "every exact command response retires its carrier poll"
             );
         }
+        assert_eq!(
+            authority_source
+                .acknowledgement_attempts()
+                .into_iter()
+                .filter(|digest| *digest == first_payload_sha256)
+                .count(),
+            usize::from(slots),
+            "every concurrent carrier acknowledges the identical source value idempotently"
+        );
+        assert_eq!(
+            authority_source.acknowledgements().first(),
+            Some(&first_payload_sha256)
+        );
     }
 }
 
@@ -751,13 +1439,22 @@ async fn durable_cancel_response_retires_its_carrier_poll() {
     let runner_id = RunnerId::new();
     let session_id = RunnerSessionId::new();
     let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let first_payload_sha256 = authority_source.contributions[0].payload_sha256();
     let shutdown = CancellationToken::new();
     let client = Arc::new(CancelClient::new(runner_id, session_id, shutdown.clone()));
 
-    runtime(runner_id, 1, client.clone(), journal.clone(), spool)
-        .run(shutdown)
-        .await
-        .expect("durable ignored cancellation completes the carrier poll");
+    runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(shutdown)
+    .await
+    .expect("durable ignored cancellation completes the carrier poll");
 
     let poll = client.poll();
     let checkpoint = journal
@@ -766,11 +1463,163 @@ async fn durable_cancel_response_retires_its_carrier_poll() {
         .session()
         .expect("session")
         .lease_poll_checkpoint(poll.slot)
-        .copied()
+        .cloned()
         .expect("checkpoint");
     assert_ne!(checkpoint.current_operation_id(), poll.operation_id);
     assert_eq!(
         checkpoint.acknowledges_operation_id(),
         Some(poll.operation_id)
+    );
+    authority_source.assert_acknowledgements(&[first_payload_sha256]);
+}
+
+#[tokio::test]
+async fn lease_authority_registry_canonicalizes_and_acks_every_extension() {
+    let scratch = support::Scratch::new("lease-poll-authority-registry");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let alpha = Arc::new(RotatingAuthorityExtension::named("alpha.test"));
+    let zulu = Arc::new(RotatingAuthorityExtension::named("zulu.test"));
+    let alpha_digest = alpha.contributions[0].payload_sha256();
+    let zulu_digest = zulu.contributions[0].payload_sha256();
+    let registry = LeaseAuthorityExtensionRegistry::new(vec![zulu.clone(), alpha.clone()])
+        .expect("canonical authority registry");
+    let shutdown = CancellationToken::new();
+    let client = Arc::new(NoWorkClient::new(
+        session_id,
+        1,
+        1,
+        0,
+        Some(shutdown.clone()),
+    ));
+
+    runtime_with_authority_registry(runner_id, 1, client.clone(), journal, spool, registry)
+        .run(shutdown)
+        .await
+        .expect("canonical authority poll");
+
+    let observations = client.observations();
+    let names = observations[0]
+        .authority_contributions
+        .as_slice()
+        .iter()
+        .map(|contribution| contribution.name().as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["alpha.test", "zulu.test"]);
+    alpha.assert_acknowledgements(&[alpha_digest]);
+    zulu.assert_acknowledgements(&[zulu_digest]);
+}
+
+#[test]
+fn lease_authority_registry_rejects_duplicate_names() {
+    let first: Arc<dyn LeaseAuthorityExtension> =
+        Arc::new(RotatingAuthorityExtension::named("test.duplicate"));
+    let second: Arc<dyn LeaseAuthorityExtension> =
+        Arc::new(RotatingAuthorityExtension::named("test.duplicate"));
+    assert!(matches!(
+        LeaseAuthorityExtensionRegistry::new(vec![first, second]),
+        Err(LeaseAuthorityExtensionError::DuplicateName)
+    ));
+}
+
+#[tokio::test]
+async fn mismatched_accepted_bundle_does_not_advance_or_ack() {
+    let scratch = support::Scratch::new("lease-poll-authority-mismatch");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let client = Arc::new(
+        NoWorkClient::new(session_id, 1, 1, 0, None)
+            .with_accepted_contributions_override(Sha256Digest::from_bytes([0x5a; 32])),
+    );
+
+    let error = runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(CancellationToken::new())
+    .await
+    .expect_err("a substituted acceptance digest fails closed");
+    assert!(matches!(error, RunnerRuntimeError::UnexpectedSyncResponse));
+
+    assert_unretired_poll(journal.as_ref(), &client.observations()[0]);
+    assert!(authority_source.acknowledgements().is_empty());
+}
+
+#[tokio::test]
+async fn missing_acceptance_response_does_not_advance_or_ack() {
+    let scratch = support::Scratch::new("lease-poll-authority-missing-response");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let client =
+        Arc::new(NoWorkClient::new(session_id, 1, 1, 0, None).with_invalid_poll_response());
+
+    let error = runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(CancellationToken::new())
+    .await
+    .expect_err("a response without a valid acceptance wrapper fails closed");
+    assert!(matches!(error, RunnerRuntimeError::Client(_)));
+
+    assert_unretired_poll(journal.as_ref(), &client.observations()[0]);
+    assert!(authority_source.acknowledgements().is_empty());
+}
+
+#[tokio::test]
+async fn direct_command_poll_response_does_not_advance_or_ack() {
+    let scratch = support::Scratch::new("lease-poll-direct-command");
+    let runner_id = RunnerId::new();
+    let session_id = RunnerSessionId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let authority_source = Arc::new(RotatingAuthorityExtension::new());
+    let client = Arc::new(
+        CancelClient::new(runner_id, session_id, CancellationToken::new())
+            .with_direct_poll_response(),
+    );
+
+    let error = runtime_with_authority(
+        runner_id,
+        1,
+        client.clone(),
+        journal.clone(),
+        spool,
+        Some(authority_source.clone()),
+    )
+    .run(CancellationToken::new())
+    .await
+    .expect_err("a direct legacy command cannot bypass poll acceptance");
+    assert!(matches!(error, RunnerRuntimeError::UnexpectedSyncResponse));
+
+    assert_unretired_poll(journal.as_ref(), &client.poll());
+    assert!(authority_source.acknowledgements().is_empty());
+}
+
+fn assert_unretired_poll(journal: &dyn RunnerJournal, poll: &PollObservation) {
+    let checkpoint = journal
+        .snapshot()
+        .expect("snapshot")
+        .session()
+        .expect("session")
+        .lease_poll_checkpoint(poll.slot)
+        .cloned()
+        .expect("checkpoint");
+    assert_eq!(checkpoint.current_operation_id(), poll.operation_id);
+    assert_eq!(
+        checkpoint.acknowledges_operation_id(),
+        poll.acknowledges_operation_id
     );
 }

--- a/crates/automata-ci-runner-runtime/tests/orphan_session_recovery.rs
+++ b/crates/automata-ci-runner-runtime/tests/orphan_session_recovery.rs
@@ -13,7 +13,7 @@ use automata_ci_core::{
     UnixMillis,
 };
 use automata_ci_protocol::{
-    CommandCursor, HandshakeErrorCode, HandshakeRejected, NegotiatedSession,
+    CommandCursor, HandshakeErrorCode, HandshakeRejected, LeasePollResponse, NegotiatedSession,
     OrphanDeliveryPermissions, RunnerToServer, SUPPORTED_PROTOCOL_RANGE, ServerHello, ServerTiming,
     ServerToRunner, SessionDisposition, SessionOrphanAuthorization,
 };
@@ -146,15 +146,16 @@ impl RunnerRuntimeControlClient for OrphanControlClient {
                 }
                 RunnerToServer::LeaseRequest(request) => {
                     self.shutdown.cancel();
-                    ServerToRunner::NoWork(automata_ci_protocol::NoWork::new(
+                    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
                         automata_ci_protocol::MessageHeader::reply(
                             request.header().protocol_version(),
                             request.header().session_id(),
                             OperationId::new(),
                             request.header().operation_id(),
                         ),
+                        request.authority_contributions().sha256_digest(),
                         1,
-                    ))
+                    )))
                 }
                 _ => return Err(invalid_control_response()),
             };

--- a/crates/automata-ci-runner-runtime/tests/semantic_observer.rs
+++ b/crates/automata-ci-runner-runtime/tests/semantic_observer.rs
@@ -14,8 +14,8 @@ use automata_ci_core::{
     LogAck, OperationId, RunnerId, RunnerSessionId, Sha256Digest, UnixMillis,
 };
 use automata_ci_protocol::{
-    CommandSequence, ErrorMessage, LeaseRenewal, LogAckMessage, MessageHeader, NegotiatedSession,
-    NoWork, OperationAck, ProtocolLimits, RemoteErrorCode, RunnerToServer,
+    CommandSequence, ErrorMessage, LeasePollResponse, LeaseRenewal, LogAckMessage, MessageHeader,
+    NegotiatedSession, OperationAck, ProtocolLimits, RemoteErrorCode, RunnerToServer,
     SUPPORTED_PROTOCOL_RANGE, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_journal::{CancellationRecord, DurableCommand, RunnerJournal};
@@ -274,7 +274,11 @@ impl RunnerRuntimeControlClient for CompletionClient {
                 }
                 RunnerToServer::LeaseRequest(poll) => {
                     self.shutdown.cancel();
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+                        reply_header(poll.header()),
+                        poll.authority_contributions().sha256_digest(),
+                        1,
+                    )))
                 }
                 RunnerToServer::RuntimeAuthorityRequest(_)
                 | RunnerToServer::RuntimeAuthorityAck(_) => {

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -17,10 +17,10 @@ use automata_ci_core::{
     JobIrEnvelope, JobLifecycle, JobPermissionRequest, JobResult, JobSecretExposure, JobSource,
     Lease, LeaseId, LogAck, LogChannel, LogFrame, LogGroupId, OperationId, RunId,
     RunValueTemplates, RunnerCapabilities, RunnerId, RunnerPlatform, RunnerRequirements,
-    RuntimeBoolean, SandboxCapabilities, SemanticStep, Sha256Digest, ShellTemplate, StepId, StepIr,
-    TrustActorEvidence, TrustActorKind, TrustAutomationKind, TrustEventKind, TrustEvidence,
-    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustTokenRecursion, UnixMillis,
-    ValueTemplate, WorkflowId,
+    RuntimeBoolean, SandboxAuthorizations, SandboxCapabilities, SemanticStep, Sha256Digest,
+    ShellTemplate, StepId, StepIr, TrustActorEvidence, TrustActorKind, TrustAutomationKind,
+    TrustEventKind, TrustEvidence, TrustOriginKind, TrustPolicy, TrustRepositoryEvidence,
+    TrustTokenRecursion, UnixMillis, ValueTemplate, WorkflowId,
 };
 use automata_ci_execution::{
     ExecutionArgv, ExecutionEnvironment, ImmutableImage, SandboxEnvironment, TargetPath,
@@ -28,11 +28,12 @@ use automata_ci_execution::{
 use automata_ci_protocol::{
     CancelJob, CommandCursor, CommandSequence, ErrorMessage, HandshakeErrorCode, HandshakeRejected,
     INITIAL_RUNTIME_AUTHORITY_GENERATION, JobResultMessage, JobRuntimeAuthorities,
-    JobRuntimeAuthority, LeaseOffer, LeaseRenewal, LogAckMessage, MessageHeader, NegotiatedSession,
-    NoWork, OperationAck, RemoteErrorCode, RunnerSlotOrdinal, RunnerToServer,
-    RuntimeAuthorityCredential, RuntimeAuthorityDeliveryBinding, RuntimeAuthorityEndpoint,
-    RuntimeAuthorityGrant, RuntimeAuthorityName, RuntimeAuthorityRequest, SUPPORTED_PROTOCOL_RANGE,
-    ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
+    JobRuntimeAuthority, LeaseOffer, LeasePollResponse, LeaseRenewal, LeaseRequest, LogAckMessage,
+    MessageHeader, NegotiatedSession, OperationAck, RemoteErrorCode, RunnerSlotOrdinal,
+    RunnerToServer, RuntimeAuthorityCredential, RuntimeAuthorityDeliveryBinding,
+    RuntimeAuthorityEndpoint, RuntimeAuthorityGrant, RuntimeAuthorityName, RuntimeAuthorityRequest,
+    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
+    SessionDisposition,
 };
 use automata_ci_protocol_protobuf::{decode_job_ir, encode_job_ir, encode_runtime_authorities};
 use automata_ci_runner_journal::{
@@ -2552,10 +2553,7 @@ impl RunnerRuntimeControlClient for RecoveringPollClient {
                     if let Some(shutdown) = &self.shutdown_after_recovery {
                         shutdown.cancel();
                     }
-                    control_reply(
-                        ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1)),
-                        &self.limits,
-                    )
+                    control_reply(lease_poll_no_work(poll, 1), &self.limits)
                 }
                 _ => Err(invalid_control_response()),
             }
@@ -2694,7 +2692,7 @@ impl RunnerRuntimeControlClient for ResumeFallbackClient {
                 }
                 RunnerToServer::LeaseRequest(poll) => {
                     self.shutdown.cancel();
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    lease_poll_no_work(poll, 1)
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -2807,7 +2805,7 @@ impl RunnerRuntimeControlClient for MaintenanceReapClient {
                         1 => {
                             assert_eq!(poll.header().session_id(), self.fresh_session_id);
                             self.shutdown.cancel();
-                            ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                            lease_poll_no_work(poll, 1)
                         }
                         _ => panic!("fresh session must stop after its first successful poll"),
                     }
@@ -2933,10 +2931,7 @@ impl RunnerRuntimeControlClient for CrossSlotReplayClient {
                             ));
                         }
                     }
-                    control_reply(
-                        ServerToRunner::LeaseOffer(Box::new(self.offer.clone())),
-                        &self.limits,
-                    )
+                    control_reply(lease_poll_offer(poll, self.offer.clone()), &self.limits)
                 }
                 RunnerToServer::CommandAck(ack) => {
                     assert_eq!(
@@ -3134,7 +3129,7 @@ impl RunnerRuntimeControlClient for CommandDuringAckClient {
                             ));
                         }
                     }
-                    ServerToRunner::LeaseOffer(Box::new(self.offers[0].clone()))
+                    lease_poll_offer(poll, self.offers[0].clone())
                 }
                 RunnerToServer::CommandAck(ack) => {
                     let cursor = ack
@@ -3291,7 +3286,7 @@ impl RunnerRuntimeControlClient for DelayedPredecessorClient {
                             RuntimeControlRetry::Never,
                         ));
                     }
-                    ServerToRunner::LeaseOffer(Box::new(offer.clone()))
+                    lease_poll_offer(poll, offer.clone())
                 }
                 RunnerToServer::CommandAck(ack) => {
                     let cursor = ack
@@ -3389,14 +3384,14 @@ impl RunnerRuntimeControlClient for IgnoredOfferReplayClient {
                 )),
                 RunnerToServer::LeaseRequest(poll) => {
                     match self.poll_calls.fetch_add(1, Ordering::SeqCst) {
-                        0 => ServerToRunner::LeaseOffer(Box::new(self.offers[0].clone())),
+                        0 => lease_poll_offer(poll, self.offers[0].clone()),
                         1 => {
                             self.replay_seen.store(true, Ordering::SeqCst);
-                            ServerToRunner::LeaseOffer(Box::new(self.offers[1].clone()))
+                            lease_poll_offer(poll, self.offers[1].clone())
                         }
                         _ => {
                             self.shutdown.cancel();
-                            ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                            lease_poll_no_work(poll, 1)
                         }
                     }
                 }
@@ -3542,16 +3537,13 @@ impl RunnerRuntimeControlClient for ScriptedControlClient {
                         });
                     }
                     self.shutdown.cancel();
-                    RuntimeControlReply::from_message(
-                        ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1)),
-                        &self.limits,
-                    )
-                    .map_err(|_| {
-                        RuntimeControlError::new(
-                            RuntimeControlErrorKind::InvalidResponse,
-                            RuntimeControlRetry::Never,
-                        )
-                    })
+                    RuntimeControlReply::from_message(lease_poll_no_work(poll, 1), &self.limits)
+                        .map_err(|_| {
+                            RuntimeControlError::new(
+                                RuntimeControlErrorKind::InvalidResponse,
+                                RuntimeControlRetry::Never,
+                            )
+                        })
                 }
                 _ => Err(RuntimeControlError::new(
                     RuntimeControlErrorKind::InvalidResponse,
@@ -4019,10 +4011,10 @@ impl RunnerRuntimeControlClient for CancellationFlowClient {
                     let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
                     if state.cancel_replayed_after_release {
                         self.shutdown.cancel();
-                        ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                        lease_poll_no_work(poll, 1)
                     } else {
                         state.cancel_replayed_after_release = true;
-                        ServerToRunner::CancelJob(self.cancellation.clone())
+                        lease_poll_cancel(poll, self.cancellation.clone())
                     }
                 }
                 _ => return Err(invalid_control_response()),
@@ -4190,7 +4182,7 @@ impl RunnerRuntimeControlClient for CancellationContentRaceClient {
                             .released_slot_polled = true;
                         self.changed.notify_waiters();
                     }
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    lease_poll_no_work(poll, 1)
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -4483,7 +4475,7 @@ impl RunnerRuntimeControlClient for FailureIsolationClient {
                     if poll.slot().get() == 1 {
                         self.released_slot_poll.notify_one();
                     }
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    lease_poll_no_work(poll, 1)
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -4640,7 +4632,7 @@ impl RunnerRuntimeControlClient for CleanupIsolationClient {
                         }
                         self.released_slot_poll.notify_one();
                     }
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    lease_poll_no_work(poll, 1)
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -4956,9 +4948,7 @@ impl RunnerRuntimeControlClient for ActiveBacklogClient {
                         LogAck::new(last.stream_id(), Some(last.sequence())),
                     ))
                 }
-                RunnerToServer::LeaseRequest(poll) => {
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
-                }
+                RunnerToServer::LeaseRequest(poll) => lease_poll_no_work(poll, 1),
                 _ => return Err(invalid_control_response()),
             };
             control_reply(response, &self.limits)
@@ -5110,9 +5100,7 @@ impl RunnerRuntimeControlClient for LogSegmentRaceClient {
                     self.changed.notify_waiters();
                     return Ok(reply);
                 }
-                RunnerToServer::LeaseRequest(poll) => {
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
-                }
+                RunnerToServer::LeaseRequest(poll) => lease_poll_no_work(poll, 1),
                 _ => return Err(invalid_control_response()),
             };
             control_reply(response, &self.limits)
@@ -5290,9 +5278,7 @@ impl RunnerRuntimeControlClient for BlockedLogClient {
                         LogAck::new(last.stream_id(), Some(last.sequence())),
                     ))
                 }
-                RunnerToServer::LeaseRequest(poll) => {
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
-                }
+                RunnerToServer::LeaseRequest(poll) => lease_poll_no_work(poll, 1),
                 _ => return Err(invalid_control_response()),
             };
             control_reply(response, &self.limits)
@@ -5498,9 +5484,7 @@ impl RunnerRuntimeControlClient for SlowLogClient {
                     self.shutdown.cancel();
                     ServerToRunner::OperationAck(OperationAck::new(reply_header(result.header())))
                 }
-                RunnerToServer::LeaseRequest(poll) => {
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
-                }
+                RunnerToServer::LeaseRequest(poll) => lease_poll_no_work(poll, 1),
                 _ => return Err(invalid_control_response()),
             };
             control_reply(response, &self.limits)
@@ -5651,7 +5635,7 @@ impl RunnerRuntimeControlClient for RecoveredFinalizationClient {
                 }
                 RunnerToServer::LeaseRequest(poll) => {
                     self.shutdown.cancel();
-                    ServerToRunner::NoWork(NoWork::new(reply_header(poll.header()), 1))
+                    lease_poll_no_work(poll, 1)
                 }
                 _ => return Err(invalid_control_response()),
             };
@@ -6019,8 +6003,13 @@ fn record_test_authority_delivery_with_expiries_and_acknowledgement(
         .expect("load accepted JobIR");
     let job = decode_job_ir(&encoded_job, &limits).expect("decode accepted JobIR");
     let authorities = if job.job().authority_profile() == JobAuthorityProfile::CredentialFree {
-        JobRuntimeAuthorities::new(Vec::new(), &job, &fixture.lease)
-            .expect("credential-free authority bundle")
+        JobRuntimeAuthorities::new(
+            Vec::new(),
+            SandboxAuthorizations::empty(),
+            &job,
+            &fixture.lease,
+        )
+        .expect("credential-free authority bundle")
     } else {
         test_runtime_authorities_with_expiries(&job, &fixture.lease, authority_expiries)
     };
@@ -6140,6 +6129,7 @@ fn test_runtime_authorities_with_expiries(
                 .expect("runtime authority")
             })
             .collect(),
+        SandboxAuthorizations::empty(),
         job,
         lease,
     )
@@ -6242,6 +6232,30 @@ fn reply_header(request: MessageHeader) -> MessageHeader {
         OperationId::new(),
         request.operation_id(),
     )
+}
+
+fn lease_poll_no_work(request: &LeaseRequest, retry_after_millis: u32) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::no_work(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        retry_after_millis,
+    )))
+}
+
+fn lease_poll_offer(request: &LeaseRequest, offer: LeaseOffer) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::lease_offer(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        offer,
+    )))
+}
+
+fn lease_poll_cancel(request: &LeaseRequest, cancel: CancelJob) -> ServerToRunner {
+    ServerToRunner::LeasePollResponse(Box::new(LeasePollResponse::cancel_job(
+        reply_header(request.header()),
+        request.authority_contributions().sha256_digest(),
+        cancel,
+    )))
 }
 
 fn observe(request: &PreparedRequest) -> ObservedRequest {

--- a/crates/automata-ci-runner-transport/src/client.rs
+++ b/crates/automata-ci-runner-transport/src/client.rs
@@ -907,6 +907,16 @@ fn sync_response_matches(prepared: &PreparedRequest, response: &ServerToRunner) 
         ServerToRunner::RuntimeAuthorityGrant(grant) => {
             grant.header().validate_reply_for(request_header).is_ok()
         }
+        ServerToRunner::LeasePollResponse(response) => {
+            response.header().validate_reply_for(request_header).is_ok()
+                && match response.outcome() {
+                    automata_ci_protocol::LeasePollOutcome::LeaseOffer(offer) => {
+                        offer.job().version() == binding.job_ir_version()
+                    }
+                    automata_ci_protocol::LeasePollOutcome::NoWork { .. }
+                    | automata_ci_protocol::LeasePollOutcome::CancelJob(_) => true,
+                }
+        }
         ServerToRunner::CancelJob(cancel) => cancel
             .header()
             .validate_for(binding.protocol_version(), binding.session_id())
@@ -917,9 +927,6 @@ fn sync_response_matches(prepared: &PreparedRequest, response: &ServerToRunner) 
         ServerToRunner::LogAck(ack) => ack.header().validate_reply_for(request_header).is_ok(),
         ServerToRunner::OperationAck(ack) => {
             ack.header().validate_reply_for(request_header).is_ok()
-        }
-        ServerToRunner::NoWork(no_work) => {
-            no_work.header().validate_reply_for(request_header).is_ok()
         }
         ServerToRunner::Error(error) => error.header().validate_reply_for(request_header).is_ok(),
     }

--- a/crates/automata-ci-runner-transport/src/server.rs
+++ b/crates/automata-ci-runner-transport/src/server.rs
@@ -1307,6 +1307,9 @@ fn sync_response_matches_request(request: &RunnerToServer, response: &ServerToRu
         ServerToRunner::RuntimeAuthorityGrant(grant) => {
             grant.header().validate_reply_for(header).is_ok()
         }
+        ServerToRunner::LeasePollResponse(response) => {
+            response.header().validate_reply_for(header).is_ok()
+        }
         ServerToRunner::CancelJob(cancel) => cancel
             .header()
             .validate_for(header.protocol_version(), header.session_id())
@@ -1316,7 +1319,6 @@ fn sync_response_matches_request(request: &RunnerToServer, response: &ServerToRu
         }
         ServerToRunner::LogAck(ack) => ack.header().validate_reply_for(header).is_ok(),
         ServerToRunner::OperationAck(ack) => ack.header().validate_reply_for(header).is_ok(),
-        ServerToRunner::NoWork(no_work) => no_work.header().validate_reply_for(header).is_ok(),
         ServerToRunner::Error(error) => error.header().validate_reply_for(header).is_ok(),
     }
 }

--- a/crates/automata-ci-runner-transport/tests/api_contract.rs
+++ b/crates/automata-ci-runner-transport/tests/api_contract.rs
@@ -2,9 +2,9 @@ use crate::support;
 
 use automata_ci_core::{JobIrVersion, OperationId, RunnerSessionId};
 use automata_ci_protocol::{
-    CommandCursor, LeaseRequest, MessageHeader, NegotiatedSession, ProtocolLimits, RemoteErrorCode,
-    RunnerSlotOrdinal, RunnerToServer, SUPPORTED_PROTOCOL_RANGE, ServerToRunner,
-    SessionDisposition,
+    CommandCursor, LeaseAuthorityPollContributions, LeaseRequest, MessageHeader, NegotiatedSession,
+    ProtocolLimits, RemoteErrorCode, RunnerSlotOrdinal, RunnerToServer, SUPPORTED_PROTOCOL_RANGE,
+    ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_transport::{
     AuthenticatedRunnerEphemeralRequest, ClientErrorKind, PrepareError, PreparedEphemeralRequest,
@@ -46,6 +46,7 @@ fn sync_preparation_rejects_a_cross_session_header() {
             OperationId::new(),
         ),
         RunnerSlotOrdinal::new(1).expect("slot"),
+        LeaseAuthorityPollContributions::empty(),
     ));
     assert!(matches!(
         PreparedRequest::for_session(request, negotiated, &ProtocolLimits::default()),

--- a/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
+++ b/crates/automata-ci-runner-transport/tests/concurrency_and_client.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use automata_ci_core::{OperationId, RunnerSessionId};
-use automata_ci_protocol::{MessageHeader, NoWork, ServerToRunner};
+use automata_ci_protocol::{LeasePollResponse, MessageHeader, ServerToRunner};
 use automata_ci_runner_transport::{
     AuthenticatedRunnerRequest, ClientErrorKind, HandlerFuture, PROTOBUF_CONTENT_TYPE, RetryClass,
     RunnerControlClient, RunnerControlClientByteDirection, RunnerControlClientObserver,
@@ -491,14 +491,17 @@ impl RunnerControlHandler for WrongSessionHandler {
                 ));
             };
             let request_header = poll.header();
-            Ok(ServerToRunner::NoWork(NoWork::new(
-                MessageHeader::reply(
-                    request_header.protocol_version(),
-                    RunnerSessionId::new(),
-                    OperationId::new(),
-                    request_header.operation_id(),
+            Ok(ServerToRunner::LeasePollResponse(Box::new(
+                LeasePollResponse::no_work(
+                    MessageHeader::reply(
+                        request_header.protocol_version(),
+                        RunnerSessionId::new(),
+                        OperationId::new(),
+                        request_header.operation_id(),
+                    ),
+                    poll.authority_contributions().sha256_digest(),
+                    10,
                 ),
-                10,
             )))
         })
     }

--- a/crates/automata-ci-runner-transport/tests/support/mod.rs
+++ b/crates/automata-ci-runner-transport/tests/support/mod.rs
@@ -24,9 +24,10 @@ use automata_ci_core::{
     RunnerPlatform, RunnerSessionId, UnixMillis,
 };
 use automata_ci_protocol::{
-    CommandCursor, ErrorMessage, LeaseHeartbeat, LeaseRequest, MessageHeader, NegotiatedSession,
-    NoWork, ProtocolLimits, RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer,
-    SUPPORTED_PROTOCOL_RANGE, ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
+    CommandCursor, ErrorMessage, LeaseAuthorityPollContributions, LeaseHeartbeat,
+    LeasePollResponse, LeaseRequest, MessageHeader, NegotiatedSession, ProtocolLimits,
+    RemoteErrorCode, RunnerHello, RunnerSlotOrdinal, RunnerToServer, SUPPORTED_PROTOCOL_RANGE,
+    ServerHello, ServerTiming, ServerToRunner, SessionDisposition,
 };
 use automata_ci_runner_transport::{
     ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, ClientTlsConfig,
@@ -642,14 +643,17 @@ fn reply_to(message: &RunnerToServer) -> Result<ServerToRunner, ApplicationError
         ))),
         RunnerToServer::LeaseRequest(request) => {
             let header = request.header();
-            Ok(ServerToRunner::NoWork(NoWork::new(
-                MessageHeader::reply(
-                    header.protocol_version(),
-                    header.session_id(),
-                    OperationId::new(),
-                    header.operation_id(),
+            Ok(ServerToRunner::LeasePollResponse(Box::new(
+                LeasePollResponse::no_work(
+                    MessageHeader::reply(
+                        header.protocol_version(),
+                        header.session_id(),
+                        OperationId::new(),
+                        header.operation_id(),
+                    ),
+                    request.authority_contributions().sha256_digest(),
+                    25,
                 ),
-                25,
             )))
         }
         _ => Err(ApplicationError::new(ApplicationErrorKind::Internal)),
@@ -684,6 +688,7 @@ pub fn poll_request() -> PreparedRequest {
         RunnerToServer::LeaseRequest(LeaseRequest::first(
             header,
             RunnerSlotOrdinal::new(1).expect("slot"),
+            LeaseAuthorityPollContributions::empty(),
         )),
         NegotiatedSession::new(
             SUPPORTED_PROTOCOL_RANGE.max(),

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -289,7 +289,13 @@ async fn run_podman(
     let Some(composition) = started else {
         return Ok(SupervisionDisposition::Complete);
     };
-    supervise_composition(config, composition, metrics_listener, shutdown).await
+    Box::pin(supervise_composition(
+        config,
+        composition,
+        metrics_listener,
+        shutdown,
+    ))
+    .await
 }
 
 async fn run_kubernetes(
@@ -334,7 +340,13 @@ async fn run_kubernetes(
     let Some(composition) = composition else {
         return Ok(SupervisionDisposition::Complete);
     };
-    supervise_composition(config, composition, metrics_listener, shutdown).await
+    Box::pin(supervise_composition(
+        config,
+        composition,
+        metrics_listener,
+        shutdown,
+    ))
+    .await
 }
 
 async fn run_windows_hyperv(
@@ -363,7 +375,13 @@ async fn run_windows_hyperv(
     let Some(composition) = composition else {
         return Ok(SupervisionDisposition::Complete);
     };
-    supervise_composition(config, composition, metrics_listener, shutdown).await
+    Box::pin(supervise_composition(
+        config,
+        composition,
+        metrics_listener,
+        shutdown,
+    ))
+    .await
 }
 
 async fn run_macos_virtualization(
@@ -392,7 +410,13 @@ async fn run_macos_virtualization(
     let Some(composition) = composition else {
         return Ok(SupervisionDisposition::Complete);
     };
-    supervise_composition(config, composition, metrics_listener, shutdown).await
+    Box::pin(supervise_composition(
+        config,
+        composition,
+        metrics_listener,
+        shutdown,
+    ))
+    .await
 }
 
 async fn supervise_composition(

--- a/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
+++ b/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
@@ -32,8 +32,8 @@ use automata_ci_core::{
 use automata_ci_core::{ExpressionProgram, ValueSource};
 use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandSequence, JobResultMessage, JobRuntimeAuthorities,
-    LeaseDisposition, LeaseOffer, LeaseRenewal, LeaseRequest, LogAckMessage, LogBatch,
-    MessageHeader, NegotiatedSession, NoWork, OperationAck, ProtocolLimits, RunnerSlotOrdinal,
+    LeaseDisposition, LeaseOffer, LeasePollResponse, LeaseRenewal, LeaseRequest, LogAckMessage,
+    LogBatch, MessageHeader, NegotiatedSession, OperationAck, ProtocolLimits, RunnerSlotOrdinal,
     RunnerToServer, RuntimeAuthorityAck, RuntimeAuthorityGrant, RuntimeAuthorityRequest,
     SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
     SessionDisposition,
@@ -118,8 +118,13 @@ async fn shipped_runner_process_executes_a_claimed_isolated_job_with_action_runt
         UnixMillis::new(unix_millis().saturating_add(i64::from(process_control_timeout_millis()))),
     )
     .expect("process test lease");
-    let authorities =
-        JobRuntimeAuthorities::new(Vec::new(), &job, &lease).expect("credential-free authorities");
+    let authorities = JobRuntimeAuthorities::new(
+        Vec::new(),
+        automata_ci_core::SandboxAuthorizations::empty(),
+        &job,
+        &lease,
+    )
+    .expect("credential-free authorities");
     let handler = Arc::new(ProcessFlowHandler::new(
         runner_id,
         session_id,
@@ -883,13 +888,22 @@ impl ProcessFlowHandler {
         let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
         if !state.offered {
             state.offered = true;
-            Ok(ServerToRunner::LeaseOffer(Box::new(self.offer.clone())))
+            Ok(ServerToRunner::LeasePollResponse(Box::new(
+                LeasePollResponse::lease_offer(
+                    reply_header(poll.header()),
+                    poll.authority_contributions().sha256_digest(),
+                    self.offer.clone(),
+                ),
+            )))
         } else if state.result_received {
             state.observation.completed_poll = true;
             self.completed_poll.notify_one();
-            Ok(ServerToRunner::NoWork(NoWork::new(
-                reply_header(poll.header()),
-                25,
+            Ok(ServerToRunner::LeasePollResponse(Box::new(
+                LeasePollResponse::no_work(
+                    reply_header(poll.header()),
+                    poll.authority_contributions().sha256_digest(),
+                    25,
+                ),
             )))
         } else {
             Err(internal_application_error())

--- a/crates/automata-ci-runner/tests/product_context.rs
+++ b/crates/automata-ci-runner/tests/product_context.rs
@@ -630,9 +630,13 @@ fn deny_all_trust_rejects_stale_authorities_and_secret_runtime_context() {
         PortErrorKind::InvalidData
     );
 
-    fixture.runtime_authorities =
-        JobRuntimeAuthorities::new(Vec::new(), &fixture.job, &fixture.lease)
-            .expect("deny-all authority bundle");
+    fixture.runtime_authorities = JobRuntimeAuthorities::new(
+        Vec::new(),
+        automata_ci_core::SandboxAuthorizations::empty(),
+        &fixture.job,
+        &fixture.lease,
+    )
+    .expect("deny-all authority bundle");
     let snapshot = fixture
         .snapshot()
         .expect("coherent deny-all context remains executable without credentials");
@@ -841,9 +845,13 @@ fn missing_or_cross_fence_results_authority_fails_closed() {
         missing.lease.expires_at(),
     )
     .expect("authority");
-    missing.runtime_authorities =
-        JobRuntimeAuthorities::new(vec![unrelated], &missing.job, &missing.lease)
-            .expect("authority bundle");
+    missing.runtime_authorities = JobRuntimeAuthorities::new(
+        vec![unrelated],
+        automata_ci_core::SandboxAuthorizations::empty(),
+        &missing.job,
+        &missing.lease,
+    )
+    .expect("authority bundle");
     assert_eq!(
         missing
             .snapshot()
@@ -1024,8 +1032,13 @@ impl ContextFixture {
             UnixMillis::new(4_000_000_000_000),
         )
         .expect("valid fixture authority");
-        let runtime_authorities = JobRuntimeAuthorities::new(vec![authority], &job, &lease)
-            .expect("valid fixture authority bundle");
+        let runtime_authorities = JobRuntimeAuthorities::new(
+            vec![authority],
+            automata_ci_core::SandboxAuthorizations::empty(),
+            &job,
+            &lease,
+        )
+        .expect("valid fixture authority bundle");
         Self {
             context,
             job,
@@ -1058,9 +1071,13 @@ impl ContextFixture {
             BTreeMap::new(),
         )
         .expect("credential-free runtime context");
-        fixture.runtime_authorities =
-            JobRuntimeAuthorities::new(Vec::new(), &fixture.job, &fixture.lease)
-                .expect("credential-free authority bundle");
+        fixture.runtime_authorities = JobRuntimeAuthorities::new(
+            Vec::new(),
+            automata_ci_core::SandboxAuthorizations::empty(),
+            &fixture.job,
+            &fixture.lease,
+        )
+        .expect("credential-free authority bundle");
         fixture
     }
 
@@ -1091,8 +1108,13 @@ impl ContextFixture {
         let mut authorities = self.runtime_authorities.as_slice().to_vec();
         authorities.push(repository);
         authorities.sort_by(|left, right| left.name().cmp(right.name()));
-        self.runtime_authorities = JobRuntimeAuthorities::new(authorities, &self.job, &self.lease)
-            .expect("authority bundle");
+        self.runtime_authorities = JobRuntimeAuthorities::new(
+            authorities,
+            automata_ci_core::SandboxAuthorizations::empty(),
+            &self.job,
+            &self.lease,
+        )
+        .expect("authority bundle");
     }
 
     fn replace_permission_request(&mut self, permission_request: JobPermissionRequest) {
@@ -1125,8 +1147,13 @@ impl ContextFixture {
         let mut authorities = self.runtime_authorities.as_slice().to_vec();
         authorities.push(oidc);
         authorities.sort_by(|left, right| left.name().cmp(right.name()));
-        self.runtime_authorities = JobRuntimeAuthorities::new(authorities, &self.job, &self.lease)
-            .expect("authority bundle");
+        self.runtime_authorities = JobRuntimeAuthorities::new(
+            authorities,
+            automata_ci_core::SandboxAuthorizations::empty(),
+            &self.job,
+            &self.lease,
+        )
+        .expect("authority bundle");
     }
 
     fn snapshot(

--- a/crates/automata-ci-sandbox-kubernetes/src/objects.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/objects.rs
@@ -84,6 +84,7 @@ fn validated_allocation(
 ) -> Result<JobResourceAllocation, automata_ci_execution::ProviderError> {
     if spec.network() != SandboxNetworkPolicy::Disabled
         || !spec.services().is_empty()
+        || !spec.sandbox_authorizations().as_slice().is_empty()
         || !spec.runtime_service_routes().is_empty()
         || spec.privilege() != automata_ci_execution::SandboxPrivilegePolicy::Unprivileged
         || !spec.has_coherent_resource_contract()
@@ -538,7 +539,8 @@ mod tests {
     use automata_ci_core::{EnvironmentProfile, EnvironmentProfileId, OperationId, Sha256Digest};
     use automata_ci_execution::{
         ExecutionArgv, ExecutionEnvironment, ImmutableImage, NetworkPolicy, ResourceLimits,
-        RootFilesystemPolicy, SandboxEnvironment, SandboxGeneration, SandboxSpec, TargetPath,
+        RootFilesystemPolicy, SandboxAuthorization, SandboxAuthorizationName,
+        SandboxAuthorizations, SandboxEnvironment, SandboxGeneration, SandboxSpec, TargetPath,
     };
 
     use super::*;
@@ -606,6 +608,31 @@ mod tests {
             ResourceLimits::new(1024 * 1024 * 1024, 1_500, 512).expect("limits"),
         )
         .with_resource_allocation(allocation)
+    }
+
+    #[test]
+    fn rejects_provider_authorizations_before_rendering_kubernetes_objects() {
+        let authorization = SandboxAuthorization::new(
+            SandboxAuthorizationName::new("another-provider").expect("authorization name"),
+            1,
+            b"opaque-authority".to_vec(),
+        )
+        .expect("authorization");
+        let spec = sandbox_spec().with_sandbox_authorizations(
+            SandboxAuthorizations::new(vec![authorization]).expect("authorization set"),
+        );
+
+        let error = build_objects("a-test-7", &spec, &config())
+            .expect_err("Kubernetes cannot consume provider-specific authorization");
+
+        assert_eq!(
+            error.kind(),
+            automata_ci_execution::ProviderErrorKind::InvalidConfiguration
+        );
+        assert_eq!(
+            error.stage(),
+            automata_ci_execution::ProviderStage::Validate
+        );
     }
 
     #[test]

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -976,6 +976,7 @@ fn validate_spec(
         && spec.resources().memory_bytes() >= template.minimum_memory_bytes
         && spec.resources().pids() == template.process_limit
         && spec.services().is_empty()
+        && spec.sandbox_authorizations().as_slice().is_empty()
         && spec.has_coherent_resource_contract()
         && !spec
             .profile()
@@ -1797,11 +1798,22 @@ fn uncertain(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ApfsContainer, ApfsInventory, ApfsPhysicalStore, ApfsVolume, WholeDiskInfo,
-        normalized_volume_uuid, select_dedicated_apfs_storage, supported_product_version,
-        valid_helper_code_requirement, whole_disk_is_physical,
+    use std::{path::PathBuf, time::Duration};
+
+    use automata_ci_execution::{
+        EnvironmentProfile, EnvironmentProfileId, ExecutionEnvironment, NetworkPolicy, OperationId,
+        ProviderErrorKind, ProviderStage, ResourceLimits, RootFilesystemPolicy, RunnerId,
+        SandboxAuthorization, SandboxAuthorizationName, SandboxAuthorizations, SandboxCustody,
+        SandboxEnvironment, SandboxGeneration, SandboxSpec, Sha256Digest, TargetPath,
     };
+
+    use super::{
+        ApfsContainer, ApfsInventory, ApfsPhysicalStore, ApfsVolume,
+        MacosVirtualizationProviderOptions, WholeDiskInfo, normalized_volume_uuid,
+        select_dedicated_apfs_storage, supported_product_version, valid_helper_code_requirement,
+        validate_spec, whole_disk_is_physical,
+    };
+    use crate::template::VerifiedTemplate;
 
     #[test]
     fn virtualization_provider_requires_macos_15_or_newer() {
@@ -1909,5 +1921,79 @@ mod tests {
         let mut system_image = info("Physical", "USB", false);
         system_image.system_image = true;
         assert!(!whole_disk_is_physical(&system_image));
+    }
+
+    #[test]
+    fn macos_provider_rejects_sandbox_authorizations_observably() {
+        let profile_id =
+            EnvironmentProfileId::new("automata.dev/macos-15-arm64-vm-v1").expect("profile ID");
+        let manifest_digest = Sha256Digest::from_bytes([0x22; 32]);
+        let profile =
+            EnvironmentProfile::new(profile_id.clone(), Sha256Digest::from_bytes([0x33; 32]));
+        let profile_workspace = TargetPath::posix("/Users/runner/work").expect("profile workspace");
+        let environment = SandboxEnvironment::virtual_machine(
+            profile,
+            manifest_digest,
+            profile_workspace,
+            ExecutionEnvironment::empty(),
+        )
+        .expect("VM environment");
+        let spec = SandboxSpec::new(
+            OperationId::new(),
+            SandboxGeneration::new(1).expect("generation"),
+            SandboxCustody::ProfileAdmission {
+                runner_id: RunnerId::new(),
+            },
+            environment,
+            TargetPath::posix("/Users/runner/work/repository").expect("workspace"),
+            NetworkPolicy::Disabled,
+            RootFilesystemPolicy::Writable,
+            ResourceLimits::new(8 * 1024 * 1024 * 1024, 4_000, 512).expect("resources"),
+        )
+        .with_scratch(TargetPath::posix("/Users/runner/scratch").expect("scratch"));
+        let template = VerifiedTemplate {
+            profile_id,
+            manifest_digest,
+            macos_version: "15.7".to_owned(),
+            macos_build: "24G222".to_owned(),
+            disk_image: PathBuf::from("/Library/Automata/template.img"),
+            auxiliary_storage: PathBuf::from("/Library/Automata/template.aux"),
+            hardware_model_base64: "AA==".to_owned(),
+            guest_agent_digest: Sha256Digest::from_bytes([0x44; 32]),
+            guest_port: 1_024,
+            job_uid: 502,
+            job_gid: 502,
+            process_limit: 512,
+            minimum_cpu_count: 2,
+            minimum_memory_bytes: 4 * 1024 * 1024 * 1024,
+        };
+        let options = MacosVirtualizationProviderOptions::new(
+            "/Volumes/AutomataVM/state",
+            "/Library/Automata/bin/automata-macos-vm-helper",
+            Sha256Digest::from_bytes([0x11; 32]),
+            "identifier \"dev.automata.macos-vm-helper\" and anchor apple generic and certificate leaf[subject.OU] = \"ABCDEFGHIJ\"".to_owned(),
+            "/Library/Automata/templates/macos-15-arm64-v1/manifest.json",
+            manifest_digest,
+            "01234567-89AB-CDEF-0123-456789ABCDEF",
+            256 * 1024 * 1024 * 1024,
+            Duration::from_mins(5),
+            Duration::from_secs(10),
+        )
+        .expect("provider options");
+
+        validate_spec(&options, &template, &spec).expect("empty authorization set is valid");
+        let authorization = SandboxAuthorization::new(
+            SandboxAuthorizationName::new("test-authority").expect("authorization name"),
+            1,
+            vec![0x5a],
+        )
+        .expect("authorization");
+        let authorized = spec.with_sandbox_authorizations(
+            SandboxAuthorizations::new(vec![authorization]).expect("authorization set"),
+        );
+        let error = validate_spec(&options, &template, &authorized)
+            .expect_err("macOS must reject unsupported sandbox authorization");
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+        assert_eq!(error.stage(), ProviderStage::Validate);
     }
 }

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -4354,6 +4354,7 @@ fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
     };
     if spec.profile().image().is_none()
         || spec.scratch().is_some()
+        || !spec.sandbox_authorizations().as_slice().is_empty()
         || !spec.runtime_service_routes().is_empty()
         || spec.network() == NetworkPolicy::Host
         || spec.root_filesystem() == RootFilesystemPolicy::Host
@@ -5237,6 +5238,11 @@ pub(crate) fn endpoint_error_from_provider(
 #[cfg(test)]
 mod capability_contract_tests {
     use super::*;
+    use automata_ci_execution::{
+        EnvironmentProfileId, ExecutionArgv, ImmutableImage, OperationId, ResourceLimits, RunnerId,
+        SandboxAuthorization, SandboxAuthorizationName, SandboxAuthorizations, SandboxEnvironment,
+        SandboxGeneration, TargetPath,
+    };
 
     #[test]
     fn service_configuration_reads_create_command_from_container_config() {
@@ -5270,5 +5276,52 @@ mod capability_contract_tests {
         assert_eq!(parse_service_health_interval(br#"{"Interval":0}"#), None);
         assert_eq!(parse_service_health_interval(br#"{"Interval":"5s"}"#), None);
         assert_eq!(parse_service_health_interval(b"null"), None);
+    }
+
+    #[test]
+    fn podman_rejects_sandbox_authorizations_at_validation() {
+        let workspace = TargetPath::posix("/workspace").expect("workspace");
+        let environment = SandboxEnvironment::new(
+            EnvironmentProfile::new(
+                EnvironmentProfileId::new("example.com/podman").expect("profile id"),
+                Sha256Digest::from_bytes([7; 32]),
+            ),
+            ImmutableImage::new(format!("registry.example/job@sha256:{}", "11".repeat(32)))
+                .expect("image"),
+            ExecutionArgv::new(
+                TargetPath::posix("/bin/sleep").expect("keepalive"),
+                vec!["infinity".to_owned()],
+            )
+            .expect("keepalive"),
+            workspace.clone(),
+            ExecutionEnvironment::empty(),
+        )
+        .expect("environment");
+        let authorization = SandboxAuthorization::new(
+            SandboxAuthorizationName::new("another-provider").expect("authorization name"),
+            1,
+            b"opaque-authority".to_vec(),
+        )
+        .expect("authorization");
+        let spec = SandboxSpec::new(
+            OperationId::new(),
+            SandboxGeneration::new(1).expect("generation"),
+            SandboxCustody::ProfileAdmission {
+                runner_id: RunnerId::new(),
+            },
+            environment,
+            workspace,
+            NetworkPolicy::Disabled,
+            RootFilesystemPolicy::Writable,
+            ResourceLimits::new(512 * 1024 * 1024, 1_000, 64).expect("limits"),
+        )
+        .with_sandbox_authorizations(
+            SandboxAuthorizations::new(vec![authorization]).expect("authorization set"),
+        );
+
+        let error = validate_spec(&spec).expect_err("Podman cannot consume the authorization");
+
+        assert_eq!(error.kind(), ProviderErrorKind::UnsupportedCapability);
+        assert_eq!(error.stage(), ProviderStage::Validate);
     }
 }

--- a/crates/automata-ci-sandbox-windows/README.md
+++ b/crates/automata-ci-sandbox-windows/README.md
@@ -22,6 +22,14 @@ The provider accepts only `SandboxLaunch::WindowsHyperVContainer` and requires:
 - one provider-owned container with immutable ownership, generation, resource,
   image, entrypoint, and policy labels.
 
+Job-custody creation also requires exactly one `windows-hyperv` sandbox
+authorization at the current broker-grant payload schema and an injected
+restricted-broker consumer. That consumer canonical-decodes, validates, and
+atomically spends the signed grant against stable lease-fenced sandbox policy
+before the provider performs any create mutation. Direct provider construction
+remains valid for profile admission only; job creation without the consumer
+fails closed.
+
 An absolute container CLI executable is pinned by SHA-256, opened without
 delete/write sharing, and invoked with a cleared environment and an empty,
 reparse-safe provider-owned CLI configuration directory that is revalidated

--- a/crates/automata-ci-sandbox-windows/src/lib.rs
+++ b/crates/automata-ci-sandbox-windows/src/lib.rs
@@ -7,6 +7,13 @@
 //! and the provider verifies the effective runtime state before returning a
 //! handle. Process-isolated and native-host Windows execution are not present.
 
+use std::fmt;
+
+use automata_ci_execution::{
+    EnvironmentProfile, JobResourceAllocation, OperationId, ProviderError, SandboxAuthorization,
+    SandboxCustody, SandboxExecutionBinding, SandboxGeneration,
+};
+
 #[cfg(windows)]
 mod command;
 #[cfg(windows)]
@@ -34,3 +41,119 @@ pub use unsupported::{WindowsHyperVContainerProvider, WindowsHyperVContainerProv
 
 /// Stable provider identifier for Hyper-V-isolated Windows containers.
 pub const WINDOWS_HYPERV_PROVIDER_ID: &str = "windows-hyperv";
+
+/// Stable sandbox fields presented to the restricted Windows authorization consumer.
+///
+/// Signed placement authority binds the exact execution and stable policy
+/// fields. The broker's consumption ledger additionally binds the grant to the
+/// first runner-local create operation so a crash retry is idempotent but the
+/// same grant cannot authorize another job or local sandbox.
+#[derive(Clone, Copy, Debug)]
+pub struct WindowsHyperVSandboxAuthorizationRequest<'a> {
+    operation_id: OperationId,
+    custody: SandboxCustody,
+    execution_binding: SandboxExecutionBinding,
+    environment_profile: &'a EnvironmentProfile,
+    generation: SandboxGeneration,
+    resource_allocation: JobResourceAllocation,
+    pids_limit: u32,
+}
+
+impl<'a> WindowsHyperVSandboxAuthorizationRequest<'a> {
+    #[cfg(windows)]
+    pub(crate) const fn new(
+        operation_id: OperationId,
+        custody: SandboxCustody,
+        execution_binding: SandboxExecutionBinding,
+        environment_profile: &'a EnvironmentProfile,
+        generation: SandboxGeneration,
+        resource_allocation: JobResourceAllocation,
+        pids_limit: u32,
+    ) -> Self {
+        Self {
+            operation_id,
+            custody,
+            execution_binding,
+            environment_profile,
+            generation,
+            resource_allocation,
+            pids_limit,
+        }
+    }
+
+    /// Returns the durable local create operation bound on first consumption.
+    #[must_use]
+    pub const fn operation_id(self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Returns the exact runner and job-slot custody selected for the sandbox.
+    #[must_use]
+    pub const fn custody(self) -> SandboxCustody {
+        self.custody
+    }
+
+    /// Returns the exact session, job, attempt, lease, offer, and `JobIR` identity.
+    #[must_use]
+    pub const fn execution_binding(self) -> SandboxExecutionBinding {
+        self.execution_binding
+    }
+
+    /// Returns the exact environment-profile attestation selected for launch.
+    #[must_use]
+    pub const fn environment_profile(self) -> &'a EnvironmentProfile {
+        self.environment_profile
+    }
+
+    /// Returns the durable lease fence used as the sandbox generation.
+    #[must_use]
+    pub const fn generation(self) -> SandboxGeneration {
+        self.generation
+    }
+
+    /// Returns the exact provider-neutral request and hard-limit allocation.
+    #[must_use]
+    pub const fn resource_allocation(self) -> JobResourceAllocation {
+        self.resource_allocation
+    }
+
+    /// Returns the exact hard process ceiling selected for the sandbox.
+    #[must_use]
+    pub const fn pids_limit(self) -> u32 {
+        self.pids_limit
+    }
+
+    /// Confirms that this closed Windows launch contract disables networking.
+    #[must_use]
+    pub const fn network_disabled(self) -> bool {
+        true
+    }
+}
+
+/// Restricted broker boundary that validates and consumes one Windows placement authority.
+///
+/// Implementations must decode the canonical protobuf payload, validate its
+/// namespace and payload schema, signature, host and validity window, bind its
+/// claims to `request.execution_binding()` and every signed policy field, and
+/// atomically bind its grant digest to `request.operation_id()` in the broker's one-use ledger
+/// before returning success. An exact retry of the same grant, local operation,
+/// and stable sandbox policy must replay success so a crash between broker
+/// acceptance and the provider's local create intent remains recoverable;
+/// reuse with a different operation or policy must fail closed. Payload bytes
+/// and signatures must not be logged or persisted by the provider.
+pub trait WindowsHyperVSandboxAuthorizationConsumer: fmt::Debug + Send + Sync {
+    /// Validates and consumes the exact authorization for one new sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized provider error without consuming or launching when
+    /// the payload is malformed, stale, spent for a different execution,
+    /// operation, or policy, or does not authorize the supplied stable sandbox
+    /// fields. Exact replay after an earlier successful consumption returns
+    /// success.
+    fn consume(
+        &self,
+        authorization: &SandboxAuthorization,
+        request: WindowsHyperVSandboxAuthorizationRequest<'_>,
+    ) -> Result<(), ProviderError>;
+}

--- a/crates/automata-ci-sandbox-windows/src/provider.rs
+++ b/crates/automata-ci-sandbox-windows/src/provider.rs
@@ -16,9 +16,9 @@ use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, EnvironmentProfile, EnvironmentProfileId,
     NeverCancelled, OperationId, OperationOutcome, ProviderCapabilities, ProviderError,
     ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy, RunnerId,
-    SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection, SandboxLaunch,
-    SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
-    Sha256Digest, TargetPath, TargetPlatform,
+    SandboxAuthorization, SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection,
+    SandboxLaunch, SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec,
+    SandboxState, Sha256Digest, TargetPath, TargetPlatform,
 };
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
@@ -26,6 +26,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{
     RuntimeCommandExecutor, RuntimeCommandOutput, RuntimeCommandRequest, RuntimeCommandTermination,
     SystemRuntimeCommandExecutor, WINDOWS_HYPERV_PROVIDER_ID,
+    WindowsHyperVSandboxAuthorizationConsumer, WindowsHyperVSandboxAuthorizationRequest,
     endpoint::{EndpointReplayCache, WindowsHyperVExecutionEndpoint},
     error,
     naming::ResourceName,
@@ -174,7 +175,26 @@ impl WindowsHyperVContainerProvider {
     /// Fails when the pinned runtime binary or dedicated state root cannot be
     /// verified. No container is created during open.
     pub fn open(options: WindowsHyperVContainerProviderOptions) -> Result<Self, ProviderError> {
-        Self::open_with_executor(options, Arc::new(SystemRuntimeCommandExecutor))
+        Self::open_with_boundaries(options, Arc::new(SystemRuntimeCommandExecutor), None)
+    }
+
+    /// Opens the provider with a restricted authorization-consumer boundary.
+    ///
+    /// Job-custody creates require this boundary. Profile-admission creates may
+    /// use [`Self::open`] because they carry no workload placement authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized configuration or local-storage failure.
+    pub fn open_with_authorization_consumer(
+        options: WindowsHyperVContainerProviderOptions,
+        authorization_consumer: Arc<dyn WindowsHyperVSandboxAuthorizationConsumer>,
+    ) -> Result<Self, ProviderError> {
+        Self::open_with_boundaries(
+            options,
+            Arc::new(SystemRuntimeCommandExecutor),
+            Some(authorization_consumer),
+        )
     }
 
     /// Opens the provider with an injected runtime boundary.
@@ -188,6 +208,31 @@ impl WindowsHyperVContainerProvider {
     pub fn open_with_executor(
         options: WindowsHyperVContainerProviderOptions,
         executor: Arc<dyn RuntimeCommandExecutor>,
+    ) -> Result<Self, ProviderError> {
+        Self::open_with_boundaries(options, executor, None)
+    }
+
+    /// Opens the provider with injected runtime and authorization boundaries.
+    ///
+    /// This is intended for shipped conformance tests. Future broker composition
+    /// may use [`Self::open_with_authorization_consumer`]; current product wiring
+    /// leaves job custody fail closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized configuration or local-storage failure.
+    pub fn open_with_executor_and_authorization_consumer(
+        options: WindowsHyperVContainerProviderOptions,
+        executor: Arc<dyn RuntimeCommandExecutor>,
+        authorization_consumer: Arc<dyn WindowsHyperVSandboxAuthorizationConsumer>,
+    ) -> Result<Self, ProviderError> {
+        Self::open_with_boundaries(options, executor, Some(authorization_consumer))
+    }
+
+    fn open_with_boundaries(
+        options: WindowsHyperVContainerProviderOptions,
+        executor: Arc<dyn RuntimeCommandExecutor>,
+        authorization_consumer: Option<Arc<dyn WindowsHyperVSandboxAuthorizationConsumer>>,
     ) -> Result<Self, ProviderError> {
         prepare_state_root(options.state_root())?;
         prepare_empty_runtime_config(options.state_root())?;
@@ -233,6 +278,7 @@ impl WindowsHyperVContainerProvider {
         let inner = Arc::new(ProviderInner {
             options,
             executor,
+            authorization_consumer,
             provider_id,
             capabilities,
             _runtime_guard: runtime_guard,
@@ -270,7 +316,7 @@ impl SandboxProvider for WindowsHyperVContainerProvider {
         spec: &SandboxSpec,
         cancellation: &dyn Cancellation,
     ) -> Result<SandboxRecord, ProviderError> {
-        validate_spec(spec)?;
+        validate_spec(spec, self.inner.authorization_consumer.is_some())?;
         let names = ResourceName::for_create(spec.operation_id(), spec.generation());
         let fingerprint = spec_fingerprint(spec);
         self.inner.runtime_request(
@@ -356,6 +402,7 @@ impl SandboxProvider for WindowsHyperVContainerProvider {
 pub(crate) struct ProviderInner {
     pub(crate) options: WindowsHyperVContainerProviderOptions,
     executor: Arc<dyn RuntimeCommandExecutor>,
+    authorization_consumer: Option<Arc<dyn WindowsHyperVSandboxAuthorizationConsumer>>,
     provider_id: ProviderId,
     capabilities: ProviderCapabilities,
     _runtime_guard: File,
@@ -507,6 +554,44 @@ impl ProviderInner {
         Ok(lock)
     }
 
+    fn consume_sandbox_authorization(&self, spec: &SandboxSpec) -> Result<(), ProviderError> {
+        let Some(authorization) =
+            sandbox_authorization(spec, self.authorization_consumer.is_some())?
+        else {
+            return Ok(());
+        };
+        let consumer = self.authorization_consumer.as_ref().ok_or_else(|| {
+            error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let allocation = spec.resource_allocation().ok_or_else(|| {
+            error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        let execution_binding = spec.execution_binding().ok_or_else(|| {
+            error::known(
+                ProviderErrorKind::InvalidConfiguration,
+                ProviderStage::Validate,
+            )
+        })?;
+        consumer.consume(
+            authorization,
+            WindowsHyperVSandboxAuthorizationRequest::new(
+                spec.operation_id(),
+                spec.custody(),
+                execution_binding,
+                spec.profile().attestation(),
+                spec.generation(),
+                allocation,
+                spec.resources().pids(),
+            ),
+        )
+    }
+
     #[allow(clippy::too_many_lines)] // One locked durable transition is easier to audit intact.
     fn create(
         &self,
@@ -572,6 +657,7 @@ impl ProviderInner {
             }
             false
         } else {
+            self.consume_sandbox_authorization(spec)?;
             if self.inspect_optional(names, cancellation)?.is_some() {
                 return Err(error::known(
                     ProviderErrorKind::Conflict,
@@ -1519,7 +1605,10 @@ fn expected_labels(
     ])
 }
 
-fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
+fn validate_spec(
+    spec: &SandboxSpec,
+    authorization_consumer_configured: bool,
+) -> Result<(), ProviderError> {
     let SandboxLaunch::WindowsHyperVContainer { .. } = spec.profile().launch() else {
         return Err(error::known(
             ProviderErrorKind::UnsupportedCapability,
@@ -1544,7 +1633,37 @@ fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
             ProviderStage::Validate,
         ));
     }
+    sandbox_authorization(spec, authorization_consumer_configured)?;
     Ok(())
+}
+
+fn sandbox_authorization(
+    spec: &SandboxSpec,
+    authorization_consumer_configured: bool,
+) -> Result<Option<&SandboxAuthorization>, ProviderError> {
+    let authorizations = spec.sandbox_authorizations().as_slice();
+    match spec.custody() {
+        SandboxCustody::ProfileAdmission { .. } if authorizations.is_empty() => Ok(None),
+        SandboxCustody::Job { .. } if authorization_consumer_configured => {
+            let [authorization] = authorizations else {
+                return Err(error::known(
+                    ProviderErrorKind::InvalidConfiguration,
+                    ProviderStage::Validate,
+                ));
+            };
+            if spec.resource_allocation().is_none() || spec.execution_binding().is_none() {
+                return Err(error::known(
+                    ProviderErrorKind::InvalidConfiguration,
+                    ProviderStage::Validate,
+                ));
+            }
+            Ok(Some(authorization))
+        }
+        SandboxCustody::ProfileAdmission { .. } | SandboxCustody::Job { .. } => Err(error::known(
+            ProviderErrorKind::InvalidConfiguration,
+            ProviderStage::Validate,
+        )),
+    }
 }
 
 fn resource_from_durable(
@@ -1866,7 +1985,7 @@ fn record(names: &ResourceName, profile: EnvironmentProfile, state: SandboxState
 
 fn spec_fingerprint(spec: &SandboxSpec) -> String {
     let mut hash = Sha256::new();
-    hash_field(&mut hash, b"automata-windows-hyperv-spec-v2");
+    hash_field(&mut hash, b"automata-windows-hyperv-spec-v3");
     hash_custody(&mut hash, spec.custody());
     for value in [
         spec.profile().id().as_str(),
@@ -1908,6 +2027,38 @@ fn spec_fingerprint(spec: &SandboxSpec) -> String {
         }
     } else {
         hash_field(&mut hash, b"allocation-absent");
+    }
+    if let Some(binding) = spec.execution_binding() {
+        hash_field(&mut hash, b"execution-binding-present");
+        hash_field(&mut hash, binding.runner_session_id().as_uuid().as_bytes());
+        hash_field(&mut hash, binding.run_id().as_uuid().as_bytes());
+        hash_field(&mut hash, binding.job_id().as_uuid().as_bytes());
+        hash_field(&mut hash, binding.attempt_id().as_uuid().as_bytes());
+        hash_field(&mut hash, binding.guard().lease_id().as_uuid().as_bytes());
+        hash_field(
+            &mut hash,
+            &binding.guard().fencing_token().get().to_be_bytes(),
+        );
+        hash_field(
+            &mut hash,
+            binding.accepted_offer_operation_id().as_uuid().as_bytes(),
+        );
+        hash_field(
+            &mut hash,
+            &binding.accepted_offer_sequence().get().to_be_bytes(),
+        );
+        hash_field(&mut hash, &binding.job_ir_version().get().to_be_bytes());
+        hash_field(&mut hash, binding.job_ir_digest().as_bytes());
+    } else {
+        hash_field(&mut hash, b"execution-binding-absent");
+    }
+    for authorization in spec.sandbox_authorizations().as_slice() {
+        hash_field(&mut hash, authorization.name().as_str().as_bytes());
+        hash_field(
+            &mut hash,
+            &authorization.payload_schema_version().to_be_bytes(),
+        );
+        hash_field(&mut hash, authorization.payload_sha256().as_bytes());
     }
     hex_digest(hash.finalize().into())
 }
@@ -2458,17 +2609,23 @@ mod tests {
     use std::{
         collections::VecDeque,
         env, fs,
-        num::NonZeroU16,
+        num::{NonZeroU16, NonZeroU64},
         path::PathBuf,
         sync::{Arc, Mutex},
     };
 
     use super::*;
     use automata_ci_execution::{
-        ExecutionArgv, ExecutionEnvironment, ImmutableImage, NetworkPolicy, ResourceLimits,
-        RunnerId, SandboxEnvironment, SandboxGeneration, SandboxPrivilegePolicy,
+        AttemptId, ExecutionArgv, ExecutionEnvironment, ImmutableImage, JobId, JobIrVersion,
+        JobResourceAllocation, LeaseGuard, LeaseId, NetworkPolicy, ResourceCapacity,
+        ResourceLimits, RunId, RunnerId, RunnerSessionId, SandboxAuthorization,
+        SandboxAuthorizationName, SandboxAuthorizations, SandboxEnvironment,
+        SandboxExecutionBinding, SandboxGeneration, SandboxPrivilegePolicy,
     };
     use serde_json::{Value, json};
+
+    const TEST_WINDOWS_AUTHORIZATION_NAME: &str = "windows-hyperv";
+    const TEST_WINDOWS_AUTHORIZATION_SCHEMA: u16 = 4;
 
     #[derive(Debug)]
     struct ScriptedExecutor {
@@ -2507,6 +2664,142 @@ mod tests {
                 .expect("outputs lock")
                 .pop_front()
                 .expect("one scripted output per runtime call")
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct ConsumedAuthorization {
+        authorization: SandboxAuthorization,
+        operation_id: OperationId,
+        custody: SandboxCustody,
+        execution_binding: SandboxExecutionBinding,
+        environment_profile: EnvironmentProfile,
+        generation: SandboxGeneration,
+        resource_allocation: JobResourceAllocation,
+        pids_limit: u32,
+        network_disabled: bool,
+    }
+
+    #[derive(Debug)]
+    struct RecordingAuthorizationConsumer {
+        runtime: Arc<ScriptedExecutor>,
+        calls: Mutex<Vec<ConsumedAuthorization>>,
+    }
+
+    impl RecordingAuthorizationConsumer {
+        fn new(runtime: Arc<ScriptedExecutor>) -> Self {
+            Self {
+                runtime,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<ConsumedAuthorization> {
+            self.calls.lock().expect("consumer calls lock").clone()
+        }
+    }
+
+    impl WindowsHyperVSandboxAuthorizationConsumer for RecordingAuthorizationConsumer {
+        fn consume(
+            &self,
+            authorization: &SandboxAuthorization,
+            request: WindowsHyperVSandboxAuthorizationRequest<'_>,
+        ) -> Result<(), ProviderError> {
+            assert_eq!(
+                self.runtime.calls.lock().expect("runtime calls lock").len(),
+                1,
+                "authorization must be consumed before any create-path runtime call"
+            );
+            self.calls
+                .lock()
+                .expect("consumer calls lock")
+                .push(ConsumedAuthorization {
+                    authorization: authorization.clone(),
+                    operation_id: request.operation_id(),
+                    custody: request.custody(),
+                    execution_binding: request.execution_binding(),
+                    environment_profile: request.environment_profile().clone(),
+                    generation: request.generation(),
+                    resource_allocation: request.resource_allocation(),
+                    pids_limit: request.pids_limit(),
+                    network_disabled: request.network_disabled(),
+                });
+            if authorization.name().as_str() != TEST_WINDOWS_AUTHORIZATION_NAME
+                || authorization.payload_schema_version() != TEST_WINDOWS_AUTHORIZATION_SCHEMA
+                || authorization.payload() != b"valid-grant"
+            {
+                return Err(error::known(
+                    ProviderErrorKind::InvalidConfiguration,
+                    ProviderStage::Validate,
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct LedgerAuthorizationConsumer {
+        runtime: Arc<ScriptedExecutor>,
+        retained: Mutex<Option<ConsumedAuthorization>>,
+        calls: Mutex<Vec<ConsumedAuthorization>>,
+    }
+
+    impl LedgerAuthorizationConsumer {
+        fn new(runtime: Arc<ScriptedExecutor>) -> Self {
+            Self {
+                runtime,
+                retained: Mutex::new(None),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<ConsumedAuthorization> {
+            self.calls.lock().expect("consumer calls lock").clone()
+        }
+    }
+
+    impl WindowsHyperVSandboxAuthorizationConsumer for LedgerAuthorizationConsumer {
+        fn consume(
+            &self,
+            authorization: &SandboxAuthorization,
+            request: WindowsHyperVSandboxAuthorizationRequest<'_>,
+        ) -> Result<(), ProviderError> {
+            assert!(
+                !self
+                    .runtime
+                    .calls
+                    .lock()
+                    .expect("runtime calls lock")
+                    .is_empty(),
+                "provider must complete startup before authorization consumption"
+            );
+            let consumed = ConsumedAuthorization {
+                authorization: authorization.clone(),
+                operation_id: request.operation_id(),
+                custody: request.custody(),
+                execution_binding: request.execution_binding(),
+                environment_profile: request.environment_profile().clone(),
+                generation: request.generation(),
+                resource_allocation: request.resource_allocation(),
+                pids_limit: request.pids_limit(),
+                network_disabled: request.network_disabled(),
+            };
+            self.calls
+                .lock()
+                .expect("consumer calls lock")
+                .push(consumed.clone());
+            let mut retained = self.retained.lock().expect("authorization ledger lock");
+            match retained.as_ref() {
+                None => {
+                    *retained = Some(consumed);
+                    Ok(())
+                }
+                Some(existing) if existing == &consumed => Ok(()),
+                Some(_) => Err(error::known(
+                    ProviderErrorKind::Conflict,
+                    ProviderStage::Validate,
+                )),
+            }
         }
     }
 
@@ -2561,6 +2854,335 @@ mod tests {
             RootFilesystemPolicy::Writable,
             ResourceLimits::new(2 * 1024 * 1024 * 1024, 2_500, 384).expect("limits"),
         )
+    }
+
+    fn sandbox_authorizations(
+        name: &str,
+        payload_schema_version: u16,
+        payload: &[u8],
+    ) -> SandboxAuthorizations {
+        SandboxAuthorizations::new(vec![
+            SandboxAuthorization::new(
+                SandboxAuthorizationName::new(name).expect("authorization name"),
+                payload_schema_version,
+                payload.to_vec(),
+            )
+            .expect("authorization"),
+        ])
+        .expect("authorization set")
+    }
+
+    fn job_hyperv_spec(authorizations: SandboxAuthorizations) -> SandboxSpec {
+        job_hyperv_spec_without_execution_binding(authorizations)
+            .with_execution_binding(test_execution_binding())
+    }
+
+    fn job_hyperv_spec_without_execution_binding(
+        authorizations: SandboxAuthorizations,
+    ) -> SandboxSpec {
+        let resources = ResourceCapacity::new(2_500, 2 * 1024 * 1024 * 1024, 0, 0);
+        hyperv_spec_with_custody(
+            vec!["keepalive".to_owned()],
+            SandboxCustody::Job {
+                runner_id: RunnerId::new(),
+                slot_ordinal: NonZeroU16::new(1).expect("non-zero slot"),
+            },
+        )
+        .with_resource_allocation(
+            JobResourceAllocation::new(resources, resources).expect("resource allocation"),
+        )
+        .with_sandbox_authorizations(authorizations)
+    }
+
+    fn test_execution_binding() -> SandboxExecutionBinding {
+        SandboxExecutionBinding::new(
+            RunnerSessionId::new(),
+            RunId::new(),
+            JobId::new(),
+            AttemptId::new(),
+            LeaseGuard::new(
+                LeaseId::new(),
+                automata_ci_execution::FencingToken::new(3).expect("fencing token"),
+            ),
+            OperationId::new(),
+            NonZeroU64::new(1).expect("offer sequence"),
+            JobIrVersion::current(),
+            Sha256Digest::from_bytes([0x5a; 32]),
+        )
+    }
+
+    fn clone_job_spec_with_operation_id(
+        spec: &SandboxSpec,
+        operation_id: OperationId,
+    ) -> SandboxSpec {
+        let mut cloned = SandboxSpec::new(
+            operation_id,
+            spec.generation(),
+            spec.custody(),
+            spec.profile().clone(),
+            spec.workspace().clone(),
+            spec.network(),
+            spec.root_filesystem(),
+            spec.resources(),
+        )
+        .with_privilege(spec.privilege())
+        .with_services(spec.services().clone())
+        .with_runtime_service_routes(spec.runtime_service_routes().clone())
+        .with_sandbox_authorizations(spec.sandbox_authorizations().clone())
+        .with_execution_binding(spec.execution_binding().expect("execution binding"));
+        if let Some(scratch) = spec.scratch() {
+            cloned = cloned.with_scratch(scratch.clone());
+        }
+        if let Some(allocation) = spec.resource_allocation() {
+            cloned = cloned.with_resource_allocation(allocation);
+        }
+        cloned
+    }
+
+    fn assert_no_durable_create(root: &TestRoot) {
+        let (journal, snapshot) =
+            LifecycleJournal::open(&root.path).expect("reopen lifecycle journal");
+        assert!(snapshot.creates.is_empty());
+        assert!(snapshot.entries.is_empty());
+        drop(journal);
+    }
+
+    #[test]
+    fn job_custody_without_consumer_or_exact_authorization_fails_before_provider_work() {
+        for (label, authorizations, expected_consumer_calls) in [
+            ("missing", SandboxAuthorizations::empty(), 0),
+            (
+                "wrong-name",
+                sandbox_authorizations(
+                    "another-provider",
+                    TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+                    b"valid-grant",
+                ),
+                1,
+            ),
+            (
+                "wrong-schema",
+                sandbox_authorizations(
+                    TEST_WINDOWS_AUTHORIZATION_NAME,
+                    TEST_WINDOWS_AUTHORIZATION_SCHEMA - 1,
+                    b"valid-grant",
+                ),
+                1,
+            ),
+        ] {
+            let root = TestRoot::new(&format!("authorization-{label}"));
+            let runtime = Arc::new(ScriptedExecutor::new([RuntimeCommandOutput::success(
+                Vec::new(),
+            )]));
+            let consumer = Arc::new(RecordingAuthorizationConsumer::new(runtime.clone()));
+            let provider =
+                WindowsHyperVContainerProvider::open_with_executor_and_authorization_consumer(
+                    root.options(),
+                    runtime.clone(),
+                    consumer.clone(),
+                )
+                .expect("open provider");
+            let error = provider
+                .create(&job_hyperv_spec(authorizations), &NeverCancelled)
+                .expect_err("invalid job authorization must fail closed");
+            assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+            assert_eq!(error.stage(), ProviderStage::Validate);
+            assert_eq!(consumer.calls().len(), expected_consumer_calls);
+            runtime.assert_drained();
+            assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 1);
+            drop(provider);
+            assert_no_durable_create(&root);
+        }
+
+        let root = TestRoot::new("authorization-no-consumer");
+        let runtime = Arc::new(ScriptedExecutor::new([RuntimeCommandOutput::success(
+            Vec::new(),
+        )]));
+        let provider =
+            WindowsHyperVContainerProvider::open_with_executor(root.options(), runtime.clone())
+                .expect("open provider");
+        let spec = job_hyperv_spec(sandbox_authorizations(
+            TEST_WINDOWS_AUTHORIZATION_NAME,
+            TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+            b"valid-grant",
+        ));
+        assert_eq!(
+            provider
+                .create(&spec, &NeverCancelled)
+                .expect_err("direct job provider must fail closed")
+                .kind(),
+            ProviderErrorKind::InvalidConfiguration
+        );
+        runtime.assert_drained();
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 1);
+        drop(provider);
+        assert_no_durable_create(&root);
+
+        let root = TestRoot::new("authorization-missing-execution-binding");
+        let runtime = Arc::new(ScriptedExecutor::new([RuntimeCommandOutput::success(
+            Vec::new(),
+        )]));
+        let consumer = Arc::new(RecordingAuthorizationConsumer::new(runtime.clone()));
+        let provider =
+            WindowsHyperVContainerProvider::open_with_executor_and_authorization_consumer(
+                root.options(),
+                runtime.clone(),
+                consumer.clone(),
+            )
+            .expect("open provider");
+        let spec = job_hyperv_spec_without_execution_binding(sandbox_authorizations(
+            TEST_WINDOWS_AUTHORIZATION_NAME,
+            TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+            b"valid-grant",
+        ));
+        let error = provider
+            .create(&spec, &NeverCancelled)
+            .expect_err("job custody requires an exact execution binding");
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+        assert_eq!(error.stage(), ProviderStage::Validate);
+        assert!(consumer.calls().is_empty());
+        runtime.assert_drained();
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 1);
+        drop(provider);
+        assert_no_durable_create(&root);
+    }
+
+    #[test]
+    fn consumer_receives_exact_stable_request_and_rejects_malformed_payload_before_provider_work() {
+        let root = TestRoot::new("authorization-malformed");
+        let runtime = Arc::new(ScriptedExecutor::new([RuntimeCommandOutput::success(
+            Vec::new(),
+        )]));
+        let consumer = Arc::new(RecordingAuthorizationConsumer::new(runtime.clone()));
+        let provider =
+            WindowsHyperVContainerProvider::open_with_executor_and_authorization_consumer(
+                root.options(),
+                runtime.clone(),
+                consumer.clone(),
+            )
+            .expect("open provider");
+        let spec = job_hyperv_spec(sandbox_authorizations(
+            TEST_WINDOWS_AUTHORIZATION_NAME,
+            TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+            b"malformed-protobuf",
+        ));
+        let error = provider
+            .create(&spec, &NeverCancelled)
+            .expect_err("malformed broker payload must fail closed");
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+        assert_eq!(error.stage(), ProviderStage::Validate);
+        let calls = consumer.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].authorization,
+            spec.sandbox_authorizations().as_slice()[0]
+        );
+        assert_eq!(calls[0].operation_id, spec.operation_id());
+        assert_eq!(calls[0].custody, spec.custody());
+        assert_eq!(
+            calls[0].execution_binding,
+            spec.execution_binding().expect("execution binding")
+        );
+        assert_eq!(calls[0].environment_profile, *spec.profile().attestation());
+        assert_eq!(calls[0].generation, spec.generation());
+        assert_eq!(
+            calls[0].resource_allocation,
+            spec.resource_allocation().expect("allocation")
+        );
+        assert_eq!(calls[0].pids_limit, spec.resources().pids());
+        assert!(calls[0].network_disabled);
+        runtime.assert_drained();
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 1);
+        drop(provider);
+        assert_no_durable_create(&root);
+    }
+
+    #[test]
+    fn accepted_authorization_is_consumed_before_the_first_create_path_runtime_call() {
+        let root = TestRoot::new("authorization-accepted");
+        let runtime = Arc::new(ScriptedExecutor::new([
+            RuntimeCommandOutput::success(Vec::new()),
+            RuntimeCommandOutput::failure(1, b"runtime unavailable".to_vec()),
+        ]));
+        let consumer = Arc::new(RecordingAuthorizationConsumer::new(runtime.clone()));
+        let provider =
+            WindowsHyperVContainerProvider::open_with_executor_and_authorization_consumer(
+                root.options(),
+                runtime.clone(),
+                consumer.clone(),
+            )
+            .expect("open provider");
+        let spec = job_hyperv_spec(sandbox_authorizations(
+            TEST_WINDOWS_AUTHORIZATION_NAME,
+            TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+            b"valid-grant",
+        ));
+        let error = provider
+            .create(&spec, &NeverCancelled)
+            .expect_err("scripted runtime failure stops before create mutation");
+        assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+        assert_eq!(error.stage(), ProviderStage::Inspect);
+        assert_eq!(consumer.calls().len(), 1);
+        runtime.assert_drained();
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 2);
+        drop(provider);
+        assert_no_durable_create(&root);
+    }
+
+    #[test]
+    fn authorization_ledger_replays_exact_consumption_and_rejects_attempt_substitution() {
+        let root = TestRoot::new("authorization-ledger");
+        let runtime = Arc::new(ScriptedExecutor::new([
+            RuntimeCommandOutput::success(Vec::new()),
+            RuntimeCommandOutput::failure(1, b"runtime unavailable".to_vec()),
+            RuntimeCommandOutput::failure(1, b"runtime unavailable".to_vec()),
+        ]));
+        let consumer = Arc::new(LedgerAuthorizationConsumer::new(runtime.clone()));
+        let provider =
+            WindowsHyperVContainerProvider::open_with_executor_and_authorization_consumer(
+                root.options(),
+                runtime.clone(),
+                consumer.clone(),
+            )
+            .expect("open provider");
+        let spec = job_hyperv_spec(sandbox_authorizations(
+            TEST_WINDOWS_AUTHORIZATION_NAME,
+            TEST_WINDOWS_AUTHORIZATION_SCHEMA,
+            b"valid-grant",
+        ));
+
+        for _ in 0..2 {
+            let error = provider
+                .create(&spec, &NeverCancelled)
+                .expect_err("scripted failure occurs after authorization consumption");
+            assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+            assert_eq!(error.stage(), ProviderStage::Inspect);
+        }
+        assert_eq!(consumer.calls().len(), 2);
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 3);
+
+        let substituted = spec
+            .clone()
+            .with_execution_binding(test_execution_binding());
+        let error = provider
+            .create(&substituted, &NeverCancelled)
+            .expect_err("one grant cannot be first-spent for another execution binding");
+        assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+        assert_eq!(error.stage(), ProviderStage::Validate);
+        assert_eq!(consumer.calls().len(), 3);
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 3);
+
+        let substituted = clone_job_spec_with_operation_id(&spec, OperationId::new());
+        let error = provider
+            .create(&substituted, &NeverCancelled)
+            .expect_err("one grant cannot be first-spent for another create operation");
+        assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+        assert_eq!(error.stage(), ProviderStage::Validate);
+        assert_eq!(consumer.calls().len(), 4);
+        assert_eq!(runtime.calls.lock().expect("runtime calls lock").len(), 3);
+        runtime.assert_drained();
+        drop(provider);
+        assert_no_durable_create(&root);
     }
 
     #[test]
@@ -2686,13 +3308,20 @@ mod tests {
     #[test]
     fn provider_rejects_every_non_hyperv_or_weakened_spec() {
         let spec = hyperv_spec();
-        assert!(validate_spec(&spec).is_ok());
-        assert!(validate_spec(&spec.clone().with_privilege(SandboxPrivilegePolicy::Host)).is_err());
+        assert!(validate_spec(&spec, false).is_ok());
+        assert!(
+            validate_spec(
+                &spec.clone().with_privilege(SandboxPrivilegePolicy::Host),
+                false
+            )
+            .is_err()
+        );
         assert!(
             validate_spec(
                 &spec
                     .clone()
-                    .with_root_filesystem(RootFilesystemPolicy::ReadOnly)
+                    .with_root_filesystem(RootFilesystemPolicy::ReadOnly),
+                false,
             )
             .is_err()
         );
@@ -2725,7 +3354,7 @@ mod tests {
             ResourceLimits::new(2 * 1024 * 1024 * 1024, 2_500, 384).expect("limits"),
         );
         assert_eq!(
-            validate_spec(&generic)
+            validate_spec(&generic, false)
                 .expect_err("generic container must be rejected")
                 .kind(),
             ProviderErrorKind::UnsupportedCapability

--- a/crates/automata-ci-store-postgres/migrations/0062_runner_protocol_v3.sql
+++ b/crates/automata-ci-store-postgres/migrations/0062_runner_protocol_v3.sql
@@ -1,0 +1,13 @@
+ALTER TABLE runner_sessions
+    DROP CONSTRAINT runner_sessions_protocol_known;
+
+ALTER TABLE runner_sessions
+    ADD CONSTRAINT runner_sessions_protocol_known
+    CHECK (protocol_version IN (1, 2, 3));
+
+ALTER TABLE runner_runtime_authority_deliveries
+    DROP CONSTRAINT runner_runtime_authority_deliveries_protocol_v2;
+
+ALTER TABLE runner_runtime_authority_deliveries
+    ADD CONSTRAINT runner_runtime_authority_deliveries_protocol_known
+    CHECK (protocol_version IN (2, 3));

--- a/crates/automata-ci-store-postgres/src/g1.rs
+++ b/crates/automata-ci-store-postgres/src/g1.rs
@@ -14,10 +14,10 @@ use automata_ci_control::{
     },
     lease::{
         AuthenticatedPlacementTrust, BeginLeaseRequest, BegunLeaseRequest, ClaimRejection,
-        ClaimedAttempt, CompleteLeaseRequest, LeaseRequestCompletion, LeaseRequestKey,
-        NoWorkLeaseRequest, RevokedLeaseOfferFallback, RunnableAttempt, RunnableQueueKey,
-        RunnableScanLimit, RunnableScanPage, RunnableScanRequest, TryClaimAttempt, TryClaimOutcome,
-        TryClaimReceipt,
+        ClaimedAttempt, CompleteLeaseRequest, LeaseAuthorityPollContributions,
+        LeaseRequestCompletion, LeaseRequestKey, NoWorkLeaseRequest, RevokedLeaseOfferFallback,
+        RunnableAttempt, RunnableQueueKey, RunnableScanLimit, RunnableScanPage,
+        RunnableScanRequest, TryClaimAttempt, TryClaimOutcome, TryClaimReceipt,
         repository::{
             RunnableAttemptRepository, RunnerClaimRepository, RunnerLeaseRequestRepository,
         },
@@ -77,8 +77,9 @@ use automata_ci_store::{
 
 const LEASE_OPERATION_KIND: &str = "automata.lease-request.v1";
 const LEASE_RPC_OPERATION_KIND: &str = "automata.runner.lease-request.v1";
-const LEASE_OFFER_COMMAND_KIND: &str = "automata.runner.lease-offer.v2";
-const LEASE_OFFER_COMMAND_SCHEMA: u16 = 2;
+const LEASE_OFFER_COMMAND_KIND: &str = "automata.runner.lease-offer.v3";
+const LEASE_OFFER_COMMAND_SCHEMA: u16 = 3;
+const CURRENT_RUNNER_PROTOCOL_VERSION: u16 = 3;
 const RUNTIME_AUTHORITY_REQUEST_KIND: &str = "automata.runner.runtime-authority-request.v2";
 const RUNTIME_AUTHORITY_ACK_KIND: &str = "automata.runner.runtime-authority-ack.v2";
 const COMMAND_ENVELOPE_METADATA_DOMAIN: &[u8] =
@@ -1586,10 +1587,12 @@ impl RunnerLeaseOfferRepository for PostgresStore {
             .await?;
         let routing = lock_live_routing(&mut transaction, request.request().session()).await?;
         routing.require_online(request.request().session())?;
+        let receipt = lock_exact_lease_offer_claim(&mut transaction, &request, &routing).await?;
         if let Some(publication) =
             load_lease_offer_publication(&mut transaction, encryption, &request, None, None, true)
                 .await?
         {
+            validate_published_lease_offer_claim_receipt(&receipt, &request)?;
             if !matches!(
                 classify_locked_published_lease_offer(&mut transaction, &publication).await?,
                 LockedLeaseOfferDeliveryStatus::Live
@@ -1600,7 +1603,7 @@ impl RunnerLeaseOfferRepository for PostgresStore {
             transaction.commit().await.map_err(operation_error)?;
             return Ok(LeaseOfferClaimStatus::Published(Box::new(publication)));
         }
-        lock_exact_lease_offer_claim(&mut transaction, &request, &routing).await?;
+        require_current_lease_offer_claim(&receipt, &request)?;
         let current = lock_publishable_lease_offer_attempt(&mut transaction, &request).await?;
         if current && !routing.accepts_new_work {
             return Err(StoreError::RunnerNotAcceptingWork(
@@ -1675,6 +1678,8 @@ impl RunnerLeaseOfferRepository for PostgresStore {
             .await?;
         let routing = lock_live_routing(&mut transaction, request.request().session()).await?;
         routing.require_online(request.request().session())?;
+        let receipt =
+            lock_exact_lease_offer_claim(&mut transaction, request.claim(), &routing).await?;
         if let Some(publication) = load_lease_offer_publication(
             &mut transaction,
             encryption,
@@ -1685,6 +1690,7 @@ impl RunnerLeaseOfferRepository for PostgresStore {
         )
         .await?
         {
+            validate_published_lease_offer_claim_receipt(&receipt, request.claim())?;
             if !matches!(
                 classify_locked_published_lease_offer(&mut transaction, &publication).await?,
                 LockedLeaseOfferDeliveryStatus::Live
@@ -1696,7 +1702,7 @@ impl RunnerLeaseOfferRepository for PostgresStore {
             transaction.commit().await.map_err(operation_error)?;
             return Ok(publication);
         }
-        lock_exact_lease_offer_claim(&mut transaction, request.claim(), &routing).await?;
+        require_current_lease_offer_claim(&receipt, request.claim())?;
         if !lock_publishable_lease_offer_attempt(&mut transaction, request.claim()).await? {
             return Err(StoreError::AttemptFenceRejected(
                 request.lease().attempt_id(),
@@ -5372,7 +5378,7 @@ async fn load_runtime_authority_offer_by_command(
     );
     let protocol_version =
         decode_protocol(row.try_get("protocol_version").map_err(operation_error)?)?;
-    if protocol_version.get() != LEASE_OFFER_COMMAND_SCHEMA {
+    if protocol_version.get() != CURRENT_RUNNER_PROTOCOL_VERSION {
         return Err(StoreError::corrupt_data(
             "runtime-authority offer has invalid protocol metadata",
         ));
@@ -5668,7 +5674,7 @@ async fn lock_exact_lease_offer_claim(
     transaction: &mut Transaction<'_, Postgres>,
     request: &LeaseOfferClaim,
     routing: &LockedRouting,
-) -> Result<(), StoreError> {
+) -> Result<TryClaimReceipt, StoreError> {
     let conflict = || StoreError::OperationConflict {
         session_id: request.request().session().session_id(),
         operation_id: request.request().operation_id(),
@@ -5722,7 +5728,18 @@ async fn lock_exact_lease_offer_claim(
     let receipt = claim_receipt_row(transaction, key)
         .await?
         .ok_or_else(conflict)
-        .and_then(|row| decode_claim_receipt(&row, key, true))?;
+        .and_then(|row| decode_claim_receipt(&row, key, request.authority_contributions(), true))?;
+    Ok(receipt)
+}
+
+fn require_current_lease_offer_claim(
+    receipt: &TryClaimReceipt,
+    request: &LeaseOfferClaim,
+) -> Result<(), StoreError> {
+    let conflict = || StoreError::OperationConflict {
+        session_id: request.request().session().session_id(),
+        operation_id: request.request().operation_id(),
+    };
     let TryClaimOutcome::Claimed(claimed) = receipt.outcome() else {
         return Err(conflict());
     };
@@ -5733,6 +5750,21 @@ async fn lock_exact_lease_offer_claim(
         return Err(conflict());
     }
     Ok(())
+}
+
+fn validate_published_lease_offer_claim_receipt(
+    receipt: &TryClaimReceipt,
+    request: &LeaseOfferClaim,
+) -> Result<(), StoreError> {
+    match receipt.outcome() {
+        TryClaimOutcome::Claimed(_) => require_current_lease_offer_claim(receipt, request),
+        TryClaimOutcome::Rejected(
+            ClaimRejection::ClaimExpired | ClaimRejection::ClaimSuperseded,
+        ) => Ok(()),
+        TryClaimOutcome::Rejected(_) | TryClaimOutcome::NoWork => Err(StoreError::corrupt_data(
+            "published lease offer has an incompatible claim receipt",
+        )),
+    }
 }
 
 /// Locks the attempt row even when the repository-level concurrency advisory is absent.
@@ -6535,6 +6567,7 @@ impl RunnerClaimRepository for PostgresStore {
     async fn lookup_lease_request(
         &self,
         request: LeaseRequestKey,
+        authority_contributions: &LeaseAuthorityPollContributions,
     ) -> Result<Option<TryClaimReceipt>, StoreError> {
         let mut transaction = self.pool.begin().await.map_err(operation_error)?;
         super::pin_runner_attempt_read_committed(&mut transaction).await?;
@@ -6544,7 +6577,7 @@ impl RunnerClaimRepository for PostgresStore {
         lock_current_lease_request_head(&mut transaction, request, None).await?;
         let row = claim_receipt_row(&mut transaction, request).await?;
         let receipt = if let Some(row) = row.as_ref() {
-            let receipt = decode_claim_receipt(row, request, true)?;
+            let receipt = decode_claim_receipt(row, request, authority_contributions, true)?;
             Some(resolve_claim_receipt(&mut transaction, receipt).await?)
         } else {
             None
@@ -6602,7 +6635,12 @@ impl RunnerClaimRepository for PostgresStore {
         .rows_affected();
 
         if inserted == 0 {
-            let receipt = replay_claim(&mut transaction, request.request_key()).await?;
+            let receipt = replay_claim(
+                &mut transaction,
+                request.request_key(),
+                request.authority_contributions(),
+            )
+            .await?;
             transaction.commit().await.map_err(operation_error)?;
             return Ok(receipt);
         }
@@ -6633,7 +6671,12 @@ impl RunnerClaimRepository for PostgresStore {
         };
         complete_claim_receipt(&mut transaction, &request, &outcome, committed_cursor).await?;
         transaction.commit().await.map_err(operation_error)?;
-        Ok(TryClaimReceipt::new(request.request_key(), outcome, false))
+        Ok(TryClaimReceipt::new(
+            request.request_key(),
+            request.request_digest(),
+            outcome,
+            false,
+        ))
     }
 
     async fn record_no_work(
@@ -6642,7 +6685,7 @@ impl RunnerClaimRepository for PostgresStore {
     ) -> Result<TryClaimReceipt, StoreError> {
         let request_key = request.request_key();
         let cursor = automata_ci_control::adapter_spi::no_work_lease_request_cursor(&request);
-        let digest = request_key.request_digest();
+        let digest = request.request_digest();
         let mut transaction = self.pool.begin().await.map_err(operation_error)?;
         super::pin_runner_attempt_read_committed(&mut transaction).await?;
         let routing = lock_live_routing(&mut transaction, request_key.session()).await?;
@@ -6690,9 +6733,14 @@ impl RunnerClaimRepository for PostgresStore {
             };
             complete_no_work_receipt(&mut transaction, &request, &outcome, committed_cursor)
                 .await?;
-            TryClaimReceipt::new(request_key, outcome, false)
+            TryClaimReceipt::new(request_key, digest, outcome, false)
         } else {
-            replay_claim(&mut transaction, request_key).await?
+            replay_claim(
+                &mut transaction,
+                request_key,
+                request.authority_contributions(),
+            )
+            .await?
         };
         transaction.commit().await.map_err(operation_error)?;
         Ok(receipt)
@@ -8461,12 +8509,6 @@ async fn evaluate_claim(
     let job_version =
         decode_job_ir_version(row.try_get("job_ir_schema").map_err(operation_error)?)?;
     let durable_candidate = decode_runnable_attempt(&row)?;
-    if !automata_ci_control::adapter_spi::try_claim_attempt_matches_runnable(
-        request,
-        &durable_candidate,
-    ) {
-        return Ok(TryClaimOutcome::Rejected(ClaimRejection::NotRoutable));
-    }
     let requirements = durable_candidate.requirements().clone();
     let machine_requirements = requirements
         .clone()
@@ -8557,8 +8599,13 @@ async fn evaluate_claim(
     .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
     let assignment = AttemptAssignment::new(request.session(), request.slot());
     let metadata = durable_candidate.job_ir().clone();
-    let claimed = ClaimedAttempt::try_new(lease, assignment, metadata)
-        .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
+    let claimed = ClaimedAttempt::try_new(
+        lease,
+        assignment,
+        metadata,
+        request.authority_contributions().clone(),
+    )
+    .map_err(|error| StoreError::corrupt_data(error.to_string()))?;
     Ok(TryClaimOutcome::Claimed(Box::new(claimed)))
 }
 
@@ -8727,11 +8774,12 @@ async fn complete_no_work_receipt(
 async fn replay_claim(
     transaction: &mut Transaction<'_, Postgres>,
     request: LeaseRequestKey,
+    authority_contributions: &LeaseAuthorityPollContributions,
 ) -> Result<TryClaimReceipt, StoreError> {
     let row = claim_receipt_row(transaction, request)
         .await?
         .ok_or_else(|| invalid_operation_receipt("conflicting receipt disappeared"))?;
-    let receipt = decode_claim_receipt(&row, request, true)?;
+    let receipt = decode_claim_receipt(&row, request, authority_contributions, true)?;
     resolve_claim_receipt(transaction, receipt).await
 }
 
@@ -8836,6 +8884,7 @@ async fn resolve_claim_receipt(
     }
     Ok(TryClaimReceipt::new(
         receipt.request_key(),
+        receipt.request_digest(),
         TryClaimOutcome::Rejected(rejection),
         true,
     ))
@@ -8869,6 +8918,7 @@ async fn claim_receipt_row(
 fn decode_claim_receipt(
     row: &sqlx::postgres::PgRow,
     request: LeaseRequestKey,
+    authority_contributions: &LeaseAuthorityPollContributions,
     replayed: bool,
 ) -> Result<TryClaimReceipt, StoreError> {
     let kind: &str = row.try_get("operation_kind").map_err(operation_error)?;
@@ -8881,7 +8931,7 @@ fn decode_claim_receipt(
         .and_then(|value| StableRunnerSlot::new(value).ok())
         .ok_or_else(|| invalid_operation_receipt("invalid runner slot"))?;
     if kind != LEASE_OPERATION_KIND
-        || stored_digest != request.request_digest()
+        || stored_digest != request.decision_request_digest(authority_contributions)
         || stored_slot != request.slot()
     {
         return Err(StoreError::OperationConflict {
@@ -8916,6 +8966,7 @@ fn decode_claim_receipt(
                 lease,
                 AttemptAssignment::new(request.session(), stored_slot),
                 decode_receipt_job_ir(row)?,
+                authority_contributions.clone(),
             )
             .map_err(|error| invalid_operation_receipt(error.to_string()))?;
             TryClaimOutcome::Claimed(Box::new(claimed))
@@ -8957,7 +9008,12 @@ fn decode_claim_receipt(
             )));
         }
     };
-    Ok(TryClaimReceipt::new(request, outcome, replayed))
+    Ok(TryClaimReceipt::new(
+        request,
+        stored_digest,
+        outcome,
+        replayed,
+    ))
 }
 
 fn decode_receipt_job_ir(row: &sqlx::postgres::PgRow) -> Result<JobIrMetadata, StoreError> {

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -249,6 +249,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0061_job_check_topology.sql",
         "befdac4d4754eb1b39e6954c95b012b67797fccb7baa248a53c0559162d295b38069f41e78f0e724ded395df965c5e58",
     ),
+    (
+        "0062_runner_protocol_v3.sql",
+        "3cab21e969aa502ded9cfdf2d0442cb610426072a82506f844961aea72ad13ce7fb9020043e07dce0b4752355bfe3561",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci/src/server/workload_oidc.rs
+++ b/crates/automata-ci/src/server/workload_oidc.rs
@@ -1642,8 +1642,13 @@ norlX3KEHNe7cTke5cP4OA==";
                 request.lease().expires_at(),
             )
             .map_err(|_| ControlPortError::Corrupt)?;
-            JobRuntimeAuthorities::new(vec![authority], request.job(), request.lease())
-                .map_err(|_| ControlPortError::Corrupt)
+            JobRuntimeAuthorities::new(
+                vec![authority],
+                automata_ci_core::SandboxAuthorizations::empty(),
+                request.job(),
+                request.lease(),
+            )
+            .map_err(|_| ControlPortError::Corrupt)
         }
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,14 @@ token. Every state change and published result compares that token. A delayed
 runner may repeat a request, but it cannot commit after a newer lease takes
 ownership.
 
+Runner protocol 3 carries provider-owned lease evidence through a required
+canonical contribution bundle, not provider-specific lease fields. A poll
+result must correlate to the exact request and accept that bundle's digest
+before the runner changes its poll checkpoint. Extension sources are
+acknowledged only after the nested outcome reaches its required durable state.
+See [Runtime-authority delivery](runtime-authority-delivery.md) for the exact
+ordering and retry contract.
+
 The runner journals a lease and sandbox handle before acknowledging the work.
 After a restart it reattaches to a live attempt or terminates and removes an
 orphan. Cancellation is stored first, prevents another step from starting,
@@ -197,9 +205,13 @@ bindings from the built-in provider at exact pinned versions. Durable lease
 state records only a value-free binding overlay; the runner fetches values over
 a direct mTLS-bound ephemeral channel after leasing, holds them in zeroizing
 custody, and installs every log mask before acknowledging delivery or starting
-work. External or dynamic providers and variable-value delivery remain
-unsupported. This path does not make every workflow eligible, and protected-
-environment acceptance remains a separate boundary. See
+work. The protected `JobRuntimeAuthorities` schema-2 bundle also carries
+canonical, opaque `SandboxAuthorizations`; the generic runner and executor pass
+them unchanged, and an isolation provider must consume its own exact namespace
+and schema before mutation or reject the job. External or dynamic providers
+and variable-value delivery remain unsupported. This path does not make every
+workflow eligible, and protected-environment acceptance remains a separate
+boundary. See
 [Authentication and authorization](authentication.md) for the current
 interfaces and limits.
 

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -18,11 +18,11 @@ fail during logical projection, compile without scheduler enforcement, work
 only in focused component tests, work only on Linux, lack production ingress or
 credentials, or deliberately diverge from GitHub.
 
-The 2026-08-12 refresh includes the runtime restoration merged in PR #29:
-runner protocol v2, message schema v1, JobIR schema v1, runner-requirements
-schema v1, a frozen additive PostgreSQL migration lineage, three isolated
-single-slot Linux runner processes, the Kubernetes product configuration path,
-durable rerun and protected-environment authority,
+The current baseline builds on the 2026-08-12 runtime restoration merged in
+PR #29 and uses runner protocol v3, message schema v1, JobIR schema v1,
+runner-requirements schema v1, a frozen additive PostgreSQL migration lineage,
+three isolated single-slot Linux runner processes, the Kubernetes product
+configuration path, durable rerun and protected-environment authority,
 value-safe managed-secret delivery, and immutable multi-workflow fanout. The
 lineage is gap-free, checksum-verified, and extended only through a new
 migration. These are component or experimental foundations unless a later item
@@ -1117,7 +1117,7 @@ runner.
 - [x] Remove privileged static fleet bootstrap rather than retaining a
   migration or break-glass compatibility path.
 - [x] Negotiate the runner protocol and JobIR ranges before a session or lease;
-  the current baseline admits protocol v2 only.
+  the current baseline admits protocol v3 only.
 - [x] Add a runner enrollment and registration API.
 - [ ] Add credential rotation.
 - [ ] Add disable and enable.

--- a/docs/github-actions-parity-execution-plan.md
+++ b/docs/github-actions-parity-execution-plan.md
@@ -12,7 +12,7 @@ current support. The [implementation plan](implementation-plan.md) owns release
 gates. This page is an execution aid: unchecked tasks are planned work, not
 availability claims.
 
-The refreshed greenfield baseline uses runner protocol v2, message schema v1,
+The refreshed greenfield baseline uses runner protocol v3, message schema v1,
 JobIR schema v1, runner-requirements schema v1, and a frozen additive
 PostgreSQL migration lineage. The lineage is gap-free, checksum-verified, and
 extended only through a new migration. The baseline also contains a real

--- a/docs/github-actions-parity/github-actions-parity-01-foundations.md
+++ b/docs/github-actions-parity/github-actions-parity-01-foundations.md
@@ -171,7 +171,7 @@ Acceptance:
 
 **Owner:** rotating integration owner. **Size:** S. **Dependencies:** none.
 
-Current baseline: runner protocol v2, message schema v1, JobIR schema v1,
+Current baseline: runner protocol v3, message schema v1, JobIR schema v1,
 runner-requirements schema v1, and a frozen additive PostgreSQL migration
 lineage. The lineage is gap-free, checksum-verified, and extended only through
 a new migration. Version, reader, rejection, and limit tests remain with their

--- a/docs/github-actions-parity/github-actions-parity-08-results.md
+++ b/docs/github-actions-parity/github-actions-parity-08-results.md
@@ -44,7 +44,7 @@ S3 blob implementation and retains an identifier-free transcript. The ordinary
 CI workflow supplies its isolated PostgreSQL, RustFS, Node, and exact-module
 environment; direct local invocation remains opt-in because it requires those
 same services and immutable inputs.
-After exact lease acceptance, runner protocol v2 delivers the required
+After exact lease acceptance, runner protocol v3 delivers the required
 per-attempt Results authority bundle through the separate runtime-authority
 exchange. Lease offers and their persisted outbox payloads contain no
 credential values; there is no runner- or fleet-wide Results credential.

--- a/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
+++ b/docs/github-actions-parity/github-actions-parity-10-operations-gates.md
@@ -92,8 +92,8 @@ cores, 54 GiB, and 13,824 tasks. Inventory schema 3 admits a host only with
 slots 1, 2, and 3.
 
 Authenticated Handshake/Sync already negotiates the exact current runner
-protocol v2 and JobIR v1 contract before lease traffic; the supported protocol
-range is currently min=max v2. Rotation and lifecycle update channels remain
+protocol v3 and JobIR v1 contract before lease traffic; the supported protocol
+range is currently min=max v3. Rotation and lifecycle update channels remain
 separate work; version skew is unsupported.
 
 Tasks:
@@ -108,7 +108,7 @@ Tasks:
 - [x] Remove the privileged static fleet path without a compatibility mode and
   document enrollment for the exact three-process reference deployment.
 - [ ] Add disable, drain, replace, delete, and audit operations.
-- [x] Negotiate the exact protocol v2 and JobIR v1 range during authenticated
+- [x] Negotiate the exact protocol v3 and JobIR v1 range during authenticated
   Handshake/Sync before accepting lease traffic.
 - [ ] Keep enrollment and updates pinned to the exact current protocol and
   block mixed-version automatic replacement.

--- a/docs/github-actions-parity/trust-snapshots.md
+++ b/docs/github-actions-parity/trust-snapshots.md
@@ -221,8 +221,9 @@ the snapshot's exact authority decision:
 - Job outputs from restricted sources are marked untrusted; secret-derived
   output values are not published as plaintext.
 - Results credentials preserve standard, untrusted, or denied authority
-  exactly. A valid deny-all job may therefore carry an intentionally empty
-  runtime-authority bundle rather than receiving fallback authority.
+  exactly. A valid deny-all job therefore carries no credential authority
+  rather than receiving fallback repository access. Its provider-owned sandbox
+  authorization set remains a separate contract.
 - Runner context decoding and protocol boundaries reject missing, mismatched,
   malformed, or noncanonical snapshot evidence before user work begins.
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -16,7 +16,7 @@ evidence from real Windows hosts.
 | Initial network profile | Disabled |
 | Security priority | Isolation integrity, trust routing, management-plane least privilege, destructive cleanup, then action parity |
 | Work packages | WIN-ISO-00 through WIN-ISO-12; WIN-01 through WIN-03 remain capability work behind the isolation gate |
-| Last reviewed | 2026-08-16 |
+| Last reviewed | 2026-08-18 |
 
 The words **must**, **must not**, **should**, and **may** express required,
 recommended, and optional constraints. An unchecked task is planned work. It
@@ -158,22 +158,35 @@ must place that authority behind a narrow broker, or prove an equivalently
 restricted engine service identity and API surface, before hostile jobs are
 admitted.
 
-The current source tree now also has a local pre-lease admission increment. It
-rehydrates the canonical AUTH-02 trust snapshot and immutable materialization
-authority, filters Windows candidates without complete authenticated evidence,
-and derives a server-only one-use `WindowsHyperVPlacementGrant`. The value binds
-the attempt, poll operation, runner generation/session/slot, lease, JobIR,
-trust-policy and snapshot digests, authority profile, exact current
-requirements, environment profile, and expiry. PostgreSQL re-derives that value
-from locked current state immediately before changing `queued` to `leased`, so
-a missing grant, a legacy direct-claim bypass, or stale trust/requirements state
-cannot fall through to another Windows boundary.
+The current source tree now also has a provider-neutral lease-authority
+extension boundary. Before scheduling, protocol 3 carries a bounded canonical
+contribution bundle which registered control-side extensions validate and
+commit durably. The exact bundle digest is bound to the claim receipt and its
+replay. After locked `JobIR` verification, the Windows extension derives
+value-free placement evidence from its contribution and records that evidence
+in the lease-offer v3 command. Only after exact offer acceptance may the
+extension prepare and commit a signed one-use sandbox authorization.
 
-That value is intentionally not a broker credential: it is not serialized,
-signed, or accepted from a runner. WIN-ISO-02 must define and independently
-verify the broker-consumable signed form. This increment therefore closes the
-local pre-placement seam without live-provider credentials, not the hostile-host
-acceptance gate.
+That provider-owned value is not a general broker credential and is never
+interpreted by generic orchestration. The source tree defines these component
+seams without claiming their production composition:
+
+- protocol 3 can carry a Windows renewal envelope as one provider-owned,
+  canonical lease-poll contribution instead of adding Windows fields to the
+  generic lease request;
+- post-accept `JobRuntimeAuthorities` schema 2 can carry the signed
+  `WindowsHyperVBrokerGrant` as one `windows-hyperv` sandbox authorization; and
+- the Windows provider requires exactly one such authorization plus an
+  injected restricted-broker consumer, which must validate and atomically
+  spend the grant before any job-custody create mutation.
+
+The generic runner and executor do not interpret either Windows payload. A
+provider without a matching consumer rejects a nonempty authorization set, and
+the Windows provider rejects job creation when its consumer is absent. Direct
+provider construction remains useful only for profile admission. The runner
+product still does not install a Windows lease-authority adapter or a
+production restricted-broker consumer, so these component boundaries do not
+make `automata-runner run` available on Windows or close the hostile-host gate.
 
 ## Non-negotiable invariants
 
@@ -756,8 +769,12 @@ implicit default.
       and reject generic VM or alternate-provider capabilities before lease.
 - [x] Reject unknown, missing, incomplete, or stale local placement evidence by
       re-deriving the server-only grant from locked durable state before lease.
+- [x] Define the canonical signed broker-grant payload and carry it only through
+      the provider-neutral post-accept sandbox-authorization contract.
+- [x] Require the Windows provider's injected consumer to validate and spend
+      that exact authorization before a job-custody create mutation.
 - [ ] Sign a broker-consumable one-use grant and verify it independently at the
-      restricted management boundary.
+      composed restricted management boundary.
 - [x] Ensure no scheduler, rerun, recovery, administrative API, or capacity
       fallback can select an alternate Windows boundary.
 - [x] Bind the server-only one-use admission value to attempt, operation,

--- a/docs/runtime-authority-delivery.md
+++ b/docs/runtime-authority-delivery.md
@@ -108,7 +108,10 @@ Poll contributions and sandbox authorizations are separate contracts. A poll
 contribution lets a server-side extension validate and durably retain
 provider-owned lease evidence. Any job-bound authorization derived from that
 evidence is delivered only after exact offer acceptance through the protected
-runtime-authority exchange.
+runtime-authority exchange. The canonical evidence set has an 8 MiB encoded
+durability budget, and complete lease-offer commands are size-checked before
+publication, so an accepted extension projection cannot fail only when the
+store adapter serializes it.
 
 ## Provider-owned sandbox authorizations
 

--- a/docs/runtime-authority-delivery.md
+++ b/docs/runtime-authority-delivery.md
@@ -3,8 +3,9 @@
 Automata delivers workload credentials only after the runner has durably
 accepted an exact lease offer. The lease offer and its persisted outbox payload
 contain authority metadata, never bearer values. A separate versioned exchange
-binds any credential bundle to the accepted attempt, protects it on the runner,
-and records runner custody before user code can start.
+binds the complete runtime-authority bundle, including any credentials and
+provider-owned sandbox authorizations, to the accepted attempt, protects it on
+the runner, and records runner custody before user code can start.
 
 This contract is component complete across the protocol, control handler,
 PostgreSQL adapter, runner journal, runner supervisor, and GitHub repository
@@ -25,13 +26,16 @@ The delivery design enforces these invariants:
 - Request, grant, and acknowledgement carry one identical delivery binding.
 - The control database stores request and custody evidence plus SHA-256
   digests. It stores neither credential plaintext nor an encoded grant.
-- The runner protects the complete canonical authority bundle in its encrypted
-  spool before sending a custody acknowledgement.
+- The runner protects the complete canonical `JobRuntimeAuthorities` bundle in
+  its encrypted spool before sending a custody acknowledgement. Schema v2
+  covers both credential authorities and provider-owned sandbox authorizations.
 - The journal records the protected content reference and exact digest before
   acknowledgement. The execution adapter receives authorities only after the
   acknowledgement is durably marked complete.
-- A credential-free job receives an empty bundle. Explicit repository denial
-  and OIDC-only permission maps do not call the GitHub repository-token issuer.
+- A credential-free job receives no credential authority. Its canonical
+  sandbox-authorization set is separate and cannot grant repository access.
+  Explicit repository denial and OIDC-only permission maps do not call the
+  GitHub repository-token issuer.
 - A cancellation observed during request or acknowledgement stops the delivery
   exchange and terminalizes the attempt without invoking user code.
 - Missing, stale, conflicting, transitive, or unsupported-generation evidence
@@ -43,17 +47,19 @@ does not make an untrusted transport safe.
 
 ## Version and exact binding
 
-Runtime-authority delivery is defined only for runner protocol version 2 and
-delivery generation 1. Generation zero is invalid. A later generation is
-rejected until refresh, predecessor, and revocation semantics are specified for
-that generation. A protocol-1 runner cannot deserialize the new exchange as a
-compatible legacy offer and is rejected during negotiation or message
-validation.
+Runtime-authority delivery uses runner protocol version 3, protected
+`JobRuntimeAuthorities` schema version 2, and delivery generation 1. Generation
+zero is invalid. A later delivery generation is rejected until refresh,
+predecessor, and revocation semantics are specified for that generation. The
+current build negotiates only protocol 3, so protocol-1 and protocol-2 runners
+are rejected before lease traffic.
 
-Migration 0037 retains protocol-1 session rows as historical control-plane
-evidence while admitting protocol-2 sessions. This is not a protocol-1 delivery
-path: runtime-authority custody rows require protocol 2, and negotiation and
-message validation reject protocol-1 execution.
+Migration 0037 introduced protocol-2 runtime-authority custody. Migration 0061
+retains protocol-1 and protocol-2 session rows, and protocol-2 custody rows, as
+historical control-plane evidence while admitting protocol 3. The database
+therefore permits historical runtime-authority rows for protocols 2 and 3, but
+the current negotiation range is min=max 3; this is not a protocol-2 execution
+path.
 
 Every delivery is bound to all of these coordinates:
 
@@ -74,6 +80,51 @@ coordinates. The all-exact row is the only admitted row. A future generation is
 rejected by the authorization constructor before it can reach offer admission;
 every other mismatch returns a binding conflict.
 
+## Lease-poll authority acceptance
+
+Protocol 3 requires every `LeaseRequest` to carry a canonical
+`LeaseAuthorityPollContributions` schema-1 bundle. A runner with no extensions
+sends the canonical empty bundle. Otherwise, each extension owns one bounded,
+nonempty, versioned payload under a lowercase namespace; entries are strictly
+ordered by unique namespace, and the bundle digest commits to the schema,
+names, payload schemas, payload digests, and exact payload bytes. The runner
+retains each source value and retries one byte-identical prepared request until
+it receives a valid response.
+
+Every successful poll result is nested in `LeasePollResponse`. Its outer reply
+header must correlate to the exact request, and its
+`accepted_contributions_sha256` must equal that request's canonical bundle
+digest. `NoWork`, a lease offer, and a cancellation are outcomes inside this
+wrapper; a durable command may still be replayed on another slot's poll.
+
+The runner validates the wrapper and accepted digest before changing durable
+state. It applies a nested command, advances the carrier poll checkpoint,
+flushes the command acknowledgement, and only then acknowledges each extension
+source. `NoWork` advances the checkpoint and then acknowledges the sources.
+A missing wrapper, a correlation or digest mismatch, or a direct legacy poll
+outcome advances neither the checkpoint nor a source acknowledgement.
+
+Poll contributions and sandbox authorizations are separate contracts. A poll
+contribution lets a server-side extension validate and durably retain
+provider-owned lease evidence. Any job-bound authorization derived from that
+evidence is delivered only after exact offer acceptance through the protected
+runtime-authority exchange.
+
+## Provider-owned sandbox authorizations
+
+`JobRuntimeAuthorities` schema 2 contains the canonical credential-authority
+list and a canonical `SandboxAuthorizations` schema-1 set. Each sandbox
+authorization has a unique provider namespace, a nonzero payload schema, exact
+bounded opaque bytes, and their SHA-256 digest. The digest acknowledged by the
+runtime-authority exchange covers the canonical encoding of the whole protected
+bundle, including this set.
+
+The runner validates and protects that whole bundle, then passes the exact
+sandbox-authorization set through `ExecutionRequest` and `SandboxSpec` without
+interpreting provider payloads. A provider consumes only its own namespace and
+schema before mutation. Providers without a matching consumer reject a
+nonempty set instead of ignoring it.
+
 ## State machine
 
 | Durable state | Allowed next action | Failure behavior |
@@ -81,10 +132,10 @@ every other mismatch returns a binding conflict.
 | Value-free offer published | Runner validates and records the exact offer. | Unknown fields, unsupported protocol, invalid `JobIR`, or command conflict reject the offer. |
 | Offer accepted locally | Runner replays the deterministic accepted response until the server acknowledges it. | Restart reuses the same operation ID and canonical bytes. |
 | Acceptance acknowledged | Runner sends `RuntimeAuthorityRequest` with the exact binding. | Cancellation stops delivery. A stale session, fence, offer, or digest fails closed. |
-| Grant returned ephemerally | Runner validates binding, authorities, lease, canonical encoding, and bundle digest. | A malformed, over-broad, mismatched, expired, or differently encoded grant is discarded. |
+| Grant returned ephemerally | Runner validates binding, `JobRuntimeAuthorities` schema 2, lease, canonical encoding, and whole-bundle digest. | A malformed, over-broad, mismatched, expired, or differently encoded grant is discarded. |
 | Protected bundle journaled | Runner sends `RuntimeAuthorityAck` with the same binding and bundle digest. | Restart skips minting and replays only the stable acknowledgement. |
 | Server custody committed | Runner marks the delivery acknowledged in its journal. | A premature, different-operation, or different-digest acknowledgement conflicts. |
-| Delivery acknowledged | Runner loads and decodes the protected bundle, applies authority aliases and secret masking, then admits execution. | Missing content, digest drift, decode failure, expiry, or credential-free contamination terminalizes or fails the attempt before user code. |
+| Delivery acknowledged | Runner loads and decodes the protected bundle, applies credential aliases and secret masking, and passes sandbox authorizations unchanged into provider admission before execution. | Missing content, digest drift, decode failure, expiry, unsupported provider authorization, or credential contamination terminalizes or fails the attempt before user code. |
 
 The request and acknowledgement operation IDs are deterministic functions of
 the accepted offer, attempt, lease guard, `JobIR` digest, and generation. A
@@ -112,8 +163,9 @@ binds the offer operation ID and that same session/sequence to one command
 outbox record. The shared session/sequence proves both keys describe the same
 published command. The table does not use independent existence-only foreign
 keys that could assemble a delivery from unrelated publications. Check
-constraints require protocol 2, generation 1, positive fences and sequences,
-32-byte digests, and an all-null or all-complete acknowledgement tuple.
+constraints permit historical protocol 2 and current protocol 3 rows, require
+generation 1, positive fences and sequences, 32-byte digests, and an all-null
+or all-complete acknowledgement tuple.
 
 The following data is forbidden from the table, command outbox, operation
 response receipts, audit records, metrics, and debug output:
@@ -149,8 +201,9 @@ The control handler performs authorization in this order:
 Explicit `none` permissions, an empty explicit map, and `id-token: write`
 without repository permissions produce no GitHub repository token. They do not
 fall back to provider defaults. `CredentialFree` jobs must have an empty
-authority bundle and cannot receive secret environment values. Provider-default
-or broad read/write requests still require an exact resolver result and fail
+credential-authority list and cannot receive secret environment values; their
+provider-owned sandbox authorization set remains separate. Provider-default or
+broad read/write requests still require an exact resolver result and fail
 closed when the service authority is unavailable.
 
 Fork and Dependabot authority reductions happen when the immutable trust policy
@@ -193,9 +246,11 @@ retry with changed coordinates.
 | After server ACK, before local ACK commit | Replay the same ACK, then mark the exact digest acknowledged. |
 | After local ACK commit | Decode the protected bundle and recover execution subject to lease, authority expiry, and supported lifecycle rules. |
 
-The runner journal schema is version 2. Old journal generations that cannot
+The runner journal schema is version 6. Old journal generations that cannot
 represent protected delivery custody fail closed instead of treating a legacy
-lease-offer bearer field as authority.
+lease-offer bearer field as authority. Schema 6 also retains pending
+lease-authority source receipts across a crash between poll acceptance and
+local source acknowledgement.
 
 ## Verification
 


### PR DESCRIPTION
## Scope

- Base: `main @ 3b430a77ad6a6e69b7ada92f248b470e10c8dbe4`
- Head: `4ff49724f06fa53b7a68498f138ab201d78b3ed7`
- Diff: 110 files, +12,178/-1,357
- All predecessors in the original Windows stack are merged.

## What this slice adds

- Runner protocol 3 with a required, bounded provider-neutral lease-authority contribution bundle and an explicitly correlated poll response that echoes the accepted bundle digest.
- A provider-neutral control/runtime extension registry for poll contribution, durable authority evidence, post-response acknowledgement, and post-accept sandbox authorization. Windows parsing, renewal validation, evidence derivation, signing, and one-use authorization stay in the Windows adapter.
- Protected `JobRuntimeAuthorities` schema 2 carrying canonical `SandboxAuthorizations`; the whole protected bundle is digest-bound and replayed without a parallel Windows field.
- Atomic journal schema 6 transitions for the nested poll command, checkpoint successor, and pending authority receipts, plus a session-wide gate that drains accepted receipts before any slot executes.
- Exact authorization propagation from `ExecutionRequest` through the Actions executor into `SandboxSpec`. Unsupported providers reject nonempty authorization sets; the Windows provider requires an injected restricted-broker consumer and consumes the authorization before any create mutation.
- Windows grant schema 4 and placement evidence schema 3, binding the full execution identity and exact current renewal serial/envelope digest so a superseded but otherwise identical renewal fails closed.
- Append-only migration `0061_runner_protocol_v3.sql`, after main's 0059/0060 migrations.

The obsolete sealed-action graph and speculative Windows admission-issue surfaces are not restored. This PR changes no CI workflow and adds no Windows CI job.

## Architecture-review resolution

Generic control, runtime, execution-request, and sandbox contracts no longer contain optional Windows authority fields or branches. They carry bounded provider-neutral values; the Windows implementation lives behind the registered control adapter and sandbox consumer boundary.

The earlier propagation gap is closed end to end: the exact protected authorization and execution binding reach the final provider. Production composition deliberately does not install the still-missing durable Windows broker repositories/consumer, so Windows job custody remains fail-closed until that real broker integration is supplied; no in-process fallback is introduced.

## Validation

- Before the mechanical rebase, core/protocol/protobuf/control passed 482/482 tests and strict all-target/all-feature Clippy with warnings denied.
- Runner journal/runtime/transport, execution, Actions executor, and sandbox provider suites passed. Runtime passed 26 unit + 87 integration tests when excluding two inherited Windows locked-spool tests (`os error 33`).
- Podman strict Clippy passed for `x86_64-unknown-linux-gnu`; its native-Windows-only dead-code diagnostics are inherited from Unix-gated code.
- Fresh pinned protobuf regeneration matches the checked-in DTO (SHA-256 `D4ADF785C4E89222CE1DDDEFFE23B7A8355D8D528DB8BFCA472144E60EED9607`).
- Migration layout tests passed 16/16; migration 0061 SHA-384 matches the frozen inventory.
- Workspace all-target locked compile (excluding the Linux-only service-proxy on this Windows host), exact diff check, conflict-marker audit, and ancestry audit passed.
- After the final rebase, the hosted Rust package set passed locally with only three documented native-Windows-only exclusions; the Windows image pipeline passed 16/16, the macOS integration plan emitted all seven bounded commands, and all 88 changed non-generated Rust blobs matched pinned rustfmt output.
- The Linux-only dead-code lint from the previous hosted run is fixed with a target-accurate constructor gate; strict Linux and native-Windows Clippy both pass for the Windows sandbox crate, along with all 24 provider tests.
- Unified remote CI is green on this corrected head: Rust, PostgreSQL, Frontend, workflow aggregate, and required aggregate all passed; no Windows job was added.