### PR TITLE
Enable JavaScript actions on macOS VM runners

### DIFF
--- a/crates/automata-ci-runner/config/runner.macos.example.json
+++ b/crates/automata-ci-runner/config/runner.macos.example.json
@@ -74,7 +74,7 @@
     "maximum_output_bytes": 16777216,
     "runner_root": "/Users/automata-job/runner",
     "home": "/Users/automata-job",
-    "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    "path": "/Library/Automata/externals/node24/bin:/Library/Automata/externals/node20/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     "temp": "/Users/automata-job/tmp",
     "tool_cache": "/Users/automata-job/tool-cache",
     "toolchain": {
@@ -89,8 +89,8 @@
       "sha256sum": "/usr/bin/shasum",
       "node12": null,
       "node16": null,
-      "node20": null,
-      "node24": null
+      "node20": "/Library/Automata/externals/node20/bin/node",
+      "node24": "/Library/Automata/externals/node24/bin/node"
     }
   },
   "object_store": {

--- a/crates/automata-ci-runner/src/product/composition.rs
+++ b/crates/automata-ci-runner/src/product/composition.rs
@@ -907,7 +907,7 @@ fn admit_configured_environment_profiles(
             )
             .map_err(|_| RunnerProductError::ProviderConfiguration)?,
         RunnerProviderConfig::MacosVirtualization(_) => policy
-            .with_virtualized_macos_shells(
+            .with_virtualized_macos_tools(
                 config.executor().runner_root().clone(),
                 toolchain
                     .bash()
@@ -919,6 +919,22 @@ fn admit_configured_environment_profiles(
                     .clone(),
                 toolchain.python().cloned(),
                 toolchain.pwsh().cloned(),
+                toolchain
+                    .install()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .tar()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain
+                    .sha256sum()
+                    .ok_or(RunnerProductError::ProviderConfiguration)?
+                    .clone(),
+                toolchain.node12().cloned(),
+                toolchain.node16().cloned(),
+                toolchain.node20().cloned(),
+                toolchain.node24().cloned(),
             )
             .map_err(|_| RunnerProductError::ProviderConfiguration)?,
         RunnerProviderConfig::Podman(_)

--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -2887,6 +2887,29 @@ fn exact_windows_executable(path: &TargetPath, basename: &str) -> bool {
             .is_some_and(|value| value.eq_ignore_ascii_case(basename))
 }
 
+fn exact_posix_executable(path: &TargetPath, basename: &str) -> bool {
+    path.platform() == TargetPlatform::Posix
+        && path
+            .as_str()
+            .rsplit('/')
+            .next()
+            .is_some_and(|value| value == basename)
+}
+
+fn exact_posix_python(path: &TargetPath) -> bool {
+    if path.platform() != TargetPlatform::Posix {
+        return false;
+    }
+    let Some(basename) = path.as_str().rsplit('/').next() else {
+        return false;
+    };
+    basename == "python"
+        || basename == "python3"
+        || basename.strip_prefix("python3.").is_some_and(|version| {
+            !version.is_empty() && version.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawToolchainConfig {
@@ -2999,17 +3022,42 @@ impl RawToolchainConfig {
                     && config.install.is_none()
             }
             ProviderKind::MacosVirtualization => {
-                config.bash.is_some()
-                    && config.sh.is_some()
-                    && config.install.is_some()
-                    && config.tar.is_some()
-                    && config.sha256sum.is_some()
+                config
+                    .bash
+                    .as_ref()
+                    .is_some_and(|path| exact_posix_executable(path, "bash"))
+                    && config
+                        .sh
+                        .as_ref()
+                        .is_some_and(|path| exact_posix_executable(path, "sh"))
+                    && config.python.as_ref().is_none_or(exact_posix_python)
+                    && config
+                        .pwsh
+                        .as_ref()
+                        .is_none_or(|path| exact_posix_executable(path, "pwsh"))
+                    && config
+                        .install
+                        .as_ref()
+                        .is_some_and(|path| exact_posix_executable(path, "install"))
+                    && config
+                        .tar
+                        .as_ref()
+                        .is_some_and(|path| exact_posix_executable(path, "tar"))
+                    && config
+                        .sha256sum
+                        .as_ref()
+                        .is_some_and(|path| exact_posix_executable(path, "shasum"))
                     && config.powershell.is_none()
                     && config.cmd.is_none()
-                    && config.node12.is_none()
-                    && config.node16.is_none()
-                    && config.node20.is_none()
-                    && config.node24.is_none()
+                    && [
+                        config.node12.as_ref(),
+                        config.node16.as_ref(),
+                        config.node20.as_ref(),
+                        config.node24.as_ref(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .all(|path| exact_posix_executable(path, "node"))
             }
         };
         valid

--- a/crates/automata-ci-runner/src/product/profile_admission.rs
+++ b/crates/automata-ci-runner/src/product/profile_admission.rs
@@ -90,6 +90,7 @@ enum ShellKind {
     Install,
     Tar,
     Sha256sum,
+    Shasum,
     Node12,
     Node16,
     Node20,
@@ -112,6 +113,7 @@ impl ShellProbe {
             ShellKind::Install
             | ShellKind::Tar
             | ShellKind::Sha256sum
+            | ShellKind::Shasum
             | ShellKind::Node12
             | ShellKind::Node16
             | ShellKind::Node20
@@ -130,6 +132,7 @@ impl ShellProbe {
             ShellKind::Install => "install",
             ShellKind::Tar => "tar",
             ShellKind::Sha256sum => "sha256sum",
+            ShellKind::Shasum => "shasum",
             ShellKind::Node12 => "node12",
             ShellKind::Node16 => "node16",
             ShellKind::Node20 => "node20",
@@ -158,6 +161,7 @@ impl ShellProbe {
             ShellKind::Install
             | ShellKind::Tar
             | ShellKind::Sha256sum
+            | ShellKind::Shasum
             | ShellKind::Node12
             | ShellKind::Node16
             | ShellKind::Node20
@@ -205,8 +209,18 @@ impl ShellProbe {
                 windows_script_arguments(WindowsScriptShell::Cmd, script.expect("matched script"))
                     .ok_or_else(invalid_catalog)?
             }
-            (ShellKind::Install | ShellKind::Tar | ShellKind::Sha256sum, None) => {
+            (ShellKind::Install, None) => vec![
+                "-d".to_owned(),
+                "-m".to_owned(),
+                "0700".to_owned(),
+                "--".to_owned(),
+                self.marker(operation_id),
+            ],
+            (ShellKind::Tar | ShellKind::Sha256sum, None) => {
                 vec!["--version".to_owned()]
+            }
+            (ShellKind::Shasum, None) => {
+                vec!["-a".to_owned(), "256".to_owned(), "/dev/null".to_owned()]
             }
             (
                 ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24,
@@ -235,12 +249,16 @@ impl ShellProbe {
 
     fn expected_stdout_matches(&self, operation_id: OperationId, stdout: &[u8]) -> bool {
         match self.kind {
-            ShellKind::Install => stdout.starts_with(b"install (GNU coreutils) "),
-            ShellKind::Tar => stdout.starts_with(b"tar (GNU tar) "),
+            ShellKind::Install => stdout.is_empty(),
+            ShellKind::Tar => {
+                stdout.starts_with(b"tar (GNU tar) ") || stdout.starts_with(b"bsdtar ")
+            }
             ShellKind::Sha256sum if self.program.platform() == TargetPlatform::Windows => {
                 stdout.starts_with(b"automata-sha256 ")
             }
             ShellKind::Sha256sum => stdout.starts_with(b"sha256sum (GNU coreutils) "),
+            ShellKind::Shasum => stdout
+                == b"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /dev/null\n",
             _ => stdout == self.marker(operation_id).as_bytes(),
         }
     }
@@ -391,40 +409,57 @@ impl ProfileAdmissionPolicy {
         Ok(policy)
     }
 
-    pub(super) fn with_virtualized_macos_shells(
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn with_virtualized_macos_tools(
         mut self,
         scratch_root: TargetPath,
         bash: TargetPath,
         sh: TargetPath,
         python: Option<TargetPath>,
         pwsh: Option<TargetPath>,
+        install: TargetPath,
+        tar: TargetPath,
+        shasum: TargetPath,
+        node12: Option<TargetPath>,
+        node16: Option<TargetPath>,
+        node20: Option<TargetPath>,
+        node24: Option<TargetPath>,
     ) -> Result<Self, ProfileAdmissionError> {
-        if self.shell_probes.is_some()
-            || [scratch_root.platform(), bash.platform(), sh.platform()]
-                .into_iter()
-                .any(|platform| platform != TargetPlatform::Posix)
-            || python
-                .as_ref()
-                .is_some_and(|python| python.platform() != TargetPlatform::Posix)
-            || pwsh
-                .as_ref()
-                .is_some_and(|pwsh| pwsh.platform() != TargetPlatform::Posix)
-        {
-            return Err(invalid_catalog());
-        }
-        let mut shell_probes = vec![
+        let mut probes = vec![
             ShellProbe::new(ShellKind::Bash, bash),
             ShellProbe::new(ShellKind::Sh, sh),
         ];
         if let Some(python) = python {
-            shell_probes.push(ShellProbe::new(ShellKind::Python, python));
+            probes.push(ShellProbe::new(ShellKind::Python, python));
         }
         if let Some(pwsh) = pwsh {
-            shell_probes.push(ShellProbe::new(ShellKind::Pwsh, pwsh));
+            probes.push(ShellProbe::new(ShellKind::Pwsh, pwsh));
+        }
+        probes.extend([
+            ShellProbe::new(ShellKind::Install, install),
+            ShellProbe::new(ShellKind::Tar, tar),
+            ShellProbe::new(ShellKind::Shasum, shasum),
+        ]);
+        for (kind, program) in [
+            (ShellKind::Node12, node12),
+            (ShellKind::Node16, node16),
+            (ShellKind::Node20, node20),
+            (ShellKind::Node24, node24),
+        ] {
+            if let Some(program) = program {
+                probes.push(ShellProbe::new(kind, program));
+            }
+        }
+        if self.shell_probes.is_some()
+            || scratch_root.platform() != TargetPlatform::Posix
+            || probes.len() > MAX_SHELL_PROBE_COUNT
+            || probes.iter().any(|probe| !valid_macos_probe(probe))
+        {
+            return Err(invalid_catalog());
         }
         self.shell_probes = Some(ShellProbePolicy {
             scratch_root: Some(scratch_root),
-            probes: shell_probes,
+            probes,
         });
         Ok(self)
     }
@@ -455,7 +490,36 @@ fn valid_linux_probe(probe: &ShellProbe) -> bool {
         ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24 => {
             basename == "node"
         }
-        ShellKind::WindowsPowerShell | ShellKind::Cmd => false,
+        ShellKind::Shasum | ShellKind::WindowsPowerShell | ShellKind::Cmd => false,
+    }
+}
+
+fn valid_macos_probe(probe: &ShellProbe) -> bool {
+    if probe.program.platform() != TargetPlatform::Posix || !probe.program.as_str().starts_with('/')
+    {
+        return false;
+    }
+    let Some(basename) = probe.program.as_str().rsplit('/').next() else {
+        return false;
+    };
+    match probe.kind {
+        ShellKind::Bash => basename == "bash",
+        ShellKind::Sh => basename == "sh",
+        ShellKind::Pwsh => basename == "pwsh",
+        ShellKind::Python => {
+            basename == "python"
+                || basename == "python3"
+                || basename.strip_prefix("python3.").is_some_and(|version| {
+                    !version.is_empty() && version.bytes().all(|byte| byte.is_ascii_digit())
+                })
+        }
+        ShellKind::Install => basename == "install",
+        ShellKind::Tar => basename == "tar",
+        ShellKind::Shasum => basename == "shasum",
+        ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24 => {
+            basename == "node"
+        }
+        ShellKind::WindowsPowerShell | ShellKind::Cmd | ShellKind::Sha256sum => false,
     }
 }
 
@@ -476,7 +540,7 @@ fn valid_windows_probe(probe: &ShellProbe) -> bool {
         ShellKind::Node12 | ShellKind::Node16 | ShellKind::Node20 | ShellKind::Node24 => {
             basename.eq_ignore_ascii_case("node.exe")
         }
-        ShellKind::Bash | ShellKind::Sh | ShellKind::Install => false,
+        ShellKind::Bash | ShellKind::Sh | ShellKind::Install | ShellKind::Shasum => false,
     }
 }
 
@@ -1594,6 +1658,8 @@ mod tests {
             || basename.eq_ignore_ascii_case("automata-sha256.exe")
         {
             Some(ShellKind::Sha256sum)
+        } else if basename == "shasum" {
+            Some(ShellKind::Shasum)
         } else if basename.eq_ignore_ascii_case("node") || basename.eq_ignore_ascii_case("node.exe")
         {
             let evaluation = request.argv().arguments().last()?;
@@ -1648,7 +1714,7 @@ mod tests {
                 b"wrong-shell-probe-output".to_vec()
             } else {
                 match kind {
-                    ShellKind::Install => b"install (GNU coreutils) 9.4\n".to_vec(),
+                    ShellKind::Install => Vec::new(),
                     ShellKind::Tar => b"tar (GNU tar) 1.35\n".to_vec(),
                     ShellKind::Sha256sum
                         if request.argv().program().platform() == TargetPlatform::Windows =>
@@ -1656,19 +1722,28 @@ mod tests {
                         b"automata-sha256 1.0.0\n".to_vec()
                     }
                     ShellKind::Sha256sum => b"sha256sum (GNU coreutils) 9.4\n".to_vec(),
+                    ShellKind::Shasum => b"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /dev/null\n".to_vec(),
                     _ => ShellProbe::new(kind, request.argv().program().clone())
                         .marker(request.operation_id())
                         .into_bytes(),
                 }
             };
-            let stdout = ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, stdout)
-                .map_err(|_| {
-                    ExecutionError::new(ExecutionErrorKind::LocalStorage, ExecutionStage::Exec)
-                })?;
-            let mut records = vec![
-                stdout,
-                ExecutionOutputRecord::end_of_stream(ExecutionOutputStream::Stdout),
-            ];
+            let mut records = Vec::new();
+            if !stdout.is_empty() {
+                records.push(
+                    ExecutionOutputRecord::data(ExecutionOutputStream::Stdout, stdout).map_err(
+                        |_| {
+                            ExecutionError::new(
+                                ExecutionErrorKind::LocalStorage,
+                                ExecutionStage::Exec,
+                            )
+                        },
+                    )?,
+                );
+            }
+            records.push(ExecutionOutputRecord::end_of_stream(
+                ExecutionOutputStream::Stdout,
+            ));
             if self.behavior == FakeBehavior::ExecStderr {
                 records.push(
                     ExecutionOutputRecord::data(
@@ -1891,6 +1966,89 @@ mod tests {
         .expect("Linux tool admission policy")
     }
 
+    fn macos_tool_policy() -> ProfileAdmissionPolicy {
+        let resources = ResourceLimits::new(8 * 1024 * 1024 * 1024, 4_000, 512).expect("resources");
+        ProfileAdmissionPolicy::new(
+            NetworkPolicy::Disabled,
+            RootFilesystemPolicy::Writable,
+            SandboxPrivilegePolicy::Unprivileged,
+            resources,
+            resource_allocation(resources),
+        )
+        .with_virtualized_macos_tools(
+            TargetPath::posix("/Users/automata-job/runner").expect("scratch root"),
+            TargetPath::posix("/bin/bash").expect("bash path"),
+            TargetPath::posix("/bin/sh").expect("sh path"),
+            None,
+            None,
+            TargetPath::posix("/usr/bin/install").expect("install path"),
+            TargetPath::posix("/usr/bin/tar").expect("tar path"),
+            TargetPath::posix("/usr/bin/shasum").expect("shasum path"),
+            None,
+            None,
+            Some(
+                TargetPath::posix("/Library/Automata/externals/node20/bin/node")
+                    .expect("node20 path"),
+            ),
+            Some(
+                TargetPath::posix("/Library/Automata/externals/node24/bin/node")
+                    .expect("node24 path"),
+            ),
+        )
+        .expect("macOS tool admission policy")
+    }
+
+    #[test]
+    fn macos_profile_admission_proves_action_tools_and_nodes_inside_the_vm() {
+        let signals = ProbeCancellation::default();
+        let provider = FakeProvider::new(FakeBehavior::Happy, signals.clone());
+        let (attestation, environment) = environment("macos-tools", profile_digest(0x36), 0x47);
+        let profiles = BTreeMap::from([(attestation, environment)]);
+
+        assert_eq!(
+            admit_environment_profiles(
+                &provider,
+                runner_id(),
+                &profiles,
+                macos_tool_policy(),
+                &signals,
+            ),
+            Ok(ProfileAdmissionOutcome::Admitted)
+        );
+        let calls = provider.calls();
+        let Call::Create(spec) = &calls[0] else {
+            panic!("macOS tool admission must begin with create")
+        };
+        assert_eq!(spec.network(), NetworkPolicy::Disabled);
+        assert_eq!(spec.root_filesystem(), RootFilesystemPolicy::Writable);
+        assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Unprivileged);
+        assert!(
+            spec.scratch()
+                .is_some_and(|path| path.as_str().starts_with("/Users/automata-job/runner/"))
+        );
+        let programs = calls
+            .iter()
+            .filter_map(|call| match call {
+                Call::Exec(command) => Some(command.argv().program().as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            programs,
+            [
+                "/bin/bash",
+                "/bin/sh",
+                "/usr/bin/install",
+                "/usr/bin/tar",
+                "/usr/bin/shasum",
+                "/Library/Automata/externals/node20/bin/node",
+                "/Library/Automata/externals/node24/bin/node",
+            ]
+        );
+        assert!(matches!(calls.last(), Some(Call::Destroy(_, false))));
+        assert_eq!(provider.resource_count(), 0);
+    }
+
     #[test]
     fn linux_profile_admission_proves_every_configured_tool_in_the_exact_sandbox() {
         let signals = ProbeCancellation::default();
@@ -1961,7 +2119,12 @@ mod tests {
             assert_eq!(command.timeout(), SHELL_PROBE_TIMEOUT);
             assert_eq!(command.output_limit(), SHELL_PROBE_OUTPUT_BYTES);
         }
-        for call in &executions[3..6] {
+        let Call::Exec(install) = &executions[3] else {
+            unreachable!()
+        };
+        assert_eq!(&install.argv().arguments()[..4], ["-d", "-m", "0700", "--"]);
+        assert!(install.argv().arguments()[4].starts_with("automata-profile-install-"));
+        for call in &executions[4..6] {
             let Call::Exec(command) = call else {
                 unreachable!()
             };

--- a/crates/automata-ci-runner/tests/runner_product_config_macos.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_macos.rs
@@ -1,6 +1,6 @@
 #![cfg(all(target_os = "macos", target_arch = "aarch64"))]
 
-use automata_ci_core::SandboxFeature;
+use automata_ci_core::{RunnerFeature, SandboxFeature};
 use automata_ci_runner::product::{RunnerProductConfig, RunnerProductConfigError};
 
 fn baseline() -> serde_json::Value {
@@ -87,10 +87,10 @@ fn macos_configuration_rejects_every_weaker_boundary() {
         RunnerProductConfigError::InvalidProvider
     );
 
-    let mut javascript = baseline();
-    javascript["executor"]["toolchain"]["node20"] = serde_json::json!("/usr/local/bin/node");
+    let mut aliased_node = baseline();
+    aliased_node["executor"]["toolchain"]["node20"] = serde_json::json!("/usr/local/bin/not-node");
     assert_eq!(
-        parse(&javascript).expect_err("JavaScript actions are not supported"),
+        parse(&aliased_node).expect_err("a generic executable cannot stand in for Node"),
         RunnerProductConfigError::InvalidExecutor
     );
 
@@ -100,6 +100,35 @@ fn macos_configuration_rejects_every_weaker_boundary() {
         value["inventory"]["resources_per_job"][field] = serde_json::json!(1);
         assert!(parse(&value).is_err(), "nonzero {field} must fail closed");
     }
+}
+
+#[test]
+fn macos_configuration_advertises_only_configured_admitted_action_runtimes() {
+    let config = parse(&baseline()).expect("checked-in macOS runner configuration");
+    let features = config.inventory().features();
+    for feature in [
+        RunnerFeature::JAVASCRIPT_ACTIONS,
+        RunnerFeature::COMPOSITE_ACTIONS,
+        RunnerFeature::REPOSITORY_ACTIONS,
+        RunnerFeature::LOCAL_ACTIONS,
+        RunnerFeature::NODE20_ACTIONS,
+        RunnerFeature::NODE24_ACTIONS,
+    ] {
+        assert!(features.contains(&feature), "missing {feature}");
+    }
+    assert!(!features.contains(&RunnerFeature::NODE12_ACTIONS));
+    assert!(!features.contains(&RunnerFeature::NODE16_ACTIONS));
+
+    let mut shell_only = baseline();
+    shell_only["executor"]["toolchain"]["node20"] = serde_json::Value::Null;
+    shell_only["executor"]["toolchain"]["node24"] = serde_json::Value::Null;
+    let shell_only = parse(&shell_only).expect("Node runtimes remain optional");
+    assert!(
+        !shell_only
+            .inventory()
+            .features()
+            .contains(&RunnerFeature::JAVASCRIPT_ACTIONS)
+    );
 }
 
 #[test]

--- a/crates/automata-ci-sandbox-guest/src/main.rs
+++ b/crates/automata-ci-sandbox-guest/src/main.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::{env, ffi::OsString, future::Future, path::PathBuf, process::ExitCode};
+use std::{env, ffi::OsString, future::Future, io, path::PathBuf, process::ExitCode};
 
 #[cfg(target_os = "macos")]
 use std::fmt::Write as _;
@@ -79,11 +79,15 @@ fn serve_vm(arguments: &mut impl Iterator<Item = OsString>) -> ExitCode {
     let identity = std::fs::read(identity_path)
         .ok()
         .filter(|bytes| !bytes.is_empty() && bytes.len() <= 16 * 1024)
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .filter(valid_vm_identity);
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok());
     let Some(identity) = identity else {
+        eprintln!("automata guest identity rejected: invalid_identity_file");
         return ExitCode::FAILURE;
     };
+    if let Some(reason) = vm_identity_rejection(&identity) {
+        eprintln!("automata guest identity rejected: {reason}");
+        return ExitCode::FAILURE;
+    }
     run_future(automata_ci_sandbox_guest::serve_vm(&socket, identity))
 }
 
@@ -91,7 +95,39 @@ fn client(arguments: &mut impl Iterator<Item = OsString>) -> ExitCode {
     let Some(socket) = path_argument(arguments) else {
         return ExitCode::FAILURE;
     };
-    run_future(automata_ci_sandbox_guest::forward_stdio(&socket))
+    let result = runtime()
+        .map(|runtime| runtime.block_on(automata_ci_sandbox_guest::forward_stdio(&socket)));
+    match result {
+        Some(Ok(())) => ExitCode::SUCCESS,
+        Some(Err(automata_ci_sandbox_guest::GuestProtocolError::InvalidFrame)) => {
+            eprintln!("automata guest client rejected: invalid_frame");
+            ExitCode::FAILURE
+        }
+        Some(Err(automata_ci_sandbox_guest::GuestProtocolError::Io(error))) => {
+            eprintln!(
+                "automata guest client rejected: {}",
+                client_io_rejection(error.kind())
+            );
+            ExitCode::FAILURE
+        }
+        None => {
+            eprintln!("automata guest client rejected: runtime");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+const fn client_io_rejection(kind: io::ErrorKind) -> &'static str {
+    match kind {
+        io::ErrorKind::NotFound => "not_found",
+        io::ErrorKind::PermissionDenied => "permission_denied",
+        io::ErrorKind::ConnectionRefused => "connection_refused",
+        io::ErrorKind::ConnectionReset => "connection_reset",
+        io::ErrorKind::BrokenPipe => "broken_pipe",
+        io::ErrorKind::UnexpectedEof => "unexpected_eof",
+        io::ErrorKind::TimedOut => "timed_out",
+        _ => "io",
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -149,7 +185,9 @@ const fn success(success: bool) -> ExitCode {
 }
 
 #[cfg(target_os = "macos")]
-fn valid_vm_identity(identity: &automata_ci_sandbox_guest::GuestIdentity) -> bool {
+fn vm_identity_rejection(
+    identity: &automata_ci_sandbox_guest::GuestIdentity,
+) -> Option<&'static str> {
     let executable_digest = env::current_exe()
         .ok()
         .and_then(|path| std::fs::read(path).ok())
@@ -163,19 +201,31 @@ fn valid_vm_identity(identity: &automata_ci_sandbox_guest::GuestIdentity) -> boo
         });
     let product_version = command_output("/usr/bin/sw_vers", &["-productVersion"]);
     let build_version = command_output("/usr/bin/sw_vers", &["-buildVersion"]);
-    identity.architecture == "arm64"
-        && std::env::consts::ARCH == "aarch64"
-        && executable_digest.as_deref() == Some(identity.guest_agent_sha256.as_str())
-        && product_version.as_deref() == Some(identity.macos_version.as_str())
-        && build_version.as_deref() == Some(identity.macos_build.as_str())
-        && rustix::process::getuid().as_raw() == identity.job_uid
-        && rustix::process::getgid().as_raw() == identity.job_gid
-        && process_limit() == Some(identity.process_limit)
+    if identity.architecture != "arm64" || std::env::consts::ARCH != "aarch64" {
+        Some("architecture")
+    } else if executable_digest.as_deref() != Some(identity.guest_agent_sha256.as_str()) {
+        Some("executable_digest")
+    } else if product_version.as_deref() != Some(identity.macos_version.as_str()) {
+        Some("product_version")
+    } else if build_version.as_deref() != Some(identity.macos_build.as_str()) {
+        Some("build_version")
+    } else if rustix::process::getuid().as_raw() != identity.job_uid {
+        Some("job_uid")
+    } else if rustix::process::getgid().as_raw() != identity.job_gid {
+        Some("job_gid")
+    } else if process_limit() != Some(identity.process_limit) {
+        Some("process_limit")
+    } else {
+        None
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
-fn valid_vm_identity(_identity: &automata_ci_sandbox_guest::GuestIdentity) -> bool {
-    false
+#[allow(clippy::unnecessary_wraps)]
+fn vm_identity_rejection(
+    _identity: &automata_ci_sandbox_guest::GuestIdentity,
+) -> Option<&'static str> {
+    Some("unsupported_platform")
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/automata-ci-sandbox-macos/guest/dev.automata.guest-agent.plist
+++ b/crates/automata-ci-sandbox-macos/guest/dev.automata.guest-agent.plist
@@ -29,6 +29,11 @@
         <key>NumberOfProcesses</key>
         <integer>512</integer>
     </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfProcesses</key>
+        <integer>512</integer>
+    </dict>
     <key>ThrottleInterval</key>
     <integer>5</integer>
     <key>Umask</key>

--- a/crates/automata-ci-sandbox-macos/guest/install-node-runtime.sh
+++ b/crates/automata-ci-sandbox-macos/guest/install-node-runtime.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: install-node-runtime.sh <major> <node-executable> <sha256>" >&2
+    exit 64
+fi
+
+major=$1
+source_node=$2
+expected_sha256=$3
+install_root=/Library/Automata/externals
+
+case $major in
+    12|16|20|24) ;;
+    *) echo "unsupported Node.js action runtime" >&2; exit 64 ;;
+esac
+case $expected_sha256 in
+    *[!0-9a-f]*|'') echo "invalid Node.js SHA-256" >&2; exit 64 ;;
+esac
+if [ "${#expected_sha256}" -ne 64 ]; then
+    echo "invalid Node.js SHA-256" >&2
+    exit 64
+fi
+if [ "$(id -u)" -ne 0 ] || [ "$(uname -m)" != arm64 ]; then
+    echo "Node.js runtime installation requires root in an ARM64 macOS VM" >&2
+    exit 77
+fi
+if [ ! -f "$source_node" ] || [ ! -x "$source_node" ] || \
+   [ "$(stat -f %HT "$source_node")" != "Regular File" ]; then
+    echo "Node.js runtime must be an executable regular file" >&2
+    exit 66
+fi
+if [ "$(/usr/bin/shasum -a 256 "$source_node" | /usr/bin/awk '{print $1}')" != "$expected_sha256" ]; then
+    echo "Node.js runtime digest mismatch" >&2
+    exit 65
+fi
+if [ "$(/usr/bin/lipo -archs "$source_node")" != "arm64" ]; then
+    echo "Node.js runtime must contain only native ARM64 code" >&2
+    exit 65
+fi
+
+probe="automata-node-runtime-$major"
+if [ "$(/usr/bin/env -i PATH=/usr/bin:/bin "$source_node" --input-type=commonjs --eval \
+    "if (process.versions.node.split('.')[0] !== '$major') process.exit(64); process.stdout.write('$probe')")" != "$probe" ]; then
+    echo "Node.js runtime failed its exact-major execution probe" >&2
+    exit 65
+fi
+
+destination="$install_root/node$major/bin/node"
+/usr/bin/install -d -o root -g wheel -m 0755 \
+    "$install_root" "$install_root/node$major" "$install_root/node$major/bin"
+/usr/bin/install -o root -g wheel -m 0555 "$source_node" "$destination"
+if [ "$(/usr/bin/shasum -a 256 "$destination" | /usr/bin/awk '{print $1}')" != "$expected_sha256" ]; then
+    echo "installed Node.js runtime digest mismatch" >&2
+    exit 65
+fi
+
+echo "installed Node.js $major action runtime at $destination" >&2

--- a/crates/automata-ci-sandbox-macos/guest/install.sh
+++ b/crates/automata-ci-sandbox-macos/guest/install.sh
@@ -95,6 +95,7 @@ for label in dev.automata.guest-agent dev.automata.vsock-bridge; do
     if [ "$label" = dev.automata.guest-agent ]; then
         /usr/libexec/PlistBuddy \
             -c "Set :HardResourceLimits:NumberOfProcesses $process_limit" \
+            -c "Set :SoftResourceLimits:NumberOfProcesses $process_limit" \
             "$destination_plist"
     fi
     chown root:wheel "$destination_plist"

--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSTemplateTool/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSTemplateTool/main.swift
@@ -5,7 +5,7 @@ import Foundation
 import Virtualization
 
 private let gibibyte = UInt64(1024 * 1024 * 1024)
-private let guestProtocol: UInt16 = 2
+private let guestProtocol: UInt16 = 3
 private let guestPort: UInt32 = 10250
 
 private enum ToolFailure: Error, CustomStringConvertible {
@@ -579,7 +579,9 @@ private func sha256(_ url: URL) throws -> String {
   let handle = try FileHandle(forReadingFrom: url)
   defer { try? handle.close() }
   var digest = SHA256()
-  while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+  while let data = try autoreleasepool(invoking: {
+    try handle.read(upToCount: 1024 * 1024)
+  }), !data.isEmpty {
     digest.update(data: data)
   }
   return digest.finalize().map { String(format: "%02x", $0) }.joined()

--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVsockBridge/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVsockBridge/main.swift
@@ -2,10 +2,22 @@ import Darwin
 import Foundation
 
 private let maximumFrameBytes = 32 * 1024 * 1024
-private let guestProtocol: UInt16 = 2
+private let guestProtocol: UInt16 = 3
 
-private enum BridgeFailure: Error {
-  case rejected
+private enum BridgeFailure: String, Error {
+  case guestClientExit = "guest_client_exit"
+  case guestClientInput = "guest_client_input"
+  case guestClientLaunch = "guest_client_launch"
+  case guestClientResponse = "guest_client_response"
+  case invalidArguments = "invalid_arguments"
+  case requestEnvelope = "request_envelope"
+  case requestFrame = "request_frame"
+  case requestRejected = "request_rejected"
+  case responseWrite = "response_write"
+  case socketBind = "socket_bind"
+  case socketCreate = "socket_create"
+  case socketListen = "socket_listen"
+  case socketAccept = "socket_accept"
 }
 
 private struct RequestEnvelope: Decodable {
@@ -23,9 +35,14 @@ private func portablePort(_ value: String) -> UInt32? {
   return port
 }
 
-private func listen(port: UInt32) -> Int32? {
+private func diagnose(_ failure: BridgeFailure) {
+  let message = Data("automata vsock bridge rejected: \(failure.rawValue)\n".utf8)
+  try? FileHandle.standardError.write(contentsOf: message)
+}
+
+private func listen(port: UInt32) throws -> Int32 {
   let descriptor = socket(AF_VSOCK, SOCK_STREAM, 0)
-  guard descriptor >= 0 else { return nil }
+  guard descriptor >= 0 else { throw BridgeFailure.socketCreate }
   _ = fcntl(descriptor, F_SETFD, FD_CLOEXEC)
   var address = sockaddr_vm()
   address.svm_len = UInt8(MemoryLayout<sockaddr_vm>.size)
@@ -37,9 +54,13 @@ private func listen(port: UInt32) -> Int32? {
       Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_vm>.size))
     }
   }
-  guard bound == 0, Darwin.listen(descriptor, 8) == 0 else {
+  guard bound == 0 else {
     close(descriptor)
-    return nil
+    throw BridgeFailure.socketBind
+  }
+  guard Darwin.listen(descriptor, 8) == 0 else {
+    close(descriptor)
+    throw BridgeFailure.socketListen
   }
   return descriptor
 }
@@ -95,14 +116,27 @@ private func forward(
   client.environment = [:]
   client.standardInput = input
   client.standardOutput = output
-  client.standardError = FileHandle.nullDevice
-  try client.run()
-  try input.fileHandleForWriting.write(contentsOf: frame)
-  try input.fileHandleForWriting.close()
-  let response = try readFrame(output.fileHandleForReading)
+  client.standardError = FileHandle.standardError
+  do {
+    try client.run()
+  } catch {
+    throw BridgeFailure.guestClientLaunch
+  }
+  do {
+    try input.fileHandleForWriting.write(contentsOf: frame)
+    try input.fileHandleForWriting.close()
+  } catch {
+    throw BridgeFailure.guestClientInput
+  }
+  let response: Data
+  do {
+    response = try readFrame(output.fileHandleForReading)
+  } catch {
+    throw BridgeFailure.guestClientResponse
+  }
   client.waitUntilExit()
   guard client.terminationReason == .exit, client.terminationStatus == 0 else {
-    throw CocoaError(.fileReadUnknown)
+    throw BridgeFailure.guestClientExit
   }
   return response
 }
@@ -110,14 +144,28 @@ private func forward(
 private func serve(listener: Int32, guestClient: String, unixSocket: String) -> Never {
   var configureFrame: Data?
   var configuredLimit: UInt32?
+  var diagnosed = Set<BridgeFailure>()
   while true {
     let connection = accept(listener, nil, nil)
-    if connection < 0 { continue }
+    if connection < 0 {
+      if diagnosed.insert(.socketAccept).inserted { diagnose(.socketAccept) }
+      continue
+    }
     _ = fcntl(connection, F_SETFD, FD_CLOEXEC)
     let handle = FileHandle(fileDescriptor: connection, closeOnDealloc: true)
     do {
-      let request = try readFrame(handle)
-      let envelope = try requestEnvelope(request)
+      let request: Data
+      do {
+        request = try readFrame(handle)
+      } catch {
+        throw BridgeFailure.requestFrame
+      }
+      let envelope: RequestEnvelope
+      do {
+        envelope = try requestEnvelope(request)
+      } catch {
+        throw BridgeFailure.requestEnvelope
+      }
       let response: Data
       switch envelope.operation {
       case "hello":
@@ -127,17 +175,17 @@ private func serve(listener: Int32, guestClient: String, unixSocket: String) -> 
           limit > 0,
           configuredLimit == nil || configuredLimit == limit
         else {
-          throw BridgeFailure.rejected
+          throw BridgeFailure.requestRejected
         }
         response = try forward(request, guestClient: guestClient, unixSocket: unixSocket)
         guard configuredResponse(response) else {
-          throw BridgeFailure.rejected
+          throw BridgeFailure.requestRejected
         }
         configureFrame = request
         configuredLimit = limit
       default:
         guard let configureFrame else {
-          throw BridgeFailure.rejected
+          throw BridgeFailure.requestRejected
         }
         let configured = try forward(
           configureFrame,
@@ -145,12 +193,20 @@ private func serve(listener: Int32, guestClient: String, unixSocket: String) -> 
           unixSocket: unixSocket
         )
         guard configuredResponse(configured) else {
-          throw BridgeFailure.rejected
+          throw BridgeFailure.requestRejected
         }
         response = try forward(request, guestClient: guestClient, unixSocket: unixSocket)
       }
-      try handle.write(contentsOf: response)
-    } catch {}
+      do {
+        try handle.write(contentsOf: response)
+      } catch {
+        throw BridgeFailure.responseWrite
+      }
+    } catch let failure as BridgeFailure {
+      if diagnosed.insert(failure).inserted { diagnose(failure) }
+    } catch {
+      if diagnosed.insert(.requestRejected).inserted { diagnose(.requestRejected) }
+    }
     try? handle.close()
   }
 }
@@ -165,12 +221,20 @@ private func main() -> Int32 {
     arguments[4].hasPrefix("/"),
     arguments[6].hasPrefix("/"),
     access(arguments[4], X_OK) == 0,
-    geteuid() == 0,
-    let listener = listen(port: port)
+    geteuid() == 0
   else {
+    diagnose(.invalidArguments)
     return 64
   }
-  serve(listener: listener, guestClient: arguments[4], unixSocket: arguments[6])
+  do {
+    let listener = try listen(port: port)
+    serve(listener: listener, guestClient: arguments[4], unixSocket: arguments[6])
+  } catch let failure as BridgeFailure {
+    diagnose(failure)
+  } catch {
+    diagnose(.requestRejected)
+  }
+  return 70
 }
 
 exit(main())

--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -4,10 +4,25 @@
 use std::{path::PathBuf, time::Duration};
 
 use automata_ci_execution::{ProviderErrorKind, Sha256Digest};
+use automata_ci_sandbox_guest::GUEST_PROTOCOL_VERSION;
 use automata_ci_sandbox_macos::{MacosVirtualizationProvider, MacosVirtualizationProviderOptions};
 use static_assertions::assert_impl_all;
 
 assert_impl_all!(MacosVirtualizationProvider: Send, Sync, Clone);
+
+#[test]
+fn swift_template_and_bridge_track_the_guest_protocol() {
+    let expected = format!("private let guestProtocol: UInt16 = {GUEST_PROTOCOL_VERSION}");
+    for source in [
+        include_str!("../swift/Sources/AutomataMacOSTemplateTool/main.swift"),
+        include_str!("../swift/Sources/AutomataMacOSVsockBridge/main.swift"),
+    ] {
+        assert!(
+            source.lines().any(|line| line == expected),
+            "Swift protocol constant must match the Rust guest"
+        );
+    }
+}
 
 fn options(
     root: impl Into<PathBuf>,

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -273,15 +273,19 @@ Remaining tasks:
 - [x] Implement the `macos_virtualization` provider with an attested macOS 15
   ARM64 template, private guest protocol, APFS clone cleanup, resource
   enforcement, and self-hosted physical-machine acceptance.
-- [ ] Keep action steps, containers, GPUs, Intel hosts, signing jobs,
-  job-scoped Keychains, and broader Xcode profiles out of the initial slice;
-  gate each future addition separately.
+- [x] Gate JavaScript action generations on exact configured Node paths and
+  startup execution probes inside a disposable VM; admit repository/composite
+  materialization only with the macOS `install`, `tar`, and `shasum` tools.
+- [ ] Keep container actions, job/service containers, GPUs, Intel hosts,
+  signing jobs, job-scoped Keychains, and broader Xcode profiles gated as
+  separate future additions.
 
 Acceptance:
 
 - [ ] The shipped VM runner on Apple Silicon macOS 15 reports
   `runner.os=macOS` and `runner.arch=ARM64`, completes zero-resource Bash and
-  `sh` jobs, and rejects actions, services, and containers before launch.
+  `sh` jobs plus pinned Node 20/24 repository actions, and rejects services and
+  containers before launch.
 - [ ] Self-hosted macOS 15 differential fixtures cover stable environment,
   working-directory, command-file, output, timeout, cancellation, and
   conclusion behavior.

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -223,9 +223,25 @@ copy the provisioning bundle to a guest-local directory and run:
 ```console
 sudo guest/install.sh automata.dev/macos-15-arm64-vm-v1 \
   ./automata-ci-sandbox-guest ./automata-macos-vsock-bridge 502 502 512
+sudo guest/install-node-runtime.sh 20 ./node20 \
+  <lowercase-sha256-of-the-native-arm64-node20-binary>
+sudo guest/install-node-runtime.sh 24 ./node24 \
+  <lowercase-sha256-of-the-native-arm64-node24-binary>
 cp guest/guest-identity.json "/Volumes/My Shared Files/Output/guest-identity.json"
 sudo shutdown -h now
 ```
+
+`node20` and `node24` above are the `bin/node` regular files extracted from
+version-pinned official `darwin-arm64` Node.js distributions on the trusted
+builder. Verify each distribution against its published Node.js release
+`SHASUMS256.txt` before copying the binary into the provisioning directory.
+The installer independently pins the binary digest, rejects non-ARM64 or wrong
+major-version executables, and installs it root-owned and non-writable beneath
+`/Library/Automata/externals`. The checked-in runner example advertises both
+runtimes. Set an unavailable generation to `null`; the runner then withholds
+that exact Node capability. Node 12 and 16 use the same installer when a native
+ARM64 binary is deliberately provided, but are not part of the checked-in
+profile.
 
 The script creates the disabled-password non-admin account, installs the two
 launch daemons, writes the baked guest identity, and copies that identity beside
@@ -310,11 +326,15 @@ cargo build --release --bin automata-runner
 ```
 
 Startup refuses Intel, macOS before 15, fractional CPU allocations, multiple
-slots or profiles, services, containers, actions, GPUs, claimed ephemeral-disk
-capacity, private/host networking, host identity/filesystem policies, mutable or
+slots or profiles, services, containers, GPUs, claimed ephemeral-disk capacity,
+private/host networking, host identity/filesystem policies, mutable or
 wrong-owner artifacts, mismatched hashes/profile, untrusted helper signatures,
 an unbounded/shared/boot-container APFS layout, insufficient clone capacity, or
-overlapping host state roots. Old schema/native configuration is an error.
+overlapping host state roots. It admits Bash, `sh`, action materialization
+utilities, and every configured Node runtime by executing them inside a
+disposable VM before connecting to the control plane. Missing or wrong-major
+Node runtimes therefore cannot be advertised. Old schema/native configuration
+is an error.
 
 ## Validation
 

--- a/scripts/ci/tests/local-installation-catalog.test.py
+++ b/scripts/ci/tests/local-installation-catalog.test.py
@@ -53,6 +53,18 @@ def rust_string_constant(relative_path: str, name: str) -> str:
     return match.group(1)
 
 
+def swift_integer_constant(relative_path: str, name: str) -> int:
+    source = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+    match = re.search(
+        rf"^private let {re.escape(name)}: UInt16 = ([0-9][0-9_]*)$",
+        source,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"could not resolve Swift constant {name}")
+    return int(match.group(1).replace("_", ""))
+
+
 class LocalInstallationCatalogContract(unittest.TestCase):
     def setUp(self) -> None:
         self.release = {
@@ -210,6 +222,16 @@ class LocalInstallationCatalogContract(unittest.TestCase):
                 "GUEST_PROTOCOL_VERSION",
             ),
         )
+        for swift_source in (
+            "crates/automata-ci-sandbox-macos/swift/Sources/"
+            "AutomataMacOSTemplateTool/main.swift",
+            "crates/automata-ci-sandbox-macos/swift/Sources/"
+            "AutomataMacOSVsockBridge/main.swift",
+        ):
+            self.assertEqual(
+                source["images"]["sandbox-guest"]["runtime"]["guest_protocol"],
+                swift_integer_constant(swift_source, "guestProtocol"),
+            )
         self.assertEqual(
             runner["maximum_parallel_jobs"],
             rust_integer_constant(


### PR DESCRIPTION
## Summary

- admit macOS Bash, sh, BSD install/tar/shasum, and every configured Node generation by executing exact probes inside a disposable VM before runner registration
- provision digest-pinned native ARM64 Node action runtimes and advertise Node 20/24 in the checked-in macOS profile
- repair macOS guest startup by keeping launchd soft/hard process limits equal and moving the Swift bridge/template from stale guest protocol v2 to the current v3
- keep bridge/guest failures value-free and diagnosable, bound template hashing memory with a per-chunk autorelease pool, and add protocol-lockstep regression coverage

## Validation

- scripts/ci/run-macos-checks.sh on physical Apple Silicon, from a clean worktree rebased onto current main
  - workspace clippy passed
  - 517 control-plane library tests passed (1 ignored)
  - 120 runner unit tests passed
  - 50 runner integration tests passed (1 physical-provider test intentionally ignored)
  - all macOS provider tests passed
  - release Swift package build passed
- Linux targeted runner admission, guest behavior, clippy, and catalog contract tests passed
- real Virtualization.framework helper/guest protocol reached ready and executed:
  - Node 20.20.2 (arm64)
  - Node 24.18.1 (arm64)
  - BSD tar
  - /usr/bin/shasum -a 256 /dev/null
  - BSD install
  with exit 0, complete output, and empty stderr
- fresh sealed production template:
  - manifest SHA-256: df4875f5c09a21c91cbf1b3a2206c1c8f1af96c848a4831692d021b2e7d9f9a1
  - disk SHA-256: 9aa67c7c70066ee4676d99f91fe8ad08407803955c5a524f13249ae85aba6b7f
  - guest protocol: 3

Physical provider startup through the production Rust trust boundary remains intentionally blocked until an Apple-issued code-signing identity is installed; the raw signed helper test exercises the same VM, attestation, configure, and guest execution path without weakening production trust policy.
