### PR TITLE
A5: add complete changed-file evidence contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "async-trait",
  "automata-ci-auth",
  "automata-ci-core",
+ "automata-ci-provider",
  "bytes",
  "serde",
  "serde_json",

--- a/crates/automata-ci-scm/Cargo.toml
+++ b/crates/automata-ci-scm/Cargo.toml
@@ -15,6 +15,7 @@ publish.workspace = true
 async-trait.workspace = true
 automata-ci-auth.workspace = true
 automata-ci-core.workspace = true
+automata-ci-provider.workspace = true
 bytes.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/automata-ci-scm/README.md
+++ b/crates/automata-ci-scm/README.md
@@ -9,6 +9,11 @@ for least-privilege, short-lived repository credentials. Requests bind the
 workload, repository, permissions, and minimum validity without exposing a
 provider's root credential.
 
+The changed-file boundary binds each read to an active provider connection and
+sealed normalized trigger. It distinguishes complete, inapplicable, and
+incomplete comparisons, incrementally bounds and hashes every provider page,
+and never exposes partial paths through the complete-result API.
+
 GitHub HTTP adapters implement the snapshot ports, and `automata-ci-action`
 consumes the snapshot contracts to build verified action bundles.
 `automata-ci-credential-github` composes the credential values with

--- a/crates/automata-ci-scm/src/changed_files.rs
+++ b/crates/automata-ci-scm/src/changed_files.rs
@@ -1,0 +1,769 @@
+//! Completeness-bearing changed-file evidence for normalized provider triggers.
+
+use std::fmt;
+
+use async_trait::async_trait;
+use automata_ci_auth::secret::SecretString;
+use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_provider::{
+    ExternalRepositoryIdentity, ProviderConnectionId, ProviderConnectionManifest,
+    ProviderConnectionRevision, ProviderLifecycleState, ProviderRepositoryPath,
+    SealedNormalizedTrigger,
+};
+use bytes::Bytes;
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::ScmError;
+
+/// Maximum complete changed-file records accepted by the common boundary.
+pub const MAX_CHANGED_FILE_COUNT: usize = 100_000;
+/// Maximum provider pages represented by one changed-file observation.
+pub const MAX_CHANGED_FILE_PAGES: usize = 1_000;
+/// Maximum aggregate provider response bytes for one changed-file read.
+pub const MAX_CHANGED_FILE_RESPONSE_BYTES: u64 = 64 * 1_024 * 1_024;
+
+const CHANGED_FILE_EVIDENCE_DOMAIN: &[u8] = b"automata.scm.changed-files.v1\0";
+const CHANGED_FILE_REQUEST_DOMAIN: &[u8] = b"automata.scm.changed-files.request.v1\0";
+
+/// Independent bounds applied across one changed-file operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ChangedFileLimits {
+    files: usize,
+    pages: usize,
+    response_bytes: u64,
+}
+
+impl ChangedFileLimits {
+    /// Creates positive bounds no larger than the common hard ceilings.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero or excessive values.
+    pub const fn new(
+        maximum_files: usize,
+        maximum_pages: usize,
+        maximum_response_bytes: u64,
+    ) -> Result<Self, ChangedFileLimitsError> {
+        if maximum_files == 0
+            || maximum_files > MAX_CHANGED_FILE_COUNT
+            || maximum_pages == 0
+            || maximum_pages > MAX_CHANGED_FILE_PAGES
+            || maximum_response_bytes == 0
+            || maximum_response_bytes > MAX_CHANGED_FILE_RESPONSE_BYTES
+        {
+            return Err(ChangedFileLimitsError);
+        }
+        Ok(Self {
+            files: maximum_files,
+            pages: maximum_pages,
+            response_bytes: maximum_response_bytes,
+        })
+    }
+
+    /// Returns the complete record ceiling.
+    #[must_use]
+    pub const fn maximum_files(self) -> usize {
+        self.files
+    }
+
+    /// Returns the provider page ceiling.
+    #[must_use]
+    pub const fn maximum_pages(self) -> usize {
+        self.pages
+    }
+
+    /// Returns the aggregate response-byte ceiling.
+    #[must_use]
+    pub const fn maximum_response_bytes(self) -> u64 {
+        self.response_bytes
+    }
+}
+
+/// One connection-bound request for changed-file evidence.
+pub struct ChangedFileRequest<'request> {
+    connection: &'request ProviderConnectionManifest,
+    trigger: &'request SealedNormalizedTrigger,
+    credential: Option<&'request SecretString>,
+    limits: ChangedFileLimits,
+    observed_at: UnixMillis,
+}
+
+impl<'request> ChangedFileRequest<'request> {
+    /// Creates a credential-free changed-file request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inactive connections, pre-epoch observation times, and triggers
+    /// for another repository.
+    pub fn public(
+        connection: &'request ProviderConnectionManifest,
+        trigger: &'request SealedNormalizedTrigger,
+        limits: ChangedFileLimits,
+        observed_at: UnixMillis,
+    ) -> Result<Self, ChangedFileRequestError> {
+        Self::build(connection, trigger, None, limits, observed_at)
+    }
+
+    /// Creates a changed-file request with one explicitly borrowed credential.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inactive connections, pre-epoch observation times, and triggers
+    /// for another repository.
+    pub fn authenticated(
+        connection: &'request ProviderConnectionManifest,
+        trigger: &'request SealedNormalizedTrigger,
+        credential: &'request SecretString,
+        limits: ChangedFileLimits,
+        observed_at: UnixMillis,
+    ) -> Result<Self, ChangedFileRequestError> {
+        Self::build(connection, trigger, Some(credential), limits, observed_at)
+    }
+
+    fn build(
+        connection: &'request ProviderConnectionManifest,
+        trigger: &'request SealedNormalizedTrigger,
+        credential: Option<&'request SecretString>,
+        limits: ChangedFileLimits,
+        observed_at: UnixMillis,
+    ) -> Result<Self, ChangedFileRequestError> {
+        if connection.state() != ProviderLifecycleState::Active {
+            return Err(ChangedFileRequestError::InactiveConnection);
+        }
+        if observed_at.get() < 0 {
+            return Err(ChangedFileRequestError::InvalidObservationTime);
+        }
+        if trigger.trigger().target_repository().identity()
+            != connection.configuration().repository()
+        {
+            return Err(ChangedFileRequestError::RepositoryMismatch);
+        }
+        Ok(Self {
+            connection,
+            trigger,
+            credential,
+            limits,
+            observed_at,
+        })
+    }
+
+    /// Returns the exact active connection revision.
+    #[must_use]
+    pub const fn connection(&self) -> &ProviderConnectionManifest {
+        self.connection
+    }
+
+    /// Returns the exact canonical normalized trigger.
+    #[must_use]
+    pub const fn trigger(&self) -> &SealedNormalizedTrigger {
+        self.trigger
+    }
+
+    /// Returns the instance-scoped target repository.
+    #[must_use]
+    pub const fn repository(&self) -> &ExternalRepositoryIdentity {
+        self.connection.configuration().repository()
+    }
+
+    /// Returns the explicitly borrowed credential, when present.
+    #[must_use]
+    pub const fn credential(&self) -> Option<&SecretString> {
+        self.credential
+    }
+
+    /// Returns independent file, page, and response-byte limits.
+    #[must_use]
+    pub const fn limits(&self) -> ChangedFileLimits {
+        self.limits
+    }
+
+    /// Returns the trusted observation time bound to resulting evidence.
+    #[must_use]
+    pub const fn observed_at(&self) -> UnixMillis {
+        self.observed_at
+    }
+}
+
+impl fmt::Debug for ChangedFileRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ChangedFileRequest")
+            .field("connection_id", &self.connection.connection_id())
+            .field("connection_revision", &self.connection.revision())
+            .field("trigger_digest", &self.trigger.digest())
+            .field("repository", &self.repository())
+            .field("credential", &self.credential.map(|_| "[redacted]"))
+            .field("limits", &self.limits)
+            .field("observed_at", &self.observed_at)
+            .finish()
+    }
+}
+
+/// One canonical changed-file record, including both sides of a rename.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ChangedFile {
+    current_path: ProviderRepositoryPath,
+    previous_path: Option<ProviderRepositoryPath>,
+}
+
+impl ChangedFile {
+    /// Creates one changed path without rename evidence.
+    #[must_use]
+    pub const fn changed(current_path: ProviderRepositoryPath) -> Self {
+        Self {
+            current_path,
+            previous_path: None,
+        }
+    }
+
+    /// Creates one rename with distinct previous and current paths.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a rename whose two paths are equal.
+    pub fn renamed(
+        previous_path: ProviderRepositoryPath,
+        current_path: ProviderRepositoryPath,
+    ) -> Result<Self, ChangedFileReadError> {
+        if previous_path == current_path {
+            return Err(ChangedFileReadError::InvalidRename);
+        }
+        Ok(Self {
+            current_path,
+            previous_path: Some(previous_path),
+        })
+    }
+
+    /// Returns the current repository-relative path.
+    #[must_use]
+    pub const fn current_path(&self) -> &ProviderRepositoryPath {
+        &self.current_path
+    }
+
+    /// Returns the prior path when this record represents a rename.
+    #[must_use]
+    pub const fn previous_path(&self) -> Option<&ProviderRepositoryPath> {
+        self.previous_path.as_ref()
+    }
+}
+
+/// Why a comparison is meaningful but cannot be proven complete.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChangedFileIncompleteReason {
+    /// A created ref has no provider-proven comparison base.
+    CreatedRef,
+    /// A deleted ref has no post-update tree.
+    DeletedRef,
+    /// A forced update cannot prove the required comparison semantics.
+    ForcedUpdate,
+    /// The provider reported a gap or divergent comparison history.
+    CompareGap,
+    /// The operation exhausted its explicit page budget.
+    PaginationLimit,
+    /// The provider explicitly marked its response as truncated.
+    ProviderTruncated,
+    /// The provider's documented record window is smaller than the result.
+    ProviderRecordLimit,
+}
+
+impl ChangedFileIncompleteReason {
+    const fn code(self) -> u8 {
+        match self {
+            Self::CreatedRef => 1,
+            Self::DeletedRef => 2,
+            Self::ForcedUpdate => 3,
+            Self::CompareGap => 4,
+            Self::PaginationLimit => 5,
+            Self::ProviderTruncated => 6,
+            Self::ProviderRecordLimit => 7,
+        }
+    }
+}
+
+/// Why a normalized event has no applicable changed-file comparison.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChangedFileNotApplicableReason {
+    /// The normalized event class does not define a changed-file range.
+    EventClass,
+    /// The event has no source object against which workflows can be selected.
+    NoSourceObject,
+}
+
+/// Canonical, connection- and trigger-bound provider observation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChangedFileEvidence {
+    connection_id: ProviderConnectionId,
+    connection_revision: ProviderConnectionRevision,
+    connection_digest: Sha256Digest,
+    trigger_digest: Sha256Digest,
+    observed_at: UnixMillis,
+    observed_file_count: u64,
+    page_count: usize,
+    response_bytes: u64,
+    digest: Sha256Digest,
+}
+
+impl ChangedFileEvidence {
+    /// Returns the exact provider connection identity.
+    #[must_use]
+    pub const fn connection_id(&self) -> ProviderConnectionId {
+        self.connection_id
+    }
+
+    /// Returns the exact connection revision.
+    #[must_use]
+    pub const fn connection_revision(&self) -> ProviderConnectionRevision {
+        self.connection_revision
+    }
+
+    /// Returns the complete connection-manifest digest.
+    #[must_use]
+    pub const fn connection_digest(&self) -> Sha256Digest {
+        self.connection_digest
+    }
+
+    /// Returns the canonical normalized-trigger digest.
+    #[must_use]
+    pub const fn trigger_digest(&self) -> Sha256Digest {
+        self.trigger_digest
+    }
+
+    /// Returns the trusted observation time.
+    #[must_use]
+    pub const fn observed_at(&self) -> UnixMillis {
+        self.observed_at
+    }
+
+    /// Returns the number of provider file records observed.
+    #[must_use]
+    pub const fn observed_file_count(&self) -> u64 {
+        self.observed_file_count
+    }
+
+    /// Returns the number of provider response pages represented.
+    #[must_use]
+    pub const fn page_count(&self) -> usize {
+        self.page_count
+    }
+
+    /// Returns aggregate bytes authenticated by the page digests.
+    #[must_use]
+    pub const fn response_bytes(&self) -> u64 {
+        self.response_bytes
+    }
+
+    /// Returns the domain-separated evidence digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+/// Bounded digests for every exact provider response page.
+#[derive(Debug, Eq, PartialEq)]
+pub struct ChangedFilePageEvidence {
+    request_digest: Sha256Digest,
+    page_digests: Vec<Sha256Digest>,
+    response_bytes: u64,
+}
+
+/// Incrementally accounts for provider response pages before result decoding.
+#[derive(Debug)]
+pub struct ChangedFilePageAccumulator {
+    request_digest: Sha256Digest,
+    limits: ChangedFileLimits,
+    page_digests: Vec<Sha256Digest>,
+    response_bytes: u64,
+    current_digest: Option<Sha256>,
+    current_bytes: u64,
+    failed: bool,
+}
+
+impl ChangedFilePageAccumulator {
+    /// Starts page accounting bound to one exact changed-file request.
+    #[must_use]
+    pub fn new(request: &ChangedFileRequest<'_>) -> Self {
+        Self {
+            request_digest: changed_file_request_digest(request),
+            limits: request.limits,
+            page_digests: Vec::new(),
+            response_bytes: 0,
+            current_digest: None,
+            current_bytes: 0,
+            failed: false,
+        }
+    }
+
+    /// Starts one provider response page.
+    ///
+    /// # Errors
+    ///
+    /// Rejects nested pages and the first page beyond the page limit. A rejected
+    /// accumulator cannot seal.
+    pub fn begin_page(&mut self) -> Result<(), ChangedFileReadError> {
+        if self.failed || self.current_digest.is_some() {
+            self.failed = true;
+            return Err(ChangedFileReadError::InvalidPageState);
+        }
+        if self.page_digests.len() == self.limits.pages {
+            self.failed = true;
+            return Err(ChangedFileReadError::TooManyPages);
+        }
+        self.current_digest = Some(Sha256::new());
+        self.current_bytes = 0;
+        Ok(())
+    }
+
+    /// Accounts for one transport chunk without retaining its bytes.
+    ///
+    /// Empty transport chunks are harmless and ignored.
+    ///
+    /// # Errors
+    ///
+    /// Rejects chunks outside an open page or bytes beyond the aggregate
+    /// response limit. A rejected accumulator cannot seal.
+    pub fn push_chunk(&mut self, bytes: &Bytes) -> Result<(), ChangedFileReadError> {
+        if self.failed || self.current_digest.is_none() {
+            self.failed = true;
+            return Err(ChangedFileReadError::InvalidPageState);
+        }
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let Some(next) = self
+            .response_bytes
+            .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX))
+        else {
+            self.failed = true;
+            return Err(ChangedFileReadError::ResponseTooLarge);
+        };
+        if next > self.limits.response_bytes {
+            self.failed = true;
+            return Err(ChangedFileReadError::ResponseTooLarge);
+        }
+        let Some(current_bytes) = self
+            .current_bytes
+            .checked_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX))
+        else {
+            self.failed = true;
+            return Err(ChangedFileReadError::ResponseTooLarge);
+        };
+        let Some(digest) = self.current_digest.as_mut() else {
+            self.failed = true;
+            return Err(ChangedFileReadError::InvalidPageState);
+        };
+        self.response_bytes = next;
+        self.current_bytes = current_bytes;
+        digest.update(bytes);
+        Ok(())
+    }
+
+    /// Seals the current nonempty page digest.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a missing or empty page. A rejected accumulator cannot seal.
+    pub fn finish_page(&mut self) -> Result<(), ChangedFileReadError> {
+        let Some(digest) = self.current_digest.take() else {
+            self.failed = true;
+            return Err(ChangedFileReadError::InvalidPageState);
+        };
+        if self.failed {
+            return Err(ChangedFileReadError::InvalidPageState);
+        }
+        if self.current_bytes == 0 {
+            self.failed = true;
+            return Err(ChangedFileReadError::EmptyPage);
+        }
+        self.page_digests
+            .push(Sha256Digest::from_bytes(digest.finalize().into()));
+        self.current_bytes = 0;
+        Ok(())
+    }
+
+    /// Seals bounded page digests for complete or incomplete evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an accumulator after any page-accounting failure.
+    pub fn finish(self) -> Result<ChangedFilePageEvidence, ChangedFileReadError> {
+        if self.failed || self.current_digest.is_some() {
+            return Err(ChangedFileReadError::InvalidPageEvidence);
+        }
+        Ok(ChangedFilePageEvidence {
+            request_digest: self.request_digest,
+            page_digests: self.page_digests,
+            response_bytes: self.response_bytes,
+        })
+    }
+}
+
+/// Complete, inapplicable, or explicitly incomplete changed-file evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChangedFileRead {
+    /// Every provider record is represented in canonical path order.
+    Complete {
+        /// Unique canonical file records.
+        files: Vec<ChangedFile>,
+        /// Exact provider and request evidence.
+        evidence: ChangedFileEvidence,
+    },
+    /// The normalized event defines no changed-file comparison.
+    NotApplicable {
+        /// Closed reason the comparison does not apply.
+        reason: ChangedFileNotApplicableReason,
+    },
+    /// A comparison applies but provider evidence cannot prove completeness.
+    Incomplete {
+        /// Closed incompleteness reason.
+        reason: ChangedFileIncompleteReason,
+        /// Exact partial provider and request evidence.
+        evidence: ChangedFileEvidence,
+    },
+}
+
+impl ChangedFileRead {
+    /// Seals a complete, bounded, unique, canonical file set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate, excessive, or count-inconsistent records and
+    /// excessive page evidence.
+    pub fn complete(
+        request: &ChangedFileRequest<'_>,
+        mut files: Vec<ChangedFile>,
+        observed_file_count: u64,
+        pages: ChangedFilePageEvidence,
+    ) -> Result<Self, ChangedFileReadError> {
+        if files.len() > request.limits.files
+            || u64::try_from(files.len()).ok() != Some(observed_file_count)
+        {
+            return Err(ChangedFileReadError::InvalidFileCount);
+        }
+        files.sort();
+        if files
+            .windows(2)
+            .any(|pair| pair[0].current_path == pair[1].current_path)
+        {
+            return Err(ChangedFileReadError::DuplicatePath);
+        }
+        let evidence = seal_evidence(
+            request,
+            observed_file_count,
+            pages,
+            EvidenceShape::Complete(&files),
+        )?;
+        Ok(Self::Complete { files, evidence })
+    }
+
+    /// Records an event for which no changed-file comparison applies.
+    #[must_use]
+    pub const fn not_applicable(reason: ChangedFileNotApplicableReason) -> Self {
+        Self::NotApplicable { reason }
+    }
+
+    /// Seals partial provider evidence without manufacturing a complete path set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects excessive page evidence.
+    pub fn incomplete(
+        request: &ChangedFileRequest<'_>,
+        reason: ChangedFileIncompleteReason,
+        observed_file_count: u64,
+        pages: ChangedFilePageEvidence,
+    ) -> Result<Self, ChangedFileReadError> {
+        let evidence = seal_evidence(
+            request,
+            observed_file_count,
+            pages,
+            EvidenceShape::Incomplete(reason),
+        )?;
+        Ok(Self::Incomplete { reason, evidence })
+    }
+
+    /// Returns complete file records only when completeness was proven.
+    #[must_use]
+    pub fn complete_files(&self) -> Option<&[ChangedFile]> {
+        match self {
+            Self::Complete { files, .. } => Some(files),
+            Self::NotApplicable { .. } | Self::Incomplete { .. } => None,
+        }
+    }
+}
+
+/// Reads changed-file evidence for one exact normalized trigger.
+#[async_trait]
+pub trait ChangedFileReader: fmt::Debug + Send + Sync {
+    /// Returns a complete, inapplicable, or explicitly incomplete observation.
+    ///
+    /// Provider pagination and truncation must never be collapsed into a
+    /// successful partial list. Credentials are borrowed only for this call.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized error for authorization, transport, rate-limit, or
+    /// malformed response failures.
+    async fn read_changed_files(
+        &self,
+        request: ChangedFileRequest<'_>,
+    ) -> Result<ChangedFileRead, ScmError>;
+}
+
+#[derive(Clone, Copy)]
+enum EvidenceShape<'files> {
+    Complete(&'files [ChangedFile]),
+    Incomplete(ChangedFileIncompleteReason),
+}
+
+fn seal_evidence(
+    request: &ChangedFileRequest<'_>,
+    observed_file_count: u64,
+    pages: ChangedFilePageEvidence,
+    shape: EvidenceShape<'_>,
+) -> Result<ChangedFileEvidence, ChangedFileReadError> {
+    let ChangedFilePageEvidence {
+        request_digest,
+        page_digests,
+        response_bytes,
+    } = pages;
+    let complete = matches!(&shape, EvidenceShape::Complete(_));
+    if request_digest != changed_file_request_digest(request)
+        || page_digests.len() > request.limits.pages
+        || response_bytes > request.limits.response_bytes
+        || (complete && page_digests.is_empty())
+    {
+        return Err(ChangedFileReadError::InvalidPageEvidence);
+    }
+    let mut hash = Sha256::new();
+    hash.update(CHANGED_FILE_EVIDENCE_DOMAIN);
+    hash.update(request.connection.connection_id().as_uuid().as_bytes());
+    hash.update(request.connection.revision().get().to_be_bytes());
+    hash.update(request.connection.digest().as_bytes());
+    hash.update(request.trigger.digest().as_bytes());
+    hash.update(request.observed_at.get().to_be_bytes());
+    hash.update(observed_file_count.to_be_bytes());
+    hash.update(
+        u64::try_from(page_digests.len())
+            .expect("changed-file page hard limit fits u64")
+            .to_be_bytes(),
+    );
+    hash.update(response_bytes.to_be_bytes());
+    for page_digest in &page_digests {
+        hash.update(page_digest.as_bytes());
+    }
+    match shape {
+        EvidenceShape::Complete(files) => {
+            hash.update([1]);
+            hash.update(
+                u64::try_from(files.len())
+                    .expect("changed-file hard limit fits u64")
+                    .to_be_bytes(),
+            );
+            for file in files {
+                part(&mut hash, file.current_path.as_str().as_bytes());
+                match &file.previous_path {
+                    Some(previous) => {
+                        hash.update([1]);
+                        part(&mut hash, previous.as_str().as_bytes());
+                    }
+                    None => hash.update([0]),
+                }
+            }
+        }
+        EvidenceShape::Incomplete(reason) => {
+            hash.update([2, reason.code()]);
+        }
+    }
+    Ok(ChangedFileEvidence {
+        connection_id: request.connection.connection_id(),
+        connection_revision: request.connection.revision(),
+        connection_digest: request.connection.digest(),
+        trigger_digest: request.trigger.digest(),
+        observed_at: request.observed_at,
+        observed_file_count,
+        page_count: page_digests.len(),
+        response_bytes,
+        digest: Sha256Digest::from_bytes(hash.finalize().into()),
+    })
+}
+
+fn changed_file_request_digest(request: &ChangedFileRequest<'_>) -> Sha256Digest {
+    let mut hash = Sha256::new();
+    hash.update(CHANGED_FILE_REQUEST_DOMAIN);
+    hash.update(request.connection.connection_id().as_uuid().as_bytes());
+    hash.update(request.connection.revision().get().to_be_bytes());
+    hash.update(request.connection.digest().as_bytes());
+    hash.update(request.trigger.digest().as_bytes());
+    hash.update(
+        u64::try_from(request.limits.files)
+            .expect("changed-file hard limit fits u64")
+            .to_be_bytes(),
+    );
+    hash.update(
+        u64::try_from(request.limits.pages)
+            .expect("changed-file page hard limit fits u64")
+            .to_be_bytes(),
+    );
+    hash.update(request.limits.response_bytes.to_be_bytes());
+    hash.update(request.observed_at.get().to_be_bytes());
+    Sha256Digest::from_bytes(hash.finalize().into())
+}
+
+fn part(hash: &mut Sha256, value: &[u8]) {
+    hash.update(
+        u64::try_from(value.len())
+            .expect("provider repository path hard limit fits u64")
+            .to_be_bytes(),
+    );
+    hash.update(value);
+}
+
+/// Invalid changed-file limits.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("changed-file limits are invalid")]
+pub struct ChangedFileLimitsError;
+
+/// Invalid connection or trigger binding for a changed-file request.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ChangedFileRequestError {
+    /// New provider reads require an active connection revision.
+    #[error("changed-file connection is not active")]
+    InactiveConnection,
+    /// The normalized target repository differs from the connection repository.
+    #[error("changed-file trigger repository does not match its connection")]
+    RepositoryMismatch,
+    /// Durable provider observations cannot predate the Unix epoch.
+    #[error("changed-file observation time is invalid")]
+    InvalidObservationTime,
+}
+
+/// Invalid changed-file result construction.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ChangedFileReadError {
+    /// A rename repeated the same path on both sides.
+    #[error("changed-file rename is invalid")]
+    InvalidRename,
+    /// A complete result exceeded its limit or disagreed with provider count.
+    #[error("changed-file count is invalid")]
+    InvalidFileCount,
+    /// More than one provider record selected the same current path.
+    #[error("changed-file path is duplicated")]
+    DuplicatePath,
+    /// A provider response page was empty.
+    #[error("changed-file response page is empty")]
+    EmptyPage,
+    /// Provider evidence exceeded the request page limit.
+    #[error("changed-file page count exceeds its limit")]
+    TooManyPages,
+    /// Provider evidence exceeded the aggregate response-byte limit.
+    #[error("changed-file response bytes exceed their limit")]
+    ResponseTooLarge,
+    /// Page evidence failed earlier or belongs to another request.
+    #[error("changed-file page evidence is invalid")]
+    InvalidPageEvidence,
+    /// Page streaming calls were made out of order.
+    #[error("changed-file page stream state is invalid")]
+    InvalidPageState,
+}

