### PR TITLE
fix(github): eliminate source-fetch rate-limit exhaustion

### DIFF
--- a/crates/automata-ci-provider-github/src/checks.rs
+++ b/crates/automata-ci-provider-github/src/checks.rs
@@ -5,7 +5,7 @@ use automata_ci_core::GitObjectId;
 use automata_ci_scm::RepositoryId;
 use reqwest::{
     Response, StatusCode,
-    header::{ACCEPT, AUTHORIZATION, HeaderMap, RETRY_AFTER},
+    header::{ACCEPT, AUTHORIZATION, HeaderMap},
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
@@ -15,7 +15,9 @@ use url::Url;
 use crate::{
     config::same_origin,
     endpoint::{GithubHttpEndpoint, authorization_header},
-    pagination, repository_path,
+    pagination,
+    rate_limit::{MAX_RETRY_AFTER_SECONDS, is_rate_limited, rate_limit_headers},
+    repository_path,
     response::{decode_json, read_json_response},
 };
 
@@ -38,10 +40,6 @@ const CHECK_ANNOTATIONS_PER_PAGE: usize = 100;
 const CHECK_SUITES_PER_PAGE: usize = 100;
 const CHECK_RUNS_PER_PAGE: usize = 100;
 const MAX_GITHUB_ID: u64 = 9_223_372_036_854_775_807;
-const MAX_RETRY_AFTER_SECONDS: u64 = 86_400;
-const MAX_RATE_LIMIT_RESET_SECONDS: u64 = 253_402_300_799;
-const X_RATE_LIMIT_REMAINING: &str = "x-ratelimit-remaining";
-const X_RATE_LIMIT_RESET: &str = "x-ratelimit-reset";
 
 /// A positive GitHub App identifier used to confine Check Run responses.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -1949,42 +1947,13 @@ fn map_endpoint_error(error: GithubEndpointError) -> GithubChecksError {
     }
 }
 
