### PR TITLE
docs(execution): clarify raw endpoint and broker contracts

### DIFF
--- a/crates/automata-ci-execution/src/endpoint.rs
+++ b/crates/automata-ci-execution/src/endpoint.rs
@@ -321,7 +321,7 @@ impl fmt::Debug for ExecutionEnvironment {
     }
 }
 
-/// One idempotently identified command execution.
+/// One command execution with a stable correlation identifier.
 #[derive(Clone, Eq, PartialEq)]
 pub struct ExecutionCommand {
     operation_id: OperationId,
@@ -362,7 +362,7 @@ impl ExecutionCommand {
         })
     }
 
-    /// Returns the stable identifier used to replay this exact execution.
+    /// Returns the stable correlation identifier for this exact execution.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.operation_id
@@ -662,7 +662,7 @@ pub enum ExecutionSignal {
     Kill,
 }
 
-/// Idempotently identified signal request.
+/// Signal request with a stable correlation identifier.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SignalRequest {
     operation_id: OperationId,
@@ -670,7 +670,7 @@ pub struct SignalRequest {
 }
 
 impl SignalRequest {
-    /// Creates an idempotently identified request for one portable signal.
+    /// Creates an operation-identified request for one portable signal.
     #[must_use]
     pub const fn new(operation_id: OperationId, signal: ExecutionSignal) -> Self {
         Self {
@@ -679,7 +679,7 @@ impl SignalRequest {
         }
     }
 
-    /// Returns the stable identifier used to replay this exact signal request.
+    /// Returns the stable correlation identifier for this exact signal request.
     #[must_use]
     pub const fn operation_id(self) -> OperationId {
         self.operation_id
@@ -715,7 +715,7 @@ impl WaitRequest {
         })
     }
 
-    /// Returns the stable identifier used to replay this exact wait request.
+    /// Returns the stable correlation identifier for this exact wait request.
     #[must_use]
     pub const fn operation_id(self) -> OperationId {
         self.operation_id
@@ -757,7 +757,7 @@ impl CopyToRequest {
         })
     }
 
-    /// Returns the stable identifier used to replay this exact copy request.
+    /// Returns the stable correlation identifier for this exact copy request.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.operation_id
@@ -819,7 +819,7 @@ impl CopyFromRequest {
         })
     }
 
