### PR TITLE
Converge permission startup across control replicas

### DIFF
--- a/crates/automata-ci/src/server/github_provider_runtime.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime.rs
@@ -109,6 +109,8 @@ const MAX_SUPERVISED_SERVICE_CREDENTIAL_COMMITS: usize =
     MAX_WORKFLOW_PERMISSION_OBSERVATION_CONCURRENCY;
 const WORKFLOW_PERMISSION_CREDENTIAL_STARTUP_DEADLINE: Duration = Duration::from_mins(10);
 const WORKFLOW_PERMISSION_CREDENTIAL_RETRY_DELAY: Duration = Duration::from_millis(100);
+const WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE: Duration = Duration::from_secs(15);
+const WORKFLOW_PERMISSION_OBSERVATION_STARTUP_RETRY_DELAY: Duration = Duration::from_secs(5);
 const WORKFLOW_PERMISSION_REFRESH_SAFETY_MARGIN_MILLIS: i64 = 60_000;
 const WORKFLOW_PERMISSION_REFRESH_RETRY_MIN: Duration = Duration::from_mins(1);
 const WORKFLOW_PERMISSION_REFRESH_RETRY_MAX: Duration = Duration::from_secs(7 * 60 + 30);
@@ -907,9 +909,11 @@ impl GithubProviderRuntimeBuilder {
             owner: observation_owner,
             targets: workflow_permission_targets,
         });
-        if permission_defaults.refresh_all().await? != WorkflowPermissionRefreshOutcome::Ready {
-            return Err(GithubProviderRuntimeBuildError::WorkflowPermissionObservation);
-        }
+        converge_initial_workflow_permission_defaults(
+            || permission_defaults.refresh_all(),
+            observation_owner,
+        )
+        .await?;
         let _ready = plan.bootstrap(store.as_ref(), applied_at).await?;
         let cleanup_authorities = retire_superseded_server_service_authorities(
             credential_authority_repository.as_ref(),
@@ -2481,6 +2485,51 @@ async fn run_workflow_permission_refresh_loop(
         stop,
     )
     .await
+}
+
+/// Establishes one current permission head while treating cross-replica claim
+/// contention exactly like the live refresher: bounded and retryable. A stable
+/// provider-policy mismatch remains an immediate startup failure.
+async fn converge_initial_workflow_permission_defaults<Refresh, RefreshFuture>(
+    mut refresh_all: Refresh,
+    owner: GithubServerServiceWorkerId,
+) -> Result<(), GithubProviderRuntimeBuildError>
+where
+    Refresh: FnMut() -> RefreshFuture,
+    RefreshFuture:
+        Future<Output = Result<WorkflowPermissionRefreshOutcome, GithubProviderRuntimeBuildError>>,
+{
+    let deadline = tokio::time::Instant::now()
+        .checked_add(WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE)
+        .ok_or(GithubProviderRuntimeBuildError::WorkflowPermissionObservation)?;
+    let mut attempt = 0_u64;
+    loop {
+        let outcome = tokio::time::timeout_at(deadline, refresh_all())
+            .await
+            .map_err(|_| GithubProviderRuntimeBuildError::WorkflowPermissionObservation)?;
+        match outcome {
+            Ok(WorkflowPermissionRefreshOutcome::Ready) => return Ok(()),
+            Ok(WorkflowPermissionRefreshOutcome::PolicyMismatch) => {
+                return Err(GithubProviderRuntimeBuildError::WorkflowPermissionObservation);
+            }
+            Err(_) => {}
+        }
+
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .ok_or(GithubProviderRuntimeBuildError::WorkflowPermissionObservation)?;
+        let retry_delay = jittered_workflow_permission_retry_delay(
+            WORKFLOW_PERMISSION_OBSERVATION_STARTUP_RETRY_DELAY,
+            owner,
+            attempt,
+            WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE,
+        );
+        if retry_delay >= remaining {
+            return Err(GithubProviderRuntimeBuildError::WorkflowPermissionObservation);
+        }
+        tokio::time::sleep(retry_delay).await;
+        attempt = attempt.saturating_add(1);
+    }
 }
 
 fn jittered_workflow_permission_retry_delay(

--- a/crates/automata-ci/src/server/github_provider_runtime_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime_tests.rs
@@ -906,6 +906,67 @@ async fn workflow_permission_convergence_contention_is_rate_limited_and_cancella
 }
 
 #[tokio::test(start_paused = true)]
+async fn workflow_permission_startup_converges_after_replica_contention() {
+    let owner = GithubServerServiceWorkerId::from_uuid(Uuid::from_u128(95)).expect("worker");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let task_calls = Arc::clone(&calls);
+    let driver = tokio::spawn(async move {
+        converge_initial_workflow_permission_defaults(
+            move || {
+                let calls = Arc::clone(&task_calls);
+                async move {
+                    let call = calls.fetch_add(1, Ordering::AcqRel);
+                    if call < 2 {
+                        Err(GithubProviderRuntimeBuildError::WorkflowPermissionObservation)
+                    } else {
+                        Ok(WorkflowPermissionRefreshOutcome::Ready)
+                    }
+                }
+            },
+            owner,
+        )
+        .await
+    });
+
+    while calls.load(Ordering::Acquire) == 0 {
+        tokio::task::yield_now().await;
+    }
+    let first_delay = jittered_workflow_permission_retry_delay(
+        WORKFLOW_PERMISSION_OBSERVATION_STARTUP_RETRY_DELAY,
+        owner,
+        0,
+        WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE,
+    );
+    advance_until_call_count(&calls, first_delay, 2).await;
+    let second_delay = jittered_workflow_permission_retry_delay(
+        WORKFLOW_PERMISSION_OBSERVATION_STARTUP_RETRY_DELAY,
+        owner,
+        1,
+        WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE,
+    );
+    assert!(first_delay + second_delay < WORKFLOW_PERMISSION_OBSERVATION_STARTUP_DEADLINE);
+    advance_until_call_count(&calls, second_delay, 3).await;
+    assert!(driver.await.expect("startup convergence task").is_ok());
+}
+
+#[tokio::test(start_paused = true)]
+async fn workflow_permission_startup_rejects_a_policy_mismatch_without_retrying() {
+    let owner = GithubServerServiceWorkerId::from_uuid(Uuid::from_u128(96)).expect("worker");
+    let calls = AtomicUsize::new(0);
+    let result = converge_initial_workflow_permission_defaults(
+        || async {
+            calls.fetch_add(1, Ordering::AcqRel);
+            Ok(WorkflowPermissionRefreshOutcome::PolicyMismatch)
+        },
+        owner,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(calls.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test(start_paused = true)]
 async fn transient_workflow_permission_refresh_does_not_hot_loop() {
     let owner = GithubServerServiceWorkerId::from_uuid(Uuid::from_u128(91)).expect("worker");
     let calls = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Fix HA control-plane startup so transient cross-replica workflow-permission claim contention is handled by the same bounded retry semantics as steady-state refresh.

- retry transient startup observation failures inside a 15-second replica-jittered window
- fail immediately on a stable provider policy mismatch
- add paused-time regression tests for both paths

Verified with all 519 `automata-ci` library tests and `cargo clippy -p automata-ci --all-targets -- -D warnings`.