### PR TITLE
feat(release): bind local installation catalog

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -108,9 +108,11 @@ jobs:
           ./scripts/ci/tests/container-context.test.sh
           ./scripts/ci/tests/install.test.sh
           python3 scripts/ci/tests/integration-test-targets.test.py
+          python3 scripts/ci/tests/local-installation-catalog.test.py
           python3 scripts/ci/tests/release-handoff.test.py
           python3 scripts/ci/tests/rust-build-cache.test.py
           python3 scripts/ci/tests/rust-coverage.test.py
+          ./scripts/ci/tests/sandbox-guest-image.test.sh
           python3 scripts/ci/tests/service-proxy-buildah-containerfile.test.py
           python3 scripts/ci/tests/service-proxy-candidate.test.py
           ./scripts/ci/tests/service-proxy-image.test.sh
@@ -722,6 +724,7 @@ jobs:
           AUTOMATA_SCRATCH_RUNTIME: docker
         run: |
           ./scripts/ci/verify-static-musl.sh
+          ./scripts/ci/verify-sandbox-guest-static.sh
           ./scripts/ci/verify-service-proxy-static.sh
 
       - name: Generate binary and embedded-runtime SBOMs
@@ -738,6 +741,18 @@ jobs:
           diff --recursive --brief \
             target/distribution-input/licenses \
             target/third-party-license-reproduction
+
+      - name: Prepare and verify sandbox-guest image
+        run: |
+          ./scripts/ci/prepare-sandbox-guest-context.sh \
+            target/sandbox-guest-context \
+            "$AUTOMATA_EXPECTED_VERSION"
+          ./scripts/ci/verify-sandbox-guest-image.sh \
+            target/sandbox-guest-context \
+            "$AUTOMATA_EXPECTED_VERSION" \
+            "$AUTOMATA_EXPECTED_GIT_SHA" \
+            "$AUTOMATA_RELEASE_CREATED" \
+            "$SOURCE_DATE_EPOCH"
 
       - name: Package and reproduce deterministic distribution
         run: |

--- a/.ci/workflows/release.yml
+++ b/.ci/workflows/release.yml
@@ -192,12 +192,13 @@ jobs:
       handoff_sha256: ${{ steps.handoff.outputs.handoff_sha256 }}
       manifest_sha256: ${{ steps.handoff.outputs.manifest_sha256 }}
       runner_digest: ${{ steps.images.outputs.runner_digest }}
+      sandbox_guest_digest: ${{ steps.images.outputs.sandbox_guest_digest }}
       service_proxy_candidate_artifact_digest: ${{ steps.upload-service-proxy.outputs.artifact-digest }}
       service_proxy_candidate_artifact_id: ${{ steps.upload-service-proxy.outputs.artifact-id }}
-      service_proxy_candidate_filename: ${{ steps.service-proxy-candidate.outputs.candidate_filename }}
-      service_proxy_candidate_sha256: ${{ steps.service-proxy-candidate.outputs.candidate_sha256 }}
-      service_proxy_image_digest: ${{ steps.service-proxy-candidate.outputs.image_digest }}
-      service_proxy_provenance_sha256: ${{ steps.service-proxy-candidate.outputs.provenance_sha256 }}
+      service_proxy_candidate_filename: ${{ steps.selected-service-proxy-candidate.outputs.candidate_filename }}
+      service_proxy_candidate_sha256: ${{ steps.selected-service-proxy-candidate.outputs.candidate_sha256 }}
+      service_proxy_image_digest: ${{ steps.selected-service-proxy-candidate.outputs.image_digest }}
+      service_proxy_provenance_sha256: ${{ steps.selected-service-proxy-candidate.outputs.provenance_sha256 }}
     permissions:
       artifact-metadata: write
       attestations: write
@@ -289,6 +290,7 @@ jobs:
         run: |
           ./scripts/ci/build-static-musl.sh
           AUTOMATA_SCRATCH_RUNTIME=docker ./scripts/ci/verify-static-musl.sh
+          ./scripts/ci/verify-sandbox-guest-static.sh
           ./scripts/ci/verify-service-proxy-static.sh
 
       - name: Generate release metadata
@@ -396,9 +398,13 @@ jobs:
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           archive_name="${archive##*/}"
           checksum_name="${checksum##*/}"
           manifest_name="${manifest##*/}"
+          catalog_name="${catalog##*/}"
+          service_proxy_candidate_name="${service_proxy_candidate##*/}"
           prerelease_args=()
           case "$RELEASE_PRERELEASE" in
             true) prerelease_args=(--prerelease) ;;
@@ -433,7 +439,8 @@ jobs:
                   f"draft release contains unexpected assets: {unexpected!r}"
               )
           ' "$RELEASE_PRERELEASE" \
-            "$archive_name" "$checksum_name" "$manifest_name"
+            "$archive_name" "$checksum_name" "$manifest_name" \
+            "$catalog_name" "$service_proxy_candidate_name"
           }
 
           require_base_draft_assets() {
@@ -456,7 +463,8 @@ jobs:
                   f"draft release assets are not recoverable: {sorted(actual)!r}"
               )
           ' "$RELEASE_PRERELEASE" \
-            "$archive_name" "$checksum_name" "$manifest_name"
+            "$archive_name" "$checksum_name" "$manifest_name" \
+            "$catalog_name" "$service_proxy_candidate_name"
           }
 
           verify_remote_release_assets() (
@@ -501,6 +509,8 @@ jobs:
             gh release view "$RELEASE_TAG" --json assets \
               --jq '.assets[].name' > "$assets_file"
             mapfile -t existing_assets < "$assets_file"
+            candidate_present=false
+            catalog_present=false
             manifest_present=false
             missing_assets=()
             for expected_path in "$archive" "$checksum"; do
@@ -522,10 +532,21 @@ jobs:
               gh release upload "$RELEASE_TAG" "${missing_assets[@]}"
             fi
             for existing_asset in "${existing_assets[@]}"; do
-              if [[ "$existing_asset" == "$manifest_name" ]]; then
-                manifest_present=true
-              fi
+              case "$existing_asset" in
+                "$catalog_name") catalog_present=true ;;
+                "$service_proxy_candidate_name") candidate_present=true ;;
+                "$manifest_name") manifest_present=true ;;
+              esac
             done
+            if [[ "$catalog_present" == true && "$candidate_present" != true ]]; then
+              printf 'error: draft catalog has no preceding candidate binding\n' >&2
+              exit 1
+            fi
+            if [[ "$manifest_present" == true ]] && \
+              [[ "$catalog_present" != true || "$candidate_present" != true ]]; then
+              printf 'error: draft manifest has incomplete prerequisite bindings\n' >&2
+              exit 1
+            fi
           else
             gh release create "$RELEASE_TAG" \
               --draft \
@@ -534,11 +555,17 @@ jobs:
               --title "Automata ${RELEASE_VERSION}" \
               --verify-tag \
               "$archive" "$checksum"
+            candidate_present=false
+            catalog_present=false
             manifest_present=false
           fi
           require_base_draft_assets
           verify_remote_release_assets
-          printf 'manifest_present=%s\n' "$manifest_present" >> "$GITHUB_OUTPUT"
+          {
+            printf 'candidate_present=%s\n' "$candidate_present"
+            printf 'catalog_present=%s\n' "$catalog_present"
+            printf 'manifest_present=%s\n' "$manifest_present"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Attest accepted release archive bytes
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -547,14 +574,9 @@ jobs:
             target/distribution/automata-x86_64-unknown-linux-musl.tar.gz
             target/distribution/automata-x86_64-unknown-linux-musl.tar.gz.sha256
 
-      - name: Attest unpublished service-proxy candidate bytes
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: target/service-proxy-publication/${{ steps.service-proxy-candidate.outputs.candidate_filename }}
-
-      - name: Recover immutable image binding from the draft
+      - name: Recover immutable release binding from the draft
         id: recovered
-        if: ${{ steps.draft.outputs.manifest_present == 'true' }}
+        if: ${{ steps.draft.outputs.candidate_present == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_COMMIT: ${{ needs.gate.outputs.commit }}
@@ -565,21 +587,63 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
         run: |
+          recovery_directory="$(mktemp -d "${TMPDIR%/}/release-binding.XXXXXXXX")"
+          trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$recovery_directory"' EXIT
+          patterns=(
+            --pattern automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar
+          )
+          if [[ "${{ steps.draft.outputs.catalog_present }}" == true ]]; then
+            patterns+=(--pattern automata-local-installation-catalog.json)
+          fi
+          if [[ "${{ steps.draft.outputs.manifest_present }}" == true ]]; then
+            patterns+=(--pattern automata-release-manifest.json)
+          fi
           gh release download "$RELEASE_TAG" \
-            --dir target/distribution \
-            --pattern automata-release-manifest.json
-          env -u GH_TOKEN -u GITHUB_TOKEN \
-            python3 scripts/ci/release-handoff.py verify-manifest \
-              --repository-root . \
-              --manifest target/distribution/automata-release-manifest.json \
-              --tag "$RELEASE_TAG" \
-              --tag-object "$RELEASE_TAG_OBJECT" \
-              --commit "$RELEASE_COMMIT" \
-              --version "$RELEASE_VERSION" \
-              --prerelease "$RELEASE_PRERELEASE" \
-              --source-date-epoch "$RELEASE_SOURCE_DATE_EPOCH" \
-              --created "$RELEASE_CREATED" \
-              --github-output "$GITHUB_OUTPUT"
+            --dir "$recovery_directory" \
+            "${patterns[@]}"
+          cmp -- \
+            target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+            "$recovery_directory/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
+          if [[ "${{ steps.draft.outputs.catalog_present }}" == true ]]; then
+            gh attestation verify \
+              "$recovery_directory/automata-local-installation-catalog.json" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.ci/workflows/release.yml" \
+              --source-digest "$RELEASE_COMMIT" \
+              --source-ref "refs/tags/$RELEASE_TAG" \
+              --deny-self-hosted-runners
+            install -m 0444 -- \
+              "$recovery_directory/automata-local-installation-catalog.json" \
+              target/distribution/automata-local-installation-catalog.json
+            env -u GH_TOKEN -u GITHUB_TOKEN \
+              python3 scripts/ci/local_installation_catalog.py verify \
+                --repository-root . \
+                --catalog target/distribution/automata-local-installation-catalog.json \
+                --tag "$RELEASE_TAG" \
+                --tag-object "$RELEASE_TAG_OBJECT" \
+                --commit "$RELEASE_COMMIT" \
+                --version "$RELEASE_VERSION" \
+                --prerelease "$RELEASE_PRERELEASE" \
+                --source-date-epoch "$RELEASE_SOURCE_DATE_EPOCH" \
+                --created "$RELEASE_CREATED" \
+                --github-output "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ steps.draft.outputs.manifest_present }}" == true ]]; then
+            install -m 0444 -- \
+              "$recovery_directory/automata-release-manifest.json" \
+              target/distribution/automata-release-manifest.json
+            env -u GH_TOKEN -u GITHUB_TOKEN \
+              python3 scripts/ci/release-handoff.py verify-manifest \
+                --repository-root . \
+                --manifest target/distribution/automata-release-manifest.json \
+                --tag "$RELEASE_TAG" \
+                --tag-object "$RELEASE_TAG_OBJECT" \
+                --commit "$RELEASE_COMMIT" \
+                --version "$RELEASE_VERSION" \
+                --prerelease "$RELEASE_PRERELEASE" \
+                --source-date-epoch "$RELEASE_SOURCE_DATE_EPOCH" \
+                --created "$RELEASE_CREATED"
+          fi
           printf 'present=true\n' >> "$GITHUB_OUTPUT"
 
       - name: Prepare and verify image build context
@@ -589,6 +653,14 @@ jobs:
           ./scripts/ci/prepare-container-context.sh \
             target/distribution/automata-x86_64-unknown-linux-musl.tar.gz \
             target/container-release \
+            "$RELEASE_VERSION"
+
+      - name: Prepare sandbox-guest image build context
+        env:
+          RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+        run: |
+          ./scripts/ci/prepare-sandbox-guest-context.sh \
+            target/sandbox-guest-context \
             "$RELEASE_VERSION"
 
       - name: Sign in to GHCR
@@ -623,10 +695,11 @@ jobs:
           }
           require_absent_tag ghcr.io/automata-ci/automata
           require_absent_tag ghcr.io/automata-ci/automata-runner
+          require_absent_tag ghcr.io/automata-ci/automata-sandbox-guest
 
       - name: Build and publish Automata image
         id: automata-image
