### PR TITLE
feat(local): add closed Results gateway topology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "flate2",
+ "futures",
  "http 1.5.0",
  "http-body-util",
  "hyper",

--- a/crates/automata-ci-local/Cargo.toml
+++ b/crates/automata-ci-local/Cargo.toml
@@ -26,6 +26,7 @@ bytes.workspace = true
 cap-fs-ext.workspace = true
 cap-std.workspace = true
 flate2.workspace = true
+futures.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -23,6 +23,7 @@ mod installation;
 #[cfg(target_os = "linux")]
 mod local_docker;
 mod local_docker_error;
+mod results_transport;
 #[cfg(unix)]
 mod snapshot;
 #[cfg(not(unix))]
@@ -40,6 +41,7 @@ pub use installation::{
     InstallationName, InstallationNameError, InstallationSelectorKey,
 };
 pub use local_docker_error::{LocalDockerError, LocalDockerErrorCode};
+pub use results_transport::LocalDockerResultsTransport;
 /// Reserved in-container directory used by the fixed-relay Docker provider's protected client.
 pub const LOCAL_DOCKER_CONTROL_DIRECTORY: &str = "/automata-control";
 
@@ -49,6 +51,8 @@ pub const MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES: u64 = 256 * 1_024 * 1_024;
 pub const MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS: u32 = 1_000;
 /// Smallest process limit that can contain PID 1, the protected client, and one workload process.
 pub const MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS: u32 = 3;
+/// Largest one-based durable job-slot ordinal admitted by the local Docker topology.
+pub const MAXIMUM_LOCAL_DOCKER_JOB_SLOTS: u16 = 256;
 
 /// Connects the exact production-consumed fixed-relay Docker provider.
 ///
