### PR TITLE
Add a closed runtime transport for macOS VMs

### DIFF
--- a/crates/automata-ci-sandbox-macos/README.md
+++ b/crates/automata-ci-sandbox-macos/README.md
@@ -24,6 +24,12 @@ macOS version/build, architecture, dedicated non-admin UID/GID, and sealed
 process ceiling. The root guest bridge admits only that exact configuration;
 the agent applies it before executing commands as the dedicated guest identity.
 
+The bridge also contains a closed, bounded guest-loopback relay for future
+runtime services. The host helper exposes its fixed Virtio socket port only
+when given an owner-only Unix socket inside the current attempt directory. The
+runner currently supplies no socket, so the relay cannot reach the host and
+does not add a network capability.
+
 Lifecycle mutations remain replay-safe and generation-fenced. A new journal
 namespace deliberately rejects the deleted native provider's state instead of
 migrating it. Startup reconciles every incomplete VM attempt while holding its

--- a/crates/automata-ci-sandbox-macos/src/vm.rs
+++ b/crates/automata-ci-sandbox-macos/src/vm.rs
@@ -22,7 +22,7 @@ use crate::{
     template::{VerifiedTemplate, verify_helper},
 };
 
-const HOST_HELPER_PROTOCOL_VERSION: u16 = 1;
+const HOST_HELPER_PROTOCOL_VERSION: u16 = 2;
 const CONTROL_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const TRANSPORT_GRACE: Duration = Duration::from_secs(10);
 const PREPARE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -59,6 +59,7 @@ struct LaunchRequest<'a> {
     handshake_nonce: &'a str,
     boot_timeout_millis: u64,
     stop_timeout_millis: u64,
+    runtime_proxy_socket: Option<&'a Path>,
 }
 
 #[derive(Deserialize)]
