### PR TITLE
test(local): harden fixed-relay Docker lifecycle

### DIFF
--- a/crates/automata-ci-local/src/local_docker/engine.rs
+++ b/crates/automata-ci-local/src/local_docker/engine.rs
@@ -409,6 +409,42 @@ pub(crate) struct PinnedDockerEngine {
 
 #[cfg(unix)]
 impl PinnedDockerEngine {
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        architecture: crate::EngineArchitecture,
+        engine: Arc<dyn EngineApi>,
+    ) -> Self {
+        Self {
+            engine,
+            facts: EngineFacts {
+                engine_id: "engine-identity".to_owned(),
+                server_version: "29.7.2".to_owned(),
+                minimum_api_version: "1.40".to_owned(),
+                maximum_api_version: "1.55".to_owned(),
+                operating_system: "linux".to_owned(),
+                architecture: match architecture {
+                    crate::EngineArchitecture::Amd64 => "amd64".to_owned(),
+                    crate::EngineArchitecture::Arm64 => "arm64".to_owned(),
+                },
+                security_options: vec![
+                    SECURITY_OPTION_CGROUP_NAMESPACE.to_owned(),
+                    SECURITY_OPTION_SECCOMP_BUILTIN.to_owned(),
+                    SECURITY_OPTION_USER_NAMESPACE.to_owned(),
+                ],
+                memory_limit: true,
+                swap_limit: true,
+                cpu_cfs_period: true,
+                cpu_cfs_quota: true,
+                pids_limit: true,
+            },
+            api: ApiVersion {
+                major: 1,
+                minor: 44,
+            },
+            architecture,
+        }
+    }
+
     pub(crate) async fn verify(&self) -> Result<(), LocalDockerError> {
         let observed = self.engine.engine_facts().await.map_err(map_engine_call)?;
         validate_relay_facts(&observed, self.api)?;
@@ -525,6 +561,185 @@ fn validate_relay_facts(
         ));
     }
     Ok(architecture)
