### PR TITLE
test(macos): make VM storage quota configurable

### DIFF
--- a/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
+++ b/crates/automata-ci-runner/tests/macos_vm_runner_process_e2e.rs
@@ -87,6 +87,8 @@ const VM_STORAGE_ROOT_ENV: &str = "AUTOMATA_MACOS_VM_STORAGE_ROOT";
 #[cfg(target_os = "macos")]
 const VM_STORAGE_VOLUME_UUID_ENV: &str = "AUTOMATA_MACOS_VM_STORAGE_VOLUME_UUID";
 #[cfg(target_os = "macos")]
+const VM_STORAGE_QUOTA_BYTES_ENV: &str = "AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES";
+#[cfg(target_os = "macos")]
 const DIFFERENTIAL_REFERENCE: &str = "differential.bash=ok\nisolation.cpu=4\nisolation.memory=8589934592\nisolation.process_limit=512\nisolation.no_host_helper=true\nisolation.no_ethernet=true\ndifferential.sh=ok\ndifferential.environment=command-file\ndifferential.output=vm-output\ndifferential.workspace=true\ndifferential.conclusion=success\n";
 const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -1187,6 +1189,7 @@ fn write_runner_config(
     let template_manifest = required_macos_vm_environment(VM_TEMPLATE_MANIFEST_ENV);
     let template_sha256 = process_profile_digest().to_string();
     let storage_volume_uuid = required_macos_vm_environment(VM_STORAGE_VOLUME_UUID_ENV);
+    let storage_quota_bytes = required_macos_storage_quota_bytes();
     let config = json!({
         "schema_version": RUNNER_PRODUCT_CONFIG_SCHEMA_VERSION,
         "runner_id": runner_id.to_string(),
@@ -1230,7 +1233,7 @@ fn write_runner_config(
             "template_manifest": template_manifest,
             "template_manifest_sha256": template_sha256,
             "storage_volume_uuid": storage_volume_uuid,
-            "storage_quota_bytes": 274_877_906_944_u64,
+            "storage_quota_bytes": storage_quota_bytes,
             "boot_timeout_seconds": 300,
             "stop_timeout_seconds": 10,
         },
@@ -1299,6 +1302,31 @@ fn write_runner_config(
 #[cfg(target_os = "macos")]
 fn required_macos_vm_environment(name: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| panic!("{name} is required"))
+}
+
+#[cfg(target_os = "macos")]
+fn required_macos_storage_quota_bytes() -> u64 {
+    parse_macos_storage_quota_bytes(&required_macos_vm_environment(VM_STORAGE_QUOTA_BYTES_ENV))
+        .unwrap_or_else(|| panic!("{VM_STORAGE_QUOTA_BYTES_ENV} must be a decimal byte count"))
+}
+
+#[cfg(target_os = "macos")]
+fn parse_macos_storage_quota_bytes(value: &str) -> Option<u64> {
+    (!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| value.parse().ok())
+        .flatten()
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_storage_quota_requires_one_decimal_byte_count() {
+    assert_eq!(
+        parse_macos_storage_quota_bytes("107374182400").unwrap(),
+        107_374_182_400
+    );
+    for invalid in ["", " 107374182400", "+107374182400", "100GiB"] {
+        assert!(parse_macos_storage_quota_bytes(invalid).is_none());
+    }
 }
 
 struct TemporaryRoot {

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -102,11 +102,14 @@ Back up the host, then use Disk Utility's documented
 [**Partition** operation](https://support.apple.com/guide/disk-utility/partition-a-physical-disk-dskutl14027/mac)
 to create the fixed container. Do not use **Add APFS Volume** on `Macintosh HD`. Provision the
 container with enough capacity for the chosen quota and APFS overhead. Make the
-final volume its sole member and assign a 256 GiB (`274877906944` byte) quota;
-Apple's Disk Utility **Size Options** UI can set the quota. If a bootstrap volume
-was created during partitioning, add the quota-bearing volume and remove the
-bootstrap volume only after resolving the exact device identifiers with
-`diskutil apfs list`.
+final volume its sole member and assign a whole-GiB quota between 64 GiB and
+1 TiB. The quota must exceed the sealed virtual disk length plus auxiliary
+storage plus 32 GiB of provider headroom. For example, the minimum 64 GiB
+template can use a 100 GiB (`107374182400` byte) quota; a 128 GiB template needs
+a larger quota. Apple's Disk Utility **Size Options** UI can set the quota. If a
+bootstrap volume was created during partitioning, add the quota-bearing volume
+and remove the bootstrap volume only after resolving the exact device
+identifiers with `diskutil apfs list`.
 
 Verify the mounted result and record the volume UUID:
 
@@ -257,7 +260,7 @@ and lint the Rust and Swift components, inspect the helper entitlement, and
 exercise protocol/configuration failure paths. Before deployment, that physical
 runner must also execute the ignored
 `macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_shell_job`
-test with the seven `AUTOMATA_MACOS_VM_*` artifact
+test with the eight `AUTOMATA_MACOS_VM_*` artifact and storage
 variables. That test verifies no Ethernet device, no host helper path,
 memory/vCPU sizing, the sealed process ceiling, shell/output behavior, and
 clone cleanup. Deployment qualification must additionally inject
@@ -275,6 +278,7 @@ AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST=/Volumes/AutomataVM/templates/macos-15-arm64
 AUTOMATA_MACOS_VM_TEMPLATE_SHA256=<manifest-sha256> \
 AUTOMATA_MACOS_VM_STORAGE_ROOT=/Volumes/AutomataVM/e2e-state \
 AUTOMATA_MACOS_VM_STORAGE_VOLUME_UUID=<uppercase-volume-uuid> \
+AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=107374182400 \
 cargo test --locked -p automata-ci-runner --test runner -- \
   macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_shell_job \
   --ignored --nocapture --test-threads=1


### PR DESCRIPTION
## Summary

- require the physical macOS runner E2E to receive its exact APFS quota through `AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES`
- keep quota validation in the production provider while rejecting non-decimal test inputs early
- document sizing from the sealed disk, auxiliary storage, and mandatory 32 GiB headroom
- add a 100 GiB qualification example for the minimum 64 GiB VM template so physical testing is possible on smaller dedicated Macs

The production isolation boundary is unchanged: storage must still be the only roleless volume in a dedicated non-boot APFS container on physical media.

## Validation

- `cargo fmt --all -- --check` on Apple Silicon macOS
- `cargo clippy -p automata-ci-runner --test runner -- -D warnings` on Apple Silicon macOS
- exact decimal quota parser test on Apple Silicon macOS
- `git diff --check`