### PR TITLE
fix(ci): match remapped Cargo coverage paths

### DIFF
--- a/scripts/ci/rust-coverage-policy.json
+++ b/scripts/ci/rust-coverage-policy.json
@@ -4,7 +4,7 @@
   "llvm_coverage_export_version": "3.1.0",
   "report_scope": {
     "description": "Compiled production source in the ordinary Rust workspace set",
-    "ignore_filename_regex": "(/target/|/automata-ci-ui-renderer/|/generated/|generated_assets\\.rs$|generated_contract\\.rs$)",
+    "ignore_filename_regex": "((^|/)target/|/automata-ci-ui-renderer/|/generated/|generated_assets\\.rs$|generated_contract\\.rs$)",
     "exclusions": [
       {
         "name": "cargo-default-nonproduction-source",

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -568,6 +568,7 @@ def main() -> None:
             """#!/usr/bin/env python3
 import os
 import json
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -611,7 +612,13 @@ elif arguments[:2] == ["llvm-cov", "report"]:
         ),
         None,
     )
-    if ignore_argument is None or "/target/" not in ignore_argument:
+    generated_source = (
+        "target/llvm-cov-target/debug/build/automata-ci-provisioning-grpc-"
+        "303a492b5e06c8cb/out/automata.management.v1.rs"
+    )
+    if ignore_argument is None or re.search(
+        ignore_argument.removeprefix("--ignore-filename-regex="), generated_source
+    ) is None:
         raise SystemExit(98)
     output = Path(arguments[arguments.index("--output-path") + 1])
     fixture = (

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -612,6 +612,8 @@ elif arguments[:2] == ["llvm-cov", "report"]:
         ),
         None,
     )
+    # cargo-llvm-cov evaluates exclusions against this workspace-relative path
+    # after applying --remap-path-prefix.
     generated_source = (
         "target/llvm-cov-target/debug/build/automata-ci-provisioning-grpc-"
         "303a492b5e06c8cb/out/automata.management.v1.rs"


### PR DESCRIPTION
## Summary

- match Cargo build output both before and after cargo-llvm-cov path remapping
- execute the production exclusion regex against the exact generated protobuf path observed on `main`
- retain fail-closed validation for any unexpected non-`crates/` source

## Root cause

The first exclusion used `/target/`, but cargo-llvm-cov applies the regex to the remapped relative path `target/...`, so it did not match.

## Validation

- `python3 scripts/ci/tests/rust-coverage.test.py`
- `git diff --check`