@@ -174,6 +175,9 @@ impl VmProcess {
             handshake_nonce: &nonce,
             boot_timeout_millis: duration_millis(options.boot_timeout())?,
             stop_timeout_millis: duration_millis(options.stop_timeout())?,
+            // The transport is present in protocol 2 but remains closed until
+            // the runner supplies an attempt-scoped, route-restricted broker.
+            runtime_proxy_socket: None,
         };
         write_json_frame(&mut input, &request)?;
         let response = read_frame_controlled(

--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVMHelper/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVMHelper/main.swift
@@ -2,8 +2,10 @@ import Darwin
 import Foundation
 import Virtualization
 
-private let helperProtocol: UInt16 = 1
+private let helperProtocol: UInt16 = 2
 private let maximumFrameBytes = 32 * 1024 * 1024
+private let runtimeProxyHostPort: UInt32 = 10251
+private let runtimeProxySessionLimit = 16
 private let launchRequestKeys: Set<String> = [
   "protocol", "attempt_id", "source_disk_image", "source_auxiliary_storage",
   "attempt_directory", "hardware_model_base64", "cpu_count", "memory_bytes",
@@ -12,6 +14,7 @@ private let launchRequestKeys: Set<String> = [
   "expected_architecture", "expected_job_uid", "expected_job_gid",
   "expected_process_limit", "minimum_cpu_count", "minimum_memory_bytes",
   "handshake_nonce", "boot_timeout_millis", "stop_timeout_millis",
+  "runtime_proxy_socket",
 ]
 
 private struct LaunchRequest: Decodable {
@@ -39,6 +42,7 @@ private struct LaunchRequest: Decodable {
   let handshakeNonce: String
   let bootTimeoutMillis: UInt64
   let stopTimeoutMillis: UInt64
+  let runtimeProxySocket: String?
 
   private enum CodingKeys: String, CodingKey {
     case protocolVersion = "protocol"
@@ -65,6 +69,7 @@ private struct LaunchRequest: Decodable {
     case handshakeNonce = "handshake_nonce"
     case bootTimeoutMillis = "boot_timeout_millis"
     case stopTimeoutMillis = "stop_timeout_millis"
+    case runtimeProxySocket = "runtime_proxy_socket"
   }
 }
 
@@ -174,6 +179,123 @@ private func supportedMacOSVersion(_ value: String) -> Bool {
   return components.allSatisfy { component in
     !component.isEmpty && component.utf8.count <= 4
       && component.utf8.allSatisfy { byte in byte >= 48 && byte <= 57 }
+  }
+}
+
+private func validRuntimeProxySocket(_ path: String?, attemptDirectory: String) -> Bool {
+  guard let path else { return true }
+  guard let normalized = normalizedAbsolute(path), normalized == path else { return false }
+  let url = URL(fileURLWithPath: path)
+  guard url.deletingLastPathComponent().path == attemptDirectory,
+    url.lastPathComponent == "runtime-proxy.sock"
+  else {
+    return false
+  }
+  var status = stat()
+  return lstat(path, &status) == 0
+    && status.st_mode & S_IFMT == S_IFSOCK
+    && status.st_uid == geteuid()
+    && status.st_nlink == 1
+    && status.st_mode & 0o077 == 0
+}
+
+private func connectRuntimeProxySocket(_ path: String) -> Int32? {
+  let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+  guard descriptor >= 0 else { return nil }
+  _ = fcntl(descriptor, F_SETFD, FD_CLOEXEC)
+  var address = sockaddr_un()
+  let maximumPathBytes = MemoryLayout.size(ofValue: address.sun_path)
+  guard path.utf8.count < maximumPathBytes else {
+    close(descriptor)
+    return nil
+  }
+  address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+  address.sun_family = sa_family_t(AF_UNIX)
+  path.withCString { source in
+    withUnsafeMutablePointer(to: &address.sun_path) { tuple in
+      tuple.withMemoryRebound(to: CChar.self, capacity: maximumPathBytes) { destination in
+        _ = strlcpy(destination, source, maximumPathBytes)
+      }
+    }
+  }
+  let connected = withUnsafePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+    }
+  }
+  guard connected == 0 else {
+    close(descriptor)
+    return nil
+  }
+  return descriptor
+}
+
+private func copyRuntimeProxyStream(from source: Int32, to destination: Int32) {
+  var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+  while true {
+    let count = Darwin.read(source, &buffer, buffer.count)
+    if count == 0 { break }
+    if count < 0 {
+      if errno == EINTR { continue }
+      break
+    }
+    var offset = 0
+    while offset < count {
+      let written = buffer.withUnsafeBytes { bytes in
+        Darwin.write(destination, bytes.baseAddress!.advanced(by: offset), count - offset)
+      }
+      if written < 0, errno == EINTR { continue }
+      if written <= 0 {
+        _ = shutdown(destination, SHUT_WR)
+        return
+      }
+      offset += written
+    }
+  }
+  _ = shutdown(destination, SHUT_WR)
+}
+
+private final class RuntimeProxyListener: NSObject, VZVirtioSocketListenerDelegate {
+  private let socketPath: String
+  private let slots = DispatchSemaphore(value: runtimeProxySessionLimit)
+
+  init(socketPath: String) {
+    self.socketPath = socketPath
+    super.init()
+  }
+
+  func listener(
+    _ listener: VZVirtioSocketListener,
+    shouldAcceptNewConnection connection: VZVirtioSocketConnection,
+    from socketDevice: VZVirtioSocketDevice
+  ) -> Bool {
+    guard connection.destinationPort == runtimeProxyHostPort,
+      slots.wait(timeout: .now()) == .success
+    else {
+      return false
+    }
+    guard let upstream = connectRuntimeProxySocket(socketPath) else {
+      slots.signal()
+      return false
+    }
+    DispatchQueue.global(qos: .utility).async { [slots] in
+      let pumps = DispatchGroup()
+      for (source, destination) in [
+        (connection.fileDescriptor, upstream),
+        (upstream, connection.fileDescriptor),
+      ] {
+        pumps.enter()
+        DispatchQueue.global(qos: .utility).async {
+          copyRuntimeProxyStream(from: source, to: destination)
+          pumps.leave()
+        }
+      }
+      pumps.wait()
+      connection.close()
+      close(upstream)
+      slots.signal()
+    }
+    return true
   }
 }
 
@@ -573,7 +695,8 @@ private func run(lockPath: String) throws {
     let sourceDisk = normalizedAbsolute(request.sourceDiskImage),
     let sourceAuxiliary = normalizedAbsolute(request.sourceAuxiliaryStorage),
     URL(fileURLWithPath: normalizedLock).deletingLastPathComponent().path == attemptDirectory,
-    URL(fileURLWithPath: attemptDirectory).lastPathComponent == request.attemptID
+    URL(fileURLWithPath: attemptDirectory).lastPathComponent == request.attemptID,
+    validRuntimeProxySocket(request.runtimeProxySocket, attemptDirectory: attemptDirectory)
   else {
     throw HelperFailure(rejection: .invalidRequest)
   }
@@ -601,19 +724,29 @@ private func run(lockPath: String) throws {
   guard let device = machine.socketDevices.first as? VZVirtioSocketDevice else {
     throw HelperFailure(rejection: .invalidConfiguration)
   }
+  var runtimeProxyListener: RuntimeProxyListener?
+  if let socketPath = request.runtimeProxySocket {
+    let delegate = RuntimeProxyListener(socketPath: socketPath)
+    let listener = VZVirtioSocketListener()
+    listener.delegate = delegate
+    device.setSocketListener(listener, forPort: runtimeProxyHostPort)
+    runtimeProxyListener = delegate
+  }
   let deadline = DispatchTime.now() + .milliseconds(Int(clamping: request.bootTimeoutMillis))
   try attestGuest(request: request, device: device, queue: queue, deadline: deadline)
   emit(status: "ready")
 
-  while let requestFrame = try readFrame(FileHandle.standardInput, allowEOF: true) {
-    let response = try exchange(
-      requestFrame,
-      device: device,
-      port: request.guestPort,
-      queue: queue,
-      deadline: .now() + .seconds(24 * 60 * 60)
-    )
-    try writeFrame(response, to: FileHandle.standardOutput)
+  try withExtendedLifetime(runtimeProxyListener) {
+    while let requestFrame = try readFrame(FileHandle.standardInput, allowEOF: true) {
+      let response = try exchange(
+        requestFrame,
+        device: device,
+        port: request.guestPort,
+        queue: queue,
+        deadline: .now() + .seconds(24 * 60 * 60)
+      )
+      try writeFrame(response, to: FileHandle.standardOutput)
+    }
   }
 }
 

--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVsockBridge/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVsockBridge/main.swift
@@ -3,6 +3,9 @@ import Foundation
 
 private let maximumFrameBytes = 32 * 1024 * 1024
 private let guestProtocol: UInt16 = 3
+private let runtimeProxyGuestPort: UInt16 = 18081
+private let runtimeProxyHostPort: UInt32 = 10251
+private let runtimeProxySessionLimit = 16
 
 private enum BridgeFailure: String, Error {
   case guestClientExit = "guest_client_exit"
@@ -14,10 +17,139 @@ private enum BridgeFailure: String, Error {
   case requestFrame = "request_frame"
   case requestRejected = "request_rejected"
   case responseWrite = "response_write"
+  case runtimeProxyBind = "runtime_proxy_bind"
+  case runtimeProxyConnect = "runtime_proxy_connect"
+  case runtimeProxyListen = "runtime_proxy_listen"
   case socketBind = "socket_bind"
   case socketCreate = "socket_create"
   case socketListen = "socket_listen"
   case socketAccept = "socket_accept"
+}
+
+private func setCloseOnExec(_ descriptor: Int32) {
+  _ = fcntl(descriptor, F_SETFD, FD_CLOEXEC)
+}
+
+private func runtimeProxyListener() throws -> Int32 {
+  let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+  guard descriptor >= 0 else { throw BridgeFailure.runtimeProxyListen }
+  setCloseOnExec(descriptor)
+  var reuse: Int32 = 1
+  _ = setsockopt(
+    descriptor,
+    SOL_SOCKET,
+    SO_REUSEADDR,
+    &reuse,
+    socklen_t(MemoryLayout<Int32>.size)
+  )
+  var address = sockaddr_in()
+  address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+  address.sin_family = sa_family_t(AF_INET)
+  address.sin_port = runtimeProxyGuestPort.bigEndian
+  address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+  let bound = withUnsafePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+    }
+  }
+  guard bound == 0 else {
+    close(descriptor)
+    throw BridgeFailure.runtimeProxyBind
+  }
+  guard Darwin.listen(descriptor, Int32(runtimeProxySessionLimit)) == 0 else {
+    close(descriptor)
+    throw BridgeFailure.runtimeProxyListen
+  }
+  return descriptor
+}
+
+private func connectRuntimeProxyHost() throws -> Int32 {
+  let descriptor = socket(AF_VSOCK, SOCK_STREAM, 0)
+  guard descriptor >= 0 else { throw BridgeFailure.runtimeProxyConnect }
+  setCloseOnExec(descriptor)
+  var address = sockaddr_vm()
+  address.svm_len = UInt8(MemoryLayout<sockaddr_vm>.size)
+  address.svm_family = sa_family_t(AF_VSOCK)
+  address.svm_port = runtimeProxyHostPort
+  address.svm_cid = UInt32(VMADDR_CID_HOST)
+  let connected = withUnsafePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_vm>.size))
+    }
+  }
+  guard connected == 0 else {
+    close(descriptor)
+    throw BridgeFailure.runtimeProxyConnect
+  }
+  return descriptor
+}
+
+private func copyStream(from source: Int32, to destination: Int32) {
+  var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+  while true {
+    let count = Darwin.read(source, &buffer, buffer.count)
+    if count == 0 { break }
+    if count < 0 {
+      if errno == EINTR { continue }
+      break
+    }
+    var offset = 0
+    while offset < count {
+      let written = buffer.withUnsafeBytes { bytes in
+        Darwin.write(destination, bytes.baseAddress!.advanced(by: offset), count - offset)
+      }
+      if written < 0, errno == EINTR { continue }
+      if written <= 0 {
+        _ = shutdown(destination, SHUT_WR)
+        return
+      }
+      offset += written
+    }
+  }
+  _ = shutdown(destination, SHUT_WR)
+}
+
+private func relayRuntimeProxy(client: Int32, host: Int32) {
+  let pumps = DispatchGroup()
+  for (source, destination) in [(client, host), (host, client)] {
+    pumps.enter()
+    DispatchQueue.global(qos: .utility).async {
+      copyStream(from: source, to: destination)
+      pumps.leave()
+    }
+  }
+  pumps.wait()
+  close(client)
+  close(host)
+}
+
+private func serveRuntimeProxy(listener: Int32) -> Never {
+  let slots = DispatchSemaphore(value: runtimeProxySessionLimit)
+  while true {
+    let client = accept(listener, nil, nil)
+    if client < 0 {
+      if errno == EINTR { continue }
+      diagnose(.socketAccept)
+      continue
+    }
+    setCloseOnExec(client)
+    guard slots.wait(timeout: .now()) == .success else {
+      close(client)
+      continue
+    }
+    let host: Int32
+    do {
+      host = try connectRuntimeProxyHost()
+    } catch {
+      close(client)
+      slots.signal()
+      continue
+    }
+    DispatchQueue.global(qos: .utility).async {
+      relayRuntimeProxy(client: client, host: host)
+      slots.signal()
+    }
+  }
 }
 
 private struct RequestEnvelope: Decodable {
@@ -227,6 +359,10 @@ private func main() -> Int32 {
     return 64
   }
   do {
+    let runtimeListener = try runtimeProxyListener()
+    DispatchQueue(label: "dev.automata.macos-vm.runtime-proxy").async {
+      serveRuntimeProxy(listener: runtimeListener)
+    }
     let listener = try listen(port: port)
     serve(listener: listener, guestClient: arguments[4], unixSocket: arguments[6])
   } catch let failure as BridgeFailure {

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -64,6 +64,21 @@ Only `network: "disabled"` is implemented. Private egress is intentionally
 rejected until a separate authenticated host broker exists; attaching a NAT
 device would weaken the current contract.
 
+The protocol-2 host helper and newly provisioned guest bridge contain the
+closed transport primitive for that broker. The guest bridge owns only
+`127.0.0.1:18081`, permits at most 16 concurrent relays, and connects to the
+host only through fixed Virtio socket port 10251. The helper registers that
+port only when its launch request names the owner-only Unix socket
+`runtime-proxy.sock` directly inside the current attempt directory. It rejects
+another path, owner, file type, link count, or group/other permission.
+
+The current runner deliberately sends `null`, so no host listener or runtime
+service route is available and no network capability is advertised. A later
+slice must supply an attempt-scoped broker that authenticates and restricts
+exact GitHub and Results routes before the runner may expose the guest
+loopback endpoint. This transport is not a generic TCP proxy and does not
+justify adding a VM network device.
+
 ## Build and sign the host tools
 
 Use Xcode's Swift toolchain on Apple Silicon:


### PR DESCRIPTION
## Summary

- reserve a fixed guest-loopback to host Virtio-socket relay for future macOS runtime services
- require the host endpoint to be an owner-only Unix socket at the exact attempt path
- bound relay concurrency and preserve full-duplex half-close behavior
- bump the host-helper protocol while keeping the transport disabled by default

## Security boundary

The VM still has no network device. The runner sends `runtime_proxy_socket: null`, so the host helper registers no listener and advertises no new capability. A follow-up must provide an attempt-scoped, route-restricted broker before checkout or Results traffic can use this transport.

The design uses Apple's documented guest-initiated `VZVirtioSocketListener` path: https://developer.apple.com/documentation/virtualization/vzvirtiosocketlistener

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p automata-ci-sandbox-macos --lib --test macos_provider`
- Apple Silicon macOS: `cargo clippy --locked -p automata-ci-sandbox-macos --all-targets --all-features -- -D warnings`
- Apple Silicon macOS: `cargo test --locked -p automata-ci-sandbox-macos --all-features --no-fail-fast`
- Apple Silicon macOS: release Swift package build
- dedicated Mac mini: ad-hoc-entitled protocol-2 helper booted and attested the sealed protocol-3 VM template twice with the runtime transport disabled, then stopped cleanly

Diff: 306 additions, 12 deletions.
