### PR TITLE
Avoid GitHub API calls for public source archives

### DIFF
--- a/crates/automata-ci-provider-github/src/repository.rs
+++ b/crates/automata-ci-provider-github/src/repository.rs
@@ -284,7 +284,6 @@ impl RepositorySource for GithubHttpEndpoint {
         &self,
         request: RepositorySourceRequest<'_>,
     ) -> Result<RepositorySourceArchive, ScmError> {
-        self.prove_repository_identity(&request).await?;
         if request.credential().is_none() {
             let location =
                 self.exact_public_archive_location(request.repository(), request.revision())?;
@@ -298,6 +297,7 @@ impl RepositorySource for GithubHttpEndpoint {
                 bytes,
             ));
         }
+        self.prove_repository_identity(&request).await?;
         self.prove_exact_revision(&request).await?;
         let location = self.exact_archive_redirect(&request).await?;
         let bytes = self

--- a/crates/automata-ci-provider-github/tests/repository_snapshots.rs
+++ b/crates/automata-ci-provider-github/tests/repository_snapshots.rs
@@ -346,9 +346,8 @@ async fn public_exact_revision_uses_the_immutable_archive_origin_without_api_req
 }
 
 #[tokio::test]
-async fn public_exact_source_proves_identity_then_uses_the_immutable_archive_origin() {
+async fn public_exact_source_uses_the_immutable_archive_origin_without_api_requests() {
     let fixture = FixtureServer::spawn().await;
-    fixture.enqueue(repository_response(42, "automata-ci/automata"));
     fixture.enqueue(ResponseSpec::binary(
         StatusCode::OK,
         "application/x-gzip",
@@ -372,14 +371,12 @@ async fn public_exact_source_proves_identity_then_uses_the_immutable_archive_ori
     assert_eq!(source.revision(), &revision);
     assert_eq!(source.size(), 8);
     let requests = fixture.requests();
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0].uri, "/api/repos/automata-ci/automata");
+    assert_eq!(requests.len(), 1);
     assert_eq!(
-        requests[1].uri,
+        requests[0].uri,
         format!("/automata-ci/automata/legacy.tar.gz/{SHA}")
     );
     assert!(!requests[0].headers.contains_key("authorization"));
-    assert!(!requests[1].headers.contains_key("authorization"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Public webhook evidence already pins the repository identity and exact commit. Fetch immutable public codeload archives directly instead of spending one anonymous REST request per delivery.

This removes the 60/hour per-host REST bottleneck that left production deliveries queued. Private source retrieval retains installation-authenticated repository identity and exact revision proofs.

Validation:
- `cargo test -p automata-ci-provider-github --test github repository_snapshots --locked`
- `cargo clippy -p automata-ci-provider-github --all-targets --all-features --locked -- -D warnings`