-fn is_rate_limited(headers: &HeaderMap) -> bool {
-    headers.contains_key(RETRY_AFTER)
-        || unique_header(headers, X_RATE_LIMIT_REMAINING)
-            .is_some_and(|value| value.as_bytes() == b"0")
-}
-
 fn retry_evidence(headers: &HeaderMap) -> GithubCheckRetryEvidence {
-    let retry_after_seconds = unique_header(headers, RETRY_AFTER.as_str())
-        .and_then(|value| parse_bounded_decimal(value.as_bytes(), MAX_RETRY_AFTER_SECONDS));
-    let rate_limit_reset_at = unique_header(headers, X_RATE_LIMIT_RESET)
-        .and_then(|value| parse_bounded_decimal(value.as_bytes(), MAX_RATE_LIMIT_RESET_SECONDS));
-    let rate_limit_remaining_zero = unique_header(headers, X_RATE_LIMIT_REMAINING)
-        .is_some_and(|value| value.as_bytes() == b"0");
+    let evidence = rate_limit_headers(headers);
     GithubCheckRetryEvidence {
-        retry_after_seconds,
-        rate_limit_reset_at,
-        rate_limit_remaining_zero,
+        retry_after_seconds: evidence.retry_after_seconds,
+        rate_limit_reset_at: evidence.rate_limit_reset_at,
+        rate_limit_remaining_zero: evidence.rate_limit_remaining_zero,
     }
-}
-
-fn unique_header<'a>(
-    headers: &'a HeaderMap,
-    name: &str,
-) -> Option<&'a reqwest::header::HeaderValue> {
-    let mut values = headers.get_all(name).iter();
-    let first = values.next()?;
-    values.next().is_none().then_some(first)
-}
-
-fn parse_bounded_decimal(bytes: &[u8], maximum: u64) -> Option<u64> {
-    if bytes.is_empty() || bytes.len() > 15 || !bytes.iter().all(u8::is_ascii_digit) {
-        return None;
-    }
-    let raw = std::str::from_utf8(bytes).ok()?;
-    let value = raw.parse::<u64>().ok()?;
-    (value <= maximum && value.to_string() == raw).then_some(value)
 }
 
 fn validate_annotation(

--- a/crates/automata-ci-provider-github/src/lib.rs
+++ b/crates/automata-ci-provider-github/src/lib.rs
@@ -12,6 +12,7 @@ mod endpoint;
 mod event;
 mod factory;
 mod pagination;
+mod rate_limit;
 mod repository;
 mod repository_path;
 mod response;

--- a/crates/automata-ci-provider-github/src/rate_limit.rs
+++ b/crates/automata-ci-provider-github/src/rate_limit.rs
@@ -1,0 +1,119 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+
+pub(crate) const MAX_RETRY_AFTER_SECONDS: u64 = 86_400;
+pub(crate) const MAX_RATE_LIMIT_RESET_SECONDS: u64 = 253_402_300_799;
+const X_RATE_LIMIT_REMAINING: &str = "x-ratelimit-remaining";
+const X_RATE_LIMIT_RESET: &str = "x-ratelimit-reset";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct GithubRateLimitHeaders {
+    pub(crate) retry_after_seconds: Option<u64>,
+    pub(crate) rate_limit_reset_at: Option<u64>,
+    pub(crate) rate_limit_remaining_zero: bool,
+}
+
+pub(crate) fn is_rate_limited(headers: &HeaderMap) -> bool {
+    headers.contains_key(RETRY_AFTER)
+        || unique_header(headers, X_RATE_LIMIT_REMAINING)
+            .is_some_and(|value| value.as_bytes() == b"0")
+}
+
+pub(crate) fn rate_limit_headers(headers: &HeaderMap) -> GithubRateLimitHeaders {
+    let retry_after_seconds = unique_header(headers, RETRY_AFTER.as_str())
+        .and_then(|value| parse_bounded_decimal(value.as_bytes(), MAX_RETRY_AFTER_SECONDS));
+    let rate_limit_reset_at = unique_header(headers, X_RATE_LIMIT_RESET)
+        .and_then(|value| parse_bounded_decimal(value.as_bytes(), MAX_RATE_LIMIT_RESET_SECONDS));
+    let rate_limit_remaining_zero = unique_header(headers, X_RATE_LIMIT_REMAINING)
+        .is_some_and(|value| value.as_bytes() == b"0");
+    GithubRateLimitHeaders {
+        retry_after_seconds,
+        rate_limit_reset_at,
+        rate_limit_remaining_zero,
+    }
+}
+
+pub(crate) fn retry_delay_seconds(headers: &HeaderMap) -> Option<u64> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    retry_delay_seconds_at(headers, now)
+}
+
+fn retry_delay_seconds_at(headers: &HeaderMap, now: u64) -> Option<u64> {
+    let evidence = rate_limit_headers(headers);
+    if let Some(retry_after_seconds) = evidence.retry_after_seconds {
+        return Some(retry_after_seconds);
+    }
+    if !evidence.rate_limit_remaining_zero {
+        return None;
+    }
+    evidence
+        .rate_limit_reset_at?
+        .checked_sub(now)?
+        .checked_add(1)
+        .filter(|delay| *delay <= MAX_RETRY_AFTER_SECONDS)
+}
+
+fn unique_header<'a>(
+    headers: &'a HeaderMap,
+    name: &str,
+) -> Option<&'a reqwest::header::HeaderValue> {
+    let mut values = headers.get_all(name).iter();
+    let first = values.next()?;
+    values.next().is_none().then_some(first)
+}
+
+fn parse_bounded_decimal(bytes: &[u8], maximum: u64) -> Option<u64> {
+    if bytes.is_empty() || bytes.len() > 15 || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let raw = std::str::from_utf8(bytes).ok()?;
+    let value = raw.parse::<u64>().ok()?;
+    (value <= maximum && value.to_string() == raw).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    use super::{
+        GithubRateLimitHeaders, is_rate_limited, rate_limit_headers, retry_delay_seconds_at,
+    };
+
+    #[test]
+    fn primary_limit_reset_becomes_a_relative_delay_with_boundary_margin() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ratelimit-remaining", HeaderValue::from_static("0"));
+        headers.insert("x-ratelimit-reset", HeaderValue::from_static("230"));
+
+        assert!(is_rate_limited(&headers));
+        assert_eq!(retry_delay_seconds_at(&headers, 200), Some(31));
+    }
+
+    #[test]
+    fn retry_after_takes_precedence_over_primary_limit_reset() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("17"));
+        headers.insert("x-ratelimit-remaining", HeaderValue::from_static("0"));
+        headers.insert("x-ratelimit-reset", HeaderValue::from_static("230"));
+
+        assert_eq!(retry_delay_seconds_at(&headers, 200), Some(17));
+    }
+
+    #[test]
+    fn malformed_duplicate_and_stale_evidence_is_not_trusted() {
+        let mut malformed = HeaderMap::new();
+        malformed.insert("retry-after", HeaderValue::from_static("017"));
+        malformed.insert("x-ratelimit-remaining", HeaderValue::from_static("0"));
+        malformed.insert("x-ratelimit-reset", HeaderValue::from_static("199"));
+        assert_eq!(retry_delay_seconds_at(&malformed, 200), None);
+
+        let mut duplicate = HeaderMap::new();
+        duplicate.append("retry-after", HeaderValue::from_static("17"));
+        duplicate.append("retry-after", HeaderValue::from_static("18"));
+        assert_eq!(
+            rate_limit_headers(&duplicate),
+            GithubRateLimitHeaders::default()
+        );
+    }
+}

