### PR TITLE
Fix live logs and browser management interactions

### DIFF
--- a/crates/automata-ci-auth-postgres/src/management.rs
+++ b/crates/automata-ci-auth-postgres/src/management.rs
@@ -1086,10 +1086,22 @@ async fn load_management_direct_bindings(
          AND membership.principal_id=binding.principal_id
         JOIN human_principals AS principal ON principal.id=binding.principal_id
         LEFT JOIN LATERAL (
-            SELECT provider_id,provider_subject,provider_login,display_name
-            FROM human_provider_identities
-            WHERE principal_id=binding.principal_id
-            ORDER BY provider_id,provider_subject
+            SELECT candidate.provider_id,candidate.provider_login,
+                   candidate.display_name
+            FROM (
+                SELECT provider_id,provider_subject AS identity_subject,
+                       provider_login,display_name,0 AS identity_priority
+                FROM human_provider_identities
+                WHERE principal_id=binding.principal_id
+                UNION ALL
+                SELECT issuer AS provider_id,subject::text AS identity_subject,
+                       subject::text AS provider_login,display_name,
+                       1 AS identity_priority
+                FROM delegated_actor_identities
+                WHERE principal_id=binding.principal_id
+            ) AS candidate
+            ORDER BY candidate.identity_priority,candidate.provider_id,
+                     candidate.identity_subject
             LIMIT 1
         ) AS identity ON TRUE
         JOIN rbac_roles AS role
@@ -3091,5 +3103,48 @@ mod tests {
             "ea2556ba-c0e0-42b8-b0ca-bde08a3ba5c4"
         );
         assert_eq!(record.display_name(), Some("CI operator"));
+    }
+
+    #[test]
+    fn delegated_identity_projection_is_a_valid_direct_binding() {
+        let principal_id =
+            Uuid::parse_str("39d3a601-9130-405b-8e1c-fa7de8ad9d8a").expect("principal ID");
+        let record = ManagementDirectBindingRow {
+            tenant_id: "acme-production".to_owned(),
+            id: Uuid::parse_str("e5ccb3f9-5615-4278-b28e-8ae42060ed75").expect("binding ID"),
+            principal_id,
+            provider_id: Some("https://ci.example.test".to_owned()),
+            provider_login: Some("ea2556ba-c0e0-42b8-b0ca-bde08a3ba5c4".to_owned()),
+            principal_display_name: Some("CI operator".to_owned()),
+            membership_status: "active".to_owned(),
+            authorization_revision: 2,
+            membership_revision: 1,
+            role_id: Uuid::parse_str("01fea869-4617-4ed8-a661-2a0e833c2e29").expect("role ID"),
+            role_name: "tenant.admin".to_owned(),
+            role_display_name: "Tenant administrator".to_owned(),
+            scope_kind: "tenant".to_owned(),
+            repository_id: None,
+            repository_tenant_id: None,
+            runner_group_id: None,
+            runner_group_tenant_id: None,
+            scope_display_name: Some("Acme production".to_owned()),
+            assignment_source: "bootstrap".to_owned(),
+            status: "active".to_owned(),
+            valid_until_ms: None,
+            revision: 1,
+        }
+        .into_record("acme-production")
+        .expect("delegated direct-binding projection");
+
+        assert_eq!(record.principal().principal_id().as_uuid(), principal_id);
+        assert_eq!(
+            record.principal().provider_id().as_str(),
+            "https://ci.example.test"
+        );
+        assert_eq!(record.principal().display_name(), Some("CI operator"));
+        assert_eq!(
+            record.source(),
+            ManagementRoleBindingSource::Direct(DirectRoleBindingSource::Bootstrap)
+        );
     }
 }

