### PR TITLE
Lead the README with workflow setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,52 @@ Automata runs this repository's own CI. The
 [public dashboard](https://ci.automata-ci.com/automata-ci/automata/actions)
 shows push and pull-request runs, jobs, runner-redacted logs, and artifacts.
 
-## Try the interface
+## Run workflows
 
 You need Git, [rustup](https://rustup.rs/), and a native C/C++ build toolchain.
-The repository pins its Rust toolchain in `rust-toolchain.toml`.
+The repository pins its Rust toolchain in `rust-toolchain.toml`. No public
+package or image has been published, so build both commands from a reviewed
+source checkout:
 
 ```console
 git clone https://github.com/automata-ci/automata.git
 cd automata
-cargo run --locked --bin automata -- preview
+cargo install --path crates/automata-ci --locked
+cargo install --path crates/automata-ci-runner --locked
+automata --version
+automata-runner --version
 ```
 
-Open <http://127.0.0.1:8080>. Verify the process from another terminal:
+Then bring up the complete path:
+
+1. Configure PostgreSQL, S3-compatible object storage, the Results service,
+   runner mutual TLS, and the GitHub App integration. The
+   [`automata` configuration reference](crates/automata-ci/README.md) owns the
+   required server options, secret references, listener boundaries, and
+   startup checks. Start `automata server` only after those inputs are in
+   place.
+2. Prepare a Linux execution host with rootless Podman, enroll its identity,
+   and start `automata-runner run --config /ABSOLUTE/PATH/runner.json` under
+   the same dedicated account that owns the configuration. Follow the
+   [runner bootstrap guide](crates/automata-ci-runner/config/README.md); the
+   runner performs mandatory host and sandbox admission before it accepts a
+   job.
+3. Put Automata workflows in `.ci/workflows`, register the repository through
+   the configured GitHub provider, and push or dispatch a supported event.
+   Automata admits the workflow, leases its jobs to eligible runners, and
+   publishes the results through its UI and GitHub Checks.
+
+After the server starts, verify process and dependency readiness on the human
+listener:
 
 ```console
 curl --fail http://127.0.0.1:8080/healthz
 curl --fail http://127.0.0.1:8080/readyz
 ```
 
-Preview mode serves the server-rendered interface and health endpoints without
-external services. It does not accept webhooks, schedule jobs, connect to
-runners, or expose the Results API. The
-[hosted demo](https://automata-ci.github.io/automata/) shows the same interface
-with sample data and cannot execute workflows.
-
-To run workflows, configure the complete server and at least one runner. Start
-with the [`automata` configuration reference](crates/automata-ci/README.md) and
-the [Linux runner bootstrap guide](crates/automata-ci-runner/config/README.md).
+`/readyz` reports database, object-store, and autonomous-worker readiness. The
+server fails closed when a required dependency or credential is missing; it
+does not fall back to a preview process.
 
 ## What works
 
@@ -85,7 +104,6 @@ These are not all at the same release stage. In particular:
 
 | Area | Status | Boundary |
 | --- | --- | --- |
-| Web preview | Available | Source-build UI and health endpoints only; no workflow execution |
 | Local host and workflow checks | Available | Read-only source-build inspection; no admission or execution |
 | GitHub-to-runner workflow execution | Experimental | Runs real workflows; operating requirements and supported syntax may change |
 | GitHub provider and Checks | Experimental | Authenticated ingress and result projection are composed; production acceptance remains open |
@@ -113,21 +131,8 @@ The workspace builds two product commands:
 
 | Command | Purpose |
 | --- | --- |
-| `automata` | Run the control plane and use its preview, local inspection, authentication, secret, environment-review, rerun, runner-management, and administration operations |
+| `automata` | Run the control plane and perform local inspection, authentication, secret, environment-review, rerun, runner-management, and administration operations |
 | `automata-runner` | Enroll an execution host, inspect its capabilities, and execute leased jobs through one configured sandbox provider |
-
-Build and install both commands from the same reviewed checkout:
-
-```console
-cargo install --path crates/automata-ci --locked
-cargo install --path crates/automata-ci-runner --locked
-automata --version
-automata-runner --version
-```
-
-No crates.io package, release archive, or GHCR product image is public until an
-exact version appears in that registry and in
-[GitHub Releases](https://github.com/automata-ci/automata/releases).
 
 ### Inspect a local repository
 


### PR DESCRIPTION
## Outcome

Replace the README preview tutorial with the path for running real workflows:

- build and verify both product commands from source;
- configure the complete control plane and its PostgreSQL, object-store, Results, mTLS, and GitHub boundaries;
- bootstrap and start a rootless-Podman Linux runner;
- submit workflows from `.ci/workflows`; and
- verify process and dependency readiness.

This follows up #435. The preview tutorial, hosted-demo copy, preview status row, and duplicate installation block are removed.

## Related issue

None.

## Trust and compatibility impact

Documentation only. This changes no credential, isolation, storage, protocol, release, or GitHub Actions behavior. The new path links to the existing control-plane and runner guides for exact security and configuration requirements.

## Verification

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- checked every relative link in `README.md` against the worktree
- confirmed the preview tutorial, hosted-demo copy, preview command, and preview status row are absent
- runtime tests not run because the change is documentation-only

## AI assistance

OpenAI Codex materially contributed by revising the copy and checking the commands against the mainline CLI and operator guides.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.