+}
+
+#[cfg(all(test, unix))]
+mod relay_tests {
+    use automata_ci_core::Architecture;
+
+    use super::{
+        ApiVersion, EngineFacts, LocalDockerErrorCode, SECURITY_OPTION_CGROUP_NAMESPACE,
+        SECURITY_OPTION_NO_NEW_PRIVILEGES, SECURITY_OPTION_ROOTLESS,
+        SECURITY_OPTION_SECCOMP_BUILTIN, SECURITY_OPTION_USER_NAMESPACE,
+        relay_matches_runner_architecture, validate_relay_facts,
+    };
+    use crate::EngineArchitecture;
+
+    fn facts(security_options: &[&str]) -> EngineFacts {
+        EngineFacts {
+            engine_id: "relay-engine".to_owned(),
+            server_version: "29.7.2".to_owned(),
+            minimum_api_version: "1.40".to_owned(),
+            maximum_api_version: "1.55".to_owned(),
+            operating_system: "linux".to_owned(),
+            architecture: "amd64".to_owned(),
+            security_options: security_options
+                .iter()
+                .map(|option| (*option).to_owned())
+                .collect(),
+            memory_limit: true,
+            swap_limit: true,
+            cpu_cfs_period: true,
+            cpu_cfs_quota: true,
+            pids_limit: true,
+        }
+    }
+
+    fn code(security_options: &[&str]) -> LocalDockerErrorCode {
+        validate_relay_facts(
+            &facts(security_options),
+            ApiVersion {
+                major: 1,
+                minor: 44,
+            },
+        )
+        .expect_err("security options must be rejected")
+        .code()
+    }
+
+    const fn api() -> ApiVersion {
+        ApiVersion {
+            major: 1,
+            minor: 44,
+        }
+    }
+
+    fn qualified_facts() -> EngineFacts {
+        facts(&[
+            SECURITY_OPTION_CGROUP_NAMESPACE,
+            SECURITY_OPTION_SECCOMP_BUILTIN,
+            SECURITY_OPTION_USER_NAMESPACE,
+        ])
+    }
+
+    #[test]
+    fn relay_requires_the_closed_rootful_security_envelope() {
+        assert!(validate_relay_facts(&qualified_facts(), api()).is_ok());
+        assert!(
+            validate_relay_facts(
+                &facts(&[
+                    SECURITY_OPTION_CGROUP_NAMESPACE,
+                    SECURITY_OPTION_NO_NEW_PRIVILEGES,
+                    SECURITY_OPTION_SECCOMP_BUILTIN,
+                    SECURITY_OPTION_USER_NAMESPACE,
+                ]),
+                api(),
+            )
+            .is_ok()
+        );
+        assert_eq!(code(&[]), LocalDockerErrorCode::InvalidEngineResponse);
+        for rejected in [
+            vec![
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+            vec![
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+            vec![
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+            ],
+            vec![
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_ROOTLESS,
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+            vec![
+                "name=apparmor",
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+            vec![
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                "name=selinux",
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+            vec![
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                "name=future-security-feature",
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ],
+        ] {
+            assert_eq!(
+                code(&rejected),
+                LocalDockerErrorCode::EngineIsolationUnavailable
+            );
+        }
+        assert_eq!(
+            code(&[
+                SECURITY_OPTION_CGROUP_NAMESPACE,
+                SECURITY_OPTION_SECCOMP_BUILTIN,
+                SECURITY_OPTION_USER_NAMESPACE,
+                SECURITY_OPTION_USER_NAMESPACE,
+            ]),
+            LocalDockerErrorCode::InvalidEngineResponse
+        );
+        assert_eq!(
+            code(&[SECURITY_OPTION_USER_NAMESPACE, ""]),
+            LocalDockerErrorCode::InvalidEngineResponse
+        );
+    }
+
+    #[test]
+    fn relay_requires_every_advertised_resource_controller() {
+        for disabled in 0..5 {
+            let mut facts = qualified_facts();
+            match disabled {
+                0 => facts.memory_limit = false,
+                1 => facts.swap_limit = false,
+                2 => facts.cpu_cfs_period = false,
+                3 => facts.cpu_cfs_quota = false,
+                4 => facts.pids_limit = false,
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                validate_relay_facts(&facts, api())
+                    .expect_err("missing controller must reject the relay")
+                    .code(),
+                LocalDockerErrorCode::EngineIsolationUnavailable
+            );
+        }
+    }
+
+    #[test]
+    fn relay_architecture_must_equal_the_advertised_runner_architecture() {
+        assert!(relay_matches_runner_architecture(
+            EngineArchitecture::Amd64,
+            &Architecture::X86_64,
+        ));
+        assert!(relay_matches_runner_architecture(
+            EngineArchitecture::Arm64,
+            &Architecture::Aarch64,
+        ));
+        assert!(!relay_matches_runner_architecture(
+            EngineArchitecture::Amd64,
+            &Architecture::Aarch64,
+        ));
+        assert!(!relay_matches_runner_architecture(
+            EngineArchitecture::Arm64,
+            &Architecture::X86_64,
+        ));
+        assert!(!relay_matches_runner_architecture(
+            EngineArchitecture::Amd64,
+            &Architecture::Other("amd64".to_owned()),
+        ));
+    }
 }
 
 #[cfg(unix)]

--- a/crates/automata-ci-local/src/local_docker/engine/http_engine.rs
+++ b/crates/automata-ci-local/src/local_docker/engine/http_engine.rs
@@ -2063,3 +2063,520 @@ struct ContainerSummary {
     #[serde(rename = "Id")]
     id: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::{Value, json};
+
+    use super::{
+        ContainerCustodyResponse, ContainerDefinition, EngineContainerState, ExecInspectResponse,
+        ImageResponse, InfoResponse, MASKED_PATHS, READ_ONLY_PATHS, normalize_container,
+        normalize_container_custody, normalize_image, valid_object_id,
+    };
+    use super::{EngineExecRequest, PreparedEngineExec};
+
+    #[test]
+    fn accepts_only_full_canonical_container_ids() {
+        assert!(valid_object_id(&"a".repeat(64)));
+        assert!(!valid_object_id(&"a".repeat(63)));
+        assert!(!valid_object_id(&"g".repeat(64)));
+        assert!(!valid_object_id(&"A".repeat(64)));
+    }
+
+    #[test]
+    fn daemon_security_options_are_retained_as_bounded_engine_evidence() {
+        let value = json!({
+            "ID": "relay-engine",
+            "ServerVersion": "29.7.2",
+            "Architecture": "x86_64",
+            "OSType": "linux",
+            "SecurityOptions": [
+                "name=seccomp,profile=builtin",
+                "name=userns",
+                "name=cgroupns"
+            ],
+            "MemoryLimit": true,
+            "SwapLimit": true,
+            "CpuCfsPeriod": true,
+            "CpuCfsQuota": true,
+            "PidsLimit": true
+        });
+        let response: InfoResponse =
+            serde_json::from_value(value.clone()).expect("Docker info response");
+        assert_eq!(
+            response
+                .security_options
+                .expect("security options")
+                .as_slice(),
+            [
+                "name=seccomp,profile=builtin",
+                "name=userns",
+                "name=cgroupns"
+            ]
+        );
+        for field in [
+            "MemoryLimit",
+            "SwapLimit",
+            "CpuCfsPeriod",
+            "CpuCfsQuota",
+            "PidsLimit",
+        ] {
+            let mut missing = value.clone();
+            missing.as_object_mut().expect("info object").remove(field);
+            assert!(serde_json::from_value::<InfoResponse>(missing).is_err());
+            for invalid in [Value::Null, json!("true")] {
+                let mut wrong_type = value.clone();
+                wrong_type[field] = invalid;
+                assert!(serde_json::from_value::<InfoResponse>(wrong_type).is_err());
+            }
+        }
+    }
+
+    fn image_json(environment: &Value) -> Value {
+        json!({
+            "Id": format!("sha256:{}", "2".repeat(64)),
+            "RepoDigests": [format!("registry.example/job@sha256:{}", "1".repeat(64))],
+            "Os": "linux",
+            "Architecture": "amd64",
+            "Config": {
+                "Env": environment,
+                "Volumes": null,
+                "Labels": {"org.opencontainers.image.version": "1"}
+            }
+        })
+    }
+
+    #[test]
+    fn image_environment_is_reduced_to_unique_sorted_names() {
+        let response: ImageResponse =
+            serde_json::from_value(image_json(&json!(["Z=value", "PATH=/bin", "A="])))
+                .expect("image response");
+        assert_eq!(
+            normalize_image(response)
+                .expect("canonical image environment")
+                .environment_names,
+            ["A", "PATH", "Z"]
+        );
+        for environment in [json!(["PATH=/bin", "PATH=/usr/bin"]), json!(["bad-name=x"])] {
+            let response =
+                serde_json::from_value(image_json(&environment)).expect("image response");
+            assert!(normalize_image(response).is_err());
+        }
+    }
+
+    #[test]
+    fn image_port_and_healthcheck_defaults_are_captured_before_create() {
+        for exposed_ports in [Value::Null, json!({})] {
+            let mut value = image_json(&json!([]));
+            value["Config"]["ExposedPorts"] = exposed_ports;
+            let image = normalize_image(
+                serde_json::from_value(value).expect("typed empty exposed-port image"),
+            )
+            .expect("empty exposed ports");
+            assert!(image.declared_exposed_ports.is_empty());
+            assert!(!image.has_healthcheck);
+        }
+
+        let mut port = image_json(&json!([]));
+        port["Config"]["ExposedPorts"] = json!({"8080/tcp": {}});
+        assert_eq!(
+            normalize_image(serde_json::from_value(port).expect("typed exposed-port image"))
+                .expect("canonical exposed port")
+                .declared_exposed_ports,
+            ["8080/tcp"]
+        );
+
+        for healthcheck in [
+            json!({}),
+            json!({"Test": null}),
+            json!({"Test": ["NONE"]}),
+            json!({
+                "Test": ["CMD-SHELL", "exit 0"],
+                "Interval": 1_000_000_000_i64,
+                "Timeout": 2_000_000_000_i64,
+                "Retries": 3,
+                "StartPeriod": 4_000_000_000_i64,
+                "StartInterval": 5_000_000_000_i64
+            }),
+        ] {
+            let mut value = image_json(&json!([]));
+            value["Config"]["Healthcheck"] = healthcheck;
+            assert!(
+                normalize_image(serde_json::from_value(value).expect("typed image healthcheck"))
+                    .expect("canonical image")
+                    .has_healthcheck
+            );
+        }
+
+        let mut too_many_ports = image_json(&json!([]));
+        too_many_ports["Config"]["ExposedPorts"] = Value::Object(
+            (0..65)
+                .map(|port| (format!("{port}/tcp"), json!({})))
+                .collect(),
+        );
+        assert!(serde_json::from_value::<ImageResponse>(too_many_ports).is_err());
+
+        let mut too_many_tests = image_json(&json!([]));
+        too_many_tests["Config"]["Healthcheck"] = json!({"Test": vec!["x"; 9]});
+        assert!(serde_json::from_value::<ImageResponse>(too_many_tests).is_err());
+    }
+
+    fn expected_definition() -> ContainerDefinition {
+        ContainerDefinition {
+            name: "automata-exact-fixture".to_owned(),
+            image: format!("registry.example/job@sha256:{}", "1".repeat(64)),
+            entrypoint: "/automata/bin/automata-ci-sandbox-guest".to_owned(),
+            arguments: vec!["serve-local".to_owned()],
+            labels: BTreeMap::from([("io.automata.test".to_owned(), "true".to_owned())]),
+            environment: vec!["PATH=".to_owned()],
+            tmpfs: BTreeMap::from([
+                (
+                    "/workspace/repository".to_owned(),
+                    "rw,exec,nosuid,nodev,size=268435456,mode=0777,uid=0,gid=0".to_owned(),
+                ),
+                (
+                    "/automata-control".to_owned(),
+                    "rw,exec,nosuid,nodev,size=67108864,mode=0733,uid=65533,gid=65532".to_owned(),
+                ),
+            ]),
+            working_directory: "/workspace/repository".to_owned(),
+            user: "0:0".to_owned(),
+            read_only_root: false,
+            memory_bytes: 268_435_456,
+            nano_cpus: 1_000_000_000,
+            pids_limit: 128,
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn realized_container_json() -> Value {
+        let id = "a".repeat(64);
+        let definition = expected_definition();
+        let config = json!({
+            "Hostname": &id[..12],
+            "Domainname": "",
+            "User": definition.user,
+            "AttachStdin": false,
+            "AttachStdout": false,
+            "AttachStderr": false,
+            "Tty": false,
+            "OpenStdin": false,
+            "StdinOnce": false,
+            "ArgsEscaped": false,
+            "Env": definition.environment,
+            "Cmd": definition.arguments,
+            "Healthcheck": {"Test": ["NONE"]},
+            "Image": definition.image,
+            "ExposedPorts": {},
+            "Volumes": null,
+            "WorkingDir": definition.working_directory,
+            "Entrypoint": [definition.entrypoint],
+            "NetworkDisabled": true,
+            "Labels": definition.labels,
+            "OnBuild": [],
+            "Shell": [],
+            "StopSignal": "SIGKILL",
+            "StopTimeout": 0,
+            "MacAddress": ""
+        });
+        let mut host_config = json!({
+            "Binds": [],
+            "ContainerIDFile": "",
+            "LogConfig": {"Type": "none", "Config": {}},
+            "NetworkMode": "none",
+            "PortBindings": {},
+            "RestartPolicy": {"Name": "no", "MaximumRetryCount": 0},
+            "AutoRemove": false,
+            "VolumeDriver": "",
+            "VolumesFrom": [],
+            "CapAdd": [],
+            "CapDrop": ["ALL"],
+            "CgroupnsMode": "private",
+            "Dns": [],
+            "DnsOptions": [],
+            "DnsSearch": [],
+            "ExtraHosts": [],
+            "GroupAdd": [],
+            "IpcMode": "private",
+            "Cgroup": "",
+            "Links": null,
+            "OomScoreAdj": 0,
+            "PidMode": "",
+            "Privileged": false,
+            "PublishAllPorts": false,
+            "ReadonlyRootfs": false,
+            "SecurityOpt": ["no-new-privileges=true", "seccomp=builtin"],
+            "UTSMode": "",
+            "UsernsMode": "",
+            "Runtime": "runc",
+            "Isolation": "",
+            "ShmSize": 67_108_864,
+            "ConsoleSize": [0, 0]
+        });
+        let resource_config = json!({
+            "CpuShares": 0,
+            "CgroupParent": "",
+            "BlkioWeight": 0,
+            "BlkioWeightDevice": null,
+            "BlkioDeviceReadBps": null,
+            "BlkioDeviceWriteBps": null,
+            "BlkioDeviceReadIOps": null,
+            "BlkioDeviceWriteIOps": null,
+            "CpuPeriod": 0,
+            "CpuQuota": 0,
+            "CpuRealtimePeriod": 0,
+            "CpuRealtimeRuntime": 0,
+            "CpusetCpus": "",
+            "CpusetMems": "",
+            "Memory": 268_435_456,
+            "MemoryReservation": 0,
+            "MemorySwap": 268_435_456,
+            "MemorySwappiness": null,
+            "NanoCpus": 1_000_000_000,
+            "OomKillDisable": null,
+            "PidsLimit": 128,
+            "Ulimits": [],
+            "Devices": [],
+            "DeviceCgroupRules": [],
+            "DeviceRequests": [],
+            "Mounts": null,
+            "Tmpfs": definition.tmpfs,
+            "Init": false,
+            "CpuCount": 0,
+            "CpuPercent": 0,
+            "IOMaximumIOps": 0,
+            "IOMaximumBandwidth": 0,
+            "StorageOpt": {},
+            "Sysctls": {},
+            "MaskedPaths": MASKED_PATHS,
+            "ReadonlyPaths": READ_ONLY_PATHS
+        });
+        host_config.as_object_mut().expect("host object").extend(
+            resource_config
+                .as_object()
+                .expect("resource object")
+                .clone(),
+        );
+        json!({
+            "Id": id,
+            "Image": format!("sha256:{}", "2".repeat(64)),
+            "Name": format!("/{}", definition.name),
+            "Created": "2026-08-16T00:00:00Z",
+            "Path": definition.entrypoint,
+            "Args": definition.arguments,
+            "ResolvConfPath": "/var/lib/docker/containers/fixture/resolv.conf",
+            "HostnamePath": "/var/lib/docker/containers/fixture/hostname",
+            "HostsPath": "/var/lib/docker/containers/fixture/hosts",
+            "LogPath": "",
+            "RestartCount": 0,
+            "Driver": "overlay2",
+            "Platform": "linux",
+            "MountLabel": "",
+            "ProcessLabel": "",
+            "AppArmorProfile": "",
+            "ExecIDs": null,
+            "State": {
+                "Status": "running",
+                "Running": true,
+                "Paused": false,
+                "Restarting": false,
+                "OOMKilled": false,
+                "Dead": false,
+                "Pid": 42,
+                "ExitCode": 0,
+                "Error": "",
+                "StartedAt": "2026-08-16T00:00:01Z",
+                "FinishedAt": "0001-01-01T00:00:00Z"
+            },
+            "Config": config,
+            "HostConfig": host_config,
+            "Mounts": [],
+            "NetworkSettings": {
+                "SandboxID": "",
+                "SandboxKey": "",
+                "Ports": {},
+                "Networks": {}
+            },
+            "GraphDriver": {"Name": "overlay2", "Data": {}}
+        })
+    }
+
+    fn normalized(value: Value) -> Result<super::InspectedContainer, super::EngineApiError> {
+        let response =
+            serde_json::from_value(value).map_err(|_| super::EngineApiError::InvalidResponse)?;
+        normalize_container(response)
+    }
+
+    #[test]
+    fn exact_realized_configuration_matches_the_generated_contract() {
+        let container = normalized(realized_container_json()).expect("valid inspect fixture");
+        assert_eq!(container.definition, expected_definition());
+        assert_eq!(container.state, EngineContainerState::Running);
+        assert!(container.isolated);
+    }
+
+    #[test]
+    fn custody_parser_survives_runtime_defaults_that_execution_rejects() {
+        let mut value = realized_container_json();
+        value["AppArmorProfile"] = json!("docker-default");
+        value["MountLabel"] = json!("system_u:object_r:container_file_t:s0:c1,c2");
+        value["ProcessLabel"] = json!("system_u:system_r:container_t:s0:c1,c2");
+        value["LogPath"] = json!("/var/lib/docker/containers/fixture-json.log");
+        value["HostConfig"]["Ulimits"] = json!([{"Name": "nofile", "Soft": 1024, "Hard": 1024}]);
+        assert!(normalized(value.clone()).is_err());
+
+        let custody = normalize_container_custody(
+            serde_json::from_value::<ContainerCustodyResponse>(value)
+                .expect("minimal custody response"),
+        )
+        .expect("custody identity remains recoverable");
+        assert_eq!(custody.name, expected_definition().name);
+        assert_eq!(custody.id, "a".repeat(64));
+        assert_eq!(custody.state, EngineContainerState::Running);
+    }
+
+    #[test]
+    fn transient_exec_ids_must_be_bounded_canonical_and_unique() {
+        let mut value = realized_container_json();
+        *value.pointer_mut("/ExecIDs").expect("fixture pointer") =
+            json!(["a".repeat(64), "b".repeat(64)]);
+        assert!(normalized(value.clone()).is_ok());
+
+        for invalid in [
+            json!(["a".repeat(63)]),
+            json!(["A".repeat(64)]),
+            json!(["a".repeat(64), "a".repeat(64)]),
+        ] {
+            *value.pointer_mut("/ExecIDs").expect("fixture pointer") = invalid;
+            assert!(normalized(value.clone()).is_err());
+        }
+
+        *value.pointer_mut("/ExecIDs").expect("fixture pointer") = Value::Array(
+            (0..17)
+                .map(|index| json!(format!("{index:064x}")))
+                .collect(),
+        );
+        assert!(normalized(value).is_err());
+    }
+
+    #[test]
+    fn oom_kill_disable_accepts_only_the_two_v1_44_false_normalizations() {
+        for realized in [Value::Null, json!(false)] {
+            let mut value = realized_container_json();
+            *value
+                .pointer_mut("/HostConfig/OomKillDisable")
+                .expect("fixture pointer") = realized;
+            assert!(normalized(value).expect("false form").isolated);
+        }
+        let mut value = realized_container_json();
+        *value
+            .pointer_mut("/HostConfig/OomKillDisable")
+            .expect("fixture pointer") = json!(true);
+        assert!(!normalized(value).expect("typed true form").isolated);
+    }
+
+    fn exec_inspect_json(running: bool, exit_code: &Value, pid: i64) -> Value {
+        json!({
+            "ID": "a".repeat(64),
+            "Running": running,
+            "ExitCode": exit_code,
+            "ProcessConfig": {
+                "tty": false,
+                "entrypoint": "/automata-control/automata-ci-sandbox-guest",
+                "arguments": ["local-client"],
+                "privileged": false,
+                "user": "65532:65532"
+            },
+            "OpenStdin": true,
+            "OpenStderr": true,
+            "OpenStdout": true,
+            "CanRemove": false,
+            "ContainerID": "b".repeat(64),
+            "DetachKeys": "",
+            "Pid": pid
+        })
+    }
+
+    #[test]
+    fn exec_inspection_has_disjoint_exact_created_and_finished_states() {
+        let command = vec![
+            "/automata-control/automata-ci-sandbox-guest".to_owned(),
+            "local-client".to_owned(),
+        ];
+        let created: ExecInspectResponse =
+            serde_json::from_value(exec_inspect_json(false, &Value::Null, 0))
+                .expect("created exec");
+        assert!(
+            created.matches_created(&"a".repeat(64), &"b".repeat(64), &command, "65532:65532",)
+        );
+
+        let prepared = PreparedEngineExec {
+            id: "a".repeat(64),
+            container_id: "b".repeat(64),
+            command: command.clone(),
+            user: "65532:65532".to_owned(),
+        };
+        let request = EngineExecRequest {
+            container_id: prepared.container_id.clone(),
+            command,
+            user: prepared.user.clone(),
+            stdin: Vec::new(),
+            stdout_limit: 1,
+            stderr_limit: 1,
+            timeout: std::time::Duration::from_secs(1),
+        };
+        let finished: ExecInspectResponse =
+            serde_json::from_value(exec_inspect_json(false, &json!(0), 42)).expect("finished exec");
+        assert!(finished.matches_finished(&prepared, &request));
+        for invalid in [
+            exec_inspect_json(false, &json!(0), 0),
+            exec_inspect_json(true, &json!(0), 42),
+        ] {
+            let invalid: ExecInspectResponse =
+                serde_json::from_value(invalid).expect("typed invalid exec state");
+            assert!(!invalid.matches_finished(&prepared, &request));
+        }
+        let mut unknown = exec_inspect_json(false, &Value::Null, 0);
+        unknown
+            .as_object_mut()
+            .expect("exec object")
+            .insert("Unexpected".to_owned(), json!(true));
+        assert!(serde_json::from_value::<ExecInspectResponse>(unknown).is_err());
+    }
+
+    #[test]
+    fn high_risk_realized_configuration_tampering_fails_closed() {
+        for (pointer, replacement) in [
+            ("/Config/Env", json!(["PATH=", "SECRET=leaked"])),
+            ("/Config/Volumes", json!({"/host": {}})),
+            ("/Config/ExposedPorts", json!({"8080/tcp": {}})),
+            ("/HostConfig/NetworkMode", json!("host")),
+            ("/HostConfig/Privileged", json!(true)),
+            ("/HostConfig/Binds", json!(["/host:/guest"])),
+            ("/HostConfig/Tmpfs", json!({"/foreign": "rw"})),
+            (
+                "/HostConfig/Tmpfs/~1automata-control",
+                json!("rw,exec,size=33554432,mode=0733,uid=65533,gid=65532"),
+            ),
+            ("/HostConfig/Init", json!(true)),
+            ("/HostConfig/OomKillDisable", json!(true)),
+            ("/Mounts", json!([{"Type": "volume"}])),
+            ("/HostConfig/Devices", json!([{"PathOnHost": "/dev/kvm"}])),
+            ("/HostConfig/Sysctls", json!({"kernel.hostname": "foreign"})),
+            ("/HostConfig/SecurityOpt", json!(["seccomp=unconfined"])),
+            ("/HostConfig/ReadonlyRootfs", json!(true)),
+            ("/NetworkSettings/Networks", json!({"bridge": {}})),
+        ] {
+            let mut value = realized_container_json();
+            *value.pointer_mut(pointer).expect("fixture pointer") = replacement;
+            if let Ok(container) = normalized(value) {
+                assert!(
+                    !container.isolated || container.definition != expected_definition(),
+                    "accepted tamper at {pointer}"
+                );
+            }
+        }
+    }
+}

--- a/crates/automata-ci-local/src/local_docker/engine/transport.rs
+++ b/crates/automata-ci-local/src/local_docker/engine/transport.rs
@@ -781,3 +781,565 @@ where
         deserializer.deserialize_map(BoundedMapVisitor::<K, V, LIMIT>(PhantomData))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde::Serialize;
+
+    use super::{
+        BoundedMap, BoundedVec, REQUEST_BYTES, TransportError, encode_json, encode_path_component,
+    };
+    use super::{ERROR_BYTES, MAX_IN_FLIGHT_REQUESTS, MAX_RESPONSE_HEADERS, deadline};
+
+    #[test]
+    fn path_components_are_encoded_without_query_or_path_injection() {
+        assert_eq!(
+            encode_path_component("name/with?filters={\"x\":1}&nul=\0"),
+            "name%2Fwith%3Ffilters%3D%7B%22x%22%3A1%7D%26nul%3D%00"
+        );
+        assert_eq!(encode_path_component("AZaz09-._~"), "AZaz09-._~");
+    }
+
+    #[test]
+    fn bounded_arrays_reject_the_first_excess_entry() {
+        type Two = BoundedVec<u8, 2>;
+        assert_eq!(
+            serde_json::from_str::<Two>("[1,2]")
+                .expect("at-limit array")
+                .into_inner(),
+            vec![1, 2]
+        );
+        assert!(serde_json::from_str::<Two>("[1,2,3]").is_err());
+    }
+
+    #[test]
+    fn bounded_objects_reject_excess_and_duplicate_keys() {
+        type One = BoundedMap<String, u8, 1>;
+        type Two = BoundedMap<String, u8, 2>;
+
+        assert_eq!(
+            serde_json::from_str::<One>(r#"{"a":1}"#)
+                .expect("at-limit object")
+                .into_inner(),
+            std::collections::BTreeMap::from([("a".to_owned(), 1)])
+        );
+        assert!(serde_json::from_str::<One>(r#"{"a":1,"b":2}"#).is_err());
+
+        assert!(serde_json::from_str::<Two>(r#"{"a":1,"a":2}"#).is_err());
+    }
+
+    #[derive(Serialize)]
+    struct Request<'a> {
+        value: &'a str,
+    }
+
+    #[test]
+    fn request_serialization_refuses_growth_past_the_wire_limit() {
+        let oversized = "x".repeat(REQUEST_BYTES);
+        assert_eq!(
+            encode_json(&Request { value: &oversized }),
+            Err(TransportError::InvalidRequest)
+        );
+    }
+
+    #[cfg(unix)]
+    fn transport_with_one_response(
+        status: &str,
+        content_type: &str,
+        body: &[u8],
+        declared_length: usize,
+    ) -> (
+        super::DockerHttpTransport,
+        std::path::PathBuf,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind fake Docker socket");
+        let response = [
+            format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {declared_length}\r\nConnection: close\r\n\r\n"
+            )
+            .into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept fake request");
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).await.expect("read fake request");
+                assert_ne!(read, 0, "request ended before its headers");
+                request.extend_from_slice(&chunk[..read]);
+                assert!(request.len() <= 16 * 1024, "request headers are bounded");
+            }
+            stream
+                .write_all(&response)
+                .await
+                .expect("write fake response");
+            stream.shutdown().await.expect("close fake response");
+        });
+        let transport = super::DockerHttpTransport::connect_unix_socket(
+            &socket,
+            crate::ApiVersion {
+                major: 1,
+                minor: 53,
+            },
+        )
+        .expect("fake Docker transport");
+        (transport, socket, server)
+    }
+
+    async fn finish_fake_response(socket: &std::path::Path, server: tokio::task::JoinHandle<()>) {
+        server.await.expect("fake Docker server");
+        std::fs::remove_file(socket).expect("remove exact fake socket");
+    }
+
+    fn transport_with_raw_response(
+        response: Vec<u8>,
+    ) -> (
+        super::DockerHttpTransport,
+        std::path::PathBuf,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use tokio::io::AsyncWriteExt as _;
+
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind fake Docker socket");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept fake request");
+            read_request_headers(&mut stream).await;
+            let _ignored = stream.write_all(&response).await;
+            let _ignored = stream.shutdown().await;
+        });
+        (fake_transport(&socket), socket, server)
+    }
+
+    fn fake_transport(socket: &std::path::Path) -> super::DockerHttpTransport {
+        super::DockerHttpTransport::connect_unix_socket(
+            socket,
+            crate::ApiVersion {
+                major: 1,
+                minor: 53,
+            },
+        )
+        .expect("fake Docker transport")
+    }
+
+    async fn read_request_headers(stream: &mut tokio::net::UnixStream) {
+        use tokio::io::AsyncReadExt as _;
+
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+            let read = stream.read(&mut chunk).await.expect("read fake request");
+            assert_ne!(read, 0, "request ended before its headers");
+            request.extend_from_slice(&chunk[..read]);
+            assert!(request.len() <= 16 * 1024, "request headers are bounded");
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn response_content_length_is_rejected_before_body_collection() {
+        let (transport, socket, server) =
+            transport_with_one_response("200 OK", "application/json", b"{}", 4096);
+        let result = transport
+            .json::<serde_json::Value, ()>(
+                http::Method::GET,
+                "/bounded",
+                None,
+                http::StatusCode::OK,
+                16,
+            )
+            .await;
+        assert_eq!(result, Err(TransportError::ResponseTooLarge));
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn optional_responses_require_a_bounded_structured_docker_error() {
+        let body = br#"{"message":"missing"}"#;
+        let (transport, socket, server) =
+            transport_with_one_response("404 Not Found", "application/json", body, body.len());
+        assert_eq!(
+            transport
+                .optional_json::<serde_json::Value>("/missing", 16)
+                .await,
+            Ok(None)
+        );
+        finish_fake_response(&socket, server).await;
+
+        let body = b"{}";
+        let (transport, socket, server) =
+            transport_with_one_response("404 Not Found", "application/json", body, body.len());
+        assert_eq!(
+            transport
+                .optional_json::<serde_json::Value>("/malformed-error", 16)
+                .await,
+            Err(TransportError::InvalidResponse)
+        );
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn endpoint_json_cardinality_is_enforced() {
+        let body = b"[1,2,3]";
+        let (transport, socket, server) =
+            transport_with_one_response("200 OK", "application/json", body, body.len());
+        let result = transport
+            .json::<BoundedVec<u8, 2>, ()>(
+                http::Method::GET,
+                "/cardinality",
+                None,
+                http::StatusCode::OK,
+                body.len(),
+            )
+            .await;
+        assert_eq!(result, Err(TransportError::InvalidResponse));
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn chunked_success_and_error_bodies_are_bounded_while_streaming() {
+        let payload = "x".repeat(32);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{:X}\r\n{}\r\n0\r\n\r\n",
+            payload.len(),
+            payload
+        )
+        .into_bytes();
+        let (transport, socket, server) = transport_with_raw_response(response);
+        assert_eq!(
+            transport
+                .json::<serde_json::Value, ()>(
+                    http::Method::GET,
+                    "/chunked-success-overflow",
+                    None,
+                    http::StatusCode::OK,
+                    16,
+                )
+                .await,
+            Err(TransportError::ResponseTooLarge)
+        );
+        finish_fake_response(&socket, server).await;
+
+        let payload = "x".repeat(ERROR_BYTES + 1);
+        let response = format!(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{:X}\r\n{}\r\n0\r\n\r\n",
+            payload.len(),
+            payload
+        )
+        .into_bytes();
+        let (transport, socket, server) = transport_with_raw_response(response);
+        assert_eq!(
+            transport
+                .optional_json::<serde_json::Value>("/chunked-error-overflow", 16)
+                .await,
+            Err(TransportError::ResponseTooLarge)
+        );
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn response_header_count_bytes_and_duplicate_content_type_fail_closed() {
+        use std::fmt::Write as _;
+
+        let mut many_headers = String::new();
+        for index in 0..MAX_RESPONSE_HEADERS {
+            write!(many_headers, "X-Test-{index}: x\r\n").expect("write response header");
+        }
+        for response in [
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{many_headers}Content-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+            )
+            .into_bytes(),
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Wide: {}\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}",
+                "x".repeat(super::MAX_RESPONSE_HEADER_BYTES)
+            )
+            .into_bytes(),
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}".to_vec(),
+        ] {
+            let (transport, socket, server) = transport_with_raw_response(response);
+            assert!(
+                transport
+                    .json::<serde_json::Value, ()>(
+                        http::Method::GET,
+                        "/invalid-headers",
+                        None,
+                        http::StatusCode::OK,
+                        16,
+                    )
+                    .await
+                    .is_err()
+            );
+            finish_fake_response(&socket, server).await;
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ambiguous_response_framing_is_never_accepted() {
+        for response in [
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nContent-Length: 2\r\nConnection: close\r\n\r\n2\r\n{}\r\n0\r\n\r\n".to_vec(),
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nContent-Length: 3\r\nConnection: close\r\n\r\n{}".to_vec(),
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: gzip, chunked\r\nConnection: close\r\n\r\n2\r\n{}\r\n0\r\n\r\n".to_vec(),
+        ] {
+            let (transport, socket, server) = transport_with_raw_response(response);
+            assert!(
+                transport
+                    .json::<serde_json::Value, ()>(
+                        http::Method::GET,
+                        "/ambiguous-framing",
+                        None,
+                        http::StatusCode::OK,
+                        16,
+                    )
+                    .await
+                    .is_err()
+            );
+            finish_fake_response(&socket, server).await;
+        }
+    }
+
+    #[cfg(unix)]
+    async fn assert_stalled_response_is_cancelled(prefix: &'static [u8]) {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-stall-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind stalled Docker socket");
+        let (stalled_tx, stalled_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept stalled request");
+            read_request_headers(&mut stream).await;
+            stream
+                .write_all(prefix)
+                .await
+                .expect("write stalled prefix");
+            stalled_tx
+                .send(())
+                .expect("report that the exact response is stalled");
+            let mut byte = [0_u8; 1];
+            let closed = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut byte))
+                .await
+                .expect("cancelled client closes its exact socket")
+                .expect("read client close");
+            assert_eq!(closed, 0, "cancelled connection must not remain detached");
+        });
+        let transport = fake_transport(&socket);
+        let mut request = Box::pin(transport.json::<serde_json::Value, ()>(
+            http::Method::GET,
+            "/stalled",
+            None,
+            http::StatusCode::OK,
+            16,
+        ));
+        tokio::select! {
+            result = &mut request => panic!("request ended before cancellation: {result:?}"),
+            stalled = tokio::time::timeout(Duration::from_secs(1), stalled_rx) => {
+                stalled
+                    .expect("request reaches the stalled response boundary")
+                    .expect("fake server reports the stalled response");
+            }
+        }
+        assert_eq!(
+            deadline(Duration::from_millis(25), request.as_mut()).await,
+            Err(TransportError::RequestFailed)
+        );
+        drop(request);
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stalled_headers_and_bodies_are_cancelled_without_detached_connections() {
+        assert_stalled_response_is_cancelled(b"").await;
+        assert_stalled_response_is_cancelled(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 8\r\nConnection: close\r\n\r\n{",
+        )
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancellation_during_driver_finish_aborts_the_task_and_closes_its_socket() {
+        use tokio::io::AsyncReadExt as _;
+
+        let (client, mut peer) = tokio::net::UnixStream::pair().expect("Unix socket pair");
+        let task = tokio::spawn(async move {
+            let result = std::future::pending::<Result<(), hyper::Error>>().await;
+            drop(client);
+            result
+        });
+        let driver = super::ConnectionDriver(Some(task));
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), driver.finish())
+                .await
+                .is_err(),
+            "the test driver remains pending until cancellation"
+        );
+        let mut byte = [0_u8; 1];
+        let closed = tokio::time::timeout(Duration::from_secs(1), peer.read(&mut byte))
+            .await
+            .expect("cancelled finish closes the driver socket")
+            .expect("read driver socket close");
+        assert_eq!(
+            closed, 0,
+            "driver task must not detach on finish cancellation"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn every_request_reconnects_to_the_exact_rebound_unix_socket() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-rebind-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let transport = fake_transport(&socket);
+        for expected in [1_u8, 2] {
+            let listener = tokio::net::UnixListener::bind(&socket).expect("bind rebound socket");
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.expect("accept rebound request");
+                read_request_headers(&mut stream).await;
+                let body = format!("{{\"server\":{expected}}}");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write rebound response");
+            });
+            let observed: serde_json::Value = transport
+                .json(
+                    http::Method::GET,
+                    "/rebind",
+                    None::<&()>,
+                    http::StatusCode::OK,
+                    64,
+                )
+                .await
+                .expect("request reaches current listener");
+            assert_eq!(observed["server"], expected);
+            server.await.expect("rebound server");
+            std::fs::remove_file(&socket).expect("remove rebound socket name");
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_connection_is_not_implicitly_retried() {
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-no-retry-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind no-retry socket");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept first request");
+            drop(stream);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "one operation must open exactly one connection"
+            );
+        });
+        let transport = fake_transport(&socket);
+        assert_eq!(
+            transport
+                .json::<serde_json::Value, ()>(
+                    http::Method::GET,
+                    "/no-retry",
+                    None,
+                    http::StatusCode::OK,
+                    16,
+                )
+                .await,
+            Err(TransportError::RequestFailed)
+        );
+        finish_fake_response(&socket, server).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concurrent_connection_cardinality_is_hard_bounded() {
+        let socket = std::env::temp_dir().join(format!(
+            "automata-docker-transport-cardinality-{}.sock",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind cardinality socket");
+        let (accepted_tx, mut accepted_rx) = tokio::sync::mpsc::channel(MAX_IN_FLIGHT_REQUESTS);
+        let (checked_tx, checked_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let mut streams = Vec::with_capacity(MAX_IN_FLIGHT_REQUESTS);
+            for _ in 0..MAX_IN_FLIGHT_REQUESTS {
+                let (mut stream, _) = listener.accept().await.expect("accept bounded request");
+                read_request_headers(&mut stream).await;
+                streams.push(stream);
+                accepted_tx.send(()).await.expect("report accepted request");
+            }
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "request cardinality exceeded the transport bound"
+            );
+            drop(listener);
+            checked_tx.send(()).expect("report cardinality check");
+            drop(streams);
+        });
+        let transport = fake_transport(&socket);
+        let mut requests = Vec::new();
+        for _ in 0..=MAX_IN_FLIGHT_REQUESTS {
+            let transport = transport.clone();
+            requests.push(tokio::spawn(async move {
+                transport
+                    .json::<serde_json::Value, ()>(
+                        http::Method::GET,
+                        "/cardinality",
+                        None,
+                        http::StatusCode::OK,
+                        16,
+                    )
+                    .await
+            }));
+        }
+        for _ in 0..MAX_IN_FLIGHT_REQUESTS {
+            tokio::time::timeout(Duration::from_secs(1), accepted_rx.recv())
+                .await
+                .expect("bounded request connects")
+                .expect("server reports bounded request");
+        }
+        checked_rx
+            .await
+            .expect("server completes cardinality check");
+        for request in requests {
+            request.abort();
+            let _ignored = request.await;
+        }
+        finish_fake_response(&socket, server).await;
+    }
+}

