### PR TITLE
Preserve migration lineage for workload OIDC rename

### DIFF
--- a/crates/automata-ci-store-postgres/migrations/0001_baseline_routines_01.sql
+++ b/crates/automata-ci-store-postgres/migrations/0001_baseline_routines_01.sql
@@ -833,7 +833,7 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION automata_enforce_workload_oidc_issuance_replacement() RETURNS trigger
+CREATE FUNCTION automata_enforce_github_oidc_issuance_replacement() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -844,15 +844,15 @@ BEGIN
         OR NEW.generation <> OLD.generation + 1
         OR NEW.issued_at_seconds < OLD.expires_at_seconds
     THEN
-        RAISE EXCEPTION 'Automata workload OIDC slot replacement is invalid'
+        RAISE EXCEPTION 'GitHub-compatible OIDC slot replacement is invalid'
             USING ERRCODE = 'integrity_constraint_violation',
-                  CONSTRAINT = 'workload_oidc_issuance_slot_replacement';
+                  CONSTRAINT = 'github_oidc_issuance_slot_replacement';
     END IF;
     RETURN NEW;
 END;
 $$;
 
-CREATE FUNCTION automata_enforce_workload_oidc_key_deadline() RETURNS trigger
+CREATE FUNCTION automata_enforce_github_oidc_key_deadline() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -862,9 +862,9 @@ BEGIN
         OR NEW.max_not_after_seconds < OLD.max_not_after_seconds
         OR NEW.updated_at_seconds < OLD.updated_at_seconds
     THEN
-        RAISE EXCEPTION 'Automata workload OIDC key retention cannot regress'
+        RAISE EXCEPTION 'GitHub-compatible OIDC key retention cannot regress'
             USING ERRCODE = 'integrity_constraint_violation',
-                  CONSTRAINT = 'workload_oidc_key_deadline_monotonic';
+                  CONSTRAINT = 'github_oidc_key_deadline_monotonic';
     END IF;
     RETURN NEW;
 END;

--- a/crates/automata-ci-store-postgres/migrations/0003_baseline_routines_03.sql
+++ b/crates/automata-ci-store-postgres/migrations/0003_baseline_routines_03.sql
@@ -1311,7 +1311,7 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION automata_workload_oidc_claim_set_valid(claims jsonb) RETURNS boolean
+CREATE FUNCTION automata_github_oidc_claim_set_valid(claims jsonb) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE STRICT
     AS $_$
 DECLARE
@@ -1350,7 +1350,7 @@ SET default_tablespace = '';
 
 SET default_table_access_method = heap;
 
