### PR TITLE
fix(release): retain service-proxy load identity

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -793,6 +793,10 @@ jobs:
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --output target/service-proxy-policy-review
+          python3 scripts/ci/verify-service-proxy-candidate-load.py \
+            --candidate target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+            --source-directory "$GITHUB_WORKSPACE" \
+            --expected-commit "$GITHUB_SHA"
 
       - name: Upload unpublished service-proxy image candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.ci/workflows/release.yml
+++ b/.ci/workflows/release.yml
@@ -318,6 +318,10 @@ jobs:
           ./scripts/ci/build-service-proxy-candidate.sh \
             target/service-proxy-context \
             target/service-proxy-publication
+          python3 scripts/ci/verify-service-proxy-candidate-load.py \
+            --candidate target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+            --source-directory "$GITHUB_WORKSPACE" \
+            --expected-commit "$RELEASE_COMMIT"
 
       - name: Require complete private service-proxy candidate evidence
         env:

--- a/.ci/workflows/service-proxy-image.yml
+++ b/.ci/workflows/service-proxy-image.yml
@@ -212,6 +212,10 @@ jobs:
           cmp -- \
             target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
             target/service-proxy-publication-reproduction/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar
+          python3 scripts/ci/verify-service-proxy-candidate-load.py \
+            --candidate target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
+            --source-directory "$CANDIDATE_SOURCE_DIRECTORY" \
+            --expected-commit "$CANDIDATE_COMMIT"
 
       - name: Record exact unpublished handoff bytes
         id: handoff

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -232,6 +232,20 @@ contract. Buildah still inspects the image metadata, and
 configuration, source bindings, and candidate provenance before the subsequent
 `prepare-candidate` policy gate accepts it.
 
+The canonical candidate retains one deterministic local reference on the sole
+OCI index descriptor:
+`automata.local/automata-ci-service-proxy:manifest-<manifest-sha256>`.
+Ordinary CI, release staging, and the dedicated promotion workflow load the
+completed candidate into Docker and prove that this tag creates the matching
+immutable image before removing it again. The loader derives a bounded Docker
+save transport from the validated OCI manifest, config, layers, and rootfs
+diff IDs so both classic and containerd-backed Engine stores are supported.
+The imported tag must resolve to exactly the OCI manifest ID or config ID;
+containerd-backed stores additionally expose the matching
+`automata.local/automata-ci-service-proxy@sha256:<manifest>` identity, while
+classic stores do not synthesize a repository digest. The manifest digest
+remains the source-image authority; the tag is the closed local import name.
+
 Every image and publication validator requires the sole current
 `io.automata.service-proxy.protocol-version=2` capability. Protocol 1 images
 predate the Results mode and cannot be admitted or promoted by this path.

--- a/scripts/ci/local_installation_catalog.py
+++ b/scripts/ci/local_installation_catalog.py
@@ -635,6 +635,8 @@ def validate_service_proxy_candidate(
     source_image: dict,
 ) -> dict:
     publication, candidate_module = service_proxy_module()