-    /// Returns the stable identifier used to replay this exact copy request.
+    /// Returns the stable correlation identifier for this exact copy request.
     #[must_use]
     pub const fn operation_id(&self) -> OperationId {
         self.operation_id
@@ -843,6 +843,12 @@ impl CopyFromRequest {
 /// provider-specific authority observed at adapter cancellation checkpoints;
 /// the disposition or an endpoint return is not evidence that remotely
 /// initiated work has quiesced.
+///
+/// Operation identifiers are correlation inputs for an exact-request replay
+/// boundary. A raw provider endpoint may be attempt-once; callers that can
+/// retry must first install a durable decorator that binds each identifier to
+/// the complete request and its protected result. A direct caller must never
+/// retry a raw operation after an ambiguous return.
 pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
     /// Returns the exact opaque sandbox handle to which this endpoint is bound.
     fn handle(&self) -> &SandboxHandle;
@@ -852,9 +858,10 @@ pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
     /// Executes one literal argv request.
     ///
     /// Implementations must not insert a shell, must enforce the command's
-    /// timeout and aggregate output limit, and must bind the operation ID to
-    /// exact request material for idempotent replay. Environment values may
-    /// contain secrets and must not pass through durable host-side staging.
+    /// timeout and aggregate output limit. A replay-owning decorator binds the
+    /// operation ID to exact request material before invoking a raw endpoint.
+    /// Environment values may contain secrets and must not pass through
+    /// durable host-side staging.
     ///
     /// # Errors
     ///
@@ -867,8 +874,9 @@ pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
 
     /// Signals the sandbox's primary workload.
     ///
-    /// Implementations must map only the declared portable signal and bind the
-    /// operation ID to the exact request for idempotent replay.
+    /// Implementations must map only the declared portable signal. A
+    /// replay-owning decorator binds the operation ID to the exact request
+    /// before invoking a raw endpoint.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-execution/src/error.rs
+++ b/crates/automata-ci-execution/src/error.rs
@@ -252,9 +252,10 @@ pub enum ExecutionErrorKind {
 
 /// Secret-free execution failure.
 ///
-/// Endpoint requests carry operation identifiers so callers can retry the
-/// exact request. Adapters must not embed raw backend diagnostics, command
-/// output, paths, environment values, or copied payloads in this error.
+/// Endpoint requests carry operation identifiers as correlation keys for a
+/// caller-owned exact-request replay boundary; they do not make a raw endpoint
+/// retryable. Adapters must not embed raw backend diagnostics, command output,
+/// paths, environment values, or copied payloads in this error.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 #[error("execution endpoint failed during {stage:?}: {kind:?}")]
 pub struct ExecutionError {

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -16,11 +16,17 @@
 //! never host paths. Provider and container handles are opaque ownership
 //! tokens; callers must not parse them or substitute backend identifiers.
 //!
-//! Mutating requests carry an [`OperationId`] so an adapter can replay an exact
-//! request idempotently. When a backend might have changed external state, a
-//! [`ProviderError`] reports [`OperationOutcome::Uncertain`] and may carry a
-//! recovery handle. Callers must inspect or retry that exact operation rather
-//! than assuming it had no effect.
+//! Sandbox-provider mutations carry an [`OperationId`] for exact, idempotent
+//! lifecycle replay. When a lifecycle backend might have changed external
+//! state, a [`ProviderError`] reports [`OperationOutcome::Uncertain`] and may
+//! carry a recovery handle. Callers must reconcile or retry that exact
+//! lifecycle request rather than assuming it had no effect.
+//!
+//! Execution-endpoint requests also carry an [`OperationId`], but a raw
+//! endpoint adapter may be attempt-once. Callers that can retry must install a
+//! durable decorator that binds the identifier to the complete request and its
+//! protected result. Direct callers must not retry a raw endpoint operation
+//! after an ambiguous return.
 //!
 //! Environment values, argv entries, copied bytes, output, health commands,
 //! and opaque handles are redacted from selected `Debug` implementations.

--- a/crates/automata-ci-execution/src/value.rs
+++ b/crates/automata-ci-execution/src/value.rs
@@ -530,14 +530,22 @@ impl ResourceLimits {
     }
 }
 
-/// Exact provider launch mechanism selected by an environment profile.
+/// Exact provider launch material selected by an environment profile.
+///
+/// A direct-launch provider realizes this material as the sandbox's initial
+/// process. A broker-based container provider may substitute its own guest as
+/// PID 1 under the [`SandboxLaunch::Container`] keepalive contract.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SandboxLaunch {
     /// Launch inside a digest-pinned container kept alive for the whole job.
     Container {
         /// Exact immutable image selected by the admitted profile.
         image: ImmutableImage,
-        /// Literal command keeping the whole-job container alive.
+        /// Literal liveness command for a direct-launch provider.
+        ///
+        /// A broker-based provider may substitute its own guest process as
+        /// PID 1, but must bind this value as part of the complete profile and
+        /// sandbox identity. This command is not an initialization contract.
         keepalive: ExecutionArgv,
     },
     /// Launch inside a Windows container whose runtime is required to enforce
@@ -659,7 +667,7 @@ impl SandboxEnvironment {
         self.attestation.digest()
     }
 
-    /// Returns the exact launch mechanism selected by the profile.
+    /// Returns the exact profile-bound launch material.
     #[must_use]
     pub const fn launch(&self) -> &SandboxLaunch {
         &self.launch
@@ -675,9 +683,11 @@ impl SandboxEnvironment {
         }
     }
 
-    /// Returns the literal keepalive command for a container launch.
+    /// Returns the profile-bound liveness command for a container launch.
     ///
-    /// Arguments are potentially sensitive and redacted by `Debug`.
+    /// A direct-launch provider executes this command. A broker-based provider
+    /// may bind it without executing it, and it is never an initialization
+    /// contract. Arguments are potentially sensitive and redacted by `Debug`.
     #[must_use]
     pub const fn keepalive(&self) -> Option<&ExecutionArgv> {
         match &self.launch {


### PR DESCRIPTION
## Summary

- distinguish raw attempt-once execution endpoints from caller-owned durable replay
- preserve exact sandbox lifecycle replay semantics
- clarify direct keepalive execution versus broker-owned PID1 providers

This is the documentation prerequisite for the fixed-relay LocalDocker provider stack.

## Verification

- independent exact-range review: CLEAN
- `cargo fmt --all -- --check`
- exact-range `git diff --check`
- execution tests: 17 passed
- strict Clippy and warning-denied rustdoc