--- a/crates/automata-ci-scm/src/lib.rs
+++ b/crates/automata-ci-scm/src/lib.rs
@@ -22,9 +22,17 @@
 /// Provider-neutral workload credential request, result, and failure contracts.
 pub mod credential;
 
+mod changed_files;
 mod model;
 mod port;
 
+pub use changed_files::{
+    ChangedFile, ChangedFileEvidence, ChangedFileIncompleteReason, ChangedFileLimits,
+    ChangedFileLimitsError, ChangedFileNotApplicableReason, ChangedFilePageAccumulator,
+    ChangedFilePageEvidence, ChangedFileRead, ChangedFileReadError, ChangedFileReader,
+    ChangedFileRequest, ChangedFileRequestError, MAX_CHANGED_FILE_COUNT, MAX_CHANGED_FILE_PAGES,
+    MAX_CHANGED_FILE_RESPONSE_BYTES,
+};
 pub use model::{
     ArchiveFormat, ArchiveLimits, ArchiveLimitsError, RepositoryId, RepositoryIdError,
     RepositorySnapshot, RepositorySource, RepositorySourceRequest, RevisionError, RevisionSpec,

--- a/crates/automata-ci-scm/tests/changed_files.rs
+++ b/crates/automata-ci-scm/tests/changed_files.rs
@@ -1,0 +1,314 @@
+mod support;
+
+use automata_ci_core::{GitObjectId, UnixMillis};
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger, ProviderGitRef,
+    ProviderGitRefKind, ProviderInstanceId, ProviderLifecycleState, ProviderRepository,
+    ProviderRepositoryPath, PushTrigger, RepositoryVisibility,
+};
+use automata_ci_scm::{
+    ChangedFile, ChangedFileIncompleteReason, ChangedFileLimits, ChangedFileNotApplicableReason,
+    ChangedFilePageAccumulator, ChangedFilePageEvidence, ChangedFileRead, ChangedFileReadError,
+    ChangedFileReader, ChangedFileRequest, ChangedFileRequestError,
+};
+use bytes::Bytes;
+use static_assertions::assert_obj_safe;
+
+use support::{active_connection, connection_with_state};
+
+assert_obj_safe!(ChangedFileReader);
+
+fn page_evidence(
+    request: &ChangedFileRequest<'_>,
+    pages: &[&'static [u8]],
+) -> ChangedFilePageEvidence {
+    let mut evidence = ChangedFilePageAccumulator::new(request);
+    for page in pages {
+        evidence.begin_page().unwrap();
+        let split = page.len() / 2;
+        evidence
+            .push_chunk(&Bytes::copy_from_slice(&page[..split]))
+            .unwrap();
+        evidence
+            .push_chunk(&Bytes::copy_from_slice(&page[split..]))
+            .unwrap();
+        evidence.finish_page().unwrap();
+    }
+    evidence.finish().unwrap()
+}
+
+fn push(repository: ExternalRepositoryIdentity) -> automata_ci_provider::SealedNormalizedTrigger {
+    NormalizedTrigger::Push(
+        PushTrigger::new(
+            ProviderRepository::new(
+                repository,
+                ProviderRepositoryPath::new("org/repository").unwrap(),
+                RepositoryVisibility::Private,
+            ),
+            ProviderGitRef::new("refs/heads/main", ProviderGitRefKind::Branch).unwrap(),
+            Some(
+                GitObjectId::from_provider_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(),
+            ),
+            Some(
+                GitObjectId::from_provider_hex("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap(),
+            ),
+            false,
+            None,
+        )
+        .unwrap(),
+    )
+    .seal()
+    .unwrap()
+}
+
+#[test]
+fn request_is_connection_repository_and_trigger_bound() {
+    let connection = active_connection("repository-42");
+    let trigger = push(connection.configuration().repository().clone());
+    let request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+        UnixMillis::new(2_000),
+    )
+    .unwrap();
+    assert_eq!(request.connection(), &connection);
+    assert_eq!(
+        request.repository(),
+        connection.configuration().repository()
+    );
+    assert_eq!(request.trigger().digest(), trigger.digest());
+
+    let disabled = connection_with_state("repository-42", ProviderLifecycleState::Disabled);
+    let disabled_trigger = push(disabled.configuration().repository().clone());
+    assert_eq!(
+        ChangedFileRequest::public(
+            &disabled,
+            &disabled_trigger,
+            ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+            UnixMillis::new(2_000),
+        )
+        .unwrap_err(),
+        ChangedFileRequestError::InactiveConnection
+    );
+
+    assert_eq!(
+        ChangedFileRequest::public(
+            &connection,
+            &trigger,
+            ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+            UnixMillis::new(-1),
+        )
+        .unwrap_err(),
+        ChangedFileRequestError::InvalidObservationTime
+    );
+
+    let foreign = push(ExternalRepositoryIdentity::new(
+        "44444444-4444-4444-8444-444444444444"
+            .parse::<ProviderInstanceId>()
+            .unwrap(),
+        ExternalRepositoryId::new("repository-42").unwrap(),
+    ));
+    assert_eq!(
+        ChangedFileRequest::public(
+            &connection,
+            &foreign,
+            ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+            UnixMillis::new(2_000),
+        )
+        .unwrap_err(),
+        ChangedFileRequestError::RepositoryMismatch
+    );
+}
+
+#[test]
+fn complete_files_are_canonical_unique_and_evidence_bound() {
+    let connection = active_connection("repository-42");
+    let trigger = push(connection.configuration().repository().clone());
+    let request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+        UnixMillis::new(2_000),
+    )
+    .unwrap();
+    let renamed = ChangedFile::renamed(
+        ProviderRepositoryPath::new("old/name.rs").unwrap(),
+        ProviderRepositoryPath::new("src/name.rs").unwrap(),
+    )
+    .unwrap();
+    let pages = page_evidence(&request, &[b"page one"]);
+    let stale_pages = page_evidence(&request, &[b"page one"]);
+    let read = ChangedFileRead::complete(
+        &request,
+        vec![
+            renamed,
+            ChangedFile::changed(ProviderRepositoryPath::new("README.md").unwrap()),
+        ],
+        2,
+        pages,
+    )
+    .unwrap();
+    let ChangedFileRead::Complete { files, evidence } = read else {
+        panic!("expected complete files");
+    };
+    assert_eq!(files[0].current_path().as_str(), "README.md");
+    assert_eq!(files[1].current_path().as_str(), "src/name.rs");
+    assert_eq!(evidence.connection_digest(), connection.digest());
+    assert_eq!(evidence.trigger_digest(), trigger.digest());
+    assert_eq!(evidence.observed_file_count(), 2);
+    assert_eq!(evidence.page_count(), 1);
+    assert_eq!(evidence.response_bytes(), 8);
+
+    let later_request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 2, 4_096).unwrap(),
+        UnixMillis::new(2_001),
+    )
+    .unwrap();
+    assert_eq!(
+        ChangedFileRead::complete(
+            &later_request,
+            vec![
+                ChangedFile::changed(ProviderRepositoryPath::new("README.md").unwrap()),
+                ChangedFile::changed(ProviderRepositoryPath::new("src/name.rs").unwrap()),
+            ],
+            2,
+            stale_pages,
+        ),
+        Err(ChangedFileReadError::InvalidPageEvidence)
+    );
+
+    let duplicate = ProviderRepositoryPath::new("README.md").unwrap();
+    assert_eq!(
+        ChangedFileRead::complete(
+            &request,
+            vec![
+                ChangedFile::changed(duplicate.clone()),
+                ChangedFile::changed(duplicate),
+            ],
+            2,
+            page_evidence(&request, &[]),
+        ),
+        Err(ChangedFileReadError::DuplicatePath)
+    );
+}
+
+#[test]
+fn incompleteness_is_durable_and_never_exposes_partial_paths_as_complete() {
+    let connection = active_connection("repository-42");
+    let trigger = push(connection.configuration().repository().clone());
+    let request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 1, 4_096).unwrap(),
+        UnixMillis::new(2_000),
+    )
+    .unwrap();
+    let incomplete = ChangedFileRead::incomplete(
+        &request,
+        ChangedFileIncompleteReason::ProviderTruncated,
+        300,
+        page_evidence(&request, &[b"partial page"]),
+    )
+    .unwrap();
+    assert!(incomplete.complete_files().is_none());
+    let ChangedFileRead::Incomplete { reason, evidence } = incomplete else {
+        panic!("expected incomplete evidence");
+    };
+    assert_eq!(reason, ChangedFileIncompleteReason::ProviderTruncated);
+    assert_eq!(evidence.observed_file_count(), 300);
+
+    let mut excessive_pages = ChangedFilePageAccumulator::new(&request);
+    excessive_pages.begin_page().unwrap();
+    excessive_pages
+        .push_chunk(&Bytes::from_static(b"first"))
+        .unwrap();
+    excessive_pages.finish_page().unwrap();
+    assert_eq!(
+        excessive_pages.begin_page(),
+        Err(ChangedFileReadError::TooManyPages)
+    );
+    assert_eq!(
+        excessive_pages.finish(),
+        Err(ChangedFileReadError::InvalidPageEvidence)
+    );
+
+    let not_applicable =
+        ChangedFileRead::not_applicable(ChangedFileNotApplicableReason::EventClass);
+    assert!(not_applicable.complete_files().is_none());
+}
+
+#[test]
+fn limits_and_renames_fail_at_exact_boundaries() {
+    assert!(ChangedFileLimits::new(1, 1, 1).is_ok());
+    assert!(ChangedFileLimits::new(0, 1, 1).is_err());
+    assert!(ChangedFileLimits::new(1, 0, 1).is_err());
+    assert!(ChangedFileLimits::new(1, 1, 0).is_err());
+    let path = ProviderRepositoryPath::new("same.rs").unwrap();
+    assert_eq!(
+        ChangedFile::renamed(path.clone(), path),
+        Err(ChangedFileReadError::InvalidRename)
+    );
+}
+
+#[test]
+fn zero_changed_files_can_be_proven_complete() {
+    let connection = active_connection("repository-42");
+    let trigger = push(connection.configuration().repository().clone());
+    let request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 1, 4_096).unwrap(),
+        UnixMillis::new(2_000),
+    )
+    .unwrap();
+    let result = ChangedFileRead::complete(
+        &request,
+        Vec::new(),
+        0,
+        page_evidence(&request, &[b"empty comparison"]),
+    )
+    .unwrap();
+    assert_eq!(result.complete_files(), Some([].as_slice()));
+}
+
+#[test]
+fn page_streaming_fails_closed_at_state_and_byte_boundaries() {
+    let connection = active_connection("repository-42");
+    let trigger = push(connection.configuration().repository().clone());
+    let request = ChangedFileRequest::public(
+        &connection,
+        &trigger,
+        ChangedFileLimits::new(10, 2, 5).unwrap(),
+        UnixMillis::new(2_000),
+    )
+    .unwrap();
+
+    let mut unopened = ChangedFilePageAccumulator::new(&request);
+    assert_eq!(
+        unopened.push_chunk(&Bytes::from_static(b"data")),
+        Err(ChangedFileReadError::InvalidPageState)
+    );
+    assert_eq!(
+        unopened.finish(),
+        Err(ChangedFileReadError::InvalidPageEvidence)
+    );
+
+    let mut empty = ChangedFilePageAccumulator::new(&request);
+    empty.begin_page().unwrap();
+    assert_eq!(empty.finish_page(), Err(ChangedFileReadError::EmptyPage));
+
+    let mut oversized = ChangedFilePageAccumulator::new(&request);
+    oversized.begin_page().unwrap();
+    oversized.push_chunk(&Bytes::from_static(b"123")).unwrap();
+    assert_eq!(
+        oversized.push_chunk(&Bytes::from_static(b"456")),
+        Err(ChangedFileReadError::ResponseTooLarge)
+    );
+    assert_eq!(
+        oversized.finish(),
+        Err(ChangedFileReadError::InvalidPageEvidence)
+    );
+}

