### PR TITLE
Fix APFS runner cache reopen and macOS validation

### DIFF
--- a/crates/automata-ci-runner/src/product/action_cache/archive_cache.rs
+++ b/crates/automata-ci-runner/src/product/action_cache/archive_cache.rs
@@ -147,7 +147,10 @@ impl FileActionArchiveCache {
     ) -> Result<Self, BlobStoreError> {
         fs::create_dir_all(root.as_path()).map_err(|_| unavailable())?;
         let metadata = fs::symlink_metadata(root.as_path()).map_err(|_| unavailable())?;
-        if !metadata.file_type().is_dir() || metadata.nlink() != 2 {
+        // Directory link counts are filesystem-specific and can change when
+        // cache files are added. `symlink_metadata` still keeps symlink and
+        // non-directory roots fail-closed without interpreting that count.
+        if !metadata.file_type().is_dir() {
             return Err(integrity());
         }
         fs::set_permissions(root.as_path(), fs::Permissions::from_mode(0o700))

--- a/crates/automata-ci-runner/src/product/action_cache/tests/archive.rs
+++ b/crates/automata-ci-runner/src/product/action_cache/tests/archive.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    os::unix::fs::symlink,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -15,7 +16,7 @@ use bytes::Bytes;
 static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(1);
 
 #[tokio::test]
-async fn archive_bytes_survive_reopen_and_are_verified() {
+async fn archive_cache_reopens_with_lock_and_archive_content() {
     let scratch = Scratch::new("reopen");
     let payload = payload(b"immutable action archive");
     let descriptor = payload.descriptor().clone();
@@ -27,9 +28,36 @@ async fn archive_bytes_survive_reopen_and_are_verified() {
             PutBlobOutcome::Created
         );
     }
+    assert!(scratch.path().join(".action-archive-cache.lock").is_file());
+    assert!(
+        scratch
+            .path()
+            .join(format!("action-archive-v1-{}.tar.gz", descriptor.digest()))
+            .is_file()
+    );
     let reopened = FileActionArchiveCache::open(scratch.root(), limits).unwrap();
     let loaded = reopened.get_verified(&descriptor, 1024).await.unwrap();
     assert_eq!(loaded.bytes().as_ref(), b"immutable action archive");
+}
+
+#[test]
+fn archive_cache_rejects_non_directory_and_symlink_roots() {
+    let scratch = Scratch::new("unsafe-roots");
+    fs::create_dir_all(scratch.path()).unwrap();
+
+    let file_root = scratch.path().join("file-root");
+    fs::write(&file_root, b"not a directory").unwrap();
+    let file_root = ActionArchiveCacheRoot::explicit(file_root).unwrap();
+    assert!(FileActionArchiveCache::open(file_root, ActionArchiveCacheLimits::default()).is_err());
+
+    let target = scratch.path().join("target");
+    fs::create_dir(&target).unwrap();
+    let symlink_root = scratch.path().join("symlink-root");
+    symlink(&target, &symlink_root).unwrap();
+    let symlink_root = ActionArchiveCacheRoot::explicit(symlink_root).unwrap();
+    let error = FileActionArchiveCache::open(symlink_root, ActionArchiveCacheLimits::default())
+        .unwrap_err();
+    assert_eq!(error.kind(), BlobStoreErrorKind::Integrity);
 }
 
 #[tokio::test]
@@ -114,6 +142,10 @@ impl Scratch {
 
     fn root(&self) -> ActionArchiveCacheRoot {
         ActionArchiveCacheRoot::explicit(self.0.clone()).unwrap()
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
     }
 }
 

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -236,6 +236,10 @@ async fn run_local_docker(
 }
 
 #[cfg(not(target_os = "linux"))]
+#[allow(
+    clippy::unused_async,
+    reason = "the platform stub preserves the shared async provider dispatch contract"
+)]
 async fn run_local_docker(
     _config: &RunnerProductConfig,
     _shutdown: RunnerShutdown,

--- a/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
+++ b/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
@@ -34,10 +34,11 @@ use automata_ci_protocol::{
     CommandAck, CommandCursor, CommandSequence, JobResultMessage, JobRuntimeAuthorities,
     LeaseDisposition, LeaseOffer, LeaseRenewal, LeaseRequest, LogAckMessage, LogBatch,
     MessageHeader, NegotiatedSession, NoWork, OperationAck, ProtocolLimits, RunnerSlotOrdinal,
-    RunnerToServer, SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming,
-    ServerToRunner, SessionDisposition,
+    RunnerToServer, RuntimeAuthorityAck, RuntimeAuthorityGrant, RuntimeAuthorityRequest,
+    SUPPORTED_PROTOCOL_RANGE, ServerCommandHeader, ServerHello, ServerTiming, ServerToRunner,
+    SessionDisposition,
 };
-use automata_ci_protocol_protobuf::encode_job_runtime_context;
+use automata_ci_protocol_protobuf::{encode_job_runtime_context, encode_runtime_authorities};
 use automata_ci_runner::product::RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION;
 use automata_ci_runner_transport::{
     ApplicationError, ApplicationErrorKind, AuthenticatedRunnerRequest, HandlerFuture,
@@ -199,6 +200,15 @@ async fn shipped_runner_process_executes_a_claimed_isolated_shell_job() {
         observation.command_cursor,
         Some(handler.offer_cursor()),
         "runner did not durably acknowledge the offered command cursor"
+    );
+    assert!(
+        observation.runtime_authority_progress != RuntimeAuthorityProgress::NotRequested,
+        "runner did not request the post-accept runtime-authority bundle"
+    );
+    assert_eq!(
+        observation.runtime_authority_progress,
+        RuntimeAuthorityProgress::Acknowledged,
+        "runner did not acknowledge durable adoption of the runtime-authority bundle"
     );
     assert_eq!(observation.conclusion, Some(JobConclusion::Success));
     let logs = String::from_utf8_lossy(&observation.logs);
@@ -617,9 +627,18 @@ struct ProcessObservation {
     hello_operating_system: Option<OperatingSystem>,
     accepted: bool,
     command_cursor: Option<CommandCursor>,
+    runtime_authority_progress: RuntimeAuthorityProgress,
     logs: Vec<u8>,
     conclusion: Option<JobConclusion>,
     completed_poll: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum RuntimeAuthorityProgress {
+    #[default]
+    NotRequested,
+    Requested,
+    Acknowledged,
 }
 
 #[derive(Debug)]
@@ -628,6 +647,7 @@ struct ProcessFlowHandler {
     session_id: RunnerSessionId,
     lease: Lease,
     offer: LeaseOffer,
+    authorities: JobRuntimeAuthorities,
     state: Mutex<ProcessFlowState>,
     result_ready: tokio::sync::Notify,
     completed_poll: tokio::sync::Notify,
@@ -658,13 +678,13 @@ impl ProcessFlowHandler {
             RunnerSlotOrdinal::new(1).expect("slot"),
             lease.clone(),
             job,
-            authorities,
         );
         Self {
             runner_id,
             session_id,
             lease,
             offer,
+            authorities,
             state: Mutex::new(ProcessFlowState::default()),
             result_ready: tokio::sync::Notify::new(),
             completed_poll: tokio::sync::Notify::new(),
@@ -747,6 +767,10 @@ impl ProcessFlowHandler {
                     reply_header(response.header()),
                 )))
             }
+            RunnerToServer::RuntimeAuthorityRequest(request) => {
+                self.handle_runtime_authority_request(request)
+            }
+            RunnerToServer::RuntimeAuthorityAck(ack) => self.handle_runtime_authority_ack(*ack),
             RunnerToServer::Heartbeat(heartbeat) => {
                 if heartbeat.attempt_id() != self.lease.attempt_id()
                     || heartbeat.guard() != self.lease.guard()
@@ -774,6 +798,64 @@ impl ProcessFlowHandler {
             RunnerToServer::JobResult(result) => self.handle_job_result(result),
             RunnerToServer::CommandAck(ack) => self.handle_command_ack(*ack),
         }
+    }
+
+    fn runtime_authority_bundle_digest(&self) -> Result<Sha256Digest, ApplicationError> {
+        let encoded = encode_runtime_authorities(
+            &self.authorities,
+            self.offer.job(),
+            self.offer.lease(),
+            &ProtocolLimits::default(),
+        )
+        .map_err(|_| internal_application_error())?;
+        Ok(Sha256Digest::from_bytes(Sha256::digest(&encoded).into()))
+    }
+
+    fn handle_runtime_authority_request(
+        &self,
+        request: &RuntimeAuthorityRequest,
+    ) -> Result<ServerToRunner, ApplicationError> {
+        request
+            .binding()
+            .validate_for_offer(&self.offer)
+            .map_err(|_| internal_application_error())?;
+        let bundle_digest = self.runtime_authority_bundle_digest()?;
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if !state.observation.accepted {
+            return Err(internal_application_error());
+        }
+        if state.observation.runtime_authority_progress == RuntimeAuthorityProgress::NotRequested {
+            state.observation.runtime_authority_progress = RuntimeAuthorityProgress::Requested;
+        }
+        Ok(ServerToRunner::RuntimeAuthorityGrant(Box::new(
+            RuntimeAuthorityGrant::new(
+                reply_header(request.header()),
+                request.binding(),
+                bundle_digest,
+                self.authorities.clone(),
+            ),
+        )))
+    }
+
+    fn handle_runtime_authority_ack(
+        &self,
+        acknowledgement: RuntimeAuthorityAck,
+    ) -> Result<ServerToRunner, ApplicationError> {
+        acknowledgement
+            .binding()
+            .validate_for_offer(&self.offer)
+            .map_err(|_| internal_application_error())?;
+        if acknowledgement.bundle_digest() != self.runtime_authority_bundle_digest()? {
+            return Err(internal_application_error());
+        }
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if state.observation.runtime_authority_progress == RuntimeAuthorityProgress::NotRequested {
+            return Err(internal_application_error());
+        }
+        state.observation.runtime_authority_progress = RuntimeAuthorityProgress::Acknowledged;
+        Ok(ServerToRunner::OperationAck(OperationAck::new(
+            reply_header(acknowledgement.header()),
+        )))
     }
 
     fn handle_lease_request(


### PR DESCRIPTION
## Outcome

Allow the runner's local action-archive cache to reopen reliably on APFS after it creates its lock file or stores archives. APFS changes a directory's reported link count as entries are added, so requiring an exact link count caused the next runner startup to fail with an integrity error even though the cache contents were valid.

Also bring the physical macOS runner E2E fixture up to the current post-accept runtime-authority request/grant/acknowledgement protocol, and keep the non-Linux LocalDocker platform stub clean under the runner's strict all-target Clippy gate.

No user-facing documentation changes are needed: commands and configuration are unchanged.

## Related issue

None.

## Trust and compatibility impact

Storage validation changes only for the archive-cache root directory: it no longer treats a filesystem-specific directory link count as an integrity signal. `symlink_metadata` and the real-directory requirement remain, and lock/archive files continue to use no-follow opens plus regular-file and single-link validation. Regression coverage verifies populated-cache reopen and rejects file and symlink roots.

The production runner protocol is unchanged. The macOS E2E fake control plane now implements the existing runtime-authority delivery sequence, validates the exact offer binding and canonical bundle digest, rejects acknowledgement before request, and preserves idempotent request replay.

There are no credential, isolation-model, release, dependency, or GitHub Actions compatibility changes.

## Verification

- `cargo fmt --all -- --check` — passed.
- `cargo build --locked` — passed on Apple Silicon macOS.
- `cargo test --locked -p automata-ci-runner --lib -- --test-threads=1` — 108 passed.
- `cargo test --locked -p automata-ci-runner --test runner -- --test-threads=1` — 48 passed; 1 physical sealed-VM E2E ignored.
- `cargo clippy --locked -p automata-ci-runner --all-targets --no-deps -- -D warnings` — passed; existing dependency-only Podman dead-code warnings remain.
- Preview `/healthz` and `/readyz` — healthy from commit `054aff11a8fae8258b54500f6eba2493663f0c4b`.
- `automata-runner doctor --server http://127.0.0.1:8180 --json` — process execution usable and preview healthy.

The ignored physical-VM E2E was not run because this host does not have a Developer ID-signed helper, sealed macOS VM template, or the required dedicated 256-GiB APFS volume. The full workspace baseline was not run because the workspace contains Linux-only targets that intentionally reject macOS compilation; validation was scoped to the owning runner package and the supported default Mac build.

## AI assistance

OpenAI Codex materially assisted with diagnosing the APFS portability failure, updating the test control-plane fixture, implementing the fixes, and running macOS validation. The complete diff and its trust-boundary implications were reviewed before submission.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
