### PR TITLE
fix(ci): bound coverage memory pressure

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Lint workflows and shell scripts
         run: |
           ./scripts/ci/install-actionlint.sh target/ci-tools
-          target/ci-tools/actionlint .ci/workflows/*.yml
+          ./scripts/ci/lint-workflows.sh
           shellcheck -x \
             scripts/install.sh \
             scripts/ci/*.sh \
@@ -270,6 +270,9 @@ jobs:
     name: Rust coverage and PostgreSQL invariants
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    resources:
+      limits:
+        memory: 4Gi
     services:
       postgres:
         image: docker.io/library/postgres@sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568
@@ -291,6 +294,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      RUST_TEST_THREADS: "4"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:

--- a/.ci/workflows/pull-request.yml
+++ b/.ci/workflows/pull-request.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Validate workflow syntax
         run: |
           ./scripts/ci/install-actionlint.sh target/ci-tools
-          target/ci-tools/actionlint .ci/workflows/*.yml
+          ./scripts/ci/lint-workflows.sh
 
   frontend:
     name: Critical frontend checks

--- a/scripts/ci/lint-workflows.sh
+++ b/scripts/ci/lint-workflows.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+actionlint="$repository_root/target/ci-tools/actionlint"
+if [[ ! -x "$actionlint" ]]; then
+  printf 'error: install actionlint before linting workflows\n' >&2
+  exit 2
+fi
+
+# `resources` is Automata's validated per-job resource extension. Keep all of
+# actionlint's GitHub dialect checks while admitting exactly that extra key.
+"$actionlint" \
+  -ignore '^unexpected key "resources" for "job" section\.' \
+  "$repository_root"/.ci/workflows/*.yml

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -234,6 +234,15 @@ def fingerprint(repository: Path) -> tuple[str, str, str, str]:
 
 
 def main() -> None:
+    workflow = (ROOT.parent / ".ci" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    coverage_job = workflow.split("  rust_coverage:\n", 1)[1].split(
+        "\n  results_client_acceptance:", 1
+    )[0]
+    assert "    resources:\n      limits:\n        memory: 4Gi\n" in coverage_job
+    assert '      RUST_TEST_THREADS: "4"\n' in coverage_job
+
     scratch_root = ROOT.parent / "target" / "task-tmp"
     scratch_root.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="rust-coverage-contract-", dir=scratch_root) as raw:


### PR DESCRIPTION
The full main coverage job exceeded the default 2 GiB service-container cgroup on the 96-core Hetzner runner. PostgreSQL was OOM-killed after reaching the exact cgroup limit, which made the run red after the coverage policy itself had passed.

- give the coverage job an explicit 4 GiB memory limit
- bound Rust test concurrency to four threads
- retain actionlint for the GitHub dialect while admitting Automata’s validated per-job `resources` extension
- lock the resource contract in the coverage test

Locally verified with the coverage contract, actionlint, and shellcheck.