### PR TITLE
Provider platform B4b: separate processing invocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ automata-ci-metrics = { path = "crates/automata-ci-metrics", version = "0.1.0" }
 automata-ci-workload-oidc = { path = "crates/automata-ci-workload-oidc", version = "0.1.0" }
 automata-ci-postgres = { path = "crates/automata-ci-postgres", version = "0.1.0" }
 automata-ci-provider = { path = "crates/automata-ci-provider", version = "0.1.0" }
+automata-ci-provider-delivery = { path = "crates/automata-ci-provider-delivery", version = "0.1.0" }
 automata-ci-provider-postgres = { path = "crates/automata-ci-provider-postgres", version = "0.1.0" }
 automata-ci-protocol = { path = "crates/automata-ci-protocol", version = "0.1.0" }
 automata-ci-protocol-protobuf = { path = "crates/automata-ci-protocol-protobuf", version = "0.1.0" }

--- a/crates/automata-ci-github-delivery/src/lib.rs
+++ b/crates/automata-ci-github-delivery/src/lib.rs
@@ -698,7 +698,7 @@ impl GithubDeliveryIngress {
             VerifiedGithubWebhook::CheckRun(check) => (
                 check.app_id().get(),
                 check.head_revision(),
-                check.sender_id().get(),
+                check.actor().id().get(),
                 GithubCheckRerunTarget::Run {
                     run_id: GithubCheckRunId::new(check.run_id().get())
                         .map_err(|_| GithubDeliveryIngressError::InvariantViolation)?,
@@ -716,7 +716,7 @@ impl GithubDeliveryIngress {
             VerifiedGithubWebhook::CheckSuite(check) => (
                 check.app_id().get(),
                 check.head_revision(),
-                check.sender_id().get(),
+                check.actor().id().get(),
                 GithubCheckRerunTarget::Suite {
                     suite_id: GithubCheckSuiteId::new(check.suite_id().get())
                         .map_err(|_| GithubDeliveryIngressError::InvariantViolation)?,

--- a/crates/automata-ci-github-delivery/src/processor.rs
+++ b/crates/automata-ci-github-delivery/src/processor.rs
@@ -1582,12 +1582,12 @@ mod renewal_tests {
         LogicalWorkflowAdmissionReceipt, LogicalWorkflowAdmissionRepository,
         LogicalWorkflowAdmissionStoreError, ManifestPinnedGithubDeliveryEvidence,
         ManifestPinnedGithubDeliveryReceipt, ObjectKey, ProviderDeliveryClaimFence,
-        ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
-        ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRepository,
-        ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryWorkflowInventory,
+        ProviderDeliveryEventEnvelope, ProviderDeliveryId, ProviderDeliveryIdentity,
+        ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
+        ProviderDeliveryStoreError, ProviderDeliveryWorkflowInventory,
         ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
-        ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-        ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+        ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryCoordinates,
+        ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
         RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
         RejectProviderDelivery, RenewedProviderDeliveryClaim, RepositoryId as StoreRepositoryId,
         RetryProviderDelivery, TenantScope,
@@ -2318,7 +2318,7 @@ mod renewal_tests {
         .expect("claim receipt");
         let claim = ProviderDeliveryClaimFence::from_durable_parts(
             delivery_id,
-            ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("claim owner"),
+            ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("claim owner"),
             7,
         )
         .expect("claim fence");

--- a/crates/automata-ci-github-delivery/src/processor/changed_files_provider_tests.rs
+++ b/crates/automata-ci-github-delivery/src/processor/changed_files_provider_tests.rs
@@ -16,9 +16,9 @@ use automata_ci_provider_github::{
 };
 use automata_ci_store::{
     AdmissionObject, ClaimedProviderDelivery, ObjectKey, ProviderDeliveryClaimFence,
-    ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
-    ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryState,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
+    ProviderDeliveryEventEnvelope, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderDeliveryReceipt, ProviderDeliveryState, ProviderInstallationId,
+    ProviderProcessingWorkerId, ProviderRepositoryCoordinates, ProviderRepositoryId,
     ProviderRepositoryVisibility, TenantScope,
 };
 use bytes::Bytes;
@@ -208,7 +208,7 @@ fn delivery_fixture(visibility: ProviderRepositoryVisibility) -> DeliveryFixture
     .expect("claim receipt");
     let claim = ProviderDeliveryClaimFence::from_durable_parts(
         delivery_id,
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("claim owner"),
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("claim owner"),
         7,
     )
     .expect("claim fence");

--- a/crates/automata-ci-github-delivery/src/service.rs
+++ b/crates/automata-ci-github-delivery/src/service.rs
@@ -22,11 +22,11 @@ use automata_ci_store::{
     GithubServerServiceRevision, GithubServerServiceWorkerId, GithubSubjectEvidenceRepository,
     MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, MAX_PROVIDER_DELIVERY_ATTEMPTS,
     MAX_PROVIDER_DELIVERY_CLAIM_MILLIS, MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS,
-    ProviderDeliveryClaimOwnerId, ProviderDeliveryClaimRenewalRepository, ProviderDeliveryIdentity,
+    ProviderDeliveryClaimRenewalRepository, ProviderDeliveryIdentity,
     ProviderDeliveryRenewalTiming, ProviderDeliveryRepository, ProviderDeliveryStoreError,
-    ProviderInstallationId, ProviderRepositoryId, ProviderRepositoryOwnerId,
-    ProviderRepositoryVisibility, RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim,
-    TenantScope,
+    ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryId,
+    ProviderRepositoryOwnerId, ProviderRepositoryVisibility, RenewProviderDeliveryClaim,
+    RenewedProviderDeliveryClaim, TenantScope,
 };
 use thiserror::Error;
 use tokio::{sync::OwnedMutexGuard, time::Instant};
@@ -635,7 +635,7 @@ pub struct GithubDeliveryService {
     renewals: Arc<dyn ProviderDeliveryClaimRenewalRepository>,
     source_policy: GithubDeliverySourcePolicy,
     clock: Arc<dyn GithubDeliveryClock>,
-    worker_id: ProviderDeliveryClaimOwnerId,
+    worker_id: ProviderProcessingWorkerId,
     config: GithubDeliveryServiceConfig,
 }
 
@@ -684,7 +684,7 @@ impl GithubDeliveryService {
         workflow_processor: Arc<dyn GithubDeliveryWorkflowProcessor>,
         deliveries: Arc<R>,
         clock: Arc<dyn GithubDeliveryClock>,
-        worker_id: ProviderDeliveryClaimOwnerId,
+        worker_id: ProviderProcessingWorkerId,
         worker_config: GithubDeliveryWorkerConfig,
         config: GithubDeliveryServiceConfig,
     ) -> Result<Self, GithubDeliveryWorkerConfigurationError>
@@ -722,7 +722,7 @@ impl GithubDeliveryService {
         deliveries: Arc<R>,
         repository_dispatches: Arc<dyn GithubRepositoryDispatchEvidenceRepository>,
         clock: Arc<dyn GithubDeliveryClock>,
-        worker_id: ProviderDeliveryClaimOwnerId,
+        worker_id: ProviderProcessingWorkerId,
         worker_config: GithubDeliveryWorkerConfig,
         config: GithubDeliveryServiceConfig,
     ) -> Result<Self, GithubDeliveryWorkerConfigurationError>
@@ -763,7 +763,7 @@ impl GithubDeliveryService {
         deliveries: Arc<R>,
         credentials: Arc<dyn GithubDeliverySourceCredentialProvider>,
         clock: Arc<dyn GithubDeliveryClock>,
-        worker_id: ProviderDeliveryClaimOwnerId,
+        worker_id: ProviderProcessingWorkerId,
         worker_config: GithubDeliveryWorkerConfig,
         config: GithubDeliveryServiceConfig,
     ) -> Result<Self, GithubDeliveryWorkerConfigurationError>
@@ -805,7 +805,7 @@ impl GithubDeliveryService {
         repository_dispatches: Arc<dyn GithubRepositoryDispatchEvidenceRepository>,
         credentials: Arc<dyn GithubDeliverySourceCredentialProvider>,
         clock: Arc<dyn GithubDeliveryClock>,
-        worker_id: ProviderDeliveryClaimOwnerId,
+        worker_id: ProviderProcessingWorkerId,
         worker_config: GithubDeliveryWorkerConfig,
         config: GithubDeliveryServiceConfig,
     ) -> Result<Self, GithubDeliveryWorkerConfigurationError>
@@ -841,7 +841,7 @@ impl GithubDeliveryService {
             Arc<dyn ScmProvider>,
         )>,
         clock: Arc<dyn GithubDeliveryClock>,
-        worker_id: ProviderDeliveryClaimOwnerId,
+        worker_id: ProviderProcessingWorkerId,
         worker_config: GithubDeliveryWorkerConfig,
         config: GithubDeliveryServiceConfig,
     ) -> Result<Self, GithubDeliveryWorkerConfigurationError>
@@ -892,7 +892,7 @@ impl GithubDeliveryService {
 
     /// Returns the stable durable identity used by every claim from this service.
     #[must_use]
-    pub const fn worker_id(&self) -> ProviderDeliveryClaimOwnerId {
+    pub const fn worker_id(&self) -> ProviderProcessingWorkerId {
         self.worker_id
     }
 

--- a/crates/automata-ci-github-delivery/src/worker.rs
+++ b/crates/automata-ci-github-delivery/src/worker.rs
@@ -2647,8 +2647,8 @@ fn processor_lease_error(error: GithubDeliveryWorkerError) -> GithubDeliveryWork
 mod lease_tests {
     use automata_ci_provider::ProviderConnectionId;
     use automata_ci_store::{
-        ObjectKey, ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
-        ProviderDeliveryReceipt, ProviderInstallationId, ProviderRepositoryCoordinates,
+        ObjectKey, ProviderDeliveryEventEnvelope, ProviderDeliveryId, ProviderDeliveryReceipt,
+        ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryCoordinates,
         ProviderRepositoryId, TenantScope,
     };
     use uuid::Uuid;
@@ -2778,7 +2778,7 @@ mod lease_tests {
         .expect("raw event");
         let claim = ProviderDeliveryClaimFence::from_durable_parts(
             delivery_id,
-            ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(5)).expect("claim owner"),
+            ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(5)).expect("claim owner"),
             7,
         )
         .expect("claim");

--- a/crates/automata-ci-github-delivery/tests/delivery_service.rs
+++ b/crates/automata-ci-github-delivery/tests/delivery_service.rs
@@ -42,13 +42,13 @@ use automata_ci_store::{
     MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, MAX_PROVIDER_DELIVERY_CLAIM_MILLIS,
     MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS, ManifestPinnedGithubDeliveryEvidence,
     ManifestPinnedGithubDeliveryReceipt, ObjectKey, ProviderDeliveryClaimFence,
-    ProviderDeliveryClaimOwnerId, ProviderDeliveryClaimRenewalRepository,
-    ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind, ProviderDeliveryId,
-    ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRepository,
-    ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
+    ProviderDeliveryClaimRenewalRepository, ProviderDeliveryEventEnvelope,
+    ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
+    ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
     ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
+    ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryCoordinates,
+    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
     RejectProviderDelivery, RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim,
     RepositoryId as StoreRepositoryId, RetryProviderDelivery, TenantScope,
@@ -1199,7 +1199,7 @@ struct Harness {
     credentials: Arc<RecordingCredentialProvider>,
     source: Arc<RecordingSourcePort>,
     clock: Arc<ManualClock>,
-    worker_id: ProviderDeliveryClaimOwnerId,
+    worker_id: ProviderProcessingWorkerId,
     renewal_apply_gate: Arc<RenewalApplyGate>,
 }
 
@@ -1240,7 +1240,7 @@ fn blocking_clock_harness(
         Some(source_gate.clone()),
     ));
     let worker_id =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
     let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = GithubDeliveryService::new_public_only(
         objects,
@@ -1359,7 +1359,7 @@ fn harness_with_stored_visibility(
     let source = Arc::new(RecordingSourcePort::new(repository_source(), gate));
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
     let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = if private_source_enabled {
         GithubDeliveryService::new_with_private_source_credentials(
@@ -1460,7 +1460,7 @@ fn snapshot_processor_harness_with_config(
     });
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
     let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let service = GithubDeliveryService::new_with_private_source_credentials(
         objects.clone(),
@@ -1531,7 +1531,7 @@ fn changed_files_renewal_harness(
     let source = Arc::new(RecordingSourcePort::new(source, None));
     let clock = Arc::new(ManualClock::new(INITIAL_NOW));
     let worker_id =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("worker identity");
     let objects = Arc::new(VerifiedBlobStore::exact(descriptor, body));
     let changed_files = Arc::new(match first_disposition {
         Some(disposition) => {
@@ -2818,7 +2818,7 @@ async fn delayed_renewal_is_cancelled_before_reclaim_can_overlap_provider_work()
         .reclaim_enabled
         .store(true, Ordering::SeqCst);
     let reclaim_owner =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(0x44)).expect("reclaim owner");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(0x44)).expect("reclaim owner");
     let observed_at = UnixMillis::new(INITIAL_NOW + claim_millis);
     let expires_at = UnixMillis::new(INITIAL_NOW + claim_millis * 2);
     let repository = harness.repository.clone();
@@ -2913,7 +2913,7 @@ async fn one_hour_claim_cap_expires_exactly_before_reclaim_and_without_extra_wor
         .reclaim_enabled
         .store(true, Ordering::SeqCst);
     let reclaim_owner =
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(0x45)).expect("reclaim owner");
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(0x45)).expect("reclaim owner");
     let hard_deadline = claim_started_at
         .checked_add(Duration::from_millis(
             u64::try_from(MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS)

--- a/crates/automata-ci-github-delivery/tests/worker.rs
+++ b/crates/automata-ci-github-delivery/tests/worker.rs
@@ -36,16 +36,16 @@ use automata_ci_store::{
     GithubSubjectEvidenceStoreError, GithubWorkflowRunSubjectEvidence,
     ManifestPinnedGithubDeliveryEvidence, ManifestPinnedGithubDeliveryReceipt, ObjectKey,
     PendingGithubRepositoryDispatchEvidence, PendingGithubRepositoryDispatchReceipt,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope,
-    ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
-    ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
-    ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
-    ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
-    ProviderInstallationId, ProviderRepositoryCoordinates, ProviderRepositoryId,
-    ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
-    RejectProviderDelivery, RepositoryId as StoreRepositoryId, ResolveGithubRepositoryDispatch,
-    RetryProviderDelivery, TenantScope,
+    ProviderDeliveryClaimFence, ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind,
+    ProviderDeliveryId, ProviderDeliveryIdentity, ProviderDeliveryReceipt,
+    ProviderDeliveryRepository, ProviderDeliveryState, ProviderDeliveryStoreError,
+    ProviderDeliveryWorkflowConclusion, ProviderDeliveryWorkflowInventoryReceipt,
+    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderProcessingWorkerId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, RecordProviderDeliveryWorkflowProgress,
+    RegisterProviderDeliveryWorkflowInventory, RejectProviderDelivery,
+    RepositoryId as StoreRepositoryId, ResolveGithubRepositoryDispatch, RetryProviderDelivery,
+    TenantScope,
 };
 use automata_ci_workflow_actions::RepositoryWorkflowDiscoveryLimits;
 use bytes::Bytes;
@@ -830,7 +830,7 @@ fn claimed_fixture_with_visibility(
         UnixMillis::new(50),
     )
     .expect("claimed receipt");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 7).expect("claim fence");
     let repository = ProviderRepositoryCoordinates::new(
@@ -895,7 +895,7 @@ fn pull_request_claimed_fixture() -> ClaimedFixture {
         UnixMillis::new(50),
     )
     .expect("claimed receipt");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(12)).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(12)).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 7).expect("claim fence");
     let repository = ProviderRepositoryCoordinates::new(
@@ -970,7 +970,7 @@ fn repository_dispatch_claimed_fixture(visibility: ProviderRepositoryVisibility)
         UnixMillis::new(50),
     )
     .expect("claimed receipt");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(22)).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(22)).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 7).expect("claim fence");
     let repository = ProviderRepositoryCoordinates::new(

--- a/crates/automata-ci-github-delivery/tests/workflow_processor.rs
+++ b/crates/automata-ci-github-delivery/tests/workflow_processor.rs
@@ -43,11 +43,11 @@ use automata_ci_store::{
     LogicalWorkflowAdmissionRepository, LogicalWorkflowAdmissionStoreError,
     MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, ManifestPinnedGithubDeliveryEvidence,
     ManifestPinnedGithubDeliveryReceipt, ObjectKey, ProviderDeliveryClaimFence,
-    ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind,
-    ProviderDeliveryId, ProviderDeliveryIdentity, ProviderDeliveryReceipt,
-    ProviderDeliveryRepository, ProviderDeliveryState, ProviderDeliveryStoreError,
-    ProviderDeliveryWorkflowConclusion, ProviderDeliveryWorkflowInventoryReceipt,
-    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderRepositoryCoordinates,
+    ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind, ProviderDeliveryId,
+    ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRepository,
+    ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
+    ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
+    ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryCoordinates,
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
     RejectProviderDelivery, RepositoryId as StoreRepositoryId, RetryProviderDelivery, TenantScope,
@@ -763,7 +763,7 @@ fn claimed(
     .expect("receipt");
     let claim = ProviderDeliveryClaimFence::from_durable_parts(
         delivery_id,
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(2)).expect("owner"),
+        ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(2)).expect("owner"),
         7,
     )
     .expect("claim");

--- a/crates/automata-ci-provider-delivery/src/control.rs
+++ b/crates/automata-ci-provider-delivery/src/control.rs
@@ -1,0 +1,244 @@
+//! Provider-neutral dispatch from authenticated controls to fresh trigger invocations.
+
+use std::{collections::BTreeMap, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use automata_ci_provider::{
+    ClaimedProviderProcessing, ProviderDeliveryId, ProviderProcessingFailure,
+    ProviderProcessingInput, ProviderTypeId, VerifiedProviderControlDelivery,
+};
+use thiserror::Error;
+
+use crate::{ProviderProcessingOutcome, ProviderProcessingProcessor};
+
+const MAX_PROVIDER_CONTROL_RESOLVERS: usize = 32;
+
+/// Provider-specific authority that resolves native result identity to its trigger delivery.
+#[async_trait]
+pub trait ProviderControlResolver: fmt::Debug + Send + Sync {
+    /// Returns the exact provider adapter type handled by this resolver.
+    fn provider_type(&self) -> &ProviderTypeId;
+
+    /// Reauthorizes and resolves one authenticated control to an immutable trigger.
+    async fn resolve(
+        &self,
+        control: &VerifiedProviderControlDelivery,
+    ) -> Result<ProviderDeliveryId, ProviderControlResolutionError>;
+}
+
+/// Provider-independent workflow admission invoked only for a resolved trigger.
+#[async_trait]
+pub trait ProviderTriggerProcessor: fmt::Debug + Send + Sync {
+    /// Performs idempotent admission under the invocation's exact live fence.
+    async fn process_trigger(
+        &self,
+        invocation: &ClaimedProviderProcessing,
+    ) -> ProviderProcessingOutcome;
+}
+
+/// Exact duplicate-free registry of statically linked provider control resolvers.
+#[derive(Clone)]
+pub struct ProviderControlResolverRegistry {
+    resolvers: BTreeMap<ProviderTypeId, Arc<dyn ProviderControlResolver>>,
+}
+
+impl ProviderControlResolverRegistry {
+    /// Builds a bounded nonempty resolver registry.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty, excessive, duplicate, or self-inconsistent resolver set.
+    pub fn new(
+        resolvers: impl IntoIterator<Item = Arc<dyn ProviderControlResolver>>,
+    ) -> Result<Self, ProviderControlResolverRegistryError> {
+        let mut values = BTreeMap::new();
+        for resolver in resolvers {
+            let key = resolver.provider_type().clone();
+            if values.insert(key, resolver).is_some() {
+                return Err(ProviderControlResolverRegistryError::Duplicate);
+            }
+        }
+        if values.is_empty() || values.len() > MAX_PROVIDER_CONTROL_RESOLVERS {
+            return Err(ProviderControlResolverRegistryError::InvalidSize);
+        }
+        if values
+            .iter()
+            .any(|(key, resolver)| resolver.provider_type() != key)
+        {
+            return Err(ProviderControlResolverRegistryError::Inconsistent);
+        }
+        Ok(Self { resolvers: values })
+    }
+
+    fn resolve(&self, provider_type: &ProviderTypeId) -> Option<&dyn ProviderControlResolver> {
+        self.resolvers.get(provider_type).map(Arc::as_ref)
+    }
+}
+
+impl fmt::Debug for ProviderControlResolverRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderControlResolverRegistry")
+            .field("provider_types", &self.resolvers.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Processing handler that resolves controls before invoking common trigger admission.
+pub struct ProviderProcessingDispatcher {
+    resolvers: ProviderControlResolverRegistry,
+    triggers: Arc<dyn ProviderTriggerProcessor>,
+}
+
+impl ProviderProcessingDispatcher {
+    /// Composes exact provider control resolution with provider-independent admission.
+    #[must_use]
+    pub fn new(
+        resolvers: ProviderControlResolverRegistry,
+        triggers: Arc<dyn ProviderTriggerProcessor>,
+    ) -> Self {
+        Self {
+            resolvers,
+            triggers,
+        }
+    }
+}
+
+impl fmt::Debug for ProviderProcessingDispatcher {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderProcessingDispatcher")
+            .field("resolvers", &self.resolvers)
+            .field("triggers", &self.triggers)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl ProviderProcessingProcessor for ProviderProcessingDispatcher {
+    async fn process(&self, invocation: &ClaimedProviderProcessing) -> ProviderProcessingOutcome {
+        let ProviderProcessingInput::Control(control) = invocation.input() else {
+            return self.triggers.process_trigger(invocation).await;
+        };
+        let Some(resolver) = self.resolvers.resolve(control.evidence().provider_type()) else {
+            return ProviderProcessingOutcome::Fail(ProviderProcessingFailure::InvalidEvidence);
+        };
+        match resolver.resolve(control).await {
+            Ok(source_delivery_id) => ProviderProcessingOutcome::ResolveControl(source_delivery_id),
+            Err(ProviderControlResolutionError::Unavailable) => {
+                ProviderProcessingOutcome::Retry(ProviderProcessingFailure::DependencyUnavailable)
+            }
+            Err(
+                ProviderControlResolutionError::Unauthorized
+                | ProviderControlResolutionError::NotFound
+                | ProviderControlResolutionError::Conflict,
+            ) => ProviderProcessingOutcome::Fail(ProviderProcessingFailure::PolicyRejected),
+            Err(ProviderControlResolutionError::InvalidEvidence) => {
+                ProviderProcessingOutcome::Fail(ProviderProcessingFailure::InvalidEvidence)
+            }
+        }
+    }
+}
+
+/// Sanitized provider-native control resolution failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderControlResolutionError {
+    /// Provider or durable resolution dependencies were unavailable.
+    #[error("provider control resolution is unavailable")]
+    Unavailable,
+    /// The authenticated actor lacks current Automata authority.
+    #[error("provider control actor is unauthorized")]
+    Unauthorized,
+    /// No exact Automata result subject matched the native target.
+    #[error("provider control target was not found")]
+    NotFound,
+    /// Native identity matched conflicting Automata result evidence.
+    #[error("provider control target is ambiguous")]
+    Conflict,
+    /// Adapter evidence violated the registered control schema.
+    #[error("provider control evidence is invalid")]
+    InvalidEvidence,
+}
+
+/// Invalid control-resolver registry construction.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderControlResolverRegistryError {
+    /// Registry was empty or exceeded its hard bound.
+    #[error("provider control resolver registry size is invalid")]
+    InvalidSize,
+    /// Two resolvers registered the same provider type.
+    #[error("provider control resolver type is duplicated")]
+    Duplicate,
+    /// A resolver's declared provider type changed during construction.
+    #[error("provider control resolver identity is inconsistent")]
+    Inconsistent,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct Resolver {
+        first: ProviderTypeId,
+        subsequent: ProviderTypeId,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ProviderControlResolver for Resolver {
+        fn provider_type(&self) -> &ProviderTypeId {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                &self.first
+            } else {
+                &self.subsequent
+            }
+        }
+
+        async fn resolve(
+            &self,
+            _control: &VerifiedProviderControlDelivery,
+        ) -> Result<ProviderDeliveryId, ProviderControlResolutionError> {
+            unreachable!("registry construction never resolves controls")
+        }
+    }
+
+    fn resolver(first: &str, subsequent: &str) -> Arc<dyn ProviderControlResolver> {
+        Arc::new(Resolver {
+            first: ProviderTypeId::new(first).expect("first provider type"),
+            subsequent: ProviderTypeId::new(subsequent).expect("subsequent provider type"),
+            calls: AtomicUsize::new(0),
+        })
+    }
+
+    #[test]
+    fn registry_rejects_empty_duplicate_oversized_and_changing_identities() {
+        assert!(matches!(
+            ProviderControlResolverRegistry::new([]),
+            Err(ProviderControlResolverRegistryError::InvalidSize)
+        ));
+        assert!(matches!(
+            ProviderControlResolverRegistry::new([
+                resolver("github", "github"),
+                resolver("github", "github"),
+            ]),
+            Err(ProviderControlResolverRegistryError::Duplicate)
+        ));
+        let oversized = (0..=MAX_PROVIDER_CONTROL_RESOLVERS)
+            .map(|index| {
+                let provider_type = format!("provider-{index}");
+                resolver(&provider_type, &provider_type)
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            ProviderControlResolverRegistry::new(oversized),
+            Err(ProviderControlResolverRegistryError::InvalidSize)
+        ));
+        assert!(matches!(
+            ProviderControlResolverRegistry::new([resolver("github", "forgejo")]),
+            Err(ProviderControlResolverRegistryError::Inconsistent)
+        ));
+    }
+}

--- a/crates/automata-ci-provider-delivery/src/ingress.rs
+++ b/crates/automata-ci-provider-delivery/src/ingress.rs
@@ -265,8 +265,6 @@ const fn repository_error(error: ProviderDeliveryRepositoryError) -> ProviderDel
         }
         ProviderDeliveryRepositoryError::Unavailable => ProviderDeliveryIngressError::Unavailable,
         ProviderDeliveryRepositoryError::EndpointConflict
-        | ProviderDeliveryRepositoryError::ClaimRejected
-        | ProviderDeliveryRepositoryError::AttemptLimitReached
         | ProviderDeliveryRepositoryError::Corrupt => ProviderDeliveryIngressError::Storage,
     }
 }

--- a/crates/automata-ci-provider-delivery/src/lib.rs
+++ b/crates/automata-ci-provider-delivery/src/lib.rs
@@ -4,12 +4,17 @@
 #![deny(missing_docs)]
 
 mod clock;
+mod control;
 mod ingress;
 mod worker;
 
 pub use clock::{ProviderDeliveryClock, ProviderDeliveryClockError, SystemProviderDeliveryClock};
+pub use control::{
+    ProviderControlResolutionError, ProviderControlResolver, ProviderControlResolverRegistry,
+    ProviderControlResolverRegistryError, ProviderProcessingDispatcher, ProviderTriggerProcessor,
+};
 pub use ingress::{PreparedProviderWebhook, ProviderDeliveryIngress, ProviderDeliveryIngressError};
 pub use worker::{
-    ProviderDeliveryProcessOutcome, ProviderDeliveryProcessor, ProviderDeliveryWorker,
-    ProviderDeliveryWorkerConfig, ProviderDeliveryWorkerError, ProviderDeliveryWorkerOutcome,
+    ProviderProcessingOutcome, ProviderProcessingProcessor, ProviderProcessingWorker,
+    ProviderProcessingWorkerConfig, ProviderProcessingWorkerError, ProviderProcessingWorkerOutcome,
 };

--- a/crates/automata-ci-provider-delivery/src/worker.rs
+++ b/crates/automata-ci-provider-delivery/src/worker.rs
@@ -3,9 +3,11 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use automata_ci_core::UnixMillis;
 use automata_ci_provider::{
-    ClaimProviderDelivery, ClaimedProviderDelivery, CompleteProviderDelivery, FailProviderDelivery,
-    ProviderDeliveryFailure, ProviderDeliveryRepository, ProviderDeliveryRepositoryError,
-    ProviderDeliveryWorkerId, RenewProviderDelivery, RetryProviderDelivery,
+    BindProviderProcessingSource, ClaimProviderProcessing, ClaimedProviderProcessing,
+    CompleteProviderProcessing, FailProviderProcessing, ProviderDeliveryId,
+    ProviderProcessingFailure, ProviderProcessingInput, ProviderProcessingRepository,
+    ProviderProcessingRepositoryError, ProviderProcessingWorkerId, RenewProviderProcessing,
+    RetryProviderProcessing,
 };
 use thiserror::Error;
 use tokio::time::{Duration, sleep};
@@ -14,31 +16,33 @@ use crate::ProviderDeliveryClock;
 
 /// Final disposition returned by provider-neutral workflow admission.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ProviderDeliveryProcessOutcome {
+pub enum ProviderProcessingOutcome {
     /// All idempotent workflow-admission work completed.
     Complete,
+    /// Resolve an authenticated control to this immutable trigger delivery.
+    ResolveControl(ProviderDeliveryId),
     /// A transient dependency failure should use the worker retry policy.
-    Retry(ProviderDeliveryFailure),
+    Retry(ProviderProcessingFailure),
     /// Policy or evidence terminally rejects this delivery.
-    Fail(ProviderDeliveryFailure),
+    Fail(ProviderProcessingFailure),
 }
 
 /// Provider-independent workflow admission port invoked under a live claim fence.
 #[async_trait]
-pub trait ProviderDeliveryProcessor: fmt::Debug + Send + Sync {
+pub trait ProviderProcessingProcessor: fmt::Debug + Send + Sync {
     /// Performs idempotent admission for one normalized provider trigger.
-    async fn process(&self, delivery: &ClaimedProviderDelivery) -> ProviderDeliveryProcessOutcome;
+    async fn process(&self, delivery: &ClaimedProviderProcessing) -> ProviderProcessingOutcome;
 }
 
-/// Bounded generic delivery-worker lease and retry policy.
+/// Bounded generic processing-worker lease and retry policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ProviderDeliveryWorkerConfig {
+pub struct ProviderProcessingWorkerConfig {
     lease_millis: u64,
     retry_millis: i64,
 }
 
-impl ProviderDeliveryWorkerConfig {
-    /// Constructs worker timing policy accepted by the common delivery model.
+impl ProviderProcessingWorkerConfig {
+    /// Constructs worker timing policy accepted by the common processing model.
     ///
     /// # Errors
     ///
@@ -46,13 +50,13 @@ impl ProviderDeliveryWorkerConfig {
     pub const fn new(
         lease_millis: u64,
         retry_millis: i64,
-    ) -> Result<Self, ProviderDeliveryWorkerError> {
+    ) -> Result<Self, ProviderProcessingWorkerError> {
         if lease_millis == 0
-            || lease_millis > automata_ci_provider::MAX_PROVIDER_DELIVERY_LEASE_MILLIS as u64
+            || lease_millis > automata_ci_provider::MAX_PROVIDER_PROCESSING_LEASE_MILLIS as u64
             || retry_millis <= 0
-            || retry_millis > automata_ci_provider::MAX_PROVIDER_DELIVERY_RETRY_MILLIS
+            || retry_millis > automata_ci_provider::MAX_PROVIDER_PROCESSING_RETRY_MILLIS
         {
-            return Err(ProviderDeliveryWorkerError::InvalidConfiguration);
+            return Err(ProviderProcessingWorkerError::InvalidConfiguration);
         }
         Ok(Self {
             lease_millis,
@@ -73,24 +77,24 @@ impl ProviderDeliveryWorkerConfig {
     }
 }
 
-/// One provider-neutral fenced delivery worker.
-pub struct ProviderDeliveryWorker {
-    worker_id: ProviderDeliveryWorkerId,
-    repository: Arc<dyn ProviderDeliveryRepository>,
-    processor: Arc<dyn ProviderDeliveryProcessor>,
+/// One provider-neutral fenced processing worker.
+pub struct ProviderProcessingWorker {
+    worker_id: ProviderProcessingWorkerId,
+    repository: Arc<dyn ProviderProcessingRepository>,
+    processor: Arc<dyn ProviderProcessingProcessor>,
     clock: Arc<dyn ProviderDeliveryClock>,
-    config: ProviderDeliveryWorkerConfig,
+    config: ProviderProcessingWorkerConfig,
 }
 
-impl ProviderDeliveryWorker {
+impl ProviderProcessingWorker {
     /// Composes a stable worker identity, durable queue, processor, and clock.
     #[must_use]
     pub fn new(
-        worker_id: ProviderDeliveryWorkerId,
-        repository: Arc<dyn ProviderDeliveryRepository>,
-        processor: Arc<dyn ProviderDeliveryProcessor>,
+        worker_id: ProviderProcessingWorkerId,
+        repository: Arc<dyn ProviderProcessingRepository>,
+        processor: Arc<dyn ProviderProcessingProcessor>,
         clock: Arc<dyn ProviderDeliveryClock>,
-        config: ProviderDeliveryWorkerConfig,
+        config: ProviderProcessingWorkerConfig,
     ) -> Self {
         Self {
             worker_id,
@@ -101,92 +105,115 @@ impl ProviderDeliveryWorker {
         }
     }
 
-    /// Claims and processes at most one provider delivery.
+    /// Claims and processes at most one provider invocation.
     ///
     /// # Errors
     ///
     /// Returns sanitized clock, model, repository, or stale-claim failures.
     pub async fn run_once(
         &self,
-    ) -> Result<ProviderDeliveryWorkerOutcome, ProviderDeliveryWorkerError> {
+    ) -> Result<ProviderProcessingWorkerOutcome, ProviderProcessingWorkerError> {
         let claimed_at = self.now()?;
         let claim =
-            ClaimProviderDelivery::new(self.worker_id, claimed_at, self.config.lease_millis)
-                .map_err(|_| ProviderDeliveryWorkerError::InvalidConfiguration)?;
-        let Some(delivery) = self
+            ClaimProviderProcessing::new(self.worker_id, claimed_at, self.config.lease_millis)
+                .map_err(|_| ProviderProcessingWorkerError::InvalidConfiguration)?;
+        let Some(mut invocation) = self
             .repository
-            .claim_delivery(claim)
+            .claim_processing(claim)
             .await
             .map_err(repository_error)?
         else {
-            return Ok(ProviderDeliveryWorkerOutcome::Idle);
+            return Ok(ProviderProcessingWorkerOutcome::Idle);
         };
-        let disposition = self.process_with_renewal(&delivery).await?;
-        let finished_at = self.now()?;
-        match disposition.outcome {
-            ProviderDeliveryProcessOutcome::Complete => {
-                let command = CompleteProviderDelivery::new(disposition.fence, finished_at)
-                    .map_err(|_| ProviderDeliveryWorkerError::ClaimExpired)?;
-                self.repository
-                    .complete_delivery(command)
-                    .await
-                    .map_err(repository_error)?;
-                Ok(ProviderDeliveryWorkerOutcome::Completed)
-            }
-            ProviderDeliveryProcessOutcome::Retry(failure) => {
-                let retry_at = finished_at
-                    .get()
-                    .checked_add(self.config.retry_millis)
-                    .map(UnixMillis::new)
-                    .ok_or(ProviderDeliveryWorkerError::Clock)?;
-                let command =
-                    RetryProviderDelivery::new(disposition.fence, finished_at, retry_at, failure)
-                        .map_err(|_| ProviderDeliveryWorkerError::ClaimExpired)?;
-                self.repository
-                    .retry_delivery(command)
-                    .await
-                    .map_err(repository_error)?;
-                Ok(ProviderDeliveryWorkerOutcome::Retried)
-            }
-            ProviderDeliveryProcessOutcome::Fail(failure) => {
-                let command = FailProviderDelivery::new(disposition.fence, finished_at, failure)
-                    .map_err(|_| ProviderDeliveryWorkerError::ClaimExpired)?;
-                self.repository
-                    .fail_delivery(command)
-                    .await
-                    .map_err(repository_error)?;
-                Ok(ProviderDeliveryWorkerOutcome::Failed)
+        loop {
+            let disposition = self.process_with_renewal(&invocation).await?;
+            let finished_at = self.now()?;
+            match disposition.outcome {
+                ProviderProcessingOutcome::ResolveControl(source_delivery_id) => {
+                    if !matches!(invocation.input(), ProviderProcessingInput::Control(_)) {
+                        return Err(ProviderProcessingWorkerError::InvalidResolution);
+                    }
+                    let command = BindProviderProcessingSource::new(
+                        disposition.fence,
+                        source_delivery_id,
+                        finished_at,
+                    )
+                    .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                    invocation = self
+                        .repository
+                        .bind_processing_source(command)
+                        .await
+                        .map_err(repository_error)?;
+                }
+                ProviderProcessingOutcome::Complete => {
+                    let command = CompleteProviderProcessing::new(disposition.fence, finished_at)
+                        .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                    self.repository
+                        .complete_processing(command)
+                        .await
+                        .map_err(repository_error)?;
+                    return Ok(ProviderProcessingWorkerOutcome::Completed);
+                }
+                ProviderProcessingOutcome::Retry(failure) => {
+                    let retry_at = finished_at
+                        .get()
+                        .checked_add(self.config.retry_millis)
+                        .map(UnixMillis::new)
+                        .ok_or(ProviderProcessingWorkerError::Clock)?;
+                    let command = RetryProviderProcessing::new(
+                        disposition.fence,
+                        finished_at,
+                        retry_at,
+                        failure,
+                    )
+                    .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                    self.repository
+                        .retry_processing(command)
+                        .await
+                        .map_err(repository_error)?;
+                    return Ok(ProviderProcessingWorkerOutcome::Retried);
+                }
+                ProviderProcessingOutcome::Fail(failure) => {
+                    let command =
+                        FailProviderProcessing::new(disposition.fence, finished_at, failure)
+                            .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                    self.repository
+                        .fail_processing(command)
+                        .await
+                        .map_err(repository_error)?;
+                    return Ok(ProviderProcessingWorkerOutcome::Failed);
+                }
             }
         }
     }
 
-    fn now(&self) -> Result<UnixMillis, ProviderDeliveryWorkerError> {
+    fn now(&self) -> Result<UnixMillis, ProviderProcessingWorkerError> {
         self.clock
             .now()
-            .map_err(|_| ProviderDeliveryWorkerError::Clock)
+            .map_err(|_| ProviderProcessingWorkerError::Clock)
     }
 
     async fn process_with_renewal(
         &self,
-        delivery: &ClaimedProviderDelivery,
-    ) -> Result<ProcessedDelivery, ProviderDeliveryWorkerError> {
+        delivery: &ClaimedProviderProcessing,
+    ) -> Result<ProcessedInvocation, ProviderProcessingWorkerError> {
         let mut fence = delivery.fence();
         let process = self.processor.process(delivery);
         tokio::pin!(process);
         let heartbeat = Duration::from_millis((self.config.lease_millis / 3).max(1));
         loop {
             tokio::select! {
-                outcome = &mut process => return Ok(ProcessedDelivery { outcome, fence }),
+                outcome = &mut process => return Ok(ProcessedInvocation { outcome, fence }),
                 () = sleep(heartbeat) => {
                     let renewed_at = self.now()?;
-                    let renewal = RenewProviderDelivery::new(
+                    let renewal = RenewProviderProcessing::new(
                         fence,
                         renewed_at,
                         self.config.lease_millis,
                     )
-                    .map_err(|_| ProviderDeliveryWorkerError::ClaimExpired)?;
+                    .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
                     fence = self.repository
-                        .renew_delivery(renewal)
+                        .renew_processing(renewal)
                         .await
                         .map_err(repository_error)?;
                 }
@@ -195,15 +222,15 @@ impl ProviderDeliveryWorker {
     }
 }
 
-struct ProcessedDelivery {
-    outcome: ProviderDeliveryProcessOutcome,
-    fence: automata_ci_provider::ProviderDeliveryClaimFence,
+struct ProcessedInvocation {
+    outcome: ProviderProcessingOutcome,
+    fence: automata_ci_provider::ProviderProcessingClaimFence,
 }
 
-impl fmt::Debug for ProviderDeliveryWorker {
+impl fmt::Debug for ProviderProcessingWorker {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("ProviderDeliveryWorker")
+            .debug_struct("ProviderProcessingWorker")
             .field("worker_id", &self.worker_id)
             .field("repository", &self.repository)
             .field("processor", &self.processor)
@@ -215,7 +242,7 @@ impl fmt::Debug for ProviderDeliveryWorker {
 
 /// Result of one bounded generic worker pass.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ProviderDeliveryWorkerOutcome {
+pub enum ProviderProcessingWorkerOutcome {
     /// No eligible delivery existed.
     Idle,
     /// One delivery completed.
@@ -226,35 +253,42 @@ pub enum ProviderDeliveryWorkerOutcome {
     Failed,
 }
 
-/// Sanitized generic delivery-worker failure.
+/// Sanitized generic processing-worker failure.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum ProviderDeliveryWorkerError {
-    /// Timing policy violates common delivery bounds.
-    #[error("provider delivery worker configuration is invalid")]
+pub enum ProviderProcessingWorkerError {
+    /// Timing policy violates common processing bounds.
+    #[error("provider processing worker configuration is invalid")]
     InvalidConfiguration,
     /// Trusted time could not be obtained or represented.
-    #[error("provider delivery worker clock is unavailable")]
+    #[error("provider processing worker clock is unavailable")]
     Clock,
     /// Processing outlived or lost its exact claim fence.
-    #[error("provider delivery worker claim expired")]
+    #[error("provider processing worker claim expired")]
     ClaimExpired,
-    /// Durable delivery storage is unavailable.
-    #[error("provider delivery repository is unavailable")]
+    /// A handler attempted to resolve an already resolved trigger invocation.
+    #[error("provider processing control resolution is invalid")]
+    InvalidResolution,
+    /// Durable processing storage is unavailable.
+    #[error("provider processing repository is unavailable")]
     Unavailable,
-    /// Durable delivery state violated queue invariants.
-    #[error("provider delivery repository rejected the operation")]
+    /// Durable processing state violated queue invariants.
+    #[error("provider processing repository rejected the operation")]
     Repository,
 }
 
-const fn repository_error(error: ProviderDeliveryRepositoryError) -> ProviderDeliveryWorkerError {
+const fn repository_error(
+    error: ProviderProcessingRepositoryError,
+) -> ProviderProcessingWorkerError {
     match error {
-        ProviderDeliveryRepositoryError::Unavailable => ProviderDeliveryWorkerError::Unavailable,
-        ProviderDeliveryRepositoryError::ClaimRejected => ProviderDeliveryWorkerError::ClaimExpired,
-        ProviderDeliveryRepositoryError::EndpointConflict
-        | ProviderDeliveryRepositoryError::NotFound
-        | ProviderDeliveryRepositoryError::ReplayConflict
-        | ProviderDeliveryRepositoryError::AttemptLimitReached
-        | ProviderDeliveryRepositoryError::Corrupt => ProviderDeliveryWorkerError::Repository,
+        ProviderProcessingRepositoryError::Unavailable => {
+            ProviderProcessingWorkerError::Unavailable
+        }
+        ProviderProcessingRepositoryError::ClaimRejected => {
+            ProviderProcessingWorkerError::ClaimExpired
+        }
+        ProviderProcessingRepositoryError::NotFound
+        | ProviderProcessingRepositoryError::AttemptLimitReached
+        | ProviderProcessingRepositoryError::Corrupt => ProviderProcessingWorkerError::Repository,
     }
 }
 
@@ -267,17 +301,18 @@ mod tests {
 
     use automata_ci_core::{GitObjectId, Sha256Digest};
     use automata_ci_provider::{
-        AcceptProviderDelivery, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
+        ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
         ExternalRepositoryIdentity, NormalizedTrigger, ProviderConfigurationRevision,
-        ProviderConnectionId, ProviderConnectionRevision, ProviderDelivery,
-        ProviderDeliveryAcceptOutcome, ProviderDeliveryClaimFence, ProviderDeliveryFuture,
-        ProviderDeliveryId, ProviderDeliveryObservations, ProviderDeliveryReceipt,
-        ProviderDeliveryState, ProviderEventName, ProviderGitRef, ProviderGitRefKind,
-        ProviderInstanceId, ProviderRepository, ProviderRepositoryPath, ProviderSecretGeneration,
-        ProviderSecretName, ProviderTypeId, ProviderWebhookEndpointId,
+        ProviderConnectionId, ProviderConnectionRevision, ProviderControl, ProviderControlDocument,
+        ProviderControlKind, ProviderDeliveryId, ProviderDeliveryObservations, ProviderEventName,
+        ProviderGitRef, ProviderGitRefKind, ProviderInstanceId, ProviderProcessingClaimFence,
+        ProviderProcessingFuture, ProviderProcessingInvocationId, ProviderProcessingReceipt,
+        ProviderProcessingState, ProviderRepository, ProviderRepositoryPath, ProviderSchemaVersion,
+        ProviderSecretGeneration, ProviderSecretName, ProviderTypeId, ProviderWebhookEndpointId,
         ProviderWebhookEndpointRevision, ProviderWebhookSecretReference,
         ProviderWebhookSignatureEvidence, PushCommitEvidence, PushTrigger, RepositoryVisibility,
-        RetryProviderDelivery, VerifiedProviderDelivery, provider_raw_webhook_descriptor,
+        RetryProviderProcessing, VerifiedProviderControlDelivery, VerifiedProviderTriggerDelivery,
+        provider_raw_webhook_descriptor,
     };
 
     use super::*;
@@ -296,54 +331,69 @@ mod tests {
     struct SlowProcessor;
 
     #[async_trait]
-    impl ProviderDeliveryProcessor for SlowProcessor {
+    impl ProviderProcessingProcessor for SlowProcessor {
         async fn process(
             &self,
-            _delivery: &ClaimedProviderDelivery,
-        ) -> ProviderDeliveryProcessOutcome {
+            _delivery: &ClaimedProviderProcessing,
+        ) -> ProviderProcessingOutcome {
             sleep(Duration::from_millis(25)).await;
-            ProviderDeliveryProcessOutcome::Complete
+            ProviderProcessingOutcome::Complete
+        }
+    }
+
+    #[derive(Debug)]
+    struct ResolvingProcessor {
+        source_delivery_id: ProviderDeliveryId,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ProviderProcessingProcessor for ResolvingProcessor {
+        async fn process(&self, delivery: &ClaimedProviderProcessing) -> ProviderProcessingOutcome {
+            match (self.calls.fetch_add(1, Ordering::SeqCst), delivery.input()) {
+                (0, ProviderProcessingInput::Control(_)) => {
+                    ProviderProcessingOutcome::ResolveControl(self.source_delivery_id)
+                }
+                (1, ProviderProcessingInput::Trigger(source)) => {
+                    assert_eq!(source.evidence().delivery_id(), self.source_delivery_id);
+                    ProviderProcessingOutcome::Complete
+                }
+                _ => panic!("rerun processing escaped the control-to-trigger sequence"),
+            }
         }
     }
 
     #[derive(Debug)]
     struct RecordingRepository {
-        claim: Mutex<Option<ClaimedProviderDelivery>>,
+        claim: Mutex<Option<ClaimedProviderProcessing>>,
         renewals: AtomicUsize,
-        completed: Mutex<Option<ProviderDeliveryClaimFence>>,
+        completed: Mutex<Option<ProviderProcessingClaimFence>>,
     }
 
-    impl ProviderDeliveryRepository for RecordingRepository {
-        fn accept_delivery(
+    impl ProviderProcessingRepository for RecordingRepository {
+        fn claim_processing(
             &self,
-            _request: AcceptProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, ProviderDeliveryAcceptOutcome> {
-            Box::pin(async { Err(ProviderDeliveryRepositoryError::Corrupt) })
-        }
-
-        fn load_delivery(
-            &self,
-            _delivery_id: ProviderDeliveryId,
-        ) -> ProviderDeliveryFuture<'_, Option<ProviderDelivery>> {
-            Box::pin(async { Err(ProviderDeliveryRepositoryError::Corrupt) })
-        }
-
-        fn claim_delivery(
-            &self,
-            _request: ClaimProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, Option<ClaimedProviderDelivery>> {
+            _request: ClaimProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, Option<ClaimedProviderProcessing>> {
             Box::pin(async move { Ok(self.claim.lock().expect("claim lock").take()) })
         }
 
-        fn renew_delivery(
+        fn bind_processing_source(
             &self,
-            request: RenewProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, ProviderDeliveryClaimFence> {
+            _request: automata_ci_provider::BindProviderProcessingSource,
+        ) -> ProviderProcessingFuture<'_, ClaimedProviderProcessing> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
+        }
+
+        fn renew_processing(
+            &self,
+            request: RenewProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingClaimFence> {
             Box::pin(async move {
                 self.renewals.fetch_add(1, Ordering::SeqCst);
                 let fence = request.fence();
-                ProviderDeliveryClaimFence::new(
-                    fence.delivery_id(),
+                ProviderProcessingClaimFence::new(
+                    fence.invocation_id(),
                     fence.worker_id(),
                     fence.token(),
                     fence.claimed_at(),
@@ -352,60 +402,134 @@ mod tests {
                             + i64::try_from(request.lease_millis()).expect("lease"),
                     ),
                 )
-                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+                .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
             })
         }
 
-        fn complete_delivery(
+        fn complete_processing(
             &self,
-            request: CompleteProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
+            request: CompleteProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
             Box::pin(async move {
                 *self.completed.lock().expect("completion lock") = Some(request.fence());
-                ProviderDeliveryReceipt::new(
-                    request.fence().delivery_id(),
-                    ProviderDeliveryState::Completed,
+                ProviderProcessingReceipt::new(
+                    request.fence().invocation_id(),
+                    ProviderDeliveryId::new(),
+                    Some(ProviderDeliveryId::new()),
+                    ProviderProcessingState::Completed,
                     1,
                     UnixMillis::new(1_000),
                 )
-                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+                .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
             })
         }
 
-        fn retry_delivery(
+        fn retry_processing(
             &self,
-            _request: RetryProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
-            Box::pin(async { Err(ProviderDeliveryRepositoryError::Corrupt) })
+            _request: RetryProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
         }
 
-        fn fail_delivery(
+        fn fail_processing(
             &self,
-            _request: FailProviderDelivery,
-        ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
-            Box::pin(async { Err(ProviderDeliveryRepositoryError::Corrupt) })
+            _request: FailProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct ResolvingRepository {
+        claim: Mutex<Option<ClaimedProviderProcessing>>,
+        bound: ClaimedProviderProcessing,
+        bindings: AtomicUsize,
+        completed: Mutex<Option<ProviderProcessingClaimFence>>,
+    }
+
+    impl ProviderProcessingRepository for ResolvingRepository {
+        fn claim_processing(
+            &self,
+            _request: ClaimProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, Option<ClaimedProviderProcessing>> {
+            Box::pin(async move { Ok(self.claim.lock().expect("claim lock").take()) })
+        }
+
+        fn bind_processing_source(
+            &self,
+            request: BindProviderProcessingSource,
+        ) -> ProviderProcessingFuture<'_, ClaimedProviderProcessing> {
+            Box::pin(async move {
+                assert_eq!(
+                    request.source_delivery_id(),
+                    self.bound.receipt().source_delivery_id().expect("source")
+                );
+                assert_eq!(request.fence(), self.bound.fence());
+                self.bindings.fetch_add(1, Ordering::SeqCst);
+                Ok(self.bound.clone())
+            })
+        }
+
+        fn renew_processing(
+            &self,
+            _request: RenewProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingClaimFence> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
+        }
+
+        fn complete_processing(
+            &self,
+            request: CompleteProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+            Box::pin(async move {
+                *self.completed.lock().expect("completion lock") = Some(request.fence());
+                let receipt = self.bound.receipt();
+                ProviderProcessingReceipt::new(
+                    receipt.invocation_id(),
+                    receipt.cause_delivery_id(),
+                    receipt.source_delivery_id(),
+                    ProviderProcessingState::Completed,
+                    receipt.attempts(),
+                    receipt.created_at(),
+                )
+                .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
+            })
+        }
+
+        fn retry_processing(
+            &self,
+            _request: RetryProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
+        }
+
+        fn fail_processing(
+            &self,
+            _request: FailProviderProcessing,
+        ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+            Box::pin(async { Err(ProviderProcessingRepositoryError::Corrupt) })
         }
     }
 
     #[tokio::test]
     async fn long_processing_renews_and_completes_with_the_latest_fence() {
-        let worker_id = ProviderDeliveryWorkerId::new();
+        let worker_id = ProviderProcessingWorkerId::new();
         let repository = Arc::new(RecordingRepository {
             claim: Mutex::new(Some(claimed(worker_id))),
             renewals: AtomicUsize::new(0),
             completed: Mutex::new(None),
         });
-        let worker = ProviderDeliveryWorker::new(
+        let worker = ProviderProcessingWorker::new(
             worker_id,
-            Arc::clone(&repository) as Arc<dyn ProviderDeliveryRepository>,
+            Arc::clone(&repository) as Arc<dyn ProviderProcessingRepository>,
             Arc::new(SlowProcessor),
             Arc::new(StepClock(AtomicI64::new(1_000))),
-            ProviderDeliveryWorkerConfig::new(30, 30).expect("config"),
+            ProviderProcessingWorkerConfig::new(30, 30).expect("config"),
         );
 
         assert_eq!(
             worker.run_once().await.expect("worker pass"),
-            ProviderDeliveryWorkerOutcome::Completed
+            ProviderProcessingWorkerOutcome::Completed
         );
         assert!(repository.renewals.load(Ordering::SeqCst) >= 1);
         assert!(
@@ -419,7 +543,145 @@ mod tests {
         );
     }
 
-    fn claimed(worker_id: ProviderDeliveryWorkerId) -> ClaimedProviderDelivery {
+    #[tokio::test]
+    async fn rerun_control_resolves_and_processes_a_fresh_trigger_invocation() {
+        let worker_id = ProviderProcessingWorkerId::new();
+        let (control, bound, source_delivery_id) = rerun_claims(worker_id);
+        let repository = Arc::new(ResolvingRepository {
+            claim: Mutex::new(Some(control)),
+            bound,
+            bindings: AtomicUsize::new(0),
+            completed: Mutex::new(None),
+        });
+        let processor = Arc::new(ResolvingProcessor {
+            source_delivery_id,
+            calls: AtomicUsize::new(0),
+        });
+        let worker = ProviderProcessingWorker::new(
+            worker_id,
+            Arc::clone(&repository) as Arc<dyn ProviderProcessingRepository>,
+            Arc::clone(&processor) as Arc<dyn ProviderProcessingProcessor>,
+            Arc::new(StepClock(AtomicI64::new(1_000))),
+            ProviderProcessingWorkerConfig::new(60, 30).expect("config"),
+        );
+
+        assert_eq!(
+            worker.run_once().await.expect("worker pass"),
+            ProviderProcessingWorkerOutcome::Completed
+        );
+        assert_eq!(repository.bindings.load(Ordering::SeqCst), 1);
+        assert_eq!(processor.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            repository
+                .completed
+                .lock()
+                .expect("completion lock")
+                .expect("completion fence"),
+            repository.bound.fence()
+        );
+    }
+
+    fn rerun_claims(
+        worker_id: ProviderProcessingWorkerId,
+    ) -> (
+        ClaimedProviderProcessing,
+        ClaimedProviderProcessing,
+        ProviderDeliveryId,
+    ) {
+        let source_claim = claimed(worker_id);
+        let ProviderProcessingInput::Trigger(source) = source_claim.input().clone() else {
+            unreachable!("fixture is a trigger");
+        };
+        let source_delivery_id = source.evidence().delivery_id();
+        let cause_delivery_id = ProviderDeliveryId::new();
+        let source_evidence = source.evidence();
+        let control_evidence = automata_ci_provider::ProviderDeliveryEvidence::rehydrate(
+            cause_delivery_id,
+            source_evidence.endpoint_id(),
+            source_evidence.endpoint_revision(),
+            source_evidence.provider_type().clone(),
+            source_evidence.instance_id(),
+            source_evidence.provider_revision(),
+            source_evidence.connection_id(),
+            source_evidence.connection_revision(),
+            ExternalDeliveryIdentity::new(
+                source_evidence.instance_id(),
+                ExternalDeliveryId::new("delivery-rerequested").expect("delivery"),
+            ),
+            ProviderEventName::new("check_run").expect("event"),
+            source_evidence.received_at(),
+            source_evidence.raw_body().clone(),
+            source_evidence.raw_retain_until(),
+            source_evidence.signature().clone(),
+            source_evidence.observations().clone(),
+        )
+        .expect("control evidence");
+        let repository = source
+            .trigger()
+            .trigger()
+            .target_repository()
+            .identity()
+            .clone();
+        let control = ProviderControl::new(
+            ProviderControlKind::Rerun,
+            repository,
+            GitObjectId::from_provider_hex("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+                .expect("object"),
+            None,
+            ProviderControlDocument::new(
+                ProviderSchemaVersion::new(1).expect("schema"),
+                br#"{"schema":1,"target":{"kind":"check_run","run_id":601}}"#.to_vec(),
+            )
+            .expect("document"),
+        )
+        .expect("control");
+        let control = VerifiedProviderControlDelivery::rehydrate(control_evidence, control)
+            .expect("verified control");
+        let invocation_id = source_claim.receipt().invocation_id();
+        let fence = ProviderProcessingClaimFence::new(
+            invocation_id,
+            worker_id,
+            source_claim.fence().token(),
+            UnixMillis::new(1_000),
+            UnixMillis::new(1_060),
+        )
+        .expect("claim fence");
+        let control_receipt = ProviderProcessingReceipt::new(
+            invocation_id,
+            cause_delivery_id,
+            None,
+            ProviderProcessingState::Claimed,
+            1,
+            source_claim.receipt().created_at(),
+        )
+        .expect("control receipt");
+        let bound_receipt = ProviderProcessingReceipt::new(
+            invocation_id,
+            cause_delivery_id,
+            Some(source_delivery_id),
+            ProviderProcessingState::Claimed,
+            1,
+            source_claim.receipt().created_at(),
+        )
+        .expect("bound receipt");
+        (
+            ClaimedProviderProcessing::new(
+                control_receipt,
+                ProviderProcessingInput::Control(Box::new(control)),
+                fence,
+            )
+            .expect("control claim"),
+            ClaimedProviderProcessing::new(
+                bound_receipt,
+                ProviderProcessingInput::Trigger(source),
+                fence,
+            )
+            .expect("bound trigger claim"),
+            source_delivery_id,
+        )
+    }
+
+    fn claimed(worker_id: ProviderProcessingWorkerId) -> ClaimedProviderProcessing {
         let instance_id = ProviderInstanceId::new();
         let delivery_id = ProviderDeliveryId::new();
         let repository = ProviderRepository::new(
@@ -456,7 +718,7 @@ mod tests {
         let connection_revision = ProviderConnectionRevision::new(1).expect("connection revision");
         let raw = provider_raw_webhook_descriptor(Sha256Digest::from_bytes([7; 32]), 1)
             .expect("raw descriptor");
-        let delivery = VerifiedProviderDelivery::rehydrate(
+        let evidence = automata_ci_provider::ProviderDeliveryEvidence::rehydrate(
             delivery_id,
             endpoint_id,
             endpoint_revision,
@@ -482,25 +744,34 @@ mod tests {
                 ),
             )
             .expect("signature"),
-            trigger,
             ProviderDeliveryObservations::new(Vec::new()).expect("observations"),
         )
-        .expect("delivery");
-        let receipt = ProviderDeliveryReceipt::new(
+        .expect("evidence");
+        let delivery =
+            VerifiedProviderTriggerDelivery::rehydrate(evidence, trigger).expect("delivery");
+        let invocation_id = ProviderProcessingInvocationId::new();
+        let receipt = ProviderProcessingReceipt::new(
+            invocation_id,
             delivery_id,
-            ProviderDeliveryState::Claimed,
+            Some(delivery_id),
+            ProviderProcessingState::Claimed,
             1,
             UnixMillis::new(950),
         )
         .expect("receipt");
-        let fence = ProviderDeliveryClaimFence::new(
-            delivery_id,
+        let fence = ProviderProcessingClaimFence::new(
+            invocation_id,
             worker_id,
             1,
             UnixMillis::new(1_000),
             UnixMillis::new(1_030),
         )
         .expect("fence");
-        ClaimedProviderDelivery::new(receipt, delivery, fence).expect("claim")
+        ClaimedProviderProcessing::new(
+            receipt,
+            automata_ci_provider::ProviderProcessingInput::Trigger(Box::new(delivery)),
+            fence,
+        )
+        .expect("claim")
     }
 }

--- a/crates/automata-ci-provider-github/src/control.rs
+++ b/crates/automata-ci-provider-github/src/control.rs
@@ -1,0 +1,230 @@
+//! Canonical GitHub-native control evidence decoded by the GitHub resolver.
+
+use automata_ci_provider::{
+    MAX_PROVIDER_CONTROL_DOCUMENT_BYTES, ProviderControlDocument, ProviderSchemaVersion,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::GithubCheckRunAction;
+
+const SCHEMA: u16 = 1;
+
+/// Exact GitHub Check Run target retained inside a common rerun control.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GithubCheckRunControl {
+    installation_id: u64,
+    app_id: u64,
+    run_id: u64,
+    suite_id: u64,
+    external_id: String,
+    action: GithubCheckRunAction,
+}
+
+impl GithubCheckRunControl {
+    /// Constructs bounded positive GitHub Check Run identity.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero, non-durable numeric IDs or an invalid external identity.
+    pub fn new(
+        installation_id: u64,
+        app_id: u64,
+        run_id: u64,
+        suite_id: u64,
+        external_id: impl Into<String>,
+        action: GithubCheckRunAction,
+    ) -> Result<Self, GithubControlError> {
+        let external_id = external_id.into();
+        if [installation_id, app_id, run_id, suite_id]
+            .into_iter()
+            .any(|value| value == 0 || i64::try_from(value).is_err())
+            || external_id.is_empty()
+            || external_id.len() > 1_024
+            || external_id.chars().any(char::is_control)
+        {
+            return Err(GithubControlError);
+        }
+        Ok(Self {
+            installation_id,
+            app_id,
+            run_id,
+            suite_id,
+            external_id,
+            action,
+        })
+    }
+
+    /// Decodes only the current exact canonical GitHub control schema.
+    ///
+    /// # Errors
+    ///
+    /// Rejects schema drift, unknown fields, noncanonical bytes, or invalid values.
+    pub fn decode(document: &ProviderControlDocument) -> Result<Self, GithubControlError> {
+        if document.schema().get() != SCHEMA {
+            return Err(GithubControlError);
+        }
+        let wire: GithubControlDocument =
+            serde_json::from_slice(document.bytes()).map_err(|_| GithubControlError)?;
+        if wire.schema != SCHEMA {
+            return Err(GithubControlError);
+        }
+        let control = match wire.target {
+            GithubControlTarget::CheckRun {
+                app_id,
+                run_id,
+                suite_id,
+                external_id,
+                action,
+            } => Self::new(
+                wire.installation_id,
+                app_id,
+                run_id,
+                suite_id,
+                external_id,
+                parse_action(&action)?,
+            )?,
+        };
+        if control.document()?.bytes() != document.bytes() {
+            return Err(GithubControlError);
+        }
+        Ok(control)
+    }
+
+    /// Encodes the exact canonical adapter document stored by common ingress.
+    ///
+    /// # Errors
+    ///
+    /// Fails only if canonical serialization violates the common document bound.
+    pub fn document(&self) -> Result<ProviderControlDocument, GithubControlError> {
+        let bytes = serde_json::to_vec(&GithubControlDocument {
+            schema: SCHEMA,
+            installation_id: self.installation_id,
+            target: GithubControlTarget::CheckRun {
+                app_id: self.app_id,
+                run_id: self.run_id,
+                suite_id: self.suite_id,
+                external_id: self.external_id.clone(),
+                action: self.action.as_str().to_owned(),
+            },
+        })
+        .map_err(|_| GithubControlError)?;
+        if bytes.len() > MAX_PROVIDER_CONTROL_DOCUMENT_BYTES {
+            return Err(GithubControlError);
+        }
+        ProviderControlDocument::new(
+            ProviderSchemaVersion::new(SCHEMA).map_err(|_| GithubControlError)?,
+            bytes,
+        )
+        .map_err(|_| GithubControlError)
+    }
+
+    /// Returns the GitHub App installation.
+    #[must_use]
+    pub const fn installation_id(&self) -> u64 {
+        self.installation_id
+    }
+
+    /// Returns the GitHub App that owns the Check.
+    #[must_use]
+    pub const fn app_id(&self) -> u64 {
+        self.app_id
+    }
+
+    /// Returns the exact Check Run identity.
+    #[must_use]
+    pub const fn run_id(&self) -> u64 {
+        self.run_id
+    }
+
+    /// Returns the exact parent Check Suite identity.
+    #[must_use]
+    pub const fn suite_id(&self) -> u64 {
+        self.suite_id
+    }
+
+    /// Returns Automata's external result-subject identity echoed by GitHub.
+    #[must_use]
+    pub fn external_id(&self) -> &str {
+        &self.external_id
+    }
+
+    /// Returns the requested Check Run rerun action.
+    #[must_use]
+    pub const fn action(&self) -> GithubCheckRunAction {
+        self.action
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct GithubControlDocument {
+    schema: u16,
+    installation_id: u64,
+    target: GithubControlTarget,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum GithubControlTarget {
+    CheckRun {
+        app_id: u64,
+        run_id: u64,
+        suite_id: u64,
+        external_id: String,
+        action: String,
+    },
+}
+
+fn parse_action(value: &str) -> Result<GithubCheckRunAction, GithubControlError> {
+    match value {
+        "rerequested" => Ok(GithubCheckRunAction::Rerequested),
+        "rerun_all" => Ok(GithubCheckRunAction::RerunAll),
+        "rerun_failed" => Ok(GithubCheckRunAction::RerunFailed),
+        "rerun_job" => Ok(GithubCheckRunAction::RerunJob),
+        _ => Err(GithubControlError),
+    }
+}
+
+/// Invalid or noncanonical GitHub control evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("GitHub control evidence is invalid")]
+pub struct GithubControlError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_document_round_trips_canonically() {
+        let control = GithubCheckRunControl::new(
+            71,
+            501,
+            601,
+            701,
+            "automata-result-subject",
+            GithubCheckRunAction::Rerequested,
+        )
+        .expect("control");
+        let document = control.document().expect("document");
+        assert_eq!(
+            GithubCheckRunControl::decode(&document).expect("decode"),
+            control
+        );
+    }
+
+    #[test]
+    fn unknown_fields_and_noncanonical_bytes_fail_closed() {
+        let schema = ProviderSchemaVersion::new(1).expect("schema");
+        for bytes in [
+            br#"{"schema":1,"installation_id":71,"target":{"kind":"check_run","app_id":501,"run_id":601,"suite_id":701,"external_id":"subject","action":"rerequested","future":true}}"#.to_vec(),
+            br#"{ "schema":1,"installation_id":71,"target":{"kind":"check_run","app_id":501,"run_id":601,"suite_id":701,"external_id":"subject","action":"rerequested"}}"#.to_vec(),
+        ] {
+            let document = ProviderControlDocument::new(schema, bytes).expect("bounded document");
+            assert_eq!(
+                GithubCheckRunControl::decode(&document),
+                Err(GithubControlError)
+            );
+        }
+    }
+}

--- a/crates/automata-ci-provider-github/src/delivery_adapter.rs
+++ b/crates/automata-ci-provider-github/src/delivery_adapter.rs
@@ -7,10 +7,11 @@ use automata_ci_provider::{
     AuthenticatedProviderWebhook, DeliveryAdapter, ExternalChangeId, ExternalDeliveryId,
     ExternalDeliveryIdentity, ExternalMergeQueueId, ExternalRepositoryId,
     ExternalRepositoryIdentity, ExternalSubjectId, ExternalSubjectIdentity, ExternalSubjectKind,
-    MergeQueueActivity, MergeQueueTrigger, NormalizedTrigger, ProviderDeliveryDraft,
-    ProviderDeliveryId, ProviderDeliveryNormalization, ProviderDeliveryObservations,
-    ProviderDeliveryRejection, ProviderDispatchInput, ProviderEventName, ProviderGitRef,
-    ProviderGitRefKind, ProviderRepository, ProviderRepositoryPath,
+    MergeQueueActivity, MergeQueueTrigger, NormalizedTrigger, ProviderControl,
+    ProviderControlDeliveryDraft, ProviderControlKind, ProviderDeliveryId,
+    ProviderDeliveryNormalization, ProviderDeliveryObservations, ProviderDeliveryRejection,
+    ProviderDispatchInput, ProviderEventName, ProviderGitRef, ProviderGitRefKind,
+    ProviderRepository, ProviderRepositoryPath, ProviderTriggerDeliveryDraft,
     ProviderWebhookAuthenticationError, ProviderWebhookAuthenticationRequest,
     ProviderWebhookHeaderName, ProviderWebhookRequest, ProviderWebhookSignatureEvidence,
     PullRequestActivity, PullRequestTrigger, PushCommitEvidence, PushTrigger,
@@ -21,12 +22,12 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Serialize;
 
 use crate::{
-    GithubEventActor, GithubEventActorKind, GithubMergeGroupAction, GithubPullRequestAction,
-    GithubRepositoryVisibility, GithubWebhookError, GithubWebhookRef, GithubWebhookRefKind,
-    GithubWebhookRepository, GithubWebhookVerifier, VerifiedGithubMergeGroup,
-    VerifiedGithubPullRequest, VerifiedGithubPush, VerifiedGithubRepositoryDispatch,
-    VerifiedGithubWebhook, X_GITHUB_DELIVERY, X_GITHUB_EVENT, X_HUB_SIGNATURE_256,
-    factory::decode_connection, webhook::AuthenticatedGithubWebhook,
+    GithubCheckRunControl, GithubEventActor, GithubEventActorKind, GithubMergeGroupAction,
+    GithubPullRequestAction, GithubRepositoryVisibility, GithubWebhookError, GithubWebhookRef,
+    GithubWebhookRefKind, GithubWebhookRepository, GithubWebhookVerifier, VerifiedGithubCheckRun,
+    VerifiedGithubMergeGroup, VerifiedGithubPullRequest, VerifiedGithubPush,
+    VerifiedGithubRepositoryDispatch, VerifiedGithubWebhook, X_GITHUB_DELIVERY, X_GITHUB_EVENT,
+    X_HUB_SIGNATURE_256, factory::decode_connection, webhook::AuthenticatedGithubWebhook,
 };
 
 const GITHUB_SIGNATURE_SCHEME: &str = "github-hmac-sha256";
@@ -166,10 +167,33 @@ fn normalize_authenticated(
         }
     };
     let repository = external_repository(instance_id, native.repository());
-    if matches!(
-        native,
-        VerifiedGithubWebhook::CheckRun(_) | VerifiedGithubWebhook::CheckSuite(_)
-    ) {
+    let observations =
+        observations(&native).expect("fixed GitHub delivery observations satisfy the common bound");
+    if matches!(native, VerifiedGithubWebhook::CheckRun(_)) {
+        let control = match normalize_control(request, &native) {
+            Ok(control) => control,
+            Err(reason) => {
+                return rejected(
+                    authenticated,
+                    external_delivery,
+                    event_type,
+                    Some(repository),
+                    reason,
+                );
+            }
+        };
+        let draft = ProviderControlDeliveryDraft::new(
+            ProviderDeliveryId::new(),
+            external_delivery,
+            event_type,
+            authenticated,
+            control,
+            observations,
+        )
+        .expect("GitHub control normalization preserves common endpoint identities");
+        return ProviderDeliveryNormalization::Control(Box::new(draft));
+    }
+    if matches!(native, VerifiedGithubWebhook::CheckSuite(_)) {
         return rejected(
             authenticated,
             external_delivery,
@@ -178,8 +202,6 @@ fn normalize_authenticated(
             ProviderDeliveryRejection::UnsupportedEvent,
         );
     }
-    let observations =
-        observations(&native).expect("fixed GitHub delivery observations satisfy the common bound");
     let trigger = match normalize_trigger(request, &native) {
         Ok(trigger) => trigger,
         Err(reason) => {
@@ -192,7 +214,7 @@ fn normalize_authenticated(
             );
         }
     };
-    let draft = ProviderDeliveryDraft::new(
+    let draft = ProviderTriggerDeliveryDraft::new(
         ProviderDeliveryId::new(),
         external_delivery,
         event_type,
@@ -201,7 +223,64 @@ fn normalize_authenticated(
         observations,
     )
     .expect("GitHub normalization preserves common endpoint identities");
-    ProviderDeliveryNormalization::Accepted(Box::new(draft))
+    ProviderDeliveryNormalization::Trigger(Box::new(draft))
+}
+
+fn normalize_control(
+    request: &ProviderWebhookRequest,
+    event: &VerifiedGithubWebhook,
+) -> Result<ProviderControl, ProviderDeliveryRejection> {
+    let (repository, object, actor_value, native) = match event {
+        VerifiedGithubWebhook::CheckRun(check) => check_run_control(request, check)?,
+        _ => return Err(ProviderDeliveryRejection::UnsupportedEvent),
+    };
+    let document = native
+        .document()
+        .map_err(|_| ProviderDeliveryRejection::InvalidPayload)?;
+    ProviderControl::new(
+        ProviderControlKind::Rerun,
+        repository,
+        object,
+        Some(actor_value),
+        document,
+    )
+    .map_err(|_| ProviderDeliveryRejection::InvalidPayload)
+}
+
+fn check_run_control(
+    request: &ProviderWebhookRequest,
+    event: &VerifiedGithubCheckRun,
+) -> Result<
+    (
+        ExternalRepositoryIdentity,
+        GitObjectId,
+        ExternalSubjectIdentity,
+        GithubCheckRunControl,
+    ),
+    ProviderDeliveryRejection,
+> {
+    if event.action() != crate::GithubCheckRunAction::Rerequested {
+        return Err(ProviderDeliveryRejection::UnsupportedEvent);
+    }
+    let repository = target_repository(request, event.installation_id().get(), event.repository())?
+        .identity()
+        .clone();
+    let actor =
+        actor(request, Some(event.actor()))?.ok_or(ProviderDeliveryRejection::IncompleteEvent)?;
+    Ok((
+        repository,
+        *event.head_revision(),
+        actor,
+        GithubCheckRunControl::new(
+            event.installation_id().get(),
+            event.app_id().get(),
+            event.run_id().get(),
+            event.suite_id().get(),
+            event.external_id(),
+            event.action(),
+        )
+        .map_err(|_| ProviderDeliveryRejection::InvalidPayload)?,
+    ))
 }
 
 fn normalize_trigger(

--- a/crates/automata-ci-provider-github/src/event/actor.rs
+++ b/crates/automata-ci-provider-github/src/event/actor.rs
@@ -34,10 +34,8 @@ impl GithubEventActorKind {
 
 /// Stable actor facts retained from an authenticated GitHub webhook body.
 ///
-/// Older synthetic and replay fixtures may only provide the durable numeric
-/// identity. Production GitHub payloads additionally retain the bounded login
-/// and closed account kind so authorization can fail closed without reparsing
-/// the raw JSON object.
+/// The bounded login and closed account kind are retained when GitHub supplies
+/// them so authorization can fail closed without reparsing the raw JSON object.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubEventActor {
@@ -54,9 +52,8 @@ impl GithubEventActor {
     ) -> Result<Self, GithubWebhookError> {
         let id = durable_provider_id(id)?;
         let login = login.map(normalize_login).transpose()?;
-        // A future provider kind remains incomplete classification. AUTH-02
-        // can deny trust without making event normalization incompatible with
-        // a provider-side enum extension.
+        // A future provider kind remains incomplete classification, allowing
+        // authorization to deny trust without treating signed bytes as malformed.
         let kind = kind.and_then(GithubEventActorKind::from_webhook);
         Ok(Self { id, login, kind })
     }

--- a/crates/automata-ci-provider-github/src/lib.rs
+++ b/crates/automata-ci-provider-github/src/lib.rs
@@ -7,6 +7,7 @@
 mod changed_files;
 mod checks;
 mod config;
+mod control;
 mod delivery_adapter;
 mod endpoint;
 mod event;
@@ -40,6 +41,7 @@ pub use checks::{
 pub use config::{
     GITHUB_API_VERSION, GithubHttpConfigurationError, GithubHttpLimits, GithubTrustedOrigins,
 };
+pub use control::{GithubCheckRunControl, GithubControlError};
 pub use delivery_adapter::GithubDeliveryAdapter;
 pub use endpoint::GithubHttpEndpoint;
 pub use event::{

--- a/crates/automata-ci-provider-github/src/webhook_event.rs
+++ b/crates/automata-ci-provider-github/src/webhook_event.rs
@@ -160,6 +160,19 @@ pub enum GithubCheckRunAction {
     RerunJob,
 }
 
+impl GithubCheckRunAction {
+    /// Returns the canonical GitHub/Automata action spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Rerequested => "rerequested",
+            Self::RerunAll => "rerun_all",
+            Self::RerunFailed => "rerun_failed",
+            Self::RerunJob => "rerun_job",
+        }
+    }
+}
+
 impl GithubMergeGroupAction {
     /// Returns GitHub's canonical activity spelling.
     #[must_use]
@@ -291,7 +304,7 @@ pub struct VerifiedGithubCheckRun {
     authenticated: AuthenticatedGithubWebhook,
     installation_id: NonZeroU64,
     repository: GithubWebhookRepository,
-    sender_id: NonZeroU64,
+    actor: GithubEventActor,
     app_id: NonZeroU64,
     run_id: NonZeroU64,
     suite_id: NonZeroU64,
@@ -331,10 +344,10 @@ impl VerifiedGithubCheckRun {
     pub const fn repository(&self) -> &GithubWebhookRepository {
         &self.repository
     }
-    /// Returns the nonzero GitHub sender identity to reauthorize.
+    /// Returns the authenticated GitHub sender facts to reauthorize.
     #[must_use]
-    pub const fn sender_id(&self) -> NonZeroU64 {
-        self.sender_id
+    pub const fn actor(&self) -> &GithubEventActor {
+        &self.actor
     }
     /// Returns the GitHub App that owns the Check Run.
     #[must_use]
@@ -377,7 +390,7 @@ impl fmt::Debug for VerifiedGithubCheckRun {
             .field("body_sha256", &self.authenticated.body_sha256())
             .field("installation_id", &self.installation_id)
             .field("repository", &self.repository)
-            .field("sender_id", &self.sender_id)
+            .field("actor", &self.actor)
             .field("app_id", &self.app_id)
             .field("run_id", &self.run_id)
             .field("suite_id", &self.suite_id)
@@ -394,7 +407,7 @@ pub struct VerifiedGithubCheckSuite {
     authenticated: AuthenticatedGithubWebhook,
     installation_id: NonZeroU64,
     repository: GithubWebhookRepository,
-    sender_id: NonZeroU64,
+    actor: GithubEventActor,
     app_id: NonZeroU64,
     suite_id: NonZeroU64,
     head_revision: GitObjectId,
@@ -431,10 +444,10 @@ impl VerifiedGithubCheckSuite {
     pub const fn repository(&self) -> &GithubWebhookRepository {
         &self.repository
     }
-    /// Returns the nonzero GitHub sender identity to reauthorize.
+    /// Returns the authenticated GitHub sender facts to reauthorize.
     #[must_use]
-    pub const fn sender_id(&self) -> NonZeroU64 {
-        self.sender_id
+    pub const fn actor(&self) -> &GithubEventActor {
+        &self.actor
     }
     /// Returns the GitHub App that owns the Check Suite.
     #[must_use]
@@ -462,7 +475,7 @@ impl fmt::Debug for VerifiedGithubCheckSuite {
             .field("body_sha256", &self.authenticated.body_sha256())
             .field("installation_id", &self.installation_id)
             .field("repository", &self.repository)
-            .field("sender_id", &self.sender_id)
+            .field("actor", &self.actor)
             .field("app_id", &self.app_id)
             .field("suite_id", &self.suite_id)
             .field("head_revision", &"[redacted]")
@@ -1077,11 +1090,12 @@ pub(crate) fn normalize_check_run(
     if head_revision != suite_revision {
         return Err(GithubWebhookError::InvalidPayload);
     }
+    let actor = payload.sender.normalize()?;
     Ok(VerifiedGithubCheckRun {
         authenticated,
         installation_id: durable_provider_id(payload.installation.id)?,
         repository: payload.repository.normalize()?,
-        sender_id: durable_provider_id(payload.sender.id)?,
+        actor,
         app_id: durable_provider_id(payload.check_run.app.id)?,
         run_id: durable_provider_id(payload.check_run.id)?,
         suite_id: durable_provider_id(payload.check_run.check_suite.id)?,
@@ -1102,11 +1116,12 @@ pub(crate) fn normalize_check_suite(
     {
         return Err(GithubWebhookError::InvalidPayload);
     }
+    let actor = payload.sender.normalize()?;
     Ok(VerifiedGithubCheckSuite {
         authenticated,
         installation_id: durable_provider_id(payload.installation.id)?,
         repository: payload.repository.normalize()?,
-        sender_id: durable_provider_id(payload.sender.id)?,
+        actor,
         app_id: durable_provider_id(payload.check_suite.app.id)?,
         suite_id: durable_provider_id(payload.check_suite.id)?,
         head_revision: exact_revision(payload.check_suite.head_sha)?,

--- a/crates/automata-ci-provider-github/tests/delivery_adapter.rs
+++ b/crates/automata-ci-provider-github/tests/delivery_adapter.rs
@@ -9,10 +9,10 @@ use automata_ci_provider::{
     DeliveryAdapter as _, ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger,
     ProviderArchiveLimits, ProviderConfigurationRevision, ProviderConnectionConfiguration,
     ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionRevision,
-    ProviderDefaultBranch, ProviderDelivery, ProviderDeliveryRejection, ProviderInstanceId,
-    ProviderLifecycleState, ProviderRepositoryPath, ProviderRunnerPolicyBinding,
-    ProviderSchemaVersion, ProviderSecret, ProviderSecretGeneration, ProviderSecretName,
-    ProviderWebhookAuthenticationError, ProviderWebhookAuthenticationRequest,
+    ProviderControlKind, ProviderDefaultBranch, ProviderDelivery, ProviderDeliveryRejection,
+    ProviderInstanceId, ProviderLifecycleState, ProviderRepositoryPath,
+    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret, ProviderSecretGeneration,
+    ProviderSecretName, ProviderWebhookAuthenticationError, ProviderWebhookAuthenticationRequest,
     ProviderWebhookEndpointId, ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision,
     ProviderWebhookEndpointState, ProviderWebhookHeaderName, ProviderWebhookHeaders,
     ProviderWebhookMethod, ProviderWebhookRequest, ProviderWebhookSecretCandidates,
@@ -241,7 +241,10 @@ fn all_admission_events_normalize_through_the_common_contract() {
             }
         };
         assert_eq!(actual, expected);
-        assert_eq!(delivery.connection_id(), fixture.connection.connection_id());
+        assert_eq!(
+            delivery.evidence().connection_id(),
+            fixture.connection.connection_id()
+        );
     }
 }
 
@@ -266,6 +269,89 @@ fn endpoint_repository_identity_is_enforced_after_authentication() {
         delivery.reason(),
         ProviderDeliveryRejection::PayloadIdentityMismatch
     );
+}
+
+#[test]
+fn rerequested_check_run_becomes_an_authenticated_control() {
+    let fixture = Fixture::new(ProviderInstanceId::new(), "41");
+    let adapter = GithubDeliveryAdapter::new();
+    let authenticated = adapter
+        .authenticate(fixture.authentication(
+            &check_run_rerequested_payload(),
+            "check_run",
+            "delivery-check-run-rerequested",
+            CURRENT_SECRET,
+        ))
+        .expect("signature");
+    let normalized = adapter.normalize(authenticated);
+    let descriptor = normalized.raw_descriptor().expect("raw descriptor");
+    let ProviderDelivery::Control(delivery) = normalized.seal(descriptor).expect("seal") else {
+        panic!("rerequested Check Run was not admitted as a control");
+    };
+    assert_eq!(delivery.control().kind(), ProviderControlKind::Rerun);
+    assert_eq!(delivery.control().repository().external_id().as_str(), "41");
+    assert_eq!(delivery.control().object().to_string(), HEAD_SHA);
+    assert_eq!(
+        delivery
+            .control()
+            .actor()
+            .expect("authenticated sender")
+            .external_id()
+            .as_str(),
+        "301"
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(delivery.control().document().bytes())
+            .expect("canonical document"),
+        json!({
+            "schema": 1,
+            "installation_id": 71,
+            "target": {
+                "kind": "check_run",
+                "app_id": 501,
+                "run_id": 601,
+                "suite_id": 701,
+                "external_id": "automata-result-subject",
+                "action": "rerequested"
+            }
+        })
+    );
+}
+
+#[test]
+fn multi_target_rerun_events_are_rejected_until_selection_is_common() {
+    let fixture = Fixture::new(ProviderInstanceId::new(), "41");
+    let adapter = GithubDeliveryAdapter::new();
+    let mut requested_action = check_run_rerequested_payload();
+    requested_action["action"] = json!("requested_action");
+    requested_action["requested_action"] = json!({"identifier": "rerun_failed"});
+
+    for (payload, event, delivery_id) in [
+        (
+            requested_action,
+            "check_run",
+            "delivery-check-run-rerun-failed",
+        ),
+        (
+            check_suite_rerequested_payload(),
+            "check_suite",
+            "delivery-check-suite-rerequested",
+        ),
+    ] {
+        let authenticated = adapter
+            .authenticate(fixture.authentication(&payload, event, delivery_id, CURRENT_SECRET))
+            .expect("signature");
+        let normalized = adapter.normalize(authenticated);
+        let descriptor = normalized.raw_descriptor().expect("raw descriptor");
+        let ProviderDelivery::Rejected(delivery) = normalized.seal(descriptor).expect("seal")
+        else {
+            panic!("{event} unexpectedly entered singleton control processing");
+        };
+        assert_eq!(
+            delivery.reason(),
+            ProviderDeliveryRejection::UnsupportedEvent
+        );
+    }
 }
 
 #[test]
@@ -316,6 +402,40 @@ fn push_payload() -> Value {
         "installation": { "id": 71 },
         "sender": { "id": 301, "login": "octocat", "type": "User" },
         "commits": [{"id": HEAD_SHA}, {"id": MERGE_SHA}]
+    })
+}
+
+fn check_run_rerequested_payload() -> Value {
+    json!({
+        "action": "rerequested",
+        "check_run": {
+            "id": 601,
+            "head_sha": HEAD_SHA,
+            "external_id": "automata-result-subject",
+            "status": "completed",
+            "conclusion": "failure",
+            "app": { "id": 501 },
+            "check_suite": { "id": 701, "head_sha": HEAD_SHA }
+        },
+        "repository": base_repository(),
+        "installation": { "id": 71 },
+        "sender": { "id": 301, "login": "octocat", "type": "User" }
+    })
+}
+
+fn check_suite_rerequested_payload() -> Value {
+    json!({
+        "action": "rerequested",
+        "check_suite": {
+            "id": 701,
+            "head_sha": HEAD_SHA,
+            "status": "completed",
+            "conclusion": "failure",
+            "app": { "id": 501 }
+        },
+        "repository": base_repository(),
+        "installation": { "id": 71 },
+        "sender": { "id": 301, "login": "octocat", "type": "User" }
     })
 }
 

--- a/crates/automata-ci-provider-github/tests/webhook_event_normalization.rs
+++ b/crates/automata-ci-provider-github/tests/webhook_event_normalization.rs
@@ -25,7 +25,7 @@ fn check_run_controls_retain_exact_signed_identity() {
     };
     assert_eq!(event.installation_id().get(), 71);
     assert_eq!(event.repository().id().get(), 41);
-    assert_eq!(event.sender_id().get(), 301);
+    assert_eq!(event.actor().id().get(), 301);
     assert_eq!(event.app_id().get(), 17);
     assert_eq!(event.run_id().get(), 41);
     assert_eq!(event.suite_id().get(), 23);
@@ -76,7 +76,7 @@ fn check_suite_rerequest_retains_suite_app_sender_and_revision() {
     let VerifiedGithubWebhook::CheckSuite(event) = event else {
         panic!("expected check-suite evidence");
     };
-    assert_eq!(event.sender_id().get(), 301);
+    assert_eq!(event.actor().id().get(), 301);
     assert_eq!(event.app_id().get(), 17);
     assert_eq!(event.suite_id().get(), 23);
     assert_eq!(event.head_revision().to_string(), HEAD_SHA);

--- a/crates/automata-ci-provider-postgres/src/delivery.rs
+++ b/crates/automata-ci-provider-postgres/src/delivery.rs
@@ -1,18 +1,22 @@
 use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
-use automata_ci_core::{Sha256Digest, UnixMillis};
+use automata_ci_core::{GitObjectId, Sha256Digest, UnixMillis};
 use automata_ci_provider::{
-    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
-    CompleteProviderDelivery, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
-    ExternalRepositoryIdentity, FailProviderDelivery, MAX_PROVIDER_DELIVERY_ATTEMPTS,
-    ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionRevision,
-    ProviderDelivery, ProviderDeliveryAcceptOutcome, ProviderDeliveryClaimFence,
-    ProviderDeliveryFailure, ProviderDeliveryId, ProviderDeliveryObservations,
-    ProviderDeliveryReceipt, ProviderDeliveryRejection, ProviderDeliveryRepositoryError,
-    ProviderDeliveryState, ProviderEventName, ProviderInstanceId, ProviderSecretGeneration,
-    ProviderSecretName, ProviderTypeId, ProviderWebhookEndpointId, ProviderWebhookEndpointRevision,
-    ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, RejectedProviderDelivery,
-    RenewProviderDelivery, RetryProviderDelivery, SealedNormalizedTrigger,
-    VerifiedProviderDelivery,
+    AcceptProviderDelivery, BindProviderProcessingSource, ClaimProviderProcessing,
+    ClaimedProviderProcessing, CompleteProviderProcessing, ExternalDeliveryId,
+    ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity, ExternalSubjectId,
+    ExternalSubjectIdentity, ExternalSubjectKind, FailProviderProcessing,
+    MAX_PROVIDER_PROCESSING_ATTEMPTS, ProviderConfigurationRevision, ProviderConnectionId,
+    ProviderConnectionRevision, ProviderControl, ProviderControlDocument, ProviderControlKind,
+    ProviderDelivery, ProviderDeliveryAcceptOutcome, ProviderDeliveryEvidence, ProviderDeliveryId,
+    ProviderDeliveryObservations, ProviderDeliveryReceipt, ProviderDeliveryRejection,
+    ProviderDeliveryRepositoryError, ProviderEventName, ProviderInstanceId,
+    ProviderProcessingClaimFence, ProviderProcessingFailure, ProviderProcessingInvocationId,
+    ProviderProcessingReceipt, ProviderProcessingRepositoryError, ProviderProcessingState,
+    ProviderSchemaVersion, ProviderSecretGeneration, ProviderSecretName, ProviderTypeId,
+    ProviderWebhookEndpointId, ProviderWebhookEndpointRevision, ProviderWebhookSecretReference,
+    ProviderWebhookSignatureEvidence, RejectedProviderDelivery, RenewProviderProcessing,
+    RetryProviderProcessing, SealedNormalizedTrigger, VerifiedProviderControlDelivery,
+    VerifiedProviderTriggerDelivery,
 };
 use sqlx::{FromRow, Postgres, Transaction};
 
@@ -43,29 +47,37 @@ struct DeliveryRow {
     signature_secret_generation: i64,
     disposition: String,
     repository_external_id: Option<String>,
-    normalized_trigger: Option<Vec<u8>>,
-    normalized_trigger_digest: Option<Vec<u8>>,
+    normalized_payload: Option<Vec<u8>>,
+    normalized_payload_digest: Option<Vec<u8>>,
+    control_kind: Option<String>,
+    control_object_id: Option<Vec<u8>>,
+    control_actor_kind: Option<String>,
+    control_actor_external_id: Option<String>,
+    control_document_schema: Option<i64>,
     rejection_reason: Option<String>,
     observations: Vec<u8>,
     observations_digest: Vec<u8>,
-    state: String,
-    attempts: i16,
-    available_at_ms: i64,
     accepted_at_ms: i64,
-    claim_worker_id: Option<uuid::Uuid>,
+}
+
+#[derive(FromRow)]
+struct ProcessingRow {
+    invocation_id: uuid::Uuid,
+    cause_delivery_id: uuid::Uuid,
+    source_delivery_id: Option<uuid::Uuid>,
+    attempts: i16,
+    created_at_ms: i64,
     claim_fence: Option<i64>,
-    claim_started_at_ms: Option<i64>,
-    claim_expires_at_ms: Option<i64>,
-    completed_at_ms: Option<i64>,
-    failure_kind: Option<String>,
 }
 
 #[derive(FromRow)]
 struct ReceiptRow {
-    delivery_id: uuid::Uuid,
+    invocation_id: uuid::Uuid,
+    cause_delivery_id: uuid::Uuid,
+    source_delivery_id: Option<uuid::Uuid>,
     state: String,
     attempts: i16,
-    accepted_at_ms: i64,
+    created_at_ms: i64,
 }
 
 impl PostgresProviderManifestRepository {
@@ -73,7 +85,7 @@ impl PostgresProviderManifestRepository {
         &self,
         request: AcceptProviderDelivery,
     ) -> Result<ProviderDeliveryAcceptOutcome, ProviderDeliveryRepositoryError> {
-        let (delivery, accepted_at) = request.into_parts();
+        let (delivery, invocation_id, accepted_at) = request.into_parts();
         let fingerprint = delivery.replay_fingerprint();
         let mut transaction = self.pool.begin().await.map_err(unavailable)?;
         let inserted = insert_delivery(
@@ -84,25 +96,32 @@ impl PostgresProviderManifestRepository {
         )
         .await?;
         if inserted {
+            if let Some(invocation_id) = invocation_id {
+                insert_initial_invocation(
+                    &mut transaction,
+                    invocation_id,
+                    delivery.delivery_id(),
+                    matches!(delivery, ProviderDelivery::Trigger(_)),
+                    accepted_at,
+                )
+                .await?;
+            }
             transaction.commit().await.map_err(unavailable)?;
-            let receipt = ProviderDeliveryReceipt::new(
-                delivery.delivery_id(),
-                match delivery {
-                    ProviderDelivery::Trigger(_) => ProviderDeliveryState::Pending,
-                    ProviderDelivery::Rejected(_) => ProviderDeliveryState::Discarded,
-                },
-                0,
-                accepted_at,
-            )
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            let receipt =
+                ProviderDeliveryReceipt::new(delivery.delivery_id(), invocation_id, accepted_at)
+                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
             return Ok(ProviderDeliveryAcceptOutcome::Inserted(receipt));
         }
 
         let row = sqlx::query_as::<_, ReceiptReplayRow>(
             r"
-            SELECT delivery_id, state, attempts, accepted_at_ms, replay_fingerprint
-            FROM provider_delivery_records
-            WHERE provider_instance_id = $1 AND external_delivery_id = $2
+            SELECT delivery.delivery_id, delivery.accepted_at_ms,
+                   delivery.replay_fingerprint, invocation.invocation_id
+            FROM provider_deliveries AS delivery
+            LEFT JOIN provider_processing_invocations AS invocation
+              ON invocation.cause_delivery_id = delivery.delivery_id
+            WHERE delivery.provider_instance_id = $1
+              AND delivery.external_delivery_id = $2
             ",
         )
         .bind(delivery.external_delivery().instance_id().as_uuid())
@@ -117,46 +136,50 @@ impl PostgresProviderManifestRepository {
         if digest(row.replay_fingerprint)? != fingerprint.digest() {
             return Err(ProviderDeliveryRepositoryError::ReplayConflict);
         }
-        Ok(ProviderDeliveryAcceptOutcome::Duplicate(decode_receipt(
-            ReceiptRow {
-                delivery_id: row.delivery_id,
-                state: row.state,
-                attempts: row.attempts,
-                accepted_at_ms: row.accepted_at_ms,
-            },
-        )?))
+        let invocation_id = row
+            .invocation_id
+            .map(ProviderProcessingInvocationId::from_uuid)
+            .transpose()
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+        let receipt = ProviderDeliveryReceipt::new(
+            ProviderDeliveryId::from_uuid(row.delivery_id)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            invocation_id,
+            UnixMillis::new(row.accepted_at_ms),
+        )
+        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+        Ok(ProviderDeliveryAcceptOutcome::Duplicate(receipt))
     }
 
     pub(crate) async fn load_delivery_inner(
         &self,
         delivery_id: ProviderDeliveryId,
     ) -> Result<Option<ProviderDelivery>, ProviderDeliveryRepositoryError> {
-        sqlx::query_as::<_, DeliveryRow>(
-            "SELECT * FROM provider_delivery_records WHERE delivery_id = $1",
-        )
-        .bind(delivery_id.as_uuid())
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(unavailable)?
-        .map(decode_delivery)
-        .transpose()
+        sqlx::query_as::<_, DeliveryRow>("SELECT * FROM provider_deliveries WHERE delivery_id = $1")
+            .bind(delivery_id.as_uuid())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(unavailable)?
+            .map(decode_delivery)
+            .transpose()
     }
 
-    pub(crate) async fn claim_delivery_inner(
+    pub(crate) async fn claim_processing_inner(
         &self,
-        request: ClaimProviderDelivery,
-    ) -> Result<Option<ClaimedProviderDelivery>, ProviderDeliveryRepositoryError> {
-        let mut transaction = self.pool.begin().await.map_err(unavailable)?;
-        let row = sqlx::query_as::<_, DeliveryRow>(
+        request: ClaimProviderProcessing,
+    ) -> Result<Option<ClaimedProviderProcessing>, ProviderProcessingRepositoryError> {
+        let mut transaction = self.pool.begin().await.map_err(processing_unavailable)?;
+        let row = sqlx::query_as::<_, ProcessingRow>(
             r"
-            SELECT * FROM provider_delivery_records
-            WHERE disposition = 'trigger'
-              AND attempts < 16
+            SELECT invocation_id, cause_delivery_id, source_delivery_id,
+                   attempts, created_at_ms, claim_fence
+            FROM provider_processing_invocations
+            WHERE attempts < 16
               AND (
                 (state IN ('pending', 'retry-pending') AND available_at_ms <= $1)
                 OR (state = 'claimed' AND claim_expires_at_ms <= $1)
               )
-            ORDER BY available_at_ms, accepted_at_ms, delivery_id
+            ORDER BY available_at_ms, created_at_ms, invocation_id
             FOR UPDATE SKIP LOCKED
             LIMIT 1
             ",
@@ -164,21 +187,21 @@ impl PostgresProviderManifestRepository {
         .bind(request.claimed_at().get())
         .fetch_optional(&mut *transaction)
         .await
-        .map_err(unavailable)?;
+        .map_err(processing_unavailable)?;
         let Some(row) = row else {
-            transaction.commit().await.map_err(unavailable)?;
+            transaction.commit().await.map_err(processing_unavailable)?;
             return Ok(None);
         };
-        let next_attempt = positive_u16(row.attempts)?
+        let next_attempt = processing_positive_u16(row.attempts)?
             .checked_add(1)
-            .ok_or(ProviderDeliveryRepositoryError::AttemptLimitReached)?;
-        if next_attempt > MAX_PROVIDER_DELIVERY_ATTEMPTS {
-            return Err(ProviderDeliveryRepositoryError::AttemptLimitReached);
+            .ok_or(ProviderProcessingRepositoryError::AttemptLimitReached)?;
+        if next_attempt > MAX_PROVIDER_PROCESSING_ATTEMPTS {
+            return Err(ProviderProcessingRepositoryError::AttemptLimitReached);
         }
         let next_fence = match row.claim_fence {
-            Some(value) => positive_u64(value)?
+            Some(value) => processing_positive_u64(value)?
                 .checked_add(1)
-                .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+                .ok_or(ProviderProcessingRepositoryError::Corrupt)?,
             None => 1,
         };
         let expires_at = request
@@ -186,58 +209,50 @@ impl PostgresProviderManifestRepository {
             .get()
             .checked_add(
                 i64::try_from(request.lease_millis())
-                    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                    .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
             )
-            .ok_or(ProviderDeliveryRepositoryError::Corrupt)?;
+            .ok_or(ProviderProcessingRepositoryError::Corrupt)?;
         sqlx::query(
             r"
-            UPDATE provider_delivery_records
+            UPDATE provider_processing_invocations
             SET state = 'claimed', attempts = $2, claim_worker_id = $3,
                 claim_fence = $4, claim_started_at_ms = $6,
                 claim_expires_at_ms = $5, failure_kind = NULL
-            WHERE delivery_id = $1
+            WHERE invocation_id = $1
             ",
         )
-        .bind(row.delivery_id)
-        .bind(i16::try_from(next_attempt).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?)
+        .bind(row.invocation_id)
+        .bind(i16::try_from(next_attempt).map_err(|_| ProviderProcessingRepositoryError::Corrupt)?)
         .bind(request.worker_id().as_uuid())
-        .bind(durable_u64(next_fence)?)
+        .bind(processing_durable_u64(next_fence)?)
         .bind(expires_at)
         .bind(request.claimed_at().get())
         .execute(&mut *transaction)
         .await
-        .map_err(unavailable)?;
-        transaction.commit().await.map_err(unavailable)?;
-
-        let accepted_at = row.accepted_at_ms;
-        let delivery = match decode_delivery(row)? {
-            ProviderDelivery::Trigger(value) => *value,
-            ProviderDelivery::Rejected(_) => return Err(ProviderDeliveryRepositoryError::Corrupt),
-        };
-        let receipt = ProviderDeliveryReceipt::new(
-            delivery.delivery_id(),
-            ProviderDeliveryState::Claimed,
+        .map_err(processing_unavailable)?;
+        let delivery_row = sqlx::query_as::<_, DeliveryRow>(
+            "SELECT * FROM provider_deliveries WHERE delivery_id = $1",
+        )
+        .bind(row.source_delivery_id.unwrap_or(row.cause_delivery_id))
+        .fetch_one(&mut *transaction)
+        .await
+        .map_err(processing_unavailable)?;
+        transaction.commit().await.map_err(processing_unavailable)?;
+        decode_claim(
+            &row,
+            delivery_row,
+            request,
             next_attempt,
-            UnixMillis::new(accepted_at),
-        )
-        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
-        let fence = ProviderDeliveryClaimFence::new(
-            delivery.delivery_id(),
-            request.worker_id(),
             next_fence,
-            request.claimed_at(),
-            UnixMillis::new(expires_at),
+            expires_at,
         )
-        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
-        ClaimedProviderDelivery::new(receipt, delivery, fence)
-            .map(Some)
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+        .map(Some)
     }
 
-    pub(crate) async fn complete_delivery_inner(
+    pub(crate) async fn complete_processing_inner(
         &self,
-        request: CompleteProviderDelivery,
-    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        request: CompleteProviderProcessing,
+    ) -> Result<ProviderProcessingReceipt, ProviderProcessingRepositoryError> {
         mutate_claim(
             &self.pool,
             request.fence(),
@@ -249,23 +264,23 @@ impl PostgresProviderManifestRepository {
         .await
     }
 
-    pub(crate) async fn renew_delivery_inner(
+    pub(crate) async fn renew_processing_inner(
         &self,
-        request: RenewProviderDelivery,
-    ) -> Result<ProviderDeliveryClaimFence, ProviderDeliveryRepositoryError> {
+        request: RenewProviderProcessing,
+    ) -> Result<ProviderProcessingClaimFence, ProviderProcessingRepositoryError> {
         let fence = request.fence();
         let extension = i64::try_from(request.lease_millis())
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?;
         let expires_at = request
             .renewed_at()
             .get()
             .checked_add(extension)
-            .ok_or(ProviderDeliveryRepositoryError::Corrupt)?;
+            .ok_or(ProviderProcessingRepositoryError::Corrupt)?;
         let renewed = sqlx::query_scalar::<_, i64>(
             r"
-            UPDATE provider_delivery_records
+            UPDATE provider_processing_invocations
             SET claim_expires_at_ms = $5
-            WHERE delivery_id = $1 AND state = 'claimed'
+            WHERE invocation_id = $1 AND state = 'claimed'
               AND claim_worker_id = $2 AND claim_fence = $3
               AND claim_started_at_ms <= $4
               AND claim_expires_at_ms > $4
@@ -274,30 +289,30 @@ impl PostgresProviderManifestRepository {
             RETURNING claim_expires_at_ms
             ",
         )
-        .bind(fence.delivery_id().as_uuid())
+        .bind(fence.invocation_id().as_uuid())
         .bind(fence.worker_id().as_uuid())
-        .bind(durable_u64(fence.token())?)
+        .bind(processing_durable_u64(fence.token())?)
         .bind(request.renewed_at().get())
         .bind(expires_at)
         .bind(fence.expires_at().get())
         .fetch_optional(&self.pool)
         .await
-        .map_err(unavailable)?
-        .ok_or(ProviderDeliveryRepositoryError::ClaimRejected)?;
-        ProviderDeliveryClaimFence::new(
-            fence.delivery_id(),
+        .map_err(processing_unavailable)?
+        .ok_or(ProviderProcessingRepositoryError::ClaimRejected)?;
+        ProviderProcessingClaimFence::new(
+            fence.invocation_id(),
             fence.worker_id(),
             fence.token(),
             fence.claimed_at(),
             UnixMillis::new(renewed),
         )
-        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+        .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
     }
 
-    pub(crate) async fn retry_delivery_inner(
+    pub(crate) async fn retry_processing_inner(
         &self,
-        request: RetryProviderDelivery,
-    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        request: RetryProviderProcessing,
+    ) -> Result<ProviderProcessingReceipt, ProviderProcessingRepositoryError> {
         mutate_claim(
             &self.pool,
             request.fence(),
@@ -309,10 +324,10 @@ impl PostgresProviderManifestRepository {
         .await
     }
 
-    pub(crate) async fn fail_delivery_inner(
+    pub(crate) async fn fail_processing_inner(
         &self,
-        request: FailProviderDelivery,
-    ) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+        request: FailProviderProcessing,
+    ) -> Result<ProviderProcessingReceipt, ProviderProcessingRepositoryError> {
         mutate_claim(
             &self.pool,
             request.fence(),
@@ -323,15 +338,112 @@ impl PostgresProviderManifestRepository {
         )
         .await
     }
+
+    pub(crate) async fn bind_processing_source_inner(
+        &self,
+        request: BindProviderProcessingSource,
+    ) -> Result<ClaimedProviderProcessing, ProviderProcessingRepositoryError> {
+        let fence = request.fence();
+        let row = sqlx::query_as::<_, ReceiptRow>(
+            r"
+            UPDATE provider_processing_invocations AS invocation
+            SET source_delivery_id = source.delivery_id,
+                source_disposition = source.disposition
+            FROM provider_deliveries AS source
+            WHERE invocation.invocation_id = $1
+              AND invocation.state = 'claimed'
+              AND invocation.claim_worker_id = $2
+              AND invocation.claim_fence = $3
+              AND invocation.claim_started_at_ms <= $4
+              AND invocation.claim_expires_at_ms > $4
+              AND invocation.source_delivery_id IS NULL
+              AND source.delivery_id = $5
+              AND source.disposition = 'trigger'
+            RETURNING invocation.invocation_id, invocation.cause_delivery_id,
+                      invocation.source_delivery_id, invocation.state,
+                      invocation.attempts, invocation.created_at_ms
+            ",
+        )
+        .bind(fence.invocation_id().as_uuid())
+        .bind(fence.worker_id().as_uuid())
+        .bind(processing_durable_u64(fence.token())?)
+        .bind(request.bound_at().get())
+        .bind(request.source_delivery_id().as_uuid())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(processing_unavailable)?
+        .ok_or(ProviderProcessingRepositoryError::ClaimRejected)?;
+        let receipt = decode_receipt(row)?;
+        let input = match self
+            .load_delivery_inner(request.source_delivery_id())
+            .await
+            .map_err(processing_from_delivery)?
+            .ok_or(ProviderProcessingRepositoryError::NotFound)?
+        {
+            ProviderDelivery::Trigger(delivery) => {
+                automata_ci_provider::ProviderProcessingInput::Trigger(delivery)
+            }
+            ProviderDelivery::Control(_) | ProviderDelivery::Rejected(_) => {
+                return Err(ProviderProcessingRepositoryError::Corrupt);
+            }
+        };
+        ClaimedProviderProcessing::new(receipt, input, fence)
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
+    }
+}
+
+fn decode_claim(
+    row: &ProcessingRow,
+    delivery_row: DeliveryRow,
+    request: ClaimProviderProcessing,
+    attempt: u16,
+    fence_token: u64,
+    expires_at: i64,
+) -> Result<ClaimedProviderProcessing, ProviderProcessingRepositoryError> {
+    let input = match decode_delivery(delivery_row).map_err(processing_from_delivery)? {
+        ProviderDelivery::Trigger(value) => {
+            automata_ci_provider::ProviderProcessingInput::Trigger(value)
+        }
+        ProviderDelivery::Control(value) => {
+            automata_ci_provider::ProviderProcessingInput::Control(value)
+        }
+        ProviderDelivery::Rejected(_) => {
+            return Err(ProviderProcessingRepositoryError::Corrupt);
+        }
+    };
+    let invocation_id = ProviderProcessingInvocationId::from_uuid(row.invocation_id)
+        .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?;
+    let receipt = ProviderProcessingReceipt::new(
+        invocation_id,
+        ProviderDeliveryId::from_uuid(row.cause_delivery_id)
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
+        row.source_delivery_id
+            .map(ProviderDeliveryId::from_uuid)
+            .transpose()
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
+        ProviderProcessingState::Claimed,
+        attempt,
+        UnixMillis::new(row.created_at_ms),
+    )
+    .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?;
+    let fence = ProviderProcessingClaimFence::new(
+        invocation_id,
+        request.worker_id(),
+        fence_token,
+        request.claimed_at(),
+        UnixMillis::new(expires_at),
+    )
+    .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?;
+    ClaimedProviderProcessing::new(receipt, input, fence)
+        .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
 }
 
 #[derive(FromRow)]
 struct ReceiptReplayRow {
     delivery_id: uuid::Uuid,
-    state: String,
-    attempts: i16,
     accepted_at_ms: i64,
     replay_fingerprint: Vec<u8>,
+    invocation_id: Option<uuid::Uuid>,
 }
 
 #[allow(clippy::too_many_lines)] // Ordered bindings mirror one immutable delivery record.
@@ -341,44 +453,24 @@ async fn insert_delivery(
     accepted_at: UnixMillis,
     fingerprint: Sha256Digest,
 ) -> Result<bool, ProviderDeliveryRepositoryError> {
+    let evidence = match delivery {
+        ProviderDelivery::Trigger(value) => value.evidence(),
+        ProviderDelivery::Control(value) => value.evidence(),
+        ProviderDelivery::Rejected(value) => value.evidence(),
+    };
     let (
-        delivery_id,
-        endpoint_id,
-        endpoint_revision,
-        provider_type,
-        instance_id,
-        provider_revision,
-        connection_id,
-        connection_revision,
-        external_delivery,
-        event_type,
-        received_at,
-        raw_body,
-        raw_retain_until,
-        signature,
         disposition,
         repository_id,
-        trigger_bytes,
-        trigger_digest,
+        normalized_bytes,
+        normalized_digest,
+        control_kind,
+        control_object_id,
+        control_actor_kind,
+        control_actor_id,
+        control_document_schema,
         rejection,
-        observations,
-        state,
     ) = match delivery {
         ProviderDelivery::Trigger(value) => (
-            value.delivery_id(),
-            value.endpoint_id(),
-            value.endpoint_revision(),
-            value.provider_type(),
-            value.instance_id(),
-            value.provider_revision(),
-            value.connection_id(),
-            value.connection_revision(),
-            value.external_delivery(),
-            value.event_type(),
-            value.received_at(),
-            value.raw_body(),
-            value.raw_retain_until(),
-            value.signature(),
             "trigger",
             Some(
                 value
@@ -392,38 +484,48 @@ async fn insert_delivery(
             Some(value.trigger().canonical_bytes()),
             Some(value.trigger().digest()),
             None,
-            value.observations(),
-            "pending",
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        ProviderDelivery::Control(value) => (
+            "control",
+            Some(value.control().repository().external_id().as_str()),
+            Some(value.control().document().bytes()),
+            Some(value.control().document().digest()),
+            Some(control_kind(value.control().kind())),
+            Some(value.control().object().as_bytes().to_vec()),
+            value
+                .control()
+                .actor()
+                .map(|actor| subject_kind(actor.kind())),
+            value
+                .control()
+                .actor()
+                .map(|actor| actor.external_id().as_str()),
+            Some(i64::from(value.control().document().schema().get())),
+            None,
         ),
         ProviderDelivery::Rejected(value) => (
-            value.delivery_id(),
-            value.endpoint_id(),
-            value.endpoint_revision(),
-            value.provider_type(),
-            value.instance_id(),
-            value.provider_revision(),
-            value.connection_id(),
-            value.connection_revision(),
-            value.external_delivery(),
-            value.event_type(),
-            value.received_at(),
-            value.raw_body(),
-            value.raw_retain_until(),
-            value.signature(),
             "rejected",
             value
                 .repository()
                 .map(|identity| identity.external_id().as_str()),
             None,
             None,
+            None,
+            None,
+            None,
+            None,
+            None,
             Some(rejection_text(value.reason())),
-            value.observations(),
-            "discarded",
         ),
     };
     let result = sqlx::query(
         r"
-        INSERT INTO provider_delivery_records (
+        INSERT INTO provider_deliveries (
             delivery_id, provider_instance_id, external_delivery_id,
             replay_fingerprint, endpoint_id, endpoint_revision, provider_type,
             provider_revision, connection_id, connection_revision, event_type,
@@ -431,46 +533,54 @@ async fn insert_delivery(
             raw_media_type, raw_retain_until_ms, signature_scheme,
             signature_configuration_revision,
             signature_secret_name, signature_secret_generation, disposition,
-            repository_external_id, normalized_trigger, normalized_trigger_digest,
-            rejection_reason, observations, observations_digest, state, attempts,
-            available_at_ms, accepted_at_ms
+            repository_external_id, normalized_payload, normalized_payload_digest,
+            control_kind, control_object_id, control_actor_kind,
+            control_actor_external_id, control_document_schema,
+            rejection_reason, observations, observations_digest, accepted_at_ms
         ) VALUES (
             $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
-            $18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,0,$30,$30
+            $18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,
+            $33,$34
         ) ON CONFLICT DO NOTHING
         ",
     )
-    .bind(delivery_id.as_uuid())
-    .bind(instance_id.as_uuid())
-    .bind(external_delivery.external_id().as_str())
+    .bind(evidence.delivery_id().as_uuid())
+    .bind(evidence.instance_id().as_uuid())
+    .bind(evidence.external_delivery().external_id().as_str())
     .bind(fingerprint.as_bytes().as_slice())
-    .bind(endpoint_id.as_uuid())
-    .bind(durable_u64(endpoint_revision.get())?)
-    .bind(provider_type.as_str())
-    .bind(durable_u64(provider_revision.get())?)
-    .bind(connection_id.as_uuid())
-    .bind(durable_u64(connection_revision.get())?)
-    .bind(event_type.as_str())
-    .bind(received_at.get())
-    .bind(raw_body.key().as_str())
-    .bind(raw_body.digest().as_bytes().as_slice())
-    .bind(durable_u64(raw_body.size())?)
-    .bind(raw_body.media_type().as_str())
-    .bind(raw_retain_until.get())
-    .bind(signature.scheme())
+    .bind(evidence.endpoint_id().as_uuid())
+    .bind(durable_u64(evidence.endpoint_revision().get())?)
+    .bind(evidence.provider_type().as_str())
+    .bind(durable_u64(evidence.provider_revision().get())?)
+    .bind(evidence.connection_id().as_uuid())
+    .bind(durable_u64(evidence.connection_revision().get())?)
+    .bind(evidence.event_type().as_str())
+    .bind(evidence.received_at().get())
+    .bind(evidence.raw_body().key().as_str())
+    .bind(evidence.raw_body().digest().as_bytes().as_slice())
+    .bind(durable_u64(evidence.raw_body().size())?)
+    .bind(evidence.raw_body().media_type().as_str())
+    .bind(evidence.raw_retain_until().get())
+    .bind(evidence.signature().scheme())
     .bind(durable_u64(
-        signature.secret().configuration_revision().get(),
+        evidence.signature().secret().configuration_revision().get(),
     )?)
-    .bind(signature.secret().name().as_str())
-    .bind(durable_u64(signature.secret().generation().get())?)
+    .bind(evidence.signature().secret().name().as_str())
+    .bind(durable_u64(
+        evidence.signature().secret().generation().get(),
+    )?)
     .bind(disposition)
     .bind(repository_id)
-    .bind(trigger_bytes)
-    .bind(trigger_digest.map(|value| value.as_bytes().to_vec()))
+    .bind(normalized_bytes)
+    .bind(normalized_digest.map(|value| value.as_bytes().to_vec()))
+    .bind(control_kind)
+    .bind(control_object_id)
+    .bind(control_actor_kind)
+    .bind(control_actor_id)
+    .bind(control_document_schema)
     .bind(rejection)
-    .bind(observations.canonical_bytes())
-    .bind(observations.digest().as_bytes().as_slice())
-    .bind(state)
+    .bind(evidence.observations().canonical_bytes())
+    .bind(evidence.observations().digest().as_bytes().as_slice())
     .bind(accepted_at.get())
     .execute(&mut **transaction)
     .await
@@ -478,32 +588,62 @@ async fn insert_delivery(
     Ok(result.rows_affected() == 1)
 }
 
+async fn insert_initial_invocation(
+    transaction: &mut Transaction<'_, Postgres>,
+    invocation_id: ProviderProcessingInvocationId,
+    delivery_id: ProviderDeliveryId,
+    has_source: bool,
+    created_at: UnixMillis,
+) -> Result<(), ProviderDeliveryRepositoryError> {
+    let inserted = sqlx::query(
+        r"
+        INSERT INTO provider_processing_invocations (
+            invocation_id, cause_delivery_id, source_delivery_id,
+            source_disposition, state, attempts, available_at_ms, created_at_ms
+        ) VALUES ($1, $2, $3, $4, 'pending', 0, $5, $5)
+        ",
+    )
+    .bind(invocation_id.as_uuid())
+    .bind(delivery_id.as_uuid())
+    .bind(has_source.then(|| delivery_id.as_uuid()))
+    .bind(has_source.then_some("trigger"))
+    .bind(created_at.get())
+    .execute(&mut **transaction)
+    .await
+    .map_err(unavailable)?;
+    if inserted.rows_affected() != 1 {
+        return Err(ProviderDeliveryRepositoryError::Corrupt);
+    }
+    Ok(())
+}
+
 async fn mutate_claim(
     pool: &sqlx::PgPool,
-    fence: ProviderDeliveryClaimFence,
+    fence: ProviderProcessingClaimFence,
     mutation_at: UnixMillis,
     state: &'static str,
     available_or_completed_at: UnixMillis,
-    failure: Option<ProviderDeliveryFailure>,
-) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+    failure: Option<ProviderProcessingFailure>,
+) -> Result<ProviderProcessingReceipt, ProviderProcessingRepositoryError> {
     let completed_at =
         matches!(state, "completed" | "failed").then_some(available_or_completed_at.get());
     let row = sqlx::query_as::<_, ReceiptRow>(
         r"
-        UPDATE provider_delivery_records
+        UPDATE provider_processing_invocations
         SET state = $5, available_at_ms = $6, claim_worker_id = NULL,
             claim_started_at_ms = NULL, claim_expires_at_ms = NULL,
             completed_at_ms = $7, failure_kind = $8
-        WHERE delivery_id = $1 AND state = 'claimed'
+        WHERE invocation_id = $1 AND state = 'claimed'
           AND claim_worker_id = $2 AND claim_fence = $3
           AND claim_started_at_ms <= $4
           AND claim_expires_at_ms > $4
-        RETURNING delivery_id, state, attempts, accepted_at_ms
+        RETURNING invocation_id, cause_delivery_id, source_delivery_id,
+                  state, attempts, created_at_ms
         ",
     )
-    .bind(fence.delivery_id().as_uuid())
+    .bind(fence.invocation_id().as_uuid())
     .bind(fence.worker_id().as_uuid())
-    .bind(durable_u64(fence.token())?)
+    .bind(processing_durable_u64(fence.token())?)
     .bind(mutation_at.get())
     .bind(state)
     .bind(available_or_completed_at.get())
@@ -511,27 +651,14 @@ async fn mutate_claim(
     .bind(failure.map(failure_text))
     .fetch_optional(pool)
     .await
-    .map_err(unavailable)?
-    .ok_or(ProviderDeliveryRepositoryError::ClaimRejected)?;
+    .map_err(processing_unavailable)?
+    .ok_or(ProviderProcessingRepositoryError::ClaimRejected)?;
     decode_receipt(row)
 }
 
 #[allow(clippy::too_many_lines)] // Strict decoding validates every durable evidence field.
 fn decode_delivery(row: DeliveryRow) -> Result<ProviderDelivery, ProviderDeliveryRepositoryError> {
-    // Lifecycle-only columns are decoded separately by receipt operations.
-    let _ = (
-        &row.replay_fingerprint,
-        &row.state,
-        row.attempts,
-        row.available_at_ms,
-        row.accepted_at_ms,
-        row.claim_worker_id,
-        row.claim_fence,
-        row.claim_started_at_ms,
-        row.claim_expires_at_ms,
-        row.completed_at_ms,
-        &row.failure_kind,
-    );
+    let _ = (&row.replay_fingerprint, row.accepted_at_ms);
     let instance_id = ProviderInstanceId::from_uuid(row.provider_instance_id)
         .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
     let external_delivery = ExternalDeliveryIdentity::new(
@@ -581,37 +708,95 @@ fn decode_delivery(row: DeliveryRow) -> Result<ProviderDelivery, ProviderDeliver
             .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
     let event_type = ProviderEventName::new(row.event_type)
         .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+    let evidence = ProviderDeliveryEvidence::rehydrate(
+        delivery_id,
+        endpoint_id,
+        endpoint_revision,
+        provider_type,
+        instance_id,
+        provider_revision,
+        connection_id,
+        connection_revision,
+        external_delivery,
+        event_type,
+        UnixMillis::new(row.received_at_ms),
+        raw_body,
+        UnixMillis::new(row.raw_retain_until_ms),
+        signature,
+        observations,
+    )
+    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
     match row.disposition.as_str() {
         "trigger" => {
             let trigger = SealedNormalizedTrigger::from_canonical_bytes(
-                row.normalized_trigger
+                row.normalized_payload
                     .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
             )
             .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
-            if Some(trigger.digest()) != row.normalized_trigger_digest.map(digest).transpose()? {
+            if Some(trigger.digest()) != row.normalized_payload_digest.map(digest).transpose()? {
                 return Err(ProviderDeliveryRepositoryError::Corrupt);
             }
-            VerifiedProviderDelivery::rehydrate(
-                delivery_id,
-                endpoint_id,
-                endpoint_revision,
-                provider_type,
+            VerifiedProviderTriggerDelivery::rehydrate(evidence, trigger)
+                .map(Box::new)
+                .map(ProviderDelivery::Trigger)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+        }
+        "control" => {
+            let repository = ExternalRepositoryIdentity::new(
                 instance_id,
-                provider_revision,
-                connection_id,
-                connection_revision,
-                external_delivery,
-                event_type,
-                UnixMillis::new(row.received_at_ms),
-                raw_body,
-                UnixMillis::new(row.raw_retain_until_ms),
-                signature,
-                trigger,
-                observations,
+                ExternalRepositoryId::new(
+                    row.repository_external_id
+                        .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+                )
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+            );
+            if row.control_kind.as_deref() != Some("rerun") {
+                return Err(ProviderDeliveryRepositoryError::Corrupt);
+            }
+            let document = ProviderControlDocument::new(
+                ProviderSchemaVersion::new(
+                    u16::try_from(
+                        row.control_document_schema
+                            .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+                    )
+                    .ok()
+                    .filter(|value| *value > 0)
+                    .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+                )
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                row.normalized_payload
+                    .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
             )
-            .map(Box::new)
-            .map(ProviderDelivery::Trigger)
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            if Some(document.digest()) != row.normalized_payload_digest.map(digest).transpose()? {
+                return Err(ProviderDeliveryRepositoryError::Corrupt);
+            }
+            let actor = match (row.control_actor_kind, row.control_actor_external_id) {
+                (Some(kind), Some(external_id)) => Some(ExternalSubjectIdentity::new(
+                    instance_id,
+                    decode_subject_kind(&kind)?,
+                    ExternalSubjectId::new(external_id)
+                        .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                )),
+                (None, None) => None,
+                _ => return Err(ProviderDeliveryRepositoryError::Corrupt),
+            };
+            let control = ProviderControl::new(
+                ProviderControlKind::Rerun,
+                repository,
+                GitObjectId::from_durable_bytes(
+                    &row.control_object_id
+                        .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
+                )
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+                actor,
+                document,
+            )
+            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?;
+            VerifiedProviderControlDelivery::rehydrate(evidence, control)
+                .map(Box::new)
+                .map(ProviderDelivery::Control)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
         }
         "rejected" => {
             let repository = row
@@ -628,28 +813,10 @@ fn decode_delivery(row: DeliveryRow) -> Result<ProviderDelivery, ProviderDeliver
                     .as_deref()
                     .ok_or(ProviderDeliveryRepositoryError::Corrupt)?,
             )?;
-            RejectedProviderDelivery::rehydrate(
-                delivery_id,
-                endpoint_id,
-                endpoint_revision,
-                provider_type,
-                instance_id,
-                provider_revision,
-                connection_id,
-                connection_revision,
-                external_delivery,
-                event_type,
-                UnixMillis::new(row.received_at_ms),
-                raw_body,
-                UnixMillis::new(row.raw_retain_until_ms),
-                signature,
-                repository,
-                reason,
-                observations,
-            )
-            .map(Box::new)
-            .map(ProviderDelivery::Rejected)
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+            RejectedProviderDelivery::rehydrate(evidence, repository, reason)
+                .map(Box::new)
+                .map(ProviderDelivery::Rejected)
+                .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
         }
         _ => Err(ProviderDeliveryRepositoryError::Corrupt),
     }
@@ -657,21 +824,29 @@ fn decode_delivery(row: DeliveryRow) -> Result<ProviderDelivery, ProviderDeliver
 
 fn decode_receipt(
     row: ReceiptRow,
-) -> Result<ProviderDeliveryReceipt, ProviderDeliveryRepositoryError> {
+) -> Result<ProviderProcessingReceipt, ProviderProcessingRepositoryError> {
     let ReceiptRow {
-        delivery_id,
+        invocation_id,
+        cause_delivery_id,
+        source_delivery_id,
         state: durable_state,
         attempts,
-        accepted_at_ms,
+        created_at_ms,
     } = row;
-    ProviderDeliveryReceipt::new(
-        ProviderDeliveryId::from_uuid(delivery_id)
-            .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)?,
+    ProviderProcessingReceipt::new(
+        ProviderProcessingInvocationId::from_uuid(invocation_id)
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
+        ProviderDeliveryId::from_uuid(cause_delivery_id)
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
+        source_delivery_id
+            .map(ProviderDeliveryId::from_uuid)
+            .transpose()
+            .map_err(|_| ProviderProcessingRepositoryError::Corrupt)?,
         state(&durable_state)?,
-        positive_u16(attempts)?,
-        UnixMillis::new(accepted_at_ms),
+        processing_positive_u16(attempts)?,
+        UnixMillis::new(created_at_ms),
     )
-    .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
+    .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
 }
 
 fn digest(value: Vec<u8>) -> Result<Sha256Digest, ProviderDeliveryRepositoryError> {
@@ -681,15 +856,14 @@ fn digest(value: Vec<u8>) -> Result<Sha256Digest, ProviderDeliveryRepositoryErro
         .map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
 }
 
-fn state(value: &str) -> Result<ProviderDeliveryState, ProviderDeliveryRepositoryError> {
+fn state(value: &str) -> Result<ProviderProcessingState, ProviderProcessingRepositoryError> {
     match value {
-        "pending" => Ok(ProviderDeliveryState::Pending),
-        "retry-pending" => Ok(ProviderDeliveryState::RetryPending),
-        "claimed" => Ok(ProviderDeliveryState::Claimed),
-        "completed" => Ok(ProviderDeliveryState::Completed),
-        "failed" => Ok(ProviderDeliveryState::Failed),
-        "discarded" => Ok(ProviderDeliveryState::Discarded),
-        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
+        "pending" => Ok(ProviderProcessingState::Pending),
+        "retry-pending" => Ok(ProviderProcessingState::RetryPending),
+        "claimed" => Ok(ProviderProcessingState::Claimed),
+        "completed" => Ok(ProviderProcessingState::Completed),
+        "failed" => Ok(ProviderProcessingState::Failed),
+        _ => Err(ProviderProcessingRepositoryError::Corrupt),
     }
 }
 
@@ -700,6 +874,33 @@ const fn rejection_text(value: ProviderDeliveryRejection) -> &'static str {
         ProviderDeliveryRejection::IncompleteEvent => "incomplete-event",
         ProviderDeliveryRejection::PayloadIdentityMismatch => "payload-identity-mismatch",
         ProviderDeliveryRejection::InvalidPayload => "invalid-payload",
+    }
+}
+
+const fn control_kind(value: ProviderControlKind) -> &'static str {
+    match value {
+        ProviderControlKind::Rerun => "rerun",
+    }
+}
+
+const fn subject_kind(value: ExternalSubjectKind) -> &'static str {
+    match value {
+        ExternalSubjectKind::User => "user",
+        ExternalSubjectKind::Organization => "organization",
+        ExternalSubjectKind::Team => "team",
+        ExternalSubjectKind::ServiceAccount => "service-account",
+    }
+}
+
+fn decode_subject_kind(
+    value: &str,
+) -> Result<ExternalSubjectKind, ProviderDeliveryRepositoryError> {
+    match value {
+        "user" => Ok(ExternalSubjectKind::User),
+        "organization" => Ok(ExternalSubjectKind::Organization),
+        "team" => Ok(ExternalSubjectKind::Team),
+        "service-account" => Ok(ExternalSubjectKind::ServiceAccount),
+        _ => Err(ProviderDeliveryRepositoryError::Corrupt),
     }
 }
 
@@ -714,11 +915,11 @@ fn rejection(value: &str) -> Result<ProviderDeliveryRejection, ProviderDeliveryR
     }
 }
 
-const fn failure_text(value: ProviderDeliveryFailure) -> &'static str {
+const fn failure_text(value: ProviderProcessingFailure) -> &'static str {
     match value {
-        ProviderDeliveryFailure::DependencyUnavailable => "dependency-unavailable",
-        ProviderDeliveryFailure::PolicyRejected => "policy-rejected",
-        ProviderDeliveryFailure::InvalidEvidence => "invalid-evidence",
+        ProviderProcessingFailure::DependencyUnavailable => "dependency-unavailable",
+        ProviderProcessingFailure::PolicyRejected => "policy-rejected",
+        ProviderProcessingFailure::InvalidEvidence => "invalid-evidence",
     }
 }
 
@@ -733,10 +934,39 @@ fn positive_u64(value: i64) -> Result<u64, ProviderDeliveryRepositoryError> {
         .ok_or(ProviderDeliveryRepositoryError::Corrupt)
 }
 
-fn positive_u16(value: i16) -> Result<u16, ProviderDeliveryRepositoryError> {
-    u16::try_from(value).map_err(|_| ProviderDeliveryRepositoryError::Corrupt)
-}
-
 fn unavailable(_: sqlx::Error) -> ProviderDeliveryRepositoryError {
     ProviderDeliveryRepositoryError::Unavailable
+}
+
+fn processing_durable_u64(value: u64) -> Result<i64, ProviderProcessingRepositoryError> {
+    i64::try_from(value).map_err(|_| ProviderProcessingRepositoryError::Corrupt)
+}
+
+fn processing_positive_u64(value: i64) -> Result<u64, ProviderProcessingRepositoryError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ProviderProcessingRepositoryError::Corrupt)
+}
+
+fn processing_positive_u16(value: i16) -> Result<u16, ProviderProcessingRepositoryError> {
+    u16::try_from(value).map_err(|_| ProviderProcessingRepositoryError::Corrupt)
+}
+
+const fn processing_from_delivery(
+    error: ProviderDeliveryRepositoryError,
+) -> ProviderProcessingRepositoryError {
+    match error {
+        ProviderDeliveryRepositoryError::NotFound => ProviderProcessingRepositoryError::NotFound,
+        ProviderDeliveryRepositoryError::Unavailable => {
+            ProviderProcessingRepositoryError::Unavailable
+        }
+        ProviderDeliveryRepositoryError::EndpointConflict
+        | ProviderDeliveryRepositoryError::ReplayConflict
+        | ProviderDeliveryRepositoryError::Corrupt => ProviderProcessingRepositoryError::Corrupt,
+    }
+}
+
+fn processing_unavailable(_: sqlx::Error) -> ProviderProcessingRepositoryError {
+    ProviderProcessingRepositoryError::Unavailable
 }

--- a/crates/automata-ci-provider-postgres/src/lib.rs
+++ b/crates/automata-ci-provider-postgres/src/lib.rs
@@ -10,16 +10,16 @@ use automata_ci_key_management::{
     KeyPurpose, WrappedDataKey,
 };
 use automata_ci_provider::{
-    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
-    CompleteProviderDelivery, FailProviderDelivery, ProviderConnectionId,
+    AcceptProviderDelivery, ClaimProviderProcessing, ClaimedProviderProcessing,
+    CompleteProviderProcessing, FailProviderProcessing, ProviderConnectionId,
     ProviderConnectionManifest, ProviderConnectionRevision, ProviderDelivery,
     ProviderDeliveryAcceptOutcome, ProviderDeliveryFuture, ProviderDeliveryId,
-    ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderInstanceId,
-    ProviderInstanceRecord, ProviderManifestRepository, ProviderRepositoryError,
-    ProviderRepositoryFuture, ProviderSaveOutcome, ProviderWebhookEndpointId,
-    ProviderWebhookEndpointManifest, ProviderWebhookEndpointRecord,
-    ProviderWebhookEndpointRepository, ProviderWebhookEndpointRevision, RenewProviderDelivery,
-    RetryProviderDelivery,
+    ProviderDeliveryRepository, ProviderInstanceId, ProviderInstanceRecord,
+    ProviderManifestRepository, ProviderProcessingFuture, ProviderProcessingReceipt,
+    ProviderProcessingRepository, ProviderRepositoryError, ProviderRepositoryFuture,
+    ProviderSaveOutcome, ProviderWebhookEndpointId, ProviderWebhookEndpointManifest,
+    ProviderWebhookEndpointRecord, ProviderWebhookEndpointRepository,
+    ProviderWebhookEndpointRevision, RenewProviderProcessing, RetryProviderProcessing,
 };
 use sqlx::{PgPool, Postgres, Transaction};
 
@@ -151,40 +151,49 @@ impl ProviderDeliveryRepository for PostgresProviderManifestRepository {
     ) -> ProviderDeliveryFuture<'_, Option<ProviderDelivery>> {
         Box::pin(self.load_delivery_inner(delivery_id))
     }
+}
 
-    fn claim_delivery(
+impl ProviderProcessingRepository for PostgresProviderManifestRepository {
+    fn claim_processing(
         &self,
-        request: ClaimProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, Option<ClaimedProviderDelivery>> {
-        Box::pin(self.claim_delivery_inner(request))
+        request: ClaimProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, Option<ClaimedProviderProcessing>> {
+        Box::pin(self.claim_processing_inner(request))
     }
 
-    fn complete_delivery(
+    fn bind_processing_source(
         &self,
-        request: CompleteProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
-        Box::pin(self.complete_delivery_inner(request))
+        request: automata_ci_provider::BindProviderProcessingSource,
+    ) -> ProviderProcessingFuture<'_, ClaimedProviderProcessing> {
+        Box::pin(self.bind_processing_source_inner(request))
     }
 
-    fn renew_delivery(
+    fn complete_processing(
         &self,
-        request: RenewProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, automata_ci_provider::ProviderDeliveryClaimFence> {
-        Box::pin(self.renew_delivery_inner(request))
+        request: CompleteProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+        Box::pin(self.complete_processing_inner(request))
     }
 
-    fn retry_delivery(
+    fn renew_processing(
         &self,
-        request: RetryProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
-        Box::pin(self.retry_delivery_inner(request))
+        request: RenewProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, automata_ci_provider::ProviderProcessingClaimFence> {
+        Box::pin(self.renew_processing_inner(request))
     }
 
-    fn fail_delivery(
+    fn retry_processing(
         &self,
-        request: FailProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt> {
-        Box::pin(self.fail_delivery_inner(request))
+        request: RetryProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+        Box::pin(self.retry_processing_inner(request))
+    }
+
+    fn fail_processing(
+        &self,
+        request: FailProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
+        Box::pin(self.fail_processing_inner(request))
     }
 }
 

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -4,17 +4,21 @@ use automata_ci_core::{GitObjectAlgorithm, Sha256Digest, UnixMillis, WorkspaceId
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
 use automata_ci_postgres::test_support::{TestResult, run_with_database};
 use automata_ci_provider::{
-    AcceptProviderDelivery, ClaimProviderDelivery, CompleteProviderDelivery, ExternalDeliveryId,
-    ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger,
-    ProviderArchiveLimits, ProviderCapabilities, ProviderCapability, ProviderConfigurationDocument,
-    ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
-    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    AcceptProviderDelivery, BindProviderProcessingSource, ClaimProviderProcessing,
+    CompleteProviderProcessing, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
+    ExternalRepositoryIdentity, ExternalSubjectId, ExternalSubjectIdentity, ExternalSubjectKind,
+    NormalizedTrigger, ProviderArchiveLimits, ProviderCapabilities, ProviderCapability,
+    ProviderConfigurationDocument, ProviderConfigurationRevision, ProviderConnectionConfiguration,
+    ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionPolicyDocument,
+    ProviderConnectionRevision, ProviderControl, ProviderControlDocument, ProviderControlKind,
     ProviderDefaultBranch, ProviderDelivery, ProviderDeliveryAcceptOutcome,
-    ProviderDeliveryFailure, ProviderDeliveryId, ProviderDeliveryObservations,
-    ProviderDeliveryRepository as _, ProviderDeliveryRepositoryError, ProviderDeliveryState,
-    ProviderDeliveryWorkerId, ProviderEventName, ProviderGitRef, ProviderGitRefKind,
-    ProviderInstanceId, ProviderInstanceManifest, ProviderInstanceRecord, ProviderLifecycleState,
-    ProviderManifestRepository as _, ProviderOrigins, ProviderRepository, ProviderRepositoryError,
+    ProviderDeliveryEvidence, ProviderDeliveryId, ProviderDeliveryObservations,
+    ProviderDeliveryRepository as _, ProviderDeliveryRepositoryError, ProviderEventName,
+    ProviderGitRef, ProviderGitRefKind, ProviderInstanceId, ProviderInstanceManifest,
+    ProviderInstanceRecord, ProviderLifecycleState, ProviderManifestRepository as _,
+    ProviderOrigins, ProviderProcessingFailure, ProviderProcessingInput,
+    ProviderProcessingRepository as _, ProviderProcessingRepositoryError, ProviderProcessingState,
+    ProviderProcessingWorkerId, ProviderRepository, ProviderRepositoryError,
     ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSaveOutcome,
     ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding, ProviderSecretBindings,
     ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet, ProviderTypeId,
@@ -22,8 +26,8 @@ use automata_ci_provider::{
     ProviderWebhookEndpointRepository as _, ProviderWebhookEndpointRevision,
     ProviderWebhookEndpointState, ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence,
     ProviderWorkflowSource, PushCommitEvidence, PushTrigger, RepositoryVisibility,
-    RetryProviderDelivery, SourceReadCapability, VerifiedProviderDelivery,
-    provider_capability_digest, provider_raw_webhook_descriptor,
+    RetryProviderProcessing, SourceReadCapability, VerifiedProviderControlDelivery,
+    VerifiedProviderTriggerDelivery, provider_capability_digest, provider_raw_webhook_descriptor,
 };
 use automata_ci_provider_postgres::PostgresProviderManifestRepository;
 use sha2::{Digest as _, Sha256};
@@ -392,7 +396,7 @@ fn verified_delivery(
     endpoint: &ProviderWebhookEndpointManifest,
     delivery_id: ProviderDeliveryId,
     raw_body: &[u8],
-) -> VerifiedProviderDelivery {
+) -> VerifiedProviderTriggerDelivery {
     let digest = secret_digest(raw_body);
     let raw =
         provider_raw_webhook_descriptor(digest, raw_body.len() as u64).expect("raw descriptor");
@@ -422,7 +426,7 @@ fn verified_delivery(
     )
     .seal()
     .expect("sealed trigger");
-    VerifiedProviderDelivery::rehydrate(
+    let evidence = ProviderDeliveryEvidence::rehydrate(
         delivery_id,
         endpoint.endpoint_id(),
         endpoint.revision(),
@@ -448,11 +452,71 @@ fn verified_delivery(
             endpoint.secret_references()[0].clone(),
         )
         .expect("signature evidence"),
-        trigger,
         ProviderDeliveryObservations::new(br#"{"fixture":"postgres"}"#.to_vec())
             .expect("observations"),
     )
-    .expect("verified delivery")
+    .expect("delivery evidence");
+    VerifiedProviderTriggerDelivery::rehydrate(evidence, trigger).expect("verified delivery")
+}
+
+fn verified_control(
+    endpoint: &ProviderWebhookEndpointManifest,
+    delivery_id: ProviderDeliveryId,
+    raw_body: &[u8],
+) -> VerifiedProviderControlDelivery {
+    let raw = provider_raw_webhook_descriptor(secret_digest(raw_body), raw_body.len() as u64)
+        .expect("raw descriptor");
+    let evidence = ProviderDeliveryEvidence::rehydrate(
+        delivery_id,
+        endpoint.endpoint_id(),
+        endpoint.revision(),
+        endpoint.provider_type().clone(),
+        endpoint.instance_id(),
+        endpoint.provider_revision(),
+        endpoint.connection_id(),
+        endpoint.connection_revision(),
+        ExternalDeliveryIdentity::new(
+            endpoint.instance_id(),
+            ExternalDeliveryId::new("control-100").expect("external delivery"),
+        ),
+        ProviderEventName::new("check_run").expect("event type"),
+        UnixMillis::new(8_000),
+        raw,
+        UnixMillis::new(
+            8_000
+                + i64::try_from(endpoint.raw_retention_millis())
+                    .expect("retention is in signed range"),
+        ),
+        ProviderWebhookSignatureEvidence::new(
+            "fake-sha256",
+            endpoint.secret_references()[0].clone(),
+        )
+        .expect("signature evidence"),
+        ProviderDeliveryObservations::new(br#"{"fixture":"control"}"#.to_vec())
+            .expect("observations"),
+    )
+    .expect("delivery evidence");
+    let control = ProviderControl::new(
+        ProviderControlKind::Rerun,
+        ExternalRepositoryIdentity::new(
+            endpoint.instance_id(),
+            ExternalRepositoryId::new("42").expect("repository ID"),
+        ),
+        automata_ci_core::GitObjectId::from_hex(GitObjectAlgorithm::Sha1, &"b".repeat(40))
+            .expect("object"),
+        Some(ExternalSubjectIdentity::new(
+            endpoint.instance_id(),
+            ExternalSubjectKind::User,
+            ExternalSubjectId::new("301").expect("actor"),
+        )),
+        ProviderControlDocument::new(
+            ProviderSchemaVersion::new(1).expect("schema"),
+            br#"{"schema":1,"target":{"kind":"check_run","run_id":601}}"#.to_vec(),
+        )
+        .expect("control document"),
+    )
+    .expect("control");
+    VerifiedProviderControlDelivery::rehydrate(evidence, control).expect("verified control")
 }
 
 #[tokio::test]
@@ -536,10 +600,10 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
             repository.accept_delivery(acceptance).await?,
             ProviderDeliveryAcceptOutcome::Inserted(receipt)
                 if receipt.delivery_id() == first_id
-                    && receipt.state() == ProviderDeliveryState::Pending
+                    && receipt.invocation_id().is_some()
         ));
         let immutable_update = sqlx::query(
-            "UPDATE provider_delivery_records SET event_type = 'tampered' WHERE delivery_id = $1",
+            "UPDATE provider_deliveries SET event_type = 'tampered' WHERE delivery_id = $1",
         )
         .bind(first_id.as_uuid())
         .execute(database.pool())
@@ -577,9 +641,9 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
             Err(ProviderDeliveryRepositoryError::ReplayConflict)
         );
 
-        let worker = ProviderDeliveryWorkerId::from_uuid(Uuid::from_u128(106))?;
+        let worker = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(106))?;
         let first_claim = repository
-            .claim_delivery(ClaimProviderDelivery::new(
+            .claim_processing(ClaimProviderProcessing::new(
                 worker,
                 UnixMillis::new(5_000),
                 1_000,
@@ -587,17 +651,17 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
             .await?
             .expect("first claim");
         let retry = repository
-            .retry_delivery(RetryProviderDelivery::new(
+            .retry_processing(RetryProviderProcessing::new(
                 first_claim.fence(),
                 UnixMillis::new(5_500),
                 UnixMillis::new(7_000),
-                ProviderDeliveryFailure::DependencyUnavailable,
+                ProviderProcessingFailure::DependencyUnavailable,
             )?)
             .await?;
-        assert_eq!(retry.state(), ProviderDeliveryState::RetryPending);
+        assert_eq!(retry.state(), ProviderProcessingState::RetryPending);
         assert!(
             repository
-                .claim_delivery(ClaimProviderDelivery::new(
+                .claim_processing(ClaimProviderProcessing::new(
                     worker,
                     UnixMillis::new(6_999),
                     1_000,
@@ -606,7 +670,7 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
                 .is_none()
         );
         let second_claim = repository
-            .claim_delivery(ClaimProviderDelivery::new(
+            .claim_processing(ClaimProviderProcessing::new(
                 worker,
                 UnixMillis::new(7_000),
                 1_000,
@@ -615,12 +679,89 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
             .expect("second claim");
         assert!(second_claim.fence().token() > first_claim.fence().token());
         let completed = repository
-            .complete_delivery(CompleteProviderDelivery::new(
+            .complete_processing(CompleteProviderProcessing::new(
                 second_claim.fence(),
                 UnixMillis::new(7_500),
             )?)
             .await?;
-        assert_eq!(completed.state(), ProviderDeliveryState::Completed);
+        assert_eq!(completed.state(), ProviderProcessingState::Completed);
+
+        let control_id = ProviderDeliveryId::from_uuid(Uuid::from_u128(107))?;
+        let control = ProviderDelivery::Control(Box::new(verified_control(
+            &endpoint,
+            control_id,
+            b"control-body",
+        )));
+        let ProviderDeliveryAcceptOutcome::Inserted(control_receipt) = repository
+            .accept_delivery(AcceptProviderDelivery::new(
+                control,
+                UnixMillis::new(8_100),
+            )?)
+            .await?
+        else {
+            panic!("new control was not inserted");
+        };
+        assert_eq!(control_receipt.delivery_id(), control_id);
+        assert!(control_receipt.invocation_id().is_some());
+        let replay = ProviderDelivery::Control(Box::new(verified_control(
+            &endpoint,
+            ProviderDeliveryId::from_uuid(Uuid::from_u128(108))?,
+            b"control-body",
+        )));
+        assert!(matches!(
+            repository
+                .accept_delivery(AcceptProviderDelivery::new(
+                    replay,
+                    UnixMillis::new(8_150),
+                )?)
+                .await?,
+            ProviderDeliveryAcceptOutcome::Duplicate(receipt)
+                if receipt.delivery_id() == control_id
+                    && receipt.invocation_id() == control_receipt.invocation_id()
+        ));
+        let control_claim = repository
+            .claim_processing(ClaimProviderProcessing::new(
+                worker,
+                UnixMillis::new(8_200),
+                1_000,
+            )?)
+            .await?
+            .expect("control claim");
+        assert!(matches!(
+            control_claim.input(),
+            ProviderProcessingInput::Control(delivery)
+                if delivery.evidence().delivery_id() == control_id
+        ));
+        assert!(control_claim.receipt().source_delivery_id().is_none());
+        let bound = repository
+            .bind_processing_source(BindProviderProcessingSource::new(
+                control_claim.fence(),
+                first_id,
+                UnixMillis::new(8_300),
+            )?)
+            .await?;
+        assert_eq!(bound.receipt().source_delivery_id(), Some(first_id));
+        assert_eq!(
+            repository
+                .bind_processing_source(BindProviderProcessingSource::new(
+                    control_claim.fence(),
+                    first_id,
+                    UnixMillis::new(8_400),
+                )?)
+                .await,
+            Err(ProviderProcessingRepositoryError::ClaimRejected),
+            "a control source can only be bound once"
+        );
+        assert_eq!(
+            repository
+                .complete_processing(CompleteProviderProcessing::new(
+                    control_claim.fence(),
+                    UnixMillis::new(8_500),
+                )?)
+                .await?
+                .state(),
+            ProviderProcessingState::Completed
+        );
 
         let disabled_connection = ProviderConnectionManifest::new(
             connection.connection_id(),

--- a/crates/automata-ci-provider/src/control.rs
+++ b/crates/automata-ci-provider/src/control.rs
@@ -1,0 +1,216 @@
+//! Provider-neutral authenticated control requests.
+
+use std::fmt;
+
+use automata_ci_core::{GitObjectAlgorithm, GitObjectId, Sha256Digest};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+use crate::{ExternalRepositoryIdentity, ExternalSubjectIdentity, ProviderSchemaVersion};
+
+/// Maximum adapter-owned canonical bytes retained for one provider control.
+pub const MAX_PROVIDER_CONTROL_DOCUMENT_BYTES: usize = 16 * 1_024;
+
+const CONTROL_DOCUMENT_DOMAIN: &[u8] = b"automata.provider.control-document.v1\0";
+const CONTROL_DOMAIN: &[u8] = b"automata.provider.control.v1\0";
+
+/// Common operation requested by an authenticated provider-native control.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ProviderControlKind {
+    /// Create a fresh processing invocation from an earlier result subject.
+    Rerun,
+}
+
+/// Bounded schema-versioned canonical evidence decoded only by its adapter.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderControlDocument {
+    schema: ProviderSchemaVersion,
+    bytes: Vec<u8>,
+    digest: Sha256Digest,
+}
+
+impl ProviderControlDocument {
+    /// Stores one nonempty bounded adapter control document.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty or oversized bytes.
+    pub fn new(
+        schema: ProviderSchemaVersion,
+        bytes: Vec<u8>,
+    ) -> Result<Self, ProviderControlError> {
+        if bytes.is_empty() || bytes.len() > MAX_PROVIDER_CONTROL_DOCUMENT_BYTES {
+            return Err(ProviderControlError::InvalidDocument);
+        }
+        let mut hash = Sha256::new();
+        hash.update(CONTROL_DOCUMENT_DOMAIN);
+        hash.update(schema.get().to_be_bytes());
+        part(&mut hash, &bytes);
+        Ok(Self {
+            schema,
+            bytes,
+            digest: Sha256Digest::from_bytes(hash.finalize().into()),
+        })
+    }
+
+    /// Returns the adapter schema version.
+    #[must_use]
+    pub const fn schema(&self) -> ProviderSchemaVersion {
+        self.schema
+    }
+
+    /// Returns exact canonical adapter bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the domain-separated document digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+impl fmt::Debug for ProviderControlDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderControlDocument")
+            .field("schema", &self.schema)
+            .field("bytes", &"[CANONICAL]")
+            .field("byte_length", &self.bytes.len())
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+/// Authenticated provider-independent control facts plus adapter evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderControl {
+    kind: ProviderControlKind,
+    repository: ExternalRepositoryIdentity,
+    object: GitObjectId,
+    actor: Option<ExternalSubjectIdentity>,
+    document: ProviderControlDocument,
+    digest: Sha256Digest,
+}
+
+impl ProviderControl {
+    /// Constructs one instance-scoped control request.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an actor from another provider instance.
+    pub fn new(
+        kind: ProviderControlKind,
+        repository: ExternalRepositoryIdentity,
+        object: GitObjectId,
+        actor: Option<ExternalSubjectIdentity>,
+        document: ProviderControlDocument,
+    ) -> Result<Self, ProviderControlError> {
+        if actor
+            .as_ref()
+            .is_some_and(|value| value.instance_id() != repository.instance_id())
+        {
+            return Err(ProviderControlError::InstanceMismatch);
+        }
+        let mut value = Self {
+            kind,
+            repository,
+            object,
+            actor,
+            document,
+            digest: Sha256Digest::from_bytes([0; 32]),
+        };
+        value.digest = value.calculate_digest();
+        Ok(value)
+    }
+
+    fn calculate_digest(&self) -> Sha256Digest {
+        let mut hash = Sha256::new();
+        hash.update(CONTROL_DOMAIN);
+        hash.update([match self.kind {
+            ProviderControlKind::Rerun => 1,
+        }]);
+        hash.update(self.repository.instance_id().as_uuid().as_bytes());
+        part(&mut hash, self.repository.external_id().as_str().as_bytes());
+        hash.update([match self.object.algorithm() {
+            GitObjectAlgorithm::Sha1 => 1,
+            GitObjectAlgorithm::Sha256 => 2,
+        }]);
+        hash.update(self.object.as_bytes());
+        match &self.actor {
+            Some(actor) => {
+                hash.update([1]);
+                hash.update(actor.instance_id().as_uuid().as_bytes());
+                hash.update([actor_kind(actor)]);
+                part(&mut hash, actor.external_id().as_str().as_bytes());
+            }
+            None => hash.update([0]),
+        }
+        hash.update(self.document.digest().as_bytes());
+        Sha256Digest::from_bytes(hash.finalize().into())
+    }
+
+    /// Returns the common operation.
+    #[must_use]
+    pub const fn kind(&self) -> ProviderControlKind {
+        self.kind
+    }
+
+    /// Returns the instance-scoped target repository.
+    #[must_use]
+    pub const fn repository(&self) -> &ExternalRepositoryIdentity {
+        &self.repository
+    }
+
+    /// Returns the exact target commit.
+    #[must_use]
+    pub const fn object(&self) -> GitObjectId {
+        self.object
+    }
+
+    /// Returns the authenticated actor when the provider supplies one.
+    #[must_use]
+    pub const fn actor(&self) -> Option<&ExternalSubjectIdentity> {
+        self.actor.as_ref()
+    }
+
+    /// Returns adapter-owned target and selection evidence.
+    #[must_use]
+    pub const fn document(&self) -> &ProviderControlDocument {
+        &self.document
+    }
+
+    /// Returns the complete domain-separated control digest.
+    #[must_use]
+    pub const fn digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+fn actor_kind(actor: &ExternalSubjectIdentity) -> u8 {
+    use crate::ExternalSubjectKind::{Organization, ServiceAccount, Team, User};
+    match actor.kind() {
+        User => 1,
+        Organization => 2,
+        Team => 3,
+        ServiceAccount => 4,
+    }
+}
+
+fn part(hash: &mut Sha256, value: &[u8]) {
+    hash.update((value.len() as u64).to_be_bytes());
+    hash.update(value);
+}
+
+/// Invalid normalized provider control evidence.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderControlError {
+    /// Adapter document bytes were empty or exceeded the common bound.
+    #[error("provider control document is invalid")]
+    InvalidDocument,
+    /// Repository and actor identities belong to different provider instances.
+    #[error("provider control identity is inconsistent")]
+    InstanceMismatch,
+}

--- a/crates/automata-ci-provider/src/delivery.rs
+++ b/crates/automata-ci-provider/src/delivery.rs
@@ -1,4 +1,4 @@
-//! Replay-safe provider delivery inbox and worker ports.
+//! Replay-safe provider delivery evidence and processing-invocation ports.
 
 use std::{fmt, future::Future, num::NonZeroU64, pin::Pin};
 
@@ -8,20 +8,21 @@ use thiserror::Error;
 
 use crate::{
     ExternalDeliveryIdentity, ProviderConnectionManifest, ProviderDeliveryId,
-    ProviderDeliveryRejection, ProviderDeliveryWorkerId, ProviderLifecycleState,
-    ProviderSaveOutcome, ProviderWebhookEndpointId, ProviderWebhookEndpointManifest,
-    ProviderWebhookEndpointRevision, ProviderWebhookError, ProviderWebhookSecretCandidates,
-    RejectedProviderDelivery, VerifiedProviderDelivery,
+    ProviderDeliveryRejection, ProviderLifecycleState, ProviderProcessingInvocationId,
+    ProviderProcessingWorkerId, ProviderSaveOutcome, ProviderWebhookEndpointId,
+    ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision, ProviderWebhookError,
+    ProviderWebhookSecretCandidates, RejectedProviderDelivery, VerifiedProviderControlDelivery,
+    VerifiedProviderTriggerDelivery,
 };
 
 /// Maximum processing attempts for one admitted provider delivery.
-pub const MAX_PROVIDER_DELIVERY_ATTEMPTS: u16 = 16;
-/// Maximum duration of one delivery worker lease.
-pub const MAX_PROVIDER_DELIVERY_LEASE_MILLIS: i64 = 15 * 60 * 1_000;
-/// Maximum total lifetime of one delivery claim across all renewals.
-pub const MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS: i64 = 60 * 60 * 1_000;
-/// Maximum delay before a transiently failed delivery becomes eligible again.
-pub const MAX_PROVIDER_DELIVERY_RETRY_MILLIS: i64 = 24 * 60 * 60 * 1_000;
+pub const MAX_PROVIDER_PROCESSING_ATTEMPTS: u16 = 16;
+/// Maximum duration of one processing-worker lease.
+pub const MAX_PROVIDER_PROCESSING_LEASE_MILLIS: i64 = 15 * 60 * 1_000;
+/// Maximum total lifetime of one processing claim across all renewals.
+pub const MAX_PROVIDER_PROCESSING_TOTAL_CLAIM_MILLIS: i64 = 60 * 60 * 1_000;
+/// Maximum delay before a transiently failed invocation becomes eligible again.
+pub const MAX_PROVIDER_PROCESSING_RETRY_MILLIS: i64 = 24 * 60 * 60 * 1_000;
 
 const DELIVERY_FINGERPRINT_DOMAIN: &[u8] = b"automata.provider.delivery-fingerprint.v1\0";
 
@@ -105,7 +106,9 @@ impl fmt::Debug for ProviderWebhookEndpointRecord {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProviderDelivery {
     /// A complete normalized trigger eligible for workflow admission.
-    Trigger(Box<VerifiedProviderDelivery>),
+    Trigger(Box<VerifiedProviderTriggerDelivery>),
+    /// An authenticated provider-native control request.
+    Control(Box<VerifiedProviderControlDelivery>),
     /// An authenticated unknown, unsupported, incomplete, or conflicting event.
     Rejected(Box<RejectedProviderDelivery>),
 }
@@ -115,8 +118,9 @@ impl ProviderDelivery {
     #[must_use]
     pub const fn delivery_id(&self) -> ProviderDeliveryId {
         match self {
-            Self::Trigger(value) => value.delivery_id(),
-            Self::Rejected(value) => value.delivery_id(),
+            Self::Trigger(value) => value.evidence().delivery_id(),
+            Self::Control(value) => value.evidence().delivery_id(),
+            Self::Rejected(value) => value.evidence().delivery_id(),
         }
     }
 
@@ -124,8 +128,9 @@ impl ProviderDelivery {
     #[must_use]
     pub const fn external_delivery(&self) -> &ExternalDeliveryIdentity {
         match self {
-            Self::Trigger(value) => value.external_delivery(),
-            Self::Rejected(value) => value.external_delivery(),
+            Self::Trigger(value) => value.evidence().external_delivery(),
+            Self::Control(value) => value.evidence().external_delivery(),
+            Self::Rejected(value) => value.evidence().external_delivery(),
         }
     }
 
@@ -133,8 +138,9 @@ impl ProviderDelivery {
     #[must_use]
     pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
         match self {
-            Self::Trigger(value) => value.endpoint_id(),
-            Self::Rejected(value) => value.endpoint_id(),
+            Self::Trigger(value) => value.evidence().endpoint_id(),
+            Self::Control(value) => value.evidence().endpoint_id(),
+            Self::Rejected(value) => value.evidence().endpoint_id(),
         }
     }
 
@@ -142,8 +148,9 @@ impl ProviderDelivery {
     #[must_use]
     pub const fn raw_body_digest(&self) -> Sha256Digest {
         match self {
-            Self::Trigger(value) => value.raw_body().digest(),
-            Self::Rejected(value) => value.raw_body().digest(),
+            Self::Trigger(value) => value.evidence().raw_body().digest(),
+            Self::Control(value) => value.evidence().raw_body().digest(),
+            Self::Rejected(value) => value.evidence().raw_body().digest(),
         }
     }
 
@@ -151,8 +158,9 @@ impl ProviderDelivery {
     #[must_use]
     pub const fn received_at(&self) -> UnixMillis {
         match self {
-            Self::Trigger(value) => value.received_at(),
-            Self::Rejected(value) => value.received_at(),
+            Self::Trigger(value) => value.evidence().received_at(),
+            Self::Control(value) => value.evidence().received_at(),
+            Self::Rejected(value) => value.evidence().received_at(),
         }
     }
 
@@ -175,7 +183,7 @@ impl ProviderDelivery {
         match self {
             Self::Trigger(value) => {
                 part(&mut hash, b"trigger");
-                part(&mut hash, value.event_type().as_str().as_bytes());
+                part(&mut hash, value.evidence().event_type().as_str().as_bytes());
                 part(
                     &mut hash,
                     value
@@ -189,9 +197,23 @@ impl ProviderDelivery {
                 );
                 part(&mut hash, value.trigger().digest().as_bytes());
             }
+            Self::Control(value) => {
+                part(&mut hash, b"control");
+                part(&mut hash, value.evidence().event_type().as_str().as_bytes());
+                part(
+                    &mut hash,
+                    value
+                        .control()
+                        .repository()
+                        .external_id()
+                        .as_str()
+                        .as_bytes(),
+                );
+                part(&mut hash, value.control().digest().as_bytes());
+            }
             Self::Rejected(value) => {
                 part(&mut hash, b"rejected");
-                part(&mut hash, value.event_type().as_str().as_bytes());
+                part(&mut hash, value.evidence().event_type().as_str().as_bytes());
                 match value.repository() {
                     Some(repository) => {
                         hash.update([1]);
@@ -210,6 +232,7 @@ impl ProviderDelivery {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AcceptProviderDelivery {
     delivery: ProviderDelivery,
+    invocation_id: Option<ProviderProcessingInvocationId>,
     accepted_at: UnixMillis,
 }
 
@@ -226,8 +249,14 @@ impl AcceptProviderDelivery {
         if accepted_at.get() < 0 || accepted_at < delivery.received_at() {
             return Err(ProviderDeliveryModelError::InvalidAcceptanceTime);
         }
+        let invocation_id = matches!(
+            delivery,
+            ProviderDelivery::Trigger(_) | ProviderDelivery::Control(_)
+        )
+        .then(ProviderProcessingInvocationId::new);
         Ok(Self {
             delivery,
+            invocation_id,
             accepted_at,
         })
     }
@@ -244,10 +273,22 @@ impl AcceptProviderDelivery {
         self.accepted_at
     }
 
+    /// Returns the new invocation identity reserved for actionable evidence.
+    #[must_use]
+    pub const fn invocation_id(&self) -> Option<ProviderProcessingInvocationId> {
+        self.invocation_id
+    }
+
     /// Consumes the command into evidence and acceptance time.
     #[must_use]
-    pub fn into_parts(self) -> (ProviderDelivery, UnixMillis) {
-        (self.delivery, self.accepted_at)
+    pub fn into_parts(
+        self,
+    ) -> (
+        ProviderDelivery,
+        Option<ProviderProcessingInvocationId>,
+        UnixMillis,
+    ) {
+        (self.delivery, self.invocation_id, self.accepted_at)
     }
 }
 
@@ -263,9 +304,9 @@ impl ProviderDeliveryReplayFingerprint {
     }
 }
 
-/// Durable provider delivery lifecycle.
+/// Durable lifecycle of one processing invocation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum ProviderDeliveryState {
+pub enum ProviderProcessingState {
     /// A normalized trigger is ready for a worker.
     Pending,
     /// A previous transient attempt is waiting for its retry deadline.
@@ -276,68 +317,128 @@ pub enum ProviderDeliveryState {
     Completed,
     /// A complete trigger was terminally rejected by processing policy.
     Failed,
-    /// Authenticated event evidence was recorded without admission.
-    Discarded,
 }
 
-/// Durable receipt returned by inbox mutations.
+/// Immutable receipt for one accepted provider delivery.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProviderDeliveryReceipt {
     delivery_id: ProviderDeliveryId,
-    state: ProviderDeliveryState,
-    attempts: u16,
+    invocation_id: Option<ProviderProcessingInvocationId>,
     accepted_at: UnixMillis,
 }
 
 impl ProviderDeliveryReceipt {
+    /// Rehydrates delivery acceptance and its optional processing invocation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects pre-epoch acceptance evidence.
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        invocation_id: Option<ProviderProcessingInvocationId>,
+        accepted_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        if accepted_at.get() < 0 {
+            return Err(ProviderDeliveryModelError::InvalidReceipt);
+        }
+        Ok(Self {
+            delivery_id,
+            invocation_id,
+            accepted_at,
+        })
+    }
+
+    /// Returns the immutable delivery identity.
+    #[must_use]
+    pub const fn delivery_id(self) -> ProviderDeliveryId {
+        self.delivery_id
+    }
+
+    /// Returns the invocation created for actionable evidence.
+    #[must_use]
+    pub const fn invocation_id(self) -> Option<ProviderProcessingInvocationId> {
+        self.invocation_id
+    }
+
+    /// Returns the durable acceptance timestamp.
+    #[must_use]
+    pub const fn accepted_at(self) -> UnixMillis {
+        self.accepted_at
+    }
+}
+
+/// Durable receipt returned by processing-invocation mutations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProviderProcessingReceipt {
+    invocation_id: ProviderProcessingInvocationId,
+    cause_delivery_id: ProviderDeliveryId,
+    source_delivery_id: Option<ProviderDeliveryId>,
+    state: ProviderProcessingState,
+    attempts: u16,
+    created_at: UnixMillis,
+}
+
+impl ProviderProcessingReceipt {
     /// Rehydrates a validated durable receipt.
     ///
     /// # Errors
     ///
     /// Rejects negative time, excessive attempts, or state/attempt disagreement.
     pub fn new(
-        delivery_id: ProviderDeliveryId,
-        state: ProviderDeliveryState,
+        invocation_id: ProviderProcessingInvocationId,
+        cause_delivery_id: ProviderDeliveryId,
+        source_delivery_id: Option<ProviderDeliveryId>,
+        state: ProviderProcessingState,
         attempts: u16,
-        accepted_at: UnixMillis,
+        created_at: UnixMillis,
     ) -> Result<Self, ProviderDeliveryModelError> {
-        if accepted_at.get() < 0 || attempts > MAX_PROVIDER_DELIVERY_ATTEMPTS {
+        if created_at.get() < 0 || attempts > MAX_PROVIDER_PROCESSING_ATTEMPTS {
+            return Err(ProviderDeliveryModelError::InvalidReceipt);
+        }
+        if state == ProviderProcessingState::Pending && attempts != 0 {
             return Err(ProviderDeliveryModelError::InvalidReceipt);
         }
         if matches!(
             state,
-            ProviderDeliveryState::Pending | ProviderDeliveryState::Discarded
-        ) && attempts != 0
-        {
-            return Err(ProviderDeliveryModelError::InvalidReceipt);
-        }
-        if matches!(
-            state,
-            ProviderDeliveryState::RetryPending
-                | ProviderDeliveryState::Claimed
-                | ProviderDeliveryState::Completed
-                | ProviderDeliveryState::Failed
+            ProviderProcessingState::RetryPending
+                | ProviderProcessingState::Claimed
+                | ProviderProcessingState::Completed
+                | ProviderProcessingState::Failed
         ) && attempts == 0
         {
             return Err(ProviderDeliveryModelError::InvalidReceipt);
         }
         Ok(Self {
-            delivery_id,
+            invocation_id,
+            cause_delivery_id,
+            source_delivery_id,
             state,
             attempts,
-            accepted_at,
+            created_at,
         })
     }
 
-    /// Returns the server-owned delivery identity.
+    /// Returns the server-owned invocation identity.
     #[must_use]
-    pub const fn delivery_id(self) -> ProviderDeliveryId {
-        self.delivery_id
+    pub const fn invocation_id(self) -> ProviderProcessingInvocationId {
+        self.invocation_id
+    }
+
+    /// Returns the immutable delivery that requested this invocation.
+    #[must_use]
+    pub const fn cause_delivery_id(self) -> ProviderDeliveryId {
+        self.cause_delivery_id
+    }
+
+    /// Returns the resolved immutable trigger delivery, if one is already bound.
+    #[must_use]
+    pub const fn source_delivery_id(self) -> Option<ProviderDeliveryId> {
+        self.source_delivery_id
     }
 
     /// Returns current durable state.
     #[must_use]
-    pub const fn state(self) -> ProviderDeliveryState {
+    pub const fn state(self) -> ProviderProcessingState {
         self.state
     }
 
@@ -349,8 +450,8 @@ impl ProviderDeliveryReceipt {
 
     /// Returns initial durable acceptance time.
     #[must_use]
-    pub const fn accepted_at(self) -> UnixMillis {
-        self.accepted_at
+    pub const fn created_at(self) -> UnixMillis {
+        self.created_at
     }
 }
 
@@ -365,25 +466,25 @@ pub enum ProviderDeliveryAcceptOutcome {
 
 /// Bounded request to claim one eligible normalized trigger.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ClaimProviderDelivery {
-    worker_id: ProviderDeliveryWorkerId,
+pub struct ClaimProviderProcessing {
+    worker_id: ProviderProcessingWorkerId,
     claimed_at: UnixMillis,
     lease_millis: NonZeroU64,
 }
 
-impl ClaimProviderDelivery {
+impl ClaimProviderProcessing {
     /// Constructs a worker claim request.
     ///
     /// # Errors
     ///
     /// Rejects negative time or zero/excessive lease duration.
     pub fn new(
-        worker_id: ProviderDeliveryWorkerId,
+        worker_id: ProviderProcessingWorkerId,
         claimed_at: UnixMillis,
         lease_millis: u64,
     ) -> Result<Self, ProviderDeliveryModelError> {
         let lease_millis = NonZeroU64::new(lease_millis)
-            .filter(|value| value.get() <= MAX_PROVIDER_DELIVERY_LEASE_MILLIS as u64)
+            .filter(|value| value.get() <= MAX_PROVIDER_PROCESSING_LEASE_MILLIS as u64)
             .ok_or(ProviderDeliveryModelError::InvalidLease)?;
         let lease_i64 = i64::try_from(lease_millis.get())
             .map_err(|_| ProviderDeliveryModelError::InvalidLease)?;
@@ -399,7 +500,7 @@ impl ClaimProviderDelivery {
 
     /// Returns the worker requesting ownership.
     #[must_use]
-    pub const fn worker_id(self) -> ProviderDeliveryWorkerId {
+    pub const fn worker_id(self) -> ProviderProcessingWorkerId {
         self.worker_id
     }
 
@@ -418,23 +519,23 @@ impl ClaimProviderDelivery {
 
 /// Exact worker ownership and fencing evidence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ProviderDeliveryClaimFence {
-    delivery_id: ProviderDeliveryId,
-    worker_id: ProviderDeliveryWorkerId,
+pub struct ProviderProcessingClaimFence {
+    invocation_id: ProviderProcessingInvocationId,
+    worker_id: ProviderProcessingWorkerId,
     token: NonZeroU64,
     claimed_at: UnixMillis,
     expires_at: UnixMillis,
 }
 
-impl ProviderDeliveryClaimFence {
+impl ProviderProcessingClaimFence {
     /// Rehydrates a positive, unexpired-at-issuance fence.
     ///
     /// # Errors
     ///
     /// Rejects zero token or negative expiry.
     pub fn new(
-        delivery_id: ProviderDeliveryId,
-        worker_id: ProviderDeliveryWorkerId,
+        invocation_id: ProviderProcessingInvocationId,
+        worker_id: ProviderProcessingWorkerId,
         token: u64,
         claimed_at: UnixMillis,
         expires_at: UnixMillis,
@@ -444,12 +545,12 @@ impl ProviderDeliveryClaimFence {
             .ok_or(ProviderDeliveryModelError::InvalidFence)?;
         if claimed_at.get() < 0
             || expires_at <= claimed_at
-            || expires_at.get() - claimed_at.get() > MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS
+            || expires_at.get() - claimed_at.get() > MAX_PROVIDER_PROCESSING_TOTAL_CLAIM_MILLIS
         {
             return Err(ProviderDeliveryModelError::InvalidFence);
         }
         Ok(Self {
-            delivery_id,
+            invocation_id,
             worker_id,
             token,
             claimed_at,
@@ -457,15 +558,15 @@ impl ProviderDeliveryClaimFence {
         })
     }
 
-    /// Returns the claimed delivery.
+    /// Returns the claimed processing invocation.
     #[must_use]
-    pub const fn delivery_id(self) -> ProviderDeliveryId {
-        self.delivery_id
+    pub const fn invocation_id(self) -> ProviderProcessingInvocationId {
+        self.invocation_id
     }
 
     /// Returns the owning worker.
     #[must_use]
-    pub const fn worker_id(self) -> ProviderDeliveryWorkerId {
+    pub const fn worker_id(self) -> ProviderProcessingWorkerId {
         self.worker_id
     }
 
@@ -488,66 +589,141 @@ impl ProviderDeliveryClaimFence {
     }
 }
 
-/// One normalized trigger and its exact live worker fence.
+/// Immutable actionable input that caused or supplies one processing invocation.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ClaimedProviderDelivery {
-    receipt: ProviderDeliveryReceipt,
-    delivery: VerifiedProviderDelivery,
-    fence: ProviderDeliveryClaimFence,
+pub enum ProviderProcessingInput {
+    /// A normalized trigger ready for admission.
+    Trigger(Box<VerifiedProviderTriggerDelivery>),
+    /// An authenticated control whose trigger target must be resolved exactly.
+    Control(Box<VerifiedProviderControlDelivery>),
 }
 
-impl ClaimedProviderDelivery {
+impl ProviderProcessingInput {
+    /// Returns the input delivery identity.
+    #[must_use]
+    pub const fn delivery_id(&self) -> ProviderDeliveryId {
+        match self {
+            Self::Trigger(value) => value.evidence().delivery_id(),
+            Self::Control(value) => value.evidence().delivery_id(),
+        }
+    }
+}
+
+/// One actionable input and its exact live worker fence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimedProviderProcessing {
+    receipt: ProviderProcessingReceipt,
+    input: ProviderProcessingInput,
+    fence: ProviderProcessingClaimFence,
+}
+
+impl ClaimedProviderProcessing {
     /// Rehydrates mutually consistent claim evidence.
     ///
     /// # Errors
     ///
     /// Rejects identity or state disagreement.
     pub fn new(
-        receipt: ProviderDeliveryReceipt,
-        delivery: VerifiedProviderDelivery,
-        fence: ProviderDeliveryClaimFence,
+        receipt: ProviderProcessingReceipt,
+        input: ProviderProcessingInput,
+        fence: ProviderProcessingClaimFence,
     ) -> Result<Self, ProviderDeliveryModelError> {
-        if receipt.state() != ProviderDeliveryState::Claimed
-            || receipt.delivery_id() != delivery.delivery_id()
-            || receipt.delivery_id() != fence.delivery_id()
+        let identity_is_consistent = match &input {
+            ProviderProcessingInput::Trigger(delivery) => {
+                receipt.source_delivery_id() == Some(delivery.evidence().delivery_id())
+            }
+            ProviderProcessingInput::Control(delivery) => {
+                receipt.source_delivery_id().is_none()
+                    && receipt.cause_delivery_id() == delivery.evidence().delivery_id()
+            }
+        };
+        if receipt.state() != ProviderProcessingState::Claimed
+            || !identity_is_consistent
+            || receipt.invocation_id() != fence.invocation_id()
         {
             return Err(ProviderDeliveryModelError::InvalidClaim);
         }
         Ok(Self {
             receipt,
-            delivery,
+            input,
             fence,
         })
     }
 
     /// Returns claimed receipt state.
     #[must_use]
-    pub const fn receipt(&self) -> ProviderDeliveryReceipt {
+    pub const fn receipt(&self) -> ProviderProcessingReceipt {
         self.receipt
     }
 
-    /// Returns immutable normalized delivery evidence.
+    /// Returns the immutable actionable input.
     #[must_use]
-    pub const fn delivery(&self) -> &VerifiedProviderDelivery {
-        &self.delivery
+    pub const fn input(&self) -> &ProviderProcessingInput {
+        &self.input
     }
 
     /// Returns exact live fencing evidence.
     #[must_use]
-    pub const fn fence(&self) -> ProviderDeliveryClaimFence {
+    pub const fn fence(&self) -> ProviderProcessingClaimFence {
         self.fence
+    }
+}
+
+/// Exact-fence command that resolves an unresolved control to one trigger delivery.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BindProviderProcessingSource {
+    fence: ProviderProcessingClaimFence,
+    source_delivery_id: ProviderDeliveryId,
+    bound_at: UnixMillis,
+}
+
+impl BindProviderProcessingSource {
+    /// Constructs a source binding under a live processing claim.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a binding timestamp outside the exact live lease.
+    pub fn new(
+        fence: ProviderProcessingClaimFence,
+        source_delivery_id: ProviderDeliveryId,
+        bound_at: UnixMillis,
+    ) -> Result<Self, ProviderDeliveryModelError> {
+        validate_fenced_time(fence, bound_at)?;
+        Ok(Self {
+            fence,
+            source_delivery_id,
+            bound_at,
+        })
+    }
+
+    /// Returns exact live claim ownership.
+    #[must_use]
+    pub const fn fence(self) -> ProviderProcessingClaimFence {
+        self.fence
+    }
+
+    /// Returns the resolved immutable trigger delivery.
+    #[must_use]
+    pub const fn source_delivery_id(self) -> ProviderDeliveryId {
+        self.source_delivery_id
+    }
+
+    /// Returns trusted resolution time.
+    #[must_use]
+    pub const fn bound_at(self) -> UnixMillis {
+        self.bound_at
     }
 }
 
 /// Command that extends one exact live claim without changing its fence token.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RenewProviderDelivery {
-    fence: ProviderDeliveryClaimFence,
+pub struct RenewProviderProcessing {
+    fence: ProviderProcessingClaimFence,
     renewed_at: UnixMillis,
     lease_millis: NonZeroU64,
 }
 
-impl RenewProviderDelivery {
+impl RenewProviderProcessing {
     /// Constructs a strictly extending live-lease renewal.
     ///
     /// # Errors
@@ -555,13 +731,13 @@ impl RenewProviderDelivery {
     /// Rejects renewal outside the current lease, excessive per-renewal or
     /// total duration, overflow, or a deadline that would not extend the claim.
     pub fn new(
-        fence: ProviderDeliveryClaimFence,
+        fence: ProviderProcessingClaimFence,
         renewed_at: UnixMillis,
         lease_millis: u64,
     ) -> Result<Self, ProviderDeliveryModelError> {
         validate_fenced_time(fence, renewed_at)?;
         let lease_millis = NonZeroU64::new(lease_millis)
-            .filter(|value| value.get() <= MAX_PROVIDER_DELIVERY_LEASE_MILLIS as u64)
+            .filter(|value| value.get() <= MAX_PROVIDER_PROCESSING_LEASE_MILLIS as u64)
             .ok_or(ProviderDeliveryModelError::InvalidLease)?;
         let extension = i64::try_from(lease_millis.get())
             .map_err(|_| ProviderDeliveryModelError::InvalidLease)?;
@@ -573,7 +749,7 @@ impl RenewProviderDelivery {
             .checked_sub(fence.claimed_at().get())
             .ok_or(ProviderDeliveryModelError::InvalidLease)?;
         if expires_at <= fence.expires_at().get()
-            || total_lifetime > MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS
+            || total_lifetime > MAX_PROVIDER_PROCESSING_TOTAL_CLAIM_MILLIS
         {
             return Err(ProviderDeliveryModelError::InvalidLease);
         }
@@ -586,7 +762,7 @@ impl RenewProviderDelivery {
 
     /// Returns exact current claim ownership.
     #[must_use]
-    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+    pub const fn fence(self) -> ProviderProcessingClaimFence {
         self.fence
     }
 
@@ -605,7 +781,7 @@ impl RenewProviderDelivery {
 
 /// Sanitized terminal or transient processing failure category.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum ProviderDeliveryFailure {
+pub enum ProviderProcessingFailure {
     /// A required dependent service was temporarily unavailable.
     DependencyUnavailable,
     /// Current configuration or policy cannot admit the trigger.
@@ -616,19 +792,19 @@ pub enum ProviderDeliveryFailure {
 
 /// Command that closes an exact live claim successfully.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CompleteProviderDelivery {
-    fence: ProviderDeliveryClaimFence,
+pub struct CompleteProviderProcessing {
+    fence: ProviderProcessingClaimFence,
     completed_at: UnixMillis,
 }
 
-impl CompleteProviderDelivery {
+impl CompleteProviderProcessing {
     /// Constructs a completion command.
     ///
     /// # Errors
     ///
     /// Rejects time outside the live lease.
     pub fn new(
-        fence: ProviderDeliveryClaimFence,
+        fence: ProviderProcessingClaimFence,
         completed_at: UnixMillis,
     ) -> Result<Self, ProviderDeliveryModelError> {
         validate_fenced_time(fence, completed_at)?;
@@ -640,7 +816,7 @@ impl CompleteProviderDelivery {
 
     /// Returns exact ownership evidence.
     #[must_use]
-    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+    pub const fn fence(self) -> ProviderProcessingClaimFence {
         self.fence
     }
 
@@ -653,31 +829,31 @@ impl CompleteProviderDelivery {
 
 /// Command that releases an exact live claim into delayed retry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RetryProviderDelivery {
-    fence: ProviderDeliveryClaimFence,
+pub struct RetryProviderProcessing {
+    fence: ProviderProcessingClaimFence,
     failed_at: UnixMillis,
     retry_at: UnixMillis,
-    failure: ProviderDeliveryFailure,
+    failure: ProviderProcessingFailure,
 }
 
-impl RetryProviderDelivery {
+impl RetryProviderProcessing {
     /// Constructs a bounded delayed retry.
     ///
     /// # Errors
     ///
     /// Rejects time outside the lease, a nonfuture deadline, or excessive delay.
     pub fn new(
-        fence: ProviderDeliveryClaimFence,
+        fence: ProviderProcessingClaimFence,
         failed_at: UnixMillis,
         retry_at: UnixMillis,
-        failure: ProviderDeliveryFailure,
+        failure: ProviderProcessingFailure,
     ) -> Result<Self, ProviderDeliveryModelError> {
         validate_fenced_time(fence, failed_at)?;
         let delay = retry_at
             .get()
             .checked_sub(failed_at.get())
             .ok_or(ProviderDeliveryModelError::InvalidRetry)?;
-        if delay <= 0 || delay > MAX_PROVIDER_DELIVERY_RETRY_MILLIS {
+        if delay <= 0 || delay > MAX_PROVIDER_PROCESSING_RETRY_MILLIS {
             return Err(ProviderDeliveryModelError::InvalidRetry);
         }
         Ok(Self {
@@ -690,7 +866,7 @@ impl RetryProviderDelivery {
 
     /// Returns exact ownership evidence.
     #[must_use]
-    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+    pub const fn fence(self) -> ProviderProcessingClaimFence {
         self.fence
     }
 
@@ -708,29 +884,29 @@ impl RetryProviderDelivery {
 
     /// Returns the sanitized failure category.
     #[must_use]
-    pub const fn failure(self) -> ProviderDeliveryFailure {
+    pub const fn failure(self) -> ProviderProcessingFailure {
         self.failure
     }
 }
 
 /// Command that terminally rejects an exact live claim.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FailProviderDelivery {
-    fence: ProviderDeliveryClaimFence,
+pub struct FailProviderProcessing {
+    fence: ProviderProcessingClaimFence,
     failed_at: UnixMillis,
-    failure: ProviderDeliveryFailure,
+    failure: ProviderProcessingFailure,
 }
 
-impl FailProviderDelivery {
+impl FailProviderProcessing {
     /// Constructs a terminal processing failure.
     ///
     /// # Errors
     ///
     /// Rejects time outside the live lease.
     pub fn new(
-        fence: ProviderDeliveryClaimFence,
+        fence: ProviderProcessingClaimFence,
         failed_at: UnixMillis,
-        failure: ProviderDeliveryFailure,
+        failure: ProviderProcessingFailure,
     ) -> Result<Self, ProviderDeliveryModelError> {
         validate_fenced_time(fence, failed_at)?;
         Ok(Self {
@@ -742,7 +918,7 @@ impl FailProviderDelivery {
 
     /// Returns exact ownership evidence.
     #[must_use]
-    pub const fn fence(self) -> ProviderDeliveryClaimFence {
+    pub const fn fence(self) -> ProviderProcessingClaimFence {
         self.fence
     }
 
@@ -754,7 +930,7 @@ impl FailProviderDelivery {
 
     /// Returns the sanitized failure category.
     #[must_use]
-    pub const fn failure(self) -> ProviderDeliveryFailure {
+    pub const fn failure(self) -> ProviderProcessingFailure {
         self.failure
     }
 }
@@ -762,6 +938,10 @@ impl FailProviderDelivery {
 /// Boxed future returned by provider delivery repository operations.
 pub type ProviderDeliveryFuture<'a, T> =
     Pin<Box<dyn Future<Output = Result<T, ProviderDeliveryRepositoryError>> + Send + 'a>>;
+
+/// Boxed future returned by processing-invocation repository operations.
+pub type ProviderProcessingFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, ProviderProcessingRepositoryError>> + Send + 'a>>;
 
 /// Durable opaque endpoint repository with secret-generation custody.
 pub trait ProviderWebhookEndpointRepository: fmt::Debug + Send + Sync {
@@ -785,7 +965,7 @@ pub trait ProviderWebhookEndpointRepository: fmt::Debug + Send + Sync {
     ) -> ProviderDeliveryFuture<'_, Option<ProviderWebhookEndpointRecord>>;
 }
 
-/// Durable replay-safe provider delivery inbox and worker queue.
+/// Durable replay-safe immutable provider delivery inbox.
 pub trait ProviderDeliveryRepository: fmt::Debug + Send + Sync {
     /// Inserts new authenticated evidence or returns an exact replay receipt.
     /// Reusing an instance-scoped external delivery ID with a different replay
@@ -800,36 +980,45 @@ pub trait ProviderDeliveryRepository: fmt::Debug + Send + Sync {
         &self,
         delivery_id: ProviderDeliveryId,
     ) -> ProviderDeliveryFuture<'_, Option<ProviderDelivery>>;
+}
 
-    /// Claims at most one eligible normalized trigger with skip-locked semantics.
-    fn claim_delivery(
+/// Durable queue of processing invocations derived from immutable deliveries.
+pub trait ProviderProcessingRepository: fmt::Debug + Send + Sync {
+    /// Claims at most one eligible processing invocation with skip-locked semantics.
+    fn claim_processing(
         &self,
-        request: ClaimProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, Option<ClaimedProviderDelivery>>;
+        request: ClaimProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, Option<ClaimedProviderProcessing>>;
+
+    /// Binds one unresolved control invocation to an immutable trigger exactly once.
+    fn bind_processing_source(
+        &self,
+        request: BindProviderProcessingSource,
+    ) -> ProviderProcessingFuture<'_, ClaimedProviderProcessing>;
 
     /// Extends one exact live claim while preserving its fencing token.
-    fn renew_delivery(
+    fn renew_processing(
         &self,
-        request: RenewProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryClaimFence>;
+        request: RenewProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingClaimFence>;
 
     /// Closes an exact live claim successfully.
-    fn complete_delivery(
+    fn complete_processing(
         &self,
-        request: CompleteProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+        request: CompleteProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt>;
 
     /// Releases an exact live claim into bounded delayed retry.
-    fn retry_delivery(
+    fn retry_processing(
         &self,
-        request: RetryProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+        request: RetryProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt>;
 
     /// Terminally fails an exact live claim.
-    fn fail_delivery(
+    fn fail_processing(
         &self,
-        request: FailProviderDelivery,
-    ) -> ProviderDeliveryFuture<'_, ProviderDeliveryReceipt>;
+        request: FailProviderProcessing,
+    ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt>;
 }
 
 /// Invalid delivery values rejected before repository access.
@@ -845,7 +1034,7 @@ pub enum ProviderDeliveryModelError {
     #[error("provider delivery lease is invalid")]
     InvalidLease,
     /// Fencing token or expiry was invalid.
-    #[error("provider delivery claim fence is invalid")]
+    #[error("provider processing claim fence is invalid")]
     InvalidFence,
     /// Claimed receipt, delivery, and fence identities disagreed.
     #[error("claimed provider delivery evidence is inconsistent")]
@@ -870,12 +1059,6 @@ pub enum ProviderDeliveryRepositoryError {
     /// An external delivery replay key was reused with different immutable evidence.
     #[error("provider delivery replay evidence conflicts with durable state")]
     ReplayConflict,
-    /// A claim fence was stale, expired, or owned by another worker.
-    #[error("provider delivery claim was rejected")]
-    ClaimRejected,
-    /// The hard attempt bound was reached.
-    #[error("provider delivery attempt limit was reached")]
-    AttemptLimitReached,
     /// Durable rows violated provider model invariants.
     #[error("provider delivery storage is corrupt")]
     Corrupt,
@@ -884,8 +1067,28 @@ pub enum ProviderDeliveryRepositoryError {
     Unavailable,
 }
 
+/// Sanitized durable processing-invocation repository failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderProcessingRepositoryError {
+    /// A referenced processing invocation or source delivery does not exist.
+    #[error("provider processing reference does not exist")]
+    NotFound,
+    /// A processing claim fence was stale, expired, or owned by another worker.
+    #[error("provider processing claim was rejected")]
+    ClaimRejected,
+    /// The hard processing attempt bound was reached.
+    #[error("provider processing attempt limit was reached")]
+    AttemptLimitReached,
+    /// Durable rows violated processing model invariants.
+    #[error("provider processing storage is corrupt")]
+    Corrupt,
+    /// The durable processing repository was unavailable.
+    #[error("provider processing repository is unavailable")]
+    Unavailable,
+}
+
 fn validate_fenced_time(
-    fence: ProviderDeliveryClaimFence,
+    fence: ProviderProcessingClaimFence,
     timestamp: UnixMillis,
 ) -> Result<(), ProviderDeliveryModelError> {
     if timestamp < fence.claimed_at() || timestamp >= fence.expires_at() {

--- a/crates/automata-ci-provider/src/identity.rs
+++ b/crates/automata-ci-provider/src/identity.rs
@@ -192,9 +192,14 @@ uuid_identity!(
     "provider delivery ID"
 );
 uuid_identity!(
-    /// Durable identity of one provider-delivery worker.
-    ProviderDeliveryWorkerId,
-    "provider delivery worker ID"
+    /// Durable identity of one processing invocation derived from an immutable delivery.
+    ProviderProcessingInvocationId,
+    "provider processing invocation ID"
+);
+uuid_identity!(
+    /// Durable identity of one provider processing worker.
+    ProviderProcessingWorkerId,
+    "provider processing worker ID"
 );
 uuid_identity!(
     /// Durable identity of one provider result subject.

--- a/crates/automata-ci-provider/src/lib.rs
+++ b/crates/automata-ci-provider/src/lib.rs
@@ -10,6 +10,7 @@
 mod capability;
 mod configuration;
 mod connection;
+mod control;
 mod credential;
 mod delivery;
 mod factory;
@@ -46,6 +47,10 @@ pub use connection::{
     ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderWorkflowSource,
     RepositoryVisibility,
 };
+pub use control::{
+    MAX_PROVIDER_CONTROL_DOCUMENT_BYTES, ProviderControl, ProviderControlDocument,
+    ProviderControlError, ProviderControlKind,
+};
 pub use credential::{
     ControlCredential, ControlCredentialFuture, ControlCredentialProvider,
     ControlCredentialProviderError, ControlCredentialRequest, ControlCredentialRevocation,
@@ -59,14 +64,16 @@ pub use credential::{
     WorkloadCredentialRevocationOutcome,
 };
 pub use delivery::{
-    AcceptProviderDelivery, ClaimProviderDelivery, ClaimedProviderDelivery,
-    CompleteProviderDelivery, FailProviderDelivery, MAX_PROVIDER_DELIVERY_ATTEMPTS,
-    MAX_PROVIDER_DELIVERY_LEASE_MILLIS, MAX_PROVIDER_DELIVERY_RETRY_MILLIS, ProviderDelivery,
-    ProviderDeliveryAcceptOutcome, ProviderDeliveryClaimFence, ProviderDeliveryFailure,
+    AcceptProviderDelivery, BindProviderProcessingSource, ClaimProviderProcessing,
+    ClaimedProviderProcessing, CompleteProviderProcessing, FailProviderProcessing,
+    MAX_PROVIDER_PROCESSING_ATTEMPTS, MAX_PROVIDER_PROCESSING_LEASE_MILLIS,
+    MAX_PROVIDER_PROCESSING_RETRY_MILLIS, ProviderDelivery, ProviderDeliveryAcceptOutcome,
     ProviderDeliveryFuture, ProviderDeliveryModelError, ProviderDeliveryReceipt,
     ProviderDeliveryReplayFingerprint, ProviderDeliveryRepository, ProviderDeliveryRepositoryError,
-    ProviderDeliveryState, ProviderWebhookEndpointRecord, ProviderWebhookEndpointRepository,
-    RenewProviderDelivery, RetryProviderDelivery,
+    ProviderProcessingClaimFence, ProviderProcessingFailure, ProviderProcessingFuture,
+    ProviderProcessingInput, ProviderProcessingReceipt, ProviderProcessingRepository,
+    ProviderProcessingRepositoryError, ProviderProcessingState, ProviderWebhookEndpointRecord,
+    ProviderWebhookEndpointRepository, RenewProviderProcessing, RetryProviderProcessing,
 };
 pub use factory::{
     MAX_PROVIDER_FACTORIES, ProviderConfigurationFactory, ProviderConnectionFactoryRequest,
@@ -89,9 +96,9 @@ pub use identity::{
     ExternalMergeQueueId, ExternalRepositoryId, ExternalRepositoryIdentity, ExternalResultId,
     ExternalSubjectId, ExternalSubjectIdentity, ExternalSubjectKind, MAX_EXTERNAL_ID_BYTES,
     MAX_PROVIDER_TYPE_ID_BYTES, ProviderConnectionId, ProviderControlCredentialId,
-    ProviderDeliveryId, ProviderDeliveryWorkerId, ProviderIdentityError, ProviderInstanceId,
-    ProviderResultSubjectId, ProviderResultWorkerId, ProviderTypeId, ProviderWebhookEndpointId,
-    ProviderWorkloadCredentialId,
+    ProviderDeliveryId, ProviderIdentityError, ProviderInstanceId, ProviderProcessingInvocationId,
+    ProviderProcessingWorkerId, ProviderResultSubjectId, ProviderResultWorkerId, ProviderTypeId,
+    ProviderWebhookEndpointId, ProviderWorkloadCredentialId,
 };
 pub use result::{
     ClaimProviderResult, ClaimedProviderResult, CompleteProviderResult, DesiredProviderResult,
@@ -127,12 +134,14 @@ pub use webhook::{
     MAX_PROVIDER_WEBHOOK_HEADER_BYTES, MAX_PROVIDER_WEBHOOK_HEADER_NAME_BYTES,
     MAX_PROVIDER_WEBHOOK_HEADER_VALUE_BYTES, MAX_PROVIDER_WEBHOOK_HEADERS,
     MAX_PROVIDER_WEBHOOK_SECRET_CANDIDATES, PROVIDER_RAW_WEBHOOK_KEY_PREFIX,
-    PROVIDER_RAW_WEBHOOK_MEDIA_TYPE, ProviderDeliveryDraft, ProviderDeliveryNormalization,
-    ProviderDeliveryObservations, ProviderDeliveryRejection, ProviderWebhookAuthenticationError,
+    PROVIDER_RAW_WEBHOOK_MEDIA_TYPE, ProviderControlDeliveryDraft, ProviderDeliveryEvidence,
+    ProviderDeliveryNormalization, ProviderDeliveryObservations, ProviderDeliveryRejection,
+    ProviderTriggerDeliveryDraft, ProviderWebhookAuthenticationError,
     ProviderWebhookAuthenticationRequest, ProviderWebhookEndpointManifest,
     ProviderWebhookEndpointRevision, ProviderWebhookEndpointState, ProviderWebhookError,
     ProviderWebhookHeaderName, ProviderWebhookHeaders, ProviderWebhookMethod,
     ProviderWebhookRequest, ProviderWebhookSecretCandidate, ProviderWebhookSecretCandidates,
     ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, RejectedProviderDelivery,
-    RejectedProviderDeliveryDraft, VerifiedProviderDelivery, provider_raw_webhook_descriptor,
+    RejectedProviderDeliveryDraft, VerifiedProviderControlDelivery,
+    VerifiedProviderTriggerDelivery, provider_raw_webhook_descriptor,
 };

--- a/crates/automata-ci-provider/src/webhook.rs
+++ b/crates/automata-ci-provider/src/webhook.rs
@@ -11,9 +11,10 @@ use thiserror::Error;
 use crate::{
     ExternalDeliveryIdentity, ExternalRepositoryIdentity, NormalizedTrigger,
     ProviderConfigurationRevision, ProviderConnectionId, ProviderConnectionManifest,
-    ProviderConnectionRevision, ProviderDeliveryId, ProviderEventName, ProviderInstanceId,
-    ProviderLifecycleState, ProviderSecret, ProviderSecretGeneration, ProviderSecretName,
-    ProviderTriggerError, ProviderTypeId, ProviderWebhookEndpointId, SealedNormalizedTrigger,
+    ProviderConnectionRevision, ProviderControl, ProviderDeliveryId, ProviderEventName,
+    ProviderInstanceId, ProviderLifecycleState, ProviderSecret, ProviderSecretGeneration,
+    ProviderSecretName, ProviderTriggerError, ProviderTypeId, ProviderWebhookEndpointId,
+    SealedNormalizedTrigger,
 };
 
 /// Hard upper bound for any provider webhook body.
@@ -841,51 +842,25 @@ impl fmt::Debug for ProviderDeliveryObservations {
     }
 }
 
-/// Authenticated and normalized delivery awaiting immutable raw-body storage.
+/// Authenticated delivery facts shared by every normalization outcome.
 #[derive(Debug)]
-pub struct ProviderDeliveryDraft {
+struct ProviderDeliveryDraftEvidence {
     delivery_id: ProviderDeliveryId,
     external_delivery: ExternalDeliveryIdentity,
     event_type: ProviderEventName,
     authenticated: AuthenticatedProviderWebhook,
-    trigger: SealedNormalizedTrigger,
     observations: ProviderDeliveryObservations,
 }
 
-/// Authenticated non-admission delivery awaiting immutable raw-body storage.
-#[derive(Debug)]
-pub struct RejectedProviderDeliveryDraft {
-    delivery_id: ProviderDeliveryId,
-    external_delivery: ExternalDeliveryIdentity,
-    event_type: ProviderEventName,
-    authenticated: AuthenticatedProviderWebhook,
-    repository: Option<ExternalRepositoryIdentity>,
-    reason: ProviderDeliveryRejection,
-    observations: ProviderDeliveryObservations,
-}
-
-impl RejectedProviderDeliveryDraft {
-    /// Constructs a bounded authenticated rejection record.
-    ///
-    /// # Errors
-    ///
-    /// Rejects delivery or optional repository evidence from another instance.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
+impl ProviderDeliveryDraftEvidence {
+    fn new(
         delivery_id: ProviderDeliveryId,
         external_delivery: ExternalDeliveryIdentity,
         event_type: ProviderEventName,
         authenticated: AuthenticatedProviderWebhook,
-        repository: Option<ExternalRepositoryIdentity>,
-        reason: ProviderDeliveryRejection,
         observations: ProviderDeliveryObservations,
     ) -> Result<Self, ProviderWebhookError> {
-        let instance_id = authenticated.request().endpoint().instance_id();
-        if external_delivery.instance_id() != instance_id
-            || repository
-                .as_ref()
-                .is_some_and(|value| value.instance_id() != instance_id)
-        {
+        if external_delivery.instance_id() != authenticated.request().endpoint().instance_id() {
             return Err(ProviderWebhookError::PayloadIdentityMismatch);
         }
         Ok(Self {
@@ -893,48 +868,47 @@ impl RejectedProviderDeliveryDraft {
             external_delivery,
             event_type,
             authenticated,
-            repository,
-            reason,
             observations,
         })
     }
-}
 
-impl ProviderDeliveryDraft {
-    /// Binds adapter output to exact endpoint, instance, and repository evidence.
-    ///
-    /// # Errors
-    ///
-    /// Rejects cross-instance delivery or normalized repository identities.
-    pub fn new(
-        delivery_id: ProviderDeliveryId,
-        external_delivery: ExternalDeliveryIdentity,
-        event_type: ProviderEventName,
-        authenticated: AuthenticatedProviderWebhook,
-        trigger: &NormalizedTrigger,
-        observations: ProviderDeliveryObservations,
-    ) -> Result<Self, ProviderWebhookError> {
-        let endpoint_instance = authenticated.request().endpoint().instance_id();
-        if external_delivery.instance_id() != endpoint_instance
-            || trigger.target_repository().identity().instance_id() != endpoint_instance
-        {
-            return Err(ProviderWebhookError::PayloadIdentityMismatch);
-        }
-        let trigger = trigger.seal().map_err(ProviderWebhookError::Trigger)?;
-        Ok(Self {
-            delivery_id,
-            external_delivery,
-            event_type,
-            authenticated,
-            trigger,
-            observations,
-        })
+    fn request(&self) -> &ProviderWebhookRequest {
+        self.authenticated.request()
+    }
+
+    fn seal(
+        self,
+        raw_body: BlobDescriptor,
+    ) -> Result<ProviderDeliveryEvidence, ProviderWebhookError> {
+        validate_raw_descriptor(self.authenticated.request(), &raw_body)?;
+        let endpoint = self.authenticated.request().endpoint();
+        let raw_retain_until = retention_deadline(
+            self.authenticated.request().received_at(),
+            endpoint.raw_retention_millis(),
+        )?;
+        ProviderDeliveryEvidence::rehydrate(
+            self.delivery_id,
+            endpoint.endpoint_id(),
+            endpoint.revision(),
+            endpoint.provider_type().clone(),
+            endpoint.instance_id(),
+            endpoint.provider_revision(),
+            endpoint.connection_id(),
+            endpoint.connection_revision(),
+            self.external_delivery,
+            self.event_type,
+            self.authenticated.request().received_at(),
+            raw_body,
+            raw_retain_until,
+            self.authenticated.signature().clone(),
+            self.observations,
+        )
     }
 }
 
-/// Complete verified delivery with immutable raw-body evidence.
+/// Complete immutable authenticated evidence shared by all delivery outcomes.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VerifiedProviderDelivery {
+pub struct ProviderDeliveryEvidence {
     delivery_id: ProviderDeliveryId,
     endpoint_id: ProviderWebhookEndpointId,
     endpoint_revision: ProviderWebhookEndpointRevision,
@@ -949,17 +923,15 @@ pub struct VerifiedProviderDelivery {
     raw_body: BlobDescriptor,
     raw_retain_until: UnixMillis,
     signature: ProviderWebhookSignatureEvidence,
-    trigger: SealedNormalizedTrigger,
     observations: ProviderDeliveryObservations,
 }
 
-impl VerifiedProviderDelivery {
-    /// Rehydrates complete durable verified-delivery evidence.
+impl ProviderDeliveryEvidence {
+    /// Rehydrates exact durable evidence shared by every delivery disposition.
     ///
     /// # Errors
     ///
-    /// Rejects cross-instance identities, negative receipt time, or a raw object
-    /// descriptor that is not the canonical content-addressed representation.
+    /// Rejects cross-instance identities, invalid times, or noncanonical raw evidence.
     #[allow(clippy::too_many_arguments)]
     pub fn rehydrate(
         delivery_id: ProviderDeliveryId,
@@ -976,7 +948,6 @@ impl VerifiedProviderDelivery {
         raw_body: BlobDescriptor,
         raw_retain_until: UnixMillis,
         signature: ProviderWebhookSignatureEvidence,
-        trigger: SealedNormalizedTrigger,
         observations: ProviderDeliveryObservations,
     ) -> Result<Self, ProviderWebhookError> {
         validate_durable_evidence(
@@ -986,15 +957,6 @@ impl VerifiedProviderDelivery {
             &raw_body,
             raw_retain_until,
         )?;
-        if trigger
-            .trigger()
-            .target_repository()
-            .identity()
-            .instance_id()
-            != instance_id
-        {
-            return Err(ProviderWebhookError::PayloadIdentityMismatch);
-        }
         Ok(Self {
             delivery_id,
             endpoint_id,
@@ -1010,44 +972,7 @@ impl VerifiedProviderDelivery {
             raw_body,
             raw_retain_until,
             signature,
-            trigger,
             observations,
-        })
-    }
-
-    /// Seals normalized output against an immutable content-addressed raw body.
-    ///
-    /// # Errors
-    ///
-    /// Rejects a raw descriptor whose digest, size, media type, or key differs
-    /// from the authenticated request.
-    pub fn seal(
-        draft: ProviderDeliveryDraft,
-        raw_body: BlobDescriptor,
-    ) -> Result<Self, ProviderWebhookError> {
-        validate_raw_descriptor(draft.authenticated.request(), &raw_body)?;
-        let endpoint = draft.authenticated.request().endpoint();
-        let raw_retain_until = retention_deadline(
-            draft.authenticated.request().received_at(),
-            endpoint.raw_retention_millis(),
-        )?;
-        Ok(Self {
-            delivery_id: draft.delivery_id,
-            endpoint_id: endpoint.endpoint_id(),
-            endpoint_revision: endpoint.revision(),
-            provider_type: endpoint.provider_type().clone(),
-            instance_id: endpoint.instance_id(),
-            provider_revision: endpoint.provider_revision(),
-            connection_id: endpoint.connection_id(),
-            connection_revision: endpoint.connection_revision(),
-            external_delivery: draft.external_delivery,
-            event_type: draft.event_type,
-            received_at: draft.authenticated.request().received_at(),
-            raw_body,
-            raw_retain_until,
-            signature: draft.authenticated.signature().clone(),
-            trigger: draft.trigger,
-            observations: draft.observations,
         })
     }
 
@@ -1135,12 +1060,6 @@ impl VerifiedProviderDelivery {
         &self.signature
     }
 
-    /// Returns the strongly typed normalized trigger.
-    #[must_use]
-    pub const fn trigger(&self) -> &SealedNormalizedTrigger {
-        &self.trigger
-    }
-
     /// Returns bounded adapter audit observations.
     #[must_use]
     pub const fn observations(&self) -> &ProviderDeliveryObservations {
@@ -1148,207 +1067,271 @@ impl VerifiedProviderDelivery {
     }
 }
 
-/// Complete authenticated rejection with immutable raw-body evidence.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RejectedProviderDelivery {
-    delivery_id: ProviderDeliveryId,
-    endpoint_id: ProviderWebhookEndpointId,
-    endpoint_revision: ProviderWebhookEndpointRevision,
-    provider_type: ProviderTypeId,
-    instance_id: ProviderInstanceId,
-    provider_revision: ProviderConfigurationRevision,
-    connection_id: ProviderConnectionId,
-    connection_revision: ProviderConnectionRevision,
-    external_delivery: ExternalDeliveryIdentity,
-    event_type: ProviderEventName,
-    received_at: UnixMillis,
-    raw_body: BlobDescriptor,
-    raw_retain_until: UnixMillis,
-    signature: ProviderWebhookSignatureEvidence,
-    repository: Option<ExternalRepositoryIdentity>,
-    reason: ProviderDeliveryRejection,
-    observations: ProviderDeliveryObservations,
+/// Authenticated normalized trigger awaiting immutable raw-body storage.
+#[derive(Debug)]
+pub struct ProviderTriggerDeliveryDraft {
+    evidence: ProviderDeliveryDraftEvidence,
+    trigger: SealedNormalizedTrigger,
 }
 
-impl RejectedProviderDelivery {
-    /// Rehydrates complete durable authenticated rejection evidence.
+impl ProviderTriggerDeliveryDraft {
+    /// Binds adapter output to exact endpoint, instance, and repository evidence.
     ///
     /// # Errors
     ///
-    /// Rejects cross-instance identities, negative receipt time, or a noncanonical
-    /// immutable raw object descriptor.
-    #[allow(clippy::too_many_arguments)]
-    pub fn rehydrate(
+    /// Rejects inconsistent provider identities or an invalid normalized trigger.
+    pub fn new(
         delivery_id: ProviderDeliveryId,
-        endpoint_id: ProviderWebhookEndpointId,
-        endpoint_revision: ProviderWebhookEndpointRevision,
-        provider_type: ProviderTypeId,
-        instance_id: ProviderInstanceId,
-        provider_revision: ProviderConfigurationRevision,
-        connection_id: ProviderConnectionId,
-        connection_revision: ProviderConnectionRevision,
         external_delivery: ExternalDeliveryIdentity,
         event_type: ProviderEventName,
-        received_at: UnixMillis,
-        raw_body: BlobDescriptor,
-        raw_retain_until: UnixMillis,
-        signature: ProviderWebhookSignatureEvidence,
-        repository: Option<ExternalRepositoryIdentity>,
-        reason: ProviderDeliveryRejection,
+        authenticated: AuthenticatedProviderWebhook,
+        trigger: &NormalizedTrigger,
         observations: ProviderDeliveryObservations,
     ) -> Result<Self, ProviderWebhookError> {
-        validate_durable_evidence(
-            instance_id,
-            &external_delivery,
-            received_at,
-            &raw_body,
-            raw_retain_until,
+        let evidence = ProviderDeliveryDraftEvidence::new(
+            delivery_id,
+            external_delivery,
+            event_type,
+            authenticated,
+            observations,
         )?;
-        if repository
-            .as_ref()
-            .is_some_and(|value| value.instance_id() != instance_id)
+        if trigger.target_repository().identity().instance_id()
+            != evidence.request().endpoint().instance_id()
         {
             return Err(ProviderWebhookError::PayloadIdentityMismatch);
         }
         Ok(Self {
-            delivery_id,
-            endpoint_id,
-            endpoint_revision,
-            provider_type,
-            instance_id,
-            provider_revision,
-            connection_id,
-            connection_revision,
-            external_delivery,
-            event_type,
-            received_at,
-            raw_body,
-            raw_retain_until,
-            signature,
-            repository,
-            reason,
-            observations,
+            evidence,
+            trigger: trigger.seal().map_err(ProviderWebhookError::Trigger)?,
         })
     }
+}
 
-    /// Seals an authenticated rejection against immutable raw-body evidence.
+/// Authenticated normalized control awaiting immutable raw-body storage.
+#[derive(Debug)]
+pub struct ProviderControlDeliveryDraft {
+    evidence: ProviderDeliveryDraftEvidence,
+    control: ProviderControl,
+}
+
+impl ProviderControlDeliveryDraft {
+    /// Binds adapter control output to the exact authenticated instance.
     ///
     /// # Errors
     ///
-    /// Rejects a descriptor that disagrees with the exact authenticated body.
-    pub fn seal(
-        draft: RejectedProviderDeliveryDraft,
+    /// Rejects a control targeting another provider instance.
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        authenticated: AuthenticatedProviderWebhook,
+        control: ProviderControl,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        let evidence = ProviderDeliveryDraftEvidence::new(
+            delivery_id,
+            external_delivery,
+            event_type,
+            authenticated,
+            observations,
+        )?;
+        if control.repository().instance_id() != evidence.request().endpoint().instance_id() {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self { evidence, control })
+    }
+}
+
+/// Authenticated non-admission delivery awaiting immutable raw-body storage.
+#[derive(Debug)]
+pub struct RejectedProviderDeliveryDraft {
+    evidence: ProviderDeliveryDraftEvidence,
+    repository: Option<ExternalRepositoryIdentity>,
+    reason: ProviderDeliveryRejection,
+}
+
+impl RejectedProviderDeliveryDraft {
+    /// Constructs a bounded authenticated rejection record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects rejection evidence targeting another provider instance.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        delivery_id: ProviderDeliveryId,
+        external_delivery: ExternalDeliveryIdentity,
+        event_type: ProviderEventName,
+        authenticated: AuthenticatedProviderWebhook,
+        repository: Option<ExternalRepositoryIdentity>,
+        reason: ProviderDeliveryRejection,
+        observations: ProviderDeliveryObservations,
+    ) -> Result<Self, ProviderWebhookError> {
+        let evidence = ProviderDeliveryDraftEvidence::new(
+            delivery_id,
+            external_delivery,
+            event_type,
+            authenticated,
+            observations,
+        )?;
+        if repository
+            .as_ref()
+            .is_some_and(|value| value.instance_id() != evidence.request().endpoint().instance_id())
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self {
+            evidence,
+            repository,
+            reason,
+        })
+    }
+}
+
+/// Complete normalized trigger with immutable authenticated evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedProviderTriggerDelivery {
+    evidence: ProviderDeliveryEvidence,
+    trigger: SealedNormalizedTrigger,
+}
+
+impl VerifiedProviderTriggerDelivery {
+    /// Rehydrates a trigger from common evidence and normalized payload.
+    ///
+    /// # Errors
+    ///
+    /// Rejects trigger and delivery evidence from different provider instances.
+    pub fn rehydrate(
+        evidence: ProviderDeliveryEvidence,
+        trigger: SealedNormalizedTrigger,
+    ) -> Result<Self, ProviderWebhookError> {
+        if trigger
+            .trigger()
+            .target_repository()
+            .identity()
+            .instance_id()
+            != evidence.instance_id()
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self { evidence, trigger })
+    }
+
+    fn seal(
+        draft: ProviderTriggerDeliveryDraft,
         raw_body: BlobDescriptor,
     ) -> Result<Self, ProviderWebhookError> {
-        validate_raw_descriptor(draft.authenticated.request(), &raw_body)?;
-        let endpoint = draft.authenticated.request().endpoint();
-        let raw_retain_until = retention_deadline(
-            draft.authenticated.request().received_at(),
-            endpoint.raw_retention_millis(),
-        )?;
         Ok(Self {
-            delivery_id: draft.delivery_id,
-            endpoint_id: endpoint.endpoint_id(),
-            endpoint_revision: endpoint.revision(),
-            provider_type: endpoint.provider_type().clone(),
-            instance_id: endpoint.instance_id(),
-            provider_revision: endpoint.provider_revision(),
-            connection_id: endpoint.connection_id(),
-            connection_revision: endpoint.connection_revision(),
-            external_delivery: draft.external_delivery,
-            event_type: draft.event_type,
-            received_at: draft.authenticated.request().received_at(),
-            raw_body,
-            raw_retain_until,
-            signature: draft.authenticated.signature().clone(),
-            repository: draft.repository,
-            reason: draft.reason,
-            observations: draft.observations,
+            evidence: draft.evidence.seal(raw_body)?,
+            trigger: draft.trigger,
         })
     }
 
-    /// Returns the durable server-owned delivery identity.
+    /// Returns the immutable authenticated envelope.
     #[must_use]
-    pub const fn delivery_id(&self) -> ProviderDeliveryId {
-        self.delivery_id
+    pub const fn evidence(&self) -> &ProviderDeliveryEvidence {
+        &self.evidence
     }
 
-    /// Returns the exact public endpoint used for ingress.
+    /// Returns the strongly typed normalized trigger.
     #[must_use]
-    pub const fn endpoint_id(&self) -> ProviderWebhookEndpointId {
-        self.endpoint_id
+    pub const fn trigger(&self) -> &SealedNormalizedTrigger {
+        &self.trigger
+    }
+}
+
+/// Complete normalized control with immutable authenticated evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedProviderControlDelivery {
+    evidence: ProviderDeliveryEvidence,
+    control: ProviderControl,
+}
+
+impl VerifiedProviderControlDelivery {
+    /// Rehydrates a control from common evidence and adapter-owned target evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects control and delivery evidence from different provider instances.
+    pub fn rehydrate(
+        evidence: ProviderDeliveryEvidence,
+        control: ProviderControl,
+    ) -> Result<Self, ProviderWebhookError> {
+        if control.repository().instance_id() != evidence.instance_id() {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self { evidence, control })
     }
 
-    /// Returns the endpoint policy revision used for authentication.
-    #[must_use]
-    pub const fn endpoint_revision(&self) -> ProviderWebhookEndpointRevision {
-        self.endpoint_revision
+    fn seal(
+        draft: ProviderControlDeliveryDraft,
+        raw_body: BlobDescriptor,
+    ) -> Result<Self, ProviderWebhookError> {
+        Ok(Self {
+            evidence: draft.evidence.seal(raw_body)?,
+            control: draft.control,
+        })
     }
 
-    /// Returns the exact provider adapter type.
+    /// Returns the immutable authenticated envelope.
     #[must_use]
-    pub const fn provider_type(&self) -> &ProviderTypeId {
-        &self.provider_type
+    pub const fn evidence(&self) -> &ProviderDeliveryEvidence {
+        &self.evidence
     }
 
-    /// Returns the configured provider instance.
+    /// Returns normalized provider-independent control facts.
     #[must_use]
-    pub const fn instance_id(&self) -> ProviderInstanceId {
-        self.instance_id
+    pub const fn control(&self) -> &ProviderControl {
+        &self.control
+    }
+}
+
+/// Complete authenticated rejection with immutable raw-body evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RejectedProviderDelivery {
+    evidence: ProviderDeliveryEvidence,
+    repository: Option<ExternalRepositoryIdentity>,
+    reason: ProviderDeliveryRejection,
+}
+
+impl RejectedProviderDelivery {
+    /// Rehydrates an authenticated rejection from common evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects repository and delivery evidence from different provider instances.
+    pub fn rehydrate(
+        evidence: ProviderDeliveryEvidence,
+        repository: Option<ExternalRepositoryIdentity>,
+        reason: ProviderDeliveryRejection,
+    ) -> Result<Self, ProviderWebhookError> {
+        if repository
+            .as_ref()
+            .is_some_and(|value| value.instance_id() != evidence.instance_id())
+        {
+            return Err(ProviderWebhookError::PayloadIdentityMismatch);
+        }
+        Ok(Self {
+            evidence,
+            repository,
+            reason,
+        })
     }
 
-    /// Returns the exact provider configuration revision used for normalization.
-    #[must_use]
-    pub const fn provider_revision(&self) -> ProviderConfigurationRevision {
-        self.provider_revision
+    fn seal(
+        draft: RejectedProviderDeliveryDraft,
+        raw_body: BlobDescriptor,
+    ) -> Result<Self, ProviderWebhookError> {
+        Ok(Self {
+            evidence: draft.evidence.seal(raw_body)?,
+            repository: draft.repository,
+            reason: draft.reason,
+        })
     }
 
-    /// Returns the endpoint-bound connection.
+    /// Returns the immutable authenticated envelope.
     #[must_use]
-    pub const fn connection_id(&self) -> ProviderConnectionId {
-        self.connection_id
-    }
-
-    /// Returns the exact endpoint-bound connection policy revision.
-    #[must_use]
-    pub const fn connection_revision(&self) -> ProviderConnectionRevision {
-        self.connection_revision
-    }
-
-    /// Returns instance-scoped provider replay identity.
-    #[must_use]
-    pub const fn external_delivery(&self) -> &ExternalDeliveryIdentity {
-        &self.external_delivery
-    }
-
-    /// Returns provider-native event-name evidence.
-    #[must_use]
-    pub const fn event_type(&self) -> &ProviderEventName {
-        &self.event_type
-    }
-
-    /// Returns trusted ingress receipt time.
-    #[must_use]
-    pub const fn received_at(&self) -> UnixMillis {
-        self.received_at
-    }
-
-    /// Returns immutable raw request-body evidence.
-    #[must_use]
-    pub const fn raw_body(&self) -> &BlobDescriptor {
-        &self.raw_body
-    }
-
-    /// Returns the inclusive raw-evidence retention deadline.
-    #[must_use]
-    pub const fn raw_retain_until(&self) -> UnixMillis {
-        self.raw_retain_until
-    }
-
-    /// Returns signature scheme and accepted generation evidence.
-    #[must_use]
-    pub const fn signature(&self) -> &ProviderWebhookSignatureEvidence {
-        &self.signature
+    pub const fn evidence(&self) -> &ProviderDeliveryEvidence {
+        &self.evidence
     }
 
     /// Returns repository identity when the authenticated shape contained it.
@@ -1361,12 +1344,6 @@ impl RejectedProviderDelivery {
     #[must_use]
     pub const fn reason(&self) -> ProviderDeliveryRejection {
         self.reason
-    }
-
-    /// Returns bounded adapter audit observations.
-    #[must_use]
-    pub const fn observations(&self) -> &ProviderDeliveryObservations {
-        &self.observations
     }
 }
 
@@ -1394,7 +1371,9 @@ pub enum ProviderDeliveryRejection {
 #[derive(Debug)]
 pub enum ProviderDeliveryNormalization {
     /// A complete trigger ready for raw evidence storage and durable acceptance.
-    Accepted(Box<ProviderDeliveryDraft>),
+    Trigger(Box<ProviderTriggerDeliveryDraft>),
+    /// A complete authenticated control ready for durable processing.
+    Control(Box<ProviderControlDeliveryDraft>),
     /// A sanitized authenticated rejection retained for audit but not admission.
     Rejected(Box<RejectedProviderDeliveryDraft>),
 }
@@ -1404,8 +1383,9 @@ impl ProviderDeliveryNormalization {
     #[must_use]
     pub fn raw_body(&self) -> &[u8] {
         match self {
-            Self::Accepted(value) => value.authenticated.request().body(),
-            Self::Rejected(value) => value.authenticated.request().body(),
+            Self::Trigger(value) => value.evidence.request().body(),
+            Self::Control(value) => value.evidence.request().body(),
+            Self::Rejected(value) => value.evidence.request().body(),
         }
     }
 
@@ -1416,14 +1396,15 @@ impl ProviderDeliveryNormalization {
     /// Fails only if the static provider raw-evidence blob contract is invalid.
     pub fn raw_descriptor(&self) -> Result<BlobDescriptor, ProviderWebhookError> {
         let request = match self {
-            Self::Accepted(value) => value.authenticated.request(),
-            Self::Rejected(value) => value.authenticated.request(),
+            Self::Trigger(value) => value.evidence.request(),
+            Self::Control(value) => value.evidence.request(),
+            Self::Rejected(value) => value.evidence.request(),
         };
         provider_raw_webhook_descriptor(request.body_digest(), request.body().len() as u64)
     }
 
-    /// Seals either normalized trigger or authenticated rejection after the
-    /// caller durably stores exact raw body bytes under `raw_body`.
+    /// Seals normalized trigger, control, or rejection evidence after the caller
+    /// durably stores exact raw body bytes under `raw_body`.
     ///
     /// # Errors
     ///
@@ -1433,9 +1414,12 @@ impl ProviderDeliveryNormalization {
         raw_body: BlobDescriptor,
     ) -> Result<crate::ProviderDelivery, ProviderWebhookError> {
         match self {
-            Self::Accepted(value) => VerifiedProviderDelivery::seal(*value, raw_body)
+            Self::Trigger(value) => VerifiedProviderTriggerDelivery::seal(*value, raw_body)
                 .map(Box::new)
                 .map(crate::ProviderDelivery::Trigger),
+            Self::Control(value) => VerifiedProviderControlDelivery::seal(*value, raw_body)
+                .map(Box::new)
+                .map(crate::ProviderDelivery::Control),
             Self::Rejected(value) => RejectedProviderDelivery::seal(*value, raw_body)
                 .map(Box::new)
                 .map(crate::ProviderDelivery::Rejected),

--- a/crates/automata-ci-provider/tests/delivery.rs
+++ b/crates/automata-ci-provider/tests/delivery.rs
@@ -9,23 +9,23 @@ use std::{
 use automata_ci_core::{GitObjectAlgorithm, GitObjectId, Sha256Digest, UnixMillis, WorkspaceId};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
-    AuthenticatedProviderWebhook, CompleteProviderDelivery, DeliveryAdapter,
+    AuthenticatedProviderWebhook, CompleteProviderProcessing, DeliveryAdapter,
     DeliveryAdapterRegistry, ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
     ExternalRepositoryIdentity, NormalizedTrigger, ProviderArchiveLimits,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
     ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
-    ProviderDefaultBranch, ProviderDeliveryClaimFence, ProviderDeliveryDraft, ProviderDeliveryId,
-    ProviderDeliveryNormalization, ProviderDeliveryObservations, ProviderDeliveryRejection,
-    ProviderDeliveryWorkerId, ProviderEventName, ProviderGitRef, ProviderGitRefKind,
-    ProviderInstanceId, ProviderLifecycleState, ProviderRepository, ProviderRepositoryPath,
-    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret, ProviderSecretGeneration,
-    ProviderSecretName, ProviderTypeId, ProviderWebhookAuthenticationError,
-    ProviderWebhookAuthenticationRequest, ProviderWebhookEndpointId,
-    ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision, ProviderWebhookEndpointState,
-    ProviderWebhookHeaderName, ProviderWebhookHeaders, ProviderWebhookMethod,
-    ProviderWebhookRequest, ProviderWebhookSecretCandidates, ProviderWebhookSecretReference,
-    ProviderWebhookSignatureEvidence, ProviderWorkflowSource, PushCommitEvidence, PushTrigger,
-    RenewProviderDelivery, RepositoryVisibility,
+    ProviderDefaultBranch, ProviderDeliveryId, ProviderDeliveryNormalization,
+    ProviderDeliveryObservations, ProviderDeliveryRejection, ProviderEventName, ProviderGitRef,
+    ProviderGitRefKind, ProviderInstanceId, ProviderLifecycleState, ProviderProcessingClaimFence,
+    ProviderProcessingInvocationId, ProviderProcessingWorkerId, ProviderRepository,
+    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret,
+    ProviderSecretGeneration, ProviderSecretName, ProviderTriggerDeliveryDraft, ProviderTypeId,
+    ProviderWebhookAuthenticationError, ProviderWebhookAuthenticationRequest,
+    ProviderWebhookEndpointId, ProviderWebhookEndpointManifest, ProviderWebhookEndpointRevision,
+    ProviderWebhookEndpointState, ProviderWebhookHeaderName, ProviderWebhookHeaders,
+    ProviderWebhookMethod, ProviderWebhookRequest, ProviderWebhookSecretCandidates,
+    ProviderWebhookSecretReference, ProviderWebhookSignatureEvidence, ProviderWorkflowSource,
+    PushCommitEvidence, PushTrigger, RenewProviderProcessing, RepositoryVisibility,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -119,8 +119,8 @@ impl DeliveryAdapter for FakeAdapter {
             None,
         )
         .expect("push");
-        ProviderDeliveryNormalization::Accepted(Box::new(
-            ProviderDeliveryDraft::new(
+        ProviderDeliveryNormalization::Trigger(Box::new(
+            ProviderTriggerDeliveryDraft::new(
                 ProviderDeliveryId::new(),
                 ExternalDeliveryIdentity::new(
                     instance_id,
@@ -387,40 +387,40 @@ fn authenticated_invalid_json_is_recorded_without_admission() {
 
 #[test]
 fn worker_fence_rejects_mutations_before_claim_or_at_expiry() {
-    let fence = ProviderDeliveryClaimFence::new(
-        ProviderDeliveryId::new(),
-        ProviderDeliveryWorkerId::new(),
+    let fence = ProviderProcessingClaimFence::new(
+        ProviderProcessingInvocationId::new(),
+        ProviderProcessingWorkerId::new(),
         1,
         UnixMillis::new(100),
         UnixMillis::new(200),
     )
     .expect("fence");
 
-    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(99)).is_err());
-    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(200)).is_err());
-    assert!(CompleteProviderDelivery::new(fence, UnixMillis::new(150)).is_ok());
+    assert!(CompleteProviderProcessing::new(fence, UnixMillis::new(99)).is_err());
+    assert!(CompleteProviderProcessing::new(fence, UnixMillis::new(200)).is_err());
+    assert!(CompleteProviderProcessing::new(fence, UnixMillis::new(150)).is_ok());
 }
 
 #[test]
 fn claim_renewal_must_strictly_extend_a_live_fence() {
-    let fence = ProviderDeliveryClaimFence::new(
-        ProviderDeliveryId::new(),
-        ProviderDeliveryWorkerId::new(),
+    let fence = ProviderProcessingClaimFence::new(
+        ProviderProcessingInvocationId::new(),
+        ProviderProcessingWorkerId::new(),
         1,
         UnixMillis::new(1_000),
         UnixMillis::new(2_000),
     )
     .expect("fence");
-    let renewal =
-        RenewProviderDelivery::new(fence, UnixMillis::new(1_500), 1_000).expect("strict extension");
+    let renewal = RenewProviderProcessing::new(fence, UnixMillis::new(1_500), 1_000)
+        .expect("strict extension");
     assert_eq!(renewal.fence(), fence);
     assert_eq!(renewal.renewed_at(), UnixMillis::new(1_500));
     assert_eq!(renewal.lease_millis(), 1_000);
-    assert!(RenewProviderDelivery::new(fence, UnixMillis::new(1_000), 1_000).is_err());
-    assert!(RenewProviderDelivery::new(fence, UnixMillis::new(2_000), 1_000).is_err());
+    assert!(RenewProviderProcessing::new(fence, UnixMillis::new(1_000), 1_000).is_err());
+    assert!(RenewProviderProcessing::new(fence, UnixMillis::new(2_000), 1_000).is_err());
 
-    let near_total_limit = ProviderDeliveryClaimFence::new(
-        fence.delivery_id(),
+    let near_total_limit = ProviderProcessingClaimFence::new(
+        fence.invocation_id(),
         fence.worker_id(),
         fence.token(),
         UnixMillis::new(1_000),
@@ -428,6 +428,7 @@ fn claim_renewal_must_strictly_extend_a_live_fence() {
     )
     .expect("claim below total lifetime limit");
     assert!(
-        RenewProviderDelivery::new(near_total_limit, UnixMillis::new(3_400_000), 900_000).is_err()
+        RenewProviderProcessing::new(near_total_limit, UnixMillis::new(3_400_000), 900_000)
+            .is_err()
     );
 }

--- a/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
+++ b/crates/automata-ci-sandbox-kubernetes/tests/endpoint.rs
@@ -512,6 +512,50 @@ fn assert_required_policy_checks(server: &FakeExecServer, exchange_count: usize)
     );
 }
 
+fn assert_round_trip_requests(
+    requests: &[GuestRequest],
+    command: &ExecutionCommand,
+    copy_to: &CopyToRequest,
+    copy_from: &CopyFromRequest,
+) {
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        requests[0],
+        GuestRequest::Exec {
+            protocol: GUEST_PROTOCOL_VERSION,
+            operation_id: command.operation_id().to_string(),
+            program: "/usr/bin/example".into(),
+            arguments: vec!["literal argument".into(), "$(never-a-shell)".into()],
+            environment: BTreeMap::from([
+                ("PUBLIC_VALUE".into(), "visible".into()),
+                ("SECRET_TOKEN".into(), "sensitive-value".into()),
+            ]),
+            working_directory: "/workspace/subdir".into(),
+            timeout_millis: 1_250,
+            output_limit: 1_024,
+            process_limit: None,
+        }
+    );
+    assert_eq!(
+        requests[1],
+        GuestRequest::WriteFile {
+            protocol: GUEST_PROTOCOL_VERSION,
+            operation_id: copy_to.operation_id().to_string(),
+            path: "/workspace/input.bin".into(),
+            content_base64: BASE64.encode([0, 1, 2, 255]),
+        }
+    );
+    assert_eq!(
+        requests[2],
+        GuestRequest::ReadFile {
+            protocol: GUEST_PROTOCOL_VERSION,
+            operation_id: copy_from.operation_id().to_string(),
+            path: "/workspace/output.bin".into(),
+            byte_limit: 64,
+        }
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_and_copy_round_trips_preserve_exact_guest_requests_and_results() {
     let exec_response = guest_response(json!({
@@ -573,43 +617,7 @@ async fn exec_and_copy_round_trips_preserve_exact_guest_requests_and_results() {
     assert_eq!(output.records()[0].stream(), ExecutionOutputStream::Stdout);
     assert_eq!(output.records()[1].stream(), ExecutionOutputStream::Stderr);
     assert_eq!(copied, b"copied bytes");
-    let requests = server.guest_requests();
-    assert_eq!(requests.len(), 3);
-    assert_eq!(
-        requests[0],
-        GuestRequest::Exec {
-            protocol: GUEST_PROTOCOL_VERSION,
-            operation_id: command.operation_id().to_string(),
-            program: "/usr/bin/example".into(),
-            arguments: vec!["literal argument".into(), "$(never-a-shell)".into()],
-            environment: BTreeMap::from([
-                ("PUBLIC_VALUE".into(), "visible".into()),
-                ("SECRET_TOKEN".into(), "sensitive-value".into()),
-            ]),
-            working_directory: "/workspace/subdir".into(),
-            timeout_millis: 1_250,
-            output_limit: 1_024,
-            process_limit: None,
-        }
-    );
-    assert_eq!(
-        requests[1],
-        GuestRequest::WriteFile {
-            protocol: GUEST_PROTOCOL_VERSION,
-            operation_id: copy_to.operation_id().to_string(),
-            path: "/workspace/input.bin".into(),
-            content_base64: BASE64.encode([0, 1, 2, 255]),
-        }
-    );
-    assert_eq!(
-        requests[2],
-        GuestRequest::ReadFile {
-            protocol: GUEST_PROTOCOL_VERSION,
-            operation_id: copy_from.operation_id().to_string(),
-            path: "/workspace/output.bin".into(),
-            byte_limit: 64,
-        }
-    );
+    assert_round_trip_requests(&server.guest_requests(), &command, &copy_to, &copy_from);
     assert!(server.websocket_uris().iter().all(|uri| {
         uri.starts_with(&format!(
             "/api/v1/namespaces/{NAMESPACE}/pods/{HANDLE}/exec?"

--- a/crates/automata-ci-sandbox-podman/tests/command_executor.rs
+++ b/crates/automata-ci-sandbox-podman/tests/command_executor.rs
@@ -362,8 +362,13 @@ fn assert_ordered_records_reconstruct_split_output(
             bytes.extend_from_slice(record.bytes());
         }
     }
-    assert_eq!(stdout_ends, 1);
-    assert_eq!(stderr_ends, 1);
+    if output.was_truncated() {
+        assert!(stdout_ends <= 1);
+        assert!(stderr_ends <= 1);
+    } else {
+        assert_eq!(stdout_ends, 1);
+        assert_eq!(stderr_ends, 1);
+    }
     assert_eq!(stdout, output.stdout());
     assert_eq!(stderr, output.stderr());
 }

--- a/crates/automata-ci-store-postgres/migrations/0056_provider_processing_invocations.sql
+++ b/crates/automata-ci-store-postgres/migrations/0056_provider_processing_invocations.sql
@@ -1,0 +1,295 @@
+-- Forward-only greenfield cutover from the combined delivery queue to immutable
+-- provider evidence and independently retryable processing invocations.
+
+DROP TABLE provider_delivery_records;
+DROP FUNCTION automata_enforce_provider_delivery_transition();
+
+CREATE TABLE provider_deliveries (
+    delivery_id UUID PRIMARY KEY,
+    provider_instance_id UUID NOT NULL,
+    external_delivery_id TEXT NOT NULL,
+    replay_fingerprint BYTEA NOT NULL,
+    endpoint_id UUID NOT NULL,
+    endpoint_revision BIGINT NOT NULL,
+    provider_type TEXT NOT NULL,
+    provider_revision BIGINT NOT NULL,
+    connection_id UUID NOT NULL,
+    connection_revision BIGINT NOT NULL,
+    event_type TEXT NOT NULL,
+    received_at_ms BIGINT NOT NULL,
+    raw_object_key TEXT NOT NULL,
+    raw_body_digest BYTEA NOT NULL,
+    raw_body_size BIGINT NOT NULL,
+    raw_media_type TEXT NOT NULL,
+    raw_retain_until_ms BIGINT NOT NULL,
+    signature_scheme TEXT NOT NULL,
+    signature_configuration_revision BIGINT NOT NULL,
+    signature_secret_name TEXT NOT NULL,
+    signature_secret_generation BIGINT NOT NULL,
+    disposition TEXT NOT NULL,
+    repository_external_id TEXT,
+    normalized_payload BYTEA,
+    normalized_payload_digest BYTEA,
+    control_kind TEXT,
+    control_object_id BYTEA,
+    control_actor_kind TEXT,
+    control_actor_external_id TEXT,
+    control_document_schema BIGINT,
+    rejection_reason TEXT,
+    observations BYTEA NOT NULL,
+    observations_digest BYTEA NOT NULL,
+    accepted_at_ms BIGINT NOT NULL,
+    UNIQUE (provider_instance_id, external_delivery_id),
+    UNIQUE (delivery_id, disposition),
+    FOREIGN KEY (
+        endpoint_id, endpoint_revision, provider_type,
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
+    ) REFERENCES provider_webhook_endpoint_revisions (
+        endpoint_id, revision, provider_type,
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
+    ) ON DELETE RESTRICT,
+    FOREIGN KEY (
+        provider_instance_id, signature_configuration_revision,
+        signature_secret_name, signature_secret_generation
+    ) REFERENCES provider_instance_secret_bindings (
+        instance_id, revision, secret_name, secret_generation
+    ) ON DELETE RESTRICT,
+    CHECK (octet_length(external_delivery_id) BETWEEN 1 AND 512),
+    CHECK (octet_length(replay_fingerprint) = 32),
+    CHECK (octet_length(event_type) BETWEEN 1 AND 128),
+    CHECK (received_at_ms >= 0),
+    CHECK (octet_length(raw_object_key) BETWEEN 1 AND 1024),
+    CHECK (octet_length(raw_body_digest) = 32),
+    CHECK (raw_body_size BETWEEN 0 AND 33554432),
+    CHECK (octet_length(raw_media_type) BETWEEN 1 AND 128),
+    CHECK (raw_retain_until_ms > received_at_ms),
+    CHECK (octet_length(signature_scheme) BETWEEN 1 AND 64),
+    CHECK (octet_length(signature_secret_name) BETWEEN 1 AND 64),
+    CHECK (disposition IN ('trigger', 'control', 'rejected')),
+    CHECK (
+        repository_external_id IS NULL
+        OR octet_length(repository_external_id) BETWEEN 1 AND 512
+    ),
+    CHECK (
+        (disposition = 'trigger'
+            AND repository_external_id IS NOT NULL
+            AND octet_length(normalized_payload) BETWEEN 1 AND 65536
+            AND octet_length(normalized_payload_digest) = 32
+            AND control_kind IS NULL
+            AND control_object_id IS NULL
+            AND control_actor_kind IS NULL
+            AND control_actor_external_id IS NULL
+            AND control_document_schema IS NULL
+            AND rejection_reason IS NULL)
+        OR
+        (disposition = 'control'
+            AND repository_external_id IS NOT NULL
+            AND octet_length(normalized_payload) BETWEEN 1 AND 16384
+            AND octet_length(normalized_payload_digest) = 32
+            AND control_kind = 'rerun'
+            AND octet_length(control_object_id) IN (20, 32)
+            AND (control_actor_kind IS NULL) = (control_actor_external_id IS NULL)
+            AND (control_actor_kind IS NULL OR control_actor_kind IN (
+                'user', 'organization', 'team', 'service-account'
+            ))
+            AND (control_actor_external_id IS NULL OR
+                octet_length(control_actor_external_id) BETWEEN 1 AND 512)
+            AND control_document_schema > 0
+            AND rejection_reason IS NULL)
+        OR
+        (disposition = 'rejected'
+            AND normalized_payload IS NULL
+            AND normalized_payload_digest IS NULL
+            AND control_kind IS NULL
+            AND control_object_id IS NULL
+            AND control_actor_kind IS NULL
+            AND control_actor_external_id IS NULL
+            AND control_document_schema IS NULL
+            AND rejection_reason IN (
+                'unknown-event', 'unsupported-event', 'incomplete-event',
+                'payload-identity-mismatch', 'invalid-payload'
+            ))
+    ),
+    CHECK (octet_length(observations) <= 16384),
+    CHECK (octet_length(observations_digest) = 32),
+    CHECK (accepted_at_ms >= received_at_ms)
+);
+
+CREATE TABLE provider_processing_invocations (
+    invocation_id UUID PRIMARY KEY,
+    cause_delivery_id UUID NOT NULL UNIQUE,
+    source_delivery_id UUID,
+    source_disposition TEXT,
+    state TEXT NOT NULL,
+    attempts SMALLINT NOT NULL,
+    available_at_ms BIGINT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    claim_worker_id UUID,
+    claim_fence BIGINT,
+    claim_started_at_ms BIGINT,
+    claim_expires_at_ms BIGINT,
+    completed_at_ms BIGINT,
+    failure_kind TEXT,
+    FOREIGN KEY (cause_delivery_id)
+        REFERENCES provider_deliveries (delivery_id) ON DELETE RESTRICT,
+    FOREIGN KEY (source_delivery_id, source_disposition)
+        REFERENCES provider_deliveries (delivery_id, disposition) ON DELETE RESTRICT,
+    CHECK (
+        (source_delivery_id IS NULL AND source_disposition IS NULL)
+        OR (source_delivery_id IS NOT NULL AND source_disposition = 'trigger')
+    ),
+    CHECK (state IN (
+        'pending', 'retry-pending', 'claimed', 'completed', 'failed'
+    )),
+    CHECK (attempts BETWEEN 0 AND 16),
+    CHECK (available_at_ms >= created_at_ms),
+    CHECK (created_at_ms >= 0),
+    CHECK (
+        (state = 'pending' AND attempts = 0)
+        OR (state <> 'pending' AND attempts > 0)
+    ),
+    CHECK (
+        (state = 'claimed'
+            AND claim_worker_id IS NOT NULL
+            AND claim_fence > 0
+            AND claim_started_at_ms >= created_at_ms
+            AND claim_expires_at_ms > claim_started_at_ms)
+        OR (state <> 'claimed'
+            AND claim_worker_id IS NULL
+            AND claim_started_at_ms IS NULL
+            AND claim_expires_at_ms IS NULL)
+    ),
+    CHECK (
+        (state IN ('completed', 'failed') AND completed_at_ms IS NOT NULL)
+        OR (state NOT IN ('completed', 'failed') AND completed_at_ms IS NULL)
+    ),
+    CHECK (
+        (state IN ('retry-pending', 'failed') AND failure_kind IN (
+            'dependency-unavailable', 'policy-rejected', 'invalid-evidence'
+        ))
+        OR (state NOT IN ('retry-pending', 'failed') AND failure_kind IS NULL)
+    )
+);
+
+CREATE INDEX provider_processing_invocations_ready
+    ON provider_processing_invocations (
+        available_at_ms, created_at_ms, invocation_id
+    )
+    WHERE state IN ('pending', 'retry-pending', 'claimed');
+
+CREATE FUNCTION automata_reject_provider_delivery_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'provider delivery evidence is immutable'
+        USING ERRCODE = 'integrity_constraint_violation';
+END;
+$$;
+
+CREATE TRIGGER provider_deliveries_immutable
+BEFORE UPDATE OR DELETE ON provider_deliveries
+FOR EACH ROW EXECUTE FUNCTION automata_reject_provider_delivery_mutation();
+
+CREATE FUNCTION automata_enforce_provider_processing_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE'
+       OR NEW.invocation_id IS DISTINCT FROM OLD.invocation_id
+       OR NEW.cause_delivery_id IS DISTINCT FROM OLD.cause_delivery_id
+       OR NEW.created_at_ms IS DISTINCT FROM OLD.created_at_ms THEN
+        RAISE EXCEPTION 'provider processing invocation evidence is immutable'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+
+    IF (NEW.source_delivery_id IS DISTINCT FROM OLD.source_delivery_id
+        OR NEW.source_disposition IS DISTINCT FROM OLD.source_disposition)
+       AND NOT (
+           OLD.state = 'claimed'
+           AND NEW.state = 'claimed'
+           AND OLD.source_delivery_id IS NULL
+           AND OLD.source_disposition IS NULL
+           AND NEW.source_delivery_id IS NOT NULL
+           AND NEW.source_disposition = 'trigger'
+       ) THEN
+        RAISE EXCEPTION 'provider processing source binding is invalid'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+
+    IF OLD.state = 'claimed'
+       AND NEW.state = 'claimed'
+       AND OLD.source_delivery_id IS NULL
+       AND NEW.source_delivery_id IS NOT NULL THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.available_at_ms <> OLD.available_at_ms
+           OR NEW.claim_worker_id IS DISTINCT FROM OLD.claim_worker_id
+           OR NEW.claim_fence IS DISTINCT FROM OLD.claim_fence
+           OR NEW.claim_started_at_ms IS DISTINCT FROM OLD.claim_started_at_ms
+           OR NEW.claim_expires_at_ms IS DISTINCT FROM OLD.claim_expires_at_ms
+           OR NEW.completed_at_ms IS DISTINCT FROM OLD.completed_at_ms
+           OR NEW.failure_kind IS DISTINCT FROM OLD.failure_kind THEN
+            RAISE EXCEPTION 'provider processing source binding changed lifecycle state'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state IN ('pending', 'retry-pending') AND NEW.state = 'claimed' THEN
+        IF NEW.attempts <> OLD.attempts + 1
+           OR NEW.claim_fence <> COALESCE(OLD.claim_fence, 0) + 1
+           OR NEW.available_at_ms <> OLD.available_at_ms
+           OR NEW.failure_kind IS NOT NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider processing initial claim transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'claimed' THEN
+        IF NEW.attempts <> OLD.attempts + 1
+           OR NEW.claim_fence <> OLD.claim_fence + 1
+           OR NEW.claim_started_at_ms < OLD.claim_expires_at_ms
+           OR NEW.claim_expires_at_ms <= OLD.claim_expires_at_ms
+           OR NEW.available_at_ms <> OLD.available_at_ms
+           OR NEW.failure_kind IS NOT NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider processing reclaim transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'retry-pending' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.available_at_ms <= OLD.available_at_ms
+           OR NEW.failure_kind IS NULL
+           OR NEW.completed_at_ms IS NOT NULL THEN
+            RAISE EXCEPTION 'provider processing retry transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'completed' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.completed_at_ms IS DISTINCT FROM NEW.available_at_ms
+           OR NEW.completed_at_ms >= OLD.claim_expires_at_ms
+           OR NEW.failure_kind IS NOT NULL THEN
+            RAISE EXCEPTION 'provider processing completion transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSIF OLD.state = 'claimed' AND NEW.state = 'failed' THEN
+        IF NEW.attempts <> OLD.attempts
+           OR NEW.claim_fence <> OLD.claim_fence
+           OR NEW.completed_at_ms IS DISTINCT FROM NEW.available_at_ms
+           OR NEW.completed_at_ms >= OLD.claim_expires_at_ms
+           OR NEW.failure_kind IS NULL THEN
+            RAISE EXCEPTION 'provider processing failure transition is invalid'
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'provider processing lifecycle transition is invalid'
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER provider_processing_invocations_transition
+BEFORE UPDATE OR DELETE ON provider_processing_invocations
+FOR EACH ROW EXECUTE FUNCTION automata_enforce_provider_processing_transition();

--- a/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
+++ b/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
@@ -22,8 +22,8 @@ use automata_ci_store::{
     GithubWorkflowRunSubjectEvidence, LogicalWorkflowInvocationId,
     ManifestPinnedGithubDeliveryEvidence, ManifestPinnedGithubDeliveryReceipt, ObjectKey,
     PendingGithubRepositoryDispatchEvidence, PendingGithubRepositoryDispatchReceipt,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId, ProviderDeliveryId,
-    ProviderInstallationId, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderDeliveryClaimFence, ProviderDeliveryId, ProviderInstallationId,
+    ProviderProcessingWorkerId, ProviderRepositoryId, ProviderRepositoryOwnerId,
     ProviderRepositoryVisibility, RecordGithubWorkflowRunSubjectEvidence, RepositoryId,
     ResolveGithubRepositoryDispatch, TenantScope, ValidateGithubWorkflowRunSubjectEvidenceReplay,
     WorkflowAdmissionIdempotency, WorkflowRuntimePolicyRevision, WorkflowSnapshotId,
@@ -2458,7 +2458,7 @@ fn decode_run_evidence(
     let admission_claim = AuthenticatedGithubDeliveryClaim::new(
         ProviderDeliveryClaimFence::from_durable_parts(
             delivery_id,
-            ProviderDeliveryClaimOwnerId::from_uuid(claim_owner)
+            ProviderProcessingWorkerId::from_uuid(claim_owner)
                 .map_err(|_| GithubSubjectEvidenceStoreError::CorruptData)?,
             positive_u64(claim_fence)?,
         )

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -225,6 +225,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0055_terminal_log_output_v3.sql",
         "aad28f96b40e06578af7609ef1ef9073315c4a2cf3e9b04d464eb44762ce59f4b3613e73c18710c491ca3d6e1064571f",
     ),
+    (
+        "0056_provider_processing_invocations.sql",
+        "47302f91ed241062d1d9366a326d48d804bd6bbf7daba589501f6c2b92dbf6ef23707fea7999f27398bc1ef7b54203f5",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -685,6 +689,46 @@ fn canonical_git_object_ids_are_a_forward_only_exact_transition() {
         assert!(
             !source.contains(forbidden),
             "canonical Git object migration retained ambiguous transition surface: {forbidden}",
+        );
+    }
+}
+
+#[test]
+fn provider_processing_cutover_is_destructive_single_path_and_fenced() {
+    let source = include_str!("../migrations/0056_provider_processing_invocations.sql");
+
+    for required in [
+        "DROP TABLE provider_delivery_records;",
+        "DROP FUNCTION automata_enforce_provider_delivery_transition();",
+        "CREATE TABLE provider_deliveries (",
+        "CREATE TABLE provider_processing_invocations (",
+        "disposition IN ('trigger', 'control', 'rejected')",
+        "control_kind = 'rerun'",
+        "cause_delivery_id UUID NOT NULL UNIQUE",
+        "source_delivery_id UUID",
+        "source_disposition TEXT",
+        "NEW.source_disposition = 'trigger'",
+        "provider delivery evidence is immutable",
+        "provider processing source binding is invalid",
+        "provider processing source binding changed lifecycle state",
+        "CREATE TRIGGER provider_deliveries_immutable",
+        "CREATE TRIGGER provider_processing_invocations_transition",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider processing cutover lost required contract: {required}",
+        );
+    }
+    for forbidden in [
+        "CREATE TABLE provider_delivery_records",
+        "CREATE FUNCTION automata_enforce_provider_delivery_transition",
+        "IF EXISTS",
+        "IF NOT EXISTS",
+        " CASCADE",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "provider processing cutover retained a second schema path: {forbidden}",
         );
     }
 }

--- a/crates/automata-ci-store-postgres/src/provider_delivery.rs
+++ b/crates/automata-ci-store-postgres/src/provider_delivery.rs
@@ -9,16 +9,17 @@ use automata_ci_store::{
     AcceptProviderDelivery, AdmissionObject, ClaimProviderDelivery, ClaimedProviderDelivery,
     CompleteProviderDelivery, GithubCheckTerminalCause, MAX_PROVIDER_DELIVERY_ATTEMPTS,
     MAX_PROVIDER_DELIVERY_CLAIM_MILLIS, MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS, ObjectKey,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryClaimRenewalRepository, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
-    ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRepository,
-    ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
+    ProviderDeliveryClaimFence, ProviderDeliveryClaimRenewalRepository,
+    ProviderDeliveryEventEnvelope, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderDeliveryReceipt, ProviderDeliveryRepository, ProviderDeliveryState,
+    ProviderDeliveryStoreError, ProviderDeliveryWorkflowConclusion,
     ProviderDeliveryWorkflowInventory, ProviderDeliveryWorkflowInventoryEntry,
     ProviderDeliveryWorkflowInventoryReceipt, ProviderDeliveryWorkflowOutcome,
-    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryVisibility, RecordProviderDeliveryWorkflowProgress,
-    RegisterProviderDeliveryWorkflowInventory, RejectProviderDelivery, RenewProviderDeliveryClaim,
-    RenewedProviderDeliveryClaim, RetryProviderDelivery, Sha256Digest, TenantScope,
+    ProviderDeliveryWorkflowSourceState, ProviderInstallationId, ProviderProcessingWorkerId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryVisibility,
+    RecordProviderDeliveryWorkflowProgress, RegisterProviderDeliveryWorkflowInventory,
+    RejectProviderDelivery, RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim,
+    RetryProviderDelivery, Sha256Digest, TenantScope,
 };
 
 use super::{
@@ -756,7 +757,7 @@ fn caller_time_is_admissible(observed_at: UnixMillis, database_time: UnixMillis)
 /// work while ensuring it can never be claimed and interpreted from raw JSON.
 async fn quarantine_legacy_unsealed_deliveries(
     transaction: &mut Transaction<'_, Postgres>,
-    owner: ProviderDeliveryClaimOwnerId,
+    owner: ProviderProcessingWorkerId,
     observed_at: UnixMillis,
 ) -> Result<(), ProviderDeliveryStoreError> {
     sqlx::query(
@@ -1010,7 +1011,7 @@ fn decode_exact_renewal(
         .map_err(operation_error)?;
     let claim = ProviderDeliveryClaimFence::from_durable_parts(
         request.claim().delivery_id(),
-        ProviderDeliveryClaimOwnerId::from_uuid(returned_owner)
+        ProviderProcessingWorkerId::from_uuid(returned_owner)
             .map_err(|_| ProviderDeliveryStoreError::CorruptData)?,
         u64::try_from(returned_fence).map_err(|_| ProviderDeliveryStoreError::CorruptData)?,
     )
@@ -1221,7 +1222,7 @@ fn decode_claimed_delivery(
     let expires_at: i64 = row
         .try_get("claim_expires_at_ms")
         .map_err(operation_error)?;
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(owner)
+    let owner = ProviderProcessingWorkerId::from_uuid(owner)
         .map_err(|_| ProviderDeliveryStoreError::CorruptData)?;
     let claim = ProviderDeliveryClaimFence::from_durable_parts(
         durable.receipt.id(),

--- a/crates/automata-ci-store/src/lib.rs
+++ b/crates/automata-ci-store/src/lib.rs
@@ -67,6 +67,7 @@ pub use admission::{
 };
 pub use assignment::{AttemptAssignment, AttemptAssignmentError};
 pub use automata_ci_core::Sha256Digest;
+pub use automata_ci_provider::{ProviderDeliveryId, ProviderProcessingWorkerId};
 pub use conformance::{
     ConformanceDelivery, ConformanceDeliveryQuery, ConformanceDeliveryState,
     ConformanceReadRepository, ConformanceReadValueError, ConformanceWorkflowOutcome,
@@ -333,9 +334,8 @@ pub use provider_delivery::{
     CompleteProviderDelivery, MAX_PROVIDER_DELIVERY_ATTEMPTS, MAX_PROVIDER_DELIVERY_CLAIM_MILLIS,
     MAX_PROVIDER_DELIVERY_EVENT_ENVELOPE_BYTES, MAX_PROVIDER_DELIVERY_RETRY_BACKOFF_MILLIS,
     MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS, MAX_PROVIDER_DELIVERY_WORKFLOW_OUTCOMES,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryClaimRenewalRepository, ProviderDeliveryEventEnvelope,
-    ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderDeliveryClaimFence, ProviderDeliveryClaimRenewalRepository,
+    ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind, ProviderDeliveryIdentity,
     ProviderDeliveryReceipt, ProviderDeliveryRenewalTiming, ProviderDeliveryRepository,
     ProviderDeliveryState, ProviderDeliveryStoreError, ProviderDeliveryValueError,
     ProviderDeliveryWorkflowConclusion, ProviderDeliveryWorkflowInventory,

--- a/crates/automata-ci-store/src/provider_delivery.rs
+++ b/crates/automata-ci-store/src/provider_delivery.rs
@@ -6,11 +6,10 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_core::{GitObjectId, RunId, UnixMillis};
-use automata_ci_provider::ProviderConnectionId;
+use automata_ci_provider::{ProviderConnectionId, ProviderDeliveryId, ProviderProcessingWorkerId};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use tokio::time::Instant;
-use uuid::Uuid;
 
 use crate::{AdmissionObject, RepositoryOperationError, Sha256Digest, TenantScope};
 
@@ -36,38 +35,6 @@ const MAX_WORKFLOW_PATH_BYTES: usize = 1_024;
 const COMPLETION_DIGEST_DOMAIN: &[u8] = b"automata.store.provider-delivery-completion.v1\0";
 const WORKFLOW_INVENTORY_DIGEST_DOMAIN: &[u8] =
     b"automata.store.provider-delivery-workflow-inventory.v1\0";
-
-macro_rules! uuid_identity {
-    ($(#[$meta:meta])* $name:ident, $field:literal) => {
-        $(#[$meta])*
-        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        pub struct $name(Uuid);
-
-        impl $name {
-            /// Constructs a non-nil durable UUID identity.
-            ///
-            /// # Errors
-            ///
-            /// Rejects the nil UUID sentinel.
-            pub fn from_uuid(value: Uuid) -> Result<Self, ProviderDeliveryValueError> {
-                if value.is_nil() {
-                    return Err(ProviderDeliveryValueError::NilUuid($field));
-                }
-                Ok(Self(value))
-            }
-
-            #[must_use]
-            pub const fn as_uuid(self) -> Uuid {
-                self.0
-            }
-        }
-    };
-}
-
-uuid_identity!(/// Durable identity of one accepted provider delivery.
-    ProviderDeliveryId, "provider delivery ID");
-uuid_identity!(/// Durable identity of a provider-delivery worker.
-    ProviderDeliveryClaimOwnerId, "provider delivery claim owner ID");
 
 macro_rules! positive_provider_id {
     ($(#[$meta:meta])* $name:ident, $field:literal) => {
@@ -511,7 +478,7 @@ impl ProviderDeliveryReceipt {
 /// across provider, blob, compiler, or admission work.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClaimProviderDelivery {
-    owner: ProviderDeliveryClaimOwnerId,
+    owner: ProviderProcessingWorkerId,
     observed_at: UnixMillis,
     expires_at: UnixMillis,
 }
@@ -524,7 +491,7 @@ impl ClaimProviderDelivery {
     /// Rejects negative time, an empty interval, or a lease longer than the
     /// fixed provider-delivery claim bound.
     pub fn new(
-        owner: ProviderDeliveryClaimOwnerId,
+        owner: ProviderProcessingWorkerId,
         observed_at: UnixMillis,
         expires_at: UnixMillis,
     ) -> Result<Self, ProviderDeliveryValueError> {
@@ -544,7 +511,7 @@ impl ClaimProviderDelivery {
     }
 
     #[must_use]
-    pub const fn owner(self) -> ProviderDeliveryClaimOwnerId {
+    pub const fn owner(self) -> ProviderProcessingWorkerId {
         self.owner
     }
 
@@ -563,7 +530,7 @@ impl ClaimProviderDelivery {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProviderDeliveryClaimFence {
     delivery_id: ProviderDeliveryId,
-    owner: ProviderDeliveryClaimOwnerId,
+    owner: ProviderProcessingWorkerId,
     fence: NonZeroU64,
 }
 
@@ -575,7 +542,7 @@ impl ProviderDeliveryClaimFence {
     /// Rejects a zero fence or one outside the signed 64-bit storage boundary.
     pub fn from_durable_parts(
         delivery_id: ProviderDeliveryId,
-        owner: ProviderDeliveryClaimOwnerId,
+        owner: ProviderProcessingWorkerId,
         fence: u64,
     ) -> Result<Self, ProviderDeliveryValueError> {
         let fence = NonZeroU64::new(fence)
@@ -594,7 +561,7 @@ impl ProviderDeliveryClaimFence {
     }
 
     #[must_use]
-    pub const fn owner(self) -> ProviderDeliveryClaimOwnerId {
+    pub const fn owner(self) -> ProviderProcessingWorkerId {
         self.owner
     }
 

--- a/crates/automata-ci-store/tests/github_subject_evidence_api.rs
+++ b/crates/automata-ci-store/tests/github_subject_evidence_api.rs
@@ -16,8 +16,8 @@ use automata_ci_store::{
     GithubWorkflowRunSubjectEvidence, LogicalWorkflowInvocationId,
     ManifestPinnedGithubDeliveryEvidence, ManifestPinnedGithubDeliveryReceipt, ObjectKey,
     PendingGithubRepositoryDispatchEvidence, ProviderDeliveryClaimFence,
-    ProviderDeliveryClaimOwnerId, ProviderDeliveryEventEnvelope, ProviderDeliveryId,
-    ProviderDeliveryIdentity, ProviderInstallationId, ProviderRepositoryCoordinates,
+    ProviderDeliveryEventEnvelope, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderInstallationId, ProviderProcessingWorkerId, ProviderRepositoryCoordinates,
     ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
     RecordGithubWorkflowRunSubjectEvidence, RepositoryId, ResolveGithubRepositoryDispatch,
     TenantScope, WorkflowSnapshotId,
@@ -506,7 +506,7 @@ fn admission_claim(
     AuthenticatedGithubDeliveryClaim::new(
         ProviderDeliveryClaimFence::from_durable_parts(
             delivery_id,
-            ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(0x401)).expect("claim owner"),
+            ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(0x401)).expect("claim owner"),
             1,
         )
         .expect("claim fence"),

--- a/crates/automata-ci-store/tests/provider_delivery_api.rs
+++ b/crates/automata-ci-store/tests/provider_delivery_api.rs
@@ -5,13 +5,14 @@ use automata_ci_store::{
     MAX_ADMISSION_EVENT_BYTES, MAX_ADMISSION_OBJECT_BYTES, MAX_PROVIDER_DELIVERY_ATTEMPTS,
     MAX_PROVIDER_DELIVERY_CLAIM_MILLIS, MAX_PROVIDER_DELIVERY_EVENT_ENVELOPE_BYTES,
     MAX_PROVIDER_DELIVERY_RETRY_BACKOFF_MILLIS, MAX_PROVIDER_DELIVERY_TOTAL_CLAIM_MILLIS,
-    ObjectKey, ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId,
-    ProviderDeliveryEventEnvelope, ProviderDeliveryFailureKind, ProviderDeliveryId,
-    ProviderDeliveryIdentity, ProviderDeliveryReceipt, ProviderDeliveryRenewalTiming,
-    ProviderDeliveryState, ProviderDeliveryValueError, ProviderDeliveryWorkflowConclusion,
-    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderRepositoryCoordinates,
-    ProviderRepositoryId, ProviderRepositoryOwnerId, ProviderRepositoryVisibility,
-    RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim, TenantScope,
+    ObjectKey, ProviderDeliveryClaimFence, ProviderDeliveryEventEnvelope,
+    ProviderDeliveryFailureKind, ProviderDeliveryId, ProviderDeliveryIdentity,
+    ProviderDeliveryReceipt, ProviderDeliveryRenewalTiming, ProviderDeliveryState,
+    ProviderDeliveryValueError, ProviderDeliveryWorkflowConclusion,
+    ProviderDeliveryWorkflowOutcome, ProviderInstallationId, ProviderProcessingWorkerId,
+    ProviderRepositoryCoordinates, ProviderRepositoryId, ProviderRepositoryOwnerId,
+    ProviderRepositoryVisibility, RenewProviderDeliveryClaim, RenewedProviderDeliveryClaim,
+    TenantScope,
 };
 use std::time::Duration;
 use tokio::time::Instant;
@@ -150,9 +151,9 @@ fn provider_authority_rejects_sentinels_and_unbounded_values() {
         Err(ProviderIdentityError::NilUuid("provider connection ID"))
     ));
     assert!(matches!(
-        ProviderDeliveryClaimOwnerId::from_uuid(Uuid::nil()),
-        Err(ProviderDeliveryValueError::NilUuid(
-            "provider delivery claim owner ID"
+        ProviderProcessingWorkerId::from_uuid(Uuid::nil()),
+        Err(ProviderIdentityError::NilUuid(
+            "provider processing worker ID"
         ))
     ));
     assert!(matches!(
@@ -251,7 +252,7 @@ fn acceptance_retains_only_bounded_immutable_object_evidence() {
 
 #[test]
 fn claims_and_retry_classifications_are_strictly_bounded() {
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4()).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4()).expect("owner");
     let claim = ClaimProviderDelivery::new(
         owner,
         UnixMillis::new(1_000),
@@ -288,7 +289,7 @@ fn claims_and_retry_classifications_are_strictly_bounded() {
 fn durable_claim_rehydration_revalidates_receipt_fence_and_time() {
     let delivery_id = ProviderDeliveryId::from_uuid(Uuid::new_v4()).expect("delivery");
     let other_delivery_id = ProviderDeliveryId::from_uuid(Uuid::new_v4()).expect("other delivery");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4()).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4()).expect("owner");
     let receipt = ProviderDeliveryReceipt::from_durable_parts(
         delivery_id,
         ProviderDeliveryState::Claimed,
@@ -370,7 +371,7 @@ fn durable_claim_rehydration_revalidates_receipt_fence_and_time() {
 #[test]
 fn durable_renewal_rehydration_revalidates_rotated_fence_and_bounded_time() {
     let delivery_id = ProviderDeliveryId::from_uuid(Uuid::new_v4()).expect("delivery");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4()).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4()).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 9).expect("claim fence");
     let renewed = RenewedProviderDeliveryClaim::from_durable_parts(
@@ -474,7 +475,7 @@ fn durable_renewal_rehydration_revalidates_rotated_fence_and_bounded_time() {
 #[test]
 fn renewal_request_binds_the_exact_predecessor_to_one_monotonic_deadline() {
     let delivery_id = ProviderDeliveryId::from_uuid(Uuid::new_v4()).expect("delivery");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4()).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4()).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 9).expect("claim");
     let monotonic_observed_at = Instant::now();
@@ -524,7 +525,7 @@ fn renewal_request_binds_the_exact_predecessor_to_one_monotonic_deadline() {
 #[test]
 fn renewal_request_rejects_stale_or_inconsistent_evidence() {
     let delivery_id = ProviderDeliveryId::from_uuid(Uuid::new_v4()).expect("delivery");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4()).expect("owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4()).expect("owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 9).expect("claim");
     let monotonic_observed_at = Instant::now();

--- a/crates/automata-ci-workflow-service/tests/live_admission.rs
+++ b/crates/automata-ci-workflow-service/tests/live_admission.rs
@@ -12,7 +12,7 @@ use automata_ci_core::UnixMillis;
 use automata_ci_store::{
     AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim, LogicalWorkflowAdmissionReceipt,
     LogicalWorkflowAdmissionRepository, LogicalWorkflowAdmissionStoreError,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId, ProviderDeliveryId,
+    ProviderDeliveryClaimFence, ProviderDeliveryId, ProviderProcessingWorkerId,
 };
 use automata_ci_workflow_service::{
     GithubWorkflowPlanVerifier, WorkflowAdmissionError, WorkflowAdmissionService,
@@ -176,7 +176,7 @@ fn authenticated_claim() -> AuthenticatedGithubDeliveryClaim {
     .expect("current time fits i64");
     let delivery_id =
         ProviderDeliveryId::from_uuid(Uuid::from_u128(42)).expect("provider delivery ID");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(900))
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(900))
         .expect("provider delivery owner");
     let claim = ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 1)
         .expect("provider delivery fence");

--- a/crates/automata-ci-workflow-service/tests/projection.rs
+++ b/crates/automata-ci-workflow-service/tests/projection.rs
@@ -19,7 +19,7 @@ use automata_ci_core::{
 use automata_ci_store::{
     AdmitLogicalWorkflowRun, AuthenticatedGithubDeliveryClaim, LogicalWorkflowAdmissionReceipt,
     LogicalWorkflowAdmissionRepository, LogicalWorkflowAdmissionStoreError,
-    ProviderDeliveryClaimFence, ProviderDeliveryClaimOwnerId, ProviderDeliveryId,
+    ProviderDeliveryClaimFence, ProviderDeliveryId, ProviderProcessingWorkerId,
     WorkflowAdmissionIdempotency, WorkflowAdmissionValueError,
 };
 use automata_ci_workflow_actions::{
@@ -784,7 +784,7 @@ fn authenticated_claim(delivery_id: ProviderDeliveryId) -> AuthenticatedGithubDe
             .as_millis(),
     )
     .expect("current time fits i64");
-    let owner = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::from_u128(900)).expect("claim owner");
+    let owner = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(900)).expect("claim owner");
     let claim =
         ProviderDeliveryClaimFence::from_durable_parts(delivery_id, owner, 1).expect("claim fence");
     AuthenticatedGithubDeliveryClaim::new(

--- a/crates/automata-ci/src/server/github_provider_runtime.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime.rs
@@ -69,7 +69,7 @@ use automata_ci_store::{
     GithubServerServiceWorkerId, GithubSubjectEvidenceRepository,
     GithubWorkflowPermissionDefaultsObservation,
     GithubWorkflowPermissionDefaultsObservationRepository, LogicalWorkflowAdmissionRepository,
-    MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, ProviderDeliveryClaimOwnerId,
+    MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS, ProviderProcessingWorkerId,
     ProviderRepositoryVisibility, RetireGithubServerServiceAuthority, TenantScope,
 };
 use automata_ci_store_postgres::PostgresStore;
@@ -978,7 +978,7 @@ impl GithubProviderRuntimeBuilder {
         let repository_dispatch_resolver = Arc::new(endpoint.clone());
         let repository_dispatch_evidence: Arc<dyn GithubRepositoryDispatchEvidenceRepository> =
             store.clone();
-        let delivery_worker = ProviderDeliveryClaimOwnerId::from_uuid(Uuid::new_v4())
+        let delivery_worker = ProviderProcessingWorkerId::from_uuid(Uuid::new_v4())
             .map_err(|_| GithubProviderRuntimeBuildError::InvalidWorkerIdentity)?;
         let delivery = match shape.source_mode() {
             GithubProviderSourceMode::PublicOnly => {

--- a/crates/automata-ci/tests/github_webhook.rs
+++ b/crates/automata-ci/tests/github_webhook.rs
@@ -438,13 +438,13 @@ fn private_body() -> Bytes {
 
 fn public_pull_request_body() -> Bytes {
     Bytes::from(format!(
-        r#"{{"action":"opened","number":7,"pull_request":{{"number":7,"merged":false,"merge_commit_sha":"{AFTER_COMMIT}","head":{{"ref":"feature/topic","sha":"{AFTER_COMMIT}","repo":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}}}},"base":{{"ref":"main","sha":"{BEFORE_COMMIT}","repo":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}}}}}},"repository":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}},"installation":{{"id":11}},"sender":{{"id":301}}}}"#
+        r#"{{"action":"opened","number":7,"pull_request":{{"number":7,"merged":false,"draft":false,"merge_commit_sha":"{AFTER_COMMIT}","user":{{"id":302,"login":"contributor","type":"User"}},"head":{{"ref":"feature/topic","sha":"{AFTER_COMMIT}","repo":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}}}},"base":{{"ref":"main","sha":"{BEFORE_COMMIT}","repo":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}}}}}},"repository":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}},"installation":{{"id":11}},"sender":{{"id":301,"login":"octocat","type":"User"}}}}"#
     ))
 }
 
 fn public_merge_group_body() -> Bytes {
     Bytes::from(format!(
-        r#"{{"action":"checks_requested","merge_group":{{"head_sha":"{AFTER_COMMIT}","head_ref":"refs/heads/merge-queue/main/group-7","base_sha":"{BEFORE_COMMIT}","base_ref":"refs/heads/main","head_commit":{{}}}},"repository":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}},"installation":{{"id":11}},"sender":{{"id":301}}}}"#
+        r#"{{"action":"checks_requested","merge_group":{{"head_sha":"{AFTER_COMMIT}","head_ref":"refs/heads/merge-queue/main/group-7","base_sha":"{BEFORE_COMMIT}","base_ref":"refs/heads/main","head_commit":{{}}}},"repository":{{"id":101,"private":false,"visibility":"public","name":"public-repository","full_name":"octo-public/public-repository","owner":{{"id":1001,"login":"octo-public"}}}},"installation":{{"id":11}},"sender":{{"id":301,"login":"octocat","type":"User"}}}}"#
     ))
 }
 


### PR DESCRIPTION
## Summary

- replace the combined provider delivery queue with immutable `provider_deliveries` evidence plus independently fenced `provider_processing_invocations`
- add provider-neutral control documents, resolver registration, trigger processing dispatch, and exact one-time control-to-trigger source binding
- recognize authenticated GitHub `check_run.rerequested` as a canonical rerun control while rejecting multi-target Check controls until a common selection model exists
- move processing invocation and worker identities into the provider domain and remove store-owned aliases and processing-only delivery errors
- preserve completed Checks and source deliveries as immutable; a rerun gets one fresh invocation instead of reopening terminal state
- tighten two unrelated CI tests uncovered by the full workspace gates

## Stage boundary

This is the B4b foundation PR. It intentionally does not retain or add a second production composition path. B4c will atomically wire the generic ingress and worker, add the GitHub control resolver with a real PostgreSQL fixture, move Check subject references to the new immutable delivery identity, and delete the GitHub-only ingress, queue, worker, and route.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test -j 2 --workspace --exclude automata-ci-ui-renderer --all-targets --all-features --locked --no-fail-fast -- --quiet --test-threads=2`
- `./scripts/ci/run-postgres-tests.sh` against PostgreSQL 18: 73 passed
- migration lineage and SHA-384 inventory green

Diff budget: 4,527 changed lines, below the 10k PR limit.