### PR TITLE
test(core): consolidate limit contract boundaries

### DIFF
--- a/crates/automata-ci-core/src/capability/selector.rs
+++ b/crates/automata-ci-core/src/capability/selector.rs
@@ -137,25 +137,13 @@ const fn selector_length_rejection(characters: usize, kind: &'static str) -> Opt
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{MAX_SELECTOR_LENGTH, SelectorError, selector_length_rejection};
-
-    #[test]
-    fn selector_character_limit_has_exact_boundaries() {
-        assert_eq!(
-            selector_length_rejection(MAX_SELECTOR_LENGTH - 1, "runner label"),
-            None
-        );
-        assert_eq!(
-            selector_length_rejection(MAX_SELECTOR_LENGTH, "runner label"),
-            None
-        );
-        assert_eq!(
-            selector_length_rejection(MAX_SELECTOR_LENGTH + 1, "runner label"),
-            Some(SelectorError::TooLong {
-                kind: "runner label",
-                max: MAX_SELECTOR_LENGTH,
-            })
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    selector_character_limit_has_exact_boundaries: (
+        super::selector_length_rejection,
+        super::MAX_SELECTOR_LENGTH,
+        "runner label",
+    ) => super::SelectorError::TooLong {
+        kind: "runner label",
+        max: super::MAX_SELECTOR_LENGTH,
+    };
 }

--- a/crates/automata-ci-core/src/job/context.rs
+++ b/crates/automata-ci-core/src/job/context.rs
@@ -1011,71 +1011,23 @@ fn validate_opaque_identifier(value: &str, field: &'static str) -> Result<(), Ru
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        MAX_CONTEXT_VALUE_DEPTH, MAX_CONTEXT_VALUE_NODES, MAX_CONTEXT_VALUE_TEXT_BYTES,
-        MAX_RUNTIME_CONTEXT_IDENTIFIER_BYTES, RuntimeContextLimitRejection,
-        context_value_depth_rejection, context_value_node_rejection,
-        context_value_text_byte_rejection, runtime_context_identifier_byte_rejection,
-    };
-
-    #[test]
-    fn context_value_depth_limit_has_exact_boundaries() {
-        assert_eq!(
-            context_value_depth_rejection(MAX_CONTEXT_VALUE_DEPTH - 1),
-            None
-        );
-        assert_eq!(context_value_depth_rejection(MAX_CONTEXT_VALUE_DEPTH), None);
-        assert_eq!(
-            context_value_depth_rejection(MAX_CONTEXT_VALUE_DEPTH + 1),
-            Some(RuntimeContextLimitRejection::ValueDepth)
-        );
-    }
-
-    #[test]
-    fn context_value_node_limit_has_exact_boundaries() {
-        assert_eq!(
-            context_value_node_rejection(MAX_CONTEXT_VALUE_NODES - 1),
-            None
-        );
-        assert_eq!(context_value_node_rejection(MAX_CONTEXT_VALUE_NODES), None);
-        assert_eq!(
-            context_value_node_rejection(MAX_CONTEXT_VALUE_NODES + 1),
-            Some(RuntimeContextLimitRejection::ValueNodes)
-        );
-    }
-
-    #[test]
-    fn context_value_text_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            context_value_text_byte_rejection(MAX_CONTEXT_VALUE_TEXT_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            context_value_text_byte_rejection(MAX_CONTEXT_VALUE_TEXT_BYTES),
-            None
-        );
-        assert_eq!(
-            context_value_text_byte_rejection(MAX_CONTEXT_VALUE_TEXT_BYTES + 1),
-            Some(RuntimeContextLimitRejection::ValueTextBytes)
-        );
-    }
-
-    #[test]
-    fn runtime_context_identifier_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            runtime_context_identifier_byte_rejection(MAX_RUNTIME_CONTEXT_IDENTIFIER_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            runtime_context_identifier_byte_rejection(MAX_RUNTIME_CONTEXT_IDENTIFIER_BYTES),
-            None
-        );
-        assert_eq!(
-            runtime_context_identifier_byte_rejection(MAX_RUNTIME_CONTEXT_IDENTIFIER_BYTES + 1),
-            Some(RuntimeContextLimitRejection::IdentifierBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    context_value_depth_limit_has_exact_boundaries: (
+        super::context_value_depth_rejection,
+        super::MAX_CONTEXT_VALUE_DEPTH,
+    ) => super::RuntimeContextLimitRejection::ValueDepth;
+    context_value_node_limit_has_exact_boundaries: (
+        super::context_value_node_rejection,
+        super::MAX_CONTEXT_VALUE_NODES,
+    ) => super::RuntimeContextLimitRejection::ValueNodes;
+    context_value_text_byte_limit_has_exact_boundaries: (
+        super::context_value_text_byte_rejection,
+        super::MAX_CONTEXT_VALUE_TEXT_BYTES,
+    ) => super::RuntimeContextLimitRejection::ValueTextBytes;
+    runtime_context_identifier_byte_limit_has_exact_boundaries: (
+        super::runtime_context_identifier_byte_rejection,
+        super::MAX_RUNTIME_CONTEXT_IDENTIFIER_BYTES,
+    ) => super::RuntimeContextLimitRejection::IdentifierBytes;
 }
 
 /// Invalid canonical value or runtime-context blob.

--- a/crates/automata-ci-core/src/job/expression.rs
+++ b/crates/automata-ci-core/src/job/expression.rs
@@ -557,88 +557,27 @@ fn push_value(
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        ExpressionProgramLimitRejection, MAX_EXPRESSION_DEPTH, MAX_EXPRESSION_DIALECT_LENGTH,
-        MAX_EXPRESSION_INSTRUCTIONS, MAX_EXPRESSION_SOURCE_BYTES, MAX_EXPRESSION_TEXT_BYTES,
-        expression_depth_rejection, expression_dialect_byte_rejection,
-        expression_instruction_rejection, expression_source_byte_rejection,
-        expression_text_byte_rejection,
-    };
-
-    #[test]
-    fn expression_source_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            expression_source_byte_rejection(MAX_EXPRESSION_SOURCE_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            expression_source_byte_rejection(MAX_EXPRESSION_SOURCE_BYTES),
-            None
-        );
-        assert_eq!(
-            expression_source_byte_rejection(MAX_EXPRESSION_SOURCE_BYTES + 1),
-            Some(ExpressionProgramLimitRejection::SourceBytes)
-        );
-    }
-
-    #[test]
-    fn expression_instruction_limit_has_exact_boundaries() {
-        assert_eq!(
-            expression_instruction_rejection(MAX_EXPRESSION_INSTRUCTIONS - 1),
-            None
-        );
-        assert_eq!(
-            expression_instruction_rejection(MAX_EXPRESSION_INSTRUCTIONS),
-            None
-        );
-        assert_eq!(
-            expression_instruction_rejection(MAX_EXPRESSION_INSTRUCTIONS + 1),
-            Some(ExpressionProgramLimitRejection::Instructions)
-        );
-    }
-
-    #[test]
-    fn expression_depth_limit_has_exact_boundaries() {
-        assert_eq!(expression_depth_rejection(MAX_EXPRESSION_DEPTH - 1), None);
-        assert_eq!(expression_depth_rejection(MAX_EXPRESSION_DEPTH), None);
-        assert_eq!(
-            expression_depth_rejection(MAX_EXPRESSION_DEPTH + 1),
-            Some(ExpressionProgramLimitRejection::Depth)
-        );
-    }
-
-    #[test]
-    fn expression_text_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            expression_text_byte_rejection(MAX_EXPRESSION_TEXT_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            expression_text_byte_rejection(MAX_EXPRESSION_TEXT_BYTES),
-            None
-        );
-        assert_eq!(
-            expression_text_byte_rejection(MAX_EXPRESSION_TEXT_BYTES + 1),
-            Some(ExpressionProgramLimitRejection::TextBytes)
-        );
-    }
-
-    #[test]
-    fn expression_dialect_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            expression_dialect_byte_rejection(MAX_EXPRESSION_DIALECT_LENGTH - 1),
-            None
-        );
-        assert_eq!(
-            expression_dialect_byte_rejection(MAX_EXPRESSION_DIALECT_LENGTH),
-            None
-        );
-        assert_eq!(
-            expression_dialect_byte_rejection(MAX_EXPRESSION_DIALECT_LENGTH + 1),
-            Some(ExpressionProgramLimitRejection::DialectBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    expression_source_byte_limit_has_exact_boundaries: (
+        super::expression_source_byte_rejection,
+        super::MAX_EXPRESSION_SOURCE_BYTES,
+    ) => super::ExpressionProgramLimitRejection::SourceBytes;
+    expression_instruction_limit_has_exact_boundaries: (
+        super::expression_instruction_rejection,
+        super::MAX_EXPRESSION_INSTRUCTIONS,
+    ) => super::ExpressionProgramLimitRejection::Instructions;
+    expression_depth_limit_has_exact_boundaries: (
+        super::expression_depth_rejection,
+        super::MAX_EXPRESSION_DEPTH,
+    ) => super::ExpressionProgramLimitRejection::Depth;
+    expression_text_byte_limit_has_exact_boundaries: (
+        super::expression_text_byte_rejection,
+        super::MAX_EXPRESSION_TEXT_BYTES,
+    ) => super::ExpressionProgramLimitRejection::TextBytes;
+    expression_dialect_byte_limit_has_exact_boundaries: (
+        super::expression_dialect_byte_rejection,
+        super::MAX_EXPRESSION_DIALECT_LENGTH,
+    ) => super::ExpressionProgramLimitRejection::DialectBytes;
 }
 
 /// Invalid durable expression dialect, source, or canonical program.

--- a/crates/automata-ci-core/src/job/identifier.rs
+++ b/crates/automata-ci-core/src/job/identifier.rs
@@ -97,16 +97,9 @@ impl<'de> Deserialize<'de> for StepId {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{JobIdentifierLimitRejection, MAX_SEMANTIC_ID_LENGTH, step_id_byte_rejection};
-
-    #[test]
-    fn step_id_byte_limit_has_exact_boundaries() {
-        assert_eq!(step_id_byte_rejection(MAX_SEMANTIC_ID_LENGTH - 1), None);
-        assert_eq!(step_id_byte_rejection(MAX_SEMANTIC_ID_LENGTH), None);
-        assert_eq!(
-            step_id_byte_rejection(MAX_SEMANTIC_ID_LENGTH + 1),
-            Some(JobIdentifierLimitRejection::StepIdBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    step_id_byte_limit_has_exact_boundaries: (
+        super::step_id_byte_rejection,
+        super::MAX_SEMANTIC_ID_LENGTH,
+    ) => super::JobIdentifierLimitRejection::StepIdBytes;
 }

--- a/crates/automata-ci-core/src/job/instance.rs
+++ b/crates/automata-ci-core/src/job/instance.rs
@@ -233,41 +233,13 @@ pub(super) fn validate_logical_name(
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        JobInstanceLimitRejection, MAX_JOB_LOGICAL_NAME_BYTES, MAX_JOB_OUTPUT_DEFINITIONS,
-        job_logical_name_byte_rejection, job_output_definition_rejection,
-    };
-
-    #[test]
-    fn job_logical_name_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_logical_name_byte_rejection(MAX_JOB_LOGICAL_NAME_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            job_logical_name_byte_rejection(MAX_JOB_LOGICAL_NAME_BYTES),
-            None
-        );
-        assert_eq!(
-            job_logical_name_byte_rejection(MAX_JOB_LOGICAL_NAME_BYTES + 1),
-            Some(JobInstanceLimitRejection::LogicalNameBytes)
-        );
-    }
-
-    #[test]
-    fn job_output_definition_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_output_definition_rejection(MAX_JOB_OUTPUT_DEFINITIONS - 1),
-            None
-        );
-        assert_eq!(
-            job_output_definition_rejection(MAX_JOB_OUTPUT_DEFINITIONS),
-            None
-        );
-        assert_eq!(
-            job_output_definition_rejection(MAX_JOB_OUTPUT_DEFINITIONS + 1),
-            Some(JobInstanceLimitRejection::OutputDefinitions)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    job_logical_name_byte_limit_has_exact_boundaries: (
+        super::job_logical_name_byte_rejection,
+        super::MAX_JOB_LOGICAL_NAME_BYTES,
+    ) => super::JobInstanceLimitRejection::LogicalNameBytes;
+    job_output_definition_limit_has_exact_boundaries: (
+        super::job_output_definition_rejection,
+        super::MAX_JOB_OUTPUT_DEFINITIONS,
+    ) => super::JobInstanceLimitRejection::OutputDefinitions;
 }

--- a/crates/automata-ci-core/src/job/permission.rs
+++ b/crates/automata-ci-core/src/job/permission.rs
@@ -197,41 +197,13 @@ fn canonical_permission_name(value: &str) -> bool {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        JobPermissionLimitRejection, MAX_JOB_PERMISSION_GRANTS, MAX_JOB_PERMISSION_NAME_BYTES,
-        job_permission_grant_rejection, job_permission_name_byte_rejection,
-    };
-
-    #[test]
-    fn job_permission_grant_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_permission_grant_rejection(MAX_JOB_PERMISSION_GRANTS - 1),
-            None
-        );
-        assert_eq!(
-            job_permission_grant_rejection(MAX_JOB_PERMISSION_GRANTS),
-            None
-        );
-        assert_eq!(
-            job_permission_grant_rejection(MAX_JOB_PERMISSION_GRANTS + 1),
-            Some(JobPermissionLimitRejection::Grants)
-        );
-    }
-
-    #[test]
-    fn job_permission_name_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_permission_name_byte_rejection(MAX_JOB_PERMISSION_NAME_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            job_permission_name_byte_rejection(MAX_JOB_PERMISSION_NAME_BYTES),
-            None
-        );
-        assert_eq!(
-            job_permission_name_byte_rejection(MAX_JOB_PERMISSION_NAME_BYTES + 1),
-            Some(JobPermissionLimitRejection::NameBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    job_permission_grant_limit_has_exact_boundaries: (
+        super::job_permission_grant_rejection,
+        super::MAX_JOB_PERMISSION_GRANTS,
+    ) => super::JobPermissionLimitRejection::Grants;
+    job_permission_name_byte_limit_has_exact_boundaries: (
+        super::job_permission_name_byte_rejection,
+        super::MAX_JOB_PERMISSION_NAME_BYTES,
+    ) => super::JobPermissionLimitRejection::NameBytes;
 }

--- a/crates/automata-ci-core/src/job/result.rs
+++ b/crates/automata-ci-core/src/job/result.rs
@@ -754,101 +754,29 @@ pub enum JobResultValidationError {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::*;
-
-    #[test]
-    fn job_result_output_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_result_output_byte_rejection(MAX_JOB_RESULT_OUTPUT_UTF16_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            job_result_output_byte_rejection(MAX_JOB_RESULT_OUTPUT_UTF16_BYTES),
-            None
-        );
-        assert_eq!(
-            job_result_output_byte_rejection(MAX_JOB_RESULT_OUTPUT_UTF16_BYTES + 1),
-            Some(JobResultLimitRejection::OutputUtf16Bytes)
-        );
-    }
-    #[test]
-    fn job_result_attachment_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_result_attachment_byte_rejection(MAX_JOB_RESULT_ATTACHMENT_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            job_result_attachment_byte_rejection(MAX_JOB_RESULT_ATTACHMENT_BYTES),
-            None
-        );
-        assert_eq!(
-            job_result_attachment_byte_rejection(MAX_JOB_RESULT_ATTACHMENT_BYTES + 1),
-            Some(JobResultLimitRejection::AttachmentBytes)
-        );
-    }
-    #[test]
-    fn job_result_annotation_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            job_result_annotation_count_rejection(MAX_JOB_RESULT_ANNOTATIONS - 1),
-            None
-        );
-        assert_eq!(
-            job_result_annotation_count_rejection(MAX_JOB_RESULT_ANNOTATIONS),
-            None
-        );
-        assert_eq!(
-            job_result_annotation_count_rejection(MAX_JOB_RESULT_ANNOTATIONS + 1),
-            Some(JobResultLimitRejection::Annotations)
-        );
-    }
-    #[test]
-    fn step_annotation_property_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            step_annotation_property_count_rejection(MAX_STEP_ANNOTATION_PROPERTIES - 1),
-            None
-        );
-        assert_eq!(
-            step_annotation_property_count_rejection(MAX_STEP_ANNOTATION_PROPERTIES),
-            None
-        );
-        assert_eq!(
-            step_annotation_property_count_rejection(MAX_STEP_ANNOTATION_PROPERTIES + 1),
-            Some(JobResultLimitRejection::AnnotationProperties)
-        );
-    }
-    #[test]
-    fn step_attachment_text_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            step_attachment_text_byte_rejection(MAX_STEP_ATTACHMENT_TEXT_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            step_attachment_text_byte_rejection(MAX_STEP_ATTACHMENT_TEXT_BYTES),
-            None
-        );
-        assert_eq!(
-            step_attachment_text_byte_rejection(MAX_STEP_ATTACHMENT_TEXT_BYTES + 1),
-            Some(JobResultLimitRejection::StepAttachmentTextBytes)
-        );
-    }
-    #[test]
-    fn step_annotation_property_name_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            step_annotation_property_name_byte_rejection(
-                MAX_STEP_ANNOTATION_PROPERTY_NAME_BYTES - 1
-            ),
-            None
-        );
-        assert_eq!(
-            step_annotation_property_name_byte_rejection(MAX_STEP_ANNOTATION_PROPERTY_NAME_BYTES),
-            None
-        );
-        assert_eq!(
-            step_annotation_property_name_byte_rejection(
-                MAX_STEP_ANNOTATION_PROPERTY_NAME_BYTES + 1
-            ),
-            Some(JobResultLimitRejection::AnnotationPropertyNameBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    job_result_output_byte_limit_has_exact_boundaries: (
+        super::job_result_output_byte_rejection,
+        super::MAX_JOB_RESULT_OUTPUT_UTF16_BYTES,
+    ) => super::JobResultLimitRejection::OutputUtf16Bytes;
+    job_result_attachment_byte_limit_has_exact_boundaries: (
+        super::job_result_attachment_byte_rejection,
+        super::MAX_JOB_RESULT_ATTACHMENT_BYTES,
+    ) => super::JobResultLimitRejection::AttachmentBytes;
+    job_result_annotation_count_limit_has_exact_boundaries: (
+        super::job_result_annotation_count_rejection,
+        super::MAX_JOB_RESULT_ANNOTATIONS,
+    ) => super::JobResultLimitRejection::Annotations;
+    step_annotation_property_count_limit_has_exact_boundaries: (
+        super::step_annotation_property_count_rejection,
+        super::MAX_STEP_ANNOTATION_PROPERTIES,
+    ) => super::JobResultLimitRejection::AnnotationProperties;
+    step_attachment_text_byte_limit_has_exact_boundaries: (
+        super::step_attachment_text_byte_rejection,
+        super::MAX_STEP_ATTACHMENT_TEXT_BYTES,
+    ) => super::JobResultLimitRejection::StepAttachmentTextBytes;
+    step_annotation_property_name_byte_limit_has_exact_boundaries: (
+        super::step_annotation_property_name_byte_rejection,
+        super::MAX_STEP_ANNOTATION_PROPERTY_NAME_BYTES,
+    ) => super::JobResultLimitRejection::AnnotationPropertyNameBytes;
 }

--- a/crates/automata-ci-core/src/job/template.rs
+++ b/crates/automata-ci-core/src/job/template.rs
@@ -198,43 +198,15 @@ impl ValueTemplate {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        MAX_VALUE_TEMPLATE_SEGMENTS, MAX_VALUE_TEMPLATE_TEXT_BYTES, ValueTemplateLimitRejection,
-        value_template_segment_rejection, value_template_text_byte_rejection,
-    };
-
-    #[test]
-    fn value_template_segment_limit_has_exact_boundaries() {
-        assert_eq!(
-            value_template_segment_rejection(MAX_VALUE_TEMPLATE_SEGMENTS - 1),
-            None
-        );
-        assert_eq!(
-            value_template_segment_rejection(MAX_VALUE_TEMPLATE_SEGMENTS),
-            None
-        );
-        assert_eq!(
-            value_template_segment_rejection(MAX_VALUE_TEMPLATE_SEGMENTS + 1),
-            Some(ValueTemplateLimitRejection::Segments)
-        );
-    }
-
-    #[test]
-    fn value_template_text_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            value_template_text_byte_rejection(MAX_VALUE_TEMPLATE_TEXT_BYTES - 1),
-            None
-        );
-        assert_eq!(
-            value_template_text_byte_rejection(MAX_VALUE_TEMPLATE_TEXT_BYTES),
-            None
-        );
-        assert_eq!(
-            value_template_text_byte_rejection(MAX_VALUE_TEMPLATE_TEXT_BYTES + 1),
-            Some(ValueTemplateLimitRejection::TextBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    value_template_segment_limit_has_exact_boundaries: (
+        super::value_template_segment_rejection,
+        super::MAX_VALUE_TEMPLATE_SEGMENTS,
+    ) => super::ValueTemplateLimitRejection::Segments;
+    value_template_text_byte_limit_has_exact_boundaries: (
+        super::value_template_text_byte_rejection,
+        super::MAX_VALUE_TEMPLATE_TEXT_BYTES,
+    ) => super::ValueTemplateLimitRejection::TextBytes;
 }
 
 /// A boolean that may remain deferred until a step is about to execute.

--- a/crates/automata-ci-core/src/lib.rs
+++ b/crates/automata-ci-core/src/lib.rs
@@ -16,6 +16,9 @@ pub mod time;
 pub mod trust;
 pub mod workflow;
 
+#[cfg(test)]
+mod test_support;
+
 pub use capability::*;
 pub use digest::*;
 pub use execution::*;

--- a/crates/automata-ci-core/src/test_support.rs
+++ b/crates/automata-ci-core/src/test_support.rs
@@ -1,0 +1,25 @@
+macro_rules! limit_contract_tests {
+    (
+        $(
+            $name:ident: (
+                $check:path,
+                $maximum:path
+                $(, $argument:expr)*
+                $(,)?
+            ) => $above:expr;
+        )+
+    ) => {
+        mod limit_contract_tests {
+            $(
+                #[test]
+                fn $name() {
+                    assert_eq!($check($maximum - 1 $(, $argument)*), None);
+                    assert_eq!($check($maximum $(, $argument)*), None);
+                    assert_eq!($check($maximum + 1 $(, $argument)*), Some($above));
+                }
+            )+
+        }
+    };
+}
+
+pub(crate) use limit_contract_tests;

--- a/crates/automata-ci-core/src/workflow/identifier.rs
+++ b/crates/automata-ci-core/src/workflow/identifier.rs
@@ -105,24 +105,9 @@ plan_key!(/// Stable workflow or logical-job output identity.
     WorkflowOutputKey, "workflow output key");
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::{
-        MAX_PLAN_KEY_LENGTH, WorkflowIdentifierLimitRejection, workflow_identifier_byte_rejection,
-    };
-
-    #[test]
-    fn workflow_identifier_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            workflow_identifier_byte_rejection(MAX_PLAN_KEY_LENGTH - 1),
-            None
-        );
-        assert_eq!(
-            workflow_identifier_byte_rejection(MAX_PLAN_KEY_LENGTH),
-            None
-        );
-        assert_eq!(
-            workflow_identifier_byte_rejection(MAX_PLAN_KEY_LENGTH + 1),
-            Some(WorkflowIdentifierLimitRejection::KeyBytes)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    workflow_identifier_byte_limit_has_exact_boundaries: (
+        super::workflow_identifier_byte_rejection,
+        super::MAX_PLAN_KEY_LENGTH,
+    ) => super::WorkflowIdentifierLimitRejection::KeyBytes;
 }

