### PR TITLE
fix(runner): backpressure durable log bursts

### DIFF
--- a/crates/automata-ci-protocol/src/message/limits.rs
+++ b/crates/automata-ci-protocol/src/message/limits.rs
@@ -7,7 +7,11 @@ pub const MAX_CONFIGURABLE_FRAME_BYTES: usize = 64 * 1024 * 1024;
 const DEFAULT_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_COLLECTION_ITEMS: usize = 4_096;
 const DEFAULT_TEXT_BYTES: usize = 1024 * 1024;
-const DEFAULT_LOG_FRAMES: usize = 16;
+// One completed process can hand the executor up to 65,536 ordered output
+// records at once. Keep one delivery batch at the existing collection ceiling
+// so a bounded command-output burst cannot exhaust the durable segment queue
+// merely because network acknowledgement is slower than local publication.
+const DEFAULT_LOG_FRAMES: usize = DEFAULT_COLLECTION_ITEMS;
 const DEFAULT_LOG_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 
 /// Bounded allocation policy selected by trusted transport configuration.

--- a/crates/automata-ci-runner-runtime/src/content.rs
+++ b/crates/automata-ci-runner-runtime/src/content.rs
@@ -1,9 +1,16 @@
-use std::sync::{Mutex, PoisonError};
+use std::{
+    sync::{Condvar, Mutex, PoisonError},
+    time::Duration,
+};
 
 use automata_ci_runner_journal::{JournalContentRetainSet, RunnerJournal};
 use automata_ci_runner_spool::{
     DurableContentStore, EndpointResultCapacityReservation, SpoolError,
 };