--- a/crates/automata-ci-provider-github/src/repository.rs
+++ b/crates/automata-ci-provider-github/src/repository.rs
@@ -8,7 +8,7 @@ use automata_ci_scm::{
 use bytes::{Bytes, BytesMut};
 use reqwest::{
     Response, StatusCode,
-    header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, RETRY_AFTER},
+    header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION},
 };
 use serde::Deserialize;
 use url::Url;
@@ -16,23 +16,16 @@ use url::Url;
 use crate::{
     config::same_origin,
     endpoint::{GithubHttpEndpoint, authorization_header},
+    rate_limit::{is_rate_limited as headers_are_rate_limited, retry_delay_seconds},
     repository_path::{self, has_ascii_case_insensitive_suffix},
     response::{decode_json, read_json_response},
 };
 
 const ACCEPT_API_JSON: &str = "application/vnd.github+json";
 const ACCEPT_ARCHIVE: &str = "application/octet-stream";
-const X_RATE_LIMIT_REMAINING: &str = "x-ratelimit-remaining";
-
 #[derive(Deserialize)]
 struct CommitResponse {
     sha: String,
-}
-
-#[derive(Deserialize)]
-struct RepositoryResponse {
-    id: u64,
-    full_name: String,
 }
 
 impl GithubHttpEndpoint {
@@ -95,57 +88,6 @@ impl GithubHttpEndpoint {
                 .map_err(map_endpoint_error)?;
         let commit: CommitResponse = decode_json(&response.body).map_err(map_endpoint_error)?;
         validate_commit_sha(&commit.sha)
-    }
-
-    async fn prove_exact_revision(
-        &self,
-        request: &RepositorySourceRequest<'_>,
-    ) -> Result<(), ScmError> {
-        let revision = request.revision().to_string();
-        let endpoint = self.repository_url(request.repository(), &["commits", &revision])?;
-        let response = self
-            .authenticated_get(endpoint, request.credential())?
-            .send()
-            .await
-            .map_err(|_| ScmError::new(ScmErrorKind::Unavailable))?;
-        reject_api_status(&response)?;
-        let response =
-            read_json_response(response, self.trusted.limits().max_response_bytes, false)
-                .await
-                .map_err(map_endpoint_error)?;
-        let commit: CommitResponse = decode_json(&response.body).map_err(map_endpoint_error)?;
-        let resolved = GitObjectId::from_provider_hex(commit.sha)
-            .map_err(|_| ScmError::new(ScmErrorKind::InvalidResponse))?;
-        if &resolved != request.revision() {
-            return Err(ScmError::new(ScmErrorKind::InvalidResponse));
-        }
-        Ok(())
-    }
-
-    async fn prove_repository_identity(
-        &self,
-        request: &RepositorySourceRequest<'_>,
-    ) -> Result<(), ScmError> {
-        let endpoint = self.repository_url(request.repository(), &[])?;
-        let response = self
-            .authenticated_get(endpoint, request.credential())?
-            .send()
-            .await
-            .map_err(|_| ScmError::new(ScmErrorKind::Unavailable))?;
-        reject_api_status(&response)?;
-        let response =
-            read_json_response(response, self.trusted.limits().max_response_bytes, false)
-                .await
-                .map_err(map_endpoint_error)?;
-        let repository: RepositoryResponse =
-            decode_json(&response.body).map_err(map_endpoint_error)?;
-        if repository.id == 0
-            || repository.id.to_string() != request.connection().external_repository_id().as_str()
-            || repository.full_name != request.repository().as_str()
-        {
-            return Err(ScmError::new(ScmErrorKind::InvalidResponse));
-        }
-        Ok(())
     }
 
     async fn archive_redirect(
@@ -284,6 +226,11 @@ impl RepositorySource for GithubHttpEndpoint {
         &self,
         request: RepositorySourceRequest<'_>,
     ) -> Result<RepositorySourceArchive, ScmError> {
+        // The caller's authenticated admission evidence already binds the
+        // provider-native repository ID to this route. The immutable archive
+        // path proves the exact commit without a redundant repository or
+        // commit lookup. Public deliveries therefore consume no REST quota;
+        // private deliveries consume only the authenticated redirect request.
         if request.credential().is_none() {
             let location =
                 self.exact_public_archive_location(request.repository(), request.revision())?;
@@ -297,8 +244,6 @@ impl RepositorySource for GithubHttpEndpoint {
                 bytes,
             ));
         }
-        self.prove_repository_identity(&request).await?;
-        self.prove_exact_revision(&request).await?;
         let location = self.exact_archive_redirect(&request).await?;
         let bytes = self
             .download_archive(location, request.limits().maximum_bytes())
@@ -371,10 +316,12 @@ fn map_status(response: &Response) -> ScmError {
         StatusCode::NOT_FOUND => ScmError::new(ScmErrorKind::NotFound),
         StatusCode::UNAUTHORIZED => ScmError::new(ScmErrorKind::Unauthorized),
         StatusCode::FORBIDDEN if is_rate_limited(response) => {
-            ScmError::rate_limited(retry_after_seconds(response))
+            ScmError::rate_limited(retry_delay_seconds(response.headers()))
         }
         StatusCode::FORBIDDEN => ScmError::new(ScmErrorKind::Forbidden),
-        StatusCode::TOO_MANY_REQUESTS => ScmError::rate_limited(retry_after_seconds(response)),
+        StatusCode::TOO_MANY_REQUESTS => {
+            ScmError::rate_limited(retry_delay_seconds(response.headers()))
+        }
         StatusCode::REQUEST_TIMEOUT => ScmError::new(ScmErrorKind::Unavailable),
         _ if status.is_server_error() => ScmError::new(ScmErrorKind::Unavailable),
         _ => ScmError::new(ScmErrorKind::InvalidResponse),
@@ -382,19 +329,7 @@ fn map_status(response: &Response) -> ScmError {
 }
 
 fn is_rate_limited(response: &Response) -> bool {
-    response.headers().contains_key(RETRY_AFTER)
-        || response
-            .headers()
-            .get(X_RATE_LIMIT_REMAINING)
-            .is_some_and(|value| value.as_bytes() == b"0")
-}
-
-fn retry_after_seconds(response: &Response) -> Option<u64> {
-    response
-        .headers()
-        .get(RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse().ok())
+    headers_are_rate_limited(response.headers())
 }
 
 fn validate_archive_content_type(response: &Response) -> Result<(), ScmError> {

--- a/crates/automata-ci-provider-github/src/response.rs
+++ b/crates/automata-ci-provider-github/src/response.rs
@@ -1,12 +1,12 @@
 use automata_ci_auth::github::GithubEndpointError;
 use reqwest::{
     Response, StatusCode,
-    header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, RETRY_AFTER},
+    header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap},
 };
 use serde::de::DeserializeOwned;
 use zeroize::Zeroizing;
 
-const X_RATE_LIMIT_REMAINING: &str = "x-ratelimit-remaining";
+use crate::rate_limit::{is_rate_limited, retry_delay_seconds};
 
 pub(crate) struct JsonResponse {
     pub(crate) status: StatusCode,
@@ -151,26 +151,12 @@ fn map_status(status: StatusCode, headers: &HeaderMap) -> GithubEndpointError {
     match status {
         StatusCode::UNAUTHORIZED => GithubEndpointError::Unauthorized,
         StatusCode::FORBIDDEN if is_rate_limited(headers) => GithubEndpointError::RateLimited {
-            retry_after_seconds: retry_after_seconds(headers),
+            retry_after_seconds: retry_delay_seconds(headers),
         },
         StatusCode::FORBIDDEN => GithubEndpointError::Forbidden,
         StatusCode::TOO_MANY_REQUESTS => GithubEndpointError::RateLimited {
-            retry_after_seconds: retry_after_seconds(headers),
+            retry_after_seconds: retry_delay_seconds(headers),
         },
         _ => GithubEndpointError::InvalidResponse,
     }
-}
-
-fn is_rate_limited(headers: &HeaderMap) -> bool {
-    headers.contains_key(RETRY_AFTER)
-        || headers
-            .get(X_RATE_LIMIT_REMAINING)
-            .is_some_and(|value| value.as_bytes() == b"0")
-}
-
-fn retry_after_seconds(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse().ok())
 }

--- a/crates/automata-ci-provider-github/tests/api_transport.rs
+++ b/crates/automata-ci-provider-github/tests/api_transport.rs
@@ -1,6 +1,6 @@
 use crate::support;
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use automata_ci_auth::{
     github::{GithubCurrentUserRequest, GithubEndpoint, GithubEndpointError},
@@ -53,6 +53,16 @@ async fn authentication_and_rate_limit_statuses_are_mapped_without_reading_bodie
         .enqueue(ResponseSpec::status(StatusCode::FORBIDDEN).header("x-ratelimit-remaining", "0"));
     fixture
         .enqueue(ResponseSpec::status(StatusCode::TOO_MANY_REQUESTS).header("retry-after", "17"));
+    let reset_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs()
+        + 120;
+    fixture.enqueue(
+        ResponseSpec::status(StatusCode::FORBIDDEN)
+            .header("x-ratelimit-remaining", "0")
+            .header("x-ratelimit-reset", reset_at.to_string()),
+    );
     let endpoint = fixture.endpoint();
     let token = token();
     let request = || GithubCurrentUserRequest {
@@ -79,6 +89,13 @@ async fn authentication_and_rate_limit_statuses_are_mapped_without_reading_bodie
             retry_after_seconds: Some(17)
         }
     );
+    let GithubEndpointError::RateLimited {
+        retry_after_seconds: Some(delay),
+    } = endpoint.current_user(request()).await.unwrap_err()
+    else {
+        panic!("expected a reset-aware rate-limit error");
+    };
+    assert!((115..=121).contains(&delay), "unexpected delay: {delay}");
 }
 
 #[tokio::test]

--- a/crates/automata-ci-provider-github/tests/repository_snapshots.rs
+++ b/crates/automata-ci-provider-github/tests/repository_snapshots.rs
@@ -1,5 +1,7 @@
 use crate::support;
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use automata_ci_auth::secret::SecretString;
 use automata_ci_core::GitObjectId;
 use automata_ci_provider::{ExternalRepositoryId, ProviderConnectionId};
@@ -14,7 +16,6 @@ use support::{FixtureServer, ResponseSpec};
 use url::Url;
 
 const SHA: &str = "de0fac2e4500dabe0009e67214ff5f5447ce83dd";
-const DIFFERENT_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
 
 fn token() -> SecretString {
     SecretString::new("ghs_installation_secret").unwrap()
@@ -30,21 +31,9 @@ fn source_connection(repository: &RepositoryId, external_id: &str) -> Repository
     )
 }
 
