### PR TITLE
feat(provider): add generic delivery foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,8 +767,10 @@ dependencies = [
 name = "automata-ci-provider"
 version = "0.1.0"
 dependencies = [
+ "automata-ci-blob",
  "automata-ci-core",
  "automata-ci-key-management",
+ "base64 0.23.1",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -781,6 +783,7 @@ dependencies = [
 name = "automata-ci-provider-postgres"
 version = "0.1.0"
 dependencies = [
+ "automata-ci-blob",
  "automata-ci-core",
  "automata-ci-key-management",
  "automata-ci-postgres",

--- a/crates/automata-ci-provider-postgres/Cargo.toml
+++ b/crates/automata-ci-provider-postgres/Cargo.toml
@@ -12,15 +12,16 @@ homepage.workspace = true
 readme = "README.md"
 
 [dependencies]
+automata-ci-blob.workspace = true
 automata-ci-core.workspace = true
 automata-ci-key-management.workspace = true
 automata-ci-provider.workspace = true
+sha2.workspace = true
 sqlx.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
 automata-ci-postgres = { workspace = true, features = ["test-support"] }
-sha2.workspace = true
 tokio.workspace = true
 
 [lints]

--- a/crates/automata-ci-provider-postgres/README.md
+++ b/crates/automata-ci-provider-postgres/README.md
@@ -1,5 +1,7 @@
 # automata-ci-provider-postgres
 
-PostgreSQL persistence for provider instance and repository connection
-manifests. Named provider secrets are stored only as authenticated encrypted
-envelopes.
+PostgreSQL persistence for provider instance, repository connection, opaque
+webhook endpoint, and provider delivery records. Named provider secrets are
+stored only as authenticated encrypted envelopes. Endpoint candidates reference
+exact encrypted generations, and immutable raw/normalized delivery evidence is
+separate from the fenced worker lifecycle.

--- a/crates/automata-ci-provider-postgres/src/delivery.rs
+++ b/crates/automata-ci-provider-postgres/src/delivery.rs
@@ -1,0 +1,696 @@
+use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_provider::{
+    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
+    CompleteProviderDelivery, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
+    ExternalRepositoryIdentity, FailProviderDelivery, MAX_PROVIDER_DELIVERY_ATTEMPTS,
+    ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionRevision,
+    ProviderDelivery, ProviderDeliveryAcceptOutcome, ProviderDeliveryClaimFence,
+    ProviderDeliveryFailure, ProviderDeliveryId, ProviderDeliveryObservations,
+    ProviderDeliveryReceipt, ProviderDeliveryRejection, ProviderDeliveryRepositoryError,
+    ProviderDeliveryState, ProviderEventName, ProviderInstanceId, ProviderSecretGeneration,
+    ProviderSecretName, ProviderTypeId, ProviderWebhookEndpointId, ProviderWebhookEndpointRevision,
+    ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, RejectedProviderDelivery,
+    RetryProviderDelivery, SealedNormalizedTrigger, VerifiedProviderDelivery,
+};
+use sqlx::{FromRow, Postgres, Transaction};
+
+use crate::PostgresProviderManifestRepository;
+
+#[derive(FromRow)]
+struct DeliveryRow {
+    delivery_id: uuid::Uuid,
+    provider_instance_id: uuid::Uuid,
+    external_delivery_id: String,
+    replay_fingerprint: Vec<u8>,
+    endpoint_id: uuid::Uuid,
+    endpoint_revision: i64,
+    provider_type: String,
+    provider_revision: i64,
+    connection_id: uuid::Uuid,
+    connection_revision: i64,
+    event_type: String,
+    received_at_ms: i64,
+    raw_object_key: String,
+    raw_body_digest: Vec<u8>,
+    raw_body_size: i64,
+    raw_media_type: String,
+    raw_retain_until_ms: i64,
+    signature_scheme: String,
+    signature_configuration_revision: i64,
+    signature_secret_name: String,
+    signature_secret_generation: i64,
+    disposition: String,
+    repository_external_id: Option<String>,
+    normalized_trigger: Option<Vec<u8>>,
+    normalized_trigger_digest: Option<Vec<u8>>,
+    rejection_reason: Option<String>,
+    observations: Vec<u8>,
+    observations_digest: Vec<u8>,
+    state: String,
+    attempts: i16,
+    available_at_ms: i64,
+    accepted_at_ms: i64,
+    claim_worker_id: Option<uuid::Uuid>,
+    claim_fence: Option<i64>,
+    claim_started_at_ms: Option<i64>,
+    claim_expires_at_ms: Option<i64>,
+    completed_at_ms: Option<i64>,
+    failure_kind: Option<String>,
+}
+
+#[derive(FromRow)]
+struct ReceiptRow {
+    delivery_id: uuid::Uuid,
+    state: String,
+    attempts: i16,
+    accepted_at_ms: i64,
+}
+
+impl PostgresProviderManifestRepository {
+    pub(crate) async fn accept_delivery_inner(
+        &self,
+        request: AcceptProviderDelivery,
+    ) -> Result<ProviderDeliveryAcceptOutcome, ProviderDeliveryRepositoryError> {
+        let (delivery, accepted_at) = request.into_parts();
+        let fingerprint = delivery.replay_fingerprint();
+        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
+        let inserted = insert_delivery(
+            &mut transaction,
+            &delivery,
+            accepted_at,
+            fingerprint.digest(),
+        )
+        .await?;
+        if inserted {
+            transaction.commit().await.map_err(unavailable)?;
+            let receipt = ProviderDeliveryReceipt::new(
+                delivery.delivery_id(),
+                match delivery {
+                    ProviderDelivery::Trigger(_) => ProviderDeliveryState::Pending,
+                    ProviderDelivery::Rejected(_) => ProviderDeliveryState::Discarded,
+                },
+                0,
+                accepted_at,
+            )
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            return Ok(ProviderDeliveryAcceptOutcome::Inserted(receipt));
+        }
+
+        let row = sqlx::query_as::<_, ReceiptReplayRow>(
+            r"
+            SELECT delivery_id, state, attempts, accepted_at_ms, replay_fingerprint
+            FROM provider_delivery_records
+            WHERE provider_instance_id = $1 AND external_delivery_id = $2
+            ",
+        )
+        .bind(delivery.external_delivery().instance_id().as_uuid())
+        .bind(delivery.external_delivery().external_id().as_str())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        transaction.rollback().await.map_err(unavailable)?;
+        let Some(row) = row else {
+            return Err(ProviderDeliveryRepositoryError::ReplayConflict);
+        };
+        if digest(row.replay_fingerprint)? != fingerprint.digest() {
+            return Err(ProviderDeliveryRepositoryError::ReplayConflict);
+        }
+        Ok(ProviderDeliveryAcceptOutcome::Duplicate(decode_receipt(
+            ReceiptRow {
+                delivery_id: row.delivery_id,
+                state: row.state,
+                attempts: row.attempts,
+                accepted_at_ms: row.accepted_at_ms,
+            },
+        )?))
+    }
+
+    pub(crate) async fn load_delivery_inner(
+        &self,
+        delivery_id: ProviderDeliveryId,
+    ) -> Result<Option<ProviderDelivery>, ProviderDeliveryRepositoryError> {
+        sqlx::query_as::<_, DeliveryRow>(
+            "SELECT * FROM provider_delivery_records WHERE delivery_id = $1",
+        )
+        .bind(delivery_id.as_uuid())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?
+        .map(decode_delivery)
+        .transpose()
+    }
+
+    pub(crate) async fn claim_delivery_inner(
+        &self,
+        request: ClaimProviderDelivery,
+    ) -> Result<Option<ClaimedProviderDelivery>, ProviderDeliveryRepositoryError> {
+        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
+        let row = sqlx::query_as::<_, DeliveryRow>(
+            r"
+            SELECT * FROM provider_delivery_records
+            WHERE disposition = 'trigger'
+              AND attempts < 16
+              AND (
+                (state IN ('pending', 'retry-pending') AND available_at_ms <= $1)
+                OR (state = 'claimed' AND claim_expires_at_ms <= $1)
+              )
+            ORDER BY available_at_ms, accepted_at_ms, delivery_id
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+            ",
+        )
+        .bind(request.claimed_at().get())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        let Some(row) = row else {
+            transaction.commit().await.map_err(unavailable)?;
+            return Ok(None);
+        };
+        let next_attempt = positive_u16(row.attempts)?
+            .checked_add(1)
+            .ok_or(ProviderDeliveryRepositoryError::AttemptLimitReached)?;
+        if next_attempt > MAX_PROVIDER_DELIVERY_ATTEMPTS {
+            return Err(ProviderDeliveryRepositoryError::AttemptLimitReached);
+        }
+        let next_fence = match row.claim_fence {
+            Some(value) => positive_u64(value)?
+                .checked_add(1)
+                .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+            None => 1,
+        };
+        let expires_at = request
+            .claimed_at()
+            .get()
+            .checked_add(
+                i64::try_from(request.lease_millis())
+                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            )
+            .ok_or(ProviderDeliveryRepositoryError::Corrupt)?;
+        sqlx::query(
+            r"
+            UPDATE provider_delivery_records
+            SET state = 'claimed', attempts = $2, claim_worker_id = $3,
+                claim_fence = $4, claim_started_at_ms = $6,
+                claim_expires_at_ms = $5, failure_kind = NULL
+            WHERE delivery_id = $1
+            ",
+        )
+        .bind(row.delivery_id)
+        .bind(i16::try_from(next_attempt).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?)
+        .bind(request.worker_id().as_uuid())
+        .bind(durable_u64(next_fence)?)
+        .bind(expires_at)
+        .bind(request.claimed_at().get())
+        .execute(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        transaction.commit().await.map_err(unavailable)?;
+
+        let accepted_at = row.accepted_at_ms;
+        let delivery = match decode_delivery(row)? {
+            ProviderDelivery::Trigger(value) => *value,
+            ProviderDelivery::Rejected(_) => return Err(ProviderDeliveryRepositoryError::Corrupt),
+        };
+        let receipt = ProviderDeliveryReceipt::new(
+            delivery.delivery_id(),
+            ProviderDeliveryState::Claimed,
+            next_attempt,
+            UnixMillis::new(accepted_at),
+        )
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+        let fence = ProviderDeliveryClaimFence::new(
+            delivery.delivery_id(),
+            request.worker_id(),
+            next_fence,
+            request.claimed_at(),
+            UnixMillis::new(expires_at),
+        )
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+        ClaimedProviderDelivery::new(receipt, delivery, fence)
+            .map(Some)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+    }
+
+    pub(crate) async fn complete_delivery_inner(
+        &self,
+        request: CompleteProviderDelivery,
+    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        mutate_claim(
+            &self.pool,
+            request.fence(),
+            request.completed_at(),
+            "completed",
+            request.completed_at(),
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn retry_delivery_inner(
+        &self,
+        request: RetryProviderDelivery,
+    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        mutate_claim(
+            &self.pool,
+            request.fence(),
+            request.failed_at(),
+            "retry-pending",
+            request.retry_at(),
+            Some(request.failure()),
+        )
+        .await
+    }
+
+    pub(crate) async fn fail_delivery_inner(
+        &self,
+        request: FailProviderDelivery,
+    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        mutate_claim(
+            &self.pool,
+            request.fence(),
+            request.failed_at(),
+            "failed",
+            request.failed_at(),
+            Some(request.failure()),
+        )
+        .await
+    }
+}
+
+#[derive(FromRow)]
+struct ReceiptReplayRow {
+    delivery_id: uuid::Uuid,
+    state: String,
+    attempts: i16,
+    accepted_at_ms: i64,
+    replay_fingerprint: Vec<u8>,
+}
+
+#[allow(clippy::too_many_lines)] // Ordered bindings mirror one immutable delivery record.
+async fn insert_delivery(
+    transaction: &mut Transaction<'_, Postgres>,
+    delivery: &ProviderDelivery,
+    accepted_at: UnixMillis,
+    fingerprint: Sha256Digest,
+) -> Result<bool, ProviderDeliveryRepositoryError> {
+    let (
+        delivery_id,
+        endpoint_id,
+        endpoint_revision,
+        provider_type,
+        instance_id,
+        provider_revision,
+        connection_id,
+        connection_revision,
+        external_delivery,
+        event_type,
+        received_at,
+        raw_body,
+        raw_retain_until,
+        signature,
+        disposition,
+        repository_id,
+        trigger_bytes,
+        trigger_digest,
+        rejection,
+        observations,
+        state,
+    ) = match delivery {
+        ProviderDelivery::Trigger(value) => (
+            value.delivery_id(),
+            value.endpoint_id(),
+            value.endpoint_revision(),
+            value.provider_type(),
+            value.instance_id(),
+            value.provider_revision(),
+            value.connection_id(),
+            value.connection_revision(),
+            value.external_delivery(),
+            value.event_type(),
+            value.received_at(),
+            value.raw_body(),
+            value.raw_retain_until(),
+            value.signature(),
+            "trigger",
+            Some(
+                value
+                    .trigger()
+                    .trigger()
+                    .target_repository()
+                    .identity()
+                    .external_id()
+                    .as_str(),
+            ),
+            Some(value.trigger().canonical_bytes()),
+            Some(value.trigger().digest()),
+            None,
+            value.observations(),
+            "pending",
+        ),
+        ProviderDelivery::Rejected(value) => (
+            value.delivery_id(),
+            value.endpoint_id(),
+            value.endpoint_revision(),
+            value.provider_type(),
+            value.instance_id(),
+            value.provider_revision(),
+            value.connection_id(),
+            value.connection_revision(),
+            value.external_delivery(),
+            value.event_type(),
+            value.received_at(),
+            value.raw_body(),
+            value.raw_retain_until(),
+            value.signature(),
+            "rejected",
+            value
+                .repository()
+                .map(|identity| identity.external_id().as_str()),
+            None,
+            None,
+            Some(rejection_text(value.reason())),
+            value.observations(),
+            "discarded",
+        ),
+    };
+    let result = sqlx::query(
+        r"
+        INSERT INTO provider_delivery_records (
+            delivery_id, provider_instance_id, external_delivery_id,
+            replay_fingerprint, endpoint_id, endpoint_revision, provider_type,
+            provider_revision, connection_id, connection_revision, event_type,
+            received_at_ms, raw_object_key, raw_body_digest, raw_body_size,
+            raw_media_type, raw_retain_until_ms, signature_scheme,
+            signature_configuration_revision,
+            signature_secret_name, signature_secret_generation, disposition,
+            repository_external_id, normalized_trigger, normalized_trigger_digest,
+            rejection_reason, observations, observations_digest, state, attempts,
+            available_at_ms, accepted_at_ms
+        ) VALUES (
+            $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+            $18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,0,$30,$30
+        ) ON CONFLICT DO NOTHING
+        ",
+    )
+    .bind(delivery_id.as_uuid())
+    .bind(instance_id.as_uuid())
+    .bind(external_delivery.external_id().as_str())
+    .bind(fingerprint.as_bytes().as_slice())
+    .bind(endpoint_id.as_uuid())
+    .bind(durable_u64(endpoint_revision.get())?)
+    .bind(provider_type.as_str())
+    .bind(durable_u64(provider_revision.get())?)
+    .bind(connection_id.as_uuid())
+    .bind(durable_u64(connection_revision.get())?)
+    .bind(event_type.as_str())
+    .bind(received_at.get())
+    .bind(raw_body.key().as_str())
+    .bind(raw_body.digest().as_bytes().as_slice())
+    .bind(durable_u64(raw_body.size())?)
+    .bind(raw_body.media_type().as_str())
+    .bind(raw_retain_until.get())
+    .bind(signature.scheme())
+    .bind(durable_u64(
+        signature.secret().configuration_revision().get(),
+    )?)
+    .bind(signature.secret().name().as_str())
+    .bind(durable_u64(signature.secret().generation().get())?)
+    .bind(disposition)
+    .bind(repository_id)
+    .bind(trigger_bytes)
+    .bind(trigger_digest.map(|value| value.as_bytes().to_vec()))
+    .bind(rejection)
+    .bind(observations.canonical_bytes())
+    .bind(observations.digest().as_bytes().as_slice())
+    .bind(state)
+    .bind(accepted_at.get())
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    Ok(result.rows_affected() == 1)
+}
+
+async fn mutate_claim(
+    pool: &sqlx::PgPool,
+    fence: ProviderDeliveryClaimFence,
+    mutation_at: UnixMillis,
+    state: &'static str,
+    available_or_completed_at: UnixMillis,
+    failure: Option<ProviderDeliveryFailure>,
+) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+    let completed_at =
+        matches!(state, "completed" | "failed").then_some(available_or_completed_at.get());
+    let row = sqlx::query_as::<_, ReceiptRow>(
+        r"
+        UPDATE provider_delivery_records
+        SET state = $5, available_at_ms = $6, claim_worker_id = NULL,
+            claim_started_at_ms = NULL, claim_expires_at_ms = NULL,
+            completed_at_ms = $7, failure_kind = $8
+        WHERE delivery_id = $1 AND state = 'claimed'
+          AND claim_worker_id = $2 AND claim_fence = $3
+          AND claim_started_at_ms <= $4
+          AND claim_expires_at_ms > $4
+        RETURNING delivery_id, state, attempts, accepted_at_ms
+        ",
+    )
+    .bind(fence.delivery_id().as_uuid())
+    .bind(fence.worker_id().as_uuid())
+    .bind(durable_u64(fence.token())?)
+    .bind(mutation_at.get())
+    .bind(state)
+    .bind(available_or_completed_at.get())
+    .bind(completed_at)
+    .bind(failure.map(failure_text))
+    .fetch_optional(pool)
+    .await
+    .map_err(unavailable)?
+    .ok_or(ProviderDeliveryRepositoryError::ClaimRejected)?;
+    decode_receipt(row)
+}
+
+#[allow(clippy::too_many_lines)] // Strict decoding validates every durable evidence field.
+fn decode_delivery(row: DeliveryRow) -> Result<ProviderDelivery, ProviderDeliveryRepositoryError> {
+    // Lifecycle-only columns are decoded separately by receipt operations.
+    let _ = (
+        &row.replay_fingerprint,
+        &row.state,
+        row.attempts,
+        row.available_at_ms,
+        row.accepted_at_ms,
+        row.claim_worker_id,
+        row.claim_fence,
+        row.claim_started_at_ms,
+        row.claim_expires_at_ms,
+        row.completed_at_ms,
+        &row.failure_kind,
+    );
+    let instance_id = ProviderInstanceId::from_uuid(row.provider_instance_id)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let external_delivery = ExternalDeliveryIdentity::new(
+        instance_id,
+        ExternalDeliveryId::new(row.external_delivery_id)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+    );
+    let raw_body = BlobDescriptor::new(
+        BlobKey::new(row.raw_object_key).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        digest(row.raw_body_digest)?,
+        positive_u64(row.raw_body_size)?,
+        MediaType::new(row.raw_media_type).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+    );
+    let signature = ProviderWebhookSignatureEvidence::new(
+        row.signature_scheme,
+        ProviderWebhookSecretReference::new(
+            ProviderConfigurationRevision::new(positive_u64(row.signature_configuration_revision)?)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            ProviderSecretName::new(row.signature_secret_name)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            ProviderSecretGeneration::new(positive_u64(row.signature_secret_generation)?)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        ),
+    )
+    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let observations = ProviderDeliveryObservations::new(row.observations)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    if observations.digest() != digest(row.observations_digest)? {
+        return Err(ProviderDeliveryRepositoryError::Corrupt);
+    }
+    let delivery_id = ProviderDeliveryId::from_uuid(row.delivery_id)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let endpoint_id = ProviderWebhookEndpointId::from_uuid(row.endpoint_id)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let endpoint_revision =
+        ProviderWebhookEndpointRevision::new(positive_u64(row.endpoint_revision)?)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let provider_type = ProviderTypeId::new(row.provider_type)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let provider_revision =
+        ProviderConfigurationRevision::new(positive_u64(row.provider_revision)?)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let connection_id = ProviderConnectionId::from_uuid(row.connection_id)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let connection_revision =
+        ProviderConnectionRevision::new(positive_u64(row.connection_revision)?)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let event_type = ProviderEventName::new(row.event_type)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    match row.disposition.as_str() {
+        "trigger" => {
+            let trigger = SealedNormalizedTrigger::from_canonical_bytes(
+                row.normalized_trigger
+                    .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+            )
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            if Some(trigger.digest()) != row.normalized_trigger_digest.map(digest).transpose()? {
+                return Err(ProviderDeliveryRepositoryError::Corrupt);
+            }
+            VerifiedProviderDelivery::rehydrate(
+                delivery_id,
+                endpoint_id,
+                endpoint_revision,
+                provider_type,
+                instance_id,
+                provider_revision,
+                connection_id,
+                connection_revision,
+                external_delivery,
+                event_type,
+                UnixMillis::new(row.received_at_ms),
+                raw_body,
+                UnixMillis::new(row.raw_retain_until_ms),
+                signature,
+                trigger,
+                observations,
+            )
+            .map(Box::new)
+            .map(ProviderDelivery::Trigger)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+        }
+        "rejected" => {
+            let repository = row
+                .repository_external_id
+                .map(|value| {
+                    ExternalRepositoryId::new(value).map(|external_id| {
+                        ExternalRepositoryIdentity::new(instance_id, external_id)
+                    })
+                })
+                .transpose()
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            let reason = rejection(
+                row.rejection_reason
+                    .as_deref()
+                    .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+            )?;
+            RejectedProviderDelivery::rehydrate(
+                delivery_id,
+                endpoint_id,
+                endpoint_revision,
+                provider_type,
+                instance_id,
+                provider_revision,
+                connection_id,
+                connection_revision,
+                external_delivery,
+                event_type,
+                UnixMillis::new(row.received_at_ms),
+                raw_body,
+                UnixMillis::new(row.raw_retain_until_ms),
+                signature,
+                repository,
+                reason,
+                observations,
+            )
+            .map(Box::new)
+            .map(ProviderDelivery::Rejected)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+        }
+        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
+    }
+}
+
+fn decode_receipt(
+    row: ReceiptRow,
+) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+    let ReceiptRow {
+        delivery_id,
+        state: durable_state,
+        attempts,
+        accepted_at_ms,
+    } = row;
+    ProviderDeliveryReceipt::new(
+        ProviderDeliveryId::from_uuid(delivery_id)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        state(&durable_state)?,
+        positive_u16(attempts)?,
+        UnixMillis::new(accepted_at_ms),
+    )
+    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn digest(value: Vec<u8>) -> Result<Sha256Digest, ProviderDeliveryRepositoryError> {
+    value
+        .try_into()
+        .map(Sha256Digest::from_bytes)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn state(value: &str) -> Result<ProviderDeliveryState, ProviderDeliveryRepositoryError> {
+    match value {
+        "pending" => Ok(ProviderDeliveryState::Pending),
+        "retry-pending" => Ok(ProviderDeliveryState::RetryPending),
+        "claimed" => Ok(ProviderDeliveryState::Claimed),
+        "completed" => Ok(ProviderDeliveryState::Completed),
+        "failed" => Ok(ProviderDeliveryState::Failed),
+        "discarded" => Ok(ProviderDeliveryState::Discarded),
+        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
+    }
+}
+
+const fn rejection_text(value: ProviderDeliveryRejection) -> &'static str {
+    match value {
+        ProviderDeliveryRejection::UnknownEvent => "unknown-event",
+        ProviderDeliveryRejection::UnsupportedEvent => "unsupported-event",
+        ProviderDeliveryRejection::IncompleteEvent => "incomplete-event",
+        ProviderDeliveryRejection::PayloadIdentityMismatch => "payload-identity-mismatch",
+        ProviderDeliveryRejection::InvalidPayload => "invalid-payload",
+    }
+}
+
+fn rejection(value: &str) -> Result<ProviderDeliveryRejection, ProviderDeliveryRepositoryError> {
+    match value {
+        "unknown-event" => Ok(ProviderDeliveryRejection::UnknownEvent),
+        "unsupported-event" => Ok(ProviderDeliveryRejection::UnsupportedEvent),
+        "incomplete-event" => Ok(ProviderDeliveryRejection::IncompleteEvent),
+        "payload-identity-mismatch" => Ok(ProviderDeliveryRejection::PayloadIdentityMismatch),
+        "invalid-payload" => Ok(ProviderDeliveryRejection::InvalidPayload),
+        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
+    }
+}
+
+const fn failure_text(value: ProviderDeliveryFailure) -> &'static str {
+    match value {
+        ProviderDeliveryFailure::DependencyUnavailable => "dependency-unavailable",
+        ProviderDeliveryFailure::PolicyRejected => "policy-rejected",
+        ProviderDeliveryFailure::InvalidEvidence => "invalid-evidence",
+    }
+}
+
+fn durable_u64(value: u64) -> Result<i64, ProviderDeliveryRepositoryError> {
+    i64::try_from(value).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn positive_u64(value: i64) -> Result<u64, ProviderDeliveryRepositoryError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn positive_u16(value: i16) -> Result<u16, ProviderDeliveryRepositoryError> {
+    u16::try_from(value).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn unavailable(_: sqlx::Error) -> ProviderDeliveryRepositoryError {
+    ProviderDeliveryRepositoryError::Unavailable
+}

--- a/crates/automata-ci-provider-postgres/src/endpoint.rs
+++ b/crates/automata-ci-provider-postgres/src/endpoint.rs
@@ -1,0 +1,451 @@
+use automata_ci_core::UnixMillis;
+use automata_ci_provider::{
+    ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionRevision,
+    ProviderDeliveryRepositoryError, ProviderInstanceId, ProviderRepositoryError,
+    ProviderSaveOutcome, ProviderSecretGeneration, ProviderSecretName, ProviderTypeId,
+    ProviderWebhookEndpointId, ProviderWebhookEndpointManifest, ProviderWebhookEndpointRecord,
+    ProviderWebhookEndpointRevision, ProviderWebhookEndpointState, ProviderWebhookSecretCandidates,
+    ProviderWebhookSecretReference,
+};
+use sqlx::{FromRow, Postgres, Transaction};
+
+use crate::{ENDPOINT_LOCK_SALT, PostgresProviderManifestRepository, lock};
+
+#[derive(FromRow)]
+struct EndpointRow {
+    endpoint_id: uuid::Uuid,
+    revision: i64,
+    lifecycle_state: String,
+    provider_type: String,
+    provider_instance_id: uuid::Uuid,
+    provider_revision: i64,
+    connection_id: uuid::Uuid,
+    connection_revision: i64,
+    body_limit: i64,
+    raw_retention_millis: i64,
+    candidate_count: i16,
+    created_at_ms: i64,
+    retired_at_ms: Option<i64>,
+}
+
+#[derive(FromRow)]
+struct CandidateRow {
+    configuration_revision: i64,
+    secret_name: String,
+    secret_generation: i64,
+}
+
+impl PostgresProviderManifestRepository {
+    pub(crate) async fn save_endpoint_inner(
+        &self,
+        endpoint: ProviderWebhookEndpointManifest,
+    ) -> Result<ProviderSaveOutcome, ProviderDeliveryRepositoryError> {
+        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
+        lock(
+            &mut transaction,
+            &endpoint.endpoint_id().to_string(),
+            ENDPOINT_LOCK_SALT,
+        )
+        .await
+        .map_err(map_manifest_error)?;
+        let current = sqlx::query_as::<_, EndpointRow>(
+            r"
+            SELECT revisions.*
+            FROM provider_webhook_endpoint_current AS current
+            JOIN provider_webhook_endpoint_revisions AS revisions
+              ON revisions.endpoint_id = current.endpoint_id
+             AND revisions.revision = current.revision
+            WHERE current.endpoint_id = $1
+            FOR UPDATE OF current
+            ",
+        )
+        .bind(endpoint.endpoint_id().as_uuid())
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        if let Some(current) = current {
+            let revision = endpoint_revision(current.revision)?;
+            let references =
+                load_references(&mut transaction, endpoint.endpoint_id(), revision).await?;
+            if usize::try_from(current.candidate_count).ok() != Some(references.len()) {
+                return Err(ProviderDeliveryRepositoryError::Corrupt);
+            }
+            let current = decode_endpoint(current, references)?;
+            if endpoint.revision() == current.revision() {
+                if endpoint == current {
+                    return Ok(ProviderSaveOutcome::Unchanged);
+                }
+                return Err(ProviderDeliveryRepositoryError::EndpointConflict);
+            }
+            endpoint
+                .validate_successor(&current)
+                .map_err(|_| ProviderDeliveryRepositoryError::EndpointConflict)?;
+        } else if endpoint.revision().get() != 1 {
+            return Err(ProviderDeliveryRepositoryError::EndpointConflict);
+        }
+
+        ensure_endpoint_references(&mut transaction, &endpoint).await?;
+        insert_endpoint(&mut transaction, &endpoint).await?;
+        insert_candidates(&mut transaction, &endpoint).await?;
+        sqlx::query(
+            r"
+            INSERT INTO provider_webhook_endpoint_current (endpoint_id, revision)
+            VALUES ($1, $2)
+            ON CONFLICT (endpoint_id) DO UPDATE SET revision = EXCLUDED.revision
+            ",
+        )
+        .bind(endpoint.endpoint_id().as_uuid())
+        .bind(durable_u64(endpoint.revision().get())?)
+        .execute(&mut *transaction)
+        .await
+        .map_err(unavailable)?;
+        transaction.commit().await.map_err(unavailable)?;
+        Ok(ProviderSaveOutcome::Inserted)
+    }
+
+    pub(crate) async fn resolve_endpoint_inner(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+    ) -> Result<Option<ProviderWebhookEndpointRecord>, ProviderDeliveryRepositoryError> {
+        let revision = sqlx::query_scalar::<_, i64>(
+            r"
+            SELECT endpoint.revision
+            FROM provider_webhook_endpoint_current AS current
+            JOIN provider_webhook_endpoint_revisions AS endpoint
+              ON endpoint.endpoint_id = current.endpoint_id
+             AND endpoint.revision = current.revision
+            JOIN provider_instance_current AS instance_current
+              ON instance_current.instance_id = endpoint.provider_instance_id
+             AND instance_current.revision = endpoint.provider_revision
+            JOIN provider_instance_revisions AS instance
+              ON instance.instance_id = instance_current.instance_id
+             AND instance.revision = instance_current.revision
+            JOIN provider_connection_current AS connection_current
+              ON connection_current.connection_id = endpoint.connection_id
+             AND connection_current.revision = endpoint.connection_revision
+            JOIN provider_connection_revisions AS connection
+              ON connection.connection_id = connection_current.connection_id
+             AND connection.revision = connection_current.revision
+            WHERE endpoint.endpoint_id = $1
+              AND endpoint.lifecycle_state = 'active'
+              AND instance.lifecycle_state = 'active'
+              AND connection.lifecycle_state = 'active'
+            ",
+        )
+        .bind(endpoint_id.as_uuid())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        match revision {
+            Some(revision) => self
+                .load_endpoint_inner(endpoint_id, endpoint_revision(revision)?)
+                .await
+                .and_then(|record| {
+                    record
+                        .ok_or(ProviderDeliveryRepositoryError::Corrupt)
+                        .map(Some)
+                }),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) async fn load_endpoint_inner(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+        revision: ProviderWebhookEndpointRevision,
+    ) -> Result<Option<ProviderWebhookEndpointRecord>, ProviderDeliveryRepositoryError> {
+        let row = sqlx::query_as::<_, EndpointRow>(
+            "SELECT * FROM provider_webhook_endpoint_revisions WHERE endpoint_id = $1 AND revision = $2",
+        )
+        .bind(endpoint_id.as_uuid())
+        .bind(durable_u64(revision.get())?)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let references = load_references_pool(self, endpoint_id, revision).await?;
+        if usize::try_from(row.candidate_count).ok() != Some(references.len()) {
+            return Err(ProviderDeliveryRepositoryError::Corrupt);
+        }
+        let endpoint = decode_endpoint(row, references.clone())?;
+        let mut secrets = Vec::with_capacity(references.len());
+        for reference in references {
+            let secret = self
+                .load_secret_inner(
+                    endpoint.instance_id(),
+                    reference.configuration_revision(),
+                    reference.name().clone(),
+                    reference.generation(),
+                )
+                .await
+                .map_err(map_manifest_error)?
+                .ok_or(ProviderDeliveryRepositoryError::Corrupt)?;
+            secrets.push((reference.configuration_revision(), secret));
+        }
+        let candidates = ProviderWebhookSecretCandidates::new(&endpoint, secrets)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+        Ok(Some(ProviderWebhookEndpointRecord::new(
+            endpoint, candidates,
+        )))
+    }
+}
+
+async fn ensure_endpoint_references(
+    transaction: &mut Transaction<'_, Postgres>,
+    endpoint: &ProviderWebhookEndpointManifest,
+) -> Result<(), ProviderDeliveryRepositoryError> {
+    let binding_exists = sqlx::query_scalar::<_, bool>(
+        r"
+        SELECT EXISTS (
+            SELECT 1
+            FROM provider_instance_revisions AS instance
+            JOIN provider_connection_revisions AS connection
+              ON connection.connection_id = $4
+             AND connection.revision = $5
+             AND connection.provider_instance_id = instance.instance_id
+             AND connection.provider_revision = instance.revision
+            WHERE instance.instance_id = $1
+              AND instance.revision = $2
+              AND instance.provider_type = $3
+              AND instance.lifecycle_state = 'active'
+              AND connection.lifecycle_state = 'active'
+        )
+        ",
+    )
+    .bind(endpoint.instance_id().as_uuid())
+    .bind(durable_u64(endpoint.provider_revision().get())?)
+    .bind(endpoint.provider_type().as_str())
+    .bind(endpoint.connection_id().as_uuid())
+    .bind(durable_u64(endpoint.connection_revision().get())?)
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    if !binding_exists {
+        return Err(ProviderDeliveryRepositoryError::NotFound);
+    }
+    for reference in endpoint.secret_references() {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r"
+            SELECT EXISTS (
+                SELECT 1 FROM provider_instance_secret_bindings
+                WHERE instance_id = $1 AND revision = $2
+                  AND secret_name = $3 AND secret_generation = $4
+            )
+            ",
+        )
+        .bind(endpoint.instance_id().as_uuid())
+        .bind(durable_u64(reference.configuration_revision().get())?)
+        .bind(reference.name().as_str())
+        .bind(durable_u64(reference.generation().get())?)
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(unavailable)?;
+        if !exists {
+            return Err(ProviderDeliveryRepositoryError::NotFound);
+        }
+    }
+    Ok(())
+}
+
+async fn insert_endpoint(
+    transaction: &mut Transaction<'_, Postgres>,
+    endpoint: &ProviderWebhookEndpointManifest,
+) -> Result<(), ProviderDeliveryRepositoryError> {
+    sqlx::query(
+        r"
+        INSERT INTO provider_webhook_endpoint_revisions (
+            endpoint_id, revision, lifecycle_state, provider_type,
+            provider_instance_id, provider_revision, connection_id,
+            connection_revision, body_limit, raw_retention_millis,
+            candidate_count, created_at_ms, retired_at_ms
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+        ",
+    )
+    .bind(endpoint.endpoint_id().as_uuid())
+    .bind(durable_u64(endpoint.revision().get())?)
+    .bind(endpoint_state_text(endpoint.state()))
+    .bind(endpoint.provider_type().as_str())
+    .bind(endpoint.instance_id().as_uuid())
+    .bind(durable_u64(endpoint.provider_revision().get())?)
+    .bind(endpoint.connection_id().as_uuid())
+    .bind(durable_u64(endpoint.connection_revision().get())?)
+    .bind(durable_u64(endpoint.body_limit())?)
+    .bind(durable_u64(endpoint.raw_retention_millis())?)
+    .bind(
+        i16::try_from(endpoint.secret_references().len())
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+    )
+    .bind(endpoint.created_at().get())
+    .bind(endpoint.retired_at().map(UnixMillis::get))
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    Ok(())
+}
+
+async fn insert_candidates(
+    transaction: &mut Transaction<'_, Postgres>,
+    endpoint: &ProviderWebhookEndpointManifest,
+) -> Result<(), ProviderDeliveryRepositoryError> {
+    for (index, reference) in endpoint.secret_references().iter().enumerate() {
+        sqlx::query(
+            r"
+            INSERT INTO provider_webhook_endpoint_secret_candidates (
+                endpoint_id, endpoint_revision, ordinal, provider_instance_id,
+                configuration_revision, secret_name, secret_generation
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7)
+            ",
+        )
+        .bind(endpoint.endpoint_id().as_uuid())
+        .bind(durable_u64(endpoint.revision().get())?)
+        .bind(i16::try_from(index + 1).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?)
+        .bind(endpoint.instance_id().as_uuid())
+        .bind(durable_u64(reference.configuration_revision().get())?)
+        .bind(reference.name().as_str())
+        .bind(durable_u64(reference.generation().get())?)
+        .execute(&mut **transaction)
+        .await
+        .map_err(unavailable)?;
+    }
+    Ok(())
+}
+
+async fn load_references(
+    transaction: &mut Transaction<'_, Postgres>,
+    endpoint_id: ProviderWebhookEndpointId,
+    revision: ProviderWebhookEndpointRevision,
+) -> Result<Vec<ProviderWebhookSecretReference>, ProviderDeliveryRepositoryError> {
+    let rows = sqlx::query_as::<_, CandidateRow>(
+        r"
+        SELECT configuration_revision, secret_name, secret_generation
+        FROM provider_webhook_endpoint_secret_candidates
+        WHERE endpoint_id = $1 AND endpoint_revision = $2
+        ORDER BY ordinal
+        ",
+    )
+    .bind(endpoint_id.as_uuid())
+    .bind(durable_u64(revision.get())?)
+    .fetch_all(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    decode_references(rows)
+}
+
+async fn load_references_pool(
+    repository: &PostgresProviderManifestRepository,
+    endpoint_id: ProviderWebhookEndpointId,
+    revision: ProviderWebhookEndpointRevision,
+) -> Result<Vec<ProviderWebhookSecretReference>, ProviderDeliveryRepositoryError> {
+    let rows = sqlx::query_as::<_, CandidateRow>(
+        r"
+        SELECT configuration_revision, secret_name, secret_generation
+        FROM provider_webhook_endpoint_secret_candidates
+        WHERE endpoint_id = $1 AND endpoint_revision = $2
+        ORDER BY ordinal
+        ",
+    )
+    .bind(endpoint_id.as_uuid())
+    .bind(durable_u64(revision.get())?)
+    .fetch_all(&repository.pool)
+    .await
+    .map_err(unavailable)?;
+    decode_references(rows)
+}
+
+fn decode_references(
+    rows: Vec<CandidateRow>,
+) -> Result<Vec<ProviderWebhookSecretReference>, ProviderDeliveryRepositoryError> {
+    rows.into_iter()
+        .map(|row| {
+            Ok(ProviderWebhookSecretReference::new(
+                ProviderConfigurationRevision::new(positive_u64(row.configuration_revision)?)
+                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                ProviderSecretName::new(row.secret_name)
+                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                ProviderSecretGeneration::new(positive_u64(row.secret_generation)?)
+                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            ))
+        })
+        .collect()
+}
+
+fn decode_endpoint(
+    row: EndpointRow,
+    references: Vec<ProviderWebhookSecretReference>,
+) -> Result<ProviderWebhookEndpointManifest, ProviderDeliveryRepositoryError> {
+    ProviderWebhookEndpointManifest::new(
+        ProviderWebhookEndpointId::from_uuid(row.endpoint_id)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        endpoint_revision(row.revision)?,
+        endpoint_state(&row.lifecycle_state)?,
+        ProviderTypeId::new(row.provider_type)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        ProviderInstanceId::from_uuid(row.provider_instance_id)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        ProviderConfigurationRevision::new(positive_u64(row.provider_revision)?)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        ProviderConnectionId::from_uuid(row.connection_id)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        ProviderConnectionRevision::new(positive_u64(row.connection_revision)?)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+        positive_u64(row.body_limit)?,
+        positive_u64(row.raw_retention_millis)?,
+        references,
+        UnixMillis::new(row.created_at_ms),
+        row.retired_at_ms.map(UnixMillis::new),
+    )
+    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn endpoint_revision(
+    value: i64,
+) -> Result<ProviderWebhookEndpointRevision, ProviderDeliveryRepositoryError> {
+    ProviderWebhookEndpointRevision::new(positive_u64(value)?)
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn endpoint_state(
+    value: &str,
+) -> Result<ProviderWebhookEndpointState, ProviderDeliveryRepositoryError> {
+    match value {
+        "active" => Ok(ProviderWebhookEndpointState::Active),
+        "disabled" => Ok(ProviderWebhookEndpointState::Disabled),
+        "retired" => Ok(ProviderWebhookEndpointState::Retired),
+        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
+    }
+}
+
+const fn endpoint_state_text(value: ProviderWebhookEndpointState) -> &'static str {
+    match value {
+        ProviderWebhookEndpointState::Active => "active",
+        ProviderWebhookEndpointState::Disabled => "disabled",
+        ProviderWebhookEndpointState::Retired => "retired",
+    }
+}
+
+fn durable_u64(value: u64) -> Result<i64, ProviderDeliveryRepositoryError> {
+    i64::try_from(value).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn positive_u64(value: i64) -> Result<u64, ProviderDeliveryRepositoryError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ProviderDeliveryRepositoryError::Corrupt)
+}
+
+fn unavailable(_: sqlx::Error) -> ProviderDeliveryRepositoryError {
+    ProviderDeliveryRepositoryError::Unavailable
+}
+
+const fn map_manifest_error(error: ProviderRepositoryError) -> ProviderDeliveryRepositoryError {
+    match error {
+        ProviderRepositoryError::NotFound => ProviderDeliveryRepositoryError::NotFound,
+        ProviderRepositoryError::Unavailable => ProviderDeliveryRepositoryError::Unavailable,
+        ProviderRepositoryError::Conflict
+        | ProviderRepositoryError::Corrupt
+        | ProviderRepositoryError::SecretCustody => ProviderDeliveryRepositoryError::Corrupt,
+    }
+}

--- a/crates/automata-ci-provider-postgres/src/instance.rs
+++ b/crates/automata-ci-provider-postgres/src/instance.rs
@@ -6,6 +6,7 @@ use automata_ci_provider::{
     ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet,
     ProviderTypeId,
 };
+use sha2::{Digest as _, Sha256};
 use sqlx::{FromRow, Postgres, Transaction};
 
 use crate::{
@@ -52,6 +53,55 @@ struct SealedSecret {
 }
 
 impl PostgresProviderManifestRepository {
+    pub(crate) async fn load_secret_inner(
+        &self,
+        instance_id: ProviderInstanceId,
+        revision: ProviderConfigurationRevision,
+        name: ProviderSecretName,
+        generation: ProviderSecretGeneration,
+    ) -> Result<Option<ProviderSecret>, ProviderRepositoryError> {
+        let row = sqlx::query_as::<_, SecretRow>(
+            r"
+            SELECT secret_name, secret_generation, plaintext_digest,
+                   envelope_schema, wrapping_key_id, wrapped_data_key,
+                   nonce, ciphertext
+            FROM provider_instance_secret_bindings
+            WHERE instance_id = $1 AND revision = $2
+              AND secret_name = $3 AND secret_generation = $4
+            ",
+        )
+        .bind(instance_id.as_uuid())
+        .bind(i64::try_from(revision.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+        .bind(name.as_str())
+        .bind(i64::try_from(generation.get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(unavailable)?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let encrypted = envelope(
+            row.envelope_schema,
+            row.wrapping_key_id,
+            row.wrapped_data_key,
+            row.nonce,
+            row.ciphertext,
+        )?;
+        let context = secret_context(instance_id, revision.get(), name.as_str(), generation.get())?;
+        let plaintext = self
+            .envelopes
+            .open(&context, &encrypted)
+            .await
+            .map_err(encryption_failure)?;
+        let plaintext_digest = automata_ci_core::Sha256Digest::from_bytes(
+            Sha256::digest(plaintext.expose_secret()).into(),
+        );
+        if digest(row.plaintext_digest)? != plaintext_digest {
+            return Err(ProviderRepositoryError::SecretCustody);
+        }
+        Ok(Some(ProviderSecret::new(name, generation, plaintext)))
+    }
+
     pub(crate) async fn save_instance_inner(
         &self,
         record: ProviderInstanceRecord,

--- a/crates/automata-ci-provider-postgres/src/lib.rs
+++ b/crates/automata-ci-provider-postgres/src/lib.rs
@@ -10,18 +10,27 @@ use automata_ci_key_management::{
     KeyPurpose, WrappedDataKey,
 };
 use automata_ci_provider::{
-    ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionRevision,
-    ProviderInstanceId, ProviderInstanceRecord, ProviderManifestRepository,
-    ProviderRepositoryError, ProviderRepositoryFuture, ProviderSaveOutcome,
+    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
+    CompleteProviderDelivery, FailProviderDelivery, ProviderConnectionId,
+    ProviderConnectionManifest, ProviderConnectionRevision, ProviderDelivery,
+    ProviderDeliveryAcceptOutcome, ProviderDeliveryFuture, ProviderDeliveryId,
+    ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderInstanceId,
+    ProviderInstanceRecord, ProviderManifestRepository, ProviderRepositoryError,
+    ProviderRepositoryFuture, ProviderSaveOutcome, ProviderWebhookEndpointId,
+    ProviderWebhookEndpointManifest, ProviderWebhookEndpointRecord,
+    ProviderWebhookEndpointRepository, ProviderWebhookEndpointRevision, RetryProviderDelivery,
 };
 use sqlx::{PgPool, Postgres, Transaction};
 
 mod connection;
+mod delivery;
+mod endpoint;
 mod instance;
 
 const SECRET_PURPOSE: &str = "provider/instance-secret:v1";
 const INSTANCE_LOCK_SALT: i64 = 6_692_456_121_835_322_101;
 const CONNECTION_LOCK_SALT: i64 = 7_752_013_457_331_067_413;
+const ENDPOINT_LOCK_SALT: i64 = 6_747_890_046_912_418_703;
 
 /// Atomic `PostgreSQL` provider manifest repository with envelope-encrypted secrets.
 #[derive(Clone)]
@@ -100,6 +109,74 @@ impl ProviderManifestRepository for PostgresProviderManifestRepository {
         connection_id: ProviderConnectionId,
     ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>> {
         Box::pin(self.current_connection_inner(connection_id))
+    }
+}
+
+impl ProviderWebhookEndpointRepository for PostgresProviderManifestRepository {
+    fn save_endpoint(
+        &self,
+        endpoint: ProviderWebhookEndpointManifest,
+    ) -> ProviderDeliveryFuture<'_, ProviderSaveOutcome> {
+        Box::pin(self.save_endpoint_inner(endpoint))
+    }
+
+    fn resolve_endpoint(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderWebhookEndpointRecord>> {
+        Box::pin(self.resolve_endpoint_inner(endpoint_id))
+    }
+
+    fn load_endpoint(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+        revision: ProviderWebhookEndpointRevision,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderWebhookEndpointRecord>> {
+        Box::pin(self.load_endpoint_inner(endpoint_id, revision))
+    }
+}
+
+impl ProviderDeliveryRepository for PostgresProviderManifestRepository {
+    fn accept_delivery(
+        &self,
+        request: AcceptProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryAcceptOutcome> {
+        Box::pin(self.accept_delivery_inner(request))
+    }
+
+    fn load_delivery(
+        &self,
+        delivery_id: ProviderDeliveryId,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderDelivery>> {
+        Box::pin(self.load_delivery_inner(delivery_id))
+    }
+
+    fn claim_delivery(
+        &self,
+        request: ClaimProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, Option<ClaimedProviderDelivery>> {
+        Box::pin(self.claim_delivery_inner(request))
+    }
+
+    fn complete_delivery(
+        &self,
+        request: CompleteProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
+        Box::pin(self.complete_delivery_inner(request))
+    }
+
+    fn retry_delivery(
+        &self,
+        request: RetryProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
+        Box::pin(self.retry_delivery_inner(request))
+    }
+
+    fn fail_delivery(
+        &self,
+        request: FailProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
+        Box::pin(self.fail_delivery_inner(request))
     }
 }
 

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -4,16 +4,26 @@ use automata_ci_core::{GitObjectAlgorithm, Sha256Digest, UnixMillis, WorkspaceId
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
 use automata_ci_postgres::test_support::{TestResult, run_with_database};
 use automata_ci_provider::{
-    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits, ProviderCapabilities,
-    ProviderCapability, ProviderConfigurationDocument, ProviderConfigurationRevision,
-    ProviderConnectionConfiguration, ProviderConnectionId, ProviderConnectionManifest,
-    ProviderConnectionPolicyDocument, ProviderConnectionRevision, ProviderDefaultBranch,
+    AcceptProviderDelivery, ClaimProviderDelivery, CompleteProviderDelivery, ExternalDeliveryId,
+    ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger,
+    ProviderArchiveLimits, ProviderCapabilities, ProviderCapability, ProviderConfigurationDocument,
+    ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
+    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    ProviderDefaultBranch, ProviderDelivery, ProviderDeliveryAcceptOutcome,
+    ProviderDeliveryFailure, ProviderDeliveryId, ProviderDeliveryObservations,
+    ProviderDeliveryRepository as _, ProviderDeliveryRepositoryError, ProviderDeliveryState,
+    ProviderDeliveryWorkerId, ProviderEventName, ProviderGitRef, ProviderGitRefKind,
     ProviderInstanceId, ProviderInstanceManifest, ProviderInstanceRecord, ProviderLifecycleState,
-    ProviderManifestRepository as _, ProviderOrigins, ProviderRepositoryError,
+    ProviderManifestRepository as _, ProviderOrigins, ProviderRepository, ProviderRepositoryError,
     ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSaveOutcome,
     ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding, ProviderSecretBindings,
     ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet, ProviderTypeId,
-    ProviderWorkflowSource, RepositoryVisibility, SourceReadCapability, provider_capability_digest,
+    ProviderWebhookEndpointId, ProviderWebhookEndpointManifest,
+    ProviderWebhookEndpointRepository as _, ProviderWebhookEndpointRevision,
+    ProviderWebhookEndpointState, ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence,
+    ProviderWorkflowSource, PushTrigger, RepositoryVisibility, RetryProviderDelivery,
+    SourceReadCapability, VerifiedProviderDelivery, provider_capability_digest,
+    provider_raw_webhook_descriptor,
 };
 use automata_ci_provider_postgres::PostgresProviderManifestRepository;
 use sha2::{Digest as _, Sha256};
@@ -373,6 +383,260 @@ async fn stale_missing_and_tampered_state_fail_closed() -> TestResult {
                 .await,
             Err(ProviderRepositoryError::SecretCustody)
         ));
+        Ok(())
+    })
+    .await
+}
+
+fn verified_delivery(
+    endpoint: &ProviderWebhookEndpointManifest,
+    delivery_id: ProviderDeliveryId,
+    raw_body: &[u8],
+) -> VerifiedProviderDelivery {
+    let digest = secret_digest(raw_body);
+    let raw =
+        provider_raw_webhook_descriptor(digest, raw_body.len() as u64).expect("raw descriptor");
+    let repository = ProviderRepository::new(
+        ExternalRepositoryIdentity::new(
+            endpoint.instance_id(),
+            ExternalRepositoryId::new("42").expect("repository ID"),
+        ),
+        ProviderRepositoryPath::new("owner/repository").expect("repository path"),
+        RepositoryVisibility::Private,
+    );
+    let before = automata_ci_core::GitObjectId::from_hex(GitObjectAlgorithm::Sha1, &"a".repeat(40))
+        .expect("before object");
+    let after = automata_ci_core::GitObjectId::from_hex(GitObjectAlgorithm::Sha1, &"b".repeat(40))
+        .expect("after object");
+    let trigger = NormalizedTrigger::Push(
+        PushTrigger::new(
+            repository,
+            ProviderGitRef::new("refs/heads/main", ProviderGitRefKind::Branch).expect("branch"),
+            Some(before),
+            Some(after),
+            false,
+            None,
+        )
+        .expect("push"),
+    )
+    .seal()
+    .expect("sealed trigger");
+    VerifiedProviderDelivery::rehydrate(
+        delivery_id,
+        endpoint.endpoint_id(),
+        endpoint.revision(),
+        endpoint.provider_type().clone(),
+        endpoint.instance_id(),
+        endpoint.provider_revision(),
+        endpoint.connection_id(),
+        endpoint.connection_revision(),
+        ExternalDeliveryIdentity::new(
+            endpoint.instance_id(),
+            ExternalDeliveryId::new("delivery-100").expect("external delivery"),
+        ),
+        ProviderEventName::new("push").expect("event type"),
+        UnixMillis::new(4_000),
+        raw,
+        UnixMillis::new(
+            4_000
+                + i64::try_from(endpoint.raw_retention_millis())
+                    .expect("retention is in signed range"),
+        ),
+        ProviderWebhookSignatureEvidence::new(
+            "fake-sha256",
+            endpoint.secret_references()[0].clone(),
+        )
+        .expect("signature evidence"),
+        trigger,
+        ProviderDeliveryObservations::new(br#"{"fixture":"postgres"}"#.to_vec())
+            .expect("observations"),
+    )
+    .expect("verified delivery")
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
+#[allow(clippy::too_many_lines)]
+async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> TestResult {
+    run_with_database(|database| async move {
+        let repository = repository(database.pool().clone());
+        let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(101))?;
+        repository
+            .save_instance(instance_record(
+                instance_id,
+                "forgejo",
+                1,
+                TOKEN,
+                1,
+                ProviderLifecycleState::Active,
+                Some(UnixMillis::new(1_000)),
+            ))
+            .await?;
+        let instance = repository
+            .current_instance(instance_id)
+            .await?
+            .expect("instance");
+        let workspace = WorkspaceId::parse("22222222-2222-4222-8222-222222222222")?;
+        sqlx::query(
+            "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Delivery test', 1, 1)",
+        )
+        .bind(workspace.to_string())
+        .execute(database.pool())
+        .await?;
+        let connection = connection(workspace, instance.manifest());
+        repository.save_connection(connection.clone()).await?;
+
+        let endpoint = ProviderWebhookEndpointManifest::new(
+            ProviderWebhookEndpointId::from_uuid(Uuid::from_u128(102))?,
+            ProviderWebhookEndpointRevision::new(1)?,
+            ProviderWebhookEndpointState::Active,
+            ProviderTypeId::new("forgejo")?,
+            instance_id,
+            instance.manifest().revision(),
+            connection.connection_id(),
+            connection.revision(),
+            1_024,
+            30 * 24 * 60 * 60 * 1_000,
+            vec![ProviderWebhookSecretReference::new(
+                instance.manifest().revision(),
+                ProviderSecretName::new("control-token")?,
+                ProviderSecretGeneration::new(1)?,
+            )],
+            UnixMillis::new(3_000),
+            None,
+        )?;
+        assert_eq!(
+            repository.save_endpoint(endpoint.clone()).await?,
+            ProviderSaveOutcome::Inserted
+        );
+        let resolved = repository
+            .resolve_endpoint(endpoint.endpoint_id())
+            .await?
+            .expect("resolved endpoint");
+        assert_eq!(
+            resolved
+                .secrets()
+                .iter()
+                .next()
+                .expect("candidate")
+                .expose_secret(),
+            TOKEN
+        );
+
+        let first_id = ProviderDeliveryId::from_uuid(Uuid::from_u128(103))?;
+        let first = ProviderDelivery::Trigger(Box::new(verified_delivery(
+            &endpoint,
+            first_id,
+            b"body-one",
+        )));
+        let acceptance = AcceptProviderDelivery::new(first, UnixMillis::new(4_100))?;
+        assert!(matches!(
+            repository.accept_delivery(acceptance).await?,
+            ProviderDeliveryAcceptOutcome::Inserted(receipt)
+                if receipt.delivery_id() == first_id
+                    && receipt.state() == ProviderDeliveryState::Pending
+        ));
+        let immutable_update = sqlx::query(
+            "UPDATE provider_delivery_records SET event_type = 'tampered' WHERE delivery_id = $1",
+        )
+        .bind(first_id.as_uuid())
+        .execute(database.pool())
+        .await;
+        assert!(immutable_update.is_err(), "raw delivery evidence is immutable");
+
+        let duplicate = ProviderDelivery::Trigger(Box::new(verified_delivery(
+            &endpoint,
+            ProviderDeliveryId::from_uuid(Uuid::from_u128(104))?,
+            b"body-one",
+        )));
+        assert!(matches!(
+            repository
+                .accept_delivery(AcceptProviderDelivery::new(
+                    duplicate,
+                    UnixMillis::new(4_200),
+                )?)
+                .await?,
+            ProviderDeliveryAcceptOutcome::Duplicate(receipt)
+                if receipt.delivery_id() == first_id
+        ));
+
+        let conflict = ProviderDelivery::Trigger(Box::new(verified_delivery(
+            &endpoint,
+            ProviderDeliveryId::from_uuid(Uuid::from_u128(105))?,
+            b"different-body",
+        )));
+        assert_eq!(
+            repository
+                .accept_delivery(AcceptProviderDelivery::new(
+                    conflict,
+                    UnixMillis::new(4_300),
+                )?)
+                .await,
+            Err(ProviderDeliveryRepositoryError::ReplayConflict)
+        );
+
+        let worker = ProviderDeliveryWorkerId::from_uuid(Uuid::from_u128(106))?;
+        let first_claim = repository
+            .claim_delivery(ClaimProviderDelivery::new(
+                worker,
+                UnixMillis::new(5_000),
+                1_000,
+            )?)
+            .await?
+            .expect("first claim");
+        let retry = repository
+            .retry_delivery(RetryProviderDelivery::new(
+                first_claim.fence(),
+                UnixMillis::new(5_500),
+                UnixMillis::new(7_000),
+                ProviderDeliveryFailure::DependencyUnavailable,
+            )?)
+            .await?;
+        assert_eq!(retry.state(), ProviderDeliveryState::RetryPending);
+        assert!(
+            repository
+                .claim_delivery(ClaimProviderDelivery::new(
+                    worker,
+                    UnixMillis::new(6_999),
+                    1_000,
+                )?)
+                .await?
+                .is_none()
+        );
+        let second_claim = repository
+            .claim_delivery(ClaimProviderDelivery::new(
+                worker,
+                UnixMillis::new(7_000),
+                1_000,
+            )?)
+            .await?
+            .expect("second claim");
+        assert!(second_claim.fence().token() > first_claim.fence().token());
+        let completed = repository
+            .complete_delivery(CompleteProviderDelivery::new(
+                second_claim.fence(),
+                UnixMillis::new(7_500),
+            )?)
+            .await?;
+        assert_eq!(completed.state(), ProviderDeliveryState::Completed);
+
+        let disabled_connection = ProviderConnectionManifest::new(
+            connection.connection_id(),
+            ProviderConnectionRevision::new(2)?,
+            ProviderLifecycleState::Disabled,
+            connection.configuration().clone(),
+            connection.created_at(),
+            connection.activated_at(),
+            None,
+        )?;
+        repository.save_connection(disabled_connection).await?;
+        assert!(
+            repository
+                .resolve_endpoint(endpoint.endpoint_id())
+                .await?
+                .is_none(),
+            "connection disablement closes ingress without a fallback revision"
+        );
         Ok(())
     })
     .await

--- a/crates/automata-ci-provider/Cargo.toml
+++ b/crates/automata-ci-provider/Cargo.toml
@@ -12,8 +12,10 @@ readme = "README.md"
 publish.workspace = true
 
 [dependencies]
+automata-ci-blob.workspace = true
 automata-ci-key-management.workspace = true
 automata-ci-core.workspace = true
+base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/automata-ci-provider/README.md
+++ b/crates/automata-ci-provider/README.md
@@ -1,9 +1,13 @@
 # automata-ci-provider
 
 `automata-ci-provider` owns source-hosting provider identity, capability,
-configuration, connection, factory-registry, and persistence-port contracts for
-Automata. GitHub, Forgejo, and future provider adapters implement these
-contracts without entering the workflow, scheduler, store, or runner domains.
+configuration, connection, delivery, factory-registry, and persistence-port
+contracts for Automata. Delivery adapters authenticate bounded raw requests
+before normalization into the closed trigger vocabulary. Opaque endpoints pin
+exact instance, connection, and secret revisions; the replay-safe inbox owns
+only evidence and worker lifecycle. GitHub, Forgejo, and future provider
+adapters implement these contracts without entering the workflow, scheduler,
+store, or runner domains.
 
 The crate contains no network client and no concrete provider implementation.
 

--- a/crates/automata-ci-provider/src/delivery.rs
+++ b/crates/automata-ci-provider/src/delivery.rs
@@ -1,0 +1,808 @@
+//! Replay-safe provider delivery inbox and worker ports.
+
+use std::{fmt, future::Future, num::NonZeroU64, pin::Pin};
+
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    ExternalDeliveryIdentity, ProviderDeliveryId, ProviderDeliveryRejection,
+    ProviderDeliveryWorkerId, ProviderSaveOutcome, ProviderWebhookEndpointId,
+    ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision,
+    ProviderWebhookSecretCandidates, RejectedProviderDelivery, VerifiedProviderDelivery,
+};
+
+/// Maximum processing attempts for one admitted provider delivery.
+pub const MAX_PROVIDER_DELIVERY_ATTEMPTS: u16 = 16;
+/// Maximum duration of one delivery worker lease.
+pub const MAX_PROVIDER_DELIVERY_LEASE_MILLIS: i64 = 15 * 60 * 1_000;
+/// Maximum delay before a transiently failed delivery becomes eligible again.
+pub const MAX_PROVIDER_DELIVERY_RETRY_MILLIS: i64 = 24 * 60 * 60 * 1_000;
+
+const DELIVERY_FINGERPRINT_DOMAIN: &[u8] = b"automata.provider.delivery-fingerprint.v1\0";
+
+/// Decrypted endpoint record returned only at trusted delivery ingress.
+pub struct ProviderWebhookEndpointRecord {
+    manifest: ProviderWebhookEndpointManifest,
+    secrets: ProviderWebhookSecretCandidates,
+}
+
+impl ProviderWebhookEndpointRecord {
+    /// Binds an endpoint manifest to its exact move-only verification candidates.
+    #[must_use]
+    pub const fn new(
+        manifest: ProviderWebhookEndpointManifest,
+        secrets: ProviderWebhookSecretCandidates,
+    ) -> Self {
+        Self { manifest, secrets }
+    }
+
+    /// Returns endpoint routing and verification policy.
+    #[must_use]
+    pub const fn manifest(&self) -> &ProviderWebhookEndpointManifest {
+        &self.manifest
+    }
+
+    /// Returns exact plaintext candidates at the authentication boundary.
+    #[must_use]
+    pub const fn secrets(&self) -> &ProviderWebhookSecretCandidates {
+        &self.secrets
+    }
+
+    /// Consumes the record into policy and secret custody values.
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ProviderWebhookEndpointManifest,
+        ProviderWebhookSecretCandidates,
+    ) {
+        (self.manifest, self.secrets)
+    }
+}
+
+impl fmt::Debug for ProviderWebhookEndpointRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookEndpointRecord")
+            .field("manifest", &self.manifest)
+            .field("secrets", &self.secrets)
+            .finish()
+    }
+}
+
+/// Complete authenticated provider delivery retained by the generic inbox.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProviderDelivery {
+    /// A complete normalized trigger eligible for workflow admission.
+    Trigger(Box<VerifiedProviderDelivery>),
+    /// An authenticated unknown, unsupported, incomplete, or conflicting event.
+    Rejected(Box<RejectedProviderDelivery>),
+}
+
+impl ProviderDelivery {
+    /// Returns the server-owned delivery identity.
+    #[must_use]
+    pub const fn delivery_id(&self) -> ProviderDeliveryId {
+        match self {
+            Self::Trigger(value) => value.delivery_id(),
+            Self::Rejected(value) => value.delivery_id(),
+        }
+    }
+
+    /// Returns instance-scoped provider replay identity.
+    #[must_use]
+    pub const fn external_delivery(&self) -> &ExternalDeliveryIdentity {
+        match self {
+            Self::Trigger(value) => value.external_delivery(),
+            Self::Rejected(value) => value.external_delivery(),
+        }
+    }
+
+    /// Returns the endpoint identity used for ingress.
+    #[must_use]
+    pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
+        match self {
+            Self::Trigger(value) => value.endpoint_id(),
+            Self::Rejected(value) => value.endpoint_id(),
+        }
+    }
+
+    /// Returns the exact raw-body digest.
+    #[must_use]
+    pub const fn raw_body_digest(&self) -> Sha256Digest {
+        match self {
+            Self::Trigger(value) => value.raw_body().digest(),
+            Self::Rejected(value) => value.raw_body().digest(),
+        }
+    }
+
+    /// Returns trusted ingress receipt time.
+    #[must_use]
+    pub const fn received_at(&self) -> UnixMillis {
+        match self {
+            Self::Trigger(value) => value.received_at(),
+            Self::Rejected(value) => value.received_at(),
+        }
+    }
+
+    /// Computes immutable replay evidence independent of receipt time, server
+    /// delivery UUID, endpoint revision, and accepted rotation generation.
+    #[must_use]
+    pub fn replay_fingerprint(&self) -> ProviderDeliveryReplayFingerprint {
+        let mut hash = Sha256::new();
+        hash.update(DELIVERY_FINGERPRINT_DOMAIN);
+        part(
+            &mut hash,
+            self.external_delivery().instance_id().as_uuid().as_bytes(),
+        );
+        part(
+            &mut hash,
+            self.external_delivery().external_id().as_str().as_bytes(),
+        );
+        part(&mut hash, self.endpoint_id().as_uuid().as_bytes());
+        part(&mut hash, self.raw_body_digest().as_bytes());
+        match self {
+            Self::Trigger(value) => {
+                part(&mut hash, b"trigger");
+                part(&mut hash, value.event_type().as_str().as_bytes());
+                part(
+                    &mut hash,
+                    value
+                        .trigger()
+                        .trigger()
+                        .target_repository()
+                        .identity()
+                        .external_id()
+                        .as_str()
+                        .as_bytes(),
+                );
+                part(&mut hash, value.trigger().digest().as_bytes());
+            }
+            Self::Rejected(value) => {
+                part(&mut hash, b"rejected");
+                part(&mut hash, value.event_type().as_str().as_bytes());
+                match value.repository() {
+                    Some(repository) => {
+                        hash.update([1]);
+                        part(&mut hash, repository.external_id().as_str().as_bytes());
+                    }
+                    None => hash.update([0]),
+                }
+                part(&mut hash, rejection_name(value.reason()).as_bytes());
+            }
+        }
+        ProviderDeliveryReplayFingerprint(Sha256Digest::from_bytes(hash.finalize().into()))
+    }
+}
+
+/// Durable inbox acceptance command with server-owned acceptance time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptProviderDelivery {
+    delivery: ProviderDelivery,
+    accepted_at: UnixMillis,
+}
+
+impl AcceptProviderDelivery {
+    /// Binds authenticated evidence to its durable acceptance time.
+    ///
+    /// # Errors
+    ///
+    /// Rejects acceptance before ingress receipt or before the Unix epoch.
+    pub fn new(
+        delivery: ProviderDelivery,
+        accepted_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        if accepted_at.get() < 0 || accepted_at < delivery.received_at() {
+            return Err(ProviderDeliveryModelError::InvalidAcceptanceTime);
+        }
+        Ok(Self {
+            delivery,
+            accepted_at,
+        })
+    }
+
+    /// Returns immutable authenticated delivery evidence.
+    #[must_use]
+    pub const fn delivery(&self) -> &ProviderDelivery {
+        &self.delivery
+    }
+
+    /// Returns trusted durable acceptance time.
+    #[must_use]
+    pub const fn accepted_at(&self) -> UnixMillis {
+        self.accepted_at
+    }
+
+    /// Consumes the command into evidence and acceptance time.
+    #[must_use]
+    pub fn into_parts(self) -> (ProviderDelivery, UnixMillis) {
+        (self.delivery, self.accepted_at)
+    }
+}
+
+/// Domain-separated exact evidence used to distinguish replay from conflict.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ProviderDeliveryReplayFingerprint(Sha256Digest);
+
+impl ProviderDeliveryReplayFingerprint {
+    /// Returns the fingerprint digest.
+    #[must_use]
+    pub const fn digest(self) -> Sha256Digest {
+        self.0
+    }
+}
+
+/// Durable provider delivery lifecycle.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ProviderDeliveryState {
+    /// A normalized trigger is ready for a worker.
+    Pending,
+    /// A previous transient attempt is waiting for its retry deadline.
+    RetryPending,
+    /// One worker holds a fenced lease.
+    Claimed,
+    /// Processing finished successfully.
+    Completed,
+    /// A complete trigger was terminally rejected by processing policy.
+    Failed,
+    /// Authenticated event evidence was recorded without admission.
+    Discarded,
+}
+
+/// Durable receipt returned by inbox mutations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProviderDeliveryReceipt {
+    delivery_id: ProviderDeliveryId,
+    state: ProviderDeliveryState,
+    attempts: u16,
+    accepted_at: UnixMillis,
+}
+
+impl ProviderDeliveryReceipt {
+    /// Rehydrates a validated durable receipt.
+    ///
+    /// # Errors
+    ///
+    /// Rejects negative time, excessive attempts, or state/attempt disagreement.
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        state: ProviderDeliveryState,
+        attempts: u16,
+        accepted_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        if accepted_at.get() < 0 || attempts > MAX_PROVIDER_DELIVERY_ATTEMPTS {
+            return Err(ProviderDeliveryModelError::InvalidReceipt);
+        }
+        if matches!(
+            state,
+            ProviderDeliveryState::Pending | ProviderDeliveryState::Discarded
+        ) && attempts != 0
+        {
+            return Err(ProviderDeliveryModelError::InvalidReceipt);
+        }
+        if matches!(
+            state,
+            ProviderDeliveryState::RetryPending
+                | ProviderDeliveryState::Claimed
+                | ProviderDeliveryState::Completed
+                | ProviderDeliveryState::Failed
+        ) && attempts == 0
+        {
+            return Err(ProviderDeliveryModelError::InvalidReceipt);
+        }
+        Ok(Self {
+            delivery_id,
+            state,
+            attempts,
+            accepted_at,
+        })
+    }
+
+    /// Returns the server-owned delivery identity.
+    #[must_use]
+    pub const fn delivery_id(self) -> ProviderDeliveryId {
+        self.delivery_id
+    }
+
+    /// Returns current durable state.
+    #[must_use]
+    pub const fn state(self) -> ProviderDeliveryState {
+        self.state
+    }
+
+    /// Returns the number of claims issued so far.
+    #[must_use]
+    pub const fn attempts(self) -> u16 {
+        self.attempts
+    }
+
+    /// Returns initial durable acceptance time.
+    #[must_use]
+    pub const fn accepted_at(self) -> UnixMillis {
+        self.accepted_at
+    }
+}
+
+/// Result of atomically accepting a delivery replay key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderDeliveryAcceptOutcome {
+    /// New immutable evidence was inserted.
+    Inserted(ProviderDeliveryReceipt),
+    /// Exact replay evidence already existed.
+    Duplicate(ProviderDeliveryReceipt),
+}
+
+/// Bounded request to claim one eligible normalized trigger.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ClaimProviderDelivery {
+    worker_id: ProviderDeliveryWorkerId,
+    claimed_at: UnixMillis,
+    lease_millis: NonZeroU64,
+}
+
+impl ClaimProviderDelivery {
+    /// Constructs a worker claim request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects negative time or zero/excessive lease duration.
+    pub fn new(
+        worker_id: ProviderDeliveryWorkerId,
+        claimed_at: UnixMillis,
+        lease_millis: u64,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        let lease_millis = NonZeroU64::new(lease_millis)
+            .filter(|value| value.get() <= MAX_PROVIDER_DELIVERY_LEASE_MILLIS as u64)
+            .ok_or(ProviderDeliveryModelError::InvalidLease)?;
+        let lease_i64 = i64::try_from(lease_millis.get())
+            .map_err(|_| ProviderDeliveryModelError::InvalidLease)?;
+        if claimed_at.get() < 0 || claimed_at.get().checked_add(lease_i64).is_none() {
+            return Err(ProviderDeliveryModelError::InvalidLease);
+        }
+        Ok(Self {
+            worker_id,
+            claimed_at,
+            lease_millis,
+        })
+    }
+
+    /// Returns the worker requesting ownership.
+    #[must_use]
+    pub const fn worker_id(self) -> ProviderDeliveryWorkerId {
+        self.worker_id
+    }
+
+    /// Returns trusted claim time.
+    #[must_use]
+    pub const fn claimed_at(self) -> UnixMillis {
+        self.claimed_at
+    }
+
+    /// Returns requested lease duration.
+    #[must_use]
+    pub const fn lease_millis(self) -> u64 {
+        self.lease_millis.get()
+    }
+}
+
+/// Exact worker ownership and fencing evidence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProviderDeliveryClaimFence {
+    delivery_id: ProviderDeliveryId,
+    worker_id: ProviderDeliveryWorkerId,
+    token: NonZeroU64,
+    claimed_at: UnixMillis,
+    expires_at: UnixMillis,
+}
+
+impl ProviderDeliveryClaimFence {
+    /// Rehydrates a positive, unexpired-at-issuance fence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero token or negative expiry.
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        worker_id: ProviderDeliveryWorkerId,
+        token: u64,
+        claimed_at: UnixMillis,
+        expires_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        let token = NonZeroU64::new(token)
+            .filter(|value| i64::try_from(value.get()).is_ok())
+            .ok_or(ProviderDeliveryModelError::InvalidFence)?;
+        if claimed_at.get() < 0 || expires_at <= claimed_at {
+            return Err(ProviderDeliveryModelError::InvalidFence);
+        }
+        Ok(Self {
+            delivery_id,
+            worker_id,
+            token,
+            claimed_at,
+            expires_at,
+        })
+    }
+
+    /// Returns the claimed delivery.
+    #[must_use]
+    pub const fn delivery_id(self) -> ProviderDeliveryId {
+        self.delivery_id
+    }
+
+    /// Returns the owning worker.
+    #[must_use]
+    pub const fn worker_id(self) -> ProviderDeliveryWorkerId {
+        self.worker_id
+    }
+
+    /// Returns the monotonic fencing token.
+    #[must_use]
+    pub const fn token(self) -> u64 {
+        self.token.get()
+    }
+
+    /// Returns trusted lease acquisition time.
+    #[must_use]
+    pub const fn claimed_at(self) -> UnixMillis {
+        self.claimed_at
+    }
+
+    /// Returns the exclusive lease deadline.
+    #[must_use]
+    pub const fn expires_at(self) -> UnixMillis {
+        self.expires_at
+    }
+}
+
+/// One normalized trigger and its exact live worker fence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimedProviderDelivery {
+    receipt: ProviderDeliveryReceipt,
+    delivery: VerifiedProviderDelivery,
+    fence: ProviderDeliveryClaimFence,
+}
+
+impl ClaimedProviderDelivery {
+    /// Rehydrates mutually consistent claim evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects identity or state disagreement.
+    pub fn new(
+        receipt: ProviderDeliveryReceipt,
+        delivery: VerifiedProviderDelivery,
+        fence: ProviderDeliveryClaimFence,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        if receipt.state() != ProviderDeliveryState::Claimed
+            || receipt.delivery_id() != delivery.delivery_id()
+            || receipt.delivery_id() != fence.delivery_id()
+        {
+            return Err(ProviderDeliveryModelError::InvalidClaim);
+        }
+        Ok(Self {
+            receipt,
+            delivery,
+            fence,
+        })
+    }
+
+    /// Returns claimed receipt state.
+    #[must_use]
+    pub const fn receipt(&self) -> ProviderDeliveryReceipt {
+        self.receipt
+    }
+
+    /// Returns immutable normalized delivery evidence.
+    #[must_use]
+    pub const fn delivery(&self) -> &VerifiedProviderDelivery {
+        &self.delivery
+    }
+
+    /// Returns exact live fencing evidence.
+    #[must_use]
+    pub const fn fence(&self) -> ProviderDeliveryClaimFence {
+        self.fence
+    }
+}
+
+/// Sanitized terminal or transient processing failure category.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ProviderDeliveryFailure {
+    /// A required dependent service was temporarily unavailable.
+    DependencyUnavailable,
+    /// Current configuration or policy cannot admit the trigger.
+    PolicyRejected,
+    /// Durable or normalized evidence violated an invariant.
+    InvalidEvidence,
+}
+
+/// Command that closes an exact live claim successfully.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CompleteProviderDelivery {
+    fence: ProviderDeliveryClaimFence,
+    completed_at: UnixMillis,
+}
+
+impl CompleteProviderDelivery {
+    /// Constructs a completion command.
+    ///
+    /// # Errors
+    ///
+    /// Rejects time outside the live lease.
+    pub fn new(
+        fence: ProviderDeliveryClaimFence,
+        completed_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        validate_fenced_time(fence, completed_at)?;
+        Ok(Self {
+            fence,
+            completed_at,
+        })
+    }
+
+    /// Returns exact ownership evidence.
+    #[must_use]
+    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+        self.fence
+    }
+
+    /// Returns trusted completion time.
+    #[must_use]
+    pub const fn completed_at(self) -> UnixMillis {
+        self.completed_at
+    }
+}
+
+/// Command that releases an exact live claim into delayed retry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RetryProviderDelivery {
+    fence: ProviderDeliveryClaimFence,
+    failed_at: UnixMillis,
+    retry_at: UnixMillis,
+    failure: ProviderDeliveryFailure,
+}
+
+impl RetryProviderDelivery {
+    /// Constructs a bounded delayed retry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects time outside the lease, a nonfuture deadline, or excessive delay.
+    pub fn new(
+        fence: ProviderDeliveryClaimFence,
+        failed_at: UnixMillis,
+        retry_at: UnixMillis,
+        failure: ProviderDeliveryFailure,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        validate_fenced_time(fence, failed_at)?;
+        let delay = retry_at
+            .get()
+            .checked_sub(failed_at.get())
+            .ok_or(ProviderDeliveryModelError::InvalidRetry)?;
+        if delay <= 0 || delay > MAX_PROVIDER_DELIVERY_RETRY_MILLIS {
+            return Err(ProviderDeliveryModelError::InvalidRetry);
+        }
+        Ok(Self {
+            fence,
+            failed_at,
+            retry_at,
+            failure,
+        })
+    }
+
+    /// Returns exact ownership evidence.
+    #[must_use]
+    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+        self.fence
+    }
+
+    /// Returns trusted failure time.
+    #[must_use]
+    pub const fn failed_at(self) -> UnixMillis {
+        self.failed_at
+    }
+
+    /// Returns the next eligibility time.
+    #[must_use]
+    pub const fn retry_at(self) -> UnixMillis {
+        self.retry_at
+    }
+
+    /// Returns the sanitized failure category.
+    #[must_use]
+    pub const fn failure(self) -> ProviderDeliveryFailure {
+        self.failure
+    }
+}
+
+/// Command that terminally rejects an exact live claim.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FailProviderDelivery {
+    fence: ProviderDeliveryClaimFence,
+    failed_at: UnixMillis,
+    failure: ProviderDeliveryFailure,
+}
+
+impl FailProviderDelivery {
+    /// Constructs a terminal processing failure.
+    ///
+    /// # Errors
+    ///
+    /// Rejects time outside the live lease.
+    pub fn new(
+        fence: ProviderDeliveryClaimFence,
+        failed_at: UnixMillis,
+        failure: ProviderDeliveryFailure,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        validate_fenced_time(fence, failed_at)?;
+        Ok(Self {
+            fence,
+            failed_at,
+            failure,
+        })
+    }
+
+    /// Returns exact ownership evidence.
+    #[must_use]
+    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+        self.fence
+    }
+
+    /// Returns trusted failure time.
+    #[must_use]
+    pub const fn failed_at(self) -> UnixMillis {
+        self.failed_at
+    }
+
+    /// Returns the sanitized failure category.
+    #[must_use]
+    pub const fn failure(self) -> ProviderDeliveryFailure {
+        self.failure
+    }
+}
+
+/// Boxed future returned by provider delivery repository operations.
+pub type ProviderDeliveryFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, ProviderDeliveryRepositoryError>> + Send + 'a>>;
+
+/// Durable opaque endpoint repository with secret-generation custody.
+pub trait ProviderWebhookEndpointRepository: fmt::Debug + Send + Sync {
+    /// Atomically stores a first or contiguous endpoint revision.
+    fn save_endpoint(
+        &self,
+        endpoint: ProviderWebhookEndpointManifest,
+    ) -> ProviderDeliveryFuture<'_, ProviderSaveOutcome>;
+
+    /// Loads and decrypts the current exact endpoint record.
+    fn resolve_endpoint(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderWebhookEndpointRecord>>;
+
+    /// Loads and decrypts one exact historical endpoint revision.
+    fn load_endpoint(
+        &self,
+        endpoint_id: ProviderWebhookEndpointId,
+        revision: ProviderWebhookEndpointRevision,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderWebhookEndpointRecord>>;
+}
+
+/// Durable replay-safe provider delivery inbox and worker queue.
+pub trait ProviderDeliveryRepository: fmt::Debug + Send + Sync {
+    /// Inserts new authenticated evidence or returns an exact replay receipt.
+    /// Reusing an instance-scoped external delivery ID with a different replay
+    /// fingerprint fails closed as [`ProviderDeliveryRepositoryError::ReplayConflict`].
+    fn accept_delivery(
+        &self,
+        request: AcceptProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryAcceptOutcome>;
+
+    /// Loads one durable authenticated delivery by server-owned identity.
+    fn load_delivery(
+        &self,
+        delivery_id: ProviderDeliveryId,
+    ) -> ProviderDeliveryFuture<'_, Option<ProviderDelivery>>;
+
+    /// Claims at most one eligible normalized trigger with skip-locked semantics.
+    fn claim_delivery(
+        &self,
+        request: ClaimProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, Option<ClaimedProviderDelivery>>;
+
+    /// Closes an exact live claim successfully.
+    fn complete_delivery(
+        &self,
+        request: CompleteProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+
+    /// Releases an exact live claim into bounded delayed retry.
+    fn retry_delivery(
+        &self,
+        request: RetryProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+
+    /// Terminally fails an exact live claim.
+    fn fail_delivery(
+        &self,
+        request: FailProviderDelivery,
+    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+}
+
+/// Invalid delivery values rejected before repository access.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderDeliveryModelError {
+    /// Durable acceptance preceded trusted ingress receipt.
+    #[error("provider delivery acceptance time is invalid")]
+    InvalidAcceptanceTime,
+    /// Receipt state, attempts, or time evidence disagreed.
+    #[error("provider delivery receipt is invalid")]
+    InvalidReceipt,
+    /// Claim lease time or duration was invalid.
+    #[error("provider delivery lease is invalid")]
+    InvalidLease,
+    /// Fencing token or expiry was invalid.
+    #[error("provider delivery claim fence is invalid")]
+    InvalidFence,
+    /// Claimed receipt, delivery, and fence identities disagreed.
+    #[error("claimed provider delivery evidence is inconsistent")]
+    InvalidClaim,
+    /// Completion or failure time was outside the exact live lease.
+    #[error("provider delivery fenced mutation time is invalid")]
+    InvalidFencedTime,
+    /// Retry deadline was nonfuture or beyond the hard delay bound.
+    #[error("provider delivery retry deadline is invalid")]
+    InvalidRetry,
+}
+
+/// Sanitized durable endpoint or delivery repository failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderDeliveryRepositoryError {
+    /// Endpoint revision was stale, noncontiguous, or disagreed with durable bytes.
+    #[error("provider webhook endpoint revision conflicts with durable state")]
+    EndpointConflict,
+    /// Referenced instance, connection, secret, endpoint, or delivery was absent.
+    #[error("provider delivery reference does not exist")]
+    NotFound,
+    /// An external delivery replay key was reused with different immutable evidence.
+    #[error("provider delivery replay evidence conflicts with durable state")]
+    ReplayConflict,
+    /// A claim fence was stale, expired, or owned by another worker.
+    #[error("provider delivery claim was rejected")]
+    ClaimRejected,
+    /// The hard attempt bound was reached.
+    #[error("provider delivery attempt limit was reached")]
+    AttemptLimitReached,
+    /// Durable rows violated provider model invariants.
+    #[error("provider delivery storage is corrupt")]
+    Corrupt,
+    /// The durable repository was unavailable.
+    #[error("provider delivery repository is unavailable")]
+    Unavailable,
+}
+
+fn validate_fenced_time(
+    fence: ProviderDeliveryClaimFence,
+    timestamp: UnixMillis,
+) -> Result<(), ProviderDeliveryModelError> {
+    if timestamp < fence.claimed_at() || timestamp >= fence.expires_at() {
+        return Err(ProviderDeliveryModelError::InvalidFencedTime);
+    }
+    Ok(())
+}
+
+fn part(hash: &mut Sha256, value: &[u8]) {
+    hash.update((value.len() as u64).to_be_bytes());
+    hash.update(value);
+}
+
+const fn rejection_name(rejection: ProviderDeliveryRejection) -> &'static str {
+    match rejection {
+        ProviderDeliveryRejection::UnknownEvent => "unknown-event",
+        ProviderDeliveryRejection::UnsupportedEvent => "unsupported-event",
+        ProviderDeliveryRejection::IncompleteEvent => "incomplete-event",
+        ProviderDeliveryRejection::PayloadIdentityMismatch => "payload-identity-mismatch",
+        ProviderDeliveryRejection::InvalidPayload => "invalid-payload",
+    }
+}

--- a/crates/automata-ci-provider/src/identity.rs
+++ b/crates/automata-ci-provider/src/identity.rs
@@ -181,6 +181,21 @@ uuid_identity!(
     ProviderConnectionId,
     "provider connection ID"
 );
+uuid_identity!(
+    /// Opaque public identity of one connection-bound webhook endpoint.
+    ProviderWebhookEndpointId,
+    "provider webhook endpoint ID"
+);
+uuid_identity!(
+    /// Durable server-owned identity of one authenticated provider delivery.
+    ProviderDeliveryId,
+    "provider delivery ID"
+);
+uuid_identity!(
+    /// Durable identity of one provider-delivery worker.
+    ProviderDeliveryWorkerId,
+    "provider delivery worker ID"
+);
 
 macro_rules! external_identity {
     ($(#[$meta:meta])* $name:ident, $field:literal) => {
@@ -258,6 +273,16 @@ external_identity!(
     /// Provider-native webhook delivery identity, interpreted within one provider instance.
     ExternalDeliveryId,
     "external delivery ID"
+);
+external_identity!(
+    /// Provider-native pull-request or merge-request identity.
+    ExternalChangeId,
+    "external change ID"
+);
+external_identity!(
+    /// Provider-native merge-queue entry or candidate identity.
+    ExternalMergeQueueId,
+    "external merge-queue ID"
 );
 
 /// Instance-scoped provider-native repository identity.

--- a/crates/automata-ci-provider/src/lib.rs
+++ b/crates/automata-ci-provider/src/lib.rs
@@ -10,9 +10,12 @@
 mod capability;
 mod configuration;
 mod connection;
+mod delivery;
 mod factory;
 mod identity;
 mod storage;
+mod trigger;
+mod webhook;
 
 pub use capability::{
     AuthorizationCodeLoginCapability, ChangedFileCapability, ChangedFileCompleteness,
@@ -40,18 +43,52 @@ pub use connection::{
     ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderWorkflowSource,
     RepositoryVisibility,
 };
+pub use delivery::{
+    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
+    CompleteProviderDelivery, FailProviderDelivery, MAX_PROVIDER_DELIVERY_ATTEMPTS,
+    MAX_PROVIDER_DELIVERY_LEASE_MILLIS, MAX_PROVIDER_DELIVERY_RETRY_MILLIS, ProviderDelivery,
+    ProviderDeliveryAcceptOutcome, ProviderDeliveryClaimFence, ProviderDeliveryFailure,
+    ProviderDeliveryFuture, ProviderDeliveryModelError, ProviderDeliveryReceipt,
+    ProviderDeliveryReplayFingerprint, ProviderDeliveryRepository, ProviderDeliveryRepositoryError,
+    ProviderDeliveryState, ProviderWebhookEndpointRecord, ProviderWebhookEndpointRepository,
+    RetryProviderDelivery,
+};
 pub use factory::{
     MAX_PROVIDER_FACTORIES, ProviderConfigurationFactory, ProviderConnectionFactoryRequest,
     ProviderDescriptor, ProviderFactoryRegistry, ProviderFactoryRegistryError,
     ProviderFactoryRequest, ProviderFactoryValidationError,
 };
 pub use identity::{
-    ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity,
-    ExternalSubjectId, ExternalSubjectIdentity, ExternalSubjectKind, MAX_EXTERNAL_ID_BYTES,
-    MAX_PROVIDER_TYPE_ID_BYTES, ProviderConnectionId, ProviderIdentityError, ProviderInstanceId,
-    ProviderTypeId,
+    ExternalChangeId, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalMergeQueueId,
+    ExternalRepositoryId, ExternalRepositoryIdentity, ExternalSubjectId, ExternalSubjectIdentity,
+    ExternalSubjectKind, MAX_EXTERNAL_ID_BYTES, MAX_PROVIDER_TYPE_ID_BYTES, ProviderConnectionId,
+    ProviderDeliveryId, ProviderDeliveryWorkerId, ProviderIdentityError, ProviderInstanceId,
+    ProviderTypeId, ProviderWebhookEndpointId,
 };
 pub use storage::{
     ProviderInstanceRecord, ProviderManifestRepository, ProviderRepositoryError,
     ProviderRepositoryFuture, ProviderSaveOutcome,
+};
+pub use trigger::{
+    MAX_NORMALIZED_TRIGGER_BYTES, MAX_PROVIDER_DISPATCH_INPUT_BYTES, MAX_PROVIDER_EVENT_NAME_BYTES,
+    MergeQueueActivity, MergeQueueTrigger, NormalizedTrigger, ProviderDispatchInput,
+    ProviderEventName, ProviderGitRef, ProviderGitRefKind, ProviderRepository,
+    ProviderTriggerError, PullRequestActivity, PullRequestTrigger, PushTrigger,
+    RepositoryDispatchTrigger, SealedNormalizedTrigger,
+};
+pub use webhook::{
+    AuthenticatedProviderWebhook, DeliveryAdapter, DeliveryAdapterRegistry,
+    DeliveryAdapterRegistryError, MAX_PROVIDER_DELIVERY_OBSERVATION_BYTES,
+    MAX_PROVIDER_RAW_WEBHOOK_RETENTION_MILLIS, MAX_PROVIDER_WEBHOOK_BODY_BYTES,
+    MAX_PROVIDER_WEBHOOK_HEADER_BYTES, MAX_PROVIDER_WEBHOOK_HEADER_NAME_BYTES,
+    MAX_PROVIDER_WEBHOOK_HEADER_VALUE_BYTES, MAX_PROVIDER_WEBHOOK_HEADERS,
+    MAX_PROVIDER_WEBHOOK_SECRET_CANDIDATES, PROVIDER_RAW_WEBHOOK_KEY_PREFIX,
+    PROVIDER_RAW_WEBHOOK_MEDIA_TYPE, ProviderDeliveryDraft, ProviderDeliveryNormalization,
+    ProviderDeliveryObservations, ProviderDeliveryRejection, ProviderWebhookAuthenticationError,
+    ProviderWebhookAuthenticationRequest, ProviderWebhookEndpointManifest,
+    ProviderWebhookEndpointRevision, ProviderWebhookEndpointState, ProviderWebhookError,
+    ProviderWebhookHeaderName, ProviderWebhookHeaders, ProviderWebhookMethod,
+    ProviderWebhookRequest, ProviderWebhookSecretCandidate, ProviderWebhookSecretCandidates,
+    ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, RejectedProviderDelivery,
+    RejectedProviderDeliveryDraft, VerifiedProviderDelivery, provider_raw_webhook_descriptor,
 };

--- a/crates/automata-ci-provider/src/trigger.rs
+++ b/crates/automata-ci-provider/src/trigger.rs
@@ -1,0 +1,988 @@
+//! Provider-neutral, authenticated webhook trigger facts.
+
+use std::fmt;
+
+use automata_ci_core::{GitObjectId, Sha256Digest};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    ExternalChangeId, ExternalMergeQueueId, ExternalRepositoryIdentity, ExternalSubjectIdentity,
+    ProviderDefaultBranch, ProviderRepositoryPath, RepositoryVisibility,
+};
+
+/// Maximum UTF-8 bytes in a provider-native event or activity name.
+pub const MAX_PROVIDER_EVENT_NAME_BYTES: usize = 128;
+/// Maximum canonical bytes retained from repository-dispatch input.
+pub const MAX_PROVIDER_DISPATCH_INPUT_BYTES: usize = 32 * 1_024;
+/// Maximum canonical bytes in one normalized trigger document.
+pub const MAX_NORMALIZED_TRIGGER_BYTES: usize = 64 * 1_024;
+
+const TRIGGER_DIGEST_DOMAIN: &[u8] = b"automata.provider.normalized-trigger.v1\0";
+const DISPATCH_INPUT_DIGEST_DOMAIN: &[u8] = b"automata.provider.dispatch-input.v1\0";
+
+/// Bounded provider-native event name retained as authenticated evidence.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ProviderEventName(String);
+
+impl ProviderEventName {
+    /// Validates a nonempty, trimmed event name without control characters.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, untrimmed, control-bearing, or oversized names.
+    pub fn new(value: impl Into<String>) -> Result<Self, ProviderTriggerError> {
+        let value = value.into();
+        validate_text(&value, MAX_PROVIDER_EVENT_NAME_BYTES)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the exact provider-native event name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for ProviderEventName {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ProviderEventName> for String {
+    fn from(value: ProviderEventName) -> Self {
+        value.0
+    }
+}
+
+/// Complete authenticated repository facts used by admission.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderRepository {
+    identity: ExternalRepositoryIdentity,
+    path: ProviderRepositoryPath,
+    visibility: RepositoryVisibility,
+}
+
+impl ProviderRepository {
+    /// Binds stable repository identity to its authenticated path and visibility.
+    #[must_use]
+    pub const fn new(
+        identity: ExternalRepositoryIdentity,
+        path: ProviderRepositoryPath,
+        visibility: RepositoryVisibility,
+    ) -> Self {
+        Self {
+            identity,
+            path,
+            visibility,
+        }
+    }
+
+    /// Returns the instance-scoped stable repository identity.
+    #[must_use]
+    pub const fn identity(&self) -> &ExternalRepositoryIdentity {
+        &self.identity
+    }
+
+    /// Returns the authenticated provider path retained for display and audit.
+    #[must_use]
+    pub const fn path(&self) -> &ProviderRepositoryPath {
+        &self.path
+    }
+
+    /// Returns authenticated repository visibility.
+    #[must_use]
+    pub const fn visibility(&self) -> RepositoryVisibility {
+        self.visibility
+    }
+}
+
+/// Provider-independent Git reference class.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderGitRefKind {
+    /// A reference below `refs/heads/`.
+    Branch,
+    /// A reference below `refs/tags/`.
+    Tag,
+}
+
+/// Exact full branch or tag reference authenticated by a provider.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "UncheckedProviderGitRef")]
+pub struct ProviderGitRef {
+    full: String,
+    kind: ProviderGitRefKind,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedProviderGitRef {
+    full: String,
+    kind: ProviderGitRefKind,
+}
+
+impl ProviderGitRef {
+    /// Validates a full branch or tag reference and its declared namespace.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an invalid Git ref, unsupported namespace, or mismatched kind.
+    pub fn new(
+        full: impl Into<String>,
+        kind: ProviderGitRefKind,
+    ) -> Result<Self, ProviderTriggerError> {
+        let full = full.into();
+        let prefix = match kind {
+            ProviderGitRefKind::Branch => "refs/heads/",
+            ProviderGitRefKind::Tag => "refs/tags/",
+        };
+        let Some(short) = full.strip_prefix(prefix) else {
+            return Err(ProviderTriggerError::InvalidGitRef);
+        };
+        if !valid_ref_name(short) {
+            return Err(ProviderTriggerError::InvalidGitRef);
+        }
+        if kind == ProviderGitRefKind::Branch
+            && ProviderDefaultBranch::new(short.to_owned()).is_err()
+        {
+            return Err(ProviderTriggerError::InvalidGitRef);
+        }
+        Ok(Self { full, kind })
+    }
+
+    /// Returns the full `refs/heads/...` or `refs/tags/...` name.
+    #[must_use]
+    pub fn full(&self) -> &str {
+        &self.full
+    }
+
+    /// Returns the unqualified ref name.
+    #[must_use]
+    pub fn short_name(&self) -> &str {
+        match self.kind {
+            ProviderGitRefKind::Branch => &self.full["refs/heads/".len()..],
+            ProviderGitRefKind::Tag => &self.full["refs/tags/".len()..],
+        }
+    }
+
+    /// Returns whether this is a branch or tag.
+    #[must_use]
+    pub const fn kind(&self) -> ProviderGitRefKind {
+        self.kind
+    }
+}
+
+impl TryFrom<UncheckedProviderGitRef> for ProviderGitRef {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: UncheckedProviderGitRef) -> Result<Self, Self::Error> {
+        Self::new(value.full, value.kind)
+    }
+}
+
+/// Authenticated push trigger.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedPushTrigger")]
+pub struct PushTrigger {
+    repository: ProviderRepository,
+    git_ref: ProviderGitRef,
+    before: Option<GitObjectId>,
+    after: Option<GitObjectId>,
+    forced: bool,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedPushTrigger {
+    repository: ProviderRepository,
+    git_ref: ProviderGitRef,
+    before: Option<GitObjectId>,
+    after: Option<GitObjectId>,
+    forced: bool,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+impl PushTrigger {
+    /// Constructs a push, creation, or deletion with exact object identities.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absent before and after identities, algorithm drift, or identities
+    /// belonging to another provider instance.
+    pub fn new(
+        repository: ProviderRepository,
+        git_ref: ProviderGitRef,
+        before: Option<GitObjectId>,
+        after: Option<GitObjectId>,
+        forced: bool,
+        actor: Option<ExternalSubjectIdentity>,
+    ) -> Result<Self, ProviderTriggerError> {
+        if before.is_none() && after.is_none() {
+            return Err(ProviderTriggerError::MissingObjectIdentity);
+        }
+        if before
+            .zip(after)
+            .is_some_and(|(before, after)| before.algorithm() != after.algorithm())
+        {
+            return Err(ProviderTriggerError::ObjectAlgorithmMismatch);
+        }
+        validate_subject_instance(repository.identity(), actor.as_ref())?;
+        Ok(Self {
+            repository,
+            git_ref,
+            before,
+            after,
+            forced,
+            actor,
+        })
+    }
+
+    /// Returns the repository receiving the reference update.
+    #[must_use]
+    pub const fn repository(&self) -> &ProviderRepository {
+        &self.repository
+    }
+
+    /// Returns the updated reference.
+    #[must_use]
+    pub const fn git_ref(&self) -> &ProviderGitRef {
+        &self.git_ref
+    }
+
+    /// Returns the pre-update object, or absence for creation.
+    #[must_use]
+    pub const fn before(&self) -> Option<GitObjectId> {
+        self.before
+    }
+
+    /// Returns the post-update object, or absence for deletion.
+    #[must_use]
+    pub const fn after(&self) -> Option<GitObjectId> {
+        self.after
+    }
+
+    /// Returns whether the provider authenticated a forced update.
+    #[must_use]
+    pub const fn forced(&self) -> bool {
+        self.forced
+    }
+
+    /// Returns the triggering actor when supplied by the provider.
+    #[must_use]
+    pub const fn actor(&self) -> Option<&ExternalSubjectIdentity> {
+        self.actor.as_ref()
+    }
+}
+
+impl TryFrom<UncheckedPushTrigger> for PushTrigger {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: UncheckedPushTrigger) -> Result<Self, Self::Error> {
+        Self::new(
+            value.repository,
+            value.git_ref,
+            value.before,
+            value.after,
+            value.forced,
+            value.actor,
+        )
+    }
+}
+
+/// Provider-independent pull-request lifecycle activity.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestActivity {
+    /// A change was opened.
+    Opened,
+    /// A previously closed change was reopened.
+    Reopened,
+    /// The source ref changed.
+    Synchronized,
+    /// The change was closed without merging.
+    Closed,
+    /// The change was merged.
+    Merged,
+    /// A draft became ready for review.
+    ReadyForReview,
+    /// A reviewable change became a draft.
+    ConvertedToDraft,
+    /// Metadata affecting workflow selection changed.
+    MetadataChanged,
+}
+
+/// Authenticated pull-request or merge-request trigger.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedPullRequestTrigger")]
+pub struct PullRequestTrigger {
+    change_id: ExternalChangeId,
+    activity: PullRequestActivity,
+    target_repository: ProviderRepository,
+    source_repository: ProviderRepository,
+    base_ref: ProviderGitRef,
+    head_ref: ProviderGitRef,
+    base_object: GitObjectId,
+    head_object: GitObjectId,
+    merge_object: Option<GitObjectId>,
+    draft: bool,
+    actor: Option<ExternalSubjectIdentity>,
+    author: Option<ExternalSubjectIdentity>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedPullRequestTrigger {
+    change_id: ExternalChangeId,
+    activity: PullRequestActivity,
+    target_repository: ProviderRepository,
+    source_repository: ProviderRepository,
+    base_ref: ProviderGitRef,
+    head_ref: ProviderGitRef,
+    base_object: GitObjectId,
+    head_object: GitObjectId,
+    merge_object: Option<GitObjectId>,
+    draft: bool,
+    actor: Option<ExternalSubjectIdentity>,
+    author: Option<ExternalSubjectIdentity>,
+}
+
+impl PullRequestTrigger {
+    /// Constructs exact source and target facts for one change event.
+    ///
+    /// # Errors
+    ///
+    /// Rejects cross-instance evidence, non-branch refs, or object-algorithm drift.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        change_id: ExternalChangeId,
+        activity: PullRequestActivity,
+        target_repository: ProviderRepository,
+        source_repository: ProviderRepository,
+        base_ref: ProviderGitRef,
+        head_ref: ProviderGitRef,
+        base_object: GitObjectId,
+        head_object: GitObjectId,
+        merge_object: Option<GitObjectId>,
+        draft: bool,
+        actor: Option<ExternalSubjectIdentity>,
+        author: Option<ExternalSubjectIdentity>,
+    ) -> Result<Self, ProviderTriggerError> {
+        if base_ref.kind() != ProviderGitRefKind::Branch
+            || head_ref.kind() != ProviderGitRefKind::Branch
+        {
+            return Err(ProviderTriggerError::InvalidGitRef);
+        }
+        let instance_id = target_repository.identity().instance_id();
+        if source_repository.identity().instance_id() != instance_id
+            || actor
+                .as_ref()
+                .is_some_and(|value| value.instance_id() != instance_id)
+            || author
+                .as_ref()
+                .is_some_and(|value| value.instance_id() != instance_id)
+        {
+            return Err(ProviderTriggerError::InstanceMismatch);
+        }
+        if base_object.algorithm() != head_object.algorithm()
+            || merge_object.is_some_and(|value| value.algorithm() != head_object.algorithm())
+        {
+            return Err(ProviderTriggerError::ObjectAlgorithmMismatch);
+        }
+        Ok(Self {
+            change_id,
+            activity,
+            target_repository,
+            source_repository,
+            base_ref,
+            head_ref,
+            base_object,
+            head_object,
+            merge_object,
+            draft,
+            actor,
+            author,
+        })
+    }
+
+    /// Returns the provider-native change identity.
+    #[must_use]
+    pub const fn change_id(&self) -> &ExternalChangeId {
+        &self.change_id
+    }
+
+    /// Returns the normalized lifecycle activity.
+    #[must_use]
+    pub const fn activity(&self) -> PullRequestActivity {
+        self.activity
+    }
+
+    /// Returns the repository in whose security context workflows execute.
+    #[must_use]
+    pub const fn target_repository(&self) -> &ProviderRepository {
+        &self.target_repository
+    }
+
+    /// Returns the authoritative source repository.
+    #[must_use]
+    pub const fn source_repository(&self) -> &ProviderRepository {
+        &self.source_repository
+    }
+
+    /// Returns the exact target object.
+    #[must_use]
+    pub const fn base_object(&self) -> GitObjectId {
+        self.base_object
+    }
+
+    /// Returns the exact source object.
+    #[must_use]
+    pub const fn head_object(&self) -> GitObjectId {
+        self.head_object
+    }
+
+    /// Returns an authenticated merge candidate when the provider supplied one.
+    #[must_use]
+    pub const fn merge_object(&self) -> Option<GitObjectId> {
+        self.merge_object
+    }
+
+    /// Returns whether the change was a draft at delivery time.
+    #[must_use]
+    pub const fn draft(&self) -> bool {
+        self.draft
+    }
+}
+
+impl TryFrom<UncheckedPullRequestTrigger> for PullRequestTrigger {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: UncheckedPullRequestTrigger) -> Result<Self, Self::Error> {
+        Self::new(
+            value.change_id,
+            value.activity,
+            value.target_repository,
+            value.source_repository,
+            value.base_ref,
+            value.head_ref,
+            value.base_object,
+            value.head_object,
+            value.merge_object,
+            value.draft,
+            value.actor,
+            value.author,
+        )
+    }
+}
+
+/// Provider-independent merge-queue lifecycle activity.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeQueueActivity {
+    /// A merge candidate entered or changed in the queue.
+    Queued,
+    /// A candidate was removed or invalidated.
+    Removed,
+}
+
+/// Authenticated merge-queue candidate trigger.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedMergeQueueTrigger")]
+pub struct MergeQueueTrigger {
+    queue_id: ExternalMergeQueueId,
+    activity: MergeQueueActivity,
+    repository: ProviderRepository,
+    target_ref: ProviderGitRef,
+    target_object: GitObjectId,
+    candidate_object: GitObjectId,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedMergeQueueTrigger {
+    queue_id: ExternalMergeQueueId,
+    activity: MergeQueueActivity,
+    repository: ProviderRepository,
+    target_ref: ProviderGitRef,
+    target_object: GitObjectId,
+    candidate_object: GitObjectId,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+impl MergeQueueTrigger {
+    /// Constructs one exact merge-queue candidate.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-branch targets, object-algorithm drift, or cross-instance actors.
+    pub fn new(
+        queue_id: ExternalMergeQueueId,
+        activity: MergeQueueActivity,
+        repository: ProviderRepository,
+        target_ref: ProviderGitRef,
+        target_object: GitObjectId,
+        candidate_object: GitObjectId,
+        actor: Option<ExternalSubjectIdentity>,
+    ) -> Result<Self, ProviderTriggerError> {
+        if target_ref.kind() != ProviderGitRefKind::Branch {
+            return Err(ProviderTriggerError::InvalidGitRef);
+        }
+        if target_object.algorithm() != candidate_object.algorithm() {
+            return Err(ProviderTriggerError::ObjectAlgorithmMismatch);
+        }
+        validate_subject_instance(repository.identity(), actor.as_ref())?;
+        Ok(Self {
+            queue_id,
+            activity,
+            repository,
+            target_ref,
+            target_object,
+            candidate_object,
+            actor,
+        })
+    }
+
+    /// Returns the merge-queue candidate identity.
+    #[must_use]
+    pub const fn queue_id(&self) -> &ExternalMergeQueueId {
+        &self.queue_id
+    }
+
+    /// Returns the normalized queue activity.
+    #[must_use]
+    pub const fn activity(&self) -> MergeQueueActivity {
+        self.activity
+    }
+
+    /// Returns the target repository.
+    #[must_use]
+    pub const fn repository(&self) -> &ProviderRepository {
+        &self.repository
+    }
+
+    /// Returns the exact synthetic candidate object.
+    #[must_use]
+    pub const fn candidate_object(&self) -> GitObjectId {
+        self.candidate_object
+    }
+}
+
+impl TryFrom<UncheckedMergeQueueTrigger> for MergeQueueTrigger {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: UncheckedMergeQueueTrigger) -> Result<Self, Self::Error> {
+        Self::new(
+            value.queue_id,
+            value.activity,
+            value.repository,
+            value.target_ref,
+            value.target_object,
+            value.candidate_object,
+            value.actor,
+        )
+    }
+}
+
+/// Bounded canonical repository-dispatch input retained for admission.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderDispatchInput {
+    canonical_bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl ProviderDispatchInput {
+    /// Accepts an exact canonical adapter encoding.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized input. Empty input is a valid empty dispatch document.
+    pub fn new(canonical_bytes: Vec<u8>) -> Result<Self, ProviderTriggerError> {
+        if canonical_bytes.len() > MAX_PROVIDER_DISPATCH_INPUT_BYTES {
+            return Err(ProviderTriggerError::DispatchInputTooLarge);
+        }
+        let mut hash = Sha256::new();
+        hash.update(DISPATCH_INPUT_DIGEST_DOMAIN);
+        hash.update((canonical_bytes.len() as u64).to_be_bytes());
+        hash.update(&canonical_bytes);
+        Ok(Self {
+            canonical_bytes,
+            digest: Sha256Digest::from_bytes(hash.finalize().into()),
+        })
+    }
+
+    /// Returns exact canonical adapter bytes.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    /// Returns the domain-separated input digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl fmt::Debug for ProviderDispatchInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderDispatchInput")
+            .field("canonical_bytes", &"[CANONICAL]")
+            .field("byte_length", &self.canonical_bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+impl Serialize for ProviderDispatchInput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&URL_SAFE_NO_PAD.encode(&self.canonical_bytes))
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderDispatchInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        let bytes = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .map_err(serde::de::Error::custom)?;
+        Self::new(bytes).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Authenticated custom repository-dispatch trigger.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "UncheckedRepositoryDispatchTrigger")]
+pub struct RepositoryDispatchTrigger {
+    repository: ProviderRepository,
+    event_type: ProviderEventName,
+    input: ProviderDispatchInput,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UncheckedRepositoryDispatchTrigger {
+    repository: ProviderRepository,
+    event_type: ProviderEventName,
+    input: ProviderDispatchInput,
+    actor: Option<ExternalSubjectIdentity>,
+}
+
+impl RepositoryDispatchTrigger {
+    /// Constructs a bounded custom event.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an actor from another provider instance.
+    pub fn new(
+        repository: ProviderRepository,
+        event_type: ProviderEventName,
+        input: ProviderDispatchInput,
+        actor: Option<ExternalSubjectIdentity>,
+    ) -> Result<Self, ProviderTriggerError> {
+        validate_subject_instance(repository.identity(), actor.as_ref())?;
+        Ok(Self {
+            repository,
+            event_type,
+            input,
+            actor,
+        })
+    }
+
+    /// Returns the target repository.
+    #[must_use]
+    pub const fn repository(&self) -> &ProviderRepository {
+        &self.repository
+    }
+
+    /// Returns the provider-normalized custom event type.
+    #[must_use]
+    pub const fn event_type(&self) -> &ProviderEventName {
+        &self.event_type
+    }
+
+    /// Returns bounded canonical dispatch input.
+    #[must_use]
+    pub const fn input(&self) -> &ProviderDispatchInput {
+        &self.input
+    }
+}
+
+impl TryFrom<UncheckedRepositoryDispatchTrigger> for RepositoryDispatchTrigger {
+    type Error = ProviderTriggerError;
+
+    fn try_from(value: UncheckedRepositoryDispatchTrigger) -> Result<Self, Self::Error> {
+        Self::new(value.repository, value.event_type, value.input, value.actor)
+    }
+}
+
+/// Closed set of webhook sources that may enter workflow admission.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "facts", rename_all = "snake_case")]
+pub enum NormalizedTrigger {
+    /// A branch or tag update.
+    Push(PushTrigger),
+    /// A pull request or merge request.
+    PullRequest(PullRequestTrigger),
+    /// A provider merge-queue candidate.
+    MergeQueue(MergeQueueTrigger),
+    /// A provider-authenticated custom repository event.
+    RepositoryDispatch(RepositoryDispatchTrigger),
+}
+
+impl NormalizedTrigger {
+    /// Returns the repository in whose security context admission occurs.
+    #[must_use]
+    pub const fn target_repository(&self) -> &ProviderRepository {
+        match self {
+            Self::Push(value) => value.repository(),
+            Self::PullRequest(value) => value.target_repository(),
+            Self::MergeQueue(value) => value.repository(),
+            Self::RepositoryDispatch(value) => value.repository(),
+        }
+    }
+
+    /// Encodes a bounded canonical trigger document and its domain-separated digest.
+    ///
+    /// # Errors
+    ///
+    /// Fails if serialization fails or exceeds the durable normalized-event bound.
+    pub fn seal(&self) -> Result<SealedNormalizedTrigger, ProviderTriggerError> {
+        let bytes = serde_json::to_vec(self).map_err(|_| ProviderTriggerError::Encoding)?;
+        if bytes.len() > MAX_NORMALIZED_TRIGGER_BYTES {
+            return Err(ProviderTriggerError::NormalizedTriggerTooLarge);
+        }
+        SealedNormalizedTrigger::from_canonical_bytes(bytes)
+    }
+}
+
+/// Exact canonical normalized-trigger bytes and identity.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SealedNormalizedTrigger {
+    trigger: NormalizedTrigger,
+    canonical_bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl SealedNormalizedTrigger {
+    /// Strictly decodes and byte-for-byte verifies canonical trigger bytes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed, noncanonical, or oversized bytes.
+    pub fn from_canonical_bytes(canonical_bytes: Vec<u8>) -> Result<Self, ProviderTriggerError> {
+        if canonical_bytes.is_empty() || canonical_bytes.len() > MAX_NORMALIZED_TRIGGER_BYTES {
+            return Err(ProviderTriggerError::NormalizedTriggerTooLarge);
+        }
+        let trigger: NormalizedTrigger =
+            serde_json::from_slice(&canonical_bytes).map_err(|_| ProviderTriggerError::Encoding)?;
+        let encoded = serde_json::to_vec(&trigger).map_err(|_| ProviderTriggerError::Encoding)?;
+        if encoded != canonical_bytes {
+            return Err(ProviderTriggerError::NonCanonicalEncoding);
+        }
+        let mut hash = Sha256::new();
+        hash.update(TRIGGER_DIGEST_DOMAIN);
+        hash.update((canonical_bytes.len() as u64).to_be_bytes());
+        hash.update(&canonical_bytes);
+        Ok(Self {
+            trigger,
+            canonical_bytes,
+            digest: Sha256Digest::from_bytes(hash.finalize().into()),
+        })
+    }
+
+    /// Returns strongly typed normalized facts.
+    #[must_use]
+    pub const fn trigger(&self) -> &NormalizedTrigger {
+        &self.trigger
+    }
+
+    /// Returns exact canonical bytes.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    /// Returns the domain-separated trigger digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl fmt::Debug for SealedNormalizedTrigger {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SealedNormalizedTrigger")
+            .field("trigger", &self.trigger)
+            .field("canonical_bytes", &"[CANONICAL]")
+            .field("byte_length", &self.canonical_bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+fn validate_subject_instance(
+    repository: &ExternalRepositoryIdentity,
+    actor: Option<&ExternalSubjectIdentity>,
+) -> Result<(), ProviderTriggerError> {
+    if actor.is_some_and(|actor| actor.instance_id() != repository.instance_id()) {
+        return Err(ProviderTriggerError::InstanceMismatch);
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, maximum: usize) -> Result<(), ProviderTriggerError> {
+    if value.is_empty() || value.trim() != value {
+        return Err(ProviderTriggerError::InvalidEventName);
+    }
+    if value.len() > maximum || value.chars().any(char::is_control) {
+        return Err(ProviderTriggerError::InvalidEventName);
+    }
+    Ok(())
+}
+
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn valid_ref_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 1_024
+        && value != "@"
+        && !value.starts_with(['-', '/', '.'])
+        && !value.ends_with(['/', '.'])
+        && !value.ends_with(".lock")
+        && !value.contains("//")
+        && !value.contains("..")
+        && !value.contains("@{")
+        && !value.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '~' | '^' | ':' | '?' | '*' | '[' | '\\')
+        })
+}
+
+/// Invalid normalized trigger evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderTriggerError {
+    /// An event name violated the bounded untrusted-text contract.
+    #[error("provider event name is invalid")]
+    InvalidEventName,
+    /// A branch or tag reference was malformed or inconsistent.
+    #[error("provider Git reference is invalid")]
+    InvalidGitRef,
+    /// A push contained neither a before nor after object.
+    #[error("provider trigger is missing an exact Git object identity")]
+    MissingObjectIdentity,
+    /// Exact objects from one repository event used different hash algorithms.
+    #[error("provider trigger Git object algorithms disagree")]
+    ObjectAlgorithmMismatch,
+    /// Provider-native identities crossed configured instance namespaces.
+    #[error("provider trigger identities belong to different instances")]
+    InstanceMismatch,
+    /// Canonical repository-dispatch input exceeded its bound.
+    #[error("provider repository-dispatch input exceeds its maximum size")]
+    DispatchInputTooLarge,
+    /// A normalized trigger exceeded its durable bound.
+    #[error("normalized provider trigger exceeds its maximum size")]
+    NormalizedTriggerTooLarge,
+    /// Strongly typed trigger encoding or decoding failed.
+    #[error("normalized provider trigger encoding is invalid")]
+    Encoding,
+    /// Supplied bytes decoded but were not the exact canonical representation.
+    #[error("normalized provider trigger is not canonically encoded")]
+    NonCanonicalEncoding,
+}
+
+#[cfg(test)]
+mod tests {
+    use automata_ci_core::GitObjectAlgorithm;
+
+    use super::*;
+    use crate::{ExternalRepositoryId, ProviderInstanceId};
+
+    fn object(hex: char) -> GitObjectId {
+        GitObjectId::from_hex(GitObjectAlgorithm::Sha1, &hex.to_string().repeat(40))
+            .expect("valid object")
+    }
+
+    fn repository(instance_id: ProviderInstanceId) -> ProviderRepository {
+        ProviderRepository::new(
+            ExternalRepositoryIdentity::new(
+                instance_id,
+                ExternalRepositoryId::new("42").expect("repository ID"),
+            ),
+            ProviderRepositoryPath::new("owner/repository").expect("repository path"),
+            RepositoryVisibility::Private,
+        )
+    }
+
+    #[test]
+    fn push_round_trip_is_canonical_and_algorithm_bearing() {
+        let trigger = NormalizedTrigger::Push(
+            PushTrigger::new(
+                repository(ProviderInstanceId::new()),
+                ProviderGitRef::new("refs/heads/main", ProviderGitRefKind::Branch).expect("branch"),
+                Some(object('a')),
+                Some(object('b')),
+                false,
+                None,
+            )
+            .expect("push"),
+        );
+
+        let sealed = trigger.seal().expect("sealed trigger");
+        let decoded =
+            SealedNormalizedTrigger::from_canonical_bytes(sealed.canonical_bytes().to_vec())
+                .expect("canonical round trip");
+        assert_eq!(decoded, sealed);
+    }
+
+    #[test]
+    fn cross_instance_pull_request_is_rejected() {
+        let result = PullRequestTrigger::new(
+            ExternalChangeId::new("7").expect("change ID"),
+            PullRequestActivity::Opened,
+            repository(ProviderInstanceId::new()),
+            repository(ProviderInstanceId::new()),
+            ProviderGitRef::new("refs/heads/main", ProviderGitRefKind::Branch).expect("base"),
+            ProviderGitRef::new("refs/heads/topic", ProviderGitRefKind::Branch).expect("head"),
+            object('a'),
+            object('b'),
+            None,
+            false,
+            None,
+            None,
+        );
+
+        assert_eq!(result, Err(ProviderTriggerError::InstanceMismatch));
+    }
+
+    #[test]
+    fn all_zero_deletion_sentinel_is_represented_as_absence() {
+        let result = PushTrigger::new(
+            repository(ProviderInstanceId::new()),
+            ProviderGitRef::new("refs/tags/v1", ProviderGitRefKind::Tag).expect("tag"),
+            None,
+            None,
+            false,
+            None,
+        );
+
+        assert_eq!(result, Err(ProviderTriggerError::MissingObjectIdentity));
+    }
+}

--- a/crates/automata-ci-provider/src/webhook.rs
+++ b/crates/automata-ci-provider/src/webhook.rs
@@ -1,0 +1,1684 @@
+//! Opaque webhook endpoints and authenticate-before-parse adapter contracts.
+
+use std::{collections::BTreeMap, fmt, num::NonZeroU64, sync::Arc};
+
+use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_key_management::SecretBytes;
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{
+    ExternalDeliveryIdentity, ExternalRepositoryIdentity, NormalizedTrigger,
+    ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionRevision,
+    ProviderDeliveryId, ProviderEventName, ProviderInstanceId, ProviderSecret,
+    ProviderSecretGeneration, ProviderSecretName, ProviderTriggerError, ProviderTypeId,
+    ProviderWebhookEndpointId, SealedNormalizedTrigger,
+};
+
+/// Hard upper bound for any provider webhook body.
+pub const MAX_PROVIDER_WEBHOOK_BODY_BYTES: u64 = 32 * 1_024 * 1_024;
+/// Maximum retention duration for authenticated raw webhook evidence.
+pub const MAX_PROVIDER_RAW_WEBHOOK_RETENTION_MILLIS: u64 = 365 * 24 * 60 * 60 * 1_000;
+/// Maximum selected headers passed to a delivery adapter.
+pub const MAX_PROVIDER_WEBHOOK_HEADERS: usize = 32;
+/// Maximum bytes in one selected header name.
+pub const MAX_PROVIDER_WEBHOOK_HEADER_NAME_BYTES: usize = 64;
+/// Maximum bytes in one selected header value.
+pub const MAX_PROVIDER_WEBHOOK_HEADER_VALUE_BYTES: usize = 4 * 1_024;
+/// Maximum total selected header bytes.
+pub const MAX_PROVIDER_WEBHOOK_HEADER_BYTES: usize = 16 * 1_024;
+/// Maximum simultaneous secret generations accepted by one endpoint.
+pub const MAX_PROVIDER_WEBHOOK_SECRET_CANDIDATES: usize = 4;
+/// Maximum canonical adapter observations retained with one delivery.
+pub const MAX_PROVIDER_DELIVERY_OBSERVATION_BYTES: usize = 16 * 1_024;
+/// Media type used for exact authenticated raw webhook bodies.
+pub const PROVIDER_RAW_WEBHOOK_MEDIA_TYPE: &str = "application/vnd.automata.provider-webhook-body";
+/// Content-addressed object-key prefix for authenticated webhook bodies.
+pub const PROVIDER_RAW_WEBHOOK_KEY_PREFIX: &str = "provider-deliveries/raw/sha256";
+
+const MAX_SIGNATURE_SCHEME_BYTES: usize = 64;
+const MAX_DELIVERY_ADAPTERS: usize = 32;
+
+/// Positive monotonic revision of one opaque endpoint.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ProviderWebhookEndpointRevision(NonZeroU64);
+
+impl ProviderWebhookEndpointRevision {
+    /// Creates a positive revision representable by `PostgreSQL BIGINT`.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero or a value beyond the signed durable range.
+    pub const fn new(value: u64) -> Result<Self, ProviderWebhookError> {
+        match NonZeroU64::new(value) {
+            Some(value) if value.get() <= i64::MAX as u64 => Ok(Self(value)),
+            _ => Err(ProviderWebhookError::InvalidEndpointRevision),
+        }
+    }
+
+    /// Returns the durable positive revision.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// Lifecycle of one public webhook endpoint.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ProviderWebhookEndpointState {
+    /// Requests may be authenticated and normalized.
+    Active,
+    /// The endpoint remains durable but rejects all requests.
+    Disabled,
+    /// The endpoint is terminal and cannot be reactivated.
+    Retired,
+}
+
+/// Exact named secret generation eligible for signature verification.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ProviderWebhookSecretReference {
+    configuration_revision: ProviderConfigurationRevision,
+    name: ProviderSecretName,
+    generation: ProviderSecretGeneration,
+}
+
+impl ProviderWebhookSecretReference {
+    /// Binds a canonical secret name to one exact generation.
+    #[must_use]
+    pub const fn new(
+        configuration_revision: ProviderConfigurationRevision,
+        name: ProviderSecretName,
+        generation: ProviderSecretGeneration,
+    ) -> Self {
+        Self {
+            configuration_revision,
+            name,
+            generation,
+        }
+    }
+
+    /// Returns the exact instance revision that owns the encrypted record.
+    #[must_use]
+    pub const fn configuration_revision(&self) -> ProviderConfigurationRevision {
+        self.configuration_revision
+    }
+
+    /// Returns the logical secret name.
+    #[must_use]
+    pub const fn name(&self) -> &ProviderSecretName {
+        &self.name
+    }
+
+    /// Returns the exact eligible generation.
+    #[must_use]
+    pub const fn generation(&self) -> ProviderSecretGeneration {
+        self.generation
+    }
+}
+
+/// Immutable connection-bound webhook endpoint revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderWebhookEndpointManifest {
+    endpoint_id: ProviderWebhookEndpointId,
+    revision: ProviderWebhookEndpointRevision,
+    state: ProviderWebhookEndpointState,
+    provider_type: ProviderTypeId,
+    instance_id: ProviderInstanceId,
+    provider_revision: ProviderConfigurationRevision,
+    connection_id: ProviderConnectionId,
+    connection_revision: ProviderConnectionRevision,
+    body_limit: NonZeroU64,
+    raw_retention_millis: NonZeroU64,
+    secret_references: Vec<ProviderWebhookSecretReference>,
+    created_at: UnixMillis,
+    retired_at: Option<UnixMillis>,
+}
+
+impl ProviderWebhookEndpointManifest {
+    /// Constructs one exact endpoint routing and verification policy revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid time evidence, body limits, empty/duplicate/excessive
+    /// secret references, or inconsistent retirement state.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        endpoint_id: ProviderWebhookEndpointId,
+        revision: ProviderWebhookEndpointRevision,
+        state: ProviderWebhookEndpointState,
+        provider_type: ProviderTypeId,
+        instance_id: ProviderInstanceId,
+        provider_revision: ProviderConfigurationRevision,
+        connection_id: ProviderConnectionId,
+        connection_revision: ProviderConnectionRevision,
+        body_limit: u64,
+        raw_retention_millis: u64,
+        mut secret_references: Vec<ProviderWebhookSecretReference>,
+        created_at: UnixMillis,
+        retired_at: Option<UnixMillis>,
+    ) -> Result<Self, ProviderWebhookError> {
+        let body_limit = NonZeroU64::new(body_limit)
+            .filter(|value| value.get() <= MAX_PROVIDER_WEBHOOK_BODY_BYTES)
+            .ok_or(ProviderWebhookError::InvalidBodyLimit)?;
+        let raw_retention_millis = NonZeroU64::new(raw_retention_millis)
+            .filter(|value| value.get() <= MAX_PROVIDER_RAW_WEBHOOK_RETENTION_MILLIS)
+            .ok_or(ProviderWebhookError::InvalidRawRetention)?;
+        secret_references.sort();
+        if secret_references.is_empty()
+            || secret_references.len() > MAX_PROVIDER_WEBHOOK_SECRET_CANDIDATES
+        {
+            return Err(ProviderWebhookError::InvalidSecretCandidates);
+        }
+        if secret_references.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(ProviderWebhookError::DuplicateSecretCandidate);
+        }
+        if created_at.get() < 0
+            || retired_at.is_some_and(|value| value.get() < created_at.get())
+            || (state == ProviderWebhookEndpointState::Retired) != retired_at.is_some()
+        {
+            return Err(ProviderWebhookError::InvalidEndpointLifecycle);
+        }
+        Ok(Self {
+            endpoint_id,
+            revision,
+            state,
+            provider_type,
+            instance_id,
+            provider_revision,
+            connection_id,
+            connection_revision,
+            body_limit,
+            raw_retention_millis,
+            secret_references,
+            created_at,
+            retired_at,
+        })
+    }
+
+    /// Returns the unguessable public endpoint identity.
+    #[must_use]
+    pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns the endpoint revision.
+    #[must_use]
+    pub const fn revision(&self) -> ProviderWebhookEndpointRevision {
+        self.revision
+    }
+
+    /// Returns endpoint lifecycle state.
+    #[must_use]
+    pub const fn state(&self) -> ProviderWebhookEndpointState {
+        self.state
+    }
+
+    /// Returns the exact delivery adapter registry key.
+    #[must_use]
+    pub const fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    /// Returns the configured provider instance.
+    #[must_use]
+    pub const fn instance_id(&self) -> ProviderInstanceId {
+        self.instance_id
+    }
+
+    /// Returns the exact provider configuration revision used by the adapter.
+    #[must_use]
+    pub const fn provider_revision(&self) -> ProviderConfigurationRevision {
+        self.provider_revision
+    }
+
+    /// Returns the only connection allowed to use this endpoint.
+    #[must_use]
+    pub const fn connection_id(&self) -> ProviderConnectionId {
+        self.connection_id
+    }
+
+    /// Returns the exact connection policy revision bound to ingress.
+    #[must_use]
+    pub const fn connection_revision(&self) -> ProviderConnectionRevision {
+        self.connection_revision
+    }
+
+    /// Returns the exact body byte limit applied before adapter invocation.
+    #[must_use]
+    pub const fn body_limit(&self) -> u64 {
+        self.body_limit.get()
+    }
+
+    /// Returns how long authenticated raw evidence must remain available.
+    #[must_use]
+    pub const fn raw_retention_millis(&self) -> u64 {
+        self.raw_retention_millis.get()
+    }
+
+    /// Returns the bounded exact secret generations eligible for verification.
+    #[must_use]
+    pub fn secret_references(&self) -> &[ProviderWebhookSecretReference] {
+        &self.secret_references
+    }
+
+    /// Returns endpoint creation evidence.
+    #[must_use]
+    pub const fn created_at(&self) -> UnixMillis {
+        self.created_at
+    }
+
+    /// Returns terminal retirement evidence.
+    #[must_use]
+    pub const fn retired_at(&self) -> Option<UnixMillis> {
+        self.retired_at
+    }
+
+    /// Validates a changed contiguous endpoint revision.
+    ///
+    /// # Errors
+    ///
+    /// Rejects identity rebinding, reactivation after retirement, time drift,
+    /// noncontiguous revisions, or an exact no-op.
+    pub fn validate_successor(&self, prior: &Self) -> Result<(), ProviderWebhookError> {
+        let next = prior
+            .revision
+            .get()
+            .checked_add(1)
+            .ok_or(ProviderWebhookError::InvalidEndpointSuccessor)?;
+        if self.endpoint_id != prior.endpoint_id
+            || self.revision.get() != next
+            || self.provider_type != prior.provider_type
+            || self.instance_id != prior.instance_id
+            || self.connection_id != prior.connection_id
+            || self.created_at != prior.created_at
+            || prior.state == ProviderWebhookEndpointState::Retired
+            || (self.state == prior.state
+                && self.provider_revision == prior.provider_revision
+                && self.connection_revision == prior.connection_revision
+                && self.body_limit == prior.body_limit
+                && self.raw_retention_millis == prior.raw_retention_millis
+                && self.secret_references == prior.secret_references
+                && self.retired_at == prior.retired_at)
+        {
+            return Err(ProviderWebhookError::InvalidEndpointSuccessor);
+        }
+        Ok(())
+    }
+}
+
+/// One move-only plaintext webhook verification candidate.
+pub struct ProviderWebhookSecretCandidate {
+    reference: ProviderWebhookSecretReference,
+    value: SecretBytes,
+}
+
+impl ProviderWebhookSecretCandidate {
+    /// Returns the exact named generation without exposing plaintext.
+    #[must_use]
+    pub const fn reference(&self) -> &ProviderWebhookSecretReference {
+        &self.reference
+    }
+
+    /// Explicitly exposes secret bytes only at the authentication boundary.
+    #[must_use]
+    pub fn expose_secret(&self) -> &[u8] {
+        self.value.expose_secret()
+    }
+}
+
+impl fmt::Debug for ProviderWebhookSecretCandidate {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookSecretCandidate")
+            .field("reference", &self.reference)
+            .field("value", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Exact plaintext candidate set resolved for one endpoint request.
+pub struct ProviderWebhookSecretCandidates {
+    endpoint_id: ProviderWebhookEndpointId,
+    endpoint_revision: ProviderWebhookEndpointRevision,
+    instance_id: ProviderInstanceId,
+    candidates: Vec<ProviderWebhookSecretCandidate>,
+}
+
+impl ProviderWebhookSecretCandidates {
+    /// Binds move-only plaintext values to the endpoint's exact candidate list.
+    ///
+    /// # Errors
+    ///
+    /// Rejects any missing, unexpected, duplicate, or reordered generation.
+    pub fn new(
+        endpoint: &ProviderWebhookEndpointManifest,
+        secrets: impl IntoIterator<Item = (ProviderConfigurationRevision, ProviderSecret)>,
+    ) -> Result<Self, ProviderWebhookError> {
+        let mut candidates = Vec::new();
+        for (configuration_revision, secret) in secrets {
+            let (name, generation, value) = secret.into_parts();
+            candidates.push(ProviderWebhookSecretCandidate {
+                reference: ProviderWebhookSecretReference::new(
+                    configuration_revision,
+                    name,
+                    generation,
+                ),
+                value,
+            });
+        }
+        candidates.sort_by(|left, right| left.reference.cmp(&right.reference));
+        if candidates.len() != endpoint.secret_references.len()
+            || candidates
+                .iter()
+                .zip(&endpoint.secret_references)
+                .any(|(candidate, expected)| candidate.reference != *expected)
+        {
+            return Err(ProviderWebhookError::InvalidSecretCandidates);
+        }
+        Ok(Self {
+            endpoint_id: endpoint.endpoint_id(),
+            endpoint_revision: endpoint.revision(),
+            instance_id: endpoint.instance_id(),
+            candidates,
+        })
+    }
+
+    /// Returns candidates in canonical name/generation order.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ProviderWebhookSecretCandidate> {
+        self.candidates.iter()
+    }
+}
+
+impl fmt::Debug for ProviderWebhookSecretCandidates {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookSecretCandidates")
+            .field("endpoint_id", &self.endpoint_id)
+            .field("endpoint_revision", &self.endpoint_revision)
+            .field("instance_id", &self.instance_id)
+            .field(
+                "references",
+                &self
+                    .candidates
+                    .iter()
+                    .map(ProviderWebhookSecretCandidate::reference)
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+/// Exact endpoint request and its endpoint-bound secret custody.
+pub struct ProviderWebhookAuthenticationRequest {
+    request: ProviderWebhookRequest,
+    candidates: ProviderWebhookSecretCandidates,
+}
+
+impl fmt::Debug for ProviderWebhookAuthenticationRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookAuthenticationRequest")
+            .field("request", &self.request)
+            .field("candidates", &self.candidates)
+            .finish()
+    }
+}
+
+impl ProviderWebhookAuthenticationRequest {
+    /// Binds raw request bytes to candidates resolved from the same endpoint record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects candidates from another endpoint, revision, or provider instance.
+    pub fn new(
+        request: ProviderWebhookRequest,
+        candidates: ProviderWebhookSecretCandidates,
+    ) -> Result<Self, ProviderWebhookError> {
+        let endpoint = request.endpoint();
+        if candidates.endpoint_id != endpoint.endpoint_id()
+            || candidates.endpoint_revision != endpoint.revision()
+            || candidates.instance_id != endpoint.instance_id()
+        {
+            return Err(ProviderWebhookError::SecretCandidateEndpointMismatch);
+        }
+        Ok(Self {
+            request,
+            candidates,
+        })
+    }
+
+    /// Returns exact raw request evidence.
+    #[must_use]
+    pub const fn request(&self) -> &ProviderWebhookRequest {
+        &self.request
+    }
+
+    /// Returns the only eligible endpoint-bound secret candidates.
+    #[must_use]
+    pub const fn candidates(&self) -> &ProviderWebhookSecretCandidates {
+        &self.candidates
+    }
+
+    /// Consumes the authentication input after a candidate verifies.
+    #[must_use]
+    pub fn into_request(self) -> ProviderWebhookRequest {
+        self.request
+    }
+}
+
+/// Canonical lower-case HTTP header name selected for an adapter.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ProviderWebhookHeaderName(String);
+
+impl ProviderWebhookHeaderName {
+    /// Validates an ASCII HTTP token in canonical lower-case form.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, uppercase, or non-token names.
+    pub fn new(value: impl Into<String>) -> Result<Self, ProviderWebhookError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > MAX_PROVIDER_WEBHOOK_HEADER_NAME_BYTES
+            || !value.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(
+                        byte,
+                        b'!' | b'#'
+                            | b'$'
+                            | b'%'
+                            | b'&'
+                            | b'\''
+                            | b'*'
+                            | b'+'
+                            | b'-'
+                            | b'.'
+                            | b'^'
+                            | b'_'
+                            | b'`'
+                            | b'|'
+                            | b'~'
+                    )
+            })
+        {
+            return Err(ProviderWebhookError::InvalidHeaderName);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical header name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Bounded exact selected HTTP headers.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderWebhookHeaders(BTreeMap<ProviderWebhookHeaderName, Vec<u8>>);
+
+impl ProviderWebhookHeaders {
+    /// Builds a duplicate-free selected header set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects excessive counts or bytes, duplicate names, or values containing
+    /// CR, LF, NUL, or other controls except horizontal tab.
+    pub fn new(
+        headers: impl IntoIterator<Item = (ProviderWebhookHeaderName, Vec<u8>)>,
+    ) -> Result<Self, ProviderWebhookError> {
+        let mut selected = BTreeMap::new();
+        let mut total = 0usize;
+        for (name, value) in headers {
+            if selected.len() == MAX_PROVIDER_WEBHOOK_HEADERS {
+                return Err(ProviderWebhookError::TooManyHeaders);
+            }
+            if value.len() > MAX_PROVIDER_WEBHOOK_HEADER_VALUE_BYTES
+                || value
+                    .iter()
+                    .any(|byte| (*byte < 0x20 && *byte != b'\t') || *byte == 0x7f)
+            {
+                return Err(ProviderWebhookError::InvalidHeaderValue);
+            }
+            total = total
+                .checked_add(name.as_str().len() + value.len())
+                .ok_or(ProviderWebhookError::HeadersTooLarge)?;
+            if total > MAX_PROVIDER_WEBHOOK_HEADER_BYTES {
+                return Err(ProviderWebhookError::HeadersTooLarge);
+            }
+            if selected.insert(name, value).is_some() {
+                return Err(ProviderWebhookError::DuplicateHeader);
+            }
+        }
+        Ok(Self(selected))
+    }
+
+    /// Returns one exact selected value.
+    #[must_use]
+    pub fn get(&self, name: &ProviderWebhookHeaderName) -> Option<&[u8]> {
+        self.0.get(name).map(Vec::as_slice)
+    }
+
+    /// Iterates selected headers in canonical name order.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&ProviderWebhookHeaderName, &[u8])> {
+        self.0.iter().map(|(name, value)| (name, value.as_slice()))
+    }
+}
+
+impl fmt::Debug for ProviderWebhookHeaders {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookHeaders")
+            .field("names", &self.0.keys().collect::<Vec<_>>())
+            .field("values", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Exact webhook method accepted by the public route.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ProviderWebhookMethod {
+    /// HTTP `POST`.
+    Post,
+}
+
+/// Bounded raw request passed to a delivery adapter before payload parsing.
+pub struct ProviderWebhookRequest {
+    endpoint: ProviderWebhookEndpointManifest,
+    method: ProviderWebhookMethod,
+    headers: ProviderWebhookHeaders,
+    body: Vec<u8>,
+    body_digest: Sha256Digest,
+    received_at: UnixMillis,
+}
+
+impl ProviderWebhookRequest {
+    /// Constructs an exact request after endpoint lookup and ingress limits.
+    ///
+    /// # Errors
+    ///
+    /// Rejects disabled endpoints, excessive body bytes, or pre-epoch receipt time.
+    pub fn new(
+        endpoint: ProviderWebhookEndpointManifest,
+        method: ProviderWebhookMethod,
+        headers: ProviderWebhookHeaders,
+        body: Vec<u8>,
+        received_at: UnixMillis,
+    ) -> Result<Self, ProviderWebhookError> {
+        if endpoint.state() != ProviderWebhookEndpointState::Active {
+            return Err(ProviderWebhookError::EndpointInactive);
+        }
+        if body.len() as u64 > endpoint.body_limit() {
+            return Err(ProviderWebhookError::BodyTooLarge);
+        }
+        if received_at.get() < 0 {
+            return Err(ProviderWebhookError::InvalidReceivedTime);
+        }
+        let body_digest = Sha256Digest::from_bytes(Sha256::digest(&body).into());
+        Ok(Self {
+            endpoint,
+            method,
+            headers,
+            body,
+            body_digest,
+            received_at,
+        })
+    }
+
+    /// Returns the resolved endpoint binding.
+    #[must_use]
+    pub const fn endpoint(&self) -> &ProviderWebhookEndpointManifest {
+        &self.endpoint
+    }
+
+    /// Returns the exact request method.
+    #[must_use]
+    pub const fn method(&self) -> ProviderWebhookMethod {
+        self.method
+    }
+
+    /// Returns selected bounded headers.
+    #[must_use]
+    pub const fn headers(&self) -> &ProviderWebhookHeaders {
+        &self.headers
+    }
+
+    /// Returns exact raw body bytes. Adapters must authenticate these before parsing.
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+
+    /// Returns the exact raw-body SHA-256 digest.
+    #[must_use]
+    pub const fn body_digest(&self) -> Sha256Digest {
+        self.body_digest
+    }
+
+    /// Returns trusted ingress receipt time.
+    #[must_use]
+    pub const fn received_at(&self) -> UnixMillis {
+        self.received_at
+    }
+}
+
+impl fmt::Debug for ProviderWebhookRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderWebhookRequest")
+            .field("endpoint", &self.endpoint)
+            .field("method", &self.method)
+            .field("headers", &self.headers)
+            .field("body", &"[REDACTED]")
+            .field("body_length", &self.body.len())
+            .field("body_digest", &self.body_digest)
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+/// Authenticated signature scheme and exact accepted secret generation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderWebhookSignatureEvidence {
+    scheme: String,
+    secret: ProviderWebhookSecretReference,
+}
+
+impl ProviderWebhookSignatureEvidence {
+    /// Constructs bounded, non-secret verification evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a noncanonical signature-scheme identifier.
+    pub fn new(
+        scheme: impl Into<String>,
+        secret: ProviderWebhookSecretReference,
+    ) -> Result<Self, ProviderWebhookError> {
+        let scheme = scheme.into();
+        if scheme.is_empty()
+            || scheme.len() > MAX_SIGNATURE_SCHEME_BYTES
+            || !scheme.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+            })
+        {
+            return Err(ProviderWebhookError::InvalidSignatureScheme);
+        }
+        Ok(Self { scheme, secret })
+    }
+
+    /// Returns the canonical adapter-owned signature scheme.
+    #[must_use]
+    pub fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    /// Returns the exact secret generation that verified the body.
+    #[must_use]
+    pub const fn secret(&self) -> &ProviderWebhookSecretReference {
+        &self.secret
+    }
+}
+
+/// Request typestate proving the raw body was authenticated before parsing.
+pub struct AuthenticatedProviderWebhook {
+    request: ProviderWebhookRequest,
+    signature: ProviderWebhookSignatureEvidence,
+}
+
+impl AuthenticatedProviderWebhook {
+    /// Marks a request authenticated by an eligible endpoint secret generation.
+    ///
+    /// This constructor is intended only for trusted adapter implementations,
+    /// after constant-time verification over [`ProviderWebhookRequest::body`].
+    ///
+    /// # Errors
+    ///
+    /// Rejects signature evidence not selected by the endpoint revision.
+    pub fn new(
+        request: ProviderWebhookRequest,
+        signature: ProviderWebhookSignatureEvidence,
+    ) -> Result<Self, ProviderWebhookError> {
+        if !request
+            .endpoint()
+            .secret_references()
+            .contains(signature.secret())
+        {
+            return Err(ProviderWebhookError::UnexpectedVerifiedSecret);
+        }
+        Ok(Self { request, signature })
+    }
+
+    /// Returns the authenticated request for post-verification parsing.
+    #[must_use]
+    pub const fn request(&self) -> &ProviderWebhookRequest {
+        &self.request
+    }
+
+    /// Returns non-secret signature evidence.
+    #[must_use]
+    pub const fn signature(&self) -> &ProviderWebhookSignatureEvidence {
+        &self.signature
+    }
+}
+
+impl fmt::Debug for AuthenticatedProviderWebhook {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthenticatedProviderWebhook")
+            .field("request", &self.request)
+            .field("signature", &self.signature)
+            .finish()
+    }
+}
+
+/// Bounded canonical, non-secret adapter observations used to audit normalization.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderDeliveryObservations {
+    canonical_bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl ProviderDeliveryObservations {
+    /// Stores exact canonical adapter bytes.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversized observations.
+    pub fn new(canonical_bytes: Vec<u8>) -> Result<Self, ProviderWebhookError> {
+        if canonical_bytes.len() > MAX_PROVIDER_DELIVERY_OBSERVATION_BYTES {
+            return Err(ProviderWebhookError::ObservationsTooLarge);
+        }
+        let digest = Sha256Digest::from_bytes(Sha256::digest(&canonical_bytes).into());
+        Ok(Self {
+            canonical_bytes,
+            digest,
+        })
+    }
+
+    /// Returns exact canonical observation bytes.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    /// Returns the observations digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl fmt::Debug for ProviderDeliveryObservations {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderDeliveryObservations")
+            .field("canonical_bytes", &"[CANONICAL]")
+            .field("byte_length", &self.canonical_bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+/// Authenticated and normalized delivery awaiting immutable raw-body storage.
+#[derive(Debug)]
+pub struct ProviderDeliveryDraft {
+    delivery_id: ProviderDeliveryId,
+    external_delivery: ExternalDeliveryIdentity,
+    event_type: ProviderEventName,
+    authenticated: AuthenticatedProviderWebhook,
+    trigger: SealedNormalizedTrigger,
+    observations: ProviderDeliveryObservations,
+}
+
+/// Authenticated non-admission delivery awaiting immutable raw-body storage.
+#[derive(Debug)]
+pub struct RejectedProviderDeliveryDraft {
+    delivery_id: ProviderDeliveryId,
+    external_delivery: ExternalDeliveryIdentity,
+    event_type: ProviderEventName,
+    authenticated: AuthenticatedProviderWebhook,
+    repository: Option<ExternalRepositoryIdentity>,
+    reason: ProviderDeliveryRejection,
+    observations: ProviderDeliveryObservations,
+}
+
+impl RejectedProviderDeliveryDraft {
+    /// Constructs a bounded authenticated rejection record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects delivery or optional repository evidence from another instance.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        authenticated: AuthenticatedProviderWebhook,
+        repository: Option<ExternalRepositoryIdentity>,
+        reason: ProviderDeliveryRejection,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        let instance_id = authenticated.request().endpoint().instance_id();
+        if external_delivery.instance_id() != instance_id
+            || repository
+                .as_ref()
+                .is_some_and(|value| value.instance_id() != instance_id)
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self {
+            delivery_id,
+            external_delivery,
+            event_type,
+            authenticated,
+            repository,
+            reason,
+            observations,
+        })
+    }
+}
+
+impl ProviderDeliveryDraft {
+    /// Binds adapter output to exact endpoint, instance, and repository evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects cross-instance delivery or normalized repository identities.
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        authenticated: AuthenticatedProviderWebhook,
+        trigger: &NormalizedTrigger,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        let endpoint_instance = authenticated.request().endpoint().instance_id();
+        if external_delivery.instance_id() != endpoint_instance
+            || trigger.target_repository().identity().instance_id() != endpoint_instance
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        let trigger = trigger.seal().map_err(ProviderWebhookError::Trigger)?;
+        Ok(Self {
+            delivery_id,
+            external_delivery,
+            event_type,
+            authenticated,
+            trigger,
+            observations,
+        })
+    }
+}
+
+/// Complete verified delivery with immutable raw-body evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedProviderDelivery {
+    delivery_id: ProviderDeliveryId,
+    endpoint_id: ProviderWebhookEndpointId,
+    endpoint_revision: ProviderWebhookEndpointRevision,
+    provider_type: ProviderTypeId,
+    instance_id: ProviderInstanceId,
+    provider_revision: ProviderConfigurationRevision,
+    connection_id: ProviderConnectionId,
+    connection_revision: ProviderConnectionRevision,
+    external_delivery: ExternalDeliveryIdentity,
+    event_type: ProviderEventName,
+    received_at: UnixMillis,
+    raw_body: BlobDescriptor,
+    raw_retain_until: UnixMillis,
+    signature: ProviderWebhookSignatureEvidence,
+    trigger: SealedNormalizedTrigger,
+    observations: ProviderDeliveryObservations,
+}
+
+impl VerifiedProviderDelivery {
+    /// Rehydrates complete durable verified-delivery evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects cross-instance identities, negative receipt time, or a raw object
+    /// descriptor that is not the canonical content-addressed representation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn rehydrate(
+        delivery_id: ProviderDeliveryId,
+        endpoint_id: ProviderWebhookEndpointId,
+        endpoint_revision: ProviderWebhookEndpointRevision,
+        provider_type: ProviderTypeId,
+        instance_id: ProviderInstanceId,
+        provider_revision: ProviderConfigurationRevision,
+        connection_id: ProviderConnectionId,
+        connection_revision: ProviderConnectionRevision,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        received_at: UnixMillis,
+        raw_body: BlobDescriptor,
+        raw_retain_until: UnixMillis,
+        signature: ProviderWebhookSignatureEvidence,
+        trigger: SealedNormalizedTrigger,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        validate_durable_evidence(
+            instance_id,
+            &external_delivery,
+            received_at,
+            &raw_body,
+            raw_retain_until,
+        )?;
+        if trigger
+            .trigger()
+            .target_repository()
+            .identity()
+            .instance_id()
+            != instance_id
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self {
+            delivery_id,
+            endpoint_id,
+            endpoint_revision,
+            provider_type,
+            instance_id,
+            provider_revision,
+            connection_id,
+            connection_revision,
+            external_delivery,
+            event_type,
+            received_at,
+            raw_body,
+            raw_retain_until,
+            signature,
+            trigger,
+            observations,
+        })
+    }
+
+    /// Seals normalized output against an immutable content-addressed raw body.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a raw descriptor whose digest, size, media type, or key differs
+    /// from the authenticated request.
+    pub fn seal(
+        draft: ProviderDeliveryDraft,
+        raw_body: BlobDescriptor,
+    ) -> Result<Self, ProviderWebhookError> {
+        validate_raw_descriptor(draft.authenticated.request(), &raw_body)?;
+        let endpoint = draft.authenticated.request().endpoint();
+        let raw_retain_until = retention_deadline(
+            draft.authenticated.request().received_at(),
+            endpoint.raw_retention_millis(),
+        )?;
+        Ok(Self {
+            delivery_id: draft.delivery_id,
+            endpoint_id: endpoint.endpoint_id(),
+            endpoint_revision: endpoint.revision(),
+            provider_type: endpoint.provider_type().clone(),
+            instance_id: endpoint.instance_id(),
+            provider_revision: endpoint.provider_revision(),
+            connection_id: endpoint.connection_id(),
+            connection_revision: endpoint.connection_revision(),
+            external_delivery: draft.external_delivery,
+            event_type: draft.event_type,
+            received_at: draft.authenticated.request().received_at(),
+            raw_body,
+            raw_retain_until,
+            signature: draft.authenticated.signature().clone(),
+            trigger: draft.trigger,
+            observations: draft.observations,
+        })
+    }
+
+    /// Returns the durable server-owned delivery identity.
+    #[must_use]
+    pub const fn delivery_id(&self) -> ProviderDeliveryId {
+        self.delivery_id
+    }
+
+    /// Returns the exact public endpoint used for ingress.
+    #[must_use]
+    pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns endpoint policy revision used for authentication.
+    #[must_use]
+    pub const fn endpoint_revision(&self) -> ProviderWebhookEndpointRevision {
+        self.endpoint_revision
+    }
+
+    /// Returns the exact provider adapter type.
+    #[must_use]
+    pub const fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    /// Returns the configured provider instance.
+    #[must_use]
+    pub const fn instance_id(&self) -> ProviderInstanceId {
+        self.instance_id
+    }
+
+    /// Returns the exact provider configuration revision used for normalization.
+    #[must_use]
+    pub const fn provider_revision(&self) -> ProviderConfigurationRevision {
+        self.provider_revision
+    }
+
+    /// Returns the endpoint-bound connection.
+    #[must_use]
+    pub const fn connection_id(&self) -> ProviderConnectionId {
+        self.connection_id
+    }
+
+    /// Returns the exact endpoint-bound connection policy revision.
+    #[must_use]
+    pub const fn connection_revision(&self) -> ProviderConnectionRevision {
+        self.connection_revision
+    }
+
+    /// Returns instance-scoped provider replay identity.
+    #[must_use]
+    pub const fn external_delivery(&self) -> &ExternalDeliveryIdentity {
+        &self.external_delivery
+    }
+
+    /// Returns provider-native event-name evidence.
+    #[must_use]
+    pub const fn event_type(&self) -> &ProviderEventName {
+        &self.event_type
+    }
+
+    /// Returns trusted ingress receipt time.
+    #[must_use]
+    pub const fn received_at(&self) -> UnixMillis {
+        self.received_at
+    }
+
+    /// Returns immutable raw request-body evidence.
+    #[must_use]
+    pub const fn raw_body(&self) -> &BlobDescriptor {
+        &self.raw_body
+    }
+
+    /// Returns the inclusive raw-evidence retention deadline.
+    #[must_use]
+    pub const fn raw_retain_until(&self) -> UnixMillis {
+        self.raw_retain_until
+    }
+
+    /// Returns signature scheme and accepted generation evidence.
+    #[must_use]
+    pub const fn signature(&self) -> &ProviderWebhookSignatureEvidence {
+        &self.signature
+    }
+
+    /// Returns the strongly typed normalized trigger.
+    #[must_use]
+    pub const fn trigger(&self) -> &SealedNormalizedTrigger {
+        &self.trigger
+    }
+
+    /// Returns bounded adapter audit observations.
+    #[must_use]
+    pub const fn observations(&self) -> &ProviderDeliveryObservations {
+        &self.observations
+    }
+}
+
+/// Complete authenticated rejection with immutable raw-body evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RejectedProviderDelivery {
+    delivery_id: ProviderDeliveryId,
+    endpoint_id: ProviderWebhookEndpointId,
+    endpoint_revision: ProviderWebhookEndpointRevision,
+    provider_type: ProviderTypeId,
+    instance_id: ProviderInstanceId,
+    provider_revision: ProviderConfigurationRevision,
+    connection_id: ProviderConnectionId,
+    connection_revision: ProviderConnectionRevision,
+    external_delivery: ExternalDeliveryIdentity,
+    event_type: ProviderEventName,
+    received_at: UnixMillis,
+    raw_body: BlobDescriptor,
+    raw_retain_until: UnixMillis,
+    signature: ProviderWebhookSignatureEvidence,
+    repository: Option<ExternalRepositoryIdentity>,
+    reason: ProviderDeliveryRejection,
+    observations: ProviderDeliveryObservations,
+}
+
+impl RejectedProviderDelivery {
+    /// Rehydrates complete durable authenticated rejection evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects cross-instance identities, negative receipt time, or a noncanonical
+    /// immutable raw object descriptor.
+    #[allow(clippy::too_many_arguments)]
+    pub fn rehydrate(
+        delivery_id: ProviderDeliveryId,
+        endpoint_id: ProviderWebhookEndpointId,
+        endpoint_revision: ProviderWebhookEndpointRevision,
+        provider_type: ProviderTypeId,
+        instance_id: ProviderInstanceId,
+        provider_revision: ProviderConfigurationRevision,
+        connection_id: ProviderConnectionId,
+        connection_revision: ProviderConnectionRevision,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        received_at: UnixMillis,
+        raw_body: BlobDescriptor,
+        raw_retain_until: UnixMillis,
+        signature: ProviderWebhookSignatureEvidence,
+        repository: Option<ExternalRepositoryIdentity>,
+        reason: ProviderDeliveryRejection,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        validate_durable_evidence(
+            instance_id,
+            &external_delivery,
+            received_at,
+            &raw_body,
+            raw_retain_until,
+        )?;
+        if repository
+            .as_ref()
+            .is_some_and(|value| value.instance_id() != instance_id)
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self {
+            delivery_id,
+            endpoint_id,
+            endpoint_revision,
+            provider_type,
+            instance_id,
+            provider_revision,
+            connection_id,
+            connection_revision,
+            external_delivery,
+            event_type,
+            received_at,
+            raw_body,
+            raw_retain_until,
+            signature,
+            repository,
+            reason,
+            observations,
+        })
+    }
+
+    /// Seals an authenticated rejection against immutable raw-body evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a descriptor that disagrees with the exact authenticated body.
+    pub fn seal(
+        draft: RejectedProviderDeliveryDraft,
+        raw_body: BlobDescriptor,
+    ) -> Result<Self, ProviderWebhookError> {
+        validate_raw_descriptor(draft.authenticated.request(), &raw_body)?;
+        let endpoint = draft.authenticated.request().endpoint();
+        let raw_retain_until = retention_deadline(
+            draft.authenticated.request().received_at(),
+            endpoint.raw_retention_millis(),
+        )?;
+        Ok(Self {
+            delivery_id: draft.delivery_id,
+            endpoint_id: endpoint.endpoint_id(),
+            endpoint_revision: endpoint.revision(),
+            provider_type: endpoint.provider_type().clone(),
+            instance_id: endpoint.instance_id(),
+            provider_revision: endpoint.provider_revision(),
+            connection_id: endpoint.connection_id(),
+            connection_revision: endpoint.connection_revision(),
+            external_delivery: draft.external_delivery,
+            event_type: draft.event_type,
+            received_at: draft.authenticated.request().received_at(),
+            raw_body,
+            raw_retain_until,
+            signature: draft.authenticated.signature().clone(),
+            repository: draft.repository,
+            reason: draft.reason,
+            observations: draft.observations,
+        })
+    }
+
+    /// Returns the durable server-owned delivery identity.
+    #[must_use]
+    pub const fn delivery_id(&self) -> ProviderDeliveryId {
+        self.delivery_id
+    }
+
+    /// Returns the exact public endpoint used for ingress.
+    #[must_use]
+    pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
+        self.endpoint_id
+    }
+
+    /// Returns the endpoint policy revision used for authentication.
+    #[must_use]
+    pub const fn endpoint_revision(&self) -> ProviderWebhookEndpointRevision {
+        self.endpoint_revision
+    }
+
+    /// Returns the exact provider adapter type.
+    #[must_use]
+    pub const fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    /// Returns the configured provider instance.
+    #[must_use]
+    pub const fn instance_id(&self) -> ProviderInstanceId {
+        self.instance_id
+    }
+
+    /// Returns the exact provider configuration revision used for normalization.
+    #[must_use]
+    pub const fn provider_revision(&self) -> ProviderConfigurationRevision {
+        self.provider_revision
+    }
+
+    /// Returns the endpoint-bound connection.
+    #[must_use]
+    pub const fn connection_id(&self) -> ProviderConnectionId {
+        self.connection_id
+    }
+
+    /// Returns the exact endpoint-bound connection policy revision.
+    #[must_use]
+    pub const fn connection_revision(&self) -> ProviderConnectionRevision {
+        self.connection_revision
+    }
+
+    /// Returns instance-scoped provider replay identity.
+    #[must_use]
+    pub const fn external_delivery(&self) -> &ExternalDeliveryIdentity {
+        &self.external_delivery
+    }
+
+    /// Returns provider-native event-name evidence.
+    #[must_use]
+    pub const fn event_type(&self) -> &ProviderEventName {
+        &self.event_type
+    }
+
+    /// Returns trusted ingress receipt time.
+    #[must_use]
+    pub const fn received_at(&self) -> UnixMillis {
+        self.received_at
+    }
+
+    /// Returns immutable raw request-body evidence.
+    #[must_use]
+    pub const fn raw_body(&self) -> &BlobDescriptor {
+        &self.raw_body
+    }
+
+    /// Returns the inclusive raw-evidence retention deadline.
+    #[must_use]
+    pub const fn raw_retain_until(&self) -> UnixMillis {
+        self.raw_retain_until
+    }
+
+    /// Returns signature scheme and accepted generation evidence.
+    #[must_use]
+    pub const fn signature(&self) -> &ProviderWebhookSignatureEvidence {
+        &self.signature
+    }
+
+    /// Returns repository identity when the authenticated shape contained it.
+    #[must_use]
+    pub const fn repository(&self) -> Option<&ExternalRepositoryIdentity> {
+        self.repository.as_ref()
+    }
+
+    /// Returns why this event cannot enter admission.
+    #[must_use]
+    pub const fn reason(&self) -> ProviderDeliveryRejection {
+        self.reason
+    }
+
+    /// Returns bounded adapter audit observations.
+    #[must_use]
+    pub const fn observations(&self) -> &ProviderDeliveryObservations {
+        &self.observations
+    }
+}
+
+/// Post-authentication event that was recorded but must not enter admission.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderDeliveryRejection {
+    /// The provider event name is not recognized by this adapter version.
+    #[error("provider webhook event is unknown")]
+    UnknownEvent,
+    /// The event is known but does not represent an admission trigger.
+    #[error("provider webhook event is unsupported")]
+    UnsupportedEvent,
+    /// Required authenticated facts were absent or ambiguous.
+    #[error("provider webhook event evidence is incomplete")]
+    IncompleteEvent,
+    /// Payload repository identity disagreed with endpoint binding.
+    #[error("provider webhook payload identity conflicts with its endpoint")]
+    PayloadIdentityMismatch,
+    /// Authenticated provider bytes were malformed.
+    #[error("provider webhook payload is invalid")]
+    InvalidPayload,
+}
+
+/// Adapter normalization result after successful authentication.
+#[derive(Debug)]
+pub enum ProviderDeliveryNormalization {
+    /// A complete trigger ready for raw evidence storage and durable acceptance.
+    Accepted(Box<ProviderDeliveryDraft>),
+    /// A sanitized authenticated rejection retained for audit but not admission.
+    Rejected(Box<RejectedProviderDeliveryDraft>),
+}
+
+impl ProviderDeliveryNormalization {
+    /// Returns exact authenticated raw body bytes for immutable object storage.
+    #[must_use]
+    pub fn raw_body(&self) -> &[u8] {
+        match self {
+            Self::Accepted(value) => value.authenticated.request().body(),
+            Self::Rejected(value) => value.authenticated.request().body(),
+        }
+    }
+
+    /// Returns the only valid content-addressed descriptor for the raw body.
+    ///
+    /// # Errors
+    ///
+    /// Fails only if the static provider raw-evidence blob contract is invalid.
+    pub fn raw_descriptor(&self) -> Result<BlobDescriptor, ProviderWebhookError> {
+        let request = match self {
+            Self::Accepted(value) => value.authenticated.request(),
+            Self::Rejected(value) => value.authenticated.request(),
+        };
+        provider_raw_webhook_descriptor(request.body_digest(), request.body().len() as u64)
+    }
+
+    /// Seals either normalized trigger or authenticated rejection after the
+    /// caller durably stores exact raw body bytes under `raw_body`.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a descriptor inconsistent with the authenticated request.
+    pub fn seal(
+        self,
+        raw_body: BlobDescriptor,
+    ) -> Result<crate::ProviderDelivery, ProviderWebhookError> {
+        match self {
+            Self::Accepted(value) => VerifiedProviderDelivery::seal(*value, raw_body)
+                .map(Box::new)
+                .map(crate::ProviderDelivery::Trigger),
+            Self::Rejected(value) => RejectedProviderDelivery::seal(*value, raw_body)
+                .map(Box::new)
+                .map(crate::ProviderDelivery::Rejected),
+        }
+    }
+}
+
+/// Provider delivery adapter with an explicit authenticate-before-normalize split.
+pub trait DeliveryAdapter: fmt::Debug + Send + Sync {
+    /// Returns the unique exact provider type served by this adapter.
+    fn provider_type(&self) -> &ProviderTypeId;
+
+    /// Returns the canonical header names ingress may select for this adapter.
+    fn selected_header_names(&self) -> &[ProviderWebhookHeaderName];
+
+    /// Authenticates the exact raw body before any JSON or payload decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized authentication rejection without retaining raw bytes.
+    fn authenticate(
+        &self,
+        request: ProviderWebhookAuthenticationRequest,
+    ) -> Result<AuthenticatedProviderWebhook, ProviderWebhookAuthenticationError>;
+
+    /// Parses and normalizes only an authenticated request typestate.
+    fn normalize(
+        &self,
+        authenticated: AuthenticatedProviderWebhook,
+    ) -> ProviderDeliveryNormalization;
+}
+
+/// Immutable exact registry of statically linked delivery adapters.
+#[derive(Clone)]
+pub struct DeliveryAdapterRegistry {
+    adapters: BTreeMap<ProviderTypeId, Arc<dyn DeliveryAdapter>>,
+}
+
+impl DeliveryAdapterRegistry {
+    /// Builds a nonempty bounded duplicate-free adapter registry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, or duplicate provider registrations.
+    pub fn new(
+        adapters: impl IntoIterator<Item = Arc<dyn DeliveryAdapter>>,
+    ) -> Result<Self, DeliveryAdapterRegistryError> {
+        let mut registered = BTreeMap::new();
+        for adapter in adapters {
+            if registered.len() == MAX_DELIVERY_ADAPTERS {
+                return Err(DeliveryAdapterRegistryError::TooManyAdapters);
+            }
+            let headers = adapter.selected_header_names();
+            let mut canonical_headers = headers.to_vec();
+            canonical_headers.sort();
+            if headers.is_empty()
+                || headers.len() > MAX_PROVIDER_WEBHOOK_HEADERS
+                || canonical_headers.windows(2).any(|pair| pair[0] == pair[1])
+            {
+                return Err(DeliveryAdapterRegistryError::InvalidHeaderSelection);
+            }
+            let provider_type = adapter.provider_type().clone();
+            if registered.insert(provider_type, adapter).is_some() {
+                return Err(DeliveryAdapterRegistryError::DuplicateAdapter);
+            }
+        }
+        if registered.is_empty() {
+            return Err(DeliveryAdapterRegistryError::NoAdapters);
+        }
+        Ok(Self {
+            adapters: registered,
+        })
+    }
+
+    /// Resolves only the exact adapter named by a durable endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed when the exact type is not statically registered.
+    pub fn resolve(
+        &self,
+        endpoint: &ProviderWebhookEndpointManifest,
+    ) -> Result<&dyn DeliveryAdapter, DeliveryAdapterRegistryError> {
+        self.adapters
+            .get(endpoint.provider_type())
+            .map(Arc::as_ref)
+            .ok_or(DeliveryAdapterRegistryError::UnknownProviderType)
+    }
+
+    /// Iterates exact provider types in canonical order.
+    pub fn provider_types(&self) -> impl ExactSizeIterator<Item = &ProviderTypeId> {
+        self.adapters.keys()
+    }
+}
+
+impl fmt::Debug for DeliveryAdapterRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DeliveryAdapterRegistry")
+            .field("provider_types", &self.adapters.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Creates the only valid immutable raw-body descriptor for authenticated bytes.
+///
+/// # Errors
+///
+/// Fails only if the statically defined key or media type violates blob contracts.
+pub fn provider_raw_webhook_descriptor(
+    digest: Sha256Digest,
+    size: u64,
+) -> Result<BlobDescriptor, ProviderWebhookError> {
+    let key = BlobKey::new(format!("{PROVIDER_RAW_WEBHOOK_KEY_PREFIX}/{digest}"))
+        .map_err(|_| ProviderWebhookError::RawDescriptor)?;
+    let media_type = MediaType::new(PROVIDER_RAW_WEBHOOK_MEDIA_TYPE)
+        .map_err(|_| ProviderWebhookError::RawDescriptor)?;
+    Ok(BlobDescriptor::new(key, digest, size, media_type))
+}
+
+fn validate_raw_descriptor(
+    request: &ProviderWebhookRequest,
+    descriptor: &BlobDescriptor,
+) -> Result<(), ProviderWebhookError> {
+    let expected =
+        provider_raw_webhook_descriptor(request.body_digest(), request.body.len() as u64)?;
+    if descriptor != &expected {
+        return Err(ProviderWebhookError::RawDescriptor);
+    }
+    Ok(())
+}
+
+fn validate_durable_evidence(
+    instance_id: ProviderInstanceId,
+    external_delivery: &ExternalDeliveryIdentity,
+    received_at: UnixMillis,
+    raw_body: &BlobDescriptor,
+    raw_retain_until: UnixMillis,
+) -> Result<(), ProviderWebhookError> {
+    if external_delivery.instance_id() != instance_id {
+        return Err(ProviderWebhookError::PayloadIdentityMismatch);
+    }
+    if received_at.get() < 0 || raw_retain_until <= received_at {
+        return Err(ProviderWebhookError::InvalidReceivedTime);
+    }
+    let expected = provider_raw_webhook_descriptor(raw_body.digest(), raw_body.size())?;
+    if raw_body != &expected {
+        return Err(ProviderWebhookError::RawDescriptor);
+    }
+    Ok(())
+}
+
+fn retention_deadline(
+    received_at: UnixMillis,
+    retention_millis: u64,
+) -> Result<UnixMillis, ProviderWebhookError> {
+    let retention_millis =
+        i64::try_from(retention_millis).map_err(|_| ProviderWebhookError::InvalidRawRetention)?;
+    received_at
+        .get()
+        .checked_add(retention_millis)
+        .map(UnixMillis::new)
+        .ok_or(ProviderWebhookError::InvalidRawRetention)
+}
+
+/// Sanitized unauthenticated webhook rejection.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderWebhookAuthenticationError {
+    /// Required canonical authentication headers were absent or malformed.
+    #[error("provider webhook authentication evidence is invalid")]
+    InvalidEvidence,
+    /// No selected secret generation authenticated the exact raw body.
+    #[error("provider webhook signature is invalid")]
+    InvalidSignature,
+}
+
+/// Invalid endpoint, request, or verified-delivery evidence.
+#[derive(Debug, Error)]
+pub enum ProviderWebhookError {
+    /// Endpoint revisions must be positive signed 64-bit values.
+    #[error("provider webhook endpoint revision is invalid")]
+    InvalidEndpointRevision,
+    /// Endpoint body limit was zero or beyond the hard ingress bound.
+    #[error("provider webhook body limit is invalid")]
+    InvalidBodyLimit,
+    /// Raw evidence retention was zero, excessive, or overflowed its deadline.
+    #[error("provider webhook raw-evidence retention is invalid")]
+    InvalidRawRetention,
+    /// Secret generation selection was empty, excessive, or disagreed with plaintext.
+    #[error("provider webhook secret candidates are invalid")]
+    InvalidSecretCandidates,
+    /// Candidate custody belonged to another endpoint record.
+    #[error("provider webhook secret candidates belong to another endpoint")]
+    SecretCandidateEndpointMismatch,
+    /// One exact named secret generation appeared more than once.
+    #[error("provider webhook secret candidate is duplicated")]
+    DuplicateSecretCandidate,
+    /// Endpoint creation, retirement, and state evidence disagreed.
+    #[error("provider webhook endpoint lifecycle is invalid")]
+    InvalidEndpointLifecycle,
+    /// A successor changed immutable binding or violated revision/lifecycle rules.
+    #[error("provider webhook endpoint successor is invalid")]
+    InvalidEndpointSuccessor,
+    /// The selected endpoint is disabled or retired.
+    #[error("provider webhook endpoint is inactive")]
+    EndpointInactive,
+    /// Selected header name was not canonical lower-case HTTP syntax.
+    #[error("provider webhook header name is invalid")]
+    InvalidHeaderName,
+    /// Selected header value was excessive or contained forbidden controls.
+    #[error("provider webhook header value is invalid")]
+    InvalidHeaderValue,
+    /// Selected header count exceeded the adapter boundary.
+    #[error("provider webhook has too many selected headers")]
+    TooManyHeaders,
+    /// Selected headers exceeded their aggregate byte bound.
+    #[error("provider webhook selected headers are too large")]
+    HeadersTooLarge,
+    /// A selected header name appeared more than once.
+    #[error("provider webhook selected header is duplicated")]
+    DuplicateHeader,
+    /// Body bytes exceeded the resolved endpoint limit.
+    #[error("provider webhook body is too large")]
+    BodyTooLarge,
+    /// Trusted receipt time was before the Unix epoch.
+    #[error("provider webhook receipt time is invalid")]
+    InvalidReceivedTime,
+    /// Adapter signature scheme identifier was not canonical.
+    #[error("provider webhook signature scheme is invalid")]
+    InvalidSignatureScheme,
+    /// An adapter claimed a secret generation not selected by the endpoint.
+    #[error("provider webhook verified with an unexpected secret generation")]
+    UnexpectedVerifiedSecret,
+    /// Adapter observations exceeded their durable bound.
+    #[error("provider delivery observations are too large")]
+    ObservationsTooLarge,
+    /// Normalized trigger evidence was invalid.
+    #[error(transparent)]
+    Trigger(ProviderTriggerError),
+    /// Payload identity disagreed with the resolved endpoint namespace.
+    #[error("provider webhook payload identity conflicts with its endpoint")]
+    PayloadIdentityMismatch,
+    /// Raw immutable object evidence disagreed with authenticated bytes.
+    #[error("provider webhook raw-body descriptor is invalid")]
+    RawDescriptor,
+}
+
+/// Invalid delivery-adapter registry composition or lookup.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum DeliveryAdapterRegistryError {
+    /// At least one adapter must be statically composed.
+    #[error("at least one provider delivery adapter is required")]
+    NoAdapters,
+    /// Statically linked adapter count exceeded the hard bound.
+    #[error("too many provider delivery adapters are registered")]
+    TooManyAdapters,
+    /// Two adapters claimed one exact provider type.
+    #[error("provider delivery adapter type is duplicated")]
+    DuplicateAdapter,
+    /// An adapter declared no headers, too many headers, or duplicate names.
+    #[error("provider delivery adapter header selection is invalid")]
+    InvalidHeaderSelection,
+    /// The endpoint's exact provider type was not registered.
+    #[error("provider delivery adapter type is not registered")]
+    UnknownProviderType,
+}