@@ -71,11 +75,15 @@ pub const MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS: u32 = 3;
 pub async fn connect_local_docker_provider(
     installation: InstallationBinding,
     guest_image: automata_ci_execution::ImmutableImage,
+    results_transport: LocalDockerResultsTransport,
+    runner_id: automata_ci_execution::RunnerId,
     expected_runner_architecture: &automata_ci_core::Architecture,
 ) -> Result<std::sync::Arc<dyn automata_ci_execution::SandboxProvider>, LocalDockerError> {
     let provider = local_docker::LocalDockerProvider::connect(
         installation,
         guest_image,
+        results_transport,
+        runner_id,
         expected_runner_architecture,
     )
     .await?;
@@ -89,8 +97,9 @@ const MAX_DOCKER_CONTEXT_NAME_BYTES: usize = 128;
 const MAX_DOCKER_ENDPOINT_BYTES: usize = 4096;
 const MIN_DOCKER_API: ApiVersion = ApiVersion {
     major: 1,
-    minor: 44,
+    minor: 48,
 };
+const MIN_DOCKER_ENGINE_MAJOR: u64 = 28;
 const MIN_COMPOSE_VERSION: (u64, u64, u64) = (2, 20, 0);
 
 /// Container engine requested by a local-installation operation.
@@ -293,7 +302,9 @@ impl DoctorIssueCode {
             Self::UnsupportedEngineArchitecture => {
                 "use a native amd64 or arm64 Linux Docker Engine"
             }
-            Self::UnsupportedDockerApi => "upgrade Docker Engine to a supported API version",
+            Self::UnsupportedDockerApi => {
+                "upgrade Docker Engine to version 28 with API 1.48 or newer"
+            }
             Self::MissingEngineIdentity => "the Docker Engine did not report a stable identity",
             Self::EngineIdentityMismatch => "Docker version and info responses disagree",
             Self::MissingEngineCapability => {
@@ -1081,6 +1092,8 @@ fn validate_version(
     if architecture != component_architecture || architecture != host_architecture {
         return Err(DoctorIssueCode::UnsupportedEngineArchitecture);
     }
+    let server_major =
+        canonical_engine_major(&server.version).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
     let client_api =
         ApiVersion::parse(&client.api_version).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
     let server_api =
@@ -1099,7 +1112,8 @@ fn validate_version(
         .ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
     let adapter_api =
         capped_adapter_api(client_api).ok_or(DoctorIssueCode::UnsupportedDockerApi)?;
-    if client_api < MIN_DOCKER_API
+    if server_major < MIN_DOCKER_ENGINE_MAJOR
+        || client_api < MIN_DOCKER_API
         || adapter_api < MIN_DOCKER_API
         || server_api < client_api
         || minimum_api > adapter_api
@@ -1113,6 +1127,23 @@ fn validate_version(
         api_version: format!("{}.{}", adapter_api.major, adapter_api.minor),
         architecture,
     })
+}
+
+fn canonical_engine_major(value: &str) -> Option<u64> {
+    let mut components = value.split('.');
+    let major = components.next()?;
+    let minor = components.next()?;
+    let patch = components.next()?;
+    if components.next().is_some()
+        || [major, minor, patch].iter().any(|component| {
+            component.is_empty()
+                || !component.bytes().all(|byte| byte.is_ascii_digit())
+                || (component.len() > 1 && component.starts_with('0'))
+        })
+    {
+        return None;
+    }
+    major.parse().ok()
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -1492,20 +1523,16 @@ mod tests {
     }
 
     #[test]
-    fn retains_an_older_negotiated_api_below_the_adapter_ceiling() {
+    fn rejects_an_api_below_the_results_transport_minimum() {
         let mut probes = healthy_probes(CONTEXT_UNIX);
         probes.version = success(
             VERSION_AMD64
                 .replacen("\"ApiVersion\":\"1.55\"", "\"ApiVersion\":\"1.44\"", 1)
                 .into_bytes(),
         );
-        let report = report("linux", "x86_64", &probes);
-        assert!(report.ready());
         assert_eq!(
-            report
-                .selected_engine()
-                .map(super::EngineSelection::api_version),
-            Some("1.44")
+            issue_codes(&report("linux", "x86_64", &probes)),
+            vec![DoctorIssueCode::UnsupportedDockerApi]
         );
     }
 

--- a/crates/automata-ci-local/src/local_docker/endpoint.rs
+++ b/crates/automata-ci-local/src/local_docker/endpoint.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, fmt, future::Future, sync::Arc, time::Duration}
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
     ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord,
-    ExecutionOutputStream, ExecutionStage, ExecutionTermination, ProviderStage, SandboxCapability,
-    SandboxHandle, SignalRequest, WaitRequest,
+    ExecutionOutputStream, ExecutionStage, ExecutionTermination, NeverCancelled, ProviderStage,
+    SandboxCapability, SandboxHandle, SignalRequest, WaitRequest,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestOutputStream, GuestRejection, GuestRequest, GuestResponse,
@@ -15,7 +15,8 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use super::engine::{EngineApiError, EngineExecRequest};
 use super::{
     AttachedIdentity, ENDPOINT_CAPABILITIES, ENGINE_TRANSPORT_OVERHEAD, HandleOperationLock,
-    LocalDockerInner, ResourceNames, cancellation_requested, guest_client_user, lock_handle,
+    LocalDockerInner, ResourceNames, ResultsTransportBudget, cancellation_requested,
+    guest_client_user, lock_handle,
 };
 use automata_ci_sandbox_guest::LOCAL_CONTROL_CLIENT;
 
@@ -58,9 +59,10 @@ impl LocalDockerEndpoint {
             let _operation = lock_handle(Arc::clone(&self.operation_lock), cancellation)
                 .await
                 .ok_or_else(|| execution_error(ExecutionErrorKind::Cancelled, stage))?;
+            let budget = ResultsTransportBudget::start();
             let container = self
                 .inner
-                .verify_attached(&self.names, &self.attached)
+                .verify_attached(&self.names, &self.attached, cancellation, budget)
                 .await
                 .map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
             let engine_request = EngineExecRequest {
@@ -73,7 +75,7 @@ impl LocalDockerEndpoint {
                 timeout,
             };
             self.inner
-                .verify_boundary_kind()
+                .verify_boundary_kind(cancellation, budget)
                 .await
                 .map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
             require_active(cancellation, stage)?;
@@ -88,7 +90,7 @@ impl LocalDockerEndpoint {
                 .await
                 .map_err(|error| execution_error(map_engine_error(error), stage))?;
             self.inner
-                .verify_boundary_kind()
+                .verify_boundary_kind(cancellation, budget)
                 .await
                 .map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
             let output = tokio::select! {
@@ -116,10 +118,19 @@ impl LocalDockerEndpoint {
             {
                 return Err(execution_error(ExecutionErrorKind::BackendRejected, stage));
             }
-            self.inner
-                .verify_attached(&self.names, &self.attached)
-                .await
-                .map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
+            // Workload execution may legitimately run for far longer than an
+            // attestation budget. Start a fresh bounded custody phase after
+            // the Engine operation completes.
+            let final_budget = ResultsTransportBudget::start();
+            let final_verification = self
+                .inner
+                .verify_attached(&self.names, &self.attached, cancellation, final_budget)
+                .await;
+            if final_verification == Err(automata_ci_execution::ProviderErrorKind::Cancelled) {
+                self.cancel_running(&container.id, stage).await?;
+                return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
+            }
+            final_verification.map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
             if cancellation.disposition().requires_termination() {
                 self.cancel_running(&container.id, stage).await?;
                 return Err(execution_error(ExecutionErrorKind::Cancelled, stage));
@@ -133,9 +144,10 @@ impl LocalDockerEndpoint {
         container_id: &str,
         stage: ExecutionStage,
     ) -> Result<(), ExecutionError> {
+        let budget = ResultsTransportBudget::start();
         let current = self
             .inner
-            .verify_attached(&self.names, &self.attached)
+            .verify_attached(&self.names, &self.attached, &NeverCancelled, budget)
             .await
             .map_err(|kind| execution_error(map_provider_kind(kind), stage))?;
         if current.id != container_id {
@@ -145,7 +157,13 @@ impl LocalDockerEndpoint {
             ));
         }
         self.inner
-            .stop_exact_running_job(&self.names, &current, &self.handle, ProviderStage::Start)
+            .stop_exact_running_job(
+                &self.names,
+                &current,
+                &self.handle,
+                ProviderStage::Start,
+                budget,
+            )
             .await
             .map_err(|error| execution_error(map_provider_kind(error.kind()), stage))
     }

--- a/crates/automata-ci-local/src/local_docker/engine.rs
+++ b/crates/automata-ci-local/src/local_docker/engine.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
+    net::Ipv4Addr,
     sync::Arc,
     time::Duration,
 };
@@ -150,7 +151,7 @@ fn classify_label_failure(managed: &BTreeMap<&str, &str>) -> LocalDockerError {
 }
 
 #[cfg(unix)]
-fn map_engine_call(error: EngineApiError) -> LocalDockerError {
+pub(crate) fn map_engine_call(error: EngineApiError) -> LocalDockerError {
     match error {
         EngineApiError::RequestFailed => {
             LocalDockerError::new(LocalDockerErrorCode::EngineRequestFailed)
@@ -160,7 +161,7 @@ fn map_engine_call(error: EngineApiError) -> LocalDockerError {
         }
         #[cfg(unix)]
         EngineApiError::OutputLimit => {
-            LocalDockerError::new(LocalDockerErrorCode::InvalidEngineResponse)
+            LocalDockerError::new(LocalDockerErrorCode::EngineOutputLimitExceeded)
         }
     }
 }
@@ -205,6 +206,11 @@ pub(crate) struct InspectedImage {
     pub(crate) has_healthcheck: bool,
     pub(crate) labels: BTreeMap<String, String>,
     pub(crate) environment_names: Vec<String>,
+    pub(crate) default_path_only: bool,
+    pub(crate) user: String,
+    pub(crate) entrypoint: Vec<String>,
+    pub(crate) command: Vec<String>,
+    pub(crate) working_directory: String,
 }
 
 #[cfg(unix)]
@@ -223,6 +229,88 @@ pub(crate) struct ContainerDefinition {
     pub(crate) memory_bytes: i64,
     pub(crate) nano_cpus: i64,
     pub(crate) pids_limit: i64,
+    pub(crate) primary_network: Option<String>,
+    pub(crate) networks: BTreeMap<String, ContainerNetworkAttachment>,
+    pub(crate) capture_logs: bool,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ContainerNetworkAttachment {
+    pub(crate) network_id: String,
+    pub(crate) ipv4_address: Ipv4Addr,
+    pub(crate) aliases: Vec<String>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Ipv4Network {
+    pub(crate) network: Ipv4Addr,
+    pub(crate) prefix: u8,
+}
+
+#[cfg(unix)]
+impl Ipv4Network {
+    pub(crate) fn contains(&self, address: Ipv4Addr) -> bool {
+        let mask = u32::MAX << (32 - self.prefix);
+        u32::from(address) & mask == u32::from(self.network)
+    }
+
+    pub(crate) fn broadcast(&self) -> Ipv4Addr {
+        let mask = u32::MAX << (32 - self.prefix);
+        Ipv4Addr::from(u32::from(self.network) | !mask)
+    }
+
+    pub(crate) fn usable(&self, address: Ipv4Addr) -> bool {
+        self.contains(address) && address != self.network && address != self.broadcast()
+    }
+
+    pub(crate) fn canonical(&self) -> String {
+        format!("{}/{}", self.network, self.prefix)
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct NetworkEndpoint {
+    pub(crate) name: String,
+    pub(crate) endpoint_id: String,
+    pub(crate) mac_address: String,
+    pub(crate) ipv4_address: Ipv4Addr,
+    pub(crate) ipv4_prefix: u8,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct InspectedNetwork {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) driver: String,
+    pub(crate) scope: String,
+    pub(crate) enable_ipv4: bool,
+    pub(crate) enable_ipv6: bool,
+    pub(crate) internal: bool,
+    pub(crate) attachable: bool,
+    pub(crate) ingress: bool,
+    pub(crate) config_only: bool,
+    pub(crate) config_from: String,
+    pub(crate) ipam_driver: String,
+    pub(crate) ipam_options: BTreeMap<String, String>,
+    pub(crate) ipv4_network: Ipv4Network,
+    pub(crate) ipv4_gateway: Ipv4Addr,
+    pub(crate) options: BTreeMap<String, String>,
+    pub(crate) labels: BTreeMap<String, String>,
+    pub(crate) containers: BTreeMap<String, NetworkEndpoint>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CreateNetwork {
+    pub(crate) name: String,
+    pub(crate) labels: BTreeMap<String, String>,
+    pub(crate) ipv4_network: Ipv4Network,
+    pub(crate) ipv4_gateway: Ipv4Addr,
 }
 
 #[cfg(unix)]
@@ -350,6 +438,8 @@ pub(crate) trait SandboxEngineApi: AnchorEngineApi {
         name: &str,
     ) -> Result<Option<InspectedContainer>, EngineApiError>;
 
+    async fn results_target_running(&self, id: &str) -> Result<bool, EngineApiError>;
+
     async fn inspect_container_custody(
         &self,
         name_or_id: &str,
@@ -369,6 +459,17 @@ pub(crate) trait SandboxEngineApi: AnchorEngineApi {
     async fn remove_container(&self, id: &str) -> Result<(), EngineApiError>;
 
     async fn kill_container(&self, id: &str) -> Result<(), EngineApiError>;
+
+    async fn inspect_network(
+        &self,
+        id_or_name: &str,
+    ) -> Result<Option<InspectedNetwork>, EngineApiError>;
+
+    async fn create_network(&self, request: CreateNetwork) -> Result<String, EngineApiError>;
+
+    async fn remove_network(&self, id: &str) -> Result<(), EngineApiError>;
+
+    async fn container_logs(&self, id: &str, byte_limit: usize) -> Result<Vec<u8>, EngineApiError>;
 
     async fn download_guest_image_binary(
         &self,
@@ -439,7 +540,7 @@ impl PinnedDockerEngine {
             },
             api: ApiVersion {
                 major: 1,
-                minor: 44,
+                minor: 48,
             },
             architecture,
         }
@@ -470,7 +571,7 @@ pub(crate) async fn connect_relay_sandbox_engine(
 ) -> Result<(PinnedDockerEngine, Arc<dyn SandboxEngineApi>), LocalDockerError> {
     let api = ApiVersion {
         major: 1,
-        minor: 44,
+        minor: 48,
     };
     let engine = Arc::new(
         HttpEngine::connect_unix_socket(std::path::Path::new(LOCAL_DOCKER_RELAY_SOCKET), api)
@@ -551,7 +652,7 @@ fn validate_relay_facts(
         ));
     }
     if facts.engine_id.is_empty()
-        || facts.server_version.is_empty()
+        || !docker_engine_28_or_newer(&facts.server_version)
         || facts.operating_system != "linux"
         || minimum > api
         || maximum < api
@@ -561,6 +662,27 @@ fn validate_relay_facts(
         ));
     }
     Ok(architecture)
+}
+
+#[cfg(unix)]
+fn docker_engine_28_or_newer(value: &str) -> bool {
+    let mut components = value.split('.');
+    let Some(major) = components.next() else {
+        return false;
+    };
+    let Some(minor) = components.next() else {
+        return false;
+    };
+    let Some(patch) = components.next() else {
+        return false;
+    };
+    components.next().is_none()
+        && [major, minor, patch].iter().all(|component| {
+            !component.is_empty()
+                && component.bytes().all(|byte| byte.is_ascii_digit())
+                && (component.len() == 1 || !component.starts_with('0'))
+        })
+        && major.parse::<u64>().is_ok_and(|major| major >= 28)
 }
 
 #[cfg(all(test, unix))]
@@ -600,7 +722,7 @@ mod relay_tests {
             &facts(security_options),
             ApiVersion {
                 major: 1,
-                minor: 44,
+                minor: 48,
             },
         )
         .expect_err("security options must be rejected")
@@ -610,7 +732,7 @@ mod relay_tests {
     const fn api() -> ApiVersion {
         ApiVersion {
             major: 1,
-            minor: 44,
+            minor: 48,
         }
     }
 

--- a/crates/automata-ci-local/src/local_docker/engine/http_engine.rs
+++ b/crates/automata-ci-local/src/local_docker/engine/http_engine.rs
@@ -1,6 +1,10 @@
-use std::{collections::BTreeMap, time::Duration};
-
-use std::path::Path;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::Ipv4Addr,
+    path::Path,
+    str::FromStr as _,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use http::{Method, StatusCode};
@@ -9,10 +13,11 @@ use serde::{Deserialize, Serialize};
 use serde::de::IgnoredAny;
 
 use super::{
-    ContainerDefinition, EngineContainerState, EngineExecOutput, EngineExecRequest,
-    InspectedContainer, InspectedContainerCustody, InspectedImage,
-    LOCAL_DOCKER_GUEST_ARCHIVE_BYTES, LOCAL_DOCKER_GUEST_IMAGE_BINARY,
-    LOCAL_DOCKER_SANDBOX_GUEST_BINARY, PreparedEngineExec, SandboxEngineApi,
+    ContainerDefinition, ContainerNetworkAttachment, CreateNetwork, EngineContainerState,
+    EngineExecOutput, EngineExecRequest, InspectedContainer, InspectedContainerCustody,
+    InspectedImage, InspectedNetwork, Ipv4Network, LOCAL_DOCKER_GUEST_ARCHIVE_BYTES,
+    LOCAL_DOCKER_GUEST_IMAGE_BINARY, LOCAL_DOCKER_SANDBOX_GUEST_BINARY, NetworkEndpoint,
+    PreparedEngineExec, SandboxEngineApi,
 };
 use super::{
     EngineApi, EngineApiError, EngineFacts, InspectedVolume,
@@ -35,6 +40,8 @@ const IMAGE_BYTES: usize = 512 * 1024;
 #[cfg(unix)]
 const CONTAINER_BYTES: usize = 512 * 1024;
 #[cfg(unix)]
+const NETWORK_BYTES: usize = 512 * 1024;
+#[cfg(unix)]
 const EXEC_BYTES: usize = 128 * 1024;
 #[cfg(unix)]
 const MAX_REPO_DIGESTS: usize = 128;
@@ -45,9 +52,18 @@ const MAX_MOUNTS: usize = 16;
 #[cfg(unix)]
 const MAX_ENVIRONMENT: usize = 256;
 #[cfg(unix)]
+const DEFAULT_CONTAINER_PATH: &str =
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+#[cfg(unix)]
+const DOCKER_STREAM_HEADER_BYTES: usize = 8;
+#[cfg(unix)]
 const MAX_ARGUMENTS: usize = 256;
 #[cfg(unix)]
 const MAX_NETWORKS: usize = 8;
+#[cfg(unix)]
+const MAX_NETWORK_CONTAINERS: usize = 1_024;
+#[cfg(unix)]
+const MAX_NETWORK_IPAM_CONFIGS: usize = 4;
 #[cfg(unix)]
 const MAX_SECURITY_OPTIONS: usize = 16;
 #[cfg(unix)]
@@ -256,6 +272,20 @@ impl SandboxEngineApi for HttpEngine {
         container.map(normalize_container_custody).transpose()
     }
 
+    async fn results_target_running(&self, id: &str) -> Result<bool, EngineApiError> {
+        require_object_id(id)?;
+        let path = format!("/containers/{}/json?size=false", encode_path_component(id));
+        let container: Option<ResultsTargetResponse> = deadline(
+            REQUEST_TIMEOUT,
+            self.transport.optional_json(&path, CONTAINER_BYTES),
+        )
+        .await
+        .map_err(map_transport)?;
+        Ok(container.is_some_and(|container| {
+            container.id == id && running_results_target(&container.state)
+        }))
+    }
+
     async fn create_container(
         &self,
         definition: ContainerDefinition,
@@ -327,6 +357,82 @@ impl SandboxEngineApi for HttpEngine {
         )
         .await
         .map_err(map_transport)
+    }
+
+    async fn inspect_network(
+        &self,
+        id_or_name: &str,
+    ) -> Result<Option<InspectedNetwork>, EngineApiError> {
+        let path = format!(
+            "/networks/{}?verbose=false&scope=local",
+            encode_path_component(id_or_name)
+        );
+        let network: Option<NetworkResponse> = deadline(
+            REQUEST_TIMEOUT,
+            self.transport.optional_json(&path, NETWORK_BYTES),
+        )
+        .await
+        .map_err(map_transport)?;
+        network.map(normalize_network).transpose()
+    }
+
+    async fn create_network(&self, request: CreateNetwork) -> Result<String, EngineApiError> {
+        let body = NetworkCreateRequest::new(&request)?;
+        let created: NetworkCreateResponse = deadline(
+            REQUEST_TIMEOUT,
+            self.transport.json(
+                Method::POST,
+                "/networks/create",
+                Some(&body),
+                StatusCode::CREATED,
+                EXEC_BYTES,
+            ),
+        )
+        .await
+        .map_err(map_transport)?;
+        if !valid_object_id(&created.id) || !created.warning.is_empty() {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        Ok(created.id)
+    }
+
+    async fn remove_network(&self, id: &str) -> Result<(), EngineApiError> {
+        require_object_id(id)?;
+        let path = format!("/networks/{}", encode_path_component(id));
+        deadline(
+            REQUEST_TIMEOUT,
+            self.transport
+                .empty_or_not_found(Method::DELETE, &path, StatusCode::NO_CONTENT),
+        )
+        .await
+        .map_err(map_transport)
+    }
+
+    async fn container_logs(&self, id: &str, byte_limit: usize) -> Result<Vec<u8>, EngineApiError> {
+        require_object_id(id)?;
+        if byte_limit == 0 || byte_limit > 64 * 1024 {
+            return Err(EngineApiError::OutputLimit);
+        }
+        let raw_limit = byte_limit
+            .checked_add(DOCKER_STREAM_HEADER_BYTES)
+            .ok_or(EngineApiError::OutputLimit)?;
+        let path = format!(
+            "/containers/{}/logs?follow=false&stdout=true&stderr=true&since=0&timestamps=false&tail=all",
+            encode_path_component(id)
+        );
+        let bytes = deadline(
+            REQUEST_TIMEOUT,
+            self.transport
+                .bytes(&path, "application/vnd.docker.raw-stream", raw_limit),
+        )
+        .await
+        .map_err(map_transport)?;
+        let (stdout, stderr) = decode_multiplexed(&bytes, byte_limit, 1)?;
+        if stderr.is_empty() {
+            Ok(stdout)
+        } else {
+            Err(EngineApiError::InvalidResponse)
+        }
     }
 
     async fn download_guest_image_binary(
@@ -549,24 +655,25 @@ fn require_object_id(value: &str) -> Result<(), EngineApiError> {
 #[cfg(unix)]
 fn normalize_image(response: ImageResponse) -> Result<InspectedImage, EngineApiError> {
     require_image_id(&response.id)?;
+    let config = response.config;
     let mut repo_digests = response.repo_digests.into_inner();
     repo_digests.sort();
     if repo_digests.is_empty() || repo_digests.iter().any(String::is_empty) {
         return Err(EngineApiError::InvalidResponse);
     }
-    let mut declared_volumes = response.config.volumes.map_or_else(Vec::new, |volumes| {
+    let mut declared_volumes = config.volumes.map_or_else(Vec::new, |volumes| {
         volumes.into_inner().into_keys().collect()
     });
     declared_volumes.sort();
-    let mut declared_exposed_ports = response
-        .config
+    let mut declared_exposed_ports = config
         .exposed_ports
         .map_or_else(Vec::new, |ports| ports.into_inner().into_keys().collect());
     declared_exposed_ports.sort();
-    let mut environment_names = response
-        .config
+    let environment = config
         .environment
-        .map_or_else(Vec::new, BoundedVec::into_inner)
+        .map_or_else(Vec::new, BoundedVec::into_inner);
+    let default_path_only = environment.as_slice() == [DEFAULT_CONTAINER_PATH];
+    let mut environment_names = environment
         .into_iter()
         .map(|entry| {
             let (name, _) = entry
@@ -592,12 +699,18 @@ fn normalize_image(response: ImageResponse) -> Result<InspectedImage, EngineApiE
         architecture: response.architecture,
         declared_volumes,
         declared_exposed_ports,
-        has_healthcheck: response.config.healthcheck.is_some(),
-        labels: response
-            .config
+        has_healthcheck: config.healthcheck.is_some(),
+        labels: config
             .labels
             .map_or_else(BTreeMap::new, BoundedMap::into_inner),
         environment_names,
+        default_path_only,
+        user: config.user,
+        entrypoint: config
+            .entrypoint
+            .map_or_else(Vec::new, BoundedVec::into_inner),
+        command: config.command.map_or_else(Vec::new, BoundedVec::into_inner),
+        working_directory: config.working_directory,
     })
 }
 
@@ -619,6 +732,162 @@ fn require_image_id(value: &str) -> Result<(), EngineApiError> {
 }
 
 #[cfg(unix)]
+fn normalize_network(response: NetworkResponse) -> Result<InspectedNetwork, EngineApiError> {
+    require_object_id(&response.id)?;
+    if response.name.is_empty()
+        || response.name.len() > 255
+        || response.created.is_empty()
+        || response.ipam.config.len() != 1
+    {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    let configuration = response
+        .ipam
+        .config
+        .into_inner()
+        .into_iter()
+        .next()
+        .ok_or(EngineApiError::InvalidResponse)?;
+    if configuration
+        .ip_range
+        .as_ref()
+        .is_some_and(|value| !value.is_empty())
+        || configuration
+            .auxiliary_addresses
+            .as_ref()
+            .is_some_and(|values| !values.is_empty())
+    {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    let ipv4_network = parse_ipv4_network(&configuration.subnet)?;
+    let ipv4_gateway = parse_canonical_ipv4_address(
+        configuration
+            .gateway
+            .as_deref()
+            .ok_or(EngineApiError::InvalidResponse)?,
+    )?;
+    if !ipv4_network.usable(ipv4_gateway) {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    let containers = response
+        .containers
+        .map_or_else(BTreeMap::new, BoundedMap::into_inner)
+        .into_iter()
+        .map(|(id, endpoint)| normalize_network_endpoint(id, endpoint))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let unique_addresses = containers
+        .values()
+        .map(|endpoint| endpoint.ipv4_address)
+        .collect::<BTreeSet<_>>();
+    if unique_addresses.len() != containers.len()
+        || unique_addresses.contains(&ipv4_gateway)
+        || containers.values().any(|endpoint| {
+            endpoint.ipv4_prefix != ipv4_network.prefix
+                || !ipv4_network.usable(endpoint.ipv4_address)
+        })
+    {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    Ok(InspectedNetwork {
+        id: response.id,
+        name: response.name,
+        driver: response.driver,
+        scope: response.scope,
+        enable_ipv4: response.enable_ipv4,
+        enable_ipv6: response.enable_ipv6,
+        internal: response.internal,
+        attachable: response.attachable,
+        ingress: response.ingress,
+        config_only: response.config_only,
+        config_from: response.config_from.network,
+        ipam_driver: response.ipam.driver,
+        ipam_options: response
+            .ipam
+            .options
+            .map_or_else(BTreeMap::new, BoundedMap::into_inner),
+        ipv4_network,
+        ipv4_gateway,
+        options: response
+            .options
+            .map_or_else(BTreeMap::new, BoundedMap::into_inner),
+        labels: response
+            .labels
+            .map_or_else(BTreeMap::new, BoundedMap::into_inner),
+        containers,
+    })
+}
+
+#[cfg(unix)]
+fn normalize_network_endpoint(
+    id: String,
+    endpoint: NetworkContainerResponse,
+) -> Result<(String, NetworkEndpoint), EngineApiError> {
+    require_object_id(&id)?;
+    require_object_id(&endpoint.endpoint_id)?;
+    if endpoint.name.is_empty()
+        || endpoint.mac_address.is_empty()
+        || !endpoint.ipv6_address.is_empty()
+    {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    let (address, prefix) = parse_ipv4_address_prefix(&endpoint.ipv4_address)?;
+    Ok((
+        id,
+        NetworkEndpoint {
+            name: endpoint.name,
+            endpoint_id: endpoint.endpoint_id,
+            mac_address: endpoint.mac_address,
+            ipv4_address: address,
+            ipv4_prefix: prefix,
+        },
+    ))
+}
+
+#[cfg(unix)]
+fn parse_ipv4_network(value: &str) -> Result<Ipv4Network, EngineApiError> {
+    let (address, prefix) = parse_ipv4_address_prefix(value)?;
+    if !(8..=30).contains(&prefix) || !address.is_private() {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    let mask = u32::MAX << (32 - prefix);
+    if u32::from(address) & mask != u32::from(address) {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    Ok(Ipv4Network {
+        network: address,
+        prefix,
+    })
+}
+
+#[cfg(unix)]
+fn parse_ipv4_address_prefix(value: &str) -> Result<(Ipv4Addr, u8), EngineApiError> {
+    let (address_text, prefix_text) = value
+        .split_once('/')
+        .ok_or(EngineApiError::InvalidResponse)?;
+    let address = Ipv4Addr::from_str(address_text).map_err(|_| EngineApiError::InvalidResponse)?;
+    let prefix = prefix_text
+        .parse::<u8>()
+        .map_err(|_| EngineApiError::InvalidResponse)?;
+    if address.to_string() != address_text
+        || prefix.to_string() != prefix_text
+        || prefix > 32
+        || format!("{address}/{prefix}") != value
+    {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    Ok((address, prefix))
+}
+
+#[cfg(unix)]
+fn parse_canonical_ipv4_address(value: &str) -> Result<Ipv4Addr, EngineApiError> {
+    let address = Ipv4Addr::from_str(value).map_err(|_| EngineApiError::InvalidResponse)?;
+    if address.to_string() != value {
+        return Err(EngineApiError::InvalidResponse);
+    }
+    Ok(address)
+}
+
+#[cfg(unix)]
 fn normalize_container(response: ContainerResponse) -> Result<InspectedContainer, EngineApiError> {
     require_object_id(&response.id)?;
     require_image_id(&response.image_id)?;
@@ -628,7 +897,6 @@ fn normalize_container(response: ContainerResponse) -> Result<InspectedContainer
         || !response.mount_label.is_empty()
         || !response.process_label.is_empty()
         || !response.app_armor_profile.is_empty()
-        || !response.log_path.is_empty()
     {
         return Err(EngineApiError::InvalidResponse);
     }
@@ -670,6 +938,14 @@ fn normalize_container(response: ContainerResponse) -> Result<InspectedContainer
         return Err(EngineApiError::InvalidResponse);
     }
     let state = normalized_container_state(&response.state);
+    let capture_logs = normalize_log_configuration(&host.log_config, &response.log_path)?;
+    let (primary_network, networks) = normalize_container_networks(
+        &response.id,
+        &name,
+        state,
+        &host.network_mode,
+        &response.network_settings,
+    )?;
     let expected_hostname = response
         .id
         .get(..12)
@@ -681,6 +957,10 @@ fn normalize_container(response: ContainerResponse) -> Result<InspectedContainer
             &host,
             &response.network_settings,
             expected_hostname,
+            primary_network.as_deref(),
+            &networks,
+            state,
+            capture_logs,
         );
     Ok(InspectedContainer {
         id: response.id,
@@ -701,6 +981,9 @@ fn normalize_container(response: ContainerResponse) -> Result<InspectedContainer
             memory_bytes: host.memory_bytes,
             nano_cpus: host.nano_cpus,
             pids_limit: host.pids_limit,
+            primary_network,
+            networks,
+            capture_logs,
         },
         state,
         isolated,
@@ -774,23 +1057,45 @@ fn normalized_container_state(state: &ContainerStateResponse) -> EngineContainer
 }
 
 #[cfg(unix)]
+fn running_results_target(state: &ContainerStateResponse) -> bool {
+    state.status == "running"
+        && state.running
+        && !state.paused
+        && !state.restarting
+        && !state.out_of_memory
+        && !state.dead
+        && state.pid > 0
+        && state.exit_code == 0
+        && state.error.is_empty()
+}
+
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
 fn exact_isolation(
     config: &ContainerConfigResponse,
     host: &HostConfigResponse,
     network: &NetworkSettingsResponse,
     expected_hostname: &str,
+    primary_network: Option<&str>,
+    networks: &BTreeMap<String, ContainerNetworkAttachment>,
+    state: EngineContainerState,
+    capture_logs: bool,
 ) -> bool {
-    exact_container_config(config, expected_hostname)
-        && exact_host_runtime(host)
+    exact_container_config(config, expected_hostname, networks.is_empty())
+        && exact_host_runtime(host, primary_network)
         && exact_host_scheduling(host)
         && exact_host_memory(host)
-        && exact_host_resource_surface(host)
+        && exact_host_resource_surface(host, capture_logs)
         && exact_host_paths(host)
-        && exact_network(network)
+        && exact_network(network, networks, state)
 }
 
 #[cfg(unix)]
-fn exact_container_config(config: &ContainerConfigResponse, expected_hostname: &str) -> bool {
+fn exact_container_config(
+    config: &ContainerConfigResponse,
+    expected_hostname: &str,
+    network_disabled: bool,
+) -> bool {
     config.hostname == expected_hostname
         && config.domain_name.is_empty()
         && !config.attach_stdin
@@ -808,7 +1113,7 @@ fn exact_container_config(config: &ContainerConfigResponse, expected_hostname: &
             .exposed_ports
             .as_ref()
             .is_none_or(BoundedMap::is_empty)
-        && config.network_disabled
+        && config.network_disabled == network_disabled
         && config.healthcheck.is_disabled()
         && config.stop_signal == "SIGKILL"
         && config.stop_timeout == Some(0)
@@ -816,10 +1121,10 @@ fn exact_container_config(config: &ContainerConfigResponse, expected_hostname: &
 }
 
 #[cfg(unix)]
-fn exact_host_runtime(host: &HostConfigResponse) -> bool {
+fn exact_host_runtime(host: &HostConfigResponse, primary_network: Option<&str>) -> bool {
     host.binds.as_ref().is_none_or(BoundedVec::is_empty)
         && host.container_id_file.is_empty()
-        && host.network_mode == "none"
+        && host.network_mode == primary_network.unwrap_or("none")
         && host.port_bindings.is_empty()
         && host.restart_policy.name == "no"
         && host.restart_policy.maximum_retry_count == 0
@@ -898,18 +1203,27 @@ fn exact_host_memory(host: &HostConfigResponse) -> bool {
         && host.memory_reservation == 0
         && host.memory_swap == host.memory_bytes
         && host.memory_swappiness.is_none()
-        // Docker v1.44 reports the requested `false` either directly while
+        // Docker v1.48 reports the requested `false` either directly while
         // created or normalized to null after start; `true` is never accepted.
         && host.oom_kill_disable.is_none_or(|disabled| !disabled)
         && host.pids_limit > 0
 }
 
 #[cfg(unix)]
-fn exact_host_resource_surface(host: &HostConfigResponse) -> bool {
+fn exact_host_resource_surface(host: &HostConfigResponse, capture_logs: bool) -> bool {
     host.ulimits.is_empty()
         && !host.init
-        && host.log_config.driver == "none"
-        && host.log_config.options.is_empty()
+        && (if capture_logs {
+            host.log_config.driver == "json-file"
+                && host.log_config.options.clone().into_inner()
+                    == BTreeMap::from([
+                        ("compress".to_owned(), "false".to_owned()),
+                        ("max-file".to_owned(), "1".to_owned()),
+                        ("max-size".to_owned(), "64k".to_owned()),
+                    ])
+        } else {
+            host.log_config.driver == "none" && host.log_config.options.is_empty()
+        })
         && host.cpu_count == 0
         && host.cpu_percent == 0
         && host.io_maximum_iops == 0
@@ -919,6 +1233,28 @@ fn exact_host_resource_surface(host: &HostConfigResponse) -> bool {
             .as_ref()
             .is_none_or(BoundedMap::is_empty)
         && host.sysctls.as_ref().is_none_or(BoundedMap::is_empty)
+}
+
+#[cfg(unix)]
+fn normalize_log_configuration(
+    log: &LogConfigResponse,
+    log_path: &str,
+) -> Result<bool, EngineApiError> {
+    match log.driver.as_str() {
+        "none" if log.options.is_empty() && log_path.is_empty() => Ok(false),
+        "json-file"
+            if !log_path.is_empty()
+                && log.options.clone().into_inner()
+                    == BTreeMap::from([
+                        ("compress".to_owned(), "false".to_owned()),
+                        ("max-file".to_owned(), "1".to_owned()),
+                        ("max-size".to_owned(), "64k".to_owned()),
+                    ]) =>
+        {
+            Ok(true)
+        }
+        _ => Err(EngineApiError::InvalidResponse),
+    }
 }
 
 #[cfg(unix)]
@@ -937,11 +1273,162 @@ fn exact_host_paths(host: &HostConfigResponse) -> bool {
 }
 
 #[cfg(unix)]
-fn exact_network(network: &NetworkSettingsResponse) -> bool {
-    network.sandbox_id.is_empty()
-        && network.sandbox_key.is_empty()
-        && network.ports.is_empty()
-        && network.networks.is_empty()
+fn normalize_container_networks(
+    container_id: &str,
+    container_name: &str,
+    state: EngineContainerState,
+    network_mode: &str,
+    network: &NetworkSettingsResponse,
+) -> Result<(Option<String>, BTreeMap<String, ContainerNetworkAttachment>), EngineApiError> {
+    let networks = network
+        .networks
+        .clone()
+        .into_inner()
+        .into_iter()
+        .map(|(name, endpoint)| {
+            if name.is_empty()
+                || name.len() > 255
+                || endpoint
+                    .links
+                    .as_ref()
+                    .is_some_and(|links| !links.is_empty())
+                || endpoint
+                    .driver_options
+                    .as_ref()
+                    .is_some_and(|options| !options.is_empty())
+                || endpoint.gateway_priority != 0
+            {
+                return Err(EngineApiError::InvalidResponse);
+            }
+            let ipam = endpoint
+                .ipam_config
+                .as_ref()
+                .ok_or(EngineApiError::InvalidResponse)?;
+            let ipv4_address = ipam
+                .ipv4_address
+                .parse::<Ipv4Addr>()
+                .map_err(|_| EngineApiError::InvalidResponse)?;
+            if ipv4_address.to_string() != ipam.ipv4_address
+                || !ipv4_address.is_private()
+                || !ipam.ipv6_address.is_empty()
+                || ipam
+                    .link_local_ips
+                    .as_ref()
+                    .is_some_and(|values| !values.is_empty())
+            {
+                return Err(EngineApiError::InvalidResponse);
+            }
+            let aliases = endpoint
+                .aliases
+                .clone()
+                .map_or_else(Vec::new, BoundedVec::into_inner);
+            if aliases.iter().any(|alias| {
+                alias.is_empty()
+                    || alias.len() > 255
+                    || !alias.is_ascii()
+                    || alias.bytes().any(|byte| {
+                        byte.is_ascii_control() || byte.is_ascii_whitespace() || byte == b'/'
+                    })
+            }) {
+                return Err(EngineApiError::InvalidResponse);
+            }
+            if !exact_endpoint_runtime(
+                &endpoint,
+                state,
+                container_id,
+                container_name,
+                ipv4_address,
+                &aliases,
+            ) {
+                return Err(EngineApiError::InvalidResponse);
+            }
+            Ok((
+                name,
+                ContainerNetworkAttachment {
+                    network_id: endpoint.network_id,
+                    ipv4_address,
+                    aliases,
+                },
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let primary = if networks.is_empty() {
+        if network_mode != "none" {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        None
+    } else if networks.contains_key(network_mode) {
+        Some(network_mode.to_owned())
+    } else {
+        return Err(EngineApiError::InvalidResponse);
+    };
+    Ok((primary, networks))
+}
+
+#[cfg(unix)]
+fn exact_endpoint_runtime(
+    endpoint: &EndpointSettingsResponse,
+    state: EngineContainerState,
+    container_id: &str,
+    container_name: &str,
+    ipv4_address: Ipv4Addr,
+    aliases: &[String],
+) -> bool {
+    let common = endpoint.gateway.is_empty()
+        && endpoint.ipv6_gateway.is_empty()
+        && endpoint.global_ipv6_address.is_empty()
+        && endpoint.global_ipv6_prefix_length == 0;
+    if !common {
+        return false;
+    }
+    let Some(short_id) = container_id.get(..12) else {
+        return false;
+    };
+    let expected_dns = std::iter::once(container_name)
+        .chain(aliases.iter().map(String::as_str))
+        .chain(std::iter::once(short_id));
+    let runtime_empty = endpoint.endpoint_id.is_empty()
+        && endpoint.ip_address.is_empty()
+        && endpoint.mac_address.is_empty()
+        && endpoint.ip_prefix_length == 0;
+    match state {
+        EngineContainerState::Created => {
+            endpoint.network_id.is_empty() && runtime_empty && endpoint.dns_names.is_none()
+        }
+        EngineContainerState::Running => {
+            valid_object_id(&endpoint.network_id)
+                && valid_object_id(&endpoint.endpoint_id)
+                && endpoint.ip_address == ipv4_address.to_string()
+                && (8..=30).contains(&endpoint.ip_prefix_length)
+                && !endpoint.mac_address.is_empty()
+                && endpoint.dns_names.as_ref().is_some_and(|names| {
+                    names.as_slice().iter().map(String::as_str).eq(expected_dns)
+                })
+        }
+        EngineContainerState::Exited(_) => {
+            valid_object_id(&endpoint.network_id)
+                && runtime_empty
+                && endpoint.dns_names.as_ref().is_some_and(|names| {
+                    names.as_slice().iter().map(String::as_str).eq(expected_dns)
+                })
+        }
+        EngineContainerState::Invalid => false,
+    }
+}
+
+#[cfg(unix)]
+fn exact_network(
+    network: &NetworkSettingsResponse,
+    networks: &BTreeMap<String, ContainerNetworkAttachment>,
+    state: EngineContainerState,
+) -> bool {
+    let active = !networks.is_empty() && state == EngineContainerState::Running;
+    (if active {
+        valid_object_id(&network.sandbox_id) && !network.sandbox_key.is_empty()
+    } else {
+        network.sandbox_id.is_empty() && network.sandbox_key.is_empty()
+    }) && network.ports.is_empty()
+        && network.networks.len() == networks.len()
         && network.bridge.as_ref().is_none_or(String::is_empty)
         && network.hairpin_mode.is_none_or(|enabled| !enabled)
         && network
@@ -999,7 +1486,9 @@ fn decode_multiplexed(
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     while !remaining.is_empty() {
-        let header = remaining.get(..8).ok_or(EngineApiError::InvalidResponse)?;
+        let header = remaining
+            .get(..DOCKER_STREAM_HEADER_BYTES)
+            .ok_or(EngineApiError::InvalidResponse)?;
         if header[1..4] != [0, 0, 0] {
             return Err(EngineApiError::InvalidResponse);
         }
@@ -1009,8 +1498,11 @@ fn decode_multiplexed(
                 .map_err(|_| EngineApiError::InvalidResponse)?,
         ))
         .map_err(|_| EngineApiError::InvalidResponse)?;
+        let frame_end = DOCKER_STREAM_HEADER_BYTES
+            .checked_add(length)
+            .ok_or(EngineApiError::InvalidResponse)?;
         let payload = remaining
-            .get(8..8 + length)
+            .get(DOCKER_STREAM_HEADER_BYTES..frame_end)
             .ok_or(EngineApiError::InvalidResponse)?;
         let (target, limit) = match header[0] {
             1 => (&mut stdout, stdout_limit),
@@ -1025,7 +1517,7 @@ fn decode_multiplexed(
             return Err(EngineApiError::OutputLimit);
         }
         target.extend_from_slice(payload);
-        remaining = &remaining[8 + length..];
+        remaining = &remaining[frame_end..];
     }
     Ok((stdout, stderr))
 }
@@ -1033,6 +1525,35 @@ fn decode_multiplexed(
 #[cfg(unix)]
 impl ContainerCreateRequest<'_> {
     fn new(definition: &ContainerDefinition) -> ContainerCreateRequest<'_> {
+        let endpoints = definition
+            .networks
+            .iter()
+            .map(|(name, attachment)| {
+                (
+                    name.clone(),
+                    EndpointSettingsRequest {
+                        ipam_config: EndpointIpamRequest {
+                            ipv4_address: attachment.ipv4_address.to_string(),
+                            ipv6_address: "",
+                            link_local_ips: Vec::new(),
+                        },
+                        links: Vec::new(),
+                        aliases: attachment.aliases.clone(),
+                        network_id: attachment.network_id.clone(),
+                        endpoint_id: "",
+                        gateway: "",
+                        ip_address: "",
+                        ip_prefix_length: 0,
+                        ipv6_gateway: "",
+                        global_ipv6_address: "",
+                        global_ipv6_prefix_length: 0,
+                        mac_address: "",
+                        driver_options: BTreeMap::new(),
+                        gateway_priority: 0,
+                    },
+                )
+            })
+            .collect();
         ContainerCreateRequest {
             hostname: "",
             domain_name: "",
@@ -1052,7 +1573,7 @@ impl ContainerCreateRequest<'_> {
             volumes: BTreeMap::new(),
             working_directory: &definition.working_directory,
             entrypoint: [&definition.entrypoint],
-            network_disabled: true,
+            network_disabled: definition.networks.is_empty(),
             labels: &definition.labels,
             on_build: Vec::new(),
             shell: Vec::new(),
@@ -1060,10 +1581,42 @@ impl ContainerCreateRequest<'_> {
             stop_timeout: 0,
             mac_address: "",
             host_config: HostConfigRequest::new(definition),
-            networking_config: NetworkingConfigRequest {
-                endpoints: BTreeMap::new(),
-            },
+            networking_config: NetworkingConfigRequest { endpoints },
         }
+    }
+}
+
+#[cfg(unix)]
+impl<'a> NetworkCreateRequest<'a> {
+    fn new(request: &'a CreateNetwork) -> Result<Self, EngineApiError> {
+        let subnet = request.ipv4_network.canonical();
+        let ipv4_network = parse_ipv4_network(&subnet)?;
+        if ipv4_network != request.ipv4_network || !ipv4_network.usable(request.ipv4_gateway) {
+            return Err(EngineApiError::InvalidResponse);
+        }
+        Ok(Self {
+            name: &request.name,
+            check_duplicate: true,
+            driver: "bridge",
+            internal: true,
+            attachable: false,
+            ingress: false,
+            enable_ipv4: true,
+            enable_ipv6: false,
+            ipam: NetworkIpamRequest {
+                driver: "default",
+                options: BTreeMap::new(),
+                config: [NetworkIpamConfigurationRequest {
+                    subnet,
+                    ip_range: "",
+                    gateway: request.ipv4_gateway.to_string(),
+                    auxiliary_addresses: BTreeMap::new(),
+                }],
+            },
+            options: BTreeMap::from([("com.docker.network.bridge.gateway_mode_ipv4", "isolated")]),
+            labels: &request.labels,
+            config_from: NetworkConfigFromRequest { network: "" },
+        })
     }
 }
 
@@ -1073,11 +1626,22 @@ impl<'a> HostConfigRequest<'a> {
         Self {
             binds: Vec::new(),
             container_id_file: "",
-            log_config: LogConfigRequest {
-                driver: "none",
-                options: BTreeMap::new(),
+            log_config: if definition.capture_logs {
+                LogConfigRequest {
+                    driver: "json-file",
+                    options: BTreeMap::from([
+                        ("compress".to_owned(), "false".to_owned()),
+                        ("max-file".to_owned(), "1".to_owned()),
+                        ("max-size".to_owned(), "64k".to_owned()),
+                    ]),
+                }
+            } else {
+                LogConfigRequest {
+                    driver: "none",
+                    options: BTreeMap::new(),
+                }
             },
-            network_mode: "none",
+            network_mode: definition.primary_network.as_deref().unwrap_or("none"),
             port_bindings: BTreeMap::new(),
             restart_policy: RestartPolicyRequest {
                 name: "no",
@@ -1251,7 +1815,7 @@ struct HostConfigRequest<'a> {
     #[serde(rename = "LogConfig")]
     log_config: LogConfigRequest,
     #[serde(rename = "NetworkMode")]
-    network_mode: &'static str,
+    network_mode: &'a str,
     #[serde(rename = "PortBindings")]
     port_bindings: BTreeMap<String, String>,
     #[serde(rename = "RestartPolicy")]
@@ -1404,7 +1968,211 @@ struct RestartPolicyRequest {
 #[derive(Serialize)]
 struct NetworkingConfigRequest {
     #[serde(rename = "EndpointsConfig")]
-    endpoints: BTreeMap<String, String>,
+    endpoints: BTreeMap<String, EndpointSettingsRequest>,
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+struct EndpointSettingsRequest {
+    #[serde(rename = "IPAMConfig")]
+    ipam_config: EndpointIpamRequest,
+    #[serde(rename = "Links")]
+    links: Vec<String>,
+    #[serde(rename = "Aliases")]
+    aliases: Vec<String>,
+    #[serde(rename = "NetworkID")]
+    network_id: String,
+    #[serde(rename = "EndpointID")]
+    endpoint_id: &'static str,
+    #[serde(rename = "Gateway")]
+    gateway: &'static str,
+    #[serde(rename = "IPAddress")]
+    ip_address: &'static str,
+    #[serde(rename = "IPPrefixLen")]
+    ip_prefix_length: i64,
+    #[serde(rename = "IPv6Gateway")]
+    ipv6_gateway: &'static str,
+    #[serde(rename = "GlobalIPv6Address")]
+    global_ipv6_address: &'static str,
+    #[serde(rename = "GlobalIPv6PrefixLen")]
+    global_ipv6_prefix_length: i64,
+    #[serde(rename = "MacAddress")]
+    mac_address: &'static str,
+    #[serde(rename = "DriverOpts")]
+    driver_options: BTreeMap<String, String>,
+    #[serde(rename = "GwPriority")]
+    gateway_priority: i64,
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+struct EndpointIpamRequest {
+    #[serde(rename = "IPv4Address")]
+    ipv4_address: String,
+    #[serde(rename = "IPv6Address")]
+    ipv6_address: &'static str,
+    #[serde(rename = "LinkLocalIPs")]
+    link_local_ips: Vec<String>,
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+#[allow(clippy::struct_excessive_bools)]
+struct NetworkCreateRequest<'a> {
+    #[serde(rename = "Name")]
+    name: &'a str,
+    #[serde(rename = "CheckDuplicate")]
+    check_duplicate: bool,
+    #[serde(rename = "Driver")]
+    driver: &'static str,
+    #[serde(rename = "Internal")]
+    internal: bool,
+    #[serde(rename = "Attachable")]
+    attachable: bool,
+    #[serde(rename = "Ingress")]
+    ingress: bool,
+    #[serde(rename = "EnableIPv4")]
+    enable_ipv4: bool,
+    #[serde(rename = "EnableIPv6")]
+    enable_ipv6: bool,
+    #[serde(rename = "IPAM")]
+    ipam: NetworkIpamRequest,
+    #[serde(rename = "Options")]
+    options: BTreeMap<&'static str, &'static str>,
+    #[serde(rename = "Labels")]
+    labels: &'a BTreeMap<String, String>,
+    #[serde(rename = "ConfigFrom")]
+    config_from: NetworkConfigFromRequest,
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+struct NetworkIpamRequest {
+    #[serde(rename = "Driver")]
+    driver: &'static str,
+    #[serde(rename = "Options")]
+    options: BTreeMap<String, String>,
+    #[serde(rename = "Config")]
+    config: [NetworkIpamConfigurationRequest; 1],
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+struct NetworkIpamConfigurationRequest {
+    #[serde(rename = "Subnet")]
+    subnet: String,
+    #[serde(rename = "IPRange")]
+    ip_range: &'static str,
+    #[serde(rename = "Gateway")]
+    gateway: String,
+    #[serde(rename = "AuxiliaryAddresses")]
+    auxiliary_addresses: BTreeMap<String, String>,
+}
+
+#[cfg(unix)]
+#[derive(Serialize)]
+struct NetworkConfigFromRequest {
+    #[serde(rename = "Network")]
+    network: &'static str,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkCreateResponse {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "Warning")]
+    warning: String,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools)]
+struct NetworkResponse {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "Created")]
+    created: String,
+    #[serde(rename = "Scope")]
+    scope: String,
+    #[serde(rename = "Driver")]
+    driver: String,
+    #[serde(rename = "EnableIPv4")]
+    enable_ipv4: bool,
+    #[serde(rename = "EnableIPv6")]
+    enable_ipv6: bool,
+    #[serde(rename = "IPAM")]
+    ipam: NetworkIpamResponse,
+    #[serde(rename = "Internal")]
+    internal: bool,
+    #[serde(rename = "Attachable")]
+    attachable: bool,
+    #[serde(rename = "Ingress")]
+    ingress: bool,
+    #[serde(rename = "ConfigFrom")]
+    config_from: NetworkConfigFromResponse,
+    #[serde(rename = "ConfigOnly")]
+    config_only: bool,
+    #[serde(rename = "Options")]
+    options: Option<BoundedMap<String, String, 32>>,
+    #[serde(rename = "Labels")]
+    labels: Option<BoundedMap<String, String, MAX_LABELS>>,
+    #[serde(rename = "Containers")]
+    containers: Option<BoundedMap<String, NetworkContainerResponse, MAX_NETWORK_CONTAINERS>>,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkIpamResponse {
+    #[serde(rename = "Driver")]
+    driver: String,
+    #[serde(rename = "Options")]
+    options: Option<BoundedMap<String, String, 32>>,
+    #[serde(rename = "Config")]
+    config: BoundedVec<NetworkIpamConfigurationResponse, MAX_NETWORK_IPAM_CONFIGS>,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkIpamConfigurationResponse {
+    #[serde(rename = "Subnet")]
+    subnet: String,
+    #[serde(rename = "IPRange")]
+    ip_range: Option<String>,
+    #[serde(rename = "Gateway")]
+    gateway: Option<String>,
+    #[serde(rename = "AuxiliaryAddresses")]
+    auxiliary_addresses: Option<BoundedMap<String, String, 32>>,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkConfigFromResponse {
+    #[serde(rename = "Network")]
+    network: String,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkContainerResponse {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "EndpointID")]
+    endpoint_id: String,
+    #[serde(rename = "MacAddress")]
+    mac_address: String,
+    #[serde(rename = "IPv4Address")]
+    ipv4_address: String,
+    #[serde(rename = "IPv6Address")]
+    ipv6_address: String,
 }
 
 #[cfg(unix)]
@@ -1444,6 +2212,14 @@ struct ImageConfigResponse {
     healthcheck: Option<ImageHealthcheckResponse>,
     #[serde(rename = "Labels")]
     labels: Option<BoundedMap<String, String, MAX_LABELS>>,
+    #[serde(rename = "User", default)]
+    user: String,
+    #[serde(rename = "Entrypoint", default)]
+    entrypoint: Option<BoundedVec<String, 4>>,
+    #[serde(rename = "Cmd", default)]
+    command: Option<BoundedVec<String, MAX_ARGUMENTS>>,
+    #[serde(rename = "WorkingDir", default)]
+    working_directory: String,
 }
 
 #[cfg(unix)]
@@ -1554,6 +2330,15 @@ struct ContainerCustodyConfigResponse {
     image: String,
     #[serde(rename = "Labels")]
     labels: Option<BoundedMap<String, String, MAX_LABELS>>,
+}
+
+#[cfg(unix)]
+#[derive(Deserialize)]
+struct ResultsTargetResponse {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "State")]
+    state: ContainerStateResponse,
 }
 
 #[cfg(unix)]
@@ -1876,7 +2661,55 @@ struct NetworkSettingsResponse {
     #[serde(rename = "Ports")]
     ports: BoundedMap<String, IgnoredAny, 64>,
     #[serde(rename = "Networks")]
-    networks: BoundedMap<String, IgnoredAny, MAX_NETWORKS>,
+    networks: BoundedMap<String, EndpointSettingsResponse, MAX_NETWORKS>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EndpointSettingsResponse {
+    #[serde(rename = "IPAMConfig")]
+    ipam_config: Option<EndpointIpamResponse>,
+    #[serde(rename = "Links")]
+    links: Option<BoundedVec<String, 16>>,
+    #[serde(rename = "Aliases")]
+    aliases: Option<BoundedVec<String, 16>>,
+    #[serde(rename = "DriverOpts")]
+    driver_options: Option<BoundedMap<String, String, 16>>,
+    #[serde(rename = "GwPriority", default)]
+    gateway_priority: i64,
+    #[serde(rename = "NetworkID")]
+    network_id: String,
+    #[serde(rename = "EndpointID")]
+    endpoint_id: String,
+    #[serde(rename = "Gateway")]
+    gateway: String,
+    #[serde(rename = "IPAddress")]
+    ip_address: String,
+    #[serde(rename = "MacAddress")]
+    mac_address: String,
+    #[serde(rename = "IPPrefixLen")]
+    ip_prefix_length: i64,
+    #[serde(rename = "IPv6Gateway")]
+    ipv6_gateway: String,
+    #[serde(rename = "GlobalIPv6Address")]
+    global_ipv6_address: String,
+    #[serde(rename = "GlobalIPv6PrefixLen")]
+    global_ipv6_prefix_length: i64,
+    #[serde(rename = "DNSNames")]
+    dns_names: Option<BoundedVec<String, 32>>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EndpointIpamResponse {
+    #[serde(rename = "IPv4Address")]
+    ipv4_address: String,
+    #[serde(rename = "IPv6Address", default)]
+    ipv6_address: String,
+    #[serde(rename = "LinkLocalIPs", default)]
+    link_local_ips: Option<BoundedVec<String, 8>>,
 }
 
 #[cfg(unix)]
@@ -1999,14 +2832,14 @@ impl ExecInspectResponse {
             &request.user,
         ) && !self.running
             && self.exit_code.is_some()
-            // Docker v1.44 retains the positive host PID after the exec has
+            // Docker v1.48 retains the positive host PID after the exec has
             // stopped; the created form above is the only accepted zero PID.
             && self.pid > 0
     }
 }
 
 #[derive(Deserialize)]
-#[allow(clippy::struct_excessive_bools)] // Exact independent Docker v1.44 capability fields.
+#[allow(clippy::struct_excessive_bools)] // Exact independent Docker v1.48 capability fields.
 struct InfoResponse {
     #[serde(rename = "ID")]
     id: String,
@@ -2066,16 +2899,20 @@ struct ContainerSummary {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, net::Ipv4Addr, path::Path};
 
     use serde_json::{Value, json};
 
+    use super::EngineApiError;
     use super::{
-        ContainerCustodyResponse, ContainerDefinition, EngineContainerState, ExecInspectResponse,
-        ImageResponse, InfoResponse, MASKED_PATHS, READ_ONLY_PATHS, normalize_container,
-        normalize_container_custody, normalize_image, valid_object_id,
+        ContainerCustodyResponse, ContainerDefinition, CreateNetwork, DEFAULT_CONTAINER_PATH,
+        EngineApi, EngineContainerState, ExecInspectResponse, HttpEngine, ImageResponse,
+        InfoResponse, Ipv4Network, MASKED_PATHS, NetworkCreateRequest, NetworkResponse,
+        READ_ONLY_PATHS, SandboxEngineApi, normalize_container, normalize_container_custody,
+        normalize_image, normalize_network, valid_object_id,
     };
     use super::{EngineExecRequest, PreparedEngineExec};
+    use crate::ApiVersion;
 
     #[test]
     fn accepts_only_full_canonical_container_ids() {
@@ -2134,6 +2971,185 @@ mod tests {
         }
     }
 
+    fn network_json() -> Value {
+        let mut value = json!({
+            "Name": "automata-results-network",
+            "Id": "a".repeat(64),
+            "Created": "2026-08-16T00:00:00Z",
+            "Scope": "local",
+            "Driver": "bridge",
+            "EnableIPv4": true,
+            "EnableIPv6": false,
+            "IPAM": {
+                "Driver": "default",
+                "Options": null,
+                "Config": [{
+                    "Subnet": "10.31.0.0/29",
+                    "IPRange": "",
+                    "Gateway": "10.31.0.1",
+                    "AuxiliaryAddresses": null
+                }]
+            },
+            "Internal": true,
+            "Attachable": false,
+            "Ingress": false,
+            "ConfigFrom": {"Network": ""},
+            "ConfigOnly": false,
+            "Options": {
+                "com.docker.network.bridge.gateway_mode_ipv4": "isolated"
+            },
+            "Labels": {"io.automata.test": "true"},
+            "Containers": {}
+        });
+        let containers = value
+            .pointer_mut("/Containers")
+            .expect("containers fixture")
+            .as_object_mut()
+            .expect("containers object");
+        containers.insert(
+            "b".repeat(64),
+            json!({
+                "Name": "automata-results-proxy",
+                "EndpointID": "c".repeat(64),
+                "MacAddress": "02:42:0a:1f:00:02",
+                "IPv4Address": "10.31.0.2/29",
+                "IPv6Address": ""
+            }),
+        );
+        containers.insert(
+            "d".repeat(64),
+            json!({
+                "Name": "automata-job",
+                "EndpointID": "e".repeat(64),
+                "MacAddress": "02:42:0a:1f:00:03",
+                "IPv4Address": "10.31.0.3/29",
+                "IPv6Address": ""
+            }),
+        );
+        value
+    }
+
+    fn normalized_network(value: Value) -> Result<super::InspectedNetwork, super::EngineApiError> {
+        let response: NetworkResponse =
+            serde_json::from_value(value).map_err(|_| super::EngineApiError::InvalidResponse)?;
+        normalize_network(response)
+    }
+
+    #[test]
+    fn network_create_request_contains_one_exact_ipv4_configuration() {
+        let labels = BTreeMap::from([("io.automata.test".to_owned(), "true".to_owned())]);
+        let request = CreateNetwork {
+            name: "automata-results-network".to_owned(),
+            labels: labels.clone(),
+            ipv4_network: Ipv4Network {
+                network: Ipv4Addr::new(10, 31, 0, 0),
+                prefix: 29,
+            },
+            ipv4_gateway: Ipv4Addr::new(10, 31, 0, 1),
+        };
+        let body = NetworkCreateRequest::new(&request).expect("canonical network request");
+        assert_eq!(
+            serde_json::to_value(body).expect("serialize network request"),
+            json!({
+                "Name": "automata-results-network",
+                "CheckDuplicate": true,
+                "Driver": "bridge",
+                "Internal": true,
+                "Attachable": false,
+                "Ingress": false,
+                "EnableIPv4": true,
+                "EnableIPv6": false,
+                "IPAM": {
+                    "Driver": "default",
+                    "Options": {},
+                    "Config": [{
+                        "Subnet": "10.31.0.0/29",
+                        "IPRange": "",
+                        "Gateway": "10.31.0.1",
+                        "AuxiliaryAddresses": {}
+                    }]
+                },
+                "Options": {
+                    "com.docker.network.bridge.gateway_mode_ipv4": "isolated"
+                },
+                "Labels": labels,
+                "ConfigFrom": {"Network": ""}
+            })
+        );
+    }
+
+    #[test]
+    fn network_create_request_rejects_noncanonical_or_reserved_ipv4_configuration() {
+        let request = |network, prefix, gateway| CreateNetwork {
+            name: "automata-results-network".to_owned(),
+            labels: BTreeMap::new(),
+            ipv4_network: Ipv4Network { network, prefix },
+            ipv4_gateway: gateway,
+        };
+        for invalid in [
+            request(Ipv4Addr::new(10, 31, 0, 1), 29, Ipv4Addr::new(10, 31, 0, 2)),
+            request(Ipv4Addr::new(10, 31, 0, 0), 29, Ipv4Addr::new(10, 31, 0, 0)),
+            request(Ipv4Addr::new(10, 31, 0, 0), 29, Ipv4Addr::new(10, 31, 0, 7)),
+            request(Ipv4Addr::new(10, 31, 0, 0), 31, Ipv4Addr::new(10, 31, 0, 1)),
+            request(Ipv4Addr::new(10, 31, 0, 0), 0, Ipv4Addr::new(10, 31, 0, 1)),
+        ] {
+            assert!(NetworkCreateRequest::new(&invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn network_inspection_requires_one_canonical_usable_gateway() {
+        let inspected = normalized_network(network_json()).expect("canonical network response");
+        assert_eq!(
+            inspected.ipv4_network,
+            Ipv4Network {
+                network: Ipv4Addr::new(10, 31, 0, 0),
+                prefix: 29,
+            }
+        );
+        assert_eq!(inspected.ipv4_gateway, Ipv4Addr::new(10, 31, 0, 1));
+
+        for gateway in [
+            Value::Null,
+            json!(""),
+            json!("10.31.0.01"),
+            json!("10.31.0.1/29"),
+            json!("10.31.0.0"),
+            json!("10.31.0.7"),
+            json!("10.31.0.8"),
+        ] {
+            let mut value = network_json();
+            *value
+                .pointer_mut("/IPAM/Config/0/Gateway")
+                .expect("gateway fixture") = gateway;
+            assert!(normalized_network(value).is_err());
+        }
+
+        let mut missing = network_json();
+        missing
+            .pointer_mut("/IPAM/Config/0")
+            .expect("configuration fixture")
+            .as_object_mut()
+            .expect("configuration object")
+            .remove("Gateway");
+        assert!(normalized_network(missing).is_err());
+    }
+
+    #[test]
+    fn network_inspection_rejects_duplicate_and_gateway_endpoint_addresses() {
+        let mut duplicate = network_json();
+        *duplicate
+            .pointer_mut(&format!("/Containers/{}/IPv4Address", "d".repeat(64)))
+            .expect("second endpoint fixture") = json!("10.31.0.2/29");
+        assert!(normalized_network(duplicate).is_err());
+
+        let mut gateway = network_json();
+        *gateway
+            .pointer_mut(&format!("/Containers/{}/IPv4Address", "b".repeat(64)))
+            .expect("first endpoint fixture") = json!("10.31.0.1/29");
+        assert!(normalized_network(gateway).is_err());
+    }
+
     fn image_json(environment: &Value) -> Value {
         json!({
             "Id": format!("sha256:{}", "2".repeat(64)),
@@ -2153,12 +3169,14 @@ mod tests {
         let response: ImageResponse =
             serde_json::from_value(image_json(&json!(["Z=value", "PATH=/bin", "A="])))
                 .expect("image response");
-        assert_eq!(
-            normalize_image(response)
-                .expect("canonical image environment")
-                .environment_names,
-            ["A", "PATH", "Z"]
-        );
+        let inspected = normalize_image(response).expect("canonical image environment");
+        assert_eq!(inspected.environment_names, ["A", "PATH", "Z"]);
+        assert!(!inspected.default_path_only);
+        let response = serde_json::from_value(image_json(&json!([DEFAULT_CONTAINER_PATH])))
+            .expect("default PATH image response");
+        let inspected = normalize_image(response).expect("exact default PATH");
+        assert_eq!(inspected.environment_names, ["PATH"]);
+        assert!(inspected.default_path_only);
         for environment in [json!(["PATH=/bin", "PATH=/usr/bin"]), json!(["bad-name=x"])] {
             let response =
                 serde_json::from_value(image_json(&environment)).expect("image response");
@@ -2247,6 +3265,9 @@ mod tests {
             memory_bytes: 268_435_456,
             nano_cpus: 1_000_000_000,
             pids_limit: 128,
+            primary_network: None,
+            networks: BTreeMap::new(),
+            capture_logs: false,
         }
     }
 
@@ -2438,6 +3459,117 @@ mod tests {
     }
 
     #[test]
+    fn results_target_requires_one_exact_running_engine_state() {
+        let running = json!({
+            "Status": "running",
+            "Running": true,
+            "Paused": false,
+            "Restarting": false,
+            "OOMKilled": false,
+            "Dead": false,
+            "Pid": 42,
+            "ExitCode": 0,
+            "Error": "",
+            "StartedAt": "2026-08-16T00:00:01Z",
+            "FinishedAt": "0001-01-01T00:00:00Z"
+        });
+        let accepted = serde_json::from_value(running.clone()).expect("running state");
+        assert!(super::running_results_target(&accepted));
+        for (pointer, replacement) in [
+            ("/Status", json!("paused")),
+            ("/Running", json!(false)),
+            ("/Paused", json!(true)),
+            ("/Restarting", json!(true)),
+            ("/OOMKilled", json!(true)),
+            ("/Dead", json!(true)),
+            ("/Pid", json!(0)),
+            ("/ExitCode", json!(1)),
+            ("/Error", json!("failed")),
+        ] {
+            let mut state = running.clone();
+            *state.pointer_mut(pointer).expect("state field") = replacement;
+            let state = serde_json::from_value(state).expect("mutated state");
+            assert!(!super::running_results_target(&state));
+        }
+    }
+
+    #[test]
+    fn endpoint_runtime_normalization_is_exact_for_each_lifecycle_state() {
+        let container_id = "a".repeat(64);
+        let container_name = "automata-results-proxy";
+        let network_id = "b".repeat(64);
+        let endpoint = |realized_network_id: &str,
+                        aliases: Value,
+                        endpoint_id: &str,
+                        ip_address: &str,
+                        prefix: i64,
+                        mac_address: &str,
+                        dns_names: Value| {
+            serde_json::from_value::<super::EndpointSettingsResponse>(json!({
+                "IPAMConfig": {"IPv4Address": "10.31.0.2", "IPv6Address": "", "LinkLocalIPs": []},
+                "Links": null,
+                "Aliases": aliases,
+                "DriverOpts": null,
+                "GwPriority": 0,
+                "NetworkID": realized_network_id,
+                "EndpointID": endpoint_id,
+                "Gateway": "",
+                "IPAddress": ip_address,
+                "MacAddress": mac_address,
+                "IPPrefixLen": prefix,
+                "IPv6Gateway": "",
+                "GlobalIPv6Address": "",
+                "GlobalIPv6PrefixLen": 0,
+                "DNSNames": dns_names,
+            }))
+            .expect("endpoint response")
+        };
+        let aliases = vec!["results.automata.invalid".to_owned()];
+        let expected_dns = json!([
+            container_name,
+            "results.automata.invalid",
+            &container_id[..12]
+        ]);
+        let created = endpoint("", Value::Null, "", "", 0, "", Value::Null);
+        let running = endpoint(
+            &network_id,
+            json!(aliases),
+            &"c".repeat(64),
+            "10.31.0.2",
+            29,
+            "02:42:0a:1f:00:02",
+            expected_dns.clone(),
+        );
+        let exited = endpoint(&network_id, json!(aliases), "", "", 0, "", expected_dns);
+        let stale_created_network = endpoint(&network_id, Value::Null, "", "", 0, "", Value::Null);
+        for (state, observed, accepted) in [
+            (EngineContainerState::Created, &created, true),
+            (EngineContainerState::Running, &running, true),
+            (EngineContainerState::Exited(137), &exited, true),
+            (EngineContainerState::Exited(137), &created, false),
+            (EngineContainerState::Created, &stale_created_network, false),
+            (EngineContainerState::Invalid, &created, false),
+        ] {
+            let normalized_aliases = observed
+                .aliases
+                .clone()
+                .map_or_else(Vec::new, super::super::transport::BoundedVec::into_inner);
+            assert_eq!(
+                super::exact_endpoint_runtime(
+                    observed,
+                    state,
+                    &container_id,
+                    container_name,
+                    "10.31.0.2".parse().expect("IPv4"),
+                    &normalized_aliases,
+                ),
+                accepted,
+                "state {state:?}"
+            );
+        }
+    }
+
+    #[test]
     fn transient_exec_ids_must_be_bounded_canonical_and_unique() {
         let mut value = realized_container_json();
         *value.pointer_mut("/ExecIDs").expect("fixture pointer") =
@@ -2462,7 +3594,7 @@ mod tests {
     }
 
     #[test]
-    fn oom_kill_disable_accepts_only_the_two_v1_44_false_normalizations() {
+    fn oom_kill_disable_accepts_only_the_two_v1_48_false_normalizations() {
         for realized in [Value::Null, json!(false)] {
             let mut value = realized_container_json();
             *value
@@ -2578,5 +3710,99 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "creates and removes one exact internal Docker Engine 28 network"]
+    async fn live_engine_28_internal_isolated_network_normalization_is_exact() {
+        let engine = HttpEngine::connect_unix_socket(
+            Path::new("/var/run/docker.sock"),
+            ApiVersion {
+                major: 1,
+                minor: 48,
+            },
+        )
+        .expect("Docker Engine socket");
+        let facts = engine.engine_facts().await.expect("Engine facts");
+        assert!(
+            facts
+                .server_version
+                .split('.')
+                .next()
+                .and_then(|major| major.parse::<u64>().ok())
+                .is_some_and(|major| major >= 28),
+            "live gate requires Docker Engine 28 or newer"
+        );
+        let name = format!("automata-results-network-live-{}", uuid::Uuid::new_v4());
+        let labels = BTreeMap::from([(
+            "io.automata.test.results-network".to_owned(),
+            "true".to_owned(),
+        )]);
+        let ipv4_network = Ipv4Network {
+            network: Ipv4Addr::new(10, 255, 255, 248),
+            prefix: 29,
+        };
+        let ipv4_gateway = Ipv4Addr::new(10, 255, 255, 249);
+        let created_id = engine
+            .create_network(CreateNetwork {
+                name: name.clone(),
+                labels: labels.clone(),
+                ipv4_network: ipv4_network.clone(),
+                ipv4_gateway,
+            })
+            .await
+            .expect("create exact network");
+        let verification = async {
+            let inspected = engine
+                .inspect_network(&name)
+                .await?
+                .ok_or(EngineApiError::InvalidResponse)?;
+            let exact = inspected.id == created_id
+                && inspected.name == name
+                && inspected.driver == "bridge"
+                && inspected.scope == "local"
+                && inspected.enable_ipv4
+                && !inspected.enable_ipv6
+                && inspected.internal
+                && !inspected.attachable
+                && !inspected.ingress
+                && !inspected.config_only
+                && inspected.config_from.is_empty()
+                && inspected.ipam_driver == "default"
+                && inspected.ipam_options.is_empty()
+                && inspected.ipv4_network == ipv4_network
+                && inspected.ipv4_gateway == ipv4_gateway
+                && inspected.options
+                    == BTreeMap::from([(
+                        "com.docker.network.bridge.gateway_mode_ipv4".to_owned(),
+                        "isolated".to_owned(),
+                    )])
+                && inspected.labels == labels
+                && inspected.containers.is_empty();
+            Ok::<_, EngineApiError>(exact)
+        }
+        .await;
+        engine
+            .remove_network(&created_id)
+            .await
+            .expect("remove exact network");
+        assert!(
+            engine
+                .inspect_network(&created_id)
+                .await
+                .expect("inspect removed ID")
+                .is_none()
+        );
+        assert!(
+            engine
+                .inspect_network(&name)
+                .await
+                .expect("inspect removed name")
+                .is_none()
+        );
+        assert!(
+            verification.expect("inspect network"),
+            "daemon normalized away the closed network contract"
+        );
     }
 }

--- a/crates/automata-ci-local/src/local_docker/engine/transport.rs
+++ b/crates/automata-ci-local/src/local_docker/engine/transport.rs
@@ -679,6 +679,11 @@ impl<T, const LIMIT: usize> BoundedVec<T, LIMIT> {
     pub(super) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    #[cfg(unix)]
+    pub(super) fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl<'de, T, const LIMIT: usize> Deserialize<'de> for BoundedVec<T, LIMIT>
@@ -734,6 +739,11 @@ impl<K: Ord, V, const LIMIT: usize> BoundedMap<K, V, LIMIT> {
     #[cfg(unix)]
     pub(super) fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    #[cfg(unix)]
+    pub(super) fn len(&self) -> usize {
+        self.0.len()
     }
 }
 

--- a/crates/automata-ci-local/src/local_docker/mod.rs
+++ b/crates/automata-ci-local/src/local_docker/mod.rs
@@ -5,6 +5,7 @@ use std::{
     fmt,
     future::Future,
     io::{Cursor, Read as _},
+    net::Ipv4Addr,
     num::NonZeroU16,
     str::FromStr as _,
     sync::{Arc, Mutex, Weak},
@@ -26,24 +27,27 @@ use automata_ci_sandbox_guest::{
     LOCAL_CONTROL_SEAL_UID, LOCAL_CONTROL_TMPFS_BYTES, LOCAL_CONTROL_UID, MAX_GUEST_FRAME_BYTES,
     MAX_LOCAL_GUEST_BINARY_BYTES, decode_frame, encode_frame,
 };
+use futures::{StreamExt as _, stream};
 use sha2::{Digest as _, Sha256};
 use tar::{Builder as TarBuilder, EntryType, Header};
 
 use crate::{
     Installation, InstallationBinding, InstallationId, LocalDockerError, LocalDockerErrorCode,
-    MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS, MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES,
-    MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS, normalize_architecture,
+    LocalDockerResultsTransport, MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS,
+    MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES, MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS,
+    normalize_architecture,
 };
 
 mod endpoint;
 mod engine;
 
 use engine::{
-    ContainerDefinition, EngineApiError, EngineContainerState, EngineExecRequest,
-    InspectedContainer, InspectedContainerCustody, InspectedImage,
-    LOCAL_DOCKER_GUEST_ARCHIVE_BYTES, LOCAL_DOCKER_GUEST_IMAGE_BINARY,
-    LOCAL_DOCKER_SANDBOX_GUEST_BINARY, PinnedDockerEngine, SandboxEngineApi,
-    connect_relay_sandbox_engine, resolve_installation_binding, verify_installation_identity,
+    ContainerDefinition, ContainerNetworkAttachment, CreateNetwork, EngineApiError,
+    EngineContainerState, EngineExecRequest, InspectedContainer, InspectedContainerCustody,
+    InspectedImage, InspectedNetwork, Ipv4Network, LOCAL_DOCKER_GUEST_ARCHIVE_BYTES,
+    LOCAL_DOCKER_GUEST_IMAGE_BINARY, LOCAL_DOCKER_SANDBOX_GUEST_BINARY, NetworkEndpoint,
+    PinnedDockerEngine, SandboxEngineApi, connect_relay_sandbox_engine, map_engine_call,
+    resolve_installation_binding, verify_installation_identity,
 };
 
 use endpoint::LocalDockerEndpoint;
@@ -68,16 +72,42 @@ const LABEL_PROFILE: &str = "io.automata.local.profile";
 const LABEL_PROFILE_DIGEST: &str = "io.automata.local.profile-sha256";
 const LABEL_SPEC_DIGEST: &str = "io.automata.local.spec-sha256";
 const LABEL_RESOURCE_KIND: &str = "io.automata.local.resource-kind";
+const LABEL_RESULTS_TRANSPORT_SCHEMA: &str = "io.automata.local.results-transport-schema";
 const MANAGED_VALUE: &str = "true";
-const JOB_SCHEMA: &str = "1";
+const JOB_SCHEMA: &str = "2";
+const RESULTS_TRANSPORT_SCHEMA: &str = "1";
 const CUSTODY_ADMISSION: &str = "profile-admission";
 const CUSTODY_JOB: &str = "job";
 const KIND_JOB: &str = "job-container";
 const KIND_GUEST_SOURCE: &str = "guest-source";
+const KIND_RESULTS_FRONT: &str = "results-front-network";
+const KIND_RESULTS_PROXY: &str = "results-proxy-container";
+const KIND_RESULTS_TRANSIT: &str = "results-transit-network";
+const RESULTS_ALIAS: &str = "results.automata.invalid";
+const RESULTS_PROXY_ENTRYPOINT: &str = "/usr/libexec/automata-ci-service-proxy";
+const RESULTS_PROXY_COMMAND: &str = "serve-results-v1";
+const RESULTS_PROXY_IMAGE_PROTOCOL_LABEL: &str = "io.automata.service-proxy.protocol-version";
+const RESULTS_PROXY_IMAGE_PROTOCOL_VERSION: &str = "2";
+const RESULTS_READY_STATUS: &[u8] = b"{\"version\":1,\"mode\":\"results-v1\",\"port\":8081}\n";
+const RESULTS_PROXY_MEMORY_BYTES: i64 = 64 * 1_024 * 1_024;
+const RESULTS_PROXY_NANO_CPUS: i64 = 250_000_000;
+// One accept loop plus, for each of the 32 bounded sessions, one coordinator
+// and two directional pumps.
+const RESULTS_PROXY_PIDS: i64 = 97;
+const RESULTS_PROXY_USER: &str = "65532:65532";
+const RESULTS_FRONT_POOL_PREFIX: u8 = 20;
+const RESULTS_FRONT_NETWORK_PREFIX: u8 = 29;
+const MAX_RESULTS_TRANSIT_PROXIES: u16 = crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS + 1;
+const MAX_RESULTS_TRANSIT_ENDPOINTS: u16 = MAX_RESULTS_TRANSIT_PROXIES + 1;
+const MAX_RESULTS_TRANSIT_CONVERGENCE_ATTEMPTS: usize = 8;
+const MAX_RESULTS_TRANSIT_ATTESTATION_CONCURRENCY: usize = 16;
+const RESULTS_TRANSPORT_ATTESTATION_TIMEOUT: Duration = Duration::from_secs(30);
+const RESULTS_PROXY_READINESS_TIMEOUT: Duration = Duration::from_secs(5);
+const RESULTS_PROXY_READINESS_INTERVAL: Duration = Duration::from_millis(25);
 const HELPER_MEMORY_BYTES: i64 = 64 * 1024 * 1024;
 const HELPER_NANO_CPUS: i64 = 500_000_000;
 const HELPER_PIDS: i64 = 32;
-const MAX_CONTAINER_LABELS: usize = 256;
+const MAX_RESOURCE_LABELS: usize = 256;
 const ENGINE_TRANSPORT_OVERHEAD: Duration = Duration::from_secs(5);
 
 fn guest_client_user() -> String {
@@ -118,7 +148,7 @@ const PROVIDER_CAPABILITIES: [SandboxCapability; 13] = [
     SandboxCapability::CopyTo,
     SandboxCapability::CopyFrom,
     SandboxCapability::EnvironmentInjection,
-    SandboxCapability::NetworkDisabled,
+    SandboxCapability::PrivateEgress,
     SandboxCapability::WritableRootFilesystem,
     SandboxCapability::Administrator,
     SandboxCapability::UserNamespace,
@@ -144,12 +174,53 @@ struct LocalDockerInner {
     guest_image_id: String,
     guest_image_labels: BTreeMap<String, String>,
     guest_image_environment: Vec<String>,
+    results: VerifiedResultsTransport,
+    runner_id: RunnerId,
     provider_id: ProviderId,
     capabilities: ProviderCapabilities,
     handle_locks: Mutex<BTreeMap<String, Weak<HandleOperationLock>>>,
 }
 
+#[derive(Clone)]
+struct VerifiedResultsTransport {
+    requested: LocalDockerResultsTransport,
+    transit_name: String,
+    transit_network: Ipv4Network,
+    transit_gateway: Ipv4Addr,
+    proxy_image_id: String,
+    proxy_image_labels: BTreeMap<String, String>,
+}
+
+struct FrontNetworkDefinition {
+    name: String,
+    labels: BTreeMap<String, String>,
+    ipv4_network: Ipv4Network,
+    ipv4_gateway: Ipv4Addr,
+}
+
+struct SandboxArchiveDefinition {
+    directory_headers: Vec<Header>,
+    guest_header: Header,
+}
+
 type HandleOperationLock = tokio::sync::Mutex<()>;
+
+#[derive(Clone, Copy)]
+struct ResultsTransportBudget {
+    deadline: tokio::time::Instant,
+}
+
+impl ResultsTransportBudget {
+    fn start() -> Self {
+        Self {
+            deadline: tokio::time::Instant::now() + RESULTS_TRANSPORT_ATTESTATION_TIMEOUT,
+        }
+    }
+
+    fn bounded_deadline(self, duration: Duration) -> tokio::time::Instant {
+        self.deadline.min(tokio::time::Instant::now() + duration)
+    }
+}
 
 impl LocalDockerProvider {
     /// Connects through the fixed private relay and verifies the exact
@@ -162,6 +233,8 @@ impl LocalDockerProvider {
     pub(super) async fn connect(
         installation: InstallationBinding,
         guest_image: ImmutableImage,
+        results_transport: LocalDockerResultsTransport,
+        runner_id: RunnerId,
         expected_runner_architecture: &Architecture,
     ) -> Result<Self, LocalDockerError> {
         let (pinned, engine) = connect_relay_sandbox_engine(expected_runner_architecture).await?;
@@ -169,9 +242,29 @@ impl LocalDockerProvider {
         let image = engine
             .inspect_image(guest_image.reference())
             .await
-            .map_err(|_| LocalDockerError::new(LocalDockerErrorCode::EngineRequestFailed))?
+            .map_err(map_engine_call)?
             .ok_or_else(|| LocalDockerError::new(LocalDockerErrorCode::ImageUnavailable))?;
         verify_image(&pinned, &guest_image, &image).map_err(LocalDockerError::new)?;
+        let proxy_image = engine
+            .inspect_image(results_transport.proxy_image.reference())
+            .await
+            .map_err(map_engine_call)?
+            .ok_or_else(|| LocalDockerError::new(LocalDockerErrorCode::ImageUnavailable))?;
+        verify_results_proxy_image(&pinned, &results_transport.proxy_image, &proxy_image)
+            .map_err(LocalDockerError::new)?;
+        let transit = verify_shared_results_transport_bounded(
+            &pinned,
+            engine.as_ref(),
+            &installation,
+            &results_transport,
+            &proxy_image.id,
+            &proxy_image.labels,
+            runner_id,
+            &NeverCancelled,
+            ResultsTransportBudget::start(),
+        )
+        .await
+        .map_err(ResultsTransportAttestationError::into_local_docker_error)?;
         let provider_id = ProviderId::new(LOCAL_DOCKER_PROVIDER_ID)
             .map_err(|_| LocalDockerError::new(LocalDockerErrorCode::InvalidEngineResponse))?;
         let capabilities = ProviderCapabilities::new(PROVIDER_CAPABILITIES)
@@ -187,6 +280,15 @@ impl LocalDockerProvider {
                 guest_image_id: image.id,
                 guest_image_labels: image.labels,
                 guest_image_environment: neutral_environment(&image.environment_names),
+                results: VerifiedResultsTransport {
+                    requested: results_transport,
+                    transit_name: transit.name,
+                    transit_network: transit.ipv4_network,
+                    transit_gateway: transit.ipv4_gateway,
+                    proxy_image_id: proxy_image.id,
+                    proxy_image_labels: proxy_image.labels,
+                },
+                runner_id,
                 provider_id,
                 capabilities,
                 handle_locks: Mutex::new(BTreeMap::new()),
@@ -201,6 +303,8 @@ impl LocalDockerProvider {
         installation: Installation,
         guest_image: ImmutableImage,
         guest_image_id: String,
+        results: VerifiedResultsTransport,
+        runner_id: RunnerId,
     ) -> Self {
         Self {
             inner: Arc::new(LocalDockerInner {
@@ -211,6 +315,8 @@ impl LocalDockerProvider {
                 guest_image_id,
                 guest_image_labels: BTreeMap::new(),
                 guest_image_environment: Vec::new(),
+                results,
+                runner_id,
                 provider_id: ProviderId::new(LOCAL_DOCKER_PROVIDER_ID).expect("provider id"),
                 capabilities: ProviderCapabilities::new(PROVIDER_CAPABILITIES)
                     .expect("capabilities"),
@@ -227,6 +333,8 @@ impl fmt::Debug for LocalDockerProvider {
             .field("provider_id", &self.inner.provider_id)
             .field("installation", &self.inner.installation.id())
             .field("guest_image", &self.inner.guest_image)
+            .field("results", &self.inner.results.requested)
+            .field("runner_id", &self.inner.runner_id)
             .field("capabilities", &self.inner.capabilities)
             .finish_non_exhaustive()
     }
@@ -246,7 +354,7 @@ impl SandboxProvider for LocalDockerProvider {
         spec: &SandboxSpec,
         cancellation: &dyn Cancellation,
     ) -> Result<SandboxRecord, ProviderError> {
-        validate_spec(spec)?;
+        validate_spec(spec, self.inner.runner_id)?;
         let names = ResourceNames::for_spec(&self.inner.installation, spec)?;
         let handle = names.handle(&self.inner.provider_id)?;
         let operation_lock = self.inner.handle_lock(&handle)?;
@@ -254,7 +362,10 @@ impl SandboxProvider for LocalDockerProvider {
             let _operation = lock_handle(operation_lock, cancellation)
                 .await
                 .ok_or_else(|| known(ProviderErrorKind::Cancelled, ProviderStage::CreateSandbox))?;
-            self.inner.create(spec, &names, &handle, cancellation).await
+            let budget = ResultsTransportBudget::start();
+            self.inner
+                .create(spec, &names, &handle, cancellation, budget)
+                .await
         })
     }
 
@@ -270,7 +381,10 @@ impl SandboxProvider for LocalDockerProvider {
             let _operation = lock_handle(Arc::clone(&operation_lock), cancellation)
                 .await
                 .ok_or_else(|| known(ProviderErrorKind::Cancelled, ProviderStage::Attach))?;
-            self.inner.attach_identity(&names, cancellation).await
+            let budget = ResultsTransportBudget::start();
+            self.inner
+                .attach_identity(&names, cancellation, budget)
+                .await
         })?;
         Ok(Box::new(LocalDockerEndpoint::new(
             Arc::clone(&self.inner),
@@ -293,7 +407,10 @@ impl SandboxProvider for LocalDockerProvider {
             let _operation = lock_handle(operation_lock, cancellation)
                 .await
                 .ok_or_else(|| known(ProviderErrorKind::Cancelled, ProviderStage::Inspect))?;
-            self.inner.inspect(handle, &names, cancellation).await
+            let budget = ResultsTransportBudget::start();
+            self.inner
+                .inspect(handle, &names, cancellation, budget)
+                .await
         })
     }
 
@@ -320,19 +437,66 @@ impl SandboxProvider for LocalDockerProvider {
                 .ok_or_else(|| {
                     known(ProviderErrorKind::Cancelled, ProviderStage::DestroySandbox)
                 })?;
-            self.inner.destroy(request, &names, cancellation).await
+            let budget = ResultsTransportBudget::start();
+            self.inner
+                .destroy(request, &names, cancellation, budget)
+                .await
         })
     }
 }
 
 impl LocalDockerInner {
-    async fn verify_boundary(&self, stage: ProviderStage) -> Result<(), ProviderError> {
-        self.verify_boundary_kind()
+    async fn verify_boundary(
+        &self,
+        stage: ProviderStage,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<(), ProviderError> {
+        self.verify_boundary_kind(cancellation, budget)
             .await
             .map_err(|kind| known(kind, stage))
     }
 
-    pub(super) async fn verify_boundary_kind(&self) -> Result<(), ProviderErrorKind> {
+    pub(super) async fn verify_boundary_kind(
+        &self,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<(), ProviderErrorKind> {
+        self.verify_custody_boundary_kind(cancellation).await?;
+        verify_shared_results_transport_bounded(
+            &self.pinned,
+            self.engine.as_ref(),
+            &self.installation,
+            &self.results.requested,
+            &self.results.proxy_image_id,
+            &self.results.proxy_image_labels,
+            self.runner_id,
+            cancellation,
+            budget,
+        )
+        .await
+        .map(|_| ())
+        .map_err(ResultsTransportAttestationError::into_provider_kind)
+    }
+
+    async fn verify_custody_boundary(
+        &self,
+        stage: ProviderStage,
+        cancellation: &dyn Cancellation,
+        _budget: ResultsTransportBudget,
+    ) -> Result<(), ProviderError> {
+        self.verify_custody_boundary_kind(cancellation)
+            .await
+            .map_err(|kind| known(kind, stage))
+    }
+
+    async fn verify_custody_boundary_kind(
+        &self,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), ProviderErrorKind> {
+        if cancellation.disposition().requires_termination() {
+            return Err(ProviderErrorKind::Cancelled);
+        }
         self.pinned
             .verify()
             .await
@@ -366,9 +530,11 @@ impl LocalDockerInner {
         names: &ResourceNames,
         handle: &SandboxHandle,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<SandboxRecord, ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::Validate)?;
-        self.verify_boundary(ProviderStage::Validate).await?;
+        self.verify_boundary(ProviderStage::Validate, cancellation, budget)
+            .await?;
         let SandboxLaunch::Container { image, .. } = spec.profile().launch() else {
             return Err(invalid_configuration());
         };
@@ -389,17 +555,28 @@ impl LocalDockerInner {
                 ProviderStage::Validate,
             ));
         }
+        let proxy_image = self
+            .verified_image(&self.results.requested.proxy_image)
+            .await
+            .map_err(|kind| known(kind, ProviderStage::Validate))?;
+        if verify_results_proxy_image(
+            &self.pinned,
+            &self.results.requested.proxy_image,
+            &proxy_image,
+        )
+        .is_err()
+            || proxy_image.id != self.results.proxy_image_id
+            || proxy_image.labels != self.results.proxy_image_labels
+        {
+            return Err(known(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::Validate,
+            ));
+        }
 
-        let fingerprint = spec_fingerprint(spec, &self.installation, &self.guest_image)?;
+        let fingerprint =
+            spec_fingerprint(spec, &self.installation, &self.guest_image, &self.results)?;
         let base_labels = base_labels(spec, &self.installation, &fingerprint);
-        let job_definition = job_definition(
-            names,
-            spec,
-            image.reference(),
-            &job_image.labels,
-            &job_image.environment_names,
-            &base_labels,
-        )?;
         let helper_definition = helper_definition(
             names,
             self.guest_image.reference(),
@@ -407,12 +584,51 @@ impl LocalDockerInner {
             &self.guest_image_environment,
             &base_labels,
         );
-        if job_definition.labels.len() > MAX_CONTAINER_LABELS
-            || helper_definition.labels.len() > MAX_CONTAINER_LABELS
+        let front_definition =
+            front_network_definition(names, &base_labels, &self.installation, spec.custody())?;
+        if ipv4_networks_overlap(
+            &front_definition.ipv4_network,
+            &self.results.transit_network,
+        ) {
+            return Err(known(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::VerifyOwnership,
+            ));
+        }
+        let transit_address = transit_proxy_address(
+            &self.results.transit_network,
+            self.results.transit_gateway,
+            self.results.requested.results_address,
+            spec.custody(),
+        )?;
+        let mut job_definition = job_definition(
+            names,
+            spec,
+            image.reference(),
+            &job_image.labels,
+            &job_image.environment_names,
+            &base_labels,
+            &front_definition,
+        )?;
+        let mut proxy_definition = planned_results_proxy_definition(
+            names,
+            &base_labels,
+            &self.results,
+            &front_definition,
+            transit_address,
+        )?;
+        let sandbox_archive_definition = sandbox_archive_definition(spec.workspace().as_str())?;
+        if [
+            front_definition.labels.len(),
+            job_definition.labels.len(),
+            helper_definition.labels.len(),
+            proxy_definition.labels.len(),
+        ]
+        .into_iter()
+        .any(|count| count > MAX_RESOURCE_LABELS)
         {
             return Err(invalid_configuration());
         }
-
         let existing_job = self
             .engine
             .inspect_container(&names.job)
@@ -423,194 +639,330 @@ impl LocalDockerInner {
             .inspect_container(&names.helper)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::CreateSandbox, None))?;
-        if let Some(helper) = existing_helper.as_ref() {
-            verify_existing_helper(helper, &helper_definition, &guest_image.id)?;
+        let existing_proxy = self
+            .engine
+            .inspect_container(&names.results_proxy)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::CreateSandbox, None))?;
+        let existing_front = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::CreateSandbox, None))?;
+        if existing_front.is_none()
+            && (existing_job.is_some() || existing_helper.is_some() || existing_proxy.is_some())
+        {
+            return Err(known(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::CreateSandbox,
+            ));
         }
+        let front = self
+            .create_or_verify_front_network(names, &front_definition, handle, cancellation, budget)
+            .await?;
+        bind_front_network(&mut job_definition, &front);
+        bind_front_network(&mut proxy_definition, &front);
 
-        if let Some(job) = existing_job.as_ref() {
-            verify_container(job, &job_definition, &job_image.id, None)?;
-            match job.state {
-                EngineContainerState::Running if existing_helper.is_none() => {
-                    if let Err(error) = self.probe(names, job, handle, &NeverCancelled).await {
-                        self.destroy_container(
-                            &InspectedContainerCustody::from(job),
+        let create_result: Result<SandboxRecord, ProviderError> = async {
+            if let Some(helper) = existing_helper.as_ref() {
+                verify_existing_helper(helper, &helper_definition, &guest_image.id)?;
+            }
+            if let Some(proxy) = existing_proxy.as_ref() {
+                verify_container(proxy, &proxy_definition, &self.results.proxy_image_id, None)?;
+            }
+
+            if let Some(job) = existing_job.as_ref() {
+                verify_container(job, &job_definition, &job_image.id, None)?;
+                match job.state {
+                    EngineContainerState::Running
+                        if existing_helper.is_none()
+                            && existing_proxy.as_ref().is_some_and(|proxy| {
+                                proxy.state == EngineContainerState::Running
+                            }) =>
+                    {
+                        let proxy = existing_proxy.as_ref().expect("guarded proxy");
+                        self.wait_for_results_proxy_ready(
+                            names,
+                            proxy,
+                            &proxy_definition,
+                            &front,
+                            Some(job),
                             handle,
-                            &NeverCancelled,
+                            ProviderStage::Start,
+                            cancellation,
+                            budget,
                         )
                         .await?;
-                        return Err(error);
+                        if let Err(error) =
+                            self.probe(names, job, handle, cancellation, budget).await
+                        {
+                            self.destroy_container(
+                                &InspectedContainerCustody::from(job),
+                                handle,
+                                &NeverCancelled,
+                                budget,
+                            )
+                            .await?;
+                            return Err(error);
+                        }
+                        ensure_not_cancelled(cancellation, ProviderStage::CreateSandbox)?;
+                        self.verify_boundary(ProviderStage::CreateSandbox, cancellation, budget)
+                            .await
+                            .map_err(|error| recovery(&error, handle))?;
+                        self.require_exact_container(
+                            job,
+                            &job_definition,
+                            &job_image.id,
+                            EngineContainerState::Running,
+                            handle,
+                        )
+                        .await?;
+                        self.require_name_absent(&names.helper, handle).await?;
+                        self.require_front_members(&front, Some(job), Some(proxy), handle)
+                            .await?;
+                        return Ok(record(handle, spec, SandboxState::Running));
                     }
-                    ensure_not_cancelled(cancellation, ProviderStage::CreateSandbox)?;
-                    self.verify_boundary(ProviderStage::CreateSandbox)
-                        .await
-                        .map_err(|error| recovery(&error, handle))?;
-                    self.require_exact_container(
-                        job,
+                    EngineContainerState::Running
+                    | EngineContainerState::Exited(_)
+                    | EngineContainerState::Invalid => {
+                        return Err(uncertain(
+                            ProviderErrorKind::InvalidState,
+                            ProviderStage::CreateSandbox,
+                            handle,
+                        ));
+                    }
+                    EngineContainerState::Created => {}
+                }
+            }
+
+            let guest_bytes = self
+                .prepare_guest(
+                    existing_helper.as_ref(),
+                    &helper_definition,
+                    &guest_image.id,
+                    handle,
+                    cancellation,
+                    budget,
+                )
+                .await?;
+            let sandbox_archive = sandbox_archive(&sandbox_archive_definition, &guest_bytes)?;
+
+            let job = if let Some(job) = existing_job {
+                job
+            } else {
+                ensure_not_cancelled(cancellation, ProviderStage::CreateContainer)?;
+                self.require_name_absent(&names.job, handle).await?;
+                self.verify_boundary(ProviderStage::CreateContainer, cancellation, budget)
+                    .await?;
+                let _untrusted_create = self.engine.create_container(job_definition.clone()).await;
+                let job = self
+                    .require_container(
+                        &names.job,
                         &job_definition,
                         &job_image.id,
-                        EngineContainerState::Running,
+                        EngineContainerState::Created,
                         handle,
                     )
                     .await?;
-                    self.require_name_absent(&names.helper, handle).await?;
-                    return Ok(record(handle, spec, SandboxState::Running));
-                }
-                EngineContainerState::Running
-                | EngineContainerState::Exited(_)
-                | EngineContainerState::Invalid => {
-                    return Err(uncertain(
-                        ProviderErrorKind::InvalidState,
-                        ProviderStage::CreateSandbox,
-                        handle,
-                    ));
-                }
-                EngineContainerState::Created => {}
-            }
-        }
+                ensure_not_cancelled_after_mutation(
+                    cancellation,
+                    ProviderStage::CreateContainer,
+                    handle,
+                )?;
+                job
+            };
 
-        let guest_bytes = self
-            .prepare_guest(
-                names,
-                existing_helper.as_ref(),
-                &helper_definition,
-                &guest_image.id,
-                handle,
-                cancellation,
-            )
-            .await?;
-        let sandbox_archive = sandbox_archive(spec.workspace().as_str(), &guest_bytes)?;
-
-        let job = if let Some(job) = existing_job {
-            job
-        } else {
-            ensure_not_cancelled(cancellation, ProviderStage::CreateContainer)?;
-            self.require_name_absent(&names.job, handle).await?;
-            self.verify_boundary(ProviderStage::CreateContainer).await?;
-            let _untrusted_create = self.engine.create_container(job_definition.clone()).await;
             let job = self
-                .require_container(
-                    &names.job,
+                .require_exact_container(
+                    &job,
                     &job_definition,
                     &job_image.id,
                     EngineContainerState::Created,
                     handle,
                 )
                 .await?;
+            self.verify_boundary(ProviderStage::CreateContainer, cancellation, budget)
+                .await
+                .map_err(|error| recovery(&error, handle))?;
+            let _untrusted_upload = self
+                .engine
+                .upload_sandbox_archive(&job.id, &sandbox_archive)
+                .await;
+            let job = self
+                .require_exact_container(
+                    &job,
+                    &job_definition,
+                    &job_image.id,
+                    EngineContainerState::Created,
+                    handle,
+                )
+                .await?;
+            let realized_archive = self
+                .engine
+                .download_sandbox_guest(&job.id, LOCAL_DOCKER_GUEST_ARCHIVE_BYTES)
+                .await
+                .map_err(|error| {
+                    map_provider_engine(error, ProviderStage::VerifyOwnership, Some(handle))
+                })?;
+            let realized_guest = extract_single_guest(&realized_archive)
+                .map_err(|error| recovery(&error, handle))?;
+            if realized_guest != guest_bytes {
+                return Err(uncertain(
+                    ProviderErrorKind::OwnershipMismatch,
+                    ProviderStage::VerifyOwnership,
+                    handle,
+                ));
+            }
             ensure_not_cancelled_after_mutation(
                 cancellation,
                 ProviderStage::CreateContainer,
                 handle,
             )?;
-            job
-        };
 
-        let job = self
-            .require_exact_container(
-                &job,
-                &job_definition,
-                &job_image.id,
-                EngineContainerState::Created,
+            let proxy = if let Some(proxy) = existing_proxy {
+                match proxy.state {
+                    EngineContainerState::Created | EngineContainerState::Running => proxy,
+                    EngineContainerState::Exited(_) | EngineContainerState::Invalid => {
+                        return Err(uncertain(
+                            ProviderErrorKind::InvalidState,
+                            ProviderStage::CreateSandbox,
+                            handle,
+                        ));
+                    }
+                }
+            } else {
+                ensure_not_cancelled(cancellation, ProviderStage::CreateContainer)?;
+                self.require_name_absent(&names.results_proxy, handle)
+                    .await?;
+                self.verify_boundary(ProviderStage::CreateContainer, cancellation, budget)
+                    .await?;
+                let _untrusted_create =
+                    self.engine.create_container(proxy_definition.clone()).await;
+                self.require_container(
+                    &names.results_proxy,
+                    &proxy_definition,
+                    &self.results.proxy_image_id,
+                    EngineContainerState::Created,
+                    handle,
+                )
+                .await?
+            };
+            let proxy = if proxy.state == EngineContainerState::Created {
+                self.verify_boundary(ProviderStage::Start, cancellation, budget)
+                    .await
+                    .map_err(|error| recovery(&error, handle))?;
+                let _untrusted_start = self.engine.start_container(&proxy.id).await;
+                self.require_exact_container(
+                    &proxy,
+                    &proxy_definition,
+                    &self.results.proxy_image_id,
+                    EngineContainerState::Running,
+                    handle,
+                )
+                .await?
+            } else {
+                self.require_exact_container(
+                    &proxy,
+                    &proxy_definition,
+                    &self.results.proxy_image_id,
+                    EngineContainerState::Running,
+                    handle,
+                )
+                .await?
+            };
+            self.wait_for_results_proxy_ready(
+                names,
+                &proxy,
+                &proxy_definition,
+                &front,
+                None,
                 handle,
+                ProviderStage::Start,
+                cancellation,
+                budget,
             )
             .await?;
-        self.verify_boundary(ProviderStage::CreateContainer)
-            .await
-            .map_err(|error| recovery(&error, handle))?;
-        let _untrusted_upload = self
-            .engine
-            .upload_sandbox_archive(&job.id, &sandbox_archive)
-            .await;
-        let job = self
-            .require_exact_container(
-                &job,
-                &job_definition,
-                &job_image.id,
-                EngineContainerState::Created,
-                handle,
-            )
-            .await?;
-        let realized_archive = self
-            .engine
-            .download_sandbox_guest(&job.id, LOCAL_DOCKER_GUEST_ARCHIVE_BYTES)
-            .await
-            .map_err(|error| {
-                map_provider_engine(error, ProviderStage::VerifyOwnership, Some(handle))
-            })?;
-        let realized_guest =
-            extract_single_guest(&realized_archive).map_err(|error| recovery(&error, handle))?;
-        if realized_guest != guest_bytes {
-            return Err(uncertain(
-                ProviderErrorKind::OwnershipMismatch,
-                ProviderStage::VerifyOwnership,
-                handle,
-            ));
-        }
-        ensure_not_cancelled_after_mutation(cancellation, ProviderStage::CreateContainer, handle)?;
 
-        let job = self
-            .require_exact_container(
-                &job,
-                &job_definition,
-                &job_image.id,
-                EngineContainerState::Created,
-                handle,
-            )
-            .await?;
-        self.verify_boundary(ProviderStage::Start)
-            .await
-            .map_err(|error| recovery(&error, handle))?;
-        let _untrusted_start = self.engine.start_container(&job.id).await;
-        let running = self
-            .require_exact_container(
-                &job,
+            let job = self
+                .require_exact_container(
+                    &job,
+                    &job_definition,
+                    &job_image.id,
+                    EngineContainerState::Created,
+                    handle,
+                )
+                .await?;
+            self.verify_boundary(ProviderStage::Start, cancellation, budget)
+                .await
+                .map_err(|error| recovery(&error, handle))?;
+            let _untrusted_start = self.engine.start_container(&job.id).await;
+            let running = self
+                .require_exact_container(
+                    &job,
+                    &job_definition,
+                    &job_image.id,
+                    EngineContainerState::Running,
+                    handle,
+                )
+                .await?;
+            self.require_front_members(&front, Some(&running), Some(&proxy), handle)
+                .await?;
+            if let Err(error) = self
+                .bootstrap_client(names, &running, handle, cancellation, budget)
+                .await
+            {
+                self.destroy_container(
+                    &InspectedContainerCustody::from(&running),
+                    handle,
+                    &NeverCancelled,
+                    budget,
+                )
+                .await?;
+                return Err(error);
+            }
+            if let Err(error) = self
+                .probe(names, &running, handle, cancellation, budget)
+                .await
+            {
+                self.destroy_container(
+                    &InspectedContainerCustody::from(&running),
+                    handle,
+                    &NeverCancelled,
+                    budget,
+                )
+                .await?;
+                return Err(error);
+            }
+            if let Err(error) =
+                ensure_not_cancelled_after_mutation(cancellation, ProviderStage::Start, handle)
+            {
+                self.destroy_container(
+                    &InspectedContainerCustody::from(&running),
+                    handle,
+                    &NeverCancelled,
+                    budget,
+                )
+                .await?;
+                return Err(error);
+            }
+            self.verify_boundary(ProviderStage::CreateSandbox, cancellation, budget)
+                .await
+                .map_err(|error| recovery(&error, handle))?;
+            self.require_exact_container(
+                &running,
                 &job_definition,
                 &job_image.id,
                 EngineContainerState::Running,
                 handle,
             )
             .await?;
-        if let Err(error) = self.bootstrap_client(names, &running, handle).await {
-            self.destroy_container(
-                &InspectedContainerCustody::from(&running),
-                handle,
-                &NeverCancelled,
-            )
-            .await?;
-            return Err(error);
+            self.require_name_absent(&names.helper, handle).await?;
+            self.require_front_members(&front, Some(&running), Some(&proxy), handle)
+                .await?;
+            Ok(record(handle, spec, SandboxState::Running))
         }
-        if let Err(error) = self.probe(names, &running, handle, &NeverCancelled).await {
-            self.destroy_container(
-                &InspectedContainerCustody::from(&running),
-                handle,
-                &NeverCancelled,
-            )
-            .await?;
-            return Err(error);
-        }
-        if let Err(error) =
-            ensure_not_cancelled_after_mutation(cancellation, ProviderStage::Start, handle)
-        {
-            self.destroy_container(
-                &InspectedContainerCustody::from(&running),
-                handle,
-                &NeverCancelled,
-            )
-            .await?;
-            return Err(error);
-        }
-        self.verify_boundary(ProviderStage::CreateSandbox)
-            .await
-            .map_err(|error| recovery(&error, handle))?;
-        self.require_exact_container(
-            &running,
-            &job_definition,
-            &job_image.id,
-            EngineContainerState::Running,
-            handle,
-        )
-        .await?;
-        self.require_name_absent(&names.helper, handle).await?;
-        Ok(record(handle, spec, SandboxState::Running))
+        .await;
+        create_result.map_err(|error| recovery(&error, handle))
     }
 
     async fn verified_image(
@@ -697,23 +1049,24 @@ impl LocalDockerInner {
 
     async fn prepare_guest(
         &self,
-        names: &ResourceNames,
         existing: Option<&InspectedContainer>,
         definition: &ContainerDefinition,
         image_id: &str,
         handle: &SandboxHandle,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<Vec<u8>, ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::CreateContainer)?;
         let helper = if let Some(helper) = existing {
             helper.clone()
         } else {
-            self.require_name_absent(&names.helper, handle).await?;
-            self.verify_boundary(ProviderStage::CreateContainer).await?;
+            self.require_name_absent(&definition.name, handle).await?;
+            self.verify_boundary(ProviderStage::CreateContainer, cancellation, budget)
+                .await?;
             let _untrusted_create = self.engine.create_container(definition.clone()).await;
             let helper = self
                 .require_container(
-                    &names.helper,
+                    &definition.name,
                     definition,
                     image_id,
                     EngineContainerState::Created,
@@ -759,9 +1112,260 @@ impl LocalDockerInner {
             &InspectedContainerCustody::from(&helper),
             handle,
             cancellation,
+            budget,
         )
         .await?;
         Ok(guest)
+    }
+
+    async fn create_or_verify_front_network(
+        &self,
+        names: &ResourceNames,
+        definition: &FrontNetworkDefinition,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<InspectedNetwork, ProviderError> {
+        let existing = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::CreateSandbox, Some(handle))
+            })?;
+        if let Some(network) = existing {
+            verify_front_network(
+                &network,
+                names,
+                &definition.labels,
+                &definition.ipv4_network,
+                handle,
+            )?;
+            return self
+                .require_exact_front_network(
+                    &network,
+                    names,
+                    &definition.labels,
+                    &definition.ipv4_network,
+                    handle,
+                )
+                .await;
+        }
+        ensure_not_cancelled(cancellation, ProviderStage::CreateSandbox)?;
+        self.verify_boundary(ProviderStage::CreateSandbox, cancellation, budget)
+            .await?;
+        let _untrusted_create = self
+            .engine
+            .create_network(CreateNetwork {
+                name: definition.name.clone(),
+                labels: definition.labels.clone(),
+                ipv4_network: definition.ipv4_network.clone(),
+                ipv4_gateway: definition.ipv4_gateway,
+            })
+            .await;
+        let network = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::CreateSandbox, Some(handle))
+            })?
+            .ok_or_else(|| {
+                uncertain(
+                    ProviderErrorKind::AdapterUnavailable,
+                    ProviderStage::CreateSandbox,
+                    handle,
+                )
+            })?;
+        verify_front_network(
+            &network,
+            names,
+            &definition.labels,
+            &definition.ipv4_network,
+            handle,
+        )?;
+        ensure_not_cancelled_after_mutation(cancellation, ProviderStage::CreateSandbox, handle)?;
+        self.require_exact_front_network(
+            &network,
+            names,
+            &definition.labels,
+            &definition.ipv4_network,
+            handle,
+        )
+        .await
+    }
+
+    async fn require_exact_front_network(
+        &self,
+        expected: &InspectedNetwork,
+        names: &ResourceNames,
+        labels: &BTreeMap<String, String>,
+        ipv4_network: &Ipv4Network,
+        handle: &SandboxHandle,
+    ) -> Result<InspectedNetwork, ProviderError> {
+        let by_id = self
+            .engine
+            .inspect_network(&expected.id)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::VerifyOwnership, Some(handle))
+            })?;
+        let by_name = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::VerifyOwnership, Some(handle))
+            })?;
+        if by_id.as_ref() != Some(expected) || by_name.as_ref() != Some(expected) {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::VerifyOwnership,
+                handle,
+            ));
+        }
+        verify_front_network(expected, names, labels, ipv4_network, handle)?;
+        Ok(expected.clone())
+    }
+
+    async fn require_front_members(
+        &self,
+        network: &InspectedNetwork,
+        job: Option<&InspectedContainer>,
+        proxy: Option<&InspectedContainer>,
+        handle: &SandboxHandle,
+    ) -> Result<InspectedNetwork, ProviderError> {
+        let current = self
+            .engine
+            .inspect_network(&network.id)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::VerifyOwnership, Some(handle))
+            })?
+            .ok_or_else(|| {
+                uncertain(
+                    ProviderErrorKind::OwnershipMismatch,
+                    ProviderStage::VerifyOwnership,
+                    handle,
+                )
+            })?;
+        let mut expected = BTreeMap::new();
+        if let Some(proxy) = proxy.filter(|proxy| proxy.state == EngineContainerState::Running) {
+            expected.insert(
+                proxy.id.clone(),
+                (
+                    proxy.definition.name.clone(),
+                    front_proxy_address(&current)?,
+                    current.ipv4_network.prefix,
+                ),
+            );
+        }
+        if let Some(job) = job.filter(|job| job.state == EngineContainerState::Running) {
+            expected.insert(
+                job.id.clone(),
+                (
+                    job.definition.name.clone(),
+                    front_job_address(&current)?,
+                    current.ipv4_network.prefix,
+                ),
+            );
+        }
+        let realized = current
+            .containers
+            .iter()
+            .map(|(id, endpoint)| {
+                (
+                    id.clone(),
+                    (
+                        endpoint.name.clone(),
+                        endpoint.ipv4_address,
+                        endpoint.ipv4_prefix,
+                    ),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut current_without_members = current.clone();
+        current_without_members.containers = network.containers.clone();
+        if current_without_members != *network || realized != expected {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::VerifyOwnership,
+                handle,
+            ));
+        }
+        Ok(current)
+    }
+
+    async fn destroy_front_network(
+        &self,
+        snapshot: &InspectedNetwork,
+        names: &ResourceNames,
+        handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<(), ProviderError> {
+        ensure_not_cancelled(cancellation, ProviderStage::DestroyContainer)?;
+        let current = self
+            .engine
+            .inspect_network(&snapshot.id)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::DestroyContainer, Some(handle))
+            })?
+            .ok_or_else(|| {
+                uncertain(
+                    ProviderErrorKind::Conflict,
+                    ProviderStage::DestroyContainer,
+                    handle,
+                )
+            })?;
+        let mut expected = snapshot.clone();
+        expected.containers.clear();
+        if current != expected || !current.containers.is_empty() {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::DestroyContainer,
+                handle,
+            ));
+        }
+        self.verify_custody_boundary(ProviderStage::DestroyContainer, cancellation, budget)
+            .await
+            .map_err(|error| recovery(&error, handle))?;
+        let _untrusted_remove = self.engine.remove_network(&current.id).await;
+        self.require_network_absent(names, Some(&current.id), handle)
+            .await?;
+        ensure_not_cancelled_after_mutation(cancellation, ProviderStage::DestroyContainer, handle)
+    }
+
+    async fn require_network_absent(
+        &self,
+        names: &ResourceNames,
+        removed_id: Option<&str>,
+        handle: &SandboxHandle,
+    ) -> Result<(), ProviderError> {
+        let by_name = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| {
+                map_provider_engine(error, ProviderStage::DestroyContainer, Some(handle))
+            })?;
+        let by_id = if let Some(id) = removed_id {
+            self.engine.inspect_network(id).await.map_err(|error| {
+                map_provider_engine(error, ProviderStage::DestroyContainer, Some(handle))
+            })?
+        } else {
+            None
+        };
+        if by_name.is_none() && by_id.is_none() {
+            Ok(())
+        } else {
+            Err(uncertain(
+                ProviderErrorKind::Conflict,
+                ProviderStage::DestroyContainer,
+                handle,
+            ))
+        }
     }
 
     async fn probe(
@@ -770,6 +1374,7 @@ impl LocalDockerInner {
         container: &InspectedContainer,
         handle: &SandboxHandle,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<(), ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::Start)?;
         let guest_request = GuestRequest::Probe {
@@ -785,7 +1390,7 @@ impl LocalDockerInner {
             stderr_limit: 1_024,
             timeout: ENGINE_TRANSPORT_OVERHEAD,
         };
-        self.verify_boundary(ProviderStage::Start)
+        self.verify_boundary(ProviderStage::Start, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         ensure_not_cancelled(cancellation, ProviderStage::Start)?;
@@ -794,19 +1399,26 @@ impl LocalDockerInner {
             .create_exec(&request.container_id, &request.command, &request.user)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::Start, Some(handle)))?;
-        self.verify_boundary(ProviderStage::Start)
+        self.verify_boundary(ProviderStage::Start, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         let result = tokio::select! {
             biased;
             () = cancellation_requested(cancellation) => {
-                self.stop_exact_running_job(names, container, handle, ProviderStage::Start).await?;
+                self.stop_exact_running_job(
+                    names,
+                    container,
+                    handle,
+                    ProviderStage::Start,
+                    budget,
+                )
+                .await?;
                 return Err(uncertain(ProviderErrorKind::Cancelled, ProviderStage::Start, handle));
             }
             result = self.engine.start_exec(&prepared, &request) => result,
         };
         if cancellation.disposition().requires_termination() {
-            self.stop_exact_running_job(names, container, handle, ProviderStage::Start)
+            self.stop_exact_running_job(names, container, handle, ProviderStage::Start, budget)
                 .await?;
             return Err(uncertain(
                 ProviderErrorKind::Cancelled,
@@ -817,7 +1429,7 @@ impl LocalDockerInner {
         let result = match result {
             Ok(result) => result,
             Err(error) => {
-                self.stop_exact_running_job(names, container, handle, ProviderStage::Start)
+                self.stop_exact_running_job(names, container, handle, ProviderStage::Start, budget)
                     .await?;
                 return Err(map_provider_engine(
                     error,
@@ -840,7 +1452,7 @@ impl LocalDockerInner {
             ));
         }
         if cancellation.disposition().requires_termination() {
-            self.stop_exact_running_job(names, container, handle, ProviderStage::Start)
+            self.stop_exact_running_job(names, container, handle, ProviderStage::Start, budget)
                 .await?;
             return Err(uncertain(
                 ProviderErrorKind::Cancelled,
@@ -856,6 +1468,8 @@ impl LocalDockerInner {
         names: &ResourceNames,
         container: &InspectedContainer,
         handle: &SandboxHandle,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<(), ProviderError> {
         let request = EngineExecRequest {
             container_id: container.id.clone(),
@@ -869,7 +1483,7 @@ impl LocalDockerInner {
             stderr_limit: 1,
             timeout: ENGINE_TRANSPORT_OVERHEAD + Duration::from_secs(10),
         };
-        self.verify_boundary(ProviderStage::Start)
+        self.verify_boundary(ProviderStage::Start, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         let prepared = self
@@ -877,13 +1491,13 @@ impl LocalDockerInner {
             .create_exec(&request.container_id, &request.command, &request.user)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::Start, Some(handle)))?;
-        self.verify_boundary(ProviderStage::Start)
+        self.verify_boundary(ProviderStage::Start, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         let result = match self.engine.start_exec(&prepared, &request).await {
             Ok(result) => result,
             Err(error) => {
-                self.stop_exact_running_job(names, container, handle, ProviderStage::Start)
+                self.stop_exact_running_job(names, container, handle, ProviderStage::Start, budget)
                     .await?;
                 return Err(map_provider_engine(
                     error,
@@ -906,16 +1520,19 @@ impl LocalDockerInner {
         &self,
         names: &ResourceNames,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<AttachedIdentity, ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::Attach)?;
-        self.verify_boundary(ProviderStage::Attach).await?;
+        self.verify_boundary(ProviderStage::Attach, cancellation, budget)
+            .await?;
         let container = self
             .engine
             .inspect_container(&names.job)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::Attach, None))?
             .ok_or_else(|| known(ProviderErrorKind::NotFound, ProviderStage::Attach))?;
-        self.verify_job(names, &container, ProviderStage::Attach)
+        let initial_identity = self
+            .verify_job(names, &container, ProviderStage::Attach)
             .await?;
         if container.state != EngineContainerState::Running {
             return Err(known(
@@ -936,8 +1553,19 @@ impl LocalDockerInner {
             ));
         }
         let handle = names.handle(&self.provider_id)?;
-        self.probe(names, &container, &handle, cancellation).await?;
-        self.verify_boundary(ProviderStage::Attach).await?;
+        self.verify_results_topology(
+            names,
+            &container,
+            &initial_identity,
+            ProviderStage::Attach,
+            cancellation,
+            budget,
+        )
+        .await?;
+        self.probe(names, &container, &handle, cancellation, budget)
+            .await?;
+        self.verify_boundary(ProviderStage::Attach, cancellation, budget)
+            .await?;
         let container = self
             .require_exact_container(
                 &container,
@@ -951,11 +1579,24 @@ impl LocalDockerInner {
         let identity = self
             .verify_job(names, &container, ProviderStage::Attach)
             .await?;
+        let (proxy, front) = self
+            .verify_results_topology(
+                names,
+                &container,
+                &identity,
+                ProviderStage::Attach,
+                cancellation,
+                budget,
+            )
+            .await?;
         ensure_not_cancelled_after_mutation(cancellation, ProviderStage::Attach, &handle)?;
         Ok(AttachedIdentity {
             container_id: container.id,
             definition: container.definition,
             base_labels: identity.base_labels,
+            proxy_id: proxy.id,
+            proxy_definition: proxy.definition,
+            front_id: front.id,
         })
     }
 
@@ -963,8 +1604,10 @@ impl LocalDockerInner {
         &self,
         names: &ResourceNames,
         attached: &AttachedIdentity,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<InspectedContainer, ProviderErrorKind> {
-        self.verify_boundary_kind().await?;
+        self.verify_boundary_kind(cancellation, budget).await?;
         let container = self
             .engine
             .inspect_container(&names.job)
@@ -994,6 +1637,23 @@ impl LocalDockerInner {
         if identity.base_labels != attached.base_labels {
             return Err(ProviderErrorKind::OwnershipMismatch);
         }
+        let (proxy, front) = self
+            .verify_results_topology(
+                names,
+                &container,
+                &identity,
+                ProviderStage::VerifyOwnership,
+                cancellation,
+                budget,
+            )
+            .await
+            .map_err(|error| error.kind())?;
+        if proxy.id != attached.proxy_id
+            || proxy.definition != attached.proxy_definition
+            || front.id != attached.front_id
+        {
+            return Err(ProviderErrorKind::OwnershipMismatch);
+        }
         Ok(container)
     }
 
@@ -1003,6 +1663,7 @@ impl LocalDockerInner {
         expected: &InspectedContainer,
         handle: &SandboxHandle,
         stage: ProviderStage,
+        budget: ResultsTransportBudget,
     ) -> Result<(), ProviderError> {
         let current = self
             .engine
@@ -1028,7 +1689,19 @@ impl LocalDockerInner {
                 handle,
             ));
         }
-        self.verify_boundary(stage)
+        let identity = parse_identity(
+            &current.definition.labels,
+            names,
+            &self.installation,
+            self.runner_id,
+            KIND_JOB,
+            stage,
+        )?;
+        let (proxy, front) = self
+            .verify_results_topology(names, &current, &identity, stage, &NeverCancelled, budget)
+            .await
+            .map_err(|error| recovery(&error, handle))?;
+        self.verify_boundary(stage, &NeverCancelled, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         let _untrusted_kill = self.engine.kill_container(&current.id).await;
@@ -1056,7 +1729,9 @@ impl LocalDockerInner {
                 handle,
             ));
         }
-        self.verify_boundary(stage)
+        self.require_front_members(&front, Some(&stopped), Some(&proxy), handle)
+            .await?;
+        self.verify_boundary(stage, &NeverCancelled, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         let final_job = self
@@ -1089,6 +1764,7 @@ impl LocalDockerInner {
             &container.definition.labels,
             names,
             &self.installation,
+            self.runner_id,
             KIND_JOB,
             stage,
         )?;
@@ -1101,15 +1777,239 @@ impl LocalDockerInner {
         if inspected.id != container.image_id {
             return Err(known(ProviderErrorKind::OwnershipMismatch, stage));
         }
+        let front = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, stage, None))?
+            .ok_or_else(|| known(ProviderErrorKind::OwnershipMismatch, stage))?;
+        verify_front_network(
+            &front,
+            names,
+            &front_network_labels(&identity.base_labels),
+            &results_front_network(&self.installation, identity.custody)?,
+            &names.handle(&self.provider_id)?,
+        )?;
         verify_job_definition(
             container,
             names,
             &inspected.labels,
             &inspected.environment_names,
             &identity.base_labels,
+            &front,
             stage,
         )?;
         Ok(identity)
+    }
+
+    async fn verify_results_topology(
+        &self,
+        names: &ResourceNames,
+        job: &InspectedContainer,
+        identity: &BaseIdentity,
+        stage: ProviderStage,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<(InspectedContainer, InspectedNetwork), ProviderError> {
+        let handle = names.handle(&self.provider_id)?;
+        let front = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, stage, None))?
+            .ok_or_else(|| known(ProviderErrorKind::OwnershipMismatch, stage))?;
+        verify_front_network(
+            &front,
+            names,
+            &front_network_labels(&identity.base_labels),
+            &results_front_network(&self.installation, identity.custody)?,
+            &handle,
+        )?;
+        let proxy = self
+            .engine
+            .inspect_container(&names.results_proxy)
+            .await
+            .map_err(|error| map_provider_engine(error, stage, None))?
+            .ok_or_else(|| known(ProviderErrorKind::OwnershipMismatch, stage))?;
+        let transit_address = transit_proxy_address(
+            &self.results.transit_network,
+            self.results.transit_gateway,
+            self.results.requested.results_address,
+            identity.custody,
+        )?;
+        let expected = results_proxy_definition(
+            names,
+            &identity.base_labels,
+            &self.results,
+            &front,
+            transit_address,
+        )?;
+        verify_container(
+            &proxy,
+            &expected,
+            &self.results.proxy_image_id,
+            Some(EngineContainerState::Running),
+        )
+        .map_err(|_| known(ProviderErrorKind::OwnershipMismatch, stage))?;
+        self.wait_for_results_proxy_ready(
+            names,
+            &proxy,
+            &expected,
+            &front,
+            Some(job),
+            &handle,
+            stage,
+            cancellation,
+            budget,
+        )
+        .await?;
+        Ok((proxy, front))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn wait_for_results_proxy_ready(
+        &self,
+        names: &ResourceNames,
+        expected_proxy: &InspectedContainer,
+        definition: &ContainerDefinition,
+        front: &InspectedNetwork,
+        job: Option<&InspectedContainer>,
+        handle: &SandboxHandle,
+        stage: ProviderStage,
+        cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
+    ) -> Result<(), ProviderError> {
+        let poll = async {
+            loop {
+                self.require_exact_results_proxy_topology(
+                    names,
+                    expected_proxy,
+                    definition,
+                    front,
+                    job,
+                    handle,
+                    stage,
+                )
+                .await?;
+                let readiness = self
+                    .engine
+                    .container_logs(&expected_proxy.id, RESULTS_READY_STATUS.len())
+                    .await
+                    .map_err(|error| map_provider_engine(error, stage, Some(handle)))?;
+                if readiness == RESULTS_READY_STATUS {
+                    self.require_exact_results_proxy_topology(
+                        names,
+                        expected_proxy,
+                        definition,
+                        front,
+                        job,
+                        handle,
+                        stage,
+                    )
+                    .await?;
+                    return Ok(());
+                }
+                if !readiness.is_empty() {
+                    return Err(uncertain(ProviderErrorKind::BackendRejected, stage, handle));
+                }
+                tokio::time::sleep(RESULTS_PROXY_READINESS_INTERVAL).await;
+            }
+        };
+        tokio::select! {
+            biased;
+            () = cancellation_requested(cancellation) => Err(uncertain(
+                ProviderErrorKind::Cancelled,
+                stage,
+                handle,
+            )),
+            result = tokio::time::timeout_at(
+                budget.bounded_deadline(RESULTS_PROXY_READINESS_TIMEOUT),
+                poll,
+            ) => result.unwrap_or_else(|_| Err(uncertain(
+                ProviderErrorKind::BackendRejected,
+                stage,
+                handle,
+            ))),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn require_exact_results_proxy_topology(
+        &self,
+        names: &ResourceNames,
+        expected_proxy: &InspectedContainer,
+        definition: &ContainerDefinition,
+        front: &InspectedNetwork,
+        job: Option<&InspectedContainer>,
+        handle: &SandboxHandle,
+        stage: ProviderStage,
+    ) -> Result<(), ProviderError> {
+        let proxy = self
+            .require_exact_container(
+                expected_proxy,
+                definition,
+                &self.results.proxy_image_id,
+                EngineContainerState::Running,
+                handle,
+            )
+            .await?;
+        let proxy_by_id = self
+            .engine
+            .inspect_container(&expected_proxy.id)
+            .await
+            .map_err(|error| map_provider_engine(error, stage, Some(handle)))?;
+        if proxy_by_id.as_ref() != Some(&proxy) {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                stage,
+                handle,
+            ));
+        }
+        let current_front = self
+            .require_front_members(front, job, Some(&proxy), handle)
+            .await?;
+        let front_by_name = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, stage, Some(handle)))?;
+        if front_by_name.as_ref() != Some(&current_front) {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                stage,
+                handle,
+            ));
+        }
+        let transit = inspect_exact_results_transit(
+            self.engine.as_ref(),
+            &self.installation,
+            &self.results.requested,
+        )
+        .await
+        .map_err(|error| map_provider_local_docker(error, stage, Some(handle)))?;
+        let transit_attachment = definition
+            .networks
+            .get(&self.results.transit_name)
+            .ok_or_else(|| uncertain(ProviderErrorKind::OwnershipMismatch, stage, handle))?;
+        let target_running =
+            results_target_is_running(self.engine.as_ref(), &self.results.requested)
+                .await
+                .map_err(|error| map_provider_local_docker(error, stage, Some(handle)))?;
+        if transit_attachment.network_id != transit.id
+            || !transit.containers.get(&proxy.id).is_some_and(|endpoint| {
+                endpoint.name == names.results_proxy
+                    && endpoint.ipv4_address == transit_attachment.ipv4_address
+                    && endpoint.ipv4_prefix == transit.ipv4_network.prefix
+            })
+            || !target_running
+        {
+            return Err(uncertain(
+                ProviderErrorKind::OwnershipMismatch,
+                stage,
+                handle,
+            ));
+        }
+        Ok(())
     }
 
     fn verify_helper(
@@ -1122,6 +2022,7 @@ impl LocalDockerInner {
             &helper.definition.labels,
             names,
             &self.installation,
+            self.runner_id,
             KIND_GUEST_SOURCE,
             stage,
         )?;
@@ -1137,17 +2038,30 @@ impl LocalDockerInner {
         Ok(identity)
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn inspect(
         &self,
         handle: &SandboxHandle,
         names: &ResourceNames,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<SandboxInspection, ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::Inspect)?;
-        self.verify_boundary(ProviderStage::Inspect).await?;
+        self.verify_boundary(ProviderStage::Inspect, cancellation, budget)
+            .await?;
         let job = self
             .engine
             .inspect_container(&names.job)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
+        let proxy = self
+            .engine
+            .inspect_container(&names.results_proxy)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
+        let front = self
+            .engine
+            .inspect_network(&names.results_front)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
         let helper = self
@@ -1163,27 +2077,76 @@ impl LocalDockerInner {
             Some(helper) => Some(self.verify_helper(names, helper, ProviderStage::Inspect)?),
             None => None,
         };
-        let identity = if job.is_none() && helper.is_none() {
-            None
-        } else {
-            Some(matching_identity(
+        let proxy_identity = proxy
+            .as_ref()
+            .map(|proxy| {
+                parse_identity(
+                    &proxy.definition.labels,
+                    names,
+                    &self.installation,
+                    self.runner_id,
+                    KIND_RESULTS_PROXY,
+                    ProviderStage::Inspect,
+                )
+            })
+            .transpose()?;
+        let front_identity = front
+            .as_ref()
+            .map(|front| {
+                parse_identity(
+                    &front.labels,
+                    names,
+                    &self.installation,
+                    self.runner_id,
+                    KIND_RESULTS_FRONT,
+                    ProviderStage::Inspect,
+                )
+            })
+            .transpose()?;
+        let identity = matching_present_identities(
+            [
                 job_identity.as_ref(),
                 helper_identity.as_ref(),
+                proxy_identity.as_ref(),
+                front_identity.as_ref(),
+            ],
+            ProviderStage::Inspect,
+        )?;
+        if let (Some(job), Some(identity)) = (job.as_ref(), identity)
+            && job.state == EngineContainerState::Running
+        {
+            self.verify_results_topology(
+                names,
+                job,
+                identity,
                 ProviderStage::Inspect,
-            )?)
-        };
-        let state = match (job.as_ref(), helper.as_ref()) {
-            (None, None) => None,
-            (None | Some(_), Some(_)) => Some(SandboxState::Degraded),
-            (Some(job), None) => Some(match job.state {
-                EngineContainerState::Created => SandboxState::Created,
-                EngineContainerState::Running => SandboxState::Running,
-                EngineContainerState::Exited(_) => SandboxState::Stopped,
-                EngineContainerState::Invalid => SandboxState::Degraded,
-            }),
+                cancellation,
+                budget,
+            )
+            .await?;
+        }
+        let state = match (
+            job.as_ref(),
+            helper.as_ref(),
+            proxy.as_ref(),
+            front.as_ref(),
+        ) {
+            (None, None, None, None) => None,
+            (Some(job), None, Some(proxy), Some(_))
+                if proxy.state == EngineContainerState::Running =>
+            {
+                Some(match job.state {
+                    EngineContainerState::Created => SandboxState::Created,
+                    EngineContainerState::Running => SandboxState::Running,
+                    EngineContainerState::Exited(_) => SandboxState::Stopped,
+                    EngineContainerState::Invalid => SandboxState::Degraded,
+                })
+            }
+            _ => Some(SandboxState::Degraded),
         };
         ensure_not_cancelled(cancellation, ProviderStage::Inspect)?;
-        self.verify_boundary(ProviderStage::Inspect).await?;
+        self.verify_boundary(ProviderStage::Inspect, cancellation, budget)
+            .await?;
         let current_job = self
             .engine
             .inspect_container(&names.job)
@@ -1194,7 +2157,21 @@ impl LocalDockerInner {
             .inspect_container(&names.helper)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
-        if current_job != job || current_helper != helper {
+        let current_proxy = self
+            .engine
+            .inspect_container(&names.results_proxy)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
+        let current_front = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::Inspect, None))?;
+        if current_job != job
+            || current_helper != helper
+            || current_proxy != proxy
+            || current_front != front
+        {
             return Err(known(
                 ProviderErrorKind::OwnershipMismatch,
                 ProviderStage::Inspect,
@@ -1212,14 +2189,17 @@ impl LocalDockerInner {
         ))
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn destroy(
         &self,
         request: &DestroySandbox,
         names: &ResourceNames,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<DestroyDisposition, ProviderError> {
         ensure_not_cancelled(cancellation, ProviderStage::DestroySandbox)?;
-        self.verify_boundary(ProviderStage::DestroySandbox).await?;
+        self.verify_custody_boundary(ProviderStage::DestroySandbox, cancellation, budget)
+            .await?;
         let job = self
             .engine
             .inspect_container_custody(&names.job)
@@ -1230,12 +2210,27 @@ impl LocalDockerInner {
             .inspect_container_custody(&names.helper)
             .await
             .map_err(|error| map_provider_engine(error, ProviderStage::DestroySandbox, None))?;
-        if job.is_none() && helper.is_none() {
+        let proxy = self
+            .engine
+            .inspect_container_custody(&names.results_proxy)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::DestroySandbox, None))?;
+        let front = self
+            .engine
+            .inspect_network(&names.results_front)
+            .await
+            .map_err(|error| map_provider_engine(error, ProviderStage::DestroySandbox, None))?;
+        if job.is_none() && helper.is_none() && proxy.is_none() && front.is_none() {
             ensure_not_cancelled(cancellation, ProviderStage::DestroySandbox)?;
-            self.verify_boundary(ProviderStage::DestroySandbox).await?;
+            self.verify_custody_boundary(ProviderStage::DestroySandbox, cancellation, budget)
+                .await?;
             self.require_name_absent(&names.job, request.handle())
                 .await?;
             self.require_name_absent(&names.helper, request.handle())
+                .await?;
+            self.require_name_absent(&names.results_proxy, request.handle())
+                .await?;
+            self.require_network_absent(names, None, request.handle())
                 .await?;
             return Ok(DestroyDisposition::AlreadyAbsent);
         }
@@ -1244,6 +2239,7 @@ impl LocalDockerInner {
                 job,
                 names,
                 &self.installation,
+                self.runner_id,
                 KIND_JOB,
                 ProviderStage::VerifyOwnership,
             )?),
@@ -1254,38 +2250,94 @@ impl LocalDockerInner {
                 helper,
                 names,
                 &self.installation,
+                self.runner_id,
                 KIND_GUEST_SOURCE,
                 ProviderStage::VerifyOwnership,
             )?),
             None => None,
         };
-        let identity = matching_identity(
-            job_identity.as_ref(),
-            helper_identity.as_ref(),
+        let proxy_identity = match proxy.as_ref() {
+            Some(proxy) => Some(verify_container_custody(
+                proxy,
+                names,
+                &self.installation,
+                self.runner_id,
+                KIND_RESULTS_PROXY,
+                ProviderStage::VerifyOwnership,
+            )?),
+            None => None,
+        };
+        let front_identity = front
+            .as_ref()
+            .map(|front| {
+                parse_identity(
+                    &front.labels,
+                    names,
+                    &self.installation,
+                    self.runner_id,
+                    KIND_RESULTS_FRONT,
+                    ProviderStage::VerifyOwnership,
+                )
+            })
+            .transpose()?;
+        let identity = matching_present_identities(
+            [
+                job_identity.as_ref(),
+                helper_identity.as_ref(),
+                proxy_identity.as_ref(),
+                front_identity.as_ref(),
+            ],
             ProviderStage::VerifyOwnership,
-        )?;
+        )?
+        .ok_or_else(|| {
+            known(
+                ProviderErrorKind::OwnershipMismatch,
+                ProviderStage::VerifyOwnership,
+            )
+        })?;
         if identity.custody != request.custody() {
             return Err(known(
                 ProviderErrorKind::OwnershipMismatch,
                 ProviderStage::VerifyOwnership,
             ));
         }
+        if let Some(front) = front.as_ref() {
+            verify_front_network(
+                front,
+                names,
+                &front_network_labels(&identity.base_labels),
+                &results_front_network(&self.installation, identity.custody)?,
+                request.handle(),
+            )?;
+        }
         ensure_not_cancelled(cancellation, ProviderStage::DestroySandbox)?;
 
         if let Some(helper) = helper.as_ref() {
-            self.destroy_container(helper, request.handle(), cancellation)
+            self.destroy_container(helper, request.handle(), cancellation, budget)
                 .await?;
         }
         if let Some(job) = job.as_ref() {
-            self.destroy_container(job, request.handle(), cancellation)
+            self.destroy_container(job, request.handle(), cancellation, budget)
                 .await?;
         }
-        self.verify_boundary(ProviderStage::DestroySandbox)
+        if let Some(proxy) = proxy.as_ref() {
+            self.destroy_container(proxy, request.handle(), cancellation, budget)
+                .await?;
+        }
+        if let Some(front) = front.as_ref() {
+            self.destroy_front_network(front, names, request.handle(), cancellation, budget)
+                .await?;
+        }
+        self.verify_custody_boundary(ProviderStage::DestroySandbox, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, request.handle()))?;
         self.require_name_absent(&names.job, request.handle())
             .await?;
         self.require_name_absent(&names.helper, request.handle())
+            .await?;
+        self.require_name_absent(&names.results_proxy, request.handle())
+            .await?;
+        self.require_network_absent(names, None, request.handle())
             .await?;
         Ok(DestroyDisposition::Destroyed)
     }
@@ -1295,11 +2347,12 @@ impl LocalDockerInner {
         snapshot: &InspectedContainerCustody,
         handle: &SandboxHandle,
         cancellation: &dyn Cancellation,
+        budget: ResultsTransportBudget,
     ) -> Result<(), ProviderError> {
         let mut current = self.require_exact_custody(snapshot, handle).await?;
         match current.state {
             EngineContainerState::Running => {
-                self.verify_boundary(ProviderStage::DestroyContainer)
+                self.verify_custody_boundary(ProviderStage::DestroyContainer, cancellation, budget)
                     .await
                     .map_err(|error| recovery(&error, handle))?;
                 current = self.require_exact_custody(snapshot, handle).await?;
@@ -1322,14 +2375,14 @@ impl LocalDockerInner {
             | EngineContainerState::Exited(_)
             | EngineContainerState::Invalid => {}
         }
-        self.verify_boundary(ProviderStage::DestroyContainer)
+        self.verify_custody_boundary(ProviderStage::DestroyContainer, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         current = self.require_exact_custody(snapshot, handle).await?;
         let _untrusted_remove = self.engine.remove_container(&current.id).await;
         self.require_custody_absent(&snapshot.name, &snapshot.id, handle)
             .await?;
-        self.verify_boundary(ProviderStage::DestroyContainer)
+        self.verify_custody_boundary(ProviderStage::DestroyContainer, cancellation, budget)
             .await
             .map_err(|error| recovery(&error, handle))?;
         ensure_not_cancelled_after_mutation(cancellation, ProviderStage::DestroyContainer, handle)
@@ -1418,6 +2471,8 @@ struct ResourceNames {
     generation: u64,
     job: String,
     helper: String,
+    results_front: String,
+    results_proxy: String,
 }
 
 impl ResourceNames {
@@ -1475,6 +2530,8 @@ impl ResourceNames {
             generation,
             job: format!("{base}-job"),
             helper: format!("{base}-guest-source"),
+            results_front: format!("{base}-results-front"),
+            results_proxy: format!("{base}-results-proxy"),
         })
     }
 
@@ -1506,9 +2563,12 @@ struct AttachedIdentity {
     container_id: String,
     definition: ContainerDefinition,
     base_labels: BTreeMap<String, String>,
+    proxy_id: String,
+    proxy_definition: ContainerDefinition,
+    front_id: String,
 }
 
-fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
+fn validate_spec(spec: &SandboxSpec, runner_id: RunnerId) -> Result<(), ProviderError> {
     let SandboxLaunch::Container { .. } = spec.profile().launch() else {
         return Err(known(
             ProviderErrorKind::UnsupportedPlatform,
@@ -1525,13 +2585,26 @@ fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
         || workspace
             .as_str()
             .starts_with(&format!("{LOCAL_CONTROL_DIRECTORY}/"));
-    if workspace.platform() != TargetPlatform::Posix
+    let custody_runner = match spec.custody() {
+        SandboxCustody::ProfileAdmission { runner_id } | SandboxCustody::Job { runner_id, .. } => {
+            runner_id
+        }
+    };
+    let custody_valid = custody_runner == runner_id
+        && match spec.custody() {
+            SandboxCustody::ProfileAdmission { .. } => true,
+            SandboxCustody::Job { slot_ordinal, .. } => {
+                slot_ordinal.get() <= crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS
+            }
+        };
+    if !custody_valid
+        || workspace.platform() != TargetPlatform::Posix
         || profile_workspace.platform() != TargetPlatform::Posix
         || (workspace != profile_workspace && !workspace.as_str().starts_with(&workspace_prefix))
         || workspace_conflicts_with_control
         || spec.scratch().is_some()
         || !spec.services().is_empty()
-        || spec.network() != NetworkPolicy::Disabled
+        || spec.network() != NetworkPolicy::PrivateEgress
         || spec.root_filesystem() != RootFilesystemPolicy::Writable
         || spec.privilege() != SandboxPrivilegePolicy::Administrator
     {
@@ -1652,6 +2725,9 @@ fn helper_definition(
         memory_bytes: HELPER_MEMORY_BYTES,
         nano_cpus: HELPER_NANO_CPUS,
         pids_limit: HELPER_PIDS,
+        primary_network: None,
+        networks: BTreeMap::new(),
+        capture_logs: false,
     }
 }
 
@@ -1662,6 +2738,7 @@ fn job_definition(
     image_labels: &BTreeMap<String, String>,
     environment_names: &[String],
     base_labels: &BTreeMap<String, String>,
+    front: &FrontNetworkDefinition,
 ) -> Result<ContainerDefinition, ProviderError> {
     let resources = spec.resources();
     let memory_bytes =
@@ -1692,7 +2769,249 @@ fn job_definition(
         memory_bytes,
         nano_cpus,
         pids_limit: i64::from(resources.pids()),
+        primary_network: Some(front.name.clone()),
+        networks: BTreeMap::from([(
+            front.name.clone(),
+            ContainerNetworkAttachment {
+                network_id: String::new(),
+                ipv4_address: network_host_address(&front.ipv4_network, 3)?,
+                aliases: Vec::new(),
+            },
+        )]),
+        capture_logs: false,
     })
+}
+
+fn results_proxy_definition(
+    names: &ResourceNames,
+    base_labels: &BTreeMap<String, String>,
+    results: &VerifiedResultsTransport,
+    front: &InspectedNetwork,
+    transit_address: Ipv4Addr,
+) -> Result<ContainerDefinition, ProviderError> {
+    results_proxy_definition_for_front(
+        names,
+        base_labels,
+        results,
+        &front.name,
+        &front.id,
+        &front.ipv4_network,
+        transit_address,
+    )
+}
+
+fn planned_results_proxy_definition(
+    names: &ResourceNames,
+    base_labels: &BTreeMap<String, String>,
+    results: &VerifiedResultsTransport,
+    front: &FrontNetworkDefinition,
+    transit_address: Ipv4Addr,
+) -> Result<ContainerDefinition, ProviderError> {
+    results_proxy_definition_for_front(
+        names,
+        base_labels,
+        results,
+        &front.name,
+        "",
+        &front.ipv4_network,
+        transit_address,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn results_proxy_definition_for_front(
+    names: &ResourceNames,
+    base_labels: &BTreeMap<String, String>,
+    results: &VerifiedResultsTransport,
+    front_name: &str,
+    front_id: &str,
+    front_network: &Ipv4Network,
+    transit_address: Ipv4Addr,
+) -> Result<ContainerDefinition, ProviderError> {
+    let front_address = network_host_address(front_network, 2)?;
+    let job_address = network_host_address(front_network, 3)?;
+    Ok(ContainerDefinition {
+        name: names.results_proxy.clone(),
+        image: results.requested.proxy_image.reference().to_owned(),
+        entrypoint: RESULTS_PROXY_ENTRYPOINT.to_owned(),
+        arguments: vec![
+            RESULTS_PROXY_COMMAND.to_owned(),
+            front_address.to_string(),
+            front_network.canonical(),
+            job_address.to_string(),
+            results.transit_network.canonical(),
+            results.requested.results_address.to_string(),
+        ],
+        labels: resource_labels(&results.proxy_image_labels, base_labels, KIND_RESULTS_PROXY),
+        environment: vec!["PATH=".to_owned()],
+        tmpfs: BTreeMap::new(),
+        working_directory: "/".to_owned(),
+        user: RESULTS_PROXY_USER.to_owned(),
+        read_only_root: true,
+        memory_bytes: RESULTS_PROXY_MEMORY_BYTES,
+        nano_cpus: RESULTS_PROXY_NANO_CPUS,
+        pids_limit: RESULTS_PROXY_PIDS,
+        primary_network: Some(front_name.to_owned()),
+        networks: BTreeMap::from([
+            (
+                front_name.to_owned(),
+                ContainerNetworkAttachment {
+                    network_id: front_id.to_owned(),
+                    ipv4_address: front_address,
+                    aliases: vec![RESULTS_ALIAS.to_owned()],
+                },
+            ),
+            (
+                results.transit_name.clone(),
+                ContainerNetworkAttachment {
+                    network_id: results.requested.transit_network_id.clone(),
+                    ipv4_address: transit_address,
+                    aliases: Vec::new(),
+                },
+            ),
+        ]),
+        capture_logs: true,
+    })
+}
+
+fn bind_front_network(definition: &mut ContainerDefinition, front: &InspectedNetwork) {
+    let attachment = definition
+        .networks
+        .get_mut(&front.name)
+        .expect("the precomputed definition contains the deterministic front network");
+    debug_assert!(attachment.network_id.is_empty());
+    attachment.network_id.clone_from(&front.id);
+}
+
+fn front_proxy_address(network: &InspectedNetwork) -> Result<Ipv4Addr, ProviderError> {
+    network_host_address(&network.ipv4_network, 2)
+}
+
+fn front_job_address(network: &InspectedNetwork) -> Result<Ipv4Addr, ProviderError> {
+    network_host_address(&network.ipv4_network, 3)
+}
+
+fn network_host_address(network: &Ipv4Network, offset: u32) -> Result<Ipv4Addr, ProviderError> {
+    u32::from(network.network)
+        .checked_add(offset)
+        .map(Ipv4Addr::from)
+        .filter(|address| network.usable(*address))
+        .ok_or_else(invalid_configuration)
+}
+
+fn custody_network_index(custody: SandboxCustody) -> Result<u16, ProviderError> {
+    match custody {
+        SandboxCustody::ProfileAdmission { .. } => Ok(0),
+        SandboxCustody::Job { slot_ordinal, .. }
+            if slot_ordinal.get() <= crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS =>
+        {
+            Ok(slot_ordinal.get())
+        }
+        SandboxCustody::Job { .. } => Err(invalid_configuration()),
+    }
+}
+
+fn results_front_pool(installation: &Installation) -> Ipv4Network {
+    let selector = installation.selector_key().digest();
+    let bytes = selector.as_bytes();
+    let bucket = (u32::from(bytes[0]) << 4) | (u32::from(bytes[1]) >> 4);
+    Ipv4Network {
+        network: Ipv4Addr::from((u32::from(Ipv4Addr::new(10, 0, 0, 0))) | (bucket << 12)),
+        prefix: RESULTS_FRONT_POOL_PREFIX,
+    }
+}
+
+fn results_front_network(
+    installation: &Installation,
+    custody: SandboxCustody,
+) -> Result<Ipv4Network, ProviderError> {
+    let pool = results_front_pool(installation);
+    let index = u32::from(custody_network_index(custody)?);
+    let network = u32::from(pool.network)
+        .checked_add(index << (32 - RESULTS_FRONT_NETWORK_PREFIX))
+        .map(Ipv4Addr::from)
+        .ok_or_else(invalid_configuration)?;
+    let result = Ipv4Network {
+        network,
+        prefix: RESULTS_FRONT_NETWORK_PREFIX,
+    };
+    if !pool.contains(result.network) || !pool.contains(result.broadcast()) {
+        return Err(invalid_configuration());
+    }
+    Ok(result)
+}
+
+fn front_network_definition(
+    names: &ResourceNames,
+    base_labels: &BTreeMap<String, String>,
+    installation: &Installation,
+    custody: SandboxCustody,
+) -> Result<FrontNetworkDefinition, ProviderError> {
+    let ipv4_network = results_front_network(installation, custody)?;
+    let ipv4_gateway = network_host_address(&ipv4_network, 1)?;
+    Ok(FrontNetworkDefinition {
+        name: names.results_front.clone(),
+        labels: front_network_labels(base_labels),
+        ipv4_network,
+        ipv4_gateway,
+    })
+}
+
+fn transit_proxy_address(
+    network: &Ipv4Network,
+    gateway: Ipv4Addr,
+    results_address: Ipv4Addr,
+    custody: SandboxCustody,
+) -> Result<Ipv4Addr, ProviderError> {
+    let index = usize::from(custody_network_index(custody)?);
+    let host_count = 1_u32
+        .checked_shl(u32::from(32 - network.prefix))
+        .and_then(|count| count.checked_sub(1))
+        .ok_or_else(invalid_configuration)?;
+    (1..host_count)
+        .filter_map(|offset| network_host_address(network, offset).ok())
+        .filter(|address| *address != gateway && *address != results_address)
+        .nth(index)
+        .ok_or_else(invalid_configuration)
+}
+
+fn front_network_labels(base_labels: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut labels = base_labels.clone();
+    labels.insert(
+        LABEL_RESOURCE_KIND.to_owned(),
+        KIND_RESULTS_FRONT.to_owned(),
+    );
+    labels
+}
+
+fn verify_front_network(
+    network: &InspectedNetwork,
+    names: &ResourceNames,
+    labels: &BTreeMap<String, String>,
+    ipv4_network: &Ipv4Network,
+    handle: &SandboxHandle,
+) -> Result<(), ProviderError> {
+    if !canonical_object_id(&network.id)
+        || !exact_closed_network(network, &names.results_front, labels)
+        || network.ipv4_network != *ipv4_network
+        || network.ipv4_gateway
+            != network_host_address(ipv4_network, 1).map_err(|_| {
+                uncertain(
+                    ProviderErrorKind::OwnershipMismatch,
+                    ProviderStage::VerifyOwnership,
+                    handle,
+                )
+            })?
+        || front_proxy_address(network).is_err()
+        || front_job_address(network).is_err()
+    {
+        return Err(uncertain(
+            ProviderErrorKind::OwnershipMismatch,
+            ProviderStage::VerifyOwnership,
+            handle,
+        ));
+    }
+    Ok(())
 }
 
 fn job_tmpfs_options(memory_bytes: i64) -> String {
@@ -1785,10 +3104,10 @@ fn extract_single_guest(archive: &[u8]) -> Result<Vec<u8>, ProviderError> {
     Ok(bytes)
 }
 
-fn sandbox_archive(workspace: &str, guest: &[u8]) -> Result<Vec<u8>, ProviderError> {
-    if guest.is_empty() || guest.len() > max_guest_binary_bytes() {
-        return Err(invalid_configuration());
-    }
+fn sandbox_archive_definition(workspace: &str) -> Result<SandboxArchiveDefinition, ProviderError> {
+    const TAR_BLOCK_BYTES: usize = 512;
+    const TAR_END_BYTES: usize = TAR_BLOCK_BYTES * 2;
+
     let mut directories = BTreeSet::from(["automata".to_owned(), "automata/bin".to_owned()]);
     let mut current = String::new();
     for component in workspace.trim_start_matches('/').split('/') {
@@ -1801,7 +3120,7 @@ fn sandbox_archive(workspace: &str, guest: &[u8]) -> Result<Vec<u8>, ProviderErr
         current.push_str(component);
         directories.insert(current.clone());
     }
-    let mut builder = TarBuilder::new(Vec::new());
+    let mut directory_headers = Vec::with_capacity(directories.len());
     for directory in directories {
         let mode = if directory == "automata" || directory == "automata/bin" {
             0o755
@@ -1819,27 +3138,63 @@ fn sandbox_archive(workspace: &str, guest: &[u8]) -> Result<Vec<u8>, ProviderErr
             .set_path(&directory)
             .map_err(|_| invalid_configuration())?;
         header.set_cksum();
-        builder
-            .append(&header, std::io::empty())
-            .map_err(|_| invalid_configuration())?;
+        directory_headers.push(header);
     }
-    let mut header = Header::new_gnu();
-    header.set_entry_type(EntryType::Regular);
-    header.set_mode(0o555);
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
-    header.set_size(u64::try_from(guest.len()).map_err(|_| invalid_configuration())?);
-    header
+    let mut guest_header = Header::new_gnu();
+    guest_header.set_entry_type(EntryType::Regular);
+    guest_header.set_mode(0o555);
+    guest_header.set_uid(0);
+    guest_header.set_gid(0);
+    guest_header.set_mtime(0);
+    guest_header.set_size(0);
+    guest_header
         .set_path(
             LOCAL_DOCKER_SANDBOX_GUEST_BINARY
                 .strip_prefix('/')
                 .ok_or_else(invalid_configuration)?,
         )
         .map_err(|_| invalid_configuration())?;
-    header.set_cksum();
+    guest_header.set_cksum();
+
+    let maximum_guest_blocks = max_guest_binary_bytes()
+        .checked_add(TAR_BLOCK_BYTES - 1)
+        .and_then(|bytes| bytes.checked_div(TAR_BLOCK_BYTES))
+        .and_then(|blocks| blocks.checked_mul(TAR_BLOCK_BYTES))
+        .ok_or_else(invalid_configuration)?;
+    let maximum_archive_bytes = directory_headers
+        .len()
+        .checked_add(1)
+        .and_then(|headers| headers.checked_mul(TAR_BLOCK_BYTES))
+        .and_then(|bytes| bytes.checked_add(maximum_guest_blocks))
+        .and_then(|bytes| bytes.checked_add(TAR_END_BYTES))
+        .ok_or_else(invalid_configuration)?;
+    if maximum_archive_bytes > LOCAL_DOCKER_GUEST_ARCHIVE_BYTES {
+        return Err(invalid_configuration());
+    }
+    Ok(SandboxArchiveDefinition {
+        directory_headers,
+        guest_header,
+    })
+}
+
+fn sandbox_archive(
+    definition: &SandboxArchiveDefinition,
+    guest: &[u8],
+) -> Result<Vec<u8>, ProviderError> {
+    if guest.is_empty() || guest.len() > max_guest_binary_bytes() {
+        return Err(invalid_configuration());
+    }
+    let mut builder = TarBuilder::new(Vec::new());
+    for header in &definition.directory_headers {
+        builder
+            .append(header, std::io::empty())
+            .map_err(|_| invalid_configuration())?;
+    }
+    let mut guest_header = definition.guest_header.clone();
+    guest_header.set_size(u64::try_from(guest.len()).map_err(|_| invalid_configuration())?);
+    guest_header.set_cksum();
     builder
-        .append(&header, guest)
+        .append(&guest_header, guest)
         .map_err(|_| invalid_configuration())?;
     let archive = builder.into_inner().map_err(|_| invalid_configuration())?;
     if archive.len() > LOCAL_DOCKER_GUEST_ARCHIVE_BYTES {
@@ -1852,9 +3207,10 @@ fn spec_fingerprint(
     spec: &SandboxSpec,
     installation: &Installation,
     guest_image: &ImmutableImage,
+    results: &VerifiedResultsTransport,
 ) -> Result<String, ProviderError> {
     let mut digest = Sha256::new();
-    hash_field(&mut digest, b"automata-local-docker-sandbox-spec-v1");
+    hash_field(&mut digest, b"automata-local-docker-sandbox-spec-v2");
     hash_field(&mut digest, installation.id().as_uuid().as_bytes());
     hash_field(
         &mut digest,
@@ -1909,6 +3265,16 @@ fn spec_fingerprint(
         None => hash_field(&mut digest, &[0]),
     }
     hash_field(&mut digest, guest_image.reference().as_bytes());
+    hash_field(
+        &mut digest,
+        results.requested.proxy_image.reference().as_bytes(),
+    );
+    hash_field(&mut digest, results.requested.transit_network_id.as_bytes());
+    hash_field(
+        &mut digest,
+        results.requested.results_container_id.as_bytes(),
+    );
+    hash_field(&mut digest, &results.requested.results_address.octets());
     Ok(Sha256Digest::from_bytes(digest.finalize().into()).to_string())
 }
 
@@ -1942,6 +3308,7 @@ fn parse_identity(
     labels: &BTreeMap<String, String>,
     names: &ResourceNames,
     installation: &Installation,
+    expected_runner_id: RunnerId,
     resource_kind: &str,
     stage: ProviderStage,
 ) -> Result<BaseIdentity, ProviderError> {
@@ -1967,6 +3334,7 @@ fn parse_identity(
     let runner_id = RunnerId::from_str(runner_text)
         .ok()
         .filter(|value| value.to_string() == runner_text)
+        .filter(|value| *value == expected_runner_id)
         .ok_or_else(|| known(ProviderErrorKind::OwnershipMismatch, stage))?;
     let custody = match required(LABEL_CUSTODY_KIND)? {
         CUSTODY_ADMISSION if !managed.contains_key(LABEL_SLOT) => {
@@ -1982,6 +3350,7 @@ fn parse_identity(
                 .ok()
                 .and_then(NonZeroU16::new)
                 .filter(|value| value.get().to_string() == slot_text)
+                .filter(|value| value.get() <= crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS)
                 .ok_or_else(|| known(ProviderErrorKind::OwnershipMismatch, stage))?;
             if managed.len() != 14 {
                 return Err(known(ProviderErrorKind::OwnershipMismatch, stage));
@@ -2008,16 +3377,18 @@ fn parse_identity(
     })
 }
 
-fn matching_identity<'a>(
-    first: Option<&'a BaseIdentity>,
-    second: Option<&'a BaseIdentity>,
+fn matching_present_identities<const N: usize>(
+    identities: [Option<&BaseIdentity>; N],
     stage: ProviderStage,
-) -> Result<&'a BaseIdentity, ProviderError> {
-    match (first, second) {
-        (Some(first), Some(second)) if first == second => Ok(first),
-        (Some(identity), None) | (None, Some(identity)) => Ok(identity),
-        (Some(_), Some(_)) => Err(known(ProviderErrorKind::OwnershipMismatch, stage)),
-        (None, None) => Err(known(ProviderErrorKind::NotFound, stage)),
+) -> Result<Option<&BaseIdentity>, ProviderError> {
+    let mut present = identities.into_iter().flatten();
+    let Some(first) = present.next() else {
+        return Ok(None);
+    };
+    if present.all(|identity| identity == first) {
+        Ok(Some(first))
+    } else {
+        Err(known(ProviderErrorKind::OwnershipMismatch, stage))
     }
 }
 
@@ -2039,12 +3410,14 @@ fn verify_container_custody(
     container: &InspectedContainerCustody,
     names: &ResourceNames,
     installation: &Installation,
+    runner_id: RunnerId,
     resource_kind: &str,
     stage: ProviderStage,
 ) -> Result<BaseIdentity, ProviderError> {
     let expected_name = match resource_kind {
         KIND_JOB => &names.job,
         KIND_GUEST_SOURCE => &names.helper,
+        KIND_RESULTS_PROXY => &names.results_proxy,
         _ => return Err(known(ProviderErrorKind::OwnershipMismatch, stage)),
     };
     if container.name != *expected_name
@@ -2058,7 +3431,14 @@ fn verify_container_custody(
     {
         return Err(known(ProviderErrorKind::OwnershipMismatch, stage));
     }
-    parse_identity(&container.labels, names, installation, resource_kind, stage)
+    parse_identity(
+        &container.labels,
+        names,
+        installation,
+        runner_id,
+        resource_kind,
+        stage,
+    )
 }
 
 fn same_container_custody(
@@ -2093,7 +3473,7 @@ fn verify_container(
     if container.id.is_empty()
         || container.image_id != image_id
         || !container.isolated
-        || container.definition != *definition
+        || !container_definition_matches(container, definition)
         || state.is_some_and(|expected| container.state != expected)
     {
         return Err(known(
@@ -2104,12 +3484,47 @@ fn verify_container(
     Ok(())
 }
 
+fn container_definition_matches(
+    container: &InspectedContainer,
+    expected: &ContainerDefinition,
+) -> bool {
+    if container.state != EngineContainerState::Created {
+        return container.definition == *expected;
+    }
+    let mut normalized = container.definition.clone();
+    if normalized.networks.len() != expected.networks.len()
+        || normalized.networks.iter().any(|(name, attachment)| {
+            expected
+                .networks
+                .get(name)
+                .is_none_or(|expected_attachment| {
+                    !attachment.network_id.is_empty()
+                        || attachment.ipv4_address != expected_attachment.ipv4_address
+                        || attachment.aliases != expected_attachment.aliases
+                })
+        })
+    {
+        return false;
+    }
+    for (name, attachment) in &mut normalized.networks {
+        attachment.network_id.clone_from(
+            &expected
+                .networks
+                .get(name)
+                .expect("network cardinality and names were checked")
+                .network_id,
+        );
+    }
+    normalized == *expected
+}
+
 fn verify_job_definition(
     container: &InspectedContainer,
     names: &ResourceNames,
     image_labels: &BTreeMap<String, String>,
     image_environment_names: &[String],
     base_labels: &BTreeMap<String, String>,
+    front: &InspectedNetwork,
     stage: ProviderStage,
 ) -> Result<(), ProviderError> {
     let definition = &container.definition;
@@ -2154,6 +3569,16 @@ fn verify_job_definition(
         || definition.user != "0:0"
         || definition.read_only_root
         || !resource_limits_valid
+        || definition.primary_network.as_deref() != Some(front.name.as_str())
+        || definition.networks
+            != BTreeMap::from([(
+                front.name.clone(),
+                ContainerNetworkAttachment {
+                    network_id: front.id.clone(),
+                    ipv4_address: front_job_address(front)?,
+                    aliases: Vec::new(),
+                },
+            )])
     {
         return Err(known(ProviderErrorKind::OwnershipMismatch, stage));
     }
@@ -2192,6 +3617,613 @@ fn verify_image(
         return Err(LocalDockerErrorCode::ImageMismatch);
     }
     Ok(())
+}
+
+fn verify_results_proxy_image(
+    pinned: &PinnedDockerEngine,
+    image: &ImmutableImage,
+    inspected: &InspectedImage,
+) -> Result<(), LocalDockerErrorCode> {
+    verify_image(pinned, image, inspected)?;
+    if inspected.default_path_only
+        && inspected.environment_names == ["PATH"]
+        && inspected.user == RESULTS_PROXY_USER
+        && inspected.entrypoint == [RESULTS_PROXY_ENTRYPOINT]
+        && inspected.command.is_empty()
+        && inspected.working_directory == "/"
+        && inspected
+            .labels
+            .get(RESULTS_PROXY_IMAGE_PROTOCOL_LABEL)
+            .is_some_and(|version| version == RESULTS_PROXY_IMAGE_PROTOCOL_VERSION)
+    {
+        Ok(())
+    } else {
+        Err(LocalDockerErrorCode::ImageMismatch)
+    }
+}
+
+enum ResultsTransportAttestationError {
+    Cancelled,
+    Deadline,
+    Verification(LocalDockerError),
+}
+
+impl ResultsTransportAttestationError {
+    const fn into_local_docker_error(self) -> LocalDockerError {
+        match self {
+            Self::Verification(error) => error,
+            Self::Cancelled | Self::Deadline => {
+                LocalDockerError::new(LocalDockerErrorCode::EngineRequestFailed)
+            }
+        }
+    }
+
+    const fn into_provider_kind(self) -> ProviderErrorKind {
+        match self {
+            Self::Cancelled => ProviderErrorKind::Cancelled,
+            Self::Deadline => ProviderErrorKind::AdapterUnavailable,
+            Self::Verification(error) => map_local_docker_kind(error),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_shared_results_transport_bounded(
+    pinned: &PinnedDockerEngine,
+    engine: &dyn SandboxEngineApi,
+    installation: &Installation,
+    transport: &LocalDockerResultsTransport,
+    proxy_image_id: &str,
+    proxy_image_labels: &BTreeMap<String, String>,
+    runner_id: RunnerId,
+    cancellation: &dyn Cancellation,
+    budget: ResultsTransportBudget,
+) -> Result<InspectedNetwork, ResultsTransportAttestationError> {
+    if cancellation.disposition().requires_termination() {
+        return Err(ResultsTransportAttestationError::Cancelled);
+    }
+    let verification = verify_shared_results_transport(
+        pinned,
+        engine,
+        installation,
+        transport,
+        proxy_image_id,
+        proxy_image_labels,
+        runner_id,
+    );
+    tokio::select! {
+        biased;
+        () = cancellation_requested(cancellation) => {
+            Err(ResultsTransportAttestationError::Cancelled)
+        }
+        result = tokio::time::timeout_at(budget.deadline, verification) => {
+            match result {
+                Ok(Ok(network)) => Ok(network),
+                Ok(Err(error)) => Err(ResultsTransportAttestationError::Verification(error)),
+                Err(_) => Err(ResultsTransportAttestationError::Deadline),
+            }
+        }
+    }
+}
+
+async fn verify_shared_results_transport(
+    pinned: &PinnedDockerEngine,
+    engine: &dyn SandboxEngineApi,
+    installation: &Installation,
+    transport: &LocalDockerResultsTransport,
+    proxy_image_id: &str,
+    proxy_image_labels: &BTreeMap<String, String>,
+    runner_id: RunnerId,
+) -> Result<InspectedNetwork, LocalDockerError> {
+    let expected_name = results_transit_name(installation);
+    if !results_target_is_running(engine, transport).await? {
+        return Err(LocalDockerError::new(
+            LocalDockerErrorCode::ResultsTransportMismatch,
+        ));
+    }
+    for _ in 0..MAX_RESULTS_TRANSIT_CONVERGENCE_ATTEMPTS {
+        let network = inspect_exact_results_transit(engine, installation, transport).await?;
+        let expected = VerifiedResultsTransport {
+            requested: transport.clone(),
+            transit_name: expected_name.clone(),
+            transit_network: network.ipv4_network.clone(),
+            transit_gateway: network.ipv4_gateway,
+            proxy_image_id: proxy_image_id.to_owned(),
+            proxy_image_labels: proxy_image_labels.clone(),
+        };
+        let peer_verifier = TransitPeerVerifier {
+            pinned,
+            engine,
+            installation,
+            runner_id,
+            results: &expected,
+            transit: &network,
+        };
+        let Some(peers) = attest_transit_snapshot(&peer_verifier, &network).await? else {
+            continue;
+        };
+        let after_peer_scan =
+            inspect_exact_results_transit(engine, installation, transport).await?;
+        if after_peer_scan != network {
+            continue;
+        }
+        if !results_target_is_running(engine, transport).await? {
+            return Err(results_transport_mismatch());
+        }
+        if !reattest_transit_snapshot(&peer_verifier, peers).await? {
+            continue;
+        }
+        let final_network = inspect_exact_results_transit(engine, installation, transport).await?;
+        if final_network != network {
+            continue;
+        }
+        if !results_target_is_running(engine, transport).await? {
+            return Err(results_transport_mismatch());
+        }
+        return Ok(final_network);
+    }
+    Err(results_transport_mismatch())
+}
+
+async fn attest_transit_snapshot(
+    verifier: &TransitPeerVerifier<'_>,
+    network: &InspectedNetwork,
+) -> Result<Option<Vec<TransitProxyPeerAttestation>>, LocalDockerError> {
+    let inputs = network
+        .containers
+        .iter()
+        .filter(|(id, _)| *id != &verifier.results.requested.results_container_id)
+        .map(|(id, endpoint)| (id.clone(), endpoint.clone()))
+        .collect::<Vec<_>>();
+    let mut results = stream::iter(inputs)
+        .map(|(container_id, endpoint)| async move {
+            let result = verifier.verify(&container_id, &endpoint).await;
+            (container_id, endpoint, result)
+        })
+        .buffer_unordered(MAX_RESULTS_TRANSIT_ATTESTATION_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    results.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut peers = Vec::with_capacity(results.len());
+    let mut failures = Vec::new();
+    for (container_id, endpoint, result) in results {
+        match result {
+            Ok(peer) => peers.push(peer),
+            Err(error) => failures.push((container_id, endpoint, error)),
+        }
+    }
+    if failures.is_empty() {
+        return Ok(Some(peers));
+    }
+    let replay = inspect_exact_results_transit(
+        verifier.engine,
+        verifier.installation,
+        &verifier.results.requested,
+    )
+    .await?;
+    for (container_id, endpoint, error) in failures {
+        if replay.containers.get(&container_id) == Some(&endpoint) {
+            return Err(error);
+        }
+    }
+    Ok(None)
+}
+
+async fn reattest_transit_snapshot(
+    verifier: &TransitPeerVerifier<'_>,
+    peers: Vec<TransitProxyPeerAttestation>,
+) -> Result<bool, LocalDockerError> {
+    let mut results = stream::iter(peers)
+        .map(|peer| async move {
+            let result = verifier
+                .verify(&peer.proxy.id, &peer.transit_endpoint)
+                .await;
+            (peer, result)
+        })
+        .buffer_unordered(MAX_RESULTS_TRANSIT_ATTESTATION_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    results.sort_by(|left, right| left.0.proxy.id.cmp(&right.0.proxy.id));
+    let mut changed = false;
+    let mut failures = Vec::new();
+    for (peer, result) in results {
+        match result {
+            Ok(fresh) if fresh == peer => {}
+            Ok(_) => changed = true,
+            Err(error) => failures.push((peer, error)),
+        }
+    }
+    if failures.is_empty() {
+        return Ok(!changed);
+    }
+    let replay = inspect_exact_results_transit(
+        verifier.engine,
+        verifier.installation,
+        &verifier.results.requested,
+    )
+    .await?;
+    for (peer, error) in failures {
+        if replay.containers.get(&peer.proxy.id) == Some(&peer.transit_endpoint) {
+            return Err(error);
+        }
+    }
+    Ok(false)
+}
+
+async fn results_target_is_running(
+    engine: &dyn SandboxEngineApi,
+    transport: &LocalDockerResultsTransport,
+) -> Result<bool, LocalDockerError> {
+    engine
+        .results_target_running(&transport.results_container_id)
+        .await
+        .map_err(map_engine_call)
+}
+
+async fn inspect_exact_results_transit(
+    engine: &dyn SandboxEngineApi,
+    installation: &Installation,
+    transport: &LocalDockerResultsTransport,
+) -> Result<InspectedNetwork, LocalDockerError> {
+    let network = engine
+        .inspect_network(&transport.transit_network_id)
+        .await
+        .map_err(map_engine_call)?
+        .ok_or_else(results_transport_mismatch)?;
+    if exact_results_transit(&network, installation, transport) {
+        Ok(network)
+    } else {
+        Err(results_transport_mismatch())
+    }
+}
+
+fn exact_results_transit(
+    network: &InspectedNetwork,
+    installation: &Installation,
+    transport: &LocalDockerResultsTransport,
+) -> bool {
+    let unique_addresses = network
+        .containers
+        .values()
+        .map(|endpoint| endpoint.ipv4_address)
+        .collect::<BTreeSet<_>>();
+    exact_closed_network(
+        network,
+        &results_transit_name(installation),
+        &results_transit_labels(installation),
+    ) && network.id == transport.transit_network_id
+        && network.ipv4_network.prefix <= 23
+        && network_host_address(&network.ipv4_network, 1)
+            .is_ok_and(|gateway| network.ipv4_gateway == gateway)
+        && !ipv4_networks_overlap(&results_front_pool(installation), &network.ipv4_network)
+        && network.containers.len() <= usize::from(MAX_RESULTS_TRANSIT_ENDPOINTS)
+        && unique_addresses.len() == network.containers.len()
+        && network
+            .containers
+            .values()
+            .all(|endpoint| endpoint.ipv4_address != network.ipv4_gateway)
+        && network.ipv4_network.usable(transport.results_address)
+        && transport.results_address != network.ipv4_gateway
+        && network
+            .containers
+            .get(&transport.results_container_id)
+            .is_some_and(|endpoint| {
+                endpoint.ipv4_address == transport.results_address
+                    && endpoint.ipv4_prefix == network.ipv4_network.prefix
+            })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TransitProxyPeerAttestation {
+    transit_endpoint: NetworkEndpoint,
+    proxy: InspectedContainer,
+    front: InspectedNetwork,
+    job: Option<InspectedContainer>,
+}
+
+struct TransitPeerVerifier<'a> {
+    pinned: &'a PinnedDockerEngine,
+    engine: &'a dyn SandboxEngineApi,
+    installation: &'a Installation,
+    runner_id: RunnerId,
+    results: &'a VerifiedResultsTransport,
+    transit: &'a InspectedNetwork,
+}
+
+impl TransitPeerVerifier<'_> {
+    async fn verify(
+        &self,
+        container_id: &str,
+        endpoint: &NetworkEndpoint,
+    ) -> Result<TransitProxyPeerAttestation, LocalDockerError> {
+        let container = self
+            .engine
+            .inspect_container(&endpoint.name)
+            .await
+            .map_err(map_engine_call)?
+            .ok_or_else(results_transport_mismatch)?;
+        let (names, identity) =
+            transit_proxy_identity(&container, self.installation, self.runner_id)?;
+        let front_attachment = container
+            .definition
+            .networks
+            .get(&names.results_front)
+            .ok_or_else(results_transport_mismatch)?;
+        let transit_attachment = container
+            .definition
+            .networks
+            .get(&self.results.transit_name)
+            .ok_or_else(results_transport_mismatch)?;
+        let front = self
+            .engine
+            .inspect_network(&front_attachment.network_id)
+            .await
+            .map_err(map_engine_call)?
+            .ok_or_else(results_transport_mismatch)?;
+        let transit_address = transit_proxy_address(
+            &self.transit.ipv4_network,
+            self.transit.ipv4_gateway,
+            self.results.requested.results_address,
+            identity.custody,
+        )
+        .map_err(|_| results_transport_mismatch())?;
+        let expected_front = results_front_network(self.installation, identity.custody)
+            .map_err(|_| results_transport_mismatch())?;
+        let expected_definition = results_proxy_definition(
+            &names,
+            &identity.base_labels,
+            self.results,
+            &front,
+            transit_address,
+        )
+        .map_err(|_| results_transport_mismatch())?;
+        let proxy_front_address =
+            front_proxy_address(&front).map_err(|_| results_transport_mismatch())?;
+        let job_front_address =
+            front_job_address(&front).map_err(|_| results_transport_mismatch())?;
+        if container.id != container_id
+            || endpoint.name != names.results_proxy
+            || endpoint.ipv4_address != transit_address
+            || endpoint.ipv4_prefix != self.transit.ipv4_network.prefix
+            || transit_attachment.ipv4_address != transit_address
+            || container.state != EngineContainerState::Running
+            || verify_container(
+                &container,
+                &expected_definition,
+                &self.results.proxy_image_id,
+                None,
+            )
+            .is_err()
+            || front.id != front_attachment.network_id
+            || front.id == self.transit.id
+            || ipv4_networks_overlap(&front.ipv4_network, &self.transit.ipv4_network)
+            || front.ipv4_network != expected_front
+            || front.ipv4_gateway
+                != network_host_address(&expected_front, 1)
+                    .map_err(|_| results_transport_mismatch())?
+            || !exact_closed_network(
+                &front,
+                &names.results_front,
+                &front_network_labels(&identity.base_labels),
+            )
+        {
+            return Err(results_transport_mismatch());
+        }
+        let job_member = exact_peer_front_members(
+            &front,
+            container_id,
+            &names,
+            proxy_front_address,
+            job_front_address,
+        )?;
+        let job = self
+            .verify_job(&names, &identity, &front, job_front_address, job_member)
+            .await?;
+        Ok(TransitProxyPeerAttestation {
+            transit_endpoint: endpoint.clone(),
+            proxy: container,
+            front,
+            job,
+        })
+    }
+
+    async fn verify_job(
+        &self,
+        names: &ResourceNames,
+        identity: &BaseIdentity,
+        front: &InspectedNetwork,
+        job_front_address: Ipv4Addr,
+        job_member: Option<(String, NetworkEndpoint)>,
+    ) -> Result<Option<InspectedContainer>, LocalDockerError> {
+        let Some((job_id, job_endpoint)) = job_member else {
+            return Ok(None);
+        };
+        let job = self
+            .engine
+            .inspect_container(&names.job)
+            .await
+            .map_err(map_engine_call)?
+            .ok_or_else(results_transport_mismatch)?;
+        let job_identity = parse_identity(
+            &job.definition.labels,
+            names,
+            self.installation,
+            self.runner_id,
+            KIND_JOB,
+            ProviderStage::VerifyOwnership,
+        )
+        .map_err(|_| results_transport_mismatch())?;
+        let image = ImmutableImage::new(job.definition.image.clone())
+            .map_err(|_| results_transport_mismatch())?;
+        let inspected_image = self
+            .engine
+            .inspect_image(image.reference())
+            .await
+            .map_err(map_engine_call)?
+            .ok_or_else(results_transport_mismatch)?;
+        if job.id != job_id
+            || job_endpoint.name != names.job
+            || job_endpoint.ipv4_address != job_front_address
+            || job_endpoint.ipv4_prefix != front.ipv4_network.prefix
+            || job.state != EngineContainerState::Running
+            || !job.isolated
+            || job_identity != *identity
+            || verify_image(self.pinned, &image, &inspected_image).is_err()
+            || job.image_id != inspected_image.id
+            || verify_job_definition(
+                &job,
+                names,
+                &inspected_image.labels,
+                &inspected_image.environment_names,
+                &identity.base_labels,
+                front,
+                ProviderStage::VerifyOwnership,
+            )
+            .is_err()
+        {
+            return Err(results_transport_mismatch());
+        }
+        Ok(Some(job))
+    }
+}
+
+fn transit_proxy_identity(
+    container: &InspectedContainer,
+    installation: &Installation,
+    runner_id: RunnerId,
+) -> Result<(ResourceNames, BaseIdentity), LocalDockerError> {
+    let managed = managed_labels(&container.definition.labels);
+    let operation_id = managed.get(LABEL_OPERATION_ID).and_then(|value| {
+        OperationId::from_str(value)
+            .ok()
+            .filter(|parsed| parsed.to_string() == *value)
+    });
+    let generation = managed.get(LABEL_GENERATION).and_then(|value| {
+        value
+            .parse::<u64>()
+            .ok()
+            .filter(|parsed| parsed.to_string() == *value)
+    });
+    let names = operation_id
+        .zip(generation)
+        .and_then(|(operation_id, generation)| {
+            ResourceNames::new(installation, operation_id, generation).ok()
+        })
+        .ok_or_else(results_transport_mismatch)?;
+    let identity = parse_identity(
+        &container.definition.labels,
+        &names,
+        installation,
+        runner_id,
+        KIND_RESULTS_PROXY,
+        ProviderStage::VerifyOwnership,
+    )
+    .map_err(|_| results_transport_mismatch())?;
+    Ok((names, identity))
+}
+
+fn exact_peer_front_members(
+    front: &InspectedNetwork,
+    proxy_id: &str,
+    names: &ResourceNames,
+    proxy_address: Ipv4Addr,
+    job_address: Ipv4Addr,
+) -> Result<Option<(String, NetworkEndpoint)>, LocalDockerError> {
+    if front.containers.is_empty()
+        || front.containers.len() > 2
+        || !front.containers.get(proxy_id).is_some_and(|member| {
+            member.name == names.results_proxy
+                && member.ipv4_address == proxy_address
+                && member.ipv4_prefix == front.ipv4_network.prefix
+        })
+    {
+        return Err(results_transport_mismatch());
+    }
+    let mut job = front
+        .containers
+        .iter()
+        .filter(|(id, _)| id.as_str() != proxy_id);
+    let member = job.next();
+    if job.next().is_some()
+        || member.is_some_and(|(_, endpoint)| {
+            endpoint.name != names.job
+                || endpoint.ipv4_address != job_address
+                || endpoint.ipv4_prefix != front.ipv4_network.prefix
+        })
+    {
+        return Err(results_transport_mismatch());
+    }
+    Ok(member.map(|(id, endpoint)| (id.clone(), endpoint.clone())))
+}
+
+const fn results_transport_mismatch() -> LocalDockerError {
+    LocalDockerError::new(LocalDockerErrorCode::ResultsTransportMismatch)
+}
+
+fn ipv4_networks_overlap(first: &Ipv4Network, second: &Ipv4Network) -> bool {
+    first.contains(second.network) || second.contains(first.network)
+}
+
+fn exact_closed_network(
+    network: &InspectedNetwork,
+    expected_name: &str,
+    expected_labels: &BTreeMap<String, String>,
+) -> bool {
+    network.name == expected_name
+        && network.driver == "bridge"
+        && network.scope == "local"
+        && network.enable_ipv4
+        && !network.enable_ipv6
+        && network.internal
+        && !network.attachable
+        && !network.ingress
+        && !network.config_only
+        && network.config_from.is_empty()
+        && network.ipam_driver == "default"
+        && network.ipam_options.is_empty()
+        && network.options
+            == BTreeMap::from([(
+                "com.docker.network.bridge.gateway_mode_ipv4".to_owned(),
+                "isolated".to_owned(),
+            )])
+        && network.labels == *expected_labels
+}
+
+fn results_transit_name(installation: &Installation) -> String {
+    format!("{}-results-transit", installation.compose_project())
+}
+
+fn results_transit_labels(installation: &Installation) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (LABEL_MANAGED.to_owned(), MANAGED_VALUE.to_owned()),
+        (
+            LABEL_RESULTS_TRANSPORT_SCHEMA.to_owned(),
+            RESULTS_TRANSPORT_SCHEMA.to_owned(),
+        ),
+        (
+            LABEL_INSTALLATION_ID.to_owned(),
+            installation.id().to_string(),
+        ),
+        (
+            LABEL_INSTALLATION_KEY.to_owned(),
+            installation.selector_key().to_string(),
+        ),
+        (
+            LABEL_COMPOSE_PROJECT.to_owned(),
+            installation.compose_project().to_string(),
+        ),
+        (
+            LABEL_RESOURCE_KIND.to_owned(),
+            KIND_RESULTS_TRANSIT.to_owned(),
+        ),
+    ])
+}
+
+fn canonical_object_id(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn record(handle: &SandboxHandle, spec: &SandboxSpec, state: SandboxState) -> SandboxRecord {
@@ -2255,11 +4287,40 @@ fn map_provider_engine(
     }
 }
 
+fn map_provider_local_docker(
+    error: LocalDockerError,
+    stage: ProviderStage,
+    recovery_handle: Option<&SandboxHandle>,
+) -> ProviderError {
+    let kind = map_local_docker_kind(error);
+    match recovery_handle {
+        Some(handle) => uncertain(kind, stage, handle),
+        None => known(kind, stage),
+    }
+}
+
 const fn map_engine_kind(error: EngineApiError) -> ProviderErrorKind {
     match error {
         EngineApiError::RequestFailed => ProviderErrorKind::AdapterUnavailable,
         EngineApiError::InvalidResponse => ProviderErrorKind::BackendRejected,
         EngineApiError::OutputLimit => ProviderErrorKind::OutputLimitExceeded,
+    }
+}
+
+const fn map_local_docker_kind(error: LocalDockerError) -> ProviderErrorKind {
+    match error.code() {
+        LocalDockerErrorCode::EngineRequestFailed
+        | LocalDockerErrorCode::EngineIdentityChanged
+        | LocalDockerErrorCode::EngineIsolationUnavailable
+        | LocalDockerErrorCode::EngineArchitectureMismatch => ProviderErrorKind::AdapterUnavailable,
+        LocalDockerErrorCode::InvalidEngineResponse => ProviderErrorKind::BackendRejected,
+        LocalDockerErrorCode::EngineOutputLimitExceeded => ProviderErrorKind::OutputLimitExceeded,
+        LocalDockerErrorCode::ImageUnavailable
+        | LocalDockerErrorCode::ImageMismatch
+        | LocalDockerErrorCode::IdentityCollision
+        | LocalDockerErrorCode::InvalidIdentityAnchor
+        | LocalDockerErrorCode::IdentityAnchorAttached
+        | LocalDockerErrorCode::ResultsTransportMismatch => ProviderErrorKind::OwnershipMismatch,
     }
 }
 

--- a/crates/automata-ci-local/src/local_docker/tests.rs
+++ b/crates/automata-ci-local/src/local_docker/tests.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet, HashSet},
+    net::Ipv4Addr,
     num::NonZeroU16,
     str::FromStr as _,
     sync::{
@@ -27,8 +28,8 @@ use super::*;
 use crate::{
     EngineArchitecture, InstallationName,
     local_docker::engine::{
-        AnchorEngineApi, EngineApi, EngineExecOutput, EngineFacts, InspectedVolume,
-        PreparedEngineExec,
+        AnchorEngineApi, CreateNetwork, EngineApi, EngineExecOutput, EngineFacts, InspectedNetwork,
+        InspectedVolume, Ipv4Network, NetworkEndpoint, PreparedEngineExec,
     },
 };
 
@@ -39,10 +40,19 @@ const JOB_IMAGE_ID: &str =
     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 const GUEST_IMAGE_ID: &str =
     "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const PROXY_DIGEST: &str = "9999999999999999999999999999999999999999999999999999999999999999";
+const PROXY_IMAGE_ID: &str =
+    "sha256:8888888888888888888888888888888888888888888888888888888888888888";
+const TRANSIT_NETWORK_ID: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+const RESULTS_CONTAINER_ID: &str =
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 const FAKE_GUEST: &[u8] = b"fake-automata-ci-sandbox-guest";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 enum Call {
+    CreateNetwork(String),
+    RemoveNetwork(String),
     CreateContainer(ContainerDefinition),
     StartContainer(String),
     RemoveContainer(String),
@@ -58,6 +68,7 @@ struct FakeState {
     images: BTreeMap<String, InspectedImage>,
     volumes: BTreeMap<String, InspectedVolume>,
     containers: BTreeMap<String, InspectedContainer>,
+    networks: BTreeMap<String, InspectedNetwork>,
     guest_binaries: BTreeMap<String, Vec<u8>>,
     files: BTreeMap<String, Vec<u8>>,
     prepared: BTreeMap<String, (String, Vec<String>, String)>,
@@ -65,6 +76,15 @@ struct FakeState {
     reject_bootstrap: bool,
     bootstrap_ready: bool,
     invalid_guest_source_archive: bool,
+    results_target_running: bool,
+    results_readiness_empty_reads: usize,
+    results_readiness_bytes: Option<Vec<u8>>,
+    replace_proxy_after_empty_readiness: bool,
+    results_log_reads: usize,
+    next_results_transit_inspect_error: Option<EngineApiError>,
+    next_results_target_error: Option<EngineApiError>,
+    readiness_followup_transit_inspect_error: Option<EngineApiError>,
+    readiness_followup_target_error: Option<EngineApiError>,
     replace_after_upload: bool,
     replace_after_start: bool,
     replace_after_probe: bool,
@@ -75,8 +95,11 @@ struct FakeState {
     first_removed_for_recreation: Option<InspectedContainer>,
     inject_daemon_default_ulimit_on_next_create: bool,
     rename_removed_container_instead: bool,
+    rename_instead_of_next_remove: bool,
+    mutate_container_after_inspecting_name: Option<(String, String)>,
     block_next_guest_exec: bool,
-    boundary_permit: bool,
+    boundary_permits: HashSet<std::thread::ThreadId>,
+    lose_next_network_create_response: bool,
     calls: Vec<Call>,
     next_id: u64,
 }
@@ -105,6 +128,7 @@ impl FakeState {
             images: BTreeMap::new(),
             volumes: BTreeMap::new(),
             containers: BTreeMap::new(),
+            networks: BTreeMap::new(),
             guest_binaries: BTreeMap::new(),
             files: BTreeMap::new(),
             prepared: BTreeMap::new(),
@@ -112,6 +136,15 @@ impl FakeState {
             reject_bootstrap: false,
             bootstrap_ready: false,
             invalid_guest_source_archive: false,
+            results_target_running: true,
+            results_readiness_empty_reads: 0,
+            results_readiness_bytes: None,
+            replace_proxy_after_empty_readiness: false,
+            results_log_reads: 0,
+            next_results_transit_inspect_error: None,
+            next_results_target_error: None,
+            readiness_followup_transit_inspect_error: None,
+            readiness_followup_target_error: None,
             replace_after_upload: false,
             replace_after_start: false,
             replace_after_probe: false,
@@ -122,8 +155,11 @@ impl FakeState {
             first_removed_for_recreation: None,
             inject_daemon_default_ulimit_on_next_create: false,
             rename_removed_container_instead: false,
+            rename_instead_of_next_remove: false,
+            mutate_container_after_inspecting_name: None,
             block_next_guest_exec: false,
-            boundary_permit: false,
+            boundary_permits: HashSet::new(),
+            lose_next_network_create_response: false,
             calls: Vec::new(),
             next_id: 1,
         }
@@ -136,7 +172,7 @@ impl FakeState {
     }
 
     fn consume_boundary(&mut self) -> Result<(), EngineApiError> {
-        if !std::mem::take(&mut self.boundary_permit) {
+        if !self.boundary_permits.remove(&std::thread::current().id()) {
             return Err(EngineApiError::InvalidResponse);
         }
         Ok(())
@@ -149,14 +185,27 @@ struct FakeEngine {
     guest_exec_blocked: AtomicBool,
     release_guest_exec: AtomicBool,
     fail_released_guest_exec: AtomicBool,
+    peer_inspection_delay_millis: AtomicUsize,
+    peer_inspections_in_flight: AtomicUsize,
+    maximum_peer_inspections_in_flight: AtomicUsize,
     accesses: AtomicUsize,
 }
 
+struct InFlightPeerInspection<'a>(&'a AtomicUsize);
+
+impl Drop for InFlightPeerInspection<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 impl FakeEngine {
+    #[allow(clippy::too_many_lines)]
     fn new(installation: &Installation) -> Self {
         let mut state = FakeState::new();
         let job = job_image();
         let guest = guest_image();
+        let proxy = proxy_image();
         state.images.insert(
             job.reference().to_owned(),
             inspected_image(&job, JOB_IMAGE_ID),
@@ -165,6 +214,19 @@ impl FakeEngine {
             guest.reference().to_owned(),
             inspected_image(&guest, GUEST_IMAGE_ID),
         );
+        let mut inspected_proxy = inspected_image(&proxy, PROXY_IMAGE_ID);
+        inspected_proxy.environment_names = vec!["PATH".to_owned()];
+        inspected_proxy.default_path_only = true;
+        inspected_proxy.user = RESULTS_PROXY_USER.to_owned();
+        inspected_proxy.entrypoint = vec![RESULTS_PROXY_ENTRYPOINT.to_owned()];
+        inspected_proxy.working_directory = "/".to_owned();
+        inspected_proxy.labels.insert(
+            RESULTS_PROXY_IMAGE_PROTOCOL_LABEL.to_owned(),
+            RESULTS_PROXY_IMAGE_PROTOCOL_VERSION.to_owned(),
+        );
+        state
+            .images
+            .insert(proxy.reference().to_owned(), inspected_proxy);
         let anchor_name = installation.anchor_volume_name().to_owned();
         state.volumes.insert(
             anchor_name.clone(),
@@ -198,12 +260,56 @@ impl FakeEngine {
                 ]),
             },
         );
+        let transit_name = results_transit_name(installation);
+        state.networks.insert(
+            transit_name.clone(),
+            InspectedNetwork {
+                id: TRANSIT_NETWORK_ID.to_owned(),
+                name: transit_name,
+                driver: "bridge".to_owned(),
+                scope: "local".to_owned(),
+                enable_ipv4: true,
+                enable_ipv6: false,
+                internal: true,
+                attachable: false,
+                ingress: false,
+                config_only: false,
+                config_from: String::new(),
+                ipam_driver: "default".to_owned(),
+                ipam_options: BTreeMap::new(),
+                ipv4_network: Ipv4Network {
+                    network: Ipv4Addr::new(10, 91, 0, 0),
+                    prefix: 16,
+                },
+                ipv4_gateway: Ipv4Addr::new(10, 91, 0, 1),
+                options: BTreeMap::from([(
+                    "com.docker.network.bridge.gateway_mode_ipv4".to_owned(),
+                    "isolated".to_owned(),
+                )]),
+                labels: results_transit_labels(installation),
+                containers: BTreeMap::from([(
+                    RESULTS_CONTAINER_ID.to_owned(),
+                    NetworkEndpoint {
+                        name: "automata-results-service".to_owned(),
+                        endpoint_id:
+                            "abababababababababababababababababababababababababababababababab"
+                                .to_owned(),
+                        mac_address: "02:42:0a:5b:00:01".to_owned(),
+                        ipv4_address: Ipv4Addr::new(10, 91, 0, 2),
+                        ipv4_prefix: 16,
+                    },
+                )]),
+            },
+        );
         Self {
             anchor_name,
             state: Mutex::new(state),
             guest_exec_blocked: AtomicBool::new(false),
             release_guest_exec: AtomicBool::new(false),
             fail_released_guest_exec: AtomicBool::new(false),
+            peer_inspection_delay_millis: AtomicUsize::new(0),
+            peer_inspections_in_flight: AtomicUsize::new(0),
+            maximum_peer_inspections_in_flight: AtomicUsize::new(0),
             accesses: AtomicUsize::new(0),
         }
     }
@@ -309,7 +415,7 @@ impl AnchorEngineApi for FakeEngine {
         if name != self.anchor_name || !state.volumes.contains_key(name) {
             return Err(EngineApiError::InvalidResponse);
         }
-        state.boundary_permit = true;
+        state.boundary_permits.insert(std::thread::current().id());
         if let Some((remaining, cancelled)) = state.cancel_after_boundaries.take() {
             if remaining == 1 {
                 cancelled.store(true, Ordering::SeqCst);
@@ -354,9 +460,23 @@ impl SandboxEngineApi for FakeEngine {
         &self,
         name_or_id: &str,
     ) -> Result<Option<InspectedContainer>, EngineApiError> {
+        let delay_millis = self.peer_inspection_delay_millis.load(Ordering::SeqCst);
+        if delay_millis > 0 && name_or_id.ends_with("-results-proxy") {
+            let in_flight = self
+                .peer_inspections_in_flight
+                .fetch_add(1, Ordering::SeqCst)
+                + 1;
+            let _in_flight = InFlightPeerInspection(&self.peer_inspections_in_flight);
+            self.maximum_peer_inspections_in_flight
+                .fetch_max(in_flight, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(
+                u64::try_from(delay_millis).expect("test delay fits u64"),
+            ))
+            .await;
+        }
         self.accesses.fetch_add(1, Ordering::SeqCst);
-        let state = self.state.lock().expect("fake state");
-        Ok(state
+        let mut state = self.state.lock().expect("fake state");
+        let inspected = state
             .containers
             .get(name_or_id)
             .or_else(|| {
@@ -365,7 +485,32 @@ impl SandboxEngineApi for FakeEngine {
                     .values()
                     .find(|container| container.id == name_or_id)
             })
-            .cloned())
+            .cloned();
+        if state
+            .mutate_container_after_inspecting_name
+            .as_ref()
+            .is_some_and(|(trigger, _)| trigger == name_or_id)
+        {
+            let (_, target) = state
+                .mutate_container_after_inspecting_name
+                .take()
+                .expect("guarded inspection mutation");
+            state
+                .containers
+                .get_mut(&target)
+                .ok_or(EngineApiError::InvalidResponse)?
+                .isolated = false;
+        }
+        Ok(inspected)
+    }
+
+    async fn results_target_running(&self, id: &str) -> Result<bool, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        if let Some(error) = state.next_results_target_error.take() {
+            return Err(error);
+        }
+        Ok(id == RESULTS_CONTAINER_ID && state.results_target_running)
     }
 
     async fn create_container(
@@ -387,12 +532,18 @@ impl SandboxEngineApi for FakeEngine {
             .clone();
         let id = state.object_id();
         let isolated = !std::mem::take(&mut state.inject_daemon_default_ulimit_on_next_create);
+        let mut realized = definition;
+        for attachment in realized.networks.values_mut() {
+            // Engine API v1.48 reports the requested endpoint IP and aliases
+            // for a created container, but leaves NetworkID empty until start.
+            attachment.network_id.clear();
+        }
         state.containers.insert(
-            definition.name.clone(),
+            realized.name.clone(),
             InspectedContainer {
                 id,
                 image_id,
-                definition,
+                definition: realized,
                 state: EngineContainerState::Created,
                 // `false` represents Docker merging a daemon default ulimit
                 // into an otherwise exact create request after mutation.
@@ -407,7 +558,35 @@ impl SandboxEngineApi for FakeEngine {
         let mut state = self.state.lock().expect("fake state");
         state.consume_boundary()?;
         state.calls.push(Call::StartContainer(id.to_owned()));
-        find_container_mut(&mut state, id)?.state = EngineContainerState::Running;
+        let name = state
+            .containers
+            .iter()
+            .find_map(|(name, container)| (container.id == id).then(|| name.clone()))
+            .ok_or(EngineApiError::InvalidResponse)?;
+        let mut container = state
+            .containers
+            .remove(&name)
+            .ok_or(EngineApiError::InvalidResponse)?;
+        container.state = EngineContainerState::Running;
+        for (network_name, attachment) in &mut container.definition.networks {
+            let endpoint_id = state.object_id();
+            let network = state
+                .networks
+                .get_mut(network_name)
+                .ok_or(EngineApiError::InvalidResponse)?;
+            attachment.network_id.clone_from(&network.id);
+            network.containers.insert(
+                container.id.clone(),
+                NetworkEndpoint {
+                    name: container.definition.name.clone(),
+                    endpoint_id,
+                    mac_address: "02:42:ac:1f:00:02".to_owned(),
+                    ipv4_address: attachment.ipv4_address,
+                    ipv4_prefix: network.ipv4_network.prefix,
+                },
+            );
+        }
+        state.containers.insert(name, container);
         if std::mem::take(&mut state.replace_after_start) {
             replace_container(&mut state, id)?;
         }
@@ -423,7 +602,7 @@ impl SandboxEngineApi for FakeEngine {
             .containers
             .iter()
             .find_map(|(name, container)| (container.id == id).then(|| name.clone()));
-        let removed = name.and_then(|name| state.containers.remove(&name));
+        let mut removed = name.and_then(|name| state.containers.remove(&name));
         if state.rename_removed_container_instead {
             if let Some(container) = removed {
                 state
@@ -431,6 +610,23 @@ impl SandboxEngineApi for FakeEngine {
                     .insert(format!("renamed-{}", container.id), container);
             }
             return Ok(());
+        }
+        if state.rename_instead_of_next_remove {
+            let mut retained = removed.take().ok_or(EngineApiError::InvalidResponse)?;
+            let renamed = format!("{}-renamed", retained.definition.name);
+            retained.definition.name.clone_from(&renamed);
+            for network in state.networks.values_mut() {
+                if let Some(endpoint) = network.containers.get_mut(&retained.id) {
+                    endpoint.name.clone_from(&renamed);
+                }
+            }
+            state.containers.insert(renamed, retained);
+            state.rename_instead_of_next_remove = false;
+        }
+        if let Some(removed) = removed.as_ref() {
+            for network in state.networks.values_mut() {
+                network.containers.remove(&removed.id);
+            }
         }
         if state.recreate_first_removed_after_following_remove {
             if let Some(mut first) = state.first_removed_for_recreation.take() {
@@ -453,7 +649,123 @@ impl SandboxEngineApi for FakeEngine {
         state.consume_boundary()?;
         state.calls.push(Call::KillContainer(id.to_owned()));
         find_container_mut(&mut state, id)?.state = EngineContainerState::Exited(137);
+        for network in state.networks.values_mut() {
+            network.containers.remove(id);
+        }
         Ok(())
+    }
+
+    async fn inspect_network(
+        &self,
+        id_or_name: &str,
+    ) -> Result<Option<InspectedNetwork>, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        let is_results_transit = state.networks.values().any(|network| {
+            network.id == TRANSIT_NETWORK_ID
+                && (network.id == id_or_name || network.name == id_or_name)
+        });
+        if is_results_transit && let Some(error) = state.next_results_transit_inspect_error.take() {
+            return Err(error);
+        }
+        Ok(state
+            .networks
+            .values()
+            .find(|network| network.name == id_or_name || network.id == id_or_name)
+            .cloned())
+    }
+
+    async fn create_network(&self, request: CreateNetwork) -> Result<String, EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::CreateNetwork(request.name.clone()));
+        if state.networks.contains_key(&request.name) {
+            return Err(EngineApiError::RequestFailed);
+        }
+        let id = state.object_id();
+        state.networks.insert(
+            request.name.clone(),
+            InspectedNetwork {
+                id: id.clone(),
+                name: request.name,
+                driver: "bridge".to_owned(),
+                scope: "local".to_owned(),
+                enable_ipv4: true,
+                enable_ipv6: false,
+                internal: true,
+                attachable: false,
+                ingress: false,
+                config_only: false,
+                config_from: String::new(),
+                ipam_driver: "default".to_owned(),
+                ipam_options: BTreeMap::new(),
+                ipv4_network: request.ipv4_network,
+                ipv4_gateway: request.ipv4_gateway,
+                options: BTreeMap::from([(
+                    "com.docker.network.bridge.gateway_mode_ipv4".to_owned(),
+                    "isolated".to_owned(),
+                )]),
+                labels: request.labels,
+                containers: BTreeMap::new(),
+            },
+        );
+        if std::mem::take(&mut state.lose_next_network_create_response) {
+            Err(EngineApiError::RequestFailed)
+        } else {
+            Ok(id)
+        }
+    }
+
+    async fn remove_network(&self, id: &str) -> Result<(), EngineApiError> {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.state.lock().expect("fake state");
+        state.consume_boundary()?;
+        state.calls.push(Call::RemoveNetwork(id.to_owned()));
+        let name = state
+            .networks
+            .iter()
+            .find_map(|(name, network)| (network.id == id).then(|| name.clone()))
+            .ok_or(EngineApiError::InvalidResponse)?;
+        if !state
+            .networks
+            .get(&name)
+            .is_some_and(|network| network.containers.is_empty())
+        {
+            return Err(EngineApiError::RequestFailed);
+        }
+        state.networks.remove(&name);
+        Ok(())
+    }
+
+    async fn container_logs(
+        &self,
+        id: &str,
+        _byte_limit: usize,
+    ) -> Result<Vec<u8>, EngineApiError> {
+        let mut state = self.state.lock().expect("fake state");
+        let is_proxy = state.containers.values().any(|container| {
+            container.id == id && container.definition.name.ends_with("-results-proxy")
+        });
+        if !is_proxy {
+            return Ok(Vec::new());
+        }
+        state.results_log_reads += 1;
+        if state.results_readiness_empty_reads > 0 {
+            state.results_readiness_empty_reads -= 1;
+            if std::mem::take(&mut state.replace_proxy_after_empty_readiness) {
+                replace_container(&mut state, id)?;
+            }
+            return Ok(Vec::new());
+        }
+        let readiness = state
+            .results_readiness_bytes
+            .clone()
+            .unwrap_or_else(|| RESULTS_READY_STATUS.to_vec());
+        state.next_results_transit_inspect_error =
+            state.readiness_followup_transit_inspect_error.take();
+        state.next_results_target_error = state.readiness_followup_target_error.take();
+        Ok(readiness)
     }
 
     async fn download_guest_image_binary(
@@ -659,6 +971,26 @@ fn replace_container(state: &mut FakeState, id: &str) -> Result<(), EngineApiErr
         .ok_or(EngineApiError::InvalidResponse)?;
     let replacement_id = state.object_id();
     replacement.id = replacement_id.clone();
+    let attached_networks = state
+        .networks
+        .iter()
+        .filter(|(_, network)| network.containers.contains_key(id))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    for network_name in attached_networks {
+        let mut endpoint = state
+            .networks
+            .get_mut(&network_name)
+            .and_then(|network| network.containers.remove(id))
+            .ok_or(EngineApiError::InvalidResponse)?;
+        endpoint.endpoint_id = state.object_id();
+        state
+            .networks
+            .get_mut(&network_name)
+            .ok_or(EngineApiError::InvalidResponse)?
+            .containers
+            .insert(replacement_id.clone(), endpoint);
+    }
     state.containers.insert(name, replacement);
     if let Some(guest) = state.guest_binaries.remove(id) {
         state.guest_binaries.insert(replacement_id, guest);
@@ -740,6 +1072,8 @@ impl Fixture {
             installation.clone(),
             guest_image(),
             GUEST_IMAGE_ID.to_owned(),
+            verified_results_transport(&installation),
+            RunnerId::from_uuid(Uuid::from_u128(2)),
         );
         Self {
             provider,
@@ -755,6 +1089,8 @@ impl Fixture {
             self.installation.clone(),
             guest_image(),
             GUEST_IMAGE_ID.to_owned(),
+            verified_results_transport(&self.installation),
+            RunnerId::from_uuid(Uuid::from_u128(2)),
         )
     }
 }
@@ -770,6 +1106,11 @@ fn inspected_image(image: &ImmutableImage, id: &str) -> InspectedImage {
         has_healthcheck: false,
         labels: BTreeMap::new(),
         environment_names: Vec::new(),
+        default_path_only: false,
+        user: String::new(),
+        entrypoint: Vec::new(),
+        command: Vec::new(),
+        working_directory: String::new(),
     }
 }
 
@@ -783,6 +1124,36 @@ fn guest_image() -> ImmutableImage {
         "registry.example/automata/guest@sha256:{GUEST_DIGEST}"
     ))
     .expect("guest image")
+}
+
+fn proxy_image() -> ImmutableImage {
+    ImmutableImage::new(format!(
+        "registry.example/automata/service-proxy@sha256:{PROXY_DIGEST}"
+    ))
+    .expect("proxy image")
+}
+
+fn verified_results_transport(installation: &Installation) -> VerifiedResultsTransport {
+    VerifiedResultsTransport {
+        requested: LocalDockerResultsTransport::new(
+            proxy_image(),
+            TRANSIT_NETWORK_ID,
+            RESULTS_CONTAINER_ID,
+            Ipv4Addr::new(10, 91, 0, 2),
+        )
+        .expect("transport"),
+        transit_name: results_transit_name(installation),
+        transit_network: Ipv4Network {
+            network: Ipv4Addr::new(10, 91, 0, 0),
+            prefix: 16,
+        },
+        transit_gateway: Ipv4Addr::new(10, 91, 0, 1),
+        proxy_image_id: PROXY_IMAGE_ID.to_owned(),
+        proxy_image_labels: BTreeMap::from([(
+            RESULTS_PROXY_IMAGE_PROTOCOL_LABEL.to_owned(),
+            RESULTS_PROXY_IMAGE_PROTOCOL_VERSION.to_owned(),
+        )]),
+    }
 }
 
 fn sandbox_spec() -> SandboxSpec {
@@ -799,7 +1170,28 @@ fn sandbox_spec_with_resources(resources: ResourceLimits) -> SandboxSpec {
     )
 }
 
+fn sandbox_spec_for_job_slot(operation: u128, slot: u16) -> SandboxSpec {
+    sandbox_spec_with_identity_and_resources(
+        operation,
+        7,
+        SandboxCustody::Job {
+            runner_id: RunnerId::from_uuid(Uuid::from_u128(2)),
+            slot_ordinal: NonZeroU16::new(slot).expect("slot"),
+        },
+        ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits"),
+    )
+}
+
 fn sandbox_spec_with_custody_and_resources(
+    custody: SandboxCustody,
+    resources: ResourceLimits,
+) -> SandboxSpec {
+    sandbox_spec_with_identity_and_resources(1, 7, custody, resources)
+}
+
+fn sandbox_spec_with_identity_and_resources(
+    operation: u128,
+    generation: u64,
     custody: SandboxCustody,
     resources: ResourceLimits,
 ) -> SandboxSpec {
@@ -820,16 +1212,31 @@ fn sandbox_spec_with_custody_and_resources(
     )
     .expect("environment");
     SandboxSpec::new(
-        OperationId::from_uuid(Uuid::from_u128(1)),
-        SandboxGeneration::new(7).expect("generation"),
+        OperationId::from_uuid(Uuid::from_u128(operation)),
+        SandboxGeneration::new(generation).expect("generation"),
         custody,
         environment,
         TargetPath::posix("/workspace/repository").expect("workspace"),
-        NetworkPolicy::Disabled,
+        NetworkPolicy::PrivateEgress,
         RootFilesystemPolicy::Writable,
         resources,
     )
     .with_privilege(SandboxPrivilegePolicy::Administrator)
+}
+
+fn sandbox_spec_with_workspace(workspace: TargetPath) -> SandboxSpec {
+    let spec = sandbox_spec();
+    SandboxSpec::new(
+        spec.operation_id(),
+        spec.generation(),
+        spec.custody(),
+        spec.profile().clone(),
+        workspace,
+        spec.network(),
+        spec.root_filesystem(),
+        spec.resources(),
+    )
+    .with_privilege(spec.privilege())
 }
 
 fn true_command(spec: &SandboxSpec, operation: u128) -> ExecutionCommand {
@@ -881,6 +1288,60 @@ fn wait_for_test(mut predicate: impl FnMut() -> bool, message: &str) {
         assert!(Instant::now() < deadline, "{message}");
         std::thread::yield_now();
     }
+}
+
+const fn engine_failure_categories() -> [(EngineApiError, ProviderErrorKind); 3] {
+    [
+        (
+            EngineApiError::RequestFailed,
+            ProviderErrorKind::AdapterUnavailable,
+        ),
+        (
+            EngineApiError::InvalidResponse,
+            ProviderErrorKind::BackendRejected,
+        ),
+        (
+            EngineApiError::OutputLimit,
+            ProviderErrorKind::OutputLimitExceeded,
+        ),
+    ]
+}
+
+fn assert_exact_create_recovery(
+    fixture: &Fixture,
+    spec: &SandboxSpec,
+    error: &ProviderError,
+) -> SandboxHandle {
+    let names = ResourceNames::for_spec(&fixture.installation, spec).expect("resource names");
+    let expected = names
+        .handle(&fixture.provider.inner.provider_id)
+        .expect("recovery handle");
+    assert_eq!(error.outcome(), OperationOutcome::Uncertain);
+    assert_eq!(error.recovery_handle(), Some(&expected));
+    expected
+}
+
+fn destroy_create_recovery(fixture: &Fixture, spec: &SandboxSpec, error: &ProviderError) {
+    let handle = assert_exact_create_recovery(fixture, spec, error);
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(0xffff)),
+        handle,
+        spec.generation(),
+        spec.custody(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&request, &NeverCancelled)
+            .expect("exact recovery cleanup"),
+        DestroyDisposition::Destroyed
+    );
+    let names = ResourceNames::for_spec(&fixture.installation, spec).expect("resource names");
+    let state = fixture.engine.state.lock().expect("fake state");
+    assert!(!state.networks.contains_key(&names.results_front));
+    assert!(!state.containers.contains_key(&names.helper));
+    assert!(!state.containers.contains_key(&names.job));
+    assert!(!state.containers.contains_key(&names.results_proxy));
 }
 
 #[test]
@@ -978,6 +1439,42 @@ fn lifecycle_uses_zero_volumes_and_exact_replay_cleanup() {
     assert_eq!(record.state(), SandboxState::Running);
     let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
     let job = fixture.engine.container(&names.job).expect("job container");
+    let proxy = fixture
+        .engine
+        .container(&names.results_proxy)
+        .expect("Results proxy container");
+    let state = fixture.engine.state.lock().expect("state");
+    let front = state
+        .networks
+        .get(&names.results_front)
+        .expect("per-sandbox Results front");
+    assert!(front.internal);
+    assert_eq!(
+        front
+            .options
+            .get("com.docker.network.bridge.gateway_mode_ipv4"),
+        Some(&"isolated".to_owned())
+    );
+    assert_eq!(job.definition.networks.len(), 1);
+    assert_eq!(proxy.definition.networks.len(), 2);
+    assert_eq!(
+        proxy
+            .definition
+            .networks
+            .get(&names.results_front)
+            .expect("proxy front")
+            .aliases,
+        [RESULTS_ALIAS]
+    );
+    assert_eq!(front.containers.len(), 2);
+    let transit = state
+        .networks
+        .values()
+        .find(|network| network.id == TRANSIT_NETWORK_ID)
+        .expect("shared transit");
+    assert_eq!(transit.containers.len(), 2);
+    assert!(transit.containers.contains_key(RESULTS_CONTAINER_ID));
+    drop(state);
     assert_eq!(
         job.definition.tmpfs,
         BTreeMap::from([
@@ -1023,11 +1520,9 @@ fn lifecycle_uses_zero_volumes_and_exact_replay_cleanup() {
             if command == &[LOCAL_DOCKER_SANDBOX_GUEST_BINARY, "bootstrap-local-client"]
                 && user == &guest_seal_user()
     )));
-    assert!(
-        calls
-            .iter()
-            .all(|call| { !matches!(call, Call::StartContainer(id) if id != &job.id) })
-    );
+    assert!(calls.iter().all(|call| {
+        !matches!(call, Call::StartContainer(id) if id != &job.id && id != &proxy.id)
+    }));
     assert!(calls.iter().any(|call| matches!(
         call,
         Call::CreateExec(command, user)
@@ -1125,6 +1620,17 @@ fn lifecycle_uses_zero_volumes_and_exact_replay_cleanup() {
             .containers
             .is_empty()
     );
+    let state = fixture.engine.state.lock().expect("state");
+    assert!(!state.networks.contains_key(&names.results_front));
+    let transit = state
+        .networks
+        .values()
+        .find(|network| network.id == TRANSIT_NETWORK_ID)
+        .expect("shared transit remains lifecycle-owned");
+    assert_eq!(
+        transit.containers.keys().cloned().collect::<Vec<_>>(),
+        [RESULTS_CONTAINER_ID.to_owned()]
+    );
 }
 
 #[test]
@@ -1191,6 +1697,7 @@ fn ambiguous_bootstrap_response_stops_and_removes_the_unproven_container() {
         .create(&spec, &NeverCancelled)
         .expect_err("ambiguous bootstrap is never accepted");
     assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert_exact_create_recovery(&fixture, &spec, &error);
     assert!(fixture.engine.container(&names.job).is_none());
     let calls = fixture.engine.calls();
     assert_eq!(
@@ -1205,6 +1712,7 @@ fn ambiguous_bootstrap_response_stops_and_removes_the_unproven_container() {
             .count(),
         1
     );
+    destroy_create_recovery(&fixture, &spec, &error);
 }
 
 #[test]
@@ -1330,6 +1838,7 @@ fn unready_bootstrap_is_destroyed_and_never_adopted_or_retried() {
         .create(&spec, &NeverCancelled)
         .expect_err("unready broker fails closed");
     assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+    assert_exact_create_recovery(&fixture, &spec, &error);
     assert!(fixture.engine.container(&names.job).is_none());
     let calls = fixture.engine.calls();
     assert_eq!(
@@ -1354,6 +1863,7 @@ fn unready_bootstrap_is_destroyed_and_never_adopted_or_retried() {
             .iter()
             .any(|call| matches!(call, Call::RemoveContainer(_)))
     );
+    destroy_create_recovery(&fixture, &spec, &error);
 }
 
 #[test]
@@ -1368,6 +1878,9 @@ fn exited_job_is_never_restarted() {
     let job_id = fixture.engine.container(&names.job).expect("job").id;
     fixture.engine.mutate(|state| {
         find_container_mut(state, &job_id).expect("job").state = EngineContainerState::Exited(0);
+        for network in state.networks.values_mut() {
+            network.containers.remove(&job_id);
+        }
     });
     let starts_before = fixture
         .engine
@@ -1903,6 +2416,7 @@ fn daemon_default_ulimit_normalization_fails_closed_and_custody_cleanup_removes_
         .create(&spec, &NeverCancelled)
         .expect_err("daemon-normalized ulimit must fail exact inspection");
     assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_exact_create_recovery(&fixture, &spec, &error);
     let helper = fixture
         .engine
         .container(&names.helper)
@@ -2074,6 +2588,9 @@ fn foreign_name_collision_fails_closed_without_mutation() {
                     memory_bytes: 1,
                     nano_cpus: 1,
                     pids_limit: 1,
+                    primary_network: None,
+                    networks: BTreeMap::new(),
+                    capture_logs: false,
                 },
                 state: EngineContainerState::Created,
                 isolated: false,
@@ -2084,24 +2601,170 @@ fn foreign_name_collision_fails_closed_without_mutation() {
         .provider
         .create(&spec, &NeverCancelled)
         .expect_err("foreign collision");
-    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
     assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn long_valid_workspace_fails_before_front_network_mutation() {
+    let fixture = Fixture::new();
+    let long_workspace = TargetPath::posix(format!("/workspace/{}", "a".repeat(128)))
+        .expect("long workspace remains a valid target path");
+    let spec = sandbox_spec_with_workspace(long_workspace);
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("workspace outside the deterministic tar layout ceiling");
+    assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+    assert_eq!(error.outcome(), OperationOutcome::KnownNoEffect);
+    assert!(error.recovery_handle().is_none());
+    assert_eq!(fixture.engine.mutation_count(), 0);
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    assert!(
+        !fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .networks
+            .contains_key(&names.results_front)
+    );
+}
+
+#[test]
+fn merged_label_overflow_fails_before_front_network_mutation() {
+    let fixture = Fixture::new();
+    fixture.engine.mutate(|state| {
+        let labels = &mut state
+            .images
+            .get_mut(job_image().reference())
+            .expect("job image")
+            .labels;
+        for index in 0..MAX_RESOURCE_LABELS {
+            labels.insert(format!("example.test.label-{index}"), "value".to_owned());
+        }
+    });
+    let spec = sandbox_spec();
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("merged job labels exceed the exact Engine ceiling");
+    assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);
+    assert_eq!(error.outcome(), OperationOutcome::KnownNoEffect);
+    assert!(error.recovery_handle().is_none());
+    assert_eq!(fixture.engine.mutation_count(), 0);
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    assert!(
+        !fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .networks
+            .contains_key(&names.results_front)
+    );
+}
+
+#[test]
+fn cancellation_at_post_front_prepare_job_and_proxy_boundaries_is_recoverable() {
+    for boundary in [3, 6, 8] {
+        let fixture = Fixture::new();
+        let spec = sandbox_spec();
+        let cancellation = ToggleCancellation::active();
+        fixture.engine.mutate(|state| {
+            state.cancel_after_boundaries = Some((boundary, Arc::clone(&cancellation.cancelled)));
+        });
+
+        let error = fixture
+            .provider
+            .create(&spec, &cancellation)
+            .expect_err("post-front boundary cancellation");
+
+        assert_eq!(error.kind(), ProviderErrorKind::Cancelled);
+        let calls = fixture.engine.calls();
+        let created = calls
+            .iter()
+            .filter_map(|call| match call {
+                Call::CreateContainer(definition) => Some(definition.name.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        match boundary {
+            3 => assert!(
+                created.is_empty(),
+                "prepare boundary must precede helper mutation"
+            ),
+            6 => assert!(
+                created.iter().all(|name| name.ends_with("-guest-source")),
+                "job boundary must precede job mutation"
+            ),
+            8 => {
+                assert!(created.iter().any(|name| name.ends_with("-job")));
+                assert!(
+                    created.iter().all(|name| !name.ends_with("-results-proxy")),
+                    "proxy boundary must precede proxy mutation"
+                );
+            }
+            _ => unreachable!(),
+        }
+        destroy_create_recovery(&fixture, &spec, &error);
+    }
 }
 
 #[test]
 fn adversarial_guest_source_archive_fails_before_job_creation() {
     let fixture = Fixture::new();
+    let spec = sandbox_spec();
     fixture
         .engine
         .mutate(|state| state.invalid_guest_source_archive = true);
     let error = fixture
         .provider
-        .create(&sandbox_spec(), &NeverCancelled)
+        .create(&spec, &NeverCancelled)
         .expect_err("multi-entry guest source archive");
     assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
     assert!(!fixture.engine.calls().iter().any(|call| {
         matches!(call, Call::CreateContainer(definition) if definition.name.ends_with("-job"))
     }));
+    destroy_create_recovery(&fixture, &spec, &error);
+}
+
+#[test]
+fn helper_rename_instead_of_removal_is_detected_by_exact_id() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.rename_instead_of_next_remove = true);
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("renamed exact helper must not count as removed");
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+
+    let state = fixture.engine.state.lock().expect("fake state");
+    let retained = state
+        .containers
+        .values()
+        .find(|container| container.definition.name.ends_with("-guest-source-renamed"))
+        .expect("renamed exact helper remains present");
+    let removed_id = state
+        .calls
+        .iter()
+        .find_map(|call| match call {
+            Call::RemoveContainer(id) => Some(id),
+            _ => None,
+        })
+        .expect("attempted exact helper removal");
+    assert_eq!(&retained.id, removed_id);
+    assert!(
+        !state.containers.contains_key(
+            retained
+                .definition
+                .name
+                .strip_suffix("-renamed")
+                .expect("renamed suffix")
+        )
+    );
 }
 
 #[test]
@@ -2117,6 +2780,7 @@ fn name_replacement_after_archive_upload_is_never_adopted_or_started() {
         .create(&spec, &NeverCancelled)
         .expect_err("post-upload name replacement");
     assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_exact_create_recovery(&fixture, &spec, &error);
     let replacement = fixture.engine.container(&names.job).expect("replacement");
     let calls = fixture.engine.calls();
     let uploaded_id = calls
@@ -2147,6 +2811,7 @@ fn name_replacement_after_start_is_never_adopted_or_bootstrapped() {
         .create(&spec, &NeverCancelled)
         .expect_err("post-start name replacement");
     assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_exact_create_recovery(&fixture, &spec, &error);
     let replacement = fixture.engine.container(&names.job).expect("replacement");
     let calls = fixture.engine.calls();
     let started_id = calls
@@ -2162,6 +2827,140 @@ fn name_replacement_after_start_is_never_adopted_or_bootstrapped() {
             .iter()
             .any(|call| matches!(call, Call::CreateExec(_, _)))
     );
+}
+
+#[test]
+fn delayed_results_proxy_readiness_is_polled_to_one_exact_line() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.results_readiness_empty_reads = 2);
+    fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect("bounded delayed readiness");
+    assert_eq!(
+        fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .results_log_reads,
+        3
+    );
+}
+
+#[test]
+fn nonempty_nonexact_results_proxy_readiness_is_rejected_immediately() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    fixture.engine.mutate(|state| {
+        state.results_readiness_bytes = Some(b"{\"version\":1}\n".to_vec());
+    });
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("nonexact readiness must fail");
+    assert_eq!(error.kind(), ProviderErrorKind::BackendRejected);
+    assert_eq!(
+        fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .results_log_reads,
+        1
+    );
+    destroy_create_recovery(&fixture, &spec, &error);
+}
+
+#[test]
+fn results_proxy_replacement_during_readiness_poll_is_detected() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    fixture.engine.mutate(|state| {
+        state.results_readiness_empty_reads = 1;
+        state.replace_proxy_after_empty_readiness = true;
+    });
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("replacement during readiness must fail");
+    assert_eq!(error.kind(), ProviderErrorKind::Conflict);
+    assert_exact_create_recovery(&fixture, &spec, &error);
+}
+
+#[test]
+fn cancellation_interrupts_results_proxy_readiness_poll() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    fixture
+        .engine
+        .mutate(|state| state.results_readiness_empty_reads = usize::MAX);
+    let cancellation = ToggleCancellation::active();
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| fixture.provider.create(&spec, &cancellation));
+        wait_for_test(
+            || {
+                fixture
+                    .engine
+                    .state
+                    .lock()
+                    .expect("state")
+                    .results_log_reads
+                    > 0
+            },
+            "readiness polling did not begin",
+        );
+        cancellation.cancel();
+        wait_for_test(
+            || call.is_finished(),
+            "cancelled readiness poll did not return within the test bound",
+        );
+        call.join()
+            .expect("create thread")
+            .expect_err("cancelled readiness")
+    });
+    assert_eq!(error.kind(), ProviderErrorKind::Cancelled);
+    destroy_create_recovery(&fixture, &spec, &error);
+}
+
+#[test]
+fn readiness_preserves_transit_and_target_engine_failure_categories() {
+    for target_failure in [false, true] {
+        for (engine_error, expected_kind) in engine_failure_categories() {
+            let fixture = Fixture::new();
+            let record = fixture
+                .provider
+                .create(&sandbox_spec(), &NeverCancelled)
+                .expect("create Results topology");
+            let mutations = fixture.engine.mutation_count();
+            fixture.engine.mutate(|state| {
+                if target_failure {
+                    state.readiness_followup_target_error = Some(engine_error);
+                } else {
+                    state.readiness_followup_transit_inspect_error = Some(engine_error);
+                }
+            });
+
+            let error = fixture
+                .provider
+                .inspect(record.handle(), &NeverCancelled)
+                .expect_err("injected readiness Engine failure");
+
+            assert_eq!(error.kind(), expected_kind);
+            assert_ne!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+            assert_eq!(fixture.engine.mutation_count(), mutations);
+            assert_eq!(
+                fixture
+                    .provider
+                    .inspect(record.handle(), &NeverCancelled)
+                    .expect("transient readiness failure must retain custody")
+                    .state(),
+                SandboxState::Running
+            );
+        }
+    }
 }
 
 #[test]
@@ -2284,6 +3083,47 @@ fn destroy_rejects_a_helper_recreated_while_the_job_is_removed() {
 }
 
 #[test]
+fn destroy_rejects_a_job_renamed_instead_of_exact_id_removal() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create");
+    fixture
+        .engine
+        .mutate(|state| state.rename_instead_of_next_remove = true);
+    let request = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(201)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+
+    let error = fixture
+        .provider
+        .destroy(&request, &NeverCancelled)
+        .expect_err("renamed exact job ID must prevent removal success");
+
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    assert!(fixture.engine.container(&names.job).is_none());
+    assert!(
+        fixture
+            .engine
+            .state
+            .lock()
+            .expect("state")
+            .containers
+            .values()
+            .any(|container| {
+                container.definition.name == format!("{}-renamed", names.job)
+                    && container.state == EngineContainerState::Exited(137)
+            })
+    );
+}
+
+#[test]
 fn exact_realized_configuration_is_rechecked_on_attach() {
     let fixture = Fixture::new();
     let spec = sandbox_spec();
@@ -2300,6 +3140,835 @@ fn exact_realized_configuration_is_rechecked_on_attach() {
         .attach(record.handle(), &NeverCancelled)
         .expect_err("tampered isolation");
     assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+}
+
+#[test]
+fn provider_advertises_only_its_current_network_contract() {
+    let fixture = Fixture::new();
+    assert!(
+        fixture
+            .provider
+            .capabilities()
+            .supports(SandboxCapability::PrivateEgress)
+    );
+    assert!(
+        !fixture
+            .provider
+            .capabilities()
+            .supports(SandboxCapability::NetworkDisabled)
+    );
+}
+
+#[test]
+fn results_transport_rejects_generic_or_public_targets() {
+    for (network_id, container_id, address) in [
+        ("short", RESULTS_CONTAINER_ID, Ipv4Addr::new(10, 91, 0, 2)),
+        (TRANSIT_NETWORK_ID, "short", Ipv4Addr::new(10, 91, 0, 2)),
+        (
+            TRANSIT_NETWORK_ID,
+            RESULTS_CONTAINER_ID,
+            Ipv4Addr::new(203, 0, 113, 2),
+        ),
+    ] {
+        assert_eq!(
+            LocalDockerResultsTransport::new(proxy_image(), network_id, container_id, address)
+                .expect_err("invalid closed transport")
+                .code(),
+            LocalDockerErrorCode::ResultsTransportMismatch
+        );
+    }
+}
+
+#[test]
+fn stale_results_proxy_image_protocol_is_rejected_before_mutation() {
+    let fixture = Fixture::new();
+    fixture.engine.mutate(|state| {
+        state
+            .images
+            .get_mut(proxy_image().reference())
+            .expect("Results proxy image")
+            .labels
+            .insert(
+                RESULTS_PROXY_IMAGE_PROTOCOL_LABEL.to_owned(),
+                "1".to_owned(),
+            );
+    });
+    let mut results = verified_results_transport(&fixture.installation);
+    results.proxy_image_labels.insert(
+        RESULTS_PROXY_IMAGE_PROTOCOL_LABEL.to_owned(),
+        "1".to_owned(),
+    );
+    let provider = LocalDockerProvider::with_test_engine(
+        PinnedDockerEngine::for_test(EngineArchitecture::Amd64, fixture.engine.clone()),
+        fixture.engine.clone(),
+        fixture.installation.clone(),
+        guest_image(),
+        GUEST_IMAGE_ID.to_owned(),
+        results,
+        RunnerId::from_uuid(Uuid::from_u128(2)),
+    );
+    let mutations = fixture.engine.mutation_count();
+
+    let error = provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("the pre-Results image protocol must fail closed");
+
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), mutations);
+}
+
+#[test]
+fn deterministic_results_addresses_cover_every_current_runner_custody() {
+    let fixture = Fixture::new();
+    let runner_id = RunnerId::from_uuid(Uuid::from_u128(2));
+    let transport = verified_results_transport(&fixture.installation);
+    let pool = results_front_pool(&fixture.installation);
+    let mut front_networks = BTreeSet::new();
+    let mut transit_addresses = BTreeSet::new();
+    let custodies = std::iter::once(SandboxCustody::ProfileAdmission { runner_id }).chain(
+        (1..=crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS).map(|slot| SandboxCustody::Job {
+            runner_id,
+            slot_ordinal: NonZeroU16::new(slot).expect("nonzero slot"),
+        }),
+    );
+
+    for custody in custodies {
+        let front = results_front_network(&fixture.installation, custody).expect("front subnet");
+        assert_eq!(front.prefix, RESULTS_FRONT_NETWORK_PREFIX);
+        assert!(pool.contains(front.network));
+        assert!(pool.contains(front.broadcast()));
+        assert!(front_networks.insert(front.network));
+        assert_eq!(
+            network_host_address(&front, 1).expect("front gateway"),
+            Ipv4Addr::from(u32::from(front.network) + 1)
+        );
+        assert_eq!(
+            network_host_address(&front, 2).expect("proxy address"),
+            Ipv4Addr::from(u32::from(front.network) + 2)
+        );
+        assert_eq!(
+            network_host_address(&front, 3).expect("job address"),
+            Ipv4Addr::from(u32::from(front.network) + 3)
+        );
+
+        let transit = transit_proxy_address(
+            &transport.transit_network,
+            transport.transit_gateway,
+            transport.requested.results_address,
+            custody,
+        )
+        .expect("transit proxy address");
+        assert!(transport.transit_network.usable(transit));
+        assert_ne!(transit, transport.transit_gateway);
+        assert_ne!(transit, transport.requested.results_address);
+        assert!(transit_addresses.insert(transit));
+    }
+
+    assert_eq!(front_networks.len(), 257);
+    assert_eq!(transit_addresses.len(), 257);
+}
+
+#[test]
+fn minimum_transit_prefix_has_capacity_for_every_target_hole_position() {
+    let transit = Ipv4Network {
+        network: Ipv4Addr::new(10, 91, 0, 0),
+        prefix: 23,
+    };
+    let gateway = network_host_address(&transit, 1).expect("gateway");
+    let runner_id = RunnerId::from_uuid(Uuid::from_u128(2));
+    for target_offset in [2, 250, 510] {
+        let target = network_host_address(&transit, target_offset).expect("target");
+        let addresses = std::iter::once(SandboxCustody::ProfileAdmission { runner_id })
+            .chain(
+                (1..=crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS).map(|slot| SandboxCustody::Job {
+                    runner_id,
+                    slot_ordinal: NonZeroU16::new(slot).expect("slot"),
+                }),
+            )
+            .map(|custody| {
+                transit_proxy_address(&transit, gateway, target, custody)
+                    .expect("minimum transit capacity")
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(addresses.len(), 257);
+        assert!(!addresses.contains(&gateway));
+        assert!(!addresses.contains(&target));
+        assert!(addresses.iter().all(|address| transit.usable(*address)));
+    }
+}
+
+#[test]
+fn default_installation_front_address_plan_is_a_stable_golden_vector() {
+    let installation = Installation::verified(
+        InstallationName::default(),
+        InstallationId::from_str("00000000-0000-4000-8000-000000000001").expect("installation ID"),
+    );
+    let runner_id = RunnerId::from_uuid(Uuid::from_u128(2));
+    assert_eq!(
+        results_front_pool(&installation),
+        Ipv4Network {
+            network: Ipv4Addr::new(10, 223, 0, 0),
+            prefix: 20,
+        }
+    );
+    for (custody, expected) in [
+        (
+            SandboxCustody::ProfileAdmission { runner_id },
+            Ipv4Addr::new(10, 223, 0, 0),
+        ),
+        (
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal: NonZeroU16::new(1).expect("slot"),
+            },
+            Ipv4Addr::new(10, 223, 0, 8),
+        ),
+        (
+            SandboxCustody::Job {
+                runner_id,
+                slot_ordinal: NonZeroU16::new(256).expect("slot"),
+            },
+            Ipv4Addr::new(10, 223, 8, 0),
+        ),
+    ] {
+        assert_eq!(
+            results_front_network(&installation, custody)
+                .expect("front network")
+                .network,
+            expected
+        );
+    }
+}
+
+#[test]
+fn one_runner_three_worker_slots_realize_disjoint_closed_topologies() {
+    let fixture = Fixture::new();
+    let resources = ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits");
+    let specs = (1_u16..=3)
+        .map(|slot| {
+            sandbox_spec_with_identity_and_resources(
+                100 + u128::from(slot),
+                7,
+                SandboxCustody::Job {
+                    runner_id: RunnerId::from_uuid(Uuid::from_u128(2)),
+                    slot_ordinal: NonZeroU16::new(slot).expect("slot"),
+                },
+                resources,
+            )
+        })
+        .collect::<Vec<_>>();
+    let records = specs
+        .iter()
+        .map(|spec| {
+            fixture
+                .provider
+                .create(spec, &NeverCancelled)
+                .expect("three-worker topology")
+        })
+        .collect::<Vec<_>>();
+
+    let state = fixture.engine.state.lock().expect("state");
+    let transit = state
+        .networks
+        .values()
+        .find(|network| network.id == TRANSIT_NETWORK_ID)
+        .expect("transit");
+    assert_eq!(transit.containers.len(), 4);
+    let mut proxy_transit_addresses = BTreeSet::new();
+    let mut front_networks = BTreeSet::new();
+    for spec in &specs {
+        let names = ResourceNames::for_spec(&fixture.installation, spec).expect("names");
+        let front = state
+            .networks
+            .get(&names.results_front)
+            .expect("slot front network");
+        assert_eq!(
+            front.ipv4_network,
+            results_front_network(&fixture.installation, spec.custody()).expect("front mapping")
+        );
+        assert!(front_networks.insert(front.ipv4_network.network));
+        let proxy = state
+            .containers
+            .get(&names.results_proxy)
+            .expect("slot proxy");
+        let transit_attachment = proxy
+            .definition
+            .networks
+            .get(&transit.name)
+            .expect("proxy transit attachment");
+        assert_eq!(
+            transit_attachment.ipv4_address,
+            transit_proxy_address(
+                &transit.ipv4_network,
+                transit.ipv4_gateway,
+                Ipv4Addr::new(10, 91, 0, 2),
+                spec.custody(),
+            )
+            .expect("transit mapping")
+        );
+        assert!(proxy_transit_addresses.insert(transit_attachment.ipv4_address));
+    }
+    drop(state);
+    assert_eq!(front_networks.len(), 3);
+    assert_eq!(proxy_transit_addresses.len(), 3);
+
+    for (record, spec) in records.into_iter().zip(specs).rev() {
+        let destroy = DestroySandbox::new(
+            OperationId::from_uuid(Uuid::new_v4()),
+            record.handle().clone(),
+            record.generation(),
+            spec.custody(),
+        );
+        assert_eq!(
+            fixture
+                .provider
+                .destroy(&destroy, &NeverCancelled)
+                .expect("destroy worker topology"),
+            DestroyDisposition::Destroyed
+        );
+    }
+    let state = fixture.engine.state.lock().expect("state");
+    assert_eq!(state.networks.len(), 1);
+    assert_eq!(
+        state
+            .networks
+            .values()
+            .next()
+            .expect("shared transit")
+            .containers
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        [RESULTS_CONTAINER_ID.to_owned()]
+    );
+}
+
+#[test]
+fn distinct_worker_slots_create_concurrently_without_transit_allocation_races() {
+    let fixture = Fixture::new();
+    let resources = ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits");
+    let specs = (1_u16..=3)
+        .map(|slot| {
+            sandbox_spec_with_identity_and_resources(
+                200 + u128::from(slot),
+                7,
+                SandboxCustody::Job {
+                    runner_id: RunnerId::from_uuid(Uuid::from_u128(2)),
+                    slot_ordinal: NonZeroU16::new(slot).expect("slot"),
+                },
+                resources,
+            )
+        })
+        .collect::<Vec<_>>();
+    std::thread::scope(|scope| {
+        let calls = specs
+            .iter()
+            .map(|spec| {
+                scope.spawn(|| {
+                    fixture
+                        .provider
+                        .create(spec, &NeverCancelled)
+                        .expect("concurrent slot creation")
+                })
+            })
+            .collect::<Vec<_>>();
+        for call in calls {
+            assert_eq!(
+                call.join().expect("create thread").state(),
+                SandboxState::Running
+            );
+        }
+    });
+
+    let state = fixture.engine.state.lock().expect("state");
+    let transit = state
+        .networks
+        .values()
+        .find(|network| network.id == TRANSIT_NETWORK_ID)
+        .expect("transit");
+    assert_eq!(transit.containers.len(), 4);
+    assert_eq!(
+        transit
+            .containers
+            .values()
+            .map(|endpoint| endpoint.ipv4_address)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        4
+    );
+}
+
+#[test]
+fn cancellation_interrupts_shared_transit_peer_attestation() {
+    let fixture = Fixture::new();
+    let record = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect("create peer for cancellation test");
+    fixture
+        .engine
+        .peer_inspection_delay_millis
+        .store(5_000, Ordering::SeqCst);
+    let cancellation = ToggleCancellation::active();
+
+    let error = std::thread::scope(|scope| {
+        let call = scope.spawn(|| fixture.provider.inspect(record.handle(), &cancellation));
+        wait_for_test(
+            || {
+                fixture
+                    .engine
+                    .maximum_peer_inspections_in_flight
+                    .load(Ordering::SeqCst)
+                    > 0
+            },
+            "shared-transit peer attestation did not begin",
+        );
+        cancellation.cancel();
+        wait_for_test(
+            || call.is_finished(),
+            "cancelled shared-transit attestation did not return within the test bound",
+        );
+        call.join()
+            .expect("inspect thread")
+            .expect_err("cancelled peer attestation")
+    });
+
+    assert_eq!(error.kind(), ProviderErrorKind::Cancelled);
+}
+
+#[test]
+fn shared_transit_peer_attestation_obeys_one_absolute_deadline() {
+    let fixture = Fixture::new();
+    fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect("create peer for deadline test");
+    fixture
+        .engine
+        .peer_inspection_delay_millis
+        .store(5_000, Ordering::SeqCst);
+    let started = Instant::now();
+    let error = run_provider(ProviderStage::Inspect, async {
+        fixture
+            .provider
+            .inner
+            .verify_boundary_kind(
+                &NeverCancelled,
+                ResultsTransportBudget {
+                    deadline: tokio::time::Instant::now() + Duration::from_millis(50),
+                },
+            )
+            .await
+            .map_err(|kind| known(kind, ProviderStage::Inspect))
+    })
+    .expect_err("the absolute attestation deadline must fail closed");
+
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "the operation-wide deadline was not enforced"
+    );
+}
+
+#[test]
+fn shared_results_attestation_preserves_engine_failure_categories_and_custody() {
+    for (engine_error, expected_kind) in engine_failure_categories() {
+        let fixture = Fixture::new();
+        let record = fixture
+            .provider
+            .create(&sandbox_spec(), &NeverCancelled)
+            .expect("create Results topology");
+        let mutations = fixture.engine.mutation_count();
+        fixture.engine.mutate(|state| {
+            state.next_results_transit_inspect_error = Some(engine_error);
+        });
+
+        let error = fixture
+            .provider
+            .inspect(record.handle(), &NeverCancelled)
+            .expect_err("injected shared-attestation Engine failure");
+
+        assert_eq!(error.kind(), expected_kind);
+        assert_ne!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+        assert_eq!(error.outcome(), OperationOutcome::KnownNoEffect);
+        assert!(error.recovery_handle().is_none());
+        assert_eq!(fixture.engine.mutation_count(), mutations);
+        assert_eq!(
+            fixture
+                .provider
+                .inspect(record.handle(), &NeverCancelled)
+                .expect("transient shared-attestation failure must retain custody")
+                .state(),
+            SandboxState::Running
+        );
+    }
+}
+
+#[test]
+fn shared_transit_peer_attestation_is_concurrent_and_bounded() {
+    let fixture = Fixture::new();
+    let records = (1_u16..=33)
+        .map(|slot| {
+            fixture
+                .provider
+                .create(
+                    &sandbox_spec_for_job_slot(400 + u128::from(slot), slot),
+                    &NeverCancelled,
+                )
+                .expect("create attested transit peer")
+        })
+        .collect::<Vec<_>>();
+    fixture
+        .engine
+        .maximum_peer_inspections_in_flight
+        .store(0, Ordering::SeqCst);
+    fixture
+        .engine
+        .peer_inspection_delay_millis
+        .store(5, Ordering::SeqCst);
+
+    fixture
+        .provider
+        .inspect(records[0].handle(), &NeverCancelled)
+        .expect("bounded concurrent transit attestation");
+
+    let maximum = fixture
+        .engine
+        .maximum_peer_inspections_in_flight
+        .load(Ordering::SeqCst);
+    assert_eq!(
+        maximum, MAX_RESULTS_TRANSIT_ATTESTATION_CONCURRENCY,
+        "peer attestation must saturate, but never exceed, its exact concurrency ceiling"
+    );
+}
+
+#[test]
+fn runner_and_slot_custody_bounds_fail_before_engine_access() {
+    for custody in [
+        SandboxCustody::Job {
+            runner_id: RunnerId::new(),
+            slot_ordinal: NonZeroU16::new(1).expect("slot"),
+        },
+        SandboxCustody::Job {
+            runner_id: RunnerId::from_uuid(Uuid::from_u128(2)),
+            slot_ordinal: NonZeroU16::new(crate::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS + 1)
+                .expect("out-of-range slot"),
+        },
+    ] {
+        let fixture = Fixture::new();
+        let spec = sandbox_spec_with_custody_and_resources(
+            custody,
+            ResourceLimits::new(256 * 1024 * 1024, 2_000, 128).expect("limits"),
+        );
+        let error = fixture
+            .provider
+            .create(&spec, &NeverCancelled)
+            .expect_err("custody outside the provider contract");
+        assert_eq!(error.kind(), ProviderErrorKind::UnsupportedCapability);
+        assert_eq!(fixture.engine.access_count(), 0);
+        assert_eq!(fixture.engine.mutation_count(), 0);
+    }
+}
+
+#[test]
+fn transit_capacity_duplicate_and_front_pool_overlap_fail_closed() {
+    let fixture = Fixture::new();
+    let transport = verified_results_transport(&fixture.installation);
+    let state = fixture.engine.state.lock().expect("state");
+    let base = state
+        .networks
+        .values()
+        .find(|network| network.id == TRANSIT_NETWORK_ID)
+        .expect("transit")
+        .clone();
+    drop(state);
+
+    let mut undersized = base.clone();
+    undersized.ipv4_network.prefix = 24;
+    undersized
+        .containers
+        .get_mut(RESULTS_CONTAINER_ID)
+        .expect("Results endpoint")
+        .ipv4_prefix = 24;
+    assert!(!exact_results_transit(
+        &undersized,
+        &fixture.installation,
+        &transport.requested,
+    ));
+
+    let mut duplicate = base.clone();
+    duplicate.containers.insert(
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_owned(),
+        NetworkEndpoint {
+            name: "duplicate".to_owned(),
+            endpoint_id: "edededededededededededededededededededededededededededededededed"
+                .to_owned(),
+            mac_address: "02:42:0a:5b:00:02".to_owned(),
+            ipv4_address: transport.requested.results_address,
+            ipv4_prefix: base.ipv4_network.prefix,
+        },
+    );
+    assert!(!exact_results_transit(
+        &duplicate,
+        &fixture.installation,
+        &transport.requested,
+    ));
+
+    let pool = results_front_pool(&fixture.installation);
+    let mut overlapping = base;
+    overlapping.ipv4_network = pool.clone();
+    overlapping.ipv4_gateway = network_host_address(&pool, 1).expect("gateway");
+    let results_address = network_host_address(&pool, 2).expect("Results address");
+    overlapping
+        .containers
+        .get_mut(RESULTS_CONTAINER_ID)
+        .expect("Results endpoint")
+        .ipv4_address = results_address;
+    overlapping
+        .containers
+        .get_mut(RESULTS_CONTAINER_ID)
+        .expect("Results endpoint")
+        .ipv4_prefix = pool.prefix;
+    let mut requested = transport.requested;
+    requested.results_address = results_address;
+    assert!(!exact_results_transit(
+        &overlapping,
+        &fixture.installation,
+        &requested,
+    ));
+}
+
+#[test]
+fn transit_drift_fails_before_any_sandbox_mutation() {
+    let fixture = Fixture::new();
+    fixture.engine.mutate(|state| {
+        state
+            .networks
+            .values_mut()
+            .find(|network| network.id == TRANSIT_NETWORK_ID)
+            .expect("transit")
+            .options
+            .insert(
+                "com.docker.network.bridge.gateway_mode_ipv4".to_owned(),
+                "nat".to_owned(),
+            );
+    });
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("transit normalization drift");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn duplicate_transit_endpoint_address_fails_before_any_sandbox_mutation() {
+    let fixture = Fixture::new();
+    fixture.engine.mutate(|state| {
+        state
+            .networks
+            .values_mut()
+            .find(|network| network.id == TRANSIT_NETWORK_ID)
+            .expect("transit")
+            .containers
+            .insert(
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_owned(),
+                NetworkEndpoint {
+                    name: "duplicate".to_owned(),
+                    endpoint_id: "edededededededededededededededededededededededededededededededed"
+                        .to_owned(),
+                    mac_address: "02:42:0a:5b:00:02".to_owned(),
+                    ipv4_address: Ipv4Addr::new(10, 91, 0, 2),
+                    ipv4_prefix: 16,
+                },
+            );
+    });
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("duplicate transit endpoint address");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn unavailable_results_target_fails_before_any_sandbox_mutation() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.results_target_running = false);
+    let error = fixture
+        .provider
+        .create(&sandbox_spec(), &NeverCancelled)
+        .expect_err("the pinned Results target must be running");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn transit_peer_requires_the_full_closed_proxy_shape_except_for_custody_cleanup() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("create sandbox");
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    fixture.engine.mutate(|state| {
+        state
+            .containers
+            .get_mut(&names.results_proxy)
+            .expect("Results proxy")
+            .definition
+            .networks
+            .insert(
+                "automata-control".to_owned(),
+                ContainerNetworkAttachment {
+                    network_id: "1212121212121212121212121212121212121212121212121212121212121212"
+                        .to_owned(),
+                    ipv4_address: Ipv4Addr::new(10, 99, 0, 2),
+                    aliases: Vec::new(),
+                },
+            );
+    });
+    let mutations_before = fixture.engine.mutation_count();
+    let error = fixture
+        .provider
+        .inspect(record.handle(), &NeverCancelled)
+        .expect_err("a proxy attached to any third network is not trusted");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), mutations_before);
+
+    let destroy = DestroySandbox::new(
+        OperationId::from_uuid(Uuid::from_u128(14)),
+        record.handle().clone(),
+        record.generation(),
+        spec.custody(),
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .destroy(&destroy, &NeverCancelled)
+            .expect("topology drift must not strand resources with exact custody"),
+        DestroyDisposition::Destroyed
+    );
+}
+
+#[test]
+fn transit_peer_job_requires_full_container_identity_before_other_slot_mutation() {
+    let fixture = Fixture::new();
+    let first = sandbox_spec_for_job_slot(301, 1);
+    fixture
+        .provider
+        .create(&first, &NeverCancelled)
+        .expect("first slot");
+    let first_names = ResourceNames::for_spec(&fixture.installation, &first).expect("first names");
+    fixture.engine.mutate(|state| {
+        let original_id = state
+            .containers
+            .get(&first_names.job)
+            .expect("first job")
+            .id
+            .clone();
+        replace_container(state, &original_id).expect("replace first job");
+        let replacement = state
+            .containers
+            .get_mut(&first_names.job)
+            .expect("replacement job");
+        replacement.isolated = false;
+        replacement
+            .definition
+            .environment
+            .push("FOREIGN=true".to_owned());
+    });
+    let mutations_before = fixture.engine.mutation_count();
+    let error = fixture
+        .provider
+        .create(&sandbox_spec_for_job_slot(302, 2), &NeverCancelled)
+        .expect_err("foreign peer job identity");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), mutations_before);
+}
+
+#[test]
+fn cached_peer_shape_is_reverified_after_later_peer_attestation() {
+    let fixture = Fixture::new();
+    let first = sandbox_spec_for_job_slot(311, 1);
+    let second = sandbox_spec_for_job_slot(312, 2);
+    fixture
+        .provider
+        .create(&first, &NeverCancelled)
+        .expect("first slot");
+    fixture
+        .provider
+        .create(&second, &NeverCancelled)
+        .expect("second slot");
+    let first_names = ResourceNames::for_spec(&fixture.installation, &first).expect("first names");
+    let second_names =
+        ResourceNames::for_spec(&fixture.installation, &second).expect("second names");
+    fixture.engine.mutate(|state| {
+        state.mutate_container_after_inspecting_name =
+            Some((second_names.results_proxy.clone(), first_names.job.clone()));
+    });
+    let mutations_before = fixture.engine.mutation_count();
+    let error = fixture
+        .provider
+        .create(&sandbox_spec_for_job_slot(313, 3), &NeverCancelled)
+        .expect_err("cached first peer must be re-attested");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), mutations_before);
+    assert!(
+        !fixture
+            .engine
+            .container(&first_names.job)
+            .expect("mutated first job")
+            .isolated
+    );
+}
+
+#[test]
+fn foreign_front_network_collision_is_not_adopted_or_mutated() {
+    let fixture = Fixture::new();
+    let spec = sandbox_spec();
+    let names = ResourceNames::for_spec(&fixture.installation, &spec).expect("names");
+    fixture.engine.mutate(|state| {
+        let mut foreign = state
+            .networks
+            .values()
+            .find(|network| network.id == TRANSIT_NETWORK_ID)
+            .expect("transit")
+            .clone();
+        foreign.id = "edededededededededededededededededededededededededededededededed".to_owned();
+        foreign.name = names.results_front.clone();
+        foreign.labels.clear();
+        foreign.containers.clear();
+        state.networks.insert(names.results_front.clone(), foreign);
+    });
+    let error = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect_err("foreign front collision");
+    assert_eq!(error.kind(), ProviderErrorKind::OwnershipMismatch);
+    assert_eq!(fixture.engine.mutation_count(), 0);
+}
+
+#[test]
+fn matching_front_network_create_race_is_reinspected_and_replayed() {
+    let fixture = Fixture::new();
+    fixture
+        .engine
+        .mutate(|state| state.lose_next_network_create_response = true);
+    let spec = sandbox_spec();
+    let record = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("post-inspected matching race winner");
+    assert_eq!(record.state(), SandboxState::Running);
+    let replay = fixture
+        .provider
+        .create(&spec, &NeverCancelled)
+        .expect("exact topology replay");
+    assert_eq!(replay, record);
 }
 
 #[test]
@@ -2383,8 +4052,10 @@ fn unsupported_spec_shape_is_rejected_before_engine_access() {
 
 #[test]
 fn archive_builder_is_deterministic_and_contains_only_owned_paths() {
-    let first = sandbox_archive("/workspace/repository", FAKE_GUEST).expect("archive");
-    let second = sandbox_archive("/workspace/repository", FAKE_GUEST).expect("archive");
+    let definition =
+        sandbox_archive_definition("/workspace/repository").expect("archive definition");
+    let first = sandbox_archive(&definition, FAKE_GUEST).expect("archive");
+    let second = sandbox_archive(&definition, FAKE_GUEST).expect("archive");
     assert_eq!(first, second);
     assert_eq!(extract_uploaded_guest(&first).expect("guest"), FAKE_GUEST);
 }
@@ -2413,6 +4084,22 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
             .expect("set a present digest-pinned sandbox-guest image"),
     )
     .expect("guest image");
+    let results_transport = LocalDockerResultsTransport::new(
+        ImmutableImage::new(
+            std::env::var("AUTOMATA_LOCAL_DOCKER_RESULTS_PROXY_IMAGE")
+                .expect("set the digest-pinned Results proxy image"),
+        )
+        .expect("Results proxy image"),
+        std::env::var("AUTOMATA_LOCAL_DOCKER_RESULTS_TRANSIT_NETWORK_ID")
+            .expect("set the exact Results transit network ID"),
+        std::env::var("AUTOMATA_LOCAL_DOCKER_RESULTS_CONTAINER_ID")
+            .expect("set the exact Results service container ID"),
+        std::env::var("AUTOMATA_LOCAL_DOCKER_RESULTS_ADDRESS")
+            .expect("set the exact private Results address")
+            .parse()
+            .expect("private Results IPv4 address"),
+    )
+    .expect("Results transport");
     assert!(
         std::path::Path::new(super::engine::LOCAL_DOCKER_RELAY_SOCKET).exists(),
         "install the explicit fixed Engine relay fixture"
@@ -2424,9 +4111,16 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
         EngineArchitecture::Amd64 => automata_ci_core::Architecture::X86_64,
         EngineArchitecture::Arm64 => automata_ci_core::Architecture::Aarch64,
     };
-    let provider = LocalDockerProvider::connect(installation, guest_image, &runner_architecture)
-        .await
-        .expect("local Docker provider");
+    let runner_id = RunnerId::new();
+    let provider = LocalDockerProvider::connect(
+        installation,
+        guest_image,
+        results_transport,
+        runner_id,
+        &runner_architecture,
+    )
+    .await
+    .expect("local Docker provider");
     let profile = EnvironmentProfile::new(
         EnvironmentProfileId::new("automata.local/live-linux").expect("profile id"),
         Sha256Digest::from_str(PROFILE_DIGEST).expect("profile digest"),
@@ -2448,12 +4142,12 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
         OperationId::new(),
         generation,
         SandboxCustody::Job {
-            runner_id: RunnerId::new(),
+            runner_id,
             slot_ordinal: NonZeroU16::new(1).expect("slot"),
         },
         environment,
         TargetPath::posix("/workspace/repository").expect("workspace"),
-        NetworkPolicy::Disabled,
+        NetworkPolicy::PrivateEgress,
         RootFilesystemPolicy::Writable,
         ResourceLimits::new(512 * 1024 * 1024, 1_000, 128).expect("resources"),
     )
@@ -2595,6 +4289,39 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
                 ExecutionTermination::Exited(0),
                 "capless root must not receive a broker response"
             );
+
+            let network_gate = ExecutionCommand::new(
+            OperationId::new(),
+            ExecutionArgv::new(
+                TargetPath::posix("/usr/bin/node")?,
+                vec![
+                    "-e".to_owned(),
+                    concat!(
+                        "const dns=require('dns');const net=require('net');",
+                        "const fail=(m)=>{console.error(m);process.exit(1)};",
+                        "const timeout=(p)=>Promise.race([p,new Promise((_,r)=>setTimeout(()=>r(new Error('timeout')),2000))]);",
+                        "const connect=(host,port,request)=>timeout(new Promise((resolve,reject)=>{",
+                        "const s=net.createConnection({host,port});let n=0;",
+                        "s.on('connect',()=>{if(request)s.write('GET / HTTP/1.0\\r\\nHost: results.automata.invalid\\r\\n\\r\\n')});",
+                        "s.on('data',b=>{n+=b.length;s.destroy()});s.on('close',()=>n?resolve():reject(new Error('empty')));",
+                        "s.on('error',reject)}));",
+                        "(async()=>{await connect('results.automata.invalid',8081,true);",
+                        "let externalDns=false;try{await timeout(dns.promises.resolve4('example.com'));externalDns=true}catch{}",
+                        "if(externalDns)fail('external DNS escaped');",
+                        "let internet=false;try{await connect('1.1.1.1',80,false);internet=true}catch{}",
+                        "if(internet)fail('public egress escaped');process.stdout.write('closed-results-live')})().catch(e=>fail(e.message));"
+                    )
+                    .to_owned(),
+                ],
+            )?,
+            spec.workspace().clone(),
+            ExecutionEnvironment::empty(),
+            Duration::from_secs(10),
+            64 * 1024,
+        )?;
+            let output = endpoint.exec(&network_gate, &NeverCancelled)?;
+            assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+            assert_eq!(output.stdout(), b"closed-results-live");
 
             let forbidden_bootstrap = ExecutionCommand::new(
                 OperationId::new(),

--- a/crates/automata-ci-local/src/local_docker_error.rs
+++ b/crates/automata-ci-local/src/local_docker_error.rs
@@ -15,6 +15,8 @@ pub enum LocalDockerErrorCode {
     EngineArchitectureMismatch,
     /// Docker returned an incomplete or internally inconsistent response.
     InvalidEngineResponse,
+    /// A bounded Docker Engine response exceeded the adapter's hard limit.
+    EngineOutputLimitExceeded,
     /// A required digest-pinned local sandbox image is absent.
     ImageUnavailable,
     /// A local sandbox image does not match its pinned digest or engine platform.
@@ -25,6 +27,8 @@ pub enum LocalDockerErrorCode {
     InvalidIdentityAnchor,
     /// A container is attached to the identity anchor.
     IdentityAnchorAttached,
+    /// A required closed Results network or endpoint does not match its contract.
+    ResultsTransportMismatch,
 }
 
 impl LocalDockerErrorCode {
@@ -43,6 +47,9 @@ impl LocalDockerErrorCode {
             Self::InvalidEngineResponse => {
                 "the Docker Engine returned an incomplete or inconsistent response"
             }
+            Self::EngineOutputLimitExceeded => {
+                "the Docker Engine response exceeded its hard output limit"
+            }
             Self::ImageUnavailable => {
                 "a required digest-pinned local sandbox image is not present in Docker"
             }
@@ -57,6 +64,9 @@ impl LocalDockerErrorCode {
             }
             Self::IdentityAnchorAttached => {
                 "the installation identity anchor is unexpectedly attached to a container"
+            }
+            Self::ResultsTransportMismatch => {
+                "the local Results transport does not satisfy its closed network contract"
             }
         }
     }

--- a/crates/automata-ci-local/src/results_transport.rs
+++ b/crates/automata-ci-local/src/results_transport.rs
@@ -1,0 +1,94 @@
+use std::{fmt, net::Ipv4Addr};
+
+use automata_ci_execution::ImmutableImage;
+
+use crate::{LocalDockerError, LocalDockerErrorCode};
+
+/// Closed pre-provisioned Results transport consumed by the local Docker provider.
+///
+/// The installation lifecycle, not the per-sandbox provider, owns the shared
+/// transit network and the control-plane Results interface. This value pins
+/// their immutable Engine identities plus the digest-pinned credential-free
+/// relay image; it cannot describe an arbitrary network, port, or target.
+#[derive(Clone, Eq, PartialEq)]
+pub struct LocalDockerResultsTransport {
+    pub(crate) proxy_image: ImmutableImage,
+    pub(crate) transit_network_id: String,
+    pub(crate) results_container_id: String,
+    pub(crate) results_address: Ipv4Addr,
+}
+
+impl LocalDockerResultsTransport {
+    /// Constructs one exact pre-provisioned local Results route.
+    ///
+    /// # Errors
+    ///
+    /// Rejects noncanonical Engine object identities and non-private target
+    /// addresses. The fixed listener and target port is always 8081.
+    pub fn new(
+        proxy_image: ImmutableImage,
+        transit_network_id: impl Into<String>,
+        results_container_id: impl Into<String>,
+        results_address: Ipv4Addr,
+    ) -> Result<Self, LocalDockerError> {
+        let transit_network_id = transit_network_id.into();
+        let results_container_id = results_container_id.into();
+        if !canonical_object_id(&transit_network_id)
+            || !canonical_object_id(&results_container_id)
+            || !results_address.is_private()
+        {
+            return Err(LocalDockerError::new(
+                LocalDockerErrorCode::ResultsTransportMismatch,
+            ));
+        }
+        Ok(Self {
+            proxy_image,
+            transit_network_id,
+            results_container_id,
+            results_address,
+        })
+    }
+
+    /// Returns the immutable credential-free proxy image.
+    #[must_use]
+    pub const fn proxy_image(&self) -> &ImmutableImage {
+        &self.proxy_image
+    }
+
+    /// Returns the exact pre-provisioned transit-network Engine identity.
+    #[must_use]
+    pub fn transit_network_id(&self) -> &str {
+        &self.transit_network_id
+    }
+
+    /// Returns the exact Results-container Engine identity.
+    #[must_use]
+    pub fn results_container_id(&self) -> &str {
+        &self.results_container_id
+    }
+
+    /// Returns the exact private numeric Results target address.
+    #[must_use]
+    pub const fn results_address(&self) -> Ipv4Addr {
+        self.results_address
+    }
+}
+
+impl fmt::Debug for LocalDockerResultsTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalDockerResultsTransport")
+            .field("proxy_image", &self.proxy_image)
+            .field("transit_network_id", &"[REDACTED]")
+            .field("results_container_id", &"[REDACTED]")
+            .field("results_address", &self.results_address)
+            .finish()
+    }
+}
+
+fn canonical_object_id(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/crates/automata-ci-runner/config/runner.local-1.example.json
+++ b/crates/automata-ci-runner/config/runner.local-1.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "runner_id": "6e561f8b-9098-418d-b573-d82f5c73006e",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {

--- a/crates/automata-ci-runner/config/runner.local-2.example.json
+++ b/crates/automata-ci-runner/config/runner.local-2.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "runner_id": "2f269f2a-1d5d-4a48-9f9e-797ea2fc97e2",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {

--- a/crates/automata-ci-runner/config/runner.local-3.example.json
+++ b/crates/automata-ci-runner/config/runner.local-3.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "runner_id": "a3e2f8e1-7094-4ca5-a904-82991e0c8df3",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {

--- a/crates/automata-ci-runner/config/runner.macos.example.json
+++ b/crates/automata-ci-runner/config/runner.macos.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "runner_id": "75934d27-b027-45df-94c4-97e5a91f4011",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -202,6 +202,8 @@ async fn run_local_docker(
     let provider = automata_ci_local::connect_local_docker_provider(
         local.installation_binding().clone(),
         local.guest_image().clone(),
+        local.results_transport().clone(),
+        config.runner_id(),
         config.inventory().platform().architecture(),
     )
     .await?;

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    net::SocketAddr,
+    net::{Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     str::FromStr as _,
     time::Duration,
@@ -34,7 +34,7 @@ use super::files::{
 use super::spool_crypto::MAX_DECRYPT_ONLY_CONTENT_KEYS;
 
 /// Current on-disk runner product configuration schema.
-pub const RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION: u16 = 5;
+pub const RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION: u16 = 6;
 /// Hard ceiling applied before parsing a runner configuration document.
 pub const MAX_RUNNER_CONFIG_BYTES: usize = 256 * 1024;
 const PODMAN_RUNTIME_ROOT_NAME: &str = "automata-ci-podman";
@@ -337,6 +337,7 @@ pub enum RunnerProviderConfig {
 pub struct LocalDockerProductConfig {
     installation_binding: automata_ci_local::InstallationBinding,
     guest_image: ImmutableImage,
+    results_transport: automata_ci_local::LocalDockerResultsTransport,
 }
 
 impl LocalDockerProductConfig {
@@ -350,6 +351,12 @@ impl LocalDockerProductConfig {
     #[must_use]
     pub const fn guest_image(&self) -> &ImmutableImage {
         &self.guest_image
+    }
+
+    /// Returns the exact externally provisioned Results transport identity.
+    #[must_use]
+    pub const fn results_transport(&self) -> &automata_ci_local::LocalDockerResultsTransport {
+        &self.results_transport
     }
 }
 
@@ -1580,6 +1587,8 @@ impl RawInventory {
             || (provider_kind == ProviderKind::MacosVirtualization
                 && self.environment_profiles.len() != 1)
             || (provider_kind == ProviderKind::MacosVirtualization && self.max_parallel_jobs != 1)
+            || (provider_kind == ProviderKind::LocalDocker
+                && self.max_parallel_jobs > automata_ci_local::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS)
         {
             return Err(RunnerProductConfigError::InvalidInventory);
         }
@@ -1943,6 +1952,16 @@ struct RawLocalDockerProductConfig {
     installation_name: String,
     installation_id: String,
     guest_image: String,
+    results_transport: RawLocalDockerResultsTransport,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLocalDockerResultsTransport {
+    proxy_image: String,
+    transit_network_id: String,
+    results_container_id: String,
+    results_address: String,
 }
 
 impl RawLocalDockerProductConfig {
@@ -1967,9 +1986,26 @@ impl RawLocalDockerProductConfig {
             .map_err(|_| RunnerProductConfigError::InvalidLocalDocker)?;
         let guest_image = ImmutableImage::new(self.guest_image)
             .map_err(|_| RunnerProductConfigError::InvalidLocalDocker)?;
+        let proxy_image = ImmutableImage::new(self.results_transport.proxy_image)
+            .map_err(|_| RunnerProductConfigError::InvalidLocalDocker)?;
+        let results_address = self
+            .results_transport
+            .results_address
+            .parse::<Ipv4Addr>()
+            .ok()
+            .filter(|address| address.to_string() == self.results_transport.results_address)
+            .ok_or(RunnerProductConfigError::InvalidLocalDocker)?;
+        let results_transport = automata_ci_local::LocalDockerResultsTransport::new(
+            proxy_image,
+            self.results_transport.transit_network_id,
+            self.results_transport.results_container_id,
+            results_address,
+        )
+        .map_err(|_| RunnerProductConfigError::InvalidLocalDocker)?;
         Ok(LocalDockerProductConfig {
             installation_binding: automata_ci_local::InstallationBinding::new(name, id),
             guest_image,
+            results_transport,
         })
     }
 }
@@ -2457,7 +2493,7 @@ impl RawExecutorProductConfig {
                     || root_filesystem != RootFilesystemPolicy::Writable
                     || privilege != SandboxPrivilegePolicy::Unprivileged))
             || (provider_kind == ProviderKind::LocalDocker
-                && (network != NetworkPolicy::Disabled
+                && (network != NetworkPolicy::PrivateEgress
                     || root_filesystem != RootFilesystemPolicy::Writable
                     || privilege != SandboxPrivilegePolicy::Administrator))
         {

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -1944,7 +1944,7 @@ mod tests {
             SandboxCapability::CopyTo,
             SandboxCapability::CopyFrom,
             SandboxCapability::EnvironmentInjection,
-            SandboxCapability::NetworkDisabled,
+            SandboxCapability::PrivateEgress,
             SandboxCapability::WritableRootFilesystem,
             SandboxCapability::Administrator,
             SandboxCapability::UserNamespace,
@@ -1954,8 +1954,7 @@ mod tests {
         .expect("exact LocalDocker provider capabilities");
         let (profile, sandbox) = environment("local-docker-tools", profile_digest(0x69), 0x7a);
         let profiles = BTreeMap::from([(profile, sandbox)]);
-        let mut policy = linux_tool_policy();
-        policy.network = NetworkPolicy::Disabled;
+        let policy = linux_tool_policy();
 
         assert_eq!(
             admit_environment_profiles(&provider, runner_id(), &profiles, policy, &signals,),

--- a/crates/automata-ci-runner/tests/fixtures/runner.windows.product.json
+++ b/crates/automata-ci-runner/tests/fixtures/runner.windows.product.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "runner_id": "6e561f8b-9098-418d-b573-d82f5c73006e",
   "control_endpoint": "https://127.0.0.1:9090/",
   "state": {

--- a/crates/automata-ci-runner/tests/runner_product_config.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config.rs
@@ -1221,14 +1221,20 @@ fn local_docker_configuration() -> serde_json::Value {
         .as_object_mut()
         .expect("state object")
         .remove("podman");
-    value["executor"]["network"] = serde_json::json!("disabled");
+    value["executor"]["network"] = serde_json::json!("private_egress");
     value["local_docker"] = serde_json::json!({
         "installation_name": "evaluation",
         "installation_id": "6e561f8b-9098-418d-b573-d82f5c73006e",
         "guest_image": format!(
             "registry.example/automata/guest@sha256:{}",
             "ab".repeat(32)
-        )
+        ),
+        "results_transport": {
+            "proxy_image": SERVICE_PROXY_IMAGE,
+            "transit_network_id": "cd".repeat(32),
+            "results_container_id": "ef".repeat(32),
+            "results_address": "10.91.0.2"
+        }
     });
     value
 }
@@ -1248,6 +1254,25 @@ fn local_docker_configuration_is_closed_current_only_and_mutually_exclusive() {
     );
     assert!(local.guest_image().reference().ends_with(&"ab".repeat(32)));
     assert!(configured.inventory().containers().features().is_empty());
+
+    let mut three_workers = value.clone();
+    three_workers["inventory"]["max_parallel_jobs"] = serde_json::json!(3);
+    assert_eq!(
+        parse_value(&three_workers)
+            .expect("the current LocalDocker topology supports three workers")
+            .inventory()
+            .max_parallel_jobs(),
+        3
+    );
+
+    let mut above_local_slot_ceiling = value.clone();
+    above_local_slot_ceiling["inventory"]["max_parallel_jobs"] =
+        serde_json::json!(automata_ci_local::MAXIMUM_LOCAL_DOCKER_JOB_SLOTS + 1);
+    assert_eq!(
+        parse_value(&above_local_slot_ceiling)
+            .expect_err("LocalDocker slot ordinals must fit the deterministic address pool"),
+        RunnerProductConfigError::InvalidInventory
+    );
     assert_eq!(
         configured.executor().privilege(),
         SandboxPrivilegePolicy::Administrator
@@ -1277,10 +1302,10 @@ fn local_docker_configuration_is_closed_current_only_and_mutually_exclusive() {
         RunnerProductConfigError::InvalidLocalDocker
     );
 
-    let mut egress = value.clone();
-    egress["executor"]["network"] = serde_json::json!("private_egress");
+    let mut disabled = value.clone();
+    disabled["executor"]["network"] = serde_json::json!("disabled");
     assert_eq!(
-        parse_value(&egress).expect_err("local Docker is network-disabled only"),
+        parse_value(&disabled).expect_err("local Docker requires its closed private Results route"),
         RunnerProductConfigError::InvalidExecutor
     );
 
@@ -1324,6 +1349,63 @@ fn local_docker_configuration_is_closed_current_only_and_mutually_exclusive() {
         parse_value(&ambiguous).expect_err("providers are mutually exclusive"),
         RunnerProductConfigError::InvalidProvider
     );
+}
+
+#[test]
+fn local_docker_results_transport_is_mandatory_exact_and_nonconfigurable() {
+    let value = local_docker_configuration();
+    let configured = parse_value(&value).expect("local Docker configuration");
+    let results = configured
+        .local_docker()
+        .expect("local Docker policy")
+        .results_transport();
+    assert_eq!(results.proxy_image().reference(), SERVICE_PROXY_IMAGE);
+    assert_eq!(results.transit_network_id(), "cd".repeat(32));
+    assert_eq!(results.results_container_id(), "ef".repeat(32));
+    assert_eq!(results.results_address().to_string(), "10.91.0.2");
+    let results_debug = format!("{results:?}");
+    assert!(results_debug.contains("[REDACTED]"));
+    assert!(!results_debug.contains(&"cd".repeat(32)));
+    assert!(!results_debug.contains(&"ef".repeat(32)));
+
+    let mut missing_results = value.clone();
+    missing_results["local_docker"]
+        .as_object_mut()
+        .expect("local Docker object")
+        .remove("results_transport");
+    assert_eq!(
+        parse_value(&missing_results).expect_err("Results transport is mandatory"),
+        RunnerProductConfigError::InvalidDocument
+    );
+
+    let mut dynamic_port = value.clone();
+    dynamic_port["local_docker"]["results_transport"]["port"] = serde_json::json!(8081);
+    assert_eq!(
+        parse_value(&dynamic_port).expect_err("the fixed Results port is not configurable"),
+        RunnerProductConfigError::InvalidDocument
+    );
+
+    for (field, invalid) in [
+        (
+            "proxy_image",
+            serde_json::json!("registry.example/automata/proxy:latest"),
+        ),
+        ("transit_network_id", serde_json::json!("cd".repeat(31))),
+        ("results_container_id", serde_json::json!("EF".repeat(32))),
+        ("results_address", serde_json::json!("203.0.113.2")),
+        (
+            "results_address",
+            serde_json::json!("results.automata.invalid"),
+        ),
+        ("results_address", serde_json::json!("10.91.0.2:8081")),
+    ] {
+        let mut invalid_transport = value.clone();
+        invalid_transport["local_docker"]["results_transport"][field] = invalid;
+        assert_eq!(
+            parse_value(&invalid_transport).expect_err("Results transport must stay exact"),
+            RunnerProductConfigError::InvalidLocalDocker
+        );
+    }
 }
 
 #[test]
@@ -1385,7 +1467,7 @@ fn only_the_current_product_schema_is_accepted() {
     let current: serde_json::Value =
         serde_json::from_str(&valid_configuration()).expect("configuration JSON");
     assert!(parse_value(&current).is_ok());
-    for unsupported in [0, 1, 2, 3, 4, u16::MAX] {
+    for unsupported in [0, 1, 2, 3, 4, 5, u16::MAX] {
         let mut document = current.clone();
         document["schema_version"] = serde_json::json!(unsupported);
         assert_eq!(


### PR DESCRIPTION
## Summary

- route LocalDocker jobs to Results through a unique internal isolated front network and a capless per-sandbox proxy
- validate but never create, adopt, or delete the externally owned installation Results-transit network and exact numeric Results target
- deterministically allocate isolated /29 front addresses and unique transit addresses for admission plus 256 job slots
- require Docker Engine 28 / API 1.48 and exact isolated-gateway normalization
- advance the runner product contract to schema 6 with mandatory closed Results transport
- advertise `PrivateEgress` only for the exact Results-only route

## Security and recovery

- preserves the merged fixed-relay, user-namespace, architecture, resource-controller, image-inheritance, and exact-custody boundary
- bounds whole-transit peer attestation to one cancellation-aware 30-second budget with fixed concurrency
- proves proxy readiness and both network memberships before exposing the endpoint
- precomputes all deterministic definitions before front-network mutation
- returns exact recovery custody for every post-front failure or cancellation
- owns and removes only per-sandbox front networks and proxies; shared transit ownership remains external

## Verification

- independent strict review and amended rereview: CLEAN
- LocalDocker: 163 passed, 3 explicit live ignores
- runner profile admission: 19 passed; runner integration: 104 passed
- full `automata-ci` library: 515 passed
- locked workspace all-target/all-feature check
- strict Clippy across all affected crates
- exact topology, concurrency, cancellation, error-category, rollback, and cleanup regressions