-        if: ${{ steps.draft.outputs.manifest_present != 'true' }}
+        if: ${{ steps.draft.outputs.catalog_present != 'true' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: target/container-release
@@ -643,7 +716,7 @@ jobs:
 
       - name: Build and publish runner image
         id: runner-image
-        if: ${{ steps.draft.outputs.manifest_present != 'true' }}
+        if: ${{ steps.draft.outputs.catalog_present != 'true' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: target/container-release
@@ -658,11 +731,29 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Build and publish sandbox-guest image
+        id: sandbox-guest-image
+        if: ${{ steps.draft.outputs.catalog_present != 'true' }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: target/sandbox-guest-context
+          file: target/sandbox-guest-context/Containerfile
+          platforms: linux/amd64
+          outputs: type=image,name=ghcr.io/automata-ci/automata-sandbox-guest,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            AUTOMATA_CREATED=${{ needs.gate.outputs.created }}
+            AUTOMATA_REVISION=${{ needs.gate.outputs.commit }}
+            AUTOMATA_VERSION=${{ needs.gate.outputs.version }}
+            SOURCE_DATE_EPOCH=${{ needs.gate.outputs.source_date_epoch }}
+          provenance: mode=max
+          sbom: true
+
       - name: Select immutable image digests
         id: images
         env:
           AUTOMATA_DIGEST: ${{ steps.recovered.outputs.automata_digest || steps.automata-image.outputs.digest }}
           RUNNER_DIGEST: ${{ steps.recovered.outputs.runner_digest || steps.runner-image.outputs.digest }}
+          SANDBOX_GUEST_DIGEST: ${{ steps.recovered.outputs.sandbox_guest_digest || steps.sandbox-guest-image.outputs.digest }}
         run: |
           [[ "$AUTOMATA_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || {
             printf 'error: invalid Automata image digest: %s\n' \
@@ -674,10 +765,98 @@ jobs:
               "$RUNNER_DIGEST" >&2
             exit 1
           }
+          [[ "$SANDBOX_GUEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            printf 'error: invalid sandbox-guest image digest: %s\n' \
+              "$SANDBOX_GUEST_DIGEST" >&2
+            exit 1
+          }
           {
             printf 'automata_digest=%s\n' "$AUTOMATA_DIGEST"
             printf 'runner_digest=%s\n' "$RUNNER_DIGEST"
+            printf 'sandbox_guest_digest=%s\n' "$SANDBOX_GUEST_DIGEST"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Create verified local-installation catalog
+        if: ${{ steps.draft.outputs.catalog_present != 'true' }}
+        env:
+          AUTOMATA_DIGEST: ${{ steps.images.outputs.automata_digest }}
+          RELEASE_COMMIT: ${{ needs.gate.outputs.commit }}
+          RELEASE_CREATED: ${{ needs.gate.outputs.created }}
+          RELEASE_PRERELEASE: ${{ needs.gate.outputs.prerelease }}
+          RELEASE_SOURCE_DATE_EPOCH: ${{ needs.gate.outputs.source_date_epoch }}
+          RELEASE_TAG: ${{ needs.gate.outputs.tag }}
+          RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
+          RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+          RUNNER_DIGEST: ${{ steps.images.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ steps.images.outputs.sandbox_guest_digest }}
+        run: |
+          evidence_directory="target/local-installation-evidence"
+          install -d -m 0700 -- "$evidence_directory"
+          capture() {
+            local role="$1"
+            local source="$2"
+            python3 scripts/ci/local_installation_catalog.py capture-registry \
+              --source "$source" \
+              --output "${evidence_directory}/${role}.json"
+          }
+          capture automata \
+            "ghcr.io/automata-ci/automata@${AUTOMATA_DIGEST}"
+          capture runner \
+            "ghcr.io/automata-ci/automata-runner@${RUNNER_DIGEST}"
+          capture sandbox-guest \
+            "ghcr.io/automata-ci/automata-sandbox-guest@${SANDBOX_GUEST_DIGEST}"
+          capture postgres \
+            "docker.io/library/postgres:18.4-bookworm@sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568"
+          capture rustfs \
+            "docker.io/rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c"
+          capture profile \
+            "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194"
+          python3 scripts/ci/local_installation_catalog.py create \
+            --repository-root . \
+            --output target/distribution/automata-local-installation-catalog.json \
+            --service-proxy-candidate \
+              target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+            --evidence "automata=${evidence_directory}/automata.json" \
+            --evidence "runner=${evidence_directory}/runner.json" \
+            --evidence "sandbox-guest=${evidence_directory}/sandbox-guest.json" \
+            --evidence "postgres=${evidence_directory}/postgres.json" \
+            --evidence "rustfs=${evidence_directory}/rustfs.json" \
+            --evidence "profile=${evidence_directory}/profile.json" \
+            --tag "$RELEASE_TAG" \
+            --tag-object "$RELEASE_TAG_OBJECT" \
+            --commit "$RELEASE_COMMIT" \
+            --version "$RELEASE_VERSION" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --source-date-epoch "$RELEASE_SOURCE_DATE_EPOCH" \
+            --created "$RELEASE_CREATED"
+
+      - name: Select the verified service-proxy candidate binding
+        id: selected-service-proxy-candidate
+        env:
+          RELEASE_COMMIT: ${{ needs.gate.outputs.commit }}
+          RELEASE_CREATED: ${{ needs.gate.outputs.created }}
+          RELEASE_PRERELEASE: ${{ needs.gate.outputs.prerelease }}
+          RELEASE_SOURCE_DATE_EPOCH: ${{ needs.gate.outputs.source_date_epoch }}
+          RELEASE_TAG: ${{ needs.gate.outputs.tag }}
+          RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
+          RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+        run: |
+          python3 scripts/ci/local_installation_catalog.py verify \
+            --repository-root . \
+            --catalog target/distribution/automata-local-installation-catalog.json \
+            --tag "$RELEASE_TAG" \
+            --tag-object "$RELEASE_TAG_OBJECT" \
+            --commit "$RELEASE_COMMIT" \
+            --version "$RELEASE_VERSION" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --source-date-epoch "$RELEASE_SOURCE_DATE_EPOCH" \
+            --created "$RELEASE_CREATED" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Attest release-scoped service-proxy candidate bytes
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: target/service-proxy-publication/${{ steps.selected-service-proxy-candidate.outputs.candidate_filename }}
 
       - name: Create immutable cross-job handoff
         id: handoff
@@ -692,6 +871,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ steps.images.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ steps.images.outputs.sandbox_guest_digest }}
         run: |
           handoff="target/release-handoff/automata-release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.tar"
           common=(
@@ -723,8 +903,14 @@ jobs:
             python3 scripts/ci/release-handoff.py create \
               "${common[@]}" \
               --automata-digest "$AUTOMATA_DIGEST" \
-              --runner-digest "$RUNNER_DIGEST"
+              --runner-digest "$RUNNER_DIGEST" \
+              --sandbox-guest-digest "$SANDBOX_GUEST_DIGEST"
           fi
+
+      - name: Attest local-installation catalog bytes
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: target/distribution/automata-local-installation-catalog.json
 
       - name: Revalidate identity before the immutable image binding
         env:
@@ -763,12 +949,33 @@ jobs:
               --version "$RELEASE_VERSION" \
               --prerelease "$RELEASE_PRERELEASE" < "$release_state"
 
-      - name: Bind new image digests in the draft manifest
+      - name: Bind new catalog artifacts and image digests in the draft
         if: ${{ steps.draft.outputs.manifest_present != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.gate.outputs.tag }}
         run: |
+          assets_file="$RUNNER_TEMP/binding-assets.txt"
+          gh release view "$RELEASE_TAG" --json assets \
+            --jq '.assets[].name' > "$assets_file"
+          verification_directory="$(mktemp -d "${TMPDIR%/}/binding-assets.XXXXXXXX")"
+          trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$verification_directory"' EXIT
+          bind_payload() {
+            local path="$1"
+            local name="${path##*/}"
+            if grep -Fx "$name" "$assets_file" >/dev/null; then
+              gh release download "$RELEASE_TAG" \
+                --dir "$verification_directory" \
+                --pattern "$name"
+              cmp -- "$path" "$verification_directory/$name"
+            else
+              gh release upload "$RELEASE_TAG" "$path"
+            fi
+          }
+          bind_payload \
+            target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar
+          bind_payload \
+            target/distribution/automata-local-installation-catalog.json
           gh release upload "$RELEASE_TAG" \
             target/distribution/automata-release-manifest.json
 
@@ -781,6 +988,8 @@ jobs:
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           verification_directory="$(mktemp -d "${TMPDIR%/}/bound-assets.XXXXXXXX")"
           trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$verification_directory"' EXIT
           gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,assets |
@@ -798,24 +1007,34 @@ jobs:
           if actual != expected:
               raise SystemExit(f"draft release assets differ: {actual!r}")
           ' "$RELEASE_PRERELEASE" \
-            "${archive##*/}" "${checksum##*/}" "${manifest##*/}"
+            "${archive##*/}" "${checksum##*/}" "${manifest##*/}" \
+            "${catalog##*/}" "${service_proxy_candidate##*/}"
           gh release download "$RELEASE_TAG" \
             --dir "$verification_directory" \
             --pattern "${archive##*/}" \
             --pattern "${checksum##*/}" \
-            --pattern "${manifest##*/}"
+            --pattern "${manifest##*/}" \
+            --pattern "${catalog##*/}" \
+            --pattern "${service_proxy_candidate##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$archive" "$verification_directory/${archive##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$checksum" "$verification_directory/${checksum##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$manifest" "$verification_directory/${manifest##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- "$catalog" "$verification_directory/${catalog##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- \
+              "$service_proxy_candidate" \
+              "$verification_directory/${service_proxy_candidate##*/}"
 
       - name: Create or verify immutable version image tags
         env:
           AUTOMATA_DIGEST: ${{ steps.images.outputs.automata_digest }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ steps.images.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ steps.images.outputs.sandbox_guest_digest }}
         run: |
           bind_version_tag() {
             local image="$1"
@@ -849,6 +1068,9 @@ jobs:
           }
           bind_version_tag ghcr.io/automata-ci/automata "$AUTOMATA_DIGEST"
           bind_version_tag ghcr.io/automata-ci/automata-runner "$RUNNER_DIGEST"
+          bind_version_tag \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       - name: Attest Automata image provenance
         env:
@@ -892,11 +1114,33 @@ jobs:
           sbom-path: target/container-release/sbom/automata-runner.cdx.json
           push-to-registry: true
 
+      - name: Attest sandbox-guest image provenance
+        env:
+          HOME: ${{ env.ATTESTATION_HOME }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/automata-ci/automata-sandbox-guest
+          subject-digest: ${{ steps.images.outputs.sandbox_guest_digest }}
+          subject-version: ${{ needs.gate.outputs.version }}
+          push-to-registry: true
+
+      - name: Attest sandbox-guest image SBOM
+        env:
+          HOME: ${{ env.ATTESTATION_HOME }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/automata-ci/automata-sandbox-guest
+          subject-digest: ${{ steps.images.outputs.sandbox_guest_digest }}
+          subject-version: ${{ needs.gate.outputs.version }}
+          sbom-path: target/sandbox-guest-context/sbom/automata-ci-sandbox-guest.cdx.json
+          push-to-registry: true
+
       - name: Verify anonymous versioned GHCR images
         env:
           AUTOMATA_DIGEST: ${{ steps.images.outputs.automata_digest }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ steps.images.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ steps.images.outputs.sandbox_guest_digest }}
         run: |
           docker logout ghcr.io
 
@@ -931,6 +1175,10 @@ jobs:
             ghcr.io/automata-ci/automata-runner \
             "$RUNNER_DIGEST" \
             "$RELEASE_VERSION"
+          verify_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST" \
+            "$RELEASE_VERSION"
 
       - name: Upload raw immutable release handoff
         id: upload-handoff
@@ -941,21 +1189,21 @@ jobs:
           path: target/release-handoff/${{ steps.handoff.outputs.handoff_filename }}
           retention-days: 90
 
-      - name: Upload raw unpublished service-proxy candidate
+      - name: Upload raw release-scoped service-proxy candidate
         id: upload-service-proxy
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           archive: false
           if-no-files-found: error
           name: automata-service-proxy-candidate-x86_64-unknown-linux-musl
-          path: target/service-proxy-publication/${{ steps.service-proxy-candidate.outputs.candidate_filename }}
+          path: target/service-proxy-publication/${{ steps.selected-service-proxy-candidate.outputs.candidate_filename }}
           retention-days: 90
 
       - name: Verify uploaded service-proxy candidate identity
         env:
           ARTIFACT_DIGEST: ${{ steps.upload-service-proxy.outputs.artifact-digest }}
           ARTIFACT_ID: ${{ steps.upload-service-proxy.outputs.artifact-id }}
-          CANDIDATE_SHA256: ${{ steps.service-proxy-candidate.outputs.candidate_sha256 }}
+          CANDIDATE_SHA256: ${{ steps.selected-service-proxy-candidate.outputs.candidate_sha256 }}
         run: |
           artifact_digest="${ARTIFACT_DIGEST#sha256:}"
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
@@ -1104,6 +1352,7 @@ jobs:
             --handoff-sha256 "$HANDOFF_SHA256" \
             --automata-digest "${{ needs.stage_release.outputs.automata_digest }}" \
             --runner-digest "${{ needs.stage_release.outputs.runner_digest }}" \
+            --sandbox-guest-digest "${{ needs.stage_release.outputs.sandbox_guest_digest }}" \
             --extract-root . \
             --tag "$RELEASE_TAG" \
             --tag-object "$RELEASE_TAG_OBJECT" \
@@ -1138,6 +1387,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           install -d -m 0700 -- "$TMPDIR"
           remote_refs="$(
@@ -1163,6 +1413,8 @@ jobs:
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           verification_directory="$(mktemp -d "${TMPDIR%/}/draft.XXXXXXXX")"
           trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$verification_directory"' EXIT
           gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,assets |
@@ -1180,18 +1432,27 @@ jobs:
           if actual != expected:
               raise SystemExit(f"draft assets differ: {actual!r}")
           ' "$RELEASE_PRERELEASE" \
-            "${archive##*/}" "${checksum##*/}" "${manifest##*/}"
+            "${archive##*/}" "${checksum##*/}" "${manifest##*/}" \
+            "${catalog##*/}" "${service_proxy_candidate##*/}"
           gh release download "$RELEASE_TAG" \
             --dir "$verification_directory" \
             --pattern "${archive##*/}" \
             --pattern "${checksum##*/}" \
-            --pattern "${manifest##*/}"
+            --pattern "${manifest##*/}" \
+            --pattern "${catalog##*/}" \
+            --pattern "${service_proxy_candidate##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$archive" "$verification_directory/${archive##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$checksum" "$verification_directory/${checksum##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$manifest" "$verification_directory/${manifest##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- "$catalog" "$verification_directory/${catalog##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- \
+              "$service_proxy_candidate" \
+              "$verification_directory/${service_proxy_candidate##*/}"
 
           release_state="$RUNNER_TEMP/github-releases-before-crates.json"
           gh api --paginate --slurp \
@@ -1217,6 +1478,9 @@ jobs:
           }
           verify_image ghcr.io/automata-ci/automata "$AUTOMATA_DIGEST"
           verify_image ghcr.io/automata-ci/automata-runner "$RUNNER_DIGEST"
+          verify_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       - name: Verify packages and prepare the credential-free publication plan
         id: prepare
@@ -1252,9 +1516,18 @@ jobs:
           tools="target/release-publisher-tools/${TOOLS_FILENAME}"
           install -d -m 0700 -- "${tools%/*}"
           for source in \
+            Cargo.toml \
+            LICENSE \
+            images/github-hosted-ubuntu-24.04-x64/profile-lock.json \
+            images/github-hosted-ubuntu-24.04-x64/profile-manifest.json \
+            images/local-installation/catalog-v1.json \
+            images/service-proxy/Containerfile \
             scripts/ci/check-release-order.py \
+            scripts/ci/local_installation_catalog.py \
             scripts/ci/publish-crates.py \
-            scripts/ci/release-handoff.py; do
+            scripts/ci/release-handoff.py \
+            scripts/ci/service-proxy-candidate.py \
+            scripts/ci/service-proxy-publication.py; do
             [[ -f "$source" && ! -L "$source" ]] || {
               printf 'error: publisher tool is not a regular source file: %s\n' \
                 "$source" >&2
@@ -1272,9 +1545,18 @@ jobs:
             --owner=0 \
             --sort=name \
             -- \
+            Cargo.toml \
+            LICENSE \
+            images/github-hosted-ubuntu-24.04-x64/profile-lock.json \
+            images/github-hosted-ubuntu-24.04-x64/profile-manifest.json \
+            images/local-installation/catalog-v1.json \
+            images/service-proxy/Containerfile \
             scripts/ci/check-release-order.py \
+            scripts/ci/local_installation_catalog.py \
             scripts/ci/publish-crates.py \
-            scripts/ci/release-handoff.py
+            scripts/ci/release-handoff.py \
+            scripts/ci/service-proxy-candidate.py \
+            scripts/ci/service-proxy-publication.py
           tools_sha256="$(sha256sum "$tools" | awk '{print $1}')"
           {
             printf 'tools_filename=%s\n' "$TOOLS_FILENAME"
@@ -1383,6 +1665,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
           TOOLS_ARTIFACT_DIGEST: ${{ needs.prepare_crates.outputs.tools_artifact_digest }}
           TOOLS_FILENAME: ${{ needs.prepare_crates.outputs.tools_filename }}
           TOOLS_SHA256: ${{ needs.prepare_crates.outputs.tools_sha256 }}
@@ -1443,9 +1726,18 @@ jobs:
           destination = pathlib.Path(sys.argv[2])
           expected_digest = sys.argv[3]
           expected = {
+              "Cargo.toml",
+              "LICENSE",
+              "images/github-hosted-ubuntu-24.04-x64/profile-lock.json",
+              "images/github-hosted-ubuntu-24.04-x64/profile-manifest.json",
+              "images/local-installation/catalog-v1.json",
+              "images/service-proxy/Containerfile",
               "scripts/ci/check-release-order.py",
+              "scripts/ci/local_installation_catalog.py",
               "scripts/ci/publish-crates.py",
               "scripts/ci/release-handoff.py",
+              "scripts/ci/service-proxy-candidate.py",
+              "scripts/ci/service-proxy-publication.py",
           }
           flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
           flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -1497,6 +1789,7 @@ jobs:
             --handoff-sha256 "$HANDOFF_SHA256" \
             --automata-digest "$AUTOMATA_DIGEST" \
             --runner-digest "$RUNNER_DIGEST" \
+            --sandbox-guest-digest "$SANDBOX_GUEST_DIGEST" \
             --extract-root "$publish_root" \
             --tag "$RELEASE_TAG" \
             --tag-object "$RELEASE_TAG_OBJECT" \
@@ -1524,6 +1817,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           cd -- "$PUBLISH_ROOT"
           remote_refs="$(
@@ -1550,6 +1844,8 @@ jobs:
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           verification_directory="$(
             mktemp -d "$RUNNER_TEMP/crates-approved.XXXXXXXX"
           )"
@@ -1569,18 +1865,27 @@ jobs:
           if actual != expected:
               raise SystemExit(f"draft assets differ: {actual!r}")
           ' "$RELEASE_PRERELEASE" \
-            "${archive##*/}" "${checksum##*/}" "${manifest##*/}"
+            "${archive##*/}" "${checksum##*/}" "${manifest##*/}" \
+            "${catalog##*/}" "${service_proxy_candidate##*/}"
           gh release download "$RELEASE_TAG" \
             --dir "$verification_directory" \
             --pattern "${archive##*/}" \
             --pattern "${checksum##*/}" \
-            --pattern "${manifest##*/}"
+            --pattern "${manifest##*/}" \
+            --pattern "${catalog##*/}" \
+            --pattern "${service_proxy_candidate##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$archive" "$verification_directory/${archive##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$checksum" "$verification_directory/${checksum##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$manifest" "$verification_directory/${manifest##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- "$catalog" "$verification_directory/${catalog##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- \
+              "$service_proxy_candidate" \
+              "$verification_directory/${service_proxy_candidate##*/}"
 
           release_state="$RUNNER_TEMP/github-releases-after-approval.json"
           gh api --paginate --slurp \
@@ -1606,10 +1911,13 @@ jobs:
           }
           verify_image ghcr.io/automata-ci/automata "$AUTOMATA_DIGEST"
           verify_image ghcr.io/automata-ci/automata-runner "$RUNNER_DIGEST"
+          verify_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       # id-token permission is job-wide. Before this explicit crates.io exchange,
       # this job runs only pinned artifact downloads, bounded materialization,
-      # fixed runner clients, and the three digest-bound audited release helpers.
+      # fixed runner clients, and the digest-bound audited release helpers.
       # It checks out no repository and runs no build or dependency code.
       - name: Request short-lived crates.io credentials
         id: crates-auth
@@ -1719,6 +2027,7 @@ jobs:
             --handoff-sha256 "$HANDOFF_SHA256" \
             --automata-digest "${{ needs.stage_release.outputs.automata_digest }}" \
             --runner-digest "${{ needs.stage_release.outputs.runner_digest }}" \
+            --sandbox-guest-digest "${{ needs.stage_release.outputs.sandbox_guest_digest }}" \
             --extract-root . \
             --tag "$RELEASE_TAG" \
             --tag-object "$RELEASE_TAG_OBJECT" \
@@ -1741,6 +2050,7 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           local_object="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}")"
           local_commit="$(git rev-parse --verify 'HEAD^{commit}')"
@@ -1772,6 +2082,8 @@ jobs:
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           verification_directory="$(mktemp -d "${TMPDIR%/}/finalize.XXXXXXXX")"
           trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$verification_directory"' EXIT
           gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,assets |
@@ -1789,18 +2101,27 @@ jobs:
           if actual != expected:
               raise SystemExit(f"draft assets differ: {actual!r}")
           ' "$RELEASE_PRERELEASE" \
-            "${archive##*/}" "${checksum##*/}" "${manifest##*/}"
+            "${archive##*/}" "${checksum##*/}" "${manifest##*/}" \
+            "${catalog##*/}" "${service_proxy_candidate##*/}"
           gh release download "$RELEASE_TAG" \
             --dir "$verification_directory" \
             --pattern "${archive##*/}" \
             --pattern "${checksum##*/}" \
-            --pattern "${manifest##*/}"
+            --pattern "${manifest##*/}" \
+            --pattern "${catalog##*/}" \
+            --pattern "${service_proxy_candidate##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$archive" "$verification_directory/${archive##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$checksum" "$verification_directory/${checksum##*/}"
           env -u GH_TOKEN -u GITHUB_TOKEN \
             cmp -- "$manifest" "$verification_directory/${manifest##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- "$catalog" "$verification_directory/${catalog##*/}"
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            cmp -- \
+              "$service_proxy_candidate" \
+              "$verification_directory/${service_proxy_candidate##*/}"
 
           verify_image() {
             local image="$1"
@@ -1817,6 +2138,9 @@ jobs:
           }
           verify_image ghcr.io/automata-ci/automata "$AUTOMATA_DIGEST"
           verify_image ghcr.io/automata-ci/automata-runner "$RUNNER_DIGEST"
+          verify_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       - name: Revalidate release order before finalization
         env:
@@ -1855,6 +2179,7 @@ jobs:
         env:
           AUTOMATA_DIGEST: ${{ needs.stage_release.outputs.automata_digest }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           promote_image() {
             local image="$1"
@@ -1870,12 +2195,16 @@ jobs:
           promote_image \
             ghcr.io/automata-ci/automata-runner \
             "$RUNNER_DIGEST"
+          promote_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       - name: Verify anonymous stable aliases
         if: ${{ needs.gate.outputs.prerelease == 'false' }}
         env:
           AUTOMATA_DIGEST: ${{ needs.stage_release.outputs.automata_digest }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           docker logout ghcr.io
 
@@ -1905,6 +2234,9 @@ jobs:
           verify_alias \
             ghcr.io/automata-ci/automata-runner \
             "$RUNNER_DIGEST"
+          verify_alias \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
 
       - name: Sign out of GHCR
         if: ${{ always() }}
@@ -1920,13 +2252,18 @@ jobs:
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
           RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           archive="target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
           checksum="${archive}.sha256"
           manifest="target/distribution/automata-release-manifest.json"
+          catalog="target/distribution/automata-local-installation-catalog.json"
+          service_proxy_candidate="target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
           archive_name="${archive##*/}"
           checksum_name="${checksum##*/}"
           manifest_name="${manifest##*/}"
+          catalog_name="${catalog##*/}"
+          service_proxy_candidate_name="${service_proxy_candidate##*/}"
 
           require_remote_release_commit() {
             local direct_object=''
@@ -1977,7 +2314,9 @@ jobs:
               raise SystemExit(
                   f"draft release assets differ from the exact expected set: {actual!r}"
               )
-          ' "$IS_PRERELEASE" "$archive_name" "$checksum_name" "$manifest_name"
+          ' "$IS_PRERELEASE" \
+            "$archive_name" "$checksum_name" "$manifest_name" \
+            "$catalog_name" "$service_proxy_candidate_name"
           }
 
           require_exact_published_release() {
@@ -2002,7 +2341,8 @@ jobs:
                   f"published release assets differ from the exact set: {actual!r}"
               )
           ' "$IS_PRERELEASE" "$RELEASE_TAG" \
-            "$archive_name" "$checksum_name" "$manifest_name"
+            "$archive_name" "$checksum_name" "$manifest_name" \
+            "$catalog_name" "$service_proxy_candidate_name"
             if [[ "$IS_PRERELEASE" == false ]]; then
               latest_tag="$(
                 gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
@@ -2053,13 +2393,21 @@ jobs:
               --dir "$verification_directory" \
               --pattern "$archive_name" \
               --pattern "$checksum_name" \
-              --pattern "$manifest_name"
+              --pattern "$manifest_name" \
+              --pattern "$catalog_name" \
+              --pattern "$service_proxy_candidate_name"
             env -u GH_TOKEN -u GITHUB_TOKEN \
               cmp -- "$archive" "$verification_directory/$archive_name"
             env -u GH_TOKEN -u GITHUB_TOKEN \
               cmp -- "$checksum" "$verification_directory/$checksum_name"
             env -u GH_TOKEN -u GITHUB_TOKEN \
               cmp -- "$manifest" "$verification_directory/$manifest_name"
+            env -u GH_TOKEN -u GITHUB_TOKEN \
+              cmp -- "$catalog" "$verification_directory/$catalog_name"
+            env -u GH_TOKEN -u GITHUB_TOKEN \
+              cmp -- \
+                "$service_proxy_candidate" \
+                "$verification_directory/$service_proxy_candidate_name"
             (
               cd -- "$verification_directory"
               env -u GH_TOKEN -u GITHUB_TOKEN \
@@ -2074,6 +2422,9 @@ jobs:
             ghcr.io/automata-ci/automata "$AUTOMATA_DIGEST"
           require_exact_version_image \
             ghcr.io/automata-ci/automata-runner "$RUNNER_DIGEST"
+          require_exact_version_image \
+            ghcr.io/automata-ci/automata-sandbox-guest \
+            "$SANDBOX_GUEST_DIGEST"
           require_exact_draft_assets
           require_remote_release_commit
           edit_status=0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,10 +25,10 @@ workspace version `X.Y.Z` is intended to publish:
 | Destination | Published names |
 | --- | --- |
 | crates.io | Every publishable workspace package in dependency order, including `automata-ci` and `automata-ci-runner` |
-| GitHub Release | `automata-x86_64-unknown-linux-musl.tar.gz`, its `.sha256` file, and `automata-release-manifest.json` |
-| GHCR | `ghcr.io/automata-ci/automata:X.Y.Z` and `ghcr.io/automata-ci/automata-runner:X.Y.Z` |
-| Stable aliases | Both GHCR images also receive `latest` for a non-prerelease version |
-| Attestations | The release archive, checksum, and both image digests |
+| GitHub Release | `automata-x86_64-unknown-linux-musl.tar.gz`, its `.sha256` file, `automata-release-manifest.json`, `automata-local-installation-catalog.json`, and `automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar` |
+| GHCR | `ghcr.io/automata-ci/automata:X.Y.Z`, `ghcr.io/automata-ci/automata-runner:X.Y.Z`, and `ghcr.io/automata-ci/automata-sandbox-guest:X.Y.Z` |
+| Stable aliases | All three GHCR images also receive `latest` for a non-prerelease version |
+| Attestations | The release archive and checksum, local-installation catalog, service-proxy candidate, and provenance and SBOM statements for all three images |
 
 The archive contains `automata`, `automata-runner`, the license, third-party
 notices, SBOMs, a version file, and internal checksums. The filename stays
@@ -134,11 +134,12 @@ GitHub's `id-token` permission is job-wide rather than step-scoped. The
 `crates-io` job therefore checks out no repository and runs no build or
 dependency command. Before the explicit crates.io authentication action, it
 runs only pinned artifact-download code, fixed runner clients, bounded
-materialization, and the three small release helpers from a same-run raw tool
-bundle selected by artifact ID and verified against both the artifact-service
-digest and the preparation-job SHA-256. Those helpers are part of the audited
-credential-bound trusted code; changes to them require the same review as the
-workflow itself.
+materialization, and the closed release-helper module set from a same-run raw
+tool bundle selected by artifact ID and verified against both the
+artifact-service digest and the preparation-job SHA-256. Those helpers and
+their exact catalog, profile, Containerfile, license, and workspace-version
+inputs are part of the audited credential-bound trusted code; changes to them
+require the same review as the workflow itself.
 
 ### 4. Enable private security reporting and dependency alerts
 
@@ -164,11 +165,11 @@ publishing crates whose homepage metadata points there.
 ### 6. Plan the first GHCR visibility change
 
 New organization container packages are private by default. After a future
-authorized workflow first pushes `automata` and `automata-runner`, an
-organization owner or package administrator must change both packages to
-**Public** under their package settings. Public Container Registry packages can
-then be pulled anonymously; GitHub documents the irreversible visibility
-change in
+authorized workflow first pushes `automata`, `automata-runner`, and
+`automata-sandbox-guest`, an organization owner or package administrator must
+change all three packages to **Public** under their package settings. Public
+Container Registry packages can then be pulled anonymously; GitHub documents
+the irreversible visibility change in
 [Configuring package access and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility).
 
 The future sequence must test anonymous manifest access before publishing any
@@ -300,11 +301,12 @@ used only to make the review metadata well formed; they do not claim a hosted
 workflow identity. `prepare-candidate` applies the same trusted publisher policy
 as ordinary CI and extracts the reviewed OCI bytes. The operator handoff is
 `target/service-proxy-policy-review/automata-service-proxy.oci.tar`; the outer
-`automata-service-proxy-candidate-*.tar` is only the reproducible policy input,
-not the upload artifact. Review the adjacent proposed lock, source identity,
-source provenance, and SBOM together with that OCI archive. These steps write
-only below `target/`; they do not push an image, bind a tag, or create an
-attestation.
+`automata-service-proxy-candidate-*.tar` is the reproducible policy input, not
+the image-registry upload artifact. A release also retains that outer candidate
+as the byte-exact local-installation payload named by its catalog. Review the
+adjacent proposed lock, source identity, source provenance, and SBOM together
+with the OCI archive. These steps write only below `target/`; they do not push
+an image, bind a tag, or create an attestation.
 
 A separately authorized operator may upload only the reviewed OCI archive and
 must capture and anonymously re-read the registry digest before proposing a
@@ -313,6 +315,23 @@ authenticate an Automata-issued statement binding the publisher commit,
 `.ci/workflows/service-proxy-image.yml`, an authenticated Automata dispatch,
 the main ref, the candidate source commit, source-provenance digest, and exact
 image digest.
+
+## Local-installation release catalog
+
+`images/local-installation/catalog-v1.json` is the reviewed source contract for
+one Unix-hosted, `linux/amd64` installation. Its role set is closed to exactly
+Automata, runner, sandbox guest, service proxy, PostgreSQL, RustFS, and the
+GitHub-hosted Ubuntu 24.04 x64 compatibility profile. The release workflow
+resolves the three first-party images produced by that release, retains the
+protocol 2 service-proxy OCI candidate, and qualifies each fixed third-party or
+profile image with its top-level, platform-manifest, and configuration digests.
+The emitted catalog also binds the exact profile manifest and lock bytes.
+
+The catalog is declarative release evidence. It does not materialize engine
+objects, install or bootstrap a runner, mint credentials, select secrets, or
+add a relay or generic image-fetch API. A later installation implementation
+must consume this closed schema in its own reviewed slice and still prove the
+downloaded assets and registry content against these bindings.
 
 ## Prepare a release
 
@@ -398,20 +417,22 @@ mismatched checkout, or a dirty release build.
 
 When enabled, the tag push starts `.ci/workflows/release.yml`. Every version
 shares one repository-wide publication lock, so crates.io publication and the
-two global `latest` aliases cannot race another release. A different unfinished
-draft blocks the next tag, and a stable version must be newer than every stable
-GitHub Release already published. The future pipeline must perform these gates
-in order:
+three global `latest` aliases cannot race another release. A different
+unfinished draft blocks the next tag, and a stable version must be newer than
+every stable GitHub Release already published. The future pipeline must perform
+these gates in order:
 
 1. prove, before mutation, that the tag commit is an ancestor of current `main`
    and that exact provider-authenticated Automata CI authority passed for that
    SHA;
-2. stage every crate and exercise both static musl executables inside the
-   protected `release` environment;
-3. generate SBOMs, license material, the deterministic archive, checksums, and
-   the canonical release manifest;
-4. create or recover the exact draft, verify its accepted bytes, attest the
-   archive, and bind the two image digests before creating version tags;
+2. stage every crate and exercise the two distribution executables and both
+   fixed helper executables as static musl binaries inside the protected
+   `release` environment;
+3. generate SBOMs, license material, the deterministic archive and checksum,
+   the release-scoped service-proxy candidate, the closed local-installation
+   catalog, and the canonical release manifest;
+4. create or recover the exact draft, verify and attest its accepted bytes, and
+   bind the three release-image digests before creating version tags;
 5. transfer the bounded payload, publication plan, and minimal release-helper
    bundle through same-run raw artifacts selected by numeric ID and checked
    against both service and producer digests;
@@ -423,13 +444,14 @@ in order:
    the official length-prefixed crates.io API in dependency order;
 8. verify every exact non-yanked crates.io version and its owner set before any
    mutable alias changes;
-9. move both GHCR `latest` aliases only for a stable release and verify them; and
+9. move all three GHCR `latest` aliases only for a stable release and verify
+   them; and
 10. revalidate the remote tag, release order, version images, and draft bytes in
     the last pre-publication window, then make the GitHub Release public without
     OIDC credentials.
 
 Versions containing a prerelease suffix publish as GitHub prereleases and do
-not move either GHCR `latest` tag.
+not move any GHCR `latest` tag.
 
 ## Verify the published release
 
@@ -438,12 +460,33 @@ credentials:
 
 ```console
 version="$(./scripts/ci/workspace-version.sh)"
+release_commit="$(git rev-parse "v${version}^{commit}")"
 
 curl --fail --location \
   "https://github.com/automata-ci/automata/releases/download/v${version}/automata-x86_64-unknown-linux-musl.tar.gz.sha256"
+curl --fail --location --output automata-local-installation-catalog.json \
+  "https://github.com/automata-ci/automata/releases/download/v${version}/automata-local-installation-catalog.json"
+curl --fail --location \
+  --output automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+  "https://github.com/automata-ci/automata/releases/download/v${version}/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
+gh attestation verify automata-local-installation-catalog.json \
+  --repo automata-ci/automata \
+  --signer-workflow automata-ci/automata/.ci/workflows/release.yml \
+  --source-ref "refs/tags/v${version}" \
+  --source-digest "$release_commit" \
+  --deny-self-hosted-runners
+gh attestation verify \
+  automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+  --repo automata-ci/automata \
+  --signer-workflow automata-ci/automata/.ci/workflows/release.yml \
+  --source-ref "refs/tags/v${version}" \
+  --source-digest "$release_commit" \
+  --deny-self-hosted-runners
 cargo search automata-ci --limit 1
 podman manifest inspect "ghcr.io/automata-ci/automata:${version}" >/dev/null
 podman manifest inspect "ghcr.io/automata-ci/automata-runner:${version}" >/dev/null
+podman manifest inspect \
+  "ghcr.io/automata-ci/automata-sandbox-guest:${version}" >/dev/null
 ```
 
 Test the installer on a disposable x86-64 Linux account or container, confirm
@@ -460,18 +503,20 @@ immutable tag only through an authenticated Automata dispatch that rebinds the
 trusted provider origin, repository, tag and commit, workflow/event/ref,
 logical job, and exact run/job authority. The intended recovery contract is:
 
-- an interrupted draft may contain the archive/checksum pair, the canonical
-  manifest, all three, or none, but no unexpected asset; the workflow
-  byte-verifies every existing asset, uploads only an absent expected member,
-  and requires the exact three downloaded bytes plus a valid checksum before
-  publication;
+- a draft always starts with the archive/checksum pair and may then contain the
+  service-proxy candidate, the candidate plus catalog, or the candidate plus
+  catalog and manifest, but no other partial order or unexpected asset; recovery
+  byte-verifies the deterministic candidate, authenticates an existing catalog
+  attestation before accepting its image digests, validates the manifest against
+  those exact payloads, and requires all five downloaded assets plus a valid
+  checksum before publication;
 - an already published crate is skipped only when its crates.io checksum
   exactly matches the local package archive;
 - a checksum mismatch fails rather than assuming the version is equivalent;
   and
-- once the draft manifest binds image digests, recovery does not rebuild them;
-  missing version tags are created from those exact digests and any different or
-  unbound version tag fails closed.
+- once the attested draft catalog binds image digests, recovery does not rebuild
+  them; missing version tags are created from those exact digests and any
+  different or unbound version tag fails closed.
 
 The handoff and the second credential-free `cargo package` output must match
 byte for byte before publication is authorized. The credentialed executor does
@@ -492,10 +537,10 @@ tag to repair a failed release. If the tagged source is wrong, publish a new
 patch version. A crates.io version cannot be overwritten, and the future
 workflow must treat a public GitHub Release as immutable.
 
-The two GHCR `latest` updates are sequential and cannot be transactional. A
-failure between them can temporarily leave one alias ahead; authenticated
-recovery must reapply and verify both exact digests. Use immutable version tags,
-not `latest`, as the release-completeness signal.
+The three GHCR `latest` updates are sequential and cannot be transactional. A
+failure between them can temporarily leave one or two aliases ahead;
+authenticated recovery must reapply and verify all three exact digests. Use
+immutable version tags, not `latest`, as the release-completeness signal.
 
 Finalization reconciles an error from `gh release edit` by re-reading the exact
 public tag, prerelease/latest state, asset set and bytes, and annotated tag
@@ -513,13 +558,25 @@ The development scripts can exercise the archive path without publishing:
 export AUTOMATA_EXPECTED_VERSION="$(./scripts/ci/workspace-version.sh)"
 export AUTOMATA_EXPECTED_GIT_SHA="$(git rev-parse --verify 'HEAD^{commit}')"
 export AUTOMATA_BUILD_GIT_SHA="$AUTOMATA_EXPECTED_GIT_SHA"
+export AUTOMATA_RELEASE_CREATED="$(git show -s --format=%cI HEAD)"
 export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
 
 ./scripts/ci/build-static-musl.sh
 ./scripts/ci/verify-static-musl.sh
+./scripts/ci/verify-sandbox-guest-static.sh
+./scripts/ci/verify-service-proxy-static.sh
 ./scripts/ci/generate-sboms.sh
 ./scripts/ci/prepare-third-party-license-sources.sh
 ./scripts/ci/generate-third-party-licenses.sh
+./scripts/ci/prepare-sandbox-guest-context.sh \
+  target/sandbox-guest-context \
+  "$AUTOMATA_EXPECTED_VERSION"
+./scripts/ci/verify-sandbox-guest-image.sh \
+  target/sandbox-guest-context \
+  "$AUTOMATA_EXPECTED_VERSION" \
+  "$AUTOMATA_EXPECTED_GIT_SHA" \
+  "$AUTOMATA_RELEASE_CREATED" \
+  "$SOURCE_DATE_EPOCH"
 ./scripts/ci/package-static-musl.sh
 bash scripts/ci/tests/install.test.sh
 bash scripts/ci/tests/container-context.test.sh

--- a/images/automata-runner.Containerfile
+++ b/images/automata-runner.Containerfile
@@ -23,6 +23,7 @@ COPY --chmod=0444 THIRD_PARTY_NOTICES.txt /usr/share/licenses/automata-runner/TH
 COPY --chmod=0444 VERSION /usr/share/doc/automata-runner/VERSION
 COPY --chmod=0444 sbom/automata-runner.cdx.json /usr/share/sbom/automata-runner.cdx.json
 
+WORKDIR /
 USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/automata-runner"]
 CMD ["doctor", "--json"]

--- a/images/automata-sandbox-guest.Containerfile
+++ b/images/automata-sandbox-guest.Containerfile
@@ -1,0 +1,34 @@
+FROM scratch
+
+ARG AUTOMATA_CREATED
+ARG AUTOMATA_REVISION
+ARG AUTOMATA_VERSION
+ARG SOURCE_DATE_EPOCH
+
+LABEL org.opencontainers.image.title="Automata Sandbox Guest" \
+      org.opencontainers.image.description="Fixed protocol guest for Automata local job sandboxes" \
+      org.opencontainers.image.source="https://github.com/automata-ci/automata" \
+      org.opencontainers.image.url="https://github.com/automata-ci/automata" \
+      org.opencontainers.image.documentation="https://github.com/automata-ci/automata/blob/main/crates/automata-ci-sandbox-guest/README.md" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.created="${AUTOMATA_CREATED}" \
+      org.opencontainers.image.version="${AUTOMATA_VERSION}" \
+      org.opencontainers.image.revision="${AUTOMATA_REVISION}" \
+      io.automata.sandbox-guest.protocol-version="3"
+
+COPY --chmod=0555 automata-ci-sandbox-guest \
+    /usr/local/bin/automata-ci-sandbox-guest
+COPY --chmod=0444 LICENSE \
+    /usr/share/licenses/automata-ci-sandbox-guest/LICENSE
+COPY --chmod=0444 THIRD_PARTY_LICENSES.txt \
+    /usr/share/licenses/automata-ci-sandbox-guest/THIRD_PARTY_LICENSES.txt
+COPY --chmod=0444 THIRD_PARTY_NOTICES.txt \
+    /usr/share/licenses/automata-ci-sandbox-guest/THIRD_PARTY_NOTICES.txt
+COPY --chmod=0444 VERSION \
+    /usr/share/doc/automata-ci-sandbox-guest/VERSION
+COPY --chmod=0444 sbom/automata-ci-sandbox-guest.cdx.json \
+    /usr/share/sbom/automata-ci-sandbox-guest.cdx.json
+
+WORKDIR /
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/automata-ci-sandbox-guest"]

--- a/images/automata.Containerfile
+++ b/images/automata.Containerfile
@@ -25,6 +25,7 @@ COPY --chmod=0444 sbom/automata.cdx.json /usr/share/sbom/automata.cdx.json
 COPY --chmod=0444 sbom/renderer.cdx.json /usr/share/sbom/renderer.cdx.json
 COPY --chmod=0444 sbom/ui-runtime.cdx.json /usr/share/sbom/ui-runtime.cdx.json
 
+WORKDIR /
 USER 65532:65532
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/automata"]

--- a/images/local-installation/catalog-v1.json
+++ b/images/local-installation/catalog-v1.json
@@ -1,0 +1,304 @@
+{
+  "images": {
+    "automata": {
+      "canonical_repository": "automata.local/automata",
+      "config": {
+        "command": [
+          "preview",
+          "--listen",
+          "0.0.0.0:8080"
+        ],
+        "entrypoint": [
+          "/usr/local/bin/automata"
+        ],
+        "required_environment": {},
+        "required_labels": {
+          "org.opencontainers.image.licenses": "MIT",
+          "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+          "org.opencontainers.image.title": "Automata"
+        },
+        "user": "65532:65532",
+        "working_directory": "/"
+      },
+      "runtime": {
+        "binary": "/usr/local/bin/automata",
+        "gid": 65532,
+        "uid": 65532
+      },
+      "source": {
+        "kind": "release-registry",
+        "repository": "ghcr.io/automata-ci/automata"
+      }
+    },
+    "postgres": {
+      "canonical_repository": "automata.local/postgres",
+      "config": {
+        "command": [
+          "postgres"
+        ],
+        "entrypoint": [
+          "docker-entrypoint.sh"
+        ],
+        "required_environment": {
+          "PGDATA": "/var/lib/postgresql/18/docker",
+          "PG_MAJOR": "18",
+          "PG_VERSION": "18.4-1.pgdg12+1"
+        },
+        "required_labels": {},
+        "user": "",
+        "working_directory": ""
+      },
+      "runtime": {
+        "bootstrap_gid": 0,
+        "bootstrap_uid": 0,
+        "data_gid": 999,
+        "data_mount": "/var/lib/postgresql",
+        "data_uid": 999,
+        "entrypoint": "/usr/local/bin/docker-entrypoint.sh",
+        "password_file_environment": "POSTGRES_PASSWORD_FILE",
+        "pg_isready": "/usr/bin/pg_isready",
+        "pgdata": "/var/lib/postgresql/18/docker",
+        "postgres": "/usr/lib/postgresql/18/bin/postgres",
+        "server_certificate": "/run/automata-local/postgres/tls/server.pem",
+        "server_private_key": "/run/automata-local/postgres/tls/server-key.pem",
+        "server_private_key_modes": [
+          "0600-owner",
+          "0640-root-server-group"
+        ]
+      },
+      "source": {
+        "config_digest": "sha256:526573c93ea530a230b553cc513075ab9d70b63bfd2300ef5eb5ad1cafbbc595",
+        "kind": "registry",
+        "platform_manifest_digest": "sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568",
+        "reference": "docker.io/library/postgres:18.4-bookworm@sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568"
+      }
+    },
+    "profile": {
+      "canonical_repository": "automata.local/github-hosted-ubuntu-24.04-x64",
+      "config": {
+        "command": [
+          "/bin/sleep",
+          "infinity"
+        ],
+        "entrypoint": [],
+        "required_environment": {
+          "AUTOMATA_ENVIRONMENT_PROFILE_ID": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
+          "CARGO_HOME": "/opt/cargo",
+          "RUNNER_TOOL_CACHE": "/opt/hostedtoolcache",
+          "RUSTUP_HOME": "/opt/rustup"
+        },
+        "required_labels": {
+          "io.automata.environment-profile": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
+          "org.opencontainers.image.licenses": "MIT",
+          "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+          "org.opencontainers.image.title": "Automata GitHub-hosted Ubuntu 24.04 x64 compatibility profile"
+        },
+        "user": "0:0",
+        "working_directory": "/__w"
+      },
+      "runtime": {
+        "gid": 0,
+        "uid": 0,
+        "workspace": "/__w"
+      },
+      "source": {
+        "config_digest": "sha256:95b914337d8f4c55ae2c8d9d065e94b79007a2627927b4552c1643189d6e0813",
+        "kind": "registry",
+        "platform_manifest_digest": "sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194",
+        "reference": "ghcr.io/automata-ci/automata-ubuntu-24.04-x64@sha256:e2c20ad25ff71fb61d9609e84daf8384a122b8f26a047836ac50d832c632e194"
+      }
+    },
+    "runner": {
+      "canonical_repository": "automata.local/automata-runner",
+      "config": {
+        "command": [
+          "doctor",
+          "--json"
+        ],
+        "entrypoint": [
+          "/usr/local/bin/automata-runner"
+        ],
+        "required_environment": {},
+        "required_labels": {
+          "org.opencontainers.image.licenses": "MIT",
+          "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+          "org.opencontainers.image.title": "Automata Runner"
+        },
+        "user": "65532:65532",
+        "working_directory": "/"
+      },
+      "runtime": {
+        "binary": "/usr/local/bin/automata-runner",
+        "commands": [
+          "enroll",
+          "run"
+        ],
+        "gid": 65532,
+        "product_config_schema": 6,
+        "uid": 65532
+      },
+      "source": {
+        "kind": "release-registry",
+        "repository": "ghcr.io/automata-ci/automata-runner"
+      }
+    },
+    "rustfs": {
+      "canonical_repository": "automata.local/rustfs",
+      "config": {
+        "command": [
+          "rustfs"
+        ],
+        "entrypoint": [
+          "/entrypoint.sh"
+        ],
+        "required_environment": {
+          "RUSTFS_VOLUMES": "/data"
+        },
+        "required_labels": {},
+        "user": "rustfs",
+        "working_directory": "/"
+      },
+      "runtime": {
+        "access_key_file_environment": "RUSTFS_ACCESS_KEY_FILE",
+        "ca_certificate_name": "ca.crt",
+        "data_gid": 10001,
+        "data_mode": "0750",
+        "data_mount": "/data",
+        "data_uid": 10001,
+        "entrypoint": "/entrypoint.sh",
+        "gid": 10001,
+        "health_client": "/usr/bin/curl",
+        "health_path": "/health",
+        "secret_key_file_environment": "RUSTFS_SECRET_KEY_FILE",
+        "server": "/usr/bin/rustfs",
+        "server_certificate_name": "rustfs_cert.pem",
+        "server_private_key_name": "rustfs_key.pem",
+        "sse_master_key_environment": "RUSTFS_SSE_S3_MASTER_KEY",
+        "tls_path_environment": "RUSTFS_TLS_PATH",
+        "uid": 10001
+      },
+      "source": {
+        "config_digest": "sha256:93dda33a086d9d7a8dd16ac7d398c937fd9a1f0ccd539d22e95c7bea4ae9213f",
+        "kind": "registry",
+        "platform_manifest_digest": "sha256:e4151ec4728f4d39a714a2c5f6e1f4bc8e0789fe5af4874b95121bae39c6cd12",
+        "reference": "docker.io/rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c"
+      }
+    },
+    "sandbox-guest": {
+      "canonical_repository": "automata.local/automata-ci-sandbox-guest",
+      "config": {
+        "command": [],
+        "entrypoint": [
+          "/usr/local/bin/automata-ci-sandbox-guest"
+        ],
+        "required_environment": {},
+        "required_labels": {
+          "io.automata.sandbox-guest.protocol-version": "3",
+          "org.opencontainers.image.licenses": "MIT",
+          "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+          "org.opencontainers.image.title": "Automata Sandbox Guest"
+        },
+        "user": "65532:65532",
+        "working_directory": "/"
+      },
+      "runtime": {
+        "binary": "/usr/local/bin/automata-ci-sandbox-guest",
+        "gid": 65532,
+        "guest_protocol": 3,
+        "uid": 65532
+      },
+      "source": {
+        "kind": "release-registry",
+        "repository": "ghcr.io/automata-ci/automata-sandbox-guest"
+      }
+    },
+    "service-proxy": {
+      "canonical_repository": "automata.local/automata-ci-service-proxy",
+      "config": {
+        "command": [],
+        "entrypoint": [
+          "/usr/libexec/automata-ci-service-proxy"
+        ],
+        "required_environment": {},
+        "required_labels": {
+          "io.automata.service-proxy.protocol-version": "2",
+          "org.opencontainers.image.licenses": "MIT",
+          "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+          "org.opencontainers.image.title": "Automata CI service proxy"
+        },
+        "user": "65532:65532",
+        "working_directory": "/"
+      },
+      "runtime": {
+        "binary": "/usr/libexec/automata-ci-service-proxy",
+        "gid": 65532,
+        "protocol": 2,
+        "uid": 65532
+      },
+      "source": {
+        "kind": "release-candidate",
+        "path": "target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
+      }
+    }
+  },
+  "platform": {
+    "architecture": "amd64",
+    "os": "linux"
+  },
+  "profile": {
+    "compatibility_label": "ubuntu-24.04",
+    "id": "automata.dev/github-hosted-ubuntu-24-04-x64-v1",
+    "image_role": "profile",
+    "lock_path": "images/github-hosted-ubuntu-24.04-x64/profile-lock.json",
+    "lock_sha256": "05fb47e52d497bb1cb887c19e4b865cfe49da73d462df57451d1b6efaa669238",
+    "manifest_path": "images/github-hosted-ubuntu-24.04-x64/profile-manifest.json",
+    "manifest_sha256": "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21"
+  },
+  "schema": "automata.local/release-catalog-source/v1",
+  "scope": {
+    "engine": "linux/amd64",
+    "host": "unix"
+  },
+  "services": {
+    "dns": {
+      "objects": "objects.automata.invalid",
+      "postgres": "postgres.automata.invalid",
+      "results": "results.automata.invalid",
+      "runner": "runner.automata.invalid"
+    },
+    "object_store": {
+      "bucket": "automata",
+      "force_path_style": true,
+      "operation_timeout_seconds": 30,
+      "port": 9000,
+      "prefix": "objects/v1",
+      "region": "us-east-1",
+      "transport": "https-private-ca"
+    },
+    "ports": {
+      "human": 8080,
+      "results": 8081,
+      "runner_control": 9090
+    },
+    "runner": {
+      "executor": "github",
+      "executor_contract": {
+        "ephemeral_disk_bytes": 0,
+        "minimum_cpu_millis": 1000,
+        "minimum_memory_bytes": 268435456,
+        "minimum_pids": 3,
+        "network": "private_egress",
+        "privilege": "administrator",
+        "root_filesystem": "writable",
+        "runner_root": "/__automata",
+        "workspace": "/__w"
+      },
+      "maximum_parallel_jobs": 256,
+      "profile_role": "profile",
+      "provider": "local-docker",
+      "provider_control_directory": "/automata-control",
+      "sandbox_guest_role": "sandbox-guest",
+      "service_proxy_role": "service-proxy"
+    }
+  }
+}

--- a/scripts/ci/build-static-musl.sh
+++ b/scripts/ci/build-static-musl.sh
@@ -54,11 +54,13 @@ cargo build \
   --bin automata \
   --bin automata-runner
 
-# This non-publishable binary exists only as input to its scratch helper image.
-# It is deliberately outside the public distribution archive above.
+# These non-publishable binaries exist only as inputs to their scratch helper
+# images. They are deliberately outside the public distribution archive above.
 cargo build \
   --locked \
   --release \
   --target "$target" \
   --package automata-ci-service-proxy \
-  --bin automata-ci-service-proxy
+  --bin automata-ci-service-proxy \
+  --package automata-ci-sandbox-guest \
+  --bin automata-ci-sandbox-guest

--- a/scripts/ci/generate-sboms.sh
+++ b/scripts/ci/generate-sboms.sh
@@ -62,19 +62,29 @@ target_directory="$(
 automata_binary="${target_directory}/${target}/release/automata"
 runner_binary="${target_directory}/${target}/release/automata-runner"
 service_proxy_binary="${target_directory}/${target}/release/automata-ci-service-proxy"
-readonly target_directory automata_binary runner_binary service_proxy_binary
+sandbox_guest_binary="${target_directory}/${target}/release/automata-ci-sandbox-guest"
+readonly \
+    target_directory \
+    automata_binary \
+    runner_binary \
+    service_proxy_binary \
+    sandbox_guest_binary
 [[ -x "${automata_binary}" ]] || die "missing executable ${automata_binary}"
 [[ -x "${runner_binary}" ]] || die "missing executable ${runner_binary}"
 [[ -x "${service_proxy_binary}" ]] || \
     die "missing executable ${service_proxy_binary}"
+[[ -x "${sandbox_guest_binary}" ]] || \
+    die "missing executable ${sandbox_guest_binary}"
 
 automata_raw="${repository_root}/crates/automata-ci/automata_bin.cdx.json"
 runner_raw="${repository_root}/crates/automata-ci-runner/automata-runner_bin.cdx.json"
 service_proxy_raw="${repository_root}/crates/automata-ci-service-proxy/automata-ci-service-proxy_bin.cdx.json"
-readonly automata_raw runner_raw service_proxy_raw
+sandbox_guest_raw="${repository_root}/crates/automata-ci-sandbox-guest/automata-ci-sandbox-guest_bin.cdx.json"
+readonly automata_raw runner_raw service_proxy_raw sandbox_guest_raw
 [[ ! -e "${automata_raw}" ]] || die "refusing to overwrite ${automata_raw}"
 [[ ! -e "${runner_raw}" ]] || die "refusing to overwrite ${runner_raw}"
 [[ ! -e "${service_proxy_raw}" ]] || die "refusing to overwrite ${service_proxy_raw}"
+[[ ! -e "${sandbox_guest_raw}" ]] || die "refusing to overwrite ${sandbox_guest_raw}"
 
 scratch_root="$(
     automata_canonical_target_child \
@@ -85,7 +95,11 @@ mkdir -p -- "${scratch_root}"
 scratch_directory="$(mktemp -d "${scratch_root}/release.XXXXXXXX")"
 readonly scratch_directory
 cleanup() {
-    rm -f -- "${automata_raw}" "${runner_raw}" "${service_proxy_raw}"
+    rm -f -- \
+        "${automata_raw}" \
+        "${runner_raw}" \
+        "${service_proxy_raw}" \
+        "${sandbox_guest_raw}"
     rm -rf -- "${scratch_directory}"
 }
 trap cleanup EXIT
@@ -136,6 +150,12 @@ generate_rust_sbom \
     "${service_proxy_raw}" \
     "${service_proxy_binary}" \
     automata-ci-service-proxy.cdx.json
+generate_rust_sbom \
+    automata-ci-sandbox-guest \
+    "${repository_root}/crates/automata-ci-sandbox-guest/Cargo.toml" \
+    "${sandbox_guest_raw}" \
+    "${sandbox_guest_binary}" \
+    automata-ci-sandbox-guest.cdx.json
 
 npm --prefix "${embedded_runtime_input}" sbom \
     --omit=dev \
@@ -172,10 +192,11 @@ mkdir -p -- "${output_directory}"
 for name in \
     automata.cdx.json \
     automata-runner.cdx.json \
+    automata-ci-sandbox-guest.cdx.json \
     automata-ci-service-proxy.cdx.json \
     renderer.cdx.json \
     ui-runtime.cdx.json
 do
     install -m 0444 -- "${scratch_directory}/${name}" "${output_directory}/${name}"
 done
-printf 'Created five CycloneDX SBOMs in %s\n' "${output_directory}"
+printf 'Created six CycloneDX SBOMs in %s\n' "${output_directory}"

--- a/scripts/ci/local_installation_catalog.py
+++ b/scripts/ci/local_installation_catalog.py
@@ -1,0 +1,1019 @@
+#!/usr/bin/env python3
+"""Build and verify the closed local-installation release catalog."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Mapping
+from typing import NoReturn
+
+
+CATALOG_SCHEMA = "automata.local/release-catalog/v1"
+SOURCE_SCHEMA = "automata.local/release-catalog-source/v1"
+SOURCE_PATH = "images/local-installation/catalog-v1.json"
+SOURCE_SHA256 = "66bd4ce7f50e877632efa761e0a9ef55ff73c92c38829300882f796bc95cff41"
+CATALOG_PATH = "target/distribution/automata-local-installation-catalog.json"
+PROFILE_MANIFEST_PATH = (
+    "images/github-hosted-ubuntu-24.04-x64/profile-manifest.json"
+)
+PROFILE_LOCK_PATH = "images/github-hosted-ubuntu-24.04-x64/profile-lock.json"
+SERVICE_PROXY_CANDIDATE_PATH = (
+    "target/service-proxy-publication/"
+    "automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
+)
+ROLES = {
+    "automata",
+    "postgres",
+    "profile",
+    "runner",
+    "rustfs",
+    "sandbox-guest",
+    "service-proxy",
+}
+REGISTRY_ROLES = ROLES - {"service-proxy"}
+RELEASE_REGISTRY_ROLES = {"automata", "runner", "sandbox-guest"}
+OCI_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+SHA256 = re.compile(r"[0-9a-f]{64}")
+GIT_OBJECT = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+IMAGE_REFERENCE = re.compile(
+    r"[a-z0-9]+(?:[._-][a-z0-9]+)*(?::[0-9]+)?"
+    r"(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+"
+    r"(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?"
+    r"@sha256:[0-9a-f]{64}"
+)
+MAX_JSON_SIZE = 1024 * 1024
+MAX_CANDIDATE_SIZE = 160 * 1024 * 1024
+MAX_TEXT_SIZE = 512
+RELEASE_LABEL_ROLES = {
+    "automata": "Automata",
+    "runner": "Automata Runner",
+    "sandbox-guest": "Automata Sandbox Guest",
+}
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"local-installation-catalog: {message}")
+
+
+def canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(value, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+
+
+def sha256_bytes(contents: bytes) -> str:
+    return hashlib.sha256(contents).hexdigest()
+
+
+def file_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def read_regular(path: pathlib.Path, label: str, maximum: int) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        fail(f"{label} must be a regular, non-symbolic-link file: {path}: {error}")
+    with os.fdopen(descriptor, "rb") as stream:
+        before = os.fstat(stream.fileno())
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size > maximum
+        ):
+            fail(f"{label} is not one bounded regular file: {path}")
+        contents = stream.read(maximum + 1)
+        after = os.fstat(stream.fileno())
+    if len(contents) != before.st_size or file_identity(before) != file_identity(after):
+        fail(f"{label} changed while it was read: {path}")
+    return contents
+
+
+def unique_object(pairs: list[tuple[str, object]]) -> dict:
+    value: dict[str, object] = {}
+    for name, entry in pairs:
+        if name in value:
+            raise ValueError(f"duplicate JSON key: {name}")
+        value[name] = entry
+    return value
+
+
+def invalid_constant(value: str) -> NoReturn:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+def parse_json(contents: bytes, label: str, *, canonical: bool) -> object:
+    try:
+        value = json.loads(
+            contents,
+            object_pairs_hook=unique_object,
+            parse_constant=invalid_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+        fail(f"{label} is invalid JSON: {error}")
+    if canonical and canonical_json(value) != contents:
+        fail(f"{label} is not canonical JSON")
+    return value
+
+
+def exact_object(value: object, keys: set[str], label: str) -> dict:
+    if not isinstance(value, dict) or set(value) != keys:
+        actual = sorted(value) if isinstance(value, dict) else type(value).__name__
+        fail(f"{label} keys differ: expected {sorted(keys)!r}, got {actual!r}")
+    return value
+
+
+def exact_list(value: object, label: str, maximum: int = 64) -> list:
+    if not isinstance(value, list) or len(value) > maximum:
+        fail(f"{label} must be one bounded array")
+    return value
+
+
+def one_line(value: object, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_TEXT_SIZE
+        or "\n" in value
+        or "\r" in value
+    ):
+        fail(f"{label} must be one bounded non-empty line")
+    return value
+
+
+def digest(value: object, label: str, *, prefix: bool = True) -> str:
+    pattern = OCI_DIGEST if prefix else SHA256
+    text = one_line(value, label)
+    if pattern.fullmatch(text) is None:
+        fail(f"{label} is not one SHA-256 digest")
+    return text
+
+
+def load_canonical(path: pathlib.Path, label: str, maximum: int = MAX_JSON_SIZE) -> dict:
+    value = parse_json(read_regular(path, label, maximum), label, canonical=True)
+    if not isinstance(value, dict):
+        fail(f"{label} root must be an object")
+    return value
+
+
+def load_source(repository_root: pathlib.Path) -> dict:
+    path = repository_root / SOURCE_PATH
+    contents = read_regular(path, "catalog source contract", MAX_JSON_SIZE)
+    if sha256_bytes(contents) != SOURCE_SHA256:
+        fail("catalog source contract differs from the reviewed v1 bytes")
+    value = parse_json(contents, "catalog source contract", canonical=True)
+    source = exact_object(
+        value,
+        {"images", "platform", "profile", "schema", "scope", "services"},
+        "catalog source contract",
+    )
+    if source["schema"] != SOURCE_SCHEMA:
+        fail("catalog source schema differs")
+    if source["platform"] != {"architecture": "amd64", "os": "linux"}:
+        fail("catalog source platform differs")
+    if source["scope"] != {"engine": "linux/amd64", "host": "unix"}:
+        fail("catalog source scope differs")
+    images = exact_object(source["images"], ROLES, "catalog source images")
+    repositories: set[str] = set()
+    for role in sorted(ROLES):
+        image = exact_object(
+            images[role],
+            {"canonical_repository", "config", "runtime", "source"},
+            f"catalog source {role}",
+        )
+        repository = one_line(
+            image["canonical_repository"], f"catalog source {role} alias"
+        )
+        if not repository.startswith("automata.local/") or "@" in repository:
+            fail(f"catalog source {role} alias is not canonical")
+        if repository in repositories:
+            fail("catalog source aliases must be unique")
+        exact_object(
+            image["config"],
+            {
+                "command",
+                "entrypoint",
+                "required_environment",
+                "required_labels",
+                "user",
+                "working_directory",
+            },
+            f"catalog source {role} config",
+        )
+        if not isinstance(image["runtime"], dict) or not image["runtime"]:
+            fail(f"catalog source {role} runtime contract is missing")
+        source_binding = image["source"]
+        if role == "service-proxy":
+            expected = {"kind", "path"}
+            kind = "release-candidate"
+        elif role in RELEASE_REGISTRY_ROLES:
+            expected = {"kind", "repository"}
+            kind = "release-registry"
+        else:
+            expected = {
+                "config_digest",
+                "kind",
+                "platform_manifest_digest",
+                "reference",
+            }
+            kind = "registry"
+        binding = exact_object(source_binding, expected, f"catalog source {role} source")
+        if binding["kind"] != kind:
+            fail(f"catalog source {role} kind differs")
+    return source
+
+
+def load_profile(repository_root: pathlib.Path, source: dict) -> dict:
+    profile = exact_object(
+        source["profile"],
+        {
+            "compatibility_label",
+            "id",
+            "image_role",
+            "lock_path",
+            "lock_sha256",
+            "manifest_path",
+            "manifest_sha256",
+        },
+        "catalog source profile",
+    )
+    if (
+        profile["lock_path"] != PROFILE_LOCK_PATH
+        or profile["manifest_path"] != PROFILE_MANIFEST_PATH
+        or profile["image_role"] != "profile"
+    ):
+        fail("catalog source profile paths or role differ")
+    manifest_path = repository_root / PROFILE_MANIFEST_PATH
+    lock_path = repository_root / PROFILE_LOCK_PATH
+    manifest_contents = read_regular(
+        manifest_path, "profile manifest", MAX_JSON_SIZE
+    )
+    manifest = parse_json(manifest_contents, "profile manifest", canonical=False)
+    lock_contents = read_regular(lock_path, "profile lock", MAX_JSON_SIZE)
+    lock = parse_json(lock_contents, "profile lock", canonical=False)
+    if not isinstance(manifest, dict) or not isinstance(lock, dict):
+        fail("profile manifest and lock must be objects")
+    manifest_sha256 = sha256_bytes(manifest_contents)
+    lock_sha256 = sha256_bytes(lock_contents)
+    image_source = source["images"]["profile"]["source"]
+    if (
+        manifest_sha256 != profile["manifest_sha256"]
+        or lock_sha256 != profile["lock_sha256"]
+        or manifest.get("schema_version") != 2
+        or manifest.get("profile_id") != profile["id"]
+        or (manifest.get("platform") or {}).get("os") != "linux"
+        or (manifest.get("platform") or {}).get("architecture") != "x86_64"
+        or (manifest.get("platform") or {}).get("compatibility_label")
+        != profile["compatibility_label"]
+        or manifest.get("image") != image_source["reference"]
+        or lock.get("schema_version") != 2
+        or lock.get("profile_id") != profile["id"]
+        or lock.get("profile_manifest_sha256") != manifest_sha256
+        or lock.get("image") != image_source["reference"]
+    ):
+        fail("profile manifest, lock, and catalog source differ")
+    return {
+        "compatibility_label": profile["compatibility_label"],
+        "id": profile["id"],
+        "image_role": "profile",
+        "lock": {
+            "path": PROFILE_LOCK_PATH,
+            "sha256": lock_sha256,
+        },
+        "manifest": {
+            "path": PROFILE_MANIFEST_PATH,
+            "sha256": manifest_sha256,
+        },
+    }
+
+
+def repository_from_reference(reference: str) -> str:
+    name = reference.rsplit("@", 1)[0]
+    last_slash = name.rfind("/")
+    tag = name.find(":", last_slash + 1)
+    return name if tag == -1 else name[:tag]
+
+
+def parse_environment(value: object, label: str) -> dict[str, str]:
+    entries = exact_list(value if value is not None else [], label, 256)
+    environment: dict[str, str] = {}
+    for entry in entries:
+        text = one_line(entry, f"{label} entry")
+        name, separator, configured = text.partition("=")
+        if not separator or not name or name in environment:
+            fail(f"{label} contains a malformed or duplicate name")
+        environment[name] = configured
+    return environment
+
+
+def process_value(process: dict, name: str, default: object) -> object:
+    value = process.get(name, default)
+    return default if value is None else value
+
+
+def validate_process(
+    role: str,
+    process: object,
+    expected: dict,
+    release: Mapping[str, object],
+) -> None:
+    if not isinstance(process, dict):
+        fail(f"{role} image process configuration is missing")
+    actual = {
+        "command": process_value(process, "Cmd", []),
+        "entrypoint": process_value(process, "Entrypoint", []),
+        "user": process_value(process, "User", ""),
+        "working_directory": process_value(process, "WorkingDir", ""),
+    }
+    for name, value in actual.items():
+        if value != expected[name]:
+            fail(f"{role} image {name} differs from the catalog contract")
+    environment = parse_environment(process.get("Env", []), f"{role} image environment")
+    required_environment = expected["required_environment"]
+    if not isinstance(required_environment, dict) or any(
+        environment.get(name) != value
+        for name, value in required_environment.items()
+    ):
+        fail(f"{role} image environment differs from the catalog contract")
+    labels = process.get("Labels") or {}
+    required_labels = expected["required_labels"]
+    if (
+        not isinstance(labels, dict)
+        or not isinstance(required_labels, dict)
+        or any(labels.get(name) != value for name, value in required_labels.items())
+    ):
+        fail(f"{role} image labels differ from the catalog contract")
+    if role in RELEASE_LABEL_ROLES:
+        dynamic = {
+            "org.opencontainers.image.created": release["created"],
+            "org.opencontainers.image.revision": release["commit"],
+            "org.opencontainers.image.version": release["version"],
+        }
+        if any(labels.get(name) != value for name, value in dynamic.items()):
+            fail(f"{role} image release labels differ from the gated release")
+
+
+def require_release(value: object) -> dict:
+    release = exact_object(
+        value,
+        {
+            "commit",
+            "created",
+            "prerelease",
+            "source_date_epoch",
+            "tag",
+            "tag_object",
+            "version",
+        },
+        "catalog release",
+    )
+    for key in ("commit", "tag_object"):
+        if GIT_OBJECT.fullmatch(one_line(release[key], f"catalog release {key}")) is None:
+            fail(f"catalog release {key} is invalid")
+    for key in ("created", "tag", "version"):
+        one_line(release[key], f"catalog release {key}")
+    if type(release["prerelease"]) is not bool:
+        fail("catalog release prerelease must be a boolean")
+    if type(release["source_date_epoch"]) is not int or release["source_date_epoch"] < 0:
+        fail("catalog release source date epoch is invalid")
+    if release["tag"] != f"v{release['version']}":
+        fail("catalog release tag and version differ")
+    return release
+
+
+def run_inspect(arguments: list[str], label: str) -> bytes:
+    try:
+        result = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", *arguments],
+            check=False,
+            capture_output=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        fail(f"could not inspect {label}: {error}")
+    if result.returncode != 0 or result.stderr:
+        fail(f"could not inspect {label}")
+    return result.stdout
+
+
+def capture_registry_evidence(reference: str) -> dict:
+    if IMAGE_REFERENCE.fullmatch(reference) is None:
+        fail("registry source must be a canonical digest-qualified reference")
+    top_digest = reference.rsplit("@", 1)[1]
+    top_bytes = run_inspect([reference, "--raw"], "top-level manifest")
+    if f"sha256:{sha256_bytes(top_bytes)}" != top_digest:
+        fail("registry top-level manifest bytes differ from their digest")
+    manifest = parse_json(top_bytes, "registry top-level manifest", canonical=False)
+    if not isinstance(manifest, dict):
+        fail("registry top-level manifest is missing")
+    media_type = manifest.get("mediaType")
+    if media_type == "application/vnd.oci.image.index.v1+json":
+        manifests = manifest.get("manifests")
+        if not isinstance(manifests, list):
+            fail("registry index manifest set is missing")
+        candidates = [
+            entry
+            for entry in manifests
+            if isinstance(entry, dict)
+            and entry.get("platform") == {"architecture": "amd64", "os": "linux"}
+        ]
+        if len(candidates) != 1:
+            fail("registry index must contain exactly one linux/amd64 image")
+        platform_digest = digest(
+            candidates[0].get("digest"), "registry platform manifest digest"
+        )
+    elif media_type == "application/vnd.oci.image.manifest.v1+json":
+        platform_digest = top_digest
+    else:
+        fail("registry image has an unsupported top-level media type")
+    repository = repository_from_reference(reference)
+    child_reference = f"{repository}@{platform_digest}"
+    child_bytes = (
+        top_bytes
+        if platform_digest == top_digest
+        else run_inspect([child_reference, "--raw"], "platform manifest")
+    )
+    if f"sha256:{sha256_bytes(child_bytes)}" != platform_digest:
+        fail("registry platform manifest bytes differ from their digest")
+    child = parse_json(child_bytes, "registry platform manifest", canonical=False)
+    if not isinstance(child, dict) or child.get("mediaType") not in {
+        None,
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+    }:
+        fail("registry platform manifest schema differs")
+    config = child.get("config")
+    if not isinstance(config, dict):
+        fail("registry platform manifest config descriptor is missing")
+    config_digest = digest(config.get("digest"), "registry config digest")
+
+    # Resolve the process configuration through the exact child descriptor, not
+    # through the mutable tag or the index's convenience platform mapping.
+    # Buildx verifies the content-addressed manifest and config descriptors while
+    # producing this view; checking both the returned name and manifest digest
+    # prevents process metadata from an unrelated inspection being accepted.
+    formatted = run_inspect(
+        [child_reference, "--format", "{{json .}}"], "platform image"
+    )
+    inspection = parse_json(formatted, "registry inspection", canonical=False)
+    inspection = exact_object(
+        inspection, {"image", "manifest", "name"}, "registry inspection"
+    )
+    if inspection["name"] != child_reference:
+        fail("registry inspection name differs from the platform reference")
+    inspected_manifest = inspection["manifest"]
+    if (
+        not isinstance(inspected_manifest, dict)
+        or inspected_manifest.get("digest") != platform_digest
+        or inspected_manifest.get("mediaType")
+        not in {
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "application/vnd.oci.image.manifest.v1+json",
+        }
+    ):
+        fail("registry inspection platform manifest differs")
+    image = inspection["image"]
+    if not isinstance(image, dict):
+        fail("registry image configuration is missing")
+    if image.get("architecture") != "amd64" or image.get("os") != "linux":
+        fail("registry image platform differs")
+    process = image.get("config")
+    if not isinstance(process, dict):
+        fail("registry image process configuration is missing")
+    return {
+        "architecture": "amd64",
+        "config": process,
+        "config_digest": config_digest,
+        "os": "linux",
+        "platform_manifest_digest": platform_digest,
+        "reference": reference,
+        "top_level_digest": top_digest,
+    }
+
+
+def load_evidence(path: pathlib.Path, role: str) -> dict:
+    evidence = load_canonical(path, f"{role} registry evidence")
+    return exact_object(
+        evidence,
+        {
+            "architecture",
+            "config",
+            "config_digest",
+            "os",
+            "platform_manifest_digest",
+            "reference",
+            "top_level_digest",
+        },
+        f"{role} registry evidence",
+    )
+
+
+def validate_registry_evidence(
+    role: str,
+    evidence: dict,
+    source_image: dict,
+    release: dict,
+) -> dict:
+    if evidence["architecture"] != "amd64" or evidence["os"] != "linux":
+        fail(f"{role} registry evidence platform differs")
+    reference = one_line(evidence["reference"], f"{role} registry reference")
+    if IMAGE_REFERENCE.fullmatch(reference) is None:
+        fail(f"{role} registry reference is not canonical and digest-qualified")
+    top_digest = digest(evidence["top_level_digest"], f"{role} top-level digest")
+    if reference.rsplit("@", 1)[1] != top_digest:
+        fail(f"{role} registry reference and top-level digest differ")
+    platform_digest = digest(
+        evidence["platform_manifest_digest"], f"{role} platform digest"
+    )
+    config_digest = digest(evidence["config_digest"], f"{role} config digest")
+    source_binding = source_image["source"]
+    if role in RELEASE_REGISTRY_ROLES:
+        expected_repository = source_binding["repository"]
+        if repository_from_reference(reference) != expected_repository:
+            fail(f"{role} registry repository differs from the release contract")
+    else:
+        if reference != source_binding["reference"]:
+            fail(f"{role} registry reference differs from the fixed contract")
+        if platform_digest != source_binding["platform_manifest_digest"]:
+            fail(f"{role} platform digest differs from the fixed contract")
+        if config_digest != source_binding["config_digest"]:
+            fail(f"{role} config digest differs from the fixed contract")
+    validate_process(role, evidence["config"], source_image["config"], release)
+    return {
+        "config_digest": config_digest,
+        "kind": "registry",
+        "platform_manifest_digest": platform_digest,
+        "reference": reference,
+        "top_level_digest": top_digest,
+    }
+
+
+def service_proxy_module() -> tuple[object, object]:
+    script_directory = pathlib.Path(__file__).resolve().parent
+    publication_path = script_directory / "service-proxy-publication.py"
+    candidate_path = script_directory / "service-proxy-candidate.py"
+    candidate_spec = importlib.util.spec_from_file_location(
+        "local_catalog_service_proxy_candidate", candidate_path
+    )
+    if candidate_spec is None or candidate_spec.loader is None:
+        raise RuntimeError(f"could not load {candidate_path}")
+    candidate = importlib.util.module_from_spec(candidate_spec)
+    sys.modules[candidate_spec.name] = candidate
+    candidate_spec.loader.exec_module(candidate)
+    publication_spec = importlib.util.spec_from_file_location(
+        "local_catalog_service_proxy_publication", publication_path
+    )
+    if publication_spec is None or publication_spec.loader is None:
+        raise RuntimeError(f"could not load {publication_path}")
+    publication = importlib.util.module_from_spec(publication_spec)
+    sys.modules[publication_spec.name] = publication
+    publication_spec.loader.exec_module(publication)
+    return publication, candidate
+
+
+def oci_config_binding(oci_bytes: bytes, manifest_digest: str) -> tuple[str, dict]:
+    try:
+        with tarfile.open(fileobj=io.BytesIO(oci_bytes), mode="r:") as archive:
+            members = {
+                entry.name: archive.extractfile(entry).read()  # type: ignore[union-attr]
+                for entry in archive.getmembers()
+                if entry.isfile()
+            }
+    except tarfile.TarError:
+        fail("service-proxy candidate OCI archive is invalid")
+    manifest_name = f"blobs/sha256/{manifest_digest.removeprefix('sha256:')}"
+    manifest = parse_json(
+        members.get(manifest_name, b""),
+        "service-proxy OCI manifest",
+        canonical=False,
+    )
+    if not isinstance(manifest, dict):
+        fail("service-proxy OCI manifest is not an object")
+    config_descriptor = manifest.get("config")
+    if not isinstance(config_descriptor, dict):
+        fail("service-proxy OCI config descriptor is missing")
+    config_digest = digest(
+        config_descriptor.get("digest"), "service-proxy config digest"
+    )
+    config_name = f"blobs/sha256/{config_digest.removeprefix('sha256:')}"
+    config = parse_json(
+        members.get(config_name, b""),
+        "service-proxy OCI config",
+        canonical=False,
+    )
+    if not isinstance(config, dict):
+        fail("service-proxy OCI config is not an object")
+    return config_digest, config
+
+
+def validate_service_proxy_candidate(
+    repository_root: pathlib.Path,
+    candidate_path: pathlib.Path,
+    release: dict,
+    source_image: dict,
+) -> dict:
+    publication, candidate_module = service_proxy_module()
+    members, source, identity, _, candidate_sha256 = (
+        publication.load_candidate_archive(  # type: ignore[attr-defined]
+            candidate_path,
+            repository_root,
+            release["commit"],
+        )
+    )
+    if source["release"] != {
+        "created": release["created"],
+        "revision": release["commit"],
+        "source_date_epoch": release["source_date_epoch"],
+        "version": release["version"],
+    }:
+        fail("service-proxy candidate release differs from the gated release")
+    image = identity["image"]
+    manifest_digest = digest(
+        image["manifest_digest"], "service-proxy image manifest digest"
+    )
+    oci_bytes = members[candidate_module.IMAGE_ARCHIVE_NAME]
+    config_digest, config = oci_config_binding(oci_bytes, manifest_digest)
+    if config.get("architecture") != "amd64" or config.get("os") != "linux":
+        fail("service-proxy candidate platform differs")
+    validate_process(
+        "service-proxy", config.get("config"), source_image["config"], release
+    )
+    return {
+        "candidate_provenance_sha256": sha256_bytes(
+            members[candidate_module.IDENTITY_NAME]
+        ),
+        "config_digest": config_digest,
+        "image_digest": manifest_digest,
+        "image_name": image["name"],
+        "kind": "release-candidate",
+        "oci_archive_sha256": image["oci_archive_sha256"],
+        "path": SERVICE_PROXY_CANDIDATE_PATH,
+        "sha256": candidate_sha256,
+        "source_provenance_sha256": image["source_provenance_sha256"],
+    }
+
+
+def validate_service_proxy_payload(
+    repository_root: pathlib.Path,
+    release: dict,
+    source_image: dict,
+    payloads: Mapping[str, bytes] | None,
+) -> dict:
+    if payloads is None:
+        return validate_service_proxy_candidate(
+            repository_root,
+            repository_root / SERVICE_PROXY_CANDIDATE_PATH,
+            release,
+            source_image,
+        )
+    contents = payloads.get(SERVICE_PROXY_CANDIDATE_PATH)
+    if contents is None:
+        fail("local-installation payload omits the service-proxy candidate")
+    if len(contents) > MAX_CANDIDATE_SIZE:
+        fail("local-installation service-proxy candidate exceeds its size limit")
+    scratch = repository_root / "target" / "task-tmp" / "catalog-verification"
+    scratch.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary_path: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=scratch,
+            prefix="service-proxy.",
+            suffix=".tar",
+            delete=False,
+        ) as stream:
+            temporary_path = pathlib.Path(stream.name)
+            stream.write(contents)
+            stream.flush()
+            os.fsync(stream.fileno())
+        return validate_service_proxy_candidate(
+            repository_root, temporary_path, release, source_image
+        )
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def build_catalog(
+    repository_root: pathlib.Path,
+    release_value: object,
+    evidence: Mapping[str, dict],
+    candidate_path: pathlib.Path,
+) -> dict:
+    release = require_release(release_value)
+    source = load_source(repository_root)
+    if set(evidence) != REGISTRY_ROLES:
+        fail("registry evidence role set differs from the closed catalog")
+    images: dict[str, dict] = {}
+    for role in sorted(REGISTRY_ROLES):
+        source_image = source["images"][role]
+        images[role] = {
+            "canonical_repository": source_image["canonical_repository"],
+            "config": source_image["config"],
+            "runtime": source_image["runtime"],
+            "source": validate_registry_evidence(
+                role, evidence[role], source_image, release
+            ),
+        }
+    service_source = source["images"]["service-proxy"]
+    images["service-proxy"] = {
+        "canonical_repository": service_source["canonical_repository"],
+        "config": service_source["config"],
+        "runtime": service_source["runtime"],
+        "source": validate_service_proxy_candidate(
+            repository_root, candidate_path, release, service_source
+        ),
+    }
+    return {
+        "images": images,
+        "platform": source["platform"],
+        "profile": load_profile(repository_root, source),
+        "release": release,
+        "schema": CATALOG_SCHEMA,
+        "scope": source["scope"],
+        "services": source["services"],
+        "source_contract_sha256": SOURCE_SHA256,
+    }
+
+
+def validate_catalog(
+    document: object,
+    expected_release: object,
+    *,
+    repository_root: pathlib.Path | None = None,
+    expected_registry_digests: Mapping[str, str] | None = None,
+    payloads: Mapping[str, bytes] | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    catalog = exact_object(
+        document,
+        {
+            "images",
+            "platform",
+            "profile",
+            "release",
+            "schema",
+            "scope",
+            "services",
+            "source_contract_sha256",
+        },
+        "local-installation catalog",
+    )
+    if catalog["schema"] != CATALOG_SCHEMA:
+        fail("local-installation catalog schema differs")
+    release = require_release(catalog["release"])
+    if release != require_release(expected_release):
+        fail("local-installation catalog release differs from the gated release")
+    if catalog["source_contract_sha256"] != SOURCE_SHA256:
+        fail("local-installation catalog source contract digest differs")
+    if repository_root is None:
+        repository_root = pathlib.Path(__file__).resolve().parents[2]
+    source = load_source(repository_root)
+    if (
+        catalog["platform"] != source["platform"]
+        or catalog["scope"] != source["scope"]
+        or catalog["services"] != source["services"]
+        or catalog["profile"] != load_profile(repository_root, source)
+    ):
+        fail("local-installation catalog platform/profile/service contract differs")
+    images = exact_object(catalog["images"], ROLES, "local-installation images")
+    registry_digests: dict[str, str] = {}
+    payload_paths: list[str] = []
+    for role in sorted(ROLES):
+        value = exact_object(
+            images[role],
+            {"canonical_repository", "config", "runtime", "source"},
+            f"local-installation {role}",
+        )
+        expected = source["images"][role]
+        for key in ("canonical_repository", "config", "runtime"):
+            if value[key] != expected[key]:
+                fail(f"local-installation {role} {key} differs")
+        binding = value["source"]
+        if role == "service-proxy":
+            binding = exact_object(
+                binding,
+                {
+                    "candidate_provenance_sha256",
+                    "config_digest",
+                    "image_digest",
+                    "image_name",
+                    "kind",
+                    "oci_archive_sha256",
+                    "path",
+                    "sha256",
+                    "source_provenance_sha256",
+                },
+                "local-installation service-proxy source",
+            )
+            if (
+                binding["kind"] != "release-candidate"
+                or binding["path"] != SERVICE_PROXY_CANDIDATE_PATH
+            ):
+                fail("local-installation service-proxy source differs")
+            for name in (
+                "candidate_provenance_sha256",
+                "oci_archive_sha256",
+                "sha256",
+                "source_provenance_sha256",
+            ):
+                digest(binding[name], f"service-proxy {name}", prefix=False)
+            digest(binding["config_digest"], "service-proxy config digest")
+            digest(binding["image_digest"], "service-proxy image digest")
+            one_line(binding["image_name"], "service-proxy image name")
+            actual = validate_service_proxy_payload(
+                repository_root,
+                release,
+                expected,
+                payloads,
+            )
+            if binding != actual:
+                fail("local-installation service-proxy candidate binding differs")
+            payload_paths.append(SERVICE_PROXY_CANDIDATE_PATH)
+            continue
+        binding = exact_object(
+            binding,
+            {
+                "config_digest",
+                "kind",
+                "platform_manifest_digest",
+                "reference",
+                "top_level_digest",
+            },
+            f"local-installation {role} registry source",
+        )
+        if binding["kind"] != "registry":
+            fail(f"local-installation {role} source kind differs")
+        reference = one_line(binding["reference"], f"{role} registry reference")
+        top_digest = digest(binding["top_level_digest"], f"{role} top digest")
+        if IMAGE_REFERENCE.fullmatch(reference) is None or reference.rsplit("@", 1)[1] != top_digest:
+            fail(f"local-installation {role} registry reference differs")
+        digest(binding["platform_manifest_digest"], f"{role} platform digest")
+        digest(binding["config_digest"], f"{role} config digest")
+        if role in RELEASE_REGISTRY_ROLES:
+            if repository_from_reference(reference) != expected["source"]["repository"]:
+                fail(f"local-installation {role} release repository differs")
+        elif (
+            reference != expected["source"]["reference"]
+            or binding["platform_manifest_digest"]
+            != expected["source"]["platform_manifest_digest"]
+            or binding["config_digest"] != expected["source"]["config_digest"]
+        ):
+            fail(f"local-installation {role} fixed registry binding differs")
+        registry_digests[role] = top_digest
+    if expected_registry_digests is not None:
+        if set(expected_registry_digests) != RELEASE_REGISTRY_ROLES:
+            fail("expected release registry digest role set differs")
+        for role, expected_digest in expected_registry_digests.items():
+            if registry_digests[role] != expected_digest:
+                fail(f"local-installation {role} digest differs from staging")
+    return registry_digests, payload_paths
+
+
+def write_exclusive(path: pathlib.Path, contents: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o444)
+    except OSError as error:
+        fail(f"refusing to overwrite output {path}: {error}")
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(contents)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def write_outputs(path: pathlib.Path | None, values: Mapping[str, str]) -> None:
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as stream:
+        for name, value in values.items():
+            one_line(value, f"output {name}")
+            stream.write(f"{name}={value}\n")
+
+
+def identity_from_arguments(arguments: argparse.Namespace) -> dict:
+    return require_release(
+        {
+            "commit": arguments.commit,
+            "created": arguments.created,
+            "prerelease": arguments.prerelease == "true",
+            "source_date_epoch": arguments.source_date_epoch,
+            "tag": arguments.tag,
+            "tag_object": arguments.tag_object,
+            "version": arguments.version,
+        }
+    )
+
+
+def add_identity_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--tag-object", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--prerelease", required=True, choices=("true", "false"))
+    parser.add_argument("--source-date-epoch", required=True, type=int)
+    parser.add_argument("--created", required=True)
+
+
+def parse_evidence(values: list[str]) -> dict[str, pathlib.Path]:
+    result: dict[str, pathlib.Path] = {}
+    for value in values:
+        role, separator, path = value.partition("=")
+        if not separator or role not in REGISTRY_ROLES or role in result or not path:
+            fail("--evidence must name each exact registry role once as ROLE=PATH")
+        result[role] = pathlib.Path(path)
+    if set(result) != REGISTRY_ROLES:
+        fail("--evidence role set differs from the closed registry role set")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+    capture = subparsers.add_parser("capture-registry")
+    capture.add_argument("--source", required=True)
+    capture.add_argument("--output", required=True, type=pathlib.Path)
+
+    create = subparsers.add_parser("create")
+    add_identity_arguments(create)
+    create.add_argument("--repository-root", required=True, type=pathlib.Path)
+    create.add_argument("--output", required=True, type=pathlib.Path)
+    create.add_argument("--evidence", action="append", required=True)
+    create.add_argument(
+        "--service-proxy-candidate", required=True, type=pathlib.Path
+    )
+
+    verify = subparsers.add_parser("verify")
+    add_identity_arguments(verify)
+    verify.add_argument("--repository-root", required=True, type=pathlib.Path)
+    verify.add_argument("--catalog", required=True, type=pathlib.Path)
+    verify.add_argument("--github-output", type=pathlib.Path)
+
+    arguments = parser.parse_args()
+    if arguments.operation == "capture-registry":
+        evidence = capture_registry_evidence(arguments.source)
+        write_exclusive(arguments.output, canonical_json(evidence))
+        return
+    repository_root = arguments.repository_root.resolve(strict=True)
+    release = identity_from_arguments(arguments)
+    if arguments.operation == "create":
+        evidence_paths = parse_evidence(arguments.evidence)
+        evidence = {
+            role: load_evidence(path, role) for role, path in evidence_paths.items()
+        }
+        catalog = build_catalog(
+            repository_root,
+            release,
+            evidence,
+            arguments.service_proxy_candidate,
+        )
+        write_exclusive(arguments.output, canonical_json(catalog))
+        return
+    catalog = load_canonical(arguments.catalog, "local-installation catalog")
+    registry_digests, _ = validate_catalog(
+        catalog, release, repository_root=repository_root
+    )
+    service_proxy = catalog["images"]["service-proxy"]["source"]
+    write_outputs(
+        arguments.github_output,
+        {
+            "automata_digest": registry_digests["automata"],
+            "candidate_filename": pathlib.PurePosixPath(service_proxy["path"]).name,
+            "candidate_sha256": service_proxy["sha256"],
+            "image_digest": service_proxy["image_digest"],
+            "provenance_sha256": service_proxy["candidate_provenance_sha256"],
+            "runner_digest": registry_digests["runner"],
+            "sandbox_guest_digest": registry_digests["sandbox-guest"],
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/prepare-sandbox-guest-context.sh
+++ b/scripts/ci/prepare-sandbox-guest-context.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../.." && pwd)"
+readonly script_directory repository_root
+# shellcheck source=scripts/ci/lib/target-paths.sh
+source "${script_directory}/lib/target-paths.sh"
+
+die() {
+  printf 'sandbox-guest-context: %s\n' "$*" >&2
+  exit 1
+}
+
+if (( $# != 2 )); then
+  die "usage: $0 CONTEXT VERSION"
+fi
+context="$1"
+version="$2"
+readonly version
+[[ -n "$version" && ${#version} -le 120 && "$version" != *$'\n'* && "$version" != *$'\r'* ]] \
+  || die "version must be one bounded non-empty line"
+
+automata_init_target_root "$repository_root"
+if [[ "$context" != /* ]]; then
+  context="${repository_root}/${context}"
+fi
+context="$(automata_canonical_target_child "$context" "sandbox-guest image context")"
+readonly context
+if [[ -e "$context" ]]; then
+  [[ -d "$context" && -z "$(find "$context" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+    || die "context must be an absent or empty target directory"
+else
+  install -d -m 0700 -- "$context"
+fi
+
+target_directory="${CARGO_TARGET_DIR:-target}"
+if [[ "$target_directory" != /* ]]; then
+  target_directory="${repository_root}/${target_directory}"
+fi
+target_directory="$(automata_canonical_target_path "$target_directory" "Cargo target directory")"
+binary="${target_directory}/x86_64-unknown-linux-musl/release/automata-ci-sandbox-guest"
+sbom="${target_directory}/distribution-input/sbom/automata-ci-sandbox-guest.cdx.json"
+license_directory="${target_directory}/distribution-input/licenses"
+containerfile="${repository_root}/images/automata-sandbox-guest.Containerfile"
+readonly target_directory binary sbom license_directory containerfile
+
+for required in \
+  "$binary" \
+  "$repository_root/LICENSE" \
+  "$sbom" \
+  "$license_directory/THIRD_PARTY_LICENSES.txt" \
+  "$license_directory/THIRD_PARTY_NOTICES.txt" \
+  "$containerfile"
+do
+  [[ -f "$required" && ! -L "$required" ]] \
+    || die "required image input is missing"
+done
+"${script_directory}/verify-sandbox-guest-static.sh" "$binary"
+
+install -m 0555 -- "$binary" "$context/automata-ci-sandbox-guest"
+install -m 0444 -- "$repository_root/LICENSE" "$context/LICENSE"
+install -m 0444 -- \
+  "$license_directory/THIRD_PARTY_LICENSES.txt" \
+  "$context/THIRD_PARTY_LICENSES.txt"
+install -m 0444 -- \
+  "$license_directory/THIRD_PARTY_NOTICES.txt" \
+  "$context/THIRD_PARTY_NOTICES.txt"
+install -m 0444 -- "$containerfile" "$context/Containerfile"
+install -d -m 0755 -- "$context/sbom"
+install -m 0444 -- "$sbom" "$context/sbom/automata-ci-sandbox-guest.cdx.json"
+chmod 0555 -- "$context/sbom"
+printf '%s\n' "$version" > "$context/VERSION"
+chmod 0444 -- "$context/VERSION"
+
+printf 'Prepared sandbox-guest image context at %s\n' "$context"

--- a/scripts/ci/release-handoff.py
+++ b/scripts/ci/release-handoff.py
@@ -5,25 +5,42 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import io
 import json
 import os
 import pathlib
 import re
 import stat
+import sys
 import tarfile
 from collections.abc import Collection
 from dataclasses import dataclass
 from typing import BinaryIO, NoReturn
 
 
-SCHEMA_VERSION = 1
+SCRIPT_DIRECTORY = pathlib.Path(__file__).resolve().parent
+CATALOG_SCRIPT = SCRIPT_DIRECTORY / "local_installation_catalog.py"
+CATALOG_SPEC = importlib.util.spec_from_file_location(
+    "release_local_installation_catalog", CATALOG_SCRIPT
+)
+if CATALOG_SPEC is None or CATALOG_SPEC.loader is None:
+    raise RuntimeError(f"could not load {CATALOG_SCRIPT}")
+local_catalog = importlib.util.module_from_spec(CATALOG_SPEC)
+sys.modules[CATALOG_SPEC.name] = local_catalog
+CATALOG_SPEC.loader.exec_module(local_catalog)
+
+
+SCHEMA_VERSION = 2
 ARCHIVE_PATH = "target/distribution/automata-x86_64-unknown-linux-musl.tar.gz"
 CHECKSUM_PATH = f"{ARCHIVE_PATH}.sha256"
 MANIFEST_PATH = "target/distribution/automata-release-manifest.json"
+CATALOG_PATH = local_catalog.CATALOG_PATH
+SERVICE_PROXY_CANDIDATE_PATH = local_catalog.SERVICE_PROXY_CANDIDATE_PATH
 IMAGE_NAMES = {
     "automata": "ghcr.io/automata-ci/automata",
     "automata-runner": "ghcr.io/automata-ci/automata-runner",
+    "automata-sandbox-guest": "ghcr.io/automata-ci/automata-sandbox-guest",
 }
 SHA256 = re.compile(r"[0-9a-f]{64}")
 OCI_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
@@ -33,9 +50,13 @@ MAX_HANDOFF_SIZE = 768 * 1024 * 1024
 MAX_HANDOFF_CONTENT_SIZE = 700 * 1024 * 1024
 MAX_HANDOFF_MEMBER_SIZE = 256 * 1024 * 1024
 MAX_HANDOFF_MEMBERS = 128
+FIXED_HANDOFF_MEMBERS = 5
+MAX_CRATE_ENTRIES = MAX_HANDOFF_MEMBERS - FIXED_HANDOFF_MEMBERS
 MAX_MANIFEST_SIZE = 1024 * 1024
 MAX_CRATE_SIZE = 10 * 1024 * 1024
 MAX_RELEASE_ARCHIVE_SIZE = 256 * 1024 * 1024
+MAX_CATALOG_SIZE = local_catalog.MAX_JSON_SIZE
+MAX_SERVICE_PROXY_CANDIDATE_SIZE = local_catalog.MAX_CANDIDATE_SIZE
 MAX_TEXT_SIZE = 512
 
 
@@ -241,7 +262,7 @@ def package_entries(
                 "version": version,
             }
         )
-        if len(entries) > MAX_HANDOFF_MEMBERS - 3:
+        if len(entries) > MAX_CRATE_ENTRIES:
             fail("too many crate archives for one release handoff")
     if not entries:
         fail("no crate archives were found")
@@ -256,10 +277,14 @@ def build_manifest(
     identity: ReleaseIdentity,
     automata_digest: str,
     runner_digest: str,
+    sandbox_guest_digest: str,
     expected_crates: Collection[str],
 ) -> dict:
     automata_digest = require_match(automata_digest, OCI_DIGEST, "Automata image digest")
     runner_digest = require_match(runner_digest, OCI_DIGEST, "runner image digest")
+    sandbox_guest_digest = require_match(
+        sandbox_guest_digest, OCI_DIGEST, "sandbox-guest image digest"
+    )
     archive = file_entry(
         ARCHIVE_PATH,
         repository_root,
@@ -273,6 +298,33 @@ def build_manifest(
         MAX_TEXT_SIZE,
     )
     validate_checksum(repository_root / CHECKSUM_PATH, archive["sha256"])
+    catalog_entry = file_entry(
+        CATALOG_PATH,
+        repository_root,
+        "local-installation catalog",
+        MAX_CATALOG_SIZE,
+    )
+    candidate_entry = file_entry(
+        SERVICE_PROXY_CANDIDATE_PATH,
+        repository_root,
+        "service-proxy candidate",
+        MAX_SERVICE_PROXY_CANDIDATE_SIZE,
+    )
+    catalog_document = local_catalog.load_canonical(
+        repository_root / CATALOG_PATH,
+        "local-installation catalog",
+        MAX_CATALOG_SIZE,
+    )
+    local_catalog.validate_catalog(
+        catalog_document,
+        identity.document(),
+        repository_root=repository_root,
+        expected_registry_digests={
+            "automata": automata_digest,
+            "runner": runner_digest,
+            "sandbox-guest": sandbox_guest_digest,
+        },
+    )
     return {
         "crates": package_entries(
             repository_root, identity.version, expected_crates
@@ -286,9 +338,13 @@ def build_manifest(
                 "digest": runner_digest,
                 "name": IMAGE_NAMES["automata-runner"],
             },
+            "automata-sandbox-guest": {
+                "digest": sandbox_guest_digest,
+                "name": IMAGE_NAMES["automata-sandbox-guest"],
+            },
         },
         "release": identity.document(),
-        "release_assets": [archive, checksum],
+        "release_assets": [archive, checksum, catalog_entry, candidate_entry],
         "schema_version": SCHEMA_VERSION,
     }
 
@@ -325,8 +381,9 @@ def validate_manifest(
     repository_root: pathlib.Path | None = None,
     expected_automata_digest: str | None = None,
     expected_runner_digest: str | None = None,
+    expected_sandbox_guest_digest: str | None = None,
     expected_crates: Collection[str] | None = None,
-) -> tuple[str, str, list[str]]:
+) -> tuple[str, str, str, list[str]]:
     require_exact_keys(
         document,
         {"crates", "images", "release", "release_assets", "schema_version"},
@@ -366,9 +423,14 @@ def validate_manifest(
         fail("manifest release identity differs from the gated release")
 
     assets = document["release_assets"]
-    if not isinstance(assets, list) or len(assets) != 2:
-        fail("manifest must contain exactly two release asset records")
-    expected_asset_paths = [ARCHIVE_PATH, CHECKSUM_PATH]
+    if not isinstance(assets, list) or len(assets) != 4:
+        fail("manifest must contain exactly four release asset records")
+    expected_asset_paths = [
+        ARCHIVE_PATH,
+        CHECKSUM_PATH,
+        CATALOG_PATH,
+        SERVICE_PROXY_CANDIDATE_PATH,
+    ]
     asset_paths: list[str] = []
     asset_digests: dict[str, str] = {}
     for index, value in enumerate(assets):
@@ -384,7 +446,7 @@ def validate_manifest(
     if (
         not isinstance(crates, list)
         or not crates
-        or len(crates) > MAX_HANDOFF_MEMBERS - 3
+        or len(crates) > MAX_CRATE_ENTRIES
     ):
         fail("manifest must contain a bounded, non-empty crate archive list")
     crate_paths: list[str] = []
@@ -430,6 +492,11 @@ def validate_manifest(
         image_digests["automata-runner"] != expected_runner_digest
     ):
         fail("manifest runner image digest differs from the staged digest")
+    if expected_sandbox_guest_digest is not None and (
+        image_digests["automata-sandbox-guest"]
+        != expected_sandbox_guest_digest
+    ):
+        fail("manifest sandbox-guest image digest differs from the staged digest")
 
     file_paths = asset_paths + crate_paths
     if len(file_paths) != len(set(file_paths)):
@@ -441,6 +508,10 @@ def validate_manifest(
                 if entry["path"] == ARCHIVE_PATH
                 else MAX_TEXT_SIZE
                 if entry["path"] == CHECKSUM_PATH
+                else MAX_CATALOG_SIZE
+                if entry["path"] == CATALOG_PATH
+                else MAX_SERVICE_PROXY_CANDIDATE_SIZE
+                if entry["path"] == SERVICE_PROXY_CANDIDATE_PATH
                 else MAX_CRATE_SIZE
             )
             actual = file_digest(
@@ -453,7 +524,27 @@ def validate_manifest(
         validate_checksum(
             repository_root / CHECKSUM_PATH, asset_digests[ARCHIVE_PATH]
         )
-    return image_digests["automata"], image_digests["automata-runner"], file_paths
+        catalog_document = local_catalog.load_canonical(
+            repository_root / CATALOG_PATH,
+            "local-installation catalog",
+            MAX_CATALOG_SIZE,
+        )
+        local_catalog.validate_catalog(
+            catalog_document,
+            identity.document(),
+            repository_root=repository_root,
+            expected_registry_digests={
+                "automata": image_digests["automata"],
+                "runner": image_digests["automata-runner"],
+                "sandbox-guest": image_digests["automata-sandbox-guest"],
+            },
+        )
+    return (
+        image_digests["automata"],
+        image_digests["automata-runner"],
+        image_digests["automata-sandbox-guest"],
+        file_paths,
+    )
 
 
 def write_file_exclusive(path: pathlib.Path, contents: bytes, mode: int = 0o644) -> None:
@@ -489,6 +580,10 @@ def add_tar_file(
         if relative_path == ARCHIVE_PATH
         else MAX_TEXT_SIZE
         if relative_path == CHECKSUM_PATH
+        else MAX_CATALOG_SIZE
+        if relative_path == CATALOG_PATH
+        else MAX_SERVICE_PROXY_CANDIDATE_SIZE
+        if relative_path == SERVICE_PROXY_CANDIDATE_PATH
         else MAX_CRATE_SIZE
     )
     regular_file(path, f"handoff member {relative_path}", maximum_size)
@@ -541,7 +636,7 @@ def pack_handoff(
     if manifest_path.resolve(strict=False) != expected_manifest_path.resolve(strict=False):
         fail(f"manifest input must be {expected_manifest_path}")
     manifest, manifest_bytes = load_manifest(manifest_path)
-    _, _, payload_paths = validate_manifest(
+    _, _, _, payload_paths = validate_manifest(
         manifest,
         identity,
         repository_root,
@@ -669,6 +764,7 @@ def verify_handoff(
     identity: ReleaseIdentity,
     expected_automata_digest: str,
     expected_runner_digest: str,
+    expected_sandbox_guest_digest: str,
     *,
     expected_handoff_digest: str | None = None,
 ) -> tuple[dict, dict[str, bytes]]:
@@ -685,11 +781,12 @@ def verify_handoff(
         manifest, _, contents = load_handoff_stream(stream, before.st_size, identity)
         if file_identity(os.fstat(stream.fileno())) != file_identity(before):
             fail("handoff archive changed while it was verified")
-    _, _, payload_paths = validate_manifest(
+    _, _, _, payload_paths = validate_manifest(
         manifest,
         identity,
         expected_automata_digest=expected_automata_digest,
         expected_runner_digest=expected_runner_digest,
+        expected_sandbox_guest_digest=expected_sandbox_guest_digest,
     )
     expected_members = sorted([MANIFEST_PATH, *payload_paths])
     if sorted(contents) != expected_members:
@@ -713,6 +810,21 @@ def verify_handoff(
     )
     if checksum != expected_checksum:
         fail("handoff checksum does not exactly describe the release archive")
+    catalog_document = local_catalog.parse_json(
+        contents[CATALOG_PATH],
+        "local-installation catalog",
+        canonical=True,
+    )
+    local_catalog.validate_catalog(
+        catalog_document,
+        identity.document(),
+        expected_registry_digests={
+            "automata": expected_automata_digest,
+            "runner": expected_runner_digest,
+            "sandbox-guest": expected_sandbox_guest_digest,
+        },
+        payloads=contents,
+    )
     return manifest, contents
 
 
@@ -807,6 +919,7 @@ def main() -> None:
     create.add_argument("--handoff", required=True, type=pathlib.Path)
     create.add_argument("--automata-digest", required=True)
     create.add_argument("--runner-digest", required=True)
+    create.add_argument("--sandbox-guest-digest", required=True)
     create.add_argument("--expected-crate", action="append", required=True)
     create.add_argument("--github-output", type=pathlib.Path)
 
@@ -830,6 +943,7 @@ def main() -> None:
     verify.add_argument("--handoff-sha256", required=True)
     verify.add_argument("--automata-digest", required=True)
     verify.add_argument("--runner-digest", required=True)
+    verify.add_argument("--sandbox-guest-digest", required=True)
     verify.add_argument("--extract-root", type=pathlib.Path)
     verify.add_argument("--github-output", type=pathlib.Path)
 
@@ -843,6 +957,7 @@ def main() -> None:
             identity,
             arguments.automata_digest,
             arguments.runner_digest,
+            arguments.sandbox_guest_digest,
             arguments.expected_crate,
         )
         manifest_digest, handoff_digest = create_handoff(
@@ -885,7 +1000,7 @@ def main() -> None:
     if arguments.operation == "verify-manifest":
         repository_root = arguments.repository_root.resolve(strict=True)
         manifest, contents = load_manifest(arguments.manifest)
-        automata_digest, runner_digest, _ = validate_manifest(
+        automata_digest, runner_digest, sandbox_guest_digest, _ = validate_manifest(
             manifest, identity, repository_root
         )
         write_outputs(
@@ -893,6 +1008,7 @@ def main() -> None:
             {
                 "automata_digest": automata_digest,
                 "runner_digest": runner_digest,
+                "sandbox_guest_digest": sandbox_guest_digest,
                 "manifest_sha256": sha256_bytes(contents),
             },
         )
@@ -903,6 +1019,7 @@ def main() -> None:
         identity,
         arguments.automata_digest,
         arguments.runner_digest,
+        arguments.sandbox_guest_digest,
         expected_handoff_digest=arguments.handoff_sha256,
     )
     if arguments.extract_root is not None:
@@ -912,6 +1029,9 @@ def main() -> None:
         {
             "automata_digest": manifest["images"]["automata"]["digest"],
             "runner_digest": manifest["images"]["automata-runner"]["digest"],
+            "sandbox_guest_digest": manifest["images"]["automata-sandbox-guest"][
+                "digest"
+            ],
             "manifest_sha256": sha256_bytes(contents[MANIFEST_PATH]),
         },
     )

--- a/scripts/ci/tests/local-installation-catalog.test.py
+++ b/scripts/ci/tests/local-installation-catalog.test.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Fail-closed tests for the local-installation release catalog."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
+SCRIPT = REPOSITORY_ROOT / "scripts" / "ci" / "local_installation_catalog.py"
+SPEC = importlib.util.spec_from_file_location("local_installation_catalog", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {SCRIPT}")
+catalog = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = catalog
+SPEC.loader.exec_module(catalog)
+
+
+def rust_integer_constant(relative_path: str, name: str) -> int:
+    source = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+    match = re.search(
+        rf"^pub const {re.escape(name)}: [A-Za-z0-9_:]+ = "
+        r"([0-9][0-9_]*(?: \* [0-9][0-9_]*)*);$",
+        source,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"could not resolve Rust constant {name}")
+    factors = (int(value.replace("_", "")) for value in match.group(1).split(" * "))
+    result = 1
+    for factor in factors:
+        result *= factor
+    return result
+
+
+def rust_string_constant(relative_path: str, name: str) -> str:
+    source = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+    match = re.search(
+        rf'^(?:pub(?:\(crate\))? )?const {re.escape(name)}: &str = "([^"\\]*)";$',
+        source,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"could not resolve Rust constant {name}")
+    return match.group(1)
+
+
+class LocalInstallationCatalogContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.release = {
+            "commit": "a" * 40,
+            "created": "2026-08-17T00:00:00+00:00",
+            "prerelease": False,
+            "source_date_epoch": 1_786_924_800,
+            "tag": "v1.2.3",
+            "tag_object": "b" * 40,
+            "version": "1.2.3",
+        }
+        self.source = catalog.load_source(REPOSITORY_ROOT)
+        self.candidate_binding = {
+            "candidate_provenance_sha256": "1" * 64,
+            "config_digest": f"sha256:{'2' * 64}",
+            "image_digest": f"sha256:{'3' * 64}",
+            "image_name": "ghcr.io/automata-ci/automata-service-proxy",
+            "kind": "release-candidate",
+            "oci_archive_sha256": "4" * 64,
+            "path": catalog.SERVICE_PROXY_CANDIDATE_PATH,
+            "sha256": "5" * 64,
+            "source_provenance_sha256": "6" * 64,
+        }
+
+    def process(self, role: str) -> dict:
+        expected = self.source["images"][role]["config"]
+        labels = dict(expected["required_labels"])
+        if role in catalog.RELEASE_REGISTRY_ROLES:
+            labels.update(
+                {
+                    "org.opencontainers.image.created": self.release["created"],
+                    "org.opencontainers.image.revision": self.release["commit"],
+                    "org.opencontainers.image.version": self.release["version"],
+                }
+            )
+        return {
+            "Cmd": expected["command"],
+            "Entrypoint": expected["entrypoint"],
+            "Env": [
+                f"{name}={value}"
+                for name, value in expected["required_environment"].items()
+            ],
+            "Labels": labels,
+            "User": expected["user"],
+            "WorkingDir": expected["working_directory"],
+        }
+
+    def evidence(self, role: str, byte: str) -> dict:
+        source = self.source["images"][role]["source"]
+        if role in catalog.RELEASE_REGISTRY_ROLES:
+            top = f"sha256:{byte * 64}"
+            reference = f"{source['repository']}@{top}"
+            platform = f"sha256:{chr(ord(byte) + 1) * 64}"
+            config_digest = f"sha256:{chr(ord(byte) + 2) * 64}"
+        else:
+            reference = source["reference"]
+            top = reference.rsplit("@", 1)[1]
+            platform = source["platform_manifest_digest"]
+            config_digest = source["config_digest"]
+        return {
+            "architecture": "amd64",
+            "config": self.process(role),
+            "config_digest": config_digest,
+            "os": "linux",
+            "platform_manifest_digest": platform,
+            "reference": reference,
+            "top_level_digest": top,
+        }
+
+    def all_evidence(self) -> dict[str, dict]:
+        return {
+            role: self.evidence(role, byte)
+            for role, byte in zip(
+                sorted(catalog.REGISTRY_ROLES), "789abc", strict=True
+            )
+        }
+
+    def build(self) -> dict:
+        with mock.patch.object(
+            catalog,
+            "validate_service_proxy_candidate",
+            return_value=self.candidate_binding,
+        ):
+            return catalog.build_catalog(
+                REPOSITORY_ROOT,
+                self.release,
+                self.all_evidence(),
+                REPOSITORY_ROOT / catalog.SERVICE_PROXY_CANDIDATE_PATH,
+            )
+
+    def test_source_contract_and_profile_bind_exact_reviewed_bytes(self) -> None:
+        source = catalog.load_source(REPOSITORY_ROOT)
+        self.assertEqual(set(source["images"]), catalog.ROLES)
+        self.assertEqual(source["scope"], {"engine": "linux/amd64", "host": "unix"})
+        profile = catalog.load_profile(REPOSITORY_ROOT, source)
+        self.assertEqual(
+            profile["manifest"]["sha256"],
+            "f7a6f8e592a484f59330bf2cedd839adc75488618ee58efcc3c3d4957d186e21",
+        )
+        self.assertEqual(
+            profile["lock"]["sha256"],
+            "05fb47e52d497bb1cb887c19e4b865cfe49da73d462df57451d1b6efaa669238",
+        )
+        self.assertEqual(profile["id"], source["profile"]["id"])
+        self.assertEqual(
+            source["services"]["runner"]["executor_contract"],
+            {
+                "ephemeral_disk_bytes": 0,
+                "minimum_cpu_millis": 1000,
+                "minimum_memory_bytes": 268435456,
+                "minimum_pids": 3,
+                "network": "private_egress",
+                "privilege": "administrator",
+                "root_filesystem": "writable",
+                "runner_root": "/__automata",
+                "workspace": "/__w",
+            },
+        )
+        self.assertEqual(
+            source["services"]["runner"]["maximum_parallel_jobs"], 256
+        )
+
+    def test_runtime_literals_track_the_production_contracts(self) -> None:
+        source = self.source
+        runner = source["services"]["runner"]
+        executor = runner["executor_contract"]
+        for role, containerfile_path in (
+            ("automata", "images/automata.Containerfile"),
+            ("runner", "images/automata-runner.Containerfile"),
+            ("sandbox-guest", "images/automata-sandbox-guest.Containerfile"),
+        ):
+            self.assertEqual(
+                source["images"][role]["config"]["working_directory"], "/"
+            )
+            containerfile = (REPOSITORY_ROOT / containerfile_path).read_text(
+                encoding="utf-8"
+            )
+            self.assertRegex(containerfile, r"(?m)^WORKDIR /$")
+        self.assertEqual(
+            source["images"]["runner"]["runtime"]["product_config_schema"],
+            rust_integer_constant(
+                "crates/automata-ci-runner/src/product/config.rs",
+                "RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION",
+            ),
+        )
+        self.assertEqual(
+            source["images"]["sandbox-guest"]["runtime"]["guest_protocol"],
+            rust_integer_constant(
+                "crates/automata-ci-sandbox-guest/src/lib.rs",
+                "GUEST_PROTOCOL_VERSION",
+            ),
+        )
+        self.assertEqual(
+            runner["maximum_parallel_jobs"],
+            rust_integer_constant(
+                "crates/automata-ci-local/src/lib.rs",
+                "MAXIMUM_LOCAL_DOCKER_JOB_SLOTS",
+            ),
+        )
+        for field, constant in (
+            ("minimum_cpu_millis", "MINIMUM_LOCAL_DOCKER_SANDBOX_CPU_MILLIS"),
+            ("minimum_memory_bytes", "MINIMUM_LOCAL_DOCKER_SANDBOX_MEMORY_BYTES"),
+            ("minimum_pids", "MINIMUM_LOCAL_DOCKER_SANDBOX_PIDS"),
+        ):
+            self.assertEqual(
+                executor[field],
+                rust_integer_constant("crates/automata-ci-local/src/lib.rs", constant),
+            )
+        self.assertEqual(
+            runner["provider_control_directory"],
+            rust_string_constant(
+                "crates/automata-ci-local/src/lib.rs",
+                "LOCAL_DOCKER_CONTROL_DIRECTORY",
+            ),
+        )
+        self.assertEqual(
+            runner["provider_control_directory"],
+            rust_string_constant(
+                "crates/automata-ci-sandbox-guest/src/lib.rs",
+                "LOCAL_CONTROL_DIRECTORY",
+            ),
+        )
+
+        guest_protocol = str(
+            source["images"]["sandbox-guest"]["runtime"]["guest_protocol"]
+        )
+        guest_containerfile = (
+            REPOSITORY_ROOT / "images/automata-sandbox-guest.Containerfile"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            f'io.automata.sandbox-guest.protocol-version="{guest_protocol}"',
+            guest_containerfile,
+        )
+        self.assertEqual(
+            source["images"]["sandbox-guest"]["config"]["required_labels"][
+                "io.automata.sandbox-guest.protocol-version"
+            ],
+            guest_protocol,
+        )
+
+        proxy_protocol = str(
+            source["images"]["service-proxy"]["runtime"]["protocol"]
+        )
+        proxy_containerfile = (
+            REPOSITORY_ROOT / "images/service-proxy/Containerfile"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            f'io.automata.service-proxy.protocol-version="{proxy_protocol}"',
+            proxy_containerfile,
+        )
+        self.assertEqual(
+            source["images"]["service-proxy"]["config"]["required_labels"][
+                "io.automata.service-proxy.protocol-version"
+            ],
+            proxy_protocol,
+        )
+        self.assertEqual(
+            proxy_protocol,
+            rust_string_constant(
+                "crates/automata-ci-local/src/local_docker/mod.rs",
+                "RESULTS_PROXY_IMAGE_PROTOCOL_VERSION",
+            ),
+        )
+        self.assertEqual(
+            proxy_protocol,
+            rust_string_constant(
+                "crates/automata-ci-sandbox-podman/src/provider.rs",
+                "SERVICE_PROXY_IMAGE_PROTOCOL_VERSION",
+            ),
+        )
+
+    def test_catalog_round_trips_the_closed_role_and_payload_set(self) -> None:
+        document = self.build()
+        expected = {
+            role: document["images"][role]["source"]["top_level_digest"]
+            for role in catalog.RELEASE_REGISTRY_ROLES
+        }
+        with mock.patch.object(
+            catalog,
+            "validate_service_proxy_candidate",
+            return_value=self.candidate_binding,
+        ):
+            digests, payloads = catalog.validate_catalog(
+                document,
+                self.release,
+                repository_root=REPOSITORY_ROOT,
+                expected_registry_digests=expected,
+            )
+        self.assertEqual(set(digests), catalog.REGISTRY_ROLES)
+        self.assertEqual(payloads, [catalog.SERVICE_PROXY_CANDIDATE_PATH])
+        self.assertEqual(
+            catalog.canonical_json(document),
+            catalog.canonical_json(
+                json.loads(catalog.canonical_json(document))
+            ),
+        )
+
+    def test_handoff_payload_revalidates_the_exact_candidate_bytes(self) -> None:
+        document = self.build()
+        release_digests = {
+            role: document["images"][role]["source"]["top_level_digest"]
+            for role in catalog.RELEASE_REGISTRY_ROLES
+        }
+        candidate_bytes = b"exact service-proxy candidate\n"
+
+        def validate_candidate(
+            _repository_root: pathlib.Path,
+            candidate_path: pathlib.Path,
+            _release: dict,
+            _source_image: dict,
+        ) -> dict:
+            self.assertEqual(candidate_path.read_bytes(), candidate_bytes)
+            return self.candidate_binding
+
+        with mock.patch.object(
+            catalog,
+            "validate_service_proxy_candidate",
+            side_effect=validate_candidate,
+        ):
+            _, payload_paths = catalog.validate_catalog(
+                document,
+                self.release,
+                repository_root=REPOSITORY_ROOT,
+                expected_registry_digests=release_digests,
+                payloads={catalog.SERVICE_PROXY_CANDIDATE_PATH: candidate_bytes},
+            )
+        self.assertEqual(payload_paths, [catalog.SERVICE_PROXY_CANDIDATE_PATH])
+
+        with self.assertRaisesRegex(SystemExit, "omits the service-proxy candidate"):
+            catalog.validate_catalog(
+                document,
+                self.release,
+                repository_root=REPOSITORY_ROOT,
+                expected_registry_digests=release_digests,
+                payloads={},
+            )
+
+    def test_real_candidate_catalog_and_handoff_survive_relocated_tools(self) -> None:
+        publication_test_path = (
+            REPOSITORY_ROOT
+            / "scripts/ci/tests/service-proxy-publication.test.py"
+        )
+        publication_spec = importlib.util.spec_from_file_location(
+            "catalog_integration_publication_fixture", publication_test_path
+        )
+        if publication_spec is None or publication_spec.loader is None:
+            raise RuntimeError(f"could not load {publication_test_path}")
+        publication_test = importlib.util.module_from_spec(publication_spec)
+        sys.modules[publication_spec.name] = publication_test
+        publication_spec.loader.exec_module(publication_test)
+        fixture = publication_test.PublicationContract()
+        fixture.setUp()
+        try:
+            scratch_root = (
+                REPOSITORY_ROOT / "target/task-tmp/catalog-integration-tests"
+            )
+            scratch_root.mkdir(parents=True, exist_ok=True)
+            with tempfile.TemporaryDirectory(
+                prefix="relocated.", dir=scratch_root
+            ) as temporary:
+                relocated_root = pathlib.Path(temporary)
+                copied_paths = (
+                    "scripts/ci/release-handoff.py",
+                    "scripts/ci/local_installation_catalog.py",
+                    "scripts/ci/service-proxy-candidate.py",
+                    "scripts/ci/service-proxy-publication.py",
+                    "images/local-installation/catalog-v1.json",
+                    catalog.PROFILE_MANIFEST_PATH,
+                    catalog.PROFILE_LOCK_PATH,
+                )
+                for relative in copied_paths:
+                    destination = relocated_root / relative
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(REPOSITORY_ROOT / relative, destination)
+                source_files = {
+                    "Cargo.toml": fixture.source_directory / "Cargo.toml",
+                    "LICENSE": fixture.context / "LICENSE",
+                    "images/service-proxy/Containerfile": (
+                        fixture.context / "Containerfile"
+                    ),
+                }
+                for relative, source_path in source_files.items():
+                    destination = relocated_root / relative
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(source_path, destination)
+
+                handoff_path = relocated_root / "scripts/ci/release-handoff.py"
+                handoff_spec = importlib.util.spec_from_file_location(
+                    "relocated_catalog_release_handoff", handoff_path
+                )
+                if handoff_spec is None or handoff_spec.loader is None:
+                    raise RuntimeError(f"could not load {handoff_path}")
+                handoff = importlib.util.module_from_spec(handoff_spec)
+                sys.modules[handoff_spec.name] = handoff
+                handoff_spec.loader.exec_module(handoff)
+
+                identity = handoff.ReleaseIdentity(
+                    tag="v1.2.3",
+                    tag_object="b" * 40,
+                    commit=fixture.candidate_commit,
+                    version=fixture.release["version"],
+                    prerelease=False,
+                    source_date_epoch=fixture.release["source_date_epoch"],
+                    created=fixture.release["created"],
+                )
+                self.release = identity.document()
+                evidence = self.all_evidence()
+                candidate_path = relocated_root / handoff.SERVICE_PROXY_CANDIDATE_PATH
+                candidate_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(fixture.candidate, candidate_path)
+                document = handoff.local_catalog.build_catalog(
+                    relocated_root,
+                    identity.document(),
+                    evidence,
+                    candidate_path,
+                )
+                catalog_path = relocated_root / handoff.CATALOG_PATH
+                catalog_path.parent.mkdir(parents=True, exist_ok=True)
+                catalog_path.write_bytes(handoff.local_catalog.canonical_json(document))
+
+                archive = relocated_root / handoff.ARCHIVE_PATH
+                archive.parent.mkdir(parents=True, exist_ok=True)
+                archive.write_bytes(b"release archive\n")
+                archive_digest = handoff.file_digest(archive, "fixture archive")
+                (relocated_root / handoff.CHECKSUM_PATH).write_text(
+                    f"{archive_digest}  {archive.name}\n", encoding="ascii"
+                )
+                package = relocated_root / "target/package/fixture-crate-1.2.3.crate"
+                package.parent.mkdir(parents=True, exist_ok=True)
+                package.write_bytes(b"crate archive\n")
+                release_digests = {
+                    role: document["images"][role]["source"]["top_level_digest"]
+                    for role in handoff.local_catalog.RELEASE_REGISTRY_ROLES
+                }
+                manifest = handoff.build_manifest(
+                    relocated_root,
+                    identity,
+                    release_digests["automata"],
+                    release_digests["runner"],
+                    release_digests["sandbox-guest"],
+                    ["fixture-crate"],
+                )
+                manifest_path = relocated_root / handoff.MANIFEST_PATH
+                archive_path = relocated_root / "target/release-handoff/handoff.tar"
+                _, archive_sha256 = handoff.create_handoff(
+                    relocated_root,
+                    manifest_path,
+                    archive_path,
+                    manifest,
+                    identity,
+                    ["fixture-crate"],
+                )
+                _, contents = handoff.verify_handoff(
+                    archive_path,
+                    identity,
+                    release_digests["automata"],
+                    release_digests["runner"],
+                    release_digests["sandbox-guest"],
+                    expected_handoff_digest=archive_sha256,
+                )
+                self.assertEqual(
+                    contents[handoff.SERVICE_PROXY_CANDIDATE_PATH],
+                    fixture.candidate.read_bytes(),
+                )
+
+                changed_payloads = dict(contents)
+                changed_payloads[handoff.SERVICE_PROXY_CANDIDATE_PATH] += b"changed"
+                with self.assertRaises(SystemExit):
+                    handoff.local_catalog.validate_catalog(
+                        document,
+                        identity.document(),
+                        repository_root=relocated_root,
+                        expected_registry_digests=release_digests,
+                        payloads=changed_payloads,
+                    )
+        finally:
+            fixture.tearDown()
+
+    def test_registry_contract_rejects_user_environment_and_digest_drift(self) -> None:
+        for mutation, diagnostic in (
+            (lambda evidence: evidence["config"].__setitem__("User", "0:0"), "user differs"),
+            (
+                lambda evidence: evidence["config"].__setitem__("Env", []),
+                "environment differs",
+            ),
+            (
+                lambda evidence: evidence.__setitem__(
+                    "config_digest", f"sha256:{'f' * 64}"
+                ),
+                "config digest differs",
+            ),
+        ):
+            evidence = self.evidence("postgres", "7")
+            mutation(evidence)
+            with self.assertRaisesRegex(SystemExit, diagnostic):
+                catalog.validate_registry_evidence(
+                    "postgres",
+                    evidence,
+                    self.source["images"]["postgres"],
+                    self.release,
+                )
+
+    def test_release_registry_requires_exact_repository_and_release_labels(self) -> None:
+        evidence = self.evidence("automata", "7")
+        evidence["reference"] = (
+            f"ghcr.io/example/automata@{evidence['top_level_digest']}"
+        )
+        with self.assertRaisesRegex(SystemExit, "repository differs"):
+            catalog.validate_registry_evidence(
+                "automata",
+                evidence,
+                self.source["images"]["automata"],
+                self.release,
+            )
+
+        evidence = self.evidence("automata", "7")
+        evidence["config"]["Labels"]["org.opencontainers.image.revision"] = "c" * 40
+        with self.assertRaisesRegex(SystemExit, "release labels differ"):
+            catalog.validate_registry_evidence(
+                "automata",
+                evidence,
+                self.source["images"]["automata"],
+                self.release,
+            )
+
+    def test_capture_resolves_one_linux_amd64_child_and_config_digest(self) -> None:
+        child = {
+            "config": {
+                "digest": f"sha256:{'c' * 64}",
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "size": 1,
+            },
+            "layers": [],
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "schemaVersion": 2,
+        }
+        child_bytes = json.dumps(child, separators=(",", ":")).encode()
+        child_digest = f"sha256:{catalog.sha256_bytes(child_bytes)}"
+        top = {
+            "manifests": [
+                {
+                    "digest": child_digest,
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "platform": {"architecture": "amd64", "os": "linux"},
+                }
+            ],
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "schemaVersion": 2,
+        }
+        top_bytes = json.dumps(top, separators=(",", ":")).encode()
+        top_digest = f"sha256:{catalog.sha256_bytes(top_bytes)}"
+        repository = "registry.example.test/team/image"
+        reference = f"{repository}@{top_digest}"
+        child_inspection = {
+            "image": {
+                "architecture": "amd64",
+                "config": self.process("automata"),
+                "os": "linux",
+            },
+            "manifest": {
+                "digest": child_digest,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            },
+            "name": f"{repository}@{child_digest}",
+        }
+        with mock.patch.object(
+            catalog,
+            "run_inspect",
+            side_effect=[
+                top_bytes,
+                child_bytes,
+                json.dumps(child_inspection).encode(),
+            ],
+        ):
+            evidence = catalog.capture_registry_evidence(reference)
+        self.assertEqual(evidence["platform_manifest_digest"], child_digest)
+        self.assertEqual(evidence["config_digest"], f"sha256:{'c' * 64}")
+
+        top["manifests"].append(dict(top["manifests"][0]))
+        top_bytes = json.dumps(top, separators=(",", ":")).encode()
+        reference = (
+            f"{repository}@sha256:{catalog.sha256_bytes(top_bytes)}"
+        )
+        with (
+            mock.patch.object(
+                catalog,
+                "run_inspect",
+                return_value=top_bytes,
+            ),
+            self.assertRaisesRegex(SystemExit, "exactly one linux/amd64"),
+        ):
+            catalog.capture_registry_evidence(reference)
+
+        top["manifests"].pop()
+        top_bytes = json.dumps(top, separators=(",", ":")).encode()
+        reference = (
+            f"{repository}@sha256:{catalog.sha256_bytes(top_bytes)}"
+        )
+        child_inspection["name"] = (
+            f"registry.example.test/team/other@{child_digest}"
+        )
+        with (
+            mock.patch.object(
+                catalog,
+                "run_inspect",
+                side_effect=[
+                    top_bytes,
+                    child_bytes,
+                    json.dumps(child_inspection).encode(),
+                ],
+            ),
+            self.assertRaisesRegex(SystemExit, "inspection name differs"),
+        ):
+            catalog.capture_registry_evidence(reference)
+
+    def test_verify_cli_emits_only_verified_release_bindings(self) -> None:
+        document = self.build()
+        expected_registry = {
+            role: document["images"][role]["source"]["top_level_digest"]
+            for role in catalog.REGISTRY_ROLES
+        }
+        scratch_root = REPOSITORY_ROOT / "target" / "task-tmp" / "catalog-tests"
+        scratch_root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="outputs.", dir=scratch_root) as temporary:
+            directory = pathlib.Path(temporary)
+            catalog_path = directory / "catalog.json"
+            output_path = directory / "github-output"
+            catalog_path.write_bytes(catalog.canonical_json(document))
+            output_path.write_bytes(b"")
+            arguments = [
+                str(SCRIPT),
+                "verify",
+                "--repository-root",
+                str(REPOSITORY_ROOT),
+                "--catalog",
+                str(catalog_path),
+                "--tag",
+                self.release["tag"],
+                "--tag-object",
+                self.release["tag_object"],
+                "--commit",
+                self.release["commit"],
+                "--version",
+                self.release["version"],
+                "--prerelease",
+                "false",
+                "--source-date-epoch",
+                str(self.release["source_date_epoch"]),
+                "--created",
+                self.release["created"],
+                "--github-output",
+                str(output_path),
+            ]
+            with (
+                mock.patch.object(sys, "argv", arguments),
+                mock.patch.object(
+                    catalog,
+                    "validate_catalog",
+                    return_value=(expected_registry, [catalog.SERVICE_PROXY_CANDIDATE_PATH]),
+                ),
+            ):
+                catalog.main()
+            outputs = dict(
+                line.split("=", 1)
+                for line in output_path.read_text(encoding="utf-8").splitlines()
+            )
+        self.assertEqual(outputs["automata_digest"], expected_registry["automata"])
+        self.assertEqual(outputs["runner_digest"], expected_registry["runner"])
+        self.assertEqual(
+            outputs["sandbox_guest_digest"], expected_registry["sandbox-guest"]
+        )
+        self.assertEqual(outputs["candidate_sha256"], self.candidate_binding["sha256"])
+        self.assertEqual(outputs["image_digest"], self.candidate_binding["image_digest"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/release-handoff.test.py
+++ b/scripts/ci/tests/release-handoff.test.py
@@ -42,6 +42,10 @@ class ReleaseHandoffContract(unittest.TestCase):
         )
         (packages / "automata-ci-1.2.3.crate").write_bytes(b"crate one\n")
         (packages / "automata-ci-runner-1.2.3.crate").write_bytes(b"crate two\n")
+        (self.root / release_handoff.CATALOG_PATH).write_bytes(b"{}\n")
+        candidate = self.root / release_handoff.SERVICE_PROXY_CANDIDATE_PATH
+        candidate.parent.mkdir(parents=True)
+        candidate.write_bytes(b"service proxy candidate\n")
         self.identity = release_handoff.ReleaseIdentity(
             tag="v1.2.3",
             tag_object="a" * 40,
@@ -53,9 +57,24 @@ class ReleaseHandoffContract(unittest.TestCase):
         )
         self.automata_digest = f"sha256:{'c' * 64}"
         self.runner_digest = f"sha256:{'d' * 64}"
+        self.sandbox_guest_digest = f"sha256:{'e' * 64}"
         self.expected_crates = ["automata-ci", "automata-ci-runner"]
+        self.catalog_validation = mock.patch.object(
+            release_handoff.local_catalog,
+            "validate_catalog",
+            return_value=(
+                {
+                    "automata": self.automata_digest,
+                    "runner": self.runner_digest,
+                    "sandbox-guest": self.sandbox_guest_digest,
+                },
+                [release_handoff.SERVICE_PROXY_CANDIDATE_PATH],
+            ),
+        )
+        self.catalog_validation.start()
 
     def tearDown(self) -> None:
+        self.catalog_validation.stop()
         self.temporary.cleanup()
 
     def create(self, name: str = "handoff.tar") -> tuple[pathlib.Path, pathlib.Path, str]:
@@ -66,6 +85,7 @@ class ReleaseHandoffContract(unittest.TestCase):
             self.identity,
             self.automata_digest,
             self.runner_digest,
+            self.sandbox_guest_digest,
             self.expected_crates,
         )
         _, digest = release_handoff.create_handoff(
@@ -119,6 +139,7 @@ class ReleaseHandoffContract(unittest.TestCase):
             self.identity,
             self.automata_digest,
             self.runner_digest,
+            self.sandbox_guest_digest,
         )
         extraction_root = self.root / "consumer"
         extraction_root.mkdir()
@@ -129,16 +150,19 @@ class ReleaseHandoffContract(unittest.TestCase):
     def test_manifest_binds_identity_images_assets_and_every_crate(self) -> None:
         manifest_path, _, _ = self.create()
         manifest, _ = release_handoff.load_manifest(manifest_path)
-        automata, runner, paths = release_handoff.validate_manifest(
+        automata, runner, sandbox_guest, paths = release_handoff.validate_manifest(
             manifest, self.identity, self.root
         )
         self.assertEqual(automata, self.automata_digest)
         self.assertEqual(runner, self.runner_digest)
+        self.assertEqual(sandbox_guest, self.sandbox_guest_digest)
         self.assertEqual(
             paths,
             [
                 release_handoff.ARCHIVE_PATH,
                 release_handoff.CHECKSUM_PATH,
+                release_handoff.CATALOG_PATH,
+                release_handoff.SERVICE_PROXY_CANDIDATE_PATH,
                 "target/package/automata-ci-1.2.3.crate",
                 "target/package/automata-ci-runner-1.2.3.crate",
             ],
@@ -159,6 +183,7 @@ class ReleaseHandoffContract(unittest.TestCase):
                 self.identity,
                 self.automata_digest,
                 self.runner_digest,
+                self.sandbox_guest_digest,
                 self.expected_crates,
             )
 
@@ -172,7 +197,29 @@ class ReleaseHandoffContract(unittest.TestCase):
                 self.identity,
                 self.automata_digest,
                 self.runner_digest,
+                self.sandbox_guest_digest,
                 self.expected_crates,
+            )
+
+    def test_crate_limit_accounts_for_every_fixed_handoff_member(self) -> None:
+        package_directory = self.root / "target" / "package"
+        for archive in package_directory.glob("*.crate"):
+            archive.unlink()
+        expected = []
+        for index in range(release_handoff.MAX_CRATE_ENTRIES):
+            name = f"crate-{index:03d}"
+            expected.append(name)
+            (package_directory / f"{name}-1.2.3.crate").write_bytes(b"x")
+        entries = release_handoff.package_entries(
+            self.root, self.identity.version, expected
+        )
+        self.assertEqual(len(entries), release_handoff.MAX_CRATE_ENTRIES)
+
+        overflow = "crate-overflow"
+        (package_directory / f"{overflow}-1.2.3.crate").write_bytes(b"x")
+        with self.assertRaisesRegex(SystemExit, "too many crate archives"):
+            release_handoff.package_entries(
+                self.root, self.identity.version, [*expected, overflow]
             )
 
     def test_manifest_rejects_json_type_confusion(self) -> None:
@@ -182,7 +229,7 @@ class ReleaseHandoffContract(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "schema version"):
             release_handoff.validate_manifest(manifest, self.identity, self.root)
 
-        manifest["schema_version"] = 1
+        manifest["schema_version"] = release_handoff.SCHEMA_VERSION
         manifest["release"]["prerelease"] = 0
         with self.assertRaisesRegex(SystemExit, "must be a boolean"):
             release_handoff.validate_manifest(manifest, self.identity, self.root)
@@ -206,7 +253,11 @@ class ReleaseHandoffContract(unittest.TestCase):
         )
         with self.assertRaisesRegex(SystemExit, "handoff digest mismatch"):
             release_handoff.verify_handoff(
-                changed, self.identity, self.automata_digest, self.runner_digest
+                changed,
+                self.identity,
+                self.automata_digest,
+                self.runner_digest,
+                self.sandbox_guest_digest,
             )
 
         extra = handoff_path.with_name("extra.tar")
@@ -227,7 +278,11 @@ class ReleaseHandoffContract(unittest.TestCase):
             archive.addfile(unexpected, io.BytesIO(b"x"))
         with self.assertRaisesRegex(SystemExit, "canonical order|exact manifest set"):
             release_handoff.verify_handoff(
-                extra, self.identity, self.automata_digest, self.runner_digest
+                extra,
+                self.identity,
+                self.automata_digest,
+                self.runner_digest,
+                self.sandbox_guest_digest,
             )
 
     def test_non_regular_or_noncanonical_tar_metadata_fails_closed(self) -> None:
@@ -246,7 +301,11 @@ class ReleaseHandoffContract(unittest.TestCase):
                 archive.addfile(member, io.BytesIO(payload[member.name]))
         with self.assertRaisesRegex(SystemExit, "metadata is not canonical"):
             release_handoff.verify_handoff(
-                unsafe, self.identity, self.automata_digest, self.runner_digest
+                unsafe,
+                self.identity,
+                self.automata_digest,
+                self.runner_digest,
+                self.sandbox_guest_digest,
             )
 
         trailing = handoff_path.with_name("trailing.tar")
@@ -296,6 +355,8 @@ class ReleaseHandoffContract(unittest.TestCase):
             self.automata_digest,
             "--runner-digest",
             self.runner_digest,
+            "--sandbox-guest-digest",
+            self.sandbox_guest_digest,
         ]
         result = subprocess.run(command, check=False, capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
@@ -327,6 +388,7 @@ class ReleaseHandoffContract(unittest.TestCase):
                     self.identity,
                     self.automata_digest,
                     self.runner_digest,
+                    self.sandbox_guest_digest,
                     expected_handoff_digest=digest,
                 )
         self.assertEqual(opened.call_count, 1)
@@ -335,7 +397,11 @@ class ReleaseHandoffContract(unittest.TestCase):
     def test_extraction_refuses_to_overwrite_or_follow_parent_symlink(self) -> None:
         _, handoff_path, _ = self.create()
         _, contents = release_handoff.verify_handoff(
-            handoff_path, self.identity, self.automata_digest, self.runner_digest
+            handoff_path,
+            self.identity,
+            self.automata_digest,
+            self.runner_digest,
+            self.sandbox_guest_digest,
         )
         extraction_root = self.root / "consumer"
         extraction_root.mkdir()

--- a/scripts/ci/tests/sandbox-guest-image.test.sh
+++ b/scripts/ci/tests/sandbox-guest-image.test.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../../.." && pwd)"
+verifier="${repository_root}/scripts/ci/verify-sandbox-guest-image.sh"
+readonly repository_root verifier
+
+install -d -m 0755 -- "${repository_root}/target"
+scratch_directory="$(
+  mktemp -d "${repository_root}/target/sandbox-guest-image-test.XXXXXXXX"
+)"
+readonly scratch_directory
+cleanup() {
+  rm -rf -- "$scratch_directory"
+}
+trap cleanup EXIT
+
+fake_bin="${scratch_directory}/bin"
+runtime_tmp="${scratch_directory}/tmp"
+context="${scratch_directory}/context"
+invocation_log="${scratch_directory}/docker.log"
+image_state="${scratch_directory}/image"
+stdout_log="${scratch_directory}/stdout"
+stderr_log="${scratch_directory}/stderr"
+install -d -m 0700 -- "$fake_bin" "$runtime_tmp" "$context/sbom"
+readonly fake_bin runtime_tmp context invocation_log image_state stdout_log stderr_log
+
+install -m 0444 -- \
+  "${repository_root}/images/automata-sandbox-guest.Containerfile" \
+  "$context/Containerfile"
+for required in \
+  LICENSE \
+  THIRD_PARTY_LICENSES.txt \
+  THIRD_PARTY_NOTICES.txt \
+  automata-ci-sandbox-guest \
+  sbom/automata-ci-sandbox-guest.cdx.json
+do
+  : >"$context/$required"
+done
+printf '1.2.3\n' >"$context/VERSION"
+
+cat >"${fake_bin}/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  printf '%q' "$1"
+  for argument in "${@:2}"; do
+    printf ' %q' "$argument"
+  done
+  printf '\n'
+} >>"${AUTOMATA_FAKE_DOCKER_LOG:?}"
+
+if [[ "$1" == build ]]; then
+  shift
+  no_cache=0
+  network=""
+  platform=""
+  pull=""
+  containerfile=""
+  image=""
+  build_args=()
+  while (( $# > 1 )); do
+    case "$1" in
+      --no-cache)
+        no_cache=1
+        shift
+        ;;
+      --network)
+        network="${2:-}"
+        shift 2
+        ;;
+      --platform)
+        platform="${2:-}"
+        shift 2
+        ;;
+      --pull=false)
+        pull=false
+        shift
+        ;;
+      --file)
+        containerfile="${2:-}"
+        shift 2
+        ;;
+      --tag)
+        image="${2:-}"
+        shift 2
+        ;;
+      --build-arg)
+        build_args+=("${2:-}")
+        shift 2
+        ;;
+      *)
+        printf 'fake-docker: unexpected build option %s\n' "$1" >&2
+        exit 70
+        ;;
+    esac
+  done
+  (( $# == 1 )) || exit 70
+  [[ "$1" == "${AUTOMATA_FAKE_DOCKER_CONTEXT:?}" ]] || exit 70
+  (( no_cache == 1 )) || exit 70
+  [[ "$network" == none && "$platform" == linux/amd64 && "$pull" == false ]] \
+    || exit 70
+  [[ "$containerfile" == "$1/Containerfile" ]] || exit 70
+  [[ "$image" == automata-ci/sandbox-guest-verification:* ]] || exit 70
+  [[ "${build_args[*]}" == \
+    "AUTOMATA_CREATED=2025-01-01T00:00:00Z AUTOMATA_REVISION=0123456789abcdef0123456789abcdef01234567 AUTOMATA_VERSION=1.2.3 SOURCE_DATE_EPOCH=1735689600" ]] \
+    || exit 70
+  printf '%s\n' "$image" >"${AUTOMATA_FAKE_DOCKER_IMAGE:?}"
+  exit 0
+fi
+
+if [[ "$1" == image && "${2:-}" == inspect && $# -eq 3 ]]; then
+  [[ "$3" == "$(<"${AUTOMATA_FAKE_DOCKER_IMAGE:?}")" ]] || exit 70
+  cat -- "${AUTOMATA_FAKE_DOCKER_INSPECTION:?}"
+  exit 0
+fi
+
+if [[ "$1" == image && "${2:-}" == rm && "${3:-}" == --force && $# -eq 4 ]]; then
+  [[ "$4" == "$(<"${AUTOMATA_FAKE_DOCKER_IMAGE:?}")" ]] || exit 70
+  exit 0
+fi
+
+if [[ "$1" == run ]]; then
+  (( $# == 10 || $# == 11 )) || exit 70
+  [[ "$2" == --rm ]] || exit 70
+  [[ "$3" == --network && "$4" == none ]] || exit 70
+  [[ "$5" == --read-only ]] || exit 70
+  [[ "$6" == --security-opt && "$7" == no-new-privileges ]] || exit 70
+  [[ "$8" == --cap-drop && "$9" == ALL ]] || exit 70
+  [[ "${10}" == "$(<"${AUTOMATA_FAKE_DOCKER_IMAGE:?}")" ]] || exit 70
+  if (( $# == 11 )); then
+    [[ "${11}" == unsupported-command ]] || exit 70
+  fi
+  case "${AUTOMATA_FAKE_DOCKER_RUN_RESULT:?}" in
+    silent)
+      exit 1
+      ;;
+    noisy)
+      printf 'unexpected guest diagnostic\n' >&2
+      exit 1
+      ;;
+    empty-success)
+      (( $# == 10 )) && exit 0
+      exit 1
+      ;;
+    unsupported-success)
+      (( $# == 11 )) && exit 0
+      exit 1
+      ;;
+    *)
+      exit 70
+      ;;
+  esac
+fi
+
+printf 'fake-docker: unsupported invocation\n' >&2
+exit 70
+DOCKER
+chmod 0700 -- "${fake_bin}/docker"
+
+valid_inspection="${scratch_directory}/valid-inspection.json"
+extra_label_inspection="${scratch_directory}/extra-label-inspection.json"
+bad_platform_inspection="${scratch_directory}/bad-platform-inspection.json"
+bad_config_inspection="${scratch_directory}/bad-config-inspection.json"
+readonly valid_inspection extra_label_inspection bad_platform_inspection \
+  bad_config_inspection
+python3 - \
+  "$valid_inspection" \
+  "$extra_label_inspection" \
+  "$bad_platform_inspection" \
+  "$bad_config_inspection" <<'PY'
+import copy
+import json
+import pathlib
+import sys
+
+valid_path, extra_label_path, bad_platform_path, bad_config_path = map(
+    pathlib.Path, sys.argv[1:]
+)
+labels = {
+    "io.automata.sandbox-guest.protocol-version": "3",
+    "org.opencontainers.image.created": "2025-01-01T00:00:00Z",
+    "org.opencontainers.image.description": (
+        "Fixed protocol guest for Automata local job sandboxes"
+    ),
+    "org.opencontainers.image.documentation": (
+        "https://github.com/automata-ci/automata/blob/main/"
+        "crates/automata-ci-sandbox-guest/README.md"
+    ),
+    "org.opencontainers.image.licenses": "MIT",
+    "org.opencontainers.image.revision": (
+        "0123456789abcdef0123456789abcdef01234567"
+    ),
+    "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+    "org.opencontainers.image.title": "Automata Sandbox Guest",
+    "org.opencontainers.image.url": "https://github.com/automata-ci/automata",
+    "org.opencontainers.image.version": "1.2.3",
+}
+document = [
+    {
+        "Architecture": "amd64",
+        "Config": {
+            "Entrypoint": ["/usr/local/bin/automata-ci-sandbox-guest"],
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ],
+            "Labels": labels,
+            "User": "65532:65532",
+            "WorkingDir": "/",
+        },
+        "Os": "linux",
+        "RootFS": {"Layers": ["sha256:fixture"], "Type": "layers"},
+    }
+]
+
+
+def write(path: pathlib.Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+
+
+write(valid_path, document)
+extra_label = copy.deepcopy(document)
+extra_label[0]["Config"]["Labels"]["unexpected"] = "surface"
+write(extra_label_path, extra_label)
+bad_platform = copy.deepcopy(document)
+bad_platform[0]["Architecture"] = "arm64"
+write(bad_platform_path, bad_platform)
+bad_config = copy.deepcopy(document)
+bad_config[0]["Config"]["Cmd"] = ["serve"]
+write(bad_config_path, bad_config)
+PY
+
+case_status=0
+run_verifier() {
+  local inspection="$1"
+  local run_result="$2"
+  local source_date_epoch="${3:-1735689600}"
+  : >"$invocation_log"
+  rm -f -- "$image_state"
+  set +e
+  env \
+    "AUTOMATA_FAKE_DOCKER_CONTEXT=$context" \
+    "AUTOMATA_FAKE_DOCKER_IMAGE=$image_state" \
+    "AUTOMATA_FAKE_DOCKER_INSPECTION=$inspection" \
+    "AUTOMATA_FAKE_DOCKER_LOG=$invocation_log" \
+    "AUTOMATA_FAKE_DOCKER_RUN_RESULT=$run_result" \
+    "PATH=$fake_bin:$PATH" \
+    "TMPDIR=$runtime_tmp" \
+    bash "$verifier" \
+      "$context" \
+      1.2.3 \
+      0123456789abcdef0123456789abcdef01234567 \
+      2025-01-01T00:00:00Z \
+      "$source_date_epoch" \
+      >"$stdout_log" 2>"$stderr_log"
+  case_status=$?
+  set -e
+}
+
+expect_success() {
+  (( case_status == 0 )) || {
+    printf 'sandbox-guest image verifier unexpectedly returned %d\n' \
+      "$case_status" >&2
+    sed -n '1,120p' "$stderr_log" >&2
+    exit 1
+  }
+  cmp -s "$stdout_log" <(
+    printf 'Sandbox-guest image process and metadata verified\n'
+  ) || {
+    printf 'sandbox-guest image verifier success output differed\n' >&2
+    exit 1
+  }
+  [[ ! -s "$stderr_log" ]] || {
+    printf 'sandbox-guest image verifier wrote unexpected stderr\n' >&2
+    exit 1
+  }
+}
+
+expect_failure() {
+  local diagnostic="$1"
+  (( case_status != 0 )) || {
+    printf 'sandbox-guest image verifier unexpectedly succeeded\n' >&2
+    exit 1
+  }
+  grep -Fq -- "$diagnostic" "$stderr_log" || {
+    printf 'sandbox-guest image verifier omitted diagnostic: %s\n' \
+      "$diagnostic" >&2
+    sed -n '1,120p' "$stderr_log" >&2
+    exit 1
+  }
+}
+
+expect_log_count() {
+  local prefix="$1"
+  local expected="$2"
+  local actual
+  actual="$(grep -c -- "^${prefix}" "$invocation_log" || true)"
+  [[ "$actual" == "$expected" ]] || {
+    printf 'fake Docker logged %s %s calls, expected %s\n' \
+      "$actual" "$prefix" "$expected" >&2
+    exit 1
+  }
+}
+
+run_verifier "$valid_inspection" silent
+expect_success
+expect_log_count build 1
+expect_log_count 'image inspect' 1
+expect_log_count run 2
+expect_log_count 'image rm' 1
+
+: >"$context/unexpected"
+run_verifier "$valid_inspection" silent
+expect_failure 'prepared image context has a noncanonical entry set'
+expect_log_count build 0
+rm -f -- "$context/unexpected"
+
+mv -- "$context/LICENSE" "$scratch_directory/LICENSE"
+ln -s -- "$scratch_directory/LICENSE" "$context/LICENSE"
+run_verifier "$valid_inspection" silent
+expect_failure 'prepared image context is missing LICENSE'
+expect_log_count build 0
+rm -f -- "$context/LICENSE"
+mv -- "$scratch_directory/LICENSE" "$context/LICENSE"
+
+run_verifier "$extra_label_inspection" silent
+expect_failure 'image labels differ'
+expect_log_count run 0
+expect_log_count 'image rm' 1
+
+run_verifier "$bad_platform_inspection" silent
+expect_failure 'image platform is not linux/amd64'
+
+run_verifier "$bad_config_inspection" silent
+expect_failure 'image declares an unexpected Cmd setting'
+
+run_verifier "$valid_inspection" noisy
+expect_failure 'empty invocation wrote to stderr'
+
+run_verifier "$valid_inspection" empty-success
+expect_failure 'empty invocation unexpectedly succeeded'
+
+run_verifier "$valid_inspection" unsupported-success
+expect_failure 'unsupported invocation unexpectedly succeeded'
+expect_log_count run 2
+
+run_verifier "$valid_inspection" silent 1735689601
+expect_failure 'release timestamps differ'
+expect_log_count build 0
+
+printf 'sandbox-guest image verifier tests passed\n'

--- a/scripts/ci/verify-sandbox-guest-image.sh
+++ b/scripts/ci/verify-sandbox-guest-image.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../.." && pwd)"
+readonly script_directory repository_root
+# shellcheck source=scripts/ci/lib/target-paths.sh
+source "${script_directory}/lib/target-paths.sh"
+
+die() {
+  printf 'sandbox-guest-image: %s\n' "$*" >&2
+  exit 1
+}
+
+if (( $# != 5 )); then
+  die "usage: $0 CONTEXT VERSION REVISION CREATED SOURCE_DATE_EPOCH"
+fi
+context="$1"
+version="$2"
+revision="$3"
+created="$4"
+source_date_epoch="$5"
+readonly version revision created source_date_epoch
+
+[[ -n "$version" && ${#version} -le 120 && "$version" != *$'\n'* && "$version" != *$'\r'* ]] \
+  || die "version must be one bounded non-empty line"
+[[ "$revision" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]] \
+  || die "revision must be one complete lowercase Git object ID"
+[[ -n "$created" && "$created" != *$'\n'* && "$created" != *$'\r'* ]] \
+  || die "created timestamp must be one non-empty line"
+[[ "$source_date_epoch" =~ ^[0-9]+$ ]] \
+  || die "SOURCE_DATE_EPOCH must be Unix seconds"
+(( ${#source_date_epoch} <= 10 && 10#$source_date_epoch <= 8589934591 )) \
+  || die "SOURCE_DATE_EPOCH exceeds the canonical archive limit"
+command -v docker >/dev/null 2>&1 || die "Docker is required"
+command -v python3 >/dev/null 2>&1 || die "Python 3 is required"
+python3 - "$created" "$source_date_epoch" <<'PY'
+import datetime
+import re
+import sys
+
+created, source_date_epoch = sys.argv[1:]
+if re.fullmatch(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:Z|[+-][0-9]{2}:[0-9]{2})",
+    created,
+) is None:
+    raise SystemExit("sandbox-guest-image: created timestamp is not canonical RFC 3339")
+try:
+    parsed = datetime.datetime.fromisoformat(created.replace("Z", "+00:00"))
+except ValueError:
+    raise SystemExit("sandbox-guest-image: created timestamp is invalid") from None
+if parsed.utcoffset() is None or int(parsed.timestamp()) != int(source_date_epoch):
+    raise SystemExit("sandbox-guest-image: release timestamps differ")
+PY
+
+automata_init_target_root "$repository_root"
+if [[ "$context" != /* ]]; then
+  context="${repository_root}/${context}"
+fi
+context="$(
+  automata_canonical_exact_target_child \
+    "$context" \
+    "sandbox-guest image context"
+)"
+readonly context
+[[ -d "$context" && ! -L "$context" ]] \
+  || die "sandbox-guest image context is missing"
+
+for required in \
+  Containerfile \
+  LICENSE \
+  THIRD_PARTY_LICENSES.txt \
+  THIRD_PARTY_NOTICES.txt \
+  VERSION \
+  automata-ci-sandbox-guest \
+  sbom/automata-ci-sandbox-guest.cdx.json
+do
+  [[ -f "$context/$required" && ! -L "$context/$required" ]] \
+    || die "prepared image context is missing $required"
+done
+[[ -d "$context/sbom" && ! -L "$context/sbom" ]] \
+  || die "prepared image context has an invalid SBOM directory"
+actual_context_entries="$(
+  find -P "$context" -mindepth 1 -printf '%P\n' | LC_ALL=C sort
+)"
+expected_context_entries="$({
+  printf '%s\n' \
+    Containerfile \
+    LICENSE \
+    THIRD_PARTY_LICENSES.txt \
+    THIRD_PARTY_NOTICES.txt \
+    VERSION \
+    automata-ci-sandbox-guest \
+    sbom \
+    sbom/automata-ci-sandbox-guest.cdx.json
+})"
+readonly actual_context_entries expected_context_entries
+[[ "$actual_context_entries" == "$expected_context_entries" ]] \
+  || die "prepared image context has a noncanonical entry set"
+cmp -s "$context/Containerfile" \
+  "$repository_root/images/automata-sandbox-guest.Containerfile" \
+  || die "prepared image context has a stale Containerfile"
+cmp -s "$context/VERSION" <(printf '%s\n' "$version") \
+  || die "prepared image context has a stale VERSION"
+
+automata_set_target_tmpdir \
+  "$repository_root" \
+  "$repository_root/target/task-tmp/sandbox-guest-image"
+scratch_directory="$(mktemp -d "$TMPDIR/sandbox-guest-image.XXXXXXXX")"
+image_suffix="${scratch_directory##*.}"
+image="automata-ci/sandbox-guest-verification:${image_suffix}"
+readonly scratch_directory image_suffix image
+image_built=0
+cleanup() {
+  local cleanup_status=$?
+  trap - EXIT
+  if (( image_built )); then
+    docker image rm --force "$image" >/dev/null 2>&1 || true
+  fi
+  rm -rf -- "$scratch_directory"
+  exit "$cleanup_status"
+}
+trap cleanup EXIT
+
+docker build \
+  --no-cache \
+  --network none \
+  --platform linux/amd64 \
+  --pull=false \
+  --file "$context/Containerfile" \
+  --tag "$image" \
+  --build-arg "AUTOMATA_CREATED=$created" \
+  --build-arg "AUTOMATA_REVISION=$revision" \
+  --build-arg "AUTOMATA_VERSION=$version" \
+  --build-arg "SOURCE_DATE_EPOCH=$source_date_epoch" \
+  "$context" \
+  || die "Docker failed to build the sandbox-guest image"
+image_built=1
+
+docker image inspect "$image" >"$scratch_directory/inspection.json" \
+  || die "Docker failed to inspect the sandbox-guest image"
+python3 - \
+  "$scratch_directory/inspection.json" \
+  "$version" \
+  "$revision" \
+  "$created" <<'PY'
+import json
+import pathlib
+import sys
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"sandbox-guest-image: {message}")
+
+
+try:
+    inspection = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+except (OSError, json.JSONDecodeError):
+    fail("image inspection is not valid JSON")
+version, revision, created = sys.argv[2:5]
+if not isinstance(inspection, list) or len(inspection) != 1:
+    fail("image inspection was not singular")
+image = inspection[0]
+if not isinstance(image, dict):
+    fail("image inspection entry is invalid")
+if image.get("Os") != "linux" or image.get("Architecture") != "amd64":
+    fail("image platform is not linux/amd64")
+if image.get("Variant") not in (None, ""):
+    fail("image declares an unexpected platform variant")
+rootfs = image.get("RootFS")
+if not isinstance(rootfs, dict) or rootfs.get("Type") != "layers":
+    fail("image root filesystem is invalid")
+
+config = image.get("Config")
+if not isinstance(config, dict):
+    fail("image configuration is missing")
+expected_labels = {
+    "io.automata.sandbox-guest.protocol-version": "3",
+    "org.opencontainers.image.created": created,
+    "org.opencontainers.image.description": (
+        "Fixed protocol guest for Automata local job sandboxes"
+    ),
+    "org.opencontainers.image.documentation": (
+        "https://github.com/automata-ci/automata/blob/main/"
+        "crates/automata-ci-sandbox-guest/README.md"
+    ),
+    "org.opencontainers.image.licenses": "MIT",
+    "org.opencontainers.image.revision": revision,
+    "org.opencontainers.image.source": "https://github.com/automata-ci/automata",
+    "org.opencontainers.image.title": "Automata Sandbox Guest",
+    "org.opencontainers.image.url": "https://github.com/automata-ci/automata",
+    "org.opencontainers.image.version": version,
+}
+if config.get("Labels") != expected_labels:
+    fail("image labels differ")
+if config.get("Entrypoint") != ["/usr/local/bin/automata-ci-sandbox-guest"]:
+    fail("image entrypoint differs")
+if config.get("User") != "65532:65532":
+    fail("image user differs")
+if config.get("Env") != [
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+]:
+    fail("image environment differs")
+if config.get("WorkingDir") != "/":
+    fail("image working directory differs")
+for field in (
+    "Cmd",
+    "ExposedPorts",
+    "Healthcheck",
+    "OnBuild",
+    "Shell",
+    "StopSignal",
+    "Volumes",
+):
+    if config.get(field) is not None:
+        fail(f"image declares an unexpected {field} setting")
+PY
+
+probe_silent_nonzero() {
+  local probe_name="$1"
+  local status
+  shift
+  set +e
+  docker run \
+    --rm \
+    --network none \
+    --read-only \
+    --security-opt no-new-privileges \
+    --cap-drop ALL \
+    "$image" \
+    "$@" \
+    >"$scratch_directory/${probe_name}.stdout" \
+    2>"$scratch_directory/${probe_name}.stderr"
+  status=$?
+  set -e
+  (( status != 0 )) || die "$probe_name invocation unexpectedly succeeded"
+  [[ ! -s "$scratch_directory/${probe_name}.stdout" ]] \
+    || die "$probe_name invocation wrote to stdout"
+  [[ ! -s "$scratch_directory/${probe_name}.stderr" ]] \
+    || die "$probe_name invocation wrote to stderr"
+}
+
+probe_silent_nonzero empty
+probe_silent_nonzero unsupported unsupported-command
+
+printf 'Sandbox-guest image process and metadata verified\n'

--- a/scripts/ci/verify-sandbox-guest-static.sh
+++ b/scripts/ci/verify-sandbox-guest-static.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly target="x86_64-unknown-linux-musl"
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../.." && pwd)"
+readonly script_directory repository_root
+
+die() {
+  printf 'sandbox-guest-static: %s\n' "$*" >&2
+  exit 1
+}
+
+if (( $# > 1 )); then
+  die "usage: $0 [BINARY]"
+fi
+binary="${1:-${repository_root}/target/${target}/release/automata-ci-sandbox-guest}"
+readonly binary
+
+command -v readelf >/dev/null 2>&1 || die "readelf is required"
+[[ -f "$binary" && -x "$binary" ]] || die "static guest executable is missing"
+readelf --file-header --wide "$binary" >/dev/null \
+  || die "guest is not a readable ELF executable"
+if readelf --program-headers --wide "$binary" | grep -Eq '^[[:space:]]*INTERP[[:space:]]'; then
+  die "guest contains a PT_INTERP program header"
+fi
+if readelf --dynamic --wide "$binary" 2>/dev/null | grep -Eq '\(NEEDED\)'; then
+  die "guest contains a dynamic dependency"
+fi
+
+scratch_directory="$(mktemp -d "${repository_root}/target/sandbox-guest-static.XXXXXXXX")"
+readonly scratch_directory
+cleanup() {
+  rm -rf -- "$scratch_directory"
+}
+trap cleanup EXIT
+
+set +e
+"$binary" >"$scratch_directory/stdout" 2>"$scratch_directory/stderr"
+status=$?
+set -e
+(( status != 0 )) || die "guest accepted an absent fixed command"
+[[ ! -s "$scratch_directory/stdout" ]] || die "failed guest wrote to stdout"
+[[ ! -s "$scratch_directory/stderr" ]] || die "failed guest wrote to stderr"
+
+set +e
+"$binary" unsupported-command \
+  >"$scratch_directory/unknown-stdout" \
+  2>"$scratch_directory/unknown-stderr"
+status=$?
+set -e
+(( status != 0 )) || die "guest accepted an unsupported fixed command"
+[[ ! -s "$scratch_directory/unknown-stdout" ]] \
+  || die "unsupported command wrote to stdout"
+[[ ! -s "$scratch_directory/unknown-stderr" ]] \
+  || die "unsupported command wrote to stderr"
+
+printf 'Static sandbox guest verified: %s\n' \
+  "$(sha256sum "$binary" | awk '{print $1}')"


### PR DESCRIPTION
## Summary

- add a canonical, bounded local-installation catalog consumed by release manifest and handoff verification
- bind exactly seven Unix/linux-amd64 roles: Automata, runner, PostgreSQL, RustFS, sandbox guest, service proxy, and the checked execution profile image
- capture raw top-level and amd64 child OCI manifests, config digests, process metadata, provenance, and exact role contracts
- make the sandbox guest a release-built static scratch image with SBOM, context, image-shape, and process verification
- carry the protocol-2 service-proxy OCI candidate as an exact handoff asset
- advance the release handoff atomically with deterministic recovery and tamper rejection

## Boundary

This is a release/distribution authority only. It adds no local materializer, bootstrap, relay, credential, image-fetch, or generic runtime API. Later local initialization consumes the verified catalog bytes.

## Verification

- independent strict review and post-rebase review: CLEAN
- catalog tests: 9
- release-handoff tests: 10
- service-proxy candidate/publication/Buildah/image validators
- real linux/amd64 Automata, runner, and sandbox-guest scratch builds and process probes
- live fixed PostgreSQL/RustFS image metadata capture
- reproducible SBOM generation
- pinned workflow lint/actionlint, shellcheck, YAML parsing, source-hash checks
- locked workspace all-target/all-feature check and strict Clippy
