### PR TITLE
refactor(github): retire stored push facade

### DIFF
--- a/crates/automata-ci-github-delivery/src/changed_files.rs
+++ b/crates/automata-ci-github-delivery/src/changed_files.rs
@@ -310,9 +310,9 @@ fn changed_file_selection(
 mod tests {
     use automata_ci_auth::secret::SecretString;
     use automata_ci_github::{
-        GITHUB_PUSH_EVENT_MEDIA_TYPE, GithubPushDiffIncompleteReason, GithubRepositoryVisibility,
-        GithubWebhookBodyDigest, StoredAuthenticatedGithubPush,
-        rehydrate_stored_authenticated_github_push,
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubPushDiffIncompleteReason,
+        GithubRepositoryVisibility, GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook,
+        VerifiedGithubWebhook, rehydrate_stored_authenticated_github_webhook,
     };
     use bytes::Bytes;
     use sha2::{Digest as _, Sha256};
@@ -416,12 +416,13 @@ mod tests {
         let mut digest_bytes = [0_u8; 32];
         digest_bytes.copy_from_slice(&digest);
         let encoded_size = u64::try_from(body.len()).unwrap();
-        rehydrate_stored_authenticated_github_push(
-            StoredAuthenticatedGithubPush::from_durable_coordinates(
+        let event = rehydrate_stored_authenticated_github_webhook(
+            StoredAuthenticatedGithubWebhook::from_durable_coordinates(
                 body,
                 GithubWebhookBodyDigest::from_bytes(digest_bytes),
                 encoded_size,
-                GITHUB_PUSH_EVENT_MEDIA_TYPE,
+                GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+                "push",
                 "delivery-test",
                 9,
                 42,
@@ -431,6 +432,10 @@ mod tests {
                 "repo",
             ),
         )
-        .unwrap()
+        .unwrap();
+        let VerifiedGithubWebhook::Push(push) = event else {
+            panic!("expected push fixture");
+        };
+        push
     }
 }

--- a/crates/automata-ci-github-delivery/src/lib.rs
+++ b/crates/automata-ci-github-delivery/src/lib.rs
@@ -110,8 +110,6 @@ use http::HeaderMap;
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
-/// Canonical media type retained for an authenticated raw GitHub push event.
-pub const GITHUB_PUSH_EVENT_MEDIA_TYPE: &str = "application/vnd.automata.github-push+json";
 /// Media type for a generic authenticated raw GitHub event.
 pub const GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE: &str =
     automata_ci_github::GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE;

--- a/crates/automata-ci-github-delivery/src/processor/changed_files_provider_tests.rs
+++ b/crates/automata-ci-github-delivery/src/processor/changed_files_provider_tests.rs
@@ -10,8 +10,8 @@ use automata_ci_core::{Sha256Digest, UnixMillis};
 use automata_ci_github::{
     GITHUB_API_VERSION, GITHUB_EVENT_ENVELOPE_V1_MEDIA_TYPE, GITHUB_RAW_EVENT_OBJECT_KEY_PREFIX,
     GithubHttpEndpoint, GithubHttpLimits, GithubRepositoryVisibility, GithubSealedEventEnvelopeV1,
-    GithubWebhookBodyDigest, StoredAuthenticatedGithubPush, VerifiedGithubPush,
-    VerifiedGithubWebhook, rehydrate_stored_authenticated_github_push,
+    GithubWebhookBodyDigest, StoredAuthenticatedGithubWebhook, VerifiedGithubPush,
+    VerifiedGithubWebhook, rehydrate_stored_authenticated_github_webhook,
 };
 use automata_ci_store::{
     AdmissionObject, ClaimedProviderDelivery, ObjectKey, ProviderConnectionId,
@@ -35,8 +35,7 @@ use super::{
     GithubPushChangedFilesRequest,
 };
 use crate::{
-    GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GITHUB_PUSH_EVENT_MEDIA_TYPE,
-    GithubRestPushChangedFilesProvider,
+    GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubRestPushChangedFilesProvider,
     service::provider_required_through,
     worker::{GithubDeliveryClaimLease, GithubDeliveryClaimSnapshot},
 };
@@ -166,12 +165,13 @@ fn delivery_fixture(visibility: ProviderRepositoryVisibility) -> DeliveryFixture
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
     )
     .expect("raw event");
-    let push = rehydrate_stored_authenticated_github_push(
-        StoredAuthenticatedGithubPush::from_durable_coordinates(
+    let event = rehydrate_stored_authenticated_github_webhook(
+        StoredAuthenticatedGithubWebhook::from_durable_coordinates(
             body,
             GithubWebhookBodyDigest::from_bytes(digest_bytes),
             encoded_size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+            "push",
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -181,7 +181,10 @@ fn delivery_fixture(visibility: ProviderRepositoryVisibility) -> DeliveryFixture
             REPOSITORY,
         ),
     )
-    .expect("verified push");
+    .expect("verified webhook");
+    let VerifiedGithubWebhook::Push(push) = event else {
+        panic!("expected push fixture");
+    };
     let sealed_event =
         GithubSealedEventEnvelopeV1::seal(&VerifiedGithubWebhook::Push(push.clone()), descriptor)
             .expect("sealed event envelope");

--- a/crates/automata-ci-github/src/lib.rs
+++ b/crates/automata-ci-github/src/lib.rs
@@ -51,14 +51,12 @@ pub use event::{
     GithubWorkflowEventKind, MAX_GITHUB_EVENT_ENVELOPE_BYTES, derive_github_trust_snapshot,
 };
 pub use webhook::{
-    AuthenticatedGithubWebhook, GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
-    GITHUB_PUSH_EVENT_MEDIA_TYPE, GithubPushRef, GithubPushRefKind, GithubPushRepository,
-    GithubRepositoryVisibility, GithubStoredPushError, GithubStoredWebhookError,
+    AuthenticatedGithubWebhook, GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubPushRef,
+    GithubPushRefKind, GithubPushRepository, GithubRepositoryVisibility, GithubStoredWebhookError,
     GithubWebhookBodyDigest, GithubWebhookError, GithubWebhookEventMetadata, GithubWebhookVerifier,
     GithubWebhookVerifierFingerprint, MAX_GITHUB_PUSH_COMMITS, MAX_GITHUB_WEBHOOK_BODY_BYTES,
-    MAX_GITHUB_WEBHOOK_SECRET_BYTES, StoredAuthenticatedGithubPush,
-    StoredAuthenticatedGithubWebhook, VerifiedGithubPush, X_GITHUB_DELIVERY, X_GITHUB_EVENT,
-    X_HUB_SIGNATURE_256, rehydrate_stored_authenticated_github_push,
+    MAX_GITHUB_WEBHOOK_SECRET_BYTES, StoredAuthenticatedGithubWebhook, VerifiedGithubPush,
+    X_GITHUB_DELIVERY, X_GITHUB_EVENT, X_HUB_SIGNATURE_256,
     rehydrate_stored_authenticated_github_webhook,
 };
 pub use webhook_event::{

--- a/crates/automata-ci-github/src/webhook.rs
+++ b/crates/automata-ci-github/src/webhook.rs
@@ -18,8 +18,6 @@ pub const MAX_GITHUB_WEBHOOK_BODY_BYTES: usize = 26_214_400;
 pub const MAX_GITHUB_WEBHOOK_SECRET_BYTES: usize = 16_384;
 /// Maximum commit summaries GitHub documents in one push webhook.
 pub const MAX_GITHUB_PUSH_COMMITS: usize = 2_048;
-/// Exact durable media type required for a stored authenticated GitHub push.
-pub const GITHUB_PUSH_EVENT_MEDIA_TYPE: &str = "application/vnd.automata.github-push+json";
 /// Exact durable media type for a authenticated GitHub event.
 pub const GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE: &str =
     "application/vnd.automata.github-authenticated-event+json";
@@ -109,31 +107,10 @@ impl fmt::Debug for GithubWebhookVerifierFingerprint {
     }
 }
 
-/// Exact stored object and durable identity evidence for one authenticated push.
-///
-/// Construction does not authenticate or decode the body. The value exists so
-/// the only stored-body rehydration entry point must receive the complete
-/// immutable coordinates recorded after webhook authentication. Call
-/// [`rehydrate_stored_authenticated_github_push`] to validate and consume it.
-pub struct StoredAuthenticatedGithubPush {
-    raw_body: Bytes,
-    body_sha256: GithubWebhookBodyDigest,
-    encoded_size: u64,
-    media_type: Box<str>,
-    delivery_id: Box<str>,
-    installation_id: u64,
-    repository_id: u64,
-    repository_owner_id: u64,
-    repository_visibility: GithubRepositoryVisibility,
-    repository_owner: Box<str>,
-    repository_name: Box<str>,
-}
-
 /// Durable coordinates for any supported authenticated GitHub event.
 ///
-/// This evidence is distinct from [`StoredAuthenticatedGithubPush`]. The media
-/// type and explicit event name prevent rows from being silently reinterpreted
-/// as another event kind. Construction is inert; only
+/// The media type and explicit event name prevent rows from being silently
+/// reinterpreted as another event kind. Construction is inert; only
 /// [`rehydrate_stored_authenticated_github_webhook`] validates and consumes
 /// the coordinates.
 pub struct StoredAuthenticatedGithubWebhook {
@@ -206,118 +183,6 @@ impl fmt::Debug for StoredAuthenticatedGithubWebhook {
             .field("repository_name", &"[redacted]")
             .finish()
     }
-}
-
-impl StoredAuthenticatedGithubPush {
-    /// Binds exact stored bytes to all durable object and routing coordinates.
-    ///
-    /// This constructor deliberately performs no partial validation. The
-    /// consuming rehydration call checks every coordinate before decoding JSON,
-    /// which prevents callers from accidentally treating construction as an
-    /// authentication or integrity decision.
-    #[allow(clippy::too_many_arguments)]
-    #[must_use]
-    pub fn from_durable_coordinates(
-        raw_body: Bytes,
-        body_sha256: GithubWebhookBodyDigest,
-        encoded_size: u64,
-        media_type: impl Into<Box<str>>,
-        delivery_id: impl Into<Box<str>>,
-        installation_id: u64,
-        repository_id: u64,
-        repository_owner_id: u64,
-        repository_visibility: GithubRepositoryVisibility,
-        repository_owner: impl Into<Box<str>>,
-        repository_name: impl Into<Box<str>>,
-    ) -> Self {
-        Self {
-            raw_body,
-            body_sha256,
-            encoded_size,
-            media_type: media_type.into(),
-            delivery_id: delivery_id.into(),
-            installation_id,
-            repository_id,
-            repository_owner_id,
-            repository_visibility,
-            repository_owner: repository_owner.into(),
-            repository_name: repository_name.into(),
-        }
-    }
-}
-
-impl fmt::Debug for StoredAuthenticatedGithubPush {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("StoredAuthenticatedGithubPush")
-            .field("raw_body", &"[redacted]")
-            .field("body_sha256", &"[redacted]")
-            .field("encoded_size", &self.encoded_size)
-            .field("media_type", &"[redacted]")
-            .field("delivery_id", &"[redacted]")
-            .field("installation_id", &self.installation_id)
-            .field("repository_id", &self.repository_id)
-            .field("repository_owner_id", &self.repository_owner_id)
-            .field("repository_visibility", &self.repository_visibility)
-            .field("repository_owner", &"[redacted]")
-            .field("repository_name", &"[redacted]")
-            .finish()
-    }
-}
-
-/// Rehydrates one previously authenticated exact push object.
-///
-/// Media type, encoded size, SHA-256, and every durable routing identity are
-/// checked before the result is returned. Media, size, and digest validation
-/// precede JSON decoding. The body is not authenticated again: callers must
-/// supply coordinates committed only after the original HMAC boundary accepted
-/// these exact bytes.
-///
-/// # Errors
-///
-/// Rejects noncanonical object coordinates, digest or identity mismatches,
-/// malformed JSON, and any payload that violates the same strict normalization
-/// rules as [`GithubWebhookVerifier`].
-pub fn rehydrate_stored_authenticated_github_push(
-    evidence: StoredAuthenticatedGithubPush,
-) -> Result<VerifiedGithubPush, GithubStoredPushError> {
-    if evidence.media_type.as_ref() != GITHUB_PUSH_EVENT_MEDIA_TYPE {
-        return Err(GithubStoredPushError::UnexpectedMediaType);
-    }
-    let actual_size = u64::try_from(evidence.raw_body.len()).unwrap_or(u64::MAX);
-    if evidence.encoded_size == 0
-        || evidence.raw_body.len() > MAX_GITHUB_WEBHOOK_BODY_BYTES
-        || actual_size != evidence.encoded_size
-    {
-        return Err(GithubStoredPushError::SizeMismatch);
-    }
-    let actual_digest = webhook_body_digest(&evidence.raw_body);
-    if actual_digest != evidence.body_sha256 {
-        return Err(GithubStoredPushError::DigestMismatch);
-    }
-    validate_stored_identity(&evidence)?;
-
-    let payload: PushPayload = serde_json::from_slice(&evidence.raw_body)
-        .map_err(|_| GithubStoredPushError::MalformedPayload)?;
-    validate_stored_payload_identity(&payload, &evidence)?;
-    normalize_push(
-        PushRequestHeaders {
-            event_name: "push".into(),
-            delivery_id: evidence.delivery_id,
-        },
-        evidence.raw_body,
-        payload,
-    )
-    .map_err(|error| match error {
-        GithubWebhookError::MalformedPayload => GithubStoredPushError::MalformedPayload,
-        GithubWebhookError::InvalidPayload
-        | GithubWebhookError::InvalidSecret
-        | GithubWebhookError::InvalidHeaders
-        | GithubWebhookError::InvalidSignature
-        | GithubWebhookError::BodyTooLarge
-        | GithubWebhookError::AuthenticationFailed
-        | GithubWebhookError::UnsupportedEvent => GithubStoredPushError::InvalidPayload,
-    })
 }
 
 /// Rehydrates one authenticated GitHub event envelope.
@@ -1021,32 +886,6 @@ pub enum GithubWebhookError {
     InvalidPayload,
 }
 
-/// Sanitized stored authenticated-push rehydration failures.
-#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum GithubStoredPushError {
-    /// The durable object is not the canonical authenticated-push media type.
-    #[error("the stored GitHub push media type is invalid")]
-    UnexpectedMediaType,
-    /// The durable encoded size is zero, excessive, or differs from the bytes.
-    #[error("the stored GitHub push size is invalid")]
-    SizeMismatch,
-    /// The exact stored bytes do not match the durable SHA-256 coordinate.
-    #[error("the stored GitHub push digest does not match")]
-    DigestMismatch,
-    /// Durable routing coordinates violate the authenticated ingress shape.
-    #[error("the stored GitHub push identity is invalid")]
-    InvalidDurableIdentity,
-    /// The exact stored bytes are not an unambiguous push JSON document.
-    #[error("the stored GitHub push payload is malformed")]
-    MalformedPayload,
-    /// The stored body identity differs from its durable routing coordinates.
-    #[error("the stored GitHub push identity does not match its payload")]
-    IdentityMismatch,
-    /// Stored provider fields violate strict push invariants.
-    #[error("the stored GitHub push payload is inconsistent")]
-    InvalidPayload,
-}
-
 /// Sanitized authenticated-event rehydration failures.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum GithubStoredWebhookError {
@@ -1368,22 +1207,6 @@ fn webhook_body_digest(raw_body: &[u8]) -> GithubWebhookBodyDigest {
     GithubWebhookBodyDigest::from_bytes(bytes)
 }
 
-fn validate_stored_identity(
-    evidence: &StoredAuthenticatedGithubPush,
-) -> Result<(), GithubStoredPushError> {
-    if !valid_stored_identity(
-        evidence.installation_id,
-        evidence.repository_id,
-        evidence.repository_owner_id,
-        evidence.delivery_id.as_bytes(),
-        &evidence.repository_owner,
-        &evidence.repository_name,
-    ) {
-        return Err(GithubStoredPushError::InvalidDurableIdentity);
-    }
-    Ok(())
-}
-
 fn valid_stored_identity(
     installation_id: u64,
     repository_id: u64,
@@ -1402,27 +1225,6 @@ fn valid_stored_identity(
         && validate_repository_component(repository_owner).is_ok()
         && validate_repository_component(repository_name).is_ok()
         && !has_ascii_case_insensitive_suffix(repository_name, ".git")
-}
-
-fn validate_stored_payload_identity(
-    payload: &PushPayload,
-    evidence: &StoredAuthenticatedGithubPush,
-) -> Result<(), GithubStoredPushError> {
-    if payload.installation.id != evidence.installation_id
-        || payload.repository.id != evidence.repository_id
-        || payload.repository.owner.id != evidence.repository_owner_id
-        || normalized_repository_visibility(
-            payload.repository.private,
-            &payload.repository.visibility,
-        )
-        .map_err(|_| GithubStoredPushError::InvalidPayload)?
-            != evidence.repository_visibility
-        || payload.repository.owner.login != evidence.repository_owner.as_ref()
-        || payload.repository.name != evidence.repository_name.as_ref()
-    {
-        return Err(GithubStoredPushError::IdentityMismatch);
-    }
-    Ok(())
 }
 
 fn validate_repository_component(value: &str) -> Result<(), GithubWebhookError> {

--- a/crates/automata-ci-github/tests/stored_push_rehydration.rs
+++ b/crates/automata-ci-github/tests/stored_push_rehydration.rs
@@ -1,9 +1,10 @@
 use crate::support::{json_body, signed_webhook_headers, webhook_body_digest};
 
 use automata_ci_github::{
-    GITHUB_PUSH_EVENT_MEDIA_TYPE, GithubRepositoryVisibility, GithubStoredPushError,
+    GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubRepositoryVisibility, GithubStoredWebhookError,
     GithubWebhookBodyDigest, GithubWebhookVerifier, MAX_GITHUB_WEBHOOK_BODY_BYTES,
-    StoredAuthenticatedGithubPush, rehydrate_stored_authenticated_github_push,
+    StoredAuthenticatedGithubWebhook, VerifiedGithubPush, VerifiedGithubWebhook,
+    rehydrate_stored_authenticated_github_webhook,
 };
 use bytes::Bytes;
 use serde_json::{Value, json};
@@ -29,11 +30,11 @@ fn durable_rehydration_is_exactly_equivalent_to_the_hmac_path() {
         )
         .expect("authenticated push");
 
-    let stored_push = rehydrate_stored_authenticated_github_push(evidence(
+    let stored_push = rehydrate_push(evidence(
         Bytes::copy_from_slice(&body),
         webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
-        GITHUB_PUSH_EVENT_MEDIA_TYPE,
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         DELIVERY,
         INSTALLATION_ID,
         REPOSITORY_ID,
@@ -74,11 +75,11 @@ fn durable_rehydration_accepts_the_exact_webhook_ceiling() {
     let body = json_body(&payload);
     assert_eq!(body.len(), MAX_GITHUB_WEBHOOK_BODY_BYTES);
 
-    let stored = rehydrate_stored_authenticated_github_push(evidence(
+    let stored = rehydrate_push(evidence(
         Bytes::from(body.clone()),
         webhook_body_digest(&body),
         u64::try_from(body.len()).expect("exact webhook ceiling fits u64"),
-        GITHUB_PUSH_EVENT_MEDIA_TYPE,
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         DELIVERY,
         INSTALLATION_ID,
         REPOSITORY_ID,
@@ -95,77 +96,81 @@ fn durable_coordinates_and_stale_body_bytes_fail_before_normalization() {
     let size = u64::try_from(malformed.len()).expect("fixture size fits u64");
     let digest = webhook_body_digest(&malformed);
 
-    assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
-            malformed.clone(),
-            digest,
-            size,
-            "application/json",
-            DELIVERY,
-            INSTALLATION_ID,
-            REPOSITORY_ID,
-            REPOSITORY_OWNER,
-            REPOSITORY_NAME,
-        ))
-        .expect_err("noncanonical media"),
-        GithubStoredPushError::UnexpectedMediaType
-    );
-    assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
-            malformed.clone(),
-            digest,
-            size + 1,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
-            DELIVERY,
-            INSTALLATION_ID,
-            REPOSITORY_ID,
-            REPOSITORY_OWNER,
-            REPOSITORY_NAME,
-        ))
-        .expect_err("changed encoded size"),
-        GithubStoredPushError::SizeMismatch
-    );
-    assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
-            malformed.clone(),
-            GithubWebhookBodyDigest::from_bytes([0x5a; 32]),
-            size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
-            DELIVERY,
-            INSTALLATION_ID,
-            REPOSITORY_ID,
-            REPOSITORY_OWNER,
-            REPOSITORY_NAME,
-        ))
-        .expect_err("changed digest"),
-        GithubStoredPushError::DigestMismatch
-    );
-    assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
-            malformed,
-            digest,
-            size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
-            "invalid delivery identity",
-            INSTALLATION_ID,
-            REPOSITORY_ID,
-            REPOSITORY_OWNER,
-            REPOSITORY_NAME,
-        ))
-        .expect_err("changed durable identity"),
-        GithubStoredPushError::InvalidDurableIdentity
-    );
+    for (label, stored, expected) in [
+        (
+            "noncanonical media",
+            evidence(
+                malformed.clone(),
+                digest,
+                size,
+                "application/json",
+                DELIVERY,
+                INSTALLATION_ID,
+                REPOSITORY_ID,
+                REPOSITORY_OWNER,
+                REPOSITORY_NAME,
+            ),
+            GithubStoredWebhookError::UnexpectedMediaType,
+        ),
+        (
+            "changed encoded size",
+            evidence(
+                malformed.clone(),
+                digest,
+                size + 1,
+                GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+                DELIVERY,
+                INSTALLATION_ID,
+                REPOSITORY_ID,
+                REPOSITORY_OWNER,
+                REPOSITORY_NAME,
+            ),
+            GithubStoredWebhookError::SizeMismatch,
+        ),
+        (
+            "changed digest",
+            evidence(
+                malformed.clone(),
+                GithubWebhookBodyDigest::from_bytes([0x5a; 32]),
+                size,
+                GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+                DELIVERY,
+                INSTALLATION_ID,
+                REPOSITORY_ID,
+                REPOSITORY_OWNER,
+                REPOSITORY_NAME,
+            ),
+            GithubStoredWebhookError::DigestMismatch,
+        ),
+        (
+            "changed durable identity",
+            evidence(
+                malformed,
+                digest,
+                size,
+                GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+                "invalid delivery identity",
+                INSTALLATION_ID,
+                REPOSITORY_ID,
+                REPOSITORY_OWNER,
+                REPOSITORY_NAME,
+            ),
+            GithubStoredWebhookError::InvalidDurableIdentity,
+        ),
+    ] {
+        assert_eq!(rehydrate_push(stored).expect_err(label), expected);
+    }
 
     let original = json_body(&valid_payload());
     let original_digest = webhook_body_digest(&original);
     let mut changed = original;
     changed.push(b' ');
     assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
+        rehydrate_push(evidence(
             Bytes::copy_from_slice(&changed),
             original_digest,
             u64::try_from(changed.len()).expect("fixture size fits u64"),
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -173,15 +178,13 @@ fn durable_coordinates_and_stale_body_bytes_fail_before_normalization() {
             REPOSITORY_NAME,
         ))
         .expect_err("stored body changed after authentication"),
-        GithubStoredPushError::DigestMismatch
+        GithubStoredWebhookError::DigestMismatch
     );
 }
 
 #[test]
-fn every_durable_identity_mismatch_precedes_push_normalization() {
-    let mut invalid_ref_payload = valid_payload();
-    invalid_ref_payload["ref"] = json!("not-a-full-ref");
-    let body = json_body(&invalid_ref_payload);
+fn valid_body_identity_mismatches_follow_payload_normalization() {
+    let body = json_body(&valid_payload());
     let size = u64::try_from(body.len()).expect("fixture size fits u64");
     let digest = webhook_body_digest(&body);
 
@@ -190,7 +193,7 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID + 1,
             REPOSITORY_ID,
@@ -201,7 +204,7 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID + 1,
@@ -212,7 +215,7 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -223,7 +226,7 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -234,7 +237,7 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -244,11 +247,29 @@ fn every_durable_identity_mismatch_precedes_push_normalization() {
         ),
     ] {
         assert_eq!(
-            rehydrate_stored_authenticated_github_push(stored)
-                .expect_err("identity mismatch precedes invalid ref normalization"),
-            GithubStoredPushError::IdentityMismatch
+            rehydrate_push(stored).expect_err("valid body identity mismatch"),
+            GithubStoredWebhookError::IdentityMismatch
         );
     }
+
+    let mut invalid_ref_payload = valid_payload();
+    invalid_ref_payload["ref"] = json!("not-a-full-ref");
+    let invalid_body = json_body(&invalid_ref_payload);
+    assert_eq!(
+        rehydrate_push(evidence(
+            Bytes::copy_from_slice(&invalid_body),
+            webhook_body_digest(&invalid_body),
+            u64::try_from(invalid_body.len()).expect("fixture size fits u64"),
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
+            DELIVERY,
+            INSTALLATION_ID + 1,
+            REPOSITORY_ID,
+            REPOSITORY_OWNER,
+            REPOSITORY_NAME,
+        ))
+        .expect_err("payload validation precedes identity comparison"),
+        GithubStoredWebhookError::InvalidPayload
+    );
 }
 
 #[test]
@@ -264,7 +285,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             0,
             REPOSITORY_ID,
@@ -275,7 +296,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             u64::MAX,
@@ -286,7 +307,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -297,7 +318,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -308,7 +329,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -320,7 +341,7 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
             Bytes::copy_from_slice(&body),
             digest,
             size,
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -330,9 +351,9 @@ fn every_invalid_durable_identity_precedes_push_normalization() {
         ),
     ] {
         assert_eq!(
-            rehydrate_stored_authenticated_github_push(stored)
+            rehydrate_push(stored)
                 .expect_err("invalid durable identity precedes push normalization"),
-            GithubStoredPushError::InvalidDurableIdentity
+            GithubStoredWebhookError::InvalidDurableIdentity
         );
     }
 }
@@ -344,37 +365,35 @@ fn stored_repository_owner_identity_rejects_missing_malformed_tampered_and_misma
         .as_object_mut()
         .expect("owner object")
         .remove("id");
-    assert_stored_error(&missing, GithubStoredPushError::MalformedPayload);
+    assert_stored_error(&missing, GithubStoredWebhookError::MalformedPayload);
 
     let mut malformed = valid_payload();
     malformed["repository"]["owner"]["id"] = json!("9876543");
-    assert_stored_error(&malformed, GithubStoredPushError::MalformedPayload);
+    assert_stored_error(&malformed, GithubStoredWebhookError::MalformedPayload);
 
-    for invalid in [
-        0,
-        u64::try_from(i64::MAX).expect("i64 fits u64") + 1,
-        REPOSITORY_OWNER_ID + 1,
-    ] {
-        let mut mismatched = valid_payload();
-        mismatched["repository"]["owner"]["id"] = json!(invalid);
-        assert_stored_error(&mismatched, GithubStoredPushError::IdentityMismatch);
+    for invalid in [0, u64::try_from(i64::MAX).expect("i64 fits u64") + 1] {
+        let mut invalid_payload = valid_payload();
+        invalid_payload["repository"]["owner"]["id"] = json!(invalid);
+        assert_stored_error(&invalid_payload, GithubStoredWebhookError::InvalidPayload);
     }
 
+    let mut mismatched = valid_payload();
+    mismatched["repository"]["owner"]["id"] = json!(REPOSITORY_OWNER_ID + 1);
+    assert_stored_error(&mismatched, GithubStoredWebhookError::IdentityMismatch);
+
     let original = json_body(&valid_payload());
-    let mut tampered = valid_payload();
-    tampered["repository"]["owner"]["id"] = json!(REPOSITORY_OWNER_ID + 1);
-    let tampered = json_body(&tampered);
+    let tampered = json_body(&mismatched);
     assert_eq!(
         tampered.len(),
         original.len(),
         "fixture changes only digits"
     );
     assert_eq!(
-        rehydrate_stored_authenticated_github_push(evidence(
+        rehydrate_push(evidence(
             Bytes::from(tampered.clone()),
             webhook_body_digest(&original),
             u64::try_from(tampered.len()).expect("fixture size fits u64"),
-            GITHUB_PUSH_EVENT_MEDIA_TYPE,
+            GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
             DELIVERY,
             INSTALLATION_ID,
             REPOSITORY_ID,
@@ -382,7 +401,7 @@ fn stored_repository_owner_identity_rejects_missing_malformed_tampered_and_misma
             REPOSITORY_NAME,
         ))
         .expect_err("tampered owner identity bytes"),
-        GithubStoredPushError::DigestMismatch
+        GithubStoredWebhookError::DigestMismatch
     );
 }
 
@@ -391,34 +410,43 @@ fn stored_body_identity_and_strict_push_constraints_cannot_be_rebound() {
     let mut changed_identity = valid_payload();
     changed_identity["repository"]["owner"]["login"] = json!("private-changed-owner");
     changed_identity["repository"]["full_name"] = json!("private-changed-owner/automata");
-    assert_stored_error(&changed_identity, GithubStoredPushError::IdentityMismatch);
+    assert_stored_error(
+        &changed_identity,
+        GithubStoredWebhookError::IdentityMismatch,
+    );
 
     let mut changed_visibility = valid_payload();
     changed_visibility["repository"]["private"] = json!(true);
     changed_visibility["repository"]["visibility"] = json!("private");
-    assert_stored_error(&changed_visibility, GithubStoredPushError::IdentityMismatch);
+    assert_stored_error(
+        &changed_visibility,
+        GithubStoredWebhookError::IdentityMismatch,
+    );
 
     let mut inconsistent_range = valid_payload();
     inconsistent_range["before"] = json!("0000000000000000000000000000000000000000");
     inconsistent_range["created"] = json!(false);
-    assert_stored_error(&inconsistent_range, GithubStoredPushError::InvalidPayload);
+    assert_stored_error(
+        &inconsistent_range,
+        GithubStoredWebhookError::InvalidPayload,
+    );
 
     let mut missing_forced = valid_payload();
     missing_forced
         .as_object_mut()
         .expect("payload object")
         .remove("forced");
-    assert_stored_error(&missing_forced, GithubStoredPushError::MalformedPayload);
+    assert_stored_error(&missing_forced, GithubStoredWebhookError::MalformedPayload);
 
     let mut duplicate_commit = valid_payload();
     duplicate_commit["commits"] = json!([{ "id": AFTER }, { "id": AFTER }]);
-    assert_stored_error(&duplicate_commit, GithubStoredPushError::InvalidPayload);
+    assert_stored_error(&duplicate_commit, GithubStoredWebhookError::InvalidPayload);
 
     let mut zero_commit = valid_payload();
     zero_commit["commits"] = json!([{
         "id": "0000000000000000000000000000000000000000"
     }]);
-    assert_stored_error(&zero_commit, GithubStoredPushError::InvalidPayload);
+    assert_stored_error(&zero_commit, GithubStoredWebhookError::InvalidPayload);
 }
 
 #[test]
@@ -442,22 +470,27 @@ fn stored_evidence_debug_and_errors_redact_body_and_identity_values() {
     );
 
     let debug = format!("{stored:?}");
+    let digest_marker = webhook_body_digest(&body).to_string();
     for marker in [
         "private-stored-body-marker",
         "private-owner-marker",
         "private-name-marker",
         "private-delivery-marker",
         "private-media-marker",
-        &webhook_body_digest(&body).to_string(),
+        &digest_marker,
     ] {
         assert!(!debug.contains(marker), "stored Debug leaked {marker}");
     }
+    assert!(
+        debug.contains("event_name: \"push\""),
+        "the non-secret event name remains visible"
+    );
 
-    let error = rehydrate_stored_authenticated_github_push(evidence(
+    let error = rehydrate_push(evidence(
         Bytes::copy_from_slice(&body),
         webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
-        GITHUB_PUSH_EVENT_MEDIA_TYPE,
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         "private-delivery-marker",
         INSTALLATION_ID,
         REPOSITORY_ID,
@@ -466,7 +499,7 @@ fn stored_evidence_debug_and_errors_redact_body_and_identity_values() {
     ))
     .expect_err("body identity differs from durable identity");
     let rendered = format!("{error:?} {error}");
-    assert_eq!(error, GithubStoredPushError::IdentityMismatch);
+    assert_eq!(error, GithubStoredWebhookError::IdentityMismatch);
     for marker in [
         "private-stored-body-marker",
         "private-owner-marker",
@@ -475,6 +508,16 @@ fn stored_evidence_debug_and_errors_redact_body_and_identity_values() {
     ] {
         assert!(!rendered.contains(marker), "stored error leaked {marker}");
     }
+}
+
+fn rehydrate_push(
+    evidence: StoredAuthenticatedGithubWebhook,
+) -> Result<VerifiedGithubPush, GithubStoredWebhookError> {
+    let event = rehydrate_stored_authenticated_github_webhook(evidence)?;
+    let VerifiedGithubWebhook::Push(push) = event else {
+        panic!("push event fixture normalized as another event kind");
+    };
+    Ok(push)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -488,7 +531,7 @@ fn evidence(
     repository_id: u64,
     repository_owner: &str,
     repository_name: &str,
-) -> StoredAuthenticatedGithubPush {
+) -> StoredAuthenticatedGithubWebhook {
     evidence_with_owner_id(
         raw_body,
         body_sha256,
@@ -515,12 +558,13 @@ fn evidence_with_owner_id(
     repository_owner_id: u64,
     repository_owner: &str,
     repository_name: &str,
-) -> StoredAuthenticatedGithubPush {
-    StoredAuthenticatedGithubPush::from_durable_coordinates(
+) -> StoredAuthenticatedGithubWebhook {
+    StoredAuthenticatedGithubWebhook::from_durable_coordinates(
         raw_body,
         body_sha256,
         encoded_size,
         media_type,
+        "push",
         delivery_id,
         installation_id,
         repository_id,
@@ -531,13 +575,13 @@ fn evidence_with_owner_id(
     )
 }
 
-fn assert_stored_error(payload: &Value, expected: GithubStoredPushError) {
+fn assert_stored_error(payload: &Value, expected: GithubStoredWebhookError) {
     let body = json_body(payload);
-    let error = rehydrate_stored_authenticated_github_push(evidence(
+    let error = rehydrate_push(evidence(
         Bytes::copy_from_slice(&body),
         webhook_body_digest(&body),
         u64::try_from(body.len()).expect("fixture size fits u64"),
-        GITHUB_PUSH_EVENT_MEDIA_TYPE,
+        GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         DELIVERY,
         INSTALLATION_ID,
         REPOSITORY_ID,


### PR DESCRIPTION
Closes #411

## Summary

- Retire the obsolete push-only durability facade, which has no production consumers.
- Keep the generic authenticated-webhook path as the authoritative durable rehydration boundary.
- Remove GITHUB_PUSH_EVENT_MEDIA_TYPE, StoredAuthenticatedGithubPush, GithubStoredPushError, rehydrate_stored_authenticated_github_push, and their push-only helpers and exports.
- Correct and retain eight durable-coordinate, validation-precedence, repository-owner identity, structural-integrity, and redaction tests on the generic path.

## Scope

- 6 files
- 538 changed lines
- 150 net lines removed

## Validation

- Focused stored-push suite: 8 passed
- Full GitHub package: 146 passed, 1 expected live-network ignore
- Full GitHub delivery package: 154 passed
- Locked all-target/all-feature package and workspace checks
- Strict combined Clippy with -D warnings
- Strict rustdoc for both packages
- Provider matrix normal invocation: 1 expected PostgreSQL 18/database-URL ignore