### PR TITLE
feat(provider): add configuration registry foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,26 @@ name = "automata-ci-provider"
 version = "0.1.0"
 dependencies = [
  "automata-ci-core",
+ "automata-ci-key-management",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "automata-ci-provider-postgres"
+version = "0.1.0"
+dependencies = [
+ "automata-ci-core",
+ "automata-ci-key-management",
+ "automata-ci-postgres",
+ "automata-ci-provider",
+ "sha2 0.11.0",
+ "sqlx",
+ "tokio",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/automata-ci-oidc-github",
     "crates/automata-ci-postgres",
     "crates/automata-ci-provider",
+    "crates/automata-ci-provider-postgres",
     "crates/automata-ci-protocol",
     "crates/automata-ci-protocol-protobuf",
     "crates/automata-ci-provisioning",
@@ -101,6 +102,7 @@ automata-ci-metrics = { path = "crates/automata-ci-metrics", version = "0.1.0" }
 automata-ci-oidc-github = { path = "crates/automata-ci-oidc-github", version = "0.1.0" }
 automata-ci-postgres = { path = "crates/automata-ci-postgres", version = "0.1.0" }
 automata-ci-provider = { path = "crates/automata-ci-provider", version = "0.1.0" }
+automata-ci-provider-postgres = { path = "crates/automata-ci-provider-postgres", version = "0.1.0" }
 automata-ci-protocol = { path = "crates/automata-ci-protocol", version = "0.1.0" }
 automata-ci-protocol-protobuf = { path = "crates/automata-ci-protocol-protobuf", version = "0.1.0" }
 automata-ci-provisioning = { path = "crates/automata-ci-provisioning", version = "0.1.0" }

--- a/crates/automata-ci-core/src/id.rs
+++ b/crates/automata-ci-core/src/id.rs
@@ -76,6 +76,77 @@ uuid_id!(/// Idempotency key for a mutating operation.
 uuid_id!(/// Identifies a durable stream of log frames.
     LogStreamId);
 
+/// Canonical non-nil identity of one Automata workspace.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct WorkspaceId(Uuid);
+
+impl WorkspaceId {
+    /// Parses an exact lower-case hyphenated non-nil workspace UUID.
+    ///
+    /// # Errors
+    ///
+    /// Rejects nil, non-hyphenated, upper-case, or otherwise noncanonical text.
+    pub fn parse(value: &str) -> Result<Self, WorkspaceIdError> {
+        let parsed = Uuid::parse_str(value).map_err(|_| WorkspaceIdError)?;
+        if parsed.is_nil() || parsed.hyphenated().to_string() != value {
+            return Err(WorkspaceIdError);
+        }
+        Ok(Self(parsed))
+    }
+
+    /// Constructs a workspace identity from a non-nil UUID.
+    ///
+    /// # Errors
+    ///
+    /// Rejects the nil UUID.
+    pub const fn from_uuid(value: Uuid) -> Result<Self, WorkspaceIdError> {
+        if value.is_nil() {
+            return Err(WorkspaceIdError);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the underlying UUID.
+    #[must_use]
+    pub const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for WorkspaceId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0.hyphenated())
+    }
+}
+
+impl FromStr for WorkspaceId {
+    type Err = WorkspaceIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for WorkspaceId {
+    type Error = WorkspaceIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(&value)
+    }
+}
+
+impl From<WorkspaceId> for String {
+    fn from(value: WorkspaceId) -> Self {
+        value.to_string()
+    }
+}
+
+/// Invalid canonical workspace identity.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("workspace ID is invalid")]
+pub struct WorkspaceIdError;
+
 /// Stable positive numeric alias for a workflow run.
 ///
 /// [`RunId`] remains the internal identity. This compact alias exists for

--- a/crates/automata-ci-core/tests/identifier_contract.rs
+++ b/crates/automata-ci-core/tests/identifier_contract.rs
@@ -1,5 +1,27 @@
-use automata_ci_core::{AttemptNumber, FencingToken, IdentifierError, RunId, RunIdAlias};
+use automata_ci_core::{
+    AttemptNumber, FencingToken, IdentifierError, RunId, RunIdAlias, WorkspaceId, WorkspaceIdError,
+};
 use uuid::Uuid;
+
+#[test]
+fn workspace_ids_are_canonical_and_non_nil() {
+    let value = "22222222-2222-4222-8222-222222222222";
+    let workspace = WorkspaceId::parse(value).expect("workspace ID");
+    assert_eq!(workspace.to_string(), value);
+    assert_eq!(
+        serde_json::from_str::<WorkspaceId>(&format!("\"{value}\"")).expect("deserialize"),
+        workspace
+    );
+
+    for invalid in [
+        "00000000-0000-0000-0000-000000000000",
+        "22222222222242228222222222222222",
+        "22222222-2222-4222-8222-22222222222A",
+    ] {
+        assert_eq!(WorkspaceId::parse(invalid), Err(WorkspaceIdError));
+    }
+    assert_eq!(WorkspaceId::from_uuid(Uuid::nil()), Err(WorkspaceIdError));
+}
 
 #[test]
 fn typed_ids_have_stable_json_string_encoding() {

--- a/crates/automata-ci-provider-postgres/Cargo.toml
+++ b/crates/automata-ci-provider-postgres/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "automata-ci-provider-postgres"
+description = "PostgreSQL provider manifest repository for Automata"
+publish.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+
+[dependencies]
+automata-ci-core.workspace = true
+automata-ci-key-management.workspace = true
+automata-ci-provider.workspace = true
+sqlx.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+automata-ci-postgres = { workspace = true, features = ["test-support"] }
+sha2.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/automata-ci-provider-postgres/LICENSE
+++ b/crates/automata-ci-provider-postgres/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Automata CI contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/automata-ci-provider-postgres/README.md
+++ b/crates/automata-ci-provider-postgres/README.md
@@ -1,0 +1,5 @@
+# automata-ci-provider-postgres
+
+PostgreSQL persistence for provider instance and repository connection
+manifests. Named provider secrets are stored only as authenticated encrypted
+envelopes.

--- a/crates/automata-ci-provider-postgres/src/connection.rs
+++ b/crates/automata-ci-provider-postgres/src/connection.rs
@@ -1,0 +1,389 @@
+use automata_ci_core::WorkspaceId;
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
+    ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
+    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    ProviderDefaultBranch, ProviderInstanceId, ProviderRepositoryError, ProviderRepositoryPath,
+    ProviderRunnerPolicyBinding, ProviderSaveOutcome, ProviderSchemaVersion,
+    ProviderWorkflowSource, RepositoryVisibility,
+};
+use sqlx::{FromRow, Postgres, Transaction};
+
+use crate::{
+    CONNECTION_LOCK_SALT, PostgresProviderManifestRepository, digest, lifecycle, lifecycle_text,
+    lock, optional_timestamp, positive_u16, positive_u64, timestamp, unavailable,
+};
+
+#[derive(FromRow)]
+struct ConnectionRow {
+    connection_id: uuid::Uuid,
+    revision: i64,
+    lifecycle_state: String,
+    workspace_id: String,
+    provider_instance_id: uuid::Uuid,
+    external_repository_id: String,
+    provider_revision: i64,
+    provider_configuration_digest: Vec<u8>,
+    capability_digest: Vec<u8>,
+    repository_visibility: String,
+    default_branch: String,
+    workflow_source_kind: String,
+    workflow_source_path: String,
+    runner_policy_schema: i16,
+    runner_policy_digest: Vec<u8>,
+    archive_compressed_bytes: i64,
+    archive_expanded_bytes: i64,
+    archive_entries: i64,
+    archive_entry_path_bytes: i64,
+    archive_workflows: i64,
+    workflow_bytes: i64,
+    adapter_policy_schema: i16,
+    adapter_policy_bytes: Vec<u8>,
+    adapter_policy_digest: Vec<u8>,
+    configuration_digest: Vec<u8>,
+    created_at_ms: i64,
+    activated_at_ms: Option<i64>,
+    retired_at_ms: Option<i64>,
+    manifest_digest: Vec<u8>,
+}
+
+impl PostgresProviderManifestRepository {
+    pub(crate) async fn save_connection_inner(
+        &self,
+        manifest: ProviderConnectionManifest,
+    ) -> Result<ProviderSaveOutcome, ProviderRepositoryError> {
+        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
+        lock(
+            &mut transaction,
+            &manifest.connection_id().to_string(),
+            CONNECTION_LOCK_SALT,
+        )
+        .await?;
+        let current = sqlx::query_as::<_, ConnectionRow>(
+            r"
+            SELECT revisions.*
+            FROM provider_connection_current AS current
+            JOIN provider_connection_revisions AS revisions
+              ON revisions.connection_id = current.connection_id
+             AND revisions.revision = current.revision
+            WHERE current.connection_id = $1
+            FOR UPDATE OF current
+            ",
+        )
+        .bind(manifest.connection_id().as_uuid())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        if let Some(current) = current {
+            let current = decode_connection(current)?;
+            if manifest.revision() == current.revision() {
+                if manifest.digest() == current.digest() {
+                    return Ok(ProviderSaveOutcome::Unchanged);
+                }
+                return Err(ProviderRepositoryError::Conflict);
+            }
+            manifest
+                .validate_successor(&current)
+                .map_err(|_| ProviderRepositoryError::Conflict)?;
+        } else if manifest.revision().get() != 1 {
+            return Err(ProviderRepositoryError::Conflict);
+        }
+
+        ensure_connection_references(&mut transaction, &manifest).await?;
+        insert_connection(&mut transaction, &manifest).await?;
+        sqlx::query(
+            r"
+            INSERT INTO provider_connection_current (connection_id, revision)
+            VALUES ($1, $2)
+            ON CONFLICT (connection_id) DO UPDATE
+            SET revision = EXCLUDED.revision
+            ",
+        )
+        .bind(manifest.connection_id().as_uuid())
+        .bind(
+            i64::try_from(manifest.revision().get())
+                .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        )
+        .execute(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        transaction.commit().await.map_err(unavailable)?;
+        Ok(ProviderSaveOutcome::Inserted)
+    }
+
+    pub(crate) async fn load_connection_inner(
+        &self,
+        connection_id: ProviderConnectionId,
+        revision: ProviderConnectionRevision,
+    ) -> Result<Option<ProviderConnectionManifest>, ProviderRepositoryError> {
+        let row = sqlx::query_as::<_, ConnectionRow>(
+            "SELECT * FROM provider_connection_revisions WHERE connection_id = $1 AND revision = $2",
+        )
+        .bind(connection_id.as_uuid())
+        .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        row.map(decode_connection).transpose()
+    }
+
+    pub(crate) async fn current_connection_inner(
+        &self,
+        connection_id: ProviderConnectionId,
+    ) -> Result<Option<ProviderConnectionManifest>, ProviderRepositoryError> {
+        let revision = sqlx::query_scalar::<_, i64>(
+            "SELECT revision FROM provider_connection_current WHERE connection_id = $1",
+        )
+        .bind(connection_id.as_uuid())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        match revision {
+            Some(revision) => {
+                let revision = ProviderConnectionRevision::new(positive_u64(revision)?)
+                    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+                self.load_connection_inner(connection_id, revision)
+                    .await
+                    .and_then(|record| record.ok_or(ProviderRepositoryError::Corrupt).map(Some))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+async fn ensure_connection_references(
+    transaction: &mut Transaction<'_, Postgres>,
+    manifest: &ProviderConnectionManifest,
+) -> Result<(), ProviderRepositoryError> {
+    let configuration = manifest.configuration();
+    let provider_exists = sqlx::query_scalar::<_, bool>(
+        r"
+        SELECT EXISTS (
+            SELECT 1 FROM provider_instance_revisions
+            WHERE instance_id = $1 AND revision = $2
+              AND configuration_digest = $3 AND capability_digest = $4
+        )
+        ",
+    )
+    .bind(configuration.repository().instance_id().as_uuid())
+    .bind(
+        i64::try_from(configuration.provider_revision().get())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        configuration
+            .provider_configuration_digest()
+            .as_bytes()
+            .as_slice(),
+    )
+    .bind(configuration.capability_digest().as_bytes().as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    let workspace_exists =
+        sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM tenants WHERE id = $1)")
+            .bind(configuration.workspace_id().to_string())
+            .fetch_one(&mut **transaction)
+            .await
+            .map_err(unavailable)?;
+    if !provider_exists || !workspace_exists {
+        return Err(ProviderRepositoryError::NotFound);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)] // The ordered bindings mirror the immutable SQL record.
+async fn insert_connection(
+    transaction: &mut Transaction<'_, Postgres>,
+    manifest: &ProviderConnectionManifest,
+) -> Result<(), ProviderRepositoryError> {
+    let configuration = manifest.configuration();
+    let (workflow_kind, workflow_path) = match configuration.workflow_source() {
+        ProviderWorkflowSource::Directory(path) => ("directory", path.as_str()),
+        ProviderWorkflowSource::File(path) => ("file", path.as_str()),
+    };
+    sqlx::query(
+        r"
+        INSERT INTO provider_connection_revisions (
+            connection_id, revision, lifecycle_state, workspace_id,
+            provider_instance_id, external_repository_id, provider_revision,
+            provider_configuration_digest, capability_digest,
+            repository_visibility, default_branch, workflow_source_kind,
+            workflow_source_path, runner_policy_schema, runner_policy_digest,
+            archive_compressed_bytes, archive_expanded_bytes, archive_entries,
+            archive_entry_path_bytes, archive_workflows, workflow_bytes,
+            adapter_policy_schema, adapter_policy_bytes, adapter_policy_digest,
+            configuration_digest, created_at_ms, activated_at_ms,
+            retired_at_ms, manifest_digest
+        ) VALUES (
+            $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,
+            $16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29
+        )
+        ",
+    )
+    .bind(manifest.connection_id().as_uuid())
+    .bind(i64::try_from(manifest.revision().get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+    .bind(lifecycle_text(manifest.state()))
+    .bind(configuration.workspace_id().to_string())
+    .bind(configuration.repository().instance_id().as_uuid())
+    .bind(configuration.repository().external_id().as_str())
+    .bind(
+        i64::try_from(configuration.provider_revision().get())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        configuration
+            .provider_configuration_digest()
+            .as_bytes()
+            .as_slice(),
+    )
+    .bind(configuration.capability_digest().as_bytes().as_slice())
+    .bind(visibility_text(configuration.visibility()))
+    .bind(configuration.default_branch().as_str())
+    .bind(workflow_kind)
+    .bind(workflow_path)
+    .bind(
+        i16::try_from(configuration.runner_policy().schema_version().get())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(configuration.runner_policy().digest().as_bytes().as_slice())
+    .bind(
+        i64::try_from(configuration.archive_limits().compressed_bytes())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i64::try_from(configuration.archive_limits().expanded_bytes())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i64::try_from(configuration.archive_limits().entries())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i64::try_from(configuration.archive_limits().entry_path_bytes())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i64::try_from(configuration.archive_limits().workflows())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i64::try_from(configuration.archive_limits().workflow_bytes())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(
+        i16::try_from(configuration.adapter_policy().schema_version().get())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(configuration.adapter_policy().bytes())
+    .bind(
+        configuration
+            .adapter_policy()
+            .digest()
+            .as_bytes()
+            .as_slice(),
+    )
+    .bind(configuration.digest().as_bytes().as_slice())
+    .bind(manifest.created_at().get())
+    .bind(
+        manifest
+            .activated_at()
+            .map(automata_ci_core::UnixMillis::get),
+    )
+    .bind(manifest.retired_at().map(automata_ci_core::UnixMillis::get))
+    .bind(manifest.digest().as_bytes().as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    Ok(())
+}
+
+fn decode_connection(
+    row: ConnectionRow,
+) -> Result<ProviderConnectionManifest, ProviderRepositoryError> {
+    let instance_id = ProviderInstanceId::from_uuid(row.provider_instance_id)
+        .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    let workflow_path = ProviderRepositoryPath::new(row.workflow_source_path)
+        .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    let workflow_source = match row.workflow_source_kind.as_str() {
+        "directory" => ProviderWorkflowSource::Directory(workflow_path),
+        "file" => ProviderWorkflowSource::File(workflow_path),
+        _ => return Err(ProviderRepositoryError::Corrupt),
+    };
+    let adapter_policy = ProviderConnectionPolicyDocument::new(
+        ProviderSchemaVersion::new(positive_u16(row.adapter_policy_schema)?)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        row.adapter_policy_bytes,
+    )
+    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    if adapter_policy.digest() != digest(row.adapter_policy_digest)? {
+        return Err(ProviderRepositoryError::Corrupt);
+    }
+    let configuration = ProviderConnectionConfiguration::new(
+        WorkspaceId::parse(&row.workspace_id).map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ExternalRepositoryIdentity::new(
+            instance_id,
+            ExternalRepositoryId::new(row.external_repository_id)
+                .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ),
+        ProviderConfigurationRevision::new(positive_u64(row.provider_revision)?)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        digest(row.provider_configuration_digest)?,
+        digest(row.capability_digest)?,
+        visibility(&row.repository_visibility)?,
+        ProviderDefaultBranch::new(row.default_branch)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        workflow_source,
+        ProviderRunnerPolicyBinding::new(
+            ProviderSchemaVersion::new(positive_u16(row.runner_policy_schema)?)
+                .map_err(|_| ProviderRepositoryError::Corrupt)?,
+            digest(row.runner_policy_digest)?,
+        ),
+        ProviderArchiveLimits::new(
+            positive_u64(row.archive_compressed_bytes)?,
+            positive_u64(row.archive_expanded_bytes)?,
+            positive_u64(row.archive_entries)?,
+            positive_u64(row.archive_entry_path_bytes)?,
+            positive_u64(row.archive_workflows)?,
+            positive_u64(row.workflow_bytes)?,
+        )
+        .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        adapter_policy,
+    );
+    if configuration.digest() != digest(row.configuration_digest)? {
+        return Err(ProviderRepositoryError::Corrupt);
+    }
+    let manifest = ProviderConnectionManifest::new(
+        ProviderConnectionId::from_uuid(row.connection_id)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ProviderConnectionRevision::new(positive_u64(row.revision)?)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        lifecycle(&row.lifecycle_state)?,
+        configuration,
+        timestamp(row.created_at_ms),
+        optional_timestamp(row.activated_at_ms),
+        optional_timestamp(row.retired_at_ms),
+    )
+    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    if manifest.digest() != digest(row.manifest_digest)? {
+        return Err(ProviderRepositoryError::Corrupt);
+    }
+    Ok(manifest)
+}
+
+const fn visibility_text(value: RepositoryVisibility) -> &'static str {
+    match value {
+        RepositoryVisibility::Public => "public",
+        RepositoryVisibility::Internal => "internal",
+        RepositoryVisibility::Private => "private",
+    }
+}
+
+fn visibility(value: &str) -> Result<RepositoryVisibility, ProviderRepositoryError> {
+    match value {
+        "public" => Ok(RepositoryVisibility::Public),
+        "internal" => Ok(RepositoryVisibility::Internal),
+        "private" => Ok(RepositoryVisibility::Private),
+        _ => Err(ProviderRepositoryError::Corrupt),
+    }
+}

--- a/crates/automata-ci-provider-postgres/src/instance.rs
+++ b/crates/automata-ci-provider-postgres/src/instance.rs
@@ -1,0 +1,442 @@
+use automata_ci_key_management::{EnvelopeCodec, EnvelopeError};
+use automata_ci_provider::{
+    ProviderConfigurationDocument, ProviderConfigurationRevision, ProviderInstanceId,
+    ProviderInstanceManifest, ProviderInstanceRecord, ProviderOrigins, ProviderRepositoryError,
+    ProviderSaveOutcome, ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding,
+    ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet,
+    ProviderTypeId,
+};
+use sqlx::{FromRow, Postgres, Transaction};
+
+use crate::{
+    EnvelopeParts, INSTANCE_LOCK_SALT, PostgresProviderManifestRepository, digest, envelope,
+    lifecycle, lifecycle_text, lock, optional_timestamp, positive_u16, positive_u64,
+    secret_context, timestamp, unavailable,
+};
+
+#[derive(FromRow)]
+struct InstanceRow {
+    instance_id: uuid::Uuid,
+    revision: i64,
+    provider_type: String,
+    lifecycle_state: String,
+    web_origin: String,
+    api_origin: String,
+    configuration_schema: i16,
+    configuration_bytes: Vec<u8>,
+    configuration_digest: Vec<u8>,
+    capability_digest: Vec<u8>,
+    created_at_ms: i64,
+    activated_at_ms: Option<i64>,
+    retired_at_ms: Option<i64>,
+    manifest_digest: Vec<u8>,
+}
+
+#[derive(FromRow)]
+struct SecretRow {
+    secret_name: String,
+    secret_generation: i64,
+    plaintext_digest: Vec<u8>,
+    envelope_schema: i16,
+    wrapping_key_id: String,
+    wrapped_data_key: Vec<u8>,
+    nonce: Vec<u8>,
+    ciphertext: Vec<u8>,
+}
+
+struct SealedSecret {
+    name: ProviderSecretName,
+    generation: ProviderSecretGeneration,
+    plaintext_digest: automata_ci_core::Sha256Digest,
+    envelope: EnvelopeParts,
+}
+
+impl PostgresProviderManifestRepository {
+    pub(crate) async fn save_instance_inner(
+        &self,
+        record: ProviderInstanceRecord,
+    ) -> Result<ProviderSaveOutcome, ProviderRepositoryError> {
+        let (manifest, secrets) = record.into_parts();
+        let sealed = seal_secrets(&self.envelopes, &manifest, secrets).await?;
+
+        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
+        lock(
+            &mut transaction,
+            &manifest.instance_id().to_string(),
+            INSTANCE_LOCK_SALT,
+        )
+        .await?;
+        let current = sqlx::query_as::<_, InstanceRow>(
+            r"
+            SELECT revisions.*
+            FROM provider_instance_current AS current
+            JOIN provider_instance_revisions AS revisions
+              ON revisions.instance_id = current.instance_id
+             AND revisions.revision = current.revision
+            WHERE current.instance_id = $1
+            FOR UPDATE OF current
+            ",
+        )
+        .bind(manifest.instance_id().as_uuid())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+
+        let prior_bindings = if let Some(current) = current {
+            let current_revision =
+                ProviderConfigurationRevision::new(positive_u64(current.revision)?)
+                    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+            let secret_rows =
+                load_secret_rows(&mut transaction, manifest.instance_id(), current_revision)
+                    .await?;
+            let current_manifest = decode_instance(current, bindings_from_rows(&secret_rows)?)?;
+            if manifest.revision() == current_manifest.revision() {
+                if manifest.digest() == current_manifest.digest() {
+                    return Ok(ProviderSaveOutcome::Unchanged);
+                }
+                return Err(ProviderRepositoryError::Conflict);
+            }
+            manifest
+                .validate_successor(&current_manifest)
+                .map_err(|_| ProviderRepositoryError::Conflict)?;
+            Some(current_manifest.secrets().clone())
+        } else if manifest.revision().get() != 1 {
+            return Err(ProviderRepositoryError::Conflict);
+        } else {
+            None
+        };
+
+        validate_historical_generations(&mut transaction, &manifest, prior_bindings.as_ref())
+            .await?;
+        insert_instance(&mut transaction, &manifest).await?;
+        for secret in sealed {
+            insert_secret(
+                &mut transaction,
+                manifest.instance_id(),
+                manifest.revision(),
+                secret,
+            )
+            .await?;
+        }
+        sqlx::query(
+            r"
+            INSERT INTO provider_instance_current (instance_id, revision)
+            VALUES ($1, $2)
+            ON CONFLICT (instance_id) DO UPDATE
+            SET revision = EXCLUDED.revision
+            ",
+        )
+        .bind(manifest.instance_id().as_uuid())
+        .bind(
+            i64::try_from(manifest.revision().get())
+                .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        )
+        .execute(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        transaction.commit().await.map_err(unavailable)?;
+        Ok(ProviderSaveOutcome::Inserted)
+    }
+
+    pub(crate) async fn load_instance_inner(
+        &self,
+        instance_id: ProviderInstanceId,
+        revision: ProviderConfigurationRevision,
+    ) -> Result<Option<ProviderInstanceRecord>, ProviderRepositoryError> {
+        let row = sqlx::query_as::<_, InstanceRow>(
+            "SELECT * FROM provider_instance_revisions WHERE instance_id = $1 AND revision = $2",
+        )
+        .bind(instance_id.as_uuid())
+        .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let rows = sqlx::query_as::<_, SecretRow>(SECRET_ROWS_SQL)
+            .bind(instance_id.as_uuid())
+            .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(unavailable)?;
+        let bindings = bindings_from_rows(&rows)?;
+        let manifest = decode_instance(row, bindings.clone())?;
+
+        let mut secrets = Vec::with_capacity(rows.len());
+        for row in rows {
+            let name = ProviderSecretName::new(row.secret_name)
+                .map_err(|_| ProviderRepositoryError::Corrupt)?;
+            let generation = ProviderSecretGeneration::new(positive_u64(row.secret_generation)?)
+                .map_err(|_| ProviderRepositoryError::Corrupt)?;
+            let encrypted = envelope(
+                row.envelope_schema,
+                row.wrapping_key_id,
+                row.wrapped_data_key,
+                row.nonce,
+                row.ciphertext,
+            )?;
+            let context =
+                secret_context(instance_id, revision.get(), name.as_str(), generation.get())?;
+            let plaintext = self
+                .envelopes
+                .open(&context, &encrypted)
+                .await
+                .map_err(encryption_failure)?;
+            secrets.push(ProviderSecret::new(name, generation, plaintext));
+        }
+        let secrets = ProviderSecretSet::new(&bindings, secrets)
+            .map_err(|_| ProviderRepositoryError::SecretCustody)?;
+        ProviderInstanceRecord::new(manifest, secrets).map(Some)
+    }
+
+    pub(crate) async fn current_instance_inner(
+        &self,
+        instance_id: ProviderInstanceId,
+    ) -> Result<Option<ProviderInstanceRecord>, ProviderRepositoryError> {
+        let revision = sqlx::query_scalar::<_, i64>(
+            "SELECT revision FROM provider_instance_current WHERE instance_id = $1",
+        )
+        .bind(instance_id.as_uuid())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        match revision {
+            Some(revision) => {
+                let revision = ProviderConfigurationRevision::new(positive_u64(revision)?)
+                    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+                self.load_instance_inner(instance_id, revision)
+                    .await
+                    .and_then(|record| record.ok_or(ProviderRepositoryError::Corrupt).map(Some))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+async fn seal_secrets(
+    codec: &EnvelopeCodec,
+    manifest: &ProviderInstanceManifest,
+    secrets: ProviderSecretSet,
+) -> Result<Vec<SealedSecret>, ProviderRepositoryError> {
+    let mut sealed = Vec::with_capacity(manifest.secrets().len());
+    for secret in secrets.into_secrets() {
+        let (name, generation, value) = secret.into_parts();
+        let binding = manifest
+            .secrets()
+            .get(&name)
+            .ok_or(ProviderRepositoryError::SecretCustody)?;
+        let context = secret_context(
+            manifest.instance_id(),
+            manifest.revision().get(),
+            name.as_str(),
+            generation.get(),
+        )?;
+        let encrypted = codec
+            .seal(&context, value)
+            .await
+            .map_err(encryption_failure)?;
+        sealed.push(SealedSecret {
+            name,
+            generation,
+            plaintext_digest: binding.digest(),
+            envelope: encrypted.try_into()?,
+        });
+    }
+    Ok(sealed)
+}
+
+async fn validate_historical_generations(
+    transaction: &mut Transaction<'_, Postgres>,
+    manifest: &ProviderInstanceManifest,
+    prior: Option<&ProviderSecretBindings>,
+) -> Result<(), ProviderRepositoryError> {
+    for binding in manifest.secrets().iter() {
+        if prior
+            .and_then(|bindings| bindings.get(binding.name()))
+            .is_some()
+        {
+            continue;
+        }
+        let maximum = sqlx::query_scalar::<_, Option<i64>>(
+            r"
+            SELECT max(secret_generation)
+            FROM provider_instance_secret_bindings
+            WHERE instance_id = $1 AND secret_name = $2
+            ",
+        )
+        .bind(manifest.instance_id().as_uuid())
+        .bind(binding.name().as_str())
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(unavailable)?;
+        let expected = maximum.map_or(Ok(1), |maximum| {
+            positive_u64(maximum)?
+                .checked_add(1)
+                .ok_or(ProviderRepositoryError::Conflict)
+        })?;
+        if binding.generation().get() != expected {
+            return Err(ProviderRepositoryError::Conflict);
+        }
+    }
+    Ok(())
+}
+
+async fn insert_instance(
+    transaction: &mut Transaction<'_, Postgres>,
+    manifest: &ProviderInstanceManifest,
+) -> Result<(), ProviderRepositoryError> {
+    sqlx::query(
+        r"
+        INSERT INTO provider_instance_revisions (
+            instance_id, revision, provider_type, lifecycle_state,
+            web_origin, api_origin, configuration_schema,
+            configuration_bytes, configuration_digest, capability_digest,
+            created_at_ms, activated_at_ms, retired_at_ms, manifest_digest
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+        ",
+    )
+    .bind(manifest.instance_id().as_uuid())
+    .bind(i64::try_from(manifest.revision().get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+    .bind(manifest.provider_type().as_str())
+    .bind(lifecycle_text(manifest.state()))
+    .bind(manifest.origins().web())
+    .bind(manifest.origins().api())
+    .bind(
+        i16::try_from(manifest.configuration().schema_version().get())
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+    )
+    .bind(manifest.configuration().bytes())
+    .bind(manifest.configuration().digest().as_bytes().as_slice())
+    .bind(manifest.capability_digest().as_bytes().as_slice())
+    .bind(manifest.created_at().get())
+    .bind(
+        manifest
+            .activated_at()
+            .map(automata_ci_core::UnixMillis::get),
+    )
+    .bind(manifest.retired_at().map(automata_ci_core::UnixMillis::get))
+    .bind(manifest.digest().as_bytes().as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    Ok(())
+}
+
+async fn insert_secret(
+    transaction: &mut Transaction<'_, Postgres>,
+    instance_id: ProviderInstanceId,
+    revision: ProviderConfigurationRevision,
+    secret: SealedSecret,
+) -> Result<(), ProviderRepositoryError> {
+    sqlx::query(
+        r"
+        INSERT INTO provider_instance_secret_bindings (
+            instance_id, revision, secret_name, secret_generation,
+            plaintext_digest, envelope_schema, wrapping_key_id,
+            wrapped_data_key, nonce, ciphertext
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        ",
+    )
+    .bind(instance_id.as_uuid())
+    .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+    .bind(secret.name.as_str())
+    .bind(i64::try_from(secret.generation.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+    .bind(secret.plaintext_digest.as_bytes().as_slice())
+    .bind(secret.envelope.schema)
+    .bind(secret.envelope.wrapping_key_id)
+    .bind(secret.envelope.wrapped_data_key)
+    .bind(secret.envelope.nonce)
+    .bind(secret.envelope.ciphertext)
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    Ok(())
+}
+
+fn decode_instance(
+    row: InstanceRow,
+    bindings: ProviderSecretBindings,
+) -> Result<ProviderInstanceManifest, ProviderRepositoryError> {
+    let configuration = ProviderConfigurationDocument::new(
+        ProviderSchemaVersion::new(positive_u16(row.configuration_schema)?)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        row.configuration_bytes,
+    )
+    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    if configuration.digest() != digest(row.configuration_digest)? {
+        return Err(ProviderRepositoryError::Corrupt);
+    }
+    let manifest = ProviderInstanceManifest::new(
+        ProviderInstanceId::from_uuid(row.instance_id)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ProviderTypeId::new(row.provider_type).map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ProviderConfigurationRevision::new(positive_u64(row.revision)?)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        lifecycle(&row.lifecycle_state)?,
+        ProviderOrigins::new(row.web_origin, row.api_origin)
+            .map_err(|_| ProviderRepositoryError::Corrupt)?,
+        configuration,
+        bindings,
+        digest(row.capability_digest)?,
+        timestamp(row.created_at_ms),
+        optional_timestamp(row.activated_at_ms),
+        optional_timestamp(row.retired_at_ms),
+    )
+    .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    if manifest.digest() != digest(row.manifest_digest)? {
+        return Err(ProviderRepositoryError::Corrupt);
+    }
+    Ok(manifest)
+}
+
+fn bindings_from_rows(
+    rows: &[SecretRow],
+) -> Result<ProviderSecretBindings, ProviderRepositoryError> {
+    let bindings = rows
+        .iter()
+        .map(|row| {
+            Ok(ProviderSecretBinding::new(
+                ProviderSecretName::new(row.secret_name.clone())
+                    .map_err(|_| ProviderRepositoryError::Corrupt)?,
+                ProviderSecretGeneration::new(positive_u64(row.secret_generation)?)
+                    .map_err(|_| ProviderRepositoryError::Corrupt)?,
+                digest(row.plaintext_digest.clone())?,
+            ))
+        })
+        .collect::<Result<Vec<_>, ProviderRepositoryError>>()?;
+    ProviderSecretBindings::new(bindings).map_err(|_| ProviderRepositoryError::Corrupt)
+}
+
+const SECRET_ROWS_SQL: &str = r"
+    SELECT secret_name, secret_generation, plaintext_digest,
+           envelope_schema, wrapping_key_id, wrapped_data_key,
+           nonce, ciphertext
+    FROM provider_instance_secret_bindings
+    WHERE instance_id = $1 AND revision = $2
+    ORDER BY secret_name
+";
+
+async fn load_secret_rows(
+    transaction: &mut Transaction<'_, Postgres>,
+    instance_id: ProviderInstanceId,
+    revision: ProviderConfigurationRevision,
+) -> Result<Vec<SecretRow>, ProviderRepositoryError> {
+    sqlx::query_as::<_, SecretRow>(SECRET_ROWS_SQL)
+        .bind(instance_id.as_uuid())
+        .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+        .fetch_all(&mut **transaction)
+        .await
+        .map_err(unavailable)
+}
+
+fn encryption_failure(error: EnvelopeError) -> ProviderRepositoryError {
+    match error {
+        EnvelopeError::KeyEncryption(_)
+        | EnvelopeError::RandomnessUnavailable
+        | EnvelopeError::CryptographicFailure => ProviderRepositoryError::Unavailable,
+        EnvelopeError::InvalidEnvelope
+        | EnvelopeError::UnsupportedSchema
+        | EnvelopeError::AuthenticationFailed => ProviderRepositoryError::SecretCustody,
+    }
+}

--- a/crates/automata-ci-provider-postgres/src/lib.rs
+++ b/crates/automata-ci-provider-postgres/src/lib.rs
@@ -1,0 +1,227 @@
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+//! `PostgreSQL` persistence for provider instance and connection manifests.
+
+use std::{fmt, sync::Arc};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_key_management::{
+    EncryptedEnvelope, EnvelopeCodec, KeyEncryptionContext, KeyEncryptionProvider, KeyId,
+    KeyPurpose, WrappedDataKey,
+};
+use automata_ci_provider::{
+    ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionRevision,
+    ProviderInstanceId, ProviderInstanceRecord, ProviderManifestRepository,
+    ProviderRepositoryError, ProviderRepositoryFuture, ProviderSaveOutcome,
+};
+use sqlx::{PgPool, Postgres, Transaction};
+
+mod connection;
+mod instance;
+
+const SECRET_PURPOSE: &str = "provider/instance-secret:v1";
+const INSTANCE_LOCK_SALT: i64 = 6_692_456_121_835_322_101;
+const CONNECTION_LOCK_SALT: i64 = 7_752_013_457_331_067_413;
+
+/// Atomic `PostgreSQL` provider manifest repository with envelope-encrypted secrets.
+#[derive(Clone)]
+pub struct PostgresProviderManifestRepository {
+    pool: PgPool,
+    envelopes: Arc<EnvelopeCodec>,
+}
+
+impl PostgresProviderManifestRepository {
+    /// Binds the repository to a pool and provider-neutral wrapping-key implementation.
+    #[must_use]
+    pub fn new(pool: PgPool, keys: Arc<dyn KeyEncryptionProvider>) -> Self {
+        Self {
+            pool,
+            envelopes: Arc::new(EnvelopeCodec::new(keys)),
+        }
+    }
+
+    /// Returns the exact database pool used by this adapter.
+    #[must_use]
+    pub const fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+impl fmt::Debug for PostgresProviderManifestRepository {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresProviderManifestRepository")
+            .field("pool", &"[CONFIGURED]")
+            .field("envelope_codec", &"[CONFIGURED]")
+            .finish()
+    }
+}
+
+impl ProviderManifestRepository for PostgresProviderManifestRepository {
+    fn save_instance(
+        &self,
+        record: ProviderInstanceRecord,
+    ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome> {
+        Box::pin(self.save_instance_inner(record))
+    }
+
+    fn load_instance(
+        &self,
+        instance_id: ProviderInstanceId,
+        revision: automata_ci_provider::ProviderConfigurationRevision,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>> {
+        Box::pin(self.load_instance_inner(instance_id, revision))
+    }
+
+    fn current_instance(
+        &self,
+        instance_id: ProviderInstanceId,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>> {
+        Box::pin(self.current_instance_inner(instance_id))
+    }
+
+    fn save_connection(
+        &self,
+        manifest: ProviderConnectionManifest,
+    ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome> {
+        Box::pin(self.save_connection_inner(manifest))
+    }
+
+    fn load_connection(
+        &self,
+        connection_id: ProviderConnectionId,
+        revision: ProviderConnectionRevision,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>> {
+        Box::pin(self.load_connection_inner(connection_id, revision))
+    }
+
+    fn current_connection(
+        &self,
+        connection_id: ProviderConnectionId,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>> {
+        Box::pin(self.current_connection_inner(connection_id))
+    }
+}
+
+async fn lock(
+    transaction: &mut Transaction<'_, Postgres>,
+    identity: &str,
+    salt: i64,
+) -> Result<(), ProviderRepositoryError> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, $2))")
+        .bind(identity)
+        .bind(salt)
+        .execute(&mut **transaction)
+        .await
+        .map_err(unavailable)?;
+    Ok(())
+}
+
+fn secret_context(
+    instance_id: ProviderInstanceId,
+    revision: u64,
+    name: &str,
+    generation: u64,
+) -> Result<KeyEncryptionContext, ProviderRepositoryError> {
+    KeyEncryptionContext::new(
+        instance_id.to_string(),
+        KeyPurpose::new(SECRET_PURPOSE).map_err(|_| ProviderRepositoryError::Corrupt)?,
+        format!("revision/{revision}/secret/{name}/generation/{generation}"),
+    )
+    .map_err(|_| ProviderRepositoryError::Corrupt)
+}
+
+#[derive(Debug)]
+struct EnvelopeParts {
+    schema: i16,
+    wrapping_key_id: String,
+    wrapped_data_key: Vec<u8>,
+    nonce: Vec<u8>,
+    ciphertext: Vec<u8>,
+}
+
+impl TryFrom<EncryptedEnvelope> for EnvelopeParts {
+    type Error = ProviderRepositoryError;
+
+    fn try_from(envelope: EncryptedEnvelope) -> Result<Self, Self::Error> {
+        let (schema, wrapped, nonce, ciphertext) = envelope.into_parts();
+        let (key_id, wrapped_data_key) = wrapped.into_parts();
+        Ok(Self {
+            schema: i16::try_from(schema).map_err(|_| ProviderRepositoryError::Corrupt)?,
+            wrapping_key_id: key_id.as_str().to_owned(),
+            wrapped_data_key,
+            nonce: nonce.to_vec(),
+            ciphertext,
+        })
+    }
+}
+
+fn envelope(
+    schema: i16,
+    wrapping_key_id: String,
+    wrapped_data_key: Vec<u8>,
+    nonce: Vec<u8>,
+    ciphertext: Vec<u8>,
+) -> Result<EncryptedEnvelope, ProviderRepositoryError> {
+    let schema = u16::try_from(schema).map_err(|_| ProviderRepositoryError::Corrupt)?;
+    let key_id = KeyId::new(wrapping_key_id).map_err(|_| ProviderRepositoryError::Corrupt)?;
+    let wrapped = WrappedDataKey::new(key_id, wrapped_data_key)
+        .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    let nonce = nonce
+        .try_into()
+        .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    EncryptedEnvelope::from_parts(schema, wrapped, nonce, ciphertext)
+        .map_err(|_| ProviderRepositoryError::Corrupt)
+}
+
+fn digest(value: Vec<u8>) -> Result<Sha256Digest, ProviderRepositoryError> {
+    let bytes = value
+        .try_into()
+        .map_err(|_| ProviderRepositoryError::Corrupt)?;
+    Ok(Sha256Digest::from_bytes(bytes))
+}
+
+fn positive_u64(value: i64) -> Result<u64, ProviderRepositoryError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ProviderRepositoryError::Corrupt)
+}
+
+fn positive_u16(value: i16) -> Result<u16, ProviderRepositoryError> {
+    u16::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ProviderRepositoryError::Corrupt)
+}
+
+fn timestamp(value: i64) -> UnixMillis {
+    UnixMillis::new(value)
+}
+
+fn optional_timestamp(value: Option<i64>) -> Option<UnixMillis> {
+    value.map(UnixMillis::new)
+}
+
+fn lifecycle(
+    value: &str,
+) -> Result<automata_ci_provider::ProviderLifecycleState, ProviderRepositoryError> {
+    match value {
+        "disabled" => Ok(automata_ci_provider::ProviderLifecycleState::Disabled),
+        "active" => Ok(automata_ci_provider::ProviderLifecycleState::Active),
+        "retired" => Ok(automata_ci_provider::ProviderLifecycleState::Retired),
+        _ => Err(ProviderRepositoryError::Corrupt),
+    }
+}
+
+const fn lifecycle_text(value: automata_ci_provider::ProviderLifecycleState) -> &'static str {
+    match value {
+        automata_ci_provider::ProviderLifecycleState::Disabled => "disabled",
+        automata_ci_provider::ProviderLifecycleState::Active => "active",
+        automata_ci_provider::ProviderLifecycleState::Retired => "retired",
+    }
+}
+
+fn unavailable(_: sqlx::Error) -> ProviderRepositoryError {
+    ProviderRepositoryError::Unavailable
+}

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -1,0 +1,379 @@
+use std::sync::Arc;
+
+use automata_ci_core::{GitObjectAlgorithm, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
+use automata_ci_postgres::test_support::{TestResult, run_with_database};
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits, ProviderCapabilities,
+    ProviderCapability, ProviderConfigurationDocument, ProviderConfigurationRevision,
+    ProviderConnectionConfiguration, ProviderConnectionId, ProviderConnectionManifest,
+    ProviderConnectionPolicyDocument, ProviderConnectionRevision, ProviderDefaultBranch,
+    ProviderInstanceId, ProviderInstanceManifest, ProviderInstanceRecord, ProviderLifecycleState,
+    ProviderManifestRepository as _, ProviderOrigins, ProviderRepositoryError,
+    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSaveOutcome,
+    ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding, ProviderSecretBindings,
+    ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet, ProviderTypeId,
+    ProviderWorkflowSource, RepositoryVisibility, SourceReadCapability, provider_capability_digest,
+};
+use automata_ci_provider_postgres::PostgresProviderManifestRepository;
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+const TOKEN: &[u8] = b"forgejo-control-token-that-must-stay-encrypted";
+
+fn repository(pool: sqlx::PgPool) -> PostgresProviderManifestRepository {
+    let material = LocalKeyMaterial::new(
+        KeyId::new("provider-test-key-v1").expect("key ID"),
+        SecretBytes::new(vec![7; 32]).expect("key bytes"),
+    )
+    .expect("key material");
+    let keys = LocalAes256GcmKeyring::new(material, Vec::new(), []).expect("local keyring");
+    PostgresProviderManifestRepository::new(pool, Arc::new(keys))
+}
+
+fn capability_digest() -> Sha256Digest {
+    let capabilities = ProviderCapabilities::new([ProviderCapability::SourceRead(
+        SourceReadCapability::new([GitObjectAlgorithm::Sha1]).expect("source capability"),
+    )])
+    .expect("capabilities");
+    provider_capability_digest(&capabilities).expect("capability digest")
+}
+
+fn secret_digest(value: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(value).into())
+}
+
+fn instance_record(
+    instance_id: ProviderInstanceId,
+    provider_type: &str,
+    revision: u64,
+    value: &[u8],
+    generation: u64,
+    state: ProviderLifecycleState,
+    activated_at: Option<UnixMillis>,
+) -> ProviderInstanceRecord {
+    let name = ProviderSecretName::new("control-token").expect("secret name");
+    let generation = ProviderSecretGeneration::new(generation).expect("secret generation");
+    let bindings = ProviderSecretBindings::new([ProviderSecretBinding::new(
+        name.clone(),
+        generation,
+        secret_digest(value),
+    )])
+    .expect("bindings");
+    let secrets = ProviderSecretSet::new(
+        &bindings,
+        [ProviderSecret::new(
+            name,
+            generation,
+            SecretBytes::new(value.to_vec()).expect("secret"),
+        )],
+    )
+    .expect("secret set");
+    let manifest = ProviderInstanceManifest::new(
+        instance_id,
+        ProviderTypeId::new(provider_type).expect("provider type"),
+        ProviderConfigurationRevision::new(revision).expect("revision"),
+        state,
+        ProviderOrigins::new("https://code.example/", "https://code.example/api/v1/")
+            .expect("origins"),
+        ProviderConfigurationDocument::new(
+            ProviderSchemaVersion::new(1).expect("schema"),
+            format!(r#"{{"provider":"{provider_type}"}}"#).into_bytes(),
+        )
+        .expect("configuration"),
+        bindings,
+        capability_digest(),
+        UnixMillis::new(1_000),
+        activated_at,
+        None,
+    )
+    .expect("manifest");
+    ProviderInstanceRecord::new(manifest, secrets).expect("record")
+}
+
+fn connection(
+    workspace_id: WorkspaceId,
+    instance: &ProviderInstanceManifest,
+) -> ProviderConnectionManifest {
+    let configuration = ProviderConnectionConfiguration::new(
+        workspace_id,
+        ExternalRepositoryIdentity::new(
+            instance.instance_id(),
+            ExternalRepositoryId::new("42").expect("repository"),
+        ),
+        instance.revision(),
+        instance.configuration().digest(),
+        instance.capability_digest(),
+        RepositoryVisibility::Private,
+        ProviderDefaultBranch::new("main").expect("branch"),
+        ProviderWorkflowSource::Directory(
+            ProviderRepositoryPath::new(".forgejo/workflows").expect("workflow path"),
+        ),
+        ProviderRunnerPolicyBinding::new(
+            ProviderSchemaVersion::new(2).expect("runner policy schema"),
+            Sha256Digest::from_bytes([8; 32]),
+        ),
+        ProviderArchiveLimits::new(
+            1_024 * 1_024,
+            8 * 1_024 * 1_024,
+            1_000,
+            1_024,
+            64,
+            512 * 1_024,
+        )
+        .expect("archive limits"),
+        ProviderConnectionPolicyDocument::new(
+            ProviderSchemaVersion::new(1).expect("policy schema"),
+            br#"{"installation_id":99}"#.to_vec(),
+        )
+        .expect("adapter policy"),
+    );
+    ProviderConnectionManifest::new(
+        ProviderConnectionId::from_uuid(Uuid::from_u128(99)).expect("connection"),
+        ProviderConnectionRevision::new(1).expect("revision"),
+        ProviderLifecycleState::Active,
+        configuration,
+        UnixMillis::new(2_000),
+        Some(UnixMillis::new(2_000)),
+        None,
+    )
+    .expect("connection manifest")
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)] // One sequence proves immutable history, rotation, and references.
+async fn instance_and_connection_revisions_are_atomic_encrypted_and_exact() -> TestResult {
+    run_with_database(|database| async move {
+        let repository = repository(database.pool().clone());
+        let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(7))?;
+        assert_eq!(
+            repository
+                .save_instance(instance_record(
+                    instance_id,
+                    "forgejo",
+                    1,
+                    TOKEN,
+                    1,
+                    ProviderLifecycleState::Disabled,
+                    None,
+                ))
+                .await?,
+            ProviderSaveOutcome::Inserted
+        );
+        assert_eq!(
+            repository
+                .save_instance(instance_record(
+                    instance_id,
+                    "forgejo",
+                    1,
+                    TOKEN,
+                    1,
+                    ProviderLifecycleState::Disabled,
+                    None,
+                ))
+                .await?,
+            ProviderSaveOutcome::Unchanged
+        );
+
+        let stored_ciphertext: Vec<u8> = sqlx::query_scalar(
+            "SELECT ciphertext FROM provider_instance_secret_bindings WHERE instance_id = $1 AND revision = 1",
+        )
+        .bind(instance_id.as_uuid())
+        .fetch_one(database.pool())
+        .await?;
+        assert!(!stored_ciphertext.windows(TOKEN.len()).any(|window| window == TOKEN));
+
+        let first_loaded = repository
+            .current_instance(instance_id)
+            .await?
+            .expect("current instance");
+        let name = ProviderSecretName::new("control-token")?;
+        assert_eq!(
+            first_loaded
+                .secrets()
+                .get(&name)
+                .expect("control token")
+                .expose_secret(),
+            TOKEN
+        );
+
+        let second_value = b"rotated-forgejo-control-token";
+        assert_eq!(
+            repository
+                .save_instance(instance_record(
+                    instance_id,
+                    "forgejo",
+                    2,
+                    second_value,
+                    2,
+                    ProviderLifecycleState::Active,
+                    Some(UnixMillis::new(2_000)),
+                ))
+                .await?,
+            ProviderSaveOutcome::Inserted
+        );
+        let current = repository
+            .current_instance(instance_id)
+            .await?
+            .expect("current instance");
+        assert_eq!(current.manifest().revision().get(), 2);
+        assert_eq!(
+            current
+                .secrets()
+                .get(&name)
+                .expect("rotated token")
+                .expose_secret(),
+            second_value
+        );
+        assert_eq!(
+            repository
+                .load_instance(
+                    instance_id,
+                    ProviderConfigurationRevision::new(1).expect("revision"),
+                )
+                .await?
+                .expect("historical instance")
+                .secrets()
+                .get(&name)
+                .expect("historical token")
+                .expose_secret(),
+            TOKEN
+        );
+
+        let workspace = WorkspaceId::parse("11111111-1111-4111-8111-111111111111")?;
+        assert_eq!(
+            repository
+                .save_connection(connection(workspace, current.manifest()))
+                .await,
+            Err(ProviderRepositoryError::NotFound)
+        );
+        sqlx::query(
+            "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Provider test', 1, 1)",
+        )
+        .bind(workspace.to_string())
+        .execute(database.pool())
+        .await?;
+        let first_connection = connection(workspace, current.manifest());
+        assert_eq!(
+            repository.save_connection(first_connection).await?,
+            ProviderSaveOutcome::Inserted
+        );
+        assert_eq!(
+            repository
+                .save_connection(connection(workspace, current.manifest()))
+                .await?,
+            ProviderSaveOutcome::Unchanged
+        );
+        let loaded_connection = repository
+            .current_connection(
+                ProviderConnectionId::from_uuid(Uuid::from_u128(99)).expect("connection"),
+            )
+            .await?
+            .expect("current connection");
+        assert_eq!(loaded_connection.configuration().workspace_id(), workspace);
+        assert_eq!(
+            loaded_connection
+                .configuration()
+                .repository()
+                .external_id()
+                .as_str(),
+            "42"
+        );
+        assert_eq!(
+            loaded_connection
+                .configuration()
+                .provider_revision()
+                .get(),
+            2
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)] // One sequence proves relational and ciphertext tamper rejection.
+async fn stale_missing_and_tampered_state_fail_closed() -> TestResult {
+    run_with_database(|database| async move {
+        let repository = repository(database.pool().clone());
+        let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(17))?;
+        assert_eq!(
+            repository
+                .save_instance(instance_record(
+                    instance_id,
+                    "github",
+                    2,
+                    TOKEN,
+                    1,
+                    ProviderLifecycleState::Active,
+                    Some(UnixMillis::new(1_000)),
+                ))
+                .await,
+            Err(ProviderRepositoryError::Conflict)
+        );
+
+        repository
+            .save_instance(instance_record(
+                instance_id,
+                "github",
+                1,
+                TOKEN,
+                1,
+                ProviderLifecycleState::Active,
+                Some(UnixMillis::new(1_000)),
+            ))
+            .await?;
+        sqlx::query(
+            "UPDATE provider_instance_revisions SET configuration_bytes = $1 WHERE instance_id = $2 AND revision = 1",
+        )
+        .bind(br#"{"provider":"tampered"}"#.as_slice())
+        .bind(instance_id.as_uuid())
+        .execute(database.pool())
+        .await?;
+        assert!(matches!(
+            repository
+                .load_instance(
+                    instance_id,
+                    ProviderConfigurationRevision::new(1).expect("revision"),
+                )
+                .await,
+            Err(ProviderRepositoryError::Corrupt)
+        ));
+
+        let encrypted_instance = ProviderInstanceId::from_uuid(Uuid::from_u128(18))?;
+        repository
+            .save_instance(instance_record(
+                encrypted_instance,
+                "github",
+                1,
+                TOKEN,
+                1,
+                ProviderLifecycleState::Active,
+                Some(UnixMillis::new(1_000)),
+            ))
+            .await?;
+        sqlx::query(
+            r"
+            UPDATE provider_instance_secret_bindings
+            SET ciphertext = set_byte(ciphertext, 0, get_byte(ciphertext, 0) # 1)
+            WHERE instance_id = $1 AND revision = 1
+            ",
+        )
+        .bind(encrypted_instance.as_uuid())
+        .execute(database.pool())
+        .await?;
+        assert!(matches!(
+            repository
+                .load_instance(
+                    encrypted_instance,
+                    ProviderConfigurationRevision::new(1).expect("revision"),
+                )
+                .await,
+            Err(ProviderRepositoryError::SecretCustody)
+        ));
+        Ok(())
+    })
+    .await
+}

--- a/crates/automata-ci-provider/Cargo.toml
+++ b/crates/automata-ci-provider/Cargo.toml
@@ -12,9 +12,13 @@ readme = "README.md"
 publish.workspace = true
 
 [dependencies]
+automata-ci-key-management.workspace = true
 automata-ci-core.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/automata-ci-provider/README.md
+++ b/crates/automata-ci-provider/README.md
@@ -1,9 +1,9 @@
 # automata-ci-provider
 
-`automata-ci-provider` owns source-hosting provider identity and capability
-contracts for Automata. GitHub, Forgejo, and future provider adapters implement
-these contracts without entering the workflow, scheduler, store, or runner
-domains.
+`automata-ci-provider` owns source-hosting provider identity, capability,
+configuration, connection, factory-registry, and persistence-port contracts for
+Automata. GitHub, Forgejo, and future provider adapters implement these
+contracts without entering the workflow, scheduler, store, or runner domains.
 
 The crate contains no network client and no concrete provider implementation.
 

--- a/crates/automata-ci-provider/src/configuration.rs
+++ b/crates/automata-ci-provider/src/configuration.rs
@@ -1,0 +1,891 @@
+//! Canonical non-secret provider configuration and named secret bindings.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    num::{NonZeroU16, NonZeroU64},
+};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_key_management::SecretBytes;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+use url::Url;
+
+use crate::{ProviderCapabilities, ProviderInstanceId, ProviderTypeId};
+
+/// Maximum canonical adapter-configuration document size.
+pub const MAX_PROVIDER_CONFIGURATION_BYTES: usize = 256 * 1_024;
+/// Largest adapter schema version representable by the durable `SMALLINT` contract.
+pub const MAX_PROVIDER_SCHEMA_VERSION: u16 = i16::MAX as u16;
+/// Maximum secrets bound to one provider instance revision.
+pub const MAX_PROVIDER_SECRET_BINDINGS: usize = 32;
+/// Maximum bytes in one canonical provider secret name.
+pub const MAX_PROVIDER_SECRET_NAME_BYTES: usize = 64;
+/// Maximum bytes in one canonical provider origin.
+pub const MAX_PROVIDER_ORIGIN_BYTES: usize = 2_048;
+
+const CONFIGURATION_DIGEST_DOMAIN: &[u8] = b"automata.provider.configuration.v1\0";
+const CAPABILITY_DIGEST_DOMAIN: &[u8] = b"automata.provider.capabilities.v1\0";
+const MANIFEST_DIGEST_DOMAIN: &[u8] = b"automata.provider.instance-manifest.v1\0";
+
+macro_rules! positive_value {
+    ($(#[$meta:meta])* $name:ident, $error:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(try_from = "u64", into = "u64")]
+        pub struct $name(NonZeroU64);
+
+        impl $name {
+            /// Creates a positive value representable by a `PostgreSQL BIGINT`.
+            ///
+            /// # Errors
+            ///
+            /// Rejects zero and values larger than `i64::MAX`.
+            pub const fn new(value: u64) -> Result<Self, ProviderConfigurationError> {
+                match NonZeroU64::new(value) {
+                    Some(value) if value.get() <= i64::MAX as u64 => Ok(Self(value)),
+                    _ => Err(ProviderConfigurationError::$error),
+                }
+            }
+
+            /// Returns the positive durable value.
+            #[must_use]
+            pub const fn get(self) -> u64 {
+                self.0.get()
+            }
+        }
+
+        impl TryFrom<u64> for $name {
+            type Error = ProviderConfigurationError;
+
+            fn try_from(value: u64) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl From<$name> for u64 {
+            fn from(value: $name) -> Self {
+                value.get()
+            }
+        }
+    };
+}
+
+positive_value!(
+    /// Monotonic revision of one configured provider instance.
+    ProviderConfigurationRevision,
+    InvalidConfigurationRevision
+);
+positive_value!(
+    /// Monotonic generation of one named provider secret.
+    ProviderSecretGeneration,
+    InvalidSecretGeneration
+);
+
+/// Positive, bounded adapter-owned configuration schema version.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "u16", into = "u16")]
+pub struct ProviderSchemaVersion(NonZeroU16);
+
+impl ProviderSchemaVersion {
+    /// Creates a schema version representable by the durable `SMALLINT` contract.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero and values larger than [`MAX_PROVIDER_SCHEMA_VERSION`].
+    pub const fn new(value: u16) -> Result<Self, ProviderConfigurationError> {
+        match NonZeroU16::new(value) {
+            Some(value) if value.get() <= MAX_PROVIDER_SCHEMA_VERSION => Ok(Self(value)),
+            _ => Err(ProviderConfigurationError::InvalidSchemaVersion),
+        }
+    }
+
+    /// Returns the positive durable schema version.
+    #[must_use]
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u16> for ProviderSchemaVersion {
+    type Error = ProviderConfigurationError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderSchemaVersion> for u16 {
+    fn from(value: ProviderSchemaVersion) -> Self {
+        value.get()
+    }
+}
+
+/// Canonical name of one adapter-required provider secret.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ProviderSecretName(String);
+
+impl ProviderSecretName {
+    /// Creates a lower-case hyphen-separated secret name.
+    ///
+    /// # Errors
+    ///
+    /// Rejects values outside `[a-z][a-z0-9]*(?:-[a-z0-9]+)*` or the byte bound.
+    pub fn new(value: impl Into<String>) -> Result<Self, ProviderConfigurationError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > MAX_PROVIDER_SECRET_NAME_BYTES {
+            return Err(ProviderConfigurationError::InvalidSecretName);
+        }
+        let mut parts = value.split('-');
+        let Some(first) = parts.next() else {
+            return Err(ProviderConfigurationError::InvalidSecretName);
+        };
+        if !valid_name_part(first, false) || !parts.all(|part| valid_name_part(part, true)) {
+            return Err(ProviderConfigurationError::InvalidSecretName);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical secret name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for ProviderSecretName {
+    type Error = ProviderConfigurationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderSecretName> for String {
+    fn from(value: ProviderSecretName) -> Self {
+        value.0
+    }
+}
+
+fn valid_name_part(value: &str, digit_first: bool) -> bool {
+    let Some(first) = value.as_bytes().first() else {
+        return false;
+    };
+    (first.is_ascii_lowercase() || (digit_first && first.is_ascii_digit()))
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+/// Canonical provider web and API origins.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedProviderOrigins")]
+pub struct ProviderOrigins {
+    web: String,
+    api: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedProviderOrigins {
+    web: String,
+    api: String,
+}
+
+impl ProviderOrigins {
+    /// Validates canonical HTTPS web and API base URLs.
+    ///
+    /// The web URL must be an origin with `/`; the API URL may have a path
+    /// prefix but must end in `/`. User info, query, and fragment are rejected.
+    ///
+    /// # Errors
+    ///
+    /// Rejects noncanonical or untrusted URL shapes.
+    pub fn new(
+        web: impl Into<String>,
+        api: impl Into<String>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        let web = web.into();
+        let api = api.into();
+        validate_origin(&web, true)?;
+        validate_origin(&api, false)?;
+        Ok(Self { web, api })
+    }
+
+    /// Returns the canonical browser origin.
+    #[must_use]
+    pub fn web(&self) -> &str {
+        &self.web
+    }
+
+    /// Returns the canonical API base.
+    #[must_use]
+    pub fn api(&self) -> &str {
+        &self.api
+    }
+}
+
+impl TryFrom<UncheckedProviderOrigins> for ProviderOrigins {
+    type Error = ProviderConfigurationError;
+
+    fn try_from(value: UncheckedProviderOrigins) -> Result<Self, Self::Error> {
+        Self::new(value.web, value.api)
+    }
+}
+
+fn validate_origin(value: &str, web: bool) -> Result<(), ProviderConfigurationError> {
+    if value.is_empty() || value.len() > MAX_PROVIDER_ORIGIN_BYTES {
+        return Err(ProviderConfigurationError::InvalidOrigin);
+    }
+    let parsed = Url::parse(value).map_err(|_| ProviderConfigurationError::InvalidOrigin)?;
+    if parsed.as_str() != value
+        || parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || (web && parsed.path() != "/")
+        || (!web && !parsed.path().ends_with('/'))
+    {
+        return Err(ProviderConfigurationError::InvalidOrigin);
+    }
+    Ok(())
+}
+
+/// One named secret generation pinned by a configuration revision.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedProviderSecretBinding")]
+pub struct ProviderSecretBinding {
+    name: ProviderSecretName,
+    generation: ProviderSecretGeneration,
+    digest: Sha256Digest,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedProviderSecretBinding {
+    name: ProviderSecretName,
+    generation: ProviderSecretGeneration,
+    digest: Sha256Digest,
+}
+
+impl ProviderSecretBinding {
+    /// Binds one name and generation to its plaintext digest.
+    #[must_use]
+    pub const fn new(
+        name: ProviderSecretName,
+        generation: ProviderSecretGeneration,
+        digest: Sha256Digest,
+    ) -> Self {
+        Self {
+            name,
+            generation,
+            digest,
+        }
+    }
+
+    /// Returns the canonical binding name.
+    #[must_use]
+    pub const fn name(&self) -> &ProviderSecretName {
+        &self.name
+    }
+
+    /// Returns the exact secret generation.
+    #[must_use]
+    pub const fn generation(&self) -> ProviderSecretGeneration {
+        self.generation
+    }
+
+    /// Returns the exact plaintext digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl TryFrom<UncheckedProviderSecretBinding> for ProviderSecretBinding {
+    type Error = ProviderConfigurationError;
+
+    fn try_from(value: UncheckedProviderSecretBinding) -> Result<Self, Self::Error> {
+        Ok(Self::new(value.name, value.generation, value.digest))
+    }
+}
+
+/// Sorted, duplicate-free named secret bindings for one instance revision.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    try_from = "Vec<ProviderSecretBinding>",
+    into = "Vec<ProviderSecretBinding>"
+)]
+pub struct ProviderSecretBindings(BTreeMap<ProviderSecretName, ProviderSecretBinding>);
+
+impl ProviderSecretBindings {
+    /// Creates a bounded binding set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate names or more than 32 bindings.
+    pub fn new(
+        bindings: impl IntoIterator<Item = ProviderSecretBinding>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        let mut indexed = BTreeMap::new();
+        for binding in bindings {
+            if indexed.len() == MAX_PROVIDER_SECRET_BINDINGS {
+                return Err(ProviderConfigurationError::TooManySecrets);
+            }
+            if indexed.insert(binding.name.clone(), binding).is_some() {
+                return Err(ProviderConfigurationError::DuplicateSecret);
+            }
+        }
+        Ok(Self(indexed))
+    }
+
+    /// Returns an empty binding set for a credential-free adapter.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Looks up one exact named binding.
+    #[must_use]
+    pub fn get(&self, name: &ProviderSecretName) -> Option<&ProviderSecretBinding> {
+        self.0.get(name)
+    }
+
+    /// Iterates bindings in canonical name order.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ProviderSecretBinding> {
+        self.0.values()
+    }
+
+    /// Returns the number of named bindings.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether no secrets are bound.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn valid_successor_of(&self, prior: &Self) -> bool {
+        self.iter().all(|binding| match prior.get(binding.name()) {
+            // The durable repository checks a newly present name against all
+            // historical revisions; the adjacent manifest has no such view.
+            None => true,
+            Some(previous) if previous.digest() == binding.digest() => {
+                previous.generation() == binding.generation()
+            }
+            Some(previous) => previous
+                .generation()
+                .get()
+                .checked_add(1)
+                .is_some_and(|next| next == binding.generation().get()),
+        })
+    }
+}
+
+impl TryFrom<Vec<ProviderSecretBinding>> for ProviderSecretBindings {
+    type Error = ProviderConfigurationError;
+
+    fn try_from(value: Vec<ProviderSecretBinding>) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderSecretBindings> for Vec<ProviderSecretBinding> {
+    fn from(value: ProviderSecretBindings) -> Self {
+        value.0.into_values().collect()
+    }
+}
+
+/// Bounded canonical adapter-owned configuration bytes.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderConfigurationDocument {
+    schema_version: ProviderSchemaVersion,
+    bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl fmt::Debug for ProviderConfigurationDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderConfigurationDocument")
+            .field("schema_version", &self.schema_version)
+            .field("bytes", &"[CANONICAL]")
+            .field("byte_length", &self.bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+impl ProviderConfigurationDocument {
+    /// Creates one nonempty bounded configuration document.
+    ///
+    /// Canonical syntax is adapter-owned; the adapter factory must decode and
+    /// byte-for-byte re-encode this document before accepting it.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty or oversized bytes.
+    pub fn new(
+        schema_version: ProviderSchemaVersion,
+        bytes: Vec<u8>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        if bytes.is_empty() || bytes.len() > MAX_PROVIDER_CONFIGURATION_BYTES {
+            return Err(ProviderConfigurationError::InvalidConfigurationDocument);
+        }
+        let mut hash = Sha256::new();
+        hash.update(CONFIGURATION_DIGEST_DOMAIN);
+        hash.update(schema_version.get().to_be_bytes());
+        hash.update((bytes.len() as u64).to_be_bytes());
+        hash.update(&bytes);
+        Ok(Self {
+            schema_version,
+            bytes,
+            digest: Sha256Digest::from_bytes(hash.finalize().into()),
+        })
+    }
+
+    /// Returns the adapter schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> ProviderSchemaVersion {
+        self.schema_version
+    }
+
+    /// Returns the exact canonical bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the domain-separated document digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+/// Enabled-state lifecycle of one provider installation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderLifecycleState {
+    /// Configuration is retained but provider side effects are disabled.
+    Disabled,
+    /// The provider instance may serve declared capabilities.
+    Active,
+    /// The instance is terminal and can never be reactivated.
+    Retired,
+}
+
+/// Immutable validated provider-instance configuration revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderInstanceManifest {
+    instance_id: ProviderInstanceId,
+    provider_type: ProviderTypeId,
+    revision: ProviderConfigurationRevision,
+    state: ProviderLifecycleState,
+    origins: ProviderOrigins,
+    configuration: ProviderConfigurationDocument,
+    secrets: ProviderSecretBindings,
+    capability_digest: Sha256Digest,
+    created_at: UnixMillis,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+    digest: Sha256Digest,
+}
+
+impl ProviderInstanceManifest {
+    /// Constructs one complete immutable manifest revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects negative or inconsistent lifecycle evidence.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        instance_id: ProviderInstanceId,
+        provider_type: ProviderTypeId,
+        revision: ProviderConfigurationRevision,
+        state: ProviderLifecycleState,
+        origins: ProviderOrigins,
+        configuration: ProviderConfigurationDocument,
+        secrets: ProviderSecretBindings,
+        capability_digest: Sha256Digest,
+        created_at: UnixMillis,
+        activated_at: Option<UnixMillis>,
+        retired_at: Option<UnixMillis>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        validate_lifecycle(state, created_at, activated_at, retired_at)?;
+        let mut manifest = Self {
+            instance_id,
+            provider_type,
+            revision,
+            state,
+            origins,
+            configuration,
+            secrets,
+            capability_digest,
+            created_at,
+            activated_at,
+            retired_at,
+            digest: Sha256Digest::from_bytes([0; 32]),
+        };
+        manifest.digest = manifest.compute_digest();
+        Ok(manifest)
+    }
+
+    /// Returns the configured instance identity.
+    #[must_use]
+    pub const fn instance_id(&self) -> ProviderInstanceId {
+        self.instance_id
+    }
+
+    /// Returns the statically registered adapter type.
+    #[must_use]
+    pub const fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    /// Returns the monotonic configuration revision.
+    #[must_use]
+    pub const fn revision(&self) -> ProviderConfigurationRevision {
+        self.revision
+    }
+
+    /// Returns the lifecycle state.
+    #[must_use]
+    pub const fn state(&self) -> ProviderLifecycleState {
+        self.state
+    }
+
+    /// Returns canonical network origins.
+    #[must_use]
+    pub const fn origins(&self) -> &ProviderOrigins {
+        &self.origins
+    }
+
+    /// Returns the canonical adapter document.
+    #[must_use]
+    pub const fn configuration(&self) -> &ProviderConfigurationDocument {
+        &self.configuration
+    }
+
+    /// Returns exact named secret bindings.
+    #[must_use]
+    pub const fn secrets(&self) -> &ProviderSecretBindings {
+        &self.secrets
+    }
+
+    /// Returns the adapter-validated capability digest.
+    #[must_use]
+    pub const fn capability_digest(&self) -> Sha256Digest {
+        self.capability_digest
+    }
+
+    /// Returns instance creation time.
+    #[must_use]
+    pub const fn created_at(&self) -> UnixMillis {
+        self.created_at
+    }
+
+    /// Returns first activation evidence when activation has occurred.
+    #[must_use]
+    pub const fn activated_at(&self) -> Option<UnixMillis> {
+        self.activated_at
+    }
+
+    /// Returns terminal retirement evidence.
+    #[must_use]
+    pub const fn retired_at(&self) -> Option<UnixMillis> {
+        self.retired_at
+    }
+
+    /// Returns the complete domain-separated manifest digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    /// Validates a strictly contiguous, changed successor revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects identity changes, reactivation after retirement, continuing
+    /// secret generation drift, noncontiguous revisions, or no-op revisions.
+    pub fn validate_successor(&self, prior: &Self) -> Result<(), ProviderConfigurationError> {
+        let next = prior
+            .revision
+            .get()
+            .checked_add(1)
+            .ok_or(ProviderConfigurationError::InvalidSuccessor)?;
+        if self.instance_id != prior.instance_id
+            || self.provider_type != prior.provider_type
+            || self.revision.get() != next
+            || self.created_at != prior.created_at
+            || prior.state == ProviderLifecycleState::Retired
+            || (prior.activated_at.is_some() && self.activated_at != prior.activated_at)
+            || (prior.activated_at.is_none()
+                && self.state != ProviderLifecycleState::Active
+                && self.activated_at.is_some())
+            || !self.secrets.valid_successor_of(&prior.secrets)
+            || !self.has_substantive_change_from(prior)
+        {
+            return Err(ProviderConfigurationError::InvalidSuccessor);
+        }
+        Ok(())
+    }
+
+    fn has_substantive_change_from(&self, prior: &Self) -> bool {
+        self.state != prior.state
+            || self.origins != prior.origins
+            || self.configuration != prior.configuration
+            || self.secrets != prior.secrets
+            || self.capability_digest != prior.capability_digest
+            || self.activated_at != prior.activated_at
+            || self.retired_at != prior.retired_at
+    }
+
+    fn compute_digest(&self) -> Sha256Digest {
+        let mut hash = Sha256::new();
+        hash.update(MANIFEST_DIGEST_DOMAIN);
+        update_part(&mut hash, self.instance_id.as_uuid().as_bytes());
+        update_part(&mut hash, self.provider_type.as_str().as_bytes());
+        update_part(&mut hash, &self.revision.get().to_be_bytes());
+        update_part(
+            &mut hash,
+            match self.state {
+                ProviderLifecycleState::Disabled => b"disabled",
+                ProviderLifecycleState::Active => b"active",
+                ProviderLifecycleState::Retired => b"retired",
+            },
+        );
+        update_part(&mut hash, self.origins.web().as_bytes());
+        update_part(&mut hash, self.origins.api().as_bytes());
+        update_part(&mut hash, self.configuration.digest().as_bytes());
+        for secret in self.secrets.iter() {
+            update_part(&mut hash, secret.name().as_str().as_bytes());
+            update_part(&mut hash, &secret.generation().get().to_be_bytes());
+            update_part(&mut hash, secret.digest().as_bytes());
+        }
+        update_part(&mut hash, self.capability_digest.as_bytes());
+        update_part(&mut hash, &self.created_at.get().to_be_bytes());
+        update_optional_time(&mut hash, self.activated_at);
+        update_optional_time(&mut hash, self.retired_at);
+        Sha256Digest::from_bytes(hash.finalize().into())
+    }
+}
+
+pub(crate) fn validate_lifecycle(
+    state: ProviderLifecycleState,
+    created_at: UnixMillis,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+) -> Result<(), ProviderConfigurationError> {
+    if created_at.get() < 0
+        || activated_at.is_some_and(|value| value.get() < created_at.get())
+        || retired_at.is_some_and(|value| value.get() < activated_at.unwrap_or(created_at).get())
+        || (state == ProviderLifecycleState::Active
+            && (activated_at.is_none() || retired_at.is_some()))
+        || (state == ProviderLifecycleState::Retired && retired_at.is_none())
+        || (state != ProviderLifecycleState::Retired && retired_at.is_some())
+    {
+        return Err(ProviderConfigurationError::InvalidLifecycle);
+    }
+    Ok(())
+}
+
+/// Plaintext named secret accepted only at the registry/factory boundary.
+pub struct ProviderSecret {
+    name: ProviderSecretName,
+    generation: ProviderSecretGeneration,
+    value: SecretBytes,
+}
+
+impl ProviderSecret {
+    /// Creates one move-only named secret value.
+    #[must_use]
+    pub const fn new(
+        name: ProviderSecretName,
+        generation: ProviderSecretGeneration,
+        value: SecretBytes,
+    ) -> Self {
+        Self {
+            name,
+            generation,
+            value,
+        }
+    }
+
+    /// Consumes the secret into its exact name, generation, and plaintext.
+    #[must_use]
+    pub fn into_parts(self) -> (ProviderSecretName, ProviderSecretGeneration, SecretBytes) {
+        (self.name, self.generation, self.value)
+    }
+}
+
+impl fmt::Debug for ProviderSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderSecret")
+            .field("name", &self.name)
+            .field("generation", &self.generation)
+            .field("value", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Exact plaintext values matching one manifest's named bindings.
+pub struct ProviderSecretSet(BTreeMap<ProviderSecretName, ProviderSecret>);
+
+impl ProviderSecretSet {
+    /// Validates exact names, generations, and plaintext digests.
+    ///
+    /// # Errors
+    ///
+    /// Rejects missing, unexpected, duplicate, or mismatched values.
+    pub fn new(
+        bindings: &ProviderSecretBindings,
+        secrets: impl IntoIterator<Item = ProviderSecret>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        let mut indexed = BTreeMap::new();
+        for secret in secrets {
+            let Some(binding) = bindings.get(&secret.name) else {
+                return Err(ProviderConfigurationError::UnexpectedSecret);
+            };
+            let digest =
+                Sha256Digest::from_bytes(Sha256::digest(secret.value.expose_secret()).into());
+            if binding.generation() != secret.generation || binding.digest() != digest {
+                return Err(ProviderConfigurationError::SecretMismatch);
+            }
+            if indexed.insert(secret.name.clone(), secret).is_some() {
+                return Err(ProviderConfigurationError::DuplicateSecret);
+            }
+        }
+        if indexed.len() != bindings.len() {
+            return Err(ProviderConfigurationError::MissingSecret);
+        }
+        Ok(Self(indexed))
+    }
+
+    /// Borrows one exact secret value.
+    #[must_use]
+    pub fn get(&self, name: &ProviderSecretName) -> Option<&SecretBytes> {
+        self.0.get(name).map(|secret| &secret.value)
+    }
+
+    /// Iterates canonical secret names without exposing values.
+    pub fn names(&self) -> impl ExactSizeIterator<Item = &ProviderSecretName> {
+        self.0.keys()
+    }
+
+    /// Consumes the set into secrets in canonical name order.
+    pub fn into_secrets(self) -> impl ExactSizeIterator<Item = ProviderSecret> {
+        self.0.into_values()
+    }
+
+    pub(crate) fn matches(&self, bindings: &ProviderSecretBindings) -> bool {
+        self.0.len() == bindings.len()
+            && self.0.iter().all(|(name, secret)| {
+                bindings.get(name).is_some_and(|binding| {
+                    binding.generation() == secret.generation
+                        && binding.digest()
+                            == Sha256Digest::from_bytes(
+                                Sha256::digest(secret.value.expose_secret()).into(),
+                            )
+                })
+            })
+    }
+}
+
+impl fmt::Debug for ProviderSecretSet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderSecretSet")
+            .field("names", &self.0.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Computes the canonical digest of one validated capability declaration.
+///
+/// # Errors
+///
+/// Returns an error only if the closed capability model cannot serialize.
+pub fn provider_capability_digest(
+    capabilities: &ProviderCapabilities,
+) -> Result<Sha256Digest, ProviderConfigurationError> {
+    let bytes = serde_json::to_vec(capabilities)
+        .map_err(|_| ProviderConfigurationError::CapabilityEncoding)?;
+    let mut hash = Sha256::new();
+    hash.update(CAPABILITY_DIGEST_DOMAIN);
+    hash.update((bytes.len() as u64).to_be_bytes());
+    hash.update(bytes);
+    Ok(Sha256Digest::from_bytes(hash.finalize().into()))
+}
+
+fn update_part(hash: &mut Sha256, value: &[u8]) {
+    hash.update((value.len() as u64).to_be_bytes());
+    hash.update(value);
+}
+
+fn update_optional_time(hash: &mut Sha256, value: Option<UnixMillis>) {
+    match value {
+        Some(value) => {
+            hash.update([1]);
+            hash.update(value.get().to_be_bytes());
+        }
+        None => hash.update([0]),
+    }
+}
+
+/// Invalid common provider configuration or secret evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderConfigurationError {
+    /// Configuration revisions must be positive signed 64-bit values.
+    #[error("provider configuration revision is invalid")]
+    InvalidConfigurationRevision,
+    /// Adapter schema versions must fit the positive durable `SMALLINT` range.
+    #[error("provider configuration schema version is invalid")]
+    InvalidSchemaVersion,
+    /// Secret generations must be positive signed 64-bit values.
+    #[error("provider secret generation is invalid")]
+    InvalidSecretGeneration,
+    /// A secret name was noncanonical or oversized.
+    #[error("provider secret name is invalid")]
+    InvalidSecretName,
+    /// A provider origin was noncanonical or did not use HTTPS.
+    #[error("provider origin is invalid")]
+    InvalidOrigin,
+    /// The adapter document was empty or oversized.
+    #[error("provider configuration document is invalid")]
+    InvalidConfigurationDocument,
+    /// More than the closed secret-binding bound was supplied.
+    #[error("too many provider secrets were configured")]
+    TooManySecrets,
+    /// One secret name appeared more than once.
+    #[error("a provider secret name was duplicated")]
+    DuplicateSecret,
+    /// Plaintext was supplied for a name absent from the manifest.
+    #[error("an unexpected provider secret was supplied")]
+    UnexpectedSecret,
+    /// One manifest binding had no plaintext value.
+    #[error("a required provider secret is missing")]
+    MissingSecret,
+    /// Secret generation or digest evidence did not match plaintext.
+    #[error("provider secret evidence does not match")]
+    SecretMismatch,
+    /// Lifecycle state and timestamps were inconsistent.
+    #[error("provider instance lifecycle is invalid")]
+    InvalidLifecycle,
+    /// A revision did not strictly succeed its predecessor.
+    #[error("provider configuration successor is invalid")]
+    InvalidSuccessor,
+    /// Closed capability serialization failed.
+    #[error("provider capability encoding failed")]
+    CapabilityEncoding,
+}

--- a/crates/automata-ci-provider/src/connection.rs
+++ b/crates/automata-ci-provider/src/connection.rs
@@ -1,0 +1,800 @@
+//! Provider-neutral repository connection configuration.
+
+use std::{fmt, num::NonZeroU64};
+
+use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    ExternalRepositoryIdentity, ProviderConfigurationRevision, ProviderConnectionId,
+    ProviderLifecycleState, ProviderSchemaVersion, configuration::validate_lifecycle,
+};
+
+/// Maximum bytes in a repository-relative workflow path.
+pub const MAX_PROVIDER_REPOSITORY_PATH_BYTES: usize = 1_024;
+/// Maximum bytes in an adapter-owned connection-policy document.
+pub const MAX_PROVIDER_CONNECTION_POLICY_BYTES: usize = 64 * 1_024;
+/// Maximum accepted compressed repository archive size.
+pub const MAX_PROVIDER_ARCHIVE_COMPRESSED_BYTES: u64 = 4 * 1_024 * 1_024 * 1_024;
+/// Maximum accepted expanded repository archive size.
+pub const MAX_PROVIDER_ARCHIVE_EXPANDED_BYTES: u64 = 16 * 1_024 * 1_024 * 1_024;
+/// Maximum accepted repository archive entries.
+pub const MAX_PROVIDER_ARCHIVE_ENTRIES: u64 = 1_000_000;
+/// Maximum accepted bytes in one repository archive path.
+pub const MAX_PROVIDER_ARCHIVE_ENTRY_PATH_BYTES: u64 = 16 * 1_024;
+/// Maximum workflow files discovered in one repository archive.
+pub const MAX_PROVIDER_ARCHIVE_WORKFLOWS: u64 = 4_096;
+/// Maximum bytes in one workflow source file.
+pub const MAX_PROVIDER_WORKFLOW_BYTES: u64 = 4 * 1_024 * 1_024;
+
+const CONNECTION_POLICY_DIGEST_DOMAIN: &[u8] = b"automata.provider.connection-policy.v1\0";
+const CONNECTION_CONFIGURATION_DIGEST_DOMAIN: &[u8] =
+    b"automata.provider.connection-configuration.v1\0";
+const CONNECTION_MANIFEST_DIGEST_DOMAIN: &[u8] = b"automata.provider.connection-manifest.v1\0";
+
+/// Monotonic revision of one provider repository connection.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "u64", into = "u64")]
+pub struct ProviderConnectionRevision(NonZeroU64);
+
+impl ProviderConnectionRevision {
+    /// Creates a positive revision representable by a `PostgreSQL BIGINT`.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero or values beyond the signed durable range.
+    pub const fn new(value: u64) -> Result<Self, ProviderConnectionError> {
+        match NonZeroU64::new(value) {
+            Some(value) if value.get() <= i64::MAX as u64 => Ok(Self(value)),
+            _ => Err(ProviderConnectionError::InvalidRevision),
+        }
+    }
+
+    /// Returns the positive revision.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u64> for ProviderConnectionRevision {
+    type Error = ProviderConnectionError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderConnectionRevision> for u64 {
+    fn from(value: ProviderConnectionRevision) -> Self {
+        value.get()
+    }
+}
+
+/// Authenticated visibility of one provider repository.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryVisibility {
+    /// Repository contents are available without authentication.
+    Public,
+    /// Repository contents are visible inside a provider-defined internal scope.
+    Internal,
+    /// Repository contents require explicit authorization.
+    Private,
+}
+
+/// Canonical default branch name without the `refs/heads/` prefix.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ProviderDefaultBranch(String);
+
+impl ProviderDefaultBranch {
+    /// Validates a complete provider branch name.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, ambiguous, unsafe, or oversized Git branch names.
+    pub fn new(value: impl Into<String>) -> Result<Self, ProviderConnectionError> {
+        let value = value.into();
+        if !valid_branch_name(&value) {
+            return Err(ProviderConnectionError::InvalidDefaultBranch);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the branch name without `refs/heads/`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for ProviderDefaultBranch {
+    type Error = ProviderConnectionError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderDefaultBranch> for String {
+    fn from(value: ProviderDefaultBranch) -> Self {
+        value.0
+    }
+}
+
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn valid_branch_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && value != "@"
+        && !value.starts_with("refs/")
+        && !value.starts_with(['-', '/', '.'])
+        && !value.ends_with(['/', '.'])
+        && !value.ends_with(".lock")
+        && !value.contains("//")
+        && !value.contains("..")
+        && !value.contains("@{")
+        && !value.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '~' | '^' | ':' | '?' | '*' | '[' | '\\')
+        })
+}
+
+/// Canonical repository-relative path used for workflow discovery.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ProviderRepositoryPath(String);
+
+impl ProviderRepositoryPath {
+    /// Validates a normalized repository-relative path.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absolute paths, empty segments, dot segments, backslashes,
+    /// control characters, and oversized values.
+    pub fn new(value: impl Into<String>) -> Result<Self, ProviderConnectionError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > MAX_PROVIDER_REPOSITORY_PATH_BYTES
+            || value.starts_with('/')
+            || value.ends_with('/')
+            || value.contains('\\')
+            || value.chars().any(char::is_control)
+            || value
+                .split('/')
+                .any(|component| component.is_empty() || component == "." || component == "..")
+        {
+            return Err(ProviderConnectionError::InvalidRepositoryPath);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the normalized repository-relative path.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for ProviderRepositoryPath {
+    type Error = ProviderConnectionError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderRepositoryPath> for String {
+    fn from(value: ProviderRepositoryPath) -> Self {
+        value.0
+    }
+}
+
+/// Common workflow source selection shape.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "path", rename_all = "snake_case")]
+pub enum ProviderWorkflowSource {
+    /// Discover all supported workflow files below one exact directory.
+    Directory(ProviderRepositoryPath),
+    /// Load one exact workflow file.
+    File(ProviderRepositoryPath),
+}
+
+impl ProviderWorkflowSource {
+    /// Returns the selected repository-relative path.
+    #[must_use]
+    pub const fn path(&self) -> &ProviderRepositoryPath {
+        match self {
+            Self::Directory(path) | Self::File(path) => path,
+        }
+    }
+}
+
+/// Immutable reference to one already-validated common runner policy.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderRunnerPolicyBinding {
+    schema_version: ProviderSchemaVersion,
+    digest: Sha256Digest,
+}
+
+impl ProviderRunnerPolicyBinding {
+    /// Pins one runner policy schema and content digest.
+    #[must_use]
+    pub const fn new(schema_version: ProviderSchemaVersion, digest: Sha256Digest) -> Self {
+        Self {
+            schema_version,
+            digest,
+        }
+    }
+
+    /// Returns the common runner-policy schema.
+    #[must_use]
+    pub const fn schema_version(self) -> ProviderSchemaVersion {
+        self.schema_version
+    }
+
+    /// Returns the exact canonical runner-policy digest.
+    #[must_use]
+    pub const fn digest(self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+/// Hard repository archive and workflow-discovery bounds.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedProviderArchiveLimits")]
+pub struct ProviderArchiveLimits {
+    compressed_bytes: u64,
+    expanded_bytes: u64,
+    entries: u64,
+    entry_path_bytes: u64,
+    workflows: u64,
+    workflow_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedProviderArchiveLimits {
+    compressed_bytes: u64,
+    expanded_bytes: u64,
+    entries: u64,
+    entry_path_bytes: u64,
+    workflows: u64,
+    workflow_bytes: u64,
+}
+
+impl ProviderArchiveLimits {
+    /// Creates internally consistent, bounded archive limits.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero, excessive, or internally impossible limits.
+    pub const fn new(
+        compressed_bytes: u64,
+        expanded_bytes: u64,
+        entries: u64,
+        entry_path_bytes: u64,
+        workflows: u64,
+        workflow_bytes: u64,
+    ) -> Result<Self, ProviderConnectionError> {
+        if compressed_bytes == 0
+            || compressed_bytes > MAX_PROVIDER_ARCHIVE_COMPRESSED_BYTES
+            || expanded_bytes < compressed_bytes
+            || expanded_bytes > MAX_PROVIDER_ARCHIVE_EXPANDED_BYTES
+            || entries == 0
+            || entries > MAX_PROVIDER_ARCHIVE_ENTRIES
+            || entry_path_bytes == 0
+            || entry_path_bytes > MAX_PROVIDER_ARCHIVE_ENTRY_PATH_BYTES
+            || workflows == 0
+            || workflows > MAX_PROVIDER_ARCHIVE_WORKFLOWS
+            || workflows > entries
+            || workflow_bytes == 0
+            || workflow_bytes > MAX_PROVIDER_WORKFLOW_BYTES
+            || workflow_bytes > expanded_bytes
+        {
+            return Err(ProviderConnectionError::InvalidArchiveLimits);
+        }
+        Ok(Self {
+            compressed_bytes,
+            expanded_bytes,
+            entries,
+            entry_path_bytes,
+            workflows,
+            workflow_bytes,
+        })
+    }
+
+    /// Returns the maximum compressed download bytes.
+    #[must_use]
+    pub const fn compressed_bytes(self) -> u64 {
+        self.compressed_bytes
+    }
+
+    /// Returns the maximum total expanded entry bytes.
+    #[must_use]
+    pub const fn expanded_bytes(self) -> u64 {
+        self.expanded_bytes
+    }
+
+    /// Returns the maximum entry count.
+    #[must_use]
+    pub const fn entries(self) -> u64 {
+        self.entries
+    }
+
+    /// Returns the maximum encoded bytes in one entry path.
+    #[must_use]
+    pub const fn entry_path_bytes(self) -> u64 {
+        self.entry_path_bytes
+    }
+
+    /// Returns the maximum discovered workflow count.
+    #[must_use]
+    pub const fn workflows(self) -> u64 {
+        self.workflows
+    }
+
+    /// Returns the maximum bytes in one workflow source.
+    #[must_use]
+    pub const fn workflow_bytes(self) -> u64 {
+        self.workflow_bytes
+    }
+}
+
+impl TryFrom<UncheckedProviderArchiveLimits> for ProviderArchiveLimits {
+    type Error = ProviderConnectionError;
+
+    fn try_from(value: UncheckedProviderArchiveLimits) -> Result<Self, Self::Error> {
+        Self::new(
+            value.compressed_bytes,
+            value.expanded_bytes,
+            value.entries,
+            value.entry_path_bytes,
+            value.workflows,
+            value.workflow_bytes,
+        )
+    }
+}
+
+/// Bounded canonical adapter-owned connection policy.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderConnectionPolicyDocument {
+    schema_version: ProviderSchemaVersion,
+    bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl fmt::Debug for ProviderConnectionPolicyDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderConnectionPolicyDocument")
+            .field("schema_version", &self.schema_version)
+            .field("bytes", &"[CANONICAL]")
+            .field("byte_length", &self.bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+impl ProviderConnectionPolicyDocument {
+    /// Creates one nonempty bounded adapter policy document.
+    ///
+    /// The owning adapter must decode and exactly re-encode the document before
+    /// accepting it.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty or oversized bytes.
+    pub fn new(
+        schema_version: ProviderSchemaVersion,
+        bytes: Vec<u8>,
+    ) -> Result<Self, ProviderConnectionError> {
+        if bytes.is_empty() || bytes.len() > MAX_PROVIDER_CONNECTION_POLICY_BYTES {
+            return Err(ProviderConnectionError::InvalidPolicyDocument);
+        }
+        let mut hash = Sha256::new();
+        hash.update(CONNECTION_POLICY_DIGEST_DOMAIN);
+        hash.update(schema_version.get().to_be_bytes());
+        hash.update((bytes.len() as u64).to_be_bytes());
+        hash.update(&bytes);
+        Ok(Self {
+            schema_version,
+            bytes,
+            digest: Sha256Digest::from_bytes(hash.finalize().into()),
+        })
+    }
+
+    /// Returns the adapter policy schema.
+    #[must_use]
+    pub const fn schema_version(&self) -> ProviderSchemaVersion {
+        self.schema_version
+    }
+
+    /// Returns exact canonical adapter policy bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the domain-separated policy digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+/// Complete provider-neutral configuration of one repository connection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderConnectionConfiguration {
+    workspace_id: WorkspaceId,
+    repository: ExternalRepositoryIdentity,
+    provider_revision: ProviderConfigurationRevision,
+    provider_configuration_digest: Sha256Digest,
+    capability_digest: Sha256Digest,
+    visibility: RepositoryVisibility,
+    default_branch: ProviderDefaultBranch,
+    workflow_source: ProviderWorkflowSource,
+    runner_policy: ProviderRunnerPolicyBinding,
+    archive_limits: ProviderArchiveLimits,
+    adapter_policy: ProviderConnectionPolicyDocument,
+    digest: Sha256Digest,
+}
+
+impl ProviderConnectionConfiguration {
+    /// Constructs the immutable common and adapter-owned connection policy.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        workspace_id: WorkspaceId,
+        repository: ExternalRepositoryIdentity,
+        provider_revision: ProviderConfigurationRevision,
+        provider_configuration_digest: Sha256Digest,
+        capability_digest: Sha256Digest,
+        visibility: RepositoryVisibility,
+        default_branch: ProviderDefaultBranch,
+        workflow_source: ProviderWorkflowSource,
+        runner_policy: ProviderRunnerPolicyBinding,
+        archive_limits: ProviderArchiveLimits,
+        adapter_policy: ProviderConnectionPolicyDocument,
+    ) -> Self {
+        let mut value = Self {
+            workspace_id,
+            repository,
+            provider_revision,
+            provider_configuration_digest,
+            capability_digest,
+            visibility,
+            default_branch,
+            workflow_source,
+            runner_policy,
+            archive_limits,
+            adapter_policy,
+            digest: Sha256Digest::from_bytes([0; 32]),
+        };
+        value.digest = value.compute_digest();
+        value
+    }
+
+    /// Returns the owning workspace.
+    #[must_use]
+    pub const fn workspace_id(&self) -> WorkspaceId {
+        self.workspace_id
+    }
+
+    /// Returns the instance-scoped provider repository identity.
+    #[must_use]
+    pub const fn repository(&self) -> &ExternalRepositoryIdentity {
+        &self.repository
+    }
+
+    /// Returns the pinned provider configuration revision.
+    #[must_use]
+    pub const fn provider_revision(&self) -> ProviderConfigurationRevision {
+        self.provider_revision
+    }
+
+    /// Returns the pinned provider configuration digest.
+    #[must_use]
+    pub const fn provider_configuration_digest(&self) -> Sha256Digest {
+        self.provider_configuration_digest
+    }
+
+    /// Returns the pinned provider capability digest.
+    #[must_use]
+    pub const fn capability_digest(&self) -> Sha256Digest {
+        self.capability_digest
+    }
+
+    /// Returns authenticated repository visibility.
+    #[must_use]
+    pub const fn visibility(&self) -> RepositoryVisibility {
+        self.visibility
+    }
+
+    /// Returns the selected default branch.
+    #[must_use]
+    pub const fn default_branch(&self) -> &ProviderDefaultBranch {
+        &self.default_branch
+    }
+
+    /// Returns the workflow source selection.
+    #[must_use]
+    pub const fn workflow_source(&self) -> &ProviderWorkflowSource {
+        &self.workflow_source
+    }
+
+    /// Returns the pinned common runner policy.
+    #[must_use]
+    pub const fn runner_policy(&self) -> ProviderRunnerPolicyBinding {
+        self.runner_policy
+    }
+
+    /// Returns hard archive and workflow-discovery limits.
+    #[must_use]
+    pub const fn archive_limits(&self) -> ProviderArchiveLimits {
+        self.archive_limits
+    }
+
+    /// Returns adapter-owned connection policy.
+    #[must_use]
+    pub const fn adapter_policy(&self) -> &ProviderConnectionPolicyDocument {
+        &self.adapter_policy
+    }
+
+    /// Returns the complete connection-configuration digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    fn compute_digest(&self) -> Sha256Digest {
+        let mut hash = Sha256::new();
+        hash.update(CONNECTION_CONFIGURATION_DIGEST_DOMAIN);
+        part(&mut hash, self.workspace_id.as_uuid().as_bytes());
+        part(
+            &mut hash,
+            self.repository.instance_id().as_uuid().as_bytes(),
+        );
+        part(&mut hash, self.repository.external_id().as_str().as_bytes());
+        part(&mut hash, &self.provider_revision.get().to_be_bytes());
+        part(&mut hash, self.provider_configuration_digest.as_bytes());
+        part(&mut hash, self.capability_digest.as_bytes());
+        part(
+            &mut hash,
+            match self.visibility {
+                RepositoryVisibility::Public => b"public",
+                RepositoryVisibility::Internal => b"internal",
+                RepositoryVisibility::Private => b"private",
+            },
+        );
+        part(&mut hash, self.default_branch.as_str().as_bytes());
+        match &self.workflow_source {
+            ProviderWorkflowSource::Directory(path) => {
+                part(&mut hash, b"directory");
+                part(&mut hash, path.as_str().as_bytes());
+            }
+            ProviderWorkflowSource::File(path) => {
+                part(&mut hash, b"file");
+                part(&mut hash, path.as_str().as_bytes());
+            }
+        }
+        part(
+            &mut hash,
+            &self.runner_policy.schema_version().get().to_be_bytes(),
+        );
+        part(&mut hash, self.runner_policy.digest().as_bytes());
+        for limit in [
+            self.archive_limits.compressed_bytes(),
+            self.archive_limits.expanded_bytes(),
+            self.archive_limits.entries(),
+            self.archive_limits.entry_path_bytes(),
+            self.archive_limits.workflows(),
+            self.archive_limits.workflow_bytes(),
+        ] {
+            part(&mut hash, &limit.to_be_bytes());
+        }
+        part(&mut hash, self.adapter_policy.digest().as_bytes());
+        Sha256Digest::from_bytes(hash.finalize().into())
+    }
+}
+
+/// Immutable lifecycle revision of one provider repository connection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderConnectionManifest {
+    connection_id: ProviderConnectionId,
+    revision: ProviderConnectionRevision,
+    state: ProviderLifecycleState,
+    configuration: ProviderConnectionConfiguration,
+    created_at: UnixMillis,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+    digest: Sha256Digest,
+}
+
+impl ProviderConnectionManifest {
+    /// Constructs one complete immutable connection revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inconsistent lifecycle evidence.
+    pub fn new(
+        connection_id: ProviderConnectionId,
+        revision: ProviderConnectionRevision,
+        state: ProviderLifecycleState,
+        configuration: ProviderConnectionConfiguration,
+        created_at: UnixMillis,
+        activated_at: Option<UnixMillis>,
+        retired_at: Option<UnixMillis>,
+    ) -> Result<Self, ProviderConnectionError> {
+        validate_lifecycle(state, created_at, activated_at, retired_at)
+            .map_err(|_| ProviderConnectionError::InvalidLifecycle)?;
+        let mut value = Self {
+            connection_id,
+            revision,
+            state,
+            configuration,
+            created_at,
+            activated_at,
+            retired_at,
+            digest: Sha256Digest::from_bytes([0; 32]),
+        };
+        value.digest = value.compute_digest();
+        Ok(value)
+    }
+
+    /// Returns the server-owned connection identity.
+    #[must_use]
+    pub const fn connection_id(&self) -> ProviderConnectionId {
+        self.connection_id
+    }
+
+    /// Returns the monotonic connection revision.
+    #[must_use]
+    pub const fn revision(&self) -> ProviderConnectionRevision {
+        self.revision
+    }
+
+    /// Returns lifecycle state.
+    #[must_use]
+    pub const fn state(&self) -> ProviderLifecycleState {
+        self.state
+    }
+
+    /// Returns common and adapter-owned repository configuration.
+    #[must_use]
+    pub const fn configuration(&self) -> &ProviderConnectionConfiguration {
+        &self.configuration
+    }
+
+    /// Returns original creation evidence.
+    #[must_use]
+    pub const fn created_at(&self) -> UnixMillis {
+        self.created_at
+    }
+
+    /// Returns first activation evidence.
+    #[must_use]
+    pub const fn activated_at(&self) -> Option<UnixMillis> {
+        self.activated_at
+    }
+
+    /// Returns terminal retirement evidence.
+    #[must_use]
+    pub const fn retired_at(&self) -> Option<UnixMillis> {
+        self.retired_at
+    }
+
+    /// Returns the complete connection manifest digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+
+    /// Validates a contiguous, changed successor revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects identity changes, no-op revisions, lifecycle regression, and
+    /// noncontiguous revisions.
+    pub fn validate_successor(&self, prior: &Self) -> Result<(), ProviderConnectionError> {
+        let next = prior
+            .revision
+            .get()
+            .checked_add(1)
+            .ok_or(ProviderConnectionError::InvalidSuccessor)?;
+        if self.connection_id != prior.connection_id
+            || self.revision.get() != next
+            || self.created_at != prior.created_at
+            || prior.state == ProviderLifecycleState::Retired
+            || (prior.activated_at.is_some() && self.activated_at != prior.activated_at)
+            || (prior.activated_at.is_none()
+                && self.state != ProviderLifecycleState::Active
+                && self.activated_at.is_some())
+            || (self.state == prior.state
+                && self.configuration == prior.configuration
+                && self.activated_at == prior.activated_at
+                && self.retired_at == prior.retired_at)
+        {
+            return Err(ProviderConnectionError::InvalidSuccessor);
+        }
+        Ok(())
+    }
+
+    fn compute_digest(&self) -> Sha256Digest {
+        let mut hash = Sha256::new();
+        hash.update(CONNECTION_MANIFEST_DIGEST_DOMAIN);
+        part(&mut hash, self.connection_id.as_uuid().as_bytes());
+        part(&mut hash, &self.revision.get().to_be_bytes());
+        part(
+            &mut hash,
+            match self.state {
+                ProviderLifecycleState::Disabled => b"disabled",
+                ProviderLifecycleState::Active => b"active",
+                ProviderLifecycleState::Retired => b"retired",
+            },
+        );
+        part(&mut hash, self.configuration.digest().as_bytes());
+        part(&mut hash, &self.created_at.get().to_be_bytes());
+        optional_time(&mut hash, self.activated_at);
+        optional_time(&mut hash, self.retired_at);
+        Sha256Digest::from_bytes(hash.finalize().into())
+    }
+}
+
+fn part(hash: &mut Sha256, value: &[u8]) {
+    hash.update((value.len() as u64).to_be_bytes());
+    hash.update(value);
+}
+
+fn optional_time(hash: &mut Sha256, value: Option<UnixMillis>) {
+    match value {
+        Some(value) => {
+            hash.update([1]);
+            hash.update(value.get().to_be_bytes());
+        }
+        None => hash.update([0]),
+    }
+}
+
+impl fmt::Display for ProviderDefaultBranch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(formatter)
+    }
+}
+
+impl fmt::Display for ProviderRepositoryPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(formatter)
+    }
+}
+
+/// Invalid common provider connection configuration or lifecycle evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderConnectionError {
+    /// Connection revisions must be positive signed 64-bit values.
+    #[error("provider connection revision is invalid")]
+    InvalidRevision,
+    /// The default branch was not a canonical complete Git branch name.
+    #[error("provider default branch is invalid")]
+    InvalidDefaultBranch,
+    /// A workflow selection path was not normalized and repository-relative.
+    #[error("provider repository path is invalid")]
+    InvalidRepositoryPath,
+    /// Archive or workflow-discovery limits were unsafe or inconsistent.
+    #[error("provider archive limits are invalid")]
+    InvalidArchiveLimits,
+    /// The adapter policy document was empty or excessive.
+    #[error("provider connection policy document is invalid")]
+    InvalidPolicyDocument,
+    /// Lifecycle state and timestamps were inconsistent.
+    #[error("provider connection lifecycle is invalid")]
+    InvalidLifecycle,
+    /// A revision did not strictly succeed its predecessor.
+    #[error("provider connection successor is invalid")]
+    InvalidSuccessor,
+}

--- a/crates/automata-ci-provider/src/factory.rs
+++ b/crates/automata-ci-provider/src/factory.rs
@@ -1,0 +1,317 @@
+//! Static provider configuration validation and registry composition.
+
+use std::{collections::BTreeMap, fmt, sync::Arc};
+
+use thiserror::Error;
+
+use crate::{
+    ProviderCapabilities, ProviderConnectionManifest, ProviderInstanceManifest, ProviderSecretSet,
+    ProviderTypeId, provider_capability_digest,
+};
+
+/// Maximum statically linked provider adapter types in one process.
+pub const MAX_PROVIDER_FACTORIES: usize = 32;
+
+/// Exact configuration and secret evidence presented to one adapter factory.
+#[derive(Clone, Copy)]
+pub struct ProviderFactoryRequest<'a> {
+    manifest: &'a ProviderInstanceManifest,
+    secrets: &'a ProviderSecretSet,
+}
+
+impl<'a> ProviderFactoryRequest<'a> {
+    /// Binds one immutable manifest to its already verified plaintext secret set.
+    #[must_use]
+    pub const fn new(
+        manifest: &'a ProviderInstanceManifest,
+        secrets: &'a ProviderSecretSet,
+    ) -> Self {
+        Self { manifest, secrets }
+    }
+
+    /// Returns the immutable provider manifest.
+    #[must_use]
+    pub const fn manifest(self) -> &'a ProviderInstanceManifest {
+        self.manifest
+    }
+
+    /// Returns exact named plaintext values at the adapter boundary.
+    #[must_use]
+    pub const fn secrets(self) -> &'a ProviderSecretSet {
+        self.secrets
+    }
+}
+
+impl fmt::Debug for ProviderFactoryRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderFactoryRequest")
+            .field("instance_id", &self.manifest.instance_id())
+            .field("provider_type", self.manifest.provider_type())
+            .field("revision", &self.manifest.revision())
+            .field("secret_names", &self.secrets.names().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Validated instance evidence and one connection policy presented to an adapter factory.
+#[derive(Clone, Copy)]
+pub struct ProviderConnectionFactoryRequest<'a> {
+    provider: &'a ProviderDescriptor,
+    connection: &'a ProviderConnectionManifest,
+}
+
+impl<'a> ProviderConnectionFactoryRequest<'a> {
+    /// Binds one connection manifest to its exact validated provider descriptor.
+    #[must_use]
+    pub const fn new(
+        provider: &'a ProviderDescriptor,
+        connection: &'a ProviderConnectionManifest,
+    ) -> Self {
+        Self {
+            provider,
+            connection,
+        }
+    }
+
+    /// Returns the already validated provider descriptor.
+    #[must_use]
+    pub const fn provider(self) -> &'a ProviderDescriptor {
+        self.provider
+    }
+
+    /// Returns the connection manifest requiring adapter-policy validation.
+    #[must_use]
+    pub const fn connection(self) -> &'a ProviderConnectionManifest {
+        self.connection
+    }
+}
+
+impl fmt::Debug for ProviderConnectionFactoryRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderConnectionFactoryRequest")
+            .field("instance_id", &self.provider.manifest().instance_id())
+            .field("connection_id", &self.connection.connection_id())
+            .field("connection_revision", &self.connection.revision())
+            .finish()
+    }
+}
+
+/// Statically composed validator for one provider adapter type.
+pub trait ProviderConfigurationFactory: fmt::Debug + Send + Sync {
+    /// Returns the unique adapter type registered by this factory.
+    fn provider_type(&self) -> &ProviderTypeId;
+
+    /// Decodes one exact schema, verifies canonical re-encoding and named
+    /// secrets, and returns the adapter's typed capability declaration.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on unknown schema, malformed or noncanonical documents,
+    /// unsupported origins, invalid secrets, or impossible capability sets.
+    fn validate_instance(
+        &self,
+        request: ProviderFactoryRequest<'_>,
+    ) -> Result<ProviderCapabilities, ProviderFactoryValidationError>;
+
+    /// Decodes and exactly re-encodes one adapter-owned connection policy.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on unknown schema, malformed or noncanonical policy, or
+    /// policy inconsistent with the validated provider configuration.
+    fn validate_connection(
+        &self,
+        request: ProviderConnectionFactoryRequest<'_>,
+    ) -> Result<(), ProviderFactoryValidationError>;
+}
+
+/// Runtime-visible descriptor returned after one adapter validates a manifest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderDescriptor {
+    manifest: ProviderInstanceManifest,
+    capabilities: ProviderCapabilities,
+}
+
+impl ProviderDescriptor {
+    /// Returns the exact immutable provider manifest.
+    #[must_use]
+    pub const fn manifest(&self) -> &ProviderInstanceManifest {
+        &self.manifest
+    }
+
+    /// Returns the adapter-validated capabilities.
+    #[must_use]
+    pub const fn capabilities(&self) -> &ProviderCapabilities {
+        &self.capabilities
+    }
+}
+
+/// Immutable registry of statically linked provider validation factories.
+#[derive(Clone)]
+pub struct ProviderFactoryRegistry {
+    factories: BTreeMap<ProviderTypeId, Arc<dyn ProviderConfigurationFactory>>,
+}
+
+impl ProviderFactoryRegistry {
+    /// Builds a bounded, duplicate-free registry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty or oversized input and duplicate provider type IDs.
+    pub fn new(
+        factories: impl IntoIterator<Item = Arc<dyn ProviderConfigurationFactory>>,
+    ) -> Result<Self, ProviderFactoryRegistryError> {
+        let mut registered = BTreeMap::new();
+        for factory in factories {
+            if registered.len() == MAX_PROVIDER_FACTORIES {
+                return Err(ProviderFactoryRegistryError::TooManyFactories);
+            }
+            let provider_type = factory.provider_type().clone();
+            if registered.insert(provider_type, factory).is_some() {
+                return Err(ProviderFactoryRegistryError::DuplicateFactory);
+            }
+        }
+        if registered.is_empty() {
+            return Err(ProviderFactoryRegistryError::NoFactories);
+        }
+        Ok(Self {
+            factories: registered,
+        })
+    }
+
+    /// Validates one complete manifest and constructs its common descriptor.
+    ///
+    /// The adapter-returned capability digest must exactly match the durable
+    /// manifest. The registry never falls back to another provider type.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unregistered type, adapter validation failure, or capability
+    /// digest mismatch.
+    pub fn build_descriptor(
+        &self,
+        manifest: ProviderInstanceManifest,
+        secrets: &ProviderSecretSet,
+    ) -> Result<ProviderDescriptor, ProviderFactoryRegistryError> {
+        if !secrets.matches(manifest.secrets()) {
+            return Err(ProviderFactoryRegistryError::SecretEvidence);
+        }
+        let factory = self
+            .factories
+            .get(manifest.provider_type())
+            .ok_or(ProviderFactoryRegistryError::UnknownProviderType)?;
+        if factory.provider_type() != manifest.provider_type() {
+            return Err(ProviderFactoryRegistryError::FactoryIdentityMismatch);
+        }
+        let capabilities = factory
+            .validate_instance(ProviderFactoryRequest::new(&manifest, secrets))
+            .map_err(ProviderFactoryRegistryError::Validation)?;
+        let digest = provider_capability_digest(&capabilities)
+            .map_err(|_| ProviderFactoryRegistryError::CapabilityDigest)?;
+        if digest != manifest.capability_digest() {
+            return Err(ProviderFactoryRegistryError::CapabilityDigest);
+        }
+        Ok(ProviderDescriptor {
+            manifest,
+            capabilities,
+        })
+    }
+
+    /// Validates exact provider evidence and adapter-owned connection policy.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a connection pinned to different instance, configuration, or
+    /// capability evidence, and propagates adapter policy rejection.
+    pub fn validate_connection(
+        &self,
+        provider: &ProviderDescriptor,
+        connection: &ProviderConnectionManifest,
+    ) -> Result<(), ProviderFactoryRegistryError> {
+        let provider_manifest = provider.manifest();
+        let configuration = connection.configuration();
+        if configuration.repository().instance_id() != provider_manifest.instance_id()
+            || configuration.provider_revision() != provider_manifest.revision()
+            || configuration.provider_configuration_digest()
+                != provider_manifest.configuration().digest()
+            || configuration.capability_digest() != provider_manifest.capability_digest()
+        {
+            return Err(ProviderFactoryRegistryError::ConnectionEvidence);
+        }
+        let factory = self
+            .factories
+            .get(provider_manifest.provider_type())
+            .ok_or(ProviderFactoryRegistryError::UnknownProviderType)?;
+        factory
+            .validate_connection(ProviderConnectionFactoryRequest::new(provider, connection))
+            .map_err(ProviderFactoryRegistryError::Validation)
+    }
+
+    /// Iterates registered provider type IDs in canonical order.
+    pub fn provider_types(&self) -> impl ExactSizeIterator<Item = &ProviderTypeId> {
+        self.factories.keys()
+    }
+}
+
+impl fmt::Debug for ProviderFactoryRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderFactoryRegistry")
+            .field("provider_types", &self.factories.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Sanitized adapter-owned configuration rejection.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderFactoryValidationError {
+    /// The adapter does not implement the requested schema version.
+    #[error("provider configuration schema is unsupported")]
+    UnsupportedSchema,
+    /// The adapter document was malformed or not in canonical form.
+    #[error("provider configuration document is invalid")]
+    InvalidConfiguration,
+    /// Common origins violate adapter-specific trust policy.
+    #[error("provider origin policy is invalid")]
+    InvalidOrigins,
+    /// Named secret requirements were not satisfied.
+    #[error("provider secret bindings are invalid")]
+    InvalidSecrets,
+    /// The adapter could not produce a valid capability declaration.
+    #[error("provider capability declaration is invalid")]
+    InvalidCapabilities,
+}
+
+/// Closed provider-factory registry failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderFactoryRegistryError {
+    /// No factory was registered.
+    #[error("at least one provider factory is required")]
+    NoFactories,
+    /// The process-wide adapter bound was exceeded.
+    #[error("too many provider factories were registered")]
+    TooManyFactories,
+    /// Two factories claimed one provider type.
+    #[error("a provider factory type was registered more than once")]
+    DuplicateFactory,
+    /// No exact factory exists for the manifest type.
+    #[error("provider type is not registered")]
+    UnknownProviderType,
+    /// A factory returned an identity inconsistent with its registry key.
+    #[error("provider factory identity is inconsistent")]
+    FactoryIdentityMismatch,
+    /// Adapter validation rejected the configuration.
+    #[error(transparent)]
+    Validation(ProviderFactoryValidationError),
+    /// Plaintext secret evidence did not match the selected manifest.
+    #[error("provider secret evidence is inconsistent")]
+    SecretEvidence,
+    /// Adapter capabilities disagreed with durable evidence.
+    #[error("provider capability digest is inconsistent")]
+    CapabilityDigest,
+    /// A connection was pinned to different provider evidence.
+    #[error("provider connection evidence is inconsistent")]
+    ConnectionEvidence,
+}

--- a/crates/automata-ci-provider/src/lib.rs
+++ b/crates/automata-ci-provider/src/lib.rs
@@ -8,7 +8,11 @@
 #![deny(missing_docs)]
 
 mod capability;
+mod configuration;
+mod connection;
+mod factory;
 mod identity;
+mod storage;
 
 pub use capability::{
     AuthorizationCodeLoginCapability, ChangedFileCapability, ChangedFileCompleteness,
@@ -18,9 +22,36 @@ pub use capability::{
     StatusHistoryModel, WorkloadCredentialCapability, WorkloadCredentialProfile,
     WorkloadCredentialRevocation,
 };
+pub use configuration::{
+    MAX_PROVIDER_CONFIGURATION_BYTES, MAX_PROVIDER_ORIGIN_BYTES, MAX_PROVIDER_SCHEMA_VERSION,
+    MAX_PROVIDER_SECRET_BINDINGS, MAX_PROVIDER_SECRET_NAME_BYTES, ProviderConfigurationDocument,
+    ProviderConfigurationError, ProviderConfigurationRevision, ProviderInstanceManifest,
+    ProviderLifecycleState, ProviderOrigins, ProviderSchemaVersion, ProviderSecret,
+    ProviderSecretBinding, ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName,
+    ProviderSecretSet, provider_capability_digest,
+};
+pub use connection::{
+    MAX_PROVIDER_ARCHIVE_COMPRESSED_BYTES, MAX_PROVIDER_ARCHIVE_ENTRIES,
+    MAX_PROVIDER_ARCHIVE_ENTRY_PATH_BYTES, MAX_PROVIDER_ARCHIVE_EXPANDED_BYTES,
+    MAX_PROVIDER_ARCHIVE_WORKFLOWS, MAX_PROVIDER_CONNECTION_POLICY_BYTES,
+    MAX_PROVIDER_REPOSITORY_PATH_BYTES, MAX_PROVIDER_WORKFLOW_BYTES, ProviderArchiveLimits,
+    ProviderConnectionConfiguration, ProviderConnectionError, ProviderConnectionManifest,
+    ProviderConnectionPolicyDocument, ProviderConnectionRevision, ProviderDefaultBranch,
+    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderWorkflowSource,
+    RepositoryVisibility,
+};
+pub use factory::{
+    MAX_PROVIDER_FACTORIES, ProviderConfigurationFactory, ProviderConnectionFactoryRequest,
+    ProviderDescriptor, ProviderFactoryRegistry, ProviderFactoryRegistryError,
+    ProviderFactoryRequest, ProviderFactoryValidationError,
+};
 pub use identity::{
     ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity,
     ExternalSubjectId, ExternalSubjectIdentity, ExternalSubjectKind, MAX_EXTERNAL_ID_BYTES,
     MAX_PROVIDER_TYPE_ID_BYTES, ProviderConnectionId, ProviderIdentityError, ProviderInstanceId,
     ProviderTypeId,
+};
+pub use storage::{
+    ProviderInstanceRecord, ProviderManifestRepository, ProviderRepositoryError,
+    ProviderRepositoryFuture, ProviderSaveOutcome,
 };

--- a/crates/automata-ci-provider/src/storage.rs
+++ b/crates/automata-ci-provider/src/storage.rs
@@ -1,0 +1,138 @@
+//! Durable provider configuration and connection repository ports.
+
+use std::{fmt, future::Future, pin::Pin};
+
+use thiserror::Error;
+
+use crate::{
+    ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionManifest,
+    ProviderConnectionRevision, ProviderInstanceId, ProviderInstanceManifest, ProviderSecretSet,
+};
+
+/// Boxed future returned by provider manifest repository operations.
+pub type ProviderRepositoryFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, ProviderRepositoryError>> + Send + 'a>>;
+
+/// Decrypted instance manifest returned only at its trusted adapter boundary.
+pub struct ProviderInstanceRecord {
+    manifest: ProviderInstanceManifest,
+    secrets: ProviderSecretSet,
+}
+
+impl ProviderInstanceRecord {
+    /// Binds an immutable manifest to its exact validated plaintext secret set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects secret evidence belonging to another manifest revision.
+    pub fn new(
+        manifest: ProviderInstanceManifest,
+        secrets: ProviderSecretSet,
+    ) -> Result<Self, ProviderRepositoryError> {
+        if !secrets.matches(manifest.secrets()) {
+            return Err(ProviderRepositoryError::SecretCustody);
+        }
+        Ok(Self { manifest, secrets })
+    }
+
+    /// Returns the immutable instance manifest.
+    #[must_use]
+    pub const fn manifest(&self) -> &ProviderInstanceManifest {
+        &self.manifest
+    }
+
+    /// Returns the exact plaintext secret set.
+    #[must_use]
+    pub const fn secrets(&self) -> &ProviderSecretSet {
+        &self.secrets
+    }
+
+    /// Consumes the record into manifest and secret custody values.
+    #[must_use]
+    pub fn into_parts(self) -> (ProviderInstanceManifest, ProviderSecretSet) {
+        (self.manifest, self.secrets)
+    }
+}
+
+impl fmt::Debug for ProviderInstanceRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderInstanceRecord")
+            .field("manifest", &self.manifest)
+            .field("secrets", &self.secrets)
+            .finish()
+    }
+}
+
+/// Result of atomically storing an immutable revision and advancing its pointer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderSaveOutcome {
+    /// A new contiguous revision became current.
+    Inserted,
+    /// The exact current revision was already durable.
+    Unchanged,
+}
+
+/// Durable repository for provider instance and connection manifests.
+pub trait ProviderManifestRepository: fmt::Debug + Send + Sync {
+    /// Atomically stores one first or contiguous instance revision.
+    ///
+    /// A secret name newly present in the adjacent revision must use one more
+    /// than its largest historical generation, or generation one if unseen.
+    fn save_instance(
+        &self,
+        record: ProviderInstanceRecord,
+    ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome>;
+
+    /// Loads and decrypts one exact historical instance revision.
+    fn load_instance(
+        &self,
+        instance_id: ProviderInstanceId,
+        revision: ProviderConfigurationRevision,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>>;
+
+    /// Loads and decrypts the current instance revision.
+    fn current_instance(
+        &self,
+        instance_id: ProviderInstanceId,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>>;
+
+    /// Atomically stores one first or contiguous connection revision.
+    fn save_connection(
+        &self,
+        manifest: ProviderConnectionManifest,
+    ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome>;
+
+    /// Loads one exact historical connection revision.
+    fn load_connection(
+        &self,
+        connection_id: ProviderConnectionId,
+        revision: ProviderConnectionRevision,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>>;
+
+    /// Loads the current connection revision.
+    fn current_connection(
+        &self,
+        connection_id: ProviderConnectionId,
+    ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>>;
+}
+
+/// Sanitized durable provider repository failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderRepositoryError {
+    /// A revision was stale, noncontiguous, or disagreed with durable content.
+    #[error("provider manifest revision conflicts with durable state")]
+    Conflict,
+    /// Required referenced durable state was absent.
+    #[error("provider manifest reference does not exist")]
+    NotFound,
+    /// Durable bytes violated the provider model.
+    #[error("provider manifest storage is corrupt")]
+    Corrupt,
+    /// Encryption, decryption, or plaintext binding validation failed.
+    #[error("provider secret custody failed")]
+    SecretCustody,
+    /// The durable repository was unavailable.
+    #[error("provider manifest repository is unavailable")]
+    Unavailable,
+}

--- a/crates/automata-ci-provider/tests/configuration.rs
+++ b/crates/automata-ci-provider/tests/configuration.rs
@@ -1,0 +1,602 @@
+use std::sync::Arc;
+
+use automata_ci_core::{GitObjectAlgorithm, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_key_management::SecretBytes;
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, MAX_PROVIDER_SCHEMA_VERSION,
+    ProviderArchiveLimits, ProviderCapabilities, ProviderCapability, ProviderConfigurationDocument,
+    ProviderConfigurationError, ProviderConfigurationFactory, ProviderConfigurationRevision,
+    ProviderConnectionConfiguration, ProviderConnectionFactoryRequest, ProviderConnectionId,
+    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    ProviderDefaultBranch, ProviderFactoryRegistry, ProviderFactoryRegistryError,
+    ProviderFactoryRequest, ProviderFactoryValidationError, ProviderInstanceId,
+    ProviderInstanceManifest, ProviderLifecycleState, ProviderOrigins, ProviderRepositoryPath,
+    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding,
+    ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet,
+    ProviderTypeId, ProviderWorkflowSource, RepositoryVisibility, SourceReadCapability,
+    provider_capability_digest,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct FakeFactory {
+    provider_type: ProviderTypeId,
+    api_family: &'static str,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct FakeConfiguration {
+    api_family: String,
+}
+
+impl FakeFactory {
+    fn new(provider_type: &str, api_family: &'static str) -> Self {
+        Self {
+            provider_type: ProviderTypeId::new(provider_type).expect("provider type"),
+            api_family,
+        }
+    }
+}
+
+impl ProviderConfigurationFactory for FakeFactory {
+    fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    fn validate_instance(
+        &self,
+        request: ProviderFactoryRequest<'_>,
+    ) -> Result<ProviderCapabilities, ProviderFactoryValidationError> {
+        if request.manifest().configuration().schema_version().get() != 1 {
+            return Err(ProviderFactoryValidationError::UnsupportedSchema);
+        }
+        let decoded =
+            serde_json::from_slice::<FakeConfiguration>(request.manifest().configuration().bytes())
+                .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
+        let canonical = serde_json::to_vec(&decoded)
+            .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
+        if canonical != request.manifest().configuration().bytes()
+            || decoded.api_family != self.api_family
+        {
+            return Err(ProviderFactoryValidationError::InvalidConfiguration);
+        }
+
+        let token = ProviderSecretName::new("control-token").expect("secret name");
+        if request.manifest().secrets().len() != 1 || request.secrets().get(&token).is_none() {
+            return Err(ProviderFactoryValidationError::InvalidSecrets);
+        }
+
+        source_capabilities().map_err(|_| ProviderFactoryValidationError::InvalidCapabilities)
+    }
+
+    fn validate_connection(
+        &self,
+        request: ProviderConnectionFactoryRequest<'_>,
+    ) -> Result<(), ProviderFactoryValidationError> {
+        let document = request.connection().configuration().adapter_policy();
+        if document.schema_version().get() != 1 {
+            return Err(ProviderFactoryValidationError::UnsupportedSchema);
+        }
+        let decoded = serde_json::from_slice::<FakeConfiguration>(document.bytes())
+            .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
+        let canonical = serde_json::to_vec(&decoded)
+            .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
+        if canonical != document.bytes() || decoded.api_family != self.api_family {
+            return Err(ProviderFactoryValidationError::InvalidConfiguration);
+        }
+        Ok(())
+    }
+}
+
+fn source_capabilities()
+-> Result<ProviderCapabilities, automata_ci_provider::ProviderCapabilitiesError> {
+    ProviderCapabilities::new([ProviderCapability::SourceRead(SourceReadCapability::new(
+        [GitObjectAlgorithm::Sha1],
+    )?)])
+}
+
+fn secret_digest(value: &[u8]) -> Sha256Digest {
+    Sha256Digest::from_bytes(Sha256::digest(value).into())
+}
+
+fn bindings(value: &[u8], generation: u64) -> ProviderSecretBindings {
+    ProviderSecretBindings::new([ProviderSecretBinding::new(
+        ProviderSecretName::new("control-token").expect("secret name"),
+        ProviderSecretGeneration::new(generation).expect("secret generation"),
+        secret_digest(value),
+    )])
+    .expect("bindings")
+}
+
+fn secret_set(value: &[u8], generation: u64) -> ProviderSecretSet {
+    let bindings = bindings(value, generation);
+    ProviderSecretSet::new(
+        &bindings,
+        [ProviderSecret::new(
+            ProviderSecretName::new("control-token").expect("secret name"),
+            ProviderSecretGeneration::new(generation).expect("secret generation"),
+            SecretBytes::new(value.to_vec()).expect("secret bytes"),
+        )],
+    )
+    .expect("secret set")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn manifest(
+    provider_type: &str,
+    api_family: &str,
+    schema: u16,
+    revision: u64,
+    state: ProviderLifecycleState,
+    secrets: ProviderSecretBindings,
+    capability_digest: Sha256Digest,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+) -> ProviderInstanceManifest {
+    let bytes = serde_json::to_vec(&FakeConfiguration {
+        api_family: api_family.to_owned(),
+    })
+    .expect("configuration bytes");
+    ProviderInstanceManifest::new(
+        ProviderInstanceId::from_uuid(Uuid::from_u128(7)).expect("instance ID"),
+        ProviderTypeId::new(provider_type).expect("provider type"),
+        ProviderConfigurationRevision::new(revision).expect("revision"),
+        state,
+        ProviderOrigins::new("https://code.example/", "https://code.example/api/v1/")
+            .expect("origins"),
+        ProviderConfigurationDocument::new(
+            ProviderSchemaVersion::new(schema).expect("schema"),
+            bytes,
+        )
+        .expect("configuration"),
+        secrets,
+        capability_digest,
+        UnixMillis::new(1_000),
+        activated_at,
+        retired_at,
+    )
+    .expect("manifest")
+}
+
+fn registry() -> ProviderFactoryRegistry {
+    ProviderFactoryRegistry::new([
+        Arc::new(FakeFactory::new("github", "github")) as Arc<dyn ProviderConfigurationFactory>,
+        Arc::new(FakeFactory::new("forgejo", "forgejo")) as Arc<dyn ProviderConfigurationFactory>,
+    ])
+    .expect("registry")
+}
+
+fn connection_manifest(
+    instance: &ProviderInstanceManifest,
+    api_family: &str,
+    schema: u16,
+    provider_configuration_digest: Sha256Digest,
+) -> ProviderConnectionManifest {
+    let configuration = ProviderConnectionConfiguration::new(
+        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ExternalRepositoryIdentity::new(
+            instance.instance_id(),
+            ExternalRepositoryId::new("42").expect("repository"),
+        ),
+        instance.revision(),
+        provider_configuration_digest,
+        instance.capability_digest(),
+        RepositoryVisibility::Private,
+        ProviderDefaultBranch::new("main").expect("branch"),
+        ProviderWorkflowSource::Directory(
+            ProviderRepositoryPath::new(".ci/workflows").expect("workflow source"),
+        ),
+        ProviderRunnerPolicyBinding::new(
+            ProviderSchemaVersion::new(1).expect("runner schema"),
+            Sha256Digest::from_bytes([7; 32]),
+        ),
+        ProviderArchiveLimits::new(1, 1, 1, 1, 1, 1).expect("archive limits"),
+        ProviderConnectionPolicyDocument::new(
+            ProviderSchemaVersion::new(schema).expect("adapter schema"),
+            serde_json::to_vec(&FakeConfiguration {
+                api_family: api_family.to_owned(),
+            })
+            .expect("adapter policy"),
+        )
+        .expect("adapter document"),
+    );
+    ProviderConnectionManifest::new(
+        ProviderConnectionId::from_uuid(Uuid::from_u128(8)).expect("connection"),
+        ProviderConnectionRevision::new(1).expect("connection revision"),
+        ProviderLifecycleState::Active,
+        configuration,
+        UnixMillis::new(1_000),
+        Some(UnixMillis::new(1_000)),
+        None,
+    )
+    .expect("connection manifest")
+}
+
+#[test]
+fn origins_require_exact_canonical_https_bases() {
+    let valid = ProviderOrigins::new("https://code.example/", "https://code.example:8443/api/v1/")
+        .expect("origins");
+    assert_eq!(valid.web(), "https://code.example/");
+    assert_eq!(valid.api(), "https://code.example:8443/api/v1/");
+
+    for (web, api) in [
+        ("http://code.example/", "https://code.example/api/v1/"),
+        ("https://code.example/path", "https://code.example/api/v1/"),
+        ("https://user@code.example/", "https://code.example/api/v1/"),
+        ("https://code.example/", "https://code.example/api/v1"),
+        (
+            "https://code.example/",
+            "https://code.example/api/v1/?page=1",
+        ),
+        ("https://CODE.example/", "https://code.example/api/v1/"),
+    ] {
+        assert!(
+            ProviderOrigins::new(web, api).is_err(),
+            "accepted {web} {api}"
+        );
+    }
+}
+
+#[test]
+fn configuration_documents_are_positive_bounded_and_domain_separated() {
+    assert_eq!(
+        ProviderSchemaVersion::new(0),
+        Err(ProviderConfigurationError::InvalidSchemaVersion)
+    );
+    assert_eq!(
+        ProviderSchemaVersion::new(MAX_PROVIDER_SCHEMA_VERSION.saturating_add(1)),
+        Err(ProviderConfigurationError::InvalidSchemaVersion)
+    );
+    let first = ProviderConfigurationDocument::new(
+        ProviderSchemaVersion::new(1).expect("schema"),
+        b"{}".to_vec(),
+    )
+    .expect("document");
+    let second = ProviderConfigurationDocument::new(
+        ProviderSchemaVersion::new(2).expect("schema"),
+        b"{}".to_vec(),
+    )
+    .expect("document");
+    assert_ne!(first.digest(), second.digest());
+    assert_eq!(
+        ProviderConfigurationDocument::new(
+            ProviderSchemaVersion::new(1).expect("schema"),
+            Vec::new(),
+        ),
+        Err(ProviderConfigurationError::InvalidConfigurationDocument)
+    );
+}
+
+#[test]
+fn secret_sets_require_exact_names_generations_and_plaintext() {
+    let expected = bindings(b"correct", 2);
+    let valid = ProviderSecretSet::new(
+        &expected,
+        [ProviderSecret::new(
+            ProviderSecretName::new("control-token").expect("name"),
+            ProviderSecretGeneration::new(2).expect("generation"),
+            SecretBytes::new(b"correct".to_vec()).expect("secret"),
+        )],
+    )
+    .expect("secret set");
+    assert_eq!(valid.names().count(), 1);
+    assert!(!format!("{valid:?}").contains("correct"));
+
+    let missing = ProviderSecretSet::new(&expected, []);
+    assert!(matches!(
+        missing,
+        Err(ProviderConfigurationError::MissingSecret)
+    ));
+    let wrong_value = ProviderSecretSet::new(
+        &expected,
+        [ProviderSecret::new(
+            ProviderSecretName::new("control-token").expect("name"),
+            ProviderSecretGeneration::new(2).expect("generation"),
+            SecretBytes::new(b"wrong".to_vec()).expect("secret"),
+        )],
+    );
+    assert!(matches!(
+        wrong_value,
+        Err(ProviderConfigurationError::SecretMismatch)
+    ));
+    let unexpected = ProviderSecretSet::new(
+        &expected,
+        [ProviderSecret::new(
+            ProviderSecretName::new("other-token").expect("name"),
+            ProviderSecretGeneration::new(2).expect("generation"),
+            SecretBytes::new(b"correct".to_vec()).expect("secret"),
+        )],
+    );
+    assert!(matches!(
+        unexpected,
+        Err(ProviderConfigurationError::UnexpectedSecret)
+    ));
+}
+
+#[test]
+fn manifest_successors_require_real_change_and_exact_lifecycle_evidence() {
+    let capabilities = source_capabilities().expect("capabilities");
+    let digest = provider_capability_digest(&capabilities).expect("capability digest");
+    let prior = manifest(
+        "github",
+        "github",
+        1,
+        1,
+        ProviderLifecycleState::Disabled,
+        bindings(b"first", 1),
+        digest,
+        None,
+        None,
+    );
+    let revision_only = manifest(
+        "github",
+        "github",
+        1,
+        2,
+        ProviderLifecycleState::Disabled,
+        bindings(b"first", 1),
+        digest,
+        None,
+        None,
+    );
+    assert_eq!(
+        revision_only.validate_successor(&prior),
+        Err(ProviderConfigurationError::InvalidSuccessor)
+    );
+
+    let activated = manifest(
+        "github",
+        "github",
+        1,
+        2,
+        ProviderLifecycleState::Active,
+        bindings(b"first", 1),
+        digest,
+        Some(UnixMillis::new(2_000)),
+        None,
+    );
+    activated.validate_successor(&prior).expect("activation");
+
+    let rotated = manifest(
+        "github",
+        "github",
+        1,
+        3,
+        ProviderLifecycleState::Active,
+        bindings(b"second", 2),
+        digest,
+        Some(UnixMillis::new(2_000)),
+        None,
+    );
+    rotated.validate_successor(&activated).expect("rotation");
+
+    let skipped_generation = manifest(
+        "github",
+        "github",
+        1,
+        3,
+        ProviderLifecycleState::Active,
+        bindings(b"second", 3),
+        digest,
+        Some(UnixMillis::new(2_000)),
+        None,
+    );
+    assert_eq!(
+        skipped_generation.validate_successor(&activated),
+        Err(ProviderConfigurationError::InvalidSuccessor)
+    );
+}
+
+#[test]
+fn registry_dispatches_two_factories_without_provider_fallback() {
+    let registry = registry();
+    assert_eq!(
+        registry
+            .provider_types()
+            .map(ProviderTypeId::as_str)
+            .collect::<Vec<_>>(),
+        ["forgejo", "github"]
+    );
+    let capabilities = source_capabilities().expect("capabilities");
+    let digest = provider_capability_digest(&capabilities).expect("capability digest");
+
+    for (provider_type, api_family) in [("github", "github"), ("forgejo", "forgejo")] {
+        let manifest = manifest(
+            provider_type,
+            api_family,
+            1,
+            1,
+            ProviderLifecycleState::Active,
+            bindings(b"token", 1),
+            digest,
+            Some(UnixMillis::new(1_000)),
+            None,
+        );
+        let descriptor = registry
+            .build_descriptor(manifest, &secret_set(b"token", 1))
+            .expect("descriptor");
+        assert_eq!(
+            descriptor.manifest().provider_type().as_str(),
+            provider_type
+        );
+        assert_eq!(descriptor.capabilities(), &capabilities);
+    }
+
+    let unknown = manifest(
+        "gitlab",
+        "gitlab",
+        1,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"token", 1),
+        digest,
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    assert_eq!(
+        registry.build_descriptor(unknown, &secret_set(b"token", 1)),
+        Err(ProviderFactoryRegistryError::UnknownProviderType)
+    );
+}
+
+#[test]
+fn registry_validates_connection_policy_against_exact_provider_evidence() {
+    let registry = registry();
+    let capabilities = source_capabilities().expect("capabilities");
+    let digest = provider_capability_digest(&capabilities).expect("capability digest");
+    let instance = manifest(
+        "forgejo",
+        "forgejo",
+        1,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"token", 1),
+        digest,
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    let descriptor = registry
+        .build_descriptor(instance, &secret_set(b"token", 1))
+        .expect("descriptor");
+    let configuration_digest = descriptor.manifest().configuration().digest();
+    let valid = connection_manifest(descriptor.manifest(), "forgejo", 1, configuration_digest);
+    registry
+        .validate_connection(&descriptor, &valid)
+        .expect("connection policy");
+
+    let unknown_schema =
+        connection_manifest(descriptor.manifest(), "forgejo", 2, configuration_digest);
+    assert_eq!(
+        registry.validate_connection(&descriptor, &unknown_schema),
+        Err(ProviderFactoryRegistryError::Validation(
+            ProviderFactoryValidationError::UnsupportedSchema
+        ))
+    );
+    let wrong_provider_evidence = connection_manifest(
+        descriptor.manifest(),
+        "forgejo",
+        1,
+        Sha256Digest::from_bytes([9; 32]),
+    );
+    assert_eq!(
+        registry.validate_connection(&descriptor, &wrong_provider_evidence),
+        Err(ProviderFactoryRegistryError::ConnectionEvidence)
+    );
+}
+
+#[test]
+fn registry_fails_closed_on_schema_document_secret_and_capability_drift() {
+    let registry = registry();
+    let capabilities = source_capabilities().expect("capabilities");
+    let digest = provider_capability_digest(&capabilities).expect("capability digest");
+
+    let unsupported = manifest(
+        "github",
+        "github",
+        2,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"token", 1),
+        digest,
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    assert_eq!(
+        registry.build_descriptor(unsupported, &secret_set(b"token", 1)),
+        Err(ProviderFactoryRegistryError::Validation(
+            ProviderFactoryValidationError::UnsupportedSchema
+        ))
+    );
+
+    let mut unknown_field = manifest(
+        "github",
+        "github",
+        1,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"token", 1),
+        digest,
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    let document = ProviderConfigurationDocument::new(
+        ProviderSchemaVersion::new(1).expect("schema"),
+        br#"{"api_family":"github","extra":true}"#.to_vec(),
+    )
+    .expect("document");
+    unknown_field = ProviderInstanceManifest::new(
+        unknown_field.instance_id(),
+        unknown_field.provider_type().clone(),
+        unknown_field.revision(),
+        unknown_field.state(),
+        unknown_field.origins().clone(),
+        document,
+        unknown_field.secrets().clone(),
+        unknown_field.capability_digest(),
+        unknown_field.created_at(),
+        unknown_field.activated_at(),
+        unknown_field.retired_at(),
+    )
+    .expect("manifest");
+    assert_eq!(
+        registry.build_descriptor(unknown_field, &secret_set(b"token", 1)),
+        Err(ProviderFactoryRegistryError::Validation(
+            ProviderFactoryValidationError::InvalidConfiguration
+        ))
+    );
+
+    let wrong_secret_manifest = manifest(
+        "github",
+        "github",
+        1,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"first", 1),
+        digest,
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    assert_eq!(
+        registry.build_descriptor(wrong_secret_manifest, &secret_set(b"second", 1)),
+        Err(ProviderFactoryRegistryError::SecretEvidence)
+    );
+
+    let wrong_digest = manifest(
+        "github",
+        "github",
+        1,
+        1,
+        ProviderLifecycleState::Active,
+        bindings(b"token", 1),
+        Sha256Digest::from_bytes([9; 32]),
+        Some(UnixMillis::new(1_000)),
+        None,
+    );
+    assert_eq!(
+        registry.build_descriptor(wrong_digest, &secret_set(b"token", 1)),
+        Err(ProviderFactoryRegistryError::CapabilityDigest)
+    );
+}
+
+#[test]
+fn registry_rejects_empty_and_duplicate_factory_sets_without_debug_leaks() {
+    assert!(matches!(
+        ProviderFactoryRegistry::new([]),
+        Err(ProviderFactoryRegistryError::NoFactories)
+    ));
+    assert!(matches!(
+        ProviderFactoryRegistry::new([
+            Arc::new(FakeFactory::new("github", "first")) as Arc<dyn ProviderConfigurationFactory>,
+            Arc::new(FakeFactory::new("github", "second")) as Arc<dyn ProviderConfigurationFactory>,
+        ]),
+        Err(ProviderFactoryRegistryError::DuplicateFactory)
+    ));
+
+    let debug = format!("{:?}", registry());
+    assert!(debug.contains("github"));
+    assert!(debug.contains("forgejo"));
+    assert!(!debug.contains("api_family"));
+}

--- a/crates/automata-ci-provider/tests/connection.rs
+++ b/crates/automata-ci-provider/tests/connection.rs
@@ -1,0 +1,252 @@
+use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
+    ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionError,
+    ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionPolicyDocument,
+    ProviderConnectionRevision, ProviderDefaultBranch, ProviderInstanceId, ProviderLifecycleState,
+    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSchemaVersion,
+    ProviderWorkflowSource, RepositoryVisibility,
+};
+use uuid::Uuid;
+
+fn configuration(visibility: RepositoryVisibility) -> ProviderConnectionConfiguration {
+    ProviderConnectionConfiguration::new(
+        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ExternalRepositoryIdentity::new(
+            ProviderInstanceId::from_uuid(Uuid::from_u128(2)).expect("instance"),
+            ExternalRepositoryId::new("repository-42").expect("repository"),
+        ),
+        ProviderConfigurationRevision::new(3).expect("provider revision"),
+        Sha256Digest::from_bytes([3; 32]),
+        Sha256Digest::from_bytes([4; 32]),
+        visibility,
+        ProviderDefaultBranch::new("main").expect("default branch"),
+        ProviderWorkflowSource::Directory(
+            ProviderRepositoryPath::new(".forgejo/workflows").expect("workflow root"),
+        ),
+        ProviderRunnerPolicyBinding::new(
+            ProviderSchemaVersion::new(2).expect("runner schema"),
+            Sha256Digest::from_bytes([5; 32]),
+        ),
+        ProviderArchiveLimits::new(
+            256 * 1_024 * 1_024,
+            2 * 1_024 * 1_024 * 1_024,
+            100_000,
+            4 * 1_024,
+            256,
+            500 * 1_024,
+        )
+        .expect("archive limits"),
+        ProviderConnectionPolicyDocument::new(
+            ProviderSchemaVersion::new(1).expect("policy schema"),
+            br#"{"installation_id":42}"#.to_vec(),
+        )
+        .expect("adapter policy"),
+    )
+}
+
+fn manifest(
+    revision: u64,
+    state: ProviderLifecycleState,
+    configuration: ProviderConnectionConfiguration,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+) -> ProviderConnectionManifest {
+    ProviderConnectionManifest::new(
+        ProviderConnectionId::from_uuid(Uuid::from_u128(9)).expect("connection"),
+        ProviderConnectionRevision::new(revision).expect("revision"),
+        state,
+        configuration,
+        UnixMillis::new(1_000),
+        activated_at,
+        retired_at,
+    )
+    .expect("manifest")
+}
+
+#[test]
+fn default_branches_reject_ambiguous_git_names() {
+    for valid in ["main", "release/v1", "feature/привет", "topic.LOCK"] {
+        assert!(
+            ProviderDefaultBranch::new(valid).is_ok(),
+            "rejected {valid}"
+        );
+    }
+    for invalid in [
+        "",
+        "refs/heads/main",
+        "/main",
+        "main/",
+        ".hidden",
+        "main.",
+        "main.lock",
+        "feature//one",
+        "feature/../one",
+        "feature@{one",
+        "white space",
+        "question?",
+        "back\\slash",
+    ] {
+        assert!(
+            ProviderDefaultBranch::new(invalid).is_err(),
+            "accepted {invalid}"
+        );
+    }
+}
+
+#[test]
+fn workflow_sources_use_normalized_repository_relative_paths() {
+    for valid in [
+        ".github/workflows",
+        ".forgejo/workflows/build.yaml",
+        ".gitlab-ci.yml",
+    ] {
+        assert!(
+            ProviderRepositoryPath::new(valid).is_ok(),
+            "rejected {valid}"
+        );
+    }
+    for invalid in [
+        "",
+        "/.github/workflows",
+        ".github/workflows/",
+        ".github//workflows",
+        "./workflow.yml",
+        "../workflow.yml",
+        "a/../workflow.yml",
+        "a\\workflow.yml",
+        "a\nworkflow.yml",
+    ] {
+        assert!(
+            ProviderRepositoryPath::new(invalid).is_err(),
+            "accepted {invalid:?}"
+        );
+    }
+
+    let source =
+        ProviderWorkflowSource::File(ProviderRepositoryPath::new(".gitlab-ci.yml").expect("path"));
+    let encoded = serde_json::to_string(&source).expect("serialize source");
+    assert_eq!(
+        serde_json::from_str::<ProviderWorkflowSource>(&encoded).expect("deserialize source"),
+        source
+    );
+}
+
+#[test]
+fn archive_limits_are_nonzero_bounded_and_consistent() {
+    assert!(ProviderArchiveLimits::new(1, 1, 1, 1, 1, 1).is_ok());
+    for invalid in [
+        ProviderArchiveLimits::new(0, 1, 1, 1, 1, 1),
+        ProviderArchiveLimits::new(2, 1, 1, 1, 1, 1),
+        ProviderArchiveLimits::new(1, 1, 1, 1, 2, 1),
+        ProviderArchiveLimits::new(1, 1, 1, 1, 1, 2),
+    ] {
+        assert_eq!(invalid, Err(ProviderConnectionError::InvalidArchiveLimits));
+    }
+    assert!(
+        serde_json::from_str::<ProviderArchiveLimits>(
+            r#"{"compressed_bytes":1,"expanded_bytes":1,"entries":1,"entry_path_bytes":1,"workflows":1,"workflow_bytes":1,"extra":1}"#
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn connection_configuration_digest_covers_common_and_adapter_policy() {
+    let public = configuration(RepositoryVisibility::Public);
+    let private = configuration(RepositoryVisibility::Private);
+    assert_ne!(public.digest(), private.digest());
+    assert_eq!(
+        public.repository().instance_id(),
+        ProviderInstanceId::from_uuid(Uuid::from_u128(2)).expect("instance")
+    );
+    assert_eq!(public.provider_revision().get(), 3);
+    assert_eq!(public.default_branch().as_str(), "main");
+    assert_eq!(
+        public.workflow_source().path().as_str(),
+        ".forgejo/workflows"
+    );
+    assert_eq!(public.adapter_policy().schema_version().get(), 1);
+}
+
+#[test]
+fn connection_successors_require_real_change_and_terminal_retirement() {
+    let disabled = manifest(
+        1,
+        ProviderLifecycleState::Disabled,
+        configuration(RepositoryVisibility::Public),
+        None,
+        None,
+    );
+    let revision_only = manifest(
+        2,
+        ProviderLifecycleState::Disabled,
+        configuration(RepositoryVisibility::Public),
+        None,
+        None,
+    );
+    assert_eq!(
+        revision_only.validate_successor(&disabled),
+        Err(ProviderConnectionError::InvalidSuccessor)
+    );
+
+    let active = manifest(
+        2,
+        ProviderLifecycleState::Active,
+        configuration(RepositoryVisibility::Public),
+        Some(UnixMillis::new(2_000)),
+        None,
+    );
+    active.validate_successor(&disabled).expect("activation");
+
+    let retired = manifest(
+        3,
+        ProviderLifecycleState::Retired,
+        configuration(RepositoryVisibility::Public),
+        Some(UnixMillis::new(2_000)),
+        Some(UnixMillis::new(3_000)),
+    );
+    retired.validate_successor(&active).expect("retirement");
+
+    let after_retirement = manifest(
+        4,
+        ProviderLifecycleState::Retired,
+        configuration(RepositoryVisibility::Private),
+        Some(UnixMillis::new(2_000)),
+        Some(UnixMillis::new(3_000)),
+    );
+    assert_eq!(
+        after_retirement.validate_successor(&retired),
+        Err(ProviderConnectionError::InvalidSuccessor)
+    );
+}
+
+#[test]
+fn connection_lifecycle_rejects_missing_or_out_of_order_evidence() {
+    let connection = ProviderConnectionId::from_uuid(Uuid::from_u128(9)).expect("connection");
+    let revision = ProviderConnectionRevision::new(1).expect("revision");
+    assert_eq!(
+        ProviderConnectionManifest::new(
+            connection,
+            revision,
+            ProviderLifecycleState::Active,
+            configuration(RepositoryVisibility::Public),
+            UnixMillis::new(2_000),
+            None,
+            None,
+        ),
+        Err(ProviderConnectionError::InvalidLifecycle)
+    );
+    assert_eq!(
+        ProviderConnectionManifest::new(
+            connection,
+            revision,
+            ProviderLifecycleState::Retired,
+            configuration(RepositoryVisibility::Public),
+            UnixMillis::new(2_000),
+            Some(UnixMillis::new(3_000)),
+            Some(UnixMillis::new(2_500)),
+        ),
+        Err(ProviderConnectionError::InvalidLifecycle)
+    );
+}

--- a/crates/automata-ci-provisioning-grpc/src/lib.rs
+++ b/crates/automata-ci-provisioning-grpc/src/lib.rs
@@ -10,6 +10,7 @@
 use std::{fmt, sync::Arc};
 
 use automata_ci_core::JobAuthorityProfile;
+use automata_ci_core::WorkspaceId;
 use automata_ci_provisioning::{
     ApplyGithubProviderConfigurationCommand, ApplyGithubProviderConfigurationResult,
     ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
@@ -26,7 +27,7 @@ use automata_ci_provisioning::{
     ProvisioningFailureKind, ProvisioningWorkloadAuthenticator, ShardId,
     WorkloadAuthenticationEvidence, WorkspaceEntitlementApplier, WorkspaceExecutionEntitlement,
     WorkspaceGithubRepositoriesApplier, WorkspaceGithubRepositoriesFailure,
-    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision, WorkspaceId,
+    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision,
     WorkspaceProvisioner,
 };
 use automata_ci_store::{

--- a/crates/automata-ci-provisioning-postgres/src/entitlement.rs
+++ b/crates/automata-ci-provisioning-postgres/src/entitlement.rs
@@ -299,7 +299,7 @@ impl StoredOperation {
         self,
         operation_id: automata_ci_provisioning::OperationId,
         shard_id: automata_ci_provisioning::ShardId,
-        workspace_id: automata_ci_provisioning::WorkspaceId,
+        workspace_id: automata_ci_core::WorkspaceId,
     ) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
         result(
             operation_id,
@@ -340,7 +340,7 @@ async fn load_operation(
 fn result(
     operation_id: automata_ci_provisioning::OperationId,
     shard_id: automata_ci_provisioning::ShardId,
-    workspace_id: automata_ci_provisioning::WorkspaceId,
+    workspace_id: automata_ci_core::WorkspaceId,
     revision: automata_ci_provisioning::EntitlementRevision,
     applied_at_ms: i64,
     expires_at_ms: Option<i64>,

--- a/crates/automata-ci-provisioning-postgres/src/github_provider.rs
+++ b/crates/automata-ci-provisioning-postgres/src/github_provider.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use automata_ci_core::JobAuthorityProfile;
+use automata_ci_core::WorkspaceId;
 use automata_ci_key_management::{
     EncryptedEnvelope, EnvelopeCodec, EnvelopeError, KeyEncryptionContext, KeyEncryptionProvider,
     KeyId, KeyPurpose, SecretBytes, WrappedDataKey,
@@ -18,7 +19,7 @@ use automata_ci_provisioning::{
     GithubProviderTimestamp, MAX_GITHUB_PROVIDER_REPOSITORIES, ShardId,
     WorkspaceGithubRepositoriesApplicationFuture, WorkspaceGithubRepositoriesApplier,
     WorkspaceGithubRepositoriesDesiredState, WorkspaceGithubRepositoriesFailure,
-    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision, WorkspaceId,
+    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision,
 };
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -1272,7 +1273,7 @@ fn provider_result(
 fn workspace_result(
     operation_id: automata_ci_provisioning::OperationId,
     shard_id: automata_ci_provisioning::ShardId,
-    workspace_id: automata_ci_provisioning::WorkspaceId,
+    workspace_id: WorkspaceId,
     revision: WorkspaceGithubRepositoriesRevision,
     applied_at_ms: i64,
 ) -> Result<ApplyWorkspaceGithubRepositoriesResult, WorkspaceGithubRepositoriesFailure> {

--- a/crates/automata-ci-provisioning-postgres/src/lib.rs
+++ b/crates/automata-ci-provisioning-postgres/src/lib.rs
@@ -314,7 +314,7 @@ impl StoredOperation {
         self,
         operation_id: automata_ci_provisioning::OperationId,
         shard_id: automata_ci_provisioning::ShardId,
-        workspace_id: automata_ci_provisioning::WorkspaceId,
+        workspace_id: automata_ci_core::WorkspaceId,
     ) -> Result<ProvisionWorkspaceResult, ProvisioningFailure> {
         if self.state != "completed" {
             return Err(failure(ProvisioningFailureKind::Internal));

--- a/crates/automata-ci-provisioning-postgres/src/usage.rs
+++ b/crates/automata-ci-provisioning-postgres/src/usage.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
+use automata_ci_core::WorkspaceId;
 use automata_ci_provisioning::{
     AuthorizedListWorkspaceUsage, ConsumedComputeMilliseconds, EntitlementRevision, ShardId,
     UsageAttemptId, UsageEventId, UsageExportCursor, UsageExportFailure, UsageExportFailureKind,
-    UsageExportFuture, UsageTimestamp, WorkspaceId, WorkspaceUsageEvent, WorkspaceUsageExporter,
+    UsageExportFuture, UsageTimestamp, WorkspaceUsageEvent, WorkspaceUsageExporter,
     WorkspaceUsagePage,
 };
 use sqlx::{FromRow, PgPool, Postgres, Transaction};

--- a/crates/automata-ci-provisioning/src/entitlement.rs
+++ b/crates/automata-ci-provisioning/src/entitlement.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
+use automata_ci_core::WorkspaceId;
 use thiserror::Error;
 
-use crate::{OperationId, ProvisioningAuthority, ShardId, WorkspaceId};
+use crate::{OperationId, ProvisioningAuthority, ShardId};
 
 const MILLIS_PER_SECOND: u64 = 1_000;
 const MAX_DURABLE_SECONDS: u64 = (i64::MAX as u64) / MILLIS_PER_SECOND;

--- a/crates/automata-ci-provisioning/src/github_provider.rs
+++ b/crates/automata-ci-provisioning/src/github_provider.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, fmt, num::NonZeroU64};
 
-use automata_ci_core::JobAuthorityProfile;
+use automata_ci_core::{JobAuthorityProfile, WorkspaceId};
 use automata_ci_github::GithubWebhookVerifier;
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -12,7 +12,7 @@ use thiserror::Error;
 use url::Url;
 use zeroize::Zeroizing;
 
-use crate::{OperationId, ProvisioningAuthority, ShardId, WorkspaceId};
+use crate::{OperationId, ProvisioningAuthority, ShardId};
 
 /// Maximum private-key PEM accepted through the management boundary.
 pub const MAX_GITHUB_PROVIDER_PRIVATE_KEY_BYTES: usize = 32 * 1_024;

--- a/crates/automata-ci-provisioning/src/lib.rs
+++ b/crates/automata-ci-provisioning/src/lib.rs
@@ -44,8 +44,9 @@ pub use model::{
     InitialOwnerPrincipalId, OperationId, ProvisionWorkspaceCommand, ProvisionWorkspaceResult,
     ProvisionedAt, ProvisioningAuthority, ProvisioningAuthorityId, ProvisioningAuthorizationError,
     ProvisioningFailure, ProvisioningFailureKind, ProvisioningRequestId, ProvisioningValueError,
-    ShardId, WorkspaceId,
+    ShardId,
 };
+
 pub use port::{
     EntitlementApplicationFuture, GithubProviderConfigurationApplicationFuture,
     GithubProviderConfigurationApplier, GithubProviderDesiredStateLoadFuture,

--- a/crates/automata-ci-provisioning/src/model.rs
+++ b/crates/automata-ci-provisioning/src/model.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use automata_ci_core::WorkspaceId;
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
@@ -60,7 +61,6 @@ macro_rules! uuid_identifier {
 }
 
 uuid_identifier!(OperationId, InvalidOperationId, "a provisioning operation");
-uuid_identifier!(WorkspaceId, InvalidWorkspaceId, "a workspace");
 uuid_identifier!(
     ExternalAccountSubject,
     InvalidExternalAccountSubject,
@@ -522,9 +522,6 @@ pub enum ProvisioningValueError {
     /// The shard slug is invalid.
     #[error("shard ID is invalid")]
     InvalidShardId,
-    /// The workspace UUID is invalid.
-    #[error("workspace ID is invalid")]
-    InvalidWorkspaceId,
     /// A display label is invalid.
     #[error("display name is invalid")]
     InvalidDisplayName,
@@ -600,22 +597,6 @@ mod tests {
         assert_eq!(
             AuthorizedProvisionWorkspace::authorize(authority(), wrong_issuer),
             Err(ProvisioningAuthorizationError::Forbidden)
-        );
-    }
-
-    #[test]
-    fn uuid_text_is_canonical_and_non_nil() {
-        assert_eq!(
-            WorkspaceId::parse("00000000-0000-0000-0000-000000000000"),
-            Err(ProvisioningValueError::InvalidWorkspaceId)
-        );
-        assert_eq!(
-            WorkspaceId::parse("22222222222242228222222222222222"),
-            Err(ProvisioningValueError::InvalidWorkspaceId)
-        );
-        assert_eq!(
-            WorkspaceId::parse("22222222-2222-4222-8222-22222222222A"),
-            Err(ProvisioningValueError::InvalidWorkspaceId)
         );
     }
 

--- a/crates/automata-ci-provisioning/src/usage.rs
+++ b/crates/automata-ci-provisioning/src/usage.rs
@@ -1,9 +1,10 @@
 use std::fmt;
 
+use automata_ci_core::WorkspaceId;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{EntitlementRevision, ProvisioningAuthority, ShardId, WorkspaceId};
+use crate::{EntitlementRevision, ProvisioningAuthority, ShardId};
 
 const MAX_CURSOR_BYTES: usize = 512;
 const MAX_PAGE_SIZE: u32 = 1_000;

--- a/crates/automata-ci-store-postgres/migrations/0051_provider_configuration_registry.sql
+++ b/crates/automata-ci-store-postgres/migrations/0051_provider_configuration_registry.sql
@@ -1,0 +1,167 @@
+CREATE TABLE provider_instance_revisions (
+    instance_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    provider_type TEXT NOT NULL,
+    lifecycle_state TEXT NOT NULL,
+    web_origin TEXT NOT NULL,
+    api_origin TEXT NOT NULL,
+    configuration_schema SMALLINT NOT NULL,
+    configuration_bytes BYTEA NOT NULL,
+    configuration_digest BYTEA NOT NULL,
+    capability_digest BYTEA NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    activated_at_ms BIGINT,
+    retired_at_ms BIGINT,
+    manifest_digest BYTEA NOT NULL,
+    PRIMARY KEY (instance_id, revision),
+    UNIQUE (
+        instance_id, revision, configuration_digest, capability_digest
+    ),
+    CHECK (revision > 0),
+    CHECK (octet_length(provider_type) BETWEEN 1 AND 64),
+    CHECK (provider_type ~ '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$'),
+    CHECK (lifecycle_state IN ('disabled', 'active', 'retired')),
+    CHECK (octet_length(web_origin) BETWEEN 1 AND 2048),
+    CHECK (octet_length(api_origin) BETWEEN 1 AND 2048),
+    CHECK (configuration_schema > 0),
+    CHECK (octet_length(configuration_bytes) BETWEEN 1 AND 262144),
+    CHECK (octet_length(configuration_digest) = 32),
+    CHECK (octet_length(capability_digest) = 32),
+    CHECK (octet_length(manifest_digest) = 32),
+    CHECK (created_at_ms >= 0),
+    CHECK (activated_at_ms IS NULL OR activated_at_ms >= created_at_ms),
+    CHECK (
+        retired_at_ms IS NULL
+        OR retired_at_ms >= COALESCE(activated_at_ms, created_at_ms)
+    ),
+    CHECK (
+        (lifecycle_state = 'active' AND activated_at_ms IS NOT NULL AND retired_at_ms IS NULL)
+        OR (lifecycle_state = 'retired' AND retired_at_ms IS NOT NULL)
+        OR (lifecycle_state = 'disabled' AND retired_at_ms IS NULL)
+    )
+);
+
+CREATE TABLE provider_instance_secret_bindings (
+    instance_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    secret_name TEXT NOT NULL,
+    secret_generation BIGINT NOT NULL,
+    plaintext_digest BYTEA NOT NULL,
+    envelope_schema SMALLINT NOT NULL,
+    wrapping_key_id TEXT NOT NULL,
+    wrapped_data_key BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    PRIMARY KEY (instance_id, revision, secret_name),
+    FOREIGN KEY (instance_id, revision)
+        REFERENCES provider_instance_revisions (instance_id, revision)
+        ON DELETE RESTRICT,
+    CHECK (octet_length(secret_name) BETWEEN 1 AND 64),
+    CHECK (secret_name ~ '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$'),
+    CHECK (secret_generation > 0),
+    CHECK (octet_length(plaintext_digest) = 32),
+    CHECK (envelope_schema > 0),
+    CHECK (octet_length(wrapping_key_id) BETWEEN 1 AND 64),
+    CHECK (octet_length(wrapped_data_key) BETWEEN 1 AND 65536),
+    CHECK (octet_length(nonce) = 12),
+    CHECK (octet_length(ciphertext) BETWEEN 17 AND 16777232)
+);
+
+CREATE TABLE provider_instance_current (
+    instance_id UUID PRIMARY KEY,
+    revision BIGINT NOT NULL,
+    FOREIGN KEY (instance_id, revision)
+        REFERENCES provider_instance_revisions (instance_id, revision)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE provider_connection_revisions (
+    connection_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    lifecycle_state TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    provider_instance_id UUID NOT NULL,
+    external_repository_id TEXT NOT NULL,
+    provider_revision BIGINT NOT NULL,
+    provider_configuration_digest BYTEA NOT NULL,
+    capability_digest BYTEA NOT NULL,
+    repository_visibility TEXT NOT NULL,
+    default_branch TEXT NOT NULL,
+    workflow_source_kind TEXT NOT NULL,
+    workflow_source_path TEXT NOT NULL,
+    runner_policy_schema SMALLINT NOT NULL,
+    runner_policy_digest BYTEA NOT NULL,
+    archive_compressed_bytes BIGINT NOT NULL,
+    archive_expanded_bytes BIGINT NOT NULL,
+    archive_entries BIGINT NOT NULL,
+    archive_entry_path_bytes BIGINT NOT NULL,
+    archive_workflows BIGINT NOT NULL,
+    workflow_bytes BIGINT NOT NULL,
+    adapter_policy_schema SMALLINT NOT NULL,
+    adapter_policy_bytes BYTEA NOT NULL,
+    adapter_policy_digest BYTEA NOT NULL,
+    configuration_digest BYTEA NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    activated_at_ms BIGINT,
+    retired_at_ms BIGINT,
+    manifest_digest BYTEA NOT NULL,
+    PRIMARY KEY (connection_id, revision),
+    FOREIGN KEY (workspace_id) REFERENCES tenants (id) ON DELETE RESTRICT,
+    FOREIGN KEY (
+        provider_instance_id, provider_revision,
+        provider_configuration_digest, capability_digest
+    ) REFERENCES provider_instance_revisions (
+        instance_id, revision, configuration_digest, capability_digest
+    ) ON DELETE RESTRICT,
+    CHECK (revision > 0),
+    CHECK (lifecycle_state IN ('disabled', 'active', 'retired')),
+    CHECK (octet_length(external_repository_id) BETWEEN 1 AND 512),
+    CHECK (repository_visibility IN ('public', 'internal', 'private')),
+    CHECK (octet_length(default_branch) BETWEEN 1 AND 255),
+    CHECK (workflow_source_kind IN ('directory', 'file')),
+    CHECK (octet_length(workflow_source_path) BETWEEN 1 AND 1024),
+    CHECK (runner_policy_schema > 0),
+    CHECK (octet_length(runner_policy_digest) = 32),
+    CHECK (archive_compressed_bytes BETWEEN 1 AND 4294967296),
+    CHECK (
+        archive_expanded_bytes BETWEEN archive_compressed_bytes AND 17179869184
+    ),
+    CHECK (archive_entries BETWEEN 1 AND 1000000),
+    CHECK (archive_entry_path_bytes BETWEEN 1 AND 16384),
+    CHECK (archive_workflows BETWEEN 1 AND 4096),
+    CHECK (archive_workflows <= archive_entries),
+    CHECK (workflow_bytes BETWEEN 1 AND 4194304),
+    CHECK (workflow_bytes <= archive_expanded_bytes),
+    CHECK (adapter_policy_schema > 0),
+    CHECK (octet_length(adapter_policy_bytes) BETWEEN 1 AND 65536),
+    CHECK (octet_length(adapter_policy_digest) = 32),
+    CHECK (octet_length(configuration_digest) = 32),
+    CHECK (octet_length(manifest_digest) = 32),
+    CHECK (created_at_ms >= 0),
+    CHECK (activated_at_ms IS NULL OR activated_at_ms >= created_at_ms),
+    CHECK (
+        retired_at_ms IS NULL
+        OR retired_at_ms >= COALESCE(activated_at_ms, created_at_ms)
+    ),
+    CHECK (
+        (lifecycle_state = 'active' AND activated_at_ms IS NOT NULL AND retired_at_ms IS NULL)
+        OR (lifecycle_state = 'retired' AND retired_at_ms IS NOT NULL)
+        OR (lifecycle_state = 'disabled' AND retired_at_ms IS NULL)
+    )
+);
+
+CREATE TABLE provider_connection_current (
+    connection_id UUID PRIMARY KEY,
+    revision BIGINT NOT NULL,
+    FOREIGN KEY (connection_id, revision)
+        REFERENCES provider_connection_revisions (connection_id, revision)
+        ON DELETE RESTRICT
+);
+
+CREATE INDEX provider_connections_by_workspace
+    ON provider_connection_revisions (workspace_id, connection_id, revision DESC);
+
+CREATE INDEX provider_connections_by_repository
+    ON provider_connection_revisions (
+        provider_instance_id, external_repository_id, revision DESC
+    );

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -205,6 +205,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0050_structured_live_logs.sql",
         "43e00572f617031aff81bcfb6711c9712a6b755038bc6f662a6f801665eadbc4069178d57642cc14b8b25f1cf08939dd",
     ),
+    (
+        "0051_provider_configuration_registry.sql",
+        "314b9c9aa3ab29764b579c1e61f2fa33dedee2acd7e6198838fc00f74643774230fd4bf1b45a614d2288ae0ad6bcdf2c",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci/src/server/github_provider_config.rs
+++ b/crates/automata-ci/src/server/github_provider_config.rs
@@ -3,10 +3,9 @@
 use std::{collections::BTreeSet, fmt, str::FromStr as _, sync::Arc};
 
 use automata_ci_core::JobAuthorityProfile;
+use automata_ci_core::WorkspaceId;
 use automata_ci_github_delivery::GithubScheduleServiceConfig;
-use automata_ci_provisioning::{
-    GithubProviderDesiredState, GithubProviderRepositorySelection, WorkspaceId,
-};
+use automata_ci_provisioning::{GithubProviderDesiredState, GithubProviderRepositorySelection};
 use automata_ci_results_github::CacheRepositoryMetadata;
 use automata_ci_store::{
     GithubCheckName, GithubInstallationBindingGeneration, GithubProviderGitRef,

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -567,11 +567,11 @@ fn database_desired_state(
     workspace_revision: u64,
 ) -> automata_ci_provisioning::GithubProviderDesiredState {
     use automata_ci_core::JobAuthorityProfile;
+    use automata_ci_core::WorkspaceId;
     use automata_ci_provisioning::{
         GithubProviderConfiguration, GithubProviderConfigurationRevision,
         GithubProviderRepositorySelection, GithubProviderSchedulePolicy, GithubProviderSecret,
         ShardId, WorkspaceGithubRepositoriesDesiredState, WorkspaceGithubRepositoriesRevision,
-        WorkspaceId,
     };
     use automata_ci_store::{
         GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,

--- a/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
+++ b/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
@@ -3,7 +3,7 @@
 - Roadmap status: Active
 - Available provider: GitHub only
 - Target provider: Forgejo 16.0.x
-- Current checkpoint: A2 algorithm-bearing Git object identity
+- Current checkpoint: A4 delivery foundation
 - Date: 2026-08-18
 
 This roadmap owns the refactor that separates source-hosting providers from

--- a/scripts/ci/run-postgres-tests.sh
+++ b/scripts/ci/run-postgres-tests.sh
@@ -114,6 +114,15 @@ run_bounded_tests cargo test \
   --ignored \
   --test-threads=1
 
+printf 'PostgreSQL tests: provider manifests\n' >&2
+run_bounded_tests cargo test \
+  -p automata-ci-provider-postgres \
+  --test postgres \
+  --locked \
+  -- \
+  --ignored \
+  --test-threads=2
+
 printf 'PostgreSQL tests: artifacts and cache\n' >&2
 run_bounded_tests cargo test \
   -p automata-ci-results-github \


### PR DESCRIPTION
## Outcome

Adds the final provider-neutral configuration, connection, registry, and durable repository foundations required before delivery/source/result ports. This is a clean cutover: no compatibility facade, alias, provider fallback, dual write, or provider-specific branch is introduced.

## Architecture

- canonical instance manifests with HTTPS origins, bounded schema documents, lifecycle evidence, domain-separated digests, and exact named secret generations
- exact static factory dispatch for both instance and connection policy validation; fake GitHub and Forgejo factories coexist without provider-name branching
- provider-neutral connection manifests covering workspace/repository identity, provider and capability pins, visibility, default branch, workflow selection, runner policy, archive limits, and bounded adapter policy
- one core-owned `WorkspaceId`; the provisioning-owned type and re-export are deleted
- a narrow `ProviderManifestRepository` port and separate `automata-ci-provider-postgres` adapter
- immutable contiguous PostgreSQL revision history, atomic current pointers, exact relational evidence, and envelope-encrypted named secrets with history-wide monotonic generations

## Failure model

Unknown provider type, schema, field, noncanonical encoding, secret evidence, capability digest, connection evidence, lifecycle transition, stale revision, missing reference, durable digest tampering, and ciphertext tampering all fail closed. Canonical adapter bytes and plaintext secrets are redacted from diagnostics.

## Verification

- `cargo test --workspace --all-targets --locked`
- Clippy with `-D warnings` across all changed and dependent crates
- provider/core contract tests
- migration lineage and fingerprint tests
- real PostgreSQL 18 tests for encryption, idempotency, rotation/history, exact connection references, stale writes, and tamper rejection

## Size

4,845 additions + 42 deletions = 4,887 changed lines, below the 10k PR cap.

Roadmap checkpoint advances to A4 delivery foundation after merge.