--- a/crates/automata-ci-provider/tests/delivery.rs
+++ b/crates/automata-ci-provider/tests/delivery.rs
@@ -1,0 +1,358 @@
+use std::{
+    fmt::Write as _,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use automata_ci_core::{GitObjectAlgorithm, GitObjectId, UnixMillis};
+use automata_ci_key_management::SecretBytes;
+use automata_ci_provider::{
+    AuthenticatedProviderWebhook, CompleteProviderDelivery, DeliveryAdapter,
+    DeliveryAdapterRegistry, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
+    ExternalRepositoryIdentity, NormalizedTrigger, ProviderConfigurationRevision,
+    ProviderConnectionId, ProviderConnectionRevision, ProviderDeliveryClaimFence,
+    ProviderDeliveryDraft, ProviderDeliveryId, ProviderDeliveryNormalization,
+    ProviderDeliveryObservations, ProviderDeliveryRejection, ProviderDeliveryWorkerId,
+    ProviderEventName, ProviderGitRef, ProviderGitRefKind, ProviderInstanceId, ProviderRepository,
+    ProviderRepositoryPath, ProviderSecret, ProviderSecretGeneration, ProviderSecretName,
+    ProviderTypeId, ProviderWebhookAuthenticationError, ProviderWebhookAuthenticationRequest,
+    ProviderWebhookEndpointId, ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision,
+    ProviderWebhookEndpointState, ProviderWebhookHeaderName, ProviderWebhookHeaders,
+    ProviderWebhookMethod, ProviderWebhookRequest, ProviderWebhookSecretCandidates,
+    ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, PushTrigger,
+    RepositoryVisibility,
+};
+use sha2::{Digest as _, Sha256};
+
+const OLD_SECRET: &[u8] = b"old-webhook-secret";
+const NEW_SECRET: &[u8] = b"new-webhook-secret";
+
+#[derive(Debug)]
+struct FakeAdapter {
+    provider_type: ProviderTypeId,
+    header_names: Vec<ProviderWebhookHeaderName>,
+    parsed: Arc<AtomicBool>,
+}
+
+impl FakeAdapter {
+    fn new(provider_type: &str, parsed: Arc<AtomicBool>) -> Self {
+        Self {
+            provider_type: ProviderTypeId::new(provider_type).expect("provider type"),
+            header_names: vec![
+                ProviderWebhookHeaderName::new("x-fake-signature").expect("signature header"),
+            ],
+            parsed,
+        }
+    }
+}
+
+impl DeliveryAdapter for FakeAdapter {
+    fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    fn selected_header_names(&self) -> &[ProviderWebhookHeaderName] {
+        &self.header_names
+    }
+
+    fn authenticate(
+        &self,
+        authentication: ProviderWebhookAuthenticationRequest,
+    ) -> Result<AuthenticatedProviderWebhook, ProviderWebhookAuthenticationError> {
+        let signature_name = ProviderWebhookHeaderName::new("x-fake-signature")
+            .map_err(|_| ProviderWebhookAuthenticationError::InvalidEvidence)?;
+        let supplied = authentication
+            .request()
+            .headers()
+            .get(&signature_name)
+            .ok_or(ProviderWebhookAuthenticationError::InvalidEvidence)?;
+        let accepted = authentication.candidates().iter().find(|candidate| {
+            let mut hash = Sha256::new();
+            hash.update(candidate.expose_secret());
+            hash.update(authentication.request().body());
+            hex_digest(&hash.finalize()).as_bytes() == supplied
+        });
+        let accepted = accepted.ok_or(ProviderWebhookAuthenticationError::InvalidSignature)?;
+        let accepted = accepted.reference().clone();
+        let evidence = ProviderWebhookSignatureEvidence::new("fake-sha256", accepted)
+            .map_err(|_| ProviderWebhookAuthenticationError::InvalidEvidence)?;
+        AuthenticatedProviderWebhook::new(authentication.into_request(), evidence)
+            .map_err(|_| ProviderWebhookAuthenticationError::InvalidEvidence)
+    }
+
+    fn normalize(
+        &self,
+        authenticated: AuthenticatedProviderWebhook,
+    ) -> ProviderDeliveryNormalization {
+        self.parsed.store(true, Ordering::SeqCst);
+        let parsed: serde_json::Value = match serde_json::from_slice(authenticated.request().body())
+        {
+            Ok(value) => value,
+            Err(_) => {
+                return rejected(authenticated, ProviderDeliveryRejection::InvalidPayload);
+            }
+        };
+        if parsed.get("kind").and_then(serde_json::Value::as_str) != Some("push") {
+            return rejected(authenticated, ProviderDeliveryRejection::UnknownEvent);
+        }
+        let instance_id = authenticated.request().endpoint().instance_id();
+        let repository = ProviderRepository::new(
+            ExternalRepositoryIdentity::new(
+                instance_id,
+                ExternalRepositoryId::new("repository-42").expect("repository ID"),
+            ),
+            ProviderRepositoryPath::new("owner/repository").expect("repository path"),
+            RepositoryVisibility::Private,
+        );
+        let trigger = PushTrigger::new(
+            repository,
+            ProviderGitRef::new("refs/heads/main", ProviderGitRefKind::Branch).expect("branch"),
+            Some(object('a')),
+            Some(object('b')),
+            false,
+            None,
+        )
+        .expect("push");
+        ProviderDeliveryNormalization::Accepted(Box::new(
+            ProviderDeliveryDraft::new(
+                ProviderDeliveryId::new(),
+                ExternalDeliveryIdentity::new(
+                    instance_id,
+                    ExternalDeliveryId::new("delivery-1").expect("delivery ID"),
+                ),
+                ProviderEventName::new("push").expect("event type"),
+                authenticated,
+                &NormalizedTrigger::Push(trigger),
+                ProviderDeliveryObservations::new(br#"{"fixture":"fake"}"#.to_vec())
+                    .expect("observations"),
+            )
+            .expect("delivery draft"),
+        ))
+    }
+}
+
+fn rejected(
+    authenticated: AuthenticatedProviderWebhook,
+    reason: ProviderDeliveryRejection,
+) -> ProviderDeliveryNormalization {
+    let instance_id = authenticated.request().endpoint().instance_id();
+    ProviderDeliveryNormalization::Rejected(Box::new(
+        automata_ci_provider::RejectedProviderDeliveryDraft::new(
+            ProviderDeliveryId::new(),
+            ExternalDeliveryIdentity::new(
+                instance_id,
+                ExternalDeliveryId::new("delivery-1").expect("delivery ID"),
+            ),
+            ProviderEventName::new("fake").expect("event type"),
+            authenticated,
+            None,
+            reason,
+            ProviderDeliveryObservations::new(Vec::new()).expect("observations"),
+        )
+        .expect("rejected draft"),
+    ))
+}
+
+fn endpoint(
+    provider_type: &str,
+    instance_id: ProviderInstanceId,
+) -> ProviderWebhookEndpointManifest {
+    ProviderWebhookEndpointManifest::new(
+        ProviderWebhookEndpointId::new(),
+        ProviderWebhookEndpointRevision::new(1).expect("endpoint revision"),
+        ProviderWebhookEndpointState::Active,
+        ProviderTypeId::new(provider_type).expect("provider type"),
+        instance_id,
+        ProviderConfigurationRevision::new(2).expect("provider revision"),
+        ProviderConnectionId::new(),
+        ProviderConnectionRevision::new(1).expect("connection revision"),
+        1_024,
+        30 * 24 * 60 * 60 * 1_000,
+        vec![
+            ProviderWebhookSecretReference::new(
+                ProviderConfigurationRevision::new(1).expect("old revision"),
+                ProviderSecretName::new("webhook-secret").expect("secret name"),
+                ProviderSecretGeneration::new(1).expect("old generation"),
+            ),
+            ProviderWebhookSecretReference::new(
+                ProviderConfigurationRevision::new(2).expect("new revision"),
+                ProviderSecretName::new("webhook-secret").expect("secret name"),
+                ProviderSecretGeneration::new(2).expect("new generation"),
+            ),
+        ],
+        UnixMillis::new(1_000),
+        None,
+    )
+    .expect("endpoint")
+}
+
+fn candidates(endpoint: &ProviderWebhookEndpointManifest) -> ProviderWebhookSecretCandidates {
+    ProviderWebhookSecretCandidates::new(
+        endpoint,
+        [
+            (
+                ProviderConfigurationRevision::new(1).expect("old revision"),
+                ProviderSecret::new(
+                    ProviderSecretName::new("webhook-secret").expect("secret name"),
+                    ProviderSecretGeneration::new(1).expect("old generation"),
+                    SecretBytes::new(OLD_SECRET.to_vec()).expect("old secret"),
+                ),
+            ),
+            (
+                ProviderConfigurationRevision::new(2).expect("new revision"),
+                ProviderSecret::new(
+                    ProviderSecretName::new("webhook-secret").expect("secret name"),
+                    ProviderSecretGeneration::new(2).expect("new generation"),
+                    SecretBytes::new(NEW_SECRET.to_vec()).expect("new secret"),
+                ),
+            ),
+        ],
+    )
+    .expect("candidate set")
+}
+
+fn request(
+    endpoint: ProviderWebhookEndpointManifest,
+    body: &[u8],
+    secret: &[u8],
+) -> ProviderWebhookRequest {
+    let mut hash = Sha256::new();
+    hash.update(secret);
+    hash.update(body);
+    let signature = hex_digest(&hash.finalize()).into_bytes();
+    ProviderWebhookRequest::new(
+        endpoint,
+        ProviderWebhookMethod::Post,
+        ProviderWebhookHeaders::new([(
+            ProviderWebhookHeaderName::new("x-fake-signature").expect("header name"),
+            signature,
+        )])
+        .expect("headers"),
+        body.to_vec(),
+        UnixMillis::new(2_000),
+    )
+    .expect("request")
+}
+
+fn object(hex: char) -> GitObjectId {
+    GitObjectId::from_hex(GitObjectAlgorithm::Sha1, &hex.to_string().repeat(40)).expect("object")
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
+}
+
+#[test]
+fn invalid_signature_never_reaches_payload_parsing() {
+    let parsed = Arc::new(AtomicBool::new(false));
+    let adapter = FakeAdapter::new("forgejo", Arc::clone(&parsed));
+    let endpoint = endpoint("forgejo", ProviderInstanceId::new());
+    let candidates = candidates(&endpoint);
+    let request = request(endpoint, b"not-json", b"wrong-secret");
+
+    assert_eq!(
+        adapter
+            .authenticate(
+                ProviderWebhookAuthenticationRequest::new(request, candidates)
+                    .expect("authentication request"),
+            )
+            .unwrap_err(),
+        ProviderWebhookAuthenticationError::InvalidSignature
+    );
+    assert!(!parsed.load(Ordering::SeqCst));
+}
+
+#[test]
+fn rotation_records_the_exact_generation_that_verified() {
+    let adapter = FakeAdapter::new("forgejo", Arc::new(AtomicBool::new(false)));
+    let endpoint = endpoint("forgejo", ProviderInstanceId::new());
+    let candidates = candidates(&endpoint);
+    let authenticated = adapter
+        .authenticate(
+            ProviderWebhookAuthenticationRequest::new(
+                request(endpoint, br#"{"kind":"push"}"#, OLD_SECRET),
+                candidates,
+            )
+            .expect("authentication request"),
+        )
+        .expect("old secret accepted");
+
+    assert_eq!(authenticated.signature().secret().generation().get(), 1);
+    assert_eq!(
+        authenticated
+            .signature()
+            .secret()
+            .configuration_revision()
+            .get(),
+        1
+    );
+}
+
+#[test]
+fn registry_is_exact_and_instances_do_not_share_secret_candidates() {
+    let forgejo = Arc::new(FakeAdapter::new(
+        "forgejo",
+        Arc::new(AtomicBool::new(false)),
+    ));
+    let github = Arc::new(FakeAdapter::new("github", Arc::new(AtomicBool::new(false))));
+    let registry = DeliveryAdapterRegistry::new([
+        Arc::clone(&forgejo) as Arc<dyn DeliveryAdapter>,
+        Arc::clone(&github) as Arc<dyn DeliveryAdapter>,
+    ])
+    .expect("registry");
+    let first = endpoint("forgejo", ProviderInstanceId::new());
+    let second = endpoint("forgejo", ProviderInstanceId::new());
+
+    assert_eq!(
+        registry.resolve(&first).expect("adapter").provider_type(),
+        forgejo.provider_type()
+    );
+    let first_candidates = candidates(&first);
+    let second_request = request(second, br#"{"kind":"push"}"#, OLD_SECRET);
+    assert!(ProviderWebhookAuthenticationRequest::new(second_request, first_candidates).is_err());
+}
+
+#[test]
+fn authenticated_invalid_json_is_recorded_without_admission() {
+    let parsed = Arc::new(AtomicBool::new(false));
+    let adapter = FakeAdapter::new("forgejo", Arc::clone(&parsed));
+    let endpoint = endpoint("forgejo", ProviderInstanceId::new());
+    let candidates = candidates(&endpoint);
+    let authenticated = adapter
+        .authenticate(
+            ProviderWebhookAuthenticationRequest::new(
+                request(endpoint, b"not-json", NEW_SECRET),
+                candidates,
+            )
+            .expect("authentication request"),
+        )
+        .expect("signature");
+
+    assert!(matches!(
+        adapter.normalize(authenticated),
+        ProviderDeliveryNormalization::Rejected(_)
+    ));
+    assert!(parsed.load(Ordering::SeqCst));
+}
+
+#[test]
+fn worker_fence_rejects_mutations_before_claim_or_at_expiry() {
+    let fence = ProviderDeliveryClaimFence::new(
+        ProviderDeliveryId::new(),
+        ProviderDeliveryWorkerId::new(),
+        1,
+        UnixMillis::new(100),
+        UnixMillis::new(200),
+    )
+    .expect("fence");
+
+    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(99)).is_err());
+    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(200)).is_err());
+    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(150)).is_ok());
+}