-CREATE TABLE workload_oidc_authorities (
+CREATE TABLE github_oidc_authorities (
     attempt_id uuid NOT NULL,
     fencing_token bigint NOT NULL,
     authority_id uuid NOT NULL,
@@ -1388,7 +1388,7 @@ CREATE TABLE workload_oidc_authorities (
     subject_policy_mode text NOT NULL COLLATE pg_catalog."C",
     subject_policy_revision bigint NOT NULL,
     subject_policy_sha256 bytea NOT NULL,
-    github_run_subject_evidence_sha256 bytea CONSTRAINT workload_oidc_authorities_source_evidence_sha256_not_null NOT NULL,
+    github_run_subject_evidence_sha256 bytea CONSTRAINT github_oidc_authorities_source_evidence_sha256_not_null NOT NULL,
     claim_evidence_sha256 bytea NOT NULL,
     subject text NOT NULL COLLATE pg_catalog."C",
     default_audience text NOT NULL COLLATE pg_catalog."C",
@@ -1396,25 +1396,25 @@ CREATE TABLE workload_oidc_authorities (
     configuration_sha256 bytea NOT NULL,
     request_bearer_key_id text NOT NULL COLLATE pg_catalog."C",
     request_bearer_key_sha256 bytea NOT NULL,
-    request_bearer_verification_skew_seconds smallint CONSTRAINT workload_oidc_authorities_bearer_skew_not_null NOT NULL,
+    request_bearer_verification_skew_seconds smallint CONSTRAINT github_oidc_authorities_request_bearer_verification_sk_not_null NOT NULL,
     id_token_verifier_skew_seconds smallint NOT NULL,
     request_bearer_iat_seconds bigint NOT NULL,
     request_bearer_exp_seconds bigint NOT NULL,
     request_bearer_sha256 bytea NOT NULL,
     reserved_at_ms bigint NOT NULL,
-    CONSTRAINT workload_oidc_authorities_bearer_interval CHECK (((lease_issued_at_ms >= 0) AND (lease_expires_at_ms > lease_issued_at_ms) AND (reserved_at_ms >= lease_issued_at_ms) AND (reserved_at_ms < lease_expires_at_ms) AND (request_bearer_iat_seconds = (lease_issued_at_ms / 1000)) AND ((reserved_at_ms / 1000) < request_bearer_exp_seconds) AND (request_bearer_exp_seconds > request_bearer_iat_seconds) AND ((request_bearer_exp_seconds - request_bearer_iat_seconds) <= 86400) AND (request_bearer_iat_seconds <= '9223372036854775'::bigint) AND (request_bearer_exp_seconds <= '9223372036854775'::bigint) AND ((request_bearer_verification_skew_seconds >= 0) AND (request_bearer_verification_skew_seconds <= 300)) AND ((id_token_verifier_skew_seconds >= 0) AND (id_token_verifier_skew_seconds <= 300)) AND (request_bearer_exp_seconds <= ('9223372036854775807'::bigint - request_bearer_verification_skew_seconds)))),
-    CONSTRAINT workload_oidc_authorities_current_evidence_sha256 CHECK (((octet_length(plan_digest) = 32) AND (octet_length(event_digest) = 32) AND (octet_length(runtime_context_digest) = 32) AND (octet_length(permission_evidence_sha256) = 32) AND (permission_evidence_sha256 = job_ir_digest) AND (octet_length(subject_policy_sha256) = 32) AND (octet_length(github_run_subject_evidence_sha256) = 32) AND (octet_length(claim_evidence_sha256) = 32) AND (octet_length(configuration_sha256) = 32) AND (octet_length(request_bearer_sha256) = 32) AND (octet_length(request_bearer_key_sha256) = 32))),
-    CONSTRAINT workload_oidc_authorities_current_schemas CHECK (((admission_epoch = 1) AND (workflow_plan_schema = 1) AND (job_ir_schema = 1) AND ((job_ir_size_bytes >= 1) AND (job_ir_size_bytes <= 16777216)) AND (octet_length(job_ir_digest) = 32) AND ((octet_length(job_ir_object_key) >= 1) AND (octet_length(job_ir_object_key) <= 1024)) AND (job_ir_object_key !~ '[[:cntrl:]]'::text) AND ("left"(job_ir_object_key, 1) <> '/'::text) AND (job_ir_object_key !~ '(^|/)\.\.(/|$)'::text))),
-    CONSTRAINT workload_oidc_authorities_execution_numbers CHECK (((fencing_token > 0) AND (attempt_number > 0) AND (runner_session_epoch > 0) AND (runner_generation > 0) AND ((runner_slot >= 1) AND (runner_slot <= 65535)))),
-    CONSTRAINT workload_oidc_authorities_github_repository CHECK (((github_repository_id > 0) AND ((octet_length(github_repository_name) >= 3) AND (octet_length(github_repository_name) <= 140)) AND (github_repository_name ~ '^[^/]+/[^/]+$'::text) AND ((octet_length(split_part(github_repository_name, '/'::text, 1)) >= 1) AND (octet_length(split_part(github_repository_name, '/'::text, 1)) <= 39)) AND (split_part(github_repository_name, '/'::text, 1) ~ '^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$'::text) AND (split_part(github_repository_name, '/'::text, 1) !~~ '%--%'::text) AND ((octet_length(split_part(github_repository_name, '/'::text, 2)) >= 1) AND (octet_length(split_part(github_repository_name, '/'::text, 2)) <= 100)) AND (split_part(github_repository_name, '/'::text, 2) ~ '^[A-Za-z0-9._-]+$'::text) AND (split_part(github_repository_name, '/'::text, 2) <> ALL (ARRAY['.'::text, '..'::text])) AND (lower(split_part(github_repository_name, '/'::text, 2)) !~~ '%.git'::text))),
-    CONSTRAINT workload_oidc_authorities_key_id CHECK ((((octet_length(request_bearer_key_id) >= 1) AND (octet_length(request_bearer_key_id) <= 128)) AND (request_bearer_key_id ~ '^[A-Za-z0-9._-]+$'::text))),
-    CONSTRAINT workload_oidc_authorities_non_nil_ids CHECK (((attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (authority_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (repository_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (workflow_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (run_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (invocation_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (logical_job_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (instance_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (job_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (lease_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (runner_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (runner_session_id <> '00000000-0000-0000-0000-000000000000'::uuid))),
-    CONSTRAINT workload_oidc_authorities_permission_exact CHECK ((permission_mode = 'id-token:write'::text)),
-    CONSTRAINT workload_oidc_authorities_principals CHECK ((((octet_length(subject) >= 1) AND (octet_length(subject) <= 2048)) AND (btrim(subject) <> ''::text) AND (subject !~ '[[:cntrl:]]'::text) AND ((octet_length(default_audience) >= 1) AND (octet_length(default_audience) <= 2048)) AND (btrim(default_audience) <> ''::text) AND (default_audience !~ '[[:cntrl:]]'::text) AND automata_workload_oidc_claim_set_valid(additional_claims))),
-    CONSTRAINT workload_oidc_authorities_stable_owner_policy CHECK (((subject_policy_mode = 'stable_owner_evidence'::text) AND (subject_policy_revision > 0) AND (github_owner_id > 0)))
+    CONSTRAINT github_oidc_authorities_bearer_interval CHECK (((lease_issued_at_ms >= 0) AND (lease_expires_at_ms > lease_issued_at_ms) AND (reserved_at_ms >= lease_issued_at_ms) AND (reserved_at_ms < lease_expires_at_ms) AND (request_bearer_iat_seconds = (lease_issued_at_ms / 1000)) AND ((reserved_at_ms / 1000) < request_bearer_exp_seconds) AND (request_bearer_exp_seconds > request_bearer_iat_seconds) AND ((request_bearer_exp_seconds - request_bearer_iat_seconds) <= 86400) AND (request_bearer_iat_seconds <= '9223372036854775'::bigint) AND (request_bearer_exp_seconds <= '9223372036854775'::bigint) AND ((request_bearer_verification_skew_seconds >= 0) AND (request_bearer_verification_skew_seconds <= 300)) AND ((id_token_verifier_skew_seconds >= 0) AND (id_token_verifier_skew_seconds <= 300)) AND (request_bearer_exp_seconds <= ('9223372036854775807'::bigint - request_bearer_verification_skew_seconds)))),
+    CONSTRAINT github_oidc_authorities_current_evidence_sha256 CHECK (((octet_length(plan_digest) = 32) AND (octet_length(event_digest) = 32) AND (octet_length(runtime_context_digest) = 32) AND (octet_length(permission_evidence_sha256) = 32) AND (permission_evidence_sha256 = job_ir_digest) AND (octet_length(subject_policy_sha256) = 32) AND (octet_length(github_run_subject_evidence_sha256) = 32) AND (octet_length(claim_evidence_sha256) = 32) AND (octet_length(configuration_sha256) = 32) AND (octet_length(request_bearer_sha256) = 32) AND (octet_length(request_bearer_key_sha256) = 32))),
+    CONSTRAINT github_oidc_authorities_current_schemas CHECK (((admission_epoch = 1) AND (workflow_plan_schema = 1) AND (job_ir_schema = 1) AND ((job_ir_size_bytes >= 1) AND (job_ir_size_bytes <= 16777216)) AND (octet_length(job_ir_digest) = 32) AND ((octet_length(job_ir_object_key) >= 1) AND (octet_length(job_ir_object_key) <= 1024)) AND (job_ir_object_key !~ '[[:cntrl:]]'::text) AND ("left"(job_ir_object_key, 1) <> '/'::text) AND (job_ir_object_key !~ '(^|/)\.\.(/|$)'::text))),
+    CONSTRAINT github_oidc_authorities_execution_numbers CHECK (((fencing_token > 0) AND (attempt_number > 0) AND (runner_session_epoch > 0) AND (runner_generation > 0) AND ((runner_slot >= 1) AND (runner_slot <= 65535)))),
+    CONSTRAINT github_oidc_authorities_github_repository CHECK (((github_repository_id > 0) AND ((octet_length(github_repository_name) >= 3) AND (octet_length(github_repository_name) <= 140)) AND (github_repository_name ~ '^[^/]+/[^/]+$'::text) AND ((octet_length(split_part(github_repository_name, '/'::text, 1)) >= 1) AND (octet_length(split_part(github_repository_name, '/'::text, 1)) <= 39)) AND (split_part(github_repository_name, '/'::text, 1) ~ '^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$'::text) AND (split_part(github_repository_name, '/'::text, 1) !~~ '%--%'::text) AND ((octet_length(split_part(github_repository_name, '/'::text, 2)) >= 1) AND (octet_length(split_part(github_repository_name, '/'::text, 2)) <= 100)) AND (split_part(github_repository_name, '/'::text, 2) ~ '^[A-Za-z0-9._-]+$'::text) AND (split_part(github_repository_name, '/'::text, 2) <> ALL (ARRAY['.'::text, '..'::text])) AND (lower(split_part(github_repository_name, '/'::text, 2)) !~~ '%.git'::text))),
+    CONSTRAINT github_oidc_authorities_key_id CHECK ((((octet_length(request_bearer_key_id) >= 1) AND (octet_length(request_bearer_key_id) <= 128)) AND (request_bearer_key_id ~ '^[A-Za-z0-9._-]+$'::text))),
+    CONSTRAINT github_oidc_authorities_non_nil_ids CHECK (((attempt_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (authority_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (repository_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (workflow_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (run_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (invocation_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (logical_job_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (instance_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (job_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (lease_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (runner_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND (runner_session_id <> '00000000-0000-0000-0000-000000000000'::uuid))),
+    CONSTRAINT github_oidc_authorities_permission_exact CHECK ((permission_mode = 'id-token:write'::text)),
+    CONSTRAINT github_oidc_authorities_principals CHECK ((((octet_length(subject) >= 1) AND (octet_length(subject) <= 2048)) AND (btrim(subject) <> ''::text) AND (subject !~ '[[:cntrl:]]'::text) AND ((octet_length(default_audience) >= 1) AND (octet_length(default_audience) <= 2048)) AND (btrim(default_audience) <> ''::text) AND (default_audience !~ '[[:cntrl:]]'::text) AND automata_github_oidc_claim_set_valid(additional_claims))),
+    CONSTRAINT github_oidc_authorities_stable_owner_policy CHECK (((subject_policy_mode = 'stable_owner_evidence'::text) AND (subject_policy_revision > 0) AND (github_owner_id > 0)))
 );
 
-CREATE FUNCTION automata_workload_oidc_authority_is_current(authority workload_oidc_authorities, observed_at_ms bigint, required_current_before_ms bigint) RETURNS boolean
+CREATE FUNCTION automata_github_oidc_authority_is_current(authority github_oidc_authorities, observed_at_ms bigint, required_current_before_ms bigint) RETURNS boolean
     LANGUAGE sql STABLE
     AS $$
     SELECT EXISTS (

--- a/crates/automata-ci-store-postgres/migrations/0008_baseline_routines_08.sql
+++ b/crates/automata-ci-store-postgres/migrations/0008_baseline_routines_08.sql
@@ -67,7 +67,7 @@ WHERE version.tenant_id = $3 AND version.id = $5
   AND version.variable_id = $4 AND version.version_number = $6;
 $_$;
 
-CREATE FUNCTION automata_lock_workload_oidc_authority_dependencies(authority workload_oidc_authorities) RETURNS boolean
+CREATE FUNCTION automata_lock_github_oidc_authority_dependencies(authority github_oidc_authorities) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -1447,22 +1447,22 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION automata_reject_workload_oidc_authority_mutation() RETURNS trigger
+CREATE FUNCTION automata_reject_github_oidc_authority_mutation() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    RAISE EXCEPTION 'Automata workload OIDC authority is immutable'
+    RAISE EXCEPTION 'GitHub-compatible OIDC authority is immutable'
         USING ERRCODE = 'integrity_constraint_violation',
-              CONSTRAINT = 'workload_oidc_authority_immutable';
+              CONSTRAINT = 'github_oidc_authority_immutable';
 END;
 $$;
 
-CREATE FUNCTION automata_reject_workload_oidc_issuance_delete() RETURNS trigger
+CREATE FUNCTION automata_reject_github_oidc_issuance_delete() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    RAISE EXCEPTION 'Automata workload OIDC issuance slots are retained'
+    RAISE EXCEPTION 'GitHub-compatible OIDC issuance slots are retained'
         USING ERRCODE = 'integrity_constraint_violation',
-              CONSTRAINT = 'workload_oidc_issuance_slot_retained';
+              CONSTRAINT = 'github_oidc_issuance_slot_retained';
 END;
 $$;

--- a/crates/automata-ci-store-postgres/migrations/0010_baseline_routines_10.sql
+++ b/crates/automata-ci-store-postgres/migrations/0010_baseline_routines_10.sql
@@ -1170,7 +1170,7 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION automata_require_standard_workload_oidc_profile() RETURNS trigger
+CREATE FUNCTION automata_require_standard_github_oidc_profile() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -1214,9 +1214,9 @@ BEGIN
           AND manifest.authority_profile = 'standard'
           AND concrete.authority_profile = 'standard'
     ) THEN
-        RAISE EXCEPTION 'Automata workload OIDC requires historical Standard authority'
+        RAISE EXCEPTION 'GitHub-compatible OIDC requires historical Standard authority'
             USING ERRCODE = '23514',
-                  CONSTRAINT = 'workload_oidc_historical_standard_authority';
+                  CONSTRAINT = 'github_oidc_historical_standard_authority';
     END IF;
     RETURN NEW;
 END;

--- a/crates/automata-ci-store-postgres/migrations/0012_baseline_routines_12.sql
+++ b/crates/automata-ci-store-postgres/migrations/0012_baseline_routines_12.sql
@@ -1386,72 +1386,72 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION automata_validate_workload_oidc_authority_insert() RETURNS trigger
+CREATE FUNCTION automata_validate_github_oidc_authority_insert() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    IF NOT automata_lock_workload_oidc_authority_dependencies(NEW)
-        OR NOT automata_workload_oidc_authority_is_current(
+    IF NOT automata_lock_github_oidc_authority_dependencies(NEW)
+        OR NOT automata_github_oidc_authority_is_current(
             NEW, NEW.reserved_at_ms, NEW.reserved_at_ms + 1
         )
     THEN
-        RAISE EXCEPTION 'Automata workload OIDC authority is not current'
+        RAISE EXCEPTION 'GitHub-compatible OIDC authority is not current'
             USING ERRCODE = 'integrity_constraint_violation',
-                  CONSTRAINT = 'workload_oidc_authority_current_execution';
+                  CONSTRAINT = 'github_oidc_authority_current_execution';
     END IF;
     RETURN NEW;
 END;
 $$;
 
-CREATE FUNCTION automata_validate_workload_oidc_issuance_slot() RETURNS trigger
+CREATE FUNCTION automata_validate_github_oidc_issuance_slot() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
-    authority workload_oidc_authorities%ROWTYPE;
+    authority github_oidc_authorities%ROWTYPE;
     slot_count BIGINT;
 BEGIN
     IF NEW.issued_at_seconds > 9223372036854774 THEN
-        RAISE EXCEPTION 'Automata workload OIDC issuance time is out of range'
+        RAISE EXCEPTION 'GitHub-compatible OIDC issuance time is out of range'
             USING ERRCODE = 'integrity_constraint_violation',
-                  CONSTRAINT = 'workload_oidc_issuance_current_authority';
+                  CONSTRAINT = 'github_oidc_issuance_current_authority';
     END IF;
     SELECT * INTO authority
-    FROM workload_oidc_authorities
+    FROM github_oidc_authorities
     WHERE authority_id = NEW.authority_id
     FOR UPDATE;
     IF authority.authority_id IS NULL
-        OR NOT automata_lock_workload_oidc_authority_dependencies(authority)
+        OR NOT automata_lock_github_oidc_authority_dependencies(authority)
         OR NEW.resolved_audience IS DISTINCT FROM coalesce(
             NEW.requested_audience, authority.default_audience
         )
         OR NEW.issued_at_seconds < authority.request_bearer_iat_seconds
         OR NEW.not_before_seconds < authority.request_bearer_iat_seconds
         OR NEW.expires_at_seconds > authority.request_bearer_exp_seconds
-        OR NOT automata_workload_oidc_authority_is_current(
+        OR NOT automata_github_oidc_authority_is_current(
             authority,
             NEW.issued_at_seconds * 1000,
             (NEW.issued_at_seconds + 1) * 1000
         )
     THEN
-        RAISE EXCEPTION 'Automata workload OIDC issuance lacks current authority'
+        RAISE EXCEPTION 'GitHub-compatible OIDC issuance lacks current authority'
             USING ERRCODE = 'integrity_constraint_violation',
-                  CONSTRAINT = 'workload_oidc_issuance_current_authority';
+                  CONSTRAINT = 'github_oidc_issuance_current_authority';
     END IF;
     IF TG_OP = 'INSERT' THEN
         IF NEW.generation <> 1
             OR NEW.created_at_seconds <> NEW.issued_at_seconds
         THEN
-            RAISE EXCEPTION 'Automata workload OIDC initial issuance is invalid'
+            RAISE EXCEPTION 'GitHub-compatible OIDC initial issuance is invalid'
                 USING ERRCODE = 'integrity_constraint_violation',
-                      CONSTRAINT = 'workload_oidc_issuance_slot_initial';
+                      CONSTRAINT = 'github_oidc_issuance_slot_initial';
         END IF;
         SELECT count(*) INTO slot_count
-        FROM workload_oidc_issuance_slots
+        FROM github_oidc_issuance_slots
         WHERE authority_id = NEW.authority_id;
         IF slot_count >= 64 THEN
-            RAISE EXCEPTION 'Automata workload OIDC audience slot bound exceeded'
+            RAISE EXCEPTION 'GitHub-compatible OIDC audience slot bound exceeded'
                 USING ERRCODE = 'program_limit_exceeded',
-                      CONSTRAINT = 'workload_oidc_issuance_slot_bound';
+                      CONSTRAINT = 'github_oidc_issuance_slot_bound';
         END IF;
     END IF;
     RETURN NEW;

--- a/crates/automata-ci-store-postgres/migrations/0017_baseline_relations_execution.sql
+++ b/crates/automata-ci-store-postgres/migrations/0017_baseline_relations_execution.sql
@@ -352,7 +352,7 @@ CREATE TABLE github_membership_snapshots (
     CONSTRAINT github_membership_snapshots_validity CHECK ((valid_until_ms > observed_at_ms))
 );
 
-CREATE TABLE workload_oidc_issuance_slots (
+CREATE TABLE github_oidc_issuance_slots (
     authority_id uuid NOT NULL,
     audience_key_sha256 bytea NOT NULL,
     requested_audience text COLLATE pg_catalog."C",
@@ -365,23 +365,23 @@ CREATE TABLE workload_oidc_issuance_slots (
     expires_at_seconds bigint NOT NULL,
     created_at_seconds bigint NOT NULL,
     updated_at_seconds bigint NOT NULL,
-    CONSTRAINT workload_oidc_issuance_slots_audience CHECK ((((octet_length(resolved_audience) >= 1) AND (octet_length(resolved_audience) <= 2048)) AND (btrim(resolved_audience) <> ''::text) AND (resolved_audience !~ '[[:cntrl:]]'::text))),
-    CONSTRAINT workload_oidc_issuance_slots_digest CHECK ((octet_length(audience_key_sha256) = 32)),
-    CONSTRAINT workload_oidc_issuance_slots_generation CHECK ((generation > 0)),
-    CONSTRAINT workload_oidc_issuance_slots_identity CHECK (((token_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND ((octet_length(signing_key_id) >= 1) AND (octet_length(signing_key_id) <= 128)) AND (signing_key_id ~ '^[A-Za-z0-9._-]+$'::text))),
-    CONSTRAINT workload_oidc_issuance_slots_interval CHECK (((issued_at_seconds >= 0) AND (not_before_seconds >= 0) AND (not_before_seconds <= issued_at_seconds) AND (expires_at_seconds > issued_at_seconds) AND ((expires_at_seconds - issued_at_seconds) <= 3600) AND (issued_at_seconds <= '9223372036854775'::bigint) AND (created_at_seconds >= 0) AND (updated_at_seconds >= created_at_seconds) AND (updated_at_seconds = issued_at_seconds))),
-    CONSTRAINT workload_oidc_issuance_slots_requested_audience CHECK (((requested_audience IS NULL) OR (((octet_length(requested_audience) >= 1) AND (octet_length(requested_audience) <= 2048)) AND (btrim(requested_audience) <> ''::text) AND (requested_audience !~ '[[:cntrl:]]'::text))))
+    CONSTRAINT github_oidc_issuance_slots_audience CHECK ((((octet_length(resolved_audience) >= 1) AND (octet_length(resolved_audience) <= 2048)) AND (btrim(resolved_audience) <> ''::text) AND (resolved_audience !~ '[[:cntrl:]]'::text))),
+    CONSTRAINT github_oidc_issuance_slots_digest CHECK ((octet_length(audience_key_sha256) = 32)),
+    CONSTRAINT github_oidc_issuance_slots_generation CHECK ((generation > 0)),
+    CONSTRAINT github_oidc_issuance_slots_identity CHECK (((token_id <> '00000000-0000-0000-0000-000000000000'::uuid) AND ((octet_length(signing_key_id) >= 1) AND (octet_length(signing_key_id) <= 128)) AND (signing_key_id ~ '^[A-Za-z0-9._-]+$'::text))),
+    CONSTRAINT github_oidc_issuance_slots_interval CHECK (((issued_at_seconds >= 0) AND (not_before_seconds >= 0) AND (not_before_seconds <= issued_at_seconds) AND (expires_at_seconds > issued_at_seconds) AND ((expires_at_seconds - issued_at_seconds) <= 3600) AND (issued_at_seconds <= '9223372036854775'::bigint) AND (created_at_seconds >= 0) AND (updated_at_seconds >= created_at_seconds) AND (updated_at_seconds = issued_at_seconds))),
+    CONSTRAINT github_oidc_issuance_slots_requested_audience CHECK (((requested_audience IS NULL) OR (((octet_length(requested_audience) >= 1) AND (octet_length(requested_audience) <= 2048)) AND (btrim(requested_audience) <> ''::text) AND (requested_audience !~ '[[:cntrl:]]'::text))))
 );
 
-CREATE TABLE workload_oidc_key_deadlines (
+CREATE TABLE github_oidc_key_deadlines (
     key_use text NOT NULL COLLATE pg_catalog."C",
     key_id text NOT NULL COLLATE pg_catalog."C",
     key_sha256 bytea,
     max_not_after_seconds bigint NOT NULL,
     updated_at_seconds bigint NOT NULL,
-    CONSTRAINT workload_oidc_key_deadlines_key CHECK ((((octet_length(key_id) >= 1) AND (octet_length(key_id) <= 128)) AND (key_id ~ '^[A-Za-z0-9._-]+$'::text) AND ((key_sha256 IS NULL) OR (octet_length(key_sha256) = 32)))),
-    CONSTRAINT workload_oidc_key_deadlines_time CHECK (((max_not_after_seconds > 0) AND (updated_at_seconds >= 0) AND (updated_at_seconds <= max_not_after_seconds))),
-    CONSTRAINT workload_oidc_key_deadlines_use CHECK ((key_use = ANY (ARRAY['request_bearer'::text, 'id_token_signing'::text])))
+    CONSTRAINT github_oidc_key_deadlines_key CHECK ((((octet_length(key_id) >= 1) AND (octet_length(key_id) <= 128)) AND (key_id ~ '^[A-Za-z0-9._-]+$'::text) AND ((key_sha256 IS NULL) OR (octet_length(key_sha256) = 32)))),
+    CONSTRAINT github_oidc_key_deadlines_time CHECK (((max_not_after_seconds > 0) AND (updated_at_seconds >= 0) AND (updated_at_seconds <= max_not_after_seconds))),
+    CONSTRAINT github_oidc_key_deadlines_use CHECK ((key_use = ANY (ARRAY['request_bearer'::text, 'id_token_signing'::text])))
 );
 
 CREATE TABLE github_organization_membership_observations (

--- a/crates/automata-ci-store-postgres/migrations/0022_baseline_keys_and_constraints.sql
+++ b/crates/automata-ci-store-postgres/migrations/0022_baseline_keys_and_constraints.sql
@@ -97,20 +97,20 @@ ALTER TABLE ONLY github_check_subjects
 ALTER TABLE ONLY github_membership_snapshots
     ADD CONSTRAINT github_membership_snapshots_primary_key PRIMARY KEY (tenant_id, id);
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_authority_id_key UNIQUE (authority_id);
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_authority_id_key UNIQUE (authority_id);
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_primary_key PRIMARY KEY (attempt_id, fencing_token);
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_primary_key PRIMARY KEY (attempt_id, fencing_token);
 
-ALTER TABLE ONLY workload_oidc_issuance_slots
-    ADD CONSTRAINT workload_oidc_issuance_slots_primary_key PRIMARY KEY (authority_id, audience_key_sha256);
+ALTER TABLE ONLY github_oidc_issuance_slots
+    ADD CONSTRAINT github_oidc_issuance_slots_primary_key PRIMARY KEY (authority_id, audience_key_sha256);
 
-ALTER TABLE ONLY workload_oidc_issuance_slots
-    ADD CONSTRAINT workload_oidc_issuance_slots_token_id_key UNIQUE (token_id);
+ALTER TABLE ONLY github_oidc_issuance_slots
+    ADD CONSTRAINT github_oidc_issuance_slots_token_id_key UNIQUE (token_id);
 
-ALTER TABLE ONLY workload_oidc_key_deadlines
-    ADD CONSTRAINT workload_oidc_key_deadlines_primary_key PRIMARY KEY (key_use, key_id);
+ALTER TABLE ONLY github_oidc_key_deadlines
+    ADD CONSTRAINT github_oidc_key_deadlines_primary_key PRIMARY KEY (key_use, key_id);
 
 ALTER TABLE ONLY github_organization_membership_observations
     ADD CONSTRAINT github_organization_membership_observations_primary_key PRIMARY KEY (tenant_id, snapshot_id, organization_id);

--- a/crates/automata-ci-store-postgres/migrations/0023_baseline_indexes.sql
+++ b/crates/automata-ci-store-postgres/migrations/0023_baseline_indexes.sql
@@ -18,7 +18,7 @@ CREATE INDEX github_check_subjects_run ON github_check_subjects USING btree (ten
 
 CREATE INDEX github_membership_snapshots_current ON github_membership_snapshots USING btree (tenant_id, principal_id, provider_id, valid_until_ms DESC, observed_at_ms DESC);
 
-CREATE INDEX workload_oidc_key_deadlines_active_lookup ON workload_oidc_key_deadlines USING btree (key_use, max_not_after_seconds, key_id);
+CREATE INDEX github_oidc_key_deadlines_active_lookup ON github_oidc_key_deadlines USING btree (key_use, max_not_after_seconds, key_id);
 
 CREATE UNIQUE INDEX github_role_mappings_active_organization_repository ON github_role_mappings USING btree (tenant_id, provider_id, organization_id, role_id, repository_id) WHERE ((status = 'active'::text) AND (team_id IS NULL) AND (scope_kind = 'repository'::text));
 

--- a/crates/automata-ci-store-postgres/migrations/0024_baseline_triggers_control_plane.sql
+++ b/crates/automata-ci-store-postgres/migrations/0024_baseline_triggers_control_plane.sql
@@ -56,21 +56,21 @@ CREATE TRIGGER github_check_subjects_update_guard BEFORE UPDATE ON github_check_
 
 CREATE TRIGGER github_check_subjects_wake_projection AFTER UPDATE ON github_check_subjects FOR EACH ROW EXECUTE FUNCTION automata_wake_github_check_projection();
 
-CREATE TRIGGER workload_oidc_authorities_00_historical_standard_profile BEFORE INSERT ON workload_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_require_standard_workload_oidc_profile();
+CREATE TRIGGER github_oidc_authorities_00_historical_standard_profile BEFORE INSERT ON github_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_require_standard_github_oidc_profile();
 
-CREATE TRIGGER workload_oidc_authorities_insert_guard BEFORE INSERT ON workload_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_validate_workload_oidc_authority_insert();
+CREATE TRIGGER github_oidc_authorities_insert_guard BEFORE INSERT ON github_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_validate_github_oidc_authority_insert();
 
-CREATE TRIGGER workload_oidc_authorities_reject_update BEFORE DELETE OR UPDATE ON workload_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_reject_workload_oidc_authority_mutation();
+CREATE TRIGGER github_oidc_authorities_reject_update BEFORE DELETE OR UPDATE ON github_oidc_authorities FOR EACH ROW EXECUTE FUNCTION automata_reject_github_oidc_authority_mutation();
 
-CREATE TRIGGER workload_oidc_issuance_slots_reject_delete BEFORE DELETE ON workload_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_reject_workload_oidc_issuance_delete();
+CREATE TRIGGER github_oidc_issuance_slots_reject_delete BEFORE DELETE ON github_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_reject_github_oidc_issuance_delete();
 
-CREATE TRIGGER workload_oidc_issuance_slots_replace BEFORE UPDATE ON workload_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_enforce_workload_oidc_issuance_replacement();
+CREATE TRIGGER github_oidc_issuance_slots_replace BEFORE UPDATE ON github_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_enforce_github_oidc_issuance_replacement();
 
-CREATE TRIGGER workload_oidc_issuance_slots_validate BEFORE INSERT OR UPDATE ON workload_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_validate_workload_oidc_issuance_slot();
+CREATE TRIGGER github_oidc_issuance_slots_validate BEFORE INSERT OR UPDATE ON github_oidc_issuance_slots FOR EACH ROW EXECUTE FUNCTION automata_validate_github_oidc_issuance_slot();
 
-CREATE TRIGGER workload_oidc_key_deadlines_monotonic BEFORE UPDATE ON workload_oidc_key_deadlines FOR EACH ROW EXECUTE FUNCTION automata_enforce_workload_oidc_key_deadline();
+CREATE TRIGGER github_oidc_key_deadlines_monotonic BEFORE UPDATE ON github_oidc_key_deadlines FOR EACH ROW EXECUTE FUNCTION automata_enforce_github_oidc_key_deadline();
 
-CREATE TRIGGER workload_oidc_key_deadlines_reject_delete BEFORE DELETE ON workload_oidc_key_deadlines FOR EACH ROW EXECUTE FUNCTION automata_reject_workload_oidc_issuance_delete();
+CREATE TRIGGER github_oidc_key_deadlines_reject_delete BEFORE DELETE ON github_oidc_key_deadlines FOR EACH ROW EXECUTE FUNCTION automata_reject_github_oidc_issuance_delete();
 
 CREATE TRIGGER github_provider_delivery_evidence_00_authenticated_event BEFORE INSERT ON github_provider_delivery_evidence FOR EACH ROW EXECUTE FUNCTION automata_github_authenticated_event_exact();
 

--- a/crates/automata-ci-store-postgres/migrations/0026_baseline_foreign_keys.sql
+++ b/crates/automata-ci-store-postgres/migrations/0026_baseline_foreign_keys.sql
@@ -88,35 +88,35 @@ ALTER TABLE ONLY github_membership_snapshots
 ALTER TABLE ONLY github_membership_snapshots
     ADD CONSTRAINT github_membership_snapshots_membership FOREIGN KEY (tenant_id, principal_id) REFERENCES tenant_human_memberships(tenant_id, principal_id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_concrete_job FOREIGN KEY (instance_id) REFERENCES logical_workflow_concrete_jobs(instance_id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_concrete_job FOREIGN KEY (instance_id) REFERENCES logical_workflow_concrete_jobs(instance_id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_job_attempt FOREIGN KEY (job_id, attempt_id) REFERENCES job_attempts(job_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_job_attempt FOREIGN KEY (job_id, attempt_id) REFERENCES job_attempts(job_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_repository_run FOREIGN KEY (repository_id, run_id) REFERENCES workflow_runs(repository_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_repository_run FOREIGN KEY (repository_id, run_id) REFERENCES workflow_runs(repository_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_repository_workflow FOREIGN KEY (repository_id, workflow_id) REFERENCES workflow_definitions(repository_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_repository_workflow FOREIGN KEY (repository_id, workflow_id) REFERENCES workflow_definitions(repository_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_run_job FOREIGN KEY (run_id, job_id) REFERENCES jobs(run_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_run_job FOREIGN KEY (run_id, job_id) REFERENCES jobs(run_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_runner_session FOREIGN KEY (runner_id, runner_session_id, runner_session_epoch, runner_generation) REFERENCES runner_sessions(runner_id, id, session_epoch, runner_generation) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_runner_session FOREIGN KEY (runner_id, runner_session_id, runner_session_epoch, runner_generation) REFERENCES runner_sessions(runner_id, id, session_epoch, runner_generation) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_signed_run_evidence FOREIGN KEY (repository_id, run_id, github_run_subject_evidence_sha256) REFERENCES github_workflow_run_subject_evidence(repository_id, run_id, subject_evidence_sha256) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_signed_run_evidence FOREIGN KEY (repository_id, run_id, github_run_subject_evidence_sha256) REFERENCES github_workflow_run_subject_evidence(repository_id, run_id, subject_evidence_sha256) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_tenant_repository FOREIGN KEY (tenant_id, repository_id) REFERENCES repositories(tenant_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_tenant_repository FOREIGN KEY (tenant_id, repository_id) REFERENCES repositories(tenant_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_authorities
-    ADD CONSTRAINT workload_oidc_authorities_tenant_runner FOREIGN KEY (tenant_id, runner_id) REFERENCES runners(tenant_id, id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_authorities
+    ADD CONSTRAINT github_oidc_authorities_tenant_runner FOREIGN KEY (tenant_id, runner_id) REFERENCES runners(tenant_id, id) ON DELETE RESTRICT;
 
-ALTER TABLE ONLY workload_oidc_issuance_slots
-    ADD CONSTRAINT workload_oidc_issuance_slots_authority_id_fkey FOREIGN KEY (authority_id) REFERENCES workload_oidc_authorities(authority_id) ON DELETE RESTRICT;
+ALTER TABLE ONLY github_oidc_issuance_slots
+    ADD CONSTRAINT github_oidc_issuance_slots_authority_id_fkey FOREIGN KEY (authority_id) REFERENCES github_oidc_authorities(authority_id) ON DELETE RESTRICT;
 
 ALTER TABLE ONLY github_organization_membership_observations
     ADD CONSTRAINT github_organization_membership_observations_snapshot FOREIGN KEY (tenant_id, snapshot_id) REFERENCES github_membership_snapshots(tenant_id, id) ON DELETE CASCADE;

--- a/crates/automata-ci-store-postgres/migrations/0054_provider_neutral_workload_oidc.sql
+++ b/crates/automata-ci-store-postgres/migrations/0054_provider_neutral_workload_oidc.sql
@@ -1,0 +1,877 @@
+-- Keep the established baseline immutable while moving the live schema to the
+-- provider-neutral workload OIDC vocabulary. Renames preserve rows and object
+-- identities; the function replacements update stored SQL and PL/pgSQL bodies.
+
+ALTER TABLE github_oidc_authorities RENAME TO workload_oidc_authorities;
+ALTER TABLE github_oidc_issuance_slots RENAME TO workload_oidc_issuance_slots;
+ALTER TABLE github_oidc_key_deadlines RENAME TO workload_oidc_key_deadlines;
+
+ALTER FUNCTION automata_enforce_github_oidc_issuance_replacement()
+    RENAME TO automata_enforce_workload_oidc_issuance_replacement;
+ALTER FUNCTION automata_enforce_github_oidc_key_deadline()
+    RENAME TO automata_enforce_workload_oidc_key_deadline;
+ALTER FUNCTION automata_github_oidc_claim_set_valid(jsonb)
+    RENAME TO automata_workload_oidc_claim_set_valid;
+ALTER FUNCTION automata_github_oidc_authority_is_current(workload_oidc_authorities, bigint, bigint)
+    RENAME TO automata_workload_oidc_authority_is_current;
+ALTER FUNCTION automata_lock_github_oidc_authority_dependencies(workload_oidc_authorities)
+    RENAME TO automata_lock_workload_oidc_authority_dependencies;
+ALTER FUNCTION automata_reject_github_oidc_authority_mutation()
+    RENAME TO automata_reject_workload_oidc_authority_mutation;
+ALTER FUNCTION automata_reject_github_oidc_issuance_delete()
+    RENAME TO automata_reject_workload_oidc_issuance_delete;
+ALTER FUNCTION automata_require_standard_github_oidc_profile()
+    RENAME TO automata_require_standard_workload_oidc_profile;
+ALTER FUNCTION automata_validate_github_oidc_authority_insert()
+    RENAME TO automata_validate_workload_oidc_authority_insert;
+ALTER FUNCTION automata_validate_github_oidc_issuance_slot()
+    RENAME TO automata_validate_workload_oidc_issuance_slot;
+
+ALTER TABLE workload_oidc_authorities
+    RENAME CONSTRAINT github_oidc_authorities_source_evidence_sha256_not_null
+    TO workload_oidc_authorities_source_evidence_sha256_not_null;
+ALTER TABLE workload_oidc_authorities
+    RENAME CONSTRAINT github_oidc_authorities_request_bearer_verification_sk_not_null
+    TO workload_oidc_authorities_bearer_skew_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_bearer_interval TO workload_oidc_authorities_bearer_interval;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_current_evidence_sha256 TO workload_oidc_authorities_current_evidence_sha256;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_current_schemas TO workload_oidc_authorities_current_schemas;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_execution_numbers TO workload_oidc_authorities_execution_numbers;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_github_repository TO workload_oidc_authorities_github_repository;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_key_id TO workload_oidc_authorities_key_id;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_non_nil_ids TO workload_oidc_authorities_non_nil_ids;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_permission_exact TO workload_oidc_authorities_permission_exact;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_principals TO workload_oidc_authorities_principals;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_stable_owner_policy TO workload_oidc_authorities_stable_owner_policy;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_authority_id_key TO workload_oidc_authorities_authority_id_key;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_primary_key TO workload_oidc_authorities_primary_key;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_concrete_job TO workload_oidc_authorities_concrete_job;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_attempt TO workload_oidc_authorities_job_attempt;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_repository_run TO workload_oidc_authorities_repository_run;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_repository_workflow TO workload_oidc_authorities_repository_workflow;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_run_job TO workload_oidc_authorities_run_job;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_session TO workload_oidc_authorities_runner_session;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_signed_run_evidence TO workload_oidc_authorities_signed_run_evidence;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_tenant_repository TO workload_oidc_authorities_tenant_repository;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_tenant_runner TO workload_oidc_authorities_tenant_runner;
+
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_audience TO workload_oidc_issuance_slots_audience;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_digest TO workload_oidc_issuance_slots_digest;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_generation TO workload_oidc_issuance_slots_generation;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_identity TO workload_oidc_issuance_slots_identity;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_interval TO workload_oidc_issuance_slots_interval;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_requested_audience TO workload_oidc_issuance_slots_requested_audience;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_primary_key TO workload_oidc_issuance_slots_primary_key;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_token_id_key TO workload_oidc_issuance_slots_token_id_key;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_authority_id_fkey TO workload_oidc_issuance_slots_authority_id_fkey;
+
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_key TO workload_oidc_key_deadlines_key;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_time TO workload_oidc_key_deadlines_time;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_use TO workload_oidc_key_deadlines_use;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_primary_key TO workload_oidc_key_deadlines_primary_key;
+
+-- PostgreSQL 18 gives implicit NOT NULL constraints table-derived names.
+-- Rename each one so a migrated database is catalog-identical to a fresh
+-- provider-neutral schema.
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_additional_claims_not_null TO workload_oidc_authorities_additional_claims_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_admission_epoch_not_null TO workload_oidc_authorities_admission_epoch_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_attempt_id_not_null TO workload_oidc_authorities_attempt_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_attempt_number_not_null TO workload_oidc_authorities_attempt_number_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_authority_id_not_null TO workload_oidc_authorities_authority_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_claim_evidence_sha256_not_null TO workload_oidc_authorities_claim_evidence_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_configuration_sha256_not_null TO workload_oidc_authorities_configuration_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_default_audience_not_null TO workload_oidc_authorities_default_audience_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_event_digest_not_null TO workload_oidc_authorities_event_digest_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_fencing_token_not_null TO workload_oidc_authorities_fencing_token_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_github_owner_id_not_null TO workload_oidc_authorities_github_owner_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_github_repository_id_not_null TO workload_oidc_authorities_github_repository_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_github_repository_name_not_null TO workload_oidc_authorities_github_repository_name_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_id_token_verifier_skew_seconds_not_null TO workload_oidc_authorities_id_token_verifier_skew_seconds_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_instance_id_not_null TO workload_oidc_authorities_instance_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_invocation_id_not_null TO workload_oidc_authorities_invocation_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_id_not_null TO workload_oidc_authorities_job_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_ir_digest_not_null TO workload_oidc_authorities_job_ir_digest_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_ir_object_key_not_null TO workload_oidc_authorities_job_ir_object_key_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_ir_schema_not_null TO workload_oidc_authorities_job_ir_schema_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_job_ir_size_bytes_not_null TO workload_oidc_authorities_job_ir_size_bytes_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_lease_expires_at_ms_not_null TO workload_oidc_authorities_lease_expires_at_ms_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_lease_id_not_null TO workload_oidc_authorities_lease_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_lease_issued_at_ms_not_null TO workload_oidc_authorities_lease_issued_at_ms_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_logical_job_id_not_null TO workload_oidc_authorities_logical_job_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_permission_evidence_sha256_not_null TO workload_oidc_authorities_permission_evidence_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_permission_mode_not_null TO workload_oidc_authorities_permission_mode_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_plan_digest_not_null TO workload_oidc_authorities_plan_digest_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_repository_id_not_null TO workload_oidc_authorities_repository_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_request_bearer_exp_seconds_not_null TO workload_oidc_authorities_request_bearer_exp_seconds_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_request_bearer_iat_seconds_not_null TO workload_oidc_authorities_request_bearer_iat_seconds_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_request_bearer_key_id_not_null TO workload_oidc_authorities_request_bearer_key_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_request_bearer_key_sha256_not_null TO workload_oidc_authorities_request_bearer_key_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_request_bearer_sha256_not_null TO workload_oidc_authorities_request_bearer_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_reserved_at_ms_not_null TO workload_oidc_authorities_reserved_at_ms_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_run_id_not_null TO workload_oidc_authorities_run_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_generation_not_null TO workload_oidc_authorities_runner_generation_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_id_not_null TO workload_oidc_authorities_runner_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_session_epoch_not_null TO workload_oidc_authorities_runner_session_epoch_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_session_id_not_null TO workload_oidc_authorities_runner_session_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runner_slot_not_null TO workload_oidc_authorities_runner_slot_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_runtime_context_digest_not_null TO workload_oidc_authorities_runtime_context_digest_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_subject_not_null TO workload_oidc_authorities_subject_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_subject_policy_mode_not_null TO workload_oidc_authorities_subject_policy_mode_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_subject_policy_revision_not_null TO workload_oidc_authorities_subject_policy_revision_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_subject_policy_sha256_not_null TO workload_oidc_authorities_subject_policy_sha256_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_tenant_id_not_null TO workload_oidc_authorities_tenant_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_workflow_id_not_null TO workload_oidc_authorities_workflow_id_not_null;
+ALTER TABLE workload_oidc_authorities RENAME CONSTRAINT github_oidc_authorities_workflow_plan_schema_not_null TO workload_oidc_authorities_workflow_plan_schema_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_audience_key_sha256_not_null TO workload_oidc_issuance_slots_audience_key_sha256_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_authority_id_not_null TO workload_oidc_issuance_slots_authority_id_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_created_at_seconds_not_null TO workload_oidc_issuance_slots_created_at_seconds_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_expires_at_seconds_not_null TO workload_oidc_issuance_slots_expires_at_seconds_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_generation_not_null TO workload_oidc_issuance_slots_generation_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_issued_at_seconds_not_null TO workload_oidc_issuance_slots_issued_at_seconds_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_not_before_seconds_not_null TO workload_oidc_issuance_slots_not_before_seconds_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_resolved_audience_not_null TO workload_oidc_issuance_slots_resolved_audience_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_signing_key_id_not_null TO workload_oidc_issuance_slots_signing_key_id_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_token_id_not_null TO workload_oidc_issuance_slots_token_id_not_null;
+ALTER TABLE workload_oidc_issuance_slots RENAME CONSTRAINT github_oidc_issuance_slots_updated_at_seconds_not_null TO workload_oidc_issuance_slots_updated_at_seconds_not_null;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_key_id_not_null TO workload_oidc_key_deadlines_key_id_not_null;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_key_use_not_null TO workload_oidc_key_deadlines_key_use_not_null;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_max_not_after_seconds_not_null TO workload_oidc_key_deadlines_max_not_after_seconds_not_null;
+ALTER TABLE workload_oidc_key_deadlines RENAME CONSTRAINT github_oidc_key_deadlines_updated_at_seconds_not_null TO workload_oidc_key_deadlines_updated_at_seconds_not_null;
+
+ALTER INDEX github_oidc_key_deadlines_active_lookup RENAME TO workload_oidc_key_deadlines_active_lookup;
+
+ALTER TRIGGER github_oidc_authorities_00_historical_standard_profile ON workload_oidc_authorities RENAME TO workload_oidc_authorities_00_historical_standard_profile;
+ALTER TRIGGER github_oidc_authorities_insert_guard ON workload_oidc_authorities RENAME TO workload_oidc_authorities_insert_guard;
+ALTER TRIGGER github_oidc_authorities_reject_update ON workload_oidc_authorities RENAME TO workload_oidc_authorities_reject_update;
+ALTER TRIGGER github_oidc_issuance_slots_reject_delete ON workload_oidc_issuance_slots RENAME TO workload_oidc_issuance_slots_reject_delete;
+ALTER TRIGGER github_oidc_issuance_slots_replace ON workload_oidc_issuance_slots RENAME TO workload_oidc_issuance_slots_replace;
+ALTER TRIGGER github_oidc_issuance_slots_validate ON workload_oidc_issuance_slots RENAME TO workload_oidc_issuance_slots_validate;
+ALTER TRIGGER github_oidc_key_deadlines_monotonic ON workload_oidc_key_deadlines RENAME TO workload_oidc_key_deadlines_monotonic;
+ALTER TRIGGER github_oidc_key_deadlines_reject_delete ON workload_oidc_key_deadlines RENAME TO workload_oidc_key_deadlines_reject_delete;
+
+CREATE OR REPLACE FUNCTION automata_enforce_workload_oidc_issuance_replacement() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NEW.authority_id IS DISTINCT FROM OLD.authority_id
+        OR NEW.audience_key_sha256 IS DISTINCT FROM OLD.audience_key_sha256
+        OR NEW.requested_audience IS DISTINCT FROM OLD.requested_audience
+        OR NEW.created_at_seconds IS DISTINCT FROM OLD.created_at_seconds
+        OR NEW.generation <> OLD.generation + 1
+        OR NEW.issued_at_seconds < OLD.expires_at_seconds
+    THEN
+        RAISE EXCEPTION 'Automata workload OIDC slot replacement is invalid'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'workload_oidc_issuance_slot_replacement';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_enforce_workload_oidc_key_deadline() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NEW.key_use IS DISTINCT FROM OLD.key_use
+        OR NEW.key_id IS DISTINCT FROM OLD.key_id
+        OR NEW.key_sha256 IS DISTINCT FROM OLD.key_sha256
+        OR NEW.max_not_after_seconds < OLD.max_not_after_seconds
+        OR NEW.updated_at_seconds < OLD.updated_at_seconds
+    THEN
+        RAISE EXCEPTION 'Automata workload OIDC key retention cannot regress'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'workload_oidc_key_deadline_monotonic';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_workload_oidc_claim_set_valid(claims jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE STRICT
+    AS $_$
+DECLARE
+    claim RECORD;
+    claim_count INTEGER := 0;
+    claim_bytes INTEGER := 0;
+    claim_value TEXT;
+BEGIN
+    IF jsonb_typeof(claims) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+    FOR claim IN SELECT key, value FROM jsonb_each(claims) LOOP
+        claim_count := claim_count + 1;
+        IF claim_count > 32
+            OR jsonb_typeof(claim.value) <> 'string'
+            OR claim.key !~ '^[a-z][a-z0-9_]{0,63}$'
+            OR claim.key IN ('aud', 'exp', 'iat', 'iss', 'jti', 'nbf', 'sub')
+        THEN
+            RETURN FALSE;
+        END IF;
+        claim_value := claim.value #>> '{}';
+        claim_bytes := claim_bytes
+            + octet_length(claim.key) + octet_length(claim_value);
+        IF octet_length(claim_value) > 2048
+            OR claim_value ~ '[[:cntrl:]]'
+            OR claim_bytes > 16384
+        THEN
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+    RETURN TRUE;
+END;
+$_$;
+
+CREATE OR REPLACE FUNCTION automata_workload_oidc_authority_is_current(authority workload_oidc_authorities, observed_at_ms bigint, required_current_before_ms bigint) RETURNS boolean
+    LANGUAGE sql STABLE
+    AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM job_attempts AS attempt
+        JOIN jobs AS job
+          ON job.id = attempt.job_id
+         AND job.id = authority.job_id
+         AND job.run_id = authority.run_id
+        JOIN workflow_runs AS run
+          ON run.id = job.run_id
+         AND run.id = authority.run_id
+         AND run.repository_id = authority.repository_id
+         AND run.workflow_id = authority.workflow_id
+        JOIN repositories AS repository
+          ON repository.id = run.repository_id
+         AND repository.id = authority.repository_id
+         AND repository.tenant_id = authority.tenant_id
+        JOIN workflow_definitions AS workflow
+          ON workflow.id = run.workflow_id
+         AND workflow.repository_id = run.repository_id
+        JOIN workflow_snapshots AS snapshot
+          ON snapshot.id = run.snapshot_id
+         AND snapshot.workflow_id = run.workflow_id
+        JOIN logical_workflow_runs AS marker
+          ON marker.run_id = run.id
+        JOIN logical_workflow_invocations AS invocation
+          ON invocation.run_id = run.id
+         AND invocation.id = authority.invocation_id
+        JOIN logical_workflow_jobs AS logical_job
+          ON logical_job.run_id = run.id
+         AND logical_job.invocation_id = invocation.id
+         AND logical_job.id = authority.logical_job_id
+        JOIN logical_workflow_activation_preparation_claims AS preparation_claim
+          ON preparation_claim.run_id = logical_job.run_id
+         AND preparation_claim.invocation_id = logical_job.invocation_id
+         AND preparation_claim.logical_job_id = logical_job.id
+        JOIN logical_workflow_activation_preparations AS preparation
+          ON preparation.run_id = preparation_claim.run_id
+         AND preparation.invocation_id = preparation_claim.invocation_id
+         AND preparation.logical_job_id = preparation_claim.logical_job_id
+         AND preparation.descriptor_digest = preparation_claim.descriptor_digest
+        JOIN logical_workflow_activation_publications AS activation_publication
+          ON activation_publication.run_id = logical_job.run_id
+         AND activation_publication.invocation_id = logical_job.invocation_id
+         AND activation_publication.logical_job_id = logical_job.id
+         AND activation_publication.activation_input_digest =
+             preparation.activation_input_digest
+        JOIN logical_workflow_instances AS instance
+          ON instance.run_id = run.id
+         AND instance.invocation_id = invocation.id
+         AND instance.logical_job_id = logical_job.id
+         AND instance.id = authority.instance_id
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.instance_id = instance.id
+         AND concrete.run_id = run.id
+         AND concrete.invocation_id = invocation.id
+         AND concrete.logical_job_id = logical_job.id
+         AND concrete.job_id = job.id
+        JOIN logical_workflow_materialization_claims AS materialization
+          ON materialization.instance_id = concrete.instance_id
+         AND materialization.run_id = concrete.run_id
+         AND materialization.invocation_id = concrete.invocation_id
+         AND materialization.logical_job_id = concrete.logical_job_id
+         AND materialization.descriptor_digest = concrete.descriptor_digest
+         AND materialization.expected_job_id = concrete.job_id
+         AND materialization.expected_attempt_id = concrete.initial_attempt_id
+         AND materialization.owner_id = concrete.claim_owner_id
+         AND materialization.generation = concrete.claim_generation
+         AND materialization.claimed_at_ms = concrete.claim_started_at_ms
+         AND materialization.expires_at_ms = concrete.claim_expires_at_ms
+         AND materialization.updated_at_ms = concrete.committed_at_ms
+        JOIN runners AS runner
+          ON runner.id = attempt.runner_id
+         AND runner.id = authority.runner_id
+         AND runner.tenant_id = authority.tenant_id
+         AND runner.generation = authority.runner_generation
+         AND runner.session_epoch = authority.runner_session_epoch
+        JOIN runner_sessions AS session
+          ON session.id = attempt.runner_session_id
+         AND session.id = authority.runner_session_id
+         AND session.runner_id = authority.runner_id
+         AND session.session_epoch = authority.runner_session_epoch
+         AND session.runner_generation = authority.runner_generation
+        JOIN github_workflow_run_manifest_origins AS origin
+          ON origin.tenant_id = authority.tenant_id
+         AND origin.repository_id = authority.repository_id
+         AND origin.workflow_id = authority.workflow_id
+         AND origin.run_id = authority.run_id
+         AND origin.root_invocation_id = marker.root_invocation_id
+         AND origin.subject_evidence_sha256 =
+             authority.github_run_subject_evidence_sha256
+        JOIN workflow_admission_receipts AS admission_receipt
+          ON admission_receipt.tenant_id = origin.tenant_id
+         AND admission_receipt.idempotency_kind =
+             origin.admission_idempotency_kind
+         AND admission_receipt.idempotency_key =
+             origin.admission_idempotency_key
+         AND admission_receipt.request_digest = origin.logical_admission_digest
+         AND admission_receipt.repository_id = origin.repository_id
+         AND admission_receipt.run_id = origin.run_id
+         AND admission_receipt.committed_at_ms = origin.admitted_at_ms
+         AND admission_receipt.github_subject_evidence_required
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = origin.tenant_id
+         AND manifest.repository_id = origin.repository_id
+         AND manifest.provider_connection_id = origin.provider_connection_id
+         AND manifest.manifest_revision = origin.provider_manifest_revision
+         AND manifest.manifest_digest = origin.provider_manifest_digest
+        JOIN github_server_service_authorities AS checks_authority
+          ON checks_authority.tenant_id = origin.tenant_id
+         AND checks_authority.id = origin.checks_authority_id
+         AND checks_authority.repository_id = origin.repository_id
+         AND checks_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND checks_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND checks_authority.github_repository_id =
+             origin.github_repository_id
+         AND checks_authority.github_repository_name =
+             origin.github_repository_name
+         AND checks_authority.service_scope = 'checks_write'
+         AND checks_authority.identity_digest =
+             origin.checks_authority_identity_digest
+         AND checks_authority.app_configuration_revision =
+             origin.checks_authority_app_configuration_revision
+         AND checks_authority.policy_revision =
+             origin.checks_authority_policy_revision
+        LEFT JOIN github_server_service_authorities AS private_authority
+          ON private_authority.tenant_id = origin.tenant_id
+         AND private_authority.id = origin.private_source_authority_id
+         AND private_authority.repository_id = origin.repository_id
+         AND private_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND private_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND private_authority.github_repository_id =
+             origin.github_repository_id
+         AND private_authority.github_repository_name =
+             origin.github_repository_name
+         AND private_authority.service_scope =
+             'private_repository_source_read'
+         AND private_authority.identity_digest =
+             origin.private_source_authority_identity_digest
+         AND private_authority.app_configuration_revision =
+             origin.private_source_authority_app_configuration_revision
+         AND private_authority.policy_revision =
+             origin.private_source_authority_policy_revision
+        WHERE attempt.id = authority.attempt_id
+          AND attempt.job_id = authority.job_id
+          AND attempt.attempt_number = authority.attempt_number
+          AND attempt.fencing_token = authority.fencing_token
+          AND attempt.lease_id = authority.lease_id
+          AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
+          AND attempt.lease_expires_at_ms >= authority.lease_expires_at_ms
+          AND required_current_before_ms > observed_at_ms
+          AND attempt.lease_expires_at_ms >= required_current_before_ms
+          AND attempt.runner_id = authority.runner_id
+          AND attempt.runner_session_id = authority.runner_session_id
+          AND attempt.runner_session_epoch = authority.runner_session_epoch
+          AND attempt.runner_generation = authority.runner_generation
+          AND attempt.runner_slot = authority.runner_slot
+          AND attempt.lifecycle IN ('leased', 'preparing', 'running')
+          AND attempt.changed_at_ms <= observed_at_ms
+          AND job.admission_epoch = 1
+          AND job.job_ir_schema = 1
+          AND job.job_ir_schema = authority.job_ir_schema
+          AND job.job_ir_size_bytes = authority.job_ir_size_bytes
+          AND job.job_ir_digest = authority.job_ir_digest
+          AND job.job_ir_object_key = authority.job_ir_object_key
+          AND authority.permission_evidence_sha256 = authority.job_ir_digest
+          AND job.requirements @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND run.admission_epoch = 1
+          AND run.plan_schema = 1
+          AND (
+              invocation.id <> marker.root_invocation_id
+              OR run.plan_digest = authority.plan_digest
+          )
+          AND run.plan_digest = origin.plan_digest
+          AND run.event_digest = authority.event_digest
+          AND run.event_digest = origin.event_digest
+          AND run.snapshot_id = origin.snapshot_id
+          AND run.head_sha = origin.github_check_head_sha
+          AND run.event_name = origin.event_name
+          AND run.git_ref = origin.git_ref
+          AND run.status IN ('queued', 'in_progress')
+          AND (
+              origin.origin_kind = 'provider_delivery'
+              AND origin.admission_idempotency_kind = 'provider_delivery'
+              OR origin.origin_kind IN ('scheduled_fire', 'workflow_rerun')
+              AND origin.admission_idempotency_kind = 'operation'
+          )
+          AND workflow.path = origin.workflow_path
+          AND snapshot.source_digest = origin.source_digest
+          AND marker.orchestration_schema = 1
+          AND marker.root_invocation_id = origin.root_invocation_id
+          AND marker.admission_digest = origin.logical_admission_digest
+          AND marker.admitted_at_ms = origin.admitted_at_ms
+          AND marker.state IN ('pending', 'active')
+          AND automata_logical_workflow_invocation_published(
+              run.id, invocation.id
+          )
+          AND automata_reusable_workflow_oidc_permission_authorized(
+              run.id, invocation.id
+          )
+          AND invocation.plan_schema = 1
+          AND invocation.plan_digest = authority.plan_digest
+          AND invocation.state IN ('pending', 'active')
+          AND logical_job.execution_kind = 'steps'
+          AND logical_job.state = 'activated'
+          AND instance.job_ir_version = 1
+          AND instance.job_ir_digest = authority.job_ir_digest
+          AND instance.job_ir_object_key = authority.job_ir_object_key
+          AND instance.job_ir_size_bytes = authority.job_ir_size_bytes
+          AND concrete.runtime_context_schema = 1
+          AND concrete.runtime_context_digest = authority.runtime_context_digest
+          AND concrete.requirements = job.requirements
+          AND materialization.state = 'materialized'
+          AND logical_job.activation_input_digest =
+              preparation.activation_input_digest
+          AND preparation_claim.state = 'prepared'
+          AND activation_publication.condition_matched
+          AND activation_publication.job_ir_version = 1
+          AND activation_publication.runtime_context_schema = 1
+          AND manifest.authority_profile = 'standard'
+          AND logical_job.authority_profile = 'standard'
+          AND preparation_claim.authority_profile = 'standard'
+          AND preparation.authority_profile = 'standard'
+          AND activation_publication.authority_profile = 'standard'
+          AND materialization.authority_profile = 'standard'
+          AND concrete.authority_profile = 'standard'
+          AND repository.scm_provider = 'github'
+          AND repository.provider_repository_id =
+              origin.github_repository_id::TEXT
+          AND repository.owner || '/' || repository.name =
+              origin.github_repository_name
+          AND authority.github_repository_id =
+              origin.github_repository_id
+          AND authority.github_repository_name =
+              origin.github_repository_name
+          AND authority.github_owner_id =
+              origin.github_repository_owner_id
+          AND authority.subject_policy_mode = 'stable_owner_evidence'
+          AND authority.subject_policy_revision > 0
+          AND authority.subject = CASE
+              WHEN origin.event_name = 'pull_request'
+              THEN 'repo:' || origin.github_repository_name ||
+                   ':pull_request'
+              ELSE 'repo:' || origin.github_repository_name ||
+                   ':ref:' || origin.git_ref
+          END
+          AND authority.default_audience = 'https://github.com/' ||
+              split_part(origin.github_repository_name, '/', 1)
+          AND authority.additional_claims = jsonb_build_object(
+              'event_name', origin.event_name,
+              'ref', origin.git_ref,
+              'repository', origin.github_repository_name,
+              'repository_owner',
+                  split_part(origin.github_repository_name, '/', 1),
+              'run_attempt', run.run_attempt::TEXT,
+              'run_number', run.run_number::TEXT,
+              'runner_environment', 'self-hosted',
+              'sha', encode(origin.github_check_head_sha, 'hex'),
+              'workflow', run.workflow_name,
+              'workflow_ref', origin.github_repository_name || '/' ||
+                  origin.workflow_path || '@' || origin.git_ref,
+              'workflow_sha', encode(origin.github_check_head_sha, 'hex')
+          )
+          AND manifest.webhook_verifier_fingerprint_sha256 =
+              origin.authenticated_webhook_verifier_fingerprint_sha256
+          AND manifest.webhook_verifier_revision =
+              origin.authenticated_webhook_verifier_revision
+          AND manifest.provider_installation_id =
+              origin.provider_installation_id
+          AND manifest.github_repository_id =
+              origin.github_repository_id
+          AND manifest.github_repository_name =
+              origin.github_repository_name
+          AND manifest.repository_visibility =
+              origin.repository_visibility
+          AND manifest.registered_at_ms <= observed_at_ms
+          AND checks_authority.state = 'active'
+          AND checks_authority.created_at_ms <= observed_at_ms
+          AND checks_authority.state_updated_at_ms <= observed_at_ms
+          AND (
+              origin.repository_visibility = 'public'
+              AND origin.private_source_authority_id IS NULL
+              AND private_authority.id IS NULL
+              OR origin.repository_visibility = 'private'
+              AND private_authority.id IS NOT NULL
+              AND private_authority.state = 'active'
+              AND private_authority.created_at_ms <= observed_at_ms
+              AND private_authority.state_updated_at_ms <= observed_at_ms
+          )
+          AND origin.admitted_at_ms <= observed_at_ms
+          AND authority.request_bearer_iat_seconds * 1000 <= observed_at_ms
+          AND authority.request_bearer_exp_seconds * 1000 > observed_at_ms
+          AND runner.status = 'online'
+          AND runner.desired_state IN ('active', 'draining')
+          AND runner.capabilities @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND session.job_ir_schema = 1
+          AND session.capability_snapshot @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND session.disconnected_at_ms IS NULL
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION automata_lock_workload_oidc_authority_dependencies(authority workload_oidc_authorities) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    origin_visibility TEXT;
+    private_authority_id UUID;
+BEGIN
+    SELECT origin.repository_visibility,
+           origin.private_source_authority_id
+      INTO origin_visibility, private_authority_id
+    FROM job_attempts AS attempt
+    JOIN jobs AS job
+      ON job.id = attempt.job_id
+     AND job.id = authority.job_id
+     AND job.run_id = authority.run_id
+    JOIN workflow_runs AS run
+      ON run.id = job.run_id
+     AND run.id = authority.run_id
+     AND run.repository_id = authority.repository_id
+    JOIN repositories AS repository
+      ON repository.id = run.repository_id
+     AND repository.tenant_id = authority.tenant_id
+    JOIN workflow_definitions AS workflow
+      ON workflow.id = run.workflow_id
+     AND workflow.repository_id = run.repository_id
+    JOIN workflow_snapshots AS snapshot
+      ON snapshot.id = run.snapshot_id
+     AND snapshot.workflow_id = run.workflow_id
+    JOIN logical_workflow_runs AS marker ON marker.run_id = run.id
+    JOIN logical_workflow_invocations AS invocation
+      ON invocation.run_id = run.id
+     AND invocation.id = authority.invocation_id
+    JOIN logical_workflow_jobs AS logical_job
+      ON logical_job.run_id = run.id
+     AND logical_job.invocation_id = invocation.id
+     AND logical_job.id = authority.logical_job_id
+    JOIN logical_workflow_activation_preparation_claims AS preparation_claim
+      ON preparation_claim.run_id = logical_job.run_id
+     AND preparation_claim.invocation_id = logical_job.invocation_id
+     AND preparation_claim.logical_job_id = logical_job.id
+    JOIN logical_workflow_activation_preparations AS preparation
+      ON preparation.run_id = preparation_claim.run_id
+     AND preparation.invocation_id = preparation_claim.invocation_id
+     AND preparation.logical_job_id = preparation_claim.logical_job_id
+     AND preparation.descriptor_digest = preparation_claim.descriptor_digest
+    JOIN logical_workflow_activation_publications AS activation_publication
+      ON activation_publication.run_id = logical_job.run_id
+     AND activation_publication.invocation_id = logical_job.invocation_id
+     AND activation_publication.logical_job_id = logical_job.id
+     AND activation_publication.activation_input_digest =
+         preparation.activation_input_digest
+    JOIN logical_workflow_instances AS instance
+      ON instance.run_id = run.id
+     AND instance.invocation_id = invocation.id
+     AND instance.logical_job_id = logical_job.id
+     AND instance.id = authority.instance_id
+    JOIN logical_workflow_concrete_jobs AS concrete
+      ON concrete.instance_id = instance.id
+     AND concrete.run_id = run.id
+     AND concrete.invocation_id = invocation.id
+     AND concrete.logical_job_id = logical_job.id
+     AND concrete.job_id = job.id
+    JOIN logical_workflow_materialization_claims AS materialization
+      ON materialization.instance_id = concrete.instance_id
+     AND materialization.run_id = concrete.run_id
+     AND materialization.invocation_id = concrete.invocation_id
+     AND materialization.logical_job_id = concrete.logical_job_id
+     AND materialization.descriptor_digest = concrete.descriptor_digest
+     AND materialization.expected_job_id = concrete.job_id
+     AND materialization.expected_attempt_id = concrete.initial_attempt_id
+     AND materialization.owner_id = concrete.claim_owner_id
+     AND materialization.generation = concrete.claim_generation
+     AND materialization.claimed_at_ms = concrete.claim_started_at_ms
+     AND materialization.expires_at_ms = concrete.claim_expires_at_ms
+     AND materialization.updated_at_ms = concrete.committed_at_ms
+    JOIN runners AS runner
+      ON runner.id = attempt.runner_id
+     AND runner.id = authority.runner_id
+     AND runner.tenant_id = authority.tenant_id
+    JOIN runner_sessions AS session
+      ON session.id = attempt.runner_session_id
+     AND session.id = authority.runner_session_id
+     AND session.runner_id = authority.runner_id
+    JOIN github_workflow_run_manifest_origins AS origin
+      ON origin.tenant_id = authority.tenant_id
+     AND origin.repository_id = authority.repository_id
+     AND origin.workflow_id = authority.workflow_id
+     AND origin.run_id = authority.run_id
+     AND origin.root_invocation_id = marker.root_invocation_id
+     AND origin.subject_evidence_sha256 =
+         authority.github_run_subject_evidence_sha256
+    JOIN workflow_admission_receipts AS admission_receipt
+      ON admission_receipt.tenant_id = origin.tenant_id
+     AND admission_receipt.idempotency_kind =
+         origin.admission_idempotency_kind
+     AND admission_receipt.idempotency_key =
+         origin.admission_idempotency_key
+     AND admission_receipt.request_digest = origin.logical_admission_digest
+     AND admission_receipt.repository_id = origin.repository_id
+     AND admission_receipt.run_id = origin.run_id
+     AND admission_receipt.committed_at_ms = origin.admitted_at_ms
+     AND admission_receipt.github_subject_evidence_required
+    JOIN github_provider_manifest_revisions AS manifest
+      ON manifest.tenant_id = origin.tenant_id
+     AND manifest.repository_id = origin.repository_id
+     AND manifest.provider_connection_id = origin.provider_connection_id
+     AND manifest.manifest_revision = origin.provider_manifest_revision
+     AND manifest.manifest_digest = origin.provider_manifest_digest
+    JOIN github_server_service_authorities AS checks_authority
+      ON checks_authority.tenant_id = origin.tenant_id
+     AND checks_authority.id = origin.checks_authority_id
+     AND checks_authority.repository_id = origin.repository_id
+     AND checks_authority.provider_connection_id = origin.provider_connection_id
+     AND checks_authority.provider_installation_id =
+         origin.provider_installation_id
+     AND checks_authority.github_repository_id = origin.github_repository_id
+     AND checks_authority.github_repository_name =
+         origin.github_repository_name
+     AND checks_authority.service_scope = 'checks_write'
+     AND checks_authority.identity_digest =
+         origin.checks_authority_identity_digest
+     AND checks_authority.app_configuration_revision =
+         origin.checks_authority_app_configuration_revision
+     AND checks_authority.policy_revision =
+         origin.checks_authority_policy_revision
+    WHERE attempt.id = authority.attempt_id
+      AND materialization.state = 'materialized'
+      AND (
+          origin.origin_kind = 'provider_delivery'
+          AND origin.admission_idempotency_kind = 'provider_delivery'
+          OR origin.origin_kind IN ('scheduled_fire', 'workflow_rerun')
+          AND origin.admission_idempotency_kind = 'operation'
+      )
+      AND logical_job.activation_input_digest = preparation.activation_input_digest
+      AND preparation_claim.state = 'prepared'
+      AND activation_publication.condition_matched
+      AND automata_logical_workflow_invocation_published(
+          run.id, invocation.id
+      )
+      AND automata_reusable_workflow_oidc_permission_authorized(
+          run.id, invocation.id
+      )
+      AND manifest.authority_profile = 'standard'
+      AND logical_job.authority_profile = 'standard'
+      AND preparation_claim.authority_profile = 'standard'
+      AND preparation.authority_profile = 'standard'
+      AND activation_publication.authority_profile = 'standard'
+      AND materialization.authority_profile = 'standard'
+      AND concrete.authority_profile = 'standard'
+      AND checks_authority.state = 'active'
+    FOR SHARE OF attempt, job, run, repository, workflow, snapshot, marker,
+                 invocation, logical_job, preparation_claim, preparation,
+                 activation_publication, instance, concrete, materialization,
+                 runner, session,
+                 admission_receipt, manifest, checks_authority;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    IF origin_visibility = 'public' THEN
+        RETURN private_authority_id IS NULL;
+    END IF;
+    IF origin_visibility <> 'private' OR private_authority_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    PERFORM 1
+    FROM github_workflow_run_manifest_origins AS origin
+    JOIN github_server_service_authorities AS private_authority
+      ON private_authority.tenant_id = origin.tenant_id
+     AND private_authority.id = origin.private_source_authority_id
+     AND private_authority.repository_id = origin.repository_id
+     AND private_authority.provider_connection_id =
+         origin.provider_connection_id
+     AND private_authority.provider_installation_id =
+         origin.provider_installation_id
+     AND private_authority.github_repository_id =
+         origin.github_repository_id
+     AND private_authority.github_repository_name =
+         origin.github_repository_name
+     AND private_authority.service_scope = 'private_repository_source_read'
+     AND private_authority.identity_digest =
+         origin.private_source_authority_identity_digest
+     AND private_authority.app_configuration_revision =
+         origin.private_source_authority_app_configuration_revision
+     AND private_authority.policy_revision =
+         origin.private_source_authority_policy_revision
+    WHERE origin.tenant_id = authority.tenant_id
+      AND origin.repository_id = authority.repository_id
+      AND origin.workflow_id = authority.workflow_id
+      AND origin.run_id = authority.run_id
+      AND origin.subject_evidence_sha256 =
+          authority.github_run_subject_evidence_sha256
+      AND origin.private_source_authority_id = private_authority_id
+      AND private_authority.state = 'active'
+    FOR SHARE OF private_authority;
+    RETURN FOUND;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_reject_workload_oidc_authority_mutation() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE EXCEPTION 'Automata workload OIDC authority is immutable'
+        USING ERRCODE = 'integrity_constraint_violation',
+              CONSTRAINT = 'workload_oidc_authority_immutable';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_reject_workload_oidc_issuance_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE EXCEPTION 'Automata workload OIDC issuance slots are retained'
+        USING ERRCODE = 'integrity_constraint_violation',
+              CONSTRAINT = 'workload_oidc_issuance_slot_retained';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_require_standard_workload_oidc_profile() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM github_workflow_run_manifest_origins AS origin
+        JOIN logical_workflow_runs AS marker
+          ON marker.run_id = origin.run_id
+         AND marker.root_invocation_id = origin.root_invocation_id
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = origin.tenant_id
+         AND manifest.repository_id = origin.repository_id
+         AND manifest.provider_connection_id = origin.provider_connection_id
+         AND manifest.manifest_revision = origin.provider_manifest_revision
+         AND manifest.manifest_digest = origin.provider_manifest_digest
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.instance_id = NEW.instance_id
+         AND concrete.run_id = NEW.run_id
+         AND concrete.invocation_id = NEW.invocation_id
+         AND concrete.logical_job_id = NEW.logical_job_id
+         AND concrete.job_id = NEW.job_id
+         AND concrete.initial_attempt_id = NEW.attempt_id
+        WHERE origin.tenant_id = NEW.tenant_id
+          AND origin.repository_id = NEW.repository_id
+          AND origin.workflow_id = NEW.workflow_id
+          AND origin.run_id = NEW.run_id
+          AND origin.subject_evidence_sha256 =
+              NEW.github_run_subject_evidence_sha256
+          AND (
+              origin.origin_kind = 'provider_delivery'
+              AND origin.admission_idempotency_kind = 'provider_delivery'
+              OR origin.origin_kind IN ('scheduled_fire', 'workflow_rerun')
+              AND origin.admission_idempotency_kind = 'operation'
+          )
+          AND automata_logical_workflow_invocation_published(
+              NEW.run_id, NEW.invocation_id
+          )
+          AND automata_reusable_workflow_oidc_permission_authorized(
+              NEW.run_id, NEW.invocation_id
+          )
+          AND manifest.authority_profile = 'standard'
+          AND concrete.authority_profile = 'standard'
+    ) THEN
+        RAISE EXCEPTION 'Automata workload OIDC requires historical Standard authority'
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'workload_oidc_historical_standard_authority';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_validate_workload_oidc_authority_insert() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NOT automata_lock_workload_oidc_authority_dependencies(NEW)
+        OR NOT automata_workload_oidc_authority_is_current(
+            NEW, NEW.reserved_at_ms, NEW.reserved_at_ms + 1
+        )
+    THEN
+        RAISE EXCEPTION 'Automata workload OIDC authority is not current'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'workload_oidc_authority_current_execution';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION automata_validate_workload_oidc_issuance_slot() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    authority workload_oidc_authorities%ROWTYPE;
+    slot_count BIGINT;
+BEGIN
+    IF NEW.issued_at_seconds > 9223372036854774 THEN
+        RAISE EXCEPTION 'Automata workload OIDC issuance time is out of range'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'workload_oidc_issuance_current_authority';
+    END IF;
+    SELECT * INTO authority
+    FROM workload_oidc_authorities
+    WHERE authority_id = NEW.authority_id
+    FOR UPDATE;
+    IF authority.authority_id IS NULL
+        OR NOT automata_lock_workload_oidc_authority_dependencies(authority)
+        OR NEW.resolved_audience IS DISTINCT FROM coalesce(
+            NEW.requested_audience, authority.default_audience
+        )
+        OR NEW.issued_at_seconds < authority.request_bearer_iat_seconds
+        OR NEW.not_before_seconds < authority.request_bearer_iat_seconds
+        OR NEW.expires_at_seconds > authority.request_bearer_exp_seconds
+        OR NOT automata_workload_oidc_authority_is_current(
+            authority,
+            NEW.issued_at_seconds * 1000,
+            (NEW.issued_at_seconds + 1) * 1000
+        )
+    THEN
+        RAISE EXCEPTION 'Automata workload OIDC issuance lacks current authority'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'workload_oidc_issuance_current_authority';
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.generation <> 1
+            OR NEW.created_at_seconds <> NEW.issued_at_seconds
+        THEN
+            RAISE EXCEPTION 'Automata workload OIDC initial issuance is invalid'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT = 'workload_oidc_issuance_slot_initial';
+        END IF;
+        SELECT count(*) INTO slot_count
+        FROM workload_oidc_issuance_slots
+        WHERE authority_id = NEW.authority_id;
+        IF slot_count >= 64 THEN
+            RAISE EXCEPTION 'Automata workload OIDC audience slot bound exceeded'
+                USING ERRCODE = 'program_limit_exceeded',
+                      CONSTRAINT = 'workload_oidc_issuance_slot_bound';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -7,7 +7,7 @@ use crate::migration::MIGRATOR;
 const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     (
         "0001_baseline_routines_01.sql",
-        "a87ca5a60542475aedc7efea800900e9d01b0a62115cc5540bb8fe7e61059052fdc046574298eae6cd5c07d06af9c9d9",
+        "a88f5c285d9d0286eb5f9d3812c06e254ff22ded8041b014ce666f73c29436d92f2ba0ec3633fdb59d779da6918e7a2a",
     ),
     (
         "0002_baseline_routines_02.sql",
@@ -15,7 +15,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0003_baseline_routines_03.sql",
-        "bef084a13e1c66864b5c8e9a650aa049f3c89629937912c23c8849e68e4f3b300138915e2a042759cae1a298e55e70aa",
+        "6094bc86a6b041c70c8cfd3e04d202bf03272e94b39ea7131b61e7c67e30a6bb307a89771a3325e4a15a2b215237381f",
     ),
     (
         "0004_baseline_routines_04.sql",
@@ -35,7 +35,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0008_baseline_routines_08.sql",
-        "82386623c855924c858ceb37aa1d8211201d6dffb227b704ff2e162e505113d8d57eda9292f47d281007e57e0b727f10",
+        "bd208061cc3d0c296656fd50514fbbf6b2bca8eb6d7b8e07d25c2892923295f4b63348383b1b0fed8656c5d04da51def",
     ),
     (
         "0009_baseline_routines_09.sql",
@@ -43,7 +43,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0010_baseline_routines_10.sql",
-        "d953914f0abe887f7654461afea8f7a3256309e6cf91bd1dd9a9f9fcfabfe14009623f1ac8e68ad0cffe87b3eaa170b6",
+        "5e1c67bd3d713fc9521d147a31fd0965c18f2f86ee27f4ac899c0db239e33f3d11e212ee6004877aa2c7c59b23229a86",
     ),
     (
         "0011_baseline_routines_11.sql",
@@ -51,7 +51,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0012_baseline_routines_12.sql",
-        "99d8d42d04536b63d859eeb45e9242c5e08cca6f58b84fca3561b0c54db1205ad04618fd37bdce4b202615a29fba8b6f",
+        "22fe7a4a46350513482df3c314e700c0bc677087edbcb6510cbf45e9ed6020fb7ed6f30da0fb9a5bc8755e83a04f5042",
     ),
     (
         "0013_baseline_routines_13.sql",
@@ -71,7 +71,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0017_baseline_relations_execution.sql",
-        "8be21af9791391f24af6cdeb4eb15d015e2b6a6dbe636c37c6ac32e14993421daf868e9e62e181c2d3e25fafc21e8d35",
+        "9d80766241d5b07160607c4e90fcd30d9ee2ac341e89576f1033fd7072e466c0364a10a4479e8eb919bb39979a1603b9",
     ),
     (
         "0018_baseline_relations_auth_and_delivery.sql",
@@ -91,15 +91,15 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0022_baseline_keys_and_constraints.sql",
-        "ec02472313cf642e0ef9d7cdce21e2a81c0d402b8136c20cf3a6530a60330412a901e1e6f283bd25355e2afce5a37a5d",
+        "811561232385a17a9630e8534d98e0538af044ce0ec09f3abddb33a992301245264ceaf16831a92056c2bd82843340d7",
     ),
     (
         "0023_baseline_indexes.sql",
-        "110c483fdd8ef2a06b3550188bc96c2e559221cdb6ef00c14b5c6a72f98029d1519c0c0da15ba33ef1e4182728f64739",
+        "9b45a8ae13c283e0b42848782e912df82b0712b9cfdccf7656260cd23151ad27520e2c6e9ed9b65d70a98ca4ab338b59",
     ),
     (
         "0024_baseline_triggers_control_plane.sql",
-        "973e2681a8c3c19c08a5d4946b4ba47d5fb320eada4a702d4199a1b1a24cca2b349b5c6cdd33a9c4da919389d7b4e94d",
+        "b297b80748236be8b1bb1c1793de1d24be4b24bddb1ae628a93cca616457027658fc582c0560500e7331ce02e0a6a7ef",
     ),
     (
         "0025_baseline_triggers_orchestration.sql",
@@ -107,7 +107,7 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0026_baseline_foreign_keys.sql",
-        "e13d7290bcc04f62ab507d1c53c40e69d2fd9f6b322d5bccf9d0afb1c10026ed2e057e1c0500b1e737ec5bb6c26a7252",
+        "57e7e93dcdc0ee7568393785b30774259dcf5300f9a8df99ac7795d9799c60b97dec36479976ae99e5c4bd320080a977",
     ),
     (
         "0027_workspace_usage_feed.sql",
@@ -216,6 +216,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
     (
         "0053_provider_delivery_foundation.sql",
         "52a3ab7e1e78fedee448882f0f400f3b4ae9ef0accf02b2f990543fdacb261a3f280774ba7787f4a9a1c4cd99c0d93f1",
+    ),
+    (
+        "0054_provider_neutral_workload_oidc.sql",
+        "6bcb92936a5882ee9d085e8bef4da2c95903d0e75860d08dd52a140c18b94351dccb4263e0f0dd40964b337c3101dc53",
     ),
 ];
 


### PR DESCRIPTION
Restores every already-applied baseline migration byte-for-byte and moves the provider-neutral workload OIDC catalog rename into forward migration 54.

This fixes production startup failure `migration 1 was previously applied but has been modified` without resetting the database or retaining a compatibility schema. The migration renames the three tables, functions, constraints, indexes, and triggers in place, then replaces stored routine bodies with the provider-neutral definitions.

Validation:
- frozen migration inventory/layout tests passed before the final catalog-only constraint additions
- forward migration executed successfully against the pre-rename PostgreSQL 18 catalog
- baseline files compare exactly with the deployed parent revision
- final SHA-384 inventory and migration line bound verified

The local compiler gate intentionally refused a redundant recompile while another workspace test held shared memory; hosted CI is the authoritative full validation.