--- a/crates/automata-ci/src/app/live_log.rs
+++ b/crates/automata-ci/src/app/live_log.rs
@@ -575,7 +575,11 @@ struct SseLogDocument<'a> {
 }
 
 #[derive(Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 enum SseLogRecord<'a> {
     GroupStarted {
         group: SseLogGroup<'a>,
@@ -980,7 +984,29 @@ mod tests {
         let json = serde_json::to_string(&document).expect("SSE JSON");
 
         assert!(json.contains(r#""sequence":"18446744073709551615""#));
+        assert!(json.contains(r#""groupId":"phase/1""#));
+        assert!(!json.contains(r#""group_id""#));
         assert!(!json.contains(r#""sequence":18446744073709551615"#));
+    }
+
+    #[test]
+    fn every_sse_record_uses_the_browser_protocol_field_names() {
+        let finished = SseLogDocument {
+            protocol_version: HUMAN_LIVE_LOG_PROTOCOL_VERSION,
+            stream_id: Uuid::from_u128(5).to_string(),
+            sequence: "2".to_owned(),
+            fragment: None,
+            emitted_at_ms: 1_777_890_010_000,
+            record: SseLogRecord::GroupFinished {
+                group_id: "phase/1",
+                conclusion: "success",
+            },
+        };
+
+        let json = serde_json::to_string(&finished).expect("SSE JSON");
+
+        assert!(json.contains(r#""groupId":"phase/1""#));
+        assert!(!json.contains(r#""group_id""#));
     }
 
     #[test]

--- a/crates/automata-ci/src/app/web/routes.rs
+++ b/crates/automata-ci/src/app/web/routes.rs
@@ -1058,13 +1058,6 @@ async fn installation_setup(
             HeaderName::from_static("content-security-policy"),
             setup_csp,
         );
-        // A form POST uses the document's referrer policy when serializing its
-        // Origin header. `no-referrer` therefore produces `Origin: null`, which
-        // cannot satisfy the setup route's exact same-origin admission check.
-        response.headers_mut().insert(
-            HeaderName::from_static("referrer-policy"),
-            HeaderValue::from_static("same-origin"),
-        );
     }
     response
 }
@@ -1965,13 +1958,6 @@ fn html_response(html: String, csp_nonce: &str) -> Response<Body> {
         return internal_server_error();
     };
     apply_page_headers(response.headers_mut(), csp);
-    // Signed-out pages post to the same-origin login receiver, which redirects
-    // the browser to GitHub. Browsers enforce `form-action` across that entire
-    // redirect chain, and the login receiver requires an exact Origin header.
-    response.headers_mut().insert(
-        HeaderName::from_static("referrer-policy"),
-        HeaderValue::from_static("same-origin"),
-    );
     response
 }
 
@@ -1984,7 +1970,9 @@ fn apply_page_headers(headers: &mut HeaderMap, csp: HeaderValue) {
     );
     headers.insert(
         HeaderName::from_static("referrer-policy"),
-        HeaderValue::from_static("no-referrer"),
+        // Native forms require an exact same-origin Origin header. This policy
+        // preserves that evidence without disclosing a path cross-origin.
+        HeaderValue::from_static("same-origin"),
     );
     headers.insert(
         HeaderName::from_static("x-content-type-options"),
@@ -2258,14 +2246,17 @@ fn error_page_response_with_action_markup(
 }
 
 pub(crate) fn apply_static_page_headers(headers: &mut HeaderMap) {
-    apply_page_headers(
-        headers,
-        HeaderValue::from_static(
-            "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src data:; \
-             form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; \
-             script-src 'none'; style-src 'self'",
-        ),
-    );
+    apply_page_headers(headers, static_page_content_security_policy());
+}
+
+fn static_page_content_security_policy() -> HeaderValue {
+    // Signed-out static pages post to the local login receiver, whose success
+    // redirects to GitHub. Browsers enforce form-action across that chain.
+    HeaderValue::from_static(
+        "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src data:; \
+         form-action 'self' https://github.com; frame-ancestors 'none'; \
+         img-src 'self' data:; script-src 'none'; style-src 'self'",
+    )
 }
 
 #[cfg(test)]
@@ -3618,7 +3609,7 @@ mod tests {
         assert_eq!(response.headers()[CACHE_CONTROL], PAGE_CACHE_CONTROL);
         assert_eq!(response.headers()["x-content-type-options"], "nosniff");
         assert_eq!(response.headers()["x-frame-options"], "DENY");
-        assert_eq!(response.headers()["referrer-policy"], "no-referrer");
+        assert_eq!(response.headers()["referrer-policy"], "same-origin");
         assert_eq!(
             response.headers()["cross-origin-opener-policy"],
             "same-origin"
@@ -3628,6 +3619,8 @@ mod tests {
             .expect("error-page CSP must be valid text");
         assert!(csp.contains("script-src 'none'"));
         assert!(csp.contains("frame-ancestors 'none'"));
+        assert!(csp.contains("form-action 'self' https://github.com"));
+        assert!(!csp.contains("form-action *"));
         assert!(!csp.contains("nonce-"));
     }
 


### PR DESCRIPTION
## Summary

- serialize live-log record fields with the canonical browser protocol casing
- use one browser-safe form policy for rendered and static pages
- project delegated principals in direct RBAC bindings

## Reported failures fixed

- public job log streams fail after group headers
- GitHub sign-in forms are blocked by CSP
- browser logout is rejected
- direct bindings returns an internal server error

## Validation

- delegated identity and direct-binding projection unit tests
- live-log protocol serialization tests
- web route/header tests