--- a/crates/automata-ci-scm/tests/support/mod.rs
+++ b/crates/automata-ci-scm/tests/support/mod.rs
@@ -1,0 +1,66 @@
+use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_provider::{
+    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
+    ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
+    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    ProviderDefaultBranch, ProviderInstanceId, ProviderLifecycleState, ProviderRepositoryPath,
+    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderWorkflowSource,
+    RepositoryVisibility,
+};
+
+pub(crate) fn active_connection(repository: &str) -> ProviderConnectionManifest {
+    connection_with_state(repository, ProviderLifecycleState::Active)
+}
+
+pub(crate) fn connection_with_state(
+    repository: &str,
+    state: ProviderLifecycleState,
+) -> ProviderConnectionManifest {
+    let configuration = ProviderConnectionConfiguration::new(
+        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ExternalRepositoryIdentity::new(
+            "22222222-2222-4222-8222-222222222222"
+                .parse::<ProviderInstanceId>()
+                .expect("instance"),
+            ExternalRepositoryId::new(repository).expect("repository"),
+        ),
+        ProviderConfigurationRevision::new(3).expect("provider revision"),
+        Sha256Digest::from_bytes([3; 32]),
+        Sha256Digest::from_bytes([4; 32]),
+        RepositoryVisibility::Private,
+        ProviderDefaultBranch::new("main").expect("default branch"),
+        ProviderWorkflowSource::Directory(
+            ProviderRepositoryPath::new(".github/workflows").expect("workflow root"),
+        ),
+        ProviderRunnerPolicyBinding::new(
+            ProviderSchemaVersion::new(1).expect("runner schema"),
+            Sha256Digest::from_bytes([5; 32]),
+        ),
+        ProviderArchiveLimits::new(
+            16 * 1_024 * 1_024,
+            256 * 1_024 * 1_024,
+            10_000,
+            4_096,
+            256,
+            1_024 * 1_024,
+        )
+        .expect("archive limits"),
+        ProviderConnectionPolicyDocument::new(
+            ProviderSchemaVersion::new(1).expect("policy schema"),
+            b"{}".to_vec(),
+        )
+        .expect("adapter policy"),
+    );
+    ProviderConnectionManifest::new(
+        "33333333-3333-4333-8333-333333333333"
+            .parse::<ProviderConnectionId>()
+            .expect("connection"),
+        ProviderConnectionRevision::new(7).expect("connection revision"),
+        state,
+        configuration,
+        UnixMillis::new(1_000),
+        (state != ProviderLifecycleState::Disabled).then(|| UnixMillis::new(1_001)),
+        (state == ProviderLifecycleState::Retired).then(|| UnixMillis::new(1_002)),
+    )
+    .expect("active connection")
+}

