### PR TITLE
feat(windows): enforce broker admission and custody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,14 +1275,36 @@ version = "0.1.0"
 dependencies = [
  "automata-ci-core",
  "automata-ci-execution",
+ "automata-ci-protocol",
  "automata-ci-runner-spool",
  "automata-ci-sandbox-guest",
+ "automata-ci-windows-broker-core",
+ "automata-ci-windows-broker-protocol",
+ "base64 0.23.1",
+ "getrandom 0.4.3",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "automata-ci-windows-broker-core"
+version = "0.1.0"
+dependencies = [
+ "automata-ci-core",
+ "automata-ci-execution",
+ "automata-ci-protocol",
+ "automata-ci-windows-broker-protocol",
  "base64 0.23.1",
  "ring",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/automata-ci-workflow-service",
     "crates/automata-ci-windows-file-security",
     "crates/automata-ci-windows-broker",
+    "crates/automata-ci-windows-broker-core",
     "crates/automata-ci-windows-broker-hcs",
     "crates/automata-ci-windows-broker-protocol",
 ]
@@ -136,6 +137,7 @@ automata-ci-workflow-actions = { path = "crates/automata-ci-workflow-actions", v
 automata-ci-workflow-service = { path = "crates/automata-ci-workflow-service", version = "0.1.0" }
 automata-ci-windows-file-security = { path = "crates/automata-ci-windows-file-security", version = "0.1.0" }
 automata-ci-windows-broker = { path = "crates/automata-ci-windows-broker", version = "0.1.0" }
+automata-ci-windows-broker-core = { path = "crates/automata-ci-windows-broker-core", version = "0.1.0" }
 automata-ci-windows-broker-hcs = { path = "crates/automata-ci-windows-broker-hcs", version = "0.1.0" }
 automata-ci-windows-broker-protocol = { path = "crates/automata-ci-windows-broker-protocol", version = "0.1.0" }
 axum = { version = "0.8.4", features = ["http1", "json", "tokio"] }

--- a/crates/automata-ci-windows-broker-core/Cargo.toml
+++ b/crates/automata-ci-windows-broker-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "automata-ci-windows-broker"
-description = "Privileged Windows Hyper-V broker lifecycle core for Automata"
+name = "automata-ci-windows-broker-core"
+description = "Provider-independent Windows broker admission policy core for Automata"
 publish.workspace = true
 version.workspace = true
 edition.workspace = true
@@ -18,12 +18,8 @@ workspace = true
 automata-ci-core.workspace = true
 automata-ci-execution.workspace = true
 automata-ci-protocol.workspace = true
-automata-ci-runner-spool.workspace = true
-automata-ci-sandbox-guest.workspace = true
 automata-ci-windows-broker-protocol.workspace = true
-automata-ci-windows-broker-core.workspace = true
 base64.workspace = true
-getrandom.workspace = true
 ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/automata-ci-windows-broker-core/README.md
+++ b/crates/automata-ci-windows-broker-core/README.md
@@ -1,0 +1,10 @@
+# automata-ci-windows-broker-core
+
+Pure Windows broker admission contracts and policy evaluation. This crate owns
+canonical admission requests, host-input evidence, promotion/trust validation,
+capability derivation, and the synthetic-probe port. It performs no filesystem
+mutation, custody, state persistence, service composition, or host-compute I/O.
+
+`automata-ci-windows-broker` composes these policies into the privileged
+application service and supplies repository and custody adapters. Runner-side
+code depends only on the narrow broker protocol, never on either service crate.

--- a/crates/automata-ci-windows-broker-core/src/admission.rs
+++ b/crates/automata-ci-windows-broker-core/src/admission.rs
@@ -1,0 +1,1265 @@
+//! Broker-owned Windows admission policy evaluation.
+//!
+//! This module is deterministic and adapter-free. Host input acquisition and
+//! synthetic lifecycle probing cross explicit ports; service state and custody
+//! live in `automata-ci-windows-broker`.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    str::FromStr as _,
+    sync::Arc,
+};
+
+use automata_ci_core::{
+    ContainerCapabilities, IsolationLevel, RunnerCapabilities, RunnerFeature, SandboxCapabilities,
+    SandboxFeature, Sha256Digest, UnixMillis,
+};
+use automata_ci_execution::ImmutableImage;
+use automata_ci_protocol::{
+    WindowsAuthorityAdmissionEvidence, WindowsBrokerAdmissionEvidence, WindowsBrokerProfileBinding,
+    WindowsImagePromotionBinding, WindowsPromotionValidity, WindowsRunnerAdmissionBinding,
+    WindowsRunnerAdmissionEvidence,
+};
+use automata_ci_windows_broker_protocol::WINDOWS_HYPERV_PROVIDER_ID;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use ring::signature::{ED25519, UnparsedPublicKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+use crate::{
+    host_input::{
+        WindowsBrokerHostInputAttestation, WindowsBrokerHostInputKind,
+        WindowsBrokerHostInputRequest,
+    },
+    request::{WindowsAdmissionLaunchContract, WindowsBrokerAdmissionRequest},
+};
+
+const MILLIS_PER_SECOND: i64 = 1_000;
+const HOST_INPUT_ATTESTATION_LIFETIME_MILLIS: i64 = 5 * 60 * 1_000;
+const MAX_PROMOTION_LIFETIME_MILLIS: u64 = 7 * 24 * 60 * 60 * 1_000;
+const MAX_PROMOTION_FUTURE_SKEW_MILLIS: u64 = 5 * 60 * 1_000;
+const MAX_REVOKED_IMAGES: usize = 4_096;
+const PROMOTION_PAYLOAD_SCHEMA_VERSION: u16 = 2;
+const EVIDENCE_REFERENCE_MEDIA_TYPE: &str =
+    "application/vnd.automata.windows-image-evidence-reference+json";
+const PROMOTION_TRUST_BUNDLE_DOMAIN: &[u8] = b"automata.windows-promotion-trust-bundle.v1\0";
+const PROFILE_CONTRACT_DOMAIN: &[u8] = b"automata.windows-admitted-profile-contract.v2\0";
+const IMAGE_ATTESTATION_DOMAIN: &[u8] = b"automata.windows-image-attestation.v1\0";
+const AUTHORITY_ATTESTATION_DOMAIN: &[u8] = b"automata.windows-admission-authority.v1\0";
+
+/// Complete result of broker-owned input, promotion, and synthetic probing.
+///
+/// This type can be constructed only inside this crate after privileged
+/// evaluation. The issue DTO remains non-authoritative and cannot directly
+/// manufacture this value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerAdmissionEvaluation {
+    binding: WindowsRunnerAdmissionBinding,
+    evidence: WindowsRunnerAdmissionEvidence,
+    launch: WindowsAdmissionLaunchContract,
+    profile_valid_until: UnixMillis,
+}
+
+impl WindowsBrokerAdmissionEvaluation {
+    /// Creates an evaluated contract after all privileged checks complete.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a non-Windows/offline binding, launch substitution, or a
+    /// validity horizon beyond the signed image promotion.
+    pub(crate) fn new(
+        binding: WindowsRunnerAdmissionBinding,
+        evidence: &WindowsRunnerAdmissionEvidence,
+        launch: WindowsAdmissionLaunchContract,
+        profile_valid_until: UnixMillis,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let broker = binding.broker_profile();
+        let promotion_expiry =
+            i64::try_from(binding.promotion().validity().expires_at_unix_millis())
+                .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        if !broker.network_disabled()
+            || broker.profile() != launch.profile()
+            || broker.image() != launch.image()
+            || launch.network_disabled() != broker.network_disabled()
+            || launch.resources().pids() != broker.sandbox_pids_limit()
+            || profile_valid_until.get() <= 0
+            || profile_valid_until.get() > promotion_expiry
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        Ok(Self {
+            binding,
+            evidence: *evidence,
+            launch,
+            profile_valid_until,
+        })
+    }
+
+    /// Returns the exact capability-bearing signed binding.
+    #[must_use]
+    pub const fn binding(&self) -> &WindowsRunnerAdmissionBinding {
+        &self.binding
+    }
+
+    /// Returns freshly broker-derived evidence.
+    #[must_use]
+    pub const fn evidence(&self) -> WindowsRunnerAdmissionEvidence {
+        self.evidence
+    }
+
+    /// Returns the broker-retained immutable launch contract.
+    #[must_use]
+    pub const fn launch(&self) -> &WindowsAdmissionLaunchContract {
+        &self.launch
+    }
+
+    /// Returns the exclusive promotion/profile horizon.
+    #[must_use]
+    pub const fn profile_valid_until(&self) -> UnixMillis {
+        self.profile_valid_until
+    }
+}
+
+/// Privileged, independently configured admission evaluator.
+pub trait WindowsBrokerAdmissionEvaluator: fmt::Debug + Send + Sync {
+    /// Reopens and verifies every issue input, enforces promotion high-water,
+    /// creates/observes/destroys the fixed synthetic resource, and returns
+    /// only broker-derived authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free request, evidence, state, or availability error.
+    fn evaluate(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionEvaluation, WindowsBrokerAdmissionError>;
+}
+
+/// Stable-handle result for every broker-authoritative admission input.
+///
+/// The attestation covers all nine closed input roles. Bytes are retained only
+/// for the seven bounded image, evidence, revocation, and promotion documents;
+/// configuration and executable content are measured but never copied into an
+/// admission parser allocation.
+#[derive(Debug)]
+pub struct WindowsBrokerAdmissionInputSet {
+    attestation: WindowsBrokerHostInputAttestation,
+    documents: BTreeMap<WindowsBrokerHostInputKind, Zeroizing<Vec<u8>>>,
+}
+
+impl WindowsBrokerAdmissionInputSet {
+    /// Constructs one exact, content-bound input set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects missing, duplicated, empty, oversized, or digest-substituted
+    /// semantic documents, or an attestation for a different request.
+    pub fn new(
+        request: &WindowsBrokerHostInputRequest,
+        attestation: WindowsBrokerHostInputAttestation,
+        documents: BTreeMap<WindowsBrokerHostInputKind, Zeroizing<Vec<u8>>>,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        attestation
+            .validate_for(request, attestation.host_id())
+            .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let expected = request
+            .inputs()
+            .iter()
+            .filter(|descriptor| admission_document_kind(descriptor.kind()))
+            .collect::<Vec<_>>();
+        if documents.len() != expected.len()
+            || expected.iter().any(|descriptor| {
+                documents.get(&descriptor.kind()).is_none_or(|bytes| {
+                    bytes.is_empty()
+                        || u64::try_from(bytes.len())
+                            .map_or(true, |length| length > descriptor.kind().byte_limit())
+                        || sha256(bytes) != descriptor.expected_sha256()
+                })
+            })
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        Ok(Self {
+            attestation,
+            documents,
+        })
+    }
+
+    /// Returns the stable-handle aggregate attestation.
+    #[must_use]
+    pub const fn attestation(&self) -> &WindowsBrokerHostInputAttestation {
+        &self.attestation
+    }
+
+    fn document(
+        &self,
+        kind: WindowsBrokerHostInputKind,
+    ) -> Result<&[u8], WindowsBrokerAdmissionError> {
+        self.documents
+            .get(&kind)
+            .map(AsRef::as_ref)
+            .ok_or(WindowsBrokerAdmissionError::EvidenceRejected)
+    }
+}
+
+/// Closed production/test seam that reopens all admission inputs from stable
+/// service-owned handles and returns only digest-checked semantic documents.
+pub trait WindowsBrokerAdmissionInputSource: fmt::Debug + Send + Sync {
+    /// Attests and loads one exact nine-input batch.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on path, ACL, owner, volume, file-ID, content, or freshness
+    /// disagreement.
+    fn load(
+        &self,
+        request: &WindowsBrokerHostInputRequest,
+        issued_at: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionInputSet, WindowsBrokerAdmissionError>;
+}
+
+/// One independently configured Ed25519 promotion verification key.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerPromotionTrustKey {
+    key_id: String,
+    public_key: [u8; 32],
+}
+
+impl WindowsBrokerPromotionTrustKey {
+    /// Creates one trust-registry key.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed identifiers or a zero public key.
+    pub fn new(
+        key_id: impl Into<String>,
+        public_key: [u8; 32],
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let key_id = key_id.into();
+        if !valid_promotion_id(&key_id) || public_key.iter().all(|byte| *byte == 0) {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        Ok(Self { key_id, public_key })
+    }
+}
+
+/// One versioned broker-owned promotion trust bundle.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerPromotionTrustBundle {
+    trust_bundle_id: String,
+    trust_bundle_sha256: Sha256Digest,
+    keys: BTreeMap<String, [u8; 32]>,
+}
+
+impl WindowsBrokerPromotionTrustBundle {
+    /// Creates one canonical bundle and verifies its provisioned commitment.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed identifiers, duplicate/empty keys, excessive key
+    /// counts, or a commitment that does not match the canonical key set.
+    pub fn new(
+        trust_bundle_id: impl Into<String>,
+        trust_bundle_sha256: Sha256Digest,
+        keys: Vec<WindowsBrokerPromotionTrustKey>,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let trust_bundle_id = trust_bundle_id.into();
+        if !valid_trust_bundle_id(&trust_bundle_id) || keys.is_empty() || keys.len() > 32 {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        let mut canonical = BTreeMap::new();
+        for key in keys {
+            if canonical.insert(key.key_id, key.public_key).is_some() {
+                return Err(WindowsBrokerAdmissionError::InvalidRequest);
+            }
+        }
+        let expected = promotion_trust_bundle_sha256(&trust_bundle_id, &canonical);
+        if trust_bundle_sha256 != expected {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        Ok(Self {
+            trust_bundle_id,
+            trust_bundle_sha256,
+            keys: canonical,
+        })
+    }
+
+    /// Computes the canonical commitment used when provisioning a bundle.
+    #[must_use]
+    pub fn canonical_sha256(
+        trust_bundle_id: &str,
+        keys: &[WindowsBrokerPromotionTrustKey],
+    ) -> Sha256Digest {
+        let canonical = keys
+            .iter()
+            .map(|key| (key.key_id.clone(), key.public_key))
+            .collect::<BTreeMap<_, _>>();
+        promotion_trust_bundle_sha256(trust_bundle_id, &canonical)
+    }
+}
+
+/// Immutable service-owned registry of accepted promotion bundles and keys.
+#[derive(Clone, Debug)]
+pub struct WindowsBrokerPromotionTrustRegistry {
+    bundles: BTreeMap<String, WindowsBrokerPromotionTrustBundle>,
+}
+
+impl WindowsBrokerPromotionTrustRegistry {
+    /// Creates a nonempty registry with unique bundle identities.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, duplicate, or excessive bundle sets.
+    pub fn new(
+        bundles: Vec<WindowsBrokerPromotionTrustBundle>,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        if bundles.is_empty() || bundles.len() > 32 {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        let mut registry = BTreeMap::new();
+        for bundle in bundles {
+            if registry
+                .insert(bundle.trust_bundle_id.clone(), bundle)
+                .is_some()
+            {
+                return Err(WindowsBrokerAdmissionError::InvalidRequest);
+            }
+        }
+        Ok(Self { bundles: registry })
+    }
+
+    fn resolve(
+        &self,
+        trust_bundle_id: &str,
+        key_id: &str,
+    ) -> Result<(&WindowsBrokerPromotionTrustBundle, &[u8; 32]), WindowsBrokerAdmissionError> {
+        let bundle = self
+            .bundles
+            .get(trust_bundle_id)
+            .ok_or(WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let key = bundle
+            .keys
+            .get(key_id)
+            .ok_or(WindowsBrokerAdmissionError::EvidenceRejected)?;
+        Ok((bundle, key))
+    }
+}
+
+/// Evidence returned only after a fixed synthetic resource was created,
+/// independently observed, and durably cleaned by the broker boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(clippy::struct_field_names)]
+pub struct WindowsBrokerSyntheticProbeEvidence {
+    broker_attestation_sha256: Sha256Digest,
+    network_attestation_sha256: Sha256Digest,
+    cleanup_receipt_sha256: Sha256Digest,
+}
+
+impl WindowsBrokerSyntheticProbeEvidence {
+    /// Creates a complete non-placeholder probe result.
+    ///
+    /// # Errors
+    ///
+    /// Rejects any missing evidence commitment.
+    pub fn new(
+        broker_attestation_sha256: Sha256Digest,
+        network_attestation_sha256: Sha256Digest,
+        cleanup_receipt_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        if [
+            broker_attestation_sha256,
+            network_attestation_sha256,
+            cleanup_receipt_sha256,
+        ]
+        .into_iter()
+        .any(zero_digest)
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        Ok(Self {
+            broker_attestation_sha256,
+            network_attestation_sha256,
+            cleanup_receipt_sha256,
+        })
+    }
+}
+
+/// Closed seam for the mandatory create/observe/cleanup admission probe.
+pub trait WindowsBrokerSyntheticProbe: fmt::Debug + Send + Sync {
+    /// Executes the fixed probe for one exact request and returns evidence only
+    /// after cleanup is durably complete.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on create, effective-state, tool, network, or cleanup
+    /// disagreement.
+    fn execute(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        host_inputs: &WindowsBrokerHostInputAttestation,
+        now: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerSyntheticProbeEvidence, WindowsBrokerAdmissionError>;
+}
+
+/// Explicit fail-closed probe used until a ledger-backed synthetic lifecycle
+/// implementation has been injected.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UnavailableWindowsBrokerSyntheticProbe;
+
+impl WindowsBrokerSyntheticProbe for UnavailableWindowsBrokerSyntheticProbe {
+    fn execute(
+        &self,
+        _request: &WindowsBrokerAdmissionRequest,
+        _host_inputs: &WindowsBrokerHostInputAttestation,
+        _now: UnixMillis,
+        _valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerSyntheticProbeEvidence, WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+}
+
+/// Production admission evaluator with independently owned input, promotion,
+/// and synthetic-lifecycle authorities.
+pub struct VerifiedWindowsBrokerAdmissionEvaluator {
+    host_id: Sha256Digest,
+    inputs: Arc<dyn WindowsBrokerAdmissionInputSource>,
+    promotion_trust: WindowsBrokerPromotionTrustRegistry,
+    probe: Arc<dyn WindowsBrokerSyntheticProbe>,
+}
+
+impl VerifiedWindowsBrokerAdmissionEvaluator {
+    /// Composes the closed evaluator dependencies.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a placeholder broker host identity.
+    pub fn new(
+        host_id: Sha256Digest,
+        inputs: Arc<dyn WindowsBrokerAdmissionInputSource>,
+        promotion_trust: WindowsBrokerPromotionTrustRegistry,
+        probe: Arc<dyn WindowsBrokerSyntheticProbe>,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        if zero_digest(host_id) {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        Ok(Self {
+            host_id,
+            inputs,
+            promotion_trust,
+            probe,
+        })
+    }
+}
+
+impl fmt::Debug for VerifiedWindowsBrokerAdmissionEvaluator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VerifiedWindowsBrokerAdmissionEvaluator")
+            .field("host_id", &self.host_id)
+            .field("inputs", &self.inputs)
+            .field("promotion_trust", &self.promotion_trust)
+            .field("probe", &self.probe)
+            .finish()
+    }
+}
+
+impl WindowsBrokerAdmissionEvaluator for VerifiedWindowsBrokerAdmissionEvaluator {
+    fn evaluate(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionEvaluation, WindowsBrokerAdmissionError> {
+        if now.get() < 0
+            || request.broker_host_id() != self.host_id.to_string()
+            || request.sandbox_provider_id() != WINDOWS_HYPERV_PROVIDER_ID
+            || !request.launch().network_disabled()
+            || request.launch().sealed_action_trees()
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        let input_request = admission_host_input_request(request)?;
+        let input_issued_at = floor_windows_admission_issued_at(now)?;
+        let input_valid_until = UnixMillis::new(
+            now.get()
+                .checked_add(HOST_INPUT_ATTESTATION_LIFETIME_MILLIS)
+                .ok_or(WindowsBrokerAdmissionError::InvalidRequest)?,
+        );
+        let inputs = self
+            .inputs
+            .load(&input_request, input_issued_at, input_valid_until)?;
+        let promotion = verify_promotion_and_image(request, &inputs, &self.promotion_trust, now)?;
+        let profile_valid_until = UnixMillis::new(
+            i64::try_from(promotion.binding.validity().expires_at_unix_millis())
+                .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?,
+        );
+        let probe = self
+            .probe
+            .execute(request, inputs.attestation(), now, profile_valid_until)?;
+        let capabilities = shell_only_capabilities(request)?;
+        let request_sha256 = request
+            .request_sha256()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+        let broker_profile = WindowsBrokerProfileBinding::new(
+            self.host_id.to_string(),
+            WINDOWS_HYPERV_PROVIDER_ID,
+            request_sha256,
+            request.launch().profile().clone(),
+            request.launch().image().clone(),
+            request.probe().contract_sha256(),
+            true,
+            false,
+            request.launch().resources().pids(),
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let binding = WindowsRunnerAdmissionBinding::new(
+            request.transaction().clone(),
+            broker_profile,
+            promotion.binding,
+            capabilities,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let binding_bytes = serde_json::to_vec(&binding)
+            .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let profile_contract_sha256 = domain_digest(
+            PROFILE_CONTRACT_DOMAIN,
+            &[
+                self.host_id.as_bytes(),
+                request_sha256.as_bytes(),
+                inputs.attestation().digest().as_bytes(),
+                promotion.image_attestation_sha256.as_bytes(),
+                probe.broker_attestation_sha256.as_bytes(),
+                probe.network_attestation_sha256.as_bytes(),
+                probe.cleanup_receipt_sha256.as_bytes(),
+                &binding_bytes,
+            ],
+        );
+        let broker_evidence = WindowsBrokerAdmissionEvidence::new(
+            probe.broker_attestation_sha256,
+            inputs.attestation().digest(),
+            promotion.image_attestation_sha256,
+            probe.network_attestation_sha256,
+            profile_contract_sha256,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let authority_attestation_sha256 = domain_digest(
+            AUTHORITY_ATTESTATION_DOMAIN,
+            &[
+                self.host_id.as_bytes(),
+                request_sha256.as_bytes(),
+                promotion.trust_bundle_sha256.as_bytes(),
+                promotion.public_key_sha256.as_bytes(),
+                profile_contract_sha256.as_bytes(),
+            ],
+        );
+        let authority_evidence = WindowsAuthorityAdmissionEvidence::new(
+            authority_attestation_sha256,
+            promotion.trust_bundle_sha256,
+            promotion.public_key_sha256,
+            probe.cleanup_receipt_sha256,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let evidence = WindowsRunnerAdmissionEvidence::new(broker_evidence, authority_evidence);
+        WindowsBrokerAdmissionEvaluation::new(
+            binding,
+            &evidence,
+            request.launch().clone(),
+            profile_valid_until,
+        )
+    }
+}
+
+struct VerifiedPromotion {
+    binding: WindowsImagePromotionBinding,
+    image_attestation_sha256: Sha256Digest,
+    trust_bundle_sha256: Sha256Digest,
+    public_key_sha256: Sha256Digest,
+}
+
+fn admission_host_input_request(
+    request: &WindowsBrokerAdmissionRequest,
+) -> Result<WindowsBrokerHostInputRequest, WindowsBrokerAdmissionError> {
+    request
+        .host_inputs()
+        .validate()
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+    Ok(request.host_inputs().clone())
+}
+
+fn shell_only_capabilities(
+    request: &WindowsBrokerAdmissionRequest,
+) -> Result<RunnerCapabilities, WindowsBrokerAdmissionError> {
+    let ceiling = request.capability_ceiling();
+    let allowed = ceiling
+        .features()
+        .iter()
+        .filter(|feature| {
+            **feature == RunnerFeature::SHELL_STEPS
+                || **feature == RunnerFeature::DEFAULT_WINDOWS_SHELL
+                || **feature == RunnerFeature::PYTHON_SHELL
+                || **feature == RunnerFeature::PWSH_SHELL
+                || **feature == RunnerFeature::WINDOWS_POWERSHELL_SHELL
+                || **feature == RunnerFeature::CMD_SHELL
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if !allowed.contains(&RunnerFeature::SHELL_STEPS)
+        || !allowed.contains(&RunnerFeature::DEFAULT_WINDOWS_SHELL)
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    RunnerCapabilities::new(ceiling.runner_id(), ceiling.platform().clone())
+        .with_max_parallel_jobs(1)
+        .map(|capabilities| {
+            capabilities
+                .with_resources_per_job(request.launch().allocation().limits())
+                .with_sandbox(SandboxCapabilities::new(
+                    IsolationLevel::VirtualMachine,
+                    [
+                        SandboxFeature::CLEAN_WORKSPACE,
+                        SandboxFeature::NETWORK_ISOLATION,
+                        SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+                    ],
+                ))
+                .with_containers(ContainerCapabilities::default())
+                .with_features(allowed)
+                .with_environment_profiles([request.launch().profile().clone()])
+        })
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)
+}
+
+#[allow(clippy::too_many_lines)]
+fn verify_promotion_and_image(
+    request: &WindowsBrokerAdmissionRequest,
+    inputs: &WindowsBrokerAdmissionInputSet,
+    trust: &WindowsBrokerPromotionTrustRegistry,
+    now: UnixMillis,
+) -> Result<VerifiedPromotion, WindowsBrokerAdmissionError> {
+    let manifest_bytes = inputs.document(WindowsBrokerHostInputKind::ImageManifest)?;
+    let manifest_sha256 = sha256(manifest_bytes);
+    if manifest_sha256 != request.promotion().manifest_sha256() {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    let manifest: ImageManifest = parse_document(manifest_bytes)?;
+    validate_manifest(&manifest, request)?;
+
+    let lock_bytes = inputs.document(WindowsBrokerHostInputKind::ImageLock)?;
+    let lock_sha256 = sha256(lock_bytes);
+    if lock_sha256 != request.promotion().lock_sha256() {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    let lock: ImageLock = parse_document(lock_bytes)?;
+    if lock.schema_version != 1
+        || lock.profile_id != request.launch().profile().id().as_str()
+        || lock.image != request.launch().image().reference()
+        || lock.base_image != manifest.base_image
+        || parse_digest(&lock.manifest_sha256)? != manifest_sha256
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+
+    let evidence_inputs = [
+        (
+            EvidenceKind::Provenance,
+            WindowsBrokerHostInputKind::Provenance,
+            &manifest.evidence.provenance,
+        ),
+        (
+            EvidenceKind::Sbom,
+            WindowsBrokerHostInputKind::Sbom,
+            &manifest.evidence.sbom,
+        ),
+        (
+            EvidenceKind::PatchReport,
+            WindowsBrokerHostInputKind::PatchReport,
+            &manifest.evidence.patch_report,
+        ),
+        (
+            EvidenceKind::Revocations,
+            WindowsBrokerHostInputKind::Revocations,
+            &manifest.evidence.revocations,
+        ),
+    ];
+    let mut evidence_digests = BTreeMap::new();
+    let mut dispositions = BTreeMap::new();
+    let mut revocation = None;
+    for (kind, input_kind, reference) in evidence_inputs {
+        let bytes = inputs.document(input_kind)?;
+        let digest = sha256(bytes);
+        if reference.media_type != EVIDENCE_REFERENCE_MEDIA_TYPE
+            || parse_digest(&reference.sha256)? != digest
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        let document: EvidenceReferenceDocument = parse_document(bytes)?;
+        let disposition = validate_evidence_document(
+            &document,
+            kind,
+            request.launch().profile().id().as_str(),
+            request.launch().image().reference(),
+        )?;
+        if let Some(value) = disposition.revocation {
+            revocation = Some(value);
+        }
+        evidence_digests.insert(kind, digest);
+        dispositions.insert(kind, disposition);
+    }
+    require_production_evidence(&dispositions)?;
+    let revocation = revocation.ok_or(WindowsBrokerAdmissionError::EvidenceRejected)?;
+
+    let envelope_bytes = inputs.document(WindowsBrokerHostInputKind::PromotionEnvelope)?;
+    let envelope_sha256 = sha256(envelope_bytes);
+    let envelope: PromotionEnvelope = parse_document(envelope_bytes)?;
+    if envelope.schema_version != 1 || envelope.key_id != request.promotion().key_id() {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    let (trust_bundle, public_key) = trust.resolve(
+        request.promotion().trust_bundle_id(),
+        request.promotion().key_id(),
+    )?;
+    let payload_bytes = Zeroizing::new(
+        BASE64
+            .decode(&envelope.payload_base64)
+            .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?,
+    );
+    let signature = Zeroizing::new(
+        BASE64
+            .decode(&envelope.signature_base64)
+            .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?,
+    );
+    if payload_bytes.is_empty() || payload_bytes.len() > 256 * 1024 || signature.len() != 64 {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    let payload: PromotionPayload = parse_document(&payload_bytes)?;
+    if serde_json::to_vec(&payload).map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?
+        != *payload_bytes
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    validate_promotion_payload(
+        &payload,
+        request,
+        &manifest,
+        &evidence_digests,
+        revocation,
+        now,
+    )?;
+    UnparsedPublicKey::new(&ED25519, public_key)
+        .verify(&payload_bytes, &signature)
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+
+    let payload_sha256 = sha256(&payload_bytes);
+    let validity = WindowsPromotionValidity::new(
+        payload.issued_at_unix_millis,
+        payload.expires_at_unix_millis,
+    )
+    .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+    let binding = WindowsImagePromotionBinding::new(
+        request.promotion().trust_bundle_id(),
+        request.promotion().key_id(),
+        payload_sha256,
+        envelope_sha256,
+        payload.promotion_serial,
+        payload.revocation_generation,
+        validity,
+    )
+    .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+    let public_key_sha256 = sha256(public_key);
+    let image_attestation_sha256 = domain_digest(
+        IMAGE_ATTESTATION_DOMAIN,
+        &[
+            request.launch().image().digest().as_bytes(),
+            manifest_sha256.as_bytes(),
+            lock_sha256.as_bytes(),
+            evidence_digests[&EvidenceKind::Provenance].as_bytes(),
+            evidence_digests[&EvidenceKind::Sbom].as_bytes(),
+            evidence_digests[&EvidenceKind::PatchReport].as_bytes(),
+            evidence_digests[&EvidenceKind::Revocations].as_bytes(),
+            payload_sha256.as_bytes(),
+            envelope_sha256.as_bytes(),
+        ],
+    );
+    Ok(VerifiedPromotion {
+        binding,
+        image_attestation_sha256,
+        trust_bundle_sha256: trust_bundle.trust_bundle_sha256,
+        public_key_sha256,
+    })
+}
+
+fn validate_manifest(
+    manifest: &ImageManifest,
+    request: &WindowsBrokerAdmissionRequest,
+) -> Result<(), WindowsBrokerAdmissionError> {
+    if manifest.schema_version != 1
+        || manifest.status != "candidate"
+        || manifest.profile_id != request.launch().profile().id().as_str()
+        || manifest.image != request.launch().image().reference()
+        || manifest.operating_system != "windows-server-2025"
+        || manifest.variant != "server-core"
+        || manifest.architecture != "x86_64"
+        || manifest.isolation != "hyperv-container"
+        || !manifest.network_disabled
+        || !manifest.unprivileged
+        || !manifest.clean_workspace
+        || !manifest
+            .workspace
+            .eq_ignore_ascii_case(request.launch().workspace())
+        || !manifest
+            .guest_agent
+            .eq_ignore_ascii_case(request.launch().keepalive().program())
+        || ImmutableImage::new(manifest.base_image.clone()).is_err()
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    let expected_tools = request
+        .probe()
+        .tool_paths()
+        .into_iter()
+        .filter_map(|(kind, path)| {
+            (kind != "python")
+                .then_some(path.map(|path| (kind, path)))
+                .flatten()
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut actual_tools = BTreeMap::new();
+    for tool in &manifest.tools {
+        if tool.version.is_empty()
+            || tool.version.len() > 128
+            || !tool.version.is_ascii()
+            || parse_digest(&tool.sha256).is_err()
+            || actual_tools
+                .insert(tool.kind.as_str(), tool.path.as_str())
+                .is_some()
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+    }
+    if actual_tools.len() != expected_tools.len()
+        || expected_tools.iter().any(|(kind, path)| {
+            actual_tools
+                .get(kind)
+                .is_none_or(|actual| !actual.eq_ignore_ascii_case(path))
+        })
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    Ok(())
+}
+
+fn validate_evidence_document(
+    document: &EvidenceReferenceDocument,
+    expected_kind: EvidenceKind,
+    profile_id: &str,
+    image: &str,
+) -> Result<EvidenceDisposition, WindowsBrokerAdmissionError> {
+    if document.schema_version != 1
+        || document.kind != expected_kind
+        || document.profile_id != profile_id
+        || document.image != image
+        || parse_digest(&document.subject.sha256).is_err()
+        || document.subject.media_type != expected_subject_media_type(expected_kind)
+        || document.statement.is_empty()
+        || document.statement.len() > 4_096
+        || !document.statement.is_ascii()
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    if expected_kind != EvidenceKind::Revocations {
+        if document.generation.is_some()
+            || document.issued_at_unix_millis.is_some()
+            || document.expires_at_unix_millis.is_some()
+            || !document.revoked_images.is_empty()
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        return Ok(EvidenceDisposition {
+            candidate_fixture: document.candidate_fixture == Some(true),
+            revocation: None,
+        });
+    }
+    let generation = document
+        .generation
+        .filter(|generation| *generation > 0)
+        .ok_or(WindowsBrokerAdmissionError::EvidenceRejected)?;
+    if document.revoked_images.len() > MAX_REVOKED_IMAGES
+        || document
+            .revoked_images
+            .iter()
+            .any(|reference| ImmutableImage::new(reference.clone()).is_err())
+        || document
+            .revoked_images
+            .iter()
+            .any(|reference| reference == image)
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    Ok(EvidenceDisposition {
+        candidate_fixture: document.candidate_fixture == Some(true),
+        revocation: Some(RevocationMetadata {
+            generation,
+            issued_at_unix_millis: document.issued_at_unix_millis,
+            expires_at_unix_millis: document.expires_at_unix_millis,
+        }),
+    })
+}
+
+fn require_production_evidence(
+    dispositions: &BTreeMap<EvidenceKind, EvidenceDisposition>,
+) -> Result<(), WindowsBrokerAdmissionError> {
+    if dispositions.len() != 4
+        || dispositions
+            .values()
+            .any(|disposition| disposition.candidate_fixture)
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    Ok(())
+}
+
+fn validate_promotion_payload(
+    payload: &PromotionPayload,
+    request: &WindowsBrokerAdmissionRequest,
+    manifest: &ImageManifest,
+    evidence: &BTreeMap<EvidenceKind, Sha256Digest>,
+    revocation: RevocationMetadata,
+    now: UnixMillis,
+) -> Result<(), WindowsBrokerAdmissionError> {
+    let now =
+        u64::try_from(now.get()).map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+    let revocation_window = match (
+        revocation.issued_at_unix_millis,
+        revocation.expires_at_unix_millis,
+    ) {
+        (Some(issued), Some(expires)) => {
+            valid_signed_window(issued, expires, now)
+                && issued <= payload.issued_at_unix_millis
+                && expires >= payload.expires_at_unix_millis
+        }
+        _ => false,
+    };
+    if payload.schema_version != PROMOTION_PAYLOAD_SCHEMA_VERSION
+        || payload.decision != "promote"
+        || payload.promotion_serial == 0
+        || !payload.provenance_accepted
+        || !payload.sbom_accepted
+        || !payload.patch_accepted
+        || !payload.revocations_accepted
+        || payload.profile_id != request.launch().profile().id().as_str()
+        || payload.image != request.launch().image().reference()
+        || payload.base_image != manifest.base_image
+        || parse_digest(&payload.manifest_sha256)? != request.promotion().manifest_sha256()
+        || parse_digest(&payload.lock_sha256)? != request.promotion().lock_sha256()
+        || parse_digest(&payload.provenance_sha256)? != evidence[&EvidenceKind::Provenance]
+        || parse_digest(&payload.sbom_sha256)? != evidence[&EvidenceKind::Sbom]
+        || parse_digest(&payload.patch_report_sha256)? != evidence[&EvidenceKind::PatchReport]
+        || parse_digest(&payload.revocations_sha256)? != evidence[&EvidenceKind::Revocations]
+        || payload.revocation_generation == 0
+        || payload.revocation_generation != revocation.generation
+        || !valid_signed_window(
+            payload.issued_at_unix_millis,
+            payload.expires_at_unix_millis,
+            now,
+        )
+        || !revocation_window
+    {
+        return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+    }
+    Ok(())
+}
+
+fn valid_signed_window(issued: u64, expires: u64, now: u64) -> bool {
+    issued > 0
+        && expires > issued
+        && expires.saturating_sub(issued) <= MAX_PROMOTION_LIFETIME_MILLIS
+        && issued <= now.saturating_add(MAX_PROMOTION_FUTURE_SKEW_MILLIS)
+        && now < expires
+}
+
+fn parse_document<'a, T: Deserialize<'a>>(
+    bytes: &'a [u8],
+) -> Result<T, WindowsBrokerAdmissionError> {
+    serde_json::from_slice(bytes).map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)
+}
+
+fn parse_digest(value: &str) -> Result<Sha256Digest, WindowsBrokerAdmissionError> {
+    Sha256Digest::from_str(value).map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)
+}
+
+const fn expected_subject_media_type(kind: EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::Provenance => "application/vnd.in-toto+json",
+        EvidenceKind::Sbom => "application/spdx+json",
+        EvidenceKind::PatchReport => "application/vnd.automata.windows-patch-report+json",
+        EvidenceKind::Revocations => "application/vnd.automata.image-revocations+json",
+    }
+}
+
+const fn admission_document_kind(kind: WindowsBrokerHostInputKind) -> bool {
+    !matches!(
+        kind,
+        WindowsBrokerHostInputKind::Configuration | WindowsBrokerHostInputKind::BackendExecutable
+    )
+}
+
+fn promotion_trust_bundle_sha256(
+    trust_bundle_id: &str,
+    keys: &BTreeMap<String, [u8; 32]>,
+) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(PROMOTION_TRUST_BUNDLE_DOMAIN);
+    digest.update((trust_bundle_id.len() as u64).to_be_bytes());
+    digest.update(trust_bundle_id.as_bytes());
+    digest.update((keys.len() as u64).to_be_bytes());
+    for (key_id, public_key) in keys {
+        digest.update((key_id.len() as u64).to_be_bytes());
+        digest.update(key_id.as_bytes());
+        digest.update(public_key);
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}
+
+fn valid_promotion_id(value: &str) -> bool {
+    (3..=128).contains(&value.len())
+        && value.is_ascii()
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn valid_trust_bundle_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (3..=128).contains(&bytes.len())
+        && bytes
+            .first()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+fn zero_digest(value: Sha256Digest) -> bool {
+    value.as_bytes().iter().all(|byte| *byte == 0)
+}
+
+fn sha256(bytes: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(bytes).into())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImageManifest {
+    schema_version: u16,
+    status: String,
+    profile_id: String,
+    operating_system: String,
+    variant: String,
+    architecture: String,
+    isolation: String,
+    base_image: String,
+    image: String,
+    workspace: String,
+    guest_agent: String,
+    network_disabled: bool,
+    unprivileged: bool,
+    clean_workspace: bool,
+    tools: Vec<ToolRecord>,
+    evidence: EvidenceReferences,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolRecord {
+    kind: ToolKind,
+    path: String,
+    version: String,
+    sha256: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+enum ToolKind {
+    Pwsh,
+    Powershell,
+    Cmd,
+    Sha256,
+    Node12,
+    Node16,
+    Node20,
+    Node24,
+}
+
+impl ToolKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pwsh => "pwsh",
+            Self::Powershell => "powershell",
+            Self::Cmd => "cmd",
+            Self::Sha256 => "sha256",
+            Self::Node12 => "node12",
+            Self::Node16 => "node16",
+            Self::Node20 => "node20",
+            Self::Node24 => "node24",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReferences {
+    provenance: EvidenceReference,
+    sbom: EvidenceReference,
+    patch_report: EvidenceReference,
+    revocations: EvidenceReference,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReference {
+    sha256: String,
+    media_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImageLock {
+    schema_version: u16,
+    profile_id: String,
+    manifest_sha256: String,
+    base_image: String,
+    image: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceKind {
+    Provenance,
+    Sbom,
+    PatchReport,
+    Revocations,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReferenceDocument {
+    schema_version: u16,
+    kind: EvidenceKind,
+    #[serde(default)]
+    candidate_fixture: Option<bool>,
+    profile_id: String,
+    image: String,
+    subject: EvidenceSubject,
+    statement: String,
+    #[serde(default)]
+    generation: Option<u64>,
+    #[serde(default)]
+    issued_at_unix_millis: Option<u64>,
+    #[serde(default)]
+    expires_at_unix_millis: Option<u64>,
+    #[serde(default)]
+    revoked_images: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceSubject {
+    sha256: String,
+    media_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PromotionEnvelope {
+    schema_version: u16,
+    key_id: String,
+    payload_base64: String,
+    signature_base64: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+struct PromotionPayload {
+    schema_version: u16,
+    decision: String,
+    promotion_serial: u64,
+    issued_at_unix_millis: u64,
+    expires_at_unix_millis: u64,
+    profile_id: String,
+    base_image: String,
+    image: String,
+    manifest_sha256: String,
+    lock_sha256: String,
+    provenance_sha256: String,
+    sbom_sha256: String,
+    patch_report_sha256: String,
+    revocations_sha256: String,
+    revocation_generation: u64,
+    provenance_accepted: bool,
+    sbom_accepted: bool,
+    patch_accepted: bool,
+    revocations_accepted: bool,
+}
+
+#[derive(Clone, Copy)]
+struct EvidenceDisposition {
+    candidate_fixture: bool,
+    revocation: Option<RevocationMetadata>,
+}
+
+#[derive(Clone, Copy)]
+struct RevocationMetadata {
+    generation: u64,
+    issued_at_unix_millis: Option<u64>,
+    expires_at_unix_millis: Option<u64>,
+}
+
+/// Value-free admission failure shared by policy and the privileged service.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsBrokerAdmissionError {
+    /// Canonical request decoding or request binding failed.
+    #[error("Windows broker admission request is invalid")]
+    InvalidRequest,
+    /// Host input, promotion, probe, or trust verification failed.
+    #[error("Windows broker admission evidence was rejected")]
+    EvidenceRejected,
+    /// Durable issue/resume/completion state is absent, conflicting, or corrupt.
+    #[error("Windows broker admission state is invalid")]
+    InvalidState,
+    /// A returned envelope is malformed, mismatched, not current, or substituted.
+    #[error("Windows broker admission receipt is invalid")]
+    InvalidReceipt,
+    /// The complete production authority is not available.
+    #[error("Windows broker admission authority is unavailable")]
+    Unavailable,
+}
+
+/// Floors a broker admission issue timestamp to the database clock's
+/// whole-second precision without extending the receipt expiry.
+///
+/// # Errors
+///
+/// Rejects pre-epoch timestamps.
+pub fn floor_windows_admission_issued_at(
+    now: UnixMillis,
+) -> Result<UnixMillis, WindowsBrokerAdmissionError> {
+    if now.get() < 0 {
+        return Err(WindowsBrokerAdmissionError::InvalidRequest);
+    }
+    Ok(UnixMillis::new(
+        now.get() - now.get().rem_euclid(MILLIS_PER_SECOND),
+    ))
+}
+
+fn domain_digest(domain: &[u8], fields: &[&[u8]]) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}

--- a/crates/automata-ci-windows-broker-core/src/host_input.rs
+++ b/crates/automata-ci-windows-broker-core/src/host_input.rs
@@ -1,0 +1,724 @@
+//! Broker-authoritative evidence for Windows enrollment host inputs.
+
+use std::{collections::HashSet, fmt};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_windows_broker_protocol::WINDOWS_HYPERV_PROVIDER_ID;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+const HOST_INPUT_SCHEMA: u16 = 1;
+const HOST_INPUT_COUNT: usize = 9;
+const MAX_BACKEND_ID_BYTES: usize = 64;
+const MAX_PATH_BYTES: usize = 1_024;
+const MAX_OWNER_SID_BYTES: usize = 184;
+const MAX_ATTESTATION_LIFETIME_MILLIS: i64 = 5 * 60 * 1_000;
+const DIGEST_DOMAIN: &[u8] = b"automata.windows.host-input-attestation.v1\0";
+
+/// One security-sensitive file role required by Windows runner admission.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowsBrokerHostInputKind {
+    /// The exact runner product configuration loaded from disk.
+    Configuration,
+    /// The pinned runner-side broker client executable.
+    BackendExecutable,
+    /// The verified Windows image manifest.
+    ImageManifest,
+    /// The verified Windows image lock.
+    ImageLock,
+    /// Image provenance evidence.
+    Provenance,
+    /// Image software-bill-of-materials evidence.
+    Sbom,
+    /// Image patch-status evidence.
+    PatchReport,
+    /// Image revocation evidence.
+    Revocations,
+    /// The signed image-promotion envelope.
+    PromotionEnvelope,
+}
+
+impl WindowsBrokerHostInputKind {
+    const ORDERED: [Self; HOST_INPUT_COUNT] = [
+        Self::Configuration,
+        Self::BackendExecutable,
+        Self::ImageManifest,
+        Self::ImageLock,
+        Self::Provenance,
+        Self::Sbom,
+        Self::PatchReport,
+        Self::Revocations,
+        Self::PromotionEnvelope,
+    ];
+
+    const fn code(self) -> u8 {
+        match self {
+            Self::Configuration => 1,
+            Self::BackendExecutable => 2,
+            Self::ImageManifest => 3,
+            Self::ImageLock => 4,
+            Self::Provenance => 5,
+            Self::Sbom => 6,
+            Self::PatchReport => 7,
+            Self::Revocations => 8,
+            Self::PromotionEnvelope => 9,
+        }
+    }
+
+    pub(crate) const fn byte_limit(self) -> u64 {
+        match self {
+            Self::Configuration => 1024 * 1024,
+            Self::BackendExecutable => 512 * 1024 * 1024,
+            Self::ImageManifest
+            | Self::ImageLock
+            | Self::Provenance
+            | Self::Sbom
+            | Self::PatchReport
+            | Self::Revocations
+            | Self::PromotionEnvelope => 16 * 1024 * 1024,
+        }
+    }
+}
+
+/// One exact path and content digest the broker must independently attest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsBrokerHostInputDescriptor {
+    kind: WindowsBrokerHostInputKind,
+    absolute_path: String,
+    expected_sha256: Sha256Digest,
+}
+
+impl WindowsBrokerHostInputDescriptor {
+    /// Creates one bounded, absolute Windows input descriptor.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-canonical paths or a zero content digest.
+    pub fn new(
+        kind: WindowsBrokerHostInputKind,
+        absolute_path: impl Into<String>,
+        expected_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsBrokerHostInputError> {
+        let value = Self {
+            kind,
+            absolute_path: absolute_path.into(),
+            expected_sha256,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the fixed semantic role of this input.
+    #[must_use]
+    pub const fn kind(&self) -> WindowsBrokerHostInputKind {
+        self.kind
+    }
+
+    /// Returns the exact canonical absolute Windows path.
+    #[must_use]
+    pub fn absolute_path(&self) -> &str {
+        &self.absolute_path
+    }
+
+    /// Returns the content digest the broker must observe.
+    #[must_use]
+    pub const fn expected_sha256(&self) -> Sha256Digest {
+        self.expected_sha256
+    }
+
+    fn validate(&self) -> Result<(), WindowsBrokerHostInputError> {
+        if !valid_absolute_windows_path(&self.absolute_path) || zero_digest(self.expected_sha256) {
+            return Err(WindowsBrokerHostInputError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+/// Closed batch of every host file that one Windows enrollment depends on.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsBrokerHostInputRequest {
+    schema: u16,
+    backend_id: String,
+    sandbox_provider_id: String,
+    inputs: Vec<WindowsBrokerHostInputDescriptor>,
+}
+
+impl WindowsBrokerHostInputRequest {
+    /// Creates an exact nine-input request in the admission contract's fixed order.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an invalid backend identity, provider substitution, a missing or
+    /// reordered role, duplicate Windows paths, malformed paths, or zero digests.
+    pub fn new(
+        backend_id: impl Into<String>,
+        sandbox_provider_id: impl Into<String>,
+        inputs: Vec<WindowsBrokerHostInputDescriptor>,
+    ) -> Result<Self, WindowsBrokerHostInputError> {
+        let value = Self {
+            schema: HOST_INPUT_SCHEMA,
+            backend_id: backend_id.into(),
+            sandbox_provider_id: sandbox_provider_id.into(),
+            inputs,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the exact broker host/service authority identity.
+    #[must_use]
+    pub fn backend_id(&self) -> &str {
+        &self.backend_id
+    }
+
+    /// Returns the exact sandbox-provider identity used for active probing.
+    #[must_use]
+    pub fn sandbox_provider_id(&self) -> &str {
+        &self.sandbox_provider_id
+    }
+
+    /// Returns all inputs in their fixed semantic order.
+    #[must_use]
+    pub fn inputs(&self) -> &[WindowsBrokerHostInputDescriptor] {
+        &self.inputs
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), WindowsBrokerHostInputError> {
+        if self.schema != HOST_INPUT_SCHEMA
+            || !valid_backend_id(&self.backend_id)
+            || self.sandbox_provider_id != WINDOWS_HYPERV_PROVIDER_ID
+            || self.inputs.len() != HOST_INPUT_COUNT
+        {
+            return Err(WindowsBrokerHostInputError::InvalidRequest);
+        }
+        let mut paths = HashSet::with_capacity(HOST_INPUT_COUNT);
+        for (descriptor, expected_kind) in
+            self.inputs.iter().zip(WindowsBrokerHostInputKind::ORDERED)
+        {
+            descriptor.validate()?;
+            if descriptor.kind != expected_kind
+                || !paths.insert(descriptor.absolute_path.to_ascii_lowercase())
+            {
+                return Err(WindowsBrokerHostInputError::InvalidRequest);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One broker-observed, value-free Windows file identity and security policy.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsBrokerHostInputObservation {
+    kind: WindowsBrokerHostInputKind,
+    absolute_path: String,
+    content_sha256: Sha256Digest,
+    byte_len: u64,
+    volume_serial_number: u64,
+    file_id: [u8; 16],
+    owner_sid: String,
+    security_descriptor_sha256: Sha256Digest,
+}
+
+impl WindowsBrokerHostInputObservation {
+    /// Creates one broker-observed file identity after the adapter has held and
+    /// measured the exact file handle.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a substituted descriptor, unsafe metadata, placeholder
+    /// identity, untrusted owner, or mismatched content digest.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        descriptor: &WindowsBrokerHostInputDescriptor,
+        byte_len: u64,
+        volume_serial_number: u64,
+        file_id: [u8; 16],
+        owner_sid: String,
+        security_descriptor_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsBrokerHostInputError> {
+        let value = Self {
+            kind: descriptor.kind,
+            absolute_path: descriptor.absolute_path.clone(),
+            content_sha256: descriptor.expected_sha256,
+            byte_len,
+            volume_serial_number,
+            file_id,
+            owner_sid,
+            security_descriptor_sha256,
+        };
+        value.validate(descriptor)?;
+        Ok(value)
+    }
+
+    /// Returns the semantic role independently observed by the broker.
+    #[must_use]
+    pub const fn kind(&self) -> WindowsBrokerHostInputKind {
+        self.kind
+    }
+
+    /// Returns the exact path independently opened by the broker.
+    #[must_use]
+    pub fn absolute_path(&self) -> &str {
+        &self.absolute_path
+    }
+
+    /// Returns the digest computed from the broker-held file handle.
+    #[must_use]
+    pub const fn content_sha256(&self) -> Sha256Digest {
+        self.content_sha256
+    }
+
+    /// Returns the exact byte length observed by the broker.
+    #[must_use]
+    pub const fn byte_len(&self) -> u64 {
+        self.byte_len
+    }
+
+    /// Returns the pinned local-volume serial number.
+    #[must_use]
+    pub const fn volume_serial_number(&self) -> u64 {
+        self.volume_serial_number
+    }
+
+    /// Returns the exact 128-bit filesystem file identifier.
+    #[must_use]
+    pub const fn file_id(&self) -> &[u8; 16] {
+        &self.file_id
+    }
+
+    /// Returns the exact trusted owner SID.
+    #[must_use]
+    pub fn owner_sid(&self) -> &str {
+        &self.owner_sid
+    }
+
+    /// Returns the digest of the canonical protected owner/DACL descriptor.
+    #[must_use]
+    pub const fn security_descriptor_sha256(&self) -> Sha256Digest {
+        self.security_descriptor_sha256
+    }
+
+    fn validate(
+        &self,
+        descriptor: &WindowsBrokerHostInputDescriptor,
+    ) -> Result<(), WindowsBrokerHostInputError> {
+        if self.kind != descriptor.kind
+            || self.absolute_path != descriptor.absolute_path
+            || self.content_sha256 != descriptor.expected_sha256
+            || self.byte_len == 0
+            || self.byte_len > self.kind.byte_limit()
+            || self.volume_serial_number == 0
+            || self.file_id.iter().all(|byte| *byte == 0)
+            || !valid_sid(&self.owner_sid)
+            || zero_digest(self.security_descriptor_sha256)
+        {
+            return Err(WindowsBrokerHostInputError::InvalidEvidence);
+        }
+        Ok(())
+    }
+}
+
+/// Fresh aggregate broker evidence for all Windows enrollment host inputs.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsBrokerHostInputAttestation {
+    schema: u16,
+    host_id: Sha256Digest,
+    backend_id: String,
+    sandbox_provider_id: String,
+    inputs: Vec<WindowsBrokerHostInputObservation>,
+    issued_at: UnixMillis,
+    valid_until: UnixMillis,
+    digest: Sha256Digest,
+}
+
+impl WindowsBrokerHostInputAttestation {
+    /// Issues a fresh aggregate over one exact, fixed-order input request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects host or request substitution, malformed observations, and an
+    /// invalid or excessive validity horizon.
+    pub fn issue(
+        host_id: Sha256Digest,
+        request: &WindowsBrokerHostInputRequest,
+        inputs: Vec<WindowsBrokerHostInputObservation>,
+        issued_at: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<Self, WindowsBrokerHostInputError> {
+        let digest = attestation_digest(host_id, request, &inputs, issued_at, valid_until)?;
+        let value = Self {
+            schema: HOST_INPUT_SCHEMA,
+            host_id,
+            backend_id: request.backend_id.clone(),
+            sandbox_provider_id: request.sandbox_provider_id.clone(),
+            inputs,
+            issued_at,
+            valid_until,
+            digest,
+        };
+        value.validate_for(request, host_id)?;
+        Ok(value)
+    }
+
+    /// Returns the exact host identity that produced this evidence.
+    #[must_use]
+    pub const fn host_id(&self) -> Sha256Digest {
+        self.host_id
+    }
+
+    /// Returns the exact broker authority identity bound by the request.
+    #[must_use]
+    pub fn backend_id(&self) -> &str {
+        &self.backend_id
+    }
+
+    /// Returns the exact active-probe provider identity.
+    #[must_use]
+    pub fn sandbox_provider_id(&self) -> &str {
+        &self.sandbox_provider_id
+    }
+
+    /// Returns all independently observed inputs in fixed semantic order.
+    #[must_use]
+    pub fn inputs(&self) -> &[WindowsBrokerHostInputObservation] {
+        &self.inputs
+    }
+
+    /// Returns the service-clock issuance time.
+    #[must_use]
+    pub const fn issued_at(&self) -> UnixMillis {
+        self.issued_at
+    }
+
+    /// Returns the exclusive freshness deadline.
+    #[must_use]
+    pub const fn valid_until(&self) -> UnixMillis {
+        self.valid_until
+    }
+
+    /// Returns the canonical aggregate attestation digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    pub(crate) fn validate_for(
+        &self,
+        request: &WindowsBrokerHostInputRequest,
+        expected_host_id: Sha256Digest,
+    ) -> Result<(), WindowsBrokerHostInputError> {
+        request.validate()?;
+        if self.schema != HOST_INPUT_SCHEMA
+            || self.host_id != expected_host_id
+            || self.backend_id != request.backend_id
+            || self.sandbox_provider_id != request.sandbox_provider_id
+            || self.inputs.len() != request.inputs.len()
+            || self.issued_at.get() < 0
+            || self.valid_until.get() <= self.issued_at.get()
+            || self.valid_until.get().saturating_sub(self.issued_at.get())
+                > MAX_ATTESTATION_LIFETIME_MILLIS
+        {
+            return Err(WindowsBrokerHostInputError::InvalidEvidence);
+        }
+        for (observation, descriptor) in self.inputs.iter().zip(&request.inputs) {
+            observation.validate(descriptor)?;
+        }
+        let expected = attestation_digest(
+            self.host_id,
+            request,
+            &self.inputs,
+            self.issued_at,
+            self.valid_until,
+        )?;
+        if self.digest != expected || zero_digest(self.digest) {
+            return Err(WindowsBrokerHostInputError::InvalidEvidence);
+        }
+        Ok(())
+    }
+}
+
+/// Closed production/test seam for broker-side Windows file attestation.
+pub trait WindowsBrokerHostInputAttestor: fmt::Debug + Send + Sync {
+    /// Independently opens, verifies, and attests every exact request input.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on malformed requests, path races, content changes, unsafe
+    /// ownership/DACLs, the wrong volume, or unavailable platform evidence.
+    fn attest(
+        &self,
+        request: &WindowsBrokerHostInputRequest,
+        issued_at: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerHostInputAttestation, WindowsBrokerHostInputError>;
+}
+
+/// Secret-free host-input request or evidence failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsBrokerHostInputError {
+    /// The versioned request or one of its descriptors is malformed.
+    #[error("Windows broker host-input request is invalid")]
+    InvalidRequest,
+    /// Broker-observed evidence is inconsistent or malformed.
+    #[error("Windows broker host-input evidence is invalid")]
+    InvalidEvidence,
+    /// The path, volume, owner, or protected DACL violates broker policy.
+    #[error("Windows broker host-input policy rejected the file")]
+    Policy,
+    /// The file could not be opened and stabilized for attestation.
+    #[error("Windows broker host-input file could not be stabilized")]
+    File,
+}
+
+fn attestation_digest(
+    host_id: Sha256Digest,
+    request: &WindowsBrokerHostInputRequest,
+    inputs: &[WindowsBrokerHostInputObservation],
+    issued_at: UnixMillis,
+    valid_until: UnixMillis,
+) -> Result<Sha256Digest, WindowsBrokerHostInputError> {
+    if inputs.len() != request.inputs.len() {
+        return Err(WindowsBrokerHostInputError::InvalidEvidence);
+    }
+    let mut hash = Sha256::new();
+    hash.update(DIGEST_DOMAIN);
+    hash.update(host_id.as_bytes());
+    put_bytes(&mut hash, request.backend_id.as_bytes())?;
+    put_bytes(&mut hash, request.sandbox_provider_id.as_bytes())?;
+    hash.update(issued_at.get().to_be_bytes());
+    hash.update(valid_until.get().to_be_bytes());
+    hash.update(
+        u16::try_from(inputs.len())
+            .map_err(|_| WindowsBrokerHostInputError::InvalidEvidence)?
+            .to_be_bytes(),
+    );
+    for input in inputs {
+        hash.update([input.kind.code()]);
+        put_bytes(&mut hash, input.absolute_path.as_bytes())?;
+        hash.update(input.content_sha256.as_bytes());
+        hash.update(input.byte_len.to_be_bytes());
+        hash.update(input.volume_serial_number.to_be_bytes());
+        hash.update(input.file_id);
+        put_bytes(&mut hash, input.owner_sid.as_bytes())?;
+        hash.update(input.security_descriptor_sha256.as_bytes());
+    }
+    Ok(Sha256Digest::from_bytes(hash.finalize().into()))
+}
+
+fn put_bytes(hash: &mut Sha256, value: &[u8]) -> Result<(), WindowsBrokerHostInputError> {
+    let len =
+        u32::try_from(value.len()).map_err(|_| WindowsBrokerHostInputError::InvalidEvidence)?;
+    hash.update(len.to_be_bytes());
+    hash.update(value);
+    Ok(())
+}
+
+fn valid_backend_id(value: &str) -> bool {
+    value.len() == MAX_BACKEND_ID_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_absolute_windows_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() < 4
+        || bytes.len() > MAX_PATH_BYTES
+        || !bytes.is_ascii()
+        || !bytes[0].is_ascii_uppercase()
+        || bytes[1] != b':'
+        || bytes[2] != b'\\'
+        || value.contains('/')
+        || value.contains("\\\\")
+        || value.chars().any(char::is_control)
+    {
+        return false;
+    }
+    value[3..].split('\\').all(|component| {
+        !component.is_empty()
+            && component != "."
+            && component != ".."
+            && !component.ends_with([' ', '.'])
+            && !component.contains(':')
+    })
+}
+
+fn valid_sid(value: &str) -> bool {
+    value.len() >= 7
+        && value.len() <= MAX_OWNER_SID_BYTES
+        && value.starts_with("S-1-")
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'-' || byte == b'S')
+        && value
+            .split('-')
+            .skip(2)
+            .all(|part| !part.is_empty() && part.len() <= 10 && part.parse::<u32>().is_ok())
+}
+
+const fn zero_digest(value: Sha256Digest) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != 0 {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> WindowsBrokerHostInputRequest {
+        let inputs = WindowsBrokerHostInputKind::ORDERED
+            .into_iter()
+            .enumerate()
+            .map(|(index, kind)| {
+                WindowsBrokerHostInputDescriptor::new(
+                    kind,
+                    format!(r"C:\Automata\input-{index}.bin"),
+                    Sha256Digest::from_bytes([u8::try_from(index + 1).unwrap(); 32]),
+                )
+                .unwrap()
+            })
+            .collect();
+        WindowsBrokerHostInputRequest::new("a".repeat(64), WINDOWS_HYPERV_PROVIDER_ID, inputs)
+            .unwrap()
+    }
+
+    fn observations(
+        request: &WindowsBrokerHostInputRequest,
+    ) -> Vec<WindowsBrokerHostInputObservation> {
+        request
+            .inputs()
+            .iter()
+            .enumerate()
+            .map(|(index, descriptor)| {
+                WindowsBrokerHostInputObservation::new(
+                    descriptor,
+                    100,
+                    42,
+                    [u8::try_from(index + 1).unwrap(); 16],
+                    "S-1-5-80-1-2-3-4-5".to_owned(),
+                    Sha256Digest::from_bytes([99; 32]),
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn request_requires_exact_roles_order_provider_and_unique_paths() {
+        let valid = request();
+        assert_eq!(valid.inputs().len(), HOST_INPUT_COUNT);
+
+        let mut reordered = valid.inputs.clone();
+        reordered.swap(0, 1);
+        assert_eq!(
+            WindowsBrokerHostInputRequest::new(
+                valid.backend_id.clone(),
+                WINDOWS_HYPERV_PROVIDER_ID,
+                reordered,
+            ),
+            Err(WindowsBrokerHostInputError::InvalidRequest)
+        );
+        assert_eq!(
+            WindowsBrokerHostInputRequest::new(valid.backend_id, "windows-process", valid.inputs,),
+            Err(WindowsBrokerHostInputError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn attestation_digest_binds_file_identity_security_and_freshness() {
+        let request = request();
+        let host_id = Sha256Digest::from_bytes([7; 32]);
+        let issued = UnixMillis::new(1_000);
+        let valid_until = UnixMillis::new(301_000);
+        let attestation = WindowsBrokerHostInputAttestation::issue(
+            host_id,
+            &request,
+            observations(&request),
+            issued,
+            valid_until,
+        )
+        .unwrap();
+        attestation.validate_for(&request, host_id).unwrap();
+
+        let mut tampered = attestation.clone();
+        tampered.inputs[0].file_id[0] ^= 1;
+        assert_eq!(
+            tampered.validate_for(&request, host_id),
+            Err(WindowsBrokerHostInputError::InvalidEvidence)
+        );
+        let mut expired_shape = attestation;
+        expired_shape.valid_until = UnixMillis::new(301_001);
+        assert_eq!(
+            expired_shape.validate_for(&request, host_id),
+            Err(WindowsBrokerHostInputError::InvalidEvidence)
+        );
+    }
+
+    #[test]
+    fn attestation_rejects_host_substitution_and_invalid_validity_horizons() {
+        let request = request();
+        let host_id = Sha256Digest::from_bytes([7; 32]);
+        let attestation = WindowsBrokerHostInputAttestation::issue(
+            host_id,
+            &request,
+            observations(&request),
+            UnixMillis::new(1_000),
+            UnixMillis::new(301_000),
+        )
+        .unwrap();
+
+        assert_eq!(
+            attestation.validate_for(&request, Sha256Digest::from_bytes([8; 32])),
+            Err(WindowsBrokerHostInputError::InvalidEvidence)
+        );
+
+        let mut serialized = serde_json::to_value(&attestation).expect("serialize attestation");
+        serialized["host_id"] = serde_json::json!(Sha256Digest::from_bytes([8; 32]));
+        let substituted: WindowsBrokerHostInputAttestation =
+            serde_json::from_value(serialized).expect("decode substituted attestation");
+        assert_eq!(
+            substituted.validate_for(&request, Sha256Digest::from_bytes([8; 32])),
+            Err(WindowsBrokerHostInputError::InvalidEvidence)
+        );
+
+        let mut inverted = attestation;
+        inverted.valid_until = inverted.issued_at;
+        assert_eq!(
+            inverted.validate_for(&request, host_id),
+            Err(WindowsBrokerHostInputError::InvalidEvidence)
+        );
+    }
+
+    #[test]
+    fn paths_reject_unc_device_traversal_and_case_ambiguous_duplicates() {
+        for path in [
+            r"relative\file",
+            r"\\server\share\file",
+            r"\\?\C:\file",
+            r"C:\dir\..\file",
+            r"c:\file",
+            r"C:/file",
+        ] {
+            assert!(!valid_absolute_windows_path(path));
+        }
+        let mut duplicate = request();
+        duplicate.inputs[1].absolute_path = duplicate.inputs[0].absolute_path.to_ascii_lowercase();
+        assert_eq!(
+            duplicate.validate(),
+            Err(WindowsBrokerHostInputError::InvalidRequest)
+        );
+    }
+}

--- a/crates/automata-ci-windows-broker-core/src/lib.rs
+++ b/crates/automata-ci-windows-broker-core/src/lib.rs
@@ -1,0 +1,10 @@
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+//! Pure policy and contracts for privileged Windows broker admission.
+//!
+//! This crate has no filesystem, service-state, custody, or host-compute
+//! implementation. Those adapters belong to `automata-ci-windows-broker`.
+
+pub mod admission;
+pub mod host_input;
+pub mod request;

--- a/crates/automata-ci-windows-broker-core/src/request.rs
+++ b/crates/automata-ci-windows-broker-core/src/request.rs
@@ -1,0 +1,1051 @@
+//! Canonical, non-authoritative Windows broker admission request.
+//!
+//! The runner may propose this contract, but it conveys no capability
+//! authority. The privileged broker must independently reopen and attest every
+//! host input, verify the promotion through its own trust bundle and durable
+//! high-water ledger, reproduce the live probe, and sign the resulting
+//! [`automata_ci_protocol::WindowsRunnerAdmissionEnvelope`].
+
+use std::collections::BTreeSet;
+
+use automata_ci_core::{
+    EnvironmentProfile, JobResourceAllocation, OperatingSystem, RunnerCapabilities, RunnerFeature,
+    Sha256Digest,
+};
+use automata_ci_protocol::{WindowsAdmissionImage, WindowsEnrollmentTransactionBinding};
+use automata_ci_windows_broker_protocol::WINDOWS_HYPERV_PROVIDER_ID;
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::host_input::WindowsBrokerHostInputRequest;
+
+/// Schema version of the broker-verifiable admission request.
+pub const WINDOWS_BROKER_ADMISSION_REQUEST_SCHEMA_VERSION: u16 = 1;
+
+const REQUEST_DIGEST_DOMAIN: &[u8] = b"automata.windows-broker-admission-request.v1\0";
+const MAX_CANONICAL_REQUEST_BYTES: usize = 512 * 1024;
+const MAX_HOST_PATH_BYTES: usize = 4_096;
+const MAX_TARGET_PATH_BYTES: usize = 4_096;
+const MAX_ARGUMENTS: usize = 128;
+const MAX_ARGV_BYTES: usize = 64 * 1024;
+const MAX_ENVIRONMENT_VARIABLES: usize = 256;
+const MAX_ENVIRONMENT_BYTES: usize = 1024 * 1024;
+const MAX_OPERATION_TIMEOUT_MILLIS: u64 = 5 * 60 * 1_000;
+const MIN_MEMORY_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_MEMORY_BYTES: u64 = 1024 * 1024 * 1024 * 1024;
+const MAX_CPU_MILLIS: u32 = 1_000_000;
+const MAX_PIDS: u32 = 1_000_000;
+
+/// Exact broker client executable and operation timeout proposed by the runner.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionBackendContract {
+    executable_path: String,
+    executable_sha256: Sha256Digest,
+    operation_timeout_millis: u64,
+}
+
+impl WindowsAdmissionBackendContract {
+    /// Creates the backend process contract.
+    ///
+    /// # Errors
+    ///
+    /// Rejects noncanonical paths, placeholder digests, and unbounded timeouts.
+    pub fn new(
+        executable_path: impl Into<String>,
+        executable_sha256: Sha256Digest,
+        operation_timeout_millis: u64,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            executable_path: executable_path.into(),
+            executable_sha256,
+            operation_timeout_millis,
+        };
+        if !valid_windows_path(&value.executable_path)
+            || zero_digest(value.executable_sha256)
+            || !(1..=MAX_OPERATION_TIMEOUT_MILLIS).contains(&value.operation_timeout_millis)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidBackend);
+        }
+        Ok(value)
+    }
+
+    /// Returns the exact executable path.
+    #[must_use]
+    pub fn executable_path(&self) -> &str {
+        &self.executable_path
+    }
+
+    /// Returns the executable digest requiring broker reproduction.
+    #[must_use]
+    pub const fn executable_sha256(&self) -> Sha256Digest {
+        self.executable_sha256
+    }
+
+    /// Returns the per-operation timeout.
+    #[must_use]
+    pub const fn operation_timeout_millis(&self) -> u64 {
+        self.operation_timeout_millis
+    }
+}
+
+/// Literal Windows command line represented without shell reparsing.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionArgv {
+    program: String,
+    arguments: Vec<String>,
+}
+
+impl WindowsAdmissionArgv {
+    /// Creates a bounded literal argv.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsafe program path, control bytes, or excessive arguments.
+    pub fn new(
+        program: impl Into<String>,
+        arguments: Vec<String>,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            program: program.into(),
+            arguments,
+        };
+        if !valid_windows_path(&value.program)
+            || value.arguments.len() > MAX_ARGUMENTS
+            || value
+                .arguments
+                .iter()
+                .any(|argument| argument.contains('\0'))
+            || value
+                .arguments
+                .iter()
+                .try_fold(value.program.len(), |sum, argument| {
+                    sum.checked_add(argument.len())
+                })
+                .is_none_or(|bytes| bytes > MAX_ARGV_BYTES)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidLaunch);
+        }
+        Ok(value)
+    }
+
+    /// Returns the absolute executable path.
+    #[must_use]
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// Returns literal arguments in exact order.
+    #[must_use]
+    pub fn arguments(&self) -> &[String] {
+        &self.arguments
+    }
+}
+
+/// One non-secret profile-default environment variable.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionEnvironmentVariable {
+    name: String,
+    value: String,
+}
+
+impl WindowsAdmissionEnvironmentVariable {
+    /// Creates one non-secret environment entry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid names, NUL values, and excessive fields.
+    pub fn new(
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            name: name.into(),
+            value: value.into(),
+        };
+        if !valid_environment_name(&value.name)
+            || value.value.contains('\0')
+            || value.value.len() > MAX_ENVIRONMENT_BYTES
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidLaunch);
+        }
+        Ok(value)
+    }
+
+    /// Returns the exact variable name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the non-secret profile-default value.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+/// Enforceable CPU, memory, and process ceiling.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionResourceLimits {
+    memory_bytes: u64,
+    cpu_millis: u32,
+    pids: u32,
+}
+
+impl WindowsAdmissionResourceLimits {
+    /// Creates bounded non-zero resource limits.
+    ///
+    /// # Errors
+    ///
+    /// Rejects values outside the shared execution bounds.
+    pub fn new(
+        memory_bytes: u64,
+        cpu_millis: u32,
+        pids: u32,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        if !(MIN_MEMORY_BYTES..=MAX_MEMORY_BYTES).contains(&memory_bytes)
+            || !(1..=MAX_CPU_MILLIS).contains(&cpu_millis)
+            || !(1..=MAX_PIDS).contains(&pids)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidLaunch);
+        }
+        Ok(Self {
+            memory_bytes,
+            cpu_millis,
+            pids,
+        })
+    }
+
+    /// Returns the hard memory limit.
+    #[must_use]
+    pub const fn memory_bytes(self) -> u64 {
+        self.memory_bytes
+    }
+
+    /// Returns CPU quota in thousandths of one CPU.
+    #[must_use]
+    pub const fn cpu_millis(self) -> u32 {
+        self.cpu_millis
+    }
+
+    /// Returns the hard process ceiling.
+    #[must_use]
+    pub const fn pids(self) -> u32 {
+        self.pids
+    }
+}
+
+/// Complete immutable Hyper-V-container launch contract.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct WindowsAdmissionLaunchContract {
+    profile: EnvironmentProfile,
+    image: WindowsAdmissionImage,
+    keepalive: WindowsAdmissionArgv,
+    workspace: String,
+    default_environment: Vec<WindowsAdmissionEnvironmentVariable>,
+    resources: WindowsAdmissionResourceLimits,
+    allocation: JobResourceAllocation,
+    network_disabled: bool,
+    writable_disposable_root: bool,
+    unprivileged: bool,
+    hyperv_isolation: bool,
+    sealed_action_trees: bool,
+}
+
+impl WindowsAdmissionLaunchContract {
+    /// Creates the exact launch material the broker must reproduce.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-Windows, weaker-isolation, secret, duplicate, or
+    /// resource-incoherent launch contracts.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::fn_params_excessive_bools)]
+    pub fn new(
+        profile: EnvironmentProfile,
+        image: WindowsAdmissionImage,
+        keepalive: WindowsAdmissionArgv,
+        workspace: impl Into<String>,
+        default_environment: Vec<WindowsAdmissionEnvironmentVariable>,
+        resources: WindowsAdmissionResourceLimits,
+        allocation: JobResourceAllocation,
+        network_disabled: bool,
+        writable_disposable_root: bool,
+        unprivileged: bool,
+        hyperv_isolation: bool,
+        sealed_action_trees: bool,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            profile,
+            image,
+            keepalive,
+            workspace: workspace.into(),
+            default_environment,
+            resources,
+            allocation,
+            network_disabled,
+            writable_disposable_root,
+            unprivileged,
+            hyperv_isolation,
+            sealed_action_trees,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the exact environment profile.
+    #[must_use]
+    pub const fn profile(&self) -> &EnvironmentProfile {
+        &self.profile
+    }
+
+    /// Returns the exact immutable image.
+    #[must_use]
+    pub const fn image(&self) -> &WindowsAdmissionImage {
+        &self.image
+    }
+
+    /// Returns the whole-sandbox keepalive argv.
+    #[must_use]
+    pub const fn keepalive(&self) -> &WindowsAdmissionArgv {
+        &self.keepalive
+    }
+
+    /// Returns the exact Windows workspace path.
+    #[must_use]
+    pub fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Returns non-secret default variables in exact order.
+    #[must_use]
+    pub fn default_environment(&self) -> &[WindowsAdmissionEnvironmentVariable] {
+        &self.default_environment
+    }
+
+    /// Returns the hard resource limits.
+    #[must_use]
+    pub const fn resources(&self) -> WindowsAdmissionResourceLimits {
+        self.resources
+    }
+
+    /// Returns the placement/allocation contract.
+    #[must_use]
+    pub const fn allocation(&self) -> JobResourceAllocation {
+        self.allocation
+    }
+
+    /// Reports the required disabled-network policy.
+    #[must_use]
+    pub const fn network_disabled(&self) -> bool {
+        self.network_disabled
+    }
+
+    /// Reports the required disposable writable root.
+    #[must_use]
+    pub const fn writable_disposable_root(&self) -> bool {
+        self.writable_disposable_root
+    }
+
+    /// Reports the required non-administrator identity.
+    #[must_use]
+    pub const fn unprivileged(&self) -> bool {
+        self.unprivileged
+    }
+
+    /// Reports the no-fallback Hyper-V isolation contract.
+    #[must_use]
+    pub const fn hyperv_isolation(&self) -> bool {
+        self.hyperv_isolation
+    }
+
+    /// Reports whether pre-sandbox sealed action trees are mandatory.
+    #[must_use]
+    pub const fn sealed_action_trees(&self) -> bool {
+        self.sealed_action_trees
+    }
+
+    fn validate(&self) -> Result<(), WindowsBrokerAdmissionRequestError> {
+        let mut names = BTreeSet::new();
+        let environment_bytes =
+            self.default_environment
+                .iter()
+                .try_fold(0_usize, |sum, variable| {
+                    if !valid_environment_name(&variable.name)
+                        || variable.value.contains('\0')
+                        || !names.insert(variable.name.to_ascii_uppercase())
+                    {
+                        return None;
+                    }
+                    sum.checked_add(variable.name.len())?
+                        .checked_add(variable.value.len())
+                });
+        let limits = self.allocation.limits();
+        if zero_digest(self.profile.digest())
+            || !valid_windows_path(&self.workspace)
+            || self.default_environment.len() > MAX_ENVIRONMENT_VARIABLES
+            || environment_bytes.is_none_or(|bytes| bytes > MAX_ENVIRONMENT_BYTES)
+            || self.resources.memory_bytes != limits.memory_bytes()
+            || self.resources.cpu_millis != limits.cpu_millis()
+            || limits.gpu_count() != 0
+            || !self.network_disabled
+            || !self.writable_disposable_root
+            || !self.unprivileged
+            || !self.hyperv_isolation
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidLaunch);
+        }
+        WindowsAdmissionArgv::new(
+            self.keepalive.program.clone(),
+            self.keepalive.arguments.clone(),
+        )?;
+        Ok(())
+    }
+}
+
+/// Exact shared probe semantics and pinned tool paths.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionProbeContract {
+    schema_version: u16,
+    contract_sha256: Sha256Digest,
+    resources: WindowsAdmissionResourceLimits,
+    allocation: JobResourceAllocation,
+    network_disabled: bool,
+    writable_disposable_root: bool,
+    unprivileged: bool,
+    pwsh: String,
+    powershell: String,
+    cmd: String,
+    python: Option<String>,
+    sha256: String,
+    node12: Option<String>,
+    node16: Option<String>,
+    node20: Option<String>,
+    node24: Option<String>,
+}
+
+impl WindowsAdmissionProbeContract {
+    /// Creates a versioned exact probe request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects placeholders, weaker policies, and unsafe tool paths.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        schema_version: u16,
+        contract_sha256: Sha256Digest,
+        resources: WindowsAdmissionResourceLimits,
+        allocation: JobResourceAllocation,
+        network_disabled: bool,
+        writable_disposable_root: bool,
+        unprivileged: bool,
+        pwsh: impl Into<String>,
+        powershell: impl Into<String>,
+        cmd: impl Into<String>,
+        python: Option<String>,
+        sha256: impl Into<String>,
+        node12: Option<String>,
+        node16: Option<String>,
+        node20: Option<String>,
+        node24: Option<String>,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            schema_version,
+            contract_sha256,
+            resources,
+            allocation,
+            network_disabled,
+            writable_disposable_root,
+            unprivileged,
+            pwsh: pwsh.into(),
+            powershell: powershell.into(),
+            cmd: cmd.into(),
+            python,
+            sha256: sha256.into(),
+            node12,
+            node16,
+            node20,
+            node24,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Returns the shared probe schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns the digest of exact argv/scripts/output semantics.
+    #[must_use]
+    pub const fn contract_sha256(&self) -> Sha256Digest {
+        self.contract_sha256
+    }
+
+    /// Returns the hard resource limits.
+    #[must_use]
+    pub const fn resources(&self) -> WindowsAdmissionResourceLimits {
+        self.resources
+    }
+
+    /// Returns the exact placement allocation.
+    #[must_use]
+    pub const fn allocation(&self) -> JobResourceAllocation {
+        self.allocation
+    }
+
+    /// Returns required tool paths as `(name, optional path)` tuples.
+    #[must_use]
+    pub fn tool_paths(&self) -> [(&'static str, Option<&str>); 9] {
+        [
+            ("pwsh", Some(&self.pwsh)),
+            ("powershell", Some(&self.powershell)),
+            ("cmd", Some(&self.cmd)),
+            ("python", self.python.as_deref()),
+            ("sha256", Some(&self.sha256)),
+            ("node12", self.node12.as_deref()),
+            ("node16", self.node16.as_deref()),
+            ("node20", self.node20.as_deref()),
+            ("node24", self.node24.as_deref()),
+        ]
+    }
+
+    fn validate(&self) -> Result<(), WindowsBrokerAdmissionRequestError> {
+        if self.schema_version == 0
+            || zero_digest(self.contract_sha256)
+            || !self.network_disabled
+            || !self.writable_disposable_root
+            || !self.unprivileged
+            || self
+                .tool_paths()
+                .into_iter()
+                .filter_map(|(_, path)| path)
+                .any(|path| !valid_windows_path(path))
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidProbe);
+        }
+        Ok(())
+    }
+}
+
+/// External promotion input the broker must reopen and verify itself.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsAdmissionPromotionRequest {
+    envelope_path: String,
+    trust_bundle_id: String,
+    key_id: String,
+    manifest_sha256: Sha256Digest,
+    lock_sha256: Sha256Digest,
+}
+
+impl WindowsAdmissionPromotionRequest {
+    /// Creates a non-authoritative promotion request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unsafe paths, invalid identifiers, and placeholder digests.
+    pub fn new(
+        envelope_path: impl Into<String>,
+        trust_bundle_id: impl Into<String>,
+        key_id: impl Into<String>,
+        manifest_sha256: Sha256Digest,
+        lock_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            envelope_path: envelope_path.into(),
+            trust_bundle_id: trust_bundle_id.into(),
+            key_id: key_id.into(),
+            manifest_sha256,
+            lock_sha256,
+        };
+        if !valid_windows_path(&value.envelope_path)
+            || !valid_trust_bundle_id(&value.trust_bundle_id)
+            || !valid_id(&value.key_id)
+            || zero_digest(value.manifest_sha256)
+            || zero_digest(value.lock_sha256)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidPromotion);
+        }
+        Ok(value)
+    }
+
+    /// Returns the exact promotion envelope path.
+    #[must_use]
+    pub fn envelope_path(&self) -> &str {
+        &self.envelope_path
+    }
+
+    /// Returns the broker-owned trust bundle identity.
+    #[must_use]
+    pub fn trust_bundle_id(&self) -> &str {
+        &self.trust_bundle_id
+    }
+
+    /// Returns the requested key identity within the bundle.
+    #[must_use]
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    /// Returns the caller-observed manifest digest.
+    #[must_use]
+    pub const fn manifest_sha256(&self) -> Sha256Digest {
+        self.manifest_sha256
+    }
+
+    /// Returns the caller-observed lock digest.
+    #[must_use]
+    pub const fn lock_sha256(&self) -> Sha256Digest {
+        self.lock_sha256
+    }
+}
+
+/// Complete canonical proposal supplied to the privileged broker.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WindowsBrokerAdmissionRequest {
+    schema_version: u16,
+    transaction: WindowsEnrollmentTransactionBinding,
+    runner_name: String,
+    broker_host_id: String,
+    sandbox_provider_id: String,
+    backend: WindowsAdmissionBackendContract,
+    host_inputs: WindowsBrokerHostInputRequest,
+    launch: WindowsAdmissionLaunchContract,
+    probe: WindowsAdmissionProbeContract,
+    promotion: WindowsAdmissionPromotionRequest,
+    capability_ceiling: RunnerCapabilities,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedWindowsBrokerAdmissionRequest {
+    schema_version: u16,
+    transaction: WindowsEnrollmentTransactionBinding,
+    runner_name: String,
+    broker_host_id: String,
+    sandbox_provider_id: String,
+    backend: WindowsAdmissionBackendContract,
+    host_inputs: WindowsBrokerHostInputRequest,
+    launch: WindowsAdmissionLaunchContract,
+    probe: WindowsAdmissionProbeContract,
+    promotion: WindowsAdmissionPromotionRequest,
+    capability_ceiling: RunnerCapabilities,
+}
+
+impl<'de> Deserialize<'de> for WindowsBrokerAdmissionRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = UncheckedWindowsBrokerAdmissionRequest::deserialize(deserializer)?;
+        Self::new(
+            value.transaction,
+            value.runner_name,
+            value.broker_host_id,
+            value.sandbox_provider_id,
+            value.backend,
+            value.host_inputs,
+            value.launch,
+            value.probe,
+            value.promotion,
+            value.capability_ceiling,
+        )
+        .and_then(|request| {
+            (value.schema_version == WINDOWS_BROKER_ADMISSION_REQUEST_SCHEMA_VERSION)
+                .then_some(request)
+                .ok_or(WindowsBrokerAdmissionRequestError::UnsupportedSchema)
+        })
+        .map_err(D::Error::custom)
+    }
+}
+
+impl WindowsBrokerAdmissionRequest {
+    /// Creates a strict broker-verifiable proposal.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed, inconsistent, weaker, secret-bearing, or
+    /// placeholder request data.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        transaction: WindowsEnrollmentTransactionBinding,
+        runner_name: impl Into<String>,
+        broker_host_id: impl Into<String>,
+        sandbox_provider_id: impl Into<String>,
+        backend: WindowsAdmissionBackendContract,
+        host_inputs: WindowsBrokerHostInputRequest,
+        launch: WindowsAdmissionLaunchContract,
+        probe: WindowsAdmissionProbeContract,
+        promotion: WindowsAdmissionPromotionRequest,
+        capability_ceiling: RunnerCapabilities,
+    ) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        let value = Self {
+            schema_version: WINDOWS_BROKER_ADMISSION_REQUEST_SCHEMA_VERSION,
+            transaction,
+            runner_name: runner_name.into(),
+            broker_host_id: broker_host_id.into(),
+            sandbox_provider_id: sandbox_provider_id.into(),
+            backend,
+            host_inputs,
+            launch,
+            probe,
+            promotion,
+            capability_ceiling,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Decodes only the byte-for-byte canonical JSON representation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized, unknown-field, invalid, or noncanonical input.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, WindowsBrokerAdmissionRequestError> {
+        if bytes.is_empty() || bytes.len() > MAX_CANONICAL_REQUEST_BYTES {
+            return Err(WindowsBrokerAdmissionRequestError::PayloadTooLarge);
+        }
+        let value: Self = serde_json::from_slice(bytes)
+            .map_err(|_| WindowsBrokerAdmissionRequestError::InvalidCanonicalPayload)?;
+        if value.canonical_bytes()? != bytes {
+            return Err(WindowsBrokerAdmissionRequestError::NonCanonicalPayload);
+        }
+        Ok(value)
+    }
+
+    /// Serializes the unique canonical request representation.
+    ///
+    /// # Errors
+    ///
+    /// Fails if serialization exceeds the fixed protocol bound.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, WindowsBrokerAdmissionRequestError> {
+        self.validate()?;
+        let bytes = serde_json::to_vec(self)
+            .map_err(|_| WindowsBrokerAdmissionRequestError::InvalidCanonicalPayload)?;
+        if bytes.is_empty() || bytes.len() > MAX_CANONICAL_REQUEST_BYTES {
+            return Err(WindowsBrokerAdmissionRequestError::PayloadTooLarge);
+        }
+        Ok(bytes)
+    }
+
+    /// Returns the domain-separated digest bound into the broker-signed receipt.
+    ///
+    /// # Errors
+    ///
+    /// Fails if this request cannot be serialized canonically.
+    pub fn request_sha256(&self) -> Result<Sha256Digest, WindowsBrokerAdmissionRequestError> {
+        let bytes = self.canonical_bytes()?;
+        let mut digest = Sha256::new();
+        digest.update(REQUEST_DIGEST_DOMAIN);
+        digest.update((bytes.len() as u64).to_be_bytes());
+        digest.update(bytes);
+        Ok(Sha256Digest::from_bytes(digest.finalize().into()))
+    }
+
+    /// Returns the enrollment transaction binding.
+    #[must_use]
+    pub const fn transaction(&self) -> &WindowsEnrollmentTransactionBinding {
+        &self.transaction
+    }
+
+    /// Returns the exact display name whose digest is transaction-bound.
+    #[must_use]
+    pub fn runner_name(&self) -> &str {
+        &self.runner_name
+    }
+
+    /// Returns the exact broker host identity.
+    #[must_use]
+    pub fn broker_host_id(&self) -> &str {
+        &self.broker_host_id
+    }
+
+    /// Returns the fixed sandbox provider identity.
+    #[must_use]
+    pub fn sandbox_provider_id(&self) -> &str {
+        &self.sandbox_provider_id
+    }
+
+    /// Returns the backend process contract.
+    #[must_use]
+    pub const fn backend(&self) -> &WindowsAdmissionBackendContract {
+        &self.backend
+    }
+
+    /// Returns the exact ordered host inputs.
+    #[must_use]
+    pub const fn host_inputs(&self) -> &WindowsBrokerHostInputRequest {
+        &self.host_inputs
+    }
+
+    /// Returns the complete launch contract.
+    #[must_use]
+    pub const fn launch(&self) -> &WindowsAdmissionLaunchContract {
+        &self.launch
+    }
+
+    /// Returns the exact shared probe contract.
+    #[must_use]
+    pub const fn probe(&self) -> &WindowsAdmissionProbeContract {
+        &self.probe
+    }
+
+    /// Returns the external promotion inputs.
+    #[must_use]
+    pub const fn promotion(&self) -> &WindowsAdmissionPromotionRequest {
+        &self.promotion
+    }
+
+    /// Returns the non-authoritative maximum capability set the broker may prove.
+    #[must_use]
+    pub const fn capability_ceiling(&self) -> &RunnerCapabilities {
+        &self.capability_ceiling
+    }
+
+    fn validate(&self) -> Result<(), WindowsBrokerAdmissionRequestError> {
+        let name_digest =
+            Sha256Digest::from_bytes(Sha256::digest(self.runner_name.as_bytes()).into());
+        if self.schema_version != WINDOWS_BROKER_ADMISSION_REQUEST_SCHEMA_VERSION {
+            return Err(WindowsBrokerAdmissionRequestError::UnsupportedSchema);
+        }
+        if self.runner_name.is_empty()
+            || self.runner_name.len() > 255
+            || self.runner_name.trim() != self.runner_name
+            || self.runner_name.chars().any(char::is_control)
+            || name_digest != self.transaction.runner_name_sha256()
+            || self.broker_host_id.len() != 64
+            || !self
+                .broker_host_id
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            || self.sandbox_provider_id != WINDOWS_HYPERV_PROVIDER_ID
+            || self.host_inputs.backend_id() != self.broker_host_id
+            || self.host_inputs.sandbox_provider_id() != self.sandbox_provider_id
+            || self.transaction.runner_id() != self.capability_ceiling.runner_id()
+            || self.capability_ceiling.platform().operating_system() != &OperatingSystem::Windows
+            || self
+                .capability_ceiling
+                .features()
+                .contains(&RunnerFeature::LOCAL_ACTIONS)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidCapabilities);
+        }
+        self.launch.validate()?;
+        self.probe.validate()?;
+        if self
+            .launch
+            .profile
+            .digest()
+            .as_bytes()
+            .iter()
+            .all(|byte| *byte == 0)
+            || !self
+                .capability_ceiling
+                .environment_profiles()
+                .contains(&self.launch.profile)
+            || self.probe.resources != self.launch.resources
+            || self.probe.allocation != self.launch.allocation
+            || self
+                .probe
+                .contract_sha256
+                .as_bytes()
+                .iter()
+                .all(|byte| *byte == 0)
+        {
+            return Err(WindowsBrokerAdmissionRequestError::InvalidProbe);
+        }
+        validate_host_inputs(self)?;
+        validate_node_capabilities(self)?;
+        Ok(())
+    }
+}
+
+/// Fail-closed issue-request validation error.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsBrokerAdmissionRequestError {
+    /// The request uses an unsupported schema.
+    #[error("unsupported Windows broker admission request schema")]
+    UnsupportedSchema,
+    /// Host input descriptors are missing, reordered, duplicated, or unsafe.
+    #[error("invalid Windows admission host inputs")]
+    InvalidHostInputs,
+    /// Backend executable or operation policy is invalid.
+    #[error("invalid Windows admission backend contract")]
+    InvalidBackend,
+    /// Launch material or sandbox policy is invalid.
+    #[error("invalid Windows admission launch contract")]
+    InvalidLaunch,
+    /// Probe semantics, tools, or resource bindings are invalid.
+    #[error("invalid Windows admission probe contract")]
+    InvalidProbe,
+    /// Promotion inputs are invalid or do not match host inputs.
+    #[error("invalid Windows admission promotion request")]
+    InvalidPromotion,
+    /// The proposed capability ceiling is invalid or inconsistent.
+    #[error("invalid Windows admission capability ceiling")]
+    InvalidCapabilities,
+    /// The request exceeds its fixed representation bound.
+    #[error("Windows broker admission request exceeds its bounded representation")]
+    PayloadTooLarge,
+    /// The canonical request cannot be decoded.
+    #[error("invalid Windows broker admission canonical payload")]
+    InvalidCanonicalPayload,
+    /// The decoded request does not reserialize byte-for-byte.
+    #[error("noncanonical Windows admission issue payload")]
+    NonCanonicalPayload,
+}
+
+fn validate_host_inputs(
+    request: &WindowsBrokerAdmissionRequest,
+) -> Result<(), WindowsBrokerAdmissionRequestError> {
+    request
+        .host_inputs
+        .validate()
+        .map_err(|_| WindowsBrokerAdmissionRequestError::InvalidHostInputs)?;
+    let inputs = request.host_inputs.inputs();
+    let backend = &inputs[1];
+    let manifest = &inputs[2];
+    let lock = &inputs[3];
+    let envelope = &inputs[8];
+    if backend.absolute_path() != request.backend.executable_path
+        || backend.expected_sha256() != request.backend.executable_sha256
+        || manifest.expected_sha256() != request.promotion.manifest_sha256
+        || lock.expected_sha256() != request.promotion.lock_sha256
+        || envelope.absolute_path() != request.promotion.envelope_path
+    {
+        return Err(WindowsBrokerAdmissionRequestError::InvalidPromotion);
+    }
+    Ok(())
+}
+
+fn validate_node_capabilities(
+    request: &WindowsBrokerAdmissionRequest,
+) -> Result<(), WindowsBrokerAdmissionRequestError> {
+    let features = request.capability_ceiling.features();
+    let action_features = [
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE12_ACTIONS,
+        RunnerFeature::NODE16_ACTIONS,
+        RunnerFeature::NODE20_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ];
+    if !request.launch.sealed_action_trees {
+        return action_features
+            .iter()
+            .all(|feature| !features.contains(feature))
+            .then_some(())
+            .ok_or(WindowsBrokerAdmissionRequestError::InvalidCapabilities);
+    }
+    let generations = [
+        (
+            RunnerFeature::NODE12_ACTIONS,
+            request.probe.node12.is_some(),
+        ),
+        (
+            RunnerFeature::NODE16_ACTIONS,
+            request.probe.node16.is_some(),
+        ),
+        (
+            RunnerFeature::NODE20_ACTIONS,
+            request.probe.node20.is_some(),
+        ),
+        (
+            RunnerFeature::NODE24_ACTIONS,
+            request.probe.node24.is_some(),
+        ),
+    ];
+    let any_node = generations.iter().any(|(_, present)| *present);
+    if generations
+        .iter()
+        .any(|(feature, present)| features.contains(feature) != *present)
+        || features.contains(&RunnerFeature::JAVASCRIPT_ACTIONS) != any_node
+        || !features.contains(&RunnerFeature::REPOSITORY_ACTIONS)
+        || !features.contains(&RunnerFeature::COMPOSITE_ACTIONS)
+    {
+        return Err(WindowsBrokerAdmissionRequestError::InvalidCapabilities);
+    }
+    Ok(())
+}
+
+fn valid_windows_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if value.is_empty()
+        || value.len() > MAX_HOST_PATH_BYTES.max(MAX_TARGET_PATH_BYTES)
+        || !value.is_ascii()
+        || value.chars().any(char::is_control)
+        || bytes.len() < 3
+        || !bytes[0].is_ascii_uppercase()
+        || bytes[1] != b':'
+        || bytes[2] != b'\\'
+        || value.contains('/')
+        || value.starts_with("\\\\")
+    {
+        return false;
+    }
+    value[3..].split('\\').all(valid_windows_component)
+}
+
+fn valid_windows_component(value: &str) -> bool {
+    if value.is_empty()
+        || matches!(value, "." | "..")
+        || value.ends_with([' ', '.'])
+        || value
+            .bytes()
+            .any(|byte| matches!(byte, b'<' | b'>' | b':' | b'"' | b'|' | b'?' | b'*'))
+    {
+        return false;
+    }
+    let stem = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .to_ascii_uppercase();
+    !matches!(
+        stem.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" | "CLOCK$" | "CONIN$" | "CONOUT$"
+    ) && !stem
+        .strip_prefix("COM")
+        .or_else(|| stem.strip_prefix("LPT"))
+        .is_some_and(|suffix| suffix.len() == 1 && matches!(suffix.as_bytes()[0], b'1'..=b'9'))
+}
+
+fn valid_environment_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && !value.contains('=')
+        && !value.chars().any(char::is_control)
+}
+
+fn valid_id(value: &str) -> bool {
+    (3..=128).contains(&value.len())
+        && value.is_ascii()
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn valid_trust_bundle_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (3..=128).contains(&bytes.len())
+        && bytes
+            .first()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+fn zero_digest(value: Sha256Digest) -> bool {
+    value.as_bytes().iter().all(|byte| *byte == 0)
+}

--- a/crates/automata-ci-windows-broker/README.md
+++ b/crates/automata-ci-windows-broker/README.md
@@ -1,9 +1,18 @@
 # automata-ci-windows-broker
 
-Privileged Windows Hyper-V lifecycle core. It owns grant verification,
-closed lifecycle policy, durable reconciliation, and watchdog supervision.
-The file ledger is isolated behind `BrokerLedger`; HCS is isolated behind
-`WindowsHostComputeAdapter` and implemented by a separate adapter crate.
+Privileged Windows Hyper-V broker application service. Pure admission request,
+host-input, promotion, trust, and synthetic-probe policy lives in
+`automata-ci-windows-broker-core`, which has no filesystem or service adapters.
+This crate owns admission and lifecycle state machines and composes them only
+through explicit repository, custody, result-store, lifecycle-ledger, and
+host-compute ports.
+
+Concrete admission persistence is namespaced under `admission::repository`;
+concrete custody persistence is namespaced under `custody::file`. Alternative
+service deployments can supply either port without importing a file-backed
+implementation. The lifecycle file ledger is isolated behind `BrokerLedger`;
+HCS is isolated behind `WindowsHostComputeAdapter` and implemented by the
+separate `automata-ci-windows-broker-hcs` adapter crate.
 
 Successful exec and copy payloads are authenticated, encrypted, and
 synchronized through `BrokerResultStore` before the lifecycle ledger adopts an

--- a/crates/automata-ci-windows-broker/src/admission/authority.rs
+++ b/crates/automata-ci-windows-broker/src/admission/authority.rs
@@ -1,0 +1,302 @@
+//! Admission service contract and value-free receipts.
+
+use std::fmt;
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_protocol::{WindowsRunnerAdmissionEnvelope, WindowsRunnerPlacementRenewalEnvelope};
+use automata_ci_windows_broker_core::{
+    admission::WindowsBrokerAdmissionError, request::WindowsBrokerAdmissionRequest,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::custody::WindowsBrokerCustodyHandle;
+
+const HANDLE_COMMITMENT_DOMAIN: &[u8] = b"automata.windows-runner-admission-custody-handle.v1\0";
+
+/// Exact result of one broker-owned admission issue or resume operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerAdmissionReceipt {
+    handle: WindowsBrokerCustodyHandle,
+    envelope: WindowsRunnerAdmissionEnvelope,
+    envelope_sha256: Sha256Digest,
+}
+
+/// Durable, expiry-independent proof needed to complete one admission.
+///
+/// The signed enrollment receipt is deliberately short-lived, but control may
+/// have durably committed the exact enrollment before the runner receives its
+/// response. Keeping this value with the staged request allows an exact server
+/// replay to finish broker tombstoning without reopening or extending the
+/// expired admission authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerAdmissionCompletion {
+    handle: WindowsBrokerCustodyHandle,
+    envelope_sha256: Sha256Digest,
+}
+
+impl WindowsBrokerAdmissionCompletion {
+    /// Constructs an exact completion proof from durable public metadata.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero envelope commitment.
+    pub fn new(
+        handle: WindowsBrokerCustodyHandle,
+        envelope_sha256: Sha256Digest,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        if envelope_sha256.as_bytes().iter().all(|byte| *byte == 0) {
+            return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+        }
+        Ok(Self {
+            handle,
+            envelope_sha256,
+        })
+    }
+
+    /// Returns the opaque broker custody handle.
+    #[must_use]
+    pub const fn handle(&self) -> &WindowsBrokerCustodyHandle {
+        &self.handle
+    }
+
+    /// Returns the exact signed-envelope commitment.
+    #[must_use]
+    pub const fn envelope_sha256(&self) -> Sha256Digest {
+        self.envelope_sha256
+    }
+}
+
+/// Exact result of a broker-owned placement-renewal operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerPlacementRenewalReceipt {
+    envelope: WindowsRunnerPlacementRenewalEnvelope,
+    envelope_sha256: Sha256Digest,
+}
+
+impl WindowsBrokerPlacementRenewalReceipt {
+    pub(crate) fn from_wire(
+        envelope: WindowsRunnerPlacementRenewalEnvelope,
+        expected_enrollment_envelope_sha256: Sha256Digest,
+        observed_at: UnixMillis,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let claims = envelope
+            .claims()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let observed_at = u64::try_from(observed_at.get())
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        if claims.enrollment_envelope_sha256() != expected_enrollment_envelope_sha256
+            || claims.validity().issued_at_unix_millis() > observed_at
+            || claims.validity().expires_at_unix_millis() <= observed_at
+        {
+            return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+        }
+        let envelope_sha256 = envelope.envelope_sha256();
+        Ok(Self {
+            envelope,
+            envelope_sha256,
+        })
+    }
+
+    /// Returns the complete broker-signed renewal sent on a lease request.
+    #[must_use]
+    pub const fn envelope(&self) -> &WindowsRunnerPlacementRenewalEnvelope {
+        &self.envelope
+    }
+
+    /// Returns the byte-exact renewal-envelope commitment.
+    #[must_use]
+    pub const fn envelope_sha256(&self) -> Sha256Digest {
+        self.envelope_sha256
+    }
+}
+
+impl WindowsBrokerAdmissionReceipt {
+    pub(crate) fn from_wire(
+        handle: WindowsBrokerCustodyHandle,
+        envelope: WindowsRunnerAdmissionEnvelope,
+        expected_request_sha256: Sha256Digest,
+        observed_at: UnixMillis,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let claims = envelope
+            .claims()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let observed_at = u64::try_from(observed_at.get())
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        if claims.binding().broker_profile().request_binding_sha256() != expected_request_sha256
+            || claims.custody_handle_sha256() != custody_handle_commitment(&handle)
+            || claims.validity().issued_at_unix_millis() > observed_at
+            || claims.validity().expires_at_unix_millis() <= observed_at
+        {
+            return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+        }
+        let envelope_sha256 = envelope.envelope_sha256();
+        Ok(Self {
+            handle,
+            envelope,
+            envelope_sha256,
+        })
+    }
+
+    /// Returns the path-free broker custody capability.
+    #[must_use]
+    pub const fn handle(&self) -> &WindowsBrokerCustodyHandle {
+        &self.handle
+    }
+
+    /// Returns the complete broker-signed envelope sent to control.
+    #[must_use]
+    pub const fn envelope(&self) -> &WindowsRunnerAdmissionEnvelope {
+        &self.envelope
+    }
+
+    /// Returns the exact digest required for idempotent completion.
+    #[must_use]
+    pub const fn envelope_sha256(&self) -> Sha256Digest {
+        self.envelope_sha256
+    }
+
+    /// Returns expiry-independent metadata for exact post-enrollment cleanup.
+    #[must_use]
+    pub fn completion(&self) -> WindowsBrokerAdmissionCompletion {
+        WindowsBrokerAdmissionCompletion {
+            handle: self.handle.clone(),
+            envelope_sha256: self.envelope_sha256,
+        }
+    }
+}
+
+/// Privileged implementation behind the authenticated broker service.
+///
+/// Implementations must independently re-read and verify all host inputs and
+/// promotion evidence, execute and clean the fixed synthetic probe, advance
+/// durable serial floors, mint the Ed25519 envelope, and persist the admitted
+/// launch contract before returning success.
+pub trait WindowsBrokerAdmissionAuthority: fmt::Debug + Send + Sync {
+    /// Mints or exactly replays one request-indexed admission record.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free request, evidence, state, or availability error.
+    fn issue(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError>;
+
+    /// Resumes one exact live receipt without exposing generic custody bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free binding, state, receipt, or availability error.
+    fn resume(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        request_sha256: Sha256Digest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError>;
+
+    /// Atomically tombstones one exact receipt after durable enrollment.
+    /// Repeating the same completion is required to succeed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free digest, state, or availability error.
+    fn complete(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError>;
+
+    /// Returns a retained current renewal or durably mints exactly the next
+    /// serial for a completed admission handle. The implementation keeps the
+    /// handle tombstoned against enrollment reuse while retaining only the
+    /// minimal admitted contract needed for renewal.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free receipt, state, evidence, or availability error.
+    fn renew(
+        &self,
+        completed_handle: &WindowsBrokerCustodyHandle,
+        enrollment_envelope_sha256: Sha256Digest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerPlacementRenewalReceipt, WindowsBrokerAdmissionError>;
+
+    /// Acknowledges that control durably accepted one exact renewal.
+    ///
+    /// Until this exact ACK is retained, the broker replays the same serial
+    /// and never advances across an expired lost response. Repeating an exact
+    /// ACK is idempotent; substituting a handle or envelope is rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free receipt, state, or availability error.
+    fn acknowledge_renewal(
+        &self,
+        completed_handle: &WindowsBrokerCustodyHandle,
+        renewal_envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError>;
+}
+
+/// Fail-closed authority used until every production trust/input/probe
+/// dependency has been initialized and reconciled.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UnavailableWindowsBrokerAdmissionAuthority;
+
+impl WindowsBrokerAdmissionAuthority for UnavailableWindowsBrokerAdmissionAuthority {
+    fn issue(
+        &self,
+        _request: &WindowsBrokerAdmissionRequest,
+        _now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+
+    fn resume(
+        &self,
+        _handle: &WindowsBrokerCustodyHandle,
+        _request_sha256: Sha256Digest,
+        _now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+
+    fn complete(
+        &self,
+        _handle: &WindowsBrokerCustodyHandle,
+        _envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+
+    fn renew(
+        &self,
+        _completed_handle: &WindowsBrokerCustodyHandle,
+        _enrollment_envelope_sha256: Sha256Digest,
+        _now: UnixMillis,
+    ) -> Result<WindowsBrokerPlacementRenewalReceipt, WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+
+    fn acknowledge_renewal(
+        &self,
+        _completed_handle: &WindowsBrokerCustodyHandle,
+        _renewal_envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        Err(WindowsBrokerAdmissionError::Unavailable)
+    }
+}
+
+pub(crate) fn custody_handle_commitment(handle: &WindowsBrokerCustodyHandle) -> Sha256Digest {
+    domain_digest(HANDLE_COMMITMENT_DOMAIN, &[handle.opaque().as_bytes()])
+}
+
+fn domain_digest(domain: &[u8], fields: &[&[u8]]) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}

--- a/crates/automata-ci-windows-broker/src/admission/mod.rs
+++ b/crates/automata-ci-windows-broker/src/admission/mod.rs
@@ -1,0 +1,20 @@
+//! Documentation is inherited from the parent crate.
+//! Broker admission contracts, application service, and durable adapters.
+//!
+//! Pure canonical request and policy evaluation live in
+//! `automata-ci-windows-broker-core`. Concrete persistence remains namespaced
+//! under [`repository`], and custody adapters under [`crate::custody`].
+
+mod authority;
+pub mod repository;
+mod service;
+mod signing;
+
+pub use authority::{
+    UnavailableWindowsBrokerAdmissionAuthority, WindowsBrokerAdmissionAuthority,
+    WindowsBrokerAdmissionCompletion, WindowsBrokerAdmissionReceipt,
+    WindowsBrokerPlacementRenewalReceipt,
+};
+pub use automata_ci_windows_broker_core::admission::WindowsBrokerAdmissionError;
+pub use service::WindowsBrokerAdmissionService;
+pub use signing::WindowsBrokerAdmissionSigningKey;

--- a/crates/automata-ci-windows-broker/src/admission/repository.rs
+++ b/crates/automata-ci-windows-broker/src/admission/repository.rs
@@ -1,0 +1,308 @@
+//! Durable state port and file-snapshot adapter for broker admission.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fs::{self, File, OpenOptions},
+    io::{Read as _, Write as _},
+    path::{Path, PathBuf},
+};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_protocol::{WindowsRunnerAdmissionEnvelope, WindowsRunnerPlacementRenewalEnvelope};
+use automata_ci_windows_broker_core::{
+    admission::WindowsBrokerAdmissionError,
+    request::{WindowsAdmissionLaunchContract, WindowsBrokerAdmissionRequest},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::custody::WindowsBrokerCustodyHandle;
+
+const STATE_SCHEMA: u16 = 1;
+const MAX_STATE_BYTES: u64 = 64 * 1024 * 1024;
+pub(super) const MAX_ADMISSION_RECORDS: usize = 256;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AdmissionCustodyRecord {
+    pub(super) schema: u16,
+    pub(super) request_sha256: Sha256Digest,
+    pub(super) request: WindowsBrokerAdmissionRequest,
+    pub(super) envelope: WindowsRunnerAdmissionEnvelope,
+    pub(super) launch: WindowsAdmissionLaunchContract,
+    pub(super) profile_valid_until: UnixMillis,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum AdmissionRecordPhase {
+    Issuing,
+    Issued,
+    Completed,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AdmissionRenewalState {
+    pub(super) serial: u64,
+    pub(super) envelope: WindowsRunnerPlacementRenewalEnvelope,
+    pub(super) acknowledged: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AdmissionStateRecord {
+    pub(super) request_sha256: Sha256Digest,
+    pub(super) handle: String,
+    pub(super) custody_content_sha256: Sha256Digest,
+    pub(super) created_at: UnixMillis,
+    pub(super) phase: AdmissionRecordPhase,
+    pub(super) custody: AdmissionCustodyRecord,
+    pub(super) current_renewal: Option<AdmissionRenewalState>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PromotionHead {
+    pub(super) promotion_serial: u64,
+    pub(super) revocation_generation: u64,
+    pub(super) payload_sha256: Sha256Digest,
+    pub(super) envelope_sha256: Sha256Digest,
+}
+
+/// Opaque, validated application snapshot passed through repository adapters.
+///
+/// Repository implementations may serialize this value through
+/// [`Self::canonical_bytes`] and restore it through
+/// [`Self::from_canonical_bytes`]. Its internal state remains owned by the
+/// broker application service.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsBrokerAdmissionSnapshot {
+    pub(super) schema: u16,
+    pub(super) records: BTreeMap<String, AdmissionStateRecord>,
+    pub(super) promotion_heads: BTreeMap<String, PromotionHead>,
+}
+
+impl Default for WindowsBrokerAdmissionSnapshot {
+    fn default() -> Self {
+        Self {
+            schema: STATE_SCHEMA,
+            records: BTreeMap::new(),
+            promotion_heads: BTreeMap::new(),
+        }
+    }
+}
+
+impl WindowsBrokerAdmissionSnapshot {
+    /// Decodes one exact canonical snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, noncanonical, schema-invalid, or
+    /// internally inconsistent bytes.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, WindowsBrokerAdmissionError> {
+        if bytes.is_empty() || bytes.len() as u64 > MAX_STATE_BYTES {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        let state: Self =
+            serde_json::from_slice(bytes).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        state.validate()?;
+        if state.canonical_bytes()?.as_slice() != bytes {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        Ok(state)
+    }
+
+    /// Encodes the unique bounded repository representation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid internal state or an oversized snapshot.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, WindowsBrokerAdmissionError> {
+        self.validate()?;
+        let encoded =
+            serde_json::to_vec(self).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        if encoded.is_empty() || encoded.len() as u64 > MAX_STATE_BYTES {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        Ok(encoded)
+    }
+
+    fn validate(&self) -> Result<(), WindowsBrokerAdmissionError> {
+        if self.schema != STATE_SCHEMA
+            || self.records.len() > MAX_ADMISSION_RECORDS
+            || self.records.iter().any(|(key, record)| {
+                key != &record.request_sha256.to_string()
+                    || WindowsBrokerCustodyHandle::parse(&record.handle).is_err()
+                    || record.custody.request_sha256 != record.request_sha256
+            })
+        {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        Ok(())
+    }
+}
+
+/// Durable snapshot boundary used by the broker admission application service.
+pub trait WindowsBrokerAdmissionRepository: fmt::Debug + Send + Sync {
+    /// Loads the last durably committed snapshot, or an empty snapshot for a
+    /// newly initialized repository.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on unavailable, malformed, or inconsistent state.
+    fn load(&self) -> Result<WindowsBrokerAdmissionSnapshot, WindowsBrokerAdmissionError>;
+
+    /// Atomically replaces the last durable snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed unless the complete validated snapshot is durable.
+    fn store(
+        &self,
+        snapshot: &WindowsBrokerAdmissionSnapshot,
+    ) -> Result<(), WindowsBrokerAdmissionError>;
+}
+
+/// Atomic file-snapshot implementation of [`WindowsBrokerAdmissionRepository`].
+pub struct FileWindowsBrokerAdmissionRepository {
+    path: PathBuf,
+}
+
+impl FileWindowsBrokerAdmissionRepository {
+    /// Opens and reconciles one absolute service-owned snapshot path.
+    ///
+    /// # Errors
+    ///
+    /// Rejects relative paths and unrecoverable or malformed snapshot state.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, WindowsBrokerAdmissionError> {
+        let path = path.into();
+        if !path.is_absolute() || path.parent().is_none() {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        recover_state_snapshot(&path)?;
+        let repository = Self { path };
+        let _ = repository.load()?;
+        Ok(repository)
+    }
+}
+
+impl fmt::Debug for FileWindowsBrokerAdmissionRepository {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FileWindowsBrokerAdmissionRepository")
+            .field("path", &"[SERVICE_OWNED]")
+            .finish()
+    }
+}
+
+impl WindowsBrokerAdmissionRepository for FileWindowsBrokerAdmissionRepository {
+    fn load(&self) -> Result<WindowsBrokerAdmissionSnapshot, WindowsBrokerAdmissionError> {
+        read_admission_state(&self.path)
+    }
+
+    fn store(
+        &self,
+        snapshot: &WindowsBrokerAdmissionSnapshot,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        persist_admission_state(&self.path, snapshot)
+    }
+}
+
+fn read_admission_state(
+    path: &Path,
+) -> Result<WindowsBrokerAdmissionSnapshot, WindowsBrokerAdmissionError> {
+    if !path.exists() {
+        return Ok(WindowsBrokerAdmissionSnapshot::default());
+    }
+    let mut file = File::open(path).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    if file
+        .metadata()
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?
+        .len()
+        > MAX_STATE_BYTES
+    {
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    let mut encoded = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(MAX_STATE_BYTES.saturating_add(1))
+        .read_to_end(&mut encoded)
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    if encoded.is_empty() || encoded.len() as u64 > MAX_STATE_BYTES {
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    WindowsBrokerAdmissionSnapshot::from_canonical_bytes(&encoded)
+}
+
+fn persist_admission_state(
+    path: &Path,
+    state: &WindowsBrokerAdmissionSnapshot,
+) -> Result<(), WindowsBrokerAdmissionError> {
+    let encoded = state.canonical_bytes()?;
+    let (temporary, previous) = state_sidecars(path)?;
+    if temporary.exists() || previous.exists() {
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    file.write_all(&encoded)
+        .and_then(|()| file.sync_all())
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    drop(file);
+    if path.exists() {
+        fs::rename(path, &previous).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    }
+    if fs::rename(&temporary, path).is_err() {
+        if previous.exists() && !path.exists() {
+            let _ = fs::rename(&previous, path);
+        }
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    if previous.exists() {
+        fs::remove_file(previous).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    }
+    Ok(())
+}
+
+fn recover_state_snapshot(path: &Path) -> Result<(), WindowsBrokerAdmissionError> {
+    let (temporary, previous) = state_sidecars(path)?;
+    if path.exists() {
+        let _ = read_admission_state(path)?;
+        if temporary.exists() {
+            fs::remove_file(&temporary).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        }
+        if previous.exists() {
+            fs::remove_file(&previous).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        }
+        return Ok(());
+    }
+    if temporary.exists() {
+        let _ = read_admission_state(&temporary)?;
+        fs::rename(&temporary, path).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        if previous.exists() {
+            fs::remove_file(previous).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        }
+        return Ok(());
+    }
+    if previous.exists() {
+        let _ = read_admission_state(&previous)?;
+        fs::rename(previous, path).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    }
+    Ok(())
+}
+
+fn state_sidecars(path: &Path) -> Result<(PathBuf, PathBuf), WindowsBrokerAdmissionError> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+    Ok((
+        path.with_file_name(format!("{name}.write.tmp")),
+        path.with_file_name(format!("{name}.previous")),
+    ))
+}

--- a/crates/automata-ci-windows-broker/src/admission/service/mod.rs
+++ b/crates/automata-ci-windows-broker/src/admission/service/mod.rs
@@ -1,0 +1,701 @@
+//! Broker admission application state machine.
+
+use std::{
+    fmt,
+    sync::{Arc, Mutex, PoisonError},
+};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_execution::{
+    EnvironmentName, EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionEnvironment,
+    ImmutableImage, SandboxEnvironment, TargetPath,
+};
+use automata_ci_protocol::{
+    WindowsAdmissionValidity, WindowsRunnerAdmissionBinding, WindowsRunnerAdmissionClaims,
+    WindowsRunnerAdmissionEnvelope, WindowsRunnerPlacementRenewalClaims,
+    WindowsRunnerPlacementRenewalEnvelope,
+};
+use automata_ci_windows_broker_core::{
+    admission::{
+        WindowsBrokerAdmissionError, WindowsBrokerAdmissionEvaluation,
+        WindowsBrokerAdmissionEvaluator, floor_windows_admission_issued_at,
+    },
+    request::{WindowsAdmissionLaunchContract, WindowsBrokerAdmissionRequest},
+};
+use sha2::{Digest as _, Sha256};
+use zeroize::{Zeroize as _, Zeroizing};
+
+use crate::{
+    BrokerError, BrokerProfileContractResolver, WindowsHyperVAdmittedProfileContract,
+    custody::{
+        WindowsBrokerAdmissionCustody, WindowsBrokerCustodyError, WindowsBrokerCustodyHandle,
+        WindowsBrokerCustodyKind,
+    },
+};
+
+use super::{
+    authority::{
+        WindowsBrokerAdmissionAuthority, WindowsBrokerAdmissionReceipt,
+        WindowsBrokerPlacementRenewalReceipt, custody_handle_commitment,
+    },
+    repository::{
+        AdmissionCustodyRecord, AdmissionRecordPhase, AdmissionRenewalState, AdmissionStateRecord,
+        MAX_ADMISSION_RECORDS, PromotionHead, WindowsBrokerAdmissionRepository,
+        WindowsBrokerAdmissionSnapshot,
+    },
+    signing::WindowsBrokerAdmissionSigningKey,
+};
+
+const ADMISSION_LIFETIME_MILLIS: i64 = 15 * 60 * 1_000;
+const CUSTODY_RECORD_SCHEMA: u16 = 1;
+
+/// Crash-recoverable broker admission application service.
+pub struct WindowsBrokerAdmissionService {
+    repository: Arc<dyn WindowsBrokerAdmissionRepository>,
+    custody: Arc<dyn WindowsBrokerAdmissionCustody>,
+    evaluator: Arc<dyn WindowsBrokerAdmissionEvaluator>,
+    signing_key: Arc<WindowsBrokerAdmissionSigningKey>,
+    state: Mutex<WindowsBrokerAdmissionSnapshot>,
+}
+
+impl WindowsBrokerAdmissionService {
+    /// Composes and reconciles one broker admission application service.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed durable state, custody mismatch, or an incomplete
+    /// publication which cannot be recovered exactly.
+    pub fn new(
+        repository: Arc<dyn WindowsBrokerAdmissionRepository>,
+        custody: Arc<dyn WindowsBrokerAdmissionCustody>,
+        evaluator: Arc<dyn WindowsBrokerAdmissionEvaluator>,
+        signing_key: Arc<WindowsBrokerAdmissionSigningKey>,
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let state = repository.load()?;
+        let authority = Self {
+            repository,
+            custody,
+            evaluator,
+            signing_key,
+            state: Mutex::new(state),
+        };
+        authority.reconcile()?;
+        Ok(authority)
+    }
+
+    fn reconcile(&self) -> Result<(), WindowsBrokerAdmissionError> {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut changed = false;
+        for record in state.records.values_mut() {
+            let handle = WindowsBrokerCustodyHandle::parse(&record.handle)
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+            let encoded = encode_custody_record(&record.custody)?;
+            if sha256(&encoded) != record.custody_content_sha256 {
+                return Err(WindowsBrokerAdmissionError::InvalidState);
+            }
+            match record.phase {
+                AdmissionRecordPhase::Issuing => {
+                    self.custody
+                        .put_reserved(
+                            &handle,
+                            WindowsBrokerCustodyKind::AdmissionReceipt,
+                            &encoded,
+                            record.created_at,
+                        )
+                        .map_err(map_custody)?;
+                    record.phase = AdmissionRecordPhase::Issued;
+                    changed = true;
+                }
+                AdmissionRecordPhase::Issued => {
+                    match self.custody.get_admission_receipt(&handle, false) {
+                        Ok(observed) if observed.as_slice() == encoded => {}
+                        Ok(_) => return Err(WindowsBrokerAdmissionError::InvalidState),
+                        Err(WindowsBrokerCustodyError::Absent) => {
+                            let completed = self
+                                .custody
+                                .get_admission_receipt(&handle, true)
+                                .map_err(map_custody)?;
+                            if completed.as_slice() != encoded {
+                                return Err(WindowsBrokerAdmissionError::InvalidState);
+                            }
+                            record.phase = AdmissionRecordPhase::Completed;
+                            changed = true;
+                        }
+                        Err(error) => return Err(map_custody(error)),
+                    }
+                }
+                AdmissionRecordPhase::Completed => {
+                    let observed = self
+                        .custody
+                        .get_admission_receipt(&handle, true)
+                        .map_err(map_custody)?;
+                    if observed.as_slice() != encoded {
+                        return Err(WindowsBrokerAdmissionError::InvalidState);
+                    }
+                }
+            }
+        }
+        if changed {
+            self.repository.store(&state)?;
+        }
+        Ok(())
+    }
+
+    fn receipt_from_record(
+        &self,
+        record: &AdmissionStateRecord,
+        expected_request_sha256: Sha256Digest,
+        now: UnixMillis,
+        completed: bool,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError> {
+        let handle = WindowsBrokerCustodyHandle::parse(&record.handle)
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        let observed = self
+            .custody
+            .get_admission_receipt(&handle, completed)
+            .map_err(map_custody)?;
+        let decoded: AdmissionCustodyRecord = serde_json::from_slice(&observed)
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        if decoded != record.custody
+            || sha256(&observed) != record.custody_content_sha256
+            || decoded.request_sha256 != expected_request_sha256
+        {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        WindowsBrokerAdmissionReceipt::from_wire(
+            handle,
+            decoded.envelope,
+            expected_request_sha256,
+            now,
+        )
+    }
+
+    fn checked_evaluation(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionEvaluation, WindowsBrokerAdmissionError> {
+        let evaluation = self.evaluator.evaluate(request, now)?;
+        let request_sha256 = request
+            .request_sha256()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+        let binding = evaluation.binding();
+        if binding.transaction() != request.transaction()
+            || binding.broker_profile().request_binding_sha256() != request_sha256
+            || binding.broker_profile().broker_host_id() != request.broker_host_id()
+            || binding.broker_profile().sandbox_provider_id() != request.sandbox_provider_id()
+            || binding.capabilities().runner_id() != request.transaction().runner_id()
+            || !request
+                .capability_ceiling()
+                .environment_profiles()
+                .is_superset(binding.capabilities().environment_profiles())
+            || !request
+                .capability_ceiling()
+                .features()
+                .is_superset(binding.capabilities().features())
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        Ok(evaluation)
+    }
+
+    pub(super) fn enforce_and_advance_high_water(
+        state: &mut WindowsBrokerAdmissionSnapshot,
+        binding: &WindowsRunnerAdmissionBinding,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        let promotion = binding.promotion();
+        let key = promotion_head_key(binding);
+        let proposed = PromotionHead {
+            promotion_serial: promotion.promotion_serial(),
+            revocation_generation: promotion.revocation_generation(),
+            payload_sha256: promotion.payload_sha256(),
+            envelope_sha256: promotion.envelope_sha256(),
+        };
+        if let Some(current) = state.promotion_heads.get(&key)
+            && (proposed.promotion_serial < current.promotion_serial
+                || proposed.revocation_generation < current.revocation_generation
+                || (proposed.promotion_serial == current.promotion_serial && proposed != *current))
+        {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        state.promotion_heads.insert(key, proposed);
+        Ok(())
+    }
+}
+
+impl fmt::Debug for WindowsBrokerAdmissionService {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WindowsBrokerAdmissionService")
+            .field("repository", &self.repository)
+            .field("issuer_key_id", &self.signing_key.issuer_key_id())
+            .finish_non_exhaustive()
+    }
+}
+
+impl WindowsBrokerAdmissionAuthority for WindowsBrokerAdmissionService {
+    #[allow(clippy::too_many_lines)]
+    fn issue(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError> {
+        let request_sha256 = request
+            .request_sha256()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+        let request_key = request_sha256.to_string();
+        {
+            let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            if let Some(record) = state.records.get(&request_key) {
+                if record.phase == AdmissionRecordPhase::Completed {
+                    return Err(WindowsBrokerAdmissionError::InvalidState);
+                }
+                return self.receipt_from_record(record, request_sha256, now, false);
+            }
+        }
+
+        let evaluation = self.checked_evaluation(request, now)?;
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(record) = state.records.get(&request_key) {
+            if record.phase == AdmissionRecordPhase::Completed {
+                return Err(WindowsBrokerAdmissionError::InvalidState);
+            }
+            return self.receipt_from_record(record, request_sha256, now, false);
+        }
+        if state.records.len() >= MAX_ADMISSION_RECORDS {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        Self::enforce_and_advance_high_water(&mut state, evaluation.binding())?;
+
+        let issued_at = floor_windows_admission_issued_at(now)?;
+        let promotion_expiry = i64::try_from(
+            evaluation
+                .binding()
+                .promotion()
+                .validity()
+                .expires_at_unix_millis(),
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let expires_at = UnixMillis::new(
+            issued_at
+                .get()
+                .checked_add(ADMISSION_LIFETIME_MILLIS)
+                .ok_or(WindowsBrokerAdmissionError::InvalidRequest)?
+                .min(promotion_expiry),
+        );
+        if expires_at <= issued_at {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        let validity = WindowsAdmissionValidity::new(
+            u64::try_from(issued_at.get())
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?,
+            u64::try_from(expires_at.get())
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+        let handle = self
+            .custody
+            .reserve_handle(WindowsBrokerCustodyKind::AdmissionReceipt)
+            .map_err(map_custody)?;
+        let claims = WindowsRunnerAdmissionClaims::new(
+            self.signing_key.issuer_key_id(),
+            random_digest()?,
+            custody_handle_commitment(&handle),
+            random_digest()?,
+            evaluation.binding().clone(),
+            evaluation.evidence(),
+            validity,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let payload = Zeroizing::new(
+            claims
+                .canonical_bytes()
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?,
+        );
+        let envelope = WindowsRunnerAdmissionEnvelope::new(
+            self.signing_key.issuer_key_id(),
+            payload.to_vec(),
+            self.signing_key.sign_admission(&payload),
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let custody = AdmissionCustodyRecord {
+            schema: CUSTODY_RECORD_SCHEMA,
+            request_sha256,
+            request: request.clone(),
+            envelope: envelope.clone(),
+            launch: evaluation.launch().clone(),
+            profile_valid_until: evaluation.profile_valid_until(),
+        };
+        let mut encoded = Zeroizing::new(encode_custody_record(&custody)?);
+        let record = AdmissionStateRecord {
+            request_sha256,
+            handle: handle.opaque().to_owned(),
+            custody_content_sha256: sha256(&encoded),
+            created_at: issued_at,
+            phase: AdmissionRecordPhase::Issuing,
+            custody,
+            current_renewal: None,
+        };
+        state.records.insert(request_key.clone(), record);
+        self.repository.store(&state)?;
+        self.custody
+            .put_reserved(
+                &handle,
+                WindowsBrokerCustodyKind::AdmissionReceipt,
+                &encoded,
+                issued_at,
+            )
+            .map_err(map_custody)?;
+        encoded.zeroize();
+        let record = state
+            .records
+            .get_mut(&request_key)
+            .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+        record.phase = AdmissionRecordPhase::Issued;
+        self.repository.store(&state)?;
+        WindowsBrokerAdmissionReceipt::from_wire(handle, envelope, request_sha256, now)
+    }
+
+    fn resume(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        request_sha256: Sha256Digest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionReceipt, WindowsBrokerAdmissionError> {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let record = state
+            .records
+            .get(&request_sha256.to_string())
+            .filter(|record| {
+                record.handle == handle.opaque() && record.phase == AdmissionRecordPhase::Issued
+            })
+            .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+        self.receipt_from_record(record, request_sha256, now, false)
+    }
+
+    fn complete(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let record = state
+            .records
+            .values_mut()
+            .find(|record| record.handle == handle.opaque())
+            .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+        if record.custody.envelope.envelope_sha256() != envelope_sha256 {
+            return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+        }
+        self.custody
+            .complete_admission_receipt(handle, record.custody_content_sha256)
+            .map_err(map_custody)?;
+        if record.phase != AdmissionRecordPhase::Completed {
+            record.phase = AdmissionRecordPhase::Completed;
+            self.repository.store(&state)?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn renew(
+        &self,
+        completed_handle: &WindowsBrokerCustodyHandle,
+        enrollment_envelope_sha256: Sha256Digest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerPlacementRenewalReceipt, WindowsBrokerAdmissionError> {
+        let (request, original_binding) = {
+            let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let record = state
+                .records
+                .values()
+                .find(|record| {
+                    record.handle == completed_handle.opaque()
+                        && record.phase == AdmissionRecordPhase::Completed
+                })
+                .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+            if record.custody.envelope.envelope_sha256() != enrollment_envelope_sha256 {
+                return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+            }
+            if let Some(current) = &record.current_renewal
+                && !current.acknowledged
+            {
+                let claims = current
+                    .envelope
+                    .claims()
+                    .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+                if now.get()
+                    >= i64::try_from(claims.validity().expires_at_unix_millis())
+                        .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?
+                {
+                    return Err(WindowsBrokerAdmissionError::InvalidState);
+                }
+                return WindowsBrokerPlacementRenewalReceipt::from_wire(
+                    current.envelope.clone(),
+                    enrollment_envelope_sha256,
+                    now,
+                );
+            }
+            let claims = record
+                .custody
+                .envelope
+                .claims()
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+            (record.custody.request.clone(), claims.binding().clone())
+        };
+        let evaluation = self.checked_evaluation(&request, now)?;
+        if evaluation.binding() != &original_binding {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+        let issued_at = floor_windows_admission_issued_at(now)?;
+        let promotion_expiry = i64::try_from(
+            original_binding
+                .promotion()
+                .validity()
+                .expires_at_unix_millis(),
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let expires_at = UnixMillis::new(
+            issued_at
+                .get()
+                .checked_add(ADMISSION_LIFETIME_MILLIS)
+                .ok_or(WindowsBrokerAdmissionError::InvalidRequest)?
+                .min(promotion_expiry),
+        );
+        if expires_at <= issued_at {
+            return Err(WindowsBrokerAdmissionError::EvidenceRejected);
+        }
+
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let record = state
+            .records
+            .values_mut()
+            .find(|record| {
+                record.handle == completed_handle.opaque()
+                    && record.phase == AdmissionRecordPhase::Completed
+            })
+            .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+        if record.custody.envelope.envelope_sha256() != enrollment_envelope_sha256 {
+            return Err(WindowsBrokerAdmissionError::InvalidReceipt);
+        }
+        if let Some(current) = &record.current_renewal
+            && !current.acknowledged
+        {
+            let claims = current
+                .envelope
+                .claims()
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+            if now.get()
+                >= i64::try_from(claims.validity().expires_at_unix_millis())
+                    .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?
+            {
+                return Err(WindowsBrokerAdmissionError::InvalidState);
+            }
+            return WindowsBrokerPlacementRenewalReceipt::from_wire(
+                current.envelope.clone(),
+                enrollment_envelope_sha256,
+                now,
+            );
+        }
+        let serial = record
+            .current_renewal
+            .as_ref()
+            .map_or(1, |current| current.serial.saturating_add(1));
+        if serial == 0 {
+            return Err(WindowsBrokerAdmissionError::InvalidState);
+        }
+        let validity = WindowsAdmissionValidity::new(
+            u64::try_from(issued_at.get())
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?,
+            u64::try_from(expires_at.get())
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidRequest)?;
+        let claims = WindowsRunnerPlacementRenewalClaims::new(
+            self.signing_key.issuer_key_id(),
+            original_binding.transaction().runner_id(),
+            serial,
+            random_digest()?,
+            enrollment_envelope_sha256,
+            original_binding,
+            // Evidence is freshly re-evaluated. Keep the original value only
+            // to make the non-use explicit in case the evaluator changes it.
+            evaluation.evidence(),
+            validity,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let payload = claims
+            .canonical_bytes()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        let envelope = WindowsRunnerPlacementRenewalEnvelope::new(
+            self.signing_key.issuer_key_id(),
+            payload,
+            self.signing_key.sign_renewal(&claims)?,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        record.current_renewal = Some(AdmissionRenewalState {
+            serial,
+            envelope: envelope.clone(),
+            acknowledged: false,
+        });
+        self.repository.store(&state)?;
+        WindowsBrokerPlacementRenewalReceipt::from_wire(envelope, enrollment_envelope_sha256, now)
+    }
+
+    fn acknowledge_renewal(
+        &self,
+        completed_handle: &WindowsBrokerCustodyHandle,
+        renewal_envelope_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerAdmissionError> {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let record = state
+            .records
+            .values_mut()
+            .find(|record| {
+                record.handle == completed_handle.opaque()
+                    && record.phase == AdmissionRecordPhase::Completed
+            })
+            .ok_or(WindowsBrokerAdmissionError::InvalidState)?;
+        let renewal = record
+            .current_renewal
+            .as_mut()
+            .filter(|renewal| renewal.envelope.envelope_sha256() == renewal_envelope_sha256)
+            .ok_or(WindowsBrokerAdmissionError::InvalidReceipt)?;
+        if !renewal.acknowledged {
+            renewal.acknowledged = true;
+            self.repository.store(&state)?;
+        }
+        Ok(())
+    }
+}
+
+impl BrokerProfileContractResolver for WindowsBrokerAdmissionService {
+    fn resolve(
+        &self,
+        profile_contract_sha256: Sha256Digest,
+    ) -> Result<Option<WindowsHyperVAdmittedProfileContract>, BrokerError> {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let Some(record) = state.records.values().find(|record| {
+            if record.phase != AdmissionRecordPhase::Completed {
+                return false;
+            }
+            record.custody.envelope.claims().is_ok_and(|claims| {
+                claims.evidence().broker().profile_contract_sha256() == profile_contract_sha256
+            })
+        }) else {
+            return Ok(None);
+        };
+        let claims = record
+            .custody
+            .envelope
+            .claims()
+            .map_err(|_| BrokerError::InvalidProfileContract)?;
+        let host_id = claims
+            .binding()
+            .broker_profile()
+            .broker_host_id()
+            .parse()
+            .map_err(|_| BrokerError::InvalidProfileContract)?;
+        WindowsHyperVAdmittedProfileContract::new(
+            host_id,
+            profile_contract_sha256,
+            admitted_environment(&record.custody.launch)?,
+            record.custody.profile_valid_until,
+        )
+        .map(Some)
+    }
+}
+
+fn admitted_environment(
+    launch: &WindowsAdmissionLaunchContract,
+) -> Result<SandboxEnvironment, BrokerError> {
+    let image = ImmutableImage::new(launch.image().reference().to_owned())
+        .map_err(|_| BrokerError::InvalidProfileContract)?;
+    if image.digest() != launch.image().digest() {
+        return Err(BrokerError::InvalidProfileContract);
+    }
+    let keepalive = ExecutionArgv::new(
+        TargetPath::windows(launch.keepalive().program().to_owned())
+            .map_err(|_| BrokerError::InvalidProfileContract)?,
+        launch.keepalive().arguments().to_vec(),
+    )
+    .map_err(|_| BrokerError::InvalidProfileContract)?;
+    let workspace = TargetPath::windows(launch.workspace().to_owned())
+        .map_err(|_| BrokerError::InvalidProfileContract)?;
+    let environment = launch
+        .default_environment()
+        .iter()
+        .map(|variable| {
+            let name = EnvironmentName::new(variable.name().to_owned())
+                .map_err(|_| BrokerError::InvalidProfileContract)?;
+            let value = EnvironmentValue::new(variable.value().to_owned())
+                .map_err(|_| BrokerError::InvalidProfileContract)?;
+            Ok(EnvironmentVariable::new(name, value))
+        })
+        .collect::<Result<Vec<_>, BrokerError>>()?;
+    let environment =
+        ExecutionEnvironment::new(environment).map_err(|_| BrokerError::InvalidProfileContract)?;
+    SandboxEnvironment::windows_hyperv_container(
+        launch.profile().clone(),
+        image,
+        keepalive,
+        workspace,
+        environment,
+    )
+    .map_err(|_| BrokerError::InvalidProfileContract)
+}
+
+fn encode_custody_record(
+    record: &AdmissionCustodyRecord,
+) -> Result<Vec<u8>, WindowsBrokerAdmissionError> {
+    if record.schema != CUSTODY_RECORD_SCHEMA
+        || record.request_sha256
+            != record
+                .request
+                .request_sha256()
+                .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?
+        || record
+            .envelope
+            .claims()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?
+            .binding()
+            .broker_profile()
+            .request_binding_sha256()
+            != record.request_sha256
+    {
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    serde_json::to_vec(record).map_err(|_| WindowsBrokerAdmissionError::InvalidState)
+}
+
+fn promotion_head_key(binding: &WindowsRunnerAdmissionBinding) -> String {
+    format!(
+        "{}\0{}\0{}\0{}",
+        binding.broker_profile().broker_host_id(),
+        binding.promotion().trust_bundle_id(),
+        binding.promotion().key_id(),
+        binding.broker_profile().profile().digest(),
+    )
+}
+
+fn map_custody(_error: WindowsBrokerCustodyError) -> WindowsBrokerAdmissionError {
+    WindowsBrokerAdmissionError::InvalidState
+}
+
+fn random_digest() -> Result<Sha256Digest, WindowsBrokerAdmissionError> {
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    getrandom::fill(bytes.as_mut()).map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+    if bytes.iter().all(|byte| *byte == 0) {
+        return Err(WindowsBrokerAdmissionError::InvalidState);
+    }
+    let digest = Sha256Digest::from_bytes(*bytes);
+    bytes.zeroize();
+    Ok(digest)
+}
+
+pub(super) fn sha256(bytes: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(bytes).into())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/automata-ci-windows-broker/src/admission/service/tests.rs
+++ b/crates/automata-ci-windows-broker/src/admission/service/tests.rs
@@ -1,0 +1,999 @@
+use super::*;
+use crate::admission::repository::{
+    FileWindowsBrokerAdmissionRepository, WindowsBrokerAdmissionRepository,
+};
+use crate::custody::file::FileWindowsBrokerCustody;
+use automata_ci_core::{
+    Architecture, ContainerCapabilities, EnvironmentProfile, EnvironmentProfileId, IsolationLevel,
+    JobResourceAllocation, OperatingSystem, OperationId, ResourceCapacity, RunnerCapabilities,
+    RunnerFeature, RunnerId, RunnerPlatform, SandboxCapabilities, SandboxFeature,
+};
+use automata_ci_protocol::{
+    WindowsAdmissionImage, WindowsEnrollmentTransactionBinding, WindowsImagePromotionBinding,
+};
+use automata_ci_windows_broker_core::{
+    admission::{
+        VerifiedWindowsBrokerAdmissionEvaluator, WindowsBrokerAdmissionInputSet,
+        WindowsBrokerAdmissionInputSource, WindowsBrokerPromotionTrustBundle,
+        WindowsBrokerPromotionTrustKey, WindowsBrokerPromotionTrustRegistry,
+        WindowsBrokerSyntheticProbe, WindowsBrokerSyntheticProbeEvidence,
+    },
+    host_input::{
+        WindowsBrokerHostInputAttestation, WindowsBrokerHostInputDescriptor,
+        WindowsBrokerHostInputKind, WindowsBrokerHostInputObservation,
+        WindowsBrokerHostInputRequest,
+    },
+    request::{
+        WindowsAdmissionArgv, WindowsAdmissionBackendContract, WindowsAdmissionLaunchContract,
+        WindowsAdmissionProbeContract, WindowsAdmissionPromotionRequest,
+        WindowsAdmissionResourceLimits,
+    },
+};
+use automata_ci_windows_broker_protocol::WINDOWS_HYPERV_PROVIDER_ID;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use ring::{
+    rand::SystemRandom,
+    signature::{Ed25519KeyPair, KeyPair as _},
+};
+use serde::Serialize;
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::Barrier,
+};
+
+const TEST_NOW_MILLIS: i64 = 1_000_000;
+const TEST_PROMOTION_PAYLOAD_SCHEMA_VERSION: u16 = 2;
+const TEST_EVIDENCE_REFERENCE_MEDIA_TYPE: &str =
+    "application/vnd.automata.windows-image-evidence-reference+json";
+
+#[derive(Serialize)]
+struct TestPromotionPayload {
+    schema_version: u16,
+    decision: String,
+    promotion_serial: u64,
+    issued_at_unix_millis: u64,
+    expires_at_unix_millis: u64,
+    profile_id: String,
+    base_image: String,
+    image: String,
+    manifest_sha256: String,
+    lock_sha256: String,
+    provenance_sha256: String,
+    sbom_sha256: String,
+    patch_report_sha256: String,
+    revocations_sha256: String,
+    revocation_generation: u64,
+    provenance_accepted: TestAccepted,
+    sbom_accepted: TestAccepted,
+    patch_accepted: TestAccepted,
+    revocations_accepted: TestAccepted,
+}
+
+#[derive(Serialize)]
+#[serde(transparent)]
+struct TestAccepted(bool);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PromotionFault {
+    None,
+    WrongSignature,
+    UnknownKey,
+    NonCanonicalPayload,
+    Stale,
+    CandidateEvidence,
+}
+
+#[derive(Debug)]
+struct FixtureInputSource {
+    host_id: Sha256Digest,
+    documents: BTreeMap<WindowsBrokerHostInputKind, Vec<u8>>,
+}
+
+impl WindowsBrokerAdmissionInputSource for FixtureInputSource {
+    fn load(
+        &self,
+        request: &WindowsBrokerHostInputRequest,
+        issued_at: UnixMillis,
+        valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionInputSet, WindowsBrokerAdmissionError> {
+        let observations = request
+            .inputs()
+            .iter()
+            .enumerate()
+            .map(|(index, descriptor)| {
+                let byte_len = self.documents.get(&descriptor.kind()).map_or(64, Vec::len);
+                WindowsBrokerHostInputObservation::new(
+                    descriptor,
+                    u64::try_from(byte_len)
+                        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?,
+                    41,
+                    [u8::try_from(index + 1)
+                        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+                        16],
+                    "S-1-5-80-1-2-3-4-5".to_owned(),
+                    Sha256Digest::from_bytes([91; 32]),
+                )
+                .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let attestation = WindowsBrokerHostInputAttestation::issue(
+            self.host_id,
+            request,
+            observations,
+            issued_at,
+            valid_until,
+        )
+        .map_err(|_| WindowsBrokerAdmissionError::EvidenceRejected)?;
+        let documents = self
+            .documents
+            .iter()
+            .map(|(kind, bytes)| (*kind, Zeroizing::new(bytes.clone())))
+            .collect();
+        WindowsBrokerAdmissionInputSet::new(request, attestation, documents)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FixtureProbe;
+
+impl WindowsBrokerSyntheticProbe for FixtureProbe {
+    fn execute(
+        &self,
+        _request: &WindowsBrokerAdmissionRequest,
+        _host_inputs: &WindowsBrokerHostInputAttestation,
+        _now: UnixMillis,
+        _valid_until: UnixMillis,
+    ) -> Result<WindowsBrokerSyntheticProbeEvidence, WindowsBrokerAdmissionError> {
+        WindowsBrokerSyntheticProbeEvidence::new(
+            Sha256Digest::from_bytes([92; 32]),
+            Sha256Digest::from_bytes([93; 32]),
+            Sha256Digest::from_bytes([94; 32]),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct BarrierAdmissionEvaluator {
+    inner: Arc<dyn WindowsBrokerAdmissionEvaluator>,
+    rendezvous: Arc<Barrier>,
+}
+
+impl WindowsBrokerAdmissionEvaluator for BarrierAdmissionEvaluator {
+    fn evaluate(
+        &self,
+        request: &WindowsBrokerAdmissionRequest,
+        now: UnixMillis,
+    ) -> Result<WindowsBrokerAdmissionEvaluation, WindowsBrokerAdmissionError> {
+        self.rendezvous.wait();
+        self.inner.evaluate(request, now)
+    }
+}
+
+#[derive(Debug)]
+struct FixtureProtector;
+
+impl crate::custody::WindowsBrokerCustodyProtector for FixtureProtector {
+    fn seal(&self, plaintext: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+        let mut sealed = b"admission-test-v1:".to_vec();
+        sealed.extend(plaintext.iter().map(|byte| byte ^ 0xa5));
+        Ok(Zeroizing::new(sealed))
+    }
+
+    fn open(&self, sealed: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+        let ciphertext = sealed
+            .strip_prefix(b"admission-test-v1:")
+            .ok_or(WindowsBrokerCustodyError::Protector)?;
+        Ok(Zeroizing::new(
+            ciphertext.iter().map(|byte| byte ^ 0xa5).collect(),
+        ))
+    }
+}
+
+struct PromotionFixture {
+    host_id: Sha256Digest,
+    request: WindowsBrokerAdmissionRequest,
+    documents: BTreeMap<WindowsBrokerHostInputKind, Vec<u8>>,
+    trust: WindowsBrokerPromotionTrustRegistry,
+}
+
+impl PromotionFixture {
+    fn evaluator(&self) -> VerifiedWindowsBrokerAdmissionEvaluator {
+        VerifiedWindowsBrokerAdmissionEvaluator::new(
+            self.host_id,
+            Arc::new(FixtureInputSource {
+                host_id: self.host_id,
+                documents: self.documents.clone(),
+            }),
+            self.trust.clone(),
+            Arc::new(FixtureProbe),
+        )
+        .expect("fixture evaluator")
+    }
+}
+
+fn evidence_document(
+    kind: &str,
+    subject_media_type: &str,
+    image: &str,
+    candidate_fixture: bool,
+    revocation_expiry: Option<u64>,
+) -> Vec<u8> {
+    let mut document = serde_json::json!({
+        "schema_version": 1,
+        "kind": kind,
+        "candidate_fixture": candidate_fixture,
+        "profile_id": "example.com/windows-server-2025",
+        "image": image,
+        "subject": {
+            "sha256": Sha256Digest::from_bytes([52; 32]).to_string(),
+            "media_type": subject_media_type,
+        },
+        "statement": "production evidence accepted",
+    });
+    if kind == "revocations" {
+        let object = document.as_object_mut().expect("evidence object");
+        object.insert("generation".to_owned(), serde_json::json!(7));
+        object.insert(
+            "issued_at_unix_millis".to_owned(),
+            serde_json::json!(800_000_u64),
+        );
+        object.insert(
+            "expires_at_unix_millis".to_owned(),
+            serde_json::json!(revocation_expiry.expect("revocation expiry")),
+        );
+        object.insert("revoked_images".to_owned(), serde_json::json!([]));
+    }
+    serde_json::to_vec(&document).expect("evidence document")
+}
+
+#[allow(clippy::too_many_lines)]
+fn promotion_fixture(fault: PromotionFault, sealed_action_trees: bool) -> PromotionFixture {
+    let host_id = Sha256Digest::from_bytes([11; 32]);
+    let image_digest = Sha256Digest::from_bytes([12; 32]);
+    let image = format!("registry.example/windows/runner@sha256:{image_digest}");
+    let base_digest = Sha256Digest::from_bytes([13; 32]);
+    let base_image = format!("registry.example/windows/base@sha256:{base_digest}");
+    let promotion_expiry = if fault == PromotionFault::Stale {
+        u64::try_from(TEST_NOW_MILLIS).expect("positive test clock")
+    } else {
+        2_000_000
+    };
+
+    let provenance = evidence_document(
+        "provenance",
+        "application/vnd.in-toto+json",
+        &image,
+        false,
+        None,
+    );
+    let sbom = evidence_document(
+        "sbom",
+        "application/spdx+json",
+        &image,
+        fault == PromotionFault::CandidateEvidence,
+        None,
+    );
+    let patch_report = evidence_document(
+        "patch_report",
+        "application/vnd.automata.windows-patch-report+json",
+        &image,
+        false,
+        None,
+    );
+    let revocations = evidence_document(
+        "revocations",
+        "application/vnd.automata.image-revocations+json",
+        &image,
+        false,
+        Some(promotion_expiry),
+    );
+    let provenance_sha256 = sha256(&provenance);
+    let sbom_sha256 = sha256(&sbom);
+    let patch_report_sha256 = sha256(&patch_report);
+    let revocations_sha256 = sha256(&revocations);
+    let tool_sha256 = Sha256Digest::from_bytes([14; 32]).to_string();
+    let manifest = serde_json::to_vec(&serde_json::json!({
+         "schema_version": 1,
+         "status": "candidate",
+         "profile_id": "example.com/windows-server-2025",
+         "operating_system": "windows-server-2025",
+         "variant": "server-core",
+         "architecture": "x86_64",
+         "isolation": "hyperv-container",
+         "base_image": base_image,
+         "image": image,
+         "workspace": r"C:\Automata\workspace",
+         "guest_agent": r"C:\Automata\guest.exe",
+         "network_disabled": true,
+         "unprivileged": true,
+         "clean_workspace": true,
+         "tools": [
+             {"kind": "pwsh", "path": r"C:\Program Files\PowerShell\7\pwsh.exe", "version": "7.4", "sha256": tool_sha256},
+             {"kind": "powershell", "path": r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe", "version": "5.1", "sha256": tool_sha256},
+             {"kind": "cmd", "path": r"C:\Windows\System32\cmd.exe", "version": "10.0", "sha256": tool_sha256},
+             {"kind": "sha256", "path": r"C:\Automata\tools\automata-sha256.exe", "version": "1.0", "sha256": tool_sha256},
+         ],
+         "evidence": {
+             "provenance": {"sha256": provenance_sha256.to_string(), "media_type": TEST_EVIDENCE_REFERENCE_MEDIA_TYPE},
+             "sbom": {"sha256": sbom_sha256.to_string(), "media_type": TEST_EVIDENCE_REFERENCE_MEDIA_TYPE},
+             "patch_report": {"sha256": patch_report_sha256.to_string(), "media_type": TEST_EVIDENCE_REFERENCE_MEDIA_TYPE},
+             "revocations": {"sha256": revocations_sha256.to_string(), "media_type": TEST_EVIDENCE_REFERENCE_MEDIA_TYPE},
+         },
+     }))
+     .expect("manifest");
+    let manifest_sha256 = sha256(&manifest);
+    let lock = serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "profile_id": "example.com/windows-server-2025",
+        "manifest_sha256": manifest_sha256.to_string(),
+        "base_image": base_image,
+        "image": image,
+    }))
+    .expect("lock");
+    let lock_sha256 = sha256(&lock);
+    let payload = TestPromotionPayload {
+        schema_version: TEST_PROMOTION_PAYLOAD_SCHEMA_VERSION,
+        decision: "promote".to_owned(),
+        promotion_serial: 17,
+        issued_at_unix_millis: 900_000,
+        expires_at_unix_millis: promotion_expiry,
+        profile_id: "example.com/windows-server-2025".to_owned(),
+        base_image: base_image.clone(),
+        image: image.clone(),
+        manifest_sha256: manifest_sha256.to_string(),
+        lock_sha256: lock_sha256.to_string(),
+        provenance_sha256: provenance_sha256.to_string(),
+        sbom_sha256: sbom_sha256.to_string(),
+        patch_report_sha256: patch_report_sha256.to_string(),
+        revocations_sha256: revocations_sha256.to_string(),
+        revocation_generation: 7,
+        provenance_accepted: TestAccepted(true),
+        sbom_accepted: TestAccepted(true),
+        patch_accepted: TestAccepted(true),
+        revocations_accepted: TestAccepted(true),
+    };
+    let mut payload_bytes = serde_json::to_vec(&payload).expect("payload");
+    if fault == PromotionFault::NonCanonicalPayload {
+        payload_bytes.push(b' ');
+    }
+    let trusted_key_pair =
+        Ed25519KeyPair::from_seed_unchecked(&[61; 32]).expect("trusted promotion key");
+    let signing_key_pair = if fault == PromotionFault::WrongSignature {
+        Ed25519KeyPair::from_seed_unchecked(&[62; 32]).expect("untrusted promotion key")
+    } else {
+        Ed25519KeyPair::from_seed_unchecked(&[61; 32]).expect("promotion key")
+    };
+    let requested_key_id = if fault == PromotionFault::UnknownKey {
+        "missing-promotion-key"
+    } else {
+        "windows-promotion-key"
+    };
+    let signature = signing_key_pair.sign(&payload_bytes);
+    let promotion_envelope = serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "key_id": requested_key_id,
+        "payload_base64": BASE64.encode(&payload_bytes),
+        "signature_base64": BASE64.encode(signature.as_ref()),
+    }))
+    .expect("promotion envelope");
+
+    let backend_path = r"C:\Program Files\Automata\automata-windows-hyperv-broker-client.exe";
+    let envelope_path = r"C:\Automata\promotion-envelope.json";
+    let input_values = [
+        (
+            WindowsBrokerHostInputKind::Configuration,
+            r"C:\Automata\runner.json",
+            Sha256Digest::from_bytes([31; 32]),
+        ),
+        (
+            WindowsBrokerHostInputKind::BackendExecutable,
+            backend_path,
+            Sha256Digest::from_bytes([32; 32]),
+        ),
+        (
+            WindowsBrokerHostInputKind::ImageManifest,
+            r"C:\Automata\image-manifest.json",
+            manifest_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::ImageLock,
+            r"C:\Automata\image-lock.json",
+            lock_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::Provenance,
+            r"C:\Automata\provenance.json",
+            provenance_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::Sbom,
+            r"C:\Automata\sbom.json",
+            sbom_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::PatchReport,
+            r"C:\Automata\patch-report.json",
+            patch_report_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::Revocations,
+            r"C:\Automata\revocations.json",
+            revocations_sha256,
+        ),
+        (
+            WindowsBrokerHostInputKind::PromotionEnvelope,
+            envelope_path,
+            sha256(&promotion_envelope),
+        ),
+    ];
+    let host_inputs = WindowsBrokerHostInputRequest::new(
+        host_id.to_string(),
+        WINDOWS_HYPERV_PROVIDER_ID,
+        input_values
+            .into_iter()
+            .map(|(kind, path, digest)| {
+                WindowsBrokerHostInputDescriptor::new(kind, path, digest).expect("host input")
+            })
+            .collect(),
+    )
+    .expect("host inputs");
+    let profile = EnvironmentProfile::new(
+        EnvironmentProfileId::new("example.com/windows-server-2025").expect("profile id"),
+        Sha256Digest::from_bytes([15; 32]),
+    );
+    let capacity = ResourceCapacity::new(2_000, 2 * 1024 * 1024 * 1024, 0, 0);
+    let allocation = JobResourceAllocation::new(capacity, capacity).expect("allocation");
+    let resources = WindowsAdmissionResourceLimits::new(2 * 1024 * 1024 * 1024, 2_000, 128)
+        .expect("resource limits");
+    let launch = WindowsAdmissionLaunchContract::new(
+        profile.clone(),
+        WindowsAdmissionImage::new(image, image_digest).expect("image"),
+        WindowsAdmissionArgv::new(r"C:\Automata\guest.exe", vec!["keepalive".to_owned()])
+            .expect("keepalive"),
+        r"C:\Automata\workspace",
+        Vec::new(),
+        resources,
+        allocation,
+        true,
+        true,
+        true,
+        true,
+        sealed_action_trees,
+    )
+    .expect("launch");
+    let probe = WindowsAdmissionProbeContract::new(
+        1,
+        Sha256Digest::from_bytes([16; 32]),
+        resources,
+        allocation,
+        true,
+        true,
+        true,
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        r"C:\Windows\System32\cmd.exe",
+        None,
+        r"C:\Automata\tools\automata-sha256.exe",
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("probe");
+    let runner_id = RunnerId::new();
+    let runner_name = "windows-runner";
+    let transaction = WindowsEnrollmentTransactionBinding::new(
+        runner_id,
+        OperationId::new(),
+        "https://control.example/",
+        "https://enrollment.example/",
+        sha256(runner_name.as_bytes()),
+        Sha256Digest::from_bytes([17; 32]),
+        Sha256Digest::from_bytes([18; 32]),
+    )
+    .expect("transaction");
+    let mut features = vec![
+        RunnerFeature::SHELL_STEPS,
+        RunnerFeature::DEFAULT_WINDOWS_SHELL,
+        RunnerFeature::PWSH_SHELL,
+        RunnerFeature::WINDOWS_POWERSHELL_SHELL,
+        RunnerFeature::CMD_SHELL,
+    ];
+    if sealed_action_trees {
+        features.extend([
+            RunnerFeature::REPOSITORY_ACTIONS,
+            RunnerFeature::COMPOSITE_ACTIONS,
+        ]);
+    }
+    let capabilities = RunnerCapabilities::new(
+        runner_id,
+        RunnerPlatform::new(OperatingSystem::Windows, Architecture::X86_64),
+    )
+    .with_max_parallel_jobs(1)
+    .expect("parallel jobs")
+    .with_resources_per_job(capacity)
+    .with_sandbox(SandboxCapabilities::new(
+        IsolationLevel::VirtualMachine,
+        [
+            SandboxFeature::CLEAN_WORKSPACE,
+            SandboxFeature::NETWORK_ISOLATION,
+            SandboxFeature::WINDOWS_HYPERV_CONTAINER,
+        ],
+    ))
+    .with_containers(ContainerCapabilities::default())
+    .with_features(features)
+    .with_environment_profiles([profile]);
+    let promotion = WindowsAdmissionPromotionRequest::new(
+        envelope_path,
+        "windows-production-v1",
+        requested_key_id,
+        manifest_sha256,
+        lock_sha256,
+    )
+    .expect("promotion request");
+    let request = WindowsBrokerAdmissionRequest::new(
+        transaction,
+        runner_name,
+        host_id.to_string(),
+        WINDOWS_HYPERV_PROVIDER_ID,
+        WindowsAdmissionBackendContract::new(
+            backend_path,
+            Sha256Digest::from_bytes([32; 32]),
+            120_000,
+        )
+        .expect("backend"),
+        host_inputs,
+        launch,
+        probe,
+        promotion,
+        capabilities,
+    )
+    .expect("issue request");
+    let documents = BTreeMap::from([
+        (WindowsBrokerHostInputKind::ImageManifest, manifest),
+        (WindowsBrokerHostInputKind::ImageLock, lock),
+        (WindowsBrokerHostInputKind::Provenance, provenance),
+        (WindowsBrokerHostInputKind::Sbom, sbom),
+        (WindowsBrokerHostInputKind::PatchReport, patch_report),
+        (WindowsBrokerHostInputKind::Revocations, revocations),
+        (
+            WindowsBrokerHostInputKind::PromotionEnvelope,
+            promotion_envelope,
+        ),
+    ]);
+    let trusted_public_key: [u8; 32] = trusted_key_pair
+        .public_key()
+        .as_ref()
+        .try_into()
+        .expect("public key length");
+    let trust_key =
+        WindowsBrokerPromotionTrustKey::new("windows-promotion-key", trusted_public_key)
+            .expect("trust key");
+    let trust_sha256 = WindowsBrokerPromotionTrustBundle::canonical_sha256(
+        "windows-production-v1",
+        std::slice::from_ref(&trust_key),
+    );
+    let trust = WindowsBrokerPromotionTrustRegistry::new(vec![
+        WindowsBrokerPromotionTrustBundle::new(
+            "windows-production-v1",
+            trust_sha256,
+            vec![trust_key],
+        )
+        .expect("trust bundle"),
+    ])
+    .expect("trust registry");
+    PromotionFixture {
+        host_id,
+        request,
+        documents,
+        trust,
+    }
+}
+
+fn temp_root() -> PathBuf {
+    let mut nonce = [0_u8; 16];
+    getrandom::fill(&mut nonce).expect("random temp root");
+    std::env::temp_dir().join(format!("automata-admission-{}", sha256(&nonce)))
+}
+
+fn signing_key(pkcs8: &[u8]) -> Arc<WindowsBrokerAdmissionSigningKey> {
+    Arc::new(
+        WindowsBrokerAdmissionSigningKey::from_pkcs8("windows-admission-key", pkcs8)
+            .expect("admission signing key"),
+    )
+}
+
+fn file_admission_service<C>(
+    state_path: &Path,
+    custody: Arc<C>,
+    evaluator: Arc<dyn WindowsBrokerAdmissionEvaluator>,
+    signing_key: Arc<WindowsBrokerAdmissionSigningKey>,
+) -> Result<WindowsBrokerAdmissionService, WindowsBrokerAdmissionError>
+where
+    C: WindowsBrokerAdmissionCustody + 'static,
+{
+    let repository = Arc::new(FileWindowsBrokerAdmissionRepository::open(state_path)?);
+    let custody: Arc<dyn WindowsBrokerAdmissionCustody> = custody;
+    WindowsBrokerAdmissionService::new(repository, custody, evaluator, signing_key)
+}
+
+fn binding_with_promotion(
+    binding: &WindowsRunnerAdmissionBinding,
+    serial: u64,
+    revocation_generation: u64,
+    digest_marker: u8,
+) -> WindowsRunnerAdmissionBinding {
+    let promotion = WindowsImagePromotionBinding::new(
+        binding.promotion().trust_bundle_id(),
+        binding.promotion().key_id(),
+        Sha256Digest::from_bytes([digest_marker; 32]),
+        Sha256Digest::from_bytes([digest_marker.saturating_add(1); 32]),
+        serial,
+        revocation_generation,
+        binding.promotion().validity(),
+    )
+    .expect("promotion binding");
+    WindowsRunnerAdmissionBinding::new(
+        binding.transaction().clone(),
+        binding.broker_profile().clone(),
+        promotion,
+        binding.capabilities().clone(),
+    )
+    .expect("admission binding")
+}
+
+#[test]
+fn issue_timestamp_is_floored_without_moving_expiry() {
+    let observed = UnixMillis::new(12_345);
+    let expiry = UnixMillis::new(912_345);
+    assert_eq!(
+        floor_windows_admission_issued_at(observed).expect("floor"),
+        UnixMillis::new(12_000)
+    );
+    assert_eq!(expiry, UnixMillis::new(912_345));
+    assert_eq!(
+        floor_windows_admission_issued_at(UnixMillis::new(-1)),
+        Err(WindowsBrokerAdmissionError::InvalidRequest)
+    );
+}
+
+#[test]
+fn promotion_trust_bundle_commitment_is_ordered_and_exact() {
+    let first = WindowsBrokerPromotionTrustKey::new("key-a", [1_u8; 32]).expect("key");
+    let second = WindowsBrokerPromotionTrustKey::new("key-b", [2_u8; 32]).expect("key");
+    let forward = WindowsBrokerPromotionTrustBundle::canonical_sha256(
+        "windows-production-v1",
+        &[first.clone(), second.clone()],
+    );
+    let reverse = WindowsBrokerPromotionTrustBundle::canonical_sha256(
+        "windows-production-v1",
+        &[second.clone(), first.clone()],
+    );
+    assert_eq!(forward, reverse);
+    let forward_bundle = WindowsBrokerPromotionTrustBundle::new(
+        "windows-production-v1",
+        forward,
+        vec![first.clone(), second.clone()],
+    )
+    .expect("forward bundle");
+    let reverse_bundle = WindowsBrokerPromotionTrustBundle::new(
+        "windows-production-v1",
+        reverse,
+        vec![second, first.clone()],
+    )
+    .expect("reverse bundle");
+    assert_eq!(forward_bundle, reverse_bundle);
+    assert_eq!(
+        WindowsBrokerPromotionTrustBundle::new(
+            "windows-production-v1",
+            Sha256Digest::from_bytes([9_u8; 32]),
+            vec![first],
+        ),
+        Err(WindowsBrokerAdmissionError::InvalidRequest)
+    );
+}
+
+#[test]
+fn any_candidate_fixture_rejects_the_entire_promotion() {
+    let fixture = promotion_fixture(PromotionFault::CandidateEvidence, false);
+    assert!(matches!(
+        fixture
+            .evaluator()
+            .evaluate(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS)),
+        Err(WindowsBrokerAdmissionError::EvidenceRejected)
+    ));
+}
+
+#[test]
+fn verified_promotion_rejects_signature_key_canonical_stale_and_candidate_failures() {
+    let valid = promotion_fixture(PromotionFault::None, false);
+    let evaluation = valid
+        .evaluator()
+        .evaluate(&valid.request, UnixMillis::new(TEST_NOW_MILLIS))
+        .expect("valid promotion");
+    assert_eq!(evaluation.launch(), valid.request.launch());
+
+    for fault in [
+        PromotionFault::WrongSignature,
+        PromotionFault::UnknownKey,
+        PromotionFault::NonCanonicalPayload,
+        PromotionFault::Stale,
+        PromotionFault::CandidateEvidence,
+    ] {
+        let fixture = promotion_fixture(fault, false);
+        assert!(matches!(
+            fixture
+                .evaluator()
+                .evaluate(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS)),
+            Err(WindowsBrokerAdmissionError::EvidenceRejected)
+        ));
+    }
+}
+
+#[test]
+fn evaluator_rejects_action_capabilities_until_sealed_trees_are_supported() {
+    let fixture = promotion_fixture(PromotionFault::None, true);
+    assert!(matches!(
+        fixture
+            .evaluator()
+            .evaluate(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS)),
+        Err(WindowsBrokerAdmissionError::EvidenceRejected)
+    ));
+}
+
+#[test]
+fn promotion_high_water_rejects_rollback_and_same_serial_substitution() {
+    let fixture = promotion_fixture(PromotionFault::None, false);
+    let evaluation = fixture
+        .evaluator()
+        .evaluate(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS))
+        .expect("verified evaluation");
+    let binding = evaluation.binding();
+    let mut state = WindowsBrokerAdmissionSnapshot::default();
+    WindowsBrokerAdmissionService::enforce_and_advance_high_water(&mut state, binding)
+        .expect("initial head");
+    WindowsBrokerAdmissionService::enforce_and_advance_high_water(&mut state, binding)
+        .expect("exact replay");
+
+    let lower_serial = binding_with_promotion(binding, 16, 7, 81);
+    assert_eq!(
+        WindowsBrokerAdmissionService::enforce_and_advance_high_water(&mut state, &lower_serial,),
+        Err(WindowsBrokerAdmissionError::EvidenceRejected)
+    );
+    let lower_revocation = binding_with_promotion(binding, 18, 6, 82);
+    assert_eq!(
+        WindowsBrokerAdmissionService::enforce_and_advance_high_water(
+            &mut state,
+            &lower_revocation,
+        ),
+        Err(WindowsBrokerAdmissionError::EvidenceRejected)
+    );
+    let substituted = binding_with_promotion(binding, 17, 7, 83);
+    assert_eq!(
+        WindowsBrokerAdmissionService::enforce_and_advance_high_water(&mut state, &substituted,),
+        Err(WindowsBrokerAdmissionError::EvidenceRejected)
+    );
+    let advanced = binding_with_promotion(binding, 18, 8, 84);
+    WindowsBrokerAdmissionService::enforce_and_advance_high_water(&mut state, &advanced)
+        .expect("monotonic advance");
+}
+
+#[test]
+fn concurrent_renewals_replay_the_exact_retained_envelope_until_ack() {
+    let fixture = promotion_fixture(PromotionFault::None, false);
+    let root = temp_root();
+    let state_path = root.join("admission-state.json");
+    let custody = Arc::new(
+        FileWindowsBrokerCustody::open(root.join("custody"), Arc::new(FixtureProtector))
+            .expect("custody"),
+    );
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new())
+        .expect("generate admission key")
+        .as_ref()
+        .to_vec();
+    let authority = file_admission_service(
+        &state_path,
+        Arc::clone(&custody),
+        Arc::new(fixture.evaluator()),
+        signing_key(&pkcs8),
+    )
+    .expect("authority");
+    let receipt = authority
+        .issue(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS))
+        .expect("issue");
+    authority
+        .complete(receipt.handle(), receipt.envelope_sha256())
+        .expect("complete");
+    drop(authority);
+
+    let evaluator: Arc<dyn WindowsBrokerAdmissionEvaluator> = Arc::new(BarrierAdmissionEvaluator {
+        inner: Arc::new(fixture.evaluator()),
+        rendezvous: Arc::new(Barrier::new(2)),
+    });
+    let authority = file_admission_service(&state_path, custody, evaluator, signing_key(&pkcs8))
+        .expect("restart authority");
+    let now = UnixMillis::new(1_100_000);
+    let (first, second) = std::thread::scope(|scope| {
+        let first =
+            scope.spawn(|| authority.renew(receipt.handle(), receipt.envelope_sha256(), now));
+        let second =
+            scope.spawn(|| authority.renew(receipt.handle(), receipt.envelope_sha256(), now));
+        (
+            first.join().expect("first renewal thread"),
+            second.join().expect("second renewal thread"),
+        )
+    });
+    let first = first.expect("first renewal");
+    let second = second.expect("second renewal");
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .envelope()
+            .claims()
+            .expect("renewal claims")
+            .renewal_serial(),
+        1
+    );
+    authority
+        .acknowledge_renewal(receipt.handle(), first.envelope_sha256())
+        .expect("ack retained renewal");
+    authority
+        .acknowledge_renewal(receipt.handle(), first.envelope_sha256())
+        .expect("idempotent ACK");
+
+    fs::remove_dir_all(root).expect("remove temp root");
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn authority_recovers_issue_and_replays_renewal_until_exact_ack() {
+    let fixture = promotion_fixture(PromotionFault::None, false);
+    let root = temp_root();
+    let state_path = root.join("admission-state.json");
+    let custody_root = root.join("custody");
+    let protector: Arc<dyn crate::custody::WindowsBrokerCustodyProtector> =
+        Arc::new(FixtureProtector);
+    let custody = Arc::new(
+        FileWindowsBrokerCustody::open(&custody_root, Arc::clone(&protector)).expect("custody"),
+    );
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new())
+        .expect("generate admission key")
+        .as_ref()
+        .to_vec();
+    let evaluator: Arc<dyn WindowsBrokerAdmissionEvaluator> = Arc::new(fixture.evaluator());
+    let authority = file_admission_service(
+        &state_path,
+        Arc::clone(&custody),
+        Arc::clone(&evaluator),
+        signing_key(&pkcs8),
+    )
+    .expect("authority");
+
+    let now = UnixMillis::new(TEST_NOW_MILLIS);
+    let receipt = authority.issue(&fixture.request, now).expect("issue");
+    let replay = authority
+        .issue(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS + 1))
+        .expect("issue replay");
+    assert_eq!(receipt, replay);
+    let request_sha256 = fixture.request.request_sha256().expect("request digest");
+    assert_eq!(
+        authority
+            .resume(
+                receipt.handle(),
+                request_sha256,
+                UnixMillis::new(TEST_NOW_MILLIS + 2),
+            )
+            .expect("resume"),
+        receipt
+    );
+    drop(authority);
+
+    let repository =
+        FileWindowsBrokerAdmissionRepository::open(&state_path).expect("open repository");
+    let mut interrupted = repository.load().expect("read state");
+    interrupted
+        .records
+        .get_mut(&request_sha256.to_string())
+        .expect("issued record")
+        .phase = AdmissionRecordPhase::Issuing;
+    repository
+        .store(&interrupted)
+        .expect("persist interrupted issue");
+    let authority = file_admission_service(
+        &state_path,
+        Arc::clone(&custody),
+        Arc::clone(&evaluator),
+        signing_key(&pkcs8),
+    )
+    .expect("recover issuing authority");
+    assert_eq!(
+        authority
+            .resume(
+                receipt.handle(),
+                request_sha256,
+                UnixMillis::new(TEST_NOW_MILLIS + 3),
+            )
+            .expect("resume recovered issue"),
+        receipt
+    );
+    assert_eq!(
+        authority.complete(receipt.handle(), Sha256Digest::from_bytes([99; 32])),
+        Err(WindowsBrokerAdmissionError::InvalidReceipt)
+    );
+    authority
+        .complete(receipt.handle(), receipt.envelope_sha256())
+        .expect("complete");
+    authority
+        .complete(receipt.handle(), receipt.envelope_sha256())
+        .expect("idempotent completion");
+    drop(authority);
+    drop(custody);
+
+    let restarted_custody = Arc::new(
+        FileWindowsBrokerCustody::open(&custody_root, protector).expect("restart custody"),
+    );
+    let restarted = file_admission_service(
+        &state_path,
+        restarted_custody,
+        evaluator,
+        signing_key(&pkcs8),
+    )
+    .expect("restart authority");
+    assert_eq!(
+        restarted.issue(&fixture.request, UnixMillis::new(TEST_NOW_MILLIS + 4)),
+        Err(WindowsBrokerAdmissionError::InvalidState)
+    );
+
+    let first_renewal = restarted
+        .renew(
+            receipt.handle(),
+            receipt.envelope_sha256(),
+            UnixMillis::new(1_100_000),
+        )
+        .expect("first renewal");
+    let replayed_renewal = restarted
+        .renew(
+            receipt.handle(),
+            receipt.envelope_sha256(),
+            UnixMillis::new(1_100_001),
+        )
+        .expect("replayed renewal");
+    assert_eq!(first_renewal, replayed_renewal);
+    assert_eq!(
+        first_renewal
+            .envelope()
+            .claims()
+            .expect("renewal claims")
+            .renewal_serial(),
+        1
+    );
+    assert_eq!(
+        restarted.acknowledge_renewal(receipt.handle(), Sha256Digest::from_bytes([98; 32]),),
+        Err(WindowsBrokerAdmissionError::InvalidReceipt)
+    );
+    restarted
+        .acknowledge_renewal(receipt.handle(), first_renewal.envelope_sha256())
+        .expect("ack renewal");
+    restarted
+        .acknowledge_renewal(receipt.handle(), first_renewal.envelope_sha256())
+        .expect("idempotent renewal ack");
+    let second_renewal = restarted
+        .renew(
+            receipt.handle(),
+            receipt.envelope_sha256(),
+            UnixMillis::new(1_200_000),
+        )
+        .expect("second renewal");
+    assert_eq!(
+        second_renewal
+            .envelope()
+            .claims()
+            .expect("renewal claims")
+            .renewal_serial(),
+        2
+    );
+    drop(restarted);
+    fs::remove_dir_all(root).expect("remove temp root");
+}

--- a/crates/automata-ci-windows-broker/src/admission/signing.rs
+++ b/crates/automata-ci-windows-broker/src/admission/signing.rs
@@ -1,0 +1,84 @@
+//! Broker-owned admission signing key.
+
+use std::fmt;
+
+use automata_ci_protocol::WindowsRunnerPlacementRenewalClaims;
+use automata_ci_windows_broker_core::admission::WindowsBrokerAdmissionError;
+use ring::signature::{Ed25519KeyPair, KeyPair as _};
+
+/// Broker admission Ed25519 key retained outside ordinary configuration data.
+pub struct WindowsBrokerAdmissionSigningKey {
+    issuer_key_id: String,
+    key_pair: Ed25519KeyPair,
+}
+
+impl WindowsBrokerAdmissionSigningKey {
+    /// Opens one PKCS#8 Ed25519 signing key.
+    ///
+    /// Callers should supply bytes directly from service-account DPAPI
+    /// custody and zeroize the source immediately after this call.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed identifiers or invalid PKCS#8 Ed25519 material.
+    pub fn from_pkcs8(
+        issuer_key_id: impl Into<String>,
+        pkcs8: &[u8],
+    ) -> Result<Self, WindowsBrokerAdmissionError> {
+        let issuer_key_id = issuer_key_id.into();
+        if !valid_authority_id(&issuer_key_id) {
+            return Err(WindowsBrokerAdmissionError::InvalidRequest);
+        }
+        let key_pair = Ed25519KeyPair::from_pkcs8(pkcs8)
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidState)?;
+        Ok(Self {
+            issuer_key_id,
+            key_pair,
+        })
+    }
+
+    /// Returns the non-secret issuer key identifier.
+    #[must_use]
+    pub fn issuer_key_id(&self) -> &str {
+        &self.issuer_key_id
+    }
+
+    /// Returns the Ed25519 public key for provisioning/audit checks.
+    #[must_use]
+    pub fn public_key(&self) -> &[u8] {
+        self.key_pair.public_key().as_ref()
+    }
+
+    pub(super) fn sign_admission(&self, payload: &[u8]) -> Vec<u8> {
+        self.key_pair.sign(payload).as_ref().to_vec()
+    }
+
+    pub(super) fn sign_renewal(
+        &self,
+        claims: &WindowsRunnerPlacementRenewalClaims,
+    ) -> Result<Vec<u8>, WindowsBrokerAdmissionError> {
+        let bytes = claims
+            .signing_bytes()
+            .map_err(|_| WindowsBrokerAdmissionError::InvalidReceipt)?;
+        Ok(self.key_pair.sign(&bytes).as_ref().to_vec())
+    }
+}
+
+impl fmt::Debug for WindowsBrokerAdmissionSigningKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WindowsBrokerAdmissionSigningKey")
+            .field("issuer_key_id", &self.issuer_key_id)
+            .field("key_pair", &"[SECRET]")
+            .finish()
+    }
+}
+
+fn valid_authority_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    (3..=128).contains(&bytes.len())
+        && bytes[0].is_ascii_lowercase()
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(byte))
+}

--- a/crates/automata-ci-windows-broker/src/custody.rs
+++ b/crates/automata-ci-windows-broker/src/custody.rs
@@ -1,0 +1,231 @@
+//! Service-owned custody contracts for Windows enrollment material.
+//!
+//! Concrete persistence is namespaced under [`mod@file`]. Callers receive only
+//! opaque handles and authenticated value-free metadata.
+
+use std::{fmt, str::FromStr as _};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+pub mod file;
+
+const MAX_ADMISSION_RECEIPT_BYTES: usize = 256 * 1024;
+const MAX_ENROLLMENT_SECRET_BYTES: usize = 64 * 1024;
+
+/// Type of broker-custodied material.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowsBrokerCustodyKind {
+    /// Authenticated, short-lived pre-enrollment admission receipt.
+    AdmissionReceipt,
+    /// Runner enrollment secret that must never be written by the runner.
+    EnrollmentSecret,
+}
+
+impl WindowsBrokerCustodyKind {
+    const fn byte_limit(self) -> usize {
+        match self {
+            Self::AdmissionReceipt => MAX_ADMISSION_RECEIPT_BYTES,
+            Self::EnrollmentSecret => MAX_ENROLLMENT_SECRET_BYTES,
+        }
+    }
+
+    const fn domain_byte(self) -> u8 {
+        match self {
+            Self::AdmissionReceipt => 1,
+            Self::EnrollmentSecret => 2,
+        }
+    }
+}
+
+/// Opaque random capability for one service-owned custody record.
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct WindowsBrokerCustodyHandle {
+    token: String,
+    digest: Sha256Digest,
+}
+
+impl WindowsBrokerCustodyHandle {
+    /// Parses a fixed canonical custody token.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unknown versions, path-like values, and non-canonical digests.
+    pub fn parse(value: &str) -> Result<Self, WindowsBrokerCustodyError> {
+        let digest_text = value
+            .strip_prefix("bc1-")
+            .ok_or(WindowsBrokerCustodyError::InvalidHandle)?;
+        if digest_text.len() != 64
+            || !digest_text
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(WindowsBrokerCustodyError::InvalidHandle);
+        }
+        let digest = Sha256Digest::from_str(digest_text)
+            .map_err(|_| WindowsBrokerCustodyError::InvalidHandle)?;
+        if digest.as_bytes().iter().all(|byte| *byte == 0) {
+            return Err(WindowsBrokerCustodyError::InvalidHandle);
+        }
+        Ok(Self {
+            token: value.to_owned(),
+            digest,
+        })
+    }
+
+    /// Returns the path-free broker token. Treat it as opaque.
+    #[must_use]
+    pub fn opaque(&self) -> &str {
+        &self.token
+    }
+
+    /// Returns the stable value-free capability digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl fmt::Debug for WindowsBrokerCustodyHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("WindowsBrokerCustodyHandle([OPAQUE])")
+    }
+}
+
+/// Reauthenticated metadata for one custody record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WindowsBrokerCustodyMetadata {
+    kind: WindowsBrokerCustodyKind,
+    content_sha256: Sha256Digest,
+    byte_len: usize,
+    created_at: UnixMillis,
+}
+
+impl WindowsBrokerCustodyMetadata {
+    /// Returns the material class.
+    #[must_use]
+    pub const fn kind(self) -> WindowsBrokerCustodyKind {
+        self.kind
+    }
+
+    /// Returns SHA-256 of the authenticated plaintext.
+    #[must_use]
+    pub const fn content_sha256(self) -> Sha256Digest {
+        self.content_sha256
+    }
+
+    /// Returns the exact plaintext byte length.
+    #[must_use]
+    pub const fn byte_len(self) -> usize {
+        self.byte_len
+    }
+
+    /// Returns the trusted service creation time.
+    #[must_use]
+    pub const fn created_at(self) -> UnixMillis {
+        self.created_at
+    }
+}
+
+/// Safe sealing boundary used by the broker custody store.
+///
+/// The Windows service implementation uses same-account `CurrentUser` DPAPI
+/// with UI forbidden. Tests use a deliberately non-production reversible fake.
+pub trait WindowsBrokerCustodyProtector: fmt::Debug + Send + Sync {
+    /// Seals one bounded value for durable service-only storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free protector failure.
+    fn seal(&self, plaintext: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError>;
+
+    /// Opens one sealed value under the same service identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns a value-free protector failure or authentication failure.
+    fn open(&self, sealed: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError>;
+}
+
+/// Narrow custody port required by the admission application state machine.
+///
+/// Implementations own durable material, handle generation, exact replay, and
+/// completion tombstones. The application service never receives a path or a
+/// generic plaintext lookup surface.
+pub trait WindowsBrokerAdmissionCustody: fmt::Debug + Send + Sync {
+    /// Reserves a new opaque handle without publishing authority.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on entropy, capacity, or backend availability failures.
+    fn reserve_handle(
+        &self,
+        kind: WindowsBrokerCustodyKind,
+    ) -> Result<WindowsBrokerCustodyHandle, WindowsBrokerCustodyError>;
+
+    /// Publishes or exactly replays material at a reserved handle.
+    ///
+    /// # Errors
+    ///
+    /// Rejects substitution, completion reuse, capacity, and durability
+    /// failures.
+    fn put_reserved(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        kind: WindowsBrokerCustodyKind,
+        plaintext: &[u8],
+        created_at: UnixMillis,
+    ) -> Result<(), WindowsBrokerCustodyError>;
+
+    /// Opens the exact live or completed admission receipt.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absence, substitution, corruption, and backend failures.
+    fn get_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        completed: bool,
+    ) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError>;
+
+    /// Atomically completes one exact admission receipt.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absence, kind or digest substitution, corruption, and backend
+    /// failures.
+    fn complete_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        expected_content_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerCustodyError>;
+}
+
+/// Closed custody failure without secret bytes or host paths.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum WindowsBrokerCustodyError {
+    /// A handle or store configuration is malformed.
+    #[error("Windows broker custody input is invalid")]
+    InvalidHandle,
+    /// A service-owned path is not a regular non-reparse object.
+    #[error("Windows broker custody path safety check failed")]
+    UnsafePath,
+    /// A bounded filesystem operation failed.
+    #[error("Windows broker custody I/O failed")]
+    Io,
+    /// A record was modified, truncated, or schema-invalid.
+    #[error("Windows broker custody record authentication failed")]
+    Tampered,
+    /// The configured bounded store or material limit was exceeded.
+    #[error("Windows broker custody capacity was exceeded")]
+    Capacity,
+    /// The service-account sealing boundary failed.
+    #[error("Windows broker custody protector failed")]
+    Protector,
+    /// No live record exists for the exact handle.
+    #[error("Windows broker custody handle is absent")]
+    Absent,
+}

--- a/crates/automata-ci-windows-broker/src/custody/file.rs
+++ b/crates/automata-ci-windows-broker/src/custody/file.rs
@@ -1,0 +1,839 @@
+//! Create-only file adapter for broker-owned custody.
+
+use std::{
+    collections::BTreeSet,
+    fmt,
+    fs::{self, File, OpenOptions},
+    io::{Read as _, Write as _},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, PoisonError},
+};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use zeroize::{Zeroize as _, Zeroizing};
+
+use super::{
+    MAX_ADMISSION_RECEIPT_BYTES, WindowsBrokerAdmissionCustody, WindowsBrokerCustodyError,
+    WindowsBrokerCustodyHandle, WindowsBrokerCustodyKind, WindowsBrokerCustodyMetadata,
+    WindowsBrokerCustodyProtector,
+};
+
+const HANDLE_DOMAIN: &[u8] = b"automata.windows-broker-custody-handle.v1\0";
+const RECORD_DOMAIN: &[u8] = b"automata.windows-broker-custody-record.v1\0";
+const SEALED_ENVELOPE_DOMAIN: &[u8] = b"automata.windows-broker-custody-sealed-envelope.v1\0";
+const SEALED_ENVELOPE_SCHEMA: u16 = 1;
+const MAX_RECORD_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_RECORD_BYTES_USIZE: usize = 2 * 1024 * 1024;
+const MAX_ENTRY_COUNT: usize = 4_096;
+
+/// Reparse-safe, create-only file custody owned by the broker service.
+pub struct FileWindowsBrokerCustody {
+    root: PathBuf,
+    protector: Arc<dyn WindowsBrokerCustodyProtector>,
+    mutation: Mutex<()>,
+}
+
+impl FileWindowsBrokerCustody {
+    /// Opens a service-owned custody root and reconciles incomplete temp files.
+    ///
+    /// # Errors
+    ///
+    /// Rejects relative, symlink/reparse, unknown-entry, or inaccessible roots.
+    pub fn open(
+        root: impl Into<PathBuf>,
+        protector: Arc<dyn WindowsBrokerCustodyProtector>,
+    ) -> Result<Self, WindowsBrokerCustodyError> {
+        let root = root.into();
+        if !root.is_absolute() {
+            return Err(WindowsBrokerCustodyError::UnsafePath);
+        }
+        fs::create_dir_all(&root).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        validate_directory(&root)?;
+        reconcile_root(&root)?;
+        Ok(Self {
+            root,
+            protector,
+            mutation: Mutex::new(()),
+        })
+    }
+
+    /// Seals and atomically publishes one new custody record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty/oversized material, unsafe roots, capacity exhaustion,
+    /// RNG failure, sealing failure, or incomplete durable publication.
+    pub fn put(
+        &self,
+        kind: WindowsBrokerCustodyKind,
+        plaintext: &[u8],
+        created_at: UnixMillis,
+    ) -> Result<WindowsBrokerCustodyHandle, WindowsBrokerCustodyError> {
+        let handle = self.reserve_handle(kind)?;
+        self.put_reserved(&handle, kind, plaintext, created_at)?;
+        Ok(handle)
+    }
+
+    /// Reserves a random path-free handle without publishing material.
+    ///
+    /// This is restricted to broker-owned transactional protocols which first
+    /// persist a recoverable publication intent. A reservation conveys no
+    /// custody authority until [`Self::put_reserved`] succeeds.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn reserve_handle(
+        &self,
+        kind: WindowsBrokerCustodyKind,
+    ) -> Result<WindowsBrokerCustodyHandle, WindowsBrokerCustodyError> {
+        let mut entropy = Zeroizing::new([0_u8; 32]);
+        getrandom::fill(entropy.as_mut()).map_err(|_| WindowsBrokerCustodyError::Protector)?;
+        let handle_digest =
+            domain_digest(HANDLE_DOMAIN, &[&[kind.domain_byte()], entropy.as_ref()]);
+        entropy.zeroize();
+        WindowsBrokerCustodyHandle::parse(&format!("bc1-{handle_digest}"))
+    }
+
+    /// Publishes exact material at a previously reserved broker handle.
+    ///
+    /// An exact already-published record is accepted for crash recovery. A
+    /// different record, a completed handle, or any path collision fails
+    /// closed.
+    pub(crate) fn put_reserved(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        kind: WindowsBrokerCustodyKind,
+        plaintext: &[u8],
+        created_at: UnixMillis,
+    ) -> Result<(), WindowsBrokerCustodyError> {
+        if plaintext.is_empty() || plaintext.len() > kind.byte_limit() {
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        let _guard = self.mutation.lock().unwrap_or_else(PoisonError::into_inner);
+        validate_directory(&self.root)?;
+        let content_sha256 = sha256(plaintext);
+        let target = record_path(&self.root, handle);
+        let completed = completed_path(&self.root, handle);
+        if completed.exists() {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        if target.exists() {
+            let (existing, metadata) =
+                self.read_authenticated_path(handle, &target, kind.byte_limit())?;
+            if metadata.kind == kind
+                && metadata.content_sha256 == content_sha256
+                && metadata.created_at == created_at
+                && existing.as_slice() == plaintext
+            {
+                return Ok(());
+            }
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        if committed_entry_count(&self.root)? >= MAX_ENTRY_COUNT {
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        let sealed_envelope =
+            encode_sealed_envelope(handle.digest, kind, content_sha256, created_at, plaintext)?;
+        let mut sealed = self.protector.seal(&sealed_envelope)?;
+        if sealed.is_empty() || sealed.len() > MAX_RECORD_BYTES_USIZE {
+            sealed.zeroize();
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        let sealed_sha256 = sha256(&sealed);
+        let record_digest = record_digest(
+            handle.digest,
+            kind,
+            content_sha256,
+            plaintext.len(),
+            created_at,
+            sealed_sha256,
+        );
+        let record = CustodyRecord {
+            schema: 1,
+            handle_digest: handle.digest,
+            kind,
+            content_sha256,
+            byte_len: plaintext.len(),
+            created_at,
+            sealed_sha256,
+            sealed_base64: BASE64.encode(&sealed[..]),
+            record_digest,
+        };
+        sealed.zeroize();
+        let encoded = serde_json::to_vec(&record).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        if encoded.len() as u64 > MAX_RECORD_BYTES {
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        let temp = temp_path(&self.root, handle)?;
+        write_new_synchronized(&temp, &encoded)?;
+        if target.exists() || completed.exists() {
+            let _ = fs::remove_file(&temp);
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        fs::rename(&temp, &target).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        validate_regular_file(&target)?;
+        Ok(())
+    }
+
+    /// Reauthenticates a record and returns value-free metadata.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absent, unsafe, malformed, modified, or unsealable records.
+    pub fn inspect(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+    ) -> Result<WindowsBrokerCustodyMetadata, WindowsBrokerCustodyError> {
+        let (_, metadata) = self.read_authenticated(handle, usize::MAX)?;
+        Ok(metadata)
+    }
+
+    /// Reauthenticates and opens one exact bounded record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero/excessive caller limit and all inspect failures.
+    pub fn get(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        byte_limit: usize,
+    ) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+        if byte_limit == 0 || byte_limit > MAX_ADMISSION_RECEIPT_BYTES {
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        self.read_authenticated(handle, byte_limit)
+            .map(|(plaintext, _)| plaintext)
+    }
+
+    /// Reauthenticates then atomically turns one exact record into a tombstone.
+    ///
+    /// # Errors
+    ///
+    /// An absent record is idempotent. Unsafe or tampered records are retained
+    /// for operator investigation and fail closed.
+    pub fn remove(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+    ) -> Result<(), WindowsBrokerCustodyError> {
+        let _guard = self.mutation.lock().unwrap_or_else(PoisonError::into_inner);
+        validate_directory(&self.root)?;
+        let path = record_path(&self.root, handle);
+        let completed = completed_path(&self.root, handle);
+        if completed.exists() {
+            if path.exists() {
+                return Err(WindowsBrokerCustodyError::Tampered);
+            }
+            let _ = self.read_authenticated_path(handle, &completed, usize::MAX)?;
+            return Ok(());
+        }
+        if !path.exists() {
+            return Ok(());
+        }
+        let _ = self.read_authenticated(handle, usize::MAX)?;
+        fs::rename(&path, &completed).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        validate_regular_file(&completed)
+    }
+
+    /// Completes one admission receipt using its exact authenticated content digest.
+    ///
+    /// The encrypted record is atomically renamed to a stable tombstone. Repeating
+    /// the same completion after a crash succeeds, while a different digest, kind,
+    /// or any attempt to reuse the handle fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an absent live/tombstoned record, the wrong material kind or digest,
+    /// and every ordinary authentication or path-safety failure.
+    pub fn complete_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        expected_content_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerCustodyError> {
+        let _guard = self.mutation.lock().unwrap_or_else(PoisonError::into_inner);
+        validate_directory(&self.root)?;
+        let path = record_path(&self.root, handle);
+        let completed = completed_path(&self.root, handle);
+        if path.exists() && completed.exists() {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        let selected = if path.exists() {
+            &path
+        } else if completed.exists() {
+            &completed
+        } else {
+            return Err(WindowsBrokerCustodyError::Absent);
+        };
+        let (_, metadata) = self.read_authenticated_path(handle, selected, usize::MAX)?;
+        if metadata.kind != WindowsBrokerCustodyKind::AdmissionReceipt
+            || metadata.content_sha256 != expected_content_sha256
+        {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        if selected == &path {
+            fs::rename(&path, &completed).map_err(|_| WindowsBrokerCustodyError::Io)?;
+            validate_regular_file(&completed)?;
+        }
+        Ok(())
+    }
+
+    /// Opens an admission record only for the dedicated broker authority.
+    ///
+    /// Generic protocol dispatch never exposes this method. `completed`
+    /// selects the live receipt or its durable completion tombstone exactly.
+    pub(crate) fn get_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        completed: bool,
+    ) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+        let path = if completed {
+            completed_path(&self.root, handle)
+        } else {
+            record_path(&self.root, handle)
+        };
+        if !path.exists() {
+            return Err(WindowsBrokerCustodyError::Absent);
+        }
+        let (plaintext, metadata) =
+            self.read_authenticated_path(handle, &path, MAX_ADMISSION_RECEIPT_BYTES)?;
+        if metadata.kind != WindowsBrokerCustodyKind::AdmissionReceipt {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        Ok(plaintext)
+    }
+
+    fn read_authenticated(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        byte_limit: usize,
+    ) -> Result<(Zeroizing<Vec<u8>>, WindowsBrokerCustodyMetadata), WindowsBrokerCustodyError> {
+        validate_directory(&self.root)?;
+        let path = record_path(&self.root, handle);
+        if !path.exists() {
+            return Err(WindowsBrokerCustodyError::Absent);
+        }
+        self.read_authenticated_path(handle, &path, byte_limit)
+    }
+
+    fn read_authenticated_path(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        path: &Path,
+        byte_limit: usize,
+    ) -> Result<(Zeroizing<Vec<u8>>, WindowsBrokerCustodyMetadata), WindowsBrokerCustodyError> {
+        validate_regular_file(path)?;
+        let file = File::open(path).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        if file
+            .metadata()
+            .map_err(|_| WindowsBrokerCustodyError::Io)?
+            .len()
+            > MAX_RECORD_BYTES
+        {
+            return Err(WindowsBrokerCustodyError::Capacity);
+        }
+        let mut encoded = Vec::new();
+        file.take(MAX_RECORD_BYTES.saturating_add(1))
+            .read_to_end(&mut encoded)
+            .map_err(|_| WindowsBrokerCustodyError::Io)?;
+        if encoded.is_empty() || encoded.len() as u64 > MAX_RECORD_BYTES {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        let record: CustodyRecord =
+            serde_json::from_slice(&encoded).map_err(|_| WindowsBrokerCustodyError::Tampered)?;
+        if record.schema != 1
+            || record.handle_digest != handle.digest
+            || record.byte_len == 0
+            || record.byte_len > record.kind.byte_limit()
+            || record.byte_len > byte_limit
+            || record.record_digest
+                != record_digest(
+                    record.handle_digest,
+                    record.kind,
+                    record.content_sha256,
+                    record.byte_len,
+                    record.created_at,
+                    record.sealed_sha256,
+                )
+        {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        let mut sealed = Zeroizing::new(
+            BASE64
+                .decode(&record.sealed_base64)
+                .map_err(|_| WindowsBrokerCustodyError::Tampered)?,
+        );
+        if sealed.is_empty()
+            || sealed.len() > MAX_RECORD_BYTES_USIZE
+            || sha256(&sealed) != record.sealed_sha256
+        {
+            sealed.zeroize();
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+        let sealed_envelope = self.protector.open(&sealed)?;
+        sealed.zeroize();
+        let plaintext = decode_sealed_envelope(&sealed_envelope, &record)?;
+        Ok((
+            plaintext,
+            WindowsBrokerCustodyMetadata {
+                kind: record.kind,
+                content_sha256: record.content_sha256,
+                byte_len: record.byte_len,
+                created_at: record.created_at,
+            },
+        ))
+    }
+}
+
+impl WindowsBrokerAdmissionCustody for FileWindowsBrokerCustody {
+    fn reserve_handle(
+        &self,
+        kind: WindowsBrokerCustodyKind,
+    ) -> Result<WindowsBrokerCustodyHandle, WindowsBrokerCustodyError> {
+        Self::reserve_handle(self, kind)
+    }
+
+    fn put_reserved(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        kind: WindowsBrokerCustodyKind,
+        plaintext: &[u8],
+        created_at: UnixMillis,
+    ) -> Result<(), WindowsBrokerCustodyError> {
+        Self::put_reserved(self, handle, kind, plaintext, created_at)
+    }
+
+    fn get_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        completed: bool,
+    ) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+        Self::get_admission_receipt(self, handle, completed)
+    }
+
+    fn complete_admission_receipt(
+        &self,
+        handle: &WindowsBrokerCustodyHandle,
+        expected_content_sha256: Sha256Digest,
+    ) -> Result<(), WindowsBrokerCustodyError> {
+        Self::complete_admission_receipt(self, handle, expected_content_sha256)
+    }
+}
+
+impl fmt::Debug for FileWindowsBrokerCustody {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FileWindowsBrokerCustody")
+            .field("root", &"[SERVICE_OWNED]")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CustodyRecord {
+    schema: u16,
+    handle_digest: Sha256Digest,
+    kind: WindowsBrokerCustodyKind,
+    content_sha256: Sha256Digest,
+    byte_len: usize,
+    created_at: UnixMillis,
+    sealed_sha256: Sha256Digest,
+    sealed_base64: String,
+    record_digest: Sha256Digest,
+}
+
+fn record_digest(
+    handle: Sha256Digest,
+    kind: WindowsBrokerCustodyKind,
+    content: Sha256Digest,
+    byte_len: usize,
+    created_at: UnixMillis,
+    sealed: Sha256Digest,
+) -> Sha256Digest {
+    domain_digest(
+        RECORD_DOMAIN,
+        &[
+            handle.as_bytes(),
+            &[kind.domain_byte()],
+            content.as_bytes(),
+            &(byte_len as u64).to_be_bytes(),
+            &created_at.get().to_be_bytes(),
+            sealed.as_bytes(),
+        ],
+    )
+}
+
+fn encode_sealed_envelope(
+    handle: Sha256Digest,
+    kind: WindowsBrokerCustodyKind,
+    content: Sha256Digest,
+    created_at: UnixMillis,
+    plaintext: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+    let byte_len =
+        u64::try_from(plaintext.len()).map_err(|_| WindowsBrokerCustodyError::Capacity)?;
+    let capacity = SEALED_ENVELOPE_DOMAIN
+        .len()
+        .checked_add(2 + 32 + 1 + 32 + 8 + 8)
+        .and_then(|fixed| fixed.checked_add(plaintext.len()))
+        .ok_or(WindowsBrokerCustodyError::Capacity)?;
+    let mut encoded = Zeroizing::new(Vec::with_capacity(capacity));
+    encoded.extend_from_slice(SEALED_ENVELOPE_DOMAIN);
+    encoded.extend_from_slice(&SEALED_ENVELOPE_SCHEMA.to_be_bytes());
+    encoded.extend_from_slice(handle.as_bytes());
+    encoded.push(kind.domain_byte());
+    encoded.extend_from_slice(content.as_bytes());
+    encoded.extend_from_slice(&byte_len.to_be_bytes());
+    encoded.extend_from_slice(&created_at.get().to_be_bytes());
+    encoded.extend_from_slice(plaintext);
+    Ok(encoded)
+}
+
+fn decode_sealed_envelope(
+    encoded: &[u8],
+    record: &CustodyRecord,
+) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+    let mut remaining = encoded;
+    if take_bytes(&mut remaining, SEALED_ENVELOPE_DOMAIN.len())? != SEALED_ENVELOPE_DOMAIN
+        || u16::from_be_bytes(take_array(&mut remaining)?) != SEALED_ENVELOPE_SCHEMA
+        || Sha256Digest::from_bytes(take_array(&mut remaining)?) != record.handle_digest
+        || u8::from_be_bytes(take_array(&mut remaining)?) != record.kind.domain_byte()
+        || Sha256Digest::from_bytes(take_array(&mut remaining)?) != record.content_sha256
+        || u64::from_be_bytes(take_array(&mut remaining)?)
+            != u64::try_from(record.byte_len).map_err(|_| WindowsBrokerCustodyError::Tampered)?
+        || i64::from_be_bytes(take_array(&mut remaining)?) != record.created_at.get()
+        || remaining.len() != record.byte_len
+        || sha256(remaining) != record.content_sha256
+    {
+        return Err(WindowsBrokerCustodyError::Tampered);
+    }
+    Ok(Zeroizing::new(remaining.to_vec()))
+}
+
+fn take_array<const N: usize>(remaining: &mut &[u8]) -> Result<[u8; N], WindowsBrokerCustodyError> {
+    take_bytes(remaining, N)?
+        .try_into()
+        .map_err(|_| WindowsBrokerCustodyError::Tampered)
+}
+
+fn take_bytes<'a>(
+    remaining: &mut &'a [u8],
+    count: usize,
+) -> Result<&'a [u8], WindowsBrokerCustodyError> {
+    if remaining.len() < count {
+        return Err(WindowsBrokerCustodyError::Tampered);
+    }
+    let (selected, rest) = remaining.split_at(count);
+    *remaining = rest;
+    Ok(selected)
+}
+
+fn sha256(value: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(value).into())
+}
+
+fn domain_digest(domain: &[u8], fields: &[&[u8]]) -> Sha256Digest {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    Sha256Digest::from_bytes(digest.finalize().into())
+}
+
+fn record_path(root: &Path, handle: &WindowsBrokerCustodyHandle) -> PathBuf {
+    root.join(format!("{}.custody-v1", handle.digest))
+}
+
+fn temp_path(
+    root: &Path,
+    handle: &WindowsBrokerCustodyHandle,
+) -> Result<PathBuf, WindowsBrokerCustodyError> {
+    let mut nonce = [0_u8; 16];
+    getrandom::fill(&mut nonce).map_err(|_| WindowsBrokerCustodyError::Protector)?;
+    let nonce = lower_hex(&nonce);
+    Ok(root.join(format!(".tmp-{}-{nonce}", handle.digest)))
+}
+
+fn completed_path(root: &Path, handle: &WindowsBrokerCustodyHandle) -> PathBuf {
+    root.join(format!("{}.completed-v1", handle.digest))
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        encoded.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        encoded.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn write_new_synchronized(path: &Path, bytes: &[u8]) -> Result<(), WindowsBrokerCustodyError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|_| WindowsBrokerCustodyError::Io)?;
+    file.write_all(bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|_| WindowsBrokerCustodyError::Io)
+}
+
+fn committed_entry_count(root: &Path) -> Result<usize, WindowsBrokerCustodyError> {
+    let mut count = 0_usize;
+    for entry in fs::read_dir(root).map_err(|_| WindowsBrokerCustodyError::Io)? {
+        let entry = entry.map_err(|_| WindowsBrokerCustodyError::Io)?;
+        let name = entry
+            .file_name()
+            .to_str()
+            .ok_or(WindowsBrokerCustodyError::UnsafePath)?
+            .to_owned();
+        if name.ends_with(".custody-v1") || name.ends_with(".completed-v1") {
+            count = count.saturating_add(1);
+        }
+    }
+    Ok(count)
+}
+
+fn reconcile_root(root: &Path) -> Result<(), WindowsBrokerCustodyError> {
+    let mut handles = BTreeSet::new();
+    for entry in fs::read_dir(root).map_err(|_| WindowsBrokerCustodyError::Io)? {
+        let entry = entry.map_err(|_| WindowsBrokerCustodyError::Io)?;
+        let name = entry
+            .file_name()
+            .to_str()
+            .ok_or(WindowsBrokerCustodyError::UnsafePath)?
+            .to_owned();
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|_| WindowsBrokerCustodyError::UnsafePath)?;
+        if !metadata.file_type().is_file() || has_reparse_attribute(&metadata) {
+            return Err(WindowsBrokerCustodyError::UnsafePath);
+        }
+        let committed = (name.len() == 64 + ".custody-v1".len() && name.ends_with(".custody-v1")
+            || name.len() == 64 + ".completed-v1".len() && name.ends_with(".completed-v1"))
+            && name[..64]
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        let incomplete = name.starts_with(".tmp-")
+            && name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+        if incomplete {
+            fs::remove_file(entry.path()).map_err(|_| WindowsBrokerCustodyError::Io)?;
+        } else if !committed {
+            return Err(WindowsBrokerCustodyError::UnsafePath);
+        } else if !handles.insert(name[..64].to_owned()) {
+            return Err(WindowsBrokerCustodyError::Tampered);
+        }
+    }
+    Ok(())
+}
+
+fn validate_directory(path: &Path) -> Result<(), WindowsBrokerCustodyError> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| WindowsBrokerCustodyError::UnsafePath)?;
+    if !metadata.file_type().is_dir()
+        || metadata.file_type().is_symlink()
+        || has_reparse_attribute(&metadata)
+    {
+        return Err(WindowsBrokerCustodyError::UnsafePath);
+    }
+    Ok(())
+}
+
+fn validate_regular_file(path: &Path) -> Result<(), WindowsBrokerCustodyError> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| WindowsBrokerCustodyError::UnsafePath)?;
+    if !metadata.file_type().is_file()
+        || metadata.file_type().is_symlink()
+        || has_reparse_attribute(&metadata)
+    {
+        return Err(WindowsBrokerCustodyError::UnsafePath);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn has_reparse_attribute(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+const fn has_reparse_attribute(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestProtector;
+
+    impl WindowsBrokerCustodyProtector for TestProtector {
+        fn seal(&self, plaintext: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+            let mut sealed = b"test-v1:".to_vec();
+            sealed.extend(plaintext.iter().map(|byte| byte ^ 0x5a));
+            Ok(Zeroizing::new(sealed))
+        }
+
+        fn open(&self, sealed: &[u8]) -> Result<Zeroizing<Vec<u8>>, WindowsBrokerCustodyError> {
+            let ciphertext = sealed
+                .strip_prefix(b"test-v1:")
+                .ok_or(WindowsBrokerCustodyError::Protector)?;
+            Ok(Zeroizing::new(
+                ciphertext.iter().map(|byte| byte ^ 0x5a).collect(),
+            ))
+        }
+    }
+
+    fn temp_root() -> PathBuf {
+        let mut nonce = [0_u8; 16];
+        getrandom::fill(&mut nonce).expect("random temp root");
+        let nonce = lower_hex(&nonce);
+        std::env::temp_dir().join(format!("automata-custody-{nonce}"))
+    }
+
+    #[test]
+    fn survives_restart_and_removes_only_exact_handle() {
+        let root = temp_root();
+        let protector: Arc<dyn WindowsBrokerCustodyProtector> = Arc::new(TestProtector);
+        let store = FileWindowsBrokerCustody::open(&root, Arc::clone(&protector)).expect("store");
+        let handle = store
+            .put(
+                WindowsBrokerCustodyKind::EnrollmentSecret,
+                b"enrollment-secret",
+                UnixMillis::new(123),
+            )
+            .expect("put");
+        let opaque = handle.opaque().to_owned();
+        drop(store);
+
+        let restarted = FileWindowsBrokerCustody::open(&root, protector).expect("restart");
+        let parsed = WindowsBrokerCustodyHandle::parse(&opaque).expect("parse");
+        let metadata = restarted.inspect(&parsed).expect("inspect");
+        assert_eq!(metadata.kind(), WindowsBrokerCustodyKind::EnrollmentSecret);
+        assert_eq!(metadata.byte_len(), b"enrollment-secret".len());
+        assert_eq!(
+            restarted.get(&parsed, 64).expect("get").as_slice(),
+            b"enrollment-secret"
+        );
+        restarted.remove(&parsed).expect("remove");
+        restarted.remove(&parsed).expect("idempotent remove");
+        assert_eq!(
+            restarted.inspect(&parsed).expect_err("removed"),
+            WindowsBrokerCustodyError::Absent
+        );
+        fs::remove_dir_all(root).expect("remove temp root");
+    }
+
+    #[test]
+    fn admission_completion_is_exact_restart_safe_and_tombstoned() {
+        let root = temp_root();
+        let protector: Arc<dyn WindowsBrokerCustodyProtector> = Arc::new(TestProtector);
+        let store = FileWindowsBrokerCustody::open(&root, Arc::clone(&protector)).expect("store");
+        let receipt = b"signed-admission-receipt";
+        let handle = store
+            .put(
+                WindowsBrokerCustodyKind::AdmissionReceipt,
+                receipt,
+                UnixMillis::new(789),
+            )
+            .expect("put");
+        let digest = sha256(receipt);
+        assert_eq!(
+            store
+                .complete_admission_receipt(&handle, sha256(b"wrong"))
+                .expect_err("wrong digest"),
+            WindowsBrokerCustodyError::Tampered
+        );
+        store
+            .complete_admission_receipt(&handle, digest)
+            .expect("complete");
+        assert_eq!(
+            store.inspect(&handle).expect_err("not live"),
+            WindowsBrokerCustodyError::Absent
+        );
+        drop(store);
+
+        let restarted = FileWindowsBrokerCustody::open(&root, protector).expect("restart");
+        restarted
+            .complete_admission_receipt(&handle, digest)
+            .expect("idempotent exact completion");
+        assert_eq!(
+            restarted
+                .complete_admission_receipt(&handle, sha256(b"different"))
+                .expect_err("conflicting completion"),
+            WindowsBrokerCustodyError::Tampered
+        );
+        fs::remove_dir_all(root).expect("remove temp root");
+    }
+
+    #[test]
+    fn tamper_unknown_fields_and_noncanonical_handles_fail_closed() {
+        let root = temp_root();
+        let store = FileWindowsBrokerCustody::open(&root, Arc::new(TestProtector)).expect("store");
+        let handle = store
+            .put(
+                WindowsBrokerCustodyKind::AdmissionReceipt,
+                b"receipt",
+                UnixMillis::new(456),
+            )
+            .expect("put");
+        let path = record_path(&root, &handle);
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).expect("read")).expect("json");
+        value
+            .as_object_mut()
+            .expect("object")
+            .insert("unknown".to_owned(), serde_json::json!(true));
+        fs::write(&path, serde_json::to_vec(&value).expect("encode")).expect("tamper");
+        assert_eq!(
+            store.inspect(&handle).expect_err("unknown field"),
+            WindowsBrokerCustodyError::Tampered
+        );
+        assert_eq!(
+            WindowsBrokerCustodyHandle::parse(&handle.opaque().to_uppercase())
+                .expect_err("noncanonical"),
+            WindowsBrokerCustodyError::InvalidHandle
+        );
+        fs::remove_dir_all(root).expect("remove temp root");
+    }
+
+    #[test]
+    fn recomputed_outer_metadata_cannot_forge_the_sealed_record() {
+        let root = temp_root();
+        let store = FileWindowsBrokerCustody::open(&root, Arc::new(TestProtector)).expect("store");
+        let handle = store
+            .put(
+                WindowsBrokerCustodyKind::AdmissionReceipt,
+                b"receipt",
+                UnixMillis::new(456),
+            )
+            .expect("put");
+        let path = record_path(&root, &handle);
+        let mut record: CustodyRecord =
+            serde_json::from_slice(&fs::read(&path).expect("read")).expect("record");
+        record.created_at = UnixMillis::new(999);
+        record.record_digest = record_digest(
+            record.handle_digest,
+            record.kind,
+            record.content_sha256,
+            record.byte_len,
+            record.created_at,
+            record.sealed_sha256,
+        );
+        fs::write(&path, serde_json::to_vec(&record).expect("encode")).expect("forge metadata");
+
+        assert_eq!(
+            store
+                .get(&handle, 64)
+                .expect_err("sealed metadata mismatch"),
+            WindowsBrokerCustodyError::Tampered
+        );
+        fs::remove_dir_all(root).expect("remove temp root");
+    }
+}

--- a/crates/automata-ci-windows-broker/src/lib.rs
+++ b/crates/automata-ci-windows-broker/src/lib.rs
@@ -7,6 +7,8 @@
 //! ports are service-owned; concrete host-compute and file-system adapters are
 //! kept behind those ports.
 
+pub mod admission;
+pub mod custody;
 mod guest;
 mod service;
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -160,11 +160,14 @@ admitted.
 
 The broker component is split across explicit trust boundaries. The
 runner-side `automata-ci-sandbox-windows` adapter links only the bounded
-`automata-ci-windows-broker-protocol` request/consumer contract. Privileged
-grant verification, lifecycle policy, reconciliation, watchdog supervision,
-and the abstract durable/host-compute ports live in
-`automata-ci-windows-broker`; its file-ledger implementation is a separate
-module. Replay payloads use a separate protected result-store port backed by
+`automata-ci-windows-broker-protocol` request/consumer contract. Pure admission
+requests, host-input evidence, promotion/trust policy, and synthetic probing
+live in filesystem-free `automata-ci-windows-broker-core`. The privileged
+application and lifecycle state machines live in `automata-ci-windows-broker`
+and depend on repository, custody, durable-ledger, result-store, and
+host-compute ports. File-backed admission and custody implementations remain
+namespaced adapter modules rather than runner re-exports. Replay payloads use
+a separate protected result-store port backed by
 authenticated encryption; the JSON lifecycle ledger contains only operation
 metadata and opaque protected-content references. The fixed named-pipe
 HCS/container-engine implementation is isolated in


### PR DESCRIPTION
## Stack position

**8 of 9** in the Wave 1 / Windows runner stack. Its predecessor, #393, is merged and this branch is rebased directly onto current `main` (`3b16b80b852f716307e368ffabf41ee8c592c8a7`).

- Head: `1c356c318ed2d1f4f6116b43c4b661cd11e19734`
- Effective diff: 20 files, +6,624/-9
- Depends on merged #197, #382, #383, #385, #387, #390, and #393

Only the user will merge this PR. Auto-merge remains disabled.

## What this slice adds

- A filesystem-free `automata-ci-windows-broker-core` crate for canonical admission requests, host-input evidence, promotion/trust policy, and synthetic-probe evaluation.
- A privileged `automata-ci-windows-broker` application service that owns issue/resume/complete/renew/ack state transitions without hard-coding persistence.
- Explicit `WindowsBrokerAdmissionRepository` and `WindowsBrokerAdmissionCustody` ports, with file-backed implementations kept in namespaced adapter modules.
- Broker-side signature/trust/high-water checks, canonical host-input commitments, fail-closed synthetic probing, sealed custody envelopes, and exact concurrent-renewal replay/ack behavior.
- Updated Windows architecture documentation describing the core/service/adapter boundary.

This directly addresses the review request: `automata-ci-sandbox-windows` is unchanged by the effective diff and no longer owns or re-exports broker policy, signing, durable state, custody, host-input verification, or file-backed implementations. Alternative repositories/custody adapters and a separately hardened service can be composed through the new ports.

## Deliberate limits

This remains component code. It does not add production service/IPC composition, a real synthetic-probe implementation, broker-backed enrollment/TLS custody, or the server-side placement-renewal/current-admission/grant-authorization store. Those missing integrations continue to fail closed and are not claimed complete.

## Validation at this exact head

- `cargo clippy -p automata-ci-windows-broker-core -p automata-ci-windows-broker --all-targets --all-features --locked -- -D warnings`
- `cargo test -p automata-ci-windows-broker-core -p automata-ci-windows-broker --all-targets --all-features --locked` — 37/37
- Affected protocol/core/service/HCS/sandbox package tests — 61/61
- Affected package doc-tests — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p automata-ci-windows-broker-core -p automata-ci-windows-broker --all-features --no-deps --locked`
- `cargo build --workspace --exclude automata-ci-service-proxy --locked`
- Targeted formatting and `git diff --check` — clean. Full `cargo fmt --all -- --check` reports zero logical diffs; this Windows checkout reports only repository-wide CRLF diagnostics.

The exact Linux workspace lint remains the hosted Ubuntu CI gate because this Windows host lacks the Linux C toolchain. No CI workflow, SQL migration, generated file, or Windows runner job is added here.