+    if candidate_module.LOCAL_IMAGE_NAME != source_image["canonical_repository"]:
+        fail("service-proxy candidate local repository differs")
     members, source, identity, _, candidate_sha256 = (
         publication.load_candidate_archive(  # type: ignore[attr-defined]
             candidate_path,
@@ -655,6 +657,13 @@ def validate_service_proxy_candidate(
     )
     oci_bytes = members[candidate_module.IMAGE_ARCHIVE_NAME]
     config_digest, config = oci_config_binding(oci_bytes, manifest_digest)
+    _, load_config_digest = candidate_module.docker_load_archive(
+        oci_bytes,
+        manifest_digest,
+        source["release"]["source_date_epoch"],
+    )
+    if load_config_digest != config_digest:
+        fail("service-proxy Docker load config digest differs")
     if config.get("architecture") != "amd64" or config.get("os") != "linux":
         fail("service-proxy candidate platform differs")
     validate_process(

--- a/scripts/ci/service-proxy-candidate.py
+++ b/scripts/ci/service-proxy-candidate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import io
 import json
@@ -14,6 +15,7 @@ from typing import NoReturn
 
 
 IMAGE_NAME = "ghcr.io/automata-ci/automata-service-proxy"
+LOCAL_IMAGE_NAME = "automata.local/automata-ci-service-proxy"
 IMAGE_ARCHIVE_NAME = "automata-service-proxy.oci.tar"
 SBOM_NAME = "automata-ci-service-proxy.cdx.json"
 SOURCE_NAME = "source-provenance.json"
@@ -22,6 +24,13 @@ SHA256 = re.compile(r"[0-9a-f]{64}")
 OCI_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
 GIT_OBJECT = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 MAX_ARCHIVE_SIZE = 128 * 1024 * 1024
+MAX_EXPANDED_LAYER_SIZE = 64 * 1024 * 1024
+
+
+def local_reference(manifest_digest: str) -> str:
+    if OCI_DIGEST.fullmatch(manifest_digest) is None:
+        fail("OCI manifest digest is invalid")
+    return f"{LOCAL_IMAGE_NAME}:manifest-{manifest_digest.removeprefix('sha256:')}"
 
 
 def fail(message: str) -> NoReturn:
@@ -218,6 +227,11 @@ def load_oci(archive_bytes: bytes, source: dict, source_sha256: str) -> tuple[st
         {
             "manifests": [
                 {
+                    "annotations": {
+                        "org.opencontainers.image.ref.name": local_reference(
+                            manifest_descriptor["digest"]
+                        )
+                    },
                     "digest": manifest_descriptor["digest"],
                     "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "size": manifest_descriptor["size"],
@@ -256,6 +270,152 @@ def add_tar_member(archive: tarfile.TarFile, name: str, contents: bytes, mtime: 
     info.uname = info.gname = ""
     info.mtime = mtime
     archive.addfile(info, io.BytesIO(contents))
+
+
+def docker_load_archive(
+    oci_archive: bytes, manifest_digest: str, source_date_epoch: int
+) -> tuple[bytes, str]:
+    """Derive the one portable Docker-load transport from a validated OCI image."""
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(oci_archive), mode="r:")
+    except tarfile.TarError:
+        fail("canonical OCI archive is invalid")
+    members: dict[str, bytes] = {}
+    directories: set[str] = set()
+    with archive:
+        for member in archive.getmembers():
+            if member.isdir():
+                directories.add(member.name.rstrip("/"))
+                continue
+            if not member.isfile() or member.name in members:
+                fail("canonical OCI archive member set is invalid")
+            stream = archive.extractfile(member)
+            if stream is None:
+                fail("canonical OCI archive member is unreadable")
+            members[member.name] = stream.read()
+    if directories != {"blobs", "blobs/sha256"}:
+        fail("canonical OCI archive directory set differs")
+    try:
+        index = json.loads(members["index.json"])
+        descriptor = index["manifests"][0]
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError):
+        fail("canonical OCI index is invalid")
+    if (
+        not isinstance(descriptor, dict)
+        or descriptor.get("digest") != manifest_digest
+        or descriptor.get("annotations")
+        != {"org.opencontainers.image.ref.name": local_reference(manifest_digest)}
+    ):
+        fail("canonical OCI import identity differs")
+
+    def blob(value: object, label: str) -> tuple[dict, bytes]:
+        if not isinstance(value, dict):
+            fail(f"canonical OCI {label} descriptor is invalid")
+        value_digest = value.get("digest")
+        size = value.get("size")
+        if not isinstance(value_digest, str) or OCI_DIGEST.fullmatch(value_digest) is None:
+            fail(f"canonical OCI {label} digest is invalid")
+        contents = members.get(
+            f"blobs/sha256/{value_digest.removeprefix('sha256:')}"
+        )
+        if (
+            type(size) is not int
+            or contents is None
+            or len(contents) != size
+            or f"sha256:{digest(contents)}" != value_digest
+        ):
+            fail(f"canonical OCI {label} blob differs")
+        return value, contents
+
+    _, manifest_bytes = blob(descriptor, "manifest")
+    try:
+        manifest = json.loads(manifest_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        fail("canonical OCI manifest is invalid")
+    if not isinstance(manifest, dict):
+        fail("canonical OCI manifest is invalid")
+    config_descriptor, config_bytes = blob(manifest.get("config"), "config")
+    try:
+        config = json.loads(config_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        fail("canonical OCI config is invalid")
+    rootfs = config.get("rootfs") if isinstance(config, dict) else None
+    diff_ids = rootfs.get("diff_ids") if isinstance(rootfs, dict) else None
+    layers = manifest.get("layers")
+    if (
+        not isinstance(rootfs, dict)
+        or rootfs.get("type") != "layers"
+        or not isinstance(diff_ids, list)
+        or not isinstance(layers, list)
+        or len(diff_ids) != len(layers)
+    ):
+        fail("canonical OCI root filesystem differs")
+
+    docker_layers: list[str] = []
+    derived = dict(members)
+    expanded_size = len(oci_archive)
+    for position, (layer_value, diff_id) in enumerate(zip(layers, diff_ids, strict=True)):
+        layer, layer_bytes = blob(layer_value, f"layer {position}")
+        if not isinstance(diff_id, str) or OCI_DIGEST.fullmatch(diff_id) is None:
+            fail("canonical OCI layer diff ID is invalid")
+        media_type = layer.get("mediaType")
+        if media_type == "application/vnd.oci.image.layer.v1.tar":
+            expanded = layer_bytes
+        elif media_type == "application/vnd.oci.image.layer.v1.tar+gzip":
+            try:
+                with gzip.GzipFile(fileobj=io.BytesIO(layer_bytes), mode="rb") as stream:
+                    expanded = stream.read(MAX_EXPANDED_LAYER_SIZE + 1)
+            except (EOFError, OSError, gzip.BadGzipFile):
+                fail("canonical OCI gzip layer is invalid")
+        else:
+            fail("canonical OCI layer media type differs")
+        if (
+            len(expanded) > MAX_EXPANDED_LAYER_SIZE
+            or f"sha256:{digest(expanded)}" != diff_id
+        ):
+            fail("canonical OCI layer diff ID differs")
+        layer_name = f"blobs/sha256/{diff_id.removeprefix('sha256:')}"
+        existing = derived.get(layer_name)
+        if existing is not None and existing != expanded:
+            fail("canonical OCI layer blob conflicts with its diff ID")
+        if existing is None:
+            derived[layer_name] = expanded
+            expanded_size += len(expanded)
+        docker_layers.append(layer_name)
+
+    config_name = (
+        "blobs/sha256/"
+        f"{config_descriptor['digest'].removeprefix('sha256:')}"
+    )
+    docker_manifest = (
+        json.dumps(
+            [
+                {
+                    "Config": config_name,
+                    "Layers": docker_layers,
+                    "RepoTags": [local_reference(manifest_digest)],
+                }
+            ],
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode()
+    expanded_size += len(docker_manifest)
+    if expanded_size > MAX_ARCHIVE_SIZE:
+        fail("Docker load archive exceeds its size limit")
+    if "manifest.json" in derived:
+        fail("canonical OCI archive already contains a Docker manifest")
+    derived["manifest.json"] = docker_manifest
+
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for name in ("blobs", "blobs/sha256"):
+            add_tar_directory(archive, name, source_date_epoch)
+        for name, contents in sorted(derived.items()):
+            add_tar_member(archive, name, contents, source_date_epoch)
+    if output.tell() > MAX_ARCHIVE_SIZE:
+        fail("Docker load archive exceeds its size limit")
+    return output.getvalue(), config_descriptor["digest"]
 
 
 def create(arguments: argparse.Namespace) -> None:

--- a/scripts/ci/tests/local-installation-catalog.test.py
+++ b/scripts/ci/tests/local-installation-catalog.test.py
@@ -147,6 +147,11 @@ class LocalInstallationCatalogContract(unittest.TestCase):
         source = catalog.load_source(REPOSITORY_ROOT)
         self.assertEqual(set(source["images"]), catalog.ROLES)
         self.assertEqual(source["scope"], {"engine": "linux/amd64", "host": "unix"})
+        _, candidate_module = catalog.service_proxy_module()
+        self.assertEqual(
+            source["images"]["service-proxy"]["canonical_repository"],
+            candidate_module.LOCAL_IMAGE_NAME,
+        )
         profile = catalog.load_profile(REPOSITORY_ROOT, source)
         self.assertEqual(
             profile["manifest"]["sha256"],

--- a/scripts/ci/tests/service-proxy-candidate.test.py
+++ b/scripts/ci/tests/service-proxy-candidate.test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import importlib.util
 import io
@@ -13,6 +14,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from unittest import mock
 
 
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[3]
@@ -23,6 +25,18 @@ if SPEC is None or SPEC.loader is None:
 candidate = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = candidate
 SPEC.loader.exec_module(candidate)
+
+LOAD_SCRIPT = (
+    REPOSITORY_ROOT / "scripts" / "ci" / "verify-service-proxy-candidate-load.py"
+)
+LOAD_SPEC = importlib.util.spec_from_file_location(
+    "service_proxy_candidate_load", LOAD_SCRIPT
+)
+if LOAD_SPEC is None or LOAD_SPEC.loader is None:
+    raise RuntimeError(f"could not load {LOAD_SCRIPT}")
+candidate_load = importlib.util.module_from_spec(LOAD_SPEC)
+sys.modules[LOAD_SPEC.name] = candidate_load
+LOAD_SPEC.loader.exec_module(candidate_load)
 
 
 class CandidateContract(unittest.TestCase):
@@ -80,6 +94,7 @@ class CandidateContract(unittest.TestCase):
         extra_member: bool = False,
         include_index_media_type: bool = True,
         index_media_type: object = "application/vnd.oci.image.index.v1+json",
+        gzip_layer: bool = False,
     ) -> None:
         source_sha = hashlib.sha256(self.source_bytes).hexdigest()
         labels = {
@@ -91,22 +106,34 @@ class CandidateContract(unittest.TestCase):
             "io.automata.service-proxy.sbom.sha256": self.source["artifacts"]["sbom_sha256"],
             "io.automata.service-proxy.source.sha256": source_sha,
         }
+        expanded_layer = b"fixture layer"
+        layer = gzip.compress(expanded_layer, mtime=0) if gzip_layer else expanded_layer
         config = json.dumps(
             {
                 "config": {
                     "Entrypoint": ["/usr/libexec/automata-ci-service-proxy"],
                     "Labels": labels,
                     "User": "65532:65532",
-                }
+                },
+                "rootfs": {
+                    "diff_ids": [
+                        f"sha256:{hashlib.sha256(expanded_layer).hexdigest()}"
+                    ],
+                    "type": "layers",
+                },
             },
             separators=(",", ":"),
         ).encode()
-        layer = b"fixture layer"
         config_descriptor = self.descriptor(
             config, "application/vnd.oci.image.config.v1+json"
         )
         layer_descriptor = self.descriptor(
-            layer, "application/vnd.oci.image.layer.v1.tar"
+            layer,
+            (
+                "application/vnd.oci.image.layer.v1.tar+gzip"
+                if gzip_layer
+                else "application/vnd.oci.image.layer.v1.tar"
+            ),
         )
         manifest = json.dumps(
             {
@@ -174,10 +201,19 @@ class CandidateContract(unittest.TestCase):
             oci_bytes = archive.extractfile(candidate.IMAGE_ARCHIVE_NAME).read()
         with tarfile.open(fileobj=io.BytesIO(oci_bytes), mode="r:") as archive:
             members = {member.name: member for member in archive.getmembers()}
+            index = json.load(archive.extractfile("index.json"))
         self.assertEqual(members["blobs"].mode, 0o755)
         self.assertEqual(members["blobs/sha256"].mode, 0o755)
         self.assertEqual(identity["image"]["name"], candidate.IMAGE_NAME)
         self.assertRegex(identity["image"]["manifest_digest"], candidate.OCI_DIGEST)
+        self.assertEqual(
+            index["manifests"][0]["annotations"],
+            {
+                "org.opencontainers.image.ref.name": candidate.local_reference(
+                    identity["image"]["manifest_digest"]
+                )
+            },
+        )
         self.assertEqual(identity["release"], self.release)
 
     def test_mismatched_image_provenance_fails_before_candidate_output(self) -> None:
@@ -230,6 +266,144 @@ class CandidateContract(unittest.TestCase):
             )
         )
         self.assertEqual(first.read_bytes(), second.read_bytes())
+
+    def test_local_reference_is_manifest_bound(self) -> None:
+        digest = "sha256:" + "a" * 64
+        self.assertEqual(
+            candidate.local_reference(digest),
+            "automata.local/automata-ci-service-proxy:manifest-" + "a" * 64,
+        )
+        with self.assertRaisesRegex(SystemExit, "manifest digest is invalid"):
+            candidate.local_reference("sha256:not-a-digest")
+
+    def test_docker_absence_requires_the_exact_daemon_response(self) -> None:
+        reference = candidate.local_reference("sha256:" + "a" * 64)
+        absent = candidate_load.subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="[]\n",
+            stderr=f"Error response from daemon: No such image: {reference}\n",
+        )
+        with mock.patch.object(candidate_load, "docker_command", return_value=absent):
+            self.assertIsNone(candidate_load.inspect_optional("docker", reference))
+
+        unavailable = candidate_load.subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="[]\n",
+            stderr="Cannot connect to the Docker daemon\n",
+        )
+        with mock.patch.object(
+            candidate_load, "docker_command", return_value=unavailable
+        ):
+            with self.assertRaisesRegex(SystemExit, "could not prove image absence"):
+                candidate_load.inspect_optional("docker", reference)
+
+    def test_docker_load_archive_is_exactly_derived_from_the_oci_image(self) -> None:
+        self.write_oci(gzip_layer=True)
+        output = self.root / "candidate.tar"
+        candidate.create(
+            argparse.Namespace(
+                context=self.context,
+                oci_archive=self.oci,
+                output=output,
+                github_output=None,
+            )
+        )
+        with tarfile.open(output, "r:") as archive:
+            oci_bytes = archive.extractfile(candidate.IMAGE_ARCHIVE_NAME).read()
+            identity = json.load(archive.extractfile(candidate.IDENTITY_NAME))
+        manifest_digest = identity["image"]["manifest_digest"]
+        docker_bytes, config_digest = candidate.docker_load_archive(
+            oci_bytes, manifest_digest, self.release["source_date_epoch"]
+        )
+        with tarfile.open(fileobj=io.BytesIO(docker_bytes), mode="r:") as archive:
+            index = json.load(archive.extractfile("index.json"))
+            docker_manifest = json.load(archive.extractfile("manifest.json"))
+            names = {member.name for member in archive.getmembers()}
+        self.assertEqual(index["manifests"][0]["digest"], manifest_digest)
+        self.assertEqual(
+            docker_manifest,
+            [
+                {
+                    "Config": f"blobs/sha256/{config_digest.removeprefix('sha256:')}",
+                    "Layers": [
+                        "blobs/sha256/"
+                        + hashlib.sha256(b"fixture layer").hexdigest()
+                    ],
+                    "RepoTags": [candidate.local_reference(manifest_digest)],
+                }
+            ],
+        )
+        self.assertIn(docker_manifest[0]["Layers"][0], names)
+
+    def test_docker_store_identity_branches_are_exact(self) -> None:
+        manifest_digest = "sha256:" + "a" * 64
+        config_digest = "sha256:" + "b" * 64
+        reference = candidate.local_reference(manifest_digest)
+        digest_reference = f"{candidate.LOCAL_IMAGE_NAME}@{manifest_digest}"
+        classic = {
+            "Id": config_digest,
+            "RepoDigests": [],
+            "RepoTags": [reference],
+        }
+        with (
+            mock.patch.object(
+                candidate_load, "inspect_image", side_effect=[classic, classic]
+            ),
+            mock.patch.object(candidate_load, "inspect_optional", return_value=None),
+            mock.patch.object(candidate_load, "require_absent") as require_absent,
+        ):
+            candidate_load.verify_imported(
+                "docker",
+                reference,
+                digest_reference,
+                manifest_digest,
+                config_digest,
+            )
+            require_absent.assert_called_once_with("docker", manifest_digest)
+
+        containerd = {
+            "Id": manifest_digest,
+            "RepoDigests": [digest_reference],
+            "RepoTags": [reference],
+        }
+        with (
+            mock.patch.object(
+                candidate_load,
+                "inspect_image",
+                side_effect=[containerd, containerd],
+            ),
+            mock.patch.object(
+                candidate_load, "inspect_optional", return_value=containerd
+            ),
+            mock.patch.object(candidate_load, "require_absent") as require_absent,
+        ):
+            candidate_load.verify_imported(
+                "docker",
+                reference,
+                digest_reference,
+                manifest_digest,
+                config_digest,
+            )
+            require_absent.assert_called_once_with("docker", config_digest)
+
+        mixed = dict(classic, RepoDigests=[digest_reference])
+        with (
+            mock.patch.object(
+                candidate_load, "inspect_image", side_effect=[mixed, mixed]
+            ),
+            mock.patch.object(candidate_load, "inspect_optional", return_value=mixed),
+            mock.patch.object(candidate_load, "require_absent"),
+        ):
+            with self.assertRaisesRegex(SystemExit, "classic Docker"):
+                candidate_load.verify_imported(
+                    "docker",
+                    reference,
+                    digest_reference,
+                    manifest_digest,
+                    config_digest,
+                )
 
     def test_optional_index_media_type_canonicalizes_to_explicit_media_type(self) -> None:
         first = self.root / "first.tar"

--- a/scripts/ci/tests/service-proxy-image.test.sh
+++ b/scripts/ci/tests/service-proxy-image.test.sh
@@ -451,6 +451,11 @@ if candidate_step.find(policy_review) <= candidate_step.rfind(build):
     raise SystemExit(
         "service-proxy-image-test: publication policy review must follow candidate builds"
     )
+load_review = "python3 scripts/ci/verify-service-proxy-candidate-load.py"
+if candidate_step.find(load_review) <= candidate_step.find(policy_review):
+    raise SystemExit(
+        "service-proxy-image-test: Docker load verification must follow publication review"
+    )
 
 verify_tooling = step(ci, "Lint workflows and shell scripts")[1]
 for invocation in (
@@ -478,6 +483,10 @@ for relative in (".ci/workflows/release.yml", ".ci/workflows/service-proxy-image
     if "AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME: podman" not in publication:
         raise SystemExit(
             f"service-proxy-image-test: {relative} does not pin the Podman runtime"
+        )
+    if load_review not in publication:
+        raise SystemExit(
+            f"service-proxy-image-test: {relative} does not verify Docker loading"
         )
 PY
 

--- a/scripts/ci/verify-service-proxy-candidate-load.py
+++ b/scripts/ci/verify-service-proxy-candidate-load.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Prove the candidate's exact local tag and content identity in Docker."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import NoReturn
+
+
+SCRIPT_DIRECTORY = pathlib.Path(__file__).resolve().parent
+PUBLICATION_SCRIPT = SCRIPT_DIRECTORY / "service-proxy-publication.py"
+PUBLICATION_SPEC = importlib.util.spec_from_file_location(
+    "automata_service_proxy_load_publication", PUBLICATION_SCRIPT
+)
+if PUBLICATION_SPEC is None or PUBLICATION_SPEC.loader is None:
+    raise RuntimeError(f"could not load {PUBLICATION_SCRIPT}")
+publication = importlib.util.module_from_spec(PUBLICATION_SPEC)
+sys.modules[PUBLICATION_SPEC.name] = publication
+PUBLICATION_SPEC.loader.exec_module(publication)
+candidate = publication.candidate
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"service-proxy-candidate-load: {message}")
+
+
+def docker_command(binary: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [binary, *arguments],
+            check=False,
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        fail(f"Docker command did not complete: {' '.join(arguments)}")
+
+
+def inspect_optional(binary: str, reference: str) -> dict | None:
+    result = docker_command(binary, "image", "inspect", reference)
+    try:
+        document = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        fail(f"Docker image inspection is invalid JSON: {reference}")
+    if result.returncode == 1:
+        expected_error = f"Error response from daemon: No such image: {reference}\n"
+        if document == [] and result.stderr == expected_error:
+            return None
+        fail(f"Docker could not prove image absence: {reference}")
+    if result.returncode != 0 or result.stderr:
+        fail(f"Docker could not inspect the image: {reference}")
+    if not isinstance(document, list) or len(document) != 1 or not isinstance(document[0], dict):
+        fail(f"Docker image inspection is not singular: {reference}")
+    return document[0]
+
+
+def require_absent(binary: str, reference: str) -> None:
+    if inspect_optional(binary, reference) is not None:
+        fail(f"refusing to replace a pre-existing image: {reference}")
+
+
+def inspect_image(binary: str, reference: str) -> dict:
+    document = inspect_optional(binary, reference)
+    if document is None:
+        fail(f"Docker cannot inspect the imported image: {reference}")
+    return document
+
+
+def remove_imported(binary: str, references: tuple[str, ...]) -> None:
+    for reference in references:
+        if inspect_optional(binary, reference) is None:
+            continue
+        removed = docker_command(binary, "image", "rm", reference)
+        if removed.returncode != 0:
+            fail(f"Docker could not remove the imported image: {reference}")
+    for reference in references:
+        require_absent(binary, reference)
+
+
+def verify_imported(
+    binary: str,
+    reference: str,
+    digest_reference: str,
+    manifest_digest: str,
+    config_digest: str,
+) -> None:
+    by_tag = inspect_image(binary, reference)
+    imported_id = by_tag.get("Id")
+    if imported_id not in {manifest_digest, config_digest}:
+        fail("Docker imported image identity differs")
+    if by_tag.get("RepoTags") != [reference]:
+        fail("Docker imported image tags differ")
+    by_id = inspect_image(binary, imported_id)
+    if by_tag != by_id:
+        fail("Docker tag and image-ID inspections differ")
+    other_id = config_digest if imported_id == manifest_digest else manifest_digest
+    require_absent(binary, other_id)
+    repository_digests = by_tag.get("RepoDigests")
+    by_digest = inspect_optional(binary, digest_reference)
+    if imported_id == config_digest:
+        if repository_digests != []:
+            fail("classic Docker imported image digests differ")
+        if by_digest is not None:
+            fail("classic Docker exposed a repository digest")
+    else:
+        if repository_digests != [digest_reference]:
+            fail("containerd Docker imported image digests differ")
+        if by_digest != by_tag:
+            fail("Docker tag and digest inspections differ")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True, type=pathlib.Path)
+    parser.add_argument("--source-directory", required=True, type=pathlib.Path)
+    parser.add_argument("--expected-commit", required=True)
+    arguments = parser.parse_args()
+
+    docker = shutil.which("docker")
+    if docker is None:
+        fail("Docker is required")
+    docker = str(pathlib.Path(docker).resolve())
+    members, source, identity, _, _ = publication.load_candidate_archive(
+        arguments.candidate,
+        arguments.source_directory,
+        arguments.expected_commit,
+    )
+    manifest_digest = identity["image"]["manifest_digest"]
+    reference = candidate.local_reference(manifest_digest)
+    digest_reference = f"{candidate.LOCAL_IMAGE_NAME}@{manifest_digest}"
+    load_archive, expected_config_digest = candidate.docker_load_archive(
+        members[candidate.IMAGE_ARCHIVE_NAME],
+        manifest_digest,
+        source["release"]["source_date_epoch"],
+    )
+    exact_references = (
+        reference,
+        digest_reference,
+        manifest_digest,
+        expected_config_digest,
+    )
+
+    for exact_reference in exact_references:
+        require_absent(docker, exact_reference)
+    load_attempted = False
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="automata-service-proxy-", suffix=".docker.tar"
+        ) as archive:
+            archive.write(load_archive)
+            archive.flush()
+            os.fsync(archive.fileno())
+            load_attempted = True
+            result = docker_command(docker, "load", "--input", archive.name)
+            if result.returncode != 0:
+                fail("Docker rejected the derived candidate load archive")
+        verify_imported(
+            docker,
+            reference,
+            digest_reference,
+            manifest_digest,
+            expected_config_digest,
+        )
+    finally:
+        if load_attempted:
+            remove_imported(docker, exact_references)
+    print("Service-proxy candidate Docker load identity verified")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This closes the release-catalog import seam needed by the Unix local-init stack.

- retain one manifest-derived automata.local tag on the canonical OCI descriptor
- derive a bounded Docker-save transport from the already validated OCI config/layers/diff IDs
- verify exact, residue-free imports on both classic and containerd-backed Docker stores
- bind the local repository to the release catalog and run the gate in CI, release staging, and promotion

Independent strict review: CLEAN. Focused candidate/publication/catalog/handoff suites, workflow lint, shellcheck, candidate reproduction, and live classic/containerd Docker gates pass.