+
+use crate::ExecutionCancellation;
+
+const LOG_DELIVERY_WAIT_POLL: Duration = Duration::from_millis(100);
 
 pub(crate) trait CapacityReclaimError: Sized {
     fn is_capacity_exhausted(&self) -> bool;
@@ -21,6 +28,8 @@ pub(crate) trait CapacityReclaimError: Sized {
 #[derive(Debug, Default)]
 pub(crate) struct ContentOperationCoordinator {
     exclusive: Mutex<()>,
+    log_delivery_generation: Mutex<u64>,
+    log_delivery_changed: Condvar,
 }
 
 impl ContentOperationCoordinator {
@@ -30,6 +39,43 @@ impl ContentOperationCoordinator {
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
         operation()
+    }
+
+    pub(crate) fn log_delivery_generation(&self) -> u64 {
+        *self
+            .log_delivery_generation
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub(crate) fn notify_log_delivery_progress(&self) {
+        let mut generation = self
+            .log_delivery_generation
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        *generation = generation.wrapping_add(1);
+        self.log_delivery_changed.notify_all();
+    }
+
+    pub(crate) fn wait_for_log_delivery_progress(
+        &self,
+        observed: u64,
+        cancellation: &ExecutionCancellation,
+    ) -> bool {
+        let mut generation = self
+            .log_delivery_generation
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        while *generation == observed && !cancellation.is_cancelled() {
+            let waited = self
+                .log_delivery_changed
+                .wait_timeout(generation, LOG_DELIVERY_WAIT_POLL);
+            generation = match waited {
+                Ok((generation, _)) => generation,
+                Err(poisoned) => poisoned.into_inner().0,
+            };
+        }
+        *generation != observed
     }
 
     /// Publishes one complete payload-first transaction, reclaiming only
@@ -78,5 +124,43 @@ impl ContentOperationCoordinator {
                 outcome => outcome,
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Instant};
+
+    use super::{ContentOperationCoordinator, LOG_DELIVERY_WAIT_POLL};
+    use crate::ExecutionCancellation;
+
+    #[test]
+    fn log_delivery_notification_releases_all_capacity_waiters() {
+        let coordinator = Arc::new(ContentOperationCoordinator::default());
+        let cancellation = ExecutionCancellation::new();
+        let observed = coordinator.log_delivery_generation();
+        let waiter = {
+            let coordinator = Arc::clone(&coordinator);
+            let cancellation = cancellation.clone();
+            std::thread::spawn(move || {
+                coordinator.wait_for_log_delivery_progress(observed, &cancellation)
+            })
+        };
+
+        coordinator.notify_log_delivery_progress();
+
+        assert!(waiter.join().expect("capacity waiter"));
+    }
+
+    #[test]
+    fn cancellation_bounds_a_capacity_wait_without_delivery_progress() {
+        let coordinator = ContentOperationCoordinator::default();
+        let cancellation = ExecutionCancellation::new();
+        let observed = coordinator.log_delivery_generation();
+        cancellation.signal(crate::ExecutionCancellationReason::ServerRequest);
+        let started = Instant::now();
+
+        assert!(!coordinator.wait_for_log_delivery_progress(observed, &cancellation));
+        assert!(started.elapsed() < LOG_DELIVERY_WAIT_POLL);
     }
 }

--- a/crates/automata-ci-runner-runtime/src/events.rs
+++ b/crates/automata-ci-runner-runtime/src/events.rs
@@ -18,7 +18,8 @@ use automata_ci_runner_transport::PreparedRequest;
 use crate::content::ContentOperationCoordinator;
 use crate::outbox::{append_record, validate_log_segment_records};
 use crate::{
-    ExecutionEventError, ExecutionEvents, LogEvent, RuntimeClock, RuntimeIdSource, StableIdDomain,
+    ExecutionCancellation, ExecutionEventError, ExecutionEvents, LogEvent, RuntimeClock,
+    RuntimeIdSource, StableIdDomain,
 };
 
 #[derive(Clone)]
@@ -33,6 +34,7 @@ pub(crate) struct DurableExecutionEvents {
     guard: LeaseGuard,
     limits: ProtocolLimits,
     content_operations: Arc<ContentOperationCoordinator>,
+    cancellation: ExecutionCancellation,
     serial: Arc<std::sync::Mutex<()>>,
 }
 
@@ -66,6 +68,7 @@ impl DurableExecutionEvents {
         guard: LeaseGuard,
         limits: ProtocolLimits,
         content_operations: Arc<ContentOperationCoordinator>,
+        cancellation: ExecutionCancellation,
     ) -> Self {
         Self {
             journal,
@@ -78,6 +81,7 @@ impl DurableExecutionEvents {
             guard,
             limits,
             content_operations,
+            cancellation,
             serial: Arc::new(std::sync::Mutex::new(())),
         }
     }
@@ -339,6 +343,7 @@ impl DurableExecutionEvents {
     ) -> Result<(), ExecutionEventError> {
         let stream_id = self.stream_id();
         loop {
+            let delivery_generation = self.content_operations.log_delivery_generation();
             let loaded = self.load_open_log_tail(stream_id)?;
             let sequence = loaded.produced_through.map_or_else(
                 || Ok(LogSequence::new(0)),
@@ -391,6 +396,19 @@ impl DurableExecutionEvents {
                         automata_ci_runner_journal::JournalInvariantError::LogSegmentMutationConflict,
                     ),
                 )) => {}
+                Err(ExecutionEventError::Journal(
+                    automata_ci_runner_journal::JournalError::Invariant(
+                        automata_ci_runner_journal::JournalInvariantError::LogSegmentLimit
+                        | automata_ci_runner_journal::JournalInvariantError::LogBacklogLimit,
+                    ),
+                )) => {
+                    if !self.content_operations.wait_for_log_delivery_progress(
+                        delivery_generation,
+                        &self.cancellation,
+                    ) {
+                        return Err(ExecutionEventError::InvalidEvent);
+                    }
+                }
                 Err(error) => return Err(error),
             }
         }

--- a/crates/automata-ci-runner-runtime/src/orphan.rs
+++ b/crates/automata-ci-runner-runtime/src/orphan.rs
@@ -203,6 +203,7 @@ impl OrphanRecoveryCoordinator {
             .cloned()
             .ok_or(RunnerRuntimeError::ExecutorContract)?;
         if let Some(sandbox) = refreshed.sandbox().cloned() {
+            let signal = ExecutionCancellation::new();
             let negotiated = NegotiatedSession::new(
                 session.selected_protocol(),
                 session.selected_job_ir(),
@@ -221,8 +222,8 @@ impl OrphanRecoveryCoordinator {
                 guard,
                 self.protocol_limits,
                 Arc::clone(&self.content_operations),
+                signal.clone(),
             ));
-            let signal = ExecutionCancellation::new();
             let request = CleanupRequest::new(
                 self.runner_id,
                 session_id,

--- a/crates/automata-ci-runner-runtime/src/supervisor.rs
+++ b/crates/automata-ci-runner-runtime/src/supervisor.rs
@@ -1738,6 +1738,13 @@ impl RunnerSessionSupervisor {
                 .await;
         }
         let lease = durable.offer().lease().clone();
+        let signal = ExecutionCancellation::new();
+        if durable.cancellation().is_some() {
+            signal.signal(ExecutionCancellationReason::ServerRequest);
+            self.observe(RunnerRuntimeEvent::Cancellation {
+                reason: RuntimeCancellationReason::ServerRequest,
+            });
+        }
         let events: Arc<dyn ExecutionEvents> = Arc::new(DurableExecutionEvents::new(
             Arc::clone(&self.inner.ports.journal),
             Arc::clone(&self.inner.ports.spool),
@@ -1749,14 +1756,8 @@ impl RunnerSessionSupervisor {
             lease.guard(),
             *self.inner.config.protocol_limits(),
             Arc::clone(&self.inner.content_operations),
+            signal.clone(),
         ));
-        let signal = ExecutionCancellation::new();
-        if durable.cancellation().is_some() {
-            signal.signal(ExecutionCancellationReason::ServerRequest);
-            self.observe(RunnerRuntimeEvent::Cancellation {
-                reason: RuntimeCancellationReason::ServerRequest,
-            });
-        }
         {
             let mut executions = self
                 .inner
@@ -2590,6 +2591,7 @@ impl RunnerSessionSupervisor {
                 guard,
                 acknowledgement,
             )?;
+            self.inner.content_operations.notify_log_delivery_progress();
             if !snapshot
                 .content_references()
                 .any(|content| content == head_content)
@@ -3181,6 +3183,7 @@ impl RunnerSessionSupervisor {
             lease.guard(),
             *self.inner.config.protocol_limits(),
             Arc::clone(&self.inner.content_operations),
+            ExecutionCancellation::new(),
         );
         tokio::task::spawn_blocking(move || events.ensure_log_stream_closed())
             .await
@@ -3352,6 +3355,7 @@ impl RunnerSessionSupervisor {
         cancellation: CancellationToken,
     ) -> Result<(), RunnerRuntimeError> {
         let lease = durable.offer().lease();
+        let signal = ExecutionCancellation::new();
         let events: Arc<dyn ExecutionEvents> = Arc::new(DurableExecutionEvents::new(
             Arc::clone(&self.inner.ports.journal),
             Arc::clone(&self.inner.ports.spool),
@@ -3363,8 +3367,8 @@ impl RunnerSessionSupervisor {
             lease.guard(),
             *self.inner.config.protocol_limits(),
             Arc::clone(&self.inner.content_operations),
+            signal.clone(),
         ));
-        let signal = ExecutionCancellation::new();
         let request = CleanupRequest::new(
             self.inner.config.capabilities().runner_id(),
             session.negotiated.session_id(),

--- a/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
+++ b/crates/automata-ci-runner-runtime/tests/session_supervisor.rs
@@ -2951,14 +2951,16 @@ async fn active_log_backlog_uses_deadline_cadence_instead_of_heartbeat_per_batch
     let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
     let clock = Arc::new(support::ManualClock::new(10_000, 50));
     let sleeper = Arc::new(support::ManualDeadlineSleeper::new(Arc::clone(&clock)));
+    let protocol_limits = support::protocol_limits_with_log_batch_size(16);
     let client = Arc::new(support::ActiveBacklogClient::new(
         fixture.session_id,
         fixture.lease,
         Arc::clone(&sleeper),
+        protocol_limits,
     ));
     let executor = Arc::new(support::ActiveLogExecutor::new(160));
     let runtime = RunnerSessionSupervisor::new(
-        support::config(runner_id),
+        support::config_with_protocol_limits(runner_id, protocol_limits),
         RunnerRuntimePorts::new(
             client.clone(),
             journal.clone(),
@@ -3267,6 +3269,7 @@ async fn terminal_log_backlog_is_batched_and_heartbeats_continue_during_slow_del
     let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
     let shutdown = CancellationToken::new();
     let clock = Arc::new(support::ManualClock::new(10_000, 50));
+    let protocol_limits = support::protocol_limits_with_log_batch_size(16);
     let client = Arc::new(support::SlowLogClient::new(
         fixture.session_id,
         fixture.lease,
@@ -3274,11 +3277,12 @@ async fn terminal_log_backlog_is_batched_and_heartbeats_continue_during_slow_del
         shutdown.clone(),
         false,
         true,
+        protocol_limits,
     ));
     let retry = RetryPolicy::new(2, Duration::from_millis(1), Duration::from_millis(2))
         .expect("short exact-log retry");
     let runtime = RunnerSessionSupervisor::new(
-        support::config_with_retry(runner_id, retry),
+        support::config_with_protocol_limits_and_retry(runner_id, protocol_limits, retry),
         RunnerRuntimePorts::new(
             client.clone(),
             journal.clone(),
@@ -3351,6 +3355,98 @@ async fn terminal_log_backlog_is_batched_and_heartbeats_continue_during_slow_del
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn saturated_log_segments_wait_for_acknowledgements_instead_of_failing_the_job() {
+    let scratch = support::Scratch::new("saturated-log-backpressure");
+    let runner_id = RunnerId::new();
+    let (journal, spool) = support::durable_ports(&scratch, runner_id);
+    let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
+    let shutdown = CancellationToken::new();
+    let first_log_release = CancellationToken::new();
+    let clock = Arc::new(support::ManualClock::new(10_000, 50));
+    let protocol_limits = support::protocol_limits_with_log_batch_size(1);
+    let client = Arc::new(
+        support::SlowLogClient::new(
+            fixture.session_id,
+            fixture.lease,
+            Arc::clone(&clock),
+            shutdown.clone(),
+            false,
+            false,
+            protocol_limits,
+        )
+        .with_log_clock_advance(0)
+        .with_first_log_release(first_log_release.clone()),
+    );
+    let runtime = RunnerSessionSupervisor::new(
+        support::config_with_protocol_limits(runner_id, protocol_limits),
+        RunnerRuntimePorts::new(
+            client.clone(),
+            journal.clone(),
+            spool,
+            Arc::new(support::BurstLogExecutor::new(160)),
+            clock,
+            Arc::new(automata_ci_runner_runtime::TokioRuntimeSleeper),
+            Arc::new(SystemRuntimeIds),
+        ),
+    );
+
+    let task = tokio::spawn(async move { runtime.run(shutdown).await });
+    let saturation = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let segment_count = journal
+                .snapshot()
+                .expect("saturated log snapshot")
+                .slot(fixture.slot)
+                .and_then(|slot| slot.log_delivery())
+                .map_or(0, |delivery| delivery.segments().len());
+            if segment_count == automata_ci_runner_journal::MAX_LOG_SEGMENTS_PER_SLOT {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if saturation.is_err() {
+        let snapshot = journal.snapshot().expect("timed-out saturation snapshot");
+        let delivery = snapshot
+            .slot(fixture.slot)
+            .and_then(|slot| slot.log_delivery());
+        panic!(
+            "journal did not saturate: segments={}, produced={:?}, delivered_batches={}, task_finished={}",
+            delivery.map_or(0, |delivery| delivery.segments().len()),
+            delivery.and_then(automata_ci_runner_journal::LogDeliveryCursor::produced_through),
+            client.log_batches().len(),
+            task.is_finished(),
+        );
+    }
+    assert!(
+        !task.is_finished(),
+        "the executor waits for delivery capacity"
+    );
+
+    first_log_release.cancel();
+    tokio::time::timeout(Duration::from_secs(15), task)
+        .await
+        .expect("backpressured log delivery completes")
+        .expect("runtime task")
+        .expect("log saturation does not fail the job");
+
+    let batches = client.log_batches();
+    assert_eq!(batches.len(), 161, "160 output frames plus terminal EOS");
+    assert_eq!(batches.first().expect("first batch").first_sequence, 0);
+    assert_eq!(batches.last().expect("EOS batch").last_sequence, 160);
+    assert!(batches.iter().all(|batch| batch.frame_count == 1));
+    assert!(!client.starved());
+    assert!(
+        journal
+            .snapshot()
+            .expect("released saturated log delivery")
+            .slot(fixture.slot)
+            .is_none()
+    );
+}
+
 #[tokio::test]
 async fn crash_during_batched_log_request_reconstructs_the_exact_same_batch() {
     let scratch = support::Scratch::new("batched-log-crash-replay");
@@ -3358,6 +3454,7 @@ async fn crash_during_batched_log_request_reconstructs_the_exact_same_batch() {
     let (journal, spool) = support::durable_ports(&scratch, runner_id);
     let fixture = support::seed_accepted_offer(journal.as_ref(), spool.as_ref(), runner_id);
     let clock = Arc::new(support::ManualClock::new(10_000, 50));
+    let protocol_limits = support::protocol_limits_with_log_batch_size(16);
     let first_shutdown = CancellationToken::new();
     let first_client = Arc::new(support::SlowLogClient::new(
         fixture.session_id,
@@ -3366,9 +3463,10 @@ async fn crash_during_batched_log_request_reconstructs_the_exact_same_batch() {
         first_shutdown.clone(),
         true,
         false,
+        protocol_limits,
     ));
     RunnerSessionSupervisor::new(
-        support::config(runner_id),
+        support::config_with_protocol_limits(runner_id, protocol_limits),
         RunnerRuntimePorts::new(
             first_client.clone(),
             journal.clone(),
@@ -3393,9 +3491,10 @@ async fn crash_during_batched_log_request_reconstructs_the_exact_same_batch() {
         second_shutdown.clone(),
         false,
         false,
+        protocol_limits,
     ));
     RunnerSessionSupervisor::new(
-        support::config(runner_id),
+        support::config_with_protocol_limits(runner_id, protocol_limits),
         RunnerRuntimePorts::new(
             second_client.clone(),
             journal.clone(),

--- a/crates/automata-ci-runner-runtime/tests/support/mod.rs
+++ b/crates/automata-ci-runner-runtime/tests/support/mod.rs
@@ -4835,12 +4835,13 @@ impl ActiveBacklogClient {
         session_id: automata_ci_core::RunnerSessionId,
         lease: Lease,
         sleeper: Arc<ManualDeadlineSleeper>,
+        limits: automata_ci_protocol::ProtocolLimits,
     ) -> Self {
         Self {
             session_id,
             lease,
             sleeper,
-            limits: automata_ci_protocol::ProtocolLimits::default(),
+            limits,
             state: Mutex::new(ActiveBacklogState::default()),
             changed: tokio::sync::Notify::new(),
         }
@@ -5310,6 +5311,8 @@ pub struct SlowLogClient {
     stop_on_first_batch: bool,
     retry_first_batch: bool,
     log_delay: Duration,
+    log_clock_advance_millis: u64,
+    first_log_release: Option<CancellationToken>,
     limits: automata_ci_protocol::ProtocolLimits,
     state: Mutex<SlowLogState>,
 }
@@ -5322,6 +5325,7 @@ impl SlowLogClient {
         shutdown: CancellationToken,
         stop_on_first_batch: bool,
         retry_first_batch: bool,
+        limits: automata_ci_protocol::ProtocolLimits,
     ) -> Self {
         let lease_clock_anchor = clock.monotonic_now().get();
         Self {
@@ -5333,7 +5337,9 @@ impl SlowLogClient {
             stop_on_first_batch,
             retry_first_batch,
             log_delay: Duration::from_millis(3),
-            limits: automata_ci_protocol::ProtocolLimits::default(),
+            log_clock_advance_millis: 8_000,
+            first_log_release: None,
+            limits,
             state: Mutex::new(SlowLogState {
                 log_batches: Vec::new(),
                 heartbeats: Vec::new(),
@@ -5341,6 +5347,28 @@ impl SlowLogClient {
                 retried_first_batch: false,
                 starved: false,
             }),
+        }
+    }
+
+    pub fn with_log_clock_advance(mut self, millis: u64) -> Self {
+        self.log_clock_advance_millis = millis;
+        self
+    }
+
+    pub fn with_first_log_release(mut self, release: CancellationToken) -> Self {
+        self.first_log_release = Some(release);
+        self
+    }
+
+    async fn wait_for_first_log_release(&self) {
+        let is_first = self
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .log_batches
+            .is_empty();
+        if is_first && let Some(release) = self.first_log_release.as_ref() {
+            release.cancelled().await;
         }
     }
 
@@ -5421,8 +5449,9 @@ impl RunnerRuntimeControlClient for SlowLogClient {
                     ))
                 }
                 RunnerToServer::LogBatch(batch) => {
+                    self.wait_for_first_log_release().await;
                     tokio::time::sleep(self.log_delay).await;
-                    let now = self.clock.advance_monotonic(8_000);
+                    let now = self.clock.advance_monotonic(self.log_clock_advance_millis);
                     let first = batch.frames().first().expect("nonempty log batch");
                     let last = batch.frames().last().expect("nonempty log batch");
                     let retry = {
@@ -6237,6 +6266,44 @@ fn control_reply(
 
 pub fn config(runner_id: RunnerId) -> RunnerRuntimeConfig {
     config_with_retry(runner_id, RetryPolicy::default())
+}
+
+pub fn protocol_limits_with_log_batch_size(
+    max_log_frames_per_batch: usize,
+) -> automata_ci_protocol::ProtocolLimits {
+    let defaults = automata_ci_protocol::ProtocolLimits::default();
+    automata_ci_protocol::ProtocolLimits::new(
+        defaults.max_frame_bytes(),
+        defaults.max_collection_items(),
+        defaults.max_text_bytes(),
+        max_log_frames_per_batch,
+        defaults.max_log_payload_bytes_per_batch(),
+    )
+    .expect("test protocol limits")
+}
+
+pub fn config_with_protocol_limits(
+    runner_id: RunnerId,
+    protocol_limits: automata_ci_protocol::ProtocolLimits,
+) -> RunnerRuntimeConfig {
+    config_with_protocol_limits_and_retry(runner_id, protocol_limits, RetryPolicy::default())
+}
+
+pub fn config_with_protocol_limits_and_retry(
+    runner_id: RunnerId,
+    protocol_limits: automata_ci_protocol::ProtocolLimits,
+    retry: RetryPolicy,
+) -> RunnerRuntimeConfig {
+    let limits = RunnerRuntimeLimits::new(
+        retry,
+        Duration::from_millis(25),
+        Duration::from_mins(5),
+        Duration::from_millis(100),
+        Duration::from_secs(30),
+    )
+    .expect("runtime limits");
+    RunnerRuntimeConfig::new(capabilities(runner_id, 1), protocol_limits, limits)
+        .expect("runtime config")
 }
 
 pub fn config_with_retry(runner_id: RunnerId, retry: RetryPolicy) -> RunnerRuntimeConfig {


### PR DESCRIPTION
## Summary

- raise the default durable log delivery batch to the existing 4,096-item protocol and journal ceiling
- wait cancellably for durable ACK progress when the bounded journal reaches its segment or byte ceiling
- preserve per-line emission and cancellation semantics
- add an end-to-end saturation test that fills all 128 segments, releases ACK delivery, and proves the job completes with every log frame plus EOS

## Why

The full `main` coverage job completed its test process successfully but produced enough output to fill the runner journal faster than delivery acknowledgements arrived. The runner mapped `LogSegmentLimit` to an internal executor failure, so GitHub reported the check as failed despite passing tests.

## Validation

- `cargo test -p automata-ci-protocol`
- `cargo test -p automata-ci-job-executor-github`
- `cargo test -p automata-ci-runner-runtime`
- `cargo clippy -p automata-ci-protocol -p automata-ci-runner-runtime -p automata-ci-job-executor-github --all-targets -- -D warnings`
- `cargo fmt --all -- --check`