--- a/crates/automata-ci-core/src/workflow/strategy.rs
+++ b/crates/automata-ci-core/src/workflow/strategy.rs
@@ -836,100 +836,37 @@ fn is_json_number(value: &str) -> bool {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::*;
-
-    #[test]
-    fn matrix_expansion_limit_has_exact_boundaries() {
-        assert_eq!(matrix_expansion_rejection(MAX_MATRIX_EXPANSION - 1), None);
-        assert_eq!(matrix_expansion_rejection(MAX_MATRIX_EXPANSION), None);
-        assert_eq!(
-            matrix_expansion_rejection(MAX_MATRIX_EXPANSION + 1),
-            Some(MatrixLimitRejection::Expansion)
-        );
-    }
-    #[test]
-    fn matrix_axis_count_limit_has_exact_boundaries() {
-        assert_eq!(matrix_axis_count_rejection(MAX_MATRIX_AXES - 1), None);
-        assert_eq!(matrix_axis_count_rejection(MAX_MATRIX_AXES), None);
-        assert_eq!(
-            matrix_axis_count_rejection(MAX_MATRIX_AXES + 1),
-            Some(MatrixLimitRejection::Axes)
-        );
-    }
-    #[test]
-    fn matrix_axis_value_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            matrix_axis_value_count_rejection(MAX_MATRIX_AXIS_VALUES - 1),
-            None
-        );
-        assert_eq!(
-            matrix_axis_value_count_rejection(MAX_MATRIX_AXIS_VALUES),
-            None
-        );
-        assert_eq!(
-            matrix_axis_value_count_rejection(MAX_MATRIX_AXIS_VALUES + 1),
-            Some(MatrixLimitRejection::AxisValues)
-        );
-    }
-    #[test]
-    fn matrix_patch_count_limit_has_exact_boundaries() {
-        assert_eq!(matrix_patch_count_rejection(MAX_MATRIX_PATCHES - 1), None);
-        assert_eq!(matrix_patch_count_rejection(MAX_MATRIX_PATCHES), None);
-        assert_eq!(
-            matrix_patch_count_rejection(MAX_MATRIX_PATCHES + 1),
-            Some(MatrixLimitRejection::Patches)
-        );
-    }
-    #[test]
-    fn matrix_object_entry_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            matrix_object_entry_count_rejection(MAX_MATRIX_OBJECT_ENTRIES - 1),
-            None
-        );
-        assert_eq!(
-            matrix_object_entry_count_rejection(MAX_MATRIX_OBJECT_ENTRIES),
-            None
-        );
-        assert_eq!(
-            matrix_object_entry_count_rejection(MAX_MATRIX_OBJECT_ENTRIES + 1),
-            Some(MatrixLimitRejection::ObjectEntries)
-        );
-    }
-    #[test]
-    fn matrix_value_depth_limit_has_exact_boundaries() {
-        assert_eq!(
-            matrix_value_depth_rejection(MAX_MATRIX_VALUE_DEPTH - 1),
-            None
-        );
-        assert_eq!(matrix_value_depth_rejection(MAX_MATRIX_VALUE_DEPTH), None);
-        assert_eq!(
-            matrix_value_depth_rejection(MAX_MATRIX_VALUE_DEPTH + 1),
-            Some(MatrixLimitRejection::ValueDepth)
-        );
-    }
-    #[test]
-    fn matrix_text_byte_limit_has_exact_boundaries() {
-        assert_eq!(matrix_text_byte_rejection(MAX_MATRIX_TEXT_BYTES - 1), None);
-        assert_eq!(matrix_text_byte_rejection(MAX_MATRIX_TEXT_BYTES), None);
-        assert_eq!(
-            matrix_text_byte_rejection(MAX_MATRIX_TEXT_BYTES + 1),
-            Some(MatrixLimitRejection::TextBytes)
-        );
-    }
-    #[test]
-    fn matrix_static_candidate_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            matrix_static_candidate_count_rejection(MAX_STATIC_MATRIX_CANDIDATE_COMBINATIONS - 1),
-            None
-        );
-        assert_eq!(
-            matrix_static_candidate_count_rejection(MAX_STATIC_MATRIX_CANDIDATE_COMBINATIONS),
-            None
-        );
-        assert_eq!(
-            matrix_static_candidate_count_rejection(MAX_STATIC_MATRIX_CANDIDATE_COMBINATIONS + 1),
-            Some(MatrixLimitRejection::StaticCandidates)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    matrix_expansion_limit_has_exact_boundaries: (
+        super::matrix_expansion_rejection,
+        super::MAX_MATRIX_EXPANSION,
+    ) => super::MatrixLimitRejection::Expansion;
+    matrix_axis_count_limit_has_exact_boundaries: (
+        super::matrix_axis_count_rejection,
+        super::MAX_MATRIX_AXES,
+    ) => super::MatrixLimitRejection::Axes;
+    matrix_axis_value_count_limit_has_exact_boundaries: (
+        super::matrix_axis_value_count_rejection,
+        super::MAX_MATRIX_AXIS_VALUES,
+    ) => super::MatrixLimitRejection::AxisValues;
+    matrix_patch_count_limit_has_exact_boundaries: (
+        super::matrix_patch_count_rejection,
+        super::MAX_MATRIX_PATCHES,
+    ) => super::MatrixLimitRejection::Patches;
+    matrix_object_entry_count_limit_has_exact_boundaries: (
+        super::matrix_object_entry_count_rejection,
+        super::MAX_MATRIX_OBJECT_ENTRIES,
+    ) => super::MatrixLimitRejection::ObjectEntries;
+    matrix_value_depth_limit_has_exact_boundaries: (
+        super::matrix_value_depth_rejection,
+        super::MAX_MATRIX_VALUE_DEPTH,
+    ) => super::MatrixLimitRejection::ValueDepth;
+    matrix_text_byte_limit_has_exact_boundaries: (
+        super::matrix_text_byte_rejection,
+        super::MAX_MATRIX_TEXT_BYTES,
+    ) => super::MatrixLimitRejection::TextBytes;
+    matrix_static_candidate_count_limit_has_exact_boundaries: (
+        super::matrix_static_candidate_count_rejection,
+        super::MAX_STATIC_MATRIX_CANDIDATE_COMBINATIONS,
+    ) => super::MatrixLimitRejection::StaticCandidates;
 }

