### PR TITLE
ci: establish macOS build and test baseline

### DIFF
--- a/crates/automata-ci-local/src/lib.rs
+++ b/crates/automata-ci-local/src/lib.rs
@@ -545,7 +545,7 @@ impl EngineSelection {
 }
 
 impl ValidatedEngineSelection {
-    #[cfg(test)]
+    #[cfg(all(test, target_os = "linux"))]
     pub(crate) fn connection_host(&self) -> &str {
         self.connection.host()
     }

--- a/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
+++ b/crates/automata-ci-runner/src/product/windows_enrollment_admission.rs
@@ -1148,7 +1148,11 @@ mod tests {
             .enumerate()
             .map(|(index, kind)| WindowsHostInputDescriptor {
                 kind,
-                absolute_path: PathBuf::from(format!(r"C:\trusted\input-{index}.bin")),
+                absolute_path: if cfg!(windows) {
+                    PathBuf::from(format!(r"C:\trusted\input-{index}.bin"))
+                } else {
+                    PathBuf::from(format!("/trusted/input-{index}.bin"))
+                },
                 expected_sha256: Sha256Digest::from_bytes(
                     [u8::try_from(index).expect("bounded input index") + 20; 32],
                 ),

--- a/crates/automata-ci-sandbox-guest/src/main.rs
+++ b/crates/automata-ci-sandbox-guest/src/main.rs
@@ -122,6 +122,7 @@ fn path_argument(arguments: &mut impl Iterator<Item = OsString>) -> Option<PathB
     arguments.next().map(PathBuf::from)
 }
 
+#[cfg(target_os = "linux")]
 fn no_argument_future<F, E>(arguments: &mut impl Iterator<Item = OsString>, future: F) -> ExitCode
 where
     F: Future<Output = Result<(), E>>,

--- a/crates/automata-ci-sandbox-podman/src/command.rs
+++ b/crates/automata-ci-sandbox-podman/src/command.rs
@@ -1291,13 +1291,13 @@ mod cgroup_tests {
 }
 
 /// Long-running, local Podman subprocess owned by one adapter operation.
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub(crate) struct PersistentPodmanProcess {
     child: Child,
     active: bool,
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl fmt::Debug for PersistentPodmanProcess {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -1307,7 +1307,7 @@ impl fmt::Debug for PersistentPodmanProcess {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl PersistentPodmanProcess {
     pub(crate) fn spawn(
         program: &Path,
@@ -1355,7 +1355,7 @@ impl PersistentPodmanProcess {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl Drop for PersistentPodmanProcess {
     fn drop(&mut self) {
         self.stop();

--- a/crates/automata-ci-sandbox-podman/src/lib.rs
+++ b/crates/automata-ci-sandbox-podman/src/lib.rs
@@ -10,9 +10,9 @@
 
 mod command;
 mod config;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 mod docker;
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 #[path = "docker_unsupported.rs"]
 mod docker;
 mod docker_contract;

--- a/crates/automata-ci-sandbox-podman/src/state.rs
+++ b/crates/automata-ci-sandbox-podman/src/state.rs
@@ -94,7 +94,7 @@ fn validate_root_metadata(_path: &Path) -> Result<(), PodmanStateRootError> {
     Err(PodmanStateRootError::UnsupportedPlatform)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 mod local {
     use std::{
         fmt,
@@ -953,19 +953,19 @@ mod local {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub(crate) use local::{JobEnginePaths, LocalState, prepare};
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 pub(crate) fn prepare(_options: &crate::PodmanOptions) -> Result<(), PodmanStateRootError> {
     Err(PodmanStateRootError::UnsupportedPlatform)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 #[derive(Debug)]
 pub(crate) struct LocalState(std::convert::Infallible);
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 impl LocalState {
     pub(crate) fn ensure_workspace(&self, _name: &str) -> Result<PathBuf, PodmanStateRootError> {
         match self.0 {}
@@ -1023,13 +1023,13 @@ impl LocalState {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct JobEnginePaths {
     root: PathBuf,
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 impl JobEnginePaths {
     pub(crate) fn graph_root(&self) -> &Path {
         &self.root

--- a/crates/automata-ci/src/app/http.rs
+++ b/crates/automata-ci/src/app/http.rs
@@ -553,14 +553,17 @@ mod tests {
         setup_page_availability: Option<Arc<dyn web::SetupPageAvailability>>,
     ) -> Router {
         let tenant = TenantId::new("rbac-composition-test").expect("test tenant");
-        router_with_readiness_web_data(
+        let router = router_with_readiness_web_data(
             Readiness::all_ready(),
             Arc::new(web::EmptyWebData),
             rbac_data,
             setup_page_availability,
             web::RequestContext::anonymous(tenant),
         )
-        .expect("embedded renderer")
+        .expect("embedded renderer");
+        let metrics =
+            ControlPlaneMetrics::new(BuildInfo::current()).expect("control-plane metrics");
+        finalize_combined_router(router, metrics)
     }
 
     #[tokio::test]

--- a/crates/automata-ci/src/cli/credential_store.rs
+++ b/crates/automata-ci/src/cli/credential_store.rs
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     fn per_origin_lock_is_private_exclusive_and_reacquirable() {
         let _spawn_guard = PROCESS_SPAWN_GATE.blocking_lock();
-        let root = std::env::temp_dir().join(format!(
+        let root = canonical_temporary_directory().join(format!(
             "automata-auth-lock-{}-{}",
             std::process::id(),
             NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
@@ -984,7 +984,7 @@ esac
     }
 
     fn test_directory(label: &str) -> PathBuf {
-        let root = std::env::temp_dir().join(format!(
+        let root = canonical_temporary_directory().join(format!(
             "automata-{label}-{}-{}",
             std::process::id(),
             NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
@@ -992,6 +992,10 @@ esac
         std::fs::create_dir(&root).unwrap();
         std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();
         root
+    }
+
+    fn canonical_temporary_directory() -> PathBuf {
+        std::fs::canonicalize(std::env::temp_dir()).expect("canonical temporary directory")
     }
 
     fn write_test_program(root: &Path, contents: &str) -> PathBuf {

--- a/crates/automata-ci/src/cli/secret.rs
+++ b/crates/automata-ci/src/cli/secret.rs
@@ -1299,7 +1299,9 @@ mod tests {
     #[test]
     fn secret_file_input_is_absolute_owner_only_regular_and_nofollow() {
         const MARKER: &[u8] = b"unique-file-secret-marker";
-        let directory = std::env::temp_dir().join(format!("automata-secret-{}", RunId::new()));
+        let temporary_directory =
+            fs::canonicalize(std::env::temp_dir()).expect("canonical temporary directory");
+        let directory = temporary_directory.join(format!("automata-secret-{}", RunId::new()));
         fs::create_dir(&directory).expect("test directory");
         let path = directory.join("value");
         let mut file = OpenOptions::new()

--- a/crates/automata-ci/src/server/github_oidc.rs
+++ b/crates/automata-ci/src/server/github_oidc.rs
@@ -964,6 +964,7 @@ norlX3KEHNe7cTke5cP4OA==";
     fn write_private_test_file(name: &str, bytes: &[u8]) -> PathBuf {
         let test_root =
             std::env::var_os("CARGO_TARGET_TMPDIR").map_or_else(std::env::temp_dir, PathBuf::from);
+        let test_root = fs::canonicalize(test_root).expect("canonical test key root");
         let directory = test_root.join(format!(
             "automata-ci-github-oidc-product-{}",
             std::process::id()

--- a/crates/automata-ci/src/server/github_provider_runtime_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime_tests.rs
@@ -174,7 +174,9 @@ fn loopback_transport_builds_one_exact_emulator_origin() {
 
 fn config_file() -> PathBuf {
     let sequence = CONFIG_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let directory = std::env::temp_dir().join(format!(
+    let temporary_directory =
+        fs::canonicalize(std::env::temp_dir()).expect("canonical temporary directory");
+    let directory = temporary_directory.join(format!(
         "automata-github-provider-runtime-{}-{sequence}",
         std::process::id()
     ));

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -146,7 +146,9 @@ fn mixed_document() -> Value {
 }
 
 fn config_file(name: &str) -> PathBuf {
-    let directory = std::env::temp_dir().join(format!(
+    let temporary_directory =
+        fs::canonicalize(std::env::temp_dir()).expect("canonical temporary directory");
+    let directory = temporary_directory.join(format!(
         "automata-github-provider-bootstrap-{}",
         std::process::id()
     ));

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -342,9 +342,7 @@ fn internal_object_store_bucket_initialization_is_hidden_exact_and_redacted() {
     let Command::Internal(internal) = cli.command else {
         panic!("internal command expected");
     };
-    let InternalCommand::ObjectStore(object_store) = internal.command else {
-        panic!("internal object-store command expected");
-    };
+    let InternalCommand::ObjectStore(object_store) = internal.command;
     let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
     assert_eq!(args.s3.s3_tls_trust, S3TlsTrustMode::PrivateCa);
     let debug = format!("{args:?}");
@@ -401,9 +399,7 @@ fn internal_private_ca_raw_values_become_redacted_invalid_sources() {
     let Command::Internal(internal) = cli.command else {
         panic!("internal command expected");
     };
-    let InternalCommand::ObjectStore(object_store) = internal.command else {
-        panic!("internal object-store command expected");
-    };
+    let InternalCommand::ObjectStore(object_store) = internal.command;
     let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
     assert!(matches!(
         args.s3.s3_private_ca_source,

--- a/crates/automata-ci/tests/local_check_process.rs
+++ b/crates/automata-ci/tests/local_check_process.rs
@@ -233,10 +233,9 @@ impl HostileGitEnvironment {
         let trace = root.join("git-trace-private-path-marker");
         let trace2 = root.join("git-trace2-private-path-marker");
         let trace2_perf = root.join("git-trace2-perf-private-path-marker");
-        let socket_path = std::env::temp_dir().join(format!(
-            "automata-local-check-{}.socket",
-            Uuid::new_v4().simple()
-        ));
+        let nonce = Uuid::new_v4().simple().to_string();
+        let socket_path =
+            std::env::temp_dir().join(format!("a-{}-{}.sock", std::process::id(), &nonce[..12]));
         let listener = UnixListener::bind(&socket_path).expect("bind hostile trace2 socket");
         listener
             .set_nonblocking(true)

--- a/scripts/ci/run-macos-checks.sh
+++ b/scripts/ci/run-macos-checks.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
+  echo "macOS checks require an Apple Silicon macOS host" >&2
+  exit 1
+fi
+
+cargo fmt --all -- --check
+cargo clippy \
+  --locked \
+  --workspace \
+  --exclude automata-ci-service-proxy \
+  --lib \
+  --bins \
+  --all-features \
+  -- \
+  -D warnings
+cargo test \
+  --locked \
+  --all-features \
+  --no-fail-fast \
+  -p automata-ci \
+  -p automata-ci-runner \
+  -p automata-ci-sandbox-macos
+swift build \
+  -c release \
+  --package-path crates/automata-ci-sandbox-macos/swift


### PR DESCRIPTION
## Summary

- add one repeatable Apple Silicon macOS check entry point for Rust formatting, workspace linting, control-plane/runner/provider tests, and release Swift tools
- keep Linux-only Podman implementation internals out of macOS builds while preserving the unsupported provider surface
- make security-sensitive fixtures use canonical Darwin temporary paths and keep Unix socket paths within Darwin's limit
- make cross-platform runner authority fixtures use native absolute paths and exercise the fully finalized HTTP router

## Validation

- `./scripts/ci/run-macos-checks.sh` on an Apple Silicon Mac mini running macOS 26.5.1 and Xcode 26.3
  - workspace clippy passed with warnings denied (excluding the intentionally Linux-only `automata-ci-service-proxy`)
  - control-plane, runner, and macOS sandbox suites passed; the sealed physical-VM E2E remains explicitly ignored until the template is provisioned
  - all three release Swift executables built successfully
- targeted Linux regression was started with bounded parallelism, but the shared development host was saturated by unrelated builds; the changes retain the existing Linux branches exactly and normal PR CI is authoritative

## Size

74 insertions, 32 deletions.