--- a/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
+++ b/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
@@ -3,7 +3,7 @@
 - Roadmap status: Active
 - Available provider: GitHub only
 - Target provider: Forgejo 16.0.x
-- Current checkpoint: A5 source and changed-file foundation
+- Current checkpoint: A5 changed-file foundation
 - Date: 2026-08-18
 
 This roadmap owns the refactor that separates source-hosting providers from
@@ -700,7 +700,7 @@ consistent and passes fresh-database tests after every merge.
 | A2 Git object identity | Replace 40-hex `ExactRevision` with algorithm-bearing `GitObjectId` across SCM, core records, protocol, object keys, and affected schema | 5,000-8,000 | SHA-1/SHA-256 round trips; uppercase, abbreviation, algorithm mismatch, and old protocol rejected |
 | A3 Provider configuration and registry | Add canonical adapter config, named secret bindings, revision/digest lifecycle, connection manifest, final validation factory registry, and config-bearing bundle construction | 6,000-8,500 | Fresh PostgreSQL contract tests; two fake instance factories coexist; unknown schema/secret/capability fails closed |
 | A4 Delivery foundation | Add opaque webhook endpoints, verified-delivery envelope, normalized trigger events, raw evidence, and generic delivery repository/worker ports | 6,500-8,500 | Fake adapters prove signature-before-parse, replay, conflict, rotation, and instance isolation |