-fn repository_response(id: u64, full_name: &str) -> ResponseSpec {
-    ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"id":{id},"full_name":"{full_name}"}}"#),
-    )
-}
-
 #[tokio::test]
-async fn exact_source_proves_the_requested_commit_before_downloading() {
+async fn authenticated_exact_source_uses_one_api_request_and_does_not_forward_credentials() {
     let fixture = FixtureServer::spawn().await;
-    fixture.enqueue(repository_response(42, "automata-ci/automata"));
-    fixture.enqueue(ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"sha":"{SHA}","ignored":true}}"#),
-    ));
     fixture.enqueue(ResponseSpec::status(StatusCode::FOUND).header(
         "location",
         fixture.url("archive/exact-source.tar.gz").as_str(),
@@ -78,118 +67,58 @@ async fn exact_source_proves_the_requested_commit_before_downloading() {
     assert_eq!(source.size(), 8);
 
     let requests = fixture.requests();
-    assert_eq!(requests.len(), 4);
-    assert_eq!(requests[0].uri, "/api/repos/automata-ci/automata");
+    assert_eq!(requests.len(), 2);
     assert_eq!(
-        requests[1].uri,
-        format!("/api/repos/automata-ci/automata/commits/{SHA}")
-    );
-    assert_eq!(
-        requests[2].uri,
+        requests[0].uri,
         format!("/api/repos/automata-ci/automata/tarball/{SHA}")
     );
-    assert_eq!(requests[3].uri, "/archive/exact-source.tar.gz");
+    assert_eq!(requests[1].uri, "/archive/exact-source.tar.gz");
     assert_eq!(
         requests[0].headers["authorization"],
         "Bearer ghs_installation_secret"
     );
-    assert_eq!(
-        requests[1].headers["authorization"],
-        "Bearer ghs_installation_secret"
-    );
-    assert_eq!(
-        requests[2].headers["authorization"],
-        "Bearer ghs_installation_secret"
-    );
-    assert!(!requests[3].headers.contains_key("authorization"));
+    assert!(!requests[1].headers.contains_key("authorization"));
 }
 
 #[tokio::test]
-async fn exact_source_rejects_malformed_or_mismatched_commit_evidence_without_fallback() {
-    for returned_sha in [
-        DIFFERENT_SHA.to_owned(),
-        SHA.to_ascii_uppercase(),
-        "short".to_owned(),
-    ] {
-        let fixture = FixtureServer::spawn().await;
-        fixture.enqueue(repository_response(42, "automata-ci/automata"));
-        fixture.enqueue(ResponseSpec::json(
-            StatusCode::OK,
-            format!(r#"{{"sha":"{returned_sha}"}}"#),
-        ));
-        fixture.enqueue(
-            ResponseSpec::status(StatusCode::FOUND)
-                .header("location", fixture.url("must-not-download.tar.gz").as_str()),
-        );
-        fixture.enqueue(ResponseSpec::binary(
-            StatusCode::OK,
-            "application/gzip",
-            vec![0x1f, 0x8b, 0x08],
-        ));
-        let endpoint = fixture.endpoint();
-        let repository = RepositoryId::new("automata-ci/automata").unwrap();
-        let connection = source_connection(&repository, "42");
-        let revision = GitObjectId::from_provider_hex(SHA).unwrap();
-        let token = token();
+async fn exact_source_rate_limit_waits_for_the_primary_limit_reset() {
+    let fixture = FixtureServer::spawn().await;
+    let reset_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs()
+        + 120;
+    fixture.enqueue(
+        ResponseSpec::status(StatusCode::FORBIDDEN)
+            .header("x-ratelimit-remaining", "0")
+            .header("x-ratelimit-reset", reset_at.to_string()),
+    );
+    let endpoint = fixture.endpoint();
+    let repository = RepositoryId::new("automata-ci/automata").unwrap();
+    let connection = source_connection(&repository, "42");
+    let revision = GitObjectId::from_provider_hex(SHA).unwrap();
+    let token = token();
 
-        let error = endpoint
-            .fetch_repository_source(RepositorySourceRequest::authenticated(
-                &connection,
-                &revision,
-                &token,
-                ArchiveLimits::default(),
-                RepositorySourceRedirectPolicy::ConfiguredArchiveOrigin,
-            ))
-            .await
-            .unwrap_err();
+    let error = endpoint
+        .fetch_repository_source(RepositorySourceRequest::authenticated(
+            &connection,
+            &revision,
+            &token,
+            ArchiveLimits::default(),
+            RepositorySourceRedirectPolicy::ConfiguredArchiveOrigin,
+        ))
+        .await
+        .unwrap_err();
 
-        assert_eq!(error.kind(), ScmErrorKind::InvalidResponse);
-        let diagnostic = format!("{error:?} {error}");
-        assert!(!diagnostic.contains(&returned_sha));
-        assert_eq!(fixture.requests().len(), 2);
-        assert_eq!(fixture.remaining_responses(), 2);
-    }
-}
-
-#[tokio::test]
-async fn exact_source_rejects_native_identity_or_route_rebinding_before_commit_io() {
-    for repository_evidence in [
-        repository_response(41, "automata-ci/automata"),
-        repository_response(42, "attacker/rebound"),
-    ] {
-        let fixture = FixtureServer::spawn().await;
-        fixture.enqueue(repository_evidence);
-        fixture.enqueue(ResponseSpec::json(
-            StatusCode::OK,
-            format!(r#"{{"sha":"{SHA}"}}"#),
-        ));
-        let endpoint = fixture.endpoint();
-        let repository = RepositoryId::new("automata-ci/automata").unwrap();
-        let connection = source_connection(&repository, "42");
-        let revision = GitObjectId::from_provider_hex(SHA).unwrap();
-        let error = endpoint
-            .fetch_repository_source(RepositorySourceRequest::public(
-                &connection,
-                &revision,
-                ArchiveLimits::default(),
-                RepositorySourceRedirectPolicy::Deny,
-            ))
-            .await
-            .unwrap_err();
-        assert_eq!(error.kind(), ScmErrorKind::InvalidResponse);
-        assert_eq!(fixture.requests().len(), 1);
-        assert_eq!(fixture.remaining_responses(), 1);
-    }
+    assert_eq!(error.kind(), ScmErrorKind::RateLimited);
+    let delay = error.retry_after_seconds().expect("reset-aware delay");
+    assert!((115..=121).contains(&delay), "unexpected delay: {delay}");
+    assert_eq!(fixture.requests().len(), 1);
 }
 
 #[tokio::test]
 async fn authenticated_exact_source_requires_explicit_configured_redirect_authority() {
     let fixture = FixtureServer::spawn().await;
-    fixture.enqueue(repository_response(42, "automata-ci/automata"));
-    fixture.enqueue(ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"sha":"{SHA}"}}"#),
-    ));
     let endpoint = fixture.endpoint();
     let repository = RepositoryId::new("automata-ci/automata").unwrap();
     let connection = source_connection(&repository, "42");
@@ -206,17 +135,12 @@ async fn authenticated_exact_source_requires_explicit_configured_redirect_author
         .await
         .unwrap_err();
     assert_eq!(error.kind(), ScmErrorKind::InvalidResponse);
-    assert_eq!(fixture.requests().len(), 2);
+    assert!(fixture.requests().is_empty());
 }
 
 #[tokio::test]
 async fn exact_source_rejects_untrusted_redirects_and_invalid_archive_media() {
     let untrusted = FixtureServer::spawn().await;
-    untrusted.enqueue(repository_response(42, "automata-ci/automata"));
-    untrusted.enqueue(ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"sha":"{SHA}"}}"#),
-    ));
     untrusted.enqueue(
         ResponseSpec::status(StatusCode::FOUND)
             .header("location", "https://attacker.example/exact-source.tar.gz"),
@@ -237,14 +161,9 @@ async fn exact_source_rejects_untrusted_redirects_and_invalid_archive_media() {
         .await
         .unwrap_err();
     assert_eq!(error.kind(), ScmErrorKind::InvalidResponse);
-    assert_eq!(untrusted.requests().len(), 3);
+    assert_eq!(untrusted.requests().len(), 1);
 
     let invalid_media = FixtureServer::spawn().await;
-    invalid_media.enqueue(repository_response(42, "automata-ci/automata"));
-    invalid_media.enqueue(ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"sha":"{SHA}"}}"#),
-    ));
     invalid_media.enqueue(ResponseSpec::status(StatusCode::FOUND).header(
         "location",
         invalid_media.url("exact-source.tar.gz").as_str(),
@@ -271,11 +190,6 @@ async fn exact_source_rejects_untrusted_redirects_and_invalid_archive_media() {
 #[tokio::test]
 async fn exact_source_enforces_the_incremental_archive_byte_ceiling() {
     let fixture = FixtureServer::spawn().await;
-    fixture.enqueue(repository_response(42, "automata-ci/automata"));
-    fixture.enqueue(ResponseSpec::json(
-        StatusCode::OK,
-        format!(r#"{{"sha":"{SHA}"}}"#),
-    ));
     fixture.enqueue(ResponseSpec::status(StatusCode::FOUND).header(
         "location",
         fixture.url("large-exact-source.tar.gz").as_str(),

--- a/crates/automata-ci-scm/src/model.rs
+++ b/crates/automata-ci-scm/src/model.rs
@@ -314,10 +314,12 @@ impl fmt::Debug for SnapshotRequest<'_> {
 /// Provider-neutral routing evidence for one repository connection.
 ///
 /// The provider-native ID is authoritative identity. `repository` is the
-/// provider-owned route currently associated with that identity; adapters must
-/// verify both before returning source. The configured provider instance is
-/// supplied by the selected [`RepositorySource`](crate::RepositorySource)
-/// adapter, so callers cannot route a request to an arbitrary instance.
+/// provider-owned route authenticated for that identity by the caller's
+/// admission boundary. Adapters must preserve both values in returned source
+/// and prove the requested exact revision through the provider's trusted
+/// archive boundary. The configured provider instance is supplied by the
+/// selected [`RepositorySource`](crate::RepositorySource) adapter, so callers
+/// cannot route a request to an arbitrary instance.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RepositorySourceConnection {
     connection_id: ProviderConnectionId,
@@ -370,10 +372,11 @@ pub enum RepositorySourceRedirectPolicy {
 
 /// One borrowed request for source at an already known exact revision.
 ///
-/// The revision is an immutable [`GitObjectId`], so an implementation must
-/// prove that the provider resolved the request to that byte-exact commit. Any
-/// credential is borrowed for this request only and is redacted by the
-/// [`Debug`](fmt::Debug) implementation.
+/// The connection coordinates must have been authenticated by the caller's
+/// admission boundary. The revision is an immutable [`GitObjectId`], so an
+/// implementation must prove that the provider returned source for that
+/// byte-exact commit. Any credential is borrowed for this request only and is
+/// redacted by the [`Debug`](fmt::Debug) implementation.
 pub struct RepositorySourceRequest<'a> {
     connection: &'a RepositorySourceConnection,
     revision: &'a GitObjectId,
@@ -385,8 +388,9 @@ pub struct RepositorySourceRequest<'a> {
 impl<'a> RepositorySourceRequest<'a> {
     /// Creates an exact-revision source request without an explicit credential.
     ///
-    /// Providers must not substitute ambient process, filesystem, or host
-    /// credentials when this request is used.
+    /// The caller must have authenticated `connection` before constructing the
+    /// request. Providers must not substitute ambient process, filesystem, or
+    /// host credentials when this request is used.
     #[must_use]
     pub const fn public(
         connection: &'a RepositorySourceConnection,
@@ -405,9 +409,10 @@ impl<'a> RepositorySourceRequest<'a> {
 
     /// Creates an exact-revision request with one provider credential.
     ///
-    /// The credential may be presented only to the selected provider during
-    /// this operation. It must not be retained, forwarded to an archive origin,
-    /// or included in returned source, errors, or diagnostics.
+    /// The caller must have authenticated `connection` before constructing the
+    /// request. The credential may be presented only to the selected provider
+    /// during this operation. It must not be retained, forwarded to an archive
+    /// origin, or included in returned source, errors, or diagnostics.
     #[must_use]
     pub const fn authenticated(
         connection: &'a RepositorySourceConnection,


### PR DESCRIPTION
## Summary

- eliminate redundant GitHub REST lookups from exact source fetching
- reduce public delivery source fetches from **1 anonymous REST request to 0**
- reduce private delivery source fetches from **3 authenticated REST requests to 1**
- centralize strict GitHub rate-limit header parsing across Checks, generic API, and repository adapters
- honor `X-RateLimit-Reset` when `X-RateLimit-Remaining: 0`, with a one-second boundary margin
- remove obsolete repository/commit proof code and update the SCM authority contract

## Root cause

Production's public-delivery source path called unauthenticated `GET /repos/{owner}/{repo}` for every webhook delivery before downloading an immutable commit archive. Both controls share the originating-IP quota. Production headers confirmed the anonymous `core` bucket is limited to 60 requests/hour and was being consumed rapidly while the delivery backlog drained.

The lookup duplicated evidence already authenticated before source fetch:

1. the webhook HMAC authenticates the raw repository ID, route, visibility, and exact revision
2. the sealed event envelope is rehydrated and matched against the durable delivery identity
3. the source request uses those authenticated coordinates
4. the trusted immutable archive path binds the download to the exact commit

For private repositories, the exact installation-scoped tarball request already proves provider access and returns a credential-free redirect to the configured archive origin. Separate repository and commit GETs did not add a distinct trust guarantee.

Once the anonymous limit was exhausted, GitHub returned `403`, `X-RateLimit-Remaining: 0`, and `X-RateLimit-Reset`. The repository adapter recognized the limit but only parsed `Retry-After`, so the delivery worker fell back to a 30-second retry and exhausted all 16 attempts before the hourly reset. GitHub explicitly says clients must wait until `X-RateLimit-Reset`: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api

## Request budget

| Exact source path | Before | After |
| --- | ---: | ---: |
| Public repository | 1 anonymous REST + 1 archive | 0 REST + 1 archive |
| Private repository | 3 authenticated REST + 1 archive | 1 authenticated REST + 1 archive |

Mutable revision resolution remains unchanged because it genuinely needs provider resolution. Checks and workflow-permission operations already use repository-scoped installation credentials. Public changed-file comparisons, schedules, and mutable dispatch resolution still use the legacy anonymous authority; converting those remaining unavoidable REST calls to narrowly scoped installation credentials is a separate authority-model refactor. Exact public source and action archives should remain direct, credential-free archive downloads because they require no REST request at all.

## Validation

- `cargo test -p automata-ci-provider-github` — 156 passed, 1 ignored live test
- `cargo test -p automata-ci-scm` — 13 passed
- `cargo test -p automata-ci-github-delivery --test github_delivery source_rate_limit_and_processor_prerequisite_never_commit_partial_paths` — passed
- `cargo clippy -p automata-ci-scm -p automata-ci-provider-github -p automata-ci-github-delivery --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
