### PR TITLE
Run CI faster and support the merge queue

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -32,7 +33,7 @@ jobs:
     resources:
       limits:
         cpu: "4"
-        memory: 5Gi
+        memory: 8Gi
     env:
       CARGO_BUILD_JOBS: "4"
       CARGO_PROFILE_DEV_DEBUG: "0"
@@ -51,8 +52,6 @@ jobs:
         run: ./scripts/ci/install-sccache.sh
 
       - name: Run Rust and CI checks
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           cargo fmt --all -- --check
           ./scripts/ci/install-actionlint.sh target/ci-tools
@@ -84,7 +83,7 @@ jobs:
     resources:
       limits:
         cpu: "4"
-        memory: 4Gi
+        memory: 8Gi
     services:
       postgres:
         image: docker.io/library/postgres@sha256:7e6103cf85f88f7a0eddb3ec0b1ba8940eba098ed118ade25a729ca9daee5568
@@ -106,7 +105,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
-      RUST_TEST_THREADS: "2"
+      RUST_TEST_THREADS: "4"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:

--- a/scripts/ci/lint-ci-security.sh
+++ b/scripts/ci/lint-ci-security.sh
@@ -9,8 +9,6 @@ if [[ ! -x "$zizmor" ]]; then
   printf 'error: install zizmor before linting CI definitions\n' >&2
   exit 2
 fi
-: "${GH_TOKEN:?error: GH_TOKEN is required for zizmor online audits}"
-
 shopt -s nullglob
 workflow_files=(
   "$repository_root"/.ci/workflows/*.yml
@@ -25,6 +23,7 @@ fi
 "$zizmor" \
   "${workflow_files[@]}" \
   "$repository_root/.github/dependabot.yml" \
+  --offline \
   --collect all \
   --min-confidence low \
   --min-severity informational \

--- a/scripts/ci/run-postgres-tests.sh
+++ b/scripts/ci/run-postgres-tests.sh
@@ -93,15 +93,19 @@ if [[ "$plan" != true ]]; then
   fi
 fi
 
-printf 'PostgreSQL tests: authentication, runner, and web reads\n' >&2
+printf 'PostgreSQL tests: application and storage behavior\n' >&2
 run_bounded_tests cargo test \
   -p automata-ci-postgres \
+  -p automata-ci-provider-postgres \
+  -p automata-ci-results-github \
   --test postgres \
+  --test postgres_artifacts \
+  --test postgres_cache \
   --all-features \
   --locked \
   -- \
   --ignored \
-  --test-threads=2
+  --test-threads=4
 
 printf 'PostgreSQL tests: database harness\n' >&2
 run_bounded_tests cargo test \
@@ -113,23 +117,3 @@ run_bounded_tests cargo test \
   test_support::tests:: \
   --ignored \
   --test-threads=1
-
-printf 'PostgreSQL tests: provider manifests\n' >&2
-run_bounded_tests cargo test \
-  -p automata-ci-provider-postgres \
-  --test postgres \
-  --locked \
-  -- \
-  --ignored \
-  --test-threads=2
-
-printf 'PostgreSQL tests: artifacts and cache\n' >&2
-run_bounded_tests cargo test \
-  -p automata-ci-results-github \
-  --test postgres_artifacts \
-  --test postgres_cache \
-  --all-features \
-  --locked \
-  -- \
-  --ignored \
-  --test-threads=2


### PR DESCRIPTION
## Summary
- subscribe the primary CI workflow to `merge_group` so the required check runs in the merge queue
- give Rust and PostgreSQL the current provider-policy maximum of 4 CPU / 8 GiB
- compile all 62 PostgreSQL application/store integration tests in one unified Cargo graph, then run the 10 destructive harness tests serially
- increase safe PostgreSQL test parallelism from two to four
- run the workflow security audit offline so GitHub API availability cannot stall CI

## Verification
- actionlint workflow validation
- zizmor 1.29.0 offline audit (no findings)
- PostgreSQL command-plan validation
- `cargo fmt --all -- --check`
- consolidated PostgreSQL suite: 72 passed (40 + 2 + 13 + 7 + 10)