### PR TITLE
Polish UI statuses, loading states, and branding

### DIFF
--- a/ui/src/components/AutomataMark.stories.tsx
+++ b/ui/src/components/AutomataMark.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AutomataMark } from "./AutomataMark";
+
+const meta = {
+  component: AutomataMark,
+  parameters: { layout: "centered" },
+  title: "Foundations/Automata Mark",
+} satisfies Meta<typeof AutomataMark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/ui/src/components/AutomataMark.tsx
+++ b/ui/src/components/AutomataMark.tsx
@@ -1,0 +1,24 @@
+export interface AutomataMarkProps {
+  readonly className?: string;
+}
+
+/** The official Automata mark, kept decorative when paired with the wordmark. */
+export function AutomataMark({ className }: AutomataMarkProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+      focusable="false"
+      height="15"
+      viewBox="0 0 14 9"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect width="4" height="4" />
+      <rect x="5" width="4" height="4" />
+      <rect x="10" width="4" height="4" />
+      <rect x="5" y="5" width="4" height="4" />
+    </svg>
+  );
+}

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren, ReactNode } from "react";
 import type { RepositoryModel, ShellModel } from "../models";
 import { isVisibleDisplayCodePoint } from "../unicode";
+import { AutomataMark } from "./AutomataMark";
 import { Icon } from "./Icon";
 
 export interface ShellProps extends PropsWithChildren {
@@ -30,7 +31,7 @@ export function Shell({
         <div className="site-header__inner">
           <a className="wordmark" href={shell.homeHref} aria-label={`${shell.productName} home`}>
             <span className="wordmark__mark" aria-hidden="true">
-              <Icon name="workflow" size={18} />
+              <AutomataMark />
             </span>
             <span className="wordmark__label">{shell.productName}</span>
           </a>

--- a/ui/src/components/StatusBadge.tsx
+++ b/ui/src/components/StatusBadge.tsx
@@ -9,22 +9,19 @@ export interface StatusBadgeProps {
   readonly labelMode?: "visible" | "accessible" | "none";
 }
 
-type StaticStatusTone = Exclude<StatusModel["tone"], "running">;
-
-const statusIcons: Readonly<Record<StaticStatusTone, string>> = {
+const statusIcons: Readonly<Record<StatusModel["tone"], string>> = {
   neutral: "minus-circle",
   queued: "clock",
+  running: "circle-notch",
   success: "check-circle",
   failure: "x-circle",
   warning: "warning-circle",
 };
 
-export function StatusBadge({ status, labelMode = "visible" }: StatusBadgeProps) {
-  const iconClassName =
-    status.tone === "running"
-      ? "status__icon status__arc"
-      : `ph ph-${statusIcons[status.tone]} status__icon`;
-
+export function StatusBadge({
+  status,
+  labelMode = "visible",
+}: StatusBadgeProps) {
   return (
     <span
       aria-hidden={labelMode === "none" ? "true" : undefined}
@@ -32,8 +29,13 @@ export function StatusBadge({ status, labelMode = "visible" }: StatusBadgeProps)
       className={`status status--${status.tone}`}
       role={labelMode === "accessible" ? "img" : undefined}
     >
-      <i aria-hidden="true" className={iconClassName} />
-      {labelMode === "visible" ? <span className="status__label">{status.label}</span> : null}
+      <i
+        aria-hidden="true"
+        className={`ph ph-${statusIcons[status.tone]} status__icon`}
+      />
+      {labelMode === "visible" ? (
+        <span className="status__label">{status.label}</span>
+      ) : null}
     </span>
   );
 }

--- a/ui/src/styles/components/controls.css
+++ b/ui/src/styles/components/controls.css
@@ -84,6 +84,7 @@ textarea.form-control {
   align-items: center;
   justify-content: center;
   padding: 5px 12px;
+  gap: 6px;
   color: var(--fg-default);
   background: var(--control-bg);
   border: 1px solid var(--border-default);
@@ -137,6 +138,11 @@ textarea.form-control {
 .button[aria-disabled="true"] {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.button[aria-busy="true"] {
+  cursor: progress;
+  opacity: 1;
 }
 
 .button--quiet {

--- a/ui/src/styles/components/shell.css
+++ b/ui/src/styles/components/shell.css
@@ -18,12 +18,6 @@
   text-decoration: none;
 }
 
-.wordmark__mark {
-  color: var(--brand-mark-fg);
-  background: var(--brand-mark-bg);
-  border-radius: 50%;
-}
-
 .primary-nav a {
   color: var(--fg-default);
   border-radius: var(--radius-control);

--- a/ui/src/styles/components/status.css
+++ b/ui/src/styles/components/status.css
@@ -10,11 +10,11 @@
 }
 
 .status__icon {
-  flex: 0 0 24px;
-  width: 24px;
-  height: 24px;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
   color: var(--neutral-emphasis);
-  font-size: 24px;
+  font-size: 20px;
 }
 
 .status__label {
@@ -38,13 +38,6 @@
 
 .status--running .status__icon {
   animation: status-spin 1s linear infinite;
-}
-
-.status__arc {
-  border: 2px solid var(--border-muted);
-  border-color: color-mix(in srgb, currentColor 14%, transparent);
-  border-top-color: currentColor;
-  border-radius: 50%;
 }
 
 .status--queued .status__icon {

--- a/ui/src/styles/conditions/preferences.css
+++ b/ui/src/styles/conditions/preferences.css
@@ -18,7 +18,6 @@
 }
 
 @media (forced-colors: active) {
-  .wordmark__mark,
   .viewer-link__avatar,
   .button,
   .form-control,

--- a/ui/src/styles/foundations/icons.css
+++ b/ui/src/styles/foundations/icons.css
@@ -86,6 +86,10 @@
   content: "\e19a";
 }
 
+.ph.ph-circle-notch::before {
+  content: "\eb44";
+}
+
 .ph.ph-warning-circle::before {
   content: "\e4e2";
 }

--- a/ui/src/styles/foundations/tokens.css
+++ b/ui/src/styles/foundations/tokens.css
@@ -53,8 +53,6 @@
     0 8px 24px rgb(140 149 159 / 20%),
     0 8px 24px rgb(1 4 9 / 80%)
   );
-  --brand-mark-fg: light-dark(#ffffff, #0d1117);
-  --brand-mark-bg: light-dark(#24292f, #f0f6fc);
   --avatar-fg: #ffffff;
   --avatar-bg: #57606a;
 

--- a/ui/src/styles/layout/shell.css
+++ b/ui/src/styles/layout/shell.css
@@ -33,7 +33,7 @@
   place-items: center;
 }
 
-.wordmark__mark .icon {
+.wordmark__mark svg {
   display: block;
 }
 

--- a/ui/src/styles/pages/repository-directory.css
+++ b/ui/src/styles/pages/repository-directory.css
@@ -72,7 +72,3 @@
   justify-content: flex-end;
   gap: 6px;
 }
-
-.repository-directory__destinations .button {
-  gap: 6px;
-}

--- a/ui/tests/integration/setup-page.test.tsx
+++ b/ui/tests/integration/setup-page.test.tsx
@@ -143,12 +143,19 @@ describe("installation setup page", () => {
     await act(async () => root?.unmount());
   });
 
-  it("has an explicit narrow-screen single-column and full-width action contract", () => {
+  it("keeps compound actions spaced and narrow screens single-column", () => {
+    const controls = readFileSync(
+      resolve(process.cwd(), "src/styles/components/controls.css"),
+      "utf8",
+    );
     const stylesheet = readFileSync(
       resolve(process.cwd(), "src/styles/conditions/responsive.css"),
       "utf8",
     );
 
+    expect(controls).toMatch(
+      /\.button\s*\{[\s\S]*gap:\s*6px;/u,
+    );
     expect(stylesheet).toMatch(
       /@media \(max-width: 767px\)[\s\S]*\.setup-page__layout\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\);/u,
     );

--- a/ui/tests/unit/icon-contract.test.tsx
+++ b/ui/tests/unit/icon-contract.test.tsx
@@ -2,18 +2,28 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { AutomataMark } from "../../src/components/AutomataMark";
 import { Icon } from "../../src/components/Icon";
 import { StatusBadge } from "../../src/components/StatusBadge";
 import { renderPage } from "../../src/entry-server";
 import { runDetailRequest, runListRequest } from "../fixtures/renderRequests";
 
 describe("icon contract", () => {
-  it("renders both pages with the Phosphor icon font and no inline SVG", () => {
+  it("reserves inline SVG for the official mark and uses Phosphor for interface icons", () => {
     const html = `${renderPage(runListRequest)}${renderPage(runDetailRequest)}`;
 
-    expect(html).not.toContain("<svg");
+    expect(html.match(/<svg/gu)).toHaveLength(2);
+    expect(html).toContain('viewBox="0 0 14 9"');
     expect(html).toContain("ph ph-play-circle");
-    expect(html).toContain("status__arc");
+    expect(html).toContain("ph ph-circle-notch");
+  });
+
+  it("keeps the official Automata mark decorative beside its text label", () => {
+    const html = renderToStaticMarkup(<AutomataMark />);
+
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('focusable="false"');
+    expect(html.match(/<rect/gu)).toHaveLength(4);
   });
 
   it("includes the bundled Phosphor glyph used by repository settings", () => {
@@ -22,7 +32,7 @@ describe("icon contract", () => {
       "utf8",
     );
 
-    expect(styles).toContain('.ph.ph-gear-six::before');
+    expect(styles).toContain(".ph.ph-gear-six::before");
     expect(styles).toContain('content: "\\e272"');
     expect(renderToStaticMarkup(<Icon name="settings" />)).toContain(
       "ph ph-gear-six",
@@ -35,9 +45,9 @@ describe("icon contract", () => {
       "utf8",
     );
 
-    expect(styles).toContain('.ph.ph-caret-down::before');
+    expect(styles).toContain(".ph.ph-caret-down::before");
     expect(styles).toContain('content: "\\e136"');
-    expect(styles).toContain('.ph.ph-sign-out::before');
+    expect(styles).toContain(".ph.ph-sign-out::before");
     expect(styles).toContain('content: "\\e42a"');
     expect(renderToStaticMarkup(<Icon name="sign-out" />)).toContain(
       "ph ph-sign-out",
@@ -47,24 +57,27 @@ describe("icon contract", () => {
   it.each([
     ["neutral", "minus-circle"],
     ["queued", "clock"],
-    ["running", "arc"],
+    ["running", "circle-notch"],
     ["success", "check-circle"],
     ["failure", "x-circle"],
     ["warning", "warning-circle"],
-  ] as const)("keeps an accessible name for the %s icon-only status", (tone, icon) => {
-    const html = renderToStaticMarkup(
-      <StatusBadge
-        labelMode="accessible"
-        status={{ label: `Status: ${tone}`, tone }}
-      />,
-    );
+  ] as const)(
+    "keeps an accessible name for the %s icon-only status",
+    (tone, icon) => {
+      const html = renderToStaticMarkup(
+        <StatusBadge
+          labelMode="accessible"
+          status={{ label: `Status: ${tone}`, tone }}
+        />,
+      );
 
-    expect(html).toContain(tone === "running" ? "status__arc" : `ph-${icon}`);
-    expect(html).toContain('aria-hidden="true"');
-    expect(html).toContain('role="img"');
-    expect(html).toContain(`aria-label="Status: ${tone}"`);
-    expect(html).not.toContain('class="status__label"');
-  });
+      expect(html).toContain(`ph-${icon}`);
+      expect(html).toContain('aria-hidden="true"');
+      expect(html).toContain('role="img"');
+      expect(html).toContain(`aria-label="Status: ${tone}"`);
+      expect(html).not.toContain('class="status__label"');
+    },
+  );
 
   it("renders visible and decorative status modes without duplicate accessible text", () => {
     const status = { label: "In progress", tone: "running" } as const;


### PR DESCRIPTION
## Summary

- replace the header icon approximation with the official Automata SVG mark from automata-ci.com, with theme-safe `currentColor` rendering and a dedicated Storybook story
- normalize every run-status glyph to the same 20px footprint and use the matching Phosphor circle-notch spinner for in-progress states
- add consistent spacing for compound buttons, fixing the setup-page spinner/label collision
- keep busy buttons legible and expose the progress cursor while preventing duplicate submissions
- remove obsolete brand tokens, ring CSS, and duplicated button-gap styling

## Verification

- `npm run check` (527 unit tests, 79 Storybook tests, architecture checks, static Storybook, client/SSR/package builds)
- `npm run screenshots` (119 Playwright visual/interaction checks)
- manual light/dark Storybook review of StatusBadge, Shell, Automata Mark, and Setup/Submitting

The branch was created from the latest `origin/main` after #460 merged.