--- a/crates/automata-ci-store-postgres/migrations/0053_provider_delivery_foundation.sql
+++ b/crates/automata-ci-store-postgres/migrations/0053_provider_delivery_foundation.sql
@@ -1,0 +1,355 @@
+-- Final provider-neutral webhook endpoint and delivery inbox foundation.
+-- GitHub-specific delivery tables are cut over and removed in Stage B; this
+-- schema is deliberately independent and has no compatibility triggers.
+
+ALTER TABLE provider_instance_revisions
+    ADD CONSTRAINT provider_instance_revision_type_unique
+    UNIQUE (instance_id, revision, provider_type);
+
+ALTER TABLE provider_instance_secret_bindings
+    ADD CONSTRAINT provider_instance_secret_generation_unique
+    UNIQUE (instance_id, revision, secret_name, secret_generation);
+
+ALTER TABLE provider_connection_revisions
+    ADD CONSTRAINT provider_connection_provider_revision_unique
+    UNIQUE (
+        connection_id, revision, provider_instance_id, provider_revision
+    );
+
+CREATE TABLE provider_webhook_endpoint_revisions (
+    endpoint_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    lifecycle_state TEXT NOT NULL,
+    provider_type TEXT NOT NULL,
+    provider_instance_id UUID NOT NULL,
+    provider_revision BIGINT NOT NULL,
+    connection_id UUID NOT NULL,
+    connection_revision BIGINT NOT NULL,
+    body_limit BIGINT NOT NULL,
+    raw_retention_millis BIGINT NOT NULL,
+    candidate_count SMALLINT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    retired_at_ms BIGINT,
+    PRIMARY KEY (endpoint_id, revision),
+    UNIQUE (
+        endpoint_id, revision, provider_type, provider_instance_id,
+        provider_revision, connection_id, connection_revision
+    ),
+    FOREIGN KEY (provider_instance_id, provider_revision, provider_type)
+        REFERENCES provider_instance_revisions (
+            instance_id, revision, provider_type
+        ) ON DELETE RESTRICT,
+    FOREIGN KEY (
+        connection_id, connection_revision,
+        provider_instance_id, provider_revision
+    ) REFERENCES provider_connection_revisions (
+        connection_id, revision, provider_instance_id, provider_revision
+    ) ON DELETE RESTRICT,
+    CHECK (revision > 0),
+    CHECK (lifecycle_state IN ('active', 'disabled', 'retired')),
+    CHECK (octet_length(provider_type) BETWEEN 1 AND 64),
+    CHECK (body_limit BETWEEN 1 AND 33554432),
+    CHECK (raw_retention_millis BETWEEN 1 AND 31536000000),
+    CHECK (candidate_count BETWEEN 1 AND 4),
+    CHECK (created_at_ms >= 0),
+    CHECK (retired_at_ms IS NULL OR retired_at_ms >= created_at_ms),
+    CHECK (
+        (lifecycle_state = 'retired') = (retired_at_ms IS NOT NULL)
+    )
+);
+
+CREATE TABLE provider_webhook_endpoint_secret_candidates (
+    endpoint_id UUID NOT NULL,
+    endpoint_revision BIGINT NOT NULL,
+    ordinal SMALLINT NOT NULL,
+    provider_instance_id UUID NOT NULL,
+    configuration_revision BIGINT NOT NULL,
+    secret_name TEXT NOT NULL,
+    secret_generation BIGINT NOT NULL,
+    PRIMARY KEY (endpoint_id, endpoint_revision, ordinal),
+    UNIQUE (
+        endpoint_id, endpoint_revision, configuration_revision,
+        secret_name, secret_generation
+    ),
+    FOREIGN KEY (endpoint_id, endpoint_revision)
+        REFERENCES provider_webhook_endpoint_revisions (endpoint_id, revision)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (
+        provider_instance_id, configuration_revision,
+        secret_name, secret_generation
+    ) REFERENCES provider_instance_secret_bindings (
+        instance_id, revision, secret_name, secret_generation
+    ) ON DELETE RESTRICT,
+    CHECK (ordinal BETWEEN 1 AND 4)
+);
+
+CREATE TABLE provider_webhook_endpoint_current (
+    endpoint_id UUID PRIMARY KEY,
+    revision BIGINT NOT NULL,
+    FOREIGN KEY (endpoint_id, revision)
+        REFERENCES provider_webhook_endpoint_revisions (endpoint_id, revision)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE provider_delivery_records (
+    delivery_id UUID PRIMARY KEY,
+    provider_instance_id UUID NOT NULL,
+    external_delivery_id TEXT NOT NULL,
+    replay_fingerprint BYTEA NOT NULL,
+    endpoint_id UUID NOT NULL,
+    endpoint_revision BIGINT NOT NULL,
+    provider_type TEXT NOT NULL,
+    provider_revision BIGINT NOT NULL,
+    connection_id UUID NOT NULL,
+    connection_revision BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    received_at_ms BIGINT NOT NULL,
+    raw_object_key TEXT NOT NULL,
+    raw_body_digest BYTEA NOT NULL,
+    raw_body_size BIGINT NOT NULL,
+    raw_media_type TEXT NOT NULL,
+    raw_retain_until_ms BIGINT NOT NULL,
+    signature_scheme TEXT NOT NULL,
+    signature_configuration_revision BIGINT NOT NULL,
+    signature_secret_name TEXT NOT NULL,
+    signature_secret_generation BIGINT NOT NULL,
+    disposition TEXT NOT NULL,
+    repository_external_id TEXT,
+    normalized_trigger BYTEA,
+    normalized_trigger_digest BYTEA,
+    rejection_reason TEXT,
+    observations BYTEA NOT NULL,
+    observations_digest BYTEA NOT NULL,
+    state TEXT NOT NULL,
+    attempts SMALLINT NOT NULL,
+    available_at_ms BIGINT NOT NULL,
+    accepted_at_ms BIGINT NOT NULL,
+    claim_worker_id UUID,
+    claim_fence BIGINT,
+    claim_started_at_ms BIGINT,
+    claim_expires_at_ms BIGINT,
+    completed_at_ms BIGINT,
+    failure_kind TEXT,
+    UNIQUE (provider_instance_id, external_delivery_id),
+    FOREIGN KEY (
+        endpoint_id, endpoint_revision, provider_type,
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
+    ) REFERENCES provider_webhook_endpoint_revisions (
+        endpoint_id, revision, provider_type,
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
+    ) ON DELETE RESTRICT,
+    FOREIGN KEY (
+        provider_instance_id, signature_configuration_revision,
+        signature_secret_name, signature_secret_generation
+    ) REFERENCES provider_instance_secret_bindings (
+        instance_id, revision, secret_name, secret_generation
+    ) ON DELETE RESTRICT,
+    CHECK (octet_length(external_delivery_id) BETWEEN 1 AND 512),
+    CHECK (octet_length(replay_fingerprint) = 32),
+    CHECK (octet_length(event_type) BETWEEN 1 AND 128),
+    CHECK (received_at_ms >= 0),
+    CHECK (octet_length(raw_object_key) BETWEEN 1 AND 1024),
+    CHECK (octet_length(raw_body_digest) = 32),
+    CHECK (raw_body_size BETWEEN 0 AND 33554432),
+    CHECK (octet_length(raw_media_type) BETWEEN 1 AND 128),
+    CHECK (raw_retain_until_ms > received_at_ms),
+    CHECK (octet_length(signature_scheme) BETWEEN 1 AND 64),
+    CHECK (octet_length(signature_secret_name) BETWEEN 1 AND 64),
+    CHECK (disposition IN ('trigger', 'rejected')),
+    CHECK (
+        repository_external_id IS NULL
+        OR octet_length(repository_external_id) BETWEEN 1 AND 512
+    ),
+    CHECK (
+        (disposition = 'trigger'
+            AND repository_external_id IS NOT NULL
+            AND octet_length(normalized_trigger) BETWEEN 1 AND 65536
+            AND octet_length(normalized_trigger_digest) = 32
+            AND rejection_reason IS NULL)
+        OR
+        (disposition = 'rejected'
+            AND normalized_trigger IS NULL
+            AND normalized_trigger_digest IS NULL
+            AND rejection_reason IN (
+                'unknown-event', 'unsupported-event', 'incomplete-event',
+                'payload-identity-mismatch', 'invalid-payload'
+            ))
+    ),
+    CHECK (octet_length(observations) <= 16384),
+    CHECK (octet_length(observations_digest) = 32),
+    CHECK (state IN (
+        'pending', 'retry-pending', 'claimed', 'completed', 'failed', 'discarded'
+    )),
+    CHECK (attempts BETWEEN 0 AND 16),
+    CHECK (available_at_ms >= accepted_at_ms),
+    CHECK (accepted_at_ms >= 0),
+    CHECK (
+        (state IN ('pending', 'discarded') AND attempts = 0)
+        OR (state NOT IN ('pending', 'discarded') AND attempts > 0)
+    ),
+    CHECK (
+        (state = 'claimed'
+            AND claim_worker_id IS NOT NULL
+            AND claim_fence > 0
+            AND claim_started_at_ms >= accepted_at_ms
+            AND claim_expires_at_ms > claim_started_at_ms)
+        OR (state <> 'claimed'
+            AND claim_worker_id IS NULL
+            AND claim_started_at_ms IS NULL
+            AND claim_expires_at_ms IS NULL)
+    ),
+    CHECK (
+        (state IN ('completed', 'failed') AND completed_at_ms IS NOT NULL)
+        OR (state NOT IN ('completed', 'failed') AND completed_at_ms IS NULL)
+    ),
+    CHECK (
+        (state IN ('retry-pending', 'failed') AND failure_kind IN (
+            'dependency-unavailable', 'policy-rejected', 'invalid-evidence'
+        ))
+        OR (state NOT IN ('retry-pending', 'failed') AND failure_kind IS NULL)
+    ),
+    CHECK (
+        (disposition = 'trigger' AND state <> 'discarded')
+        OR (disposition = 'rejected' AND state = 'discarded')
+    )
+);
+
+CREATE INDEX provider_delivery_records_ready
+    ON provider_delivery_records (available_at_ms, accepted_at_ms, delivery_id)
+    WHERE state IN ('pending', 'retry-pending', 'claimed');
+
+CREATE FUNCTION automata_reject_provider_webhook_revision_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'provider webhook endpoint revisions and candidates are immutable'
+        USING ERRCODE = 'integrity_constraint_violation';
+END;
+$$;
+
+CREATE TRIGGER provider_webhook_endpoint_revisions_immutable
+BEFORE UPDATE OR DELETE ON provider_webhook_endpoint_revisions
+FOR EACH ROW EXECUTE FUNCTION automata_reject_provider_webhook_revision_mutation();
+
+CREATE TRIGGER provider_webhook_endpoint_candidates_immutable
+BEFORE UPDATE OR DELETE ON provider_webhook_endpoint_secret_candidates
+FOR EACH ROW EXECUTE FUNCTION automata_reject_provider_webhook_revision_mutation();
+
+CREATE FUNCTION automata_enforce_provider_webhook_current_advance()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.endpoint_id IS DISTINCT FROM OLD.endpoint_id
+       OR NEW.revision <> OLD.revision + 1 THEN
+        RAISE EXCEPTION 'provider webhook endpoint current revision must advance contiguously'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER provider_webhook_endpoint_current_contiguous
+BEFORE UPDATE ON provider_webhook_endpoint_current
+FOR EACH ROW EXECUTE FUNCTION automata_enforce_provider_webhook_current_advance();
+
+CREATE FUNCTION automata_enforce_provider_delivery_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'provider delivery evidence is immutable'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+
+    IF ROW(
+        NEW.delivery_id, NEW.provider_instance_id, NEW.external_delivery_id,
+        NEW.replay_fingerprint, NEW.endpoint_id, NEW.endpoint_revision,
+        NEW.provider_type, NEW.provider_revision, NEW.connection_id,
+        NEW.connection_revision, NEW.event_type, NEW.received_at_ms,
+        NEW.raw_object_key, NEW.raw_body_digest, NEW.raw_body_size,
+        NEW.raw_media_type, NEW.raw_retain_until_ms, NEW.signature_scheme,
+        NEW.signature_configuration_revision, NEW.signature_secret_name,
+        NEW.signature_secret_generation, NEW.disposition,
+        NEW.repository_external_id, NEW.normalized_trigger,
+        NEW.normalized_trigger_digest, NEW.rejection_reason,
+        NEW.observations, NEW.observations_digest, NEW.accepted_at_ms
+    ) IS DISTINCT FROM ROW(
+        OLD.delivery_id, OLD.provider_instance_id, OLD.external_delivery_id,
+        OLD.replay_fingerprint, OLD.endpoint_id, OLD.endpoint_revision,
+        OLD.provider_type, OLD.provider_revision, OLD.connection_id,
+        OLD.connection_revision, OLD.event_type, OLD.received_at_ms,
+        OLD.raw_object_key, OLD.raw_body_digest, OLD.raw_body_size,
+        OLD.raw_media_type, OLD.raw_retain_until_ms, OLD.signature_scheme,
+        OLD.signature_configuration_revision, OLD.signature_secret_name,
+        OLD.signature_secret_generation, OLD.disposition,
+        OLD.repository_external_id, OLD.normalized_trigger,
+        OLD.normalized_trigger_digest, OLD.rejection_reason,
+        OLD.observations, OLD.observations_digest, OLD.accepted_at_ms
+    ) THEN
+        RAISE EXCEPTION 'provider delivery immutable evidence changed'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+
+    IF OLD.state IN ('pending', 'retry-pending') AND NEW.state = 'claimed' THEN
+        IF NEW.attempts <> OLD.attempts + 1
+           OR NEW.claim_fence <> COALESCE(OLD.claim_fence, 0) + 1
+           OR NEW.available_at_ms <> OLD.available_at_ms
+           OR NEW.failure_kind IS NOT NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider delivery initial claim transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'claimed' THEN
+        IF NEW.attempts <> OLD.attempts + 1
+           OR NEW.claim_fence <> OLD.claim_fence + 1
+           OR NEW.claim_started_at_ms < OLD.claim_expires_at_ms
+           OR NEW.claim_expires_at_ms <= OLD.claim_expires_at_ms
+           OR NEW.available_at_ms <> OLD.available_at_ms
+           OR NEW.failure_kind IS NOT NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider delivery reclaim transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'retry-pending' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.available_at_ms <= OLD.available_at_ms
+           OR NEW.failure_kind IS NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider delivery retry transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'completed' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.completed_at_ms IS DISTINCT FROM NEW.available_at_ms
+           OR NEW.completed_at_ms >= OLD.claim_expires_at_ms
+           OR NEW.failure_kind IS NOT NULL THEN
+            RAISE EXCEPTION 'provider delivery completion transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'failed' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.completed_at_ms IS DISTINCT FROM NEW.available_at_ms
+           OR NEW.completed_at_ms >= OLD.claim_expires_at_ms
+           OR NEW.failure_kind IS NULL THEN
+            RAISE EXCEPTION 'provider delivery failure transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'provider delivery lifecycle transition is invalid'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER provider_delivery_records_transition
+BEFORE UPDATE OR DELETE ON provider_delivery_records
+FOR EACH ROW EXECUTE FUNCTION automata_enforce_provider_delivery_transition();

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -213,6 +213,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0052_canonical_git_object_ids.sql",
         "c3cfa4f85f13f8385bf6edd2c997018eb6e8542dc01a0821456d1caf33d062d404bc902810429315318c40a305feb0cc",
     ),
