### PR TITLE
fix(results): reclaim evicted cache objects durably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- GitHub Actions cache eviction now durably reclaims unreachable S3 blocks with
+  crash-safe, replica-safe exact-object garbage collection.
+
 - `automata-runner enroll` now requires one explicit `--token-source` selector:
   `file:ABSOLUTE_PATH`, `env:NAME`, or `stdin`. The ambient environment/stdin
   fallback and former `--token-file` option were removed; enrollment tokens now

--- a/crates/automata-ci-blob-s3/src/adapter.rs
+++ b/crates/automata-ci-blob-s3/src/adapter.rs
@@ -3,7 +3,7 @@ use std::{fmt, time::Duration};
 use async_trait::async_trait;
 use automata_ci_blob::{
     BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    PutBlobOutcome, VerifiedBlob,
+    PutBlobOutcome, ReclaimableBlobStore, VerifiedBlob,
 };
 use aws_sdk_s3::{
     Client,
@@ -321,6 +321,22 @@ impl ImmutableBlobStore for S3BlobStore {
     }
 }
 
+#[async_trait]
+impl ReclaimableBlobStore for S3BlobStore {
+    async fn delete_if_present(&self, descriptor: &BlobDescriptor) -> Result<(), BlobStoreError> {
+        let request = self
+            .client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(self.object_key(descriptor));
+        match timeout_at(Instant::now() + self.operation_timeout, request.send()).await {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(error)) => Err(map_delete_error(&error)),
+            Err(_) => Err(BlobStoreError::new(BlobStoreErrorKind::Unavailable)),
+        }
+    }
+}
+
 fn existing_object_error(error: BlobStoreError) -> BlobStoreError {
     match error.kind() {
         BlobStoreErrorKind::Integrity | BlobStoreErrorKind::NotFound => {
@@ -347,6 +363,15 @@ fn map_put_error(
 
 fn map_get_error(
     error: &aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+) -> BlobStoreError {
+    map_sdk_error(
+        response_status(error),
+        error.as_service_error().and_then(|value| value.code()),
+    )
+}
+
+fn map_delete_error(
+    error: &aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::delete_object::DeleteObjectError>,
 ) -> BlobStoreError {
     map_sdk_error(
         response_status(error),

--- a/crates/automata-ci-blob-s3/tests/rustfs_contract.rs
+++ b/crates/automata-ci-blob-s3/tests/rustfs_contract.rs
@@ -2,6 +2,7 @@ use std::{env, time::Duration};
 
 use automata_ci_blob::{
     BlobKey, BlobPayload, BlobStoreErrorKind, ImmutableBlobStore, MediaType, PutBlobOutcome,
+    ReclaimableBlobStore,
 };
 use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use bytes::Bytes;
@@ -73,4 +74,18 @@ async fn rustfs_conditional_put_and_verified_read_contract() {
         .await
         .expect_err("immutable overwrite");
     assert_eq!(error.kind(), BlobStoreErrorKind::Conflict);
+
+    store
+        .delete_if_present(payload.descriptor())
+        .await
+        .expect("delete unreachable object");
+    store
+        .delete_if_present(payload.descriptor())
+        .await
+        .expect("idempotent delete replay");
+    let error = store
+        .get_verified(payload.descriptor(), payload.descriptor().size())
+        .await
+        .expect_err("deleted object must be absent");
+    assert_eq!(error.kind(), BlobStoreErrorKind::NotFound);
 }

--- a/crates/automata-ci-blob/src/lib.rs
+++ b/crates/automata-ci-blob/src/lib.rs
@@ -15,4 +15,4 @@ pub use model::{
     BlobDescriptor, BlobKey, BlobKeyError, BlobPayload, BlobPayloadError, MediaType,
     MediaTypeError, PutBlobOutcome, VerifiedBlob,
 };
-pub use port::{BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore};
+pub use port::{BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore, ReclaimableBlobStore};

--- a/crates/automata-ci-blob/src/memory.rs
+++ b/crates/automata-ci-blob/src/memory.rs
@@ -7,13 +7,33 @@ use async_trait::async_trait;
 
 use crate::{
     BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    PutBlobOutcome, VerifiedBlob,
+    PutBlobOutcome, ReclaimableBlobStore, VerifiedBlob,
 };
 
 /// Deterministic in-memory adapter for application and contract tests.
 #[derive(Clone, Debug, Default)]
 pub struct MemoryBlobStore {
     objects: Arc<RwLock<BTreeMap<String, BlobPayload>>>,
+}
+
+#[async_trait]
+impl ReclaimableBlobStore for MemoryBlobStore {
+    async fn delete_if_present(&self, descriptor: &BlobDescriptor) -> Result<(), BlobStoreError> {
+        let mut objects = self
+            .objects
+            .write()
+            .map_err(|_| BlobStoreError::new(BlobStoreErrorKind::Unavailable))?;
+        match objects.get(descriptor.key().as_str()) {
+            Some(payload) if payload.descriptor() != descriptor => {
+                Err(BlobStoreError::new(BlobStoreErrorKind::Conflict))
+            }
+            Some(_) => {
+                objects.remove(descriptor.key().as_str());
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/automata-ci-blob/src/port.rs
+++ b/crates/automata-ci-blob/src/port.rs
@@ -61,3 +61,16 @@ pub trait ImmutableBlobStore: std::fmt::Debug + Send + Sync {
         maximum_bytes: u64,
     ) -> Result<VerifiedBlob, BlobStoreError>;
 }
+
+/// Explicit reclamation capability for immutable objects whose durable
+/// references have been retired.
+///
+/// Publication remains immutable: implementations must never overwrite an
+/// object. Deletion is idempotent and is permitted only after the coordination
+/// store has durably made the descriptor unreachable.
+#[async_trait]
+pub trait ReclaimableBlobStore: ImmutableBlobStore {
+    /// Deletes one exact unreachable object, succeeding when it is already
+    /// absent.
+    async fn delete_if_present(&self, descriptor: &BlobDescriptor) -> Result<(), BlobStoreError>;
+}

--- a/crates/automata-ci-blob/tests/immutable_store.rs
+++ b/crates/automata-ci-blob/tests/immutable_store.rs
@@ -1,12 +1,13 @@
 use automata_ci_blob::{
     BlobDescriptor, BlobKey, BlobPayload, BlobStoreErrorKind, ImmutableBlobStore, MediaType,
-    MemoryBlobStore, PutBlobOutcome,
+    MemoryBlobStore, PutBlobOutcome, ReclaimableBlobStore,
 };
 use automata_ci_core::Sha256Digest;
 use bytes::Bytes;
 use static_assertions::assert_obj_safe;
 
 assert_obj_safe!(ImmutableBlobStore);
+assert_obj_safe!(ReclaimableBlobStore);
 
 fn payload(key: &str, value: &'static [u8]) -> BlobPayload {
     BlobPayload::from_bytes(
@@ -108,4 +109,40 @@ async fn reads_fail_closed_on_limits_and_metadata_mismatch() {
         .await
         .expect_err("descriptor mismatch");
     assert_eq!(error.kind(), BlobStoreErrorKind::Integrity);
+}
+
+#[tokio::test]
+async fn reclamation_is_exact_and_idempotent() {
+    let store = MemoryBlobStore::default();
+    let first = payload("cache/unreachable", b"cache block");
+    store
+        .put_if_absent(first.clone())
+        .await
+        .expect("create fixture");
+
+    let wrong = BlobDescriptor::new(
+        first.descriptor().key().clone(),
+        Sha256Digest::from_bytes([9; 32]),
+        first.descriptor().size(),
+        first.descriptor().media_type().clone(),
+    );
+    let error = store
+        .delete_if_present(&wrong)
+        .await
+        .expect_err("mismatched descriptor must not delete");
+    assert_eq!(error.kind(), BlobStoreErrorKind::Conflict);
+
+    store
+        .delete_if_present(first.descriptor())
+        .await
+        .expect("delete unreachable object");
+    store
+        .delete_if_present(first.descriptor())
+        .await
+        .expect("deletion replay");
+    let error = store
+        .get_verified(first.descriptor(), first.descriptor().size())
+        .await
+        .expect_err("deleted object is absent");
+    assert_eq!(error.kind(), BlobStoreErrorKind::NotFound);
 }

--- a/crates/automata-ci-results-github/README.md
+++ b/crates/automata-ci-results-github/README.md
@@ -92,8 +92,11 @@ repository or unlisted-ref mismatches do not authorize a read.
 PostgreSQL owns fencing, block-list commits, last access, seven-day inactivity
 retention, and a 10 GiB per-repository quota with LRU eviction. Signed downloads
 support `HEAD`, full `GET`, and one byte range with `206` and `416` behavior.
-Eviction currently leaves unreferenced immutable objects for a future bounded
-collector. There is no cache management or delete API.
+Eviction atomically moves every unreachable block descriptor into a durable
+garbage outbox. Cache requests drain that outbox through idempotent exact-object
+deletion before accepting more cache work, so a process or S3 failure can only
+delay reclamation and cannot lose it. There is no cache management or delete
+API.
 
 The bounded Buildx/BuildKit session and provenance surface is implemented, but
 cache interoperability is not yet production-proven. Live CacheService v2

--- a/crates/automata-ci-results-github/src/cache_port.rs
+++ b/crates/automata-ci-results-github/src/cache_port.rs
@@ -1,6 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
+use automata_ci_blob::BlobDescriptor;
 use automata_ci_core::Sha256Digest;
 use thiserror::Error;
 use url::Url;
@@ -61,6 +62,18 @@ impl CacheRepositoryError {
 /// bounded request evidence and never cache-liveness authority.
 #[async_trait]
 pub trait CacheRepository: fmt::Debug + Send + Sync {
+    /// Returns a bounded deterministic batch of unreachable cache objects.
+    async fn list_garbage(
+        &self,
+        maximum: usize,
+    ) -> Result<Vec<BlobDescriptor>, CacheRepositoryError>;
+
+    /// Acknowledges exact objects after idempotent provider deletion.
+    async fn complete_garbage(
+        &self,
+        descriptors: Vec<BlobDescriptor>,
+    ) -> Result<(), CacheRepositoryError>;
+
     /// Creates a pending entry or returns the exact idempotent replay.
     async fn create(
         &self,

--- a/crates/automata-ci-results-github/src/cache_postgres.rs
+++ b/crates/automata-ci-results-github/src/cache_postgres.rs
@@ -19,6 +19,7 @@ const ACTIVE_CACHE_LIFECYCLES: &[&str] =
 const MAX_REPOSITORY_CACHE_ENTRIES: usize = 4_096;
 const CACHE_ENTRY_CENSUS_LIMIT: i64 = 4_097;
 const MAXIMUM_CACHE_CALLER_CLOCK_SKEW_SECONDS: u64 = 60;
+const MAXIMUM_CACHE_GARBAGE_BATCH: usize = 1_024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CacheRepositoryLimitRejection {
@@ -56,6 +57,61 @@ impl PostgresCacheRepository {
 
 #[async_trait]
 impl CacheRepository for PostgresCacheRepository {
+    async fn list_garbage(
+        &self,
+        maximum: usize,
+    ) -> Result<Vec<BlobDescriptor>, CacheRepositoryError> {
+        if maximum == 0 || maximum > MAXIMUM_CACHE_GARBAGE_BATCH {
+            return Err(error(CacheRepositoryErrorKind::ResourceExhausted));
+        }
+        let rows = sqlx::query(
+            r"
+            SELECT object_key, digest, size_bytes, media_type
+            FROM github_actions_cache_garbage
+            ORDER BY queued_at_seconds ASC, object_key ASC
+            LIMIT $1
+            ",
+        )
+        .bind(
+            i64::try_from(maximum)
+                .map_err(|_| error(CacheRepositoryErrorKind::ResourceExhausted))?,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(database_error)?;
+        rows.iter().map(decode_descriptor).collect()
+    }
+
+    async fn complete_garbage(
+        &self,
+        descriptors: Vec<BlobDescriptor>,
+    ) -> Result<(), CacheRepositoryError> {
+        if descriptors.len() > MAXIMUM_CACHE_GARBAGE_BATCH {
+            return Err(error(CacheRepositoryErrorKind::ResourceExhausted));
+        }
+        let mut transaction = begin_read_committed(&self.pool).await?;
+        for descriptor in descriptors {
+            let deleted = sqlx::query(
+                r"
+                DELETE FROM github_actions_cache_garbage
+                WHERE object_key = $1 AND digest = $2 AND size_bytes = $3
+                  AND media_type = $4
+                ",
+            )
+            .bind(descriptor.key().as_str())
+            .bind(descriptor.digest().as_bytes().as_slice())
+            .bind(size_i64(descriptor.size())?)
+            .bind(descriptor.media_type().as_str())
+            .execute(&mut *transaction)
+            .await
+            .map_err(database_error)?;
+            if deleted.rows_affected() > 1 {
+                return Err(error(CacheRepositoryErrorKind::CorruptData));
+            }
+        }
+        transaction.commit().await.map_err(database_error)
+    }
+
     async fn create(
         &self,
         request: CreateCacheEntry,
@@ -482,25 +538,26 @@ impl CacheRepository for PostgresCacheRepository {
         }
         enforce_repository_entry_ceiling(&mut transaction, repository.repository_id).await?;
         let inactivity_seconds = validated_inactivity_seconds(request.inactivity_seconds)?;
-        sqlx::query(
+        let inactive = sqlx::query_scalar::<_, Uuid>(
             r"
             WITH database_clock AS MATERIALIZED (
                 SELECT floor(extract(epoch FROM clock_timestamp()))::BIGINT AS now_seconds
             )
-            DELETE FROM github_actions_cache_entries
-            USING database_clock
+            SELECT id FROM github_actions_cache_entries, database_clock
             WHERE repository_id = $1 AND state = 'finalized'
               AND last_accessed_at_seconds <= greatest(
                     0::BIGINT,
                     database_clock.now_seconds - $2
               )
+            FOR UPDATE
             ",
         )
         .bind(repository.repository_id)
         .bind(seconds_i64(inactivity_seconds)?)
-        .execute(&mut *transaction)
+        .fetch_all(&mut *transaction)
         .await
         .map_err(database_error)?;
+        delete_entries_and_queue_garbage(&mut transaction, &inactive).await?;
         evict_to_fit(
             &mut transaction,
             repository.repository_id,
@@ -1164,25 +1221,27 @@ async fn delete_inactive_pending_entries(
     transaction: &mut Transaction<'_, sqlx::Postgres>,
     repository_id: Uuid,
 ) -> Result<(), CacheRepositoryError> {
-    sqlx::query(
+    let inactive = sqlx::query_scalar::<_, Uuid>(
         r"
-        DELETE FROM github_actions_cache_entries AS entry
-        USING job_attempts AS attempt
+        SELECT entry.id
+        FROM github_actions_cache_entries AS entry
+        JOIN job_attempts AS attempt
+          ON attempt.id = entry.attempt_id AND attempt.job_id = entry.job_id
         WHERE entry.repository_id = $1
           AND entry.state = 'pending'
-          AND attempt.id = entry.attempt_id
-          AND attempt.job_id = entry.job_id
           AND NOT (
               attempt.lifecycle = ANY($2::TEXT[])
               AND attempt.lease_id IS NOT NULL
           )
+        FOR UPDATE OF entry
         ",
     )
     .bind(repository_id)
     .bind(ACTIVE_CACHE_LIFECYCLES)
-    .execute(&mut **transaction)
+    .fetch_all(&mut **transaction)
     .await
     .map_err(database_error)?;
+    delete_entries_and_queue_garbage(transaction, &inactive).await?;
     Ok(())
 }
 
@@ -1231,26 +1290,24 @@ async fn reserve_repository_entry_slot(
     if count > MAX_REPOSITORY_CACHE_ENTRIES {
         return Err(error(CacheRepositoryErrorKind::ResourceExhausted));
     }
-    let deleted = sqlx::query(
+    let candidate = sqlx::query_scalar::<_, Uuid>(
         r"
-        DELETE FROM github_actions_cache_entries
-        WHERE id = (
-            SELECT id
-            FROM github_actions_cache_entries
-            WHERE repository_id = $1 AND state = 'finalized'
-            ORDER BY last_accessed_at_seconds ASC, finalized_at_seconds ASC, id ASC
-            LIMIT 1
-            FOR UPDATE
-        )
+        SELECT id
+        FROM github_actions_cache_entries
+        WHERE repository_id = $1 AND state = 'finalized'
+        ORDER BY last_accessed_at_seconds ASC, finalized_at_seconds ASC, id ASC
+        LIMIT 1
+        FOR UPDATE
         ",
     )
     .bind(repository_id)
-    .execute(&mut **transaction)
+    .fetch_optional(&mut **transaction)
     .await
     .map_err(database_error)?;
-    if deleted.rows_affected() != 1 {
+    let Some(candidate) = candidate else {
         return Err(error(CacheRepositoryErrorKind::ResourceExhausted));
-    }
+    };
+    delete_entries_and_queue_garbage(transaction, &[candidate]).await?;
     Ok(())
 }
 
@@ -1294,6 +1351,7 @@ async fn evict_to_fit(
         candidates.push((row.try_get::<Uuid, _>("id").map_err(corrupt_error)?, size));
     }
     let mut index = 0_usize;
+    let mut evicted = Vec::new();
     while total
         .checked_add(incoming_size)
         .is_none_or(|projected| projected > quota)
@@ -1301,22 +1359,49 @@ async fn evict_to_fit(
         let Some((entry_id, size)) = candidates.get(index).copied() else {
             return Err(error(CacheRepositoryErrorKind::ResourceExhausted));
         };
-        let deleted = sqlx::query(
-            "DELETE FROM github_actions_cache_entries WHERE id = $1 AND state = 'finalized'",
-        )
-        .bind(entry_id)
-        .execute(&mut **transaction)
-        .await
-        .map_err(database_error)?;
-        if deleted.rows_affected() != 1 {
-            return Err(error(CacheRepositoryErrorKind::Conflict));
-        }
+        evicted.push(entry_id);
         total = total
             .checked_sub(size)
             .ok_or_else(|| error(CacheRepositoryErrorKind::CorruptData))?;
         index = index
             .checked_add(1)
             .ok_or_else(|| error(CacheRepositoryErrorKind::CorruptData))?;
+    }
+    delete_entries_and_queue_garbage(transaction, &evicted).await?;
+    Ok(())
+}
+
+async fn delete_entries_and_queue_garbage(
+    transaction: &mut Transaction<'_, sqlx::Postgres>,
+    entry_ids: &[Uuid],
+) -> Result<(), CacheRepositoryError> {
+    if entry_ids.is_empty() {
+        return Ok(());
+    }
+    sqlx::query(
+        r"
+        INSERT INTO github_actions_cache_garbage (
+            object_key, digest, size_bytes, media_type, queued_at_seconds
+        )
+        SELECT DISTINCT ON (block.object_key)
+               block.object_key, block.digest, block.size_bytes, block.media_type,
+               floor(extract(epoch FROM clock_timestamp()))::BIGINT
+        FROM github_actions_cache_blocks AS block
+        WHERE block.entry_id = ANY($1)
+        ORDER BY block.object_key
+        ",
+    )
+    .bind(entry_ids)
+    .execute(&mut **transaction)
+    .await
+    .map_err(database_error)?;
+    let deleted = sqlx::query("DELETE FROM github_actions_cache_entries WHERE id = ANY($1)")
+        .bind(entry_ids)
+        .execute(&mut **transaction)
+        .await
+        .map_err(database_error)?;
+    if deleted.rows_affected() != u64::try_from(entry_ids.len()).unwrap_or(u64::MAX) {
+        return Err(error(CacheRepositoryErrorKind::Conflict));
     }
     Ok(())
 }

--- a/crates/automata-ci-results-github/src/cache_service.rs
+++ b/crates/automata-ci-results-github/src/cache_service.rs
@@ -1,11 +1,12 @@
 use std::{fmt, sync::Arc};
 
 use automata_ci_blob::{
-    BlobDescriptor, BlobKey, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    MediaType,
+    BlobDescriptor, BlobKey, BlobPayload, BlobStoreError, BlobStoreErrorKind, MediaType,
+    ReclaimableBlobStore,
 };
 use automata_ci_core::Sha256Digest;
 use bytes::Bytes;
+use futures::{StreamExt as _, TryStreamExt as _, stream};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
@@ -25,6 +26,7 @@ const MAXIMUM_DURABLE_CACHE_BLOCK_BYTES: u64 = 134_217_728;
 const MAXIMUM_DURABLE_CACHE_BLOCKS: usize = 50_000;
 const MAXIMUM_DURABLE_CACHE_BYTES: u64 = 10_737_418_240;
 const MAXIMUM_CACHE_KEYS: usize = 10;
+const CACHE_GARBAGE_BATCH: usize = 256;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CacheServiceLimitRejection {
@@ -243,7 +245,7 @@ pub struct PreparedCacheDownload {
 /// Application service for the current GitHub Actions cache-v2 protocol.
 pub struct CacheService {
     repository: CacheRepositoryPort,
-    objects: Arc<dyn ImmutableBlobStore>,
+    objects: Arc<dyn ReclaimableBlobStore>,
     clock: Arc<dyn ResultsClock>,
     ids: Arc<dyn ResultsIdGenerator>,
     limits: CacheLimits,
@@ -254,7 +256,7 @@ impl CacheService {
     #[must_use]
     pub fn new(
         repository: CacheRepositoryPort,
-        objects: Arc<dyn ImmutableBlobStore>,
+        objects: Arc<dyn ReclaimableBlobStore>,
         clock: Arc<dyn ResultsClock>,
         ids: Arc<dyn ResultsIdGenerator>,
         limits: CacheLimits,
@@ -287,6 +289,7 @@ impl CacheService {
         key: String,
         version: String,
     ) -> Result<CreatedCacheEntry, CacheServiceError> {
+        self.collect_garbage().await?;
         let key = CacheKey::new(key).map_err(|_| invalid())?;
         let version = CacheVersion::new(version).map_err(|_| invalid())?;
         if cache.writable_scope().is_none() {
@@ -296,7 +299,8 @@ impl CacheService {
         }
         let entry_id = CacheEntryId::new(self.ids.next_upload_id().as_uuid())
             .map_err(|_| CacheServiceError::new(CacheServiceErrorKind::Internal))?;
-        self.repository
+        let created = self
+            .repository
             .create(CreateCacheEntry {
                 execution,
                 cache,
@@ -306,7 +310,9 @@ impl CacheService {
                 observed_at_seconds: self.clock.now_seconds(),
             })
             .await
-            .map_err(map_repository_error)
+            .map_err(map_repository_error)?;
+        self.collect_garbage().await?;
+        Ok(created)
     }
 
     /// Stages one immutable Azure block.
@@ -398,6 +404,7 @@ impl CacheService {
         version: String,
         claimed_size: u64,
     ) -> Result<FinalizedCacheEntry, CacheServiceError> {
+        self.collect_garbage().await?;
         let key = CacheKey::new(key).map_err(|_| invalid())?;
         let version = CacheVersion::new(version).map_err(|_| invalid())?;
         if cache.writable_scope().is_none() || claimed_size > self.limits.maximum_entry_bytes {
@@ -422,6 +429,7 @@ impl CacheService {
             let CacheFinalizationPreparation::Finalized(finalized) = prepared else {
                 unreachable!("closed finalization preparation")
             };
+            self.collect_garbage().await?;
             return Ok(finalized);
         };
         if prepared.size != claimed_size {
@@ -444,7 +452,8 @@ impl CacheService {
             return Err(CacheServiceError::new(CacheServiceErrorKind::Conflict));
         }
         let digest = Sha256Digest::from_bytes(hasher.finalize().into());
-        self.repository
+        let finalized = self
+            .repository
             .complete_finalization(CompleteCacheFinalization {
                 execution,
                 cache,
@@ -458,7 +467,44 @@ impl CacheService {
                 inactivity_seconds: self.limits.inactivity_seconds,
             })
             .await
-            .map_err(map_repository_error)
+            .map_err(map_repository_error)?;
+        self.collect_garbage().await?;
+        Ok(finalized)
+    }
+
+    async fn collect_garbage(&self) -> Result<(), CacheServiceError> {
+        loop {
+            let descriptors = self
+                .repository
+                .list_garbage(CACHE_GARBAGE_BATCH)
+                .await
+                .map_err(map_repository_error)?;
+            if descriptors.is_empty() {
+                return Ok(());
+            }
+            let objects = Arc::clone(&self.objects);
+            stream::iter(descriptors.iter().cloned())
+                .map(move |descriptor| {
+                    let objects = Arc::clone(&objects);
+                    async move {
+                        objects
+                            .delete_if_present(&descriptor)
+                            .await
+                            .map_err(map_blob_error)
+                    }
+                })
+                .buffer_unordered(16)
+                .try_collect::<Vec<_>>()
+                .await?;
+            let complete = descriptors.len() < CACHE_GARBAGE_BATCH;
+            self.repository
+                .complete_garbage(descriptors)
+                .await
+                .map_err(map_repository_error)?;
+            if complete {
+                return Ok(());
+            }
+        }
     }
 
     /// Resolves a cache using ordered scope, exact, and prefix precedence.

--- a/crates/automata-ci-results-github/src/storage_observer.rs
+++ b/crates/automata-ci-results-github/src/storage_observer.rs
@@ -3,7 +3,7 @@ use std::{fmt, future::Future, sync::Arc, time::Instant};
 use async_trait::async_trait;
 use automata_ci_blob::{
     BlobDescriptor, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    PutBlobOutcome, VerifiedBlob,
+    PutBlobOutcome, ReclaimableBlobStore, VerifiedBlob,
 };
 
 use crate::{
@@ -23,15 +23,22 @@ use crate::{
 /// Identifier-free metrics decorator for the provider-neutral immutable-blob port.
 #[derive(Clone)]
 pub struct ObservedResultsBlobStore {
-    inner: Arc<dyn ImmutableBlobStore>,
+    inner: Arc<dyn ReclaimableBlobStore>,
     observer: Arc<dyn ResultsObserver>,
 }
 
 impl ObservedResultsBlobStore {
     /// Wraps one immutable-blob provider without changing its behavior.
     #[must_use]
-    pub fn new(inner: Arc<dyn ImmutableBlobStore>, observer: Arc<dyn ResultsObserver>) -> Self {
+    pub fn new(inner: Arc<dyn ReclaimableBlobStore>, observer: Arc<dyn ResultsObserver>) -> Self {
         Self { inner, observer }
+    }
+}
+
+#[async_trait]
+impl ReclaimableBlobStore for ObservedResultsBlobStore {
+    async fn delete_if_present(&self, descriptor: &BlobDescriptor) -> Result<(), BlobStoreError> {
+        self.inner.delete_if_present(descriptor).await
     }
 }
 

--- a/crates/automata-ci-results-github/tests/cache_http.rs
+++ b/crates/automata-ci-results-github/tests/cache_http.rs
@@ -9,7 +9,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use automata_ci_blob::MemoryBlobStore;
+use automata_ci_blob::{
+    BlobDescriptor, BlobKey, BlobPayload, BlobStoreErrorKind, ImmutableBlobStore, MediaType,
+    MemoryBlobStore,
+};
 use automata_ci_core::Sha256Digest;
 use automata_ci_results_github::{
     CacheAuthority, CacheBlock, CacheEntryId, CacheFinalizationPreparation, CacheLimits,
@@ -86,6 +89,7 @@ impl ResultsObserver for RecordingObserver {
 #[derive(Debug, Default)]
 struct MemoryCacheRepository {
     state: Mutex<Option<MemoryEntry>>,
+    garbage: Mutex<Vec<BlobDescriptor>>,
 }
 
 #[derive(Debug)]
@@ -139,6 +143,31 @@ impl MemoryEntry {
 
 #[async_trait]
 impl CacheRepository for MemoryCacheRepository {
+    async fn list_garbage(
+        &self,
+        maximum: usize,
+    ) -> Result<Vec<BlobDescriptor>, CacheRepositoryError> {
+        Ok(self
+            .garbage
+            .lock()
+            .expect("memory garbage")
+            .iter()
+            .take(maximum)
+            .cloned()
+            .collect())
+    }
+
+    async fn complete_garbage(
+        &self,
+        descriptors: Vec<BlobDescriptor>,
+    ) -> Result<(), CacheRepositoryError> {
+        self.garbage
+            .lock()
+            .expect("memory garbage")
+            .retain(|candidate| !descriptors.contains(candidate));
+        Ok(())
+    }
+
     async fn create(
         &self,
         request: CreateCacheEntry,
@@ -445,6 +474,58 @@ fn issue_cache_token(
         .expect("token")
         .expose_secret()
         .to_owned()
+}
+
+#[tokio::test]
+async fn cache_service_reclaims_durable_garbage_before_accepting_new_work() {
+    let objects = Arc::new(MemoryBlobStore::default());
+    let payload = BlobPayload::from_bytes(
+        BlobKey::new("cache-staging/unreachable").expect("garbage key"),
+        MediaType::new("application/octet-stream").expect("media type"),
+        Bytes::from_static(b"unreachable cache block"),
+    );
+    let descriptor = payload.descriptor().clone();
+    objects
+        .put_if_absent(payload)
+        .await
+        .expect("garbage fixture");
+    let repository = Arc::new(MemoryCacheRepository {
+        state: Mutex::new(None),
+        garbage: Mutex::new(vec![descriptor.clone()]),
+    });
+    let service = CacheService::new(
+        repository.clone(),
+        objects.clone(),
+        Arc::new(FixedClock(10_000)),
+        Arc::new(FixedIds(UploadId::from_uuid(Uuid::from_u128(0x9abc)))),
+        CacheLimits::default(),
+    );
+
+    service
+        .create(
+            fresh_execution_authority(1),
+            cache_authority(
+                "automata/results-test",
+                &[("refs/heads/main", CachePermission::ReadWrite)],
+            ),
+            "fresh-cache".to_owned(),
+            "version-1".to_owned(),
+        )
+        .await
+        .expect("create after garbage collection");
+
+    assert!(
+        repository
+            .garbage
+            .lock()
+            .expect("memory garbage")
+            .is_empty()
+    );
+    let error = objects
+        .get_verified(&descriptor, descriptor.size())
+        .await
+        .expect_err("garbage object must be deleted");
+    assert_eq!(error.kind(), BlobStoreErrorKind::NotFound);
 }
 
 fn fixture_with_url_observer_and_limits(

--- a/crates/automata-ci-results-github/tests/exact_client_real_store.rs
+++ b/crates/automata-ci-results-github/tests/exact_client_real_store.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use automata_ci_blob::ImmutableBlobStore;
+use automata_ci_blob::{ImmutableBlobStore, ReclaimableBlobStore};
 use automata_ci_blob_s3::{S3AtRestEncryption, S3BlobStoreConfig, StaticS3Credentials};
 use automata_ci_control::adapter_spi::{
     AcquireLease, InternalAttemptRepository as _, QueuedAttempt,
@@ -329,7 +329,7 @@ fn real_results_router(
     .with_at_rest_encryption(S3AtRestEncryption::aws_kms(
         environment.s3_kms_key_id.clone(),
     )?);
-    let objects: Arc<dyn ImmutableBlobStore> =
+    let objects: Arc<dyn ReclaimableBlobStore> =
         Arc::new(s3_config.connect(StaticS3Credentials::new(
             environment.s3_access_key.clone(),
             environment.s3_secret_key.clone(),
@@ -337,10 +337,12 @@ fn real_results_router(
         )?)?);
     let observer = Arc::new(RecordingObserver::default());
     let public_observer: Arc<dyn ResultsObserver> = observer.clone();
-    let objects: Arc<dyn ImmutableBlobStore> = Arc::new(ObservedResultsBlobStore::new(
+    let objects = Arc::new(ObservedResultsBlobStore::new(
         objects,
         Arc::clone(&public_observer),
     ));
+    let artifact_objects: Arc<dyn ImmutableBlobStore> = objects.clone();
+    let cache_objects: Arc<dyn ReclaimableBlobStore> = objects;
     let artifact_repository: Arc<dyn ArtifactRepository> =
         Arc::new(ObservedResultsArtifactRepository::new(
             Arc::new(PostgresArtifactRepository::new(database.pool().clone())),
@@ -353,7 +355,7 @@ fn real_results_router(
     let artifacts = Arc::new(
         ArtifactService::new(
             artifact_repository,
-            Arc::clone(&objects),
+            artifact_objects,
             Arc::clone(&clock),
             ids.clone(),
             ResultsLimits::default(),
@@ -362,7 +364,7 @@ fn real_results_router(
     );
     let caches = Arc::new(CacheService::new(
         cache_repository,
-        objects,
+        cache_objects,
         Arc::clone(&clock),
         ids,
         CacheLimits::default(),

--- a/crates/automata-ci-results-github/tests/postgres_cache.rs
+++ b/crates/automata-ci-results-github/tests/postgres_cache.rs
@@ -372,6 +372,19 @@ async fn cache_transactions_are_immutable_fenced_and_cross_run_readable() -> Tes
             .await
             .expect_err("quota evicts the least recently accessed entry");
         assert_eq!(evicted.kind(), CacheRepositoryErrorKind::NotFound);
+        let garbage = repository.list_garbage(10).await?;
+        let evicted_descriptor = descriptor("block-b", 3, 0x55);
+        assert!(
+            garbage.contains(&evicted_descriptor),
+            "quota eviction must durably queue its immutable block"
+        );
+        repository
+            .complete_garbage(vec![evicted_descriptor.clone()])
+            .await?;
+        assert!(
+            !repository.list_garbage(10).await?.contains(&evicted_descriptor),
+            "exact provider acknowledgement must retire the durable garbage row"
+        );
         assert_eq!(
             repository
                 .resolve_download(ResolveCacheDownload {

--- a/crates/automata-ci-results-github/tests/storage_observability.rs
+++ b/crates/automata-ci-results-github/tests/storage_observability.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use automata_ci_blob::{
     BlobDescriptor, BlobKey, BlobPayload, BlobStoreError, BlobStoreErrorKind, ImmutableBlobStore,
-    MediaType, MemoryBlobStore, PutBlobOutcome, VerifiedBlob,
+    MediaType, MemoryBlobStore, PutBlobOutcome, ReclaimableBlobStore, VerifiedBlob,
 };
 use automata_ci_results_github::{
     ObservedResultsBlobStore, ResultsBlobOperation, ResultsBlobOperationOutcome,
@@ -24,7 +24,7 @@ fn payload(key: &str, bytes: &'static [u8]) -> BlobPayload {
 #[tokio::test]
 async fn successful_put_and_get_record_only_closed_labels_and_actual_bytes() {
     let recorder = RecordingObserver::default();
-    let inner: Arc<dyn ImmutableBlobStore> = Arc::new(MemoryBlobStore::default());
+    let inner: Arc<dyn ReclaimableBlobStore> = Arc::new(MemoryBlobStore::default());
     let store = ObservedResultsBlobStore::new(inner, Arc::new(recorder.clone()));
     let private_key = "private/tenant-91/artifact-secret-digest";
     let payload = payload(private_key, b"immutable payload");
@@ -85,10 +85,17 @@ impl ImmutableBlobStore for FailingBlobStore {
     }
 }
 
+#[async_trait]
+impl ReclaimableBlobStore for FailingBlobStore {
+    async fn delete_if_present(&self, _descriptor: &BlobDescriptor) -> Result<(), BlobStoreError> {
+        Err(BlobStoreError::new(BlobStoreErrorKind::Unavailable))
+    }
+}
+
 #[tokio::test]
 async fn provider_errors_are_sanitized_and_never_emit_bytes() {
     let recorder = RecordingObserver::default();
-    let inner: Arc<dyn ImmutableBlobStore> = Arc::new(FailingBlobStore);
+    let inner: Arc<dyn ReclaimableBlobStore> = Arc::new(FailingBlobStore);
     let store = ObservedResultsBlobStore::new(inner, Arc::new(recorder.clone()));
     let payload = payload("private/error-key", b"not accepted");
     let descriptor = payload.descriptor().clone();
@@ -154,11 +161,18 @@ impl ImmutableBlobStore for PendingBlobStore {
     }
 }
 
+#[async_trait]
+impl ReclaimableBlobStore for PendingBlobStore {
+    async fn delete_if_present(&self, _descriptor: &BlobDescriptor) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn dropped_provider_future_records_one_cancellation_without_bytes() {
     let recorder = RecordingObserver::default();
     let entered = Arc::new(Notify::new());
-    let inner: Arc<dyn ImmutableBlobStore> = Arc::new(PendingBlobStore {
+    let inner: Arc<dyn ReclaimableBlobStore> = Arc::new(PendingBlobStore {
         entered: Arc::clone(&entered),
         release: Arc::new(Notify::new()),
     });

--- a/crates/automata-ci-store-postgres/migrations/0046_github_actions_cache_garbage.sql
+++ b/crates/automata-ci-store-postgres/migrations/0046_github_actions_cache_garbage.sql
@@ -1,0 +1,23 @@
+CREATE TABLE github_actions_cache_garbage (
+    object_key text PRIMARY KEY,
+    digest bytea NOT NULL,
+    size_bytes bigint NOT NULL,
+    media_type text NOT NULL,
+    queued_at_seconds bigint NOT NULL,
+    CONSTRAINT gha_cache_garbage_digest CHECK (octet_length(digest) = 32),
+    CONSTRAINT gha_cache_garbage_key_shape CHECK (
+        octet_length(object_key) BETWEEN 1 AND 1024
+        AND object_key !~ '[[:cntrl:]]'
+    ),
+    CONSTRAINT gha_cache_garbage_media_type CHECK (
+        octet_length(media_type) BETWEEN 3 AND 128
+        AND media_type !~ '[[:space:][:cntrl:];]'
+    ),
+    CONSTRAINT gha_cache_garbage_size CHECK (
+        size_bytes BETWEEN 0 AND 134217728
+    ),
+    CONSTRAINT gha_cache_garbage_time CHECK (queued_at_seconds >= 0)
+);
+
+CREATE INDEX gha_cache_garbage_order
+    ON github_actions_cache_garbage (queued_at_seconds, object_key);

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -185,6 +185,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0045_runner_certificate_renewal.sql",
         "ee79d5ee0481d72ba62d527da49817cf97b8340203ec8fa8be2cc0abcf615fade1f5854bf155487535666cd956e1181a",
     ),
+    (
+        "0046_github_actions_cache_garbage.sql",
+        "be9b180b7b989138962eb7e9f945611ecc2a6da1d7c89a2addf79c3651075f0e73f2e63c4492395788ce1a699df9b4ad",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -472,6 +476,32 @@ fn runner_certificate_renewal_is_bounded_exact_and_immutable_while_replayable() 
         assert!(
             !source.contains(forbidden),
             "runner-certificate renewal migration retained compatibility surface: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn github_actions_cache_garbage_is_exact_bounded_and_durable() {
+    let source = include_str!("../migrations/0046_github_actions_cache_garbage.sql");
+
+    for required in [
+        "CREATE TABLE github_actions_cache_garbage",
+        "object_key text PRIMARY KEY",
+        "octet_length(digest) = 32",
+        "size_bytes BETWEEN 0 AND 134217728",
+        "queued_at_seconds >= 0",
+        "CREATE INDEX gha_cache_garbage_order",
+        "(queued_at_seconds, object_key)",
+    ] {
+        assert!(
+            source.contains(required),
+            "cache-garbage migration lost required contract: {required}"
+        );
+    }
+    for forbidden in ["IF NOT EXISTS", "ON DELETE", "DEFAULT"] {
+        assert!(
+            !source.contains(forbidden),
+            "cache-garbage migration retained compatibility surface: {forbidden}"
         );
     }
 }

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -16,8 +16,8 @@ use automata_ci_auth_postgres::{
     PostgresDelegatedActorResolver, PostgresHumanRbacManagementRepository,
     PostgresRunnerEnrollmentRepository,
 };
-use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType};
-use automata_ci_blob_s3::S3BlobStoreConfigError;
+use automata_ci_blob::{BlobKey, BlobPayload, ImmutableBlobStore, MediaType, ReclaimableBlobStore};
+use automata_ci_blob_s3::{S3BlobStore, S3BlobStoreConfigError};
 use automata_ci_control::lease::{
     LeaseClock, LeaseIdGenerator, RandomLeaseIdGenerator, RunnableScanLimit, SystemLeaseClock,
     repository::RunnerLeaseRequestRepository,
@@ -270,7 +270,8 @@ impl ProductionComponents {
         metrics: &ControlPlaneMetrics,
     ) -> Result<Self, ServerCompositionError> {
         let tls = load_server_tls(config)?;
-        let blob_store = build_blob_store(config)?;
+        let reclaimable_blob_store = build_blob_store(config)?;
+        let blob_store: Arc<dyn ImmutableBlobStore> = reclaimable_blob_store.clone();
         let DatabaseBuild {
             store,
             control_plane_key_provider,
@@ -570,7 +571,7 @@ impl ProductionComponents {
         let (results_api, results_runtime_authority_issuer) = build_results(
             config,
             store.as_ref(),
-            blob_store.clone(),
+            reclaimable_blob_store,
             cache_repositories,
             metrics,
         )?;
@@ -910,7 +911,7 @@ async fn build_github_provider_runtime(
 fn build_results(
     config: &ServerConfig,
     store: &PostgresStore,
-    blob_store: Arc<dyn ImmutableBlobStore>,
+    blob_store: Arc<dyn ReclaimableBlobStore>,
     cache_repositories: Vec<CacheRepositoryMetadata>,
     metrics: &ControlPlaneMetrics,
 ) -> Result<
@@ -954,23 +955,31 @@ fn build_results(
         repository,
         Arc::clone(&observer),
     ));
-    let blob_store: Arc<dyn ImmutableBlobStore> = Arc::new(ObservedResultsBlobStore::new(
+    let blob_store = Arc::new(ObservedResultsBlobStore::new(
         blob_store,
         Arc::clone(&observer),
     ));
+    let cache_objects: Arc<dyn ReclaimableBlobStore> = blob_store.clone();
+    let artifact_objects: Arc<dyn ImmutableBlobStore> = blob_store;
     let ids: Arc<dyn ResultsIdGenerator> = Arc::new(SystemResultsIdGenerator);
     let cache_repository: Arc<dyn CacheRepository> =
         Arc::new(PostgresCacheRepository::new(store.postgres_pool().clone()));
     let cache_service = Arc::new(CacheService::new(
         cache_repository,
-        Arc::clone(&blob_store),
+        cache_objects,
         Arc::clone(&clock),
         Arc::clone(&ids),
         CacheLimits::default(),
     ));
     let service = Arc::new(
-        ArtifactService::new(repository, blob_store, clock, ids, ResultsLimits::default())
-            .with_observer(Arc::clone(&observer)),
+        ArtifactService::new(
+            repository,
+            artifact_objects,
+            clock,
+            ids,
+            ResultsLimits::default(),
+        )
+        .with_observer(Arc::clone(&observer)),
     );
     let runtime_tokens = authority.clone();
     let upload_capabilities = authority.clone();
@@ -1849,9 +1858,7 @@ impl ReadinessProbe for ImmutableBlobReadinessProbe {
     }
 }
 
-fn build_blob_store(
-    config: &ServerConfig,
-) -> Result<Arc<dyn ImmutableBlobStore>, ServerCompositionError> {
+fn build_blob_store(config: &ServerConfig) -> Result<Arc<S3BlobStore>, ServerCompositionError> {
     let store = crate::object_store::connect(&config.s3).map_err(|error| match error {
         crate::object_store::ObjectStoreConnectionError::Secret(error) => {
             ServerCompositionError::Secret(error)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,12 @@ transactions and fencing rather than process-local locks.
 
 S3-compatible storage owns immutable workflow and action bundles, log segments,
 artifacts, cache objects, and final manifests. It is not used for coordination.
+Cache quota and retention eviction first records unreachable object descriptors
+in a PostgreSQL outbox in the same transaction that removes their readable
+metadata. Either control-plane replica may then perform idempotent deletion and
+acknowledge the exact descriptor. A crash between those steps leaves durable
+work for the next cache request instead of leaking storage or exposing a missing
+object through live metadata.
 
 Scheduled GitHub workflows use a separate durable path from webhooks. A
 manifest-pinned discovery claim binds an owner-bound provider revision, exact


### PR DESCRIPTION
## Summary

- atomically queue exact immutable cache-object descriptors whenever PostgreSQL evicts cache metadata
- drain the durable outbox through idempotent S3 deletion from either control-plane replica
- cover quota eviction, retention cleanup, pending-entry cleanup, and entry-count eviction
- document the crash-safe and replica-safe reclamation contract

## Production incident

The 10 GiB logical cache quota evicted PostgreSQL metadata but left the corresponding S3 objects behind. The cache prefix reached about 91 GiB and filled the storage volume, which caused PostgreSQL checkpoint failures and CI result/log commit failures. The disposable stale objects and metadata have been cleared; this PR removes the structural leak.

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo check --locked for automata-ci, automata-ci-results-github, and automata-ci-blob-s3
- exact critical PR Rust library suite
- memory blob reclamation contract
- cache HTTP garbage-drain test
- storage observability tests
- migration layout/checksum tests
- real PostgreSQL cache transaction/quota-eviction integration test
- live RustFS delete/idempotency contract compiled and extended