### PR TITLE
feat(results): add closed private proxy protocol

### DIFF
--- a/crates/automata-ci-results-github/README.md
+++ b/crates/automata-ci-results-github/README.md
@@ -113,10 +113,22 @@ runner protects the bundle before acknowledging custody and injects it into
 that job only; there is no runner- or fleet-wide Results credential.
 
 Production uses an HTTPS public Results endpoint. Development may use literal
-loopback HTTP or one exact trusted private bind and host mapping, such as a
-Podman bridge gateway with `host.containers.internal`. Wildcard and public
-plaintext binds are rejected. The Results router stays on its dedicated
+loopback HTTP. `PrivateNetworkResultsEndpoint` represents the narrower closed
+container-network case: one exact private IPv4 listener on port 8081 paired
+with the asserted job-visible HTTP origin. Wildcard, loopback, public, IPv6,
+and other-port private binds are rejected. A LocalDocker installation will use
+`http://results.automata.invalid:8081/`, with the listener bound only to the
+Results-transit interface; there is no host publish, control-network listener,
+or TLS/CA exception inside that internal isolated topology. Production HTTPS
+and Web PKI policy are unchanged. The Results router stays on its dedicated
 listener.
+
+That listener/transport type is only a composition prerequisite. The current
+`GithubResultsRuntimeAuthorityIssuer` still requires accepted GitHub repository
+authority and has not been broadened for a local snapshot. Until the separately
+reviewed `LocalSnapshot` admission supplies real repository/cache authority,
+local composition must not inject `ACTIONS_RESULTS_URL`, cache URLs, or a
+runtime token and must not claim artifact or cache availability.
 
 ## Evidence
 

--- a/crates/automata-ci-results-github/src/lib.rs
+++ b/crates/automata-ci-results-github/src/lib.rs
@@ -72,5 +72,6 @@ pub use service::{
 };
 pub use storage_observer::{ObservedResultsArtifactRepository, ObservedResultsBlobStore};
 pub use token::{
-    HmacResultsAuthority, HmacResultsAuthorityConfig, ResultsPublicEndpoint, RuntimeToken,
+    HmacResultsAuthority, HmacResultsAuthorityConfig, PrivateNetworkResultsEndpoint,
+    ResultsPublicEndpoint, RuntimeToken,
 };

--- a/crates/automata-ci-results-github/src/token.rs
+++ b/crates/automata-ci-results-github/src/token.rs
@@ -1,4 +1,9 @@
-use std::{fmt, net::SocketAddr, str::FromStr as _, sync::Arc};
+use std::{
+    fmt,
+    net::{SocketAddr, SocketAddrV4},
+    str::FromStr as _,
+    sync::Arc,
+};
 
 use automata_ci_core::{AttemptId, FencingToken, JobId, RunId, Sha256Digest};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -41,6 +46,61 @@ pub struct ResultsPublicEndpoint {
     development_listener_bind: Option<SocketAddr>,
 }
 
+/// Exact plaintext Results origin bound only to one private local IPv4 interface.
+///
+/// This deployment type is intended for a closed container-network interface;
+/// it cannot represent wildcard, loopback, public, IPv6, or dynamic-port binds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrivateNetworkResultsEndpoint {
+    public_endpoint: ResultsPublicEndpoint,
+    listener: SocketAddrV4,
+}
+
+impl PrivateNetworkResultsEndpoint {
+    /// Validates one trusted private-development origin and its exact IPv4 bind.
+    ///
+    /// # Errors
+    ///
+    /// Rejects any bind outside private IPv4 space, any port other than 8081,
+    /// and any URL host or port that differs from the explicit assertion.
+    pub fn new(
+        url: Url,
+        listener: SocketAddrV4,
+        trusted_public_host: &str,
+    ) -> Result<Self, TokenError> {
+        if listener.port() != 8081 || !listener.ip().is_private() {
+            return Err(TokenError::Policy);
+        }
+        let public_endpoint = trusted_private_development_endpoint(
+            url,
+            SocketAddr::V4(listener),
+            trusted_public_host,
+        )?;
+        Ok(Self {
+            public_endpoint,
+            listener,
+        })
+    }
+
+    /// Returns the exact private interface to bind.
+    #[must_use]
+    pub const fn listener(&self) -> SocketAddrV4 {
+        self.listener
+    }
+
+    /// Returns the validated job-visible Results origin.
+    #[must_use]
+    pub const fn public_endpoint(&self) -> &ResultsPublicEndpoint {
+        &self.public_endpoint
+    }
+
+    /// Consumes the paired policy into the public endpoint used by authority composition.
+    #[must_use]
+    pub fn into_public_endpoint(self) -> ResultsPublicEndpoint {
+        self.public_endpoint
+    }
+}
+
 impl ResultsPublicEndpoint {
     /// Creates a production endpoint protected by TLS.
     ///
@@ -75,44 +135,6 @@ impl ResultsPublicEndpoint {
         })
     }
 