+    (
+        "0053_provider_delivery_foundation.sql",
+        "52a3ab7e1e78fedee448882f0f400f3b4ae9ef0accf02b2f990543fdacb261a3f280774ba7787f4a9a1c4cd99c0d93f1",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
+++ b/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
@@ -3,7 +3,7 @@
 - Roadmap status: Active
 - Available provider: GitHub only
 - Target provider: Forgejo 16.0.x
-- Current checkpoint: A4 delivery foundation
+- Current checkpoint: A5 source and changed-file foundation
 - Date: 2026-08-18
 
 This roadmap owns the refactor that separates source-hosting providers from


### PR DESCRIPTION
## Outcome

Adds the provider-neutral webhook delivery foundation required before migrating GitHub or implementing Forgejo. The boundary is final-form and adapter-driven: endpoints pin exact provider/instance/connection revisions, authentication happens over raw bytes before parsing, normalized triggers are provider-independent, and durable replay/worker state is generic.

## Architecture

- opaque endpoint, delivery, external-change, and merge-queue identities
- canonical push, pull-request, merge-queue, and repository-dispatch triggers with algorithm-bearing Git object IDs
- two-stage `DeliveryAdapter` authentication and normalization registry with exact header selection and endpoint-bound secret custody
- sealed verified/rejected delivery evidence, raw blob retention, and replay fingerprints
- generic delivery repository and fenced worker ports with claim, retry, completion, failure, and discard state
- PostgreSQL endpoint revisions, encrypted secret candidates, replay/conflict acceptance, immutable evidence, and skip-locked worker claims

## Failure model

Invalid signatures never parse payloads. Authenticated malformed or unsupported events become durable rejected evidence. Cross-instance candidates, stale provider/connection revisions, secret digest tampering, replay conflicts, claim fence drift, expired claims, and evidence mutation all fail closed. Connection disablement closes ingress immediately.

No compatibility facade, alias, fallback dispatch, dual write, provider-specific import, or deprecated delivery path is added. Existing GitHub behavior is unchanged until its staged cutover.

## Verification

- provider and PostgreSQL adapter all-target test suites
- strict Clippy with warnings denied for both changed crates
- migration lineage/fingerprint tests after rebasing behind canonical migration 0052
- fresh PostgreSQL 18 integration tests for encrypted endpoint secrets, replay/conflict, immutable evidence, worker fencing/retry/completion, stale/tampered state, and disabled ingress
- formatting and whitespace checks
- dependency and provider-specific import audits

## Size

5,830 additions + 21 deletions = 5,851 changed lines across 19 files, below the 10,000-line cap.

Roadmap checkpoint advances to A5 source and changed-file foundation after merge.