### PR TITLE
ci: enforce strict zizmor audits

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Install sccache
         run: ./scripts/ci/install-sccache.sh
 
-      - name: Run Rust checks
+      - name: Run Rust and CI checks
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           cargo fmt --all -- --check
           ./scripts/ci/install-actionlint.sh target/ci-tools
+          ./scripts/ci/install-zizmor.sh target/ci-tools
           ./scripts/ci/lint-workflows.sh
+          ./scripts/ci/lint-ci-security.sh
           cargo clippy --workspace --lib --bins --all-features --locked -- -D warnings
           cargo test \
             --locked \

--- a/.ci/workflows/pages.yml
+++ b/.ci/workflows/pages.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      pages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.ci/workflows/profile-image.yml
+++ b/.ci/workflows/profile-image.yml
@@ -146,11 +146,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
-      artifact-metadata: write
-      attestations: write
+      artifact-metadata: write # Bind uploaded review artifacts to service digests.
+      attestations: write # Publish provenance for the candidate image.
       contents: read
-      id-token: write
-      packages: write
+      id-token: write # Mint the OIDC identity used to sign attestations.
+      packages: write # Push the immutable review image to GHCR.
     env:
       ATTESTATION_HOME: ${{ github.workspace }}/target/task-tmp/profile-attestation-home
       CANDIDATE_COMMIT: ${{ needs.validate.outputs.candidate_commit }}
@@ -529,9 +529,9 @@ jobs:
     timeout-minutes: 45
     environment: profile-promotion
     permissions:
-      attestations: read
+      attestations: read # Verify the reviewed image's provenance before promotion.
       contents: read
-      packages: write
+      packages: write # Bind stable GHCR tags to the reviewed image digest.
     env:
       ANONYMOUS_AUTH_FILE: ${{ github.workspace }}/target/task-tmp/profile-anonymous-auth.json
       DOCKER_CONFIG: ${{ github.workspace }}/target/task-tmp/profile-docker-config

--- a/.ci/workflows/release.yml
+++ b/.ci/workflows/release.yml
@@ -200,11 +200,11 @@ jobs:
       service_proxy_image_digest: ${{ steps.selected-service-proxy-candidate.outputs.image_digest }}
       service_proxy_provenance_sha256: ${{ steps.selected-service-proxy-candidate.outputs.provenance_sha256 }}
     permissions:
-      artifact-metadata: write
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
+      artifact-metadata: write # Bind release handoff artifacts to service digests.
+      attestations: write # Publish provenance for release artifacts and images.
+      contents: write # Create the draft release and upload its immutable assets.
+      id-token: write # Mint the OIDC identity used to sign attestations.
+      packages: write # Push digest-addressed release images to GHCR.
     env:
       ATTESTATION_HOME: ${{ github.workspace }}/target/task-tmp/release/attestation-home
       CARGO_INCREMENTAL: "0"
@@ -590,16 +590,18 @@ jobs:
           RELEASE_TAG: ${{ needs.gate.outputs.tag }}
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+          CATALOG_PRESENT: ${{ steps.draft.outputs.catalog_present }}
+          MANIFEST_PRESENT: ${{ steps.draft.outputs.manifest_present }}
         run: |
           recovery_directory="$(mktemp -d "${TMPDIR%/}/release-binding.XXXXXXXX")"
           trap 'env -u GH_TOKEN -u GITHUB_TOKEN rm -rf -- "$recovery_directory"' EXIT
           patterns=(
             --pattern automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar
           )
-          if [[ "${{ steps.draft.outputs.catalog_present }}" == true ]]; then
+          if [[ "${CATALOG_PRESENT}" == true ]]; then
             patterns+=(--pattern automata-local-installation-catalog.json)
           fi
-          if [[ "${{ steps.draft.outputs.manifest_present }}" == true ]]; then
+          if [[ "${MANIFEST_PRESENT}" == true ]]; then
             patterns+=(--pattern automata-release-manifest.json)
           fi
           gh release download "$RELEASE_TAG" \
@@ -608,7 +610,7 @@ jobs:
           cmp -- \
             target/service-proxy-publication/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar \
             "$recovery_directory/automata-service-proxy-candidate-x86_64-unknown-linux-musl.tar"