-    /// Creates an explicit plaintext private-link development endpoint.
-    ///
-    /// `trusted_public_host` is the exact DNS name or private IP that the
-    /// operator maps to `listener_bind` (for example `host.containers.internal`
-    /// and the Podman bridge gateway). This assertion is deliberately required
-    /// because DNS resolution is outside deterministic configuration parsing.
-    ///
-    /// # Errors
-    ///
-    /// Rejects wildcard, loopback, or public-interface binds, a host assertion
-    /// that differs from the URL, and a mismatched listener port.
-    pub fn trusted_private_development(
-        url: Url,
-        listener_bind: SocketAddr,
-        trusted_public_host: &str,
-    ) -> Result<Self, TokenError> {
-        validate_development_listener(&url, listener_bind, false)?;
-        let actual_host = url.host_str().ok_or(TokenError::Policy)?;
-        if trusted_public_host.is_empty()
-            || trusted_public_host.len() > 255
-            || !trusted_public_host.is_ascii()
-            || trusted_public_host
-                .bytes()
-                .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
-            || trusted_public_host.contains('*')
-            || !actual_host.eq_ignore_ascii_case(trusted_public_host)
-        {
-            return Err(TokenError::Policy);
-        }
-        let runtime_endpoint = RuntimeAuthorityEndpoint::trusted_private_development(url.as_str())
-            .map_err(|_| TokenError::Policy)?;
-        Ok(Self {
-            url,
-            runtime_endpoint,
-            development_listener_bind: Some(listener_bind),
-        })
-    }
-
     /// Returns the normalized public origin injected into the job.
     #[must_use]
     pub const fn url(&self) -> &Url {
@@ -130,6 +152,33 @@ impl ResultsPublicEndpoint {
     pub const fn development_listener_bind(&self) -> Option<SocketAddr> {
         self.development_listener_bind
     }
+}
+
+fn trusted_private_development_endpoint(
+    url: Url,
+    listener_bind: SocketAddr,
+    trusted_public_host: &str,
+) -> Result<ResultsPublicEndpoint, TokenError> {
+    validate_development_listener(&url, listener_bind, false)?;
+    let actual_host = url.host_str().ok_or(TokenError::Policy)?;
+    if trusted_public_host.is_empty()
+        || trusted_public_host.len() > 255
+        || !trusted_public_host.is_ascii()
+        || trusted_public_host
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        || trusted_public_host.contains('*')
+        || !actual_host.eq_ignore_ascii_case(trusted_public_host)
+    {
+        return Err(TokenError::Policy);
+    }
+    let runtime_endpoint = RuntimeAuthorityEndpoint::trusted_private_development(url.as_str())
+        .map_err(|_| TokenError::Policy)?;
+    Ok(ResultsPublicEndpoint {
+        url,
+        runtime_endpoint,
+        development_listener_bind: Some(listener_bind),
+    })
 }
 
 fn validate_public_url(url: &Url) -> Result<(), TokenError> {

--- a/crates/automata-ci-results-github/tests/runtime_authority.rs
+++ b/crates/automata-ci-results-github/tests/runtime_authority.rs
@@ -420,40 +420,42 @@ async fn fork_cache_is_read_only_and_incomplete_evidence_mints_no_authority() {
 }
 
 #[test]
-fn development_endpoint_requires_an_exact_safe_bind_and_host_assertion() {
-    let podman = ResultsPublicEndpoint::trusted_private_development(
-        Url::parse("http://host.containers.internal:8081/").expect("URL"),
-        "10.88.0.1:8081".parse().expect("private bind"),
-        "host.containers.internal",
+fn closed_private_network_endpoint_is_ipv4_and_results_port_exact() {
+    use automata_ci_results_github::PrivateNetworkResultsEndpoint;
+
+    let endpoint = PrivateNetworkResultsEndpoint::new(
+        Url::parse("http://results.automata.invalid:8081/").expect("URL"),
+        "10.91.0.2:8081".parse().expect("private IPv4 bind"),
+        "results.automata.invalid",
     )
-    .expect("trusted Podman bridge endpoint");
+    .expect("closed private Results endpoint");
+    assert_eq!(endpoint.listener().to_string(), "10.91.0.2:8081");
     assert_eq!(
-        podman.development_listener_bind(),
-        Some("10.88.0.1:8081".parse().expect("private bind"))
+        endpoint.public_endpoint().url().as_str(),
+        "http://results.automata.invalid:8081/"
     );
 
-    for rejected in [
-        ResultsPublicEndpoint::trusted_private_development(
-            Url::parse("http://host.containers.internal:8081/").expect("URL"),
-            "0.0.0.0:8081".parse().expect("wildcard bind"),
-            "host.containers.internal",
-        ),
-        ResultsPublicEndpoint::trusted_private_development(
-            Url::parse("http://host.containers.internal:8081/").expect("URL"),
-            "10.88.0.1:8082".parse().expect("private bind"),
-            "host.containers.internal",
-        ),
-        ResultsPublicEndpoint::trusted_private_development(
-            Url::parse("http://host.containers.internal:8081/").expect("URL"),
-            "10.88.0.1:8081".parse().expect("private bind"),
-            "different.internal",
-        ),
-        ResultsPublicEndpoint::trusted_private_development(
-            Url::parse("http://host.containers.internal:8081/").expect("URL"),
-            "203.0.113.10:8081".parse().expect("public bind"),
-            "host.containers.internal",
-        ),
+    for listener in [
+        "10.91.0.2:8080",
+        "0.0.0.0:8081",
+        "127.0.0.1:8081",
+        "203.0.113.2:8081",
     ] {
-        assert_eq!(rejected, Err(TokenError::Policy));
+        assert!(
+            PrivateNetworkResultsEndpoint::new(
+                Url::parse("http://results.automata.invalid:8081/").expect("URL"),
+                listener.parse().expect("IPv4 bind"),
+                "results.automata.invalid",
+            )
+            .is_err()
+        );
     }
+    assert_eq!(
+        PrivateNetworkResultsEndpoint::new(
+            Url::parse("http://results.automata.invalid:8081/").expect("URL"),
+            "10.91.0.2:8081".parse().expect("private IPv4 bind"),
+            "different.automata.invalid",
+        ),
+        Err(TokenError::Policy)
+    );
 }

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -53,7 +53,7 @@ const MAX_SERVICE_PROCESS_ENVIRONMENT_BYTES: usize = 48 * 1024;
 const MAX_SERVICE_PROXY_PORTS: usize = 128;
 const SERVICE_PROXY_IMAGE_FORMAT: &str =
     "{{.Digest}}\n{{ index .Labels \"io.automata.service-proxy.protocol-version\" }}";
-const SERVICE_PROXY_IMAGE_VERSION: &str = "1";
+const SERVICE_PROXY_IMAGE_PROTOCOL_VERSION: &str = "2";
 const BUILDKIT_IMAGE_FORMAT: &str = "{{.Digest}}";
 const BUILDKIT_PROBE_OUTPUT_PREFIX: &str = "buildkitd github.com/moby/buildkit ";
 const BUILDKIT_ARCHIVE_NAME: &str = "automata-buildkit-image.oci";
@@ -3476,7 +3476,7 @@ impl PodmanInner {
             ProviderStage::Validate,
             None,
         )?;
-        let expected = format!("{expected_digest}\n{SERVICE_PROXY_IMAGE_VERSION}");
+        let expected = format!("{expected_digest}\n{SERVICE_PROXY_IMAGE_PROTOCOL_VERSION}");
         let actual = std::str::from_utf8(output.stdout())
             .ok()
             .map(str::trim_end)

--- a/crates/automata-ci-sandbox-podman/tests/service_containers.rs
+++ b/crates/automata-ci-sandbox-podman/tests/service_containers.rs
@@ -40,6 +40,26 @@ fn service_capability_is_not_advertised_until_the_local_helper_is_verified() {
 }
 
 #[test]
+fn pre_results_service_proxy_protocol_is_rejected_before_any_mutation() {
+    let scratch = ScratchRoot::new("service-proxy-stale-protocol");
+    let fake = Arc::new(FakePodman::default());
+    fake.override_service_proxy_protocol("1");
+
+    let error = RootlessPodmanProvider::open_with_executor(
+        options_with_service_proxy(scratch.path()),
+        Arc::clone(&fake) as Arc<dyn PodmanCommandExecutor>,
+    )
+    .expect_err("protocol 1 predates Results and must not be admitted");
+
+    assert_eq!(
+        error,
+        PodmanOpenError::Configuration(PodmanConfigurationError::ServiceProxyUnavailable)
+    );
+    assert_only_helper_image_verification(&fake);
+    assert!(fake.is_empty());
+}
+
+#[test]
 fn services_use_one_job_network_hardened_argv_and_restart_durable_bindings() {
     let Fixture {
         provider,

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -114,6 +114,7 @@ struct FakeState {
     cancel_once: Option<Vec<String>>,
     buildkit_image_missing: bool,
     buildkit_digest_override: Option<String>,
+    service_proxy_protocol_override: Option<String>,
     buildkit_probe_output: Option<CommandOutput>,
     exec_output: Option<CommandOutput>,
     copied_to: Option<Vec<u8>>,
@@ -184,6 +185,13 @@ impl FakePodman {
             .lock()
             .expect("fake lock")
             .buildkit_digest_override = Some(digest.to_owned());
+    }
+
+    pub(crate) fn override_service_proxy_protocol(&self, version: &str) {
+        self.state
+            .lock()
+            .expect("fake lock")
+            .service_proxy_protocol_override = Some(version.to_owned());
     }
 
     pub(crate) fn set_buildkit_probe_output(&self, output: CommandOutput) {
@@ -773,8 +781,12 @@ fn execute_fake_inspection(state: &FakeState, command: &[String]) -> Option<Comm
                     == "{{.Digest}}\n{{ index .Labels \"io.automata.service-proxy.protocol-version\" }}" =>
         {
             let digest = reference.rsplit_once('@').map(|(_, value)| value).unwrap_or_default();
+            let protocol = state
+                .service_proxy_protocol_override
+                .as_deref()
+                .unwrap_or("2");
             Some(CommandOutput::success(
-                format!("{digest}\n1\n").into_bytes(),
+                format!("{digest}\n{protocol}\n").into_bytes(),
             ))
         }
         [image, inspect, format, template, reference]

--- a/crates/automata-ci-service-proxy/Cargo.toml
+++ b/crates/automata-ci-service-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-service-proxy"
-description = "Bounded namespace-local service port proxy for Automata job sandboxes"
+description = "Closed bounded service and Results proxy for Automata job sandboxes"
 publish = false
 version.workspace = true
 edition.workspace = true
@@ -18,7 +18,7 @@ name = "automata-ci-service-proxy"
 path = "src/main.rs"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { workspace = true, features = ["event"] }
+rustix = { workspace = true, features = ["event", "net"] }
 
 [lints]
 workspace = true

--- a/crates/automata-ci-service-proxy/README.md
+++ b/crates/automata-ci-service-proxy/README.md
@@ -1,24 +1,52 @@
 # automata-ci-service-proxy
 
-`automata-ci-service-proxy` is Automata's Linux-only, namespace-local TCP and
-UDP port proxy for job service containers. The sandbox launches it inside the
-job network namespace with a closed `serve-v1` mapping list. It binds only
-loopback listener ports and forwards them to validated non-loopback IPv4
-service addresses.
+`automata-ci-service-proxy` is Automata's Linux-only, credential-free network
+helper. Its current `serve-v1` mode is the namespace-local TCP and UDP port
+proxy for job service containers: the sandbox launches it inside the job
+network namespace with a closed mapping list, loopback listeners, and validated
+non-loopback IPv4 service addresses.
+
+The separate `serve-results-v1` mode is not a generic mapping interface. It
+accepts exactly five canonical private-IPv4 facts: the proxy address, exact
+`/29` front CIDR, sole job source address, non-overlapping `/23`-or-wider
+transit CIDR, and numeric Results target. The front gateway, proxy, and job are
+fixed at host offsets 1, 2, and 3. The Results target must be a usable transit
+host other than its fixed first-host gateway. The helper binds only the front
+proxy address on TCP port 8081, accepts only the exact job source, and connects
+only to the supplied target on TCP port 8081. UDP, dynamic listeners, public or
+loopback addresses, partially public CIDRs, alternate address layouts,
+overlapping networks, additional targets, and additional arguments are
+rejected. Its exact readiness line is
+`{"version":1,"mode":"results-v1","port":8081}`.
 
 The process has fixed listener, TCP-session, UDP-association, datagram, and
 per-event work ceilings. TCP relays preserve normal half-close behavior. After
-the upstream closes its response half, a still-open request pump receives a
-bounded drain before it is reaped; a client request half-close does not truncate
-a delayed or streaming upstream response. UDP associations expire after
-inactivity. Startup writes one compact ordered status line to standard output;
-subsequent diagnostics are sanitized error codes and never reflect command
-input or proxied bytes.
+either peer closes its write half, that EOF is propagated only to the opposite
+write half; the other direction remains available for delayed, streaming, or
+one-way traffic. Results sessions use one shared last-activity deadline that is
+refreshed by traffic in either direction. Once the upstream response half has
+closed, a still-open request half also has a shorter inactivity drain, refreshed
+by continued uploads; a client request half-close does not activate that drain.
+UDP associations expire after inactivity. Startup writes one compact ordered
+status line to standard output; subsequent diagnostics are sanitized error
+codes and never reflect command input or proxied bytes.
+
+Results mode has an Engine-enforced listen backlog of 16, at most 32 concurrent
+sessions, a five-second target-connect deadline, a five-minute idle deadline,
+a five-second inactive request drain after response half-close, and directional
+half-close propagation. Streaming is body-neutral and bounded by
+connection/session limits rather than buffering request or response bodies; a
+genuinely inactive session is still reaped by the applicable shared deadline.
 
 This binary is an internal image helper, not a general-purpose host proxy or a
-stable operator-facing CLI. It requires Linux `epoll`, assumes the sandbox has
-already established its network and process isolation, and must be distributed
-as the reviewed immutable helper image expected by the runner profile.
+stable operator-facing CLI. The sole current image capability is
+`io.automata.service-proxy.protocol-version=2`, which binds both command modes
+above; protocol 1 images predate the Results mode and are rejected. It requires
+Linux `epoll`, assumes the sandbox has already established its network and
+process isolation, and must be distributed as the reviewed immutable scratch
+image expected by the runner profile. The image runs as `65532:65532`; callers
+must keep it read-only, capability-free, mount-free, and free of environment
+values or credentials.
 
 - [Runner configuration](https://github.com/automata-ci/automata/blob/main/crates/automata-ci-runner/config/README.md)
 - [Issues and support](https://github.com/automata-ci/automata/issues)

--- a/crates/automata-ci-service-proxy/src/config.rs
+++ b/crates/automata-ci-service-proxy/src/config.rs
@@ -5,7 +5,72 @@ use crate::error::ProxyError;
 
 pub(crate) const MAX_LISTENERS: usize = 128;
 pub(crate) const SERVICE_PROXY_SERVE_COMMAND: &str = "serve-v1";
+pub(crate) const RESULTS_PROXY_SERVE_COMMAND: &str = "serve-results-v1";
 const MAX_MAPPING_BYTES: usize = 64;
+const RESULTS_FRONT_NETWORK_PREFIX: u8 = 29;
+const RESULTS_TRANSIT_MAXIMUM_PREFIX: u8 = 23;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ProxyCommand {
+    Services(Vec<Mapping>),
+    Results(ResultsConfiguration),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Ipv4Network {
+    network: Ipv4Addr,
+    prefix: u8,
+}
+
+impl Ipv4Network {
+    fn contains(self, address: Ipv4Addr) -> bool {
+        let mask = u32::MAX << (32 - self.prefix);
+        u32::from(address) & mask == u32::from(self.network)
+    }
+
+    fn broadcast(self) -> Ipv4Addr {
+        let mask = u32::MAX << (32 - self.prefix);
+        Ipv4Addr::from(u32::from(self.network) | !mask)
+    }
+
+    fn contains_usable(self, address: Ipv4Addr) -> bool {
+        self.contains(address) && address != self.network && address != self.broadcast()
+    }
+
+    fn usable_host(self, offset: u32) -> Option<Ipv4Addr> {
+        u32::from(self.network)
+            .checked_add(offset)
+            .map(Ipv4Addr::from)
+            .filter(|address| self.contains_usable(*address))
+    }
+
+    fn overlaps(self, other: Self) -> bool {
+        self.contains(other.network) || other.contains(self.network)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ResultsConfiguration {
+    front_address: Ipv4Addr,
+    front_network: Ipv4Network,
+    job_address: Ipv4Addr,
+    transit_network: Ipv4Network,
+    target_address: Ipv4Addr,
+}
+
+impl ResultsConfiguration {
+    pub(crate) const fn front_address(self) -> Ipv4Addr {
+        self.front_address
+    }
+
+    pub(crate) const fn job_address(self) -> Ipv4Addr {
+        self.job_address
+    }
+
+    pub(crate) const fn target_address(self) -> Ipv4Addr {
+        self.target_address
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Transport {
@@ -44,14 +109,16 @@ impl Mapping {
 
 pub(crate) fn parse_command_line(
     arguments: impl IntoIterator<Item = OsString>,
-) -> Result<Vec<Mapping>, ProxyError> {
+) -> Result<ProxyCommand, ProxyError> {
     let mut arguments = arguments.into_iter();
-    if arguments
+    let command = arguments
         .next()
         .and_then(|value| value.into_string().ok())
-        .as_deref()
-        != Some(SERVICE_PROXY_SERVE_COMMAND)
-    {
+        .ok_or(ProxyError::Usage)?;
+    if command == RESULTS_PROXY_SERVE_COMMAND {
+        return parse_results(arguments).map(ProxyCommand::Results);
+    }
+    if command != SERVICE_PROXY_SERVE_COMMAND {
         return Err(ProxyError::Usage);
     }
 
@@ -69,7 +136,93 @@ pub(crate) fn parse_command_line(
     if mappings.is_empty() {
         return Err(ProxyError::Configuration);
     }
-    Ok(mappings)
+    Ok(ProxyCommand::Services(mappings))
+}
+
+fn parse_results(
+    mut arguments: impl Iterator<Item = OsString>,
+) -> Result<ResultsConfiguration, ProxyError> {
+    let front_address = parse_canonical_private_ipv4(&next_argument(&mut arguments)?)?;
+    let front_network = parse_canonical_private_network(&next_argument(&mut arguments)?)?;
+    let job_address = parse_canonical_private_ipv4(&next_argument(&mut arguments)?)?;
+    let transit_network = parse_canonical_private_network(&next_argument(&mut arguments)?)?;
+    let target_address = parse_canonical_private_ipv4(&next_argument(&mut arguments)?)?;
+    if arguments.next().is_some()
+        || front_network.prefix != RESULTS_FRONT_NETWORK_PREFIX
+        || front_network.usable_host(2) != Some(front_address)
+        || front_network.usable_host(3) != Some(job_address)
+        || transit_network.prefix > RESULTS_TRANSIT_MAXIMUM_PREFIX
+        || !transit_network.contains_usable(target_address)
+        || transit_network.usable_host(1) == Some(target_address)
+        || front_network.overlaps(transit_network)
+    {
+        return Err(ProxyError::Configuration);
+    }
+    Ok(ResultsConfiguration {
+        front_address,
+        front_network,
+        job_address,
+        transit_network,
+        target_address,
+    })
+}
+
+fn next_argument(arguments: &mut impl Iterator<Item = OsString>) -> Result<String, ProxyError> {
+    arguments
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .ok_or(ProxyError::Configuration)
+}
+
+fn parse_canonical_ipv4(value: &str) -> Result<Ipv4Addr, ProxyError> {
+    if value.is_empty() || value.len() > 15 || !value.is_ascii() {
+        return Err(ProxyError::Configuration);
+    }
+    let address = value
+        .parse::<Ipv4Addr>()
+        .map_err(|_| ProxyError::Configuration)?;
+    if address.to_string() != value || !is_valid_service_ip(address) {
+        return Err(ProxyError::Configuration);
+    }
+    Ok(address)
+}
+
+fn parse_canonical_private_ipv4(value: &str) -> Result<Ipv4Addr, ProxyError> {
+    parse_canonical_ipv4(value).and_then(|address| {
+        address
+            .is_private()
+            .then_some(address)
+            .ok_or(ProxyError::Configuration)
+    })
+}
+
+fn parse_canonical_private_network(value: &str) -> Result<Ipv4Network, ProxyError> {
+    let (address, prefix) = value.split_once('/').ok_or(ProxyError::Configuration)?;
+    let address = parse_canonical_private_ipv4(address)?;
+    if prefix.is_empty()
+        || prefix.len() > 2
+        || !prefix.bytes().all(|byte| byte.is_ascii_digit())
+        || (prefix.len() > 1 && prefix.starts_with('0'))
+    {
+        return Err(ProxyError::Configuration);
+    }
+    let prefix = prefix
+        .parse::<u8>()
+        .ok()
+        .filter(|prefix| (8..=30).contains(prefix))
+        .ok_or(ProxyError::Configuration)?;
+    let mask = u32::MAX << (32 - prefix);
+    if u32::from(address) & mask != u32::from(address) {
+        return Err(ProxyError::Configuration);
+    }
+    let network = Ipv4Network {
+        network: address,
+        prefix,
+    };
+    if !network.broadcast().is_private() {
+        return Err(ProxyError::Configuration);
+    }
+    Ok(network)
 }
 
 fn parse_mapping(value: &str) -> Result<Mapping, ProxyError> {
@@ -133,7 +286,10 @@ mod tests {
     use super::*;
 
     fn parse(values: &[&str]) -> Result<Vec<Mapping>, ProxyError> {
-        parse_command_line(values.iter().map(OsString::from))
+        match parse_command_line(values.iter().map(OsString::from))? {
+            ProxyCommand::Services(mappings) => Ok(mappings),
+            ProxyCommand::Results(_) => Err(ProxyError::Configuration),
+        }
     }
 
     #[test]
@@ -202,5 +358,189 @@ mod tests {
         values.extend((0..=MAX_LISTENERS).map(|_| "tcp|10.0.0.2|80|0".to_owned()));
         let result = parse_command_line(values.into_iter().map(OsString::from));
         assert_eq!(result, Err(ProxyError::Configuration));
+    }
+
+    #[test]
+    fn accepts_only_the_closed_results_contract() {
+        let command = parse_command_line(
+            [
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        )
+        .expect("closed Results transport");
+        assert_eq!(
+            command,
+            ProxyCommand::Results(ResultsConfiguration {
+                front_address: Ipv4Addr::new(172, 31, 8, 2),
+                front_network: Ipv4Network {
+                    network: Ipv4Addr::new(172, 31, 8, 0),
+                    prefix: 29,
+                },
+                job_address: Ipv4Addr::new(172, 31, 8, 3),
+                transit_network: Ipv4Network {
+                    network: Ipv4Addr::new(10, 91, 0, 0),
+                    prefix: 23,
+                },
+                target_address: Ipv4Addr::new(10, 91, 0, 2),
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_each_current_results_transit_capacity() {
+        for (network, target) in [
+            ("10.0.0.0/8", "10.91.0.2"),
+            ("10.91.0.0/16", "10.91.0.2"),
+            ("10.91.0.0/22", "10.91.0.2"),
+            ("10.91.0.0/23", "10.91.1.254"),
+        ] {
+            parse_command_line(
+                [
+                    RESULTS_PROXY_SERVE_COMMAND,
+                    "172.31.8.2",
+                    "172.31.8.0/29",
+                    "172.31.8.3",
+                    network,
+                    target,
+                ]
+                .into_iter()
+                .map(OsString::from),
+            )
+            .expect("current transit capacity");
+        }
+    }
+
+    fn assert_results_rejected(cases: impl IntoIterator<Item = Vec<&'static str>>) {
+        for values in cases {
+            assert!(
+                parse_command_line(values.into_iter().map(OsString::from)).is_err(),
+                "accepted invalid Results arguments"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_results_noncurrent_front_topology_or_arity() {
+        assert_results_rejected([
+            vec![RESULTS_PROXY_SERVE_COMMAND],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.2",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.1/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.2",
+                "extra",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/24",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.4",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.4",
+                "10.91.0.0/23",
+                "10.91.0.2",
+            ],
+        ]);
+    }
+
+    #[test]
+    fn rejects_results_invalid_transit_or_target() {
+        assert_results_rejected([
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "172.31.8.0/23",
+                "172.31.8.8",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "192.0.0.0/23",
+                "192.0.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/24",
+                "10.91.0.2",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.1",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.0.0",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "10.91.0.0/23",
+                "10.91.1.255",
+            ],
+            vec![
+                RESULTS_PROXY_SERVE_COMMAND,
+                "172.31.8.2",
+                "172.31.8.0/29",
+                "172.31.8.3",
+                "192.168.0.0/15",
+                "192.168.0.2",
+            ],
+        ]);
     }
 }

--- a/crates/automata-ci-service-proxy/src/main.rs
+++ b/crates/automata-ci-service-proxy/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod error;
 mod limit;
 mod proxy;
+mod results;
 mod status;
 
 use std::ffi::OsString;
@@ -29,16 +30,26 @@ fn main() -> ExitCode {
 }
 
 fn run(arguments: impl IntoIterator<Item = OsString>) -> Result<(), ProxyError> {
-    let mappings = config::parse_command_line(arguments)?;
-    let mut proxy = proxy::PreparedProxy::prepare(&mappings)?;
-    let status = status::encode_startup_status(&proxy.ports()?);
+    match config::parse_command_line(arguments)? {
+        config::ProxyCommand::Services(mappings) => {
+            let mut proxy = proxy::PreparedProxy::prepare(&mappings)?;
+            write_status(&status::encode_startup_status(&proxy.ports()?))?;
+            proxy.run()
+        }
+        config::ProxyCommand::Results(configuration) => {
+            let proxy = results::ResultsProxy::prepare(configuration)?;
+            write_status(status::RESULTS_READY_STATUS)?;
+            proxy.run()
+        }
+    }
+}
+
+fn write_status(status: &str) -> Result<(), ProxyError> {
     let mut stdout = io::stdout().lock();
     stdout
         .write_all(status.as_bytes())
         .map_err(|_| ProxyError::Status)?;
-    stdout.flush().map_err(|_| ProxyError::Status)?;
-    drop(stdout);
-    proxy.run()
+    stdout.flush().map_err(|_| ProxyError::Status)
 }
 
 fn write_sanitized_error(code: &str) {

--- a/crates/automata-ci-service-proxy/src/results.rs
+++ b/crates/automata-ci-service-proxy/src/results.rs
@@ -1,0 +1,455 @@
+use std::io::{self, Read, Write};
+use std::net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rustix::net::{AddressFamily, SocketFlags, SocketType, bind, ipproto, listen, socket_with};
+
+use crate::config::ResultsConfiguration;
+use crate::error::ProxyError;
+use crate::limit::{SlotLimiter, SlotPermit};
+
+pub(crate) const RESULTS_PORT: u16 = 8081;
+const RESULTS_BACKLOG: i32 = 16;
+const MAX_RESULTS_SESSIONS: usize = 32;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(5);
+const HALF_CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const RELAY_THREAD_STACK_BYTES: usize = 128 * 1024;
+const RELAY_BUFFER_BYTES: usize = 16 * 1024;
+
+pub(crate) struct ResultsProxy {
+    listener: TcpListener,
+    configuration: ResultsConfiguration,
+    sessions: Arc<SlotLimiter>,
+}
+
+impl ResultsProxy {
+    pub(crate) fn prepare(configuration: ResultsConfiguration) -> Result<Self, ProxyError> {
+        let socket = socket_with(
+            AddressFamily::INET,
+            SocketType::STREAM,
+            SocketFlags::CLOEXEC,
+            Some(ipproto::TCP),
+        )
+        .map_err(|_| ProxyError::Bind)?;
+        let address = SocketAddrV4::new(configuration.front_address(), RESULTS_PORT);
+        bind(&socket, &address).map_err(|_| ProxyError::Bind)?;
+        listen(&socket, RESULTS_BACKLOG).map_err(|_| ProxyError::Bind)?;
+        let listener = TcpListener::from(socket);
+        if listener.local_addr().ok() != Some(SocketAddr::V4(address)) {
+            return Err(ProxyError::Bind);
+        }
+        Ok(Self {
+            listener,
+            configuration,
+            sessions: Arc::new(SlotLimiter::new(MAX_RESULTS_SESSIONS)),
+        })
+    }
+
+    pub(crate) fn run(self) -> Result<(), ProxyError> {
+        loop {
+            let (client, peer) = match self.listener.accept() {
+                Ok(accepted) => accepted,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(_) => return Err(ProxyError::Runtime),
+            };
+            if peer.ip() != self.configuration.job_address()
+                || client.local_addr().ok()
+                    != Some(SocketAddr::V4(SocketAddrV4::new(
+                        self.configuration.front_address(),
+                        RESULTS_PORT,
+                    )))
+            {
+                continue;
+            }
+            let Some(permit) = self.sessions.try_acquire() else {
+                continue;
+            };
+            spawn_session(client, self.configuration.target_address(), permit);
+        }
+    }
+}
+
+fn spawn_session(client: TcpStream, target: Ipv4Addr, permit: SlotPermit) {
+    let session = move || relay_session(client, target, permit);
+    let _ = thread::Builder::new()
+        .name("results-proxy-session".to_owned())
+        .stack_size(RELAY_THREAD_STACK_BYTES)
+        .spawn(session);
+}
+
+fn relay_session(client: TcpStream, target: Ipv4Addr, _permit: SlotPermit) {
+    let Ok(upstream) = TcpStream::connect_timeout(
+        &SocketAddr::V4(SocketAddrV4::new(target, RESULTS_PORT)),
+        CONNECT_TIMEOUT,
+    ) else {
+        return;
+    };
+    relay_connected(
+        client,
+        upstream,
+        SESSION_IDLE_TIMEOUT,
+        HALF_CLOSE_DRAIN_TIMEOUT,
+    );
+}
+
+#[derive(Clone, Copy)]
+enum PumpDirection {
+    Request,
+    Response,
+}
+
+struct RelayTiming {
+    last_activity: Instant,
+    response_half_closed_at: Option<Instant>,
+}
+
+struct RelayState {
+    timing: Mutex<RelayTiming>,
+    pumps_finished: AtomicUsize,
+    pump_failed: AtomicBool,
+    wake: mpsc::SyncSender<()>,
+}
+
+impl RelayState {
+    fn new(wake: mpsc::SyncSender<()>) -> Self {
+        Self {
+            timing: Mutex::new(RelayTiming {
+                last_activity: Instant::now(),
+                response_half_closed_at: None,
+            }),
+            pumps_finished: AtomicUsize::new(0),
+            pump_failed: AtomicBool::new(false),
+            wake,
+        }
+    }
+
+    fn record_activity(&self) {
+        self.timing
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .last_activity = Instant::now();
+        let _ = self.wake.try_send(());
+    }
+
+    fn record_completion(&self, direction: PumpDirection, succeeded: bool) {
+        if !succeeded {
+            self.pump_failed.store(true, Ordering::SeqCst);
+        } else if matches!(direction, PumpDirection::Response) {
+            self.timing
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .response_half_closed_at = Some(Instant::now());
+        }
+        self.pumps_finished.fetch_add(1, Ordering::SeqCst);
+        let _ = self.wake.try_send(());
+    }
+
+    fn remaining(
+        &self,
+        session_idle_timeout: Duration,
+        response_drain_timeout: Duration,
+    ) -> Duration {
+        let timing = self
+            .timing
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let session_remaining = session_idle_timeout.saturating_sub(timing.last_activity.elapsed());
+        let drain_remaining =
+            timing
+                .response_half_closed_at
+                .map_or(session_remaining, |closed_at| {
+                    response_drain_timeout
+                        .saturating_sub(timing.last_activity.max(closed_at).elapsed())
+                });
+        session_remaining.min(drain_remaining)
+    }
+}
+
+fn relay_connected(
+    client: TcpStream,
+    upstream: TcpStream,
+    session_idle_timeout: Duration,
+    response_drain_timeout: Duration,
+) {
+    let client = Arc::new(client);
+    let upstream = Arc::new(upstream);
+    let (wake, wait_for_activity) = mpsc::sync_channel(1);
+    let state = Arc::new(RelayState::new(wake));
+    let Ok(client_to_upstream) = spawn_pump(
+        "results-proxy-request",
+        PumpDirection::Request,
+        Arc::clone(&client),
+        Arc::clone(&upstream),
+        Arc::clone(&state),
+    ) else {
+        return;
+    };
+    let Ok(upstream_to_client) = spawn_pump(
+        "results-proxy-response",
+        PumpDirection::Response,
+        Arc::clone(&upstream),
+        Arc::clone(&client),
+        Arc::clone(&state),
+    ) else {
+        let _ = client.shutdown(Shutdown::Both);
+        let _ = upstream.shutdown(Shutdown::Both);
+        let _ = client_to_upstream.join();
+        return;
+    };
+
+    loop {
+        if state.pump_failed.load(Ordering::SeqCst)
+            || state.pumps_finished.load(Ordering::SeqCst) == 2
+        {
+            break;
+        }
+        let remaining = state.remaining(session_idle_timeout, response_drain_timeout);
+        if remaining.is_zero() {
+            break;
+        }
+        match wait_for_activity.recv_timeout(remaining) {
+            Ok(()) | Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    let _ = client.shutdown(Shutdown::Both);
+    let _ = upstream.shutdown(Shutdown::Both);
+    let _ = client_to_upstream.join();
+    let _ = upstream_to_client.join();
+}
+
+fn spawn_pump(
+    name: &str,
+    direction: PumpDirection,
+    source: Arc<TcpStream>,
+    destination: Arc<TcpStream>,
+    state: Arc<RelayState>,
+) -> io::Result<thread::JoinHandle<()>> {
+    thread::Builder::new()
+        .name(name.to_owned())
+        .stack_size(RELAY_THREAD_STACK_BYTES)
+        .spawn(move || {
+            let mut source = &*source;
+            let mut destination = &*destination;
+            let succeeded = pump(&mut source, &mut destination, &state).is_ok()
+                && destination.shutdown(Shutdown::Write).is_ok();
+            state.record_completion(direction, succeeded);
+        })
+}
+
+fn pump(
+    source: &mut &TcpStream,
+    destination: &mut &TcpStream,
+    state: &RelayState,
+) -> io::Result<()> {
+    let mut buffer = [0_u8; RELAY_BUFFER_BYTES];
+    loop {
+        let size = match source.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(size) => size,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        state.record_activity();
+        let mut written = 0;
+        while written < size {
+            match destination.write(&buffer[written..size]) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "Results relay write made no progress",
+                    ));
+                }
+                Ok(size) => {
+                    written += size;
+                    state.record_activity();
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_IDLE_TIMEOUT: Duration = Duration::from_millis(400);
+    const TEST_DRAIN_TIMEOUT: Duration = Duration::from_millis(160);
+    const TEST_ACTIVITY_INTERVAL: Duration = Duration::from_millis(50);
+    const TEST_RESPONSE_DELAY: Duration = Duration::from_millis(250);
+    const TEST_COMPLETION_TIMEOUT: Duration = Duration::from_secs(3);
+
+    fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind test listener");
+        let connector = TcpStream::connect(listener.local_addr().expect("listener address"))
+            .expect("connect test socket");
+        let accepted = listener.accept().expect("accept test socket").0;
+        connector
+            .set_read_timeout(Some(TEST_COMPLETION_TIMEOUT))
+            .expect("set connector read timeout");
+        connector
+            .set_write_timeout(Some(TEST_COMPLETION_TIMEOUT))
+            .expect("set connector write timeout");
+        accepted
+            .set_read_timeout(Some(TEST_COMPLETION_TIMEOUT))
+            .expect("set accepted read timeout");
+        accepted
+            .set_write_timeout(Some(TEST_COMPLETION_TIMEOUT))
+            .expect("set accepted write timeout");
+        (connector, accepted)
+    }
+
+    fn test_relay(idle_timeout: Duration) -> (TcpStream, TcpStream, mpsc::Receiver<()>) {
+        let (client, relay_client) = connected_pair();
+        let (relay_upstream, target) = connected_pair();
+        let (finished, wait_for_relay) = mpsc::channel();
+        thread::spawn(move || {
+            relay_connected(
+                relay_client,
+                relay_upstream,
+                idle_timeout,
+                TEST_DRAIN_TIMEOUT,
+            );
+            let _ = finished.send(());
+        });
+        (client, target, wait_for_relay)
+    }
+
+    #[test]
+    fn results_transport_contract_is_fixed() {
+        assert_eq!(RESULTS_PORT, 8081);
+        assert_eq!(RESULTS_BACKLOG, 16);
+        assert_eq!(MAX_RESULTS_SESSIONS, 32);
+        assert_eq!(CONNECT_TIMEOUT, Duration::from_secs(5));
+        assert_eq!(SESSION_IDLE_TIMEOUT, Duration::from_mins(5));
+        assert_eq!(HALF_CLOSE_DRAIN_TIMEOUT, Duration::from_secs(5));
+        assert_eq!(RELAY_BUFFER_BYTES, 16 * 1024);
+    }
+
+    #[test]
+    fn request_half_close_preserves_a_delayed_response() {
+        let (mut client, mut target, wait_for_relay) = test_relay(TEST_IDLE_TIMEOUT);
+        client.write_all(b"request").expect("write request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("close request half");
+
+        let mut request = Vec::new();
+        target.read_to_end(&mut request).expect("read request");
+        assert_eq!(request, b"request");
+        thread::sleep(TEST_RESPONSE_DELAY);
+        target.write_all(b"response").expect("write response");
+        target
+            .shutdown(Shutdown::Write)
+            .expect("close response half");
+
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).expect("read response");
+        assert_eq!(response, b"response");
+        wait_for_relay
+            .recv_timeout(TEST_COMPLETION_TIMEOUT)
+            .expect("relay completed");
+    }
+
+    #[test]
+    fn active_one_way_upload_refreshes_the_shared_idle_deadline() {
+        let (mut client, mut target, wait_for_relay) = test_relay(TEST_IDLE_TIMEOUT);
+        target
+            .shutdown(Shutdown::Write)
+            .expect("close response half");
+        let mut response_eof = [0_u8; 1];
+        assert_eq!(
+            client.read(&mut response_eof).expect("read response EOF"),
+            0
+        );
+
+        for (index, byte) in b"upload".iter().enumerate() {
+            client.write_all(&[*byte]).expect("write request byte");
+            let mut received = [0_u8; 1];
+            target.read_exact(&mut received).expect("read request byte");
+            assert_eq!(received[0], *byte);
+            if index + 1 < b"upload".len() {
+                thread::sleep(TEST_ACTIVITY_INTERVAL);
+            }
+        }
+        client
+            .shutdown(Shutdown::Write)
+            .expect("close request half");
+        let mut request_eof = [0_u8; 1];
+        assert_eq!(target.read(&mut request_eof).expect("read request EOF"), 0);
+        wait_for_relay
+            .recv_timeout(TEST_COMPLETION_TIMEOUT)
+            .expect("relay completed");
+    }
+
+    #[test]
+    fn active_one_way_response_refreshes_the_shared_idle_deadline() {
+        let (mut client, mut target, wait_for_relay) = test_relay(TEST_IDLE_TIMEOUT);
+        client
+            .shutdown(Shutdown::Write)
+            .expect("close request half");
+        let mut request_eof = [0_u8; 1];
+        assert_eq!(target.read(&mut request_eof).expect("read request EOF"), 0);
+
+        for (index, byte) in b"responses!".iter().enumerate() {
+            target.write_all(&[*byte]).expect("write response byte");
+            let mut received = [0_u8; 1];
+            client
+                .read_exact(&mut received)
+                .expect("read response byte");
+            assert_eq!(received[0], *byte);
+            if index + 1 < b"responses!".len() {
+                thread::sleep(TEST_ACTIVITY_INTERVAL);
+            }
+        }
+        target
+            .shutdown(Shutdown::Write)
+            .expect("close response half");
+        let mut response_eof = [0_u8; 1];
+        assert_eq!(
+            client.read(&mut response_eof).expect("read response EOF"),
+            0
+        );
+        wait_for_relay
+            .recv_timeout(TEST_COMPLETION_TIMEOUT)
+            .expect("relay completed");
+    }
+
+    #[test]
+    fn genuinely_idle_session_is_reaped() {
+        let (_client, _target, wait_for_relay) = test_relay(TEST_IDLE_TIMEOUT);
+        assert!(matches!(
+            wait_for_relay.recv_timeout(TEST_IDLE_TIMEOUT / 3),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        wait_for_relay
+            .recv_timeout(TEST_COMPLETION_TIMEOUT)
+            .expect("idle relay completed");
+    }
+
+    #[test]
+    fn inactive_request_half_is_reaped_after_response_half_close() {
+        let (mut client, target, wait_for_relay) = test_relay(Duration::from_secs(2));
+        target
+            .shutdown(Shutdown::Write)
+            .expect("close response half");
+        let mut response_eof = [0_u8; 1];
+        assert_eq!(
+            client.read(&mut response_eof).expect("read response EOF"),
+            0
+        );
+        assert!(matches!(
+            wait_for_relay.recv_timeout(TEST_DRAIN_TIMEOUT / 3),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        wait_for_relay
+            .recv_timeout(TEST_COMPLETION_TIMEOUT)
+            .expect("inactive request drain completed");
+    }
+}

--- a/crates/automata-ci-service-proxy/src/status.rs
+++ b/crates/automata-ci-service-proxy/src/status.rs
@@ -1,6 +1,8 @@
 use std::fmt::Write as _;
 
 pub(crate) const SERVICE_PROXY_STATUS_SCHEMA_VERSION: u64 = 1;
+pub(crate) const RESULTS_READY_STATUS: &str =
+    "{\"version\":1,\"mode\":\"results-v1\",\"port\":8081}\n";
 
 pub(crate) fn encode_startup_status(ports: &[u16]) -> String {
     let mut status = String::with_capacity(32 + ports.len() * 6);

--- a/crates/automata-ci/src/server/config.rs
+++ b/crates/automata-ci/src/server/config.rs
@@ -1475,11 +1475,16 @@ fn development_results_endpoint(
         .results_trusted_private_host
         .as_deref()
         .ok_or(automata_ci_results_github::TokenError::Policy)?;
-    ResultsPublicEndpoint::trusted_private_development(
+    let listener = match args.results_listen {
+        SocketAddr::V4(listener) => listener,
+        SocketAddr::V6(_) => return Err(automata_ci_results_github::TokenError::Policy),
+    };
+    automata_ci_results_github::PrivateNetworkResultsEndpoint::new(
         results_url,
-        args.results_listen,
+        listener,
         trusted_host,
     )
+    .map(automata_ci_results_github::PrivateNetworkResultsEndpoint::into_public_endpoint)
 }
 
 /// Invalid server deployment configuration.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -231,6 +231,10 @@ contract. Buildah still inspects the image metadata, and
 configuration, source bindings, and candidate provenance before the subsequent
 `prepare-candidate` policy gate accepts it.
 
+Every image and publication validator requires the sole current
+`io.automata.service-proxy.protocol-version=2` capability. Protocol 1 images
+predate the Results mode and cannot be admitted or promoted by this path.
+
 Reproducibility comparisons are backend-local: CI compares two Buildah outputs,
 while the manual and release paths compare Podman outputs. Both backends produce
 OCI candidates accepted by the same validators, but their output bytes are not

--- a/images/service-proxy/Containerfile
+++ b/images/service-proxy/Containerfile
@@ -8,13 +8,13 @@ ARG AUTOMATA_SERVICE_PROXY_SOURCE_SHA256
 ARG AUTOMATA_VERSION
 
 LABEL org.opencontainers.image.title="Automata CI service proxy" \
-      org.opencontainers.image.description="Namespace-local bounded TCP and UDP proxy for job service containers" \
+      org.opencontainers.image.description="Closed bounded service and Results proxy for Automata job sandboxes" \
       org.opencontainers.image.source="https://github.com/automata-ci/automata" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.created="${AUTOMATA_CREATED}" \
       org.opencontainers.image.revision="${AUTOMATA_REVISION}" \
       org.opencontainers.image.version="${AUTOMATA_VERSION}" \
-      io.automata.service-proxy.protocol-version="1" \
+      io.automata.service-proxy.protocol-version="2" \
       io.automata.service-proxy.binary.sha256="${AUTOMATA_SERVICE_PROXY_BINARY_SHA256}" \
       io.automata.service-proxy.sbom.sha256="${AUTOMATA_SERVICE_PROXY_SBOM_SHA256}" \
       io.automata.service-proxy.source.sha256="${AUTOMATA_SERVICE_PROXY_SOURCE_SHA256}"

--- a/scripts/ci/service-proxy-candidate.py
+++ b/scripts/ci/service-proxy-candidate.py
@@ -203,7 +203,7 @@ def load_oci(archive_bytes: bytes, source: dict, source_sha256: str) -> tuple[st
         "org.opencontainers.image.created": release["created"],
         "org.opencontainers.image.revision": release["revision"],
         "org.opencontainers.image.version": release["version"],
-        "io.automata.service-proxy.protocol-version": "1",
+        "io.automata.service-proxy.protocol-version": "2",
         "io.automata.service-proxy.binary.sha256": artifacts["binary_sha256"],
         "io.automata.service-proxy.sbom.sha256": artifacts["sbom_sha256"],
         "io.automata.service-proxy.source.sha256": source_sha256,

--- a/scripts/ci/service-proxy-publication.py
+++ b/scripts/ci/service-proxy-publication.py
@@ -575,12 +575,12 @@ def expected_labels(source: dict) -> dict[str, str]:
     release = source["release"]
     return {
         "io.automata.service-proxy.binary.sha256": artifacts["binary_sha256"],
-        "io.automata.service-proxy.protocol-version": "1",
+        "io.automata.service-proxy.protocol-version": "2",
         "io.automata.service-proxy.sbom.sha256": artifacts["sbom_sha256"],
         "io.automata.service-proxy.source.sha256": sha256(canonical_json(source)),
         "org.opencontainers.image.created": release["created"],
         "org.opencontainers.image.description": (
-            "Namespace-local bounded TCP and UDP proxy for job service containers"
+            "Closed bounded service and Results proxy for Automata job sandboxes"
         ),
         "org.opencontainers.image.licenses": "MIT",
         "org.opencontainers.image.revision": release["revision"],
@@ -708,7 +708,7 @@ def prepare_candidate(arguments: argparse.Namespace) -> None:
         "release": source["release"],
         "runtime": {
             "entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
-            "protocol_version": "1",
+            "protocol_version": "2",
             "user": "65532:65532",
         },
         "schema_version": 1,
@@ -795,7 +795,7 @@ def validate_source_identity(value: object, lock: dict | None = None) -> dict:
     )
     if runtime != {
         "entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
-        "protocol_version": "1",
+        "protocol_version": "2",
         "user": "65532:65532",
     }:
         fail("source runtime contract differs")

--- a/scripts/ci/tests/service-proxy-candidate.test.py
+++ b/scripts/ci/tests/service-proxy-candidate.test.py
@@ -86,7 +86,7 @@ class CandidateContract(unittest.TestCase):
             "org.opencontainers.image.created": self.release["created"],
             "org.opencontainers.image.revision": revision or self.release["revision"],
             "org.opencontainers.image.version": self.release["version"],
-            "io.automata.service-proxy.protocol-version": "1",
+            "io.automata.service-proxy.protocol-version": "2",
             "io.automata.service-proxy.binary.sha256": self.source["artifacts"]["binary_sha256"],
             "io.automata.service-proxy.sbom.sha256": self.source["artifacts"]["sbom_sha256"],
             "io.automata.service-proxy.source.sha256": source_sha,

--- a/scripts/ci/tests/service-proxy-image.test.sh
+++ b/scripts/ci/tests/service-proxy-image.test.sh
@@ -60,7 +60,19 @@ if [[ "$1" == run ]]; then
     success)
       exit 0
       ;;
-    usage-invalid)
+    protocol-v2)
+      if (( $# == 6 )); then
+        printf 'automata-ci-service-proxy: usage-invalid\n' >&2
+        exit 64
+      fi
+      if (( $# == 7 )) && [[ "$7" == serve-results-v1 ]]; then
+        printf 'automata-ci-service-proxy: configuration-invalid\n' >&2
+        exit 64
+      fi
+      printf 'fake-podman: unexpected protocol probe\n' >&2
+      exit 70
+      ;;
+    pre-v2)
       printf 'automata-ci-service-proxy: usage-invalid\n' >&2
       exit 64
       ;;
@@ -80,19 +92,22 @@ ln -s podman "${fake_bin}/buildah"
 valid_inspection="${scratch_directory}/valid-inspection.json"
 buildah_inspection="${scratch_directory}/buildah-inspection.json"
 bad_label_inspection="${scratch_directory}/bad-label-inspection.json"
+stale_protocol_inspection="${scratch_directory}/stale-protocol-inspection.json"
 bad_config_inspection="${scratch_directory}/bad-config-inspection.json"
-readonly valid_inspection buildah_inspection bad_label_inspection bad_config_inspection
+readonly valid_inspection buildah_inspection bad_label_inspection \
+  stale_protocol_inspection bad_config_inspection
 python3 - \
   "$valid_inspection" \
   "$buildah_inspection" \
   "$bad_label_inspection" \
+  "$stale_protocol_inspection" \
   "$bad_config_inspection" <<'PY'
 import copy
 import json
 import pathlib
 import sys
 
-valid_path, buildah_path, bad_label_path, bad_config_path = map(
+valid_path, buildah_path, bad_label_path, stale_protocol_path, bad_config_path = map(
     pathlib.Path, sys.argv[1:]
 )
 labels = {
@@ -101,7 +116,7 @@ labels = {
     "org.opencontainers.image.revision": "0123456789abcdef0123456789abcdef01234567",
     "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
     "org.opencontainers.image.version": "0.1.0",
-    "io.automata.service-proxy.protocol-version": "1",
+    "io.automata.service-proxy.protocol-version": "2",
     "io.automata.service-proxy.binary.sha256": "0" * 64,
     "io.automata.service-proxy.sbom.sha256": "1" * 64,
     "io.automata.service-proxy.source.sha256": "2" * 64,
@@ -109,9 +124,15 @@ labels = {
 document = [
     {
         "Config": {
+            "Cmd": None,
             "Entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ],
             "Labels": labels,
             "User": "65532:65532",
+            "Volumes": None,
+            "WorkingDir": "/",
         }
     }
 ]
@@ -126,6 +147,11 @@ write(buildah_path, {"OCIv1": {"config": document[0]["Config"]}})
 bad_label = copy.deepcopy(document)
 bad_label[0]["Config"]["Labels"]["org.opencontainers.image.version"] = "9.9.9"
 write(bad_label_path, bad_label)
+stale_protocol = copy.deepcopy(document)
+stale_protocol[0]["Config"]["Labels"][
+    "io.automata.service-proxy.protocol-version"
+] = "1"
+write(stale_protocol_path, stale_protocol)
 bad_config = copy.deepcopy(document)
 bad_config[0]["Config"]["Entrypoint"] = ["/bin/not-the-service-proxy"]
 write(bad_config_path, bad_config)
@@ -219,8 +245,22 @@ expect_valid_buildah_metadata_log() {
 
 expect_required_log() {
   mapfile -t invocations <"$invocation_log"
+  (( ${#invocations[@]} == 3 )) || {
+    printf 'required verification did not inspect and run both probes\n' >&2
+    exit 1
+  }
+  [[ "${invocations[0]}" == \
+    'image inspect localhost/automata-ci/service-proxy:test' ]]
+  [[ "${invocations[1]}" == \
+    'run --rm --network none --read-only localhost/automata-ci/service-proxy:test' ]]
+  [[ "${invocations[2]}" == \
+    'run --rm --network none --read-only localhost/automata-ci/service-proxy:test serve-results-v1' ]]
+}
+
+expect_first_probe_log() {
+  mapfile -t invocations <"$invocation_log"
   (( ${#invocations[@]} == 2 )) || {
-    printf 'required verification did not inspect and run exactly once\n' >&2
+    printf 'failed first process probe used unexpected runtime commands\n' >&2
     exit 1
   }
   [[ "${invocations[0]}" == \
@@ -229,45 +269,51 @@ expect_required_log() {
     'run --rm --network none --read-only localhost/automata-ci/service-proxy:test' ]]
 }
 
-run_verifier metadata-only usage-invalid "$valid_inspection"
+run_verifier metadata-only protocol-v2 "$valid_inspection"
 expect_status 0
 expect_exact_stdout \
   'Service-proxy image metadata verified; process probe is covered by the static binary contract'
 [[ ! -s "$stderr_log" ]]
 expect_valid_metadata_log
 
-run_verifier metadata-only usage-invalid "$buildah_inspection" buildah
+run_verifier metadata-only protocol-v2 "$buildah_inspection" buildah
 expect_status 0
 expect_exact_stdout \
   'Service-proxy image metadata verified; process probe is covered by the static binary contract'
 [[ ! -s "$stderr_log" ]]
 expect_valid_buildah_metadata_log
 
-run_verifier default usage-invalid "$buildah_inspection" buildah
+run_verifier default protocol-v2 "$buildah_inspection" buildah
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: Buildah supports only metadata-only image verification'
 [[ ! -s "$invocation_log" ]]
 
-run_verifier metadata-only usage-invalid "$valid_inspection" buildah
+run_verifier metadata-only protocol-v2 "$valid_inspection" buildah
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: image configuration is missing'
 expect_valid_buildah_metadata_log
 
-run_verifier metadata-only usage-invalid "$bad_label_inspection"
+run_verifier metadata-only protocol-v2 "$bad_label_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: candidate labels differ'
 expect_valid_metadata_log
 
-run_verifier metadata-only usage-invalid "$bad_config_inspection"
+run_verifier metadata-only protocol-v2 "$stale_protocol_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr 'service-proxy-image: candidate labels differ'
+expect_valid_metadata_log
+
+run_verifier metadata-only protocol-v2 "$bad_config_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: candidate entrypoint differs'
 expect_valid_metadata_log
 
-run_verifier default usage-invalid "$valid_inspection"
+run_verifier default protocol-v2 "$valid_inspection"
 expect_status 0
 expect_exact_stdout 'Service-proxy image process and metadata verified'
 [[ ! -s "$stderr_log" ]]
@@ -277,21 +323,28 @@ run_verifier default success "$valid_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: candidate accepted an absent protocol command'
-expect_required_log
+expect_first_probe_log
 
 run_verifier default stdout "$valid_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: candidate failure wrote to stdout'
-expect_required_log
+expect_first_probe_log
 
 run_verifier default cgroup "$valid_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr 'service-proxy-image: candidate process diagnostic differs'
+expect_first_probe_log
+
+run_verifier default pre-v2 "$valid_inspection"
+expect_status 1
+[[ ! -s "$stdout_log" ]]
+expect_exact_stderr \
+  'service-proxy-image: candidate does not implement the protocol 2 Results capability'
 expect_required_log
 
-run_verifier unsupported usage-invalid "$valid_inspection"
+run_verifier unsupported protocol-v2 "$valid_inspection"
 expect_status 1
 [[ ! -s "$stdout_log" ]]
 expect_exact_stderr \
@@ -309,7 +362,7 @@ set +e
 env \
   "AUTOMATA_FAKE_PODMAN_INSPECTION=${valid_inspection}" \
   "AUTOMATA_FAKE_PODMAN_LOG=${invocation_log}" \
-  AUTOMATA_FAKE_PODMAN_RUN_RESULT=usage-invalid \
+  AUTOMATA_FAKE_PODMAN_RUN_RESULT=protocol-v2 \
   AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME=podman \
   AUTOMATA_SERVICE_PROXY_OCI_BUILDER=buildah-chroot \
   AUTOMATA_SERVICE_PROXY_PROCESS_PROBE=metadata-only \

--- a/scripts/ci/tests/service-proxy-publication.test.py
+++ b/scripts/ci/tests/service-proxy-publication.test.py
@@ -312,6 +312,14 @@ class PublicationContract(unittest.TestCase):
             lock["source_identity_sha256"], hashlib.sha256(identity_bytes).hexdigest()
         )
         self.assertEqual(identity["image"]["name"], publication.IMAGE_NAME)
+        self.assertEqual(
+            identity["runtime"],
+            {
+                "entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
+                "protocol_version": "2",
+                "user": "65532:65532",
+            },
+        )
         self.assertTrue(lock["image"].startswith(f"{publication.IMAGE_NAME}@sha256:"))
         self.assertEqual(
             sorted(path.name for path in output.iterdir()),
@@ -325,6 +333,11 @@ class PublicationContract(unittest.TestCase):
                 ]
             ),
         )
+
+        stale_identity = json.loads(identity_bytes)
+        stale_identity["runtime"]["protocol_version"] = "1"
+        with self.assertRaisesRegex(SystemExit, "source runtime contract differs"):
+            publication.validate_source_identity(stale_identity, lock)
 
     def test_candidate_archive_and_requested_commit_fail_closed(self) -> None:
         trailing = self.root / "trailing.tar"
@@ -563,7 +576,7 @@ class PublicationContract(unittest.TestCase):
                     "io.automata.service-proxy.binary.sha256": artifacts[
                         "binary_sha256"
                     ],
-                    "io.automata.service-proxy.protocol-version": "1",
+                    "io.automata.service-proxy.protocol-version": "2",
                     "io.automata.service-proxy.sbom.sha256": artifacts[
                         "sbom_sha256"
                     ],
@@ -572,8 +585,8 @@ class PublicationContract(unittest.TestCase):
                     ],
                     "org.opencontainers.image.created": release["created"],
                     "org.opencontainers.image.description": (
-                        "Namespace-local bounded TCP and UDP proxy for job service "
-                        "containers"
+                        "Closed bounded service and Results proxy for Automata job "
+                        "sandboxes"
                     ),
                     "org.opencontainers.image.licenses": "MIT",
                     "org.opencontainers.image.revision": identity["build"][

--- a/scripts/ci/validate-service-proxy-buildah-containerfile.py
+++ b/scripts/ci/validate-service-proxy-buildah-containerfile.py
@@ -18,14 +18,14 @@ EXPECTED_INSTRUCTIONS = (
     "ARG AUTOMATA_VERSION",
     (
         'LABEL org.opencontainers.image.title="Automata CI service proxy" '
-        'org.opencontainers.image.description="Namespace-local bounded TCP and UDP proxy '
-        'for job service containers" '
+        'org.opencontainers.image.description="Closed bounded service and Results proxy '
+        'for Automata job sandboxes" '
         'org.opencontainers.image.source="https://github.com/automata-ci/automata" '
         'org.opencontainers.image.licenses="MIT" '
         'org.opencontainers.image.created="${AUTOMATA_CREATED}" '
         'org.opencontainers.image.revision="${AUTOMATA_REVISION}" '
         'org.opencontainers.image.version="${AUTOMATA_VERSION}" '
-        'io.automata.service-proxy.protocol-version="1" '
+        'io.automata.service-proxy.protocol-version="2" '
         'io.automata.service-proxy.binary.sha256='
         '"${AUTOMATA_SERVICE_PROXY_BINARY_SHA256}" '
         'io.automata.service-proxy.sbom.sha256='

--- a/scripts/ci/verify-service-proxy-image.sh
+++ b/scripts/ci/verify-service-proxy-image.sh
@@ -92,7 +92,7 @@ expected = {
     "org.opencontainers.image.revision": revision,
     "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
     "org.opencontainers.image.version": version,
-    "io.automata.service-proxy.protocol-version": "1",
+    "io.automata.service-proxy.protocol-version": "2",
 }
 if not isinstance(labels, dict) or any(labels.get(k) != v for k, v in expected.items()):
     raise SystemExit("service-proxy-image: candidate labels differ")
@@ -112,6 +112,14 @@ if config.get("Entrypoint") != ["/usr/libexec/automata-ci-service-proxy"]:
     raise SystemExit("service-proxy-image: candidate entrypoint differs")
 if config.get("User") != "65532:65532":
     raise SystemExit("service-proxy-image: candidate user differs")
+if config.get("Env") != [
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+]:
+    raise SystemExit("service-proxy-image: candidate environment differs")
+if config.get("Cmd") is not None or config.get("Volumes") is not None:
+    raise SystemExit("service-proxy-image: candidate declares a command or volume")
+if config.get("WorkingDir") != "/":
+    raise SystemExit("service-proxy-image: candidate working directory differs")
 PY
 
 if [[ "$process_probe" == metadata-only ]]; then
@@ -129,5 +137,17 @@ set -e
 cmp -s "$scratch_directory/stderr" <(
   printf 'automata-ci-service-proxy: usage-invalid\n'
 ) || die "candidate process diagnostic differs"
+
+set +e
+"$runtime" run --rm --network none --read-only "$image" serve-results-v1 \
+  >"$scratch_directory/results-stdout" 2>"$scratch_directory/results-stderr"
+status=$?
+set -e
+(( status != 0 )) || die "candidate accepted an incomplete Results command"
+[[ ! -s "$scratch_directory/results-stdout" ]] \
+  || die "incomplete Results command wrote to stdout"
+cmp -s "$scratch_directory/results-stderr" <(
+  printf 'automata-ci-service-proxy: configuration-invalid\n'
+) || die "candidate does not implement the protocol 2 Results capability"
 
 printf 'Service-proxy image process and metadata verified\n'

--- a/scripts/ci/verify-service-proxy-static.sh
+++ b/scripts/ci/verify-service-proxy-static.sh
@@ -45,6 +45,18 @@ cmp -s "$scratch_directory/stderr" <(
   printf 'automata-ci-service-proxy: usage-invalid\n'
 ) || die "failed helper diagnostic was not the closed static category"
 
+set +e
+"$binary" serve-results-v1 \
+  >"$scratch_directory/results-stdout" 2>"$scratch_directory/results-stderr"
+status=$?
+set -e
+(( status != 0 )) || die "helper accepted an incomplete Results command"
+[[ ! -s "$scratch_directory/results-stdout" ]] \
+  || die "incomplete Results command wrote to stdout"
+cmp -s "$scratch_directory/results-stderr" <(
+  printf 'automata-ci-service-proxy: configuration-invalid\n'
+) || die "helper does not implement the protocol 2 Results capability"
+
 marker='sensitive-helper-image-marker'
 set +e
 "$binary" serve-v1 "tcp|${marker}|80|0" \


### PR DESCRIPTION
## Summary

- add a closed `serve-results-v1` service-proxy mode for exact TCP access to Results on port 8081
- require exact private IPv4 front-network facts, job source, and numeric Results target
- preserve directional half-close semantics and use shared bidirectional activity for the bounded session-idle deadline
- add the consumed `PrivateNetworkResultsEndpoint` server boundary
- advance service-proxy image capability identity to protocol 2 and prove Results semantics in publication, static, and image admission

The existing generic proxy mode remains separate; this mode cannot be configured as an arbitrary forwarder.

## Verification

- independent strict review and amended rereview: CLEAN
- service-proxy: 30 tests
- Results GitHub: 71 tests, 27 explicit external-service ignores
- Podman: 78 tests
- repeated relay/half-close/one-way-activity tests
- strict Clippy, warning-denied rustdoc, formatting, and diff checks
- publication: 11 tests; candidate/image/Buildah validators passed
- musl release/static verification: `9ae9dfd5a863a9fff1172400eb60959301424b2107f569c156cccd4cbe25f0ab`
