### PR TITLE
feat(macos): support native PostgreSQL development

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,26 @@ Frontend changes additionally need Node.js 24.19.0 and npm. Local integration
 tests need rootless Podman, `podman-compose`, PostgreSQL client tools, and
 OpenSSL. Static Linux distribution builds also need musl and ELF tooling.
 
+The native Rust workspace, control plane, and PostgreSQL contract suite are
+supported on Apple Silicon macOS. The database scripts require Bash 4 or newer;
+Apple's `/bin/bash` 3.2 is too old. A headless Homebrew setup can provide the
+required shell, PostgreSQL 18 server, and client:
+
+```console
+brew install bash postgresql@18
+brew services start postgresql@18
+export PATH="/opt/homebrew/bin:/opt/homebrew/opt/postgresql@18/bin:$HOME/.cargo/bin:$PATH"
+export AUTOMATA_PSQL_BINARY=/opt/homebrew/opt/postgresql@18/bin/psql
+```
+
+The secret-safe PostgreSQL launcher discovers that Apple Silicon Homebrew path
+and the Intel Homebrew prefix when no override is set. Keep the explicit
+absolute override for nonstandard installations. The repository's ordinary
+Linux CI service is patch-pinned to PostgreSQL 18.4; local integration tests
+accept PostgreSQL 18 or newer, while `verify-postgres-version.sh` requires an
+explicit `AUTOMATA_EXPECTED_POSTGRES_VERSION_NUM` when testing another reviewed
+patch release.
+
 Keep generated scratch data under the ignored `target/` tree. The project does
 not use the host `/tmp`, which may be shared, inode-constrained, or mounted with
 an unsuitable execution policy.
@@ -437,6 +457,11 @@ cargo test -p automata-ci-blob-s3 --test blob_s3 --all-features --locked -- rust
 ./scripts/ci/verify-postgres-version.sh
 ./scripts/ci/run-postgres-tests.sh
 ```
+
+On macOS, run the block from [Toolchains](#toolchains) first. If the installed
+PostgreSQL patch is not CI's pinned 18.4, set
+`AUTOMATA_EXPECTED_POSTGRES_VERSION_NUM` to that reviewed server's exact
+`SHOW server_version_num` value before running the version verifier.
 
 The runner always removes the exact namespace it owns. Use a fresh namespace
 for every invocation when a PostgreSQL service is reused. Individual tests may

--- a/scripts/ci/psql-test-database.py
+++ b/scripts/ci/psql-test-database.py
@@ -58,6 +58,26 @@ def sanitized_connection() -> tuple[str, str | None]:
     return sanitized, password
 
 
+def psql_binary(environment: dict[str, str]) -> pathlib.Path:
+    configured = environment.get("AUTOMATA_PSQL_BINARY")
+    if configured is not None:
+        binary = pathlib.Path(configured)
+        if not binary.is_absolute():
+            fail("AUTOMATA_PSQL_BINARY must be an absolute path")
+        return binary
+
+    candidates = [pathlib.Path("/usr/bin/psql")]
+    if sys.platform == "darwin":
+        candidates = [
+            pathlib.Path("/opt/homebrew/opt/postgresql@18/bin/psql"),
+            pathlib.Path("/usr/local/opt/postgresql@18/bin/psql"),
+            *candidates,
+        ]
+    return next(
+        (candidate for candidate in candidates if candidate.is_file()), candidates[0]
+    )
+
+
 def main() -> NoReturn:
     for argument in sys.argv[1:]:
         if argument == "-d" or argument.startswith("--dbname"):
@@ -69,16 +89,17 @@ def main() -> NoReturn:
     if password is not None:
         environment["PGPASSWORD"] = password
 
-    binary = pathlib.Path(
-        environment.get("AUTOMATA_PSQL_BINARY", "/usr/bin/psql")
-    )
-    if not binary.is_absolute():
-        fail("AUTOMATA_PSQL_BINARY must be an absolute path")
-    os.execve(
-        binary,
-        [str(binary), f"--dbname={connection}", *sys.argv[1:]],
-        environment,
-    )
+    binary = psql_binary(environment)
+    try:
+        os.execve(
+            binary,
+            [str(binary), f"--dbname={connection}", *sys.argv[1:]],
+            environment,
+        )
+    except FileNotFoundError:
+        fail("psql was not found; set AUTOMATA_PSQL_BINARY to its absolute path")
+    except PermissionError:
+        fail("the configured psql binary is not executable")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run-postgres-tests.sh
+++ b/scripts/ci/run-postgres-tests.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if (( BASH_VERSINFO[0] < 4 )); then
+  printf '%s\n' \
+    'error: PostgreSQL tests require Bash 4 or newer; on macOS install Homebrew bash and put /opt/homebrew/bin first in PATH' \
+    >&2
+  exit 2
+fi
+
 usage() {
   printf 'usage: %s [--plan] [--defer-cleanup]\n' "$0" >&2
 }

--- a/scripts/ci/tests/psql-test-database.test.py
+++ b/scripts/ci/tests/psql-test-database.test.py
@@ -67,4 +67,29 @@ assert query["argv"][1] == (
 )
 assert "query-secret" not in " ".join(query["argv"])
 
+with tempfile.TemporaryDirectory(prefix="automata-psql-launcher-missing-") as directory:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "AUTOMATA_TEST_DATABASE_URL": (
+                "postgresql://automata_ci:missing-secret@127.0.0.1/automata_ci"
+            ),
+            "AUTOMATA_PSQL_BINARY": str(pathlib.Path(directory) / "missing-psql"),
+        }
+    )
+    missing = subprocess.run(
+        [str(LAUNCHER), "--command=SELECT 1"],
+        check=False,
+        cwd=REPOSITORY,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    assert missing.returncode != 0
+    assert missing.stdout == ""
+    assert missing.stderr == (
+        "error: psql was not found; set AUTOMATA_PSQL_BINARY to its absolute path\n"
+    )
+    assert "missing-secret" not in missing.stderr
+
 print("secret-safe psql test-database launcher verified")


### PR DESCRIPTION
## Summary

- discover Homebrew PostgreSQL 18 clients on Apple Silicon and Intel macOS while retaining the explicit absolute override
- replace missing/non-executable `psql` tracebacks with bounded, secret-free diagnostics
- reject macOS's system Bash 3.2 before the PostgreSQL harness reaches unsupported syntax
- document the headless native macOS control-plane and PostgreSQL setup

## Validation

On the dedicated Apple Silicon Mac mini (macOS 26.5.1), using Homebrew Bash 5.3.15 and PostgreSQL 18.6:

- `verify-postgres-version.sh` passed without `AUTOMATA_PSQL_BINARY`, proving automatic Homebrew discovery
- `run-postgres-tests.sh --plan` passed under Homebrew Bash
- `/bin/bash run-postgres-tests.sh --plan` exited 2 with the new actionable Bash 4+ diagnostic
- the full native PostgreSQL lane passed before this portability-only patch: 40 application/store, 3 provider, 13 artifact, 7 cache, and 10 database-harness tests, with namespace cleanup

Local checks:

- `python3 scripts/ci/tests/psql-test-database.test.py`
- `python3 -m py_compile scripts/ci/psql-test-database.py scripts/ci/tests/psql-test-database.test.py`
- `bash -n scripts/ci/run-postgres-tests.sh`
- `git diff --check`