--- a/crates/automata-ci-local/src/local_docker/mod.rs
+++ b/crates/automata-ci-local/src/local_docker/mod.rs
@@ -48,6 +48,9 @@ use engine::{
 
 use endpoint::LocalDockerEndpoint;
 
+#[cfg(test)]
+mod tests;
+
 pub(crate) const LOCAL_DOCKER_PROVIDER_ID: &str = "local-docker-v1";
 
 const MANAGED_LABEL_PREFIX: &str = "io.automata.local.";
@@ -189,6 +192,31 @@ impl LocalDockerProvider {
                 handle_locks: Mutex::new(BTreeMap::new()),
             }),
         })
+    }
+
+    #[cfg(test)]
+    fn with_test_engine(
+        pinned: PinnedDockerEngine,
+        engine: Arc<dyn SandboxEngineApi>,
+        installation: Installation,
+        guest_image: ImmutableImage,
+        guest_image_id: String,
+    ) -> Self {
+        Self {
+            inner: Arc::new(LocalDockerInner {
+                pinned,
+                engine,
+                installation,
+                guest_image,
+                guest_image_id,
+                guest_image_labels: BTreeMap::new(),
+                guest_image_environment: Vec::new(),
+                provider_id: ProviderId::new(LOCAL_DOCKER_PROVIDER_ID).expect("provider id"),
+                capabilities: ProviderCapabilities::new(PROVIDER_CAPABILITIES)
+                    .expect("capabilities"),
+                handle_locks: Mutex::new(BTreeMap::new()),
+            }),
+        }
     }
 }
 