--- a/crates/automata-ci-core/src/workflow/template.rs
+++ b/crates/automata-ci-core/src/workflow/template.rs
@@ -22,48 +22,19 @@ pub(super) enum WorkflowTemplateLimitRejection {
 }
 
 #[cfg(test)]
-mod limit_contract_tests {
-    use super::*;
-
-    #[test]
-    fn workflow_template_byte_limit_has_exact_boundaries() {
-        assert_eq!(
-            workflow_template_byte_rejection(MAX_TEMPLATE_BYTES - 1),
-            None
-        );
-        assert_eq!(workflow_template_byte_rejection(MAX_TEMPLATE_BYTES), None);
-        assert_eq!(
-            workflow_template_byte_rejection(MAX_TEMPLATE_BYTES + 1),
-            Some(WorkflowTemplateLimitRejection::Bytes)
-        );
-    }
-    #[test]
-    fn workflow_template_segment_limit_has_exact_boundaries() {
-        assert_eq!(
-            workflow_template_segment_rejection(MAX_TEMPLATE_SEGMENTS - 1),
-            None
-        );
-        assert_eq!(
-            workflow_template_segment_rejection(MAX_TEMPLATE_SEGMENTS),
-            None
-        );
-        assert_eq!(
-            workflow_template_segment_rejection(MAX_TEMPLATE_SEGMENTS + 1),
-            Some(WorkflowTemplateLimitRejection::Segments)
-        );
-    }
-    #[test]
-    fn expression_context_limit_has_exact_boundaries() {
-        assert_eq!(
-            expression_context_rejection(MAX_EXPRESSION_CONTEXTS - 1),
-            None
-        );
-        assert_eq!(expression_context_rejection(MAX_EXPRESSION_CONTEXTS), None);
-        assert_eq!(
-            expression_context_rejection(MAX_EXPRESSION_CONTEXTS + 1),
-            Some(WorkflowTemplateLimitRejection::Contexts)
-        );
-    }
+crate::test_support::limit_contract_tests! {
+    workflow_template_byte_limit_has_exact_boundaries: (
+        super::workflow_template_byte_rejection,
+        super::MAX_TEMPLATE_BYTES,
+    ) => super::WorkflowTemplateLimitRejection::Bytes;
+    workflow_template_segment_limit_has_exact_boundaries: (
+        super::workflow_template_segment_rejection,
+        super::MAX_TEMPLATE_SEGMENTS,
+    ) => super::WorkflowTemplateLimitRejection::Segments;
+    expression_context_limit_has_exact_boundaries: (
+        super::expression_context_rejection,
+        super::MAX_EXPRESSION_CONTEXTS,
+    ) => super::WorkflowTemplateLimitRejection::Contexts;
 }
 
 pub(super) const fn workflow_template_byte_rejection(


### PR DESCRIPTION
## Summary

- Add one crate-private, test-only `limit_contract_tests!` macro for exact max-1/max/max+1 boundary contracts.
- Replace repeated modules across Core capability, job, and workflow types while preserving all 35 fully qualified test names and all 105 assertions.
- Keep the selector context argument explicit; production behavior and public APIs are unchanged.

## Size

- 13 files changed
- 183 additions, 546 deletions (729 changed lines; 363 net removed)

## Validation

- `cargo fmt --all -- --check`
- Locked Core check across all targets and features
- 57 focused limit-contract tests
- 181 full Core tests
- Strict Clippy with warnings denied
- Rustdoc with warnings denied

Closes #400