### PR TITLE
feat(local): inspect and reset sealed installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,22 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
   materializer with a bounded canonical stdin request. Init seals the immutable
   epoch plus credential-free canonical desired intent and supports exact
   replay; it does not independently authenticate catalog OIDC provenance,
-  generate or invoke Compose, or start services. `ResetRequired` is detectable,
-  while `local up`, `down`, `status`, and `reset` remain absent.
+  generate or invoke Compose, or start services. `ResetRequired` is detectable.
+- x86-64 Linux-only `automata local status --state-directory ABS [--json]`
+  and `automata local reset --state-directory ABS --yes`. Status is an
+  existing-only, shared-lock, nonrepairing inspection of canonical host custody
+  and exact Engine metadata; it reports volume contents as not inspected.
+  Both commands connect directly to the fixed Docker socket with pinned API
+  1.48, independent of Docker CLI/context/environment and Compose readiness.
+  Reset requires an authority-bound canonical epoch plus complete exact
+  post-Desired Engine custody, rejects copied/pre-guard custody, unexpected
+  managed resources, and foreign attachments before mutation, then durably
+  reconciles exact helper, volume, anchor, and safe fixed-record deletion.
+  Missing or malformed non-authority material/certificate records do not strand
+  exact cleanup; canonically valid conflicting selector/commit records do.
+  Imported images, the state directory, and its original operation lock are
+  retained; missing retained images do not block custody deletion. `local up`
+  and `down` remain absent.
 - Evaluation-only fixed-relay Local Docker runner execution on Linux. Runner
   schema 6 binds the private provider to an exact existing installation anchor,
   already-present digest-pinned guest and Results-proxy images, and an exact

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The workspace builds two product commands:
 
 | Command | Purpose |
 | --- | --- |
-| `automata` | Run the control plane and perform local inspection, authentication, secret, environment-review, rerun, runner-management, and administration operations |
+| `automata` | Run the control plane and perform local installation inspection and management, authentication, secret, environment-review, rerun, runner-management, and administration operations |
 | `automata-runner` | Enroll an execution host, inspect its capabilities, and execute leased jobs through one configured sandbox provider |
 
 ### Inspect a local repository
@@ -157,7 +157,7 @@ workflows and reports required credentials without exposing values. See the
 [local installation boundary](crates/automata-ci-local/README.md) for the
 snapshot and platform limits.
 
-### Seal a local Docker installation
+### Manage sealed local Docker custody
 
 On x86-64 Linux, `local init` seals an immutable installation into an explicit
 private state directory and twelve owner-specific Docker volumes:
@@ -166,6 +166,10 @@ private state directory and twelve owner-specific Docker volumes:
 automata local init \
   --state-directory /var/lib/automata-local/default \
   --catalog-source file:/srv/automata-release/local-installation-catalog.json
+automata local status \
+  --state-directory /var/lib/automata-local/default --json
+automata local reset \
+  --state-directory /var/lib/automata-local/default --yes
 ```
 
 Init accepts only the fixed local Docker socket and an operator-selected local
@@ -173,10 +177,25 @@ release catalog with its exact catalog-declared sibling candidate. It verifies
 their canonical structure and digests, but does not independently authenticate
 their release provenance. Exact replay reattests the same state and Engine
 custody. Init generates no Compose document, invokes no Compose operation, and
-starts no service. Public `local up`, `down`, `status`, and `reset` commands are
-not part of this slice; `ResetRequired` is detectable but has no remediation
-command yet. See the [local installation boundary](crates/automata-ci-local/README.md)
-for the complete custody and platform contract.
+starts no service. The epoch binds the stable local-filesystem identity of the
+private state root and its held operation lock; copied, restored, or remounted
+custody is rejected.
+
+Status opens only an existing state directory under a shared, nonrepairing lock
+and reports `recorded_sealed` only when canonical host custody and the exact
+Engine identity, image representations, twelve volume labels, attachments, and
+managed-resource union agree. It never starts a helper or inspects bytes inside
+the volumes. Status and reset connect directly to the fixed Docker socket and do
+not depend on the Docker CLI, current context, `DOCKER_API_VERSION`, or Compose
+plugin; init and doctor retain their complete preflight. Reset never prompts and
+requires `--yes`. Before mutation it requires an authority-bound canonical
+epoch plus complete exact Engine custody. Once its topology-bound intent is
+durable, reset reconciles deletion even if cancellation arrives, removes safe
+fixed host records, and retains imported images, the state directory, and its
+original operation lock. Missing or retagged retained images do not prevent
+custody deletion. `automata local run`, `up`, and `down` are not present. See the
+[local installation boundary](crates/automata-ci-local/README.md) for the full
+custody and platform contract.
 
 ## Architecture
 

--- a/crates/automata-ci-local/README.md
+++ b/crates/automata-ci-local/README.md
@@ -9,8 +9,8 @@ behavior to the control-plane crate.
 
 The user-visible slice provides read-only host preflight and snapshot-backed
 workflow checking on the qualified platforms. On x86-64 Linux it also provides
-`automata local init`, a mutating init-only operation for a Docker Engine at
-exactly `unix:///var/run/docker.sock`. During `local doctor`, context
+sealed `init`, read-only metadata `status`, and exact confirmed `reset` for a
+Docker Engine at exactly `unix:///var/run/docker.sock`. During `local doctor`, context
 discovery is completed first, subsequent daemon probes are pinned to that exact
 local Unix-socket or Windows-named-pipe endpoint, and JSON schema 3 reports the
 bounded context name. Init accepts only the fixed Unix socket so the verified
@@ -93,10 +93,28 @@ epoch and material. The desired record includes the local service-proxy tag and
 both acceptable OCI IDs so later convergence can reattest the same daemon
 representation. This slice has no renderer and generates no Compose document.
 Init invokes no Compose operation and starts no service, relay, bootstrap,
-database, object store, or runner. No public `up`, `down`, `status`, `reset`,
-relay, or bootstrap lifecycle command exists; `ResetRequired` is detectable,
-but there is no reset command. The adapter exposes no generic delete, prune, or
-arbitrary helper API.
+database, object store, or runner. Public `local status --state-directory ABS`
+opens only existing custody with a shared, nonrepairing lock. It validates the
+canonical host records and exact Engine identity, images, volume metadata,
+attachments, and related-resource union, but deliberately does not inspect
+volume contents or manifests; `recorded_sealed` is that narrower claim. Public
+`local reset --state-directory ABS --yes` never prompts. It authorizes deletion
+from an authority-bound canonical epoch plus complete exact post-Desired Engine
+custody, rejecting copied/pre-guard, mismatched, unexpectedly managed, or
+foreign-attached state before mutation. Missing or safe malformed material,
+certificate, selector, and commit records are not deletion authority and do not
+strand cleanup; a canonically valid conflicting selector or commit blocks.
+Both commands use Bollard directly at the fixed Docker socket with pinned API
+1.48; Docker CLI availability, current context, `DOCKER_API_VERSION`, and
+Compose readiness affect neither status nor reset. Init and doctor retain the
+full CLI/context/Compose preflight.
+The self-contained topology-bound intent durably reconciles helper, eleven
+roles, Desired, anchor, and whatever safe fixed host records remain. It retains
+images, the state directory, and the verified held operation lock. Missing or
+retagged images do not block deletion because reset derives any stale-helper
+contract from the sealed epoch and never owns image removal. No public `up`,
+`down`, relay, or bootstrap lifecycle command exists.
+The adapter exposes no generic delete, prune, or arbitrary helper API.
 
 On Linux, the runner also consumes one evaluation-only sandbox-provider
 factory. The concrete Docker provider and engine API stay private. They connect
@@ -170,21 +188,24 @@ there is no ambient installation credential or GitHub-authority fallback.
 An installation is one reusable control-plane and runner-capacity domain, not
 one repository. Repositories sharing an installation are one trusted set and
 retain their own admission, authorization, secret, cache, and history scope in
-the existing control plane. A separate `--installation` name is the explicit
-way to request another deployment/capacity domain.
+the existing control plane. At creation time, init's separate `--installation`
+name requests another deployment/capacity domain; status and reset recover that
+identity only from the explicit state-directory custody.
 
-`automata local init` is the sole product mutation command: it imports or pulls
-the verified image set, creates/adopts exact installation volumes, and seals
-host material plus desired topology without converging it. The runner-only
-provider boundary above still does not add a local lifecycle command. The
+`automata local init` imports or pulls the verified image set, creates/adopts
+exact installation volumes, and seals host material plus desired topology
+without converging it. `automata local reset` is the only other product mutation
+in this slice and removes one exact established installation while retaining
+images and the custody root/lock. The runner-only provider boundary above still
+does not add a local execution command. The
 snapshot boundary is consumed separately by `automata local check`, which
 compiles an explicit local manual-dispatch event and all reachable same-snapshot
 reusable workflows through the shared compiler and credential analysis. It
 does not admit or run work, mint GitHub evidence, request a token, or publish a
-Check Run. There is no mirrored live-resource inventory or public lifecycle
-state machine, and secret values never enter the desired document. This slice
-does not generate a Compose document.
+Check Run. Status derives a bounded live Engine inventory on demand rather than
+persisting a mirrored one, and secret values never enter the desired document
+or status output. This slice does not generate a Compose document.
 
 This crate has no command-line parser. The `automata` product maps its public
-CLI into the high-level local-check and x86-64 Linux init requests; filesystem,
-catalog, materializer, snapshot, and archive authority stay private.
+CLI into the high-level local-check and x86-64 Linux init/status/reset requests;
+filesystem, catalog, materializer, snapshot, and archive authority stay private.

--- a/crates/automata-ci-local/src/engine.rs
+++ b/crates/automata-ci-local/src/engine.rs
@@ -9,12 +9,27 @@ use bollard::{
 };
 use thiserror::Error;
 
+#[cfg(test)]
+use crate::EngineSelection;
 use crate::{
-    ApiVersion, DoctorReport, EngineEndpoint, EngineSelection, Installation, InstallationId,
-    InstallationName, capped_adapter_api, normalize_architecture,
+    ApiVersion, DoctorReport, EngineEndpoint, Installation, InstallationId, InstallationName,
+    ValidatedEngineSelection, capped_adapter_api, normalize_architecture,
 };
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use crate::{DockerConnection, Engine, EngineArchitecture, canonical_engine_major};
 
 const ENGINE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const FIXED_LOCAL_DOCKER_HOST: &str = "unix:///var/run/docker.sock";
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const FIXED_LOCAL_DOCKER_CONTEXT: &str = "automata-fixed-socket";
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const FIXED_LOCAL_DOCKER_API: ApiVersion = ApiVersion {
+    major: 1,
+    minor: 48,
+};
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const MINIMUM_LOCAL_DOCKER_ENGINE_MAJOR: u64 = 28;
 const MANAGED_LABEL_PREFIX: &str = "io.automata.local.";
 const LABEL_MANAGED: &str = "io.automata.local.managed";
 const LABEL_IDENTITY_SCHEMA: &str = "io.automata.local.identity-schema";
