### PR TITLE
Allow composed hosts to provide live-log access

### DIFF
--- a/ui/scripts/verify-package.mjs
+++ b/ui/scripts/verify-package.mjs
@@ -1,8 +1,16 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { createElement } from "react";
@@ -111,6 +119,8 @@ try {
     throw new Error(`npm package contains unexpected files: ${unexpected.join(", ")}`);
   }
 
+  await verifyTypeScriptConsumer(join(firstDirectory, first.filename));
+
   process.stdout.write(
     `Verified composable UI package (${files.length} files, sha256:${firstDigest}).\n`,
   );
@@ -132,6 +142,85 @@ async function pack(directory, destination) {
     throw new Error("npm pack did not report exactly one archive");
   }
   return result[0];
+}
+
+async function verifyTypeScriptConsumer(archive) {
+  const consumerDirectory = await mkdtemp(
+    join(tmpdir(), "automata-ui-consumer-"),
+  );
+  try {
+    const nodeModules = join(consumerDirectory, "node_modules");
+    const installedPackage = join(nodeModules, "@automata", "ui");
+    await mkdir(installedPackage, { recursive: true });
+    await execute(
+      "tar",
+      ["-xzf", archive, "--strip-components=1", "-C", installedPackage],
+    );
+
+    for (const dependency of ["react", "react-dom", "@types"]) {
+      const destination = join(nodeModules, dependency);
+      await mkdir(dirname(destination), { recursive: true });
+      await symlink(
+        fileURLToPath(new URL(`node_modules/${dependency}`, root)),
+        destination,
+      );
+    }
+
+    await writeFile(
+      join(consumerDirectory, "consumer.mts"),
+      `import {
+  App,
+  validateLiveLogAccess,
+  type AppProps,
+  type JobLogPageModel,
+  type LiveLogAccess,
+  type LiveLogAccessProvider,
+  type LiveLogRecord,
+} from "@automata/ui";
+
+declare const access: LiveLogAccess;
+declare const accessProvider: LiveLogAccessProvider;
+declare const page: JobLogPageModel;
+declare const record: LiveLogRecord;
+
+const props: AppProps = { page, jobLogAccess: accessProvider };
+void App;
+void props;
+void record;
+validateLiveLogAccess(access);
+`,
+    );
+    await writeFile(
+      join(consumerDirectory, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            exactOptionalPropertyTypes: true,
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            noEmit: true,
+            skipLibCheck: true,
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["consumer.mts"],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await execute(
+      process.execPath,
+      [
+        fileURLToPath(new URL("node_modules/typescript/bin/tsc", root)),
+        "--project",
+        join(consumerDirectory, "tsconfig.json"),
+      ],
+      { cwd: consumerDirectory },
+    );
+  } finally {
+    await rm(consumerDirectory, { recursive: true, force: true });
+  }
 }
 
 function digest(value) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { PageModel } from "./models";
 import type { LiveLogRecord } from "./logs/sse";
+import type { LiveLogAccessProvider } from "./logs/protocol";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { JobLogPage } from "./pages/JobLogPage";
 import { DeepLinkSignInPage } from "./pages/DeepLinkSignInPage";
@@ -20,9 +21,11 @@ import { SetupPage } from "./pages/SetupPage";
 export interface AppProps {
   readonly page: PageModel;
   readonly shellUtility?: ReactNode;
+  /** Host-supplied direct log authority for composed deployments such as Cloud. */
+  readonly jobLogAccess?: LiveLogAccessProvider;
 }
 
-export function App({ page, shellUtility }: AppProps) {
+export function App({ jobLogAccess, page, shellUtility }: AppProps) {
   const utility = shellUtility === undefined ? <ThemeToggle /> : shellUtility;
 
   switch (page.kind) {
@@ -37,7 +40,13 @@ export function App({ page, shellUtility }: AppProps) {
     case "run-detail":
       return <RunDetailPage model={page} shellUtility={utility} />;
     case "job-log":
-      return <JobLogPage model={page} shellUtility={utility} />;
+      return (
+        <JobLogPage
+          {...(jobLogAccess === undefined ? {} : { access: jobLogAccess })}
+          model={page}
+          shellUtility={utility}
+        />
+      );
     case "deep-link-sign-in":
       return <DeepLinkSignInPage model={page} shellUtility={utility} />;
     case "repository-settings":

--- a/ui/src/hooks/useJobLogs.ts
+++ b/ui/src/hooks/useJobLogs.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { JobLogPageModel } from "../models";
 import type { LiveLogRecord } from "../logs/sse";
 import { LiveLogController } from "../logs/controller";
-import { createSameOriginLiveLogAccessProvider } from "../logs/protocol";
+import {
+  createSameOriginLiveLogAccessProvider,
+  type LiveLogAccessProvider,
+} from "../logs/protocol";
 import {
   applyLogRecord,
   isNearLogBottom,
@@ -15,9 +18,11 @@ import {
 import type { JobLogsViewState, LogConnectionState } from "../viewModels/jobLogs";
 
 export function useJobLogs({
+  access,
   initialRecords,
   model,
 }: {
+  readonly access?: LiveLogAccessProvider;
   readonly initialRecords: readonly LiveLogRecord[];
   readonly model: JobLogPageModel;
 }): JobLogsViewState {
@@ -37,7 +42,9 @@ export function useJobLogs({
   useEffect(() => {
     if (model.live === null || model.logVisibility !== "full") return undefined;
     const controller = new LiveLogController({
-      access: createSameOriginLiveLogAccessProvider({ endpoint: model.live.ticketHref }),
+      access:
+        access ??
+        createSameOriginLiveLogAccessProvider({ endpoint: model.live.ticketHref }),
       onRecord: (record) => {
         shouldScrollRef.current = followingRef.current && isNearLogBottom(viewerRef.current);
         applyLogRecord(groupsRef.current, record);
@@ -69,7 +76,7 @@ export function useJobLogs({
       document.removeEventListener("visibilitychange", visibilityChanged);
       controller.dispose();
     };
-  }, [model.live, model.logVisibility]);
+  }, [access, model.live, model.logVisibility]);
 
   useLayoutEffect(() => {
     if (!shouldScrollRef.current) return;

--- a/ui/src/pages/JobLogPage.tsx
+++ b/ui/src/pages/JobLogPage.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 import type { JobLogPageModel } from "../models";
+import type { LiveLogAccessProvider } from "../logs/protocol";
 import type { LiveLogRecord } from "../logs/sse";
 import { useJobLogs } from "../hooks/useJobLogs";
 import { JobLogPageView } from "../views/JobLogPageView";
 
 export interface JobLogPageProps {
+  readonly access?: LiveLogAccessProvider;
   readonly model: JobLogPageModel;
   readonly shellUtility?: ReactNode;
   /** Structured sample records used only by the standalone UI preview. */
@@ -13,10 +15,15 @@ export interface JobLogPageProps {
 
 /** Connects the resumable log controller to a pure, storyable log view. */
 export function JobLogPage({
+  access,
   model,
   shellUtility,
   initialRecords = [],
 }: JobLogPageProps) {
-  const logs = useJobLogs({ initialRecords, model });
+  const logs = useJobLogs({
+    ...(access === undefined ? {} : { access }),
+    initialRecords,
+    model,
+  });
   return <JobLogPageView logs={logs} model={model} shellUtility={shellUtility} />;
 }

--- a/ui/src/public.ts
+++ b/ui/src/public.ts
@@ -1,16 +1,16 @@
-export { App, type AppProps } from "./App";
-export { Shell, type ShellProps } from "./components/Shell";
+export { App, type AppProps } from "./App.js";
+export { Shell, type ShellProps } from "./components/Shell.js";
 export {
   ProviderConnectionPanel,
   type ProviderConnectionLifecycle,
   type ProviderConnectionPanelProps,
-} from "./components/ProviderConnectionPanel";
+} from "./components/ProviderConnectionPanel.js";
 export {
   RepositorySelectionList,
   type RepositorySelectionListProps,
   type SelectableProviderRepository,
-} from "./components/RepositorySelectionList";
-export { ThemeToggle } from "./components/ThemeToggle";
-export { THEME_BOOTSTRAP_SCRIPT } from "./hooks/useThemePreference";
-export * from "./logs";
-export type * from "./models";
+} from "./components/RepositorySelectionList.js";
+export { ThemeToggle } from "./components/ThemeToggle.js";
+export { THEME_BOOTSTRAP_SCRIPT } from "./hooks/useThemePreference.js";
+export * from "./logs/index.js";
+export type * from "./models.js";

--- a/ui/tests/integration/hosted-live-log.test.tsx
+++ b/ui/tests/integration/hosted-live-log.test.tsx
@@ -1,0 +1,36 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App } from "../../src/App";
+import type { LiveLogAccessProvider } from "../../src/logs";
+import { jobLogRequest } from "../fixtures/renderRequests";
+
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  root = null;
+  vi.unstubAllGlobals();
+});
+
+describe("hosted live logs", () => {
+  it("uses the host-supplied live-log authority", async () => {
+    if (jobLogRequest.page.kind !== "job-log") {
+      throw new Error("The job-log fixture is unavailable");
+    }
+    const access = vi.fn<LiveLogAccessProvider>(
+      () => new Promise(() => undefined),
+    );
+    const container = document.createElement("div");
+    document.body.replaceChildren(container);
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(<App jobLogAccess={access} page={jobLogRequest.page} />);
+    });
+
+    expect(access).toHaveBeenCalledOnce();
+    expect(access.mock.calls[0]?.[0]).toBeInstanceOf(AbortSignal);
+  });
+});


### PR DESCRIPTION
## Summary

- let composed UI hosts inject the live-log access provider while preserving the same-origin self-hosted default
- pass the provider through the refactored job-log hook boundary
- make public package declarations resolvable by NodeNext consumers
- verify the packed tarball with a real external TypeScript consumer

## Validation

- npm run check
- 526 unit tests and 78 Storybook tests
- deterministic package verification
- exercised by the Automata Cloud to Core Docker smoke