-          if [[ "${{ steps.draft.outputs.catalog_present }}" == true ]]; then
+          if [[ "${CATALOG_PRESENT}" == true ]]; then
             gh attestation verify \
               "$recovery_directory/automata-local-installation-catalog.json" \
               --repo "$GITHUB_REPOSITORY" \
@@ -632,7 +634,7 @@ jobs:
                 --created "$RELEASE_CREATED" \
                 --github-output "$GITHUB_OUTPUT"
           fi
-          if [[ "${{ steps.draft.outputs.manifest_present }}" == true ]]; then
+          if [[ "${MANIFEST_PRESENT}" == true ]]; then
             install -m 0444 -- \
               "$recovery_directory/automata-release-manifest.json" \
               target/distribution/automata-release-manifest.json
@@ -1330,6 +1332,9 @@ jobs:
           RELEASE_TAG: ${{ needs.gate.outputs.tag }}
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+          EXPECTED_AUTOMATA_DIGEST: ${{ needs.stage_release.outputs.automata_digest }}
+          EXPECTED_RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          EXPECTED_SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           artifact_digest="${ARTIFACT_DIGEST#sha256:}"
           [[ "$artifact_digest" == "$HANDOFF_SHA256" ]] || {
@@ -1354,9 +1359,9 @@ jobs:
           python3 scripts/ci/release-handoff.py verify-handoff \
             --handoff "$handoff" \
             --handoff-sha256 "$HANDOFF_SHA256" \
-            --automata-digest "${{ needs.stage_release.outputs.automata_digest }}" \
-            --runner-digest "${{ needs.stage_release.outputs.runner_digest }}" \
-            --sandbox-guest-digest "${{ needs.stage_release.outputs.sandbox_guest_digest }}" \
+            --automata-digest "${EXPECTED_AUTOMATA_DIGEST}" \
+            --runner-digest "${EXPECTED_RUNNER_DIGEST}" \
+            --sandbox-guest-digest "${EXPECTED_SANDBOX_GUEST_DIGEST}" \
             --extract-root . \
             --tag "$RELEASE_TAG" \
             --tag-object "$RELEASE_TAG_OBJECT" \
@@ -1626,7 +1631,7 @@ jobs:
     environment: crates-io
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Exchange OIDC identity for a short-lived crates.io token.
     steps:
       - name: Download same-run raw handoff by artifact ID
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1970,8 +1975,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
-      contents: write
-      packages: write
+      contents: write # Publish the verified draft release and its final notes.
+      packages: write # Bind stable GHCR tags to verified release digests.
     env:
       DOCKER_CONFIG: ${{ github.workspace }}/target/task-tmp/release-finalize/docker-config
       TMPDIR: ${{ github.workspace }}/target/task-tmp/release-finalize
@@ -2004,6 +2009,9 @@ jobs:
           RELEASE_TAG: ${{ needs.gate.outputs.tag }}
           RELEASE_TAG_OBJECT: ${{ needs.gate.outputs.tag_object }}
           RELEASE_VERSION: ${{ needs.gate.outputs.version }}
+          EXPECTED_AUTOMATA_DIGEST: ${{ needs.stage_release.outputs.automata_digest }}
+          EXPECTED_RUNNER_DIGEST: ${{ needs.stage_release.outputs.runner_digest }}
+          EXPECTED_SANDBOX_GUEST_DIGEST: ${{ needs.stage_release.outputs.sandbox_guest_digest }}
         run: |
           install -d -m 0700 -- "$TMPDIR" "$DOCKER_CONFIG"
           artifact_digest="${ARTIFACT_DIGEST#sha256:}"
@@ -2029,9 +2037,9 @@ jobs:
           python3 scripts/ci/release-handoff.py verify-handoff \
             --handoff "$handoff" \
             --handoff-sha256 "$HANDOFF_SHA256" \
-            --automata-digest "${{ needs.stage_release.outputs.automata_digest }}" \
-            --runner-digest "${{ needs.stage_release.outputs.runner_digest }}" \
-            --sandbox-guest-digest "${{ needs.stage_release.outputs.sandbox_guest_digest }}" \
+            --automata-digest "${EXPECTED_AUTOMATA_DIGEST}" \
+            --runner-digest "${EXPECTED_RUNNER_DIGEST}" \
+            --sandbox-guest-digest "${EXPECTED_SANDBOX_GUEST_DIGEST}" \
             --extract-root . \
             --tag "$RELEASE_TAG" \
             --tag-object "$RELEASE_TAG_OBJECT" \

--- a/.ci/workflows/service-proxy-image.yml
+++ b/.ci/workflows/service-proxy-image.yml
@@ -264,11 +264,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
-      artifact-metadata: write
-      attestations: write
+      artifact-metadata: write # Bind uploaded review artifacts to service digests.
+      attestations: write # Publish provenance for the candidate image.
       contents: read
-      id-token: write
-      packages: write
+      id-token: write # Mint the OIDC identity used to sign attestations.
+      packages: write # Push the immutable review image to GHCR.
     env:
       ANONYMOUS_AUTH_FILE: ${{ github.workspace }}/target/task-tmp/service-proxy-anonymous-auth.json
       ATTESTATION_HOME: ${{ github.workspace }}/target/task-tmp/service-proxy-attestation-home
@@ -551,7 +551,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     permissions:
-      attestations: read
+      attestations: read # Verify the reviewed image's provenance before promotion.
       contents: read
     env:
       ANONYMOUS_AUTH_FILE: ${{ github.workspace }}/target/task-tmp/service-proxy-anonymous-auth.json
@@ -687,9 +687,13 @@ jobs:
           AUTOMATA_SERVICE_PROXY_CONTAINER_RUNTIME=podman \
             ./scripts/ci/verify-service-proxy-image.sh \
               "$LOCKED_IMAGE" \
-              "${{ steps.evidence.outputs.version }}" \
-              "${{ steps.evidence.outputs.candidate_commit }}" \
-              "${{ steps.evidence.outputs.created }}"
+              "${EVIDENCE_VERSION}" \
+              "${EVIDENCE_CANDIDATE_COMMIT}" \
+              "${EVIDENCE_CREATED}"
+        env:
+          EVIDENCE_VERSION: ${{ steps.evidence.outputs.version }}
+          EVIDENCE_CANDIDATE_COMMIT: ${{ steps.evidence.outputs.candidate_commit }}
+          EVIDENCE_CREATED: ${{ steps.evidence.outputs.created }}
 
   promote:
     name: Bind protected stable service-proxy tags
@@ -700,7 +704,7 @@ jobs:
     environment: service-proxy-promotion
     permissions:
       contents: read
-      packages: write
+      packages: write # Bind stable GHCR tags to the reviewed image digest.
     env:
       ANONYMOUS_AUTH_FILE: ${{ github.workspace }}/target/task-tmp/service-proxy-anonymous-auth.json
       CANDIDATE_COMMIT: ${{ needs.validate.outputs.candidate_commit }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /ui
@@ -29,6 +31,8 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -42,12 +46,16 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: rust-toolchain
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /images/github-hosted-ubuntu-24.04-x64
@@ -57,3 +65,5 @@ updates:
     ignore:
       # Base refreshes require the trusted candidate/lock/attestation workflow.
       - dependency-name: library/ubuntu
+    cooldown:
+      default-days: 7

--- a/scripts/ci/install-zizmor.sh
+++ b/scripts/ci/install-zizmor.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly version="1.29.0"
+destination="${1:?usage: install-zizmor.sh DESTINATION_DIRECTORY}"
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_directory
+repository_root="$(CDPATH='' cd -- "$script_directory/../.." && pwd)"
+readonly repository_root
+# shellcheck source=scripts/ci/lib/target-paths.sh
+source "${script_directory}/lib/target-paths.sh"
+automata_init_target_root "${repository_root}"
+automata_set_target_tmpdir \
+  "${repository_root}" \
+  "${repository_root}/target/task-tmp/zizmor-install"
+if [[ "${destination}" != /* ]]; then
+  destination="${repository_root}/${destination}"
+fi
+destination="$(
+  automata_canonical_target_child "${destination}" "zizmor destination"
+)"
+readonly destination
+
+case "$(uname -m)" in
+  x86_64)
+    readonly release_arch="x86_64"
+    readonly expected_sha256="dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839"
+    ;;
+  aarch64)
+    readonly release_arch="aarch64"
+    readonly expected_sha256="415eaa7c0a06479a701b8e44a3e812c1047decc848ec4bede7bd6bbf49f22d20"
+    ;;
+  *)
+    printf 'error: zizmor bootstrap does not support architecture %s\n' "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+readonly archive_name="zizmor-${release_arch}-unknown-linux-gnu.tar.gz"
+readonly release_url="https://github.com/zizmorcore/zizmor/releases/download/v${version}/${archive_name}"
+scratch_root="${AUTOMATA_CI_SCRATCH_DIR:-$repository_root/target/ci-scratch}"
+if [[ "${scratch_root}" != /* ]]; then
+  scratch_root="${repository_root}/${scratch_root}"
+fi
+scratch_root="$(
+  automata_canonical_target_child "${scratch_root}" "zizmor scratch directory"
+)"
+readonly scratch_root
+install -d -m 0700 -- "$scratch_root"
+temporary_dir="$(mktemp -d "$scratch_root/zizmor.XXXXXXXX")"
+readonly temporary_dir
+cleanup() {
+  rm -rf -- "$temporary_dir"
+}
+trap cleanup EXIT
+
+curl \
+  --fail \
+  --location \
+  --proto '=https' \
+  --retry 3 \
+  --show-error \
+  --silent \
+  --tlsv1.2 \
+  --output "$temporary_dir/$archive_name" \
+  "$release_url"
+
+printf '%s  %s\n' "$expected_sha256" "$temporary_dir/$archive_name" |
+  sha256sum --check --strict
+tar \
+  --extract \
+  --gzip \
+  --file "$temporary_dir/$archive_name" \
+  --directory "$temporary_dir" \
+  zizmor
+install -d -m 0755 -- "$destination"
+install -m 0555 -- "$temporary_dir/zizmor" "$destination/zizmor"
+"$destination/zizmor" --version

--- a/scripts/ci/lint-ci-security.sh
+++ b/scripts/ci/lint-ci-security.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+readonly repository_root
+zizmor="$repository_root/target/ci-tools/zizmor"
+readonly zizmor
+if [[ ! -x "$zizmor" ]]; then
+  printf 'error: install zizmor before linting CI definitions\n' >&2
+  exit 2
+fi
+: "${GH_TOKEN:?error: GH_TOKEN is required for zizmor online audits}"
+
+shopt -s nullglob
+workflow_files=(
+  "$repository_root"/.ci/workflows/*.yml
+  "$repository_root"/.ci/workflows/*.yaml
+)
+readonly workflow_files
+if (( ${#workflow_files[@]} == 0 )); then
+  printf 'error: no CI workflows found to audit\n' >&2
+  exit 2
+fi
+
+"$zizmor" \
+  "${workflow_files[@]}" \
+  "$repository_root/.github/dependabot.yml" \
+  --collect all \
+  --min-confidence low \
+  --min-severity informational \
+  --no-ignores \
+  --persona auditor \
+  --strict-collection


### PR DESCRIPTION
## Outcome

Run zizmor on every main and pull-request CI pass, auditing all Automata workflow definitions and Dependabot configuration with its strictest auditor settings. The repository is clean under the new gate.

The bootstrap pins zizmor v1.29.0 and verifies the upstream SHA-256 digest before installation. The lint command enables the auditor persona, informational severity, low confidence, all collectors, strict collection, online audits, and `--no-ignores`.

Existing findings are remediated by routing workflow expressions through environment variables, documenting elevated token permissions, removing an unused Pages permission, and applying a seven-day Dependabot cooldown to every update stream.

## Related issue

None.

## Trust and compatibility impact

CI receives the existing read-scoped `github.token` as `GH_TOKEN` so zizmor can perform online audits. The token is not persisted, and the downloaded zizmor binary is version- and checksum-pinned for x86_64 and aarch64 Linux.

Dependabot updates now observe a seven-day cooldown. Release and image-publishing permissions are unchanged except that their purpose is documented inline; the unused `pages: read` grant is removed.

## Verification

- `./scripts/ci/install-zizmor.sh target/ci-tools` — passed, including release checksum verification
- `GH_TOKEN="$(gh auth token)" ./scripts/ci/lint-ci-security.sh` — passed with zero findings
- `./scripts/ci/install-actionlint.sh target/ci-tools && ./scripts/ci/lint-workflows.sh` — passed
- Full repository CI shellcheck invocation — passed
- `git diff --check origin/main...HEAD` — passed

No Rust or frontend tests were run because the change is limited to CI YAML, Dependabot configuration, and shell lint/bootstrap scripts.

## AI assistance

OpenAI Codex implemented the CI integration, remediated the findings, and ran the verification listed above. All submitted changes were reviewed.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
