### PR TITLE
Bound AWS release-build memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,3 +226,9 @@ codegen-units = 1
 lto = "thin"
 panic = "abort"
 strip = "symbols"
+
+# The generated S3 client is substantially larger than any workspace crate.
+# Splitting only this dependency's code generation bounds peak compiler memory
+# while preserving the single-unit, thin-LTO profile for Automata binaries.
+[profile.release.package.aws-sdk-s3]
+codegen-units = 16


### PR DESCRIPTION
## Summary

- compile only `aws-sdk-s3` with 16 release codegen units
- preserve Automata binaries at one codegen unit with thin LTO
- reduce cold static-build compiler peak for the generated S3 client

## Validation

- `cargo fmt --all -- --check`
- local musl release build passed the previously failing `aws-sdk-s3` compile with a substantially lower memory peak

## Context

The generated S3 client exceeded the effective compiler resource envelope under the production static profile. The package-specific override bounds that dependency without weakening product optimization.