--- a/crates/automata-ci-local/src/local_docker/tests.rs
+++ b/crates/automata-ci-local/src/local_docker/tests.rs
@@ -1,0 +1,2656 @@
+use std::{
+    collections::BTreeMap,
+    num::NonZeroU16,
+    str::FromStr as _,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use automata_ci_core::{OperationId, RunnerId};
+use automata_ci_execution::{
+    Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentProfile,
+    EnvironmentProfileId, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
+    ExecutionErrorKind, ExecutionTermination, NeverCancelled, ResourceLimits, RootFilesystemPolicy,
+    SandboxCustody, SandboxGeneration, SandboxProvider, SandboxState, TargetPath,
+};
+use automata_ci_sandbox_guest::{
+    GUEST_PROTOCOL_VERSION, GuestRequest, GuestResponse, decode_frame, encode_frame,
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use uuid::Uuid;
+
+use super::*;
+use crate::{
+    EngineArchitecture, InstallationName,
+    local_docker::engine::{
+        AnchorEngineApi, EngineApi, EngineExecOutput, EngineFacts, InspectedVolume,
+        PreparedEngineExec,
+    },
+};
+
+const JOB_DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const GUEST_DIGEST: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PROFILE_DIGEST: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const JOB_IMAGE_ID: &str =
+    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+const GUEST_IMAGE_ID: &str =
+    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const FAKE_GUEST: &[u8] = b"fake-automata-ci-sandbox-guest";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Call {
+    CreateContainer(ContainerDefinition),
+    StartContainer(String),
+    RemoveContainer(String),
+    KillContainer(String),
+    UploadArchive(String),
+    CreateExec(Vec<String>, String),
+    StartExec(Vec<String>),
+}
+
+#[allow(clippy::struct_excessive_bools)]
+struct FakeState {
+    facts: EngineFacts,
+    images: BTreeMap<String, InspectedImage>,
+    volumes: BTreeMap<String, InspectedVolume>,
+    containers: BTreeMap<String, InspectedContainer>,
+    guest_binaries: BTreeMap<String, Vec<u8>>,
+    files: BTreeMap<String, Vec<u8>>,
+    prepared: BTreeMap<String, (String, Vec<String>, String)>,
+    lose_next_bootstrap_response: bool,
+    reject_bootstrap: bool,
+    bootstrap_ready: bool,
+    invalid_guest_source_archive: bool,
+    replace_after_upload: bool,
+    replace_after_start: bool,
+    replace_after_probe: bool,
+    block_next_guest_start: bool,
+    replace_job_after_boundaries: Option<usize>,
+    cancel_after_boundaries: Option<(usize, Arc<AtomicBool>)>,
+    recreate_first_removed_after_following_remove: bool,
+    first_removed_for_recreation: Option<InspectedContainer>,
+    inject_daemon_default_ulimit_on_next_create: bool,
+    rename_removed_container_instead: bool,
+    block_next_guest_exec: bool,
+    boundary_permit: bool,
+    calls: Vec<Call>,
+    next_id: u64,
+}
+
+impl FakeState {
+    fn new() -> Self {
+        Self {
+            facts: EngineFacts {
+                engine_id: "engine-identity".to_owned(),
+                server_version: "29.7.2".to_owned(),
+                minimum_api_version: "1.40".to_owned(),
+                maximum_api_version: "1.55".to_owned(),
+                operating_system: "linux".to_owned(),
+                architecture: "amd64".to_owned(),
+                security_options: vec![
+                    "name=cgroupns".to_owned(),
+                    "name=seccomp,profile=builtin".to_owned(),
+                    "name=userns".to_owned(),
+                ],
+                memory_limit: true,
+                swap_limit: true,
+                cpu_cfs_period: true,
+                cpu_cfs_quota: true,
+                pids_limit: true,
+            },
+            images: BTreeMap::new(),
+            volumes: BTreeMap::new(),
+            containers: BTreeMap::new(),
+            guest_binaries: BTreeMap::new(),
+            files: BTreeMap::new(),
+            prepared: BTreeMap::new(),
+            lose_next_bootstrap_response: false,
+            reject_bootstrap: false,
+            bootstrap_ready: false,
+            invalid_guest_source_archive: false,
+            replace_after_upload: false,
+            replace_after_start: false,
+            replace_after_probe: false,
+            block_next_guest_start: false,
+            replace_job_after_boundaries: None,
+            cancel_after_boundaries: None,
+            recreate_first_removed_after_following_remove: false,
+            first_removed_for_recreation: None,
+            inject_daemon_default_ulimit_on_next_create: false,
+            rename_removed_container_instead: false,
+            block_next_guest_exec: false,
+            boundary_permit: false,
+            calls: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    fn object_id(&mut self) -> String {
+        let id = format!("{:064x}", self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    fn consume_boundary(&mut self) -> Result<(), EngineApiError> {
+        if !std::mem::take(&mut self.boundary_permit) {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        Ok(())
+    }
+}
+
+struct FakeEngine {
+    anchor_name: String,
+    state: Mutex<FakeState>,
+    guest_exec_blocked: AtomicBool,
+    release_guest_exec: AtomicBool,
+    fail_released_guest_exec: AtomicBool,
+    accesses: AtomicUsize,
+}
+
+impl FakeEngine {
+    fn new(installation: &Installation) -> Self {
+        let mut state = FakeState::new();
+        let job = job_image();
+        let guest = guest_image();
+        state.images.insert(
+            job.reference().to_owned(),
+            inspected_image(&job, JOB_IMAGE_ID),
+        );
+        state.images.insert(
+            guest.reference().to_owned(),
+            inspected_image(&guest, GUEST_IMAGE_ID),
+        );
+        let anchor_name = installation.anchor_volume_name().to_owned();
+        state.volumes.insert(
+            anchor_name.clone(),
+            InspectedVolume {
+                name: anchor_name.clone(),
+                driver: "local".to_owned(),
+                scope: "local".to_owned(),
+                options: BTreeMap::new(),
+                labels: BTreeMap::from([
+                    ("io.automata.local.managed".to_owned(), "true".to_owned()),
+                    (
+                        "io.automata.local.identity-schema".to_owned(),
+                        "1".to_owned(),
+                    ),
+                    (
+                        "io.automata.local.installation-id".to_owned(),
+                        installation.id().to_string(),
+                    ),
+                    (
+                        "io.automata.local.installation-key".to_owned(),
+                        installation.selector_key().to_string(),
+                    ),
+                    (
+                        "io.automata.local.compose-project".to_owned(),
+                        installation.compose_project().to_string(),
+                    ),
+                    (
+                        "io.automata.local.resource-kind".to_owned(),
+                        "identity-anchor".to_owned(),
+                    ),
+                ]),
+            },
+        );
+        Self {
+            anchor_name,
+            state: Mutex::new(state),
+            guest_exec_blocked: AtomicBool::new(false),
+            release_guest_exec: AtomicBool::new(false),
+            fail_released_guest_exec: AtomicBool::new(false),
+            accesses: AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> Vec<Call> {
+        self.state.lock().expect("fake state").calls.clone()
+    }
+
+    fn mutate(&self, update: impl FnOnce(&mut FakeState)) {
+        update(&mut self.state.lock().expect("fake state"));
+    }
+
+    fn container(&self, name: &str) -> Option<InspectedContainer> {
+        self.state
+            .lock()
+            .expect("fake state")
+            .containers
+            .get(name)
+            .cloned()
+    }
+
+    fn mutation_count(&self) -> usize {
+        self.calls().len()
+    }
+
+    fn access_count(&self) -> usize {
+        self.accesses.load(Ordering::SeqCst)
+    }
+
+    fn guest_response(&self, request: GuestRequest) -> Result<GuestResponse, EngineApiError> {
+        let mut state = self.state.lock().expect("fake state");
+        let response = match request {
+            GuestRequest::Probe { .. } => GuestResponse::Ready {
+                protocol: GUEST_PROTOCOL_VERSION,
+            },
+            GuestRequest::Exec { .. } => serde_json::from_value(serde_json::json!({
+                "result": "exec",
+                "protocol": GUEST_PROTOCOL_VERSION,
+                "termination": {"kind": "exited", "code": 0},
+                "records": [
+                    {"stream": "stdout", "data_base64": BASE64.encode(b"ok"), "end_of_stream": false},
+                    {"stream": "stdout", "data_base64": "", "end_of_stream": true},
+                    {"stream": "stderr", "data_base64": "", "end_of_stream": true}
+                ],
+                "truncated": false
+            }))
+            .map_err(|_| EngineApiError::InvalidResponse)?,
+            GuestRequest::WriteFile {
+                path,
+                content_base64,
+                ..
+            } => {
+                let content = BASE64
+                    .decode(content_base64)
+                    .map_err(|_| EngineApiError::InvalidResponse)?;
+                state.files.insert(path, content);
+                GuestResponse::WriteFile {
+                    protocol: GUEST_PROTOCOL_VERSION,
+                }
+            }
+            GuestRequest::ReadFile { path, byte_limit, .. } => {
+                let content = state
+                    .files
+                    .get(&path)
+                    .filter(|content| content.len() <= byte_limit)
+                    .cloned()
+                    .ok_or(EngineApiError::InvalidResponse)?;
+                GuestResponse::ReadFile {
+                    protocol: GUEST_PROTOCOL_VERSION,
+                    content_base64: BASE64.encode(content),
+                }
+            }
+            _ => return Err(EngineApiError::InvalidResponse),
+        };
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl EngineApi for FakeEngine {
+    async fn engine_facts(&self) -> Result<EngineFacts, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        Ok(self.state.lock().expect("fake state").facts.clone())
+    }
+}
+
+#[async_trait]
+impl AnchorEngineApi for FakeEngine {
+    async fn inspect_volume(&self, name: &str) -> Result<Option<InspectedVolume>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .state
+            .lock()
+            .expect("fake state")
+            .volumes
+            .get(name)
+            .cloned())
+    }
+
+    async fn volume_attachments(&self, name: &str) -> Result<Vec<String>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        if name != self.anchor_name || !state.volumes.contains_key(name) {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        state.boundary_permit = true;
+        if let Some((remaining, cancelled)) = state.cancel_after_boundaries.take() {
+            if remaining == 1 {
+                cancelled.store(true, Ordering::SeqCst);
+            } else {
+                state.cancel_after_boundaries = Some((remaining - 1, cancelled));
+            }
+        }
+        if let Some(remaining) = state.replace_job_after_boundaries.take() {
+            if remaining == 1 {
+                let id = state
+                    .containers
+                    .values()
+                    .find(|container| container.definition.name.ends_with("-job"))
+                    .map(|container| container.id.clone())
+                    .ok_or(EngineApiError::InvalidResponse)?;
+                replace_container(&mut state, &id)?;
+            } else {
+                state.replace_job_after_boundaries = Some(remaining - 1);
+            }
+        }
+        Ok(Vec::new())
+    }
+}
+
+#[async_trait]
+impl SandboxEngineApi for FakeEngine {
+    async fn inspect_image(
+        &self,
+        reference: &str,
+    ) -> Result<Option<InspectedImage>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .state
+            .lock()
+            .expect("fake state")
+            .images
+            .get(reference)
+            .cloned())
+    }
+
+    async fn inspect_container(
+        &self,
+        name_or_id: &str,
+    ) -> Result<Option<InspectedContainer>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let state = self.state.lock().expect("fake state");
+        Ok(state
+            .containers
+            .get(name_or_id)
+            .or_else(|| {
+                state
+                    .containers
+                    .values()
+                    .find(|container| container.id == name_or_id)
+            })
+            .cloned())
+    }
+
+    async fn create_container(
+        &self,
+        definition: ContainerDefinition,
+    ) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::CreateContainer(definition.clone()));
+        if state.containers.contains_key(&definition.name) {
+            return Err(EngineApiError::RequestFailed);
+        }
+        let image_id = state
+            .images
+            .get(&definition.image)
+            .ok_or(EngineApiError::InvalidResponse)?
+            .id
+            .clone();
+        let id = state.object_id();
+        let isolated = !std::mem::take(&mut state.inject_daemon_default_ulimit_on_next_create);
+        state.containers.insert(
+            definition.name.clone(),
+            InspectedContainer {
+                id,
+                image_id,
+                definition,
+                state: EngineContainerState::Created,
+                // `false` represents Docker merging a daemon default ulimit
+                // into an otherwise exact create request after mutation.
+                isolated,
+            },
+        );
+        Ok(())
+    }
+
+    async fn start_container(&self, id: &str) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::StartContainer(id.to_owned()));
+        find_container_mut(&mut state, id)?.state = EngineContainerState::Running;
+        if std::mem::take(&mut state.replace_after_start) {
+            replace_container(&mut state, id)?;
+        }
+        Ok(())
+    }
+
+    async fn remove_container(&self, id: &str) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::RemoveContainer(id.to_owned()));
+        let name = state
+            .containers
+            .iter()
+            .find_map(|(name, container)| (container.id == id).then(|| name.clone()));
+        let removed = name.and_then(|name| state.containers.remove(&name));
+        if state.rename_removed_container_instead {
+            if let Some(container) = removed {
+                state
+                    .containers
+                    .insert(format!("renamed-{}", container.id), container);
+            }
+            return Ok(());
+        }
+        if state.recreate_first_removed_after_following_remove {
+            if let Some(mut first) = state.first_removed_for_recreation.take() {
+                first.id = state.object_id();
+                state
+                    .containers
+                    .insert(first.definition.name.clone(), first);
+                state.recreate_first_removed_after_following_remove = false;
+            } else {
+                state.first_removed_for_recreation = removed;
+            }
+        }
+        state.guest_binaries.remove(id);
+        Ok(())
+    }
+
+    async fn kill_container(&self, id: &str) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::KillContainer(id.to_owned()));
+        find_container_mut(&mut state, id)?.state = EngineContainerState::Exited(137);
+        Ok(())
+    }
+
+    async fn download_guest_image_binary(
+        &self,
+        id: &str,
+        byte_limit: usize,
+    ) -> Result<Vec<u8>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let state = self.state.lock().expect("fake state");
+        state
+            .containers
+            .values()
+            .find(|container| container.id == id)
+            .filter(|container| {
+                container.definition.name.ends_with("-guest-source")
+                    && container.state == EngineContainerState::Created
+            })
+            .ok_or(EngineApiError::InvalidResponse)?;
+        let archive = if state.invalid_guest_source_archive {
+            two_file_archive(FAKE_GUEST)
+        } else {
+            guest_archive(FAKE_GUEST)
+        }?;
+        if archive.len() > byte_limit {
+            return Err(EngineApiError::OutputLimit);
+        }
+        Ok(archive)
+    }
+
+    async fn download_sandbox_guest(
+        &self,
+        id: &str,
+        byte_limit: usize,
+    ) -> Result<Vec<u8>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let state = self.state.lock().expect("fake state");
+        let bytes = state
+            .guest_binaries
+            .get(id)
+            .ok_or(EngineApiError::InvalidResponse)?;
+        let archive = guest_archive(bytes)?;
+        if archive.len() > byte_limit {
+            return Err(EngineApiError::OutputLimit);
+        }
+        Ok(archive)
+    }
+
+    async fn upload_sandbox_archive(&self, id: &str, archive: &[u8]) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::UploadArchive(id.to_owned()));
+        let guest = extract_uploaded_guest(archive)?;
+        state.guest_binaries.insert(id.to_owned(), guest);
+        if std::mem::take(&mut state.replace_after_upload) {
+            replace_container(&mut state, id)?;
+        }
+        Ok(())
+    }
+
+    async fn create_exec(
+        &self,
+        container_id: &str,
+        command: &[String],
+        user: &str,
+    ) -> Result<PreparedEngineExec, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        if !state
+            .containers
+            .values()
+            .any(|container| container.id == container_id)
+        {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        state
+            .calls
+            .push(Call::CreateExec(command.to_vec(), user.to_owned()));
+        let id = state.object_id();
+        state.prepared.insert(
+            id.clone(),
+            (container_id.to_owned(), command.to_vec(), user.to_owned()),
+        );
+        Ok(PreparedEngineExec {
+            id,
+            container_id: container_id.to_owned(),
+            command: command.to_vec(),
+            user: user.to_owned(),
+        })
+    }
+
+    async fn start_exec(
+        &self,
+        prepared: &PreparedEngineExec,
+        request: &EngineExecRequest,
+    ) -> Result<EngineExecOutput, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let command = {
+            let mut state = self.state.lock().expect("fake state");
+            state.consume_boundary()?;
+            let (container_id, command, user) = state
+                .prepared
+                .remove(&prepared.id)
+                .ok_or(EngineApiError::InvalidResponse)?;
+            if container_id != request.container_id
+                || prepared.container_id != request.container_id
+                || prepared.command != request.command
+                || user != request.user
+                || prepared.user != request.user
+            {
+                return Err(EngineApiError::InvalidResponse);
+            }
+            state.calls.push(Call::StartExec(command.clone()));
+            command
+        };
+        if command.get(1).map(String::as_str) == Some("bootstrap-local-client") {
+            let mut state = self.state.lock().expect("fake state");
+            if state.reject_bootstrap {
+                return Ok(EngineExecOutput {
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                    exit_code: 1,
+                });
+            }
+            state.bootstrap_ready = true;
+            if std::mem::take(&mut state.lose_next_bootstrap_response) {
+                return Err(EngineApiError::RequestFailed);
+            }
+            return Ok(EngineExecOutput {
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                exit_code: 0,
+            });
+        }
+        if !self.state.lock().expect("fake state").bootstrap_ready {
+            return Err(EngineApiError::RequestFailed);
+        }
+        let guest_request: GuestRequest =
+            decode_frame(&request.stdin).map_err(|_| EngineApiError::InvalidResponse)?;
+        let block = {
+            let mut state = self.state.lock().expect("fake state");
+            if state.block_next_guest_start {
+                state.block_next_guest_start = false;
+                true
+            } else if matches!(&guest_request, GuestRequest::Exec { .. })
+                && state.block_next_guest_exec
+            {
+                state.block_next_guest_exec = false;
+                true
+            } else {
+                false
+            }
+        };
+        if block {
+            self.guest_exec_blocked.store(true, Ordering::SeqCst);
+            while !self.release_guest_exec.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            self.guest_exec_blocked.store(false, Ordering::SeqCst);
+            self.release_guest_exec.store(false, Ordering::SeqCst);
+            if self.fail_released_guest_exec.swap(false, Ordering::SeqCst) {
+                return Err(EngineApiError::RequestFailed);
+            }
+        }
+        let is_probe = matches!(&guest_request, GuestRequest::Probe { .. });
+        let response = self.guest_response(guest_request)?;
+        if is_probe {
+            let mut state = self.state.lock().expect("fake state");
+            if std::mem::take(&mut state.replace_after_probe) {
+                replace_container(&mut state, &request.container_id)?;
+            }
+        }
+        let stdout = encode_frame(&response).map_err(|_| EngineApiError::InvalidResponse)?;
+        if stdout.len() > request.stdout_limit {
+            return Err(EngineApiError::OutputLimit);
+        }
+        Ok(EngineExecOutput {
+            stdout,
+            stderr: Vec::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+fn find_container_mut<'a>(
+    state: &'a mut FakeState,
+    id: &str,
+) -> Result<&'a mut InspectedContainer, EngineApiError> {
+    state
+        .containers
+        .values_mut()
+        .find(|container| container.id == id)
+        .ok_or(EngineApiError::InvalidResponse)
+}
+
+fn replace_container(state: &mut FakeState, id: &str) -> Result<(), EngineApiError> {
+    let (name, mut replacement) = state
+        .containers
+        .iter()
+        .find(|(_, container)| container.id == id)
+        .map(|(name, container)| (name.clone(), container.clone()))
+        .ok_or(EngineApiError::InvalidResponse)?;
+    let replacement_id = state.object_id();
+    replacement.id = replacement_id.clone();
+    state.containers.insert(name, replacement);
+    if let Some(guest) = state.guest_binaries.remove(id) {
+        state.guest_binaries.insert(replacement_id, guest);
+    }
+    Ok(())
+}
+
+fn guest_archive(bytes: &[u8]) -> Result<Vec<u8>, EngineApiError> {
+    archive_with_files(&[("automata-ci-sandbox-guest", bytes)])
+}
+
+fn two_file_archive(bytes: &[u8]) -> Result<Vec<u8>, EngineApiError> {
+    archive_with_files(&[
+        ("automata-ci-sandbox-guest", bytes),
+        ("foreign", b"collision"),
+    ])
+}
+
+fn archive_with_files(files: &[(&str, &[u8])]) -> Result<Vec<u8>, EngineApiError> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, bytes) in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o555);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        header.set_size(u64::try_from(bytes.len()).map_err(|_| EngineApiError::OutputLimit)?);
+        header
+            .set_path(path)
+            .map_err(|_| EngineApiError::InvalidResponse)?;
+        header.set_cksum();
+        builder
+            .append(&header, *bytes)
+            .map_err(|_| EngineApiError::InvalidResponse)?;
+    }
+    builder
+        .into_inner()
+        .map_err(|_| EngineApiError::InvalidResponse)
+}
+
+fn extract_uploaded_guest(archive: &[u8]) -> Result<Vec<u8>, EngineApiError> {
+    let mut tar = tar::Archive::new(archive);
+    let mut guest = None;
+    for entry in tar.entries().map_err(|_| EngineApiError::InvalidResponse)? {
+        let mut entry = entry.map_err(|_| EngineApiError::InvalidResponse)?;
+        if entry
+            .path()
+            .map_err(|_| EngineApiError::InvalidResponse)?
+            .as_ref()
+            == std::path::Path::new("automata/bin/automata-ci-sandbox-guest")
+        {
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut entry, &mut bytes)
+                .map_err(|_| EngineApiError::InvalidResponse)?;
+            guest = Some(bytes);
+        }
+    }
+    guest.ok_or(EngineApiError::InvalidResponse)
+}
+
+struct Fixture {
+    provider: LocalDockerProvider,
+    engine: Arc<FakeEngine>,
+    installation: Installation,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let installation = Installation::verified(
+            InstallationName::new("test").expect("installation name"),
+            InstallationId::parse_canonical("00000000-0000-4000-8000-000000000001")
+                .expect("canonical test installation ID"),
+        );
+        let engine = Arc::new(FakeEngine::new(&installation));
+        let provider = LocalDockerProvider::with_test_engine(
+            PinnedDockerEngine::for_test(EngineArchitecture::Amd64, engine.clone()),
+            engine.clone(),
+            installation.clone(),
+            guest_image(),
+            GUEST_IMAGE_ID.to_owned(),
+        );
+        Self {
+            provider,
+            engine,
+            installation,
+        }
+    }
+
+    fn reopen_provider(&self) -> LocalDockerProvider {
+        LocalDockerProvider::with_test_engine(
+            PinnedDockerEngine::for_test(EngineArchitecture::Amd64, self.engine.clone()),
+            self.engine.clone(),
+            self.installation.clone(),
+            guest_image(),
+            GUEST_IMAGE_ID.to_owned(),
+        )
+    }
+}
+
+fn inspected_image(image: &ImmutableImage, id: &str) -> InspectedImage {
+    InspectedImage {
+        id: id.to_owned(),
+        repo_digests: vec![image.reference().to_owned()],
+        operating_system: "linux".to_owned(),
+        architecture: "amd64".to_owned(),
+        declared_volumes: Vec::new(),
+        declared_exposed_ports: Vec::new(),
+        has_healthcheck: false,
+        labels: BTreeMap::new(),
+        environment_names: Vec::new(),
+    }
+}
+
+fn job_image() -> ImmutableImage {
+    ImmutableImage::new(format!("registry.example/automata/job@sha256:{JOB_DIGEST}"))
+        .expect("job image")
+}
+
+fn guest_image() -> ImmutableImage {
+    ImmutableImage::new(format!(
+        "registry.example/automata/guest@sha256:{GUEST_DIGEST}"
+    ))
+    .expect("guest image")
+}
+
+fn sandbox_spec() -> SandboxSpec {
+    sandbox_spec_with_resources(ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits"))
+}
+
+fn sandbox_spec_with_resources(resources: ResourceLimits) -> SandboxSpec {
+    sandbox_spec_with_custody_and_resources(
+        SandboxCustody::Job {
+            runner_id: RunnerId::from_uuid(Uuid::from_u128(2)),
+            slot_ordinal: NonZeroU16::new(3).expect("slot"),
+        },
+        resources,
+    )
+}
+
+fn sandbox_spec_with_custody_and_resources(
+    custody: SandboxCustody,
+    resources: ResourceLimits,
+) -> SandboxSpec {
+    let profile = EnvironmentProfile::new(
+        EnvironmentProfileId::new("example.local/linux").expect("profile id"),
+        Sha256Digest::from_str(PROFILE_DIGEST).expect("profile digest"),
+    );
+    let environment = automata_ci_execution::SandboxEnvironment::new(
+        profile,
+        job_image(),
+        ExecutionArgv::new(
+            TargetPath::posix("/bin/sleep").expect("program"),
+            vec!["infinity".to_owned()],
+        )
+        .expect("keepalive"),
+        TargetPath::posix("/workspace").expect("profile workspace"),
+        ExecutionEnvironment::empty(),
+    )
+    .expect("environment");
+    SandboxSpec::new(
+        OperationId::from_uuid(Uuid::from_u128(1)),
+        SandboxGeneration::new(7).expect("generation"),
+        custody,
+        environment,
+        TargetPath::posix("/workspace/repository").expect("workspace"),
+        NetworkPolicy::Disabled,
+        RootFilesystemPolicy::Writable,
+        resources,
+    )
+    .with_privilege(SandboxPrivilegePolicy::Administrator)
+}
+
+fn true_command(spec: &SandboxSpec, operation: u128) -> ExecutionCommand {
+    ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(operation)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command")
+}
+
+#[derive(Clone, Debug)]
+struct ToggleCancellation {
+    cancelled: Arc<AtomicBool>,
+    observations: Arc<AtomicUsize>,
+}
+
+impl ToggleCancellation {
+    fn active() -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            observations: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Cancellation for ToggleCancellation {
+    fn disposition(&self) -> CancellationDisposition {
+        self.observations.fetch_add(1, Ordering::SeqCst);
+        if self.cancelled.load(Ordering::SeqCst) {
+            CancellationDisposition::Terminate
+        } else {
+            CancellationDisposition::Active
+        }
+    }
+}
+
+fn wait_for_test(mut predicate: impl FnMut() -> bool, message: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !predicate() {
+        assert!(Instant::now() < deadline, "{message}");
+        std::thread::yield_now();
+    }
+}
+
+#[test]
+fn provider_advertises_the_attenuated_administrator_user_namespace_boundary() {
+    let fixture = Fixture::new();
+    let capabilities = fixture.provider.capabilities();
+
+    assert!(capabilities.supports(SandboxCapability::Administrator));
+    assert!(capabilities.supports(SandboxCapability::UserNamespace));
+    assert!(!capabilities.supports(SandboxCapability::HostIdentity));
+    assert!(!capabilities.supports(SandboxCapability::HostFilesystem));
+    assert!(!capabilities.supports(SandboxCapability::HostNetwork));
+}
+
+#[tokio::test]
+async fn configured_binding_becomes_verified_only_after_anchor_resolution() {
+    let fixture = Fixture::new();
+    let binding = crate::InstallationBinding::new(
+        fixture.installation.name().clone(),
+        fixture.installation.id(),
+    );
+    assert_eq!(
+        super::engine::resolve_installation_binding(fixture.engine.as_ref(), &binding)
+            .await
+            .expect("matching anchor produces verified installation"),
+        fixture.installation
+    );
+
+    let mismatched = crate::InstallationBinding::new(
+        binding.name().clone(),
+        InstallationId::parse_canonical("00000000-0000-4000-8000-000000000002")
+            .expect("canonical mismatched ID"),
+    );
+    assert_eq!(
+        super::engine::resolve_installation_binding(fixture.engine.as_ref(), &mismatched)
+            .await
+            .expect_err("configuration assertion is not verification")
+            .code(),
+        LocalDockerErrorCode::InvalidIdentityAnchor
+    );
+}
+
+#[test]
+fn daemon_security_option_drift_invalidates_the_pinned_provider() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create before daemon drift");
+    fixture.engine.mutate(|state| {
+        state
+            .facts
+            .security_options
+            .push("name=no-new-privileges".to_owned());
+    });
+
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("changed daemon security options must invalidate the pin");
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+}
+
+#[test]
+fn resource_controller_drift_invalidates_the_provider_before_mutation() {
+    for controller in 0..5 {
+        let fixture = Fixture::new();
+        fixture.engine.mutate(|state| match controller {
+            0 => state.facts.memory_limit = false,
+            1 => state.facts.swap_limit = false,
+            2 => state.facts.cpu_cfs_period = false,
+            3 => state.facts.cpu_cfs_quota = false,
+            4 => state.facts.pids_limit = false,
+            _ => unreachable!(),
+        });
+        let error = fixture
+            .provider
+            .create(&sandbox_spec(), &NeverCancelled)
+            .expect_err("controller drift must invalidate the pin");
+        assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+        assert_eq!(fixture.engine.mutation_count(), 0);
+    }
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn lifecycle_uses_zero_volumes_and_exact_replay_cleanup() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    assert_eq!(record.state(), SandboxState::Running);
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job container");
+    assert_eq!(
+        job.definition.tmpfs,
+        BTreeMap::from([
+            (
+                "/workspace/repository".to_owned(),
+                job_tmpfs_options(256 * 1024 * 1024),
+            ),
+            (
+                LOCAL_CONTROL_DIRECTORY.to_owned(),
+                guest_control_tmpfs_options(),
+            ),
+        ])
+    );
+    assert!(fixture.engine.container(&names.helper).is_none());
+    assert_eq!(
+        fixture.engine.state.lock().expect("state").volumes.len(),
+        1,
+        "the installation anchor is the only volume"
+    );
+    let calls = fixture.engine.calls();
+    let source = calls
+        .iter()
+        .find_map(|call| match call {
+            Call::CreateContainer(definition) if definition.name.ends_with("-guest-source") => {
+                Some(definition)
+            }
+            _ => None,
+        })
+        .expect("guest source definition");
+    assert_eq!(source.entrypoint, LOCAL_DOCKER_GUEST_IMAGE_BINARY);
+    assert!(source.arguments.is_empty());
+    assert!(source.tmpfs.is_empty());
+    assert_eq!(source.user, guest_client_user());
+    assert!(source.read_only_root);
+    assert!(
+        calls
+            .iter()
+            .any(|call| matches!(call, Call::UploadArchive(_)))
+    );
+    assert!(calls.iter().any(|call| matches!(
+        call,
+        Call::CreateExec(command, user)
+            if command == &[LOCAL_DOCKER_SANDBOX_GUEST_BINARY, "bootstrap-local-client"]
+                && user == &guest_seal_user()
+    )));
+    assert!(
+        calls
+            .iter()
+            .all(|call| { !matches!(call, Call::StartContainer(id) if id != &job.id) })
+    );
+    assert!(calls.iter().any(|call| matches!(
+        call,
+        Call::CreateExec(command, user)
+            if command == &[LOCAL_CONTROL_CLIENT, "local-client"]
+                && user == &guest_client_user()
+    )));
+
+    let starts_before = calls
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    let replay = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("exact replay");
+    assert_eq!(replay, record);
+    let starts_after = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    assert_eq!(starts_before, starts_after, "running replay never restarts");
+
+    let reopened = fixture.reopen_provider();
+    let inspection = reopened
+        .inspect(record.handle(), &NeverCancelled)
+        .expect("inspect");
+    assert_eq!(inspection.state(), SandboxState::Running);
+    assert_eq!(inspection.custody(), spec.custody());
+    let endpoint = reopened
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach");
+    let command = ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(10)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command");
+    let output = endpoint.exec(&command, &NeverCancelled).expect("exec");
+    assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+    assert_eq!(output.stdout(), b"ok");
+    let path = TargetPath::posix("/workspace/repository/result.txt").expect("path");
+    endpoint
+        .copy_to(
+            &CopyToRequest::new(
+                OperationId::from_uuid(Uuid::from_u128(11)),
+                path.clone(),
+                b"artifact".to_vec(),
+            )
+            .expect("copy request"),
+            &NeverCancelled,
+        )
+        .expect("copy to");
+    assert_eq!(
+        endpoint
+            .copy_from(
+                &CopyFromRequest::new(OperationId::from_uuid(Uuid::from_u128(12)), path, 64)
+                    .expect("read request"),
+                &NeverCancelled,
+            )
+            .expect("copy from"),
+        b"artifact"
+    );
+    drop(endpoint);
+
+    let destroy = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(13)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+    assert_eq!(
+        reopened
+            .destroy(&destroy, &NeverCancelled)
+            .expect("destroy"),
+        DestroyDisposition::Destroyed
+    );
+    assert_eq!(
+        reopened
+            .destroy(&destroy, &NeverCancelled)
+            .expect("destroy replay"),
+        DestroyDisposition::AlreadyAbsent
+    );
+    assert!(
+        fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .containers
+            .is_empty()
+    );
+}
+
+#[test]
+fn raw_endpoint_duplicate_operation_ids_are_attempted_twice() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach");
+    let request = true_command(&spec, 40);
+    let raw_guest_attempts = || {
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .filter(|call| {
+                matches!(
+                    call,
+                    Call::StartExec(command)
+                        if command == &[LOCAL_CONTROL_CLIENT, "local-client"]
+                )
+            })
+            .count()
+    };
+    let before = raw_guest_attempts();
+
+    endpoint
+        .exec(&request, &NeverCancelled)
+        .expect("first raw attempt");
+    endpoint
+        .exec(&request, &NeverCancelled)
+        .expect("second raw attempt");
+
+    assert_eq!(raw_guest_attempts() - before, 2);
+    fixture
+        .provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::from_uuid(Uuid::from_u128(41)),
+                record.handle().clone(),
+                record.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("destroy");
+}
+
+#[test]
+fn ambiguous_bootstrap_response_stops_and_removes_the_unproven_container() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.lose_next_bootstrap_response = true);
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("ambiguous bootstrap is never accepted");
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert!(fixture.engine.container(&names.job).is_none());
+    let calls = fixture.engine.calls();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(
+                call,
+                Call::CreateExec(command, user)
+                    if command == &[LOCAL_DOCKER_SANDBOX_GUEST_BINARY, "bootstrap-local-client"]
+                        && user == &guest_seal_user()
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn attach_probe_start_failure_stops_exact_job_and_never_restarts_it() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let starts_before = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_start = true);
+    fixture
+        .engine
+        .fail_released_guest_exec
+        .store(true, Ordering::SeqCst);
+
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| fixture.provider.attach(record.handle(), &NeverCancelled));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "attach probe did not reach the controlled start",
+        );
+        fixture
+            .engine
+            .release_guest_exec
+            .store(true, Ordering::SeqCst);
+        call.join()
+            .expect("attach thread")
+            .expect_err("uncertain probe start")
+    });
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert_eq!(
+        fixture.engine.container(&names.job).expect("job").state,
+        EngineContainerState::Exited(137)
+    );
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+    let replay = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("exited job is never restarted");
+    assert_eq!(replay.kind(), ProviderErrorKind::InvalidState);
+    let starts_after = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    assert_eq!(starts_after, starts_before);
+}
+
+#[test]
+fn cancelled_in_flight_attach_probe_stops_exact_job_before_returning() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_start = true);
+    let cancellation = ToggleCancellation::active();
+
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| fixture.provider.attach(record.handle(), &cancellation));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "attach probe did not reach the controlled start",
+        );
+        cancellation.cancel();
+        wait_for_test(
+            || call.is_finished(),
+            "cancelled attach did not stop the exact job within the bound",
+        );
+        call.join()
+            .expect("attach thread")
+            .expect_err("cancelled probe start")
+    });
+    fixture
+        .engine
+        .guest_exec_blocked
+        .store(false, Ordering::SeqCst);
+    assert_eq!(error.kind(), ProviderErrorKind::Cancelled);
+    assert_eq!(
+        fixture.engine.container(&names.job).expect("job").state,
+        EngineContainerState::Exited(137)
+    );
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+}
+
+#[test]
+fn unready_bootstrap_is_destroyed_and_never_adopted_or_retried() {
+    let fixture = Fixture::new();
+    fixture.engine.mutate(|state| state.reject_bootstrap = true);
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("unready broker fails closed");
+    assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+    assert!(fixture.engine.container(&names.job).is_none());
+    let calls = fixture.engine.calls();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| matches!(
+                call,
+                Call::CreateExec(command, user)
+                    if command == &[LOCAL_DOCKER_SANDBOX_GUEST_BINARY, "bootstrap-local-client"]
+                        && user == &guest_seal_user()
+            ))
+            .count(),
+        1
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(_)))
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|call| matches!(call, Call::RemoveContainer(_)))
+    );
+}
+
+#[test]
+fn exited_job_is_never_restarted() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job_id = fixture.engine.container(&names.job).expect("job").id;
+    fixture.engine.mutate(|state| {
+        find_container_mut(state, &job_id).expect("job").state = EngineContainerState::Exited(0);
+    });
+    let starts_before = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job_id))
+        .count();
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("stopped create replay must fail");
+    assert_eq!(error.kind(), ProviderErrorKind::InvalidState);
+    let starts_after = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job_id))
+        .count();
+    assert_eq!(starts_before, starts_after);
+}
+
+#[test]
+fn endpoint_cancellation_is_prechecked_then_kills_only_the_exact_running_container() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("attach");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+
+    let mutations_before_pre_cancel = fixture.engine.mutation_count();
+    let pre_cancelled = ToggleCancellation::active();
+    pre_cancelled.cancel();
+    let error = endpoint
+        .exec(&true_command(&spec, 300), &pre_cancelled)
+        .expect_err("pre-cancelled exec");
+    assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
+    assert_eq!(fixture.engine.mutation_count(), mutations_before_pre_cancel);
+    assert_eq!(
+        fixture.engine.container(&names.job).expect("job").state,
+        EngineContainerState::Running
+    );
+
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_start = true);
+    let starts_before = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    let cancellation = ToggleCancellation::active();
+    let request = true_command(&spec, 301);
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| endpoint.exec(&request, &cancellation));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "endpoint did not reach the controlled guest start",
+        );
+        cancellation.cancel();
+        wait_for_test(
+            || call.is_finished(),
+            "cancelled endpoint did not stop the exact job within the bound",
+        );
+        call.join()
+            .expect("endpoint thread")
+            .expect_err("mid-exec cancellation")
+    });
+    fixture
+        .engine
+        .guest_exec_blocked
+        .store(false, Ordering::SeqCst);
+    assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+    assert_eq!(
+        fixture
+            .engine
+            .container(&names.job)
+            .expect("stopped job")
+            .state,
+        EngineContainerState::Exited(137)
+    );
+    let starts_after = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    assert_eq!(starts_after, starts_before, "cancellation never restarts");
+
+    let replay = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("exited sandbox is not restartable");
+    assert_eq!(replay.kind(), ProviderErrorKind::InvalidState);
+    let final_starts = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    assert_eq!(final_starts, starts_before);
+}
+
+#[test]
+fn queued_endpoint_cancellation_returns_before_holder_release_and_mutates_nothing() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let first = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("first endpoint");
+    let second = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("second endpoint");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let command = |operation| {
+        ExecutionCommand::new(
+            OperationId::from_uuid(Uuid::from_u128(operation)),
+            ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+                .expect("argv"),
+            spec.workspace().clone(),
+            ExecutionEnvironment::empty(),
+            Duration::from_secs(2),
+            1024,
+        )
+        .expect("command")
+    };
+    let first_command = command(302);
+    let second_command = command(303);
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_exec = true);
+    let cancellation = ToggleCancellation::active();
+
+    std::thread::scope(|scope| {
+        let first_call = scope.spawn(|| first.exec(&first_command, &NeverCancelled));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "first endpoint operation did not reach the controlled exec",
+        );
+
+        let queued_cancellation = cancellation.clone();
+        let second_call = scope.spawn(move || second.exec(&second_command, &queued_cancellation));
+        wait_for_test(
+            || cancellation.observations.load(Ordering::SeqCst) > 0,
+            "second endpoint operation did not reach its pre-lock cancellation check",
+        );
+        cancellation.cancel();
+        let mutations_before_release = fixture.engine.mutation_count();
+        wait_for_test(
+            || second_call.is_finished(),
+            "queued endpoint did not return within the cancellation bound",
+        );
+        let queued_error = second_call
+            .join()
+            .expect("second call thread")
+            .expect_err("queued cancellation");
+        assert_eq!(queued_error.kind(), ExecutionErrorKind::Cancelled);
+        assert_eq!(fixture.engine.mutation_count(), mutations_before_release);
+
+        fixture
+            .engine
+            .release_guest_exec
+            .store(true, Ordering::SeqCst);
+        let first_output = first_call
+            .join()
+            .expect("first call thread")
+            .expect("first exec");
+        assert_eq!(first_output.termination(), ExecutionTermination::Exited(0));
+    });
+
+    assert_eq!(
+        fixture
+            .engine
+            .container(&names.job)
+            .expect("running job")
+            .state,
+        EngineContainerState::Running
+    );
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .all(|call| !matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+}
+
+#[test]
+fn queued_provider_cancellation_returns_before_holder_release_and_mutates_nothing() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("endpoint");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let first_command = ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(304)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command");
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_exec = true);
+    let cancellation = ToggleCancellation::active();
+
+    std::thread::scope(|scope| {
+        let first_call = scope.spawn(|| endpoint.exec(&first_command, &NeverCancelled));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "endpoint operation did not reach the controlled exec",
+        );
+
+        let queued_cancellation = cancellation.clone();
+        let provider = &fixture.provider;
+        let handle = record.handle();
+        let provider_call = scope.spawn(move || provider.inspect(handle, &queued_cancellation));
+        wait_for_test(
+            || cancellation.observations.load(Ordering::SeqCst) > 0,
+            "provider operation did not reach cancellation-aware lock acquisition",
+        );
+        cancellation.cancel();
+        let mutations_before_release = fixture.engine.mutation_count();
+        wait_for_test(
+            || provider_call.is_finished(),
+            "queued provider call did not return within the cancellation bound",
+        );
+        let queued_error = provider_call
+            .join()
+            .expect("provider call thread")
+            .expect_err("queued cancellation");
+        assert_eq!(queued_error.kind(), ProviderErrorKind::Cancelled);
+        assert_eq!(fixture.engine.mutation_count(), mutations_before_release);
+
+        fixture
+            .engine
+            .release_guest_exec
+            .store(true, Ordering::SeqCst);
+        let first_output = first_call
+            .join()
+            .expect("endpoint call thread")
+            .expect("first exec");
+        assert_eq!(first_output.termination(), ExecutionTermination::Exited(0));
+    });
+
+    assert_eq!(
+        fixture
+            .engine
+            .container(&names.job)
+            .expect("running job")
+            .state,
+        EngineContainerState::Running
+    );
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .all(|call| !matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+}
+
+#[test]
+fn cancellation_dominates_a_simultaneous_guest_transport_failure_and_stops_exact_job() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("endpoint");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let command = ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(304)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command");
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_exec = true);
+    fixture
+        .engine
+        .fail_released_guest_exec
+        .store(true, Ordering::SeqCst);
+    let cancellation = ToggleCancellation::active();
+
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| endpoint.exec(&command, &cancellation));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "guest transport did not reach the controlled failure",
+        );
+        cancellation.cancel();
+        fixture
+            .engine
+            .release_guest_exec
+            .store(true, Ordering::SeqCst);
+        call.join()
+            .expect("endpoint thread")
+            .expect_err("terminal cancellation dominates transport failure")
+    });
+    assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+    assert_eq!(
+        fixture
+            .engine
+            .container(&names.job)
+            .expect("stopped job")
+            .state,
+        EngineContainerState::Exited(137)
+    );
+}
+
+#[test]
+fn uncertain_guest_transport_failure_stops_exact_job_and_never_restarts_it() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("endpoint");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let starts_before = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    let command = ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(305)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command");
+    fixture
+        .engine
+        .mutate(|state| state.block_next_guest_exec = true);
+    fixture
+        .engine
+        .fail_released_guest_exec
+        .store(true, Ordering::SeqCst);
+
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| endpoint.exec(&command, &NeverCancelled));
+        wait_for_test(
+            || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
+            "guest transport did not reach the controlled failure",
+        );
+        fixture
+            .engine
+            .release_guest_exec
+            .store(true, Ordering::SeqCst);
+        call.join()
+            .expect("endpoint thread")
+            .expect_err("uncertain guest transport failure")
+    });
+    assert_eq!(error.kind(), ExecutionErrorKind::BackendRejected);
+    assert_eq!(
+        fixture.engine.container(&names.job).expect("job").state,
+        EngineContainerState::Exited(137)
+    );
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+
+    let replay = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("exited job is never restarted");
+    assert_eq!(replay.kind(), ProviderErrorKind::InvalidState);
+    let starts_after = fixture
+        .engine
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::StartContainer(id) if id == &job.id))
+        .count();
+    assert_eq!(starts_after, starts_before);
+}
+
+#[test]
+fn cancellation_during_final_custody_reinspection_stops_exact_job() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let endpoint = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect("endpoint");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let cancellation = ToggleCancellation::active();
+    fixture.engine.mutate(|state| {
+        state.cancel_after_boundaries = Some((4, Arc::clone(&cancellation.cancelled)));
+    });
+    let command = ExecutionCommand::new(
+        OperationId::from_uuid(Uuid::from_u128(305)),
+        ExecutionArgv::new(TargetPath::posix("/bin/true").expect("program"), Vec::new())
+            .expect("argv"),
+        spec.workspace().clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("command");
+
+    let error = endpoint
+        .exec(&command, &cancellation)
+        .expect_err("final verification cancellation");
+    assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
+    assert!(
+        fixture
+            .engine
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::KillContainer(id) if id == &job.id))
+    );
+    assert_eq!(
+        fixture
+            .engine
+            .container(&names.job)
+            .expect("stopped job")
+            .state,
+        EngineContainerState::Exited(137)
+    );
+}
+
+#[test]
+fn inherited_image_runtime_defaults_are_rejected_before_mutation() {
+    for inherited_default in 0..3 {
+        let fixture = Fixture::new();
+        fixture.engine.mutate(|state| {
+            let image = state
+                .images
+                .get_mut(job_image().reference())
+                .expect("job image");
+            match inherited_default {
+                0 => image.declared_volumes.push("/data".to_owned()),
+                1 => image.declared_exposed_ports.push("8080/tcp".to_owned()),
+                2 => image.has_healthcheck = true,
+                _ => unreachable!(),
+            }
+        });
+        let error = fixture
+            .provider
+            .create(&sandbox_spec(), &NeverCancelled)
+            .expect_err("image default rejection");
+        assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+        assert_eq!(fixture.engine.mutation_count(), 0);
+    }
+
+    let fixture = Fixture::new();
+    let mut guest = inspected_image(&guest_image(), GUEST_IMAGE_ID);
+    guest.has_healthcheck = true;
+    assert_eq!(
+        verify_image(&fixture.provider.inner.pinned, &guest_image(), &guest),
+        Err(LocalDockerErrorCode::ImageMismatch),
+        "provider connection uses the same pre-mutation guest-image gate"
+    );
+}
+
+#[test]
+fn daemon_default_ulimit_normalization_fails_closed_and_custody_cleanup_removes_it() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.inject_daemon_default_ulimit_on_next_create = true);
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("daemon-normalized ulimit must fail exact inspection");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    let helper = fixture
+        .engine
+        .container(&names.helper)
+        .expect("rejected helper still has recoverable custody");
+    assert!(!helper.isolated);
+
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(170)),
+        error
+            .recovery_handle()
+            .expect("post-create failure carries custody handle")
+            .clone(),
+        spec.generation(),
+        spec.custody(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&request, &NeverCancelled)
+            .expect("custody-only cleanup"),
+        DestroyDisposition::Destroyed
+    );
+    assert!(fixture.engine.container(&names.helper).is_none());
+    assert!(fixture.engine.container(&helper.id).is_none());
+}
+
+#[test]
+fn custody_cleanup_survives_image_loss_runtime_drift_and_invalid_state() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job_id = fixture.engine.container(&names.job).expect("job").id;
+    fixture.engine.mutate(|state| {
+        state.images.remove(job_image().reference());
+        let job = state.containers.get_mut(&names.job).expect("job");
+        job.isolated = false;
+        job.state = EngineContainerState::Invalid;
+        job.definition.memory_bytes = 0;
+    });
+
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(171)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&request, &NeverCancelled)
+            .expect("custody does not depend on executable state or live image"),
+        DestroyDisposition::Destroyed
+    );
+    assert!(fixture.engine.container(&names.job).is_none());
+    assert!(fixture.engine.container(&job_id).is_none());
+}
+
+#[test]
+fn custody_cleanup_rejects_noncanonical_or_extra_managed_labels_before_mutation() {
+    for tamper in 0..3 {
+        let fixture = Fixture::new();
+        let spec = sandbox_spec();
+        let record = fixture
+            .provider
+            .create(&spec, &NeverCancelled)
+            .expect("create");
+        let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+        fixture.engine.mutate(|state| {
+            let labels = &mut state
+                .containers
+                .get_mut(&names.job)
+                .expect("job")
+                .definition
+                .labels;
+            match tamper {
+                0 => {
+                    labels.remove(LABEL_SPEC_DIGEST);
+                }
+                1 => {
+                    labels.insert(LABEL_SPEC_DIGEST.to_owned(), "not-a-digest".to_owned());
+                }
+                2 => {
+                    labels.insert("io.automata.local.unreviewed".to_owned(), "true".to_owned());
+                }
+                _ => unreachable!(),
+            }
+        });
+        let mutations = fixture.engine.mutation_count();
+        let request = DestroySandbox::new(
+            OperationId::from_uuid(Uuid::from_u128(172)),
+            record.handle().clone(),
+            record.generation(),
+            spec.custody(),
+        );
+        let error = fixture
+            .provider
+            .destroy(&request, &NeverCancelled)
+            .expect_err("invalid custody labels cannot authorize deletion");
+        assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+        assert_eq!(fixture.engine.mutation_count(), mutations);
+        assert!(fixture.engine.container(&names.job).is_some());
+    }
+}
+
+#[test]
+fn cleanup_proves_both_the_deterministic_name_and_original_id_absent() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job_id = fixture.engine.container(&names.job).expect("job").id;
+    fixture
+        .engine
+        .mutate(|state| state.rename_removed_container_instead = true);
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(173)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+    let error = fixture
+        .provider
+        .destroy(&request, &NeverCancelled)
+        .expect_err("name absence alone cannot prove deletion");
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert!(fixture.engine.container(&names.job).is_none());
+    assert!(
+        fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .containers
+            .values()
+            .any(|container| container.id == job_id)
+    );
+}
+
+#[test]
+fn foreign_name_collision_fails_closed_without_mutation() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    fixture.engine.mutate(|state| {
+        let id = state.object_id();
+        state.containers.insert(
+            names.job.clone(),
+            InspectedContainer {
+                id,
+                image_id: JOB_IMAGE_ID.to_owned(),
+                definition: ContainerDefinition {
+                    name: names.job,
+                    image: job_image().reference().to_owned(),
+                    entrypoint: "/bin/false".to_owned(),
+                    arguments: Vec::new(),
+                    labels: BTreeMap::new(),
+                    environment: Vec::new(),
+                    tmpfs: BTreeMap::new(),
+                    working_directory: "/".to_owned(),
+                    user: "0:0".to_owned(),
+                    read_only_root: false,
+                    memory_bytes: 1,
+                    nano_cpus: 1,
+                    pids_limit: 1,
+                },
+                state: EngineContainerState::Created,
+                isolated: false,
+            },
+        );
+    });
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("foreign collision");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn adversarial_guest_source_archive_fails_before_job_creation() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.invalid_guest_source_archive = true);
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("multi-entry guest source archive");
+    assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+    assert!(!fixture.engine.calls().iter().any(|call| {
+        matches!(call, Call::CreateContainer(definition) if definition.name.ends_with("-job"))
+    }));
+}
+
+#[test]
+fn name_replacement_after_archive_upload_is_never_adopted_or_started() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.replace_after_upload = true);
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("post-upload name replacement");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    let replacement = fixture.engine.container(&names.job).expect("replacement");
+    let calls = fixture.engine.calls();
+    let uploaded_id = calls
+        .iter()
+        .find_map(|call| match call {
+            Call::UploadArchive(id) => Some(id),
+            _ => None,
+        })
+        .expect("upload call");
+    assert_ne!(&replacement.id, uploaded_id);
+    assert!(
+        !calls
+            .iter()
+            .any(|call| matches!(call, Call::StartContainer(_)))
+    );
+}
+
+#[test]
+fn name_replacement_after_start_is_never_adopted_or_bootstrapped() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.replace_after_start = true);
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("post-start name replacement");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    let replacement = fixture.engine.container(&names.job).expect("replacement");
+    let calls = fixture.engine.calls();
+    let started_id = calls
+        .iter()
+        .find_map(|call| match call {
+            Call::StartContainer(id) => Some(id),
+            _ => None,
+        })
+        .expect("start call");
+    assert_ne!(&replacement.id, started_id);
+    assert!(
+        !calls
+            .iter()
+            .any(|call| matches!(call, Call::CreateExec(_, _)))
+    );
+}
+
+#[test]
+fn name_replacement_after_fresh_readiness_probe_is_not_reported_running() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.replace_after_probe = true);
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("post-readiness replacement");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+}
+
+#[test]
+fn name_replacement_after_recovery_probe_is_not_adopted() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("initial create");
+    fixture
+        .engine
+        .mutate(|state| state.replace_after_probe = true);
+    let error = fixture
+        .reopen_provider()
+        .create(&spec, &NeverCancelled)
+        .expect_err("post-recovery-probe replacement");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+}
+
+#[test]
+fn name_replacement_after_attach_probe_is_not_attached() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    fixture
+        .engine
+        .mutate(|state| state.replace_after_probe = true);
+    let error = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect_err("post-attach-probe replacement");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+}
+
+#[test]
+fn name_replacement_during_final_inspect_boundary_is_not_reported() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    fixture
+        .engine
+        .mutate(|state| state.replace_job_after_boundaries = Some(2));
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("final-boundary replacement must invalidate the snapshot");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+}
+
+#[test]
+fn destroy_rejects_a_helper_recreated_while_the_job_is_removed() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    let mut base_labels = job.definition.labels;
+    base_labels.remove(LABEL_RESOURCE_KIND);
+    let definition = helper_definition(
+        &names,
+        guest_image().reference(),
+        &BTreeMap::new(),
+        &[],
+        &base_labels,
+    );
+    let original_helper_id = fixture.engine.state.lock().expect("state").object_id();
+    fixture.engine.mutate(|state| {
+        state.containers.insert(
+            names.helper.clone(),
+            InspectedContainer {
+                id: original_helper_id.clone(),
+                image_id: GUEST_IMAGE_ID.to_owned(),
+                definition,
+                state: EngineContainerState::Created,
+                isolated: true,
+            },
+        );
+        state.recreate_first_removed_after_following_remove = true;
+    });
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(200)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+    let error = fixture
+        .provider
+        .destroy(&request, &NeverCancelled)
+        .expect_err("recreated deterministic helper name must prevent success");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert!(fixture.engine.container(&names.job).is_none());
+    let recreated = fixture
+        .engine
+        .container(&names.helper)
+        .expect("recreated helper remains foreign to cleanup success");
+    assert_ne!(recreated.id, original_helper_id);
+}
+
+#[test]
+fn exact_realized_configuration_is_rechecked_on_attach() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    fixture.engine.mutate(|state| {
+        state.containers.get_mut(&names.job).expect("job").isolated = false;
+    });
+    let error = fixture
+        .provider
+        .attach(record.handle(), &NeverCancelled)
+        .expect_err("tampered isolation");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+}
+
+#[test]
+fn undersized_resource_limits_are_rejected_before_engine_access() {
+    for resources in [
+        ResourceLimits::new(
+            MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES - 1,
+            1_000,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS,
+        )
+        .expect("low memory resources"),
+        ResourceLimits::new(
+            MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS - 1,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS,
+        )
+        .expect("low CPU resources"),
+        ResourceLimits::new(
+            MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS - 1,
+        )
+        .expect("low PID resources"),
+    ] {
+        let fixture = Fixture::new();
+        let accesses = fixture.engine.access_count();
+        let error = fixture
+            .provider
+            .create(&sandbox_spec_with_resources(resources), &NeverCancelled)
+            .expect_err("provider infrastructure minimum");
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+        assert_eq!(fixture.engine.access_count(), accesses);
+        assert_eq!(fixture.engine.mutation_count(), 0);
+    }
+}
+
+#[test]
+fn exact_minimum_resource_limits_are_realized_without_hidden_headroom() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec_with_resources(
+        ResourceLimits::new(
+            MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS,
+            MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS,
+        )
+        .expect("minimum resources"),
+    );
+    fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("minimum resources are supported");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    let job = fixture.engine.container(&names.job).expect("job");
+    assert_eq!(
+        job.definition.memory_bytes,
+        i64::try_from(MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES).expect("minimum fits i64")
+    );
+    assert_eq!(
+        job.definition.nano_cpus,
+        i64::from(MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS) * 1_000_000
+    );
+    assert_eq!(
+        job.definition.pids_limit,
+        i64::from(MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS)
+    );
+}
+
+#[test]
+fn unsupported_spec_shape_is_rejected_before_engine_access() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec().with_privilege(SandboxPrivilegePolicy::Unprivileged);
+    let accesses = fixture.engine.access_count();
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("unsupported privilege");
+    assert_eq!(error.kind(), ProviderErrorKind::UnsupportedCapability);
+    assert_eq!(fixture.engine.access_count(), accesses);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn archive_builder_is_deterministic_and_contains_only_owned_paths() {
+    let first = sandbox_archive("/workspace/repository", FAKE_GUEST).expect("archive");
+    let second = sandbox_archive("/workspace/repository", FAKE_GUEST).expect("archive");
+    assert_eq!(first, second);
+    assert_eq!(extract_uploaded_guest(&first).expect("guest"), FAKE_GUEST);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires the fixed relay, an existing installation anchor, and digest-pinned local images"]
+#[allow(clippy::too_many_lines)]
+async fn fixed_relay_live_shell_and_javascript_conformance() {
+    let installation_name = InstallationName::new(
+        std::env::var("AUTOMATA_LOCAL_DOCKER_INSTALLATION")
+            .expect("set the existing test installation name"),
+    )
+    .expect("installation name");
+    let installation_id = InstallationId::parse_canonical(
+        &std::env::var("AUTOMATA_LOCAL_DOCKER_INSTALLATION_ID")
+            .expect("set the existing installation UUID"),
+    )
+    .expect("canonical installation UUID");
+    let job_image = ImmutableImage::new(
+        std::env::var("AUTOMATA_LOCAL_DOCKER_JOB_IMAGE")
+            .expect("set a present digest-pinned Linux job image"),
+    )
+    .expect("job image");
+    let guest_image = ImmutableImage::new(
+        std::env::var("AUTOMATA_LOCAL_DOCKER_GUEST_IMAGE")
+            .expect("set a present digest-pinned sandbox-guest image"),
+    )
+    .expect("guest image");
+    assert!(
+        std::path::Path::new(super::engine::LOCAL_DOCKER_RELAY_SOCKET).exists(),
+        "install the explicit fixed Engine relay fixture"
+    );
+    let installation = crate::InstallationBinding::new(installation_name, installation_id);
+    let runner_architecture = match normalize_architecture(std::env::consts::ARCH)
+        .expect("the live fixture requires an amd64 or arm64 runner")
+    {
+        EngineArchitecture::Amd64 => automata_ci_core::Architecture::X86_64,
+        EngineArchitecture::Arm64 => automata_ci_core::Architecture::Aarch64,
+    };
+    let provider = LocalDockerProvider::connect(installation, guest_image, &runner_architecture)
+        .await
+        .expect("local Docker provider");
+    let profile = EnvironmentProfile::new(
+        EnvironmentProfileId::new("automata.local/live-linux").expect("profile id"),
+        Sha256Digest::from_str(PROFILE_DIGEST).expect("profile digest"),
+    );
+    let environment = automata_ci_execution::SandboxEnvironment::new(
+        profile,
+        job_image,
+        ExecutionArgv::new(
+            TargetPath::posix("/bin/sleep").expect("keepalive"),
+            vec!["infinity".to_owned()],
+        )
+        .expect("keepalive argv"),
+        TargetPath::posix("/workspace").expect("profile workspace"),
+        ExecutionEnvironment::empty(),
+    )
+    .expect("environment");
+    let generation = SandboxGeneration::new(1).expect("generation");
+    let spec = SandboxSpec::new(
+        OperationId::new(),
+        generation,
+        SandboxCustody::Job {
+            runner_id: RunnerId::new(),
+            slot_ordinal: NonZeroU16::new(1).expect("slot"),
+        },
+        environment,
+        TargetPath::posix("/workspace/repository").expect("workspace"),
+        NetworkPolicy::Disabled,
+        RootFilesystemPolicy::Writable,
+        ResourceLimits::new(512 * 1024 * 1024, 1_000, 128).expect("resources"),
+    )
+    .with_privilege(SandboxPrivilegePolicy::Administrator);
+    let record = match provider.create(&spec, &NeverCancelled) {
+        Ok(record) => record,
+        Err(error) => {
+            if let Some(handle) = error.recovery_handle().cloned()
+                && let Err(cleanup_error) = provider.destroy(
+                    &DestroySandbox::new(OperationId::new(), handle, generation, spec.custody()),
+                    &NeverCancelled,
+                )
+            {
+                panic!("create live sandbox: {error}; recovery cleanup failed: {cleanup_error}");
+            }
+            panic!("create live sandbox: {error}");
+        }
+    };
+    let run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        || -> Result<(), Box<dyn std::error::Error>> {
+            let endpoint = provider.attach(record.handle(), &NeverCancelled)?;
+            let attenuated_identity = ExecutionCommand::new(
+            OperationId::new(),
+            ExecutionArgv::new(
+                TargetPath::posix("/bin/sh")?,
+                vec![
+                    "-ceu".to_owned(),
+                    concat!(
+                        "test \"$(id -u):$(id -g)\" = 0:0; ",
+                        "grep -Eq '^Uid:[[:space:]]+0[[:space:]]+0[[:space:]]+0[[:space:]]+0$' /proc/self/status; ",
+                        "grep -Eq '^Gid:[[:space:]]+0[[:space:]]+0[[:space:]]+0[[:space:]]+0$' /proc/self/status; ",
+                        "grep -Eq '^Groups:[[:space:]]+0[[:space:]]*$' /proc/self/status; ",
+                        "for field in CapInh CapPrm CapEff CapBnd CapAmb; do ",
+                        "grep -Eq \"^${field}:[[:space:]]+0000000000000000$\" /proc/self/status; done; ",
+                        "grep -Eq '^NoNewPrivs:[[:space:]]+1$' /proc/self/status; ",
+                        "grep -Eq '^Seccomp:[[:space:]]+2$' /proc/self/status; ",
+                        "for map in /proc/self/uid_map /proc/self/gid_map; do ",
+                        "test \"$(wc -l < \"${map}\")\" -eq 1; set -- $(cat \"${map}\"); ",
+                        "test \"$#\" -eq 3; test \"$1\" -eq 0; test \"$2\" -gt 0; ",
+                        "test \"$3\" -gt 65533; done; printf attenuated-live"
+                    )
+                    .to_owned(),
+                ],
+            )?,
+            spec.workspace().clone(),
+            ExecutionEnvironment::empty(),
+            Duration::from_secs(10),
+            64 * 1024,
+        )?;
+            let output = endpoint.exec(&attenuated_identity, &NeverCancelled)?;
+            assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+            assert_eq!(output.stdout(), b"attenuated-live");
+
+            for (program, arguments, expected) in [
+                (
+                    "/bin/bash",
+                    vec!["-c".to_owned(), "printf shell-live".to_owned()],
+                    b"shell-live".as_slice(),
+                ),
+                (
+                    "/usr/bin/node",
+                    vec![
+                        "-e".to_owned(),
+                        "process.stdout.write('node-live')".to_owned(),
+                    ],
+                    b"node-live".as_slice(),
+                ),
+            ] {
+                let command = ExecutionCommand::new(
+                    OperationId::new(),
+                    ExecutionArgv::new(TargetPath::posix(program)?, arguments)?,
+                    spec.workspace().clone(),
+                    ExecutionEnvironment::empty(),
+                    Duration::from_secs(10),
+                    64 * 1024,
+                )?;
+                let output = endpoint.exec(&command, &NeverCancelled)?;
+                assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+                assert_eq!(output.stdout(), expected);
+            }
+
+            let protected_envelope = ExecutionCommand::new(
+                OperationId::new(),
+                ExecutionArgv::new(
+                    TargetPath::posix("/bin/bash")?,
+                    vec![
+                        "-c".to_owned(),
+                        format!(
+                            "set -eu; test \"$(stat -c '%u:%g:%a' {directory})\" = '{seal_uid}:{gid}:{sealed_mode:o}'; ! dd if={client} of=/dev/null status=none 2>/dev/null; ! chmod 0700 {client} 2>/dev/null; ! sh -c 'printf tamper > {client}' 2>/dev/null; ! readlink /proc/1/exe >/dev/null 2>&1; kill -KILL 1; sleep 0.1; test -d /proc/1; printf protected-live",
+                            directory = LOCAL_CONTROL_DIRECTORY,
+                            seal_uid = LOCAL_CONTROL_SEAL_UID,
+                            gid = LOCAL_CONTROL_GID,
+                            sealed_mode =
+                                automata_ci_sandbox_guest::LOCAL_CONTROL_DIRECTORY_MODE_SEALED,
+                            client = LOCAL_CONTROL_CLIENT,
+                        ),
+                    ],
+                )?,
+                spec.workspace().clone(),
+                ExecutionEnvironment::empty(),
+                Duration::from_secs(10),
+                64 * 1024,
+            )?;
+            let output = endpoint.exec(&protected_envelope, &NeverCancelled)?;
+            assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+            assert_eq!(output.stdout(), b"protected-live");
+
+            let direct_broker = ExecutionCommand::new(
+                OperationId::new(),
+                ExecutionArgv::new(
+                    TargetPath::posix("/usr/bin/node")?,
+                    vec![
+                    "-e".to_owned(),
+                    concat!(
+                        "const net=require('net');",
+                        "const body=Buffer.from(JSON.stringify({operation:'probe',",
+                        "protocol:3,operation_id:'untrusted-root-direct-probe'}));",
+                        "const frame=Buffer.alloc(4+body.length);",
+                        "frame.writeUInt32BE(body.length);body.copy(frame,4);",
+                        "const socket=net.createConnection({path:'\\0automata-ci-control-v1'});",
+                        "let received=0;socket.on('connect',()=>socket.end(frame));",
+                        "socket.on('data',chunk=>received+=chunk.length);",
+                        "socket.on('close',()=>process.exit(received===0?0:1));",
+                        "socket.on('error',()=>process.exit(0));",
+                        "setTimeout(()=>process.exit(1),1000)"
+                    )
+                    .to_owned(),
+                ],
+                )?,
+                spec.workspace().clone(),
+                ExecutionEnvironment::empty(),
+                Duration::from_secs(5),
+                64 * 1024,
+            )?;
+            assert_eq!(
+                endpoint
+                    .exec(&direct_broker, &NeverCancelled)?
+                    .termination(),
+                ExecutionTermination::Exited(0),
+                "capless root must not receive a broker response"
+            );
+
+            let forbidden_bootstrap = ExecutionCommand::new(
+                OperationId::new(),
+                ExecutionArgv::new(
+                    TargetPath::posix(LOCAL_DOCKER_SANDBOX_GUEST_BINARY)?,
+                    vec!["bootstrap-local-client".to_owned()],
+                )?,
+                spec.workspace().clone(),
+                ExecutionEnvironment::empty(),
+                Duration::from_secs(5),
+                64 * 1024,
+            )?;
+            assert_eq!(
+                endpoint
+                    .exec(&forbidden_bootstrap, &NeverCancelled)?
+                    .termination(),
+                ExecutionTermination::Exited(1),
+                "capless root cannot reopen the one-shot sealer"
+            );
+
+            let after_signal = ExecutionCommand::new(
+                OperationId::new(),
+                ExecutionArgv::new(
+                    TargetPath::posix("/bin/bash")?,
+                    vec!["-c".to_owned(), "printf broker-still-ready".to_owned()],
+                )?,
+                spec.workspace().clone(),
+                ExecutionEnvironment::empty(),
+                Duration::from_secs(5),
+                64 * 1024,
+            )?;
+            let output = endpoint.exec(&after_signal, &NeverCancelled)?;
+            assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+            assert_eq!(output.stdout(), b"broker-still-ready");
+            Ok(())
+        },
+    ));
+    let cleanup = provider.destroy(
+        &DestroySandbox::new(
+            OperationId::new(),
+            record.handle().clone(),
+            generation,
+            spec.custody(),
+        ),
+        &NeverCancelled,
+    );
+    match run {
+        Ok(run) => {
+            cleanup.expect("destroy exact live sandbox");
+            run.expect("live shell and JavaScript conformance");
+        }
+        Err(payload) => {
+            if let Err(error) = cleanup {
+                eprintln!("live fixture cleanup after panic failed: {error}");
+            }
+            std::panic::resume_unwind(payload);
+        }
+    }
+}

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -1933,6 +1933,38 @@ mod tests {
     }
 
     #[test]
