### PR TITLE
Stream command output while jobs run

### DIFF
--- a/crates/automata-ci-execution/src/endpoint.rs
+++ b/crates/automata-ci-execution/src/endpoint.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt, time::Duration};
+use std::{collections::BTreeSet, fmt, sync::Arc, time::Duration};
 
 use crate::{
     MAX_COPY_BYTES, MAX_EXECUTION_ARGUMENTS, MAX_EXECUTION_ARGV_BYTES, MAX_EXECUTION_OUTPUT_BYTES,
@@ -451,6 +451,42 @@ pub struct ExecutionOutputRecord {
     end_of_stream: bool,
 }
 
+/// Incremental consumer for one command's ordered process-output records.
+///
+/// Endpoints call this boundary as each stdout or stderr record is observed,
+/// before the command completes. The same ordered records remain present in
+/// the terminal [`ExecutionOutput`] for exact durable replay. Implementations
+/// must apply secret policy before publishing bytes outside runner custody.
+pub trait ExecutionOutputSink: fmt::Debug + Send + Sync {
+    /// Accepts the next record in canonical cross-pipe observation order.
+    ///
+    /// # Errors
+    ///
+    /// Rejecting a record terminates execution and fails the endpoint call.
+    fn observe(&self, record: &ExecutionOutputRecord) -> Result<(), ExecutionOutputSinkError>;
+}
+
+/// Sanitized rejection from an [`ExecutionOutputSink`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExecutionOutputSinkError;
+
+/// Output sink used by endpoint operations whose output is consumed only from
+/// their terminal result.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DiscardExecutionOutput;
+
+impl ExecutionOutputSink for DiscardExecutionOutput {
+    fn observe(&self, _record: &ExecutionOutputRecord) -> Result<(), ExecutionOutputSinkError> {
+        Ok(())
+    }
+}
+
+/// Returns a shared sink that deliberately discards incremental observations.
+#[must_use]
+pub fn discard_execution_output() -> Arc<dyn ExecutionOutputSink> {
+    Arc::new(DiscardExecutionOutput)
+}
+
 impl ExecutionOutputRecord {
     /// Constructs one non-empty bounded data record.
     ///
@@ -870,6 +906,7 @@ pub trait ExecutionEndpoint: fmt::Debug + Send + Sync {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError>;
 
     /// Signals the sandbox's primary workload.

--- a/crates/automata-ci-execution/src/error.rs
+++ b/crates/automata-ci-execution/src/error.rs
@@ -244,6 +244,8 @@ pub enum ExecutionErrorKind {
     InvalidState,
     /// Captured or transferred bytes would exceed the request's hard limit.
     OutputLimitExceeded,
+    /// The caller's incremental output sink rejected an observed record.
+    OutputRejected,
     /// The execution backend rejected an otherwise valid operation.
     BackendRejected,
     /// Runner-local durable or temporary storage failed.

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -47,9 +47,10 @@ pub use capability::{ProviderCapabilities, SandboxCapability};
 pub use endpoint::{
     Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, EnvironmentName,
     EnvironmentValue, EnvironmentVariable, ExecutionArgv, ExecutionCommand, ExecutionEndpoint,
-    ExecutionEnvironment, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream,
-    ExecutionSignal, ExecutionTermination, MAX_ENDPOINT_OPERATIONS_PER_JOB, NeverCancelled,
-    SignalRequest, WaitRequest,
+    ExecutionEnvironment, ExecutionOutput, ExecutionOutputRecord, ExecutionOutputSink,
+    ExecutionOutputSinkError, ExecutionOutputStream, ExecutionSignal, ExecutionTermination,
+    MAX_ENDPOINT_OPERATIONS_PER_JOB, NeverCancelled, SignalRequest, WaitRequest,
+    discard_execution_output,
 };
 pub use error::{
     ExecutionError, ExecutionErrorKind, ExecutionStage, OperationOutcome, ProviderError,

--- a/crates/automata-ci-job-executor-actions/src/executor.rs
+++ b/crates/automata-ci-job-executor-actions/src/executor.rs
@@ -39,7 +39,7 @@ use automata_ci_execution::{
     ExecutionOutput, ExecutionTermination, NetworkPolicy, ProviderCapabilities, ProviderError,
     ProviderErrorKind, RootFilesystemPolicy, SandboxCapability, SandboxGeneration, SandboxHandle,
     SandboxLaunch, SandboxProvider, SandboxState, ServiceContainerBindings, ServiceContainerSpecs,
-    TargetPath, TargetPlatform,
+    TargetPath, TargetPlatform, discard_execution_output,
 };
 use automata_ci_expression_actions::{
     ExtensionFunctionResult, GithubEvaluationContext, GithubExpressionEvaluator,
@@ -73,8 +73,7 @@ use crate::{
     },
     error::{ExecutorAdapterError, ExecutorAdapterErrorKind, PortErrorKind},
     output::{
-        DIAGNOSTICS_LOG_GROUP_ID, SecretMasker, emit_system, emit_system_for_group,
-        parse_output_with_cancellation, process_output,
+        DIAGNOSTICS_LOG_GROUP_ID, PhaseOutputSink, SecretMasker, emit_system, emit_system_for_group,
     },
     shell::{
         ShellAdmissionRejection, admit_shell_template, composite_shell, resolve_shell_template,
@@ -90,8 +89,7 @@ const MAX_ACTION_INVOCATIONS: u32 = 10_000;
 const MAX_COMPOSITE_DERIVED_BYTES: usize = 16_777_216;
 const MAX_EVENT_DEPTH: usize = 128;
 const COMPOSITE_ORDINAL_BASE: u32 = 1 << 24;
-const TRUNCATED_OUTPUT_DIAGNOSTIC: &str =
-    "command output exceeded the configured capture limit; user output was suppressed";
+const TRUNCATED_OUTPUT_DIAGNOSTIC: &str = "command output exceeded the configured capture limit";
 const MASKED_SUMMARY_LIMIT_DIAGNOSTIC: &str = "$GITHUB_STEP_SUMMARY content was omitted after secret masking exceeded the retained text limit";
 const STEP_SUMMARY_LIMIT_DIAGNOSTIC: &str =
     "$GITHUB_STEP_SUMMARY content was omitted after the cumulative step summary limit was reached";
@@ -314,7 +312,11 @@ impl SandboxExpressionFunctions {
         .ok()?;
         let output = self
             .endpoint
-            .exec(&command, &ProviderCancellationBridge(&self.cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(&self.cancellation),
+                discard_execution_output(),
+            )
             .ok()?;
         if self.cancellation.is_cancelled()
             || output.was_truncated()
@@ -3089,7 +3091,11 @@ impl ActionsJobExecutor {
         )
         .map_err(|_| ActionLoadError::Executor(invalid_job()))?;
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                discard_execution_output(),
+            )
             .map_err(map_execution_error)
             .map_err(ActionLoadError::Executor)?;
         let selected = match (
@@ -3949,7 +3955,11 @@ impl ActionsJobExecutor {
             )?,
         };
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                discard_execution_output(),
+            )
             .map_err(map_execution_error)?;
         require_success(&output)?;
         let request = action_content::copy_archive_request(
@@ -3982,7 +3992,11 @@ impl ActionsJobExecutor {
                 128,
             )?;
             let output = endpoint
-                .exec(&command, &ProviderCancellationBridge(cancellation))
+                .exec(
+                    &command,
+                    &ProviderCancellationBridge(cancellation),
+                    discard_execution_output(),
+                )
                 .map_err(map_execution_error)?;
             require_success(&output)?;
             let stdout = output
@@ -4010,7 +4024,11 @@ impl ActionsJobExecutor {
             self.config.maximum_output_bytes(),
         )?;
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                discard_execution_output(),
+            )
             .map_err(map_execution_error)?;
         require_success(&output)?;
         if paths.workspace.platform() == TargetPlatform::Windows {
@@ -4027,7 +4045,11 @@ impl ActionsJobExecutor {
                 self.config.maximum_output_bytes(),
             )?;
             let output = endpoint
-                .exec(&command, &ProviderCancellationBridge(cancellation))
+                .exec(
+                    &command,
+                    &ProviderCancellationBridge(cancellation),
+                    discard_execution_output(),
+                )
                 .map_err(map_execution_error)?;
             require_success(&output)?;
             if !output.stdout().is_empty() || !output.stderr().is_empty() {
@@ -4970,7 +4992,11 @@ impl ActionsJobExecutor {
         )
         .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                discard_execution_output(),
+            )
             .map_err(map_execution_error)?;
         require_success(&output)
     }
@@ -5083,12 +5109,38 @@ impl ActionsJobExecutor {
             .map_err(|error| {
                 observe_phase_failure(error, attempt_id, execution.phase, "build_phase_command")
             })?;
+        let phase_output = Arc::new(PhaseOutputSink::new(
+            self.workflow_command_limits,
+            self.workflow_command_policy,
+            std::mem::replace(masker, SecretMasker::new()),
+            group_id.clone(),
+            Arc::clone(events),
+            cancellation.owned_check(),
+        ));
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                phase_output.clone(),
+            )
             .map_err(map_execution_error)
             .map_err(|error| {
                 observe_phase_failure(error, attempt_id, execution.phase, "execute_phase")
             });
+        let completed_output = phase_output.finish();
+        *masker = completed_output.masker;
+        if let Some(error) = completed_output.failure {
+            let failure = Err(observe_phase_failure(
+                error,
+                attempt_id,
+                execution.phase,
+                "stream_phase_output",
+            ));
+            let Some(()) = reconcile_cancelled_operation(failure, cancellation)? else {
+                return Ok(CommandOutcome::Cancelled);
+            };
+        }
+        let annotations = completed_output.annotations;
         let Some(output) = reconcile_cancelled_operation(output, cancellation)? else {
             return Ok(CommandOutcome::Cancelled);
         };
@@ -5113,11 +5165,8 @@ impl ActionsJobExecutor {
                     execution.phase,
                     &command_paths,
                     commands.platform(),
-                    &output,
-                    group_id,
-                    masker,
-                    events,
                     cancellation,
+                    annotations,
                 )
                 .map_err(|error| {
                     observe_phase_failure(
@@ -5218,11 +5267,8 @@ impl ActionsJobExecutor {
         phase: u32,
         paths: &CommandFilePaths,
         platform: CommandFilePlatform,
-        output: &ExecutionOutput,
-        group_id: &LogGroupId,
-        masker: &mut SecretMasker,
-        events: &Arc<dyn ExecutionEvents>,
         cancellation: &dyn ExecutorCancellation,
+        annotations: Vec<automata_ci_actions_runtime::Annotation>,
     ) -> Result<CollectedPhase, ExecutorAdapterError> {
         let completed = self
             .read_command_files(endpoint, attempt_id, phase, paths, platform, cancellation)
@@ -5234,30 +5280,6 @@ impl ActionsJobExecutor {
                 ExecutorAdapterErrorKind::Cancelled,
             ));
         }
-        let parsed = parse_output_with_cancellation(
-            output.records(),
-            self.workflow_command_limits,
-            self.workflow_command_policy,
-            masker,
-            &|| cancellation.is_cancelled(),
-        )
-        .map_err(|error| observe_phase_failure(error, attempt_id, phase, "parse_output"))?;
-        if cancellation.is_cancelled() {
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::Cancelled,
-            ));
-        }
-        let mut annotations = Vec::new();
-        let processed = process_output(parsed, group_id, masker, events, &mut annotations, &|| {
-            cancellation.is_cancelled()
-        });
-        if cancellation.is_cancelled() {
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::Cancelled,
-            ));
-        }
-        processed
-            .map_err(|error| observe_phase_failure(error, attempt_id, phase, "process_output"))?;
         Ok(CollectedPhase {
             commands: completed.commands,
             artifacts: completed.artifacts,
@@ -5592,7 +5614,11 @@ impl ActionsJobExecutor {
         )
         .map_err(|_| invalid_job())?;
         let output = endpoint
-            .exec(&command, &ProviderCancellationBridge(cancellation))
+            .exec(
+                &command,
+                &ProviderCancellationBridge(cancellation),
+                discard_execution_output(),
+            )
             .map_err(map_execution_error)?;
         if cancellation.is_cancelled() || output.termination() == ExecutionTermination::Cancelled {
             return Err(cancelled());
@@ -5771,11 +5797,17 @@ impl JobExecutor for ActionsJobExecutor {
 
 trait ExecutorCancellation: Send + Sync {
     fn is_cancelled(&self) -> bool;
+    fn owned_check(&self) -> Arc<dyn Fn() -> bool + Send + Sync>;
 }
 
 impl ExecutorCancellation for ExecutionCancellation {
     fn is_cancelled(&self) -> bool {
         ExecutionCancellation::is_cancelled(self)
+    }
+
+    fn owned_check(&self) -> Arc<dyn Fn() -> bool + Send + Sync> {
+        let cancellation = self.clone();
+        Arc::new(move || cancellation.is_cancelled())
     }
 }
 
@@ -5820,6 +5852,12 @@ impl<'a> CleanupCancellation<'a> {
 impl ExecutorCancellation for CleanupCancellation<'_> {
     fn is_cancelled(&self) -> bool {
         self.execution_is_cancelled() || self.deadline_expired()
+    }
+
+    fn owned_check(&self) -> Arc<dyn Fn() -> bool + Send + Sync> {
+        let execution = self.execution.clone();
+        let deadline = self.deadline;
+        Arc::new(move || execution.is_cancelled() || Instant::now() >= deadline)
     }
 }
 
@@ -8199,6 +8237,7 @@ fn map_execution_error(error: ExecutionError) -> ExecutorAdapterError {
         | ExecutionErrorKind::OwnershipMismatch
         | ExecutionErrorKind::InvalidState
         | ExecutionErrorKind::BackendRejected
+        | ExecutionErrorKind::OutputRejected
         | ExecutionErrorKind::LocalStorage => ExecutorAdapterErrorKind::Unavailable,
     };
     ExecutorAdapterError::new(kind)
@@ -8236,20 +8275,16 @@ fn provider_failure_outcome(error: &ProviderError) -> ProviderFailureOutcome {
 #[cfg(test)]
 mod tests {
     use std::{
-        cell::Cell,
         collections::BTreeSet,
         time::{Duration, Instant},
     };
 
     use automata_ci_actions_runtime::{
         ActionsCommandFileDecoder, CommandFileDecoder, CommandFileKind, CommandFilePlatform,
-        ParsedCommandFile, WorkflowCommandLimits, WorkflowCommandPolicy,
+        ParsedCommandFile,
     };
     use automata_ci_core::AttemptId;
-    use automata_ci_execution::{
-        Cancellation, CancellationDisposition, ExecutionOutputRecord, ExecutionOutputStream,
-        TargetPath,
-    };
+    use automata_ci_execution::{Cancellation, CancellationDisposition, TargetPath};
     use automata_ci_expression_actions::GithubValue;
     use automata_ci_runner_runtime::{ExecutionCancellation, ExecutionCancellationReason};
 
@@ -8257,10 +8292,9 @@ mod tests {
         ActionBudgetRejection, ActionExecutionBudget, AttemptPaths, CleanupCancellation,
         ExecutorAdapterErrorKind, GithubStatus, JobConclusion, MAX_ACTION_INVOCATIONS,
         MAX_ACTION_NESTING_DEPTH, MAX_COMPOSITE_CHILD_STEPS, MAX_COMPOSITE_DERIVED_BYTES,
-        MAX_EVENT_DEPTH, ProviderCancellationBridge, SecretMasker,
-        action_invocation_count_rejection, composite_child_step_rejection,
-        composite_derived_bytes_rejection, encode_action_outputs, event_depth_rejection,
-        github_value_from_json, parse_output_with_cancellation, reconcile_cancelled_operation,
+        MAX_EVENT_DEPTH, ProviderCancellationBridge, action_invocation_count_rejection,
+        composite_child_step_rejection, composite_derived_bytes_rejection, encode_action_outputs,
+        event_depth_rejection, github_value_from_json, reconcile_cancelled_operation,
         reconcile_post_operation, resource_exhausted,
     };
 
@@ -8468,35 +8502,6 @@ mod tests {
             .collect::<std::collections::BTreeMap<_, _>>();
         assert_eq!(values["scalar"], "value");
         assert_eq!(values["multiline"], "line one\nline two");
-    }
-
-    #[test]
-    fn parser_cancellation_dominates_the_next_invalid_workflow_command() {
-        let records = [ExecutionOutputRecord::data(
-            ExecutionOutputStream::Stdout,
-            b"::add-mask::first-secret\n::stop-commands::add-mask\n".to_vec(),
-        )
-        .expect("bounded output record")];
-        let checks = Cell::new(0_usize);
-        let cancellation = || {
-            let observed = checks.get();
-            checks.set(observed + 1);
-            observed >= 2
-        };
-        let mut masker = SecretMasker::new();
-
-        let error = parse_output_with_cancellation(
-            &records,
-            WorkflowCommandLimits::default(),
-            WorkflowCommandPolicy::default(),
-            &mut masker,
-            &cancellation,
-        )
-        .err()
-        .expect("cancellation wins before the invalid second command is parsed");
-
-        assert!(matches!(error.kind(), ExecutorAdapterErrorKind::Cancelled));
-        assert!(masker.contains_secret("first-secret").expect("first mask"));
     }
 
     #[test]

--- a/crates/automata-ci-job-executor-actions/src/output.rs
+++ b/crates/automata-ci-job-executor-actions/src/output.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, fmt, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use aho_corasick::{AhoCorasick, AhoCorasickKind, MatchKind};
 use automata_ci_actions_runtime::{
@@ -7,7 +11,9 @@ use automata_ci_actions_runtime::{
 };
 use automata_ci_auth::output_policy::SecretExposureClass;
 use automata_ci_core::{JobSecretExposure, LogChannel, LogGroupId, MAX_LOG_FRAME_BYTES};
-use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream};
+use automata_ci_execution::{
+    ExecutionOutputRecord, ExecutionOutputSink, ExecutionOutputSinkError, ExecutionOutputStream,
+};
 use automata_ci_runner_runtime::{ExecutionEvents, LogEvent};
 use zeroize::Zeroize as _;
 
@@ -17,6 +23,232 @@ const MAX_MASKS: usize = 4_096;
 const MAX_MASK_BYTES: usize = 1_048_576;
 const MASK_REPLACEMENT: &[u8] = b"***";
 pub(crate) const DIAGNOSTICS_LOG_GROUP_ID: &str = "job/diagnostics";
+
+pub(crate) struct PhaseOutputSink {
+    state: Mutex<PhaseOutputState>,
+}
+
+struct PhaseOutputState {
+    session: ActionsWorkflowCommandSession,
+    maximum_line_bytes: usize,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    masker: SecretMasker,
+    group_id: LogGroupId,
+    events: Arc<dyn ExecutionEvents>,
+    cancellation: Arc<dyn Fn() -> bool + Send + Sync>,
+    annotations: Vec<Annotation>,
+    failure: Option<ExecutorAdapterError>,
+    finished: bool,
+}
+
+pub(crate) struct PhaseOutputCompletion {
+    pub(crate) masker: SecretMasker,
+    pub(crate) annotations: Vec<Annotation>,
+    pub(crate) failure: Option<ExecutorAdapterError>,
+}
+
+impl PhaseOutputSink {
+    pub(crate) fn new(
+        limits: WorkflowCommandLimits,
+        policy: WorkflowCommandPolicy,
+        masker: SecretMasker,
+        group_id: LogGroupId,
+        events: Arc<dyn ExecutionEvents>,
+        cancellation: Arc<dyn Fn() -> bool + Send + Sync>,
+    ) -> Self {
+        let maximum_line_bytes = limits.maximum_line_bytes();
+        Self {
+            state: Mutex::new(PhaseOutputState {
+                session: ActionsWorkflowCommandSession::new(limits, policy),
+                maximum_line_bytes,
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                masker,
+                group_id,
+                events,
+                cancellation,
+                annotations: Vec::new(),
+                failure: None,
+                finished: false,
+            }),
+        }
+    }
+
+    pub(crate) fn finish(&self) -> PhaseOutputCompletion {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.finished
+            && state.failure.is_none()
+            && let Err(error) = state.finish_streams()
+        {
+            state.failure = Some(error);
+        }
+        state.finished = true;
+        PhaseOutputCompletion {
+            masker: std::mem::replace(&mut state.masker, SecretMasker::new()),
+            annotations: std::mem::take(&mut state.annotations),
+            failure: state.failure,
+        }
+    }
+}
+
+impl fmt::Debug for PhaseOutputSink {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PhaseOutputSink")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ExecutionOutputSink for PhaseOutputSink {
+    fn observe(&self, record: &ExecutionOutputRecord) -> Result<(), ExecutionOutputSinkError> {
+        let mut state = self.state.lock().map_err(|_| ExecutionOutputSinkError)?;
+        if state.finished || state.failure.is_some() {
+            return Err(ExecutionOutputSinkError);
+        }
+        if let Err(error) = state.observe(record) {
+            state.failure = Some(error);
+            return Err(ExecutionOutputSinkError);
+        }
+        Ok(())
+    }
+}
+
+impl PhaseOutputState {
+    fn observe(&mut self, record: &ExecutionOutputRecord) -> Result<(), ExecutorAdapterError> {
+        self.ensure_active()?;
+        let channel = match record.stream() {
+            ExecutionOutputStream::Stdout => LogChannel::Stdout,
+            ExecutionOutputStream::Stderr => LogChannel::Stderr,
+        };
+        if record.is_end_of_stream() {
+            return self.finish_stream(record.stream(), channel);
+        }
+        let buffer = match record.stream() {
+            ExecutionOutputStream::Stdout => &mut self.stdout,
+            ExecutionOutputStream::Stderr => &mut self.stderr,
+        };
+        buffer.extend_from_slice(record.bytes());
+        self.process_complete_lines(record.stream(), channel)?;
+        let buffer = match record.stream() {
+            ExecutionOutputStream::Stdout => &self.stdout,
+            ExecutionOutputStream::Stderr => &self.stderr,
+        };
+        if buffer.len() > self.maximum_line_bytes {
+            return Err(ExecutorAdapterError::new(
+                ExecutorAdapterErrorKind::InvalidJob,
+            ));
+        }
+        Ok(())
+    }
+
+    fn process_complete_lines(
+        &mut self,
+        stream: ExecutionOutputStream,
+        channel: LogChannel,
+    ) -> Result<(), ExecutorAdapterError> {
+        loop {
+            self.ensure_active()?;
+            let newline = match stream {
+                ExecutionOutputStream::Stdout => self.stdout.iter().position(|byte| *byte == b'\n'),
+                ExecutionOutputStream::Stderr => self.stderr.iter().position(|byte| *byte == b'\n'),
+            };
+            let Some(newline) = newline else {
+                return Ok(());
+            };
+            let mut line = match stream {
+                ExecutionOutputStream::Stdout => self.stdout.drain(..=newline).collect::<Vec<_>>(),
+                ExecutionOutputStream::Stderr => self.stderr.drain(..=newline).collect::<Vec<_>>(),
+            };
+            line.pop();
+            self.process_line(&line, true, channel)?;
+        }
+    }
+
+    fn finish_stream(
+        &mut self,
+        stream: ExecutionOutputStream,
+        channel: LogChannel,
+    ) -> Result<(), ExecutorAdapterError> {
+        let line = match stream {
+            ExecutionOutputStream::Stdout => std::mem::take(&mut self.stdout),
+            ExecutionOutputStream::Stderr => std::mem::take(&mut self.stderr),
+        };
+        if !line.is_empty() {
+            self.process_line(&line, false, channel)?;
+        }
+        Ok(())
+    }
+
+    fn finish_streams(&mut self) -> Result<(), ExecutorAdapterError> {
+        self.finish_stream(ExecutionOutputStream::Stdout, LogChannel::Stdout)?;
+        self.finish_stream(ExecutionOutputStream::Stderr, LogChannel::Stderr)
+    }
+
+    fn process_line(
+        &mut self,
+        mut content: &[u8],
+        newline: bool,
+        channel: LogChannel,
+    ) -> Result<(), ExecutorAdapterError> {
+        self.ensure_active()?;
+        if newline && content.last() == Some(&b'\r') {
+            content = &content[..content.len() - 1];
+        }
+        let line = self
+            .session
+            .process_line(content)
+            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
+        register_dynamic_masks(&line, &mut self.masker)?;
+        let result = match line {
+            WorkflowLine::Output(output) => emit_line(
+                output.as_str().as_bytes(),
+                newline,
+                &self.group_id,
+                channel,
+                &mut self.masker,
+                &self.events,
+            ),
+            WorkflowLine::Command(WorkflowCommandEvent::Annotation(annotation)) => {
+                emit_line(
+                    annotation.message().as_bytes(),
+                    true,
+                    &self.group_id,
+                    channel,
+                    &mut self.masker,
+                    &self.events,
+                )?;
+                self.ensure_active()?;
+                self.annotations.push(annotation);
+                Ok(())
+            }
+            WorkflowLine::Command(WorkflowCommandEvent::BeginGroup(group)) => emit_line(
+                group.title().as_bytes(),
+                true,
+                &self.group_id,
+                channel,
+                &mut self.masker,
+                &self.events,
+            ),
+            WorkflowLine::Command(_) => Ok(()),
+        };
+        result?;
+        self.ensure_active()
+    }
+
+    fn ensure_active(&self) -> Result<(), ExecutorAdapterError> {
+        if (self.cancellation)() {
+            Err(ExecutorAdapterError::new(
+                ExecutorAdapterErrorKind::Cancelled,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MaskLimitRejection {
@@ -210,214 +442,6 @@ impl fmt::Debug for SecretMasker {
     }
 }
 
-pub(crate) struct ParsedOutput {
-    lines: Vec<ParsedOutputLine>,
-}
-
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "used by the external source-level regression harness"
-)]
-impl ParsedOutput {
-    pub(crate) fn output_lines(&self) -> Vec<(LogChannel, bool, String)> {
-        self.lines
-            .iter()
-            .filter_map(|line| match &line.parsed {
-                WorkflowLine::Output(output) => {
-                    Some((line.channel, line.newline, output.as_str().to_owned()))
-                }
-                WorkflowLine::Command(_) => None,
-            })
-            .collect()
-    }
-}
-
-struct ParsedOutputLine {
-    channel: LogChannel,
-    newline: bool,
-    parsed: WorkflowLine,
-}
-
-#[cfg(test)]
-#[allow(dead_code)]
-pub(crate) fn parse_output(
-    records: &[ExecutionOutputRecord],
-    limits: WorkflowCommandLimits,
-    policy: WorkflowCommandPolicy,
-    masker: &mut SecretMasker,
-) -> Result<ParsedOutput, ExecutorAdapterError> {
-    parse_output_with_cancellation(records, limits, policy, masker, &|| false)
-}
-
-pub(crate) fn parse_output_with_cancellation(
-    records: &[ExecutionOutputRecord],
-    limits: WorkflowCommandLimits,
-    policy: WorkflowCommandPolicy,
-    masker: &mut SecretMasker,
-    cancellation: &dyn Fn() -> bool,
-) -> Result<ParsedOutput, ExecutorAdapterError> {
-    let mut session = ActionsWorkflowCommandSession::new(limits, policy);
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut parsed = Vec::new();
-    for record in records {
-        require_not_cancelled(cancellation)?;
-        let (buffer, channel) = match record.stream() {
-            ExecutionOutputStream::Stdout => (&mut stdout, LogChannel::Stdout),
-            ExecutionOutputStream::Stderr => (&mut stderr, LogChannel::Stderr),
-        };
-        if record.is_end_of_stream() {
-            if !buffer.is_empty() {
-                require_not_cancelled(cancellation)?;
-                parse_line(buffer, false, channel, &mut session, masker, &mut parsed)?;
-                require_not_cancelled(cancellation)?;
-                buffer.clear();
-            }
-            continue;
-        }
-        buffer.extend_from_slice(record.bytes());
-        parse_complete_lines(
-            buffer,
-            channel,
-            &mut session,
-            masker,
-            &mut parsed,
-            cancellation,
-        )?;
-        if buffer.len() > limits.maximum_line_bytes() {
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::InvalidJob,
-            ));
-        }
-    }
-    require_not_cancelled(cancellation)?;
-    Ok(ParsedOutput { lines: parsed })
-}
-
-pub(crate) fn process_output(
-    parsed: ParsedOutput,
-    group_id: &LogGroupId,
-    masker: &mut SecretMasker,
-    events: &Arc<dyn ExecutionEvents>,
-    annotations: &mut Vec<Annotation>,
-    cancellation: &dyn Fn() -> bool,
-) -> Result<(), ExecutorAdapterError> {
-    for line in parsed.lines {
-        require_not_cancelled(cancellation)?;
-        match line.parsed {
-            WorkflowLine::Output(output) => {
-                emit_line_with_cancellation(
-                    output.as_str().as_bytes(),
-                    line.newline,
-                    group_id,
-                    line.channel,
-                    masker,
-                    events,
-                    Some(cancellation),
-                )?;
-            }
-            WorkflowLine::Command(command) => match command {
-                WorkflowCommandEvent::Annotation(annotation) => {
-                    emit_line_with_cancellation(
-                        annotation.message().as_bytes(),
-                        true,
-                        group_id,
-                        line.channel,
-                        masker,
-                        events,
-                        Some(cancellation),
-                    )?;
-                    annotations.push(annotation);
-                }
-                WorkflowCommandEvent::BeginGroup(group) => {
-                    emit_line_with_cancellation(
-                        group.title().as_bytes(),
-                        true,
-                        group_id,
-                        line.channel,
-                        masker,
-                        events,
-                        Some(cancellation),
-                    )?;
-                }
-                WorkflowCommandEvent::RegisterMask(_)
-                | WorkflowCommandEvent::Debug(_)
-                | WorkflowCommandEvent::EndGroup
-                | WorkflowCommandEvent::StopCommands(_)
-                | WorkflowCommandEvent::ResumeCommands
-                | WorkflowCommandEvent::Matcher(_)
-                | WorkflowCommandEvent::EchoChanged(_)
-                | WorkflowCommandEvent::Notice(_) => {}
-            },
-        }
-        require_not_cancelled(cancellation)?;
-    }
-    Ok(())
-}
-
-fn require_not_cancelled(cancellation: &dyn Fn() -> bool) -> Result<(), ExecutorAdapterError> {
-    if cancellation() {
-        Err(ExecutorAdapterError::new(
-            ExecutorAdapterErrorKind::Cancelled,
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn parse_complete_lines(
-    buffer: &mut Vec<u8>,
-    channel: LogChannel,
-    processor: &mut dyn WorkflowCommandProcessor,
-    masker: &mut SecretMasker,
-    parsed: &mut Vec<ParsedOutputLine>,
-    cancellation: &dyn Fn() -> bool,
-) -> Result<(), ExecutorAdapterError> {
-    let mut consumed = 0;
-    while let Some(relative) = buffer[consumed..].iter().position(|byte| *byte == b'\n') {
-        require_not_cancelled(cancellation)?;
-        let newline = consumed + relative;
-        parse_line(
-            &buffer[consumed..newline],
-            true,
-            channel,
-            processor,
-            masker,
-            parsed,
-        )?;
-        require_not_cancelled(cancellation)?;
-        consumed = newline + 1;
-    }
-    if consumed != 0 {
-        buffer.drain(..consumed);
-    }
-    Ok(())
-}
-
-fn parse_line(
-    mut content: &[u8],
-    newline: bool,
-    channel: LogChannel,
-    processor: &mut dyn WorkflowCommandProcessor,
-    masker: &mut SecretMasker,
-    parsed: &mut Vec<ParsedOutputLine>,
-) -> Result<(), ExecutorAdapterError> {
-    if newline && content.last() == Some(&b'\r') {
-        content = &content[..content.len() - 1];
-    }
-    let line = processor
-        .process_line(content)
-        .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob))?;
-    register_dynamic_masks(&line, masker)?;
-    parsed.push(ParsedOutputLine {
-        channel,
-        newline,
-        parsed: line,
-    });
-    Ok(())
-}
-
 fn register_dynamic_masks(
     line: &WorkflowLine,
     masker: &mut SecretMasker,
@@ -485,23 +509,6 @@ fn emit_line(
     masker: &mut SecretMasker,
     events: &Arc<dyn ExecutionEvents>,
 ) -> Result<(), ExecutorAdapterError> {
-    emit_line_with_cancellation(content, newline, group_id, channel, masker, events, None)
-}
-
-fn emit_line_with_cancellation(
-    content: &[u8],
-    newline: bool,
-    group_id: &LogGroupId,
-    channel: LogChannel,
-    masker: &mut SecretMasker,
-    events: &Arc<dyn ExecutionEvents>,
-    cancellation: Option<&dyn Fn() -> bool>,
-) -> Result<(), ExecutorAdapterError> {
-    if cancellation.is_some_and(|check| check()) {
-        return Err(ExecutorAdapterError::new(
-            ExecutorAdapterErrorKind::Cancelled,
-        ));
-    }
     let mut payload = masker.mask(content)?;
     if newline {
         payload.push(b'\n');
@@ -510,20 +517,9 @@ fn emit_line_with_cancellation(
         return Ok(());
     }
     for chunk in payload.chunks(MAX_LOG_FRAME_BYTES) {
-        if cancellation.is_some_and(|check| check()) {
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::Cancelled,
-            ));
-        }
-        let emitted = events
+        events
             .emit_log(LogEvent::new(group_id.clone(), channel, chunk.to_vec()))
-            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal));
-        if cancellation.is_some_and(|check| check()) {
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::Cancelled,
-            ));
-        }
-        emitted?;
+            .map_err(|_| ExecutorAdapterError::new(ExecutorAdapterErrorKind::Internal))?;
     }
     Ok(())
 }
@@ -534,8 +530,6 @@ const fn resource_exhausted() -> ExecutorAdapterError {
 
 #[cfg(test)]
 mod cancellation_tests {
-    use std::cell::Cell;
-
     use super::*;
 
     #[test]
@@ -555,40 +549,6 @@ mod cancellation_tests {
         assert_eq!(
             mask_aggregate_bytes_rejection(MAX_MASK_BYTES + 1),
             Some(MaskLimitRejection::AggregateBytes)
-        );
-    }
-
-    #[test]
-    fn parsing_stops_before_the_next_line_and_mask_after_cancellation() {
-        let records = [ExecutionOutputRecord::data(
-            ExecutionOutputStream::Stdout,
-            b"::add-mask::first-secret\n::add-mask::second-secret\n".to_vec(),
-        )
-        .expect("bounded output record")];
-        let checks = Cell::new(0_usize);
-        let cancellation = || {
-            let observed = checks.get();
-            checks.set(observed + 1);
-            observed >= 2
-        };
-        let mut masker = SecretMasker::new();
-
-        let error = parse_output_with_cancellation(
-            &records,
-            WorkflowCommandLimits::default(),
-            WorkflowCommandPolicy::new(false),
-            &mut masker,
-            &cancellation,
-        )
-        .err()
-        .expect("the cancellation boundary stops parsing");
-
-        let _ = error;
-        assert!(masker.contains_secret("first-secret").expect("first mask"));
-        assert!(
-            !masker
-                .contains_secret("second-secret")
-                .expect("second mask remains absent")
         );
     }
 }

--- a/crates/automata-ci-job-executor-actions/tests/javascript_actions.rs
+++ b/crates/automata-ci-job-executor-actions/tests/javascript_actions.rs
@@ -458,7 +458,7 @@ async fn registered_post_does_not_start_when_execution_is_cancelled_before_posts
 }
 
 #[tokio::test]
-async fn cancellation_after_post_exec_prevents_copy_output_and_later_posts() {
+async fn cancellation_after_post_exec_keeps_live_output_but_prevents_files_and_later_posts() {
     let cancellation = ExecutionCancellation::new();
     let fixture = Fixture::new(
         vec![prepared_node24_action(), prepared_node24_action()],
@@ -507,10 +507,10 @@ async fn cancellation_after_post_exec_prevents_copy_output_and_later_posts() {
         .flat_map(|event| event.payload().to_vec())
         .collect::<Vec<_>>();
     assert!(
-        !String::from_utf8(logs)
+        String::from_utf8(logs)
             .expect("UTF-8 logs")
             .contains("post output after cancellation"),
-        "cancelled post output must not be re-published"
+        "output published while the command was active remains durable"
     );
 }
 

--- a/crates/automata-ci-job-executor-actions/tests/output_masking.rs
+++ b/crates/automata-ci-job-executor-actions/tests/output_masking.rs
@@ -10,6 +10,7 @@ impl ExecutorAdapterError {
 }
 
 pub(crate) mod error {
+    #[allow(dead_code)]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub(crate) enum ExecutorAdapterErrorKind {
         InvalidJob,
@@ -23,11 +24,9 @@ pub(crate) mod error {
 #[path = "../src/output.rs"]
 mod output;
 
-use automata_ci_actions_runtime::{WorkflowCommandLimits, WorkflowCommandPolicy};
 use automata_ci_auth::output_policy::SecretExposureClass;
-use automata_ci_core::{JobSecretExposure, LogChannel};
-use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream};
-use output::{SecretMasker, parse_output};
+use automata_ci_core::JobSecretExposure;
+use output::SecretMasker;
 
 #[test]
 fn registering_a_readable_secret_permanently_narrows_output_safety() {
@@ -147,142 +146,4 @@ fn aggregate_mask_bytes_are_bounded() {
 
     masker.register(&maximum).expect("register maximum bytes");
     assert!(masker.register("t").is_err());
-}
-
-#[test]
-fn ordered_parse_finds_a_later_cross_stream_mask_before_emission() {
-    let secret = "cross-stream-secret";
-    let mut masker = SecretMasker::new();
-
-    parse_output(
-        &records([
-            (ExecutionOutputStream::Stdout, format!("{secret}\n")),
-            (
-                ExecutionOutputStream::Stderr,
-                format!("::add-mask::{secret}\n"),
-            ),
-        ]),
-        WorkflowCommandLimits::default(),
-        WorkflowCommandPolicy::new(false),
-        &mut masker,
-    )
-    .expect("ordered discovery");
-
-    assert_eq!(masker.exposure_class(), SecretExposureClass::ReadableSecret);
-    assert!(masker.contains_secret(secret).expect("secret mask"));
-}
-
-#[test]
-fn ordered_parse_rejects_invalid_recognized_stop_commands() {
-    let mut masker = SecretMasker::new();
-
-    assert!(
-        parse_output(
-            &records([
-                (
-                    ExecutionOutputStream::Stdout,
-                    "ordinary output\n".to_owned()
-                ),
-                (
-                    ExecutionOutputStream::Stderr,
-                    "::stop-commands::add-mask\n".to_owned(),
-                ),
-            ]),
-            WorkflowCommandLimits::default(),
-            WorkflowCommandPolicy::default(),
-            &mut masker,
-        )
-        .is_err()
-    );
-}
-
-#[test]
-fn ordered_line_assembly_uses_line_completion_and_stream_end_order() {
-    let mut masker = SecretMasker::new();
-    let parsed = parse_output(
-        &[
-            ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, b"out-".to_vec())
-                .expect("stdout fragment"),
-            ExecutionOutputRecord::data(ExecutionOutputStream::Stderr, b"err\n".to_vec())
-                .expect("stderr line"),
-            ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, b"tail".to_vec())
-                .expect("stdout fragment"),
-            ExecutionOutputRecord::end_of_stream(ExecutionOutputStream::Stdout),
-            ExecutionOutputRecord::end_of_stream(ExecutionOutputStream::Stderr),
-        ],
-        WorkflowCommandLimits::default(),
-        WorkflowCommandPolicy::new(false),
-        &mut masker,
-    )
-    .expect("ordered line assembly");
-
-    assert_eq!(
-        parsed.output_lines(),
-        [
-            (LogChannel::Stderr, true, "err".to_owned()),
-            (LogChannel::Stdout, false, "out-tail".to_owned()),
-        ]
-    );
-}
-
-#[test]
-fn stop_and_resume_state_crosses_streams_in_record_order() {
-    let token = "resume-token-123";
-    let mut masker = SecretMasker::new();
-    let stopped = parse_output(
-        &records([
-            (
-                ExecutionOutputStream::Stdout,
-                format!("::stop-commands::{token}\n"),
-            ),
-            (
-                ExecutionOutputStream::Stderr,
-                "::debug::visible while commands are stopped\n".to_owned(),
-            ),
-            (ExecutionOutputStream::Stdout, format!("::{token}::\n")),
-        ]),
-        WorkflowCommandLimits::default(),
-        WorkflowCommandPolicy::new(false),
-        &mut masker,
-    )
-    .expect("stopped sequence");
-    assert_eq!(stopped.output_lines().len(), 1);
-
-    let mut masker = SecretMasker::new();
-    let resumed = parse_output(
-        &records([
-            (
-                ExecutionOutputStream::Stdout,
-                format!("::stop-commands::{token}\n"),
-            ),
-            (ExecutionOutputStream::Stderr, format!("::{token}::\n")),
-            (
-                ExecutionOutputStream::Stdout,
-                "::debug::recognized after resume\n".to_owned(),
-            ),
-        ]),
-        WorkflowCommandLimits::default(),
-        WorkflowCommandPolicy::new(false),
-        &mut masker,
-    )
-    .expect("resumed sequence");
-    assert!(resumed.output_lines().is_empty());
-}
-
-fn records<const N: usize>(
-    output: [(ExecutionOutputStream, String); N],
-) -> Vec<ExecutionOutputRecord> {
-    let mut records = output
-        .into_iter()
-        .map(|(stream, bytes)| {
-            ExecutionOutputRecord::data(stream, bytes.into_bytes()).expect("bounded test record")
-        })
-        .collect::<Vec<_>>();
-    records.push(ExecutionOutputRecord::end_of_stream(
-        ExecutionOutputStream::Stdout,
-    ));
-    records.push(ExecutionOutputRecord::end_of_stream(
-        ExecutionOutputStream::Stderr,
-    ));
-    records
 }

--- a/crates/automata-ci-job-executor-actions/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-actions/tests/run_steps.rs
@@ -783,7 +783,7 @@ async fn safe_posix_command_templates_execute_as_direct_argv_without_an_outer_sh
 }
 
 #[tokio::test]
-async fn stderr_mask_registration_redacts_a_secret_captured_on_stdout() {
+async fn dynamic_masks_apply_only_after_their_ordered_registration() {
     let secret = "cross-stream-dynamic-secret";
     let response = PhaseResponse::success()
         .with_stdout(format!("{secret}\n"))
@@ -805,7 +805,7 @@ async fn stderr_mask_registration_redacts_a_secret_captured_on_stdout() {
     let logs = fixture.events.logs();
     assert_eq!(logs.len(), 1);
     assert_eq!(logs[0].channel(), automata_ci_core::LogChannel::Stdout);
-    assert_eq!(logs[0].payload(), b"***\n");
+    assert_eq!(logs[0].payload(), format!("{secret}\n").as_bytes());
 }
 
 #[tokio::test]
@@ -835,7 +835,7 @@ async fn long_stop_command_token_is_redacted_without_hiding_adjacent_output() {
 }
 
 #[tokio::test]
-async fn truncated_output_is_rejected_before_user_bytes_or_command_files_are_consumed() {
+async fn truncated_output_retains_its_bounded_prefix_but_rejects_command_files() {
     let sentinel = "truncated-output-secret-sentinel";
     let response = PhaseResponse::success()
         .with_stdout(format!("{sentinel}\n"))
@@ -860,14 +860,15 @@ async fn truncated_output_is_rejected_before_user_bytes_or_command_files_are_con
 
     assert_eq!(error.kind(), ExecutorErrorKind::ResourceExhausted);
     let logs = fixture.events.logs();
-    assert_eq!(logs.len(), 1);
-    assert_eq!(logs[0].channel(), automata_ci_core::LogChannel::System);
-    let diagnostic = std::str::from_utf8(logs[0].payload()).expect("system diagnostic is UTF-8");
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0].channel(), automata_ci_core::LogChannel::Stdout);
+    assert_eq!(logs[0].payload(), format!("{sentinel}\n").as_bytes());
+    assert_eq!(logs[1].channel(), automata_ci_core::LogChannel::System);
+    let diagnostic = std::str::from_utf8(logs[1].payload()).expect("system diagnostic is UTF-8");
     assert_eq!(
         diagnostic,
-        "command output exceeded the configured capture limit; user output was suppressed\n"
+        "command output exceeded the configured capture limit\n"
     );
-    assert!(!diagnostic.contains(sentinel));
     assert_eq!(
         fixture
             .endpoint_state

--- a/crates/automata-ci-job-executor-actions/tests/secret_matcher_oracle.rs
+++ b/crates/automata-ci-job-executor-actions/tests/secret_matcher_oracle.rs
@@ -12,6 +12,7 @@ impl ExecutorAdapterError {
 }
 
 pub(crate) mod error {
+    #[allow(dead_code)]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub(crate) enum ExecutorAdapterErrorKind {
         InvalidJob,

--- a/crates/automata-ci-job-executor-actions/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-actions/tests/support/mod.rs
@@ -1542,13 +1542,17 @@ impl ExecutionEndpoint for FakeEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn automata_ci_execution::ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let program = request.argv().program().as_str();
         let mut state = self.state.lock().expect("endpoint lock");
         state.commands.push(request.clone());
         if cancellation.disposition().requires_termination() {
-            return execution_output(ExecutionTermination::Cancelled, Vec::new(), false)
-                .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(ExecutionTermination::Cancelled, Vec::new(), false)
+                    .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
         if request
             .argv()
@@ -1585,24 +1589,30 @@ impl ExecutionEndpoint for FakeEndpoint {
                     None
                 }
             });
-            return execution_output(
-                selected
-                    .as_ref()
-                    .map_or(ExecutionTermination::Exited(44), |_| {
-                        ExecutionTermination::Exited(0)
-                    }),
-                selected
-                    .map(|bytes| vec![(ExecutionOutputStream::Stdout, bytes)])
-                    .unwrap_or_default(),
-                false,
-            )
-            .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(
+                    selected
+                        .as_ref()
+                        .map_or(ExecutionTermination::Exited(44), |_| {
+                            ExecutionTermination::Exited(0)
+                        }),
+                    selected
+                        .map(|bytes| vec![(ExecutionOutputStream::Stdout, bytes)])
+                        .unwrap_or_default(),
+                    false,
+                )
+                .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
         if matches!(program, "/usr/bin/install" | "/usr/bin/tar")
             || program.eq_ignore_ascii_case(r"C:\automata\tools\tar\tar.exe")
         {
-            return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
-                .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
+                    .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
         if program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
             && request
@@ -1611,8 +1621,11 @@ impl ExecutionEndpoint for FakeEndpoint {
                 .iter()
                 .any(|argument| argument.contains("[System.IO.Directory]::CreateDirectory"))
         {
-            return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
-                .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
+                    .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
         if program.eq_ignore_ascii_case(r"C:\Program Files\PowerShell\7\pwsh.exe")
             && request
@@ -1621,8 +1634,11 @@ impl ExecutionEndpoint for FakeEndpoint {
                 .iter()
                 .any(|argument| argument.contains("FileAttributes]::ReparsePoint"))
         {
-            return execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
-                .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(ExecutionTermination::Exited(0), Vec::new(), false)
+                    .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
         if program.eq_ignore_ascii_case(r"C:\automata\tools\hash\automata-sha256.exe") {
             let archive = request
@@ -1630,7 +1646,7 @@ impl ExecutionEndpoint for FakeEndpoint {
                 .arguments()
                 .first()
                 .expect("Windows action archive path");
-            let (termination, output) = state.files.get(archive).map_or_else(
+            let (termination, records) = state.files.get(archive).map_or_else(
                 || (ExecutionTermination::Exited(44), Vec::new()),
                 |bytes| {
                     (
@@ -1642,11 +1658,14 @@ impl ExecutionEndpoint for FakeEndpoint {
                     )
                 },
             );
-            return execution_output(termination, output, false)
-                .map_err(|_| execution_error(ExecutionStage::Exec));
+            return publish_execution_output(
+                execution_output(termination, records, false)
+                    .map_err(|_| execution_error(ExecutionStage::Exec)),
+                output.as_ref(),
+            );
         }
-        if let Some(output) = artifact_hash_output(request, &state.files) {
-            return output;
+        if let Some(result) = artifact_hash_output(request, &state.files) {
+            return publish_execution_output(result, output.as_ref());
         }
         let is_hash_files = program == "/opt/node24/bin/node"
             && request
@@ -1675,8 +1694,11 @@ impl ExecutionEndpoint for FakeEndpoint {
             apply_phase_response_files(request, &mut state, &response);
         }
         state.cancellation_before_copy_from = response.cancellation_before_copy_from;
-        execution_output(response.termination, response.output, response.truncated)
-            .map_err(|_| execution_error(ExecutionStage::Exec))
+        publish_execution_output(
+            execution_output(response.termination, response.output, response.truncated)
+                .map_err(|_| execution_error(ExecutionStage::Exec)),
+            output.as_ref(),
+        )
     }
 
     fn signal(
@@ -1808,6 +1830,19 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 
 fn execution_error(stage: ExecutionStage) -> ExecutionError {
     ExecutionError::new(ExecutionErrorKind::UnsupportedCapability, stage)
+}
+
+fn publish_execution_output(
+    result: Result<ExecutionOutput, ExecutionError>,
+    sink: &dyn automata_ci_execution::ExecutionOutputSink,
+) -> Result<ExecutionOutput, ExecutionError> {
+    let output = result?;
+    for record in output.records() {
+        sink.observe(record).map_err(|_| {
+            ExecutionError::new(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+        })?;
+    }
+    Ok(output)
 }
 
 fn execution_output(

--- a/crates/automata-ci-local/src/local_docker/endpoint.rs
+++ b/crates/automata-ci-local/src/local_docker/endpoint.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, fmt, future::Future, sync::Arc, time::Duration}
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
     ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord,
-    ExecutionOutputStream, ExecutionStage, ExecutionTermination, NeverCancelled, ProviderStage,
-    SandboxCapability, SandboxHandle, SignalRequest, WaitRequest,
+    ExecutionOutputSink, ExecutionOutputStream, ExecutionStage, ExecutionTermination,
+    NeverCancelled, ProviderStage, SandboxCapability, SandboxHandle, SignalRequest, WaitRequest,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestOutputStream, GuestRejection, GuestRequest, GuestResponse,
@@ -192,6 +192,7 @@ impl ExecutionEndpoint for LocalDockerEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let timeout = request
             .timeout()
@@ -203,7 +204,13 @@ impl ExecutionEndpoint for LocalDockerEndpoint {
             cancellation,
             ExecutionStage::Exec,
         )?;
-        execution_output(response, request.output_limit())
+        let result = execution_output(response, request.output_limit())?;
+        for record in result.records() {
+            output.observe(record).map_err(|_| {
+                execution_error(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+            })?;
+        }
+        Ok(result)
     }
 
     fn signal(

--- a/crates/automata-ci-local/src/local_docker/tests.rs
+++ b/crates/automata-ci-local/src/local_docker/tests.rs
@@ -1602,7 +1602,13 @@ fn lifecycle_uses_zero_volumes_and_exact_replay_cleanup() {
         1024,
     )
     .expect("command");
-    let output = endpoint.exec(&command, &NeverCancelled).expect("exec");
+    let output = endpoint
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
+        .expect("exec");
     assert_eq!(output.termination(), ExecutionTermination::Exited(0));
     assert_eq!(output.stdout(), b"ok");
     let path = TargetPath::posix("/workspace/repository/result.txt").expect("path");
@@ -1699,10 +1705,18 @@ fn raw_endpoint_duplicate_operation_ids_are_attempted_twice() {
     let before = raw_guest_attempts();
 
     endpoint
-        .exec(&request, &NeverCancelled)
+        .exec(
+            &request,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("first raw attempt");
     endpoint
-        .exec(&request, &NeverCancelled)
+        .exec(
+            &request,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("second raw attempt");
 
     assert_eq!(raw_guest_attempts() - before, 2);
@@ -1957,7 +1971,11 @@ fn endpoint_cancellation_is_prechecked_then_kills_only_the_exact_running_contain
     let pre_cancelled = ToggleCancellation::active();
     pre_cancelled.cancel();
     let error = endpoint
-        .exec(&true_command(&spec, 300), &pre_cancelled)
+        .exec(
+            &true_command(&spec, 300),
+            &pre_cancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect_err("pre-cancelled exec");
     assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
     assert_eq!(fixture.engine.mutation_count(), mutations_before_pre_cancel);
@@ -1978,7 +1996,13 @@ fn endpoint_cancellation_is_prechecked_then_kills_only_the_exact_running_contain
     let cancellation = ToggleCancellation::active();
     let request = true_command(&spec, 301);
     let error = std::thread::scope(|scope| {
-        let call = scope.spawn(|| endpoint.exec(&request, &cancellation));
+        let call = scope.spawn(|| {
+            endpoint.exec(
+                &request,
+                &cancellation,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
             "endpoint did not reach the controlled guest start",
@@ -2072,14 +2096,26 @@ fn queued_endpoint_cancellation_returns_before_holder_release_and_mutates_nothin
     let cancellation = ToggleCancellation::active();
 
     std::thread::scope(|scope| {
-        let first_call = scope.spawn(|| first.exec(&first_command, &NeverCancelled));
+        let first_call = scope.spawn(|| {
+            first.exec(
+                &first_command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
             "first endpoint operation did not reach the controlled exec",
         );
 
         let queued_cancellation = cancellation.clone();
-        let second_call = scope.spawn(move || second.exec(&second_command, &queued_cancellation));
+        let second_call = scope.spawn(move || {
+            second.exec(
+                &second_command,
+                &queued_cancellation,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || cancellation.observations.load(Ordering::SeqCst) > 0,
             "second endpoint operation did not reach its pre-lock cancellation check",
@@ -2155,7 +2191,13 @@ fn queued_provider_cancellation_returns_before_holder_release_and_mutates_nothin
     let cancellation = ToggleCancellation::active();
 
     std::thread::scope(|scope| {
-        let first_call = scope.spawn(|| endpoint.exec(&first_command, &NeverCancelled));
+        let first_call = scope.spawn(|| {
+            endpoint.exec(
+                &first_command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
             "endpoint operation did not reach the controlled exec",
@@ -2244,7 +2286,13 @@ fn cancellation_dominates_a_simultaneous_guest_transport_failure_and_stops_exact
     let cancellation = ToggleCancellation::active();
 
     let error = std::thread::scope(|scope| {
-        let call = scope.spawn(|| endpoint.exec(&command, &cancellation));
+        let call = scope.spawn(|| {
+            endpoint.exec(
+                &command,
+                &cancellation,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
             "guest transport did not reach the controlled failure",
@@ -2315,7 +2363,13 @@ fn uncertain_guest_transport_failure_stops_exact_job_and_never_restarts_it() {
         .store(true, Ordering::SeqCst);
 
     let error = std::thread::scope(|scope| {
-        let call = scope.spawn(|| endpoint.exec(&command, &NeverCancelled));
+        let call = scope.spawn(|| {
+            endpoint.exec(
+                &command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
+        });
         wait_for_test(
             || fixture.engine.guest_exec_blocked.load(Ordering::SeqCst),
             "guest transport did not reach the controlled failure",
@@ -2385,7 +2439,11 @@ fn cancellation_during_final_custody_reinspection_stops_exact_job() {
     .expect("command");
 
     let error = endpoint
-        .exec(&command, &cancellation)
+        .exec(
+            &command,
+            &cancellation,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect_err("final verification cancellation");
     assert_eq!(error.kind(), ExecutionErrorKind::Cancelled);
     assert!(
@@ -3446,7 +3504,11 @@ fn endpoint_exchange_reattests_missing_or_drifted_imported_proxy_before_exec_mut
         let mutations = fixture.engine.mutation_count();
 
         let error = endpoint
-            .exec(&true_command(&spec, 0x172), &NeverCancelled)
+            .exec(
+                &true_command(&spec, 0x172),
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect_err("endpoint exchange must reattest the imported image");
         assert_eq!(
             error.kind(),
@@ -4566,7 +4628,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
             Duration::from_secs(10),
             64 * 1024,
         )?;
-            let output = endpoint.exec(&attenuated_identity, &NeverCancelled)?;
+            let output = endpoint.exec(
+                &attenuated_identity,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )?;
             assert_eq!(output.termination(), ExecutionTermination::Exited(0));
             assert_eq!(output.stdout(), b"attenuated-live");
 
@@ -4593,7 +4659,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
                     Duration::from_secs(10),
                     64 * 1024,
                 )?;
-                let output = endpoint.exec(&command, &NeverCancelled)?;
+                let output = endpoint.exec(
+                    &command,
+                    &NeverCancelled,
+                    automata_ci_execution::discard_execution_output(),
+                )?;
                 assert_eq!(output.termination(), ExecutionTermination::Exited(0));
                 assert_eq!(output.stdout(), expected);
             }
@@ -4620,7 +4690,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
                 Duration::from_secs(10),
                 64 * 1024,
             )?;
-            let output = endpoint.exec(&protected_envelope, &NeverCancelled)?;
+            let output = endpoint.exec(
+                &protected_envelope,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )?;
             assert_eq!(output.termination(), ExecutionTermination::Exited(0));
             assert_eq!(output.stdout(), b"protected-live");
 
@@ -4653,7 +4727,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
             )?;
             assert_eq!(
                 endpoint
-                    .exec(&direct_broker, &NeverCancelled)?
+                    .exec(
+                        &direct_broker,
+                        &NeverCancelled,
+                        automata_ci_execution::discard_execution_output()
+                    )?
                     .termination(),
                 ExecutionTermination::Exited(0),
                 "capless root must not receive a broker response"
@@ -4688,7 +4766,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
             Duration::from_secs(10),
             64 * 1024,
         )?;
-            let output = endpoint.exec(&network_gate, &NeverCancelled)?;
+            let output = endpoint.exec(
+                &network_gate,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )?;
             assert_eq!(output.termination(), ExecutionTermination::Exited(0));
             assert_eq!(output.stdout(), b"closed-results-live");
 
@@ -4705,7 +4787,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
             )?;
             assert_eq!(
                 endpoint
-                    .exec(&forbidden_bootstrap, &NeverCancelled)?
+                    .exec(
+                        &forbidden_bootstrap,
+                        &NeverCancelled,
+                        automata_ci_execution::discard_execution_output()
+                    )?
                     .termination(),
                 ExecutionTermination::Exited(1),
                 "capless root cannot reopen the one-shot sealer"
@@ -4722,7 +4808,11 @@ async fn fixed_relay_live_shell_and_javascript_conformance() {
                 Duration::from_secs(5),
                 64 * 1024,
             )?;
-            let output = endpoint.exec(&after_signal, &NeverCancelled)?;
+            let output = endpoint.exec(
+                &after_signal,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )?;
             assert_eq!(output.termination(), ExecutionTermination::Exited(0));
             assert_eq!(output.stdout(), b"broker-still-ready");
             Ok(())

--- a/crates/automata-ci-runner-runtime/src/endpoint_replay.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_replay.rs
@@ -11,9 +11,9 @@ use std::{
 use automata_ci_core::{LeaseGuard, OperationId, RunnerSessionId};
 use automata_ci_execution::{
     Cancellation, CancellationDisposition, CopyFromRequest, CopyToRequest, ExecutionCommand,
-    ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionSignal,
-    ExecutionStage, SandboxCapability, SandboxCustody, SandboxInspection, SandboxProvider,
-    SandboxState, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+    ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputSink,
+    ExecutionSignal, ExecutionStage, SandboxCapability, SandboxCustody, SandboxInspection,
+    SandboxProvider, SandboxState, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
 };
 use automata_ci_protocol::RunnerSlotOrdinal;
 use automata_ci_runner_journal::{
@@ -31,7 +31,7 @@ use zeroize::Zeroizing;
 
 use crate::{ExecutionEventError, content::ContentOperationCoordinator, endpoint_result};
 
-const ENDPOINT_REPLAY_SCHEMA_VERSION: u16 = 2;
+const ENDPOINT_REPLAY_SCHEMA_VERSION: u16 = 3;
 const FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/runner/endpoint-request";
 
 pub(crate) struct DurableExecutionEndpoint {
@@ -50,6 +50,19 @@ pub(crate) struct DurableExecutionEndpoint {
 enum PreparedOperation {
     Replay(Vec<u8>),
     Invoke,
+}
+
+enum RunResult<T> {
+    Invoked(T),
+    Replayed(T),
+}
+
+impl<T> RunResult<T> {
+    fn into_inner(self) -> T {
+        match self {
+            Self::Invoked(value) | Self::Replayed(value) => value,
+        }
+    }
 }
 
 impl DurableExecutionEndpoint {
@@ -123,15 +136,16 @@ impl DurableExecutionEndpoint {
         invoke: impl FnOnce(&dyn Cancellation) -> Result<T, ExecutionError>,
         encode: impl FnOnce(&Result<T, ExecutionError>) -> Result<Vec<u8>, ()>,
         decode: impl FnOnce(&[u8]) -> Result<Result<T, ExecutionError>, ()>,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<RunResult<T>, ExecutionError> {
         let _serial = self
             .serial
             .lock()
             .map_err(|_| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
         let prepared = self.prepare(operation_id, kind, &request_digest, reservation, stage)?;
         if let PreparedOperation::Replay(bytes) = prepared {
-            return decode(&bytes)
+            let decoded = decode(&bytes)
                 .map_err(|()| execution_error(ExecutionErrorKind::LocalStorage, stage))?;
+            return decoded.map(RunResult::Replayed);
         }
         let PreparedOperation::Invoke = prepared else {
             unreachable!("replay returned above")
@@ -201,7 +215,7 @@ impl DurableExecutionEndpoint {
             return Err(execution_error(ExecutionErrorKind::InvalidState, stage));
         }
         self.publish_result(operation_id, &encoded, result_capacity, stage)?;
-        result
+        result.map(RunResult::Invoked)
     }
 
     fn prepare(
@@ -508,6 +522,7 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let mut fingerprint = self.fingerprint(EndpointOperationKind::Exec, request.operation_id());
         fingerprint.target_path(request.argv().program());
@@ -528,17 +543,28 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
         let reservation = endpoint_result::exec_reservation(request).ok_or_else(|| {
             execution_error(ExecutionErrorKind::InvalidState, ExecutionStage::Exec)
         })?;
-        self.run(
+        let result = self.run(
             request.operation_id(),
             EndpointOperationKind::Exec,
             request_digest,
             reservation,
             ExecutionStage::Exec,
             cancellation,
-            |observed| self.inner.exec(request, observed),
+            |observed| self.inner.exec(request, observed, Arc::clone(&output)),
             |result| endpoint_result::encode_exec(result, request),
             |encoded| endpoint_result::decode_exec(encoded, request),
-        )
+        )?;
+        match result {
+            RunResult::Invoked(result) => Ok(result),
+            RunResult::Replayed(result) => {
+                for record in result.records() {
+                    output.observe(record).map_err(|_| {
+                        execution_error(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+                    })?;
+                }
+                Ok(result)
+            }
+        }
     }
 
     fn signal(
@@ -564,6 +590,7 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
             |result| endpoint_result::encode_unit(1, ExecutionStage::Signal, *result),
             |encoded| endpoint_result::decode_unit(encoded, 1, ExecutionStage::Signal),
         )
+        .map(RunResult::into_inner)
     }
 
     fn wait(
@@ -584,6 +611,7 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
             |result| endpoint_result::encode_wait(*result),
             endpoint_result::decode_wait,
         )
+        .map(RunResult::into_inner)
     }
 
     fn copy_to(
@@ -608,6 +636,7 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
             |result| endpoint_result::encode_unit(3, ExecutionStage::CopyTo, *result),
             |encoded| endpoint_result::decode_unit(encoded, 3, ExecutionStage::CopyTo),
         )
+        .map(RunResult::into_inner)
     }
 
     fn copy_from(
@@ -633,6 +662,7 @@ impl ExecutionEndpoint for DurableExecutionEndpoint {
             |result| endpoint_result::encode_bytes(result, request),
             |encoded| endpoint_result::decode_bytes(encoded, request),
         )
+        .map(RunResult::into_inner)
     }
 }
 

--- a/crates/automata-ci-runner-runtime/src/endpoint_replay_tests.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_replay_tests.rs
@@ -350,16 +350,45 @@ impl ExecutionEndpoint for FakeEndpoint {
     }
 
     fn capabilities(&self) -> &[SandboxCapability] {
-        const CAPABILITIES: &[SandboxCapability] = &[SandboxCapability::CopyFrom];
+        const CAPABILITIES: &[SandboxCapability] =
+            &[SandboxCapability::Exec, SandboxCapability::CopyFrom];
         CAPABILITIES
     }
 
     fn exec(
         &self,
-        _request: &ExecutionCommand,
+        request: &ExecutionCommand,
         _cancellation: &dyn Cancellation,
+        output: Arc<dyn automata_ci_execution::ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
-        Err(endpoint_error(ExecutionStage::Exec))
+        if request.argv().program().as_str() != "/usr/bin/live-output" {
+            return Err(endpoint_error(ExecutionStage::Exec));
+        }
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let result = ExecutionOutput::new(
+            automata_ci_execution::ExecutionTermination::Exited(0),
+            vec![
+                automata_ci_execution::ExecutionOutputRecord::data(
+                    automata_ci_execution::ExecutionOutputStream::Stdout,
+                    b"live output\n".to_vec(),
+                )
+                .expect("bounded output"),
+                automata_ci_execution::ExecutionOutputRecord::end_of_stream(
+                    automata_ci_execution::ExecutionOutputStream::Stdout,
+                ),
+                automata_ci_execution::ExecutionOutputRecord::end_of_stream(
+                    automata_ci_execution::ExecutionOutputStream::Stderr,
+                ),
+            ],
+            false,
+        )
+        .map_err(|_| endpoint_error(ExecutionStage::Exec))?;
+        for record in result.records() {
+            output.observe(record).map_err(|_| {
+                ExecutionError::new(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+            })?;
+        }
+        Ok(result)
     }
 
     fn signal(
@@ -406,6 +435,22 @@ impl ExecutionEndpoint for FakeEndpoint {
 
 fn endpoint_error(stage: ExecutionStage) -> ExecutionError {
     ExecutionError::new(ExecutionErrorKind::UnsupportedCapability, stage)
+}
+
+#[derive(Debug, Default)]
+struct RecordingOutput(Mutex<Vec<automata_ci_execution::ExecutionOutputRecord>>);
+
+impl automata_ci_execution::ExecutionOutputSink for RecordingOutput {
+    fn observe(
+        &self,
+        record: &automata_ci_execution::ExecutionOutputRecord,
+    ) -> Result<(), automata_ci_execution::ExecutionOutputSinkError> {
+        self.0
+            .lock()
+            .expect("recording output")
+            .push(record.clone());
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -712,6 +757,54 @@ fn completed_result_replays_without_backend_and_result_wins_later_cancellation()
 }
 
 #[test]
+fn completed_exec_replays_the_exact_output_records_without_reinvoking_the_backend() {
+    let fixture = Fixture::new("completed-exec-output");
+    let command = ExecutionCommand::new(
+        OperationId::new(),
+        ExecutionArgv::new(
+            TargetPath::posix("/usr/bin/live-output").expect("program"),
+            Vec::new(),
+        )
+        .expect("argv"),
+        TargetPath::posix("/workspace").expect("working directory"),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(30),
+        1_024,
+    )
+    .expect("command");
+    let first_sink = Arc::new(RecordingOutput::default());
+    let first = fixture
+        .endpoint()
+        .exec(
+            &command,
+            &automata_ci_execution::NeverCancelled,
+            first_sink.clone(),
+        )
+        .expect("fresh execution");
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *first_sink.0.lock().expect("fresh records"),
+        first.records()
+    );
+
+    let replay_sink = Arc::new(RecordingOutput::default());
+    let replay = fixture
+        .endpoint()
+        .exec(
+            &command,
+            &automata_ci_execution::NeverCancelled,
+            replay_sink.clone(),
+        )
+        .expect("replayed execution");
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(replay, first);
+    assert_eq!(
+        *replay_sink.0.lock().expect("replayed records"),
+        replay.records()
+    );
+}
+
+#[test]
 fn secret_bearing_requests_never_serialize_into_journal_spool_identity_or_debug() {
     let fixture = Fixture::new("request-secret-redaction");
     let secret = "pin-0427";
@@ -734,7 +827,11 @@ fn secret_bearing_requests_never_serialize_into_journal_spool_identity_or_debug(
     .expect("command");
     let error = fixture
         .endpoint()
-        .exec(&command, &automata_ci_execution::NeverCancelled)
+        .exec(
+            &command,
+            &automata_ci_execution::NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect_err("fake endpoint reports unsupported exec");
     assert!(!format!("{command:?}{error:?}").contains(secret));
 

--- a/crates/automata-ci-runner-runtime/src/endpoint_result.rs
+++ b/crates/automata-ci-runner-runtime/src/endpoint_result.rs
@@ -249,6 +249,7 @@ const fn error_kind_tag(kind: ExecutionErrorKind) -> u8 {
         ExecutionErrorKind::OutputLimitExceeded => 7,
         ExecutionErrorKind::BackendRejected => 8,
         ExecutionErrorKind::LocalStorage => 9,
+        ExecutionErrorKind::OutputRejected => 10,
     }
 }
 
@@ -264,6 +265,7 @@ const fn decode_error_kind(tag: u8) -> Result<ExecutionErrorKind, ()> {
         7 => Ok(ExecutionErrorKind::OutputLimitExceeded),
         8 => Ok(ExecutionErrorKind::BackendRejected),
         9 => Ok(ExecutionErrorKind::LocalStorage),
+        10 => Ok(ExecutionErrorKind::OutputRejected),
         _ => Err(()),
     }
 }

--- a/crates/automata-ci-runner/src/product/metrics.rs
+++ b/crates/automata-ci-runner/src/product/metrics.rs
@@ -9,10 +9,10 @@ use automata_ci_core::JobLifecycle;
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, DestroyDisposition, DestroySandbox,
     ExecutionCommand, ExecutionEndpoint, ExecutionError, ExecutionErrorKind, ExecutionOutput,
-    ExecutionStage, ExecutionTermination, ProviderCapabilities, ProviderError, ProviderErrorKind,
-    ProviderId, ProviderStage, SandboxCapability, SandboxHandle, SandboxInspection,
-    SandboxProvider, SandboxRecord, SandboxSpec, ServiceContainerBindings, SignalRequest,
-    WaitRequest,
+    ExecutionOutputSink, ExecutionStage, ExecutionTermination, ProviderCapabilities, ProviderError,
+    ProviderErrorKind, ProviderId, ProviderStage, SandboxCapability, SandboxHandle,
+    SandboxInspection, SandboxProvider, SandboxRecord, SandboxSpec, ServiceContainerBindings,
+    SignalRequest, WaitRequest,
 };
 use automata_ci_metrics::{
     BuildInfo as MetricsBuildInfo, BuildInfoError, Counter, ExporterLimits, Family, Gauge,
@@ -2325,9 +2325,10 @@ impl ExecutionEndpoint for ObservedExecutionEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let result = self.call(SandboxEndpointOperation::Exec, || {
-            self.inner.exec(request, cancellation)
+            self.inner.exec(request, cancellation, output)
         });
         if let Ok(output) = &result {
             self.metrics
@@ -2480,6 +2481,7 @@ const fn endpoint_error_label(value: ExecutionErrorKind) -> &'static str {
         ExecutionErrorKind::OutputLimitExceeded => "output_limit_exceeded",
         ExecutionErrorKind::BackendRejected => "backend_rejected",
         ExecutionErrorKind::LocalStorage => "local_storage",
+        ExecutionErrorKind::OutputRejected => "output_rejected",
     }
 }
 
@@ -3684,8 +3686,9 @@ mod tests {
             &self,
             _request: &ExecutionCommand,
             _cancellation: &dyn Cancellation,
+            output: Arc<dyn ExecutionOutputSink>,
         ) -> Result<ExecutionOutput, ExecutionError> {
-            ExecutionOutput::new(
+            let result = ExecutionOutput::new(
                 ExecutionTermination::Exited(0),
                 vec![
                     automata_ci_execution::ExecutionOutputRecord::data(
@@ -3712,7 +3715,13 @@ mod tests {
                     ExecutionErrorKind::OutputLimitExceeded,
                     ExecutionStage::Exec,
                 )
-            })
+            })?;
+            for record in result.records() {
+                output.observe(record).map_err(|_| {
+                    ExecutionError::new(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+                })?;
+            }
+            Ok(result)
         }
 
         fn signal(
@@ -4325,7 +4334,11 @@ mod tests {
         )
         .expect("command");
         let output = endpoint
-            .exec(&command, &NeverCancelled)
+            .exec(
+                &command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect("truncated bounded output");
         assert!(output.was_truncated());
         assert!(matches!(

--- a/crates/automata-ci-runner/src/product/podman_process_trust.rs
+++ b/crates/automata-ci-runner/src/product/podman_process_trust.rs
@@ -975,12 +975,22 @@ mod tests {
             1_024,
         );
         let executor = SystemCommandExecutor;
-        let first = executor.execute(&request, options.process_environment(), &NeverCancelled);
+        let first = executor.execute(
+            &request,
+            options.process_environment(),
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        );
         assert_eq!(first.termination(), CommandTermination::Exited(Some(0)));
 
         executable_file(&fixture.conmon, b"replacement executable");
         assert_eq!(fixture.trust.revalidate(), Err(TrustError::Changed));
-        let second = executor.execute(&request, options.process_environment(), &NeverCancelled);
+        let second = executor.execute(
+            &request,
+            options.process_environment(),
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        );
         assert_eq!(second.termination(), CommandTermination::FailedToStart);
         assert_eq!(
             fs::read_to_string(&fixture.marker).expect("read spawn marker"),

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -1024,7 +1024,11 @@ impl ProfileAdmissionContext<'_> {
                     cleanup_error,
                 ));
             };
-            let output = match endpoint.exec(&command, &self.provisioning_cancellation) {
+            let output = match endpoint.exec(
+                &command,
+                &self.provisioning_cancellation,
+                automata_ci_execution::discard_execution_output(),
+            ) {
                 Ok(output) => output,
                 Err(error) => {
                     let (cleanup, cleanup_error) =
@@ -1623,6 +1627,7 @@ mod tests {
             &self,
             request: &ExecutionCommand,
             cancellation: &dyn Cancellation,
+            output: Arc<dyn automata_ci_execution::ExecutionOutputSink>,
         ) -> Result<ExecutionOutput, ExecutionError> {
             self.state
                 .lock()
@@ -1678,14 +1683,20 @@ mod tests {
             records.push(ExecutionOutputRecord::end_of_stream(
                 ExecutionOutputStream::Stderr,
             ));
-            ExecutionOutput::new(
+            let result = ExecutionOutput::new(
                 termination,
                 records,
                 self.behavior == FakeBehavior::ExecTruncated,
             )
             .map_err(|_| {
                 ExecutionError::new(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec)
-            })
+            })?;
+            for record in result.records() {
+                output.observe(record).map_err(|_| {
+                    ExecutionError::new(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+                })?;
+            }
+            Ok(result)
         }
 
         fn signal(

--- a/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/endpoint.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
     ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord,
-    ExecutionOutputStream, ExecutionStage, ExecutionTermination, SandboxCapability, SandboxHandle,
-    SignalRequest, WaitRequest,
+    ExecutionOutputSink, ExecutionOutputStream, ExecutionStage, ExecutionTermination,
+    SandboxCapability, SandboxHandle, SignalRequest, WaitRequest,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestOutputStream, GuestRejection, GuestRequest, GuestResponse,
@@ -223,6 +223,7 @@ impl ExecutionEndpoint for KubernetesExecutionEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let guest_request = exec_request(request)?;
         let response = self.exchange(
@@ -236,7 +237,13 @@ impl ExecutionEndpoint for KubernetesExecutionEndpoint {
             cancellation,
             ExecutionStage::Exec,
         )?;
-        execution_output(response, request.output_limit())
+        let result = execution_output(response, request.output_limit())?;
+        for record in result.records() {
+            output.observe(record).map_err(|_| {
+                execution_error(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+            })?;
+        }
+        Ok(result)
     }
 
     fn signal(

--- a/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
@@ -553,7 +553,11 @@ async fn exec_and_copy_round_trips_preserve_exact_guest_requests_and_results() {
     .expect("copy-from request");
 
     let output = endpoint
-        .exec(&command, &NeverCancelled)
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("execute command");
     endpoint
         .copy_to(&copy_to, &NeverCancelled)
@@ -758,7 +762,11 @@ async fn malformed_exec_response_shapes_fail_closed() {
     ] {
         assert_execution_error(
             endpoint
-                .exec(&execution_command(limit), &NeverCancelled)
+                .exec(
+                    &execution_command(limit),
+                    &NeverCancelled,
+                    automata_ci_execution::discard_execution_output(),
+                )
                 .expect_err(message),
             expected,
             ExecutionStage::Exec,
@@ -786,7 +794,11 @@ async fn operational_guest_rejections_remain_bounded_backend_failures() {
     for _ in rejections {
         assert_execution_error(
             endpoint
-                .exec(&execution_command(64), &NeverCancelled)
+                .exec(
+                    &execution_command(64),
+                    &NeverCancelled,
+                    automata_ci_execution::discard_execution_output(),
+                )
                 .expect_err("operational guest rejection"),
             ExecutionErrorKind::BackendRejected,
             ExecutionStage::Exec,
@@ -831,14 +843,22 @@ async fn requested_exec_limit_and_transport_stderr_fail_closed() {
     let endpoint = attach_endpoint(&server);
     assert_execution_error(
         endpoint
-            .exec(&execution_command(1024 * 1024), &NeverCancelled)
+            .exec(
+                &execution_command(1024 * 1024),
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect_err("one guest record must respect its hard bound"),
         ExecutionErrorKind::OutputLimitExceeded,
         ExecutionStage::Exec,
     );
     assert_execution_error(
         endpoint
-            .exec(&execution_command(3), &NeverCancelled)
+            .exec(
+                &execution_command(3),
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect_err("guest must not exceed the caller output limit"),
         ExecutionErrorKind::OutputLimitExceeded,
         ExecutionStage::Exec,
@@ -932,7 +952,11 @@ async fn cancellation_and_unsupported_operations_stop_before_exec_transport() {
     let cancellation = TestCancellation::cancelled();
     assert_execution_error(
         endpoint
-            .exec(&execution_command(64), &cancellation)
+            .exec(
+                &execution_command(64),
+                &cancellation,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect_err("cancelled exec"),
         ExecutionErrorKind::Cancelled,
         ExecutionStage::Exec,

--- a/crates/automata-ci-sandbox-macos/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-macos/src/endpoint.rs
@@ -8,8 +8,9 @@ use std::{
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
     ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord,
-    ExecutionOutputStream, ExecutionStage, ExecutionTermination, SandboxCapability, SandboxHandle,
-    SandboxState, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+    ExecutionOutputSink, ExecutionOutputStream, ExecutionStage, ExecutionTermination,
+    SandboxCapability, SandboxHandle, SandboxState, SignalRequest, TargetPath, TargetPlatform,
+    WaitRequest,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestOutputStream, GuestRejection, GuestRequest, GuestResponse,
@@ -23,6 +24,18 @@ use crate::{
 };
 
 const COPY_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn publish_output(
+    result: Result<ExecutionOutput, ExecutionError>,
+    sink: &dyn ExecutionOutputSink,
+) -> Result<ExecutionOutput, ExecutionError> {
+    let output = result?;
+    for record in output.records() {
+        sink.observe(record)
+            .map_err(|_| error(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec))?;
+    }
+    Ok(output)
+}
 
 #[derive(Default)]
 pub(crate) struct EndpointState {
@@ -93,6 +106,7 @@ impl ExecutionEndpoint for MacosVirtualizationEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let _operation = self
             .entry
@@ -107,7 +121,7 @@ impl ExecutionEndpoint for MacosVirtualizationEndpoint {
                 .map_err(|_| error(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec))?;
             if let Some(replay) = state.exec.get(&request.operation_id()) {
                 return if replay.request == *request {
-                    replay.result.clone()
+                    publish_output(replay.result.clone(), output.as_ref())
                 } else {
                     Err(error(
                         ExecutionErrorKind::BackendRejected,
@@ -129,7 +143,7 @@ impl ExecutionEndpoint for MacosVirtualizationEndpoint {
                     result: result.clone(),
                 },
             );
-        result
+        publish_output(result, output.as_ref())
     }
 
     fn signal(

--- a/crates/automata-ci-sandbox-podman/src/command.rs
+++ b/crates/automata-ci-sandbox-podman/src/command.rs
@@ -16,7 +16,9 @@ use std::{
 #[cfg(any(unix, test))]
 use std::sync::mpsc;
 
-use automata_ci_execution::{Cancellation, ExecutionOutputRecord, ExecutionOutputStream};
+use automata_ci_execution::{
+    Cancellation, ExecutionOutputRecord, ExecutionOutputSink, ExecutionOutputStream,
+};
 #[cfg(any(unix, test))]
 use automata_ci_execution::{MAX_EXECUTION_OUTPUT_RECORD_BYTES, MAX_EXECUTION_OUTPUT_RECORDS};
 
@@ -870,6 +872,7 @@ pub struct CommandOutput {
     stdout: Vec<u8>,
     stderr: Vec<u8>,
     truncated: bool,
+    output_rejected: bool,
     stdin_fully_written: bool,
 }
 
@@ -884,6 +887,7 @@ impl CommandOutput {
             stdout,
             stderr: Vec::new(),
             truncated: false,
+            output_rejected: false,
             stdin_fully_written: true,
         }
     }
@@ -898,6 +902,7 @@ impl CommandOutput {
             stdout: Vec::new(),
             stderr,
             truncated: false,
+            output_rejected: false,
             stdin_fully_written: true,
         }
     }
@@ -915,6 +920,7 @@ impl CommandOutput {
             stdout: Vec::new(),
             stderr: Vec::new(),
             truncated: false,
+            output_rejected: false,
             stdin_fully_written: true,
         }
     }
@@ -981,6 +987,12 @@ impl CommandOutput {
         self.truncated
     }
 
+    /// Reports whether the incremental output consumer rejected a record.
+    #[must_use]
+    pub const fn output_was_rejected(&self) -> bool {
+        self.output_rejected
+    }
+
     /// Returns whether every supplied standard-input byte reached the child.
     ///
     /// This is always `true` for requests without a standard-input payload.
@@ -1004,6 +1016,7 @@ impl fmt::Debug for CommandOutput {
             .field("stderr_bytes", &self.stderr.len())
             .field("output", &"[REDACTED]")
             .field("truncated", &self.truncated)
+            .field("output_rejected", &self.output_rejected)
             .field("stdin_fully_written", &self.stdin_fully_written)
             .finish()
     }
@@ -1022,6 +1035,7 @@ pub trait PodmanCommandExecutor: fmt::Debug + Send + Sync {
         request: &CommandRequest,
         environment: &PodmanProcessEnvironment,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> CommandOutput;
 
     /// Returns the empty delegated cgroup beneath which Podman may create jobs.
@@ -1049,8 +1063,9 @@ impl PodmanCommandExecutor for SystemCommandExecutor {
         request: &CommandRequest,
         environment: &PodmanProcessEnvironment,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> CommandOutput {
-        execute_system(request, environment, cancellation)
+        execute_system(request, environment, cancellation, output)
     }
 
     fn delegated_no_swap_cgroup(&self) -> Option<String> {
@@ -1366,6 +1381,7 @@ fn execute_system(
     request: &CommandRequest<'_>,
     environment: &PodmanProcessEnvironment,
     cancellation: &dyn Cancellation,
+    output: Arc<dyn ExecutionOutputSink>,
 ) -> CommandOutput {
     if cancellation.disposition().requires_termination() {
         return interrupted_before_stdin(request, CommandTermination::Cancelled);
@@ -1381,7 +1397,8 @@ fn execute_system(
     let Ok((mut child, stdin, stdout, stderr)) = spawn_child(request, environment) else {
         return interrupted_before_stdin(request, CommandTermination::FailedToStart);
     };
-    let Ok(output_capture) = OutputCapture::spawn(stdout, stderr, request.output_limit()) else {
+    let Ok(output_capture) = OutputCapture::spawn(stdout, stderr, request.output_limit(), output)
+    else {
         terminate_process_group(&mut child, Duration::ZERO);
         return interrupted_before_stdin(request, CommandTermination::FailedToStart);
     };
@@ -1400,7 +1417,7 @@ fn execute_system(
                 return interrupted_before_stdin(request, CommandTermination::FailedToStart);
             }
         };
-        let termination = wait_for_child(&mut child, deadline, cancellation);
+        let termination = wait_for_child(&mut child, deadline, cancellation, &output_capture);
         #[cfg(target_os = "linux")]
         if matches!(termination, CommandTermination::Exited(_)) {
             terminate_remaining_process_group(&child);
@@ -1417,7 +1434,8 @@ fn execute_system(
             records: captured.records,
             stdout: captured.stdout,
             stderr: captured.stderr,
-            truncated: captured.incomplete,
+            truncated: captured.status != CaptureStatus::Complete,
+            output_rejected: captured.status == CaptureStatus::Rejected,
             stdin_fully_written,
         }
     })
@@ -1506,6 +1524,7 @@ fn wait_for_child(
     child: &mut Child,
     deadline: Instant,
     cancellation: &dyn Cancellation,
+    output: &OutputCapture,
 ) -> CommandTermination {
     loop {
         match poll_child_exit(child) {
@@ -1516,6 +1535,10 @@ fn wait_for_child(
                 if cancellation.disposition().requires_termination() =>
             {
                 terminate_process_group(child, TERMINATION_GRACE);
+                return CommandTermination::Cancelled;
+            }
+            Ok(ChildExitObservation::Running) if output.was_rejected() => {
+                terminate_process_group(child, Duration::ZERO);
                 return CommandTermination::Cancelled;
             }
             Ok(ChildExitObservation::Running) if Instant::now() >= deadline => {
@@ -2081,12 +2104,13 @@ impl OutputCapture {
         stdout: Stdout,
         stderr: Stderr,
         output_limit: usize,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<Self, ()>
     where
         Stdout: std::io::Read + std::os::fd::AsFd + Send + 'static,
         Stderr: std::io::Read + std::os::fd::AsFd + Send + 'static,
     {
-        let state = Arc::new(Mutex::new(OutputCaptureState::new(output_limit)));
+        let state = Arc::new(Mutex::new(OutputCaptureState::new(output_limit, output)));
         let stop = Arc::new(AtomicBool::new(false));
         let stdout = OutputReader::spawn(
             stdout,
@@ -2112,6 +2136,7 @@ impl OutputCapture {
         _stdout: Stdout,
         _stderr: Stderr,
         _output_limit: usize,
+        _output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<Self, ()>
     where
         Stdout: std::io::Read + Send + 'static,
@@ -2146,6 +2171,10 @@ impl OutputCapture {
             }
         }
         capture_state(&self.state).take_output()
+    }
+
+    fn was_rejected(&self) -> bool {
+        capture_state(&self.state).status == CaptureStatus::Rejected
     }
 }
 
@@ -2220,62 +2249,50 @@ impl Drop for OutputReader {
 
 struct OutputCaptureState {
     remaining: usize,
-    records: Vec<CapturedRecord>,
+    records: Vec<ExecutionOutputRecord>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
-    stdout_ended: bool,
-    stderr_ended: bool,
-    incomplete: bool,
+    ended: [bool; 2],
+    status: CaptureStatus,
+    output: Arc<dyn ExecutionOutputSink>,
 }
 
 impl OutputCaptureState {
     #[cfg(any(unix, test))]
-    const fn new(output_limit: usize) -> Self {
+    fn new(output_limit: usize, output: Arc<dyn ExecutionOutputSink>) -> Self {
         Self {
             remaining: output_limit,
             records: Vec::new(),
             stdout: Vec::new(),
             stderr: Vec::new(),
-            stdout_ended: false,
-            stderr_ended: false,
-            incomplete: false,
+            ended: [false; 2],
+            status: CaptureStatus::Complete,
+            output,
         }
     }
 
     #[cfg(any(unix, test))]
-    fn observe_data(&mut self, stream: ExecutionOutputStream, source: &[u8]) {
+    fn observe_data(&mut self, stream: ExecutionOutputStream, source: &[u8]) -> bool {
         if self.stream_ended(stream) {
-            self.incomplete = true;
-            return;
+            self.mark_incomplete();
+            return false;
         }
         let allowed = self.remaining.min(source.len());
         let mut retained = 0;
         while retained < allowed {
-            let extended = match self.records.last_mut() {
-                Some(CapturedRecord::Data {
-                    stream: previous,
-                    bytes,
-                }) if *previous == stream && bytes.len() < MAX_EXECUTION_OUTPUT_RECORD_BYTES => {
-                    let count =
-                        (MAX_EXECUTION_OUTPUT_RECORD_BYTES - bytes.len()).min(allowed - retained);
-                    bytes.extend_from_slice(&source[retained..retained + count]);
-                    retained += count;
-                    true
-                }
-                Some(CapturedRecord::Data { .. } | CapturedRecord::End(_)) | None => false,
-            };
-            if extended {
-                continue;
-            }
-            let remaining_ends = usize::from(!self.stdout_ended) + usize::from(!self.stderr_ended);
+            let remaining_ends = self.ended.iter().filter(|ended| !**ended).count();
             if self.records.len() >= MAX_EXECUTION_OUTPUT_RECORDS.saturating_sub(remaining_ends) {
                 break;
             }
             let count = MAX_EXECUTION_OUTPUT_RECORD_BYTES.min(allowed - retained);
-            self.records.push(CapturedRecord::Data {
-                stream,
-                bytes: source[retained..retained + count].to_vec(),
-            });
+            let record =
+                ExecutionOutputRecord::data(stream, source[retained..retained + count].to_vec())
+                    .expect("captured output chunks are non-empty and bounded");
+            if self.output.observe(&record).is_err() {
+                self.status = CaptureStatus::Rejected;
+                return false;
+            }
+            self.records.push(record);
             retained += count;
         }
         let bytes = &source[..retained];
@@ -2285,47 +2302,47 @@ impl OutputCaptureState {
         }
         self.remaining -= retained;
         if retained < source.len() {
-            self.incomplete = true;
+            self.mark_incomplete();
         }
+        retained == source.len()
     }
 
     #[cfg(any(unix, test))]
-    fn observe_end(&mut self, stream: ExecutionOutputStream) {
+    fn observe_end(&mut self, stream: ExecutionOutputStream) -> bool {
         if self.stream_ended(stream) || self.records.len() >= MAX_EXECUTION_OUTPUT_RECORDS {
-            self.incomplete = true;
-            return;
+            self.mark_incomplete();
+            return false;
         }
-        match stream {
-            ExecutionOutputStream::Stdout => self.stdout_ended = true,
-            ExecutionOutputStream::Stderr => self.stderr_ended = true,
+        let record = ExecutionOutputRecord::end_of_stream(stream);
+        if self.output.observe(&record).is_err() {
+            self.status = CaptureStatus::Rejected;
+            return false;
         }
-        self.records.push(CapturedRecord::End(stream));
+        self.ended[stream_index(stream)] = true;
+        self.records.push(record);
+        true
     }
 
     #[cfg(any(unix, test))]
     fn stream_ended(&self, stream: ExecutionOutputStream) -> bool {
-        match stream {
-            ExecutionOutputStream::Stdout => self.stdout_ended,
-            ExecutionOutputStream::Stderr => self.stderr_ended,
-        }
+        self.ended[stream_index(stream)]
     }
 
     const fn mark_incomplete(&mut self) {
-        self.incomplete = true;
+        if matches!(self.status, CaptureStatus::Complete) {
+            self.status = CaptureStatus::Incomplete;
+        }
     }
 
     fn take_output(&mut self) -> CapturedOutput {
-        if !(self.stdout_ended && self.stderr_ended) {
-            self.incomplete = true;
+        if !self.ended.into_iter().all(|ended| ended) {
+            self.mark_incomplete();
         }
         CapturedOutput {
-            records: std::mem::take(&mut self.records)
-                .into_iter()
-                .map(CapturedRecord::into_execution_record)
-                .collect(),
+            records: std::mem::take(&mut self.records),
             stdout: std::mem::take(&mut self.stdout),
             stderr: std::mem::take(&mut self.stderr),
-            incomplete: self.incomplete,
+            status: self.status,
         }
     }
 }
@@ -2339,32 +2356,9 @@ impl fmt::Debug for OutputCaptureState {
             .field("stdout_bytes", &self.stdout.len())
             .field("stderr_bytes", &self.stderr.len())
             .field("output", &"[REDACTED]")
-            .field("stdout_ended", &self.stdout_ended)
-            .field("stderr_ended", &self.stderr_ended)
-            .field("incomplete", &self.incomplete)
+            .field("ended", &self.ended)
+            .field("status", &self.status)
             .finish()
-    }
-}
-
-enum CapturedRecord {
-    #[cfg(any(unix, test))]
-    Data {
-        stream: ExecutionOutputStream,
-        bytes: Vec<u8>,
-    },
-    #[cfg(any(unix, test))]
-    End(ExecutionOutputStream),
-}
-
-impl CapturedRecord {
-    fn into_execution_record(self) -> ExecutionOutputRecord {
-        match self {
-            #[cfg(any(unix, test))]
-            Self::Data { stream, bytes } => ExecutionOutputRecord::data(stream, bytes)
-                .expect("captured record bytes are non-empty and bounded"),
-            #[cfg(any(unix, test))]
-            Self::End(stream) => ExecutionOutputRecord::end_of_stream(stream),
-        }
     }
 }
 
@@ -2372,7 +2366,21 @@ struct CapturedOutput {
     records: Vec<ExecutionOutputRecord>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
-    incomplete: bool,
+    status: CaptureStatus,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CaptureStatus {
+    Complete,
+    Incomplete,
+    Rejected,
+}
+
+const fn stream_index(stream: ExecutionOutputStream) -> usize {
+    match stream {
+        ExecutionOutputStream::Stdout => 0,
+        ExecutionOutputStream::Stderr => 1,
+    }
 }
 
 fn capture_state(
@@ -2396,10 +2404,17 @@ fn read_ordered<R>(
     while !stop.load(Ordering::Acquire) {
         match reader.read(&mut buffer) {
             Ok(0) => {
-                capture_state(state).observe_end(stream);
+                if !capture_state(state).observe_end(stream) {
+                    stop.store(true, Ordering::Release);
+                }
                 return;
             }
-            Ok(count) => capture_state(state).observe_data(stream, &buffer[..count]),
+            Ok(count) => {
+                if !capture_state(state).observe_data(stream, &buffer[..count]) {
+                    stop.store(true, Ordering::Release);
+                    return;
+                }
+            }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::park_timeout(POLL_INTERVAL);
@@ -2563,8 +2578,8 @@ mod process_supervision_tests {
 
 #[cfg(test)]
 mod ordered_capture_tests {
-    use super::{OutputCaptureState, capture_state, read_ordered};
-    use automata_ci_execution::ExecutionOutputStream;
+    use super::{CaptureStatus, OutputCaptureState, capture_state, read_ordered};
+    use automata_ci_execution::{ExecutionOutputRecord, ExecutionOutputStream};
     use std::{
         io::{self, Read},
         sync::{Arc, Mutex, atomic::AtomicBool},
@@ -2572,7 +2587,8 @@ mod ordered_capture_tests {
 
     #[test]
     fn capture_state_preserves_one_observation_order_and_both_stream_ends() {
-        let mut state = OutputCaptureState::new(32);
+        let mut state =
+            OutputCaptureState::new(32, automata_ci_execution::discard_execution_output());
         state.observe_data(ExecutionOutputStream::Stdout, b"out-1");
         state.observe_data(ExecutionOutputStream::Stderr, b"err");
         state.observe_data(ExecutionOutputStream::Stdout, b"out-2");
@@ -2584,7 +2600,7 @@ mod ordered_capture_tests {
 
         let captured = state.take_output();
 
-        assert!(!captured.incomplete);
+        assert_eq!(captured.status, CaptureStatus::Complete);
         assert_eq!(captured.stdout, b"out-1out-2");
         assert_eq!(captured.stderr, b"err");
         assert_eq!(captured.records.len(), 5);
@@ -2605,22 +2621,37 @@ mod ordered_capture_tests {
     }
 
     #[test]
-    fn capture_state_distinguishes_exact_limit_from_omitted_bytes() {
-        let mut exact = OutputCaptureState::new(4);
+    fn capture_state_preserves_observation_boundaries_at_the_exact_limit() {
+        let mut exact =
+            OutputCaptureState::new(4, automata_ci_execution::discard_execution_output());
         exact.observe_data(ExecutionOutputStream::Stdout, b"12");
         exact.observe_data(ExecutionOutputStream::Stdout, b"34");
         exact.observe_end(ExecutionOutputStream::Stdout);
         exact.observe_end(ExecutionOutputStream::Stderr);
         let exact = exact.take_output();
-        assert!(!exact.incomplete);
-        assert_eq!(exact.records.len(), 3, "adjacent data must coalesce");
+        assert_eq!(exact.status, CaptureStatus::Complete);
+        assert_eq!(
+            exact
+                .records
+                .iter()
+                .map(ExecutionOutputRecord::bytes)
+                .collect::<Vec<_>>(),
+            [
+                b"12".as_slice(),
+                b"34".as_slice(),
+                b"".as_slice(),
+                b"".as_slice()
+            ],
+            "the durable replay records must preserve live observation boundaries"
+        );
 
-        let mut over = OutputCaptureState::new(4);
+        let mut over =
+            OutputCaptureState::new(4, automata_ci_execution::discard_execution_output());
         over.observe_data(ExecutionOutputStream::Stdout, b"12345");
         over.observe_end(ExecutionOutputStream::Stdout);
         over.observe_end(ExecutionOutputStream::Stderr);
         let over = over.take_output();
-        assert!(over.incomplete);
+        assert_eq!(over.status, CaptureStatus::Incomplete);
         assert_eq!(over.stdout, b"1234");
     }
 
@@ -2639,7 +2670,10 @@ mod ordered_capture_tests {
             }
         }
 
-        let state = Arc::new(Mutex::new(OutputCaptureState::new(16)));
+        let state = Arc::new(Mutex::new(OutputCaptureState::new(
+            16,
+            automata_ci_execution::discard_execution_output(),
+        )));
         read_ordered(
             FailingReader(false),
             ExecutionOutputStream::Stdout,
@@ -2648,7 +2682,7 @@ mod ordered_capture_tests {
         );
         let captured = capture_state(&state).take_output();
 
-        assert!(captured.incomplete);
+        assert_eq!(captured.status, CaptureStatus::Incomplete);
         assert_eq!(captured.stdout, b"data");
         assert!(
             captured

--- a/crates/automata-ci-sandbox-podman/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-podman/src/endpoint.rs
@@ -7,15 +7,18 @@ use std::{
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, EnvironmentVariable, ExecutionCommand,
     ExecutionEndpoint, ExecutionEnvironment, ExecutionError, ExecutionErrorKind, ExecutionOutput,
-    ExecutionSignal, ExecutionStage, ExecutionTermination, NeverCancelled, SandboxCapability,
-    SandboxHandle, SandboxState, SignalRequest, TargetPath, TargetPlatform, WaitRequest,
+    ExecutionOutputSink, ExecutionSignal, ExecutionStage, ExecutionTermination, NeverCancelled,
+    SandboxCapability, SandboxHandle, SandboxState, SignalRequest, TargetPath, TargetPlatform,
+    WaitRequest,
 };
 
 use crate::{
     CommandOutput, CommandTermination,
     command::provider_control_environment_name,
     naming::ResourceNames,
-    provider::{PodmanInner, endpoint_capabilities, endpoint_error_from_provider},
+    provider::{
+        EndpointExecution, PodmanInner, endpoint_capabilities, endpoint_error_from_provider,
+    },
 };
 
 const MAX_PODMAN_ENV_DOCUMENT_LINE_BYTES: usize = 64 * 1024 - 1;
@@ -125,32 +128,6 @@ impl PodmanExecutionEndpoint {
         }
     }
 
-    fn run_with_environment(
-        &self,
-        arguments: Vec<OsString>,
-        environment_document: EnvironmentDocument<'_>,
-        timeout: std::time::Duration,
-        output_limit: usize,
-        cancellation: &dyn Cancellation,
-        stage: ExecutionStage,
-    ) -> Result<CommandOutput, ExecutionError> {
-        let output = self.inner.run_endpoint_with_environment(
-            arguments,
-            environment_document,
-            timeout,
-            output_limit,
-            cancellation,
-            stage,
-        );
-        match output.termination() {
-            CommandTermination::FailedToStart => Err(ExecutionError::new(
-                ExecutionErrorKind::BackendRejected,
-                stage,
-            )),
-            _ => Ok(output),
-        }
-    }
-
     fn run_transport(
         &self,
         arguments: Vec<OsString>,
@@ -241,6 +218,7 @@ impl ExecutionEndpoint for PodmanExecutionEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let _operation = self.acquire(ExecutionStage::Exec)?;
         if request.argv().program().platform() != TargetPlatform::Posix
@@ -275,14 +253,29 @@ impl ExecutionEndpoint for PodmanExecutionEndpoint {
         arguments.push(self.names.container().into());
         arguments.push(request.argv().program().as_str().into());
         arguments.extend(request.argv().arguments().iter().map(OsString::from));
-        let output = self.run_with_environment(
-            arguments,
-            environment_document,
-            request.timeout(),
-            request.output_limit(),
+        let output = self.inner.run_endpoint_execution(
+            EndpointExecution::new(
+                arguments,
+                environment_document,
+                request.timeout(),
+                request.output_limit(),
+                ExecutionStage::Exec,
+                output,
+            ),
             cancellation,
-            ExecutionStage::Exec,
-        )?;
+        );
+        if output.termination() == CommandTermination::FailedToStart {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::BackendRejected,
+                ExecutionStage::Exec,
+            ));
+        }
+        if output.output_was_rejected() {
+            return Err(ExecutionError::new(
+                ExecutionErrorKind::OutputRejected,
+                ExecutionStage::Exec,
+            ));
+        }
         let termination = self.execution_termination(output.termination())?;
         if !output.stdin_was_fully_written()
             && !matches!(

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -12,12 +12,12 @@ use std::{
 use automata_ci_core::Sha256Digest;
 use automata_ci_execution::{
     Cancellation, ContainerHandle, DestroyDisposition, DestroySandbox, EnvironmentProfile,
-    ExecutionEnvironment, NetworkPolicy, NeverCancelled, OperationOutcome, ProviderCapabilities,
-    ProviderError, ProviderErrorKind, ProviderId, ProviderStage, RootFilesystemPolicy,
-    SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection, SandboxPrivilegePolicy,
-    SandboxProvider, SandboxRecord, SandboxSpec, SandboxState, ServiceContainerBinding,
-    ServiceContainerBindings, ServiceContainerSpec, ServiceHealthPolicy, ServiceNetwork,
-    ServicePortBinding, ServiceTransportProtocol,
+    ExecutionEnvironment, ExecutionOutputSink, NetworkPolicy, NeverCancelled, OperationOutcome,
+    ProviderCapabilities, ProviderError, ProviderErrorKind, ProviderId, ProviderStage,
+    RootFilesystemPolicy, SandboxCapability, SandboxCustody, SandboxHandle, SandboxInspection,
+    SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec, SandboxState,
+    ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec, ServiceHealthPolicy,
+    ServiceNetwork, ServicePortBinding, ServiceTransportProtocol, discard_execution_output,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -358,6 +358,35 @@ pub(crate) struct PodmanInner {
     capabilities: ProviderCapabilities,
     handle_locks: Mutex<BTreeMap<String, Weak<Mutex<()>>>>,
     docker_services: Mutex<BTreeMap<String, JobDockerService>>,
+}
+
+pub(crate) struct EndpointExecution<'environment> {
+    arguments: Vec<OsString>,
+    environment: EnvironmentDocument<'environment>,
+    timeout: Duration,
+    output_limit: usize,
+    stage: automata_ci_execution::ExecutionStage,
+    output: Arc<dyn ExecutionOutputSink>,
+}
+
+impl<'environment> EndpointExecution<'environment> {
+    pub(crate) fn new(
+        arguments: Vec<OsString>,
+        environment: EnvironmentDocument<'environment>,
+        timeout: Duration,
+        output_limit: usize,
+        stage: automata_ci_execution::ExecutionStage,
+        output: Arc<dyn ExecutionOutputSink>,
+    ) -> Self {
+        Self {
+            arguments,
+            environment,
+            timeout,
+            output_limit,
+            stage,
+            output,
+        }
+    }
 }
 
 impl fmt::Debug for PodmanInner {
@@ -3851,29 +3880,30 @@ impl PodmanInner {
         self.execute_observed(&request, cancellation, PodmanCommandStage::Endpoint(stage))
     }
 
-    pub(crate) fn run_endpoint_with_environment(
+    pub(crate) fn run_endpoint_execution(
         &self,
-        arguments: Vec<OsString>,
-        environment_document: EnvironmentDocument,
-        timeout: Duration,
-        output_limit: usize,
+        execution: EndpointExecution<'_>,
         cancellation: &dyn Cancellation,
-        stage: automata_ci_execution::ExecutionStage,
     ) -> CommandOutput {
         let deadline = Instant::now()
-            .checked_add(timeout)
+            .checked_add(execution.timeout)
             .unwrap_or_else(Instant::now);
         let mut request = CommandRequest::new(
             self.options.binary().as_path().to_path_buf(),
-            arguments,
-            timeout,
+            execution.arguments,
+            execution.timeout,
             deadline,
-            output_limit,
+            execution.output_limit,
         );
-        if !environment_document.is_empty() {
-            request = request.with_environment_stdin(environment_document);
+        if !execution.environment.is_empty() {
+            request = request.with_environment_stdin(execution.environment);
         }
-        self.execute_observed(&request, cancellation, PodmanCommandStage::Endpoint(stage))
+        self.execute_observed_with_output(
+            &request,
+            cancellation,
+            PodmanCommandStage::Endpoint(execution.stage),
+            execution.output,
+        )
     }
 
     pub(crate) fn run_endpoint_transport(
@@ -3959,6 +3989,16 @@ impl PodmanInner {
         cancellation: &dyn Cancellation,
         stage: PodmanCommandStage,
     ) -> CommandOutput {
+        self.execute_observed_with_output(request, cancellation, stage, discard_execution_output())
+    }
+
+    fn execute_observed_with_output(
+        &self,
+        request: &CommandRequest,
+        cancellation: &dyn Cancellation,
+        stage: PodmanCommandStage,
+        output: Arc<dyn ExecutionOutputSink>,
+    ) -> CommandOutput {
         self.observer.observe(PodmanEvent::CommandStarted { stage });
         let started = Instant::now();
         let output = if self
@@ -3969,8 +4009,12 @@ impl PodmanInner {
         {
             rejected_before_executor(request)
         } else {
-            self.executor
-                .execute(request, self.options.process_environment(), cancellation)
+            self.executor.execute(
+                request,
+                self.options.process_environment(),
+                cancellation,
+                output,
+            )
         };
         self.observer.observe(PodmanEvent::CommandCompleted {
             stage,

--- a/crates/automata-ci-sandbox-podman/tests/command_executor.rs
+++ b/crates/automata-ci-sandbox-podman/tests/command_executor.rs
@@ -11,11 +11,15 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
+        mpsc,
     },
     time::{Duration, Instant},
 };
 
-use automata_ci_execution::{Cancellation, ExecutionOutputStream, NeverCancelled};
+use automata_ci_execution::{
+    Cancellation, ExecutionOutputRecord, ExecutionOutputSink, ExecutionOutputSinkError,
+    ExecutionOutputStream, NeverCancelled,
+};
 use automata_ci_sandbox_podman::{
     CommandRequest, CommandTermination, PodmanBinary, PodmanCommandExecutor, PodmanLaunchTrust,
     PodmanLaunchTrustHandle, PodmanOptions, PodmanProcessEnvironment, PodmanStateRoot,
@@ -44,12 +48,97 @@ impl Cancellation for AtomicCancellation {
 }
 
 #[derive(Debug)]
+struct ChannelOutputSink(mpsc::Sender<Vec<u8>>);
+
+impl ExecutionOutputSink for ChannelOutputSink {
+    fn observe(&self, record: &ExecutionOutputRecord) -> Result<(), ExecutionOutputSinkError> {
+        if !record.is_end_of_stream() && record.stream() == ExecutionOutputStream::Stdout {
+            self.0
+                .send(record.bytes().to_vec())
+                .map_err(|_| ExecutionOutputSinkError)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct RejectOutput;
+
+impl ExecutionOutputSink for RejectOutput {
+    fn observe(&self, _record: &ExecutionOutputRecord) -> Result<(), ExecutionOutputSinkError> {
+        Err(ExecutionOutputSinkError)
+    }
+}
+
+#[derive(Debug)]
 struct TestTrust(Arc<AtomicBool>);
 
 impl PodmanLaunchTrust for TestTrust {
     fn revalidate(&self) -> bool {
         self.0.load(Ordering::Acquire)
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn system_executor_publishes_output_before_the_command_exits() {
+    let scratch = ScratchRoot::new("command-live-output");
+    let environment = environment(scratch.path());
+    let request = CommandRequest::new(
+        executable(&["/bin/sh", "/usr/bin/sh"]),
+        vec![
+            OsString::from("-c"),
+            OsString::from("printf first; /bin/sleep 1; printf second"),
+        ],
+        Duration::from_secs(5),
+        Instant::now() + Duration::from_secs(5),
+        1_024,
+    );
+    let (sender, receiver) = mpsc::channel();
+    let sink = Arc::new(ChannelOutputSink(sender));
+
+    std::thread::scope(|scope| {
+        let execution = scope
+            .spawn(|| SystemCommandExecutor.execute(&request, &environment, &NeverCancelled, sink));
+        assert_eq!(
+            receiver
+                .recv_timeout(Duration::from_millis(500))
+                .expect("the first record arrives while the command is sleeping"),
+            b"first"
+        );
+        let output = execution.join().expect("command execution");
+        assert_eq!(output.termination(), CommandTermination::Exited(Some(0)));
+        assert_eq!(output.stdout(), b"firstsecond");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn system_executor_terminates_the_command_when_output_is_rejected() {
+    let scratch = ScratchRoot::new("command-output-rejected");
+    let environment = environment(scratch.path());
+    let request = CommandRequest::new(
+        executable(&["/bin/sh", "/usr/bin/sh"]),
+        vec![
+            OsString::from("-c"),
+            OsString::from("printf rejected; /bin/sleep 30"),
+        ],
+        Duration::from_secs(10),
+        Instant::now() + Duration::from_secs(10),
+        1_024,
+    );
+    let started = Instant::now();
+
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        Arc::new(RejectOutput),
+    );
+
+    assert!(output.output_was_rejected());
+    assert_eq!(output.termination(), CommandTermination::Cancelled);
+    assert!(started.elapsed() < Duration::from_secs(2));
 }
 
 #[cfg(unix)]
@@ -72,7 +161,12 @@ fn system_executor_cancels_and_reaps_without_a_shell() {
         1_024,
     );
 
-    let output = SystemCommandExecutor.execute(&request, &environment, cancellation.as_ref());
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        cancellation.as_ref(),
+        automata_ci_execution::discard_execution_output(),
+    );
     worker.join().expect("cancellation trigger");
 
     assert_eq!(output.termination(), CommandTermination::Cancelled);
@@ -98,7 +192,12 @@ fn system_executor_kills_descendants_before_reaping_an_exited_leader() {
         1_024,
     );
 
-    let output = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
 
     assert_eq!(output.termination(), CommandTermination::Exited(Some(23)));
     assert_recorded_process_gone(&pid_file, "normal leader exit");
@@ -133,7 +232,12 @@ fn system_executor_cancellation_kills_the_full_process_group() {
         1_024,
     );
 
-    let output = SystemCommandExecutor.execute(&request, &environment, cancellation.as_ref());
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        cancellation.as_ref(),
+        automata_ci_execution::discard_execution_output(),
+    );
     worker.join().expect("cancellation trigger must finish");
 
     assert_eq!(output.termination(), CommandTermination::Cancelled);
@@ -154,7 +258,12 @@ fn output_is_bounded_across_process_streams_and_debug_is_redacted() {
         32,
     );
 
-    let output = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
 
     assert_eq!(output.termination(), CommandTermination::Exited(Some(0)));
     assert_eq!(output.stdout().len() + output.stderr().len(), 32);
@@ -184,8 +293,18 @@ fn exact_output_limit_is_complete_and_one_extra_byte_is_incomplete() {
         8,
     );
 
-    let exact = SystemCommandExecutor.execute(&exact, &environment, &NeverCancelled);
-    let one_over = SystemCommandExecutor.execute(&one_over, &environment, &NeverCancelled);
+    let exact = SystemCommandExecutor.execute(
+        &exact,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
+    let one_over = SystemCommandExecutor.execute(
+        &one_over,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
 
     assert_eq!(exact.stdout(), b"12345678");
     assert!(!exact.was_truncated());
@@ -210,7 +329,12 @@ fn anonymous_stdin_is_exact_and_debug_redacted() {
     )
     .with_stdin(payload.clone());
 
-    let output = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
 
     assert_eq!(output.termination(), CommandTermination::Exited(Some(0)));
     assert!(output.stdin_was_fully_written());
@@ -259,7 +383,12 @@ fn early_child_exit_reports_incomplete_stdin_without_deadlock() {
     .with_stdin(vec![0x53; 4 * 1024 * 1024]);
     let started = Instant::now();
 
-    let output = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
 
     assert_eq!(output.termination(), CommandTermination::Exited(Some(0)));
     assert!(!output.stdin_was_fully_written());
@@ -286,7 +415,12 @@ fn blocked_stdin_honors_cancellation_and_timeout_without_deadlock() {
     )
     .with_stdin(vec![0x43; 4 * 1024 * 1024]);
     let started = Instant::now();
-    let cancelled = SystemCommandExecutor.execute(&request, &environment, cancellation.as_ref());
+    let cancelled = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        cancellation.as_ref(),
+        automata_ci_execution::discard_execution_output(),
+    );
     worker.join().expect("cancellation trigger");
     assert_eq!(cancelled.termination(), CommandTermination::Cancelled);
     assert!(!cancelled.stdin_was_fully_written());
@@ -301,7 +435,12 @@ fn blocked_stdin_honors_cancellation_and_timeout_without_deadlock() {
     )
     .with_stdin(vec![0x54; 4 * 1024 * 1024]);
     let started = Instant::now();
-    let timed_out = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let timed_out = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
     assert_eq!(timed_out.termination(), CommandTermination::TimedOut);
     assert!(!timed_out.stdin_was_fully_written());
     assert!(started.elapsed() < Duration::from_secs(2));
@@ -320,7 +459,12 @@ fn process_environment_is_cleared_to_the_explicit_allowlist() {
         4_096,
     );
 
-    let output = SystemCommandExecutor.execute(&request, &environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        &environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
     let values = std::str::from_utf8(output.stdout()).expect("environment output is UTF-8");
     let values = values
         .lines()

--- a/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
+++ b/crates/automata-ci-sandbox-podman/tests/lifecycle.rs
@@ -143,7 +143,13 @@ fn whole_job_create_replay_exec_and_destroy_are_exact() {
         4_096,
     )
     .expect("command");
-    let output = endpoint.exec(&command, &cancellation).expect("exec");
+    let output = endpoint
+        .exec(
+            &command,
+            &cancellation,
+            automata_ci_execution::discard_execution_output(),
+        )
+        .expect("exec");
     assert_eq!(output.stdout(), b"executed\n");
 
     let disposition = fixture
@@ -448,7 +454,11 @@ fn exec_honors_validated_step_timeout_and_output_limit() {
     .expect("command");
 
     let result = endpoint
-        .exec(&command, &NeverCancelled)
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("bounded exec");
     let captured = fixture
         .fake
@@ -950,7 +960,11 @@ fn environment_values_are_exact_redacted_and_do_not_control_the_podman_client() 
     )
     .expect("command");
     endpoint
-        .exec(&command, &NeverCancelled)
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("environment injection");
 
     let captured = fixture.fake.last_exec_environment();
@@ -1002,7 +1016,11 @@ fn environment_values_are_exact_redacted_and_do_not_control_the_podman_client() 
         automata_ci_sandbox_podman::CommandTermination::Cancelled,
     ));
     let output = endpoint
-        .exec(&command, &NeverCancelled)
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("cancelled exec is a terminal result");
     assert_eq!(
         output.termination(),
@@ -1030,7 +1048,11 @@ fn provider_control_environment_and_unrepresentable_document_values_fail_closed(
     ] {
         let command = execution_command(environment(&[(name, value)]));
         let error = endpoint
-            .exec(&command, &NeverCancelled)
+            .exec(
+                &command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output(),
+            )
             .expect_err("unsafe environment must be rejected");
         assert_eq!(error.kind(), ExecutionErrorKind::InvalidEnvironment);
         assert!(
@@ -1046,7 +1068,11 @@ fn provider_control_environment_and_unrepresentable_document_values_fail_closed(
     let command = execution_command(environment(&[("HOME", &oversized)]));
     assert_eq!(
         endpoint
-            .exec(&command, &NeverCancelled)
+            .exec(
+                &command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output()
+            )
             .expect_err("Podman environment-document line bound must be enforced")
             .kind(),
         ExecutionErrorKind::InvalidEnvironment
@@ -1270,7 +1296,11 @@ fn interrupted_exec_stops_the_owned_whole_job() {
     .expect("command");
     assert_eq!(
         endpoint
-            .exec(&command, &NeverCancelled)
+            .exec(
+                &command,
+                &NeverCancelled,
+                automata_ci_execution::discard_execution_output()
+            )
             .expect("timeout is a terminal output")
             .termination(),
         automata_ci_execution::ExecutionTermination::TimedOut

--- a/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
+++ b/crates/automata-ci-sandbox-podman/tests/live_rootless.rs
@@ -127,7 +127,13 @@ fn opt_in_rootless_contract_leaves_no_owned_resources() {
         .attach(created.handle(), &NeverCancelled)
         .expect("attach live endpoint");
     let echo = command("/bin/echo", vec!["automata-live".to_owned()], 5);
-    let output = endpoint.exec(&echo, &NeverCancelled).expect("live exec");
+    let output = endpoint
+        .exec(
+            &echo,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
+        .expect("live exec");
     assert_eq!(output.termination(), ExecutionTermination::Exited(0));
     assert_eq!(output.stdout(), b"automata-live\n");
 
@@ -247,7 +253,11 @@ fn opt_in_rootless_services_are_healthy_discoverable_recoverable_and_exactly_rem
         10,
     );
     let output = endpoint
-        .exec(&request, &NeverCancelled)
+        .exec(
+            &request,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("reach service through job-local loopback proxy");
     assert_eq!(output.termination(), ExecutionTermination::Exited(0));
     drop(endpoint);
@@ -328,7 +338,11 @@ fn opt_in_rootless_administrator_is_confined_and_writable() {
         10,
     );
     let output = endpoint
-        .exec(&verify, &NeverCancelled)
+        .exec(
+            &verify,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("execute confined administrator contract");
     assert_eq!(output.termination(), ExecutionTermination::Exited(0));
     assert_eq!(output.stdout(), b"65534\n");
@@ -396,6 +410,7 @@ printf 'libclang-profile-ok\n'
         .exec(
             &command("/usr/bin/bash", vec!["-c".to_owned(), script], 10),
             &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
         )
         .expect("execute libclang profile contract");
     assert_eq!(
@@ -463,7 +478,11 @@ fn opt_in_host_gateway_alias_reaches_local_git_without_a_host_socket() {
         20,
     );
     let output = endpoint
-        .exec(&ls_remote, &NeverCancelled)
+        .exec(
+            &ls_remote,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("execute git ls-remote through mapped host alias");
     assert_eq!(
         output.termination(),
@@ -534,7 +553,11 @@ fn opt_in_attempt_scoped_docker_api_runs_the_distribution_command_surface() {
     install_docker_live_fixture(endpoint.as_ref(), &helper);
     let execute = docker_distribution_surface_command();
     let output = endpoint
-        .exec(&execute, &NeverCancelled)
+        .exec(
+            &execute,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("execute Docker-compatible live command");
     assert_eq!(
         output.termination(),
@@ -618,7 +641,11 @@ fn opt_in_attempt_scoped_buildx_runs_the_pinned_buildkit_container_driver() {
     install_buildx_live_fixture(endpoint.as_ref());
     let execute = buildx_live_command();
     let output = endpoint
-        .exec(&execute, &NeverCancelled)
+        .exec(
+            &execute,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("execute Buildx live command");
     assert_eq!(
         output.termination(),
@@ -861,7 +888,11 @@ fn assert_live_environment(endpoint: &dyn automata_ci_execution::ExecutionEndpoi
     .expect("live environment");
     let print_environment = environment_command(job_environment);
     let output = endpoint
-        .exec(&print_environment, &NeverCancelled)
+        .exec(
+            &print_environment,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("live environment exec");
     assert!(contains_bytes(
         output.stdout(),
@@ -880,7 +911,11 @@ fn assert_live_environment(endpoint: &dyn automata_ci_execution::ExecutionEndpoi
     )])
     .expect("core-valid multiline environment");
     let error = endpoint
-        .exec(&environment_command(multiline), &NeverCancelled)
+        .exec(
+            &environment_command(multiline),
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect_err("Podman environment documents reject multiline values");
     assert_eq!(error.kind(), ExecutionErrorKind::InvalidEnvironment);
 }
@@ -915,7 +950,11 @@ fn assert_live_cancellation(endpoint: &dyn automata_ci_execution::ExecutionEndpo
     });
     let sleep = command("/bin/sleep", vec!["30".to_owned()], 10);
     let interrupted = endpoint
-        .exec(&sleep, cancellation.as_ref())
+        .exec(
+            &sleep,
+            cancellation.as_ref(),
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect("cancelled live exec is a terminal output");
     worker.join().expect("cancellation trigger");
     assert_eq!(interrupted.termination(), ExecutionTermination::Cancelled);
@@ -1078,7 +1117,12 @@ fn assert_no_resources(
         Instant::now() + Duration::from_secs(30),
         64 * 1024,
     );
-    let output = SystemCommandExecutor.execute(&request, environment, &NeverCancelled);
+    let output = SystemCommandExecutor.execute(
+        &request,
+        environment,
+        &NeverCancelled,
+        automata_ci_execution::discard_execution_output(),
+    );
     assert_eq!(output.termination(), CommandTermination::Exited(Some(0)));
     assert!(output.stdout().iter().all(u8::is_ascii_whitespace));
 }

--- a/crates/automata-ci-sandbox-podman/tests/observability.rs
+++ b/crates/automata-ci-sandbox-podman/tests/observability.rs
@@ -129,7 +129,11 @@ fn exited_zero_with_incomplete_environment_input_is_never_observed_as_success() 
     .expect("execution command");
 
     let error = endpoint
-        .exec(&command, &NeverCancelled)
+        .exec(
+            &command,
+            &NeverCancelled,
+            automata_ci_execution::discard_execution_output(),
+        )
         .expect_err("incomplete environment input must fail closed");
     assert_eq!(error.kind(), ExecutionErrorKind::BackendRejected);
     assert!(observer.events().iter().any(|event| matches!(

--- a/crates/automata-ci-sandbox-podman/tests/support/mod.rs
+++ b/crates/automata-ci-sandbox-podman/tests/support/mod.rs
@@ -577,6 +577,7 @@ impl PodmanCommandExecutor for FakePodman {
         request: &CommandRequest,
         environment: &PodmanProcessEnvironment,
         cancellation: &dyn automata_ci_execution::Cancellation,
+        _output: std::sync::Arc<dyn automata_ci_execution::ExecutionOutputSink>,
     ) -> CommandOutput {
         if cancellation.disposition().requires_termination() {
             return interrupted_before_input(request, CommandTermination::Cancelled);

--- a/crates/automata-ci-sandbox-windows/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-windows/src/endpoint.rs
@@ -7,9 +7,9 @@ use std::{
 use automata_ci_execution::{
     Cancellation, CopyFromRequest, CopyToRequest, ExecutionCommand, ExecutionEndpoint,
     ExecutionError, ExecutionErrorKind, ExecutionOutput, ExecutionOutputRecord,
-    ExecutionOutputStream, ExecutionSignal, ExecutionStage, ExecutionTermination, NeverCancelled,
-    OperationId, ProviderErrorKind, ProviderStage, SandboxCapability, SandboxHandle, SignalRequest,
-    WaitRequest,
+    ExecutionOutputSink, ExecutionOutputStream, ExecutionSignal, ExecutionStage,
+    ExecutionTermination, NeverCancelled, OperationId, ProviderErrorKind, ProviderStage,
+    SandboxCapability, SandboxHandle, SignalRequest, WaitRequest,
 };
 use automata_ci_sandbox_guest::{
     GUEST_PROTOCOL_VERSION, GuestOutputStream, GuestRejection, GuestRequest, GuestResponse,
@@ -28,6 +28,19 @@ const ENDPOINT_CAPABILITIES: &[SandboxCapability] = &[
     SandboxCapability::CopyFrom,
     SandboxCapability::EnvironmentInjection,
 ];
+
+fn publish_output(
+    result: Result<ExecutionOutput, ExecutionError>,
+    sink: &dyn ExecutionOutputSink,
+) -> Result<ExecutionOutput, ExecutionError> {
+    let output = result?;
+    for record in output.records() {
+        sink.observe(record).map_err(|_| {
+            error::execution(ExecutionErrorKind::OutputRejected, ExecutionStage::Exec)
+        })?;
+    }
+    Ok(output)
+}
 const MAX_REPLAY_ENTRIES: usize = 256;
 const MAX_REPLAY_BYTES: usize = 64 * 1024 * 1024;
 const REPLAY_ENTRY_OVERHEAD: usize = 256;
@@ -275,6 +288,7 @@ impl ExecutionEndpoint for WindowsHyperVExecutionEndpoint {
         &self,
         request: &ExecutionCommand,
         cancellation: &dyn Cancellation,
+        output: Arc<dyn ExecutionOutputSink>,
     ) -> Result<ExecutionOutput, ExecutionError> {
         let _operation = self.operation_lock.lock().map_err(|_| {
             error::execution(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec)
@@ -284,7 +298,7 @@ impl ExecutionEndpoint for WindowsHyperVExecutionEndpoint {
             self.replay(request.operation_id(), &fingerprint, ExecutionStage::Exec)?
         {
             return match replay {
-                ReplayResult::Exec(result) => result,
+                ReplayResult::Exec(result) => publish_output(result, output.as_ref()),
                 ReplayResult::Signal(_)
                 | ReplayResult::Wait(_)
                 | ReplayResult::CopyTo(_)
@@ -301,7 +315,7 @@ impl ExecutionEndpoint for WindowsHyperVExecutionEndpoint {
             ReplayResult::Exec(result.clone()),
             ExecutionStage::Exec,
         )?;
-        result
+        publish_output(result, output.as_ref())
     }
 
     fn signal(


### PR DESCRIPTION
## Summary

- replace terminal-only command output consumption with one required incremental output sink contract
- stream Podman stdout/stderr records through Actions workflow-command parsing, masking, and durable log events before command completion
- retain ordered terminal records only for current-schema crash replay
- terminate commands immediately when durable output publication is rejected
- update every endpoint implementation and caller to the single explicit contract

## Intentional break

- bump endpoint replay schema to v3
- reject pre-refactor in-flight endpoint journals; no compatibility or migration path is retained
- delete the old parse-after-exit output pipeline and its dead tests

## Validation

- cargo test --locked --all-features --lib --no-fail-fast for the PR Rust crate set
- cargo test --workspace --no-run --locked
- cargo clippy --workspace --lib --bins --all-features --locked -- -D warnings
- Podman live-output-before-exit and output-rejection process tests
- endpoint replay exact-output test
- actionlint and zizmor workflow checks