-| A5 Source and changed-file foundation | Extend SCM with connection-scoped exact source and completeness-bearing changed-file evidence | 4,000-6,500 | Shared archive, redirect, bounds, pagination, and incomplete-evidence tests |
+| A5 Changed-file foundation | Extend SCM with connection- and trigger-scoped completeness-bearing changed-file evidence | 1,000-2,500 | Canonical paths, streaming page bounds, pagination, and incomplete-evidence tests |
 | A6 Result projection foundation | Add desired projection, generic outbox, publication lease, capability descriptor, and publisher port | 6,000-8,500 | Fake mutable and append-history publishers pass response-loss and supersession tests |
 | A7 Credential and identity foundation | Add control/workload credential strategies, generic runtime requirement, auth-code/device/identity/membership ports | 6,500-8,500 | Secret-safety, capability absence, lease binding, PKCE, and namespace tests |
 
@@ -714,7 +714,7 @@ reviewed as the permanent contracts before Stage B.
 | --- | --- | ---: | --- |
 | B1 Workflow dialect rename I | Rename workflow, expression, and action-metadata GitHub crates to the Actions dialect names; update imports and docs; no re-exports | 4,000-7,000 | Workspace and compiler golden tests unchanged semantically |
 | B2 Workflow dialect rename II | Rename executor, runtime, runner-results, permissions, and workload-OIDC crates/types that are not host-provider adapters | 6,000-8,500 | Runner/protocol/result tests; provider-specific allowlist updated |