+    fn fixed_relay_local_docker_capabilities_reach_linux_profile_admission() {
+        let signals = ProbeCancellation::default();
+        let mut provider = FakeProvider::new(FakeBehavior::Happy, signals.clone());
+        provider.capabilities = ProviderCapabilities::new([
+            SandboxCapability::WholeJob,
+            SandboxCapability::Attach,
+            SandboxCapability::Inspect,
+            SandboxCapability::Exec,
+            SandboxCapability::CopyTo,
+            SandboxCapability::CopyFrom,
+            SandboxCapability::EnvironmentInjection,
+            SandboxCapability::NetworkDisabled,
+            SandboxCapability::WritableRootFilesystem,
+            SandboxCapability::Administrator,
+            SandboxCapability::UserNamespace,
+            SandboxCapability::ResourceLimits,
+            SandboxCapability::ProcessLimits,
+        ])
+        .expect("exact LocalDocker provider capabilities");
+        let (profile, sandbox) = environment("local-docker-tools", profile_digest(0x69), 0x7a);
+        let profiles = BTreeMap::from([(profile, sandbox)]);
+        let mut policy = linux_tool_policy();
+        policy.network = NetworkPolicy::Disabled;
+
+        assert_eq!(
+            admit_environment_profiles(&provider, runner_id(), &profiles, policy, &signals,),
+            Ok(ProfileAdmissionOutcome::Admitted)
+        );
+        assert!(matches!(provider.calls().first(), Some(Call::Create(_))));
+    }
+
+    #[test]
     fn windows_python_probe_is_present_only_when_the_tool_is_configured() {
         let resources = ResourceLimits::new(256 * 1024 * 1024, 1_000, 16).expect("resources");
         let without_python = ProfileAdmissionPolicy::new(

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -4,6 +4,7 @@ use automata_ci_core::{
     Architecture, ContainerFeature, OperatingSystem, ResourceCapacity, RunnerFeature,
     RunnerRequirements, SandboxFeature, Sha256Digest,
 };
+use automata_ci_execution::SandboxPrivilegePolicy;
 use automata_ci_runner::product::{
     RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION, RunnerProductConfig, RunnerProductConfigError,
 };
@@ -1247,6 +1248,17 @@ fn local_docker_configuration_is_closed_current_only_and_mutually_exclusive() {
     );
     assert!(local.guest_image().reference().ends_with(&"ab".repeat(32)));
     assert!(configured.inventory().containers().features().is_empty());
+    assert_eq!(
+        configured.executor().privilege(),
+        SandboxPrivilegePolicy::Administrator
+    );
+    assert!(
+        configured
+            .inventory()
+            .sandbox()
+            .features()
+            .contains(&SandboxFeature::PRIVILEGED_USER)
+    );
 
     for field in ["endpoint", "socket", "docker_host"] {
         let mut open = value.clone();
@@ -1269,6 +1281,14 @@ fn local_docker_configuration_is_closed_current_only_and_mutually_exclusive() {
     egress["executor"]["network"] = serde_json::json!("private_egress");
     assert_eq!(
         parse_value(&egress).expect_err("local Docker is network-disabled only"),
+        RunnerProductConfigError::InvalidExecutor
+    );
+
+    let mut unprivileged = value.clone();
+    unprivileged["executor"]["privilege"] = serde_json::json!("unprivileged");
+    assert_eq!(
+        parse_value(&unprivileged)
+            .expect_err("local Docker uses the attenuated confined administrator identity"),
         RunnerProductConfigError::InvalidExecutor
     );
 

--- a/crates/automata-ci-sandbox-guest/src/lib.rs
+++ b/crates/automata-ci-sandbox-guest/src/lib.rs
@@ -2437,6 +2437,36 @@ mod tests {
         assert_eq!(immediate_rejection(&current), None);
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn local_id_map_is_one_canonical_nonroot_range_covering_every_control_identity() {
+        for valid in ["         0     231072      65534\n", "0 4294901762 65534\n"] {
+            assert!(valid_local_id_map(valid), "valid map: {valid:?}");
+        }
+
+        for invalid in [
+            "",
+            "0 231072 65534",
+            "0 0 65534\n",
+            "1 231072 65534\n",
+            "0 231072 65533\n",
+            "0 4294901763 65534\n",
+            "0 231072 65534 trailing\n",
+            "0 231072 65534\n1 296606 1\n",
+            "0 1000 1\n1 100000 65536\n",
+            "00 231072 65534\n",
+            "0 0231072 65534\n",
+            "0 231072 +65534\n",
+            "0 231072 -1\n",
+        ] {
+            assert!(!valid_local_id_map(invalid), "invalid map: {invalid:?}");
+        }
+        assert!(!valid_local_id_map(&format!(
+            "0 231072 {}\n",
+            "1".repeat(MAX_LOCAL_ID_MAP_BYTES)
+        )));
+    }
+
     #[cfg(any(unix, windows))]
     #[tokio::test]
     async fn write_file_creates_the_attempt_scoped_parent_directory() {

--- a/docs/development.md
+++ b/docs/development.md
@@ -336,6 +336,31 @@ GitHub token. It never admits, schedules, or runs work, contacts GitHub, or
 creates a Check Run; local admission and execution remain later roadmap
 checkpoints.
 
+The ignored fixed-relay Local Docker conformance fixture requires an existing
+installation anchor, the explicit `/run/automata-engine/docker.sock` relay, and
+already-present digest-pinned Linux job and sandbox-guest images. The relay must
+front rootful Docker with daemon-default user-namespace remapping enabled; the
+built-in seccomp and private-cgroup-namespace security options must be reported,
+AppArmor and SELinux must be disabled, every required resource controller must
+be available, and daemon `default-ulimits` must be empty. Docker v1.44 cannot
+preflight the last setting; the fixture therefore verifies the realized empty
+ulimit contract and custody-only rollback. Rootless Docker and multi-range
+UID/GID maps are intentionally rejected. The
+fixture verifies the job's nonzero host mappings, attenuated UID-0 identity and
+empty Linux capability sets, shell and JavaScript execution, and the protected
+tmpfs client. It then removes only the revalidated sibling containers it
+created:
+
+```console
+AUTOMATA_LOCAL_DOCKER_INSTALLATION='evaluation' \
+AUTOMATA_LOCAL_DOCKER_INSTALLATION_ID='6e561f8b-9098-418d-b573-d82f5c73006e' \
+AUTOMATA_LOCAL_DOCKER_JOB_IMAGE='registry.example/automata/job@sha256:<64-lowercase-hex>' \
+AUTOMATA_LOCAL_DOCKER_GUEST_IMAGE='registry.example/automata/sandbox-guest@sha256:<64-lowercase-hex>' \
+cargo test --locked -p automata-ci-local \
+  'local_docker::tests::fixed_relay_live_shell_and_javascript_conformance' \
+  -- --ignored --exact --nocapture
+```
+
 ## External integration-test services
 
 Database and object-storage integration lanes use services managed outside the


### PR DESCRIPTION
## Summary

- add stateful and adversarial transport, provider, custody, cancellation, normalization, and cleanup coverage
- make the fake engine model raw attempt-once endpoint behavior, including duplicate operation IDs
- add opt-in live fixed-relay lifecycle verification with panic-safe exact cleanup
- keep production behavior unchanged; production-file additions in this layer are test-only

## Verification

- independent strict exact-range review: CLEAN
- workspace all-target check
- strict affected-package all-target/all-feature Clippy
- warning-denied rustdoc
- LocalDocker: 125 passed, 2 intentional live ignores
- guest: 13 unit and 16 integration tests passed
- runner: 132 passed, 1 intentional ignore; integration: 103 passed
