### PR TITLE
fix(ci): exclude Cargo build output from coverage

### DIFF
--- a/scripts/ci/rust-coverage-policy.json
+++ b/scripts/ci/rust-coverage-policy.json
@@ -4,7 +4,7 @@
   "llvm_coverage_export_version": "3.1.0",
   "report_scope": {
     "description": "Compiled production source in the ordinary Rust workspace set",
-    "ignore_filename_regex": "(/automata-ci-ui-renderer/|/generated/|generated_assets\\.rs$|generated_contract\\.rs$)",
+    "ignore_filename_regex": "(/target/|/automata-ci-ui-renderer/|/generated/|generated_assets\\.rs$|generated_contract\\.rs$)",
     "exclusions": [
       {
         "name": "cargo-default-nonproduction-source",
@@ -17,6 +17,10 @@
       {
         "name": "generated-rust",
         "description": "Generated protobuf, contract, and embedded-asset Rust"
+      },
+      {
+        "name": "cargo-build-output",
+        "description": "Generated Rust emitted beneath Cargo's isolated target directory"
       }
     ]
   },

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -603,6 +603,16 @@ elif arguments and arguments[0] == "test":
 elif arguments and arguments[0] == "run":
     pass
 elif arguments[:2] == ["llvm-cov", "report"]:
+    ignore_argument = next(
+        (
+            argument
+            for argument in arguments
+            if argument.startswith("--ignore-filename-regex=")
+        ),
+        None,
+    )
+    if ignore_argument is None or "/target/" not in ignore_argument:
+        raise SystemExit(98)
     output = Path(arguments[arguments.index("--output-path") + 1])
     fixture = (
         os.environ["AUTOMATA_COVERAGE_JSON_FIXTURE"]


### PR DESCRIPTION
## Summary

- exclude Cargo target-directory generated Rust before LLVM coverage report validation
- retain fail-closed validation for unexpected non-`crates/` sources
- require the production coverage runner contract to pass the `/target/` exclusion to every report

## Production evidence

Current `main` coverage delivered 6,492 public log lines and all Rust tests passed, then failed only on generated protobuf output at `target/llvm-cov-target/.../out/automata.management.v1.rs`.

## Validation

- `python3 scripts/ci/tests/rust-coverage.test.py`
- `git diff --check`