### PR TITLE
fix(ci): recalibrate expanded Rust coverage scope

### DIFF
--- a/scripts/ci/rust-coverage-policy.json
+++ b/scripts/ci/rust-coverage-policy.json
@@ -79,13 +79,13 @@
     }
   },
   "ordinary_guard": {
-    "line_percent_floor": 82.0,
-    "minimum_measured_lines": 172000,
+    "line_percent_floor": 81.0,
+    "minimum_measured_lines": 246000,
     "reviewed_baseline": {
-      "covered_lines": 145319,
-      "measured_lines": 175150,
-      "line_percent": 82.96831287467884,
-      "report_date": "2026-08-11"
+      "covered_lines": 202158,
+      "measured_lines": 246784,
+      "line_percent": 81.91698003112033,
+      "report_date": "2026-08-17"
     }
   }
 }

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import fcntl
 import hashlib
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -133,7 +134,8 @@ def synthetic_workspace_reports(
     ordinary_covered: int,
 ) -> None:
     configuration = json.loads(policy_path.read_text(encoding="utf-8"))
-    sources = [("crates/core/src/lib.rs", ordinary_covered, 172_000)]
+    minimum_measured_lines = configuration["ordinary_guard"]["minimum_measured_lines"]
+    sources = [("crates/core/src/lib.rs", ordinary_covered, minimum_measured_lines)]
     for lane, lane_policy in configuration["lanes"].items():
         if lane == "ordinary":
             continue
@@ -657,13 +659,22 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
             encoding="utf-8",
         )
         runner_fake_mv.chmod(0o755)
+        runner_policy = json.loads(
+            (runner_ci / "rust-coverage-policy.json").read_text(encoding="utf-8")
+        )
+        runner_minimum_measured = runner_policy["ordinary_guard"][
+            "minimum_measured_lines"
+        ]
+        runner_floor = runner_policy["ordinary_guard"]["line_percent_floor"]
+        passing_covered = math.ceil(runner_minimum_measured * runner_floor / 100)
+        failing_covered = passing_covered - 1
         synthetic_summary = scratch / "synthetic-summary.json"
         synthetic_lcov = scratch / "synthetic-coverage.lcov"
         synthetic_workspace_reports(
             runner_ci / "rust-coverage-policy.json",
             synthetic_summary,
             synthetic_lcov,
-            141_040,
+            passing_covered,
         )
         runner_environment = dict(os.environ)
         runner_environment["PATH"] = f"{runner_fake_bin}:{runner_environment['PATH']}"
@@ -708,7 +719,7 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
             runner_ci / "rust-coverage-policy.json",
             failed_summary,
             failed_lcov,
-            140_000,
+            failing_covered,
         )
         combined_environment = dict(runner_environment)
         combined_environment["AUTOMATA_TEST_DATABASE_URL"] = (
@@ -1006,7 +1017,9 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
 
         invalid_lcov = scratch / "synthetic-invalid.lcov"
         invalid_lcov.write_text(
-            synthetic_lcov.read_text(encoding="utf-8").replace("LH:141040", "LH:1", 1),
+            synthetic_lcov.read_text(encoding="utf-8").replace(
+                f"LH:{passing_covered}", "LH:1", 1
+            ),
             encoding="utf-8",
         )
         invalid_environment = dict(runner_environment)


### PR DESCRIPTION
The ordinary Rust coverage report now measures 246,784 lines after the remapped-path and generated-output fixes, versus the 175,150-line reviewed baseline. The first complete main run against that corrected scope measured 202,158 covered lines (81.91698%), narrowly below the stale 82% floor.

This refreshes the reviewed baseline from the exact `926642c1` coverage artifact, raises the minimum measured-line guard from 172,000 to 246,000, and restores the original approximate one-percentage-point regression budget with an 81% floor. The contract fixture now derives its pass/fail boundary from the production policy instead of hard-coded historical counts.

Validated with the coverage policy contract suite and by rechecking the exact failed `rust-coverage-ordinary` artifact, which now reports `guard=passed`.