-| B3 GitHub instance and source adapter | Move GitHub origins, App installation policy, API client, repository identity, source, and changed files into `provider-github`; register factory | 6,500-8,500 | Existing GitHub source tests plus common source contracts; two GitHub instances |
+| B3 GitHub instance and source adapter | Replace the live exact-source interface atomically; move GitHub origins, App installation policy, API client, repository identity, source, and changed files into `provider-github`; register factory | 6,500-8,500 | Existing GitHub source tests plus common source contracts; old source interface absent; two GitHub instances |
 | B4 GitHub delivery adapter | Normalize GitHub events through the common envelope; move generic worker out of `github-delivery`; replace hard-coded route | 7,000-8,500 | Push/PR/merge-group/repository-dispatch replay and signature parity |
 | B5 GitHub result adapter | Move Checks models/reconciliation behind `ResultPublisher`; migrate desired result outbox and rerun evidence | 7,000-8,500 | Annotations, actions, rerun, supersession, and lost-response parity |
 | B6 GitHub control credentials | Move GitHub App service authority, installation token mint/reconcile, permission defaults, and revocation behind control credential ports | 7,000-8,500 | Indeterminate mint, expiry, permission, rotation, and revocation parity |


### PR DESCRIPTION
## Summary

- add a provider-neutral, connection- and trigger-bound `ChangedFileReader` capability
- model complete, not-applicable, and explicitly incomplete comparisons without exposing partial paths as complete
- incrementally bound and hash response pages, bind evidence to the exact request, and canonicalize rename-aware paths
- keep the live exact-source interface unchanged so its replacement can be deleted atomically during the GitHub adapter cutover
- update the provider roadmap to reflect that clean staging boundary

## Verification

- `cargo test -p automata-ci-scm --all-targets --offline`
- `cargo clippy -p automata-ci-scm --all-targets --offline -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p automata-ci-scm --no-deps --offline`
- staged removal/diff audit: 1,167 changed lines; no compatibility, deprecated, fallback, or abandoned source-foundation symbols