@@ -114,7 +129,7 @@ impl LocalEngineError {
 /// image pulling, container lifecycle, or Compose API.
 pub struct DockerInstallationAdapter {
     engine: Arc<dyn EngineApi>,
-    selection: EngineSelection,
+    selection: ValidatedEngineSelection,
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     docker: Option<Docker>,
 }
@@ -146,6 +161,13 @@ impl DockerInstallationAdapter {
         let selection = report
             .selected_engine()
             .ok_or_else(|| LocalEngineError::new(LocalEngineErrorCode::PreflightRequired))?;
+        let selection = selection.validated_engine();
+        Self::connect_validated_engine(&selection).await
+    }
+
+    pub(crate) async fn connect_validated_engine(
+        selection: &ValidatedEngineSelection,
+    ) -> Result<Self, LocalEngineError> {
         let engine = BollardEngine::connect(selection)?;
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         let docker = Some(engine.docker.clone());
@@ -153,6 +175,31 @@ impl DockerInstallationAdapter {
             engine: Arc::new(engine),
             selection: selection.clone(),
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            docker,
+        };
+        adapter.verify_engine().await?;
+        Ok(adapter)
+    }
+
+    /// Connects directly to the one fixed local socket without consulting the
+    /// Docker CLI, current context, Compose, or environment API overrides.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    pub(crate) async fn connect_fixed_engine() -> Result<Self, LocalEngineError> {
+        let engine = BollardEngine::connect_fixed()?;
+        let docker = Some(engine.docker.clone());
+        Self::connect_fixed_engine_api(Arc::new(engine), docker).await
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    async fn connect_fixed_engine_api(
+        engine: Arc<dyn EngineApi>,
+        docker: Option<Docker>,
+    ) -> Result<Self, LocalEngineError> {
+        let facts = engine.engine_facts().await.map_err(map_engine_call)?;
+        let selection = validate_fixed_engine_facts(&facts)?;
+        let adapter = Self {
+            engine,
+            selection,
             docker,
         };
         adapter.verify_engine().await?;
@@ -296,7 +343,15 @@ impl DockerInstallationAdapter {
     }
 
     #[cfg(test)]
-    fn with_test_engine(selection: EngineSelection, engine: Arc<dyn EngineApi>) -> Self {
+    fn with_test_engine(selection: &EngineSelection, engine: Arc<dyn EngineApi>) -> Self {
+        Self::with_test_validated_engine(selection.validated_engine(), engine)
+    }
+
+    #[cfg(test)]
+    fn with_test_validated_engine(
+        selection: ValidatedEngineSelection,
+        engine: Arc<dyn EngineApi>,
+    ) -> Self {
         Self {
             engine,
             selection,
@@ -425,7 +480,7 @@ struct BollardEngine {
 }
 
 impl BollardEngine {
-    fn connect(selection: &EngineSelection) -> Result<Self, LocalEngineError> {
+    fn connect(selection: &ValidatedEngineSelection) -> Result<Self, LocalEngineError> {
         let api = adapter_api_version(selection.api_version())?;
         let version = ClientVersion {
             major_version: usize::from(api.major),
@@ -436,6 +491,76 @@ impl BollardEngine {
             .map_err(|_error| LocalEngineError::new(LocalEngineErrorCode::ConnectionUnavailable))?;
         Ok(Self { docker })
     }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    fn connect_fixed() -> Result<Self, LocalEngineError> {
+        let docker = connect_exact_endpoint(
+            EngineEndpoint::UnixSocket,
+            FIXED_LOCAL_DOCKER_HOST,
+            &fixed_client_version(),
+        )
+        .map_err(|_error| LocalEngineError::new(LocalEngineErrorCode::ConnectionUnavailable))?;
+        Ok(Self { docker })
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn fixed_client_version() -> ClientVersion {
+    ClientVersion {
+        major_version: usize::from(FIXED_LOCAL_DOCKER_API.major),
+        minor_version: usize::from(FIXED_LOCAL_DOCKER_API.minor),
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn validate_fixed_engine_facts(
+    facts: &EngineFacts,
+) -> Result<ValidatedEngineSelection, LocalEngineError> {
+    let invalid = || LocalEngineError::new(LocalEngineErrorCode::InvalidEngineResponse);
+    let minimum_api = canonical_api_version(&facts.minimum_api_version).ok_or_else(invalid)?;
+    let maximum_api = canonical_api_version(&facts.maximum_api_version).ok_or_else(invalid)?;
+    let architecture = normalize_architecture(&facts.architecture).ok_or_else(invalid)?;
+    if facts.operating_system != "linux"
+        || architecture != EngineArchitecture::Amd64
+        || canonical_engine_major(&facts.server_version)
+            .is_none_or(|major| major < MINIMUM_LOCAL_DOCKER_ENGINE_MAJOR)
+        || !valid_engine_id(&facts.engine_id)
+        || minimum_api > FIXED_LOCAL_DOCKER_API
+        || maximum_api < FIXED_LOCAL_DOCKER_API
+    {
+        return Err(invalid());
+    }
+    Ok(ValidatedEngineSelection {
+        engine: Engine::Docker,
+        context_name: FIXED_LOCAL_DOCKER_CONTEXT.to_owned(),
+        endpoint: EngineEndpoint::UnixSocket,
+        engine_id: facts.engine_id.clone(),
+        server_version: facts.server_version.clone(),
+        api_version: format!(
+            "{}.{}",
+            FIXED_LOCAL_DOCKER_API.major, FIXED_LOCAL_DOCKER_API.minor
+        ),
+        architecture,
+        connection: DockerConnection {
+            context_name: FIXED_LOCAL_DOCKER_CONTEXT.to_owned(),
+            host: FIXED_LOCAL_DOCKER_HOST.to_owned(),
+            endpoint: EngineEndpoint::UnixSocket,
+        },
+    })
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn canonical_api_version(value: &str) -> Option<ApiVersion> {
+    let parsed = ApiVersion::parse(value)?;
+    (format!("{}.{}", parsed.major, parsed.minor) == value).then_some(parsed)
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn valid_engine_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 512
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
 }
 
 #[cfg(unix)]

--- a/crates/automata-ci-local/src/engine/tests.rs
+++ b/crates/automata-ci-local/src/engine/tests.rs
@@ -14,6 +14,11 @@ use super::{
     LABEL_RESOURCE_KIND, LocalEngineErrorCode, MANAGED_VALUE, adapter_api_version,
     complete_request, identity_labels,
 };
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use super::{
+    FIXED_LOCAL_DOCKER_HOST, connect_exact_endpoint, fixed_client_version,
+    validate_fixed_engine_facts,
+};
 use crate::{
     ComposeFrontend, DockerConnection, Engine, EngineArchitecture, EngineEndpoint, EngineSelection,
     Installation, InstallationId, InstallationName,
@@ -158,7 +163,7 @@ fn selection() -> EngineSelection {
 fn test_adapter() -> (DockerInstallationAdapter, Arc<FakeEngine>) {
     let fake = Arc::new(FakeEngine::new());
     (
-        DockerInstallationAdapter::with_test_engine(selection(), fake.clone()),
+        DockerInstallationAdapter::with_test_engine(&selection(), fake.clone()),
         fake,
     )
 }
@@ -170,6 +175,84 @@ fn adapter_api_is_capped_to_the_bollard_model_ceiling() {
 
     let older = adapter_api_version("1.44").expect("older supported API");
     assert_eq!((older.major, older.minor), (1, 44));
+}
+
+#[test]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn fixed_status_reset_engine_selection_depends_only_on_exact_daemon_facts() {
+    let facts = healthy_facts();
+    let selection = validate_fixed_engine_facts(&facts).unwrap();
+    assert_eq!(selection.connection_host(), FIXED_LOCAL_DOCKER_HOST);
+    assert_eq!(selection.api_version(), "1.48");
+    assert_eq!(selection.engine_id(), facts.engine_id);
+    assert_eq!(selection.server_version(), facts.server_version);
+    assert_eq!(selection.architecture(), EngineArchitecture::Amd64);
+    assert!(
+        connect_exact_endpoint(
+            EngineEndpoint::WindowsNamedPipe,
+            FIXED_LOCAL_DOCKER_HOST,
+            &fixed_client_version()
+        )
+        .is_err()
+    );
+
+    for invalid in [
+        ("operating-system", "windows"),
+        ("architecture", "arm64"),
+        ("minimum-api", "1.49"),
+        ("maximum-api", "1.47"),
+        ("server-version", "27.9.0"),
+        ("engine-id", " engine-identity"),
+    ] {
+        let mut facts = healthy_facts();
+        match invalid {
+            ("operating-system", value) => facts.operating_system = value.to_owned(),
+            ("architecture", value) => facts.architecture = value.to_owned(),
+            ("minimum-api", value) => facts.minimum_api_version = value.to_owned(),
+            ("maximum-api", value) => facts.maximum_api_version = value.to_owned(),
+            ("server-version", value) => facts.server_version = value.to_owned(),
+            ("engine-id", value) => facts.engine_id = value.to_owned(),
+            _ => unreachable!(),
+        }
+        assert_eq!(
+            validate_fixed_engine_facts(&facts).unwrap_err().code(),
+            LocalEngineErrorCode::InvalidEngineResponse,
+            "invalid fixed-socket daemon fact: {}",
+            invalid.0
+        );
+    }
+}
+
+#[tokio::test]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+async fn fixed_status_reset_engine_selection_rejects_post_connection_daemon_drift() {
+    let fake = Arc::new(FakeEngine::new());
+    let adapter = DockerInstallationAdapter::connect_fixed_engine_api(fake.clone(), None)
+        .await
+        .unwrap();
+    fake.mutate(|state| state.facts.engine_id = "replacement-engine".to_owned());
+    assert_eq!(
+        adapter
+            .inspect_identity(&InstallationName::default())
+            .await
+            .unwrap_err()
+            .code(),
+        LocalEngineErrorCode::EngineIdentityChanged
+    );
+
+    let fake = Arc::new(FakeEngine::new());
+    let mut replacement = healthy_facts();
+    replacement.engine_id = "replacement-engine".to_owned();
+    fake.mutate(|state| {
+        state.queued_facts = VecDeque::from([Ok(healthy_facts()), Ok(replacement)]);
+    });
+    assert_eq!(
+        DockerInstallationAdapter::connect_fixed_engine_api(fake, None)
+            .await
+            .unwrap_err()
+            .code(),
+        LocalEngineErrorCode::EngineIdentityChanged
+    );
 }
 
 #[tokio::test]
@@ -533,7 +616,8 @@ async fn live_docker_public_adapter_creates_and_re_adopts_one_exact_anchor() {
     assert_eq!(second.id(), first.id());
 
     let selection = report.selected_engine().expect("ready engine selection");
-    let cleanup_engine = super::BollardEngine::connect(selection).expect("cleanup connection");
+    let cleanup_engine =
+        super::BollardEngine::connect(&selection.validated_engine()).expect("cleanup connection");
     let verified = adapter
         .inspect_identity(&name)
         .await

--- a/crates/automata-ci-local/src/init/certificates.rs
+++ b/crates/automata-ci-local/src/init/certificates.rs
@@ -65,6 +65,15 @@ pub(super) fn load_or_issue(
     validate_record(&stored, &keys, epoch)
 }
 
+pub(super) fn validate_existing(
+    bytes: &[u8],
+    deriver: &MaterialDeriver,
+    epoch: &ImmutableEpoch,
+) -> Result<CertificateMaterial, LocalInitError> {
+    let keys = DerivedKeys::new(deriver)?;
+    validate_record(bytes, &keys, epoch)
+}
+
 struct DerivedKeys {
     ca: KeyPair,
     ca_pem: Zeroizing<String>,

--- a/crates/automata-ci-local/src/init/engine.rs
+++ b/crates/automata-ci-local/src/init/engine.rs
@@ -19,7 +19,7 @@ use bollard::{
         AttachContainerOptionsBuilder, CreateContainerOptionsBuilder, CreateImageOptionsBuilder,
         ImportImageOptionsBuilder, ListContainersOptionsBuilder, ListNetworksOptionsBuilder,
         ListVolumesOptionsBuilder, LogsOptionsBuilder, RemoveContainerOptionsBuilder,
-        WaitContainerOptionsBuilder,
+        RemoveVolumeOptionsBuilder, WaitContainerOptionsBuilder,
     },
 };
 use bytes::Bytes;
@@ -34,6 +34,7 @@ use crate::{DockerInstallationAdapter, Installation, installation::ExpectedInsta
 use super::{
     LocalInitError, LocalInitErrorCode,
     catalog::{LiveImageEvidence, VerifiedCatalog},
+    epoch::{EpochImageExpectation, ImmutableEpoch},
     materializer::{MaterializeRequest, VolumeRole},
 };
 
@@ -73,6 +74,53 @@ pub(super) struct InitOwnedUnion {
     pub(super) anchor_present: bool,
     pub(super) roles: BTreeSet<VolumeRole>,
     pub(super) helper_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct SealedImageStatus {
+    pub(super) role: String,
+    pub(super) source_kind: String,
+    pub(super) inspection_reference: String,
+    pub(super) image_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct SealedVolumeStatus {
+    pub(super) role: VolumeRole,
+    pub(super) name: String,
+    pub(super) static_material: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SealedEngineStatus {
+    pub(super) images: Vec<SealedImageStatus>,
+    pub(super) volumes: Vec<SealedVolumeStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ResetHelperBinding {
+    pub(super) reference: String,
+    pub(super) image_id: String,
+    pub(super) container_id: String,
+}
+
+pub(super) struct ResetEnginePreflight {
+    pub(super) helper: Option<ResetHelperBinding>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeleteAttemptOutcome {
+    Completed,
+    Failed,
+    TimedOut,
+}
+
+#[async_trait::async_trait]
+trait ExactVolumeDeleteDriver: Sync {
+    async fn delete_volume_untrusted(&self, name: &str) -> DeleteAttemptOutcome;
+    async fn inspect_volume_present(&self, name: &str) -> Result<bool, LocalInitError>;
+    async fn verify_after_volume_delete(&self) -> Result<(), LocalInitError>;
 }
 
 struct OwnedUnionVolumes {
@@ -240,6 +288,437 @@ impl<'a> InitEngine<'a> {
         validate_final_owned_union_with_driver(self, installation, epoch_fingerprint).await?;
         self.verify_exact_identity(installation).await?;
         self.verify_selected_engine().await
+    }
+
+    pub(super) async fn inspect_sealed(
+        &self,
+        installation: &Installation,
+        epoch: &ImmutableEpoch,
+    ) -> Result<SealedEngineStatus, LocalInitError> {
+        self.verify_selected_engine().await?;
+        self.verify_installation(installation).await?;
+        let scope = Installation::expected(installation.name());
+        let owned =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        validate_complete_owned_union(&owned, None)?;
+        let images = self.inspect_epoch_images(epoch).await?;
+        let names = volume_names(installation);
+        let expected_labels = expected_volume_labels(installation, epoch.fingerprint());
+        let mut volumes = Vec::with_capacity(VolumeRole::ALL.len());
+        for role in VolumeRole::ALL {
+            let name = names.get(&role).ok_or_else(engine_resource_mismatch)?;
+            let volume = self
+                .inspect_volume(name)
+                .await?
+                .ok_or_else(engine_resource_mismatch)?;
+            validate_volume(
+                &volume,
+                name,
+                expected_labels
+                    .get(&role)
+                    .ok_or_else(engine_resource_mismatch)?,
+            )?;
+            if !self.volume_attachments(name).await?.is_empty() {
+                return Err(engine_resource_mismatch());
+            }
+            volumes.push(SealedVolumeStatus {
+                role,
+                name: name.clone(),
+                static_material: role.is_static(),
+            });
+        }
+        let repeated =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if repeated != owned {
+            return Err(engine_resource_mismatch());
+        }
+        validate_complete_owned_union(&repeated, None)?;
+        validate_owned_volumes_with_driver(self, installation, epoch.fingerprint(), &repeated)
+            .await?;
+        self.verify_installation(installation).await?;
+        self.verify_selected_engine().await?;
+        Ok(SealedEngineStatus { images, volumes })
+    }
+
+    pub(super) async fn preflight_reset(
+        &self,
+        installation: &Installation,
+        epoch: &ImmutableEpoch,
+    ) -> Result<ResetEnginePreflight, LocalInitError> {
+        self.verify_selected_engine().await?;
+        self.verify_installation(installation).await?;
+        let scope = Installation::expected(installation.name());
+        let owned =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        let automata = epoch
+            .image_expectations()
+            .find(|image| image.role == "automata")
+            .ok_or_else(engine_resource_mismatch)?;
+        let names = volume_names(installation);
+        let expected_labels = expected_volume_labels(installation, epoch.fingerprint());
+        let helper = self
+            .inspect_reset_helper(
+                installation,
+                epoch.fingerprint(),
+                automata,
+                &names,
+                &expected_labels,
+            )
+            .await?;
+        validate_complete_owned_union(
+            &owned,
+            helper.as_ref().map(|helper| helper.container_id.as_str()),
+        )?;
+        for role in VolumeRole::ALL {
+            let name = names.get(&role).ok_or_else(engine_resource_mismatch)?;
+            let volume = self
+                .inspect_volume(name)
+                .await?
+                .ok_or_else(engine_resource_mismatch)?;
+            validate_volume(
+                &volume,
+                name,
+                expected_labels
+                    .get(&role)
+                    .ok_or_else(engine_resource_mismatch)?,
+            )?;
+            let attachments = self.volume_attachments(name).await?;
+            validate_reset_attachments(&attachments, helper.as_ref())?;
+        }
+        let repeated =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if repeated != owned {
+            return Err(engine_resource_mismatch());
+        }
+        let repeated_helper = self
+            .inspect_reset_helper(
+                installation,
+                epoch.fingerprint(),
+                automata,
+                &names,
+                &expected_labels,
+            )
+            .await?;
+        if repeated_helper != helper {
+            return Err(engine_resource_mismatch());
+        }
+        validate_complete_owned_union(
+            &repeated,
+            helper.as_ref().map(|helper| helper.container_id.as_str()),
+        )?;
+        validate_owned_volumes_with_driver(self, installation, epoch.fingerprint(), &repeated)
+            .await?;
+        self.verify_installation(installation).await?;
+        self.verify_selected_engine().await?;
+        Ok(ResetEnginePreflight { helper })
+    }
+
+    pub(super) async fn cleanup_reset_helper(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        helper: &ResetHelperBinding,
+    ) -> Result<(), LocalInitError> {
+        if !exact_container_id_text(&helper.container_id) {
+            return Err(engine_resource_mismatch());
+        }
+        let names = volume_names(installation);
+        let contract = HelperContract {
+            name: helper_name(installation),
+            image: &helper.reference,
+            image_id: &helper.image_id,
+            volumes: &names,
+            labels: helper_labels(installation, epoch_fingerprint),
+            volume_labels: expected_volume_labels(installation, epoch_fingerprint),
+        };
+        cleanup_reset_helper_with_driver(self, &contract, &helper.container_id).await
+    }
+
+    pub(super) async fn inspect_reset_progress(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+    ) -> Result<usize, LocalInitError> {
+        self.verify_selected_engine().await?;
+        let scope = Installation::expected(installation.name());
+        let owned =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if owned.helper_id.is_some() {
+            return Err(engine_resource_mismatch());
+        }
+        let labels = expected_volume_labels(installation, epoch_fingerprint);
+        let mut presence = [false; 12];
+        for (index, role) in reset_volume_order().into_iter().enumerate() {
+            presence[index] = owned.roles.contains(&role);
+            if !presence[index] {
+                continue;
+            }
+            let name = volume_name(installation.compose_project().as_str(), role);
+            let volume = self
+                .inspect_volume(&name)
+                .await?
+                .ok_or_else(engine_resource_mismatch)?;
+            validate_volume(
+                &volume,
+                &name,
+                labels.get(&role).ok_or_else(engine_resource_mismatch)?,
+            )?;
+            if !self.volume_attachments(&name).await?.is_empty() {
+                return Err(engine_resource_mismatch());
+            }
+        }
+        let anchor = self
+            .adapter
+            .inspect_identity(installation.name())
+            .await
+            .map_err(|_| engine_resource_mismatch())?;
+        let anchor_present = match anchor {
+            Some(actual) if actual == *installation => true,
+            Some(_) => return Err(engine_resource_mismatch()),
+            None => false,
+        };
+        if anchor_present != owned.anchor_present {
+            return Err(engine_resource_mismatch());
+        }
+        let deleted = reset_progress_from_presence(&presence, anchor_present)?;
+        let repeated =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if repeated != owned {
+            return Err(engine_resource_mismatch());
+        }
+        validate_owned_volumes_with_driver(self, installation, epoch_fingerprint, &repeated)
+            .await?;
+        let repeated_anchor = self
+            .adapter
+            .inspect_identity(installation.name())
+            .await
+            .map_err(|_| engine_resource_mismatch())?;
+        if repeated_anchor
+            .as_ref()
+            .is_some_and(|actual| actual != installation)
+            || repeated_anchor.is_some() != anchor_present
+        {
+            return Err(engine_resource_mismatch());
+        }
+        self.verify_selected_engine().await?;
+        Ok(deleted)
+    }
+
+    pub(super) async fn remove_reset_volume(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        role: VolumeRole,
+    ) -> Result<(), LocalInitError> {
+        self.verify_selected_engine().await?;
+        self.verify_installation(installation).await?;
+        let removed = self
+            .inspect_reset_progress(installation, epoch_fingerprint)
+            .await?;
+        if reset_volume_order().get(removed).copied() != Some(role) {
+            return Err(engine_resource_mismatch());
+        }
+        let name = volume_name(installation.compose_project().as_str(), role);
+        let labels = volume_labels(installation, epoch_fingerprint, role);
+        let volume = self
+            .inspect_volume(&name)
+            .await?
+            .ok_or_else(engine_resource_mismatch)?;
+        validate_volume(&volume, &name, &labels)?;
+        if !self.volume_attachments(&name).await?.is_empty() {
+            return Err(engine_resource_mismatch());
+        }
+        self.remove_volume_and_prove_absent(&name).await
+    }
+
+    pub(super) async fn remove_reset_anchor(
+        &self,
+        installation: &Installation,
+    ) -> Result<(), LocalInitError> {
+        self.verify_selected_engine().await?;
+        self.verify_installation(installation).await?;
+        let scope = Installation::expected(installation.name());
+        let owned =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if !owned.anchor_present || !owned.roles.is_empty() || owned.helper_id.is_some() {
+            return Err(engine_resource_mismatch());
+        }
+        let repeated =
+            inspect_owned_union_census_with_driver(self, &scope, Some(installation)).await?;
+        if repeated != owned {
+            return Err(engine_resource_mismatch());
+        }
+        self.remove_volume_and_prove_absent(installation.anchor_volume_name())
+            .await?;
+        if self
+            .adapter
+            .inspect_identity(installation.name())
+            .await
+            .map_err(|_| reset_failed())?
+            .is_some()
+        {
+            return Err(reset_failed());
+        }
+        self.verify_selected_engine().await
+    }
+
+    async fn verify_installation(&self, expected: &Installation) -> Result<(), LocalInitError> {
+        let actual = self
+            .adapter
+            .inspect_identity(expected.name())
+            .await
+            .map_err(|_| engine_resource_mismatch())?;
+        if actual.as_ref() != Some(expected) {
+            return Err(engine_resource_mismatch());
+        }
+        Ok(())
+    }
+
+    async fn inspect_epoch_images(
+        &self,
+        epoch: &ImmutableEpoch,
+    ) -> Result<Vec<SealedImageStatus>, LocalInitError> {
+        let mut statuses = Vec::new();
+        for expectation in epoch.image_expectations() {
+            let reference = expectation.inspection_reference()?;
+            let image = self
+                .inspect_image(&reference)
+                .await?
+                .ok_or_else(engine_resource_mismatch)?;
+            validate_epoch_image(expectation, &image)?;
+            self.verify_epoch_image_resolution(expectation, &image)
+                .await?;
+            statuses.push(SealedImageStatus {
+                role: expectation.role.to_owned(),
+                source_kind: expectation.source_kind.to_owned(),
+                inspection_reference: reference,
+                image_id: image
+                    .id
+                    .as_deref()
+                    .ok_or_else(engine_resource_mismatch)?
+                    .to_owned(),
+            });
+        }
+        Ok(statuses)
+    }
+
+    async fn verify_epoch_image_resolution(
+        &self,
+        expectation: EpochImageExpectation<'_>,
+        image: &bollard::models::ImageInspect,
+    ) -> Result<(), LocalInitError> {
+        let image_id = image.id.as_deref().ok_or_else(engine_resource_mismatch)?;
+        let by_id = self
+            .inspect_image(image_id)
+            .await?
+            .ok_or_else(engine_resource_mismatch)?;
+        if &by_id != image {
+            return Err(engine_resource_mismatch());
+        }
+        if expectation.source_kind != "release-candidate" {
+            return Ok(());
+        }
+        let alternate = if image_id == expectation.config_digest {
+            expectation.manifest_digest
+        } else if image_id == expectation.manifest_digest {
+            expectation.config_digest
+        } else {
+            return Err(engine_resource_mismatch());
+        };
+        if self.inspect_image(alternate).await?.is_some() {
+            return Err(engine_resource_mismatch());
+        }
+        let digest_reference = format!(
+            "{}@{}",
+            expectation.canonical_repository, expectation.manifest_digest
+        );
+        let by_digest = self.inspect_image(&digest_reference).await?;
+        if image_id == expectation.manifest_digest {
+            if by_digest.as_ref() != Some(image) {
+                return Err(engine_resource_mismatch());
+            }
+        } else if by_digest.is_some() {
+            return Err(engine_resource_mismatch());
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn inspect_reset_helper(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        image: EpochImageExpectation<'_>,
+        volumes: &BTreeMap<VolumeRole, String>,
+        volume_labels: &BTreeMap<VolumeRole, BTreeMap<String, String>>,
+    ) -> Result<Option<ResetHelperBinding>, LocalInitError> {
+        let name = helper_name(installation);
+        let Some(by_name) = self.inspect_container(&name).await? else {
+            return Ok(None);
+        };
+        if image.source_kind != "registry" {
+            return Err(engine_resource_mismatch());
+        }
+        let reference = image.inspection_reference()?;
+        let accepted_image_ids = [
+            image.config_digest,
+            image
+                .platform_manifest_digest
+                .ok_or_else(engine_resource_mismatch)?,
+        ];
+        let id = exact_container_id(&by_name)?.to_owned();
+        let labels = helper_labels(installation, epoch_fingerprint);
+        validate_helper_image_ids(
+            &by_name,
+            &id,
+            &name,
+            &reference,
+            &accepted_image_ids,
+            volumes,
+            &labels,
+        )?;
+        let by_id = self
+            .inspect_container(&id)
+            .await?
+            .ok_or_else(engine_resource_mismatch)?;
+        validate_helper_image_ids(
+            &by_id,
+            &id,
+            &name,
+            &reference,
+            &accepted_image_ids,
+            volumes,
+            &labels,
+        )?;
+        for (role, volume_name) in volumes {
+            let volume = self
+                .inspect_volume(volume_name)
+                .await?
+                .ok_or_else(engine_resource_mismatch)?;
+            validate_volume(
+                &volume,
+                volume_name,
+                volume_labels
+                    .get(role)
+                    .ok_or_else(engine_resource_mismatch)?,
+            )?;
+            if self.volume_attachments(volume_name).await?.as_slice() != [id.as_str()] {
+                return Err(engine_resource_mismatch());
+            }
+        }
+        let image_id = by_id
+            .image
+            .as_deref()
+            .ok_or_else(engine_resource_mismatch)?;
+        Ok(Some(ResetHelperBinding {
+            reference,
+            image_id: image_id.to_owned(),
+            container_id: id,
+        }))
+    }
+
+    async fn remove_volume_and_prove_absent(&self, name: &str) -> Result<(), LocalInitError> {
+        remove_volume_and_prove_absent_with_driver(self, name).await
     }
 
     pub(super) async fn qualify_images(
@@ -685,6 +1164,31 @@ impl<'a> InitEngine<'a> {
 }
 
 #[async_trait::async_trait]
+impl ExactVolumeDeleteDriver for InitEngine<'_> {
+    async fn delete_volume_untrusted(&self, name: &str) -> DeleteAttemptOutcome {
+        let options = RemoveVolumeOptionsBuilder::default().force(false).build();
+        match tokio::time::timeout(
+            ENGINE_TIMEOUT,
+            self.docker.remove_volume(name, Some(options)),
+        )
+        .await
+        {
+            Ok(Ok(())) => DeleteAttemptOutcome::Completed,
+            Ok(Err(_)) => DeleteAttemptOutcome::Failed,
+            Err(_) => DeleteAttemptOutcome::TimedOut,
+        }
+    }
+
+    async fn inspect_volume_present(&self, name: &str) -> Result<bool, LocalInitError> {
+        Ok(self.inspect_volume(name).await?.is_some())
+    }
+
+    async fn verify_after_volume_delete(&self) -> Result<(), LocalInitError> {
+        self.verify_selected_engine().await
+    }
+}
+
+#[async_trait::async_trait]
 impl OwnedUnionDriver for InitEngine<'_> {
     async fn list_owned_union_volumes(&self) -> Result<OwnedUnionVolumes, LocalInitError> {
         let listed = tokio::time::timeout(
@@ -821,6 +1325,17 @@ async fn inspect_init_owned_union_with_driver<D: OwnedUnionDriver>(
     expected: &ExpectedInstallation,
     installation: Option<&Installation>,
 ) -> Result<InitOwnedUnion, LocalInitError> {
+    let owned = inspect_owned_union_census_with_driver(driver, expected, installation).await?;
+    validate_init_owned_union(&owned)?;
+    Ok(owned)
+}
+
+#[allow(clippy::too_many_lines)]
+async fn inspect_owned_union_census_with_driver<D: OwnedUnionDriver>(
+    driver: &D,
+    expected: &ExpectedInstallation,
+    installation: Option<&Installation>,
+) -> Result<InitOwnedUnion, LocalInitError> {
     let expected_volumes = INIT_VOLUME_ORDER
         .into_iter()
         .map(|role| (volume_name(expected.compose_project.as_str(), role), role))
@@ -859,11 +1374,6 @@ async fn inspect_init_owned_union_with_driver<D: OwnedUnionDriver>(
             return Err(engine_resource_mismatch());
         }
     }
-    let prefix = validate_init_volume_prefix(&roles)?;
-    if !anchor_present && prefix != 0 {
-        return Err(engine_resource_mismatch());
-    }
-
     let containers = driver.list_owned_union_containers().await?;
     if containers.len() > MAX_ENGINE_RESOURCES {
         return Err(engine_resource_mismatch());
@@ -902,10 +1412,6 @@ async fn inspect_init_owned_union_with_driver<D: OwnedUnionDriver>(
             return Err(engine_resource_mismatch());
         }
     }
-    if helper_id.is_some() && prefix != INIT_VOLUME_ORDER.len() {
-        return Err(engine_resource_mismatch());
-    }
-
     let networks = driver.list_owned_union_networks().await?;
     if networks.len() > MAX_ENGINE_RESOURCES
         || networks.iter().any(|network| {
@@ -924,6 +1430,30 @@ async fn inspect_init_owned_union_with_driver<D: OwnedUnionDriver>(
         roles,
         helper_id,
     })
+}
+
+fn validate_init_owned_union(owned: &InitOwnedUnion) -> Result<(), LocalInitError> {
+    let prefix = validate_init_volume_prefix(&owned.roles)?;
+    if !owned.anchor_present && prefix != 0
+        || owned.helper_id.is_some() && prefix != INIT_VOLUME_ORDER.len()
+    {
+        return Err(engine_resource_mismatch());
+    }
+    Ok(())
+}
+
+fn validate_complete_owned_union(
+    owned: &InitOwnedUnion,
+    expected_helper_id: Option<&str>,
+) -> Result<(), LocalInitError> {
+    let expected_roles = INIT_VOLUME_ORDER.into_iter().collect::<BTreeSet<_>>();
+    if !owned.anchor_present
+        || owned.roles != expected_roles
+        || owned.helper_id.as_deref() != expected_helper_id
+    {
+        return Err(engine_resource_mismatch());
+    }
+    Ok(())
 }
 
 fn validate_init_volume_prefix(roles: &BTreeSet<VolumeRole>) -> Result<usize, LocalInitError> {
@@ -968,6 +1498,30 @@ fn resource_labels_related(
         || labels
             .get(COMPOSE_PROJECT_LABEL)
             .is_some_and(|value| value == expected.compose_project.as_str())
+}
+
+async fn remove_volume_and_prove_absent_with_driver<D: ExactVolumeDeleteDriver>(
+    driver: &D,
+    name: &str,
+) -> Result<(), LocalInitError> {
+    let _attempt = driver.delete_volume_untrusted(name).await;
+    if driver.inspect_volume_present(name).await? {
+        return Err(reset_failed());
+    }
+    driver.verify_after_volume_delete().await
+}
+
+fn reset_progress_from_presence(
+    presence: &[bool; 12],
+    anchor_present: bool,
+) -> Result<usize, LocalInitError> {
+    let deleted = presence.iter().take_while(|present| !**present).count();
+    if presence[deleted..].iter().any(|present| !present)
+        || !anchor_present && deleted != presence.len()
+    {
+        return Err(engine_resource_mismatch());
+    }
+    Ok(deleted + usize::from(!anchor_present))
 }
 
 #[async_trait::async_trait]
@@ -1580,6 +2134,27 @@ async fn cleanup_helper<D: HelperDriver>(
     cleanup_failure.map_or(Ok(()), Err)
 }
 
+async fn cleanup_reset_helper_with_driver<D: HelperDriver>(
+    driver: &D,
+    contract: &HelperContract<'_>,
+    pinned_id: &str,
+) -> Result<(), LocalInitError> {
+    let cleanup = cleanup_helper(driver, contract, Some(pinned_id)).await;
+    if cleanup.is_ok() {
+        return Ok(());
+    }
+    let reconciled = async {
+        driver.driver_verify().await?;
+        verify_helper_absence(driver, contract, Some(pinned_id)).await?;
+        driver.driver_verify().await
+    }
+    .await;
+    match reconciled {
+        Ok(()) => Ok(()),
+        Err(_) => cleanup,
+    }
+}
+
 async fn verify_helper_absence<D: HelperDriver>(
     driver: &D,
     contract: &HelperContract<'_>,
@@ -1658,7 +2233,7 @@ fn exact_container_id_text(id: &str) -> bool {
 }
 
 fn volume_names(installation: &Installation) -> BTreeMap<VolumeRole, String> {
-    VolumeRole::ALL
+    INIT_VOLUME_ORDER
         .into_iter()
         .map(|role| {
             (
@@ -1667,6 +2242,69 @@ fn volume_names(installation: &Installation) -> BTreeMap<VolumeRole, String> {
             )
         })
         .collect()
+}
+
+pub(super) fn reset_volume_order() -> [VolumeRole; 12] {
+    let mut roles = INIT_VOLUME_ORDER
+        .into_iter()
+        .filter(|role| *role != VolumeRole::Desired)
+        .collect::<Vec<_>>();
+    roles.push(VolumeRole::Desired);
+    roles
+        .try_into()
+        .expect("the closed reset order contains all twelve roles")
+}
+
+fn validate_epoch_image(
+    expectation: EpochImageExpectation<'_>,
+    image: &bollard::models::ImageInspect,
+) -> Result<(), LocalInitError> {
+    let image_id = image.id.as_deref().ok_or_else(engine_resource_mismatch)?;
+    let accepted_id = if expectation.source_kind == "release-candidate" {
+        image_id == expectation.config_digest || image_id == expectation.manifest_digest
+    } else {
+        image_id == expectation.config_digest
+            || expectation.platform_manifest_digest == Some(image_id)
+    };
+    if !accepted_id
+        || image.os.as_deref() != Some("linux")
+        || image.architecture.as_deref() != Some("amd64")
+        || image.config.is_none()
+    {
+        return Err(engine_resource_mismatch());
+    }
+    if expectation.source_kind == "release-candidate" {
+        let tag = expectation.inspection_reference()?;
+        let digest = format!(
+            "{}@{}",
+            expectation.canonical_repository, expectation.manifest_digest
+        );
+        if image.repo_tags.as_deref() != Some(std::slice::from_ref(&tag))
+            || if image_id == expectation.config_digest {
+                image.repo_digests.as_deref() != Some(&[])
+            } else {
+                image.repo_digests.as_deref() != Some(std::slice::from_ref(&digest))
+            }
+        {
+            return Err(engine_resource_mismatch());
+        }
+    }
+    Ok(())
+}
+
+fn validate_reset_attachments(
+    attachments: &[String],
+    helper: Option<&ResetHelperBinding>,
+) -> Result<(), LocalInitError> {
+    let expected = helper.map(|helper| helper.container_id.as_str());
+    if match expected {
+        Some(expected) => attachments != [expected],
+        None => !attachments.is_empty(),
+    } {
+        Err(engine_resource_mismatch())
+    } else {
+        Ok(())
+    }
 }
 
 pub(super) fn volume_name(compose_project: &str, role: VolumeRole) -> String {
@@ -1719,7 +2357,7 @@ fn expected_volume_labels(
     installation: &Installation,
     epoch_fingerprint: Sha256Digest,
 ) -> BTreeMap<VolumeRole, BTreeMap<String, String>> {
-    VolumeRole::ALL
+    INIT_VOLUME_ORDER
         .into_iter()
         .map(|role| (role, volume_labels(installation, epoch_fingerprint, role)))
         .collect()
@@ -1925,6 +2563,27 @@ fn validate_helper(
     volumes: &BTreeMap<VolumeRole, String>,
     labels: &BTreeMap<String, String>,
 ) -> Result<(), LocalInitError> {
+    validate_helper_image_ids(
+        container,
+        container_id,
+        name,
+        image,
+        &[image_id],
+        volumes,
+        labels,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+fn validate_helper_image_ids(
+    container: &bollard::models::ContainerInspectResponse,
+    container_id: &str,
+    name: &str,
+    image: &str,
+    accepted_image_ids: &[&str],
+    volumes: &BTreeMap<VolumeRole, String>,
+    labels: &BTreeMap<String, String>,
+) -> Result<(), LocalInitError> {
     let config = container
         .config
         .as_ref()
@@ -1951,7 +2610,10 @@ fn validate_helper(
     if container.id.as_deref() != Some(container_id)
         || !exact_container_id_text(container_id)
         || container.name.as_deref() != Some(format!("/{name}").as_str())
-        || container.image.as_deref() != Some(image_id)
+        || container
+            .image
+            .as_deref()
+            .is_none_or(|image_id| !accepted_image_ids.contains(&image_id))
         || container.platform.as_deref() != Some("linux")
         || config.image.as_deref() != Some(image)
         || config
@@ -2186,6 +2848,10 @@ fn engine_resource_mismatch() -> LocalInitError {
 
 fn materialization_failed() -> LocalInitError {
     LocalInitError::new(LocalInitErrorCode::MaterializationFailed)
+}
+
+fn reset_failed() -> LocalInitError {
+    LocalInitError::new(LocalInitErrorCode::ResetFailed)
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-local/src/init/engine/tests.rs
+++ b/crates/automata-ci-local/src/init/engine/tests.rs
@@ -783,7 +783,14 @@ struct FakeHelperState {
     volumes: BTreeMap<String, bollard::models::Volume>,
     extra_attachment: bool,
     exit_on_request: bool,
-    fail_cleanup: bool,
+    cleanup: CleanupBehavior,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CleanupBehavior {
+    Succeeds,
+    FailsBeforeApply,
+    AppliesThenFails,
 }
 
 struct FakeHelperDriver {
@@ -1089,7 +1096,7 @@ impl FakeHelperDriver {
                 volumes,
                 extra_attachment: false,
                 exit_on_request: false,
-                fail_cleanup: false,
+                cleanup: CleanupBehavior::Succeeds,
             }),
         }
     }
@@ -1271,7 +1278,7 @@ impl HelperDriver for FakeHelperDriver {
     async fn driver_force_remove(&self, id: &str) -> Result<(), LocalInitError> {
         let mut state = self.state.lock().unwrap();
         state.events.push("remove");
-        if state.fail_cleanup {
+        if state.cleanup == CleanupBehavior::FailsBeforeApply {
             return Err(materialization_failed());
         }
         assert_eq!(id, CONTAINER_ID);
@@ -1285,7 +1292,11 @@ impl HelperDriver for FakeHelperDriver {
         {
             state.by_name = None;
         }
-        Ok(())
+        if state.cleanup == CleanupBehavior::AppliesThenFails {
+            Err(materialization_failed())
+        } else {
+            Ok(())
+        }
     }
 
     async fn driver_volume_attachments(&self, _name: &str) -> Result<Vec<String>, LocalInitError> {
@@ -1695,7 +1706,7 @@ async fn cleanup_failure_dominates_latched_cancellation() {
         cancellation.clone(),
         &contract,
     );
-    driver.state.lock().unwrap().fail_cleanup = true;
+    driver.state.lock().unwrap().cleanup = CleanupBehavior::FailsBeforeApply;
     let result = super::super::cancellation_bounded(
         &cancellation,
         run_materializer_with_driver(&driver, &contract, &request, fingerprint(), &cancellation),
@@ -1709,6 +1720,24 @@ async fn cleanup_failure_dominates_latched_cancellation() {
     assert!(state.by_id.is_some());
     assert!(state.by_name.is_some());
     assert!(state.removed.is_empty());
+}
+
+#[tokio::test]
+async fn reset_helper_cleanup_accepts_an_applied_ambiguous_remove_after_exact_absence_proof() {
+    let installation = installation();
+    let contract = contract(&installation);
+    let driver = FakeHelperDriver::new(InjectedAction::None, CancellationToken::new(), &contract);
+    {
+        let mut state = driver.state.lock().unwrap();
+        state.by_id = Some(driver.template.clone());
+        state.by_name = Some(driver.template.clone());
+        state.cleanup = CleanupBehavior::AppliesThenFails;
+    }
+
+    cleanup_reset_helper_with_driver(&driver, &contract, CONTAINER_ID)
+        .await
+        .unwrap();
+    driver.assert_cleaned();
 }
 
 #[tokio::test]
@@ -2720,5 +2749,219 @@ async fn final_owned_union_census_rejects_every_absence_helper_and_drift_class()
         validate_final_owned_union_with_driver(&union_drift, &installation, fingerprint())
             .await
             .is_err()
+    );
+}
+
+#[test]
+fn reset_preflight_allows_only_the_exact_helper_as_a_volume_attachment() {
+    let helper = ResetHelperBinding {
+        reference: "registry.invalid/automata@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        image_id: CANDIDATE_CONFIG_ID.to_owned(),
+        container_id: CONTAINER_ID.to_owned(),
+    };
+    validate_reset_attachments(std::slice::from_ref(&helper.container_id), Some(&helper)).unwrap();
+    validate_reset_attachments(&[], None).unwrap();
+    for attachments in [
+        vec!["d".repeat(64)],
+        vec![helper.container_id.clone(), "d".repeat(64)],
+    ] {
+        assert_eq!(
+            validate_reset_attachments(&attachments, Some(&helper))
+                .unwrap_err()
+                .code(),
+            LocalInitErrorCode::EngineResourceMismatch
+        );
+    }
+    assert!(validate_reset_attachments(&["d".repeat(64)], None).is_err());
+}
+
+#[test]
+fn reset_order_is_complete_unique_and_keeps_desired_last() {
+    let order = reset_volume_order();
+    assert_eq!(order.len(), INIT_VOLUME_ORDER.len());
+    assert_eq!(order.last(), Some(&VolumeRole::Desired));
+    assert_eq!(
+        order.into_iter().collect::<BTreeSet<_>>(),
+        INIT_VOLUME_ORDER.into_iter().collect::<BTreeSet<_>>()
+    );
+}
+
+#[test]
+fn reset_progress_accepts_only_an_absent_prefix_and_anchor_last() {
+    for deleted in 0..=12 {
+        let mut presence = [true; 12];
+        presence[..deleted].fill(false);
+        assert_eq!(
+            reset_progress_from_presence(&presence, true).unwrap(),
+            deleted
+        );
+    }
+    assert_eq!(
+        reset_progress_from_presence(&[false; 12], false).unwrap(),
+        13
+    );
+
+    let mut hole = [true; 12];
+    hole[3] = false;
+    assert_eq!(
+        reset_progress_from_presence(&hole, true)
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::EngineResourceMismatch
+    );
+    assert_eq!(
+        reset_progress_from_presence(&[true; 12], false)
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::EngineResourceMismatch
+    );
+}
+
+#[tokio::test]
+async fn raw_union_supports_reset_suffixes_without_weakening_init_prefixes() {
+    let installation = installation();
+    let expected = Installation::expected(installation.name());
+    let reset_order = reset_volume_order();
+    for deleted in 0..=reset_order.len() {
+        let mut volumes = vec![fake_volume(
+            installation.anchor_volume_name(),
+            &BTreeMap::new(),
+        )];
+        volumes.extend(reset_order[deleted..].iter().map(|role| {
+            let name = volume_name(installation.compose_project().as_str(), *role);
+            let mut volume = fake_volume(&name, &BTreeMap::new());
+            volume
+                .labels
+                .insert("com.example.note".to_owned(), "tolerated".to_owned());
+            volume
+        }));
+        let driver = FakeOwnedUnionDriver {
+            volumes,
+            ..Default::default()
+        };
+        let observed =
+            inspect_owned_union_census_with_driver(&driver, &expected, Some(&installation))
+                .await
+                .unwrap();
+        let presence = reset_order.map(|role| observed.roles.contains(&role));
+        assert_eq!(
+            reset_progress_from_presence(&presence, observed.anchor_present).unwrap(),
+            deleted
+        );
+        if (1..reset_order.len() - 1).contains(&deleted) {
+            assert_eq!(
+                validate_init_owned_union(&observed).unwrap_err().code(),
+                LocalInitErrorCode::EngineResourceMismatch
+            );
+        }
+    }
+
+    let mut contradictory = owned_union_prefix(&installation, true, 1);
+    contradictory.volumes[1].labels.insert(
+        COMPOSE_PROJECT_LABEL.to_owned(),
+        "some-other-project".to_owned(),
+    );
+    assert_eq!(
+        inspect_owned_union_census_with_driver(&contradictory, &expected, Some(&installation),)
+            .await
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::EngineResourceMismatch
+    );
+}
+
+struct FakeExactDeleteDriver {
+    outcome: DeleteAttemptOutcome,
+    present_after: bool,
+    trace: Mutex<Vec<&'static str>>,
+}
+
+#[async_trait::async_trait]
+impl ExactVolumeDeleteDriver for FakeExactDeleteDriver {
+    async fn delete_volume_untrusted(&self, _name: &str) -> DeleteAttemptOutcome {
+        self.trace.lock().unwrap().push("delete");
+        self.outcome
+    }
+
+    async fn inspect_volume_present(&self, _name: &str) -> Result<bool, LocalInitError> {
+        self.trace.lock().unwrap().push("inspect");
+        Ok(self.present_after)
+    }
+
+    async fn verify_after_volume_delete(&self) -> Result<(), LocalInitError> {
+        self.trace.lock().unwrap().push("verify");
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn exact_volume_delete_reconciles_success_error_and_timeout_from_observed_absence() {
+    for outcome in [
+        DeleteAttemptOutcome::Completed,
+        DeleteAttemptOutcome::Failed,
+        DeleteAttemptOutcome::TimedOut,
+    ] {
+        let absent = FakeExactDeleteDriver {
+            outcome,
+            present_after: false,
+            trace: Mutex::new(Vec::new()),
+        };
+        remove_volume_and_prove_absent_with_driver(&absent, "owned")
+            .await
+            .unwrap();
+        assert_eq!(
+            *absent.trace.lock().unwrap(),
+            ["delete", "inspect", "verify"]
+        );
+
+        let present = FakeExactDeleteDriver {
+            outcome,
+            present_after: true,
+            trace: Mutex::new(Vec::new()),
+        };
+        assert_eq!(
+            remove_volume_and_prove_absent_with_driver(&present, "owned")
+                .await
+                .unwrap_err()
+                .code(),
+            LocalInitErrorCode::ResetFailed
+        );
+        assert_eq!(*present.trace.lock().unwrap(), ["delete", "inspect"]);
+    }
+}
+
+#[test]
+fn reset_helper_contract_accepts_sealed_config_or_manifest_id_without_live_image_lookup() {
+    let installation = installation();
+    let contract = contract(&installation);
+    let alternate = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    let mut inspect = valid_helper_inspect(&contract, CONTAINER_ID);
+    inspect.image = Some(alternate.to_owned());
+    validate_helper_image_ids(
+        &inspect,
+        CONTAINER_ID,
+        &contract.name,
+        contract.image,
+        &[contract.image_id, alternate],
+        contract.volumes,
+        &contract.labels,
+    )
+    .unwrap();
+
+    inspect.image =
+        Some("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_owned());
+    assert_eq!(
+        validate_helper_image_ids(
+            &inspect,
+            CONTAINER_ID,
+            &contract.name,
+            contract.image,
+            &[contract.image_id, alternate],
+            contract.volumes,
+            &contract.labels,
+        )
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::MaterializationFailed
     );
 }

--- a/crates/automata-ci-local/src/init/epoch.rs
+++ b/crates/automata-ci-local/src/init/epoch.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr as _};
 
 use automata_ci_core::Sha256Digest;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use zeroize::Zeroizing;
 
-use crate::Installation;
+use crate::{Installation, InstallationId, InstallationName, MAXIMUM_LOCAL_DOCKER_JOB_SLOTS};
 
 use super::{
     LocalInitError, LocalInitErrorCode,
@@ -125,6 +125,64 @@ impl ImmutableEpoch {
         Ok(actual)
     }
 
+    pub(super) fn from_sealed_bytes(
+        bytes: &[u8],
+        state_authority_sha256: Sha256Digest,
+        material_root: &[u8; 32],
+    ) -> Result<Self, LocalInitError> {
+        let actual = Self::from_authority_bound_bytes(bytes, state_authority_sha256)?;
+        if actual.material_root_sha256 != digest(material_root) {
+            return Err(reset_required());
+        }
+        Ok(actual)
+    }
+
+    pub(super) fn from_authority_bound_bytes(
+        bytes: &[u8],
+        state_authority_sha256: Sha256Digest,
+    ) -> Result<Self, LocalInitError> {
+        if bytes.is_empty() || bytes.len() > MAX_EPOCH_BYTES {
+            return Err(reset_required());
+        }
+        let raw: RawEpoch = serde_json::from_slice(bytes).map_err(|_| reset_required())?;
+        if raw.schema != EPOCH_SCHEMA
+            || raw.material_schema != MATERIAL_SCHEMA
+            || raw.generation != GENERATION
+            || canonical_bytes(&raw)? != bytes
+        {
+            return Err(reset_required());
+        }
+        let actual = Self {
+            schema: EPOCH_SCHEMA,
+            material_schema: MATERIAL_SCHEMA,
+            generation: raw.generation,
+            installation: raw.installation,
+            catalog: raw.catalog,
+            platform: raw.platform,
+            capacity: raw.capacity,
+            profile: raw.profile,
+            images: raw.images,
+            state_authority_sha256: raw.state_authority_sha256,
+            material_root_sha256: raw.material_root_sha256,
+            epoch_fingerprint: raw.epoch_fingerprint,
+            initial_desired_sha256: raw.initial_desired_sha256,
+        };
+        if actual.state_authority_sha256 != state_authority_sha256
+            || actual.recompute_fingerprint() != actual.epoch_fingerprint
+            || actual.platform.host != "linux/x86_64"
+            || actual.platform.engine != "linux/amd64"
+            || actual.capacity.workers == 0
+            || actual.capacity.workers > MAXIMUM_LOCAL_DOCKER_JOB_SLOTS
+            || !valid_catalog_identity(&actual.catalog)
+            || !valid_profile(&actual.profile)
+            || !valid_images(&actual.images)
+        {
+            return Err(reset_required());
+        }
+        actual.installation()?;
+        Ok(actual)
+    }
+
     pub(super) fn canonical_bytes(&self) -> Vec<u8> {
         canonical_bytes(self).expect("closed epoch document is serializable")
     }
@@ -139,6 +197,37 @@ impl ImmutableEpoch {
 
     pub(super) const fn initial_desired_sha256(&self) -> Sha256Digest {
         self.initial_desired_sha256
+    }
+
+    pub(super) const fn workers(&self) -> u16 {
+        self.capacity.workers
+    }
+
+    pub(super) fn installation(&self) -> Result<Installation, LocalInitError> {
+        let name =
+            InstallationName::new(self.installation.name.clone()).map_err(|_| reset_required())?;
+        let id = InstallationId::from_str(&self.installation.id).map_err(|_| reset_required())?;
+        let installation = Installation::verified(name, id);
+        if self.installation.selector_key != installation.selector_key().to_string()
+            || self.installation.compose_project != installation.compose_project().as_str()
+        {
+            return Err(reset_required());
+        }
+        Ok(installation)
+    }
+
+    pub(super) fn image_expectations(&self) -> impl Iterator<Item = EpochImageExpectation<'_>> {
+        self.images
+            .iter()
+            .map(|(role, image)| EpochImageExpectation {
+                role,
+                reference: &image.reference,
+                canonical_repository: &image.canonical_repository,
+                source_kind: &image.source_kind,
+                config_digest: &image.config_digest,
+                manifest_digest: &image.manifest_digest,
+                platform_manifest_digest: image.platform_manifest_digest.as_deref(),
+            })
     }
 
     fn recompute_fingerprint(&self) -> Sha256Digest {
@@ -157,6 +246,35 @@ impl ImmutableEpoch {
             initial_desired_sha256: self.initial_desired_sha256,
         }
         .fingerprint()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct EpochImageExpectation<'a> {
+    pub(super) role: &'a str,
+    pub(super) reference: &'a str,
+    pub(super) canonical_repository: &'a str,
+    pub(super) source_kind: &'a str,
+    pub(super) config_digest: &'a str,
+    pub(super) manifest_digest: &'a str,
+    pub(super) platform_manifest_digest: Option<&'a str>,
+}
+
+impl EpochImageExpectation<'_> {
+    pub(super) fn inspection_reference(self) -> Result<String, LocalInitError> {
+        if self.source_kind == "release-candidate" {
+            let digest = self
+                .manifest_digest
+                .strip_prefix("sha256:")
+                .ok_or_else(reset_required)?;
+            Ok(format!("{}:manifest-{digest}", self.canonical_repository))
+        } else {
+            let (repository, _) = self.reference.rsplit_once('@').ok_or_else(reset_required)?;
+            Ok(format!(
+                "{repository}@{}",
+                self.platform_manifest_digest.ok_or_else(reset_required)?
+            ))
+        }
     }
 }
 
@@ -274,6 +392,84 @@ impl EpochDescriptor {
         hasher.update(bytes);
         Sha256Digest::from_bytes(hasher.finalize().into())
     }
+}
+
+fn valid_catalog_identity(catalog: &EpochCatalog) -> bool {
+    catalog.commit.len() == 40
+        && catalog
+            .commit
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && !catalog.tag.is_empty()
+        && catalog.tag.len() <= 128
+        && !catalog.version.is_empty()
+        && catalog.version.len() <= 128
+        && catalog
+            .tag
+            .bytes()
+            .chain(catalog.version.bytes())
+            .all(|byte| byte.is_ascii_graphic())
+}
+
+fn valid_profile(profile: &EpochProfile) -> bool {
+    !profile.id.is_empty()
+        && profile.id.len() <= 256
+        && profile.id.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn valid_images(images: &BTreeMap<String, EpochImage>) -> bool {
+    const ROLES: [&str; 7] = [
+        "automata",
+        "postgres",
+        "profile",
+        "runner",
+        "rustfs",
+        "sandbox-guest",
+        "service-proxy",
+    ];
+    if images.keys().map(String::as_str).collect::<Vec<_>>() != ROLES {
+        return false;
+    }
+    images.iter().all(|(role, image)| {
+        let candidate = role == "service-proxy";
+        let expected_kind = if candidate {
+            "release-candidate"
+        } else {
+            "registry"
+        };
+        let expected_platform = (!candidate).then_some(image.platform_manifest_digest.as_deref());
+        image.source_kind == expected_kind
+            && oci_digest(&image.config_digest)
+            && oci_digest(&image.manifest_digest)
+            && if candidate {
+                image.platform_manifest_digest.is_none()
+            } else {
+                expected_platform.flatten().is_some_and(oci_digest)
+            }
+            && canonical_image_text(&image.reference)
+            && canonical_image_text(&image.canonical_repository)
+            && image
+                .reference
+                .rsplit_once('@')
+                .is_some_and(|(_, digest)| digest == image.manifest_digest)
+    })
+}
+
+fn canonical_image_text(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 512
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && !matches!(byte, b'\\' | b'\'' | b'\"'))
+}
+
+fn oci_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
 }
 
 pub(super) struct MaterialDeriver {
@@ -404,6 +600,54 @@ pub(super) fn certificate_test_epoch(
         epoch_fingerprint: fingerprint,
         initial_desired_sha256: descriptor.initial_desired_sha256,
     }
+}
+
+#[cfg(test)]
+pub(super) fn authority_test_epoch(
+    installation: &Installation,
+    material_root: &[u8; 32],
+    state_authority_sha256: Sha256Digest,
+) -> ImmutableEpoch {
+    let mut epoch = certificate_test_epoch(installation, material_root);
+    epoch.state_authority_sha256 = state_authority_sha256;
+    epoch.images = [
+        "automata",
+        "postgres",
+        "profile",
+        "runner",
+        "rustfs",
+        "sandbox-guest",
+        "service-proxy",
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, role)| {
+        let config = format!("sha256:{}", format!("{:02x}", index + 1).repeat(32));
+        let manifest = format!("sha256:{}", format!("{:02x}", index + 9).repeat(32));
+        let candidate = role == "service-proxy";
+        (
+            role.to_owned(),
+            EpochImage {
+                reference: format!("registry.invalid/{role}@{manifest}"),
+                canonical_repository: format!("automata.local/{role}"),
+                source_kind: if candidate {
+                    "release-candidate"
+                } else {
+                    "registry"
+                }
+                .to_owned(),
+                config_digest: config,
+                manifest_digest: manifest.clone(),
+                platform_manifest_digest: (!candidate).then_some(manifest),
+                runtime_contract_sha256: Sha256Digest::from_bytes(
+                    [u8::try_from(index).expect("closed image index fits u8") + 1; 32],
+                ),
+            },
+        )
+    })
+    .collect();
+    epoch.epoch_fingerprint = epoch.recompute_fingerprint();
+    epoch
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/automata-ci-local/src/init/epoch/tests.rs
+++ b/crates/automata-ci-local/src/init/epoch/tests.rs
@@ -44,3 +44,80 @@ fn initial_desired_and_state_authority_are_exact_replay_predicates() {
         LocalInitErrorCode::ResetRequired
     );
 }
+
+fn standalone_epoch() -> (ImmutableEpoch, [u8; 32]) {
+    let root = [7; 32];
+    let installation = crate::Installation::verified(
+        crate::InstallationName::default(),
+        crate::InstallationId::new(),
+    );
+    let epoch = authority_test_epoch(&installation, &root, Sha256Digest::from_bytes([5; 32]));
+    (epoch, root)
+}
+
+#[test]
+fn standalone_epoch_decode_recomputes_authority_material_and_identity() {
+    let (epoch, root) = standalone_epoch();
+    assert_eq!(
+        ImmutableEpoch::from_authority_bound_bytes(
+            &epoch.canonical_bytes(),
+            Sha256Digest::from_bytes([5; 32]),
+        )
+        .unwrap(),
+        epoch
+    );
+    let decoded = ImmutableEpoch::from_sealed_bytes(
+        &epoch.canonical_bytes(),
+        Sha256Digest::from_bytes([5; 32]),
+        &root,
+    )
+    .unwrap();
+    assert_eq!(decoded, epoch);
+    assert_eq!(decoded.workers(), 1);
+    assert_eq!(decoded.image_expectations().count(), 7);
+
+    assert_eq!(
+        ImmutableEpoch::from_authority_bound_bytes(
+            &epoch.canonical_bytes(),
+            Sha256Digest::from_bytes([6; 32]),
+        )
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    assert_eq!(
+        ImmutableEpoch::from_sealed_bytes(
+            &epoch.canonical_bytes(),
+            Sha256Digest::from_bytes([6; 32]),
+            &root,
+        )
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    assert_eq!(
+        ImmutableEpoch::from_sealed_bytes(
+            &epoch.canonical_bytes(),
+            Sha256Digest::from_bytes([5; 32]),
+            &[8; 32],
+        )
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    let mut copied = epoch.clone();
+    copied.installation.selector_key = "0".repeat(64);
+    copied.epoch_fingerprint = copied.recompute_fingerprint();
+    assert_eq!(
+        ImmutableEpoch::from_sealed_bytes(
+            &copied.canonical_bytes(),
+            Sha256Digest::from_bytes([5; 32]),
+            &root,
+        )
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}

--- a/crates/automata-ci-local/src/init/materializer.rs
+++ b/crates/automata-ci-local/src/init/materializer.rs
@@ -108,7 +108,7 @@ impl VolumeRole {
         }
     }
 
-    const fn is_static(self) -> bool {
+    pub(super) const fn is_static(self) -> bool {
         matches!(
             self,
             Self::ControlMaterial | Self::Desired | Self::PostgresConfig | Self::RustfsConfig

--- a/crates/automata-ci-local/src/init/mod.rs
+++ b/crates/automata-ci-local/src/init/mod.rs
@@ -6,8 +6,13 @@ mod engine;
 mod epoch;
 mod materializer;
 mod state;
+mod status_reset;
 
 pub(crate) use materializer::run_fixed_materializer;
+pub use status_reset::{
+    LocalInstallationStatus, LocalResetOutcome, LocalResetRequest, LocalStatusReport,
+    LocalStatusRequest, inspect_local_status, reset_local,
+};
 
 use std::{fmt, future::Future, net::Ipv4Addr, num::NonZeroU16, path::PathBuf};
 
@@ -44,14 +49,18 @@ pub enum LocalInitErrorCode {
     InvalidCatalogPayload,
     /// The requested worker capacity was outside the release catalog contract.
     InvalidWorkers,
-    /// Initialization was cancelled before mutation completed.
+    /// A local custody operation was cancelled before a durable reset transaction.
     Cancelled,
-    /// Docker preflight or exact Engine initialization failed.
+    /// Destructive reset was not explicitly confirmed.
+    ConfirmationRequired,
+    /// Docker preflight or exact Engine inspection failed.
     EngineUnavailable,
     /// A Docker resource failed its exact immutable custody contract.
     EngineResourceMismatch,
     /// The fixed materialization helper failed or became ambiguous.
     MaterializationFailed,
+    /// Exact reset reconciliation could not prove the requested resource absent.
+    ResetFailed,
 }
 
 impl LocalInitErrorCode {
@@ -65,7 +74,7 @@ impl LocalInitErrorCode {
             }
             Self::StateCollision => "local initialization state changed concurrently",
             Self::ResetRequired => {
-                "local installation custody is missing, corrupt, or incompatible; reset is required"
+                "local installation custody is missing, incomplete, corrupt, or incompatible; exact init replay or authorized recovery is required"
             }
             Self::InvalidCatalogSource => {
                 "catalog source must be one secure explicit file:/absolute/path"
@@ -79,13 +88,17 @@ impl LocalInitErrorCode {
             Self::InvalidWorkers => {
                 "requested workers exceed the immutable release-catalog capacity"
             }
-            Self::Cancelled => "local initialization was cancelled",
-            Self::EngineUnavailable => "the exact Docker Engine is unavailable for initialization",
+            Self::Cancelled => "the local installation operation was cancelled",
+            Self::ConfirmationRequired => "local reset requires explicit confirmation",
+            Self::EngineUnavailable => "the exact Docker Engine is unavailable for this operation",
             Self::EngineResourceMismatch => {
                 "a deterministic Docker resource disagrees with local installation custody"
             }
             Self::MaterializationFailed => {
                 "the fixed local materialization helper failed or became ambiguous"
+            }
+            Self::ResetFailed => {
+                "local reset could not prove exact owned-resource deletion complete"
             }
         }
     }
@@ -198,6 +211,20 @@ impl StateInstallationSelection {
         }
         Ok(())
     }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<InstallationName, LocalInitError> {
+        let actual: Self = serde_json::from_slice(bytes)
+            .map_err(|_| LocalInitError::new(LocalInitErrorCode::ResetRequired))?;
+        if actual.schema != INSTALLATION_SELECTION_SCHEMA || bytes != actual.canonical_bytes()? {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetRequired));
+        }
+        let installation = InstallationName::new(actual.installation)
+            .map_err(|_| LocalInitError::new(LocalInitErrorCode::ResetRequired))?;
+        if actual.selector_key != Installation::expected(&installation).selector_key.digest() {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetRequired));
+        }
+        Ok(installation)
+    }
 }
 
 #[derive(Deserialize, Eq, PartialEq, Serialize)]
@@ -230,6 +257,15 @@ impl StateMaterialization {
         }
         Ok(())
     }
+
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Sha256Digest, LocalInitError> {
+        let actual: Self = serde_json::from_slice(bytes)
+            .map_err(|_| LocalInitError::new(LocalInitErrorCode::ResetRequired))?;
+        if actual.schema != MATERIALIZATION_SCHEMA || bytes != actual.canonical_bytes()? {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetRequired));
+        }
+        Ok(actual.epoch_fingerprint)
+    }
 }
 
 impl LocalInitOutcome {
@@ -257,6 +293,9 @@ pub async fn initialize_local(
     request: LocalInitRequest,
 ) -> Result<LocalInitOutcome, LocalInitError> {
     let state = state::StateRoot::acquire(&request.state_directory)?;
+    if state.reset_intent_present()? {
+        return Err(LocalInitError::new(LocalInitErrorCode::ResetRequired));
+    }
     let evidence = state::EvidenceDirectory::open(&request.catalog_source)?;
     let catalog = catalog::VerifiedCatalog::parse(evidence.catalog())?;
     if request.workers.get() > catalog.maximum_parallel_jobs() {

--- a/crates/automata-ci-local/src/init/state.rs
+++ b/crates/automata-ci-local/src/init/state.rs
@@ -30,6 +30,7 @@ const INIT_RECORDS: [&str; 5] = [
     CERTIFICATE_RECORD,
     MATERIALIZATION_RECORD,
 ];
+const RESET_INTENT_RECORD: &str = "reset-intent.json";
 const MAX_EPOCH_BYTES: usize = 64 * 1024;
 const MAX_CERTIFICATE_RECORD_BYTES: usize = 128 * 1024;
 const MAX_CATALOG_BYTES: usize = 1024 * 1024;
@@ -42,6 +43,111 @@ pub(super) struct StateRoot {
     authority_sha256: Sha256Digest,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct StateSnapshot {
+    pub(super) material_root: Option<Vec<u8>>,
+    pub(super) epoch: Option<Vec<u8>>,
+    pub(super) certificates: Option<Vec<u8>>,
+    pub(super) installation_selection: Option<Vec<u8>>,
+    pub(super) materialization: Option<Vec<u8>>,
+    pub(super) reset_intent: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ResetRecordObservation {
+    present: bool,
+    completed_present: bool,
+    staged_present: bool,
+    completed: Option<Vec<u8>>,
+    staged: Option<Vec<u8>>,
+}
+
+impl ResetRecordObservation {
+    pub(super) const fn present(&self) -> bool {
+        self.present
+    }
+
+    pub(super) const fn completed_present(&self) -> bool {
+        self.completed_present
+    }
+
+    pub(super) const fn staged_present(&self) -> bool {
+        self.staged_present
+    }
+
+    pub(super) fn completed(&self) -> Option<&[u8]> {
+        self.completed.as_deref()
+    }
+
+    pub(super) fn staged(&self) -> Option<&[u8]> {
+        self.staged.as_deref()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ResetStateSnapshot {
+    pub(super) material_root: ResetRecordObservation,
+    pub(super) epoch: ResetRecordObservation,
+    pub(super) certificates: ResetRecordObservation,
+    pub(super) installation_selection: ResetRecordObservation,
+    pub(super) materialization: ResetRecordObservation,
+    pub(super) reset_intent: ResetRecordObservation,
+}
+
+impl ResetStateSnapshot {
+    pub(super) fn is_empty(&self) -> bool {
+        !self.material_root.present()
+            && !self.epoch.present()
+            && !self.certificates.present()
+            && !self.installation_selection.present()
+            && !self.materialization.present()
+            && !self.reset_intent.present()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum StateRecord {
+    Materialization,
+    Certificates,
+    MaterialRoot,
+    InstallationSelection,
+    Epoch,
+    ResetIntent,
+}
+
+impl StateRecord {
+    const ALL: [Self; 6] = [
+        Self::Materialization,
+        Self::Certificates,
+        Self::MaterialRoot,
+        Self::InstallationSelection,
+        Self::Epoch,
+        Self::ResetIntent,
+    ];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Materialization => MATERIALIZATION_RECORD,
+            Self::Certificates => CERTIFICATE_RECORD,
+            Self::MaterialRoot => MATERIAL_ROOT,
+            Self::InstallationSelection => INSTALLATION_SELECTION,
+            Self::Epoch => EPOCH_RECORD,
+            Self::ResetIntent => RESET_INTENT_RECORD,
+        }
+    }
+
+    const fn maximum(self) -> usize {
+        match self {
+            Self::Certificates => MAX_CERTIFICATE_RECORD_BYTES,
+            Self::MaterialRoot => 32,
+            Self::Materialization
+            | Self::InstallationSelection
+            | Self::Epoch
+            | Self::ResetIntent => MAX_EPOCH_BYTES,
+        }
+    }
+}
+
 impl StateRoot {
     pub(super) fn acquire(path: &Path) -> Result<Self, LocalInitError> {
         let (parent, name) = open_parent(path, true)?;
@@ -51,19 +157,13 @@ impl StateRoot {
         }
         let directory =
             openat(&parent, &name, directory_flags(), Mode::empty()).map_err(|_| state_path())?;
-        verify_private_directory(&directory)?;
+        let initial_root = private_directory_metadata(&directory)?;
         fs::fsync(&parent).map_err(|_| state_path())?;
 
         let operation_lock = open_operation_lock(&directory)?;
-        fs::flock(&operation_lock, FlockOperation::NonBlockingLockExclusive).map_err(|error| {
-            if error == rustix::io::Errno::AGAIN {
-                LocalInitError::new(LocalInitErrorCode::OperationInProgress)
-            } else {
-                state_path()
-            }
-        })?;
-        let root_metadata = private_directory_metadata(&directory)?;
-        let lock_metadata = verify_private_regular(&operation_lock, Some(0))?;
+        lock(&operation_lock, FlockOperation::NonBlockingLockExclusive)?;
+        let (root_metadata, lock_metadata) =
+            revalidate_root_and_lock(&parent, &name, &directory, &operation_lock, &initial_root)?;
         let authority_sha256 = state_authority_digest(&root_metadata, &lock_metadata);
         let state = Self {
             directory,
@@ -72,6 +172,36 @@ impl StateRoot {
         };
         state.validate_replay_layout()?;
         Ok(state)
+    }
+
+    pub(super) fn observe_existing(path: &Path) -> Result<Self, LocalInitError> {
+        Self::open_existing(path, FlockOperation::NonBlockingLockShared)
+    }
+
+    pub(super) fn acquire_existing(path: &Path) -> Result<Self, LocalInitError> {
+        Self::open_existing(path, FlockOperation::NonBlockingLockExclusive)
+    }
+
+    fn open_existing(path: &Path, operation: FlockOperation) -> Result<Self, LocalInitError> {
+        let (parent, name) = open_parent(path, true)?;
+        let directory =
+            openat(&parent, &name, directory_flags(), Mode::empty()).map_err(|error| {
+                if error == rustix::io::Errno::NOENT {
+                    reset_required()
+                } else {
+                    state_path()
+                }
+            })?;
+        let initial_root = private_directory_metadata(&directory)?;
+        let operation_lock = open_operation_lock_existing(&directory)?;
+        lock(&operation_lock, operation)?;
+        let (root_metadata, lock_metadata) =
+            revalidate_root_and_lock(&parent, &name, &directory, &operation_lock, &initial_root)?;
+        Ok(Self {
+            directory,
+            _operation_lock: operation_lock,
+            authority_sha256: state_authority_digest(&root_metadata, &lock_metadata),
+        })
     }
 
     pub(super) const fn authority_sha256(&self) -> Sha256Digest {
@@ -100,6 +230,166 @@ impl StateRoot {
         Ok(())
     }
 
+    pub(super) fn reset_intent_present(&self) -> Result<bool, LocalInitError> {
+        let temporary = temporary_name(RESET_INTENT_RECORD);
+        Ok(self
+            .read_private(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?
+            .is_some()
+            || self.read_private(&temporary, MAX_EPOCH_BYTES)?.is_some())
+    }
+
+    pub(super) fn snapshot_read_only(&self) -> Result<StateSnapshot, LocalInitError> {
+        let names = self.exact_entry_names(false)?;
+        let snapshot = StateSnapshot {
+            material_root: self.read_private(MATERIAL_ROOT, 32)?,
+            epoch: self.read_private(EPOCH_RECORD, MAX_EPOCH_BYTES)?,
+            certificates: self.read_private(CERTIFICATE_RECORD, MAX_CERTIFICATE_RECORD_BYTES)?,
+            installation_selection: self.read_private(INSTALLATION_SELECTION, MAX_EPOCH_BYTES)?,
+            materialization: self.read_private(MATERIALIZATION_RECORD, MAX_EPOCH_BYTES)?,
+            reset_intent: self.read_private(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?,
+        };
+        let repeated = self.exact_entry_names(false)?;
+        if repeated != names {
+            return Err(reset_required());
+        }
+        if snapshot.reset_intent.is_none() {
+            validate_init_record_layout(&repeated, None)?;
+        }
+        Ok(snapshot)
+    }
+
+    pub(super) fn snapshot_for_reset(&self) -> Result<ResetStateSnapshot, LocalInitError> {
+        let names = self.exact_entry_names(true)?;
+        let snapshot = ResetStateSnapshot {
+            material_root: self.observe_record_for_reset(StateRecord::MaterialRoot)?,
+            epoch: self.observe_record_for_reset(StateRecord::Epoch)?,
+            certificates: self.observe_record_for_reset(StateRecord::Certificates)?,
+            installation_selection: self
+                .observe_record_for_reset(StateRecord::InstallationSelection)?,
+            materialization: self.observe_record_for_reset(StateRecord::Materialization)?,
+            reset_intent: self.observe_record_for_reset(StateRecord::ResetIntent)?,
+        };
+        if self.exact_entry_names(true)? != names {
+            return Err(reset_required());
+        }
+        Ok(snapshot)
+    }
+
+    pub(super) fn observe_reset_intent_for_reset(
+        &self,
+    ) -> Result<ResetRecordObservation, LocalInitError> {
+        self.observe_record_for_reset(StateRecord::ResetIntent)
+    }
+
+    pub(super) fn reconcile_validated_reset_intent(
+        &self,
+        expected: &[u8],
+    ) -> Result<Vec<u8>, LocalInitError> {
+        let temporary = temporary_name(RESET_INTENT_RECORD);
+        let completed = self.observe_private_for_reset(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?;
+        let staged = self.observe_private_for_reset(&temporary, MAX_EPOCH_BYTES)?;
+        let completed_bytes = readable_reset_authority(&completed)?;
+        let staged_bytes = readable_reset_authority(&staged)?;
+        let Some(staged_bytes) = staged_bytes else {
+            return match completed_bytes {
+                Some(completed_bytes) if completed_bytes == expected => {
+                    Ok(completed_bytes.to_vec())
+                }
+                _ => Err(reset_required()),
+            };
+        };
+        if let Some(completed_bytes) = completed_bytes {
+            if completed_bytes != expected || staged_bytes != expected {
+                return Err(reset_required());
+            }
+            self.remove_private_for_reset(&temporary, MAX_EPOCH_BYTES)?;
+            let published = self.observe_private_for_reset(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?;
+            let residual = self.observe_private_for_reset(&temporary, MAX_EPOCH_BYTES)?;
+            if readable_reset_authority(&published)? != Some(expected) || residual.present {
+                return Err(reset_required());
+            }
+            return Ok(expected.to_vec());
+        }
+        if staged_bytes != expected {
+            return Err(reset_required());
+        }
+        renameat_with(
+            &self.directory,
+            &temporary,
+            &self.directory,
+            RESET_INTENT_RECORD,
+            rustix::fs::RenameFlags::NOREPLACE,
+        )
+        .map_err(|_| reset_required())?;
+        fs::fsync(&self.directory).map_err(|_| reset_required())?;
+        let published = self.observe_private_for_reset(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?;
+        let residual = self.observe_private_for_reset(&temporary, MAX_EPOCH_BYTES)?;
+        if readable_reset_authority(&published)? != Some(staged_bytes) || residual.present {
+            return Err(reset_required());
+        }
+        Ok(staged_bytes.to_vec())
+    }
+
+    pub(super) fn store_reset_intent(&self, bytes: &[u8]) -> Result<(), LocalInitError> {
+        if bytes.is_empty() || bytes.len() > MAX_EPOCH_BYTES {
+            return Err(state_path());
+        }
+        self.exact_entry_names(true)?;
+        let completed = self.read_private(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?;
+        let recovered = self.recover_temporary(
+            RESET_INTENT_RECORD,
+            MAX_EPOCH_BYTES,
+            completed.as_deref().or(Some(bytes)),
+        )?;
+        if let Some(existing) = completed.or(recovered) {
+            if existing != bytes {
+                return Err(reset_required());
+            }
+        } else {
+            let result = match self.create_private(RESET_INTENT_RECORD, bytes) {
+                Ok(()) => Ok(()),
+                Err(error) if error.code() == LocalInitErrorCode::StateCollision => {
+                    if self
+                        .read_private(RESET_INTENT_RECORD, MAX_EPOCH_BYTES)?
+                        .as_deref()
+                        == Some(bytes)
+                    {
+                        Ok(())
+                    } else {
+                        Err(reset_required())
+                    }
+                }
+                Err(error) => Err(error),
+            };
+            result?;
+        }
+        let snapshot = self.snapshot_for_reset()?;
+        if snapshot.reset_intent.completed() != Some(bytes)
+            || snapshot.reset_intent.staged_present()
+        {
+            return Err(reset_required());
+        }
+        Ok(())
+    }
+
+    pub(super) fn remove_record(&self, record: StateRecord) -> Result<(), LocalInitError> {
+        let name = record.name();
+        let temporary = temporary_name(name);
+        for candidate in [&temporary, name] {
+            self.remove_private_for_reset(candidate, record.maximum())?;
+        }
+        if self
+            .observe_private_for_reset(name, record.maximum())?
+            .present
+            || self
+                .observe_private_for_reset(&temporary, record.maximum())?
+                .present
+        {
+            return Err(reset_required());
+        }
+        Ok(())
+    }
+
     /// Requires the four authority/material records and no temporary before
     /// the first durable materialization-complete publication.
     pub(super) fn validate_before_materialization(&self) -> Result<(), LocalInitError> {
@@ -112,6 +402,52 @@ impl StateRoot {
     pub(super) fn validate_complete(&self) -> Result<(), LocalInitError> {
         let names = self.entry_names()?;
         validate_init_record_layout(&names, Some(INIT_RECORDS.len()))
+    }
+
+    fn remove_private_for_reset(&self, name: &str, maximum: usize) -> Result<(), LocalInitError> {
+        if self.observe_private_for_reset(name, maximum)?.present {
+            let _attempt = fs::unlinkat(&self.directory, name, fs::AtFlags::empty());
+            if self.observe_private_for_reset(name, maximum)?.present
+                || fs::fsync(&self.directory).is_err()
+            {
+                return Err(reset_required());
+            }
+        }
+        Ok(())
+    }
+
+    fn exact_entry_names(
+        &self,
+        allow_temporaries: bool,
+    ) -> Result<BTreeSet<String>, LocalInitError> {
+        let mut allowed = BTreeSet::from([OPERATION_LOCK.to_owned()]);
+        for record in StateRecord::ALL {
+            allowed.insert(record.name().to_owned());
+            if allow_temporaries {
+                allowed.insert(temporary_name(record.name()));
+            }
+        }
+        let names = self.entry_names()?;
+        if !names.contains(OPERATION_LOCK) || names.iter().any(|name| !allowed.contains(name)) {
+            return Err(reset_required());
+        }
+        Ok(names)
+    }
+
+    fn observe_record_for_reset(
+        &self,
+        record: StateRecord,
+    ) -> Result<ResetRecordObservation, LocalInitError> {
+        let completed = self.observe_private_for_reset(record.name(), record.maximum())?;
+        let temporary =
+            self.observe_private_for_reset(&temporary_name(record.name()), record.maximum())?;
+        Ok(ResetRecordObservation {
+            present: completed.present || temporary.present,
+            completed_present: completed.present,
+            staged_present: temporary.present,
+            completed: completed.completed,
+            staged: temporary.completed,
+        })
     }
 
     pub(super) fn load_material_root(&self) -> Result<Option<[u8; 32]>, LocalInitError> {
@@ -285,6 +621,66 @@ impl StateRoot {
             return Err(reset_required());
         }
         Ok(Some(bytes))
+    }
+
+    fn observe_private_for_reset(
+        &self,
+        name: &str,
+        maximum: usize,
+    ) -> Result<ResetRecordObservation, LocalInitError> {
+        let descriptor = match openat(
+            &self.directory,
+            name,
+            OFlags::PATH | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            Mode::empty(),
+        ) {
+            Ok(descriptor) => descriptor,
+            Err(rustix::io::Errno::NOENT) => return Ok(ResetRecordObservation::default()),
+            Err(_) => return Err(reset_required()),
+        };
+        let before = verify_safe_reset_regular(&descriptor)?;
+        let size = usize::try_from(before.st_size).map_err(|_| reset_required())?;
+        if size == 0 || size > maximum || before.st_mode & 0o400 == 0 {
+            let after = fstat(&descriptor).map_err(|_| reset_required())?;
+            if !same_file(&before, &after) {
+                return Err(reset_required());
+            }
+            return Ok(ResetRecordObservation {
+                present: true,
+                completed_present: true,
+                staged_present: false,
+                completed: None,
+                staged: None,
+            });
+        }
+        let readable = openat(
+            &self.directory,
+            name,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+            Mode::empty(),
+        )
+        .map_err(|_| reset_required())?;
+        let readable_before = verify_safe_reset_regular(&readable)?;
+        if !same_file(&before, &readable_before) {
+            return Err(reset_required());
+        }
+        let mut file = File::from(readable);
+        let mut bytes = Vec::with_capacity(size);
+        std::io::Read::by_ref(&mut file)
+            .take(u64::try_from(maximum + 1).expect("bounded state file size fits u64"))
+            .read_to_end(&mut bytes)
+            .map_err(|_| reset_required())?;
+        let after = fstat(&file).map_err(|_| reset_required())?;
+        if bytes.len() != size || !same_file(&readable_before, &after) {
+            return Err(reset_required());
+        }
+        Ok(ResetRecordObservation {
+            present: true,
+            completed_present: true,
+            staged_present: false,
+            completed: Some(bytes),
+            staged: None,
+        })
     }
 
     fn create_private(&self, name: &str, bytes: &[u8]) -> Result<(), LocalInitError> {
@@ -461,6 +857,63 @@ fn open_operation_lock(directory: &OwnedFd) -> Result<OwnedFd, LocalInitError> {
     Ok(descriptor)
 }
 
+fn open_operation_lock_existing(directory: &OwnedFd) -> Result<OwnedFd, LocalInitError> {
+    let descriptor = openat(
+        directory,
+        OPERATION_LOCK,
+        OFlags::RDWR | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(|_| reset_required())?;
+    verify_private_regular(&descriptor, Some(0))?;
+    Ok(descriptor)
+}
+
+fn lock(descriptor: &OwnedFd, operation: FlockOperation) -> Result<(), LocalInitError> {
+    fs::flock(descriptor, operation).map_err(|error| {
+        if error == rustix::io::Errno::AGAIN {
+            LocalInitError::new(LocalInitErrorCode::OperationInProgress)
+        } else {
+            state_path()
+        }
+    })
+}
+
+fn revalidate_root_and_lock(
+    parent: &OwnedFd,
+    name: &OsStr,
+    directory: &OwnedFd,
+    operation_lock: &OwnedFd,
+    initial_root: &rustix::fs::Stat,
+) -> Result<(rustix::fs::Stat, rustix::fs::Stat), LocalInitError> {
+    let root_metadata = private_directory_metadata(directory)?;
+    let rebound_root =
+        openat(parent, name, directory_flags(), Mode::empty()).map_err(|_| reset_required())?;
+    let rebound_root_metadata = private_directory_metadata(&rebound_root)?;
+    let lock_metadata = verify_private_regular(operation_lock, Some(0))?;
+    let rebound_lock = open_operation_lock_existing(directory)?;
+    let rebound_lock_metadata = verify_private_regular(&rebound_lock, Some(0))?;
+    if !same_inode(initial_root, &root_metadata)
+        || !same_inode(&root_metadata, &rebound_root_metadata)
+        || !same_inode(&lock_metadata, &rebound_lock_metadata)
+        || lock_metadata.st_ctime != rebound_lock_metadata.st_ctime
+        || lock_metadata.st_ctime_nsec != rebound_lock_metadata.st_ctime_nsec
+    {
+        return Err(reset_required());
+    }
+    Ok((root_metadata, lock_metadata))
+}
+
+fn readable_reset_authority(
+    observation: &ResetRecordObservation,
+) -> Result<Option<&[u8]>, LocalInitError> {
+    match (observation.present, observation.completed.as_deref()) {
+        (false, None) => Ok(None),
+        (true, Some(bytes)) => Ok(Some(bytes)),
+        _ => Err(reset_required()),
+    }
+}
+
 pub(super) struct EvidenceDirectory {
     directory: OwnedFd,
     catalog: Vec<u8>,
@@ -597,10 +1050,6 @@ fn verify_trusted_ancestor(directory: &OwnedFd, state: bool) -> Result<(), Local
     Ok(())
 }
 
-fn verify_private_directory(directory: &OwnedFd) -> Result<(), LocalInitError> {
-    private_directory_metadata(directory).map(|_| ())
-}
-
 fn private_directory_metadata(directory: &OwnedFd) -> Result<rustix::fs::Stat, LocalInitError> {
     let metadata = fstat(directory).map_err(|_| state_path())?;
     if FileType::from_raw_mode(metadata.st_mode) != FileType::Directory
@@ -647,6 +1096,18 @@ fn verify_private_regular(
     Ok(metadata)
 }
 
+fn verify_safe_reset_regular(file: &OwnedFd) -> Result<rustix::fs::Stat, LocalInitError> {
+    let metadata = fstat(file).map_err(|_| reset_required())?;
+    if FileType::from_raw_mode(metadata.st_mode) != FileType::RegularFile
+        || metadata.st_uid != rustix::process::geteuid().as_raw()
+        || metadata.st_nlink != 1
+        || metadata.st_mode & 0o7077 != 0
+    {
+        return Err(reset_required());
+    }
+    Ok(metadata)
+}
+
 fn same_file(left: &rustix::fs::Stat, right: &rustix::fs::Stat) -> bool {
     left.st_dev == right.st_dev
         && left.st_ino == right.st_ino
@@ -659,6 +1120,10 @@ fn same_file(left: &rustix::fs::Stat, right: &rustix::fs::Stat) -> bool {
         && left.st_mtime_nsec == right.st_mtime_nsec
         && left.st_ctime == right.st_ctime
         && left.st_ctime_nsec == right.st_ctime_nsec
+}
+
+fn same_inode(left: &rustix::fs::Stat, right: &rustix::fs::Stat) -> bool {
+    left.st_dev == right.st_dev && left.st_ino == right.st_ino
 }
 
 fn path_error(state: bool) -> LocalInitError {

--- a/crates/automata-ci-local/src/init/state/tests.rs
+++ b/crates/automata-ci-local/src/init/state/tests.rs
@@ -38,14 +38,19 @@ impl TestDirectory {
     }
 
     fn private_file(&self, name: &str, bytes: &[u8]) {
+        self.private_file_mode(name, bytes, 0o600);
+    }
+
+    fn private_file_mode(&self, name: &str, bytes: &[u8], mode: u32) {
         let mut file = OpenOptions::new()
             .write(true)
             .create_new(true)
-            .mode(0o600)
+            .mode(mode)
             .open(self.join(name))
             .unwrap();
         file.write_all(bytes).unwrap();
         file.sync_all().unwrap();
+        fs::set_permissions(self.join(name), fs::Permissions::from_mode(mode)).unwrap();
     }
 }
 
@@ -533,4 +538,251 @@ fn noncanonical_absolute_paths_are_rejected() {
             "{path}"
         );
     }
+}
+
+#[test]
+fn existing_observers_never_create_or_repair_state() {
+    let parent = TestDirectory::new();
+    let absent = parent.join("absent");
+    assert_eq!(
+        StateRoot::observe_existing(&absent).err().unwrap().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    assert!(!absent.exists());
+
+    let incomplete = parent.join("incomplete");
+    fs::create_dir(&incomplete).unwrap();
+    fs::set_permissions(&incomplete, fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(
+        StateRoot::observe_existing(&incomplete)
+            .err()
+            .unwrap()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    assert!(!incomplete.join(OPERATION_LOCK).exists());
+}
+
+#[test]
+fn shared_observation_is_nonrepairing_and_excludes_a_writer() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let writer = StateRoot::acquire(&path).unwrap();
+    writer.store_installation_selection(b"selection\n").unwrap();
+    writer.create_material_root().unwrap();
+    writer.store_epoch(b"epoch\n").unwrap();
+    drop(writer);
+
+    let first = StateRoot::observe_existing(&path).unwrap();
+    let second = StateRoot::observe_existing(&path).unwrap();
+    assert_eq!(
+        StateRoot::acquire_existing(&path).err().unwrap().code(),
+        LocalInitErrorCode::OperationInProgress
+    );
+    assert_eq!(
+        first.snapshot_read_only().unwrap().epoch.unwrap(),
+        b"epoch\n"
+    );
+    drop(second);
+
+    let temporary = temporary_name(CERTIFICATE_RECORD);
+    parent.private_file(&format!("state/{temporary}"), b"certificate\n");
+    assert_eq!(
+        first.snapshot_read_only().unwrap_err().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    assert!(
+        path.join(temporary).exists(),
+        "status must not publish or unlink"
+    );
+}
+
+#[test]
+fn reset_intent_poison_observation_does_not_publish_its_temporary() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    let temporary = temporary_name(RESET_INTENT_RECORD);
+    parent.private_file(&format!("state/{temporary}"), b"intent\n");
+
+    assert!(state.reset_intent_present().unwrap());
+    assert!(path.join(&temporary).exists());
+    assert!(!path.join(RESET_INTENT_RECORD).exists());
+}
+
+#[test]
+fn reset_snapshot_accepts_safe_opaque_records_that_strict_status_rejects() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    parent.private_file("state/material-root", b"");
+    parent.private_file(
+        "state/certificates.json",
+        &vec![b'x'; MAX_CERTIFICATE_RECORD_BYTES + 1],
+    );
+    parent.private_file("state/installation-selection.json", b"not-json\n");
+    parent.private_file("state/materialization.json", b"{malformed}\n");
+    parent.private_file("state/epoch.json", b"epoch-evidence\n");
+
+    let snapshot = state.snapshot_for_reset().unwrap();
+    assert!(snapshot.material_root.present());
+    assert_eq!(snapshot.material_root.completed(), None);
+    assert!(snapshot.certificates.present());
+    assert_eq!(snapshot.certificates.completed(), None);
+    assert_eq!(
+        snapshot.installation_selection.completed(),
+        Some(b"not-json\n".as_slice())
+    );
+    assert_eq!(
+        snapshot.materialization.completed(),
+        Some(b"{malformed}\n".as_slice())
+    );
+    assert_eq!(
+        state.snapshot_read_only().unwrap_err().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    for record in StateRecord::ALL {
+        state.remove_record(record).unwrap();
+    }
+    assert!(state.snapshot_for_reset().unwrap().is_empty());
+    assert!(path.join(OPERATION_LOCK).is_file());
+}
+
+#[test]
+fn reset_snapshot_accepts_owner_only_mode_drift_and_removes_unreadable_evidence() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    parent.private_file_mode("state/material-root", b"material\n", 0o400);
+    parent.private_file_mode("state/certificates.json", b"opaque\n", 0o000);
+    parent.private_file_mode("state/installation-selection.json", b"malformed\n", 0o700);
+
+    let snapshot = state.snapshot_for_reset().unwrap();
+    assert_eq!(
+        snapshot.material_root.completed(),
+        Some(b"material\n".as_slice())
+    );
+    assert!(snapshot.certificates.present());
+    assert_eq!(snapshot.certificates.completed(), None);
+    assert_eq!(
+        snapshot.installation_selection.completed(),
+        Some(b"malformed\n".as_slice())
+    );
+    for record in StateRecord::ALL {
+        state.remove_record(record).unwrap();
+    }
+    assert!(state.snapshot_for_reset().unwrap().is_empty());
+}
+
+#[test]
+fn reset_authority_records_require_owner_read_but_not_exact_mode() {
+    let readable_parent = TestDirectory::new();
+    let readable_path = readable_parent.join("state");
+    let readable = StateRoot::acquire(&readable_path).unwrap();
+    readable_parent.private_file_mode("state/reset-intent.json", b"intent\n", 0o400);
+    assert_eq!(
+        readable
+            .reconcile_validated_reset_intent(b"intent\n")
+            .unwrap(),
+        b"intent\n"
+    );
+
+    let unreadable_parent = TestDirectory::new();
+    let unreadable_path = unreadable_parent.join("state");
+    let unreadable = StateRoot::acquire(&unreadable_path).unwrap();
+    unreadable_parent.private_file_mode("state/reset-intent.json", b"intent\n", 0o000);
+    assert_eq!(
+        unreadable
+            .reconcile_validated_reset_intent(b"intent\n")
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}
+
+#[test]
+fn reset_snapshot_rejects_unknown_names_and_unsafe_fixed_records() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    parent.private_file("state/unknown.json", b"unknown\n");
+    assert_eq!(
+        state.snapshot_for_reset().unwrap_err().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    fs::remove_file(path.join("unknown.json")).unwrap();
+    symlink("/dev/null", path.join(MATERIAL_ROOT)).unwrap();
+    assert_eq!(
+        state.snapshot_for_reset().unwrap_err().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    for mode in [0o640, 0o604, 0o4600] {
+        let parent = TestDirectory::new();
+        let path = parent.join("state");
+        let state = StateRoot::acquire(&path).unwrap();
+        parent.private_file_mode("state/material-root", b"unsafe\n", mode);
+        assert_eq!(
+            state.snapshot_for_reset().unwrap_err().code(),
+            LocalInitErrorCode::ResetRequired,
+            "unsafe mode {mode:o}"
+        );
+    }
+
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    parent.private_file("state/material-root", b"linked\n");
+    fs::hard_link(path.join(MATERIAL_ROOT), parent.join("linked-evidence")).unwrap();
+    assert_eq!(
+        state.snapshot_for_reset().unwrap_err().code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}
+
+#[test]
+fn exact_reset_record_erasure_retains_the_original_root_and_lock() {
+    let parent = TestDirectory::new();
+    let path = parent.join("state");
+    let state = StateRoot::acquire(&path).unwrap();
+    let authority = state.authority_sha256();
+    state.create_private(MATERIAL_ROOT, &[0x55; 32]).unwrap();
+    state.create_private(EPOCH_RECORD, b"epoch\n").unwrap();
+    state
+        .create_private(CERTIFICATE_RECORD, b"certificates\n")
+        .unwrap();
+    state
+        .create_private(INSTALLATION_SELECTION, b"selection\n")
+        .unwrap();
+    state
+        .create_private(MATERIALIZATION_RECORD, b"materialization\n")
+        .unwrap();
+    state
+        .create_private(RESET_INTENT_RECORD, b"reset-intent\n")
+        .unwrap();
+
+    for record in [
+        StateRecord::Materialization,
+        StateRecord::Certificates,
+        StateRecord::MaterialRoot,
+        StateRecord::InstallationSelection,
+    ] {
+        state.remove_record(record).unwrap();
+        assert!(
+            path.join(EPOCH_RECORD).exists(),
+            "epoch is the late sentinel"
+        );
+        assert!(path.join(RESET_INTENT_RECORD).exists());
+    }
+    state.remove_record(StateRecord::Epoch).unwrap();
+    assert!(path.join(RESET_INTENT_RECORD).exists());
+    state.remove_record(StateRecord::ResetIntent).unwrap();
+    assert_eq!(
+        state.snapshot_read_only().unwrap(),
+        StateSnapshot::default()
+    );
+    assert!(path.is_dir());
+    assert!(path.join(OPERATION_LOCK).is_file());
+    assert_eq!(state.authority_sha256(), authority);
 }

--- a/crates/automata-ci-local/src/init/status_reset.rs
+++ b/crates/automata-ci-local/src/init/status_reset.rs
@@ -1,0 +1,1068 @@
+use std::{fmt, future::Future, path::PathBuf, str::FromStr as _};
+
+use automata_ci_core::Sha256Digest;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use tokio_util::sync::CancellationToken;
+
+use crate::{DockerInstallationAdapter, Installation, InstallationId, InstallationName};
+
+use super::{
+    LocalInitError, LocalInitErrorCode, StateInstallationSelection, StateMaterialization,
+    certificates,
+    engine::{InitEngine, ResetHelperBinding, SealedEngineStatus, reset_volume_order},
+    epoch::{ImmutableEpoch, MaterialDeriver},
+    state::{ResetStateSnapshot, StateRecord, StateRoot, StateSnapshot},
+};
+
+const STATUS_SCHEMA: &str = "automata.local/status/v1";
+const RESET_INTENT_SCHEMA: &str = "automata.local/reset-intent/v1";
+const HOST_RESET_ORDER: [StateRecord; 5] = [
+    StateRecord::Materialization,
+    StateRecord::Certificates,
+    StateRecord::MaterialRoot,
+    StateRecord::InstallationSelection,
+    StateRecord::Epoch,
+];
+
+/// Exact high-level state of the explicit local-installation custody root.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalInstallationStatus {
+    /// Initialization has not durably committed every sealed host record.
+    Incomplete,
+    /// Host records and Engine metadata are exact; volume contents were not live-inspected.
+    RecordedSealed,
+    /// An authority-bound reset transaction is durably completing or replaying.
+    ResetInProgress,
+}
+
+/// Stable redacted report for one explicitly selected state directory.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LocalStatusReport {
+    schema: &'static str,
+    status: LocalInstallationStatus,
+    installation: Option<String>,
+    installation_id: Option<String>,
+    workers: Option<u16>,
+    epoch_fingerprint: Option<Sha256Digest>,
+    records: StatusRecords,
+    engine: Option<StatusEngine>,
+    volume_contents: &'static str,
+    reset: Option<StatusReset>,
+}
+
+impl LocalStatusReport {
+    /// Returns the exact high-level custody state.
+    #[must_use]
+    pub const fn status(&self) -> LocalInstallationStatus {
+        self.status
+    }
+
+    /// Returns the canonical installation selector when one is recorded.
+    #[must_use]
+    pub fn installation(&self) -> Option<&str> {
+        self.installation.as_deref()
+    }
+
+    /// Returns the immutable installation identity when it is established.
+    #[must_use]
+    pub fn installation_id(&self) -> Option<&str> {
+        self.installation_id.as_deref()
+    }
+
+    /// Returns the recorded immutable worker capacity when an epoch exists.
+    #[must_use]
+    pub const fn workers(&self) -> Option<u16> {
+        self.workers
+    }
+
+    /// Returns the recorded epoch fingerprint when an epoch exists.
+    #[must_use]
+    pub const fn epoch_fingerprint(&self) -> Option<Sha256Digest> {
+        self.epoch_fingerprint
+    }
+
+    /// Returns the number of exact live image representations inspected.
+    #[must_use]
+    pub fn image_count(&self) -> usize {
+        self.engine.as_ref().map_or(0, |engine| engine.images.len())
+    }
+
+    /// Returns the number of exact owned volumes currently present.
+    #[must_use]
+    pub fn volume_count(&self) -> usize {
+        self.engine
+            .as_ref()
+            .map_or(0, |engine| engine.volumes.len())
+    }
+
+    /// Returns reset progress as removed and total Engine resources.
+    #[must_use]
+    pub const fn reset_progress(&self) -> Option<(usize, usize)> {
+        match &self.reset {
+            Some(reset) => Some((reset.removed_resources, reset.total_resources)),
+            None => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StatusRecords {
+    installation_selection: RecordPresence,
+    material_root: RecordPresence,
+    epoch: RecordPresence,
+    certificates: RecordPresence,
+    materialization: RecordPresence,
+    reset_intent: RecordPresence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+struct RecordPresence(bool);
+
+impl From<bool> for RecordPresence {
+    fn from(present: bool) -> Self {
+        Self(present)
+    }
+}
+
+impl From<&StateSnapshot> for StatusRecords {
+    fn from(snapshot: &StateSnapshot) -> Self {
+        Self {
+            installation_selection: snapshot.installation_selection.is_some().into(),
+            material_root: snapshot.material_root.is_some().into(),
+            epoch: snapshot.epoch.is_some().into(),
+            certificates: snapshot.certificates.is_some().into(),
+            materialization: snapshot.materialization.is_some().into(),
+            reset_intent: snapshot.reset_intent.is_some().into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StatusEngine {
+    identity: &'static str,
+    image_representations: &'static str,
+    images: Vec<StatusImage>,
+    owned_union: &'static str,
+    volumes: Vec<StatusVolume>,
+    attachments: &'static str,
+    unknown_managed_resources: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StatusImage {
+    role: String,
+    source_kind: String,
+    inspection_reference: String,
+    image_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StatusVolume {
+    role: String,
+    name: String,
+    static_material: bool,
+    manifest: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StatusReset {
+    removed_resources: usize,
+    total_resources: usize,
+}
+
+/// Explicit read-only local status request.
+#[derive(Clone)]
+pub struct LocalStatusRequest {
+    state_directory: PathBuf,
+    cancellation: CancellationToken,
+}
+
+impl LocalStatusRequest {
+    /// Constructs a status request for one canonical absolute state directory.
+    #[must_use]
+    pub fn new(state_directory: PathBuf, cancellation: CancellationToken) -> Self {
+        Self {
+            state_directory,
+            cancellation,
+        }
+    }
+}
+
+impl fmt::Debug for LocalStatusRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalStatusRequest")
+            .field("state_directory", &self.state_directory)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Explicit destructive reset request.
+#[derive(Clone)]
+pub struct LocalResetRequest {
+    state_directory: PathBuf,
+    confirmed: bool,
+    cancellation: CancellationToken,
+}
+
+impl LocalResetRequest {
+    /// Constructs one reset request; callers must pass an explicit confirmation.
+    #[must_use]
+    pub fn new(state_directory: PathBuf, confirmed: bool, cancellation: CancellationToken) -> Self {
+        Self {
+            state_directory,
+            confirmed,
+            cancellation,
+        }
+    }
+}
+
+impl fmt::Debug for LocalResetRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalResetRequest")
+            .field("state_directory", &self.state_directory)
+            .field("confirmed", &self.confirmed)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Successful exact reset result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalResetOutcome {
+    installation: InstallationName,
+    removed_volumes: u8,
+    images_retained: bool,
+    completed_after_cancellation: bool,
+}
+
+impl LocalResetOutcome {
+    /// Returns the reset installation selector.
+    #[must_use]
+    pub const fn installation(&self) -> &InstallationName {
+        &self.installation
+    }
+
+    /// Returns the number of deterministic role volumes removed, excluding the identity anchor.
+    #[must_use]
+    pub const fn removed_volumes(&self) -> u8 {
+        self.removed_volumes
+    }
+
+    /// Returns whether imported and pulled images were deliberately retained.
+    #[must_use]
+    pub const fn images_retained(&self) -> bool {
+        self.images_retained
+    }
+
+    /// Returns whether cancellation arrived after the durable reset intent.
+    #[must_use]
+    pub const fn completed_after_cancellation(&self) -> bool {
+        self.completed_after_cancellation
+    }
+}
+
+struct EstablishedState {
+    installation: Installation,
+    epoch: ImmutableEpoch,
+}
+
+enum ValidatedHostState {
+    Incomplete {
+        installation: Option<InstallationName>,
+        epoch: Option<ImmutableEpoch>,
+    },
+    Established(EstablishedState),
+}
+
+/// Inspects sealed custody without creating, repairing, or deleting host or Engine state.
+///
+/// Successful `recorded_sealed` status attests host records, identity, labels,
+/// names, image representations, attachments, and the complete managed union.
+/// It deliberately does not attest bytes inside named volumes.
+///
+/// # Errors
+///
+/// Returns a redacted failure for path, lock, custody, Engine, or cancellation drift.
+pub async fn inspect_local_status(
+    request: LocalStatusRequest,
+) -> Result<LocalStatusReport, LocalInitError> {
+    cancellation_checkpoint(&request.cancellation)?;
+    let state = StateRoot::observe_existing(&request.state_directory)?;
+    let snapshot = state.snapshot_read_only()?;
+    let records = StatusRecords::from(&snapshot);
+    if let Some(bytes) = snapshot.reset_intent.as_deref() {
+        let intent = ResetIntent::from_canonical_bytes(bytes, state.authority_sha256())?;
+        intent.validate_intent_bytes(snapshot.reset_intent.as_deref())?;
+        intent.validate_status_snapshot(&snapshot)?;
+        cancellation_checkpoint(&request.cancellation)?;
+        let adapter = connect_adapter().await?;
+        let engine = InitEngine::connect(&adapter).await?;
+        let (persistent_removed, helper_present) = match engine
+            .inspect_reset_progress(&intent.installation, intent.epoch_fingerprint)
+            .await
+        {
+            Ok(removed) => (removed, false),
+            Err(error) if intent.helper.is_some() => {
+                let Some(epoch_bytes) = snapshot.epoch.as_deref() else {
+                    return Err(error);
+                };
+                let epoch = ImmutableEpoch::from_authority_bound_bytes(
+                    epoch_bytes,
+                    state.authority_sha256(),
+                )?;
+                let preflight = engine.preflight_reset(&intent.installation, &epoch).await?;
+                if preflight.helper != intent.helper {
+                    return Err(error);
+                }
+                (0, true)
+            }
+            Err(error) => return Err(error),
+        };
+        let helper_recorded = intent.helper.is_some();
+        let removed = persistent_removed + usize::from(helper_recorded && !helper_present);
+        cancellation_checkpoint(&request.cancellation)?;
+        return Ok(LocalStatusReport {
+            schema: STATUS_SCHEMA,
+            status: LocalInstallationStatus::ResetInProgress,
+            installation: Some(intent.installation.name().as_str().to_owned()),
+            installation_id: Some(intent.installation.id().to_string()),
+            workers: None,
+            epoch_fingerprint: Some(intent.epoch_fingerprint),
+            records,
+            engine: None,
+            volume_contents: "not_inspected",
+            reset: Some(StatusReset {
+                removed_resources: removed,
+                total_resources: 13 + usize::from(helper_recorded),
+            }),
+        });
+    }
+
+    match validate_host_state(&state, &snapshot)? {
+        ValidatedHostState::Incomplete {
+            installation,
+            epoch,
+        } => {
+            cancellation_checkpoint(&request.cancellation)?;
+            Ok(LocalStatusReport {
+                schema: STATUS_SCHEMA,
+                status: LocalInstallationStatus::Incomplete,
+                installation: installation.map(|name| name.as_str().to_owned()),
+                installation_id: epoch
+                    .as_ref()
+                    .and_then(|epoch| epoch.installation().ok())
+                    .map(|installation| installation.id().to_string()),
+                workers: epoch.as_ref().map(ImmutableEpoch::workers),
+                epoch_fingerprint: epoch.as_ref().map(ImmutableEpoch::fingerprint),
+                records,
+                engine: None,
+                volume_contents: "not_inspected",
+                reset: None,
+            })
+        }
+        ValidatedHostState::Established(established) => {
+            cancellation_checkpoint(&request.cancellation)?;
+            let adapter = connect_adapter().await?;
+            let engine = InitEngine::connect(&adapter).await?;
+            let engine = engine
+                .inspect_sealed(&established.installation, &established.epoch)
+                .await?;
+            cancellation_checkpoint(&request.cancellation)?;
+            Ok(sealed_report(records, &established, engine))
+        }
+    }
+}
+
+/// Exactly removes one established local installation while retaining images and the lock root.
+///
+/// # Errors
+///
+/// Returns without Engine mutation unless confirmation, authority, post-guard
+/// ownership, full-union, unknown-resource, and attachment preflight all pass.
+/// Once the durable reset intent exists, cancellation is latched and the exact
+/// destructive transaction is reconciled to completion or a dominant error.
+pub async fn reset_local(request: LocalResetRequest) -> Result<LocalResetOutcome, LocalInitError> {
+    reset_local_with_connector(request, connect_adapter).await
+}
+
+async fn reset_local_with_connector<C, F>(
+    request: LocalResetRequest,
+    connect: C,
+) -> Result<LocalResetOutcome, LocalInitError>
+where
+    C: FnOnce() -> F,
+    F: Future<Output = Result<DockerInstallationAdapter, LocalInitError>>,
+{
+    if !request.confirmed {
+        return Err(LocalInitError::new(
+            LocalInitErrorCode::ConfirmationRequired,
+        ));
+    }
+    let state = StateRoot::acquire_existing(&request.state_directory)?;
+    let observed_intent = state.observe_reset_intent_for_reset()?;
+    let observed_intent_bytes = reset_intent_candidate(&observed_intent)?.map(<[u8]>::to_vec);
+    let replay_intent = observed_intent_bytes
+        .as_deref()
+        .map(|bytes| ResetIntent::from_canonical_bytes(bytes, state.authority_sha256()))
+        .transpose()?;
+    if replay_intent.is_none() {
+        cancellation_checkpoint(&request.cancellation)?;
+    }
+    let mut snapshot = state.snapshot_for_reset()?;
+    if reset_intent_candidate(&snapshot.reset_intent)? != observed_intent_bytes.as_deref() {
+        return Err(reset_required());
+    }
+    if let Some(intent) = replay_intent.as_ref() {
+        intent.validate_reset_candidate_snapshot(&snapshot)?;
+        let recovered = state.reconcile_validated_reset_intent(
+            observed_intent_bytes
+                .as_deref()
+                .ok_or_else(reset_required)?,
+        )?;
+        if Some(recovered.as_slice()) != observed_intent_bytes.as_deref() {
+            return Err(reset_required());
+        }
+        snapshot = state.snapshot_for_reset()?;
+        intent.validate_reset_snapshot(&snapshot)?;
+    }
+
+    let fresh = if replay_intent.is_none() {
+        Some(validate_reset_host_state(&state, &snapshot)?)
+    } else {
+        None
+    };
+
+    let adapter = connect().await?;
+    let engine = InitEngine::connect(&adapter).await?;
+    let intent = if let Some(intent) = replay_intent {
+        intent
+    } else {
+        let established = fresh.ok_or_else(reset_required)?;
+        cancellation_checkpoint(&request.cancellation)?;
+        let preflight = engine
+            .preflight_reset(&established.installation, &established.epoch)
+            .await?;
+        cancellation_checkpoint(&request.cancellation)?;
+        let proposed = ResetIntent::new(state.authority_sha256(), &established, preflight.helper);
+        state.store_reset_intent(&proposed.canonical_bytes()?)?;
+        snapshot = state.snapshot_for_reset()?;
+        let intent = ResetIntent::from_canonical_bytes(
+            snapshot
+                .reset_intent
+                .completed()
+                .ok_or_else(reset_required)?,
+            state.authority_sha256(),
+        )?;
+        intent.validate_reset_snapshot(&snapshot)?;
+        intent
+    };
+
+    snapshot = state.snapshot_for_reset()?;
+    intent.validate_reset_snapshot(&snapshot)?;
+    let mut cancellation_latched = drive_engine_reset(
+        &engine,
+        &intent.installation,
+        intent.epoch_fingerprint,
+        intent.helper.as_ref(),
+        &request.cancellation,
+    )
+    .await?;
+    drop(engine);
+    drop(adapter);
+
+    snapshot = state.snapshot_for_reset()?;
+    intent.validate_reset_snapshot(&snapshot)?;
+    let host = StateResetHostDriver {
+        state: &state,
+        intent: &intent,
+    };
+    cancellation_latched = erase_host_records(&host, &request.cancellation, cancellation_latched)?;
+    Ok(LocalResetOutcome {
+        installation: intent.installation.name().clone(),
+        removed_volumes: 12,
+        images_retained: true,
+        completed_after_cancellation: cancellation_latched,
+    })
+}
+
+trait ResetHostDriver {
+    fn validate_remaining(&self) -> Result<(), LocalInitError>;
+    fn remove_record(&self, record: StateRecord) -> Result<(), LocalInitError>;
+    fn verify_empty(&self) -> Result<(), LocalInitError>;
+}
+
+struct StateResetHostDriver<'a> {
+    state: &'a StateRoot,
+    intent: &'a ValidatedResetIntent,
+}
+
+impl ResetHostDriver for StateResetHostDriver<'_> {
+    fn validate_remaining(&self) -> Result<(), LocalInitError> {
+        let snapshot = self.state.snapshot_for_reset()?;
+        self.intent.validate_reset_snapshot(&snapshot)
+    }
+
+    fn remove_record(&self, record: StateRecord) -> Result<(), LocalInitError> {
+        self.state.remove_record(record)
+    }
+
+    fn verify_empty(&self) -> Result<(), LocalInitError> {
+        if self.state.snapshot_for_reset()?.is_empty() {
+            Ok(())
+        } else {
+            Err(reset_failed())
+        }
+    }
+}
+
+fn erase_host_records<D: ResetHostDriver>(
+    driver: &D,
+    cancellation: &CancellationToken,
+    mut cancellation_latched: bool,
+) -> Result<bool, LocalInitError> {
+    for record in HOST_RESET_ORDER {
+        driver.validate_remaining()?;
+        driver.remove_record(record)?;
+        cancellation_latched |= cancellation.is_cancelled();
+        driver.validate_remaining()?;
+    }
+    driver.validate_remaining()?;
+    driver.remove_record(StateRecord::ResetIntent)?;
+    cancellation_latched |= cancellation.is_cancelled();
+    driver.verify_empty()?;
+    cancellation_latched |= cancellation.is_cancelled();
+    Ok(cancellation_latched)
+}
+
+#[async_trait::async_trait]
+trait ResetMutationDriver: Sync {
+    async fn cleanup_helper(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        helper: &ResetHelperBinding,
+    ) -> Result<(), LocalInitError>;
+
+    async fn inspect_progress(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+    ) -> Result<usize, LocalInitError>;
+
+    async fn remove_volume(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        role: super::materializer::VolumeRole,
+    ) -> Result<(), LocalInitError>;
+
+    async fn remove_anchor(&self, installation: &Installation) -> Result<(), LocalInitError>;
+}
+
+#[async_trait::async_trait]
+impl ResetMutationDriver for InitEngine<'_> {
+    async fn cleanup_helper(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        helper: &ResetHelperBinding,
+    ) -> Result<(), LocalInitError> {
+        self.cleanup_reset_helper(installation, epoch_fingerprint, helper)
+            .await
+    }
+
+    async fn inspect_progress(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+    ) -> Result<usize, LocalInitError> {
+        self.inspect_reset_progress(installation, epoch_fingerprint)
+            .await
+    }
+
+    async fn remove_volume(
+        &self,
+        installation: &Installation,
+        epoch_fingerprint: Sha256Digest,
+        role: super::materializer::VolumeRole,
+    ) -> Result<(), LocalInitError> {
+        self.remove_reset_volume(installation, epoch_fingerprint, role)
+            .await
+    }
+
+    async fn remove_anchor(&self, installation: &Installation) -> Result<(), LocalInitError> {
+        self.remove_reset_anchor(installation).await
+    }
+}
+
+async fn drive_engine_reset<D: ResetMutationDriver>(
+    driver: &D,
+    installation: &Installation,
+    epoch_fingerprint: Sha256Digest,
+    helper: Option<&ResetHelperBinding>,
+    cancellation: &CancellationToken,
+) -> Result<bool, LocalInitError> {
+    let mut cancellation_latched = cancellation.is_cancelled();
+    if let Some(helper) = helper {
+        driver
+            .cleanup_helper(installation, epoch_fingerprint, helper)
+            .await?;
+        cancellation_latched |= cancellation.is_cancelled();
+    }
+    let mut removed = driver
+        .inspect_progress(installation, epoch_fingerprint)
+        .await?;
+    cancellation_latched |= cancellation.is_cancelled();
+    for (index, role) in reset_volume_order().into_iter().enumerate().skip(removed) {
+        driver
+            .remove_volume(installation, epoch_fingerprint, role)
+            .await?;
+        cancellation_latched |= cancellation.is_cancelled();
+        removed = driver
+            .inspect_progress(installation, epoch_fingerprint)
+            .await?;
+        if removed != index + 1 {
+            return Err(reset_failed());
+        }
+    }
+    if removed == 12 {
+        driver.remove_anchor(installation).await?;
+        cancellation_latched |= cancellation.is_cancelled();
+        removed = driver
+            .inspect_progress(installation, epoch_fingerprint)
+            .await?;
+    }
+    if removed != 13 {
+        return Err(reset_failed());
+    }
+    Ok(cancellation_latched)
+}
+
+fn validate_reset_host_state(
+    state: &StateRoot,
+    snapshot: &ResetStateSnapshot,
+) -> Result<EstablishedState, LocalInitError> {
+    let epoch = ImmutableEpoch::from_authority_bound_bytes(
+        snapshot.epoch.completed().ok_or_else(reset_required)?,
+        state.authority_sha256(),
+    )?;
+    let installation = epoch.installation()?;
+    validate_reset_candidate_conflicts(
+        snapshot,
+        state.authority_sha256(),
+        &installation,
+        epoch.fingerprint(),
+    )?;
+    Ok(EstablishedState {
+        installation,
+        epoch,
+    })
+}
+
+fn reset_intent_candidate(
+    observation: &super::state::ResetRecordObservation,
+) -> Result<Option<&[u8]>, LocalInitError> {
+    if observation.completed_present() != observation.completed().is_some()
+        || observation.staged_present() != observation.staged().is_some()
+    {
+        return Err(reset_required());
+    }
+    match (observation.completed(), observation.staged()) {
+        (Some(completed), Some(staged)) if completed == staged => Ok(Some(completed)),
+        (Some(_), Some(_)) => Err(reset_required()),
+        (Some(completed), None) => Ok(Some(completed)),
+        (None, Some(staged)) => Ok(Some(staged)),
+        (None, None) if observation.present() => Err(reset_required()),
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_reset_candidate_conflicts(
+    snapshot: &ResetStateSnapshot,
+    state_authority_sha256: Sha256Digest,
+    installation: &Installation,
+    epoch_fingerprint: Sha256Digest,
+) -> Result<(), LocalInitError> {
+    for bytes in [snapshot.epoch.completed(), snapshot.epoch.staged()]
+        .into_iter()
+        .flatten()
+    {
+        if let Ok(candidate) =
+            ImmutableEpoch::from_authority_bound_bytes(bytes, state_authority_sha256)
+        {
+            let candidate_installation = candidate.installation()?;
+            if candidate_installation != *installation
+                || candidate.fingerprint() != epoch_fingerprint
+            {
+                return Err(reset_required());
+            }
+        }
+    }
+    for bytes in [
+        snapshot.installation_selection.completed(),
+        snapshot.installation_selection.staged(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Ok(selection) = StateInstallationSelection::from_canonical_bytes(bytes)
+            && selection != *installation.name()
+        {
+            return Err(reset_required());
+        }
+    }
+    for bytes in [
+        snapshot.materialization.completed(),
+        snapshot.materialization.staged(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Ok(fingerprint) = StateMaterialization::from_canonical_bytes(bytes)
+            && fingerprint != epoch_fingerprint
+        {
+            return Err(reset_required());
+        }
+    }
+    Ok(())
+}
+
+fn validate_status_candidate_conflicts(
+    snapshot: &StateSnapshot,
+    state_authority_sha256: Sha256Digest,
+    installation: &Installation,
+    epoch_fingerprint: Sha256Digest,
+) -> Result<(), LocalInitError> {
+    if let Some(bytes) = snapshot.epoch.as_deref()
+        && let Ok(candidate) =
+            ImmutableEpoch::from_authority_bound_bytes(bytes, state_authority_sha256)
+        && (candidate.installation()? != *installation
+            || candidate.fingerprint() != epoch_fingerprint)
+    {
+        return Err(reset_required());
+    }
+    if let Some(bytes) = snapshot.installation_selection.as_deref()
+        && let Ok(selection) = StateInstallationSelection::from_canonical_bytes(bytes)
+        && selection != *installation.name()
+    {
+        return Err(reset_required());
+    }
+    if let Some(bytes) = snapshot.materialization.as_deref()
+        && let Ok(fingerprint) = StateMaterialization::from_canonical_bytes(bytes)
+        && fingerprint != epoch_fingerprint
+    {
+        return Err(reset_required());
+    }
+    Ok(())
+}
+
+fn validate_host_state(
+    state: &StateRoot,
+    snapshot: &StateSnapshot,
+) -> Result<ValidatedHostState, LocalInitError> {
+    let installation = snapshot
+        .installation_selection
+        .as_deref()
+        .map(StateInstallationSelection::from_canonical_bytes)
+        .transpose()?;
+    let material_root = snapshot
+        .material_root
+        .as_deref()
+        .map(|bytes| <[u8; 32]>::try_from(bytes).map_err(|_| reset_required()))
+        .transpose()?;
+    if installation.is_none()
+        && (material_root.is_some()
+            || snapshot.epoch.is_some()
+            || snapshot.certificates.is_some()
+            || snapshot.materialization.is_some())
+        || material_root.is_none()
+            && (snapshot.epoch.is_some()
+                || snapshot.certificates.is_some()
+                || snapshot.materialization.is_some())
+        || snapshot.epoch.is_none()
+            && (snapshot.certificates.is_some() || snapshot.materialization.is_some())
+        || snapshot.certificates.is_none() && snapshot.materialization.is_some()
+    {
+        return Err(reset_required());
+    }
+    let epoch = match (snapshot.epoch.as_deref(), material_root.as_ref()) {
+        (Some(bytes), Some(root)) => Some(ImmutableEpoch::from_sealed_bytes(
+            bytes,
+            state.authority_sha256(),
+            root,
+        )?),
+        (None, _) => None,
+        (Some(_), None) => return Err(reset_required()),
+    };
+    if let (Some(selection), Some(epoch)) = (&installation, &epoch) {
+        let epoch_installation = epoch.installation()?;
+        if epoch_installation.name() != selection {
+            return Err(reset_required());
+        }
+        if let Some(bytes) = snapshot.certificates.as_deref() {
+            let deriver = MaterialDeriver::new(
+                material_root.ok_or_else(reset_required)?,
+                &epoch_installation,
+                epoch,
+            );
+            let _validated = certificates::validate_existing(bytes, &deriver, epoch)?;
+        }
+        if let Some(bytes) = snapshot.materialization.as_deref()
+            && StateMaterialization::from_canonical_bytes(bytes)? != epoch.fingerprint()
+        {
+            return Err(reset_required());
+        }
+    }
+    if snapshot.installation_selection.is_some()
+        && snapshot.material_root.is_some()
+        && snapshot.epoch.is_some()
+        && snapshot.certificates.is_some()
+        && snapshot.materialization.is_some()
+    {
+        let epoch = epoch.ok_or_else(reset_required)?;
+        return Ok(ValidatedHostState::Established(EstablishedState {
+            installation: epoch.installation()?,
+            epoch,
+        }));
+    }
+    Ok(ValidatedHostState::Incomplete {
+        installation,
+        epoch,
+    })
+}
+
+fn sealed_report(
+    records: StatusRecords,
+    established: &EstablishedState,
+    engine: SealedEngineStatus,
+) -> LocalStatusReport {
+    let images = engine
+        .images
+        .into_iter()
+        .map(|image| StatusImage {
+            role: image.role,
+            source_kind: image.source_kind,
+            inspection_reference: image.inspection_reference,
+            image_id: image.image_id,
+        })
+        .collect();
+    let volumes = engine
+        .volumes
+        .into_iter()
+        .map(|volume| StatusVolume {
+            role: volume.role.name().to_owned(),
+            name: volume.name,
+            static_material: volume.static_material,
+            manifest: if volume.static_material {
+                "recorded_not_live_attested"
+            } else {
+                "not_applicable"
+            },
+        })
+        .collect();
+    LocalStatusReport {
+        schema: STATUS_SCHEMA,
+        status: LocalInstallationStatus::RecordedSealed,
+        installation: Some(established.installation.name().as_str().to_owned()),
+        installation_id: Some(established.installation.id().to_string()),
+        workers: Some(established.epoch.workers()),
+        epoch_fingerprint: Some(established.epoch.fingerprint()),
+        records,
+        engine: Some(StatusEngine {
+            identity: "exact",
+            image_representations: "exact",
+            images,
+            owned_union: "exact",
+            volumes,
+            attachments: "absent",
+            unknown_managed_resources: "absent",
+        }),
+        volume_contents: "not_inspected",
+        reset: None,
+    }
+}
+
+async fn connect_adapter() -> Result<DockerInstallationAdapter, LocalInitError> {
+    DockerInstallationAdapter::connect_fixed_engine()
+        .await
+        .map_err(super::map_engine_error)
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ResetIntent {
+    schema: String,
+    state_authority_sha256: Sha256Digest,
+    installation: ResetInstallation,
+    epoch_fingerprint: Sha256Digest,
+    role_set_sha256: Sha256Digest,
+    helper: Option<ResetHelperBinding>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ResetInstallation {
+    name: String,
+    id: String,
+    selector_key: String,
+    compose_project: String,
+}
+
+impl ResetIntent {
+    fn new(
+        state_authority_sha256: Sha256Digest,
+        established: &EstablishedState,
+        helper: Option<ResetHelperBinding>,
+    ) -> Self {
+        Self {
+            schema: RESET_INTENT_SCHEMA.to_owned(),
+            state_authority_sha256,
+            installation: ResetInstallation::from_installation(&established.installation),
+            epoch_fingerprint: established.epoch.fingerprint(),
+            role_set_sha256: reset_role_set_sha256(),
+            helper,
+        }
+    }
+
+    fn canonical_bytes(&self) -> Result<Vec<u8>, LocalInitError> {
+        let mut bytes = serde_json::to_vec(self).map_err(|_| reset_required())?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+
+    fn from_canonical_bytes(
+        bytes: &[u8],
+        state_authority_sha256: Sha256Digest,
+    ) -> Result<ValidatedResetIntent, LocalInitError> {
+        let intent: Self = serde_json::from_slice(bytes).map_err(|_| reset_required())?;
+        if intent.schema != RESET_INTENT_SCHEMA
+            || intent.state_authority_sha256 != state_authority_sha256
+            || intent.role_set_sha256 != reset_role_set_sha256()
+            || intent.canonical_bytes()? != bytes
+        {
+            return Err(reset_required());
+        }
+        let installation = intent.installation.to_installation()?;
+        Ok(ValidatedResetIntent {
+            state_authority_sha256,
+            installation,
+            epoch_fingerprint: intent.epoch_fingerprint,
+            helper: intent.helper,
+            canonical_bytes: bytes.to_vec(),
+        })
+    }
+}
+
+struct ValidatedResetIntent {
+    state_authority_sha256: Sha256Digest,
+    installation: Installation,
+    epoch_fingerprint: Sha256Digest,
+    helper: Option<ResetHelperBinding>,
+    canonical_bytes: Vec<u8>,
+}
+
+impl ValidatedResetIntent {
+    fn validate_intent_bytes(&self, bytes: Option<&[u8]>) -> Result<(), LocalInitError> {
+        if bytes != Some(self.canonical_bytes.as_slice()) {
+            return Err(reset_required());
+        }
+        Ok(())
+    }
+
+    fn validate_reset_snapshot(&self, snapshot: &ResetStateSnapshot) -> Result<(), LocalInitError> {
+        self.validate_intent_bytes(snapshot.reset_intent.completed())?;
+        if snapshot.reset_intent.staged_present() {
+            return Err(reset_required());
+        }
+        self.validate_reset_candidate_snapshot(snapshot)
+    }
+
+    fn validate_reset_candidate_snapshot(
+        &self,
+        snapshot: &ResetStateSnapshot,
+    ) -> Result<(), LocalInitError> {
+        validate_reset_candidate_conflicts(
+            snapshot,
+            self.state_authority_sha256,
+            &self.installation,
+            self.epoch_fingerprint,
+        )
+    }
+
+    fn validate_status_snapshot(&self, snapshot: &StateSnapshot) -> Result<(), LocalInitError> {
+        validate_status_candidate_conflicts(
+            snapshot,
+            self.state_authority_sha256,
+            &self.installation,
+            self.epoch_fingerprint,
+        )
+    }
+}
+
+impl ResetInstallation {
+    fn from_installation(installation: &Installation) -> Self {
+        Self {
+            name: installation.name().as_str().to_owned(),
+            id: installation.id().to_string(),
+            selector_key: installation.selector_key().to_string(),
+            compose_project: installation.compose_project().to_string(),
+        }
+    }
+
+    fn to_installation(&self) -> Result<Installation, LocalInitError> {
+        let name = InstallationName::new(self.name.clone()).map_err(|_| reset_required())?;
+        let id = InstallationId::from_str(&self.id).map_err(|_| reset_required())?;
+        let installation = Installation::verified(name, id);
+        if self.selector_key != installation.selector_key().to_string()
+            || self.compose_project != installation.compose_project().as_str()
+        {
+            return Err(reset_required());
+        }
+        Ok(installation)
+    }
+}
+
+fn reset_role_set_sha256() -> Sha256Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(b"automata/local/reset-role-set/v1\0");
+    for role in reset_volume_order() {
+        let name = role.name().as_bytes();
+        hasher.update(
+            u16::try_from(name.len())
+                .expect("closed volume-role name fits u16")
+                .to_be_bytes(),
+        );
+        hasher.update(name);
+    }
+    let anchor_contract = b"identity-anchor/volume/schema-1";
+    hasher.update(
+        u16::try_from(anchor_contract.len())
+            .expect("closed identity-anchor contract fits u16")
+            .to_be_bytes(),
+    );
+    hasher.update(anchor_contract);
+    Sha256Digest::from_bytes(hasher.finalize().into())
+}
+
+fn cancellation_checkpoint(cancellation: &CancellationToken) -> Result<(), LocalInitError> {
+    if cancellation.is_cancelled() {
+        Err(LocalInitError::new(LocalInitErrorCode::Cancelled))
+    } else {
+        Ok(())
+    }
+}
+
+fn reset_required() -> LocalInitError {
+    LocalInitError::new(LocalInitErrorCode::ResetRequired)
+}
+
+fn reset_failed() -> LocalInitError {
+    LocalInitError::new(LocalInitErrorCode::ResetFailed)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/automata-ci-local/src/init/status_reset/tests.rs
+++ b/crates/automata-ci-local/src/init/status_reset/tests.rs
@@ -1,0 +1,1247 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write as _,
+    os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _},
+    path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use super::*;
+use crate::InstallationId;
+
+static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .unwrap();
+        let scratch = workspace.join("target/task-tmp/automata-ci-local");
+        fs::create_dir_all(&scratch).unwrap();
+        let path = scratch.join(format!(
+            "automata-ci-local-status-reset-test-{}-{}",
+            std::process::id(),
+            NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        Self(path)
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.0.join("state")
+    }
+
+    fn private_file(&self, name: &str, bytes: &[u8]) {
+        self.private_file_mode(name, bytes, 0o600);
+    }
+
+    fn private_file_mode(&self, name: &str, bytes: &[u8], mode: u32) {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(self.state_path().join(name))
+            .unwrap();
+        file.write_all(bytes).unwrap();
+        file.sync_all().unwrap();
+        fs::set_permissions(
+            self.state_path().join(name),
+            fs::Permissions::from_mode(mode),
+        )
+        .unwrap();
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+struct FakeResetDriver {
+    state: Mutex<FakeResetState>,
+    cancellation: CancellationToken,
+}
+
+struct FakeResetState {
+    progress: usize,
+    helper: bool,
+    fail_helper: bool,
+    fail_at: Option<usize>,
+    fail_anchor: bool,
+    fail_inspect_at: Option<usize>,
+    inspect_count: usize,
+    cancel_at: Option<usize>,
+    trace: Vec<String>,
+}
+
+impl FakeResetDriver {
+    fn new(progress: usize, helper: bool) -> Self {
+        Self {
+            state: Mutex::new(FakeResetState {
+                progress,
+                helper,
+                fail_helper: false,
+                fail_at: None,
+                fail_anchor: false,
+                fail_inspect_at: None,
+                inspect_count: 0,
+                cancel_at: None,
+                trace: Vec::new(),
+            }),
+            cancellation: CancellationToken::new(),
+        }
+    }
+
+    fn trace(&self) -> Vec<String> {
+        self.state.lock().unwrap().trace.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ResetMutationDriver for FakeResetDriver {
+    async fn cleanup_helper(
+        &self,
+        _installation: &Installation,
+        _epoch_fingerprint: Sha256Digest,
+        _helper: &ResetHelperBinding,
+    ) -> Result<(), LocalInitError> {
+        let mut state = self.state.lock().unwrap();
+        assert!(state.helper);
+        state.trace.push("helper".to_owned());
+        if state.fail_helper {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetFailed));
+        }
+        state.helper = false;
+        Ok(())
+    }
+
+    async fn inspect_progress(
+        &self,
+        _installation: &Installation,
+        _epoch_fingerprint: Sha256Digest,
+    ) -> Result<usize, LocalInitError> {
+        let mut state = self.state.lock().unwrap();
+        let progress = state.progress;
+        state.trace.push(format!("inspect:{progress}"));
+        let inspection = state.inspect_count;
+        state.inspect_count += 1;
+        if state.fail_inspect_at == Some(inspection) {
+            return Err(LocalInitError::new(
+                LocalInitErrorCode::EngineResourceMismatch,
+            ));
+        }
+        Ok(progress)
+    }
+
+    async fn remove_volume(
+        &self,
+        _installation: &Installation,
+        _epoch_fingerprint: Sha256Digest,
+        role: super::super::materializer::VolumeRole,
+    ) -> Result<(), LocalInitError> {
+        let mut state = self.state.lock().unwrap();
+        let index = state.progress;
+        assert_eq!(reset_volume_order()[index], role);
+        state.trace.push(format!("volume:{}", role.name()));
+        if state.cancel_at == Some(index) {
+            self.cancellation.cancel();
+        }
+        if state.fail_at == Some(index) {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetFailed));
+        }
+        state.progress += 1;
+        Ok(())
+    }
+
+    async fn remove_anchor(&self, _installation: &Installation) -> Result<(), LocalInitError> {
+        let mut state = self.state.lock().unwrap();
+        assert_eq!(state.progress, 12);
+        state.trace.push("anchor".to_owned());
+        if state.fail_anchor {
+            return Err(LocalInitError::new(LocalInitErrorCode::ResetFailed));
+        }
+        state.progress = 13;
+        Ok(())
+    }
+}
+
+fn installation() -> Installation {
+    Installation::verified(InstallationName::default(), InstallationId::new())
+}
+
+fn helper() -> ResetHelperBinding {
+    ResetHelperBinding {
+        reference: "example.invalid/automata@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        image_id: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        container_id: "c".repeat(64),
+    }
+}
+
+#[tokio::test]
+async fn destructive_reset_is_helper_first_desired_twelfth_anchor_last_and_latched() {
+    let driver = FakeResetDriver::new(0, true);
+    driver.state.lock().unwrap().cancel_at = Some(0);
+    let installation = installation();
+    let fingerprint = Sha256Digest::from_bytes([7; 32]);
+    let completed_after_cancellation = drive_engine_reset(
+        &driver,
+        &installation,
+        fingerprint,
+        Some(&helper()),
+        &driver.cancellation,
+    )
+    .await
+    .unwrap();
+
+    assert!(completed_after_cancellation);
+    let trace = driver.trace();
+    assert_eq!(trace.first().map(String::as_str), Some("helper"));
+    assert_eq!(
+        trace
+            .iter()
+            .rfind(|event| event.starts_with("volume:"))
+            .map(String::as_str),
+        Some("volume:desired")
+    );
+    assert_eq!(
+        trace.iter().rposition(|event| event == "anchor"),
+        Some(trace.len() - 2),
+        "the final progress proof follows anchor deletion"
+    );
+    assert_eq!(trace.last().map(String::as_str), Some("inspect:13"));
+}
+
+#[tokio::test]
+async fn pre_cancelled_destructive_replay_still_completes_and_reports_the_latch() {
+    let driver = FakeResetDriver::new(7, false);
+    driver.cancellation.cancel();
+
+    let completed_after_cancellation = drive_engine_reset(
+        &driver,
+        &installation(),
+        Sha256Digest::from_bytes([0x71; 32]),
+        None,
+        &driver.cancellation,
+    )
+    .await
+    .unwrap();
+
+    assert!(completed_after_cancellation);
+    assert_eq!(
+        driver
+            .trace()
+            .iter()
+            .filter(|event| event.starts_with("volume:"))
+            .count(),
+        5
+    );
+    assert_eq!(
+        driver.trace().last().map(String::as_str),
+        Some("inspect:13")
+    );
+}
+
+#[tokio::test]
+async fn reset_replay_resumes_at_the_exact_absent_prefix() {
+    let installation = installation();
+    for progress in 0..=13 {
+        let driver = FakeResetDriver::new(progress, false);
+        drive_engine_reset(
+            &driver,
+            &installation,
+            Sha256Digest::from_bytes([8; 32]),
+            None,
+            &driver.cancellation,
+        )
+        .await
+        .unwrap();
+
+        let trace = driver.trace();
+        let removed = trace
+            .iter()
+            .filter(|event| event.starts_with("volume:"))
+            .cloned()
+            .collect::<Vec<_>>();
+        let expected = reset_volume_order()[progress.min(12)..]
+            .iter()
+            .map(|role| format!("volume:{}", role.name()))
+            .collect::<Vec<_>>();
+        assert_eq!(removed, expected, "replay prefix {progress}");
+        assert_eq!(
+            trace
+                .iter()
+                .filter(|event| event.as_str() == "anchor")
+                .count(),
+            usize::from(progress <= 12),
+            "anchor replay prefix {progress}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn reset_failure_dominates_latched_cancellation_and_stops_later_mutations() {
+    let driver = FakeResetDriver::new(0, false);
+    {
+        let mut state = driver.state.lock().unwrap();
+        state.cancel_at = Some(2);
+        state.fail_at = Some(2);
+    }
+    let error = drive_engine_reset(
+        &driver,
+        &installation(),
+        Sha256Digest::from_bytes([9; 32]),
+        None,
+        &driver.cancellation,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.code(), LocalInitErrorCode::ResetFailed);
+    assert!(driver.cancellation.is_cancelled());
+    assert_eq!(
+        driver
+            .trace()
+            .iter()
+            .filter(|event| event.starts_with("volume:"))
+            .count(),
+        3
+    );
+    assert!(!driver.trace().iter().any(|event| event == "anchor"));
+}
+
+#[tokio::test]
+async fn every_last_preflight_or_ordered_delete_failure_stops_later_mutation() {
+    let installation = installation();
+    let fingerprint = Sha256Digest::from_bytes([0x44; 32]);
+
+    let preflight = FakeResetDriver::new(0, false);
+    preflight.state.lock().unwrap().fail_inspect_at = Some(0);
+    assert_eq!(
+        drive_engine_reset(
+            &preflight,
+            &installation,
+            fingerprint,
+            None,
+            &preflight.cancellation,
+        )
+        .await
+        .unwrap_err()
+        .code(),
+        LocalInitErrorCode::EngineResourceMismatch
+    );
+    assert_eq!(preflight.trace(), ["inspect:0"]);
+
+    let helper_failure = FakeResetDriver::new(0, true);
+    helper_failure.state.lock().unwrap().fail_helper = true;
+    assert!(
+        drive_engine_reset(
+            &helper_failure,
+            &installation,
+            fingerprint,
+            Some(&helper()),
+            &helper_failure.cancellation,
+        )
+        .await
+        .is_err()
+    );
+    assert_eq!(helper_failure.trace(), ["helper"]);
+
+    let desired_failure = FakeResetDriver::new(0, false);
+    desired_failure.state.lock().unwrap().fail_at = Some(11);
+    assert!(
+        drive_engine_reset(
+            &desired_failure,
+            &installation,
+            fingerprint,
+            None,
+            &desired_failure.cancellation,
+        )
+        .await
+        .is_err()
+    );
+    assert!(
+        !desired_failure
+            .trace()
+            .iter()
+            .any(|event| event == "anchor")
+    );
+
+    let anchor_failure = FakeResetDriver::new(0, false);
+    anchor_failure.state.lock().unwrap().fail_anchor = true;
+    assert!(
+        drive_engine_reset(
+            &anchor_failure,
+            &installation,
+            fingerprint,
+            None,
+            &anchor_failure.cancellation,
+        )
+        .await
+        .is_err()
+    );
+    assert_eq!(
+        anchor_failure.trace().last().map(String::as_str),
+        Some("anchor")
+    );
+}
+
+struct FakeHostResetDriver {
+    state: Mutex<FakeHostResetState>,
+    cancellation: CancellationToken,
+}
+
+struct FakeHostResetState {
+    present: Vec<StateRecord>,
+    cancel_on: Option<StateRecord>,
+    trace: Vec<StateRecord>,
+}
+
+impl FakeHostResetDriver {
+    fn with_removed_prefix(prefix: usize) -> Self {
+        let records = HOST_RESET_ORDER
+            .into_iter()
+            .chain(std::iter::once(StateRecord::ResetIntent))
+            .collect::<Vec<_>>();
+        Self {
+            state: Mutex::new(FakeHostResetState {
+                present: records[prefix..].to_vec(),
+                cancel_on: None,
+                trace: Vec::new(),
+            }),
+            cancellation: CancellationToken::new(),
+        }
+    }
+}
+
+impl ResetHostDriver for FakeHostResetDriver {
+    fn validate_remaining(&self) -> Result<(), LocalInitError> {
+        if self
+            .state
+            .lock()
+            .unwrap()
+            .present
+            .contains(&StateRecord::ResetIntent)
+        {
+            Ok(())
+        } else {
+            Err(LocalInitError::new(LocalInitErrorCode::ResetRequired))
+        }
+    }
+
+    fn remove_record(&self, record: StateRecord) -> Result<(), LocalInitError> {
+        let mut state = self.state.lock().unwrap();
+        state.trace.push(record);
+        state.present.retain(|present| *present != record);
+        if state.cancel_on == Some(record) {
+            self.cancellation.cancel();
+        }
+        Ok(())
+    }
+
+    fn verify_empty(&self) -> Result<(), LocalInitError> {
+        if self.state.lock().unwrap().present.is_empty() {
+            Ok(())
+        } else {
+            Err(LocalInitError::new(LocalInitErrorCode::ResetFailed))
+        }
+    }
+}
+
+#[test]
+fn host_record_replay_is_fixed_order_intent_last_and_samples_final_cancellation() {
+    for prefix in 0..=HOST_RESET_ORDER.len() {
+        let driver = FakeHostResetDriver::with_removed_prefix(prefix);
+        if prefix == 0 {
+            driver.state.lock().unwrap().cancel_on = Some(StateRecord::ResetIntent);
+        }
+        let cancelled = erase_host_records(&driver, &driver.cancellation, false).unwrap();
+        assert_eq!(cancelled, prefix == 0);
+        assert_eq!(
+            driver.state.lock().unwrap().trace,
+            HOST_RESET_ORDER
+                .into_iter()
+                .chain(std::iter::once(StateRecord::ResetIntent))
+                .collect::<Vec<_>>()
+        );
+        assert!(driver.state.lock().unwrap().present.is_empty());
+    }
+}
+
+#[test]
+fn reset_authority_survives_missing_or_safe_malformed_non_authority_records() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let installation = installation();
+    let epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x51; 32],
+        state.authority_sha256(),
+    );
+    directory.private_file("epoch.json", &epoch.canonical_bytes());
+    fs::set_permissions(
+        directory.state_path().join("epoch.json"),
+        fs::Permissions::from_mode(0o400),
+    )
+    .unwrap();
+
+    let missing = validate_reset_host_state(&state, &state.snapshot_for_reset().unwrap()).unwrap();
+    assert_eq!(missing.installation, installation);
+    assert_eq!(missing.epoch, epoch);
+
+    directory.private_file("material-root", &[0x99; 32]);
+    directory.private_file("certificates.json", &vec![b'x'; 128 * 1024 + 1]);
+    let selection = StateInstallationSelection::new(installation.name())
+        .canonical_bytes()
+        .unwrap();
+    directory.private_file("installation-selection.json", &selection);
+    directory.private_file(".installation-selection.json.automata-write", &selection);
+    directory.private_file("materialization.json", b"{malformed}\n");
+    directory.private_file(".materialization.json.automata-write", b"{malformed}\n");
+    directory.private_file(".epoch.json.automata-write", &epoch.canonical_bytes());
+    let malformed =
+        validate_reset_host_state(&state, &state.snapshot_for_reset().unwrap()).unwrap();
+    assert_eq!(malformed.installation, installation);
+    assert_eq!(malformed.epoch, epoch);
+}
+
+#[test]
+fn unreadable_or_temp_only_epoch_cannot_authorize_a_fresh_reset() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let installation = installation();
+    let epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x54; 32],
+        state.authority_sha256(),
+    );
+    directory.private_file("epoch.json", &epoch.canonical_bytes());
+    fs::set_permissions(
+        directory.state_path().join("epoch.json"),
+        fs::Permissions::from_mode(0o000),
+    )
+    .unwrap();
+
+    assert_eq!(
+        validate_reset_host_state(&state, &state.snapshot_for_reset().unwrap())
+            .err()
+            .unwrap()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    let staged_directory = TestDirectory::new();
+    let staged_state = StateRoot::acquire(&staged_directory.state_path()).unwrap();
+    let staged_epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x55; 32],
+        staged_state.authority_sha256(),
+    );
+    staged_directory.private_file(
+        ".epoch.json.automata-write",
+        &staged_epoch.canonical_bytes(),
+    );
+    assert_eq!(
+        validate_reset_host_state(&staged_state, &staged_state.snapshot_for_reset().unwrap())
+            .err()
+            .unwrap()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}
+
+#[test]
+fn valid_conflicting_final_or_staged_authority_evidence_blocks_before_engine_preflight() {
+    for conflict in [
+        "selection-final",
+        "selection-staged",
+        "materialization-final",
+        "materialization-staged",
+        "epoch-staged",
+    ] {
+        let directory = TestDirectory::new();
+        let state = StateRoot::acquire(&directory.state_path()).unwrap();
+        let installation = installation();
+        let epoch = super::super::epoch::authority_test_epoch(
+            &installation,
+            &[0x52; 32],
+            state.authority_sha256(),
+        );
+        directory.private_file("epoch.json", &epoch.canonical_bytes());
+        if conflict.starts_with("selection") {
+            let other = InstallationName::new("other").unwrap();
+            let bytes = StateInstallationSelection::new(&other)
+                .canonical_bytes()
+                .unwrap();
+            if conflict.ends_with("final") {
+                directory.private_file("installation-selection.json", &bytes);
+            } else {
+                directory.private_file(".installation-selection.json.automata-write", &bytes);
+            }
+        } else if conflict.starts_with("materialization") {
+            let bytes = StateMaterialization::new(Sha256Digest::from_bytes([0x53; 32]))
+                .canonical_bytes()
+                .unwrap();
+            if conflict.ends_with("final") {
+                directory.private_file("materialization.json", &bytes);
+            } else {
+                directory.private_file(".materialization.json.automata-write", &bytes);
+            }
+        } else {
+            let conflicting = super::super::epoch::authority_test_epoch(
+                &installation,
+                &[0x55; 32],
+                state.authority_sha256(),
+            );
+            directory.private_file(".epoch.json.automata-write", &conflicting.canonical_bytes());
+        }
+
+        assert_eq!(
+            validate_reset_host_state(&state, &state.snapshot_for_reset().unwrap())
+                .err()
+                .unwrap()
+                .code(),
+            LocalInitErrorCode::ResetRequired,
+            "valid conflicting {conflict} must fail before the Engine is connected"
+        );
+    }
+}
+
+#[test]
+fn reset_intent_is_canonical_self_contained_and_binds_the_closed_topology() {
+    let installation = installation();
+    let root = [0x5a; 32];
+    let epoch = super::super::epoch::certificate_test_epoch(&installation, &root);
+    let established = EstablishedState {
+        installation,
+        epoch,
+    };
+    let authority = Sha256Digest::from_bytes([0x22; 32]);
+    let intent = ResetIntent::new(authority, &established, Some(helper()));
+    let bytes = intent.canonical_bytes().unwrap();
+    let text = std::str::from_utf8(&bytes).unwrap();
+    for secret in [
+        "ZZZZZZZZ",
+        "certificate-record-private-marker",
+        "materialization-record",
+        "certificates_sha256",
+        "material_root_sha256",
+    ] {
+        assert!(!text.contains(secret));
+    }
+    assert!(text.contains("\"role_set_sha256\""));
+
+    let validated = ResetIntent::from_canonical_bytes(&bytes, authority).unwrap();
+    validated.validate_intent_bytes(Some(&bytes)).unwrap();
+    assert_eq!(
+        validated
+            .validate_intent_bytes(Some(b"different\n"))
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+    assert_eq!(
+        ResetIntent::from_canonical_bytes(&bytes, Sha256Digest::from_bytes([0x23; 32]))
+            .err()
+            .unwrap()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+
+    let mut wrong_topology: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    wrong_topology["role_set_sha256"] =
+        serde_json::Value::String(Sha256Digest::from_bytes([0x99; 32]).to_string());
+    let mut wrong_topology = serde_json::to_vec(&wrong_topology).unwrap();
+    wrong_topology.push(b'\n');
+    assert_eq!(
+        ResetIntent::from_canonical_bytes(&wrong_topology, authority)
+            .err()
+            .unwrap()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}
+
+#[test]
+fn published_reset_intent_remains_authoritative_after_host_record_loss_or_corruption() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let installation = installation();
+    let epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x61; 32],
+        state.authority_sha256(),
+    );
+    directory.private_file("epoch.json", &epoch.canonical_bytes());
+    let intent = ResetIntent::new(
+        state.authority_sha256(),
+        &EstablishedState {
+            installation,
+            epoch,
+        },
+        None,
+    );
+    let bytes = intent.canonical_bytes().unwrap();
+    state.store_reset_intent(&bytes).unwrap();
+    fs::set_permissions(
+        directory.state_path().join("reset-intent.json"),
+        fs::Permissions::from_mode(0o400),
+    )
+    .unwrap();
+    assert_eq!(
+        state.reconcile_validated_reset_intent(&bytes).unwrap(),
+        bytes
+    );
+    state.remove_record(StateRecord::Epoch).unwrap();
+    directory.private_file("material-root", b"");
+    directory.private_file("certificates.json", &vec![b'x'; 128 * 1024 + 1]);
+    directory.private_file("epoch.json", b"{malformed}\n");
+    directory.private_file(".epoch.json.automata-write", b"{malformed}\n");
+    directory.private_file("installation-selection.json", b"{malformed}\n");
+    directory.private_file(
+        ".installation-selection.json.automata-write",
+        b"{malformed}\n",
+    );
+    directory.private_file("materialization.json", b"{malformed}\n");
+    directory.private_file(".materialization.json.automata-write", b"{malformed}\n");
+
+    let validated = ResetIntent::from_canonical_bytes(&bytes, state.authority_sha256()).unwrap();
+    validated
+        .validate_reset_snapshot(&state.snapshot_for_reset().unwrap())
+        .unwrap();
+}
+
+#[test]
+fn every_replay_phase_rejects_any_unreadable_staged_intent_evidence() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let installation = installation();
+    let epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x62; 32],
+        state.authority_sha256(),
+    );
+    let intent = ResetIntent::new(
+        state.authority_sha256(),
+        &EstablishedState {
+            installation,
+            epoch,
+        },
+        None,
+    );
+    let bytes = intent.canonical_bytes().unwrap();
+    state.store_reset_intent(&bytes).unwrap();
+    directory.private_file_mode(".reset-intent.json.automata-write", b"opaque", 0o000);
+
+    let snapshot = state.snapshot_for_reset().unwrap();
+    assert!(snapshot.reset_intent.staged_present());
+    assert_eq!(snapshot.reset_intent.staged(), None);
+    let validated = ResetIntent::from_canonical_bytes(&bytes, state.authority_sha256()).unwrap();
+    assert_eq!(
+        validated
+            .validate_reset_snapshot(&snapshot)
+            .unwrap_err()
+            .code(),
+        LocalInitErrorCode::ResetRequired
+    );
+}
+
+#[test]
+fn restored_old_intent_rejects_new_generation_final_and_staged_evidence_before_engine_mutation() {
+    for conflict in [
+        "epoch-name-final",
+        "epoch-name-staged",
+        "epoch-fingerprint-final",
+        "epoch-fingerprint-staged",
+        "selection-final",
+        "selection-staged",
+        "materialization-final",
+        "materialization-staged",
+    ] {
+        let directory = TestDirectory::new();
+        let state = StateRoot::acquire(&directory.state_path()).unwrap();
+        let old_installation = installation();
+        let old_epoch = super::super::epoch::authority_test_epoch(
+            &old_installation,
+            &[0x71; 32],
+            state.authority_sha256(),
+        );
+        let old_intent = ResetIntent::new(
+            state.authority_sha256(),
+            &EstablishedState {
+                installation: old_installation.clone(),
+                epoch: old_epoch,
+            },
+            None,
+        );
+        let old_intent_bytes = old_intent.canonical_bytes().unwrap();
+        state.store_reset_intent(&old_intent_bytes).unwrap();
+        let validated =
+            ResetIntent::from_canonical_bytes(&old_intent_bytes, state.authority_sha256()).unwrap();
+
+        let new_installation = Installation::verified(
+            InstallationName::new("replacement").unwrap(),
+            InstallationId::new(),
+        );
+        let candidate_installation = if conflict.starts_with("epoch-fingerprint") {
+            &old_installation
+        } else {
+            &new_installation
+        };
+        let new_epoch = super::super::epoch::authority_test_epoch(
+            candidate_installation,
+            &[0x72; 32],
+            state.authority_sha256(),
+        );
+        match conflict {
+            "epoch-name-final" | "epoch-fingerprint-final" => {
+                directory.private_file("epoch.json", &new_epoch.canonical_bytes());
+            }
+            "epoch-name-staged" | "epoch-fingerprint-staged" => {
+                directory.private_file(".epoch.json.automata-write", &new_epoch.canonical_bytes());
+            }
+            "selection-final" => directory.private_file(
+                "installation-selection.json",
+                &StateInstallationSelection::new(new_installation.name())
+                    .canonical_bytes()
+                    .unwrap(),
+            ),
+            "selection-staged" => directory.private_file(
+                ".installation-selection.json.automata-write",
+                &StateInstallationSelection::new(new_installation.name())
+                    .canonical_bytes()
+                    .unwrap(),
+            ),
+            "materialization-final" => directory.private_file(
+                "materialization.json",
+                &StateMaterialization::new(new_epoch.fingerprint())
+                    .canonical_bytes()
+                    .unwrap(),
+            ),
+            "materialization-staged" => directory.private_file(
+                ".materialization.json.automata-write",
+                &StateMaterialization::new(new_epoch.fingerprint())
+                    .canonical_bytes()
+                    .unwrap(),
+            ),
+            _ => unreachable!(),
+        }
+
+        assert_eq!(
+            validated
+                .validate_reset_snapshot(&state.snapshot_for_reset().unwrap())
+                .unwrap_err()
+                .code(),
+            LocalInitErrorCode::ResetRequired,
+            "restored intent must not reach the Engine with conflicting {conflict} evidence"
+        );
+    }
+}
+
+fn staged_intent_rejection_fixture(case: &str) -> TestDirectory {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let bytes = if case.starts_with("stale") {
+        let old_installation = installation();
+        let old_epoch = super::super::epoch::authority_test_epoch(
+            &old_installation,
+            &[0x81; 32],
+            state.authority_sha256(),
+        );
+        let old_intent = ResetIntent::new(
+            state.authority_sha256(),
+            &EstablishedState {
+                installation: old_installation,
+                epoch: old_epoch,
+            },
+            None,
+        );
+        let new_installation = Installation::verified(
+            InstallationName::new("replacement").unwrap(),
+            InstallationId::new(),
+        );
+        let new_epoch = super::super::epoch::authority_test_epoch(
+            &new_installation,
+            &[0x82; 32],
+            state.authority_sha256(),
+        );
+        directory.private_file("epoch.json", &new_epoch.canonical_bytes());
+        directory.private_file(
+            "installation-selection.json",
+            &StateInstallationSelection::new(new_installation.name())
+                .canonical_bytes()
+                .unwrap(),
+        );
+        directory.private_file(
+            "materialization.json",
+            &StateMaterialization::new(new_epoch.fingerprint())
+                .canonical_bytes()
+                .unwrap(),
+        );
+        old_intent.canonical_bytes().unwrap()
+    } else if case.starts_with("unreadable") {
+        let installation = installation();
+        let epoch = super::super::epoch::authority_test_epoch(
+            &installation,
+            &[0x86; 32],
+            state.authority_sha256(),
+        );
+        directory.private_file("epoch.json", &epoch.canonical_bytes());
+        ResetIntent::new(
+            state.authority_sha256(),
+            &EstablishedState {
+                installation,
+                epoch,
+            },
+            None,
+        )
+        .canonical_bytes()
+        .unwrap()
+    } else {
+        b"{malformed}\n".to_vec()
+    };
+    if case.ends_with("final-and-temp") {
+        state.store_reset_intent(&bytes).unwrap();
+    }
+    if case.starts_with("unreadable") {
+        directory.private_file_mode(".reset-intent.json.automata-write", &bytes, 0o000);
+    } else {
+        directory.private_file(".reset-intent.json.automata-write", &bytes);
+    }
+    drop(state);
+    directory
+}
+
+#[tokio::test]
+async fn reset_api_validates_staged_intent_before_publication_or_engine_connection() {
+    for case in [
+        "stale-temp",
+        "stale-final-and-temp",
+        "malformed-temp",
+        "malformed-final-and-temp",
+        "unreadable-temp",
+        "unreadable-final-and-temp",
+    ] {
+        let directory = staged_intent_rejection_fixture(case);
+
+        let engine_connections = AtomicU64::new(0);
+        let error = reset_local_with_connector(
+            LocalResetRequest::new(directory.state_path(), true, CancellationToken::new()),
+            || {
+                engine_connections.fetch_add(1, Ordering::Relaxed);
+                std::future::ready(Err(LocalInitError::new(
+                    LocalInitErrorCode::EngineUnavailable,
+                )))
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code(), LocalInitErrorCode::ResetRequired, "{case}");
+        assert_eq!(engine_connections.load(Ordering::Relaxed), 0, "{case}");
+        assert!(
+            directory
+                .state_path()
+                .join(".reset-intent.json.automata-write")
+                .is_file(),
+            "{case} must retain staged evidence"
+        );
+        assert_eq!(
+            directory.state_path().join("reset-intent.json").is_file(),
+            case.ends_with("final-and-temp"),
+            "{case} must perform no publication or unlink"
+        );
+    }
+}
+
+#[tokio::test]
+async fn valid_staged_reset_intent_is_published_and_bypasses_entry_cancellation() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let installation = installation();
+    let epoch = super::super::epoch::authority_test_epoch(
+        &installation,
+        &[0x83; 32],
+        state.authority_sha256(),
+    );
+    directory.private_file("epoch.json", &epoch.canonical_bytes());
+    let intent = ResetIntent::new(
+        state.authority_sha256(),
+        &EstablishedState {
+            installation,
+            epoch,
+        },
+        None,
+    );
+    let bytes = intent.canonical_bytes().unwrap();
+    directory.private_file(".reset-intent.json.automata-write", &bytes);
+    drop(state);
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let engine_connections = AtomicU64::new(0);
+    let error = reset_local_with_connector(
+        LocalResetRequest::new(directory.state_path(), true, cancellation),
+        || {
+            engine_connections.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(Err(LocalInitError::new(
+                LocalInitErrorCode::EngineUnavailable,
+            )))
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.code(), LocalInitErrorCode::EngineUnavailable);
+    assert_eq!(engine_connections.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        fs::read(directory.state_path().join("reset-intent.json")).unwrap(),
+        bytes
+    );
+    assert!(
+        !directory
+            .state_path()
+            .join(".reset-intent.json.automata-write")
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn pre_cancelled_fresh_reset_precedes_unrelated_corrupt_state() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    directory.private_file("unknown-record", b"corrupt\n");
+    drop(state);
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let engine_connections = AtomicU64::new(0);
+    let error = reset_local_with_connector(
+        LocalResetRequest::new(directory.state_path(), true, cancellation),
+        || {
+            engine_connections.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(Err(LocalInitError::new(
+                LocalInitErrorCode::EngineUnavailable,
+            )))
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.code(), LocalInitErrorCode::Cancelled);
+    assert_eq!(engine_connections.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn status_api_rejects_a_restored_old_intent_against_new_canonical_custody() {
+    let directory = TestDirectory::new();
+    let state = StateRoot::acquire(&directory.state_path()).unwrap();
+    let old_installation = installation();
+    let old_epoch = super::super::epoch::authority_test_epoch(
+        &old_installation,
+        &[0x84; 32],
+        state.authority_sha256(),
+    );
+    let old_intent = ResetIntent::new(
+        state.authority_sha256(),
+        &EstablishedState {
+            installation: old_installation,
+            epoch: old_epoch,
+        },
+        None,
+    );
+    state
+        .store_reset_intent(&old_intent.canonical_bytes().unwrap())
+        .unwrap();
+    let new_installation = Installation::verified(
+        InstallationName::new("replacement").unwrap(),
+        InstallationId::new(),
+    );
+    let new_epoch = super::super::epoch::authority_test_epoch(
+        &new_installation,
+        &[0x85; 32],
+        state.authority_sha256(),
+    );
+    directory.private_file("epoch.json", &new_epoch.canonical_bytes());
+    directory.private_file(
+        "installation-selection.json",
+        &StateInstallationSelection::new(new_installation.name())
+            .canonical_bytes()
+            .unwrap(),
+    );
+    directory.private_file(
+        "materialization.json",
+        &StateMaterialization::new(new_epoch.fingerprint())
+            .canonical_bytes()
+            .unwrap(),
+    );
+    drop(state);
+
+    let error = inspect_local_status(LocalStatusRequest::new(
+        directory.state_path(),
+        CancellationToken::new(),
+    ))
+    .await
+    .unwrap_err();
+    assert_eq!(error.code(), LocalInitErrorCode::ResetRequired);
+}
+
+#[test]
+fn stable_status_json_is_exact_and_redacted_for_every_public_state() {
+    let fingerprint = Sha256Digest::from_bytes([0x33; 32]);
+    let recorded = LocalStatusReport {
+        schema: STATUS_SCHEMA,
+        status: LocalInstallationStatus::RecordedSealed,
+        installation: Some("default".to_owned()),
+        installation_id: Some("11111111-1111-4111-8111-111111111111".to_owned()),
+        workers: Some(1),
+        epoch_fingerprint: Some(fingerprint),
+        records: StatusRecords {
+            installation_selection: true.into(),
+            material_root: true.into(),
+            epoch: true.into(),
+            certificates: true.into(),
+            materialization: true.into(),
+            reset_intent: false.into(),
+        },
+        engine: Some(StatusEngine {
+            identity: "exact",
+            image_representations: "exact",
+            images: Vec::new(),
+            owned_union: "exact",
+            volumes: Vec::new(),
+            attachments: "absent",
+            unknown_managed_resources: "absent",
+        }),
+        volume_contents: "not_inspected",
+        reset: None,
+    };
+    let incomplete = LocalStatusReport {
+        schema: STATUS_SCHEMA,
+        status: LocalInstallationStatus::Incomplete,
+        installation: Some("default".to_owned()),
+        installation_id: None,
+        workers: None,
+        epoch_fingerprint: None,
+        records: StatusRecords {
+            installation_selection: true.into(),
+            material_root: false.into(),
+            epoch: false.into(),
+            certificates: false.into(),
+            materialization: false.into(),
+            reset_intent: false.into(),
+        },
+        engine: None,
+        volume_contents: "not_inspected",
+        reset: None,
+    };
+    let resetting = LocalStatusReport {
+        schema: STATUS_SCHEMA,
+        status: LocalInstallationStatus::ResetInProgress,
+        installation: Some("default".to_owned()),
+        installation_id: Some("11111111-1111-4111-8111-111111111111".to_owned()),
+        workers: None,
+        epoch_fingerprint: Some(fingerprint),
+        records: StatusRecords {
+            installation_selection: false.into(),
+            material_root: false.into(),
+            epoch: true.into(),
+            certificates: false.into(),
+            materialization: false.into(),
+            reset_intent: true.into(),
+        },
+        engine: None,
+        volume_contents: "not_inspected",
+        reset: Some(StatusReset {
+            removed_resources: 7,
+            total_resources: 13,
+        }),
+    };
+
+    let cases = [
+        (
+            incomplete,
+            serde_json::json!({
+                "schema": "automata.local/status/v1",
+                "status": "incomplete",
+                "installation": "default",
+                "installation_id": null,
+                "workers": null,
+                "epoch_fingerprint": null,
+                "records": {
+                    "installation_selection": true,
+                    "material_root": false,
+                    "epoch": false,
+                    "certificates": false,
+                    "materialization": false,
+                    "reset_intent": false
+                },
+                "engine": null,
+                "volume_contents": "not_inspected",
+                "reset": null
+            }),
+        ),
+        (
+            recorded,
+            serde_json::json!({
+                "schema": "automata.local/status/v1",
+                "status": "recorded_sealed",
+                "installation": "default",
+                "installation_id": "11111111-1111-4111-8111-111111111111",
+                "workers": 1,
+                "epoch_fingerprint": fingerprint.to_string(),
+                "records": {
+                    "installation_selection": true,
+                    "material_root": true,
+                    "epoch": true,
+                    "certificates": true,
+                    "materialization": true,
+                    "reset_intent": false
+                },
+                "engine": {
+                    "identity": "exact",
+                    "image_representations": "exact",
+                    "images": [],
+                    "owned_union": "exact",
+                    "volumes": [],
+                    "attachments": "absent",
+                    "unknown_managed_resources": "absent"
+                },
+                "volume_contents": "not_inspected",
+                "reset": null
+            }),
+        ),
+        (
+            resetting,
+            serde_json::json!({
+                "schema": "automata.local/status/v1",
+                "status": "reset_in_progress",
+                "installation": "default",
+                "installation_id": "11111111-1111-4111-8111-111111111111",
+                "workers": null,
+                "epoch_fingerprint": fingerprint.to_string(),
+                "records": {
+                    "installation_selection": false,
+                    "material_root": false,
+                    "epoch": true,
+                    "certificates": false,
+                    "materialization": false,
+                    "reset_intent": true
+                },
+                "engine": null,
+                "volume_contents": "not_inspected",
+                "reset": {"removed_resources": 7, "total_resources": 13}
+            }),
+        ),
+    ];
+
+    for (report, expected) in cases {
+        assert_eq!(serde_json::to_value(&report).unwrap(), expected);
+        let json = serde_json::to_string(&report).unwrap();
+        for forbidden in ["password", "private-key", "secret-key", "material-root"] {
+            assert!(!json.contains(forbidden));
+        }
+    }
+}

--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -1,9 +1,10 @@
 //! Cross-platform boundary for disposable local Automata installations.
 //!
 //! The crate owns Docker Engine discovery and exact local workflow inspection
-//! without depending on the product CLI. Lifecycle mutation is added in
-//! separately reviewed slices; [`inspect`] and [`check_workflow`] are read-only
-//! and create no engine resources, admission records, or host state.
+//! without depending on the product CLI. On x86-64 Linux it also owns sealed
+//! initialization, recorded-custody status, and exact confirmed reset;
+//! [`inspect`] and [`check_workflow`] remain read-only and create no engine
+//! resources, admission records, or host state.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -47,7 +48,9 @@ pub(crate) use desired_spec::{
 pub use engine::{DockerInstallationAdapter, LocalEngineError, LocalEngineErrorCode};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 pub use init::{
-    LocalInitError, LocalInitErrorCode, LocalInitOutcome, LocalInitRequest, initialize_local,
+    LocalInitError, LocalInitErrorCode, LocalInitOutcome, LocalInitRequest,
+    LocalInstallationStatus, LocalResetOutcome, LocalResetRequest, LocalStatusReport,
+    LocalStatusRequest, initialize_local, inspect_local_status, reset_local,
 };
 pub use installation::{
     ComposeProjectName, Installation, InstallationBinding, InstallationId, InstallationIdError,
@@ -463,6 +466,18 @@ pub struct EngineSelection {
     connection: DockerConnection,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ValidatedEngineSelection {
+    engine: Engine,
+    context_name: String,
+    endpoint: EngineEndpoint,
+    engine_id: String,
+    server_version: String,
+    api_version: String,
+    architecture: EngineArchitecture,
+    connection: DockerConnection,
+}
+
 impl EngineSelection {
     /// Returns the selected container engine.
     pub const fn engine(&self) -> Engine {
@@ -512,6 +527,42 @@ impl EngineSelection {
     /// Returns the exact Docker Compose plugin version.
     pub fn compose_version(&self) -> &str {
         &self.compose_version
+    }
+
+    pub(crate) fn validated_engine(&self) -> ValidatedEngineSelection {
+        ValidatedEngineSelection {
+            engine: self.engine,
+            context_name: self.context_name.clone(),
+            endpoint: self.endpoint,
+            engine_id: self.engine_id.clone(),
+            server_version: self.server_version.clone(),
+            api_version: self.api_version.clone(),
+            architecture: self.architecture,
+            connection: self.connection.clone(),
+        }
+    }
+}
+
+impl ValidatedEngineSelection {
+    #[cfg(test)]
+    pub(crate) fn connection_host(&self) -> &str {
+        self.connection.host()
+    }
+
+    pub(crate) fn engine_id(&self) -> &str {
+        &self.engine_id
+    }
+
+    pub(crate) fn server_version(&self) -> &str {
+        &self.server_version
+    }
+
+    pub(crate) fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
+    pub(crate) const fn architecture(&self) -> EngineArchitecture {
+        self.architecture
     }
 
     pub(crate) const fn connection(&self) -> &DockerConnection {
@@ -818,15 +869,44 @@ fn evaluate_engine(
         ));
         return None;
     }
+    let validated_engine =
+        evaluate_engine_only(operating_system, host_architecture, probes, issues);
+    let compose: Option<DockerComposeDocument> =
+        parse_probe(DoctorProbe::DockerCompose, &probes.compose, issues);
+    let compose_version = compose.as_ref().and_then(|compose| {
+        record_validation(
+            DoctorProbe::DockerCompose,
+            validate_compose(compose),
+            issues,
+        )
+    });
+    let validated_engine = validated_engine?;
+    Some(EngineSelection {
+        engine: validated_engine.engine,
+        compose: ComposeFrontend::DockerPlugin,
+        context_name: validated_engine.context_name,
+        endpoint: validated_engine.endpoint,
+        engine_id: validated_engine.engine_id,
+        server_version: validated_engine.server_version,
+        api_version: validated_engine.api_version,
+        architecture: validated_engine.architecture,
+        compose_version: compose_version?,
+        connection: validated_engine.connection,
+    })
+}
 
+fn evaluate_engine_only(
+    operating_system: &str,
+    host_architecture: &str,
+    probes: &ProbeSet,
+    issues: &mut Vec<DoctorIssue>,
+) -> Option<ValidatedEngineSelection> {
     let context: Option<DockerContextDocument> =
         parse_probe(DoctorProbe::DockerContext, &probes.context, issues);
     let version: Option<DockerVersionDocument> =
         parse_probe(DoctorProbe::DockerVersion, &probes.version, issues);
     let info: Option<DockerInfoDocument> =
         parse_probe(DoctorProbe::DockerInfo, &probes.info, issues);
-    let compose: Option<DockerComposeDocument> =
-        parse_probe(DoctorProbe::DockerCompose, &probes.compose, issues);
 
     let connection = context.as_ref().and_then(|context| {
         record_validation(
@@ -842,13 +922,6 @@ fn evaluate_engine(
             issues,
         )
     });
-    let compose_version = compose.as_ref().and_then(|compose| {
-        record_validation(
-            DoctorProbe::DockerCompose,
-            validate_compose(compose),
-            issues,
-        )
-    });
     let engine_id = info.as_ref().and_then(|info| {
         version.as_ref().and_then(|version| {
             record_validation(
@@ -858,16 +931,14 @@ fn evaluate_engine(
             )
         })
     });
-    Some(EngineSelection {
+    Some(ValidatedEngineSelection {
         engine: Engine::Docker,
-        compose: ComposeFrontend::DockerPlugin,
         context_name: connection.as_ref()?.context_name.clone(),
         endpoint: connection.as_ref()?.endpoint,
         engine_id: engine_id?,
         server_version: version.as_ref()?.server_version.clone(),
         api_version: version.as_ref()?.api_version.clone(),
         architecture: version.as_ref()?.architecture,
-        compose_version: compose_version?,
         connection: connection?,
     })
 }

--- a/crates/automata-ci/src/cli/commands.rs
+++ b/crates/automata-ci/src/cli/commands.rs
@@ -23,7 +23,7 @@ pub enum Command {
     /// This explicit mode is intended for release-image smoke tests and local
     /// UI previews. It never starts durable stores, Results, or runner control.
     Preview(PreviewArgs),
-    /// Inspect prerequisites for a disposable local Automata installation.
+    /// Inspect or manage a disposable local Automata installation.
     Local(LocalArgs),
     /// Authenticate the operator CLI and manage its server-scoped session.
     Auth(AuthArgs),
@@ -134,6 +134,12 @@ pub enum LocalCommand {
     /// Seal or replay one x86-64 Linux epoch without starting services.
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     Init(LocalInitArgs),
+    /// Inspect recorded custody or reset progress without changing host or Engine state.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    Status(LocalStatusArgs),
+    /// Remove exact sealed Engine custody while retaining images and the state root.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    Reset(LocalResetArgs),
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -152,6 +158,30 @@ pub struct LocalInitArgs {
     /// Operator-selected canonical release evidence; init verifies structure and digests, not OIDC authenticity.
     #[arg(long, value_name = "file:ABS", value_parser = parse_catalog_source)]
     pub catalog_source: String,
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[derive(Debug, Args)]
+/// Read-only sealed-installation status inputs.
+pub struct LocalStatusArgs {
+    /// Explicit absolute host directory containing installation custody.
+    #[arg(long, value_name = "ABS", value_parser = parse_absolute_state_directory)]
+    pub state_directory: PathBuf,
+    /// Render one stable redacted JSON document instead of human text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[derive(Debug, Args)]
+/// Exact destructive local-installation reset inputs.
+pub struct LocalResetArgs {
+    /// Explicit absolute host directory containing installation custody.
+    #[arg(long, value_name = "ABS", value_parser = parse_absolute_state_directory)]
+    pub state_directory: PathBuf,
+    /// Confirm deletion without an interactive prompt.
+    #[arg(long, required = true)]
+    pub yes: bool,
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/crates/automata-ci/src/cli/mod.rs
+++ b/crates/automata-ci/src/cli/mod.rs
@@ -44,7 +44,9 @@ pub use commands::{
     SecretDeleteArgs, SecretListArgs, SecretProviderArgs, SecretProviderCommand, ServerArgs,
 };
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-pub use commands::{InternalLocalArgs, InternalLocalCommand, LocalInitArgs};
+pub use commands::{
+    InternalLocalArgs, InternalLocalCommand, LocalInitArgs, LocalResetArgs, LocalStatusArgs,
+};
 pub use output::OutputFormat;
 pub use values::{RepositoryRef, SecretScope};
 

--- a/crates/automata-ci/src/local/mod.rs
+++ b/crates/automata-ci/src/local/mod.rs
@@ -7,9 +7,9 @@ use automata_ci_workflow_github::GithubWorkflowDispatchInputs;
 use automata_ci_workflow_service::BuiltInCredentialRequirement;
 use tokio_util::sync::CancellationToken;
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-use crate::cli::LocalInitArgs;
 use crate::cli::{LocalArgs, LocalCheckArgs, LocalCommand, LocalContainerEngine, LocalDoctorArgs};
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use crate::cli::{LocalInitArgs, LocalResetArgs, LocalStatusArgs};
 
 pub(crate) async fn execute(args: &LocalArgs) -> Result<()> {
     match &args.command {
@@ -17,7 +17,145 @@ pub(crate) async fn execute(args: &LocalArgs) -> Result<()> {
         LocalCommand::Check(args) => Box::pin(check(args)).await,
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         LocalCommand::Init(args) => Box::pin(init(args)).await,
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        LocalCommand::Status(args) => Box::pin(status(args)).await,
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        LocalCommand::Reset(args) => Box::pin(reset(args)).await,
     }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+async fn status(args: &LocalStatusArgs) -> Result<()> {
+    use automata_ci_local::{LocalStatusRequest, inspect_local_status};
+
+    let cancellation = CancellationToken::new();
+    let request = LocalStatusRequest::new(args.state_directory.clone(), cancellation.clone());
+    let mut inspection = Box::pin(inspect_local_status(request));
+    let report = tokio::select! {
+        biased;
+        () = crate::shutdown::wait_without_logging() => {
+            cancellation.cancel();
+            inspection.await.map_err(anyhow::Error::from)?
+        }
+        result = &mut inspection => result.map_err(anyhow::Error::from)?,
+    };
+    if args.json {
+        serde_json::to_writer_pretty(std::io::stdout().lock(), &report)?;
+        println!();
+    } else {
+        print_local_status(&report)?;
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn print_local_status(report: &automata_ci_local::LocalStatusReport) -> std::io::Result<()> {
+    write_local_status(report, &mut std::io::stdout().lock())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+struct LocalStatusPresentation {
+    status: automata_ci_local::LocalInstallationStatus,
+    installation: Option<String>,
+    installation_id: Option<String>,
+    workers: Option<u16>,
+    epoch_fingerprint: Option<String>,
+    image_count: usize,
+    volume_count: usize,
+    reset_progress: Option<(usize, usize)>,
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+impl From<&automata_ci_local::LocalStatusReport> for LocalStatusPresentation {
+    fn from(report: &automata_ci_local::LocalStatusReport) -> Self {
+        Self {
+            status: report.status(),
+            installation: report.installation().map(str::to_owned),
+            installation_id: report.installation_id().map(str::to_owned),
+            workers: report.workers(),
+            epoch_fingerprint: report.epoch_fingerprint().map(|value| value.to_string()),
+            image_count: report.image_count(),
+            volume_count: report.volume_count(),
+            reset_progress: report.reset_progress(),
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn write_local_status(
+    report: &automata_ci_local::LocalStatusReport,
+    writer: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    write_local_status_presentation(&LocalStatusPresentation::from(report), writer)
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn write_local_status_presentation(
+    report: &LocalStatusPresentation,
+    writer: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    let status = match report.status {
+        automata_ci_local::LocalInstallationStatus::Incomplete => "incomplete",
+        automata_ci_local::LocalInstallationStatus::RecordedSealed => "recorded sealed",
+        automata_ci_local::LocalInstallationStatus::ResetInProgress => "reset in progress",
+    };
+    writeln!(writer, "Automata local installation: {status}")?;
+    if let Some(installation) = report.installation.as_deref() {
+        writeln!(writer, "Installation: {installation}")?;
+    }
+    if let Some(id) = report.installation_id.as_deref() {
+        writeln!(writer, "Installation identity: {id}")?;
+    }
+    if let Some(workers) = report.workers {
+        writeln!(writer, "Worker slots: {workers}")?;
+    }
+    if let Some(fingerprint) = report.epoch_fingerprint.as_deref() {
+        writeln!(writer, "Epoch fingerprint: {fingerprint}")?;
+    }
+    if report.status == automata_ci_local::LocalInstallationStatus::RecordedSealed {
+        writeln!(
+            writer,
+            "Engine metadata: {} image representations, {} owned volumes; no attachments or unknown managed resources",
+            report.image_count, report.volume_count
+        )?;
+        writeln!(writer, "Volume contents: not inspected")?;
+    }
+    if let Some((removed, total)) = report.reset_progress {
+        writeln!(
+            writer,
+            "Reset progress: {removed}/{total} Engine resources removed"
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+async fn reset(args: &LocalResetArgs) -> Result<()> {
+    use automata_ci_local::{LocalResetRequest, reset_local};
+
+    let cancellation = CancellationToken::new();
+    let request =
+        LocalResetRequest::new(args.state_directory.clone(), args.yes, cancellation.clone());
+    let mut reset = Box::pin(reset_local(request));
+    let outcome = tokio::select! {
+        biased;
+        () = crate::shutdown::wait_without_logging() => {
+            cancellation.cancel();
+            reset.await.map_err(anyhow::Error::from)?
+        }
+        result = &mut reset => result.map_err(anyhow::Error::from)?,
+    };
+    println!(
+        "Automata local installation '{}' reset: {} persistent role volumes and the identity anchor removed; images were not removed{}",
+        outcome.installation(),
+        outcome.removed_volumes(),
+        if outcome.completed_after_cancellation() {
+            "; completed after shutdown cancellation"
+        } else {
+            ""
+        }
+    );
+    Ok(())
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -265,5 +403,75 @@ const fn architecture_name(architecture: EngineArchitecture) -> &'static str {
     match architecture {
         EngineArchitecture::Amd64 => "amd64",
         EngineArchitecture::Arm64 => "arm64",
+    }
+}
+
+#[cfg(all(test, target_os = "linux", target_arch = "x86_64"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_status_human_presentation_is_exact_for_every_public_state() {
+        let cases = [
+            (
+                LocalStatusPresentation {
+                    status: automata_ci_local::LocalInstallationStatus::Incomplete,
+                    installation: Some("default".to_owned()),
+                    installation_id: None,
+                    workers: None,
+                    epoch_fingerprint: None,
+                    image_count: 0,
+                    volume_count: 0,
+                    reset_progress: None,
+                },
+                "Automata local installation: incomplete\nInstallation: default\n",
+            ),
+            (
+                LocalStatusPresentation {
+                    status: automata_ci_local::LocalInstallationStatus::RecordedSealed,
+                    installation: Some("default".to_owned()),
+                    installation_id: Some("11111111-1111-4111-8111-111111111111".to_owned()),
+                    workers: Some(2),
+                    epoch_fingerprint: Some("sha256:fixture".to_owned()),
+                    image_count: 4,
+                    volume_count: 12,
+                    reset_progress: None,
+                },
+                concat!(
+                    "Automata local installation: recorded sealed\n",
+                    "Installation: default\n",
+                    "Installation identity: 11111111-1111-4111-8111-111111111111\n",
+                    "Worker slots: 2\n",
+                    "Epoch fingerprint: sha256:fixture\n",
+                    "Engine metadata: 4 image representations, 12 owned volumes; no attachments or unknown managed resources\n",
+                    "Volume contents: not inspected\n",
+                ),
+            ),
+            (
+                LocalStatusPresentation {
+                    status: automata_ci_local::LocalInstallationStatus::ResetInProgress,
+                    installation: Some("default".to_owned()),
+                    installation_id: Some("11111111-1111-4111-8111-111111111111".to_owned()),
+                    workers: None,
+                    epoch_fingerprint: Some("sha256:fixture".to_owned()),
+                    image_count: 0,
+                    volume_count: 0,
+                    reset_progress: Some((7, 13)),
+                },
+                concat!(
+                    "Automata local installation: reset in progress\n",
+                    "Installation: default\n",
+                    "Installation identity: 11111111-1111-4111-8111-111111111111\n",
+                    "Epoch fingerprint: sha256:fixture\n",
+                    "Reset progress: 7/13 Engine resources removed\n",
+                ),
+            ),
+        ];
+
+        for (report, expected) in cases {
+            let mut rendered = Vec::new();
+            write_local_status_presentation(&report, &mut rendered).unwrap();
+            assert_eq!(String::from_utf8(rendered).unwrap(), expected);
+        }
     }
 }

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -188,23 +188,91 @@ fn local_init_requires_explicit_canonical_host_custody_and_catalog_evidence() {
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
-fn local_init_stops_at_sealed_desired_state_without_hidden_lifecycle_commands() {
+fn local_init_status_and_reset_stop_before_service_lifecycle_commands() {
     let mut command = Cli::command();
     let local = command.find_subcommand_mut("local").expect("local command");
     let names = local
         .get_subcommands()
         .map(clap::Command::get_name)
         .collect::<Vec<_>>();
-    assert_eq!(names, ["doctor", "check", "init"]);
+    assert_eq!(names, ["doctor", "check", "init", "status", "reset"]);
 
     let init = local.find_subcommand_mut("init").expect("init command");
     let help = init.render_long_help().to_string();
     assert!(help.contains("without starting services"));
-    for hidden_lifecycle in ["up", "down", "status", "reset", "bootstrap", "relay"] {
+    let status = local.find_subcommand_mut("status").expect("status command");
+    let help = status.render_long_help().to_string();
+    assert!(help.contains("recorded custody or reset progress"));
+    let reset = local.find_subcommand_mut("reset").expect("reset command");
+    let help = reset.render_long_help().to_string();
+    assert!(help.contains("retaining images and the state root"));
+    for hidden_lifecycle in ["up", "down", "bootstrap", "relay"] {
         assert!(
             Cli::try_parse_from(["automata", "local", hidden_lifecycle]).is_err(),
-            "{hidden_lifecycle} must not leak into the v1 init-only boundary"
+            "{hidden_lifecycle} must not leak into the current sealed-custody boundary"
         );
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn local_status_and_reset_require_explicit_state_and_reset_confirmation() {
+    let cli = Cli::try_parse_from([
+        "automata",
+        "local",
+        "status",
+        "--state-directory",
+        "/var/lib/automata-local/team",
+        "--json",
+    ])
+    .unwrap();
+    let Command::Local(local) = cli.command else {
+        panic!("local command expected");
+    };
+    let LocalCommand::Status(args) = local.command else {
+        panic!("local status expected");
+    };
+    assert_eq!(
+        args.state_directory,
+        std::path::Path::new("/var/lib/automata-local/team")
+    );
+    assert!(args.json);
+
+    let cli = Cli::try_parse_from([
+        "automata",
+        "local",
+        "reset",
+        "--state-directory",
+        "/var/lib/automata-local/team",
+        "--yes",
+    ])
+    .unwrap();
+    let Command::Local(local) = cli.command else {
+        panic!("local command expected");
+    };
+    let LocalCommand::Reset(args) = local.command else {
+        panic!("local reset expected");
+    };
+    assert!(args.yes);
+
+    for invalid in [
+        vec!["automata", "local", "status"],
+        vec![
+            "automata",
+            "local",
+            "status",
+            "--state-directory",
+            "relative",
+        ],
+        vec![
+            "automata",
+            "local",
+            "reset",
+            "--state-directory",
+            "/var/lib/automata-local/team",
+        ],
+    ] {
+        assert!(Cli::try_parse_from(invalid).is_err());
     }
 }
 
@@ -235,7 +303,7 @@ fn internal_local_materializer_is_one_fixed_argument_free_operation() {
 
 #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 #[test]
-fn local_init_and_its_internal_materializer_are_not_advertised() {
+fn linux_x86_64_local_mutations_and_internal_materializer_are_not_advertised() {
     let mut command = Cli::command();
     let local = command.find_subcommand_mut("local").expect("local command");
     let names = local
@@ -243,7 +311,9 @@ fn local_init_and_its_internal_materializer_are_not_advertised() {
         .map(clap::Command::get_name)
         .collect::<Vec<_>>();
     assert_eq!(names, ["doctor", "check"]);
-    assert!(Cli::try_parse_from(["automata", "local", "init"]).is_err());
+    for command in ["init", "status", "reset"] {
+        assert!(Cli::try_parse_from(["automata", "local", command]).is_err());
+    }
     assert!(Cli::try_parse_from(["automata", "internal", "local", "materialize"]).is_err());
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -276,7 +276,7 @@ the locked, reproducible profile environment:
 Read [the UI guide](../ui/README.md) before changing the render contract or
 adding a page kind.
 
-## Local installation preflight and sealed init
+## Local installation preflight and sealed custody
 
 The cross-platform local-installation preflight is a read-only host check for
 x86-64 Linux, Apple Silicon macOS, and x86-64 Windows. It requires a local Linux
@@ -299,6 +299,10 @@ boundary:
 cargo run --locked -p automata-ci -- local init \
   --state-directory /var/lib/automata-local/default \
   --catalog-source file:/srv/automata-release/local-installation-catalog.json
+cargo run --locked -p automata-ci -- local status \
+  --state-directory /var/lib/automata-local/default --json
+cargo run --locked -p automata-ci -- local reset \
+  --state-directory /var/lib/automata-local/default --yes
 ```
 
 It accepts only an x86-64 Linux Engine at
@@ -316,8 +320,21 @@ records/resources.
 Init stops after sealing material and desired intent. It has no renderer,
 generates no Compose document, invokes no Compose operation, and starts no
 control plane, relay, bootstrap, database, object store, or runner.
-`ResetRequired` is detectable, but no reset command exists yet; `local up`,
-`down`, `status`, and `reset` remain planned. Follow the
+`local status` opens only existing custody under a shared, nonrepairing lock and
+validates canonical host records plus exact Engine metadata. It does not run a
+volume inspector, so `recorded_sealed` explicitly means that volume contents
+and manifests were not live-attested. `local reset` never prompts and requires
+`--yes`; it requires an authority-bound canonical epoch and complete exact
+post-Desired Engine custody, then reconciles its self-contained durable deletion
+transaction despite cancellation. Safe malformed or missing non-authority
+material/certificate records do not strand cleanup, but copied/pre-guard,
+conflicting canonical, mismatched, unexpectedly managed, or foreign-attached
+custody is refused before mutation. Images, the state directory, and its
+original operation lock remain. Status and reset connect directly to the fixed
+Docker socket; they do not depend on the Docker CLI, current context,
+`DOCKER_API_VERSION`, or Compose plugin. Reset does not require retained image
+representations to remain present. `local up` and `down`
+remain planned. Follow the
 [local installation and deployment roadmap](maintainers/roadmaps/local-installation.md) for
 their merge and host-qualification gates.
 

--- a/docs/maintainers/roadmaps/local-installation.md
+++ b/docs/maintainers/roadmaps/local-installation.md
@@ -2,14 +2,16 @@
 
 - Roadmap status: Active
 - Available slice: read-only `automata local doctor`, source-only
-  `automata local check`, x86-64 Linux-only sealed `automata local init`, and
-  explicit runner-schema-6 evaluation through the fixed-relay `LocalDocker`
-  provider; init starts no services and there is no `automata local run` or
-  `up` yet
+  `automata local check`, x86-64 Linux-only sealed `automata local init`,
+  recorded-metadata `status`, exact confirmed `reset`, and explicit
+  runner-schema-6 evaluation through the fixed-relay `LocalDocker` provider;
+  init starts no services and there is no `automata local run`, `up`, or `down`
+  yet
 - Current implementation checkpoints: 2B.1 pinned Docker context and immutable
   identity anchor; 2B.2 verified catalog/image/material/epoch/desired sealing;
-  the evaluation-only 3A provider and closed Results gateway foundation; plus
-  the read-only source-validation portion of 3B
+  2B.3 read-only custody status and exact established reset; the evaluation-only
+  3A provider and closed Results gateway foundation; plus the read-only
+  source-validation portion of 3B
 - Date: 2026-08-17
 
 This roadmap owns the work required to make Automata easy to evaluate on one
@@ -124,6 +126,8 @@ automata local doctor [--json]
 automata local check [WORKFLOW] [--input NAME=VALUE]... [--json]
 automata local init --state-directory ABS --catalog-source file:ABS
   [--installation NAME] [--workers N]
+automata local status --state-directory ABS [--json]
+automata local reset --state-directory ABS --yes
 ```
 
 Init is x86-64 Linux-only and stops after sealed material and canonical desired
@@ -137,9 +141,7 @@ automata local run [WORKFLOW] [--workers N] [--event EVENT]
   [--non-interactive] [--allow-missing-secrets] [--json]
 
 automata local up
-automata local status [--json]
 automata local down
-automata local reset [--yes]
 automata local services logs [SERVICE] [--follow]
 
 automata local runs list
@@ -167,10 +169,13 @@ recovery, and repeated use; their existence must not turn the quickstart into a
 manual assembly guide. `up` never prompts for a workflow, secret, browser, or
 GitHub connection.
 
-Every command that addresses an installation accepts the same
-`--installation NAME` selector. Host-only `doctor` and source-only `check` do
-not invent or select an installation. Any native cache location is an internal
-platform choice, not installation identity or a public lifecycle selector.
+The future converged lifecycle commands that select an installation accept the
+same `--installation NAME` selector. Current sealed init accepts that selector;
+current status and reset instead derive the immutable name and ID from the
+explicit `--state-directory` custody and deliberately accept no separate
+selector. Host-only `doctor` and source-only `check` do not invent or select an
+installation. Any native cache location is an internal platform choice, not
+installation identity or a public lifecycle selector.
 An installation is a repository-agnostic deployment and runner-capacity domain:
 the same selected installation may admit snapshots from different repositories,
 and repository identity never enters its selector key, engine labels, Compose
@@ -201,7 +206,7 @@ onboarding path:
 | --- | --- | --- |
 | `automata local doctor` | Cross-platform host, Docker, Compose, and architecture preflight | It is deliberately read-only; checkpoint 2A retired checkpoint 1's proposed native state-root input, and checkpoint 2B.1 makes installation identity engine-owned |
 | `automata local check` | Deterministic bounded live-worktree archive, exact `.github/workflows` selection, local-only manual event compilation, reachable same-snapshot reusable workflows with typed call-graph and root-secret propagation, and value-free external/built-in credential discovery | It is deliberately read-only and fails closed on Windows; repository identity, local admission, scheduling, execution, and GitHub Checks remain absent |
-| `automata local init` | x86-64 Linux-only exact-socket identity/image/volume adoption, host material and one-time certificate custody, fixed materialization, and sealed canonical desired intent | It has no renderer or Compose document and starts no services; convergence, bootstrap, `up`, `down`, `status`, and reset remain absent |
+| `automata local init`, `status`, and `reset` | x86-64 Linux-only exact-socket identity/image/volume adoption, host material and one-time certificate custody, fixed materialization, sealed canonical desired intent, read-only recorded-custody inspection, and exact confirmed teardown | Status does not live-attest volume contents; reset requires an authority-bound epoch plus complete post-guard Engine custody and retains images; convergence, bootstrap, `up`, and `down` remain absent |
 | `automata-ci-local` Docker boundary | Exact-endpoint anchor and sealed-init management plus a private fixed-relay provider with deterministic closed Results topology | Convergent lifecycle must provision and reattest the renderer-owned shared transit/listener |
 | Control-plane configuration and container build | Complete server configuration and product images | Configuration and bootstrap are manual and Unix-oriented |
 | GitHub workflow crates | Frontend, compiler, typed workflow contracts, reusable-workflow handling | They need a separately authorized local snapshot source |
@@ -409,7 +414,11 @@ time alone never authorizes lock deletion.
 
 #### Exact reset
 
-Reset runs under that lock and uses this ordered transaction:
+This subsection specifies the future converged lifecycle reset after checkpoint
+2C. It includes repositories, service topology, OS credentials, and the
+Engine-held lifecycle lock; it does not describe checkpoint 2B.3's noninteractive
+sealed-custody reset, whose narrower implemented contract is recorded below.
+The converged reset runs under that lock and uses this ordered transaction:
 
 Before confirmation, the command lists the installation-wide repositories,
 history, repository-scoped secrets, and GitHub connections that will be lost;
@@ -435,8 +444,11 @@ reset is never presented as a checkout-local operation.
    labels and requery the exact credential selectors, reporting any residue or
    concurrently created installation rather than claiming success.
 
-No reset path trusts resource IDs from a host file, deletes by broad label
-query, removes a caller-supplied directory, or uses a global prune.
+Ordinary resources are rediscovered by deterministic name and immutable labels;
+the sole host-recorded resource ID is the authority-bound reset intent's
+prevalidated helper ID, which is live-reinspected before exact-ID removal. No
+reset path deletes by broad label query, removes a caller-supplied directory, or
+uses a global prune.
 
 ### Workers and job sandboxes
 
@@ -496,15 +508,17 @@ Jobs receive a copy of the admitted immutable snapshot, never a writable host
 bind. Workflows that require GitHub API authority fail with an actionable
 instruction to connect GitHub or configure a separately supported credential.
 
-### Internal native cache and secrets
+### Required custody and optional native caches
 
-The implementation may use a platform-standard native directory for a
-process-local coordinator lock, discardable inspection cache, or redacted
-diagnostic evidence. That path is internal and is not accepted as a public
-installation selector. Deleting it cannot create, adopt, lose, rebind, or reset
-an installation. Installation identity comes from the immutable external volume
-labels, desired intent comes from the digest-bound config-volume document, and
-live state comes from inspected Compose topology.
+The explicit state directory introduced by sealed init is durable authority,
+not a cache: its stable directory and operation-lock identities bind the epoch,
+and it retains one-time certificate custody. Copying, replacing, or deleting it
+cannot silently adopt or recover an installation. A future platform port may
+add a separate discardable inspection cache or redacted diagnostic evidence,
+but that cache must not contain or select custody and must remain distinct from
+the required state directory. Installation identity is also anchored in the
+immutable external volume, while current status derives bounded live metadata
+directly from the Engine rather than trusting a mirrored inventory.
 
 If a later implementation genuinely needs a crash-safe host document, that
 cross-cutting contract is designed separately after auditing the runner
@@ -568,13 +582,13 @@ restart, and keep local-manager and dependency routes private.
 
 ### Engine and Docker Desktop trust
 
-The active Docker context and daemon are part of installation scope. Doctor,
-status, and every mutation report the selected context and verified engine
-identity; an installation on another context is not silently adopted. A new
-installation plan names the active context before creating its anchor. Context
-switching can therefore make an installation appear absent until the operator
-returns to its daemon, and the documentation treats context migration as a
-separate export/restore operation rather than name reuse.
+For doctor, init, and the future portable lifecycle, the active Docker context
+and daemon are part of installation scope: those operations report the selected
+context and verified engine identity, and do not silently adopt an installation
+from another context. Checkpoint 2B.3 status/reset are the deliberate recovery
+exception: they address only the fixed Linux Docker socket and ignore the
+current CLI context. Future context migration remains a separate export/restore
+operation rather than name reuse.
 
 Anyone authorized to control that daemon is trusted as an installation
 administrator. Docker access can mount or delete volumes, alter labels, inspect
@@ -662,7 +676,10 @@ resource.
 Status: available. Host, Docker, Compose, and architecture behavior remains
 useful and is retained. Checkpoint 2A removed public state-root resolution and
 its readiness gate because checkpoint 2B.1 makes installation identity
-engine-owned and any optional native cache remains internal and discardable.
+engine-owned. Checkpoint 2B.2 later introduced an explicit operator-selected
+private custody directory for epoch material and one-time certificates. That
+directory is authority-bound durable state, not an optional or discardable
+cache.
 
 ### 2A. Retire host lifecycle state and freeze the reuse boundary
 
@@ -776,19 +793,64 @@ The slice persists canonical credential-free desired intent, including the
 imported service-proxy tag plus both acceptable OCI IDs for later reattestation.
 It has no renderer, produces no Compose document, and then stops. Init invokes
 no Compose operation and starts no control plane, relay, bootstrap, database,
-object store, or runner; `up`, `down`, `status`, and `reset` remain absent.
-`ResetRequired` is detectable, but no reset command exists yet. Stateful
+object store, or runner. `local status` is existing-only and nonrepairing: it
+reports `recorded_sealed` only after canonical host custody and exact bounded
+Engine metadata agree, while explicitly leaving volume contents uninspected.
+`local reset` requires an absolute state directory and `--yes`, authorizes an
+authority-bound canonical epoch only after exact complete post-Desired Engine
+custody agrees, completes a durable reconciling deletion transaction, and
+retains images plus the custody root and operation lock. Safe missing or
+malformed non-authority host records do not strand cleanup. Retained image
+absence or retagging does not block custody deletion. `up` and `down` remain
+absent. Stateful
 recovery, adversarial parser and filesystem tests, strict helper-inspection
 tests, and live Docker portable-load qualification cover the sealed boundary.
 This completes checkpoint 2B's material/desired-intent handoff without claiming
 convergence.
 
-### 2C. Convergent Compose lifecycle and exact reset
+#### 2B.3. Read-only recorded status and exact established reset
+
+Status acquires an existing-only shared operation lock and performs no state
+repair, helper creation, or volume-content inspection. Its stable human and JSON
+reports distinguish incomplete custody, recorded sealed metadata, and durable
+reset progress without exposing secret values. Reset requires explicit `--yes`
+and a full all-before-any preflight: an authority-bound canonical epoch,
+positive complete post-Desired ownership, the sealed-epoch-derived contract for
+any present init helper, the identity anchor and twelve roles, no foreign
+attachments, and no unexpected related volumes, containers, or networks.
+Material-root and certificate bytes never authorize deletion; missing or safely
+malformed non-authority records remain removable evidence, while a canonically
+valid conflicting selection or materialization record blocks before mutation.
+That conflict check covers both final records and readable fixed crash
+temporaries; a second different valid authority epoch also blocks, and a
+temp-only epoch must first be published by exact init replay.
+Both commands connect directly to the fixed Docker Unix socket with pinned API
+1.48 and validate/reverify daemon identity, Linux/amd64, Engine 28+, and API
+range. Docker CLI availability, its current context, `DOCKER_API_VERSION`, and
+the Compose plugin are deliberately irrelevant to inspection and teardown;
+init and public doctor retain their full CLI/context/Compose preflight.
+The reset-only reader pins fixed names with no-follow path descriptors and
+accepts only invoking-user-owned regular single-link files with owner-only,
+non-special permissions; unreadable non-authority files are opaque, while epoch
+and reset intent must remain owner-readable. Status retains the exact `0600`
+health contract. Pre-guard and copied custody never authorize Engine mutation.
+
+The authority- and closed-topology-bound reset intent is durable before the
+first deletion and is self-contained for replay even when other host records
+are later lost or corrupted. Replay removes an exact stale init helper first,
+the eleven non-Desired roles, Desired, and the identity anchor, reconciling
+ambiguous outcomes to inspected absence. Cancellation after intent is latched
+while the complete transaction finishes; operation errors still dominate. Only
+after Engine absence is rediscovered are whatever safe fixed host records
+remain removed with epoch and reset intent last. Imported images, the state
+directory, and the original verified operation lock remain.
+
+### 2C. Convergent Compose lifecycle
 
 Build on the completed 2B.2 sealed desired-intent/material handoff. Introduce
 the renderer and its complete executable command surface together, then add
 convergence, digest-labeled replaceable topology, the inert ID-held engine lock,
-union discovery, `up`, `status`, `down`, and exact reset. The command layer
+union discovery, `up`, converged live status, and `down`. The command layer
 remains private until these operations are convergent and their destructive
 boundary is proven.
 
@@ -973,7 +1035,8 @@ Gate: the one-command run works from clean state; the second secret-bearing run
 does not prompt; `--workers 3` overlaps three jobs; history and logs are useful;
 `down -> up` preserves identity, desired digest, `N`, profile, and data; and the
 ordered reset deletes only the prevalidated topology, credentials, anchor, and
-lock, with no residue on immediate reinspection.
+fixed custody records, retaining the state directory and original operation
+lock with no Engine residue on immediate reinspection.
 
 ### 6. Apple Silicon macOS qualification
 
@@ -988,9 +1051,11 @@ Keychain behavior, private discardable cache/lock creation, immutable external
 identity-volume labels, atomic desired-spec updates, interruption, and exact
 reset. The selected context and local driver/scope are reported; identity,
 desired spec, and persistent data survive down/up, Desktop restart, sleep, and
-host reboot. Deleting the host cache leaves Compose discovery and recovery
-correct. The guide records current Docker Desktop prerequisites and terms,
-engine-authorized-user trust, and the factory-reset/uninstall data-loss boundary.
+host reboot. Deleting a separate optional inspection cache leaves discovery
+correct, while missing or moved durable custody fails closed until an explicit
+migration or reset path authorizes recovery. The guide records current Docker
+Desktop prerequisites and terms, engine-authorized-user trust, and the
+factory-reset/uninstall data-loss boundary.
 
 ### 7. Windows x86-64 qualification
 
@@ -1005,10 +1070,12 @@ junction and reparse-point refusal where a cache path is used, long paths,
 immutable external identity-volume labels, interruption, and exact reset.
 The selected context, Linux daemon mode, and local driver/scope are reported;
 identity, desired spec, and persistent data survive down/up, Desktop restart,
-and host reboot. Deleting the host cache leaves Compose discovery and recovery
-correct; no native Windows execution provider is involved. Docker Desktop
-prerequisites, terms, engine-authorized-user trust, and the
-factory-reset/uninstall data-loss boundary are current.
+and host reboot. Deleting a separate optional inspection cache leaves discovery
+correct, while missing or moved durable custody fails closed until an explicit
+migration or reset path authorizes recovery; no native Windows execution
+provider is involved. Docker Desktop prerequisites, terms,
+engine-authorized-user trust, and the factory-reset/uninstall data-loss boundary
+are current.
 
 ### 8A. Frozen signed release candidate
 


### PR DESCRIPTION
## Outcome

Adds public, x86-64 Linux `automata local status` and custody-only `automata local reset` consumers for the sealed installation produced by #425.

Status is existing-only and metadata-only: it takes a shared nonblocking state lock, performs no repair or helper creation, independently validates state authority and the complete related Engine union, and reports `uninitialized_at_path`, `busy`, `unbound_initializing`, `replayable_initializing`, `recorded_sealed`, `reset_in_progress`, copied/replaced custody, or explicit recovery requirements without exposing material.

Reset requires an explicit absolute state directory and `--yes`. It authorizes deletion only from the authority-bound epoch plus positive post-Desired custody, performs an all-before-any complete Engine preflight, persists a self-contained durable reset intent, removes an exact stranded helper first, then eleven non-Desired roles, Desired, and the anchor, and erases fixed host records last while retaining images, the state directory, and the original operation lock.

## Safety and integration

- Preserves #425 strict five-record init publication and unknown-entry rejection.
- Shares the remediated full Engine resource census instead of restoring the older duplicate verifier.
- Enforces exact `io.automata.local.*` labels while tolerating unrelated foreign labels and rejecting contradictory Compose-project evidence.
- Replays final and staged reset intent safely, rejects stale same-authority rollback evidence, and shields cancellation after durable intent publication.
- Uses a direct fixed-socket Bollard path for status/reset, independent of Docker CLI context, Compose, and ambient `DOCKER_API_VERSION`; init/doctor behavior is unchanged.
- Reset is image- and volume-content-independent and never mounts persistent volumes.
- No renderer, service lifecycle, `up`, or `down` command is added.

## Verification

Exact reviewed head: `447c2230c7dfa19b8b26fce24398354c411e77b0`, parent/main `fc536987f23d5d9077988a213c739c972154551e`.

- `cargo fmt --all -- --check`
- `git diff --check HEAD^ HEAD`
- `cargo test --locked -p automata-ci-local --lib` — 279 passed, 5 ignored live-Docker tests
- `cargo test --locked -p automata-ci --lib` — 523 passed
- `cargo test --locked -p automata-ci --test cli` — 36 passed
- `cargo clippy --workspace --lib --bins --all-features --locked -- -D warnings`
- Independent state/Engine/CLI/docs audit: NO BLOCKER

A broad all-feature workspace library run reaches two unchanged Windows enrollment test failures in `automata-ci-runner`; both reproduce identically on a clean detached current-main worktree and this patch does not modify runner or dependency files.

## AI assistance

Codex materially assisted the implementation, security review, regression tests, semantic rebase, documentation, and immutable-byte verification.

## Checklist

- [x] Tests cover the owning public boundary.
- [x] User-facing documentation and compatibility status are updated.
- [x] Reports and fixtures expose no secret or private material.
- [x] Destructive operations require explicit confirmation and exact custody proof.
- [x] Unsupported lifecycle behavior remains unavailable.
- [x] I reviewed and understand every submitted change, including AI-assisted work.