### PR TITLE
Keep required checks pending through workflow completion

### DIFF
--- a/crates/automata-ci-store-postgres/migrations/0057_merge_queue_check_aggregation.sql
+++ b/crates/automata-ci-store-postgres/migrations/0057_merge_queue_check_aggregation.sql
@@ -1,0 +1,17 @@
+-- Keep per-workflow Checks distinct from the delivery-wide required Check.
+
+CREATE FUNCTION automata_github_workflow_check_name(TEXT, TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE PARALLEL SAFE STRICT
+AS $$
+SELECT CASE
+    WHEN octet_length($1) + 3 + octet_length($2) <= 255
+        THEN $1 || ' / ' || $2
+    ELSE left($1, 179) || ' / workflow-' ||
+         pg_catalog.encode(
+             pg_catalog.sha256(pg_catalog.convert_to($2, 'UTF8')),
+             'hex'
+         )
+END
+$$;

--- a/crates/automata-ci-store-postgres/src/github_check_aggregation.rs
+++ b/crates/automata-ci-store-postgres/src/github_check_aggregation.rs
@@ -1,0 +1,355 @@
+use sqlx::{Postgres, Row as _, Transaction};
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(super) enum GithubCheckAggregationError {
+    Operation(sqlx::Error),
+    CorruptData,
+}
+
+impl From<sqlx::Error> for GithubCheckAggregationError {
+    fn from(error: sqlx::Error) -> Self {
+        Self::Operation(error)
+    }
+}
+
+/// Serializes child finalization through its delivery-wide all-direct Check.
+pub(super) async fn lock_all_direct_check_for_run(
+    transaction: &mut Transaction<'_, Postgres>,
+    run_id: Uuid,
+) -> Result<Option<Uuid>, GithubCheckAggregationError> {
+    let delivery_id = sqlx::query_scalar::<_, Uuid>(
+        r"
+        SELECT child.provider_delivery_id
+        FROM github_check_subjects AS child
+        JOIN github_provider_delivery_evidence AS evidence
+          ON evidence.provider_delivery_id = child.provider_delivery_id
+         AND evidence.tenant_id = child.tenant_id
+         AND evidence.repository_id = child.repository_id
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = evidence.tenant_id
+         AND manifest.repository_id = evidence.repository_id
+         AND manifest.provider_connection_id = evidence.provider_connection_id
+         AND manifest.manifest_revision = evidence.provider_manifest_revision
+         AND manifest.manifest_digest = evidence.provider_manifest_digest
+        JOIN github_check_subjects AS aggregate
+          ON aggregate.id = evidence.github_check_subject_id
+         AND aggregate.provider_delivery_id = evidence.provider_delivery_id
+         AND aggregate.tenant_id = evidence.tenant_id
+        WHERE child.workflow_run_id = $1
+          AND child.subject_kind = 'workflow'
+          AND manifest.workflow_selection_kind = 'all_direct'
+        FOR UPDATE OF aggregate
+        ",
+    )
+    .bind(run_id)
+    .fetch_optional(&mut **transaction)
+    .await?;
+    Ok(delivery_id)
+}
+
+/// Reconciles one delivery-wide Check from admission and terminal child state.
+#[allow(clippy::too_many_lines)] // One locked reconciliation owns the aggregate transition.
+pub(super) async fn reconcile_all_direct_check(
+    transaction: &mut Transaction<'_, Postgres>,
+    delivery_id: Uuid,
+    updated_at_ms: i64,
+) -> Result<(), GithubCheckAggregationError> {
+    let aggregate = sqlx::query(
+        r"
+        SELECT aggregate.id, aggregate.desired_state,
+               aggregate.desired_conclusion, aggregate.terminal_cause,
+               aggregate.desired_revision, aggregate.desired_updated_at_ms
+        FROM github_provider_delivery_evidence AS evidence
+        JOIN provider_delivery_inbox AS inbox
+          ON inbox.id = evidence.provider_delivery_id
+         AND inbox.tenant_id = evidence.tenant_id
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = evidence.tenant_id
+         AND manifest.repository_id = evidence.repository_id
+         AND manifest.provider_connection_id = evidence.provider_connection_id
+         AND manifest.manifest_revision = evidence.provider_manifest_revision
+         AND manifest.manifest_digest = evidence.provider_manifest_digest
+        JOIN github_check_subjects AS aggregate
+          ON aggregate.id = evidence.github_check_subject_id
+         AND aggregate.provider_delivery_id = evidence.provider_delivery_id
+         AND aggregate.tenant_id = evidence.tenant_id
+        WHERE evidence.provider_delivery_id = $1
+          AND inbox.state = 'completed'
+          AND manifest.workflow_selection_kind = 'all_direct'
+        FOR UPDATE OF aggregate
+        ",
+    )
+    .bind(delivery_id)
+    .fetch_optional(&mut **transaction)
+    .await?;
+    let Some(aggregate) = aggregate else {
+        return Ok(());
+    };
+
+    let row = sqlx::query(
+        r"
+        SELECT count(*) FILTER (
+                   WHERE outcome.outcome_kind = 'failed'
+               ) AS failed_count,
+               count(*) FILTER (
+                   WHERE outcome.outcome_kind = 'admitted'
+               ) AS admitted_count,
+               count(child.id) FILTER (
+                   WHERE outcome.outcome_kind = 'admitted'
+               ) AS child_count,
+               count(*) FILTER (
+                   WHERE outcome.outcome_kind = 'admitted'
+                     AND child.desired_state = 'completed'
+               ) AS terminal_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'failure'
+               ) AS failure_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'timed_out'
+               ) AS timed_out_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'cancelled'
+               ) AS cancelled_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'action_required'
+               ) AS action_required_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'success'
+               ) AS success_count,
+               count(*) FILTER (
+                   WHERE child.desired_conclusion = 'skipped'
+               ) AS skipped_count
+        FROM provider_delivery_workflow_outcomes AS outcome
+        LEFT JOIN github_check_subjects AS child
+          ON child.provider_delivery_id = outcome.inbox_id
+         AND child.tenant_id = outcome.tenant_id
+         AND child.workflow_run_id = outcome.run_id
+         AND child.subject_kind = 'workflow'
+        WHERE outcome.inbox_id = $1
+        ",
+    )
+    .bind(delivery_id)
+    .fetch_one(&mut **transaction)
+    .await?;
+
+    let desired = desired_aggregate(AggregateCounts {
+        failed: row.try_get("failed_count")?,
+        admitted: row.try_get("admitted_count")?,
+        children: row.try_get("child_count")?,
+        terminal: row.try_get("terminal_count")?,
+        failure: row.try_get("failure_count")?,
+        timed_out: row.try_get("timed_out_count")?,
+        cancelled: row.try_get("cancelled_count")?,
+        action_required: row.try_get("action_required_count")?,
+        success: row.try_get("success_count")?,
+        skipped: row.try_get("skipped_count")?,
+    })?;
+
+    let subject_id: Uuid = aggregate.try_get("id")?;
+    let state: String = aggregate.try_get("desired_state")?;
+    let conclusion: Option<String> = aggregate.try_get("desired_conclusion")?;
+    let cause: Option<String> = aggregate.try_get("terminal_cause")?;
+    let revision: i64 = aggregate.try_get("desired_revision")?;
+    let prior_updated_at: i64 = aggregate.try_get("desired_updated_at_ms")?;
+
+    match desired {
+        DesiredAggregate::InProgress => {
+            if state == "in_progress" && conclusion.is_none() && cause.is_none() && revision == 2 {
+                return Ok(());
+            }
+            if updated_at_ms < prior_updated_at {
+                return Err(GithubCheckAggregationError::CorruptData);
+            }
+            if state != "queued" || conclusion.is_some() || cause.is_some() || revision != 1 {
+                return Err(GithubCheckAggregationError::CorruptData);
+            }
+            update_aggregate(
+                transaction,
+                subject_id,
+                "in_progress",
+                None,
+                None,
+                revision,
+                updated_at_ms,
+            )
+            .await
+        }
+        DesiredAggregate::Terminal(expected_conclusion, expected_cause) => {
+            if state == "completed"
+                && conclusion.as_deref() == Some(expected_conclusion)
+                && cause.as_deref() == Some(expected_cause)
+                && matches!(revision, 2 | 3)
+            {
+                return Ok(());
+            }
+            if updated_at_ms < prior_updated_at {
+                return Err(GithubCheckAggregationError::CorruptData);
+            }
+            if !matches!(
+                (state.as_str(), revision),
+                ("queued", 1) | ("in_progress", 2)
+            ) || conclusion.is_some()
+                || cause.is_some()
+            {
+                return Err(GithubCheckAggregationError::CorruptData);
+            }
+            update_aggregate(
+                transaction,
+                subject_id,
+                "completed",
+                Some(expected_conclusion),
+                Some(expected_cause),
+                revision,
+                updated_at_ms,
+            )
+            .await
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DesiredAggregate {
+    InProgress,
+    Terminal(&'static str, &'static str),
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AggregateCounts {
+    failed: i64,
+    admitted: i64,
+    children: i64,
+    terminal: i64,
+    failure: i64,
+    timed_out: i64,
+    cancelled: i64,
+    action_required: i64,
+    success: i64,
+    skipped: i64,
+}
+
+fn desired_aggregate(
+    counts: AggregateCounts,
+) -> Result<DesiredAggregate, GithubCheckAggregationError> {
+    let classified_terminal = counts.failure
+        + counts.timed_out
+        + counts.cancelled
+        + counts.action_required
+        + counts.success
+        + counts.skipped;
+    if counts.admitted != counts.children
+        || counts.terminal > counts.admitted
+        || (counts.terminal == counts.admitted && classified_terminal != counts.terminal)
+    {
+        return Err(GithubCheckAggregationError::CorruptData);
+    }
+    Ok(if counts.failed > 0 {
+        DesiredAggregate::Terminal("failure", "workflow_failure")
+    } else if counts.admitted == 0 {
+        DesiredAggregate::Terminal("skipped", "workflow_skipped")
+    } else if counts.terminal < counts.admitted {
+        DesiredAggregate::InProgress
+    } else if counts.failure > 0 {
+        DesiredAggregate::Terminal("failure", "workflow_failure")
+    } else if counts.timed_out > 0 {
+        DesiredAggregate::Terminal("timed_out", "workflow_timed_out")
+    } else if counts.cancelled > 0 {
+        DesiredAggregate::Terminal("cancelled", "workflow_cancelled")
+    } else if counts.action_required > 0 {
+        DesiredAggregate::Terminal("action_required", "provider_unknown")
+    } else if counts.success > 0 {
+        DesiredAggregate::Terminal("success", "workflow_success")
+    } else {
+        DesiredAggregate::Terminal("skipped", "workflow_skipped")
+    })
+}
+
+async fn update_aggregate(
+    transaction: &mut Transaction<'_, Postgres>,
+    subject_id: Uuid,
+    state: &'static str,
+    conclusion: Option<&'static str>,
+    cause: Option<&'static str>,
+    prior_revision: i64,
+    updated_at_ms: i64,
+) -> Result<(), GithubCheckAggregationError> {
+    let updated = sqlx::query_scalar::<_, Uuid>(
+        r"
+        UPDATE github_check_subjects
+        SET desired_state = $2, desired_conclusion = $3,
+            terminal_cause = $4, desired_revision = desired_revision + 1,
+            desired_updated_at_ms = $6
+        WHERE id = $1
+          AND desired_revision = $5
+          AND desired_updated_at_ms <= $6
+        RETURNING id
+        ",
+    )
+    .bind(subject_id)
+    .bind(state)
+    .bind(conclusion)
+    .bind(cause)
+    .bind(prior_revision)
+    .bind(updated_at_ms)
+    .fetch_optional(&mut **transaction)
+    .await?;
+    if updated == Some(subject_id) {
+        Ok(())
+    } else {
+        Err(GithubCheckAggregationError::CorruptData)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AggregateCounts, DesiredAggregate, desired_aggregate};
+
+    #[test]
+    fn admitted_workflows_cannot_complete_the_required_check_before_results() {
+        assert_eq!(
+            desired_aggregate(AggregateCounts {
+                admitted: 2,
+                children: 2,
+                terminal: 1,
+                success: 1,
+                ..AggregateCounts::default()
+            })
+            .expect("consistent aggregate"),
+            DesiredAggregate::InProgress
+        );
+        assert_eq!(
+            desired_aggregate(AggregateCounts {
+                admitted: 2,
+                children: 2,
+                terminal: 2,
+                success: 2,
+                ..AggregateCounts::default()
+            })
+            .expect("consistent aggregate"),
+            DesiredAggregate::Terminal("success", "workflow_success")
+        );
+    }
+
+    #[test]
+    fn aggregate_propagates_pre_admission_and_terminal_failures() {
+        assert_eq!(
+            desired_aggregate(AggregateCounts {
+                failed: 1,
+                ..AggregateCounts::default()
+            })
+            .expect("consistent aggregate"),
+            DesiredAggregate::Terminal("failure", "workflow_failure")
+        );
+        assert_eq!(
+            desired_aggregate(AggregateCounts {
+                admitted: 1,
+                children: 1,
+                terminal: 1,
+                failure: 1,
+                ..AggregateCounts::default()
+            })
+            .expect("consistent aggregate"),
+            DesiredAggregate::Terminal("failure", "workflow_failure")
+        );
+    }
+}

--- a/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
+++ b/crates/automata-ci-store-postgres/src/github_subject_evidence.rs
@@ -354,7 +354,9 @@ pub(crate) async fn validate_github_workflow_selection_in_transaction(
            AND subject.github_repository_name = evidence.github_repository_name
            AND subject.github_app_id = manifest.github_app_id
            AND subject.head_sha = evidence.github_check_head_sha
-           AND subject.check_name = manifest.check_name
+           AND subject.check_name = automata_github_workflow_check_name(
+                   manifest.check_name, entry.workflow_path
+               )
            AND subject.created_at_ms = inbox.accepted_at_ms
            AND subject.workflow_run_id IS NULL
            AND subject.linked_at_ms IS NULL
@@ -874,7 +876,9 @@ async fn insert_all_direct_workflow_check_subject(
                evidence.provider_connection_id, evidence.provider_installation_id,
                evidence.github_repository_id, evidence.github_repository_name,
                manifest.github_app_id, evidence.github_check_head_sha,
-               manifest.check_name, $2, inbox.accepted_at_ms,
+               automata_github_workflow_check_name(
+                   manifest.check_name, entry.workflow_path
+               ), $2, inbox.accepted_at_ms,
                inbox.accepted_at_ms
         FROM github_provider_delivery_evidence AS evidence
         JOIN provider_delivery_inbox AS inbox
@@ -964,7 +968,9 @@ async fn load_queued_workflow_check_subject(
           AND subject.github_app_id = manifest.github_app_id
           AND subject.head_sha = $5
           AND subject.head_sha = evidence.github_check_head_sha
-          AND subject.check_name = manifest.check_name
+          AND subject.check_name = automata_github_workflow_check_name(
+                  manifest.check_name, subject.subject_key
+              )
           AND subject.created_at_ms = inbox.accepted_at_ms
           AND subject.workflow_run_id IS NULL
           AND subject.linked_at_ms IS NULL

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -40,6 +40,7 @@ mod connection;
 mod durable_schema;
 mod event_subject;
 mod g1;
+mod github_check_aggregation;
 mod github_checks;
 mod github_job_runtime_authority;
 mod github_provider_manifest;

--- a/crates/automata-ci-store-postgres/src/logical_run_finalization.rs
+++ b/crates/automata-ci-store-postgres/src/logical_run_finalization.rs
@@ -5,6 +5,9 @@ use automata_ci_core::{
 };
 use sqlx::{PgPool, Postgres, Row as _, Transaction, postgres::PgRow};
 
+use super::github_check_aggregation::{
+    GithubCheckAggregationError, lock_all_direct_check_for_run, reconcile_all_direct_check,
+};
 use super::{PostgresStore, durable_schema::current_durable_schemas, pg_bigint};
 use automata_ci_store::{
     ClaimLogicalRunFinalization, ClaimedLogicalRunFinalization, CommitLogicalRunFinalization,
@@ -266,7 +269,18 @@ impl LogicalRunFinalizationRepository for PostgresStore {
         transition_invocation(&mut transaction, &request).await?;
         transition_marker(&mut transaction, &request).await?;
         transition_workflow_run(&mut transaction, &request).await?;
+        let all_direct_delivery = lock_all_direct_check_for_run(
+            &mut transaction,
+            request.claim().target().run_id().as_uuid(),
+        )
+        .await
+        .map_err(logical_finalization_aggregation_error)?;
         transition_linked_github_check(&mut transaction, &request).await?;
+        if let Some(delivery_id) = all_direct_delivery {
+            reconcile_all_direct_check(&mut transaction, delivery_id, request.finalized_at().get())
+                .await
+                .map_err(logical_finalization_aggregation_error)?;
+        }
         super::admission::reconcile_terminal_concurrency(
             &mut transaction,
             repository_id,
@@ -1233,4 +1247,16 @@ fn corrupt_value(error: impl std::fmt::Display) -> LogicalRunFinalizationStoreEr
 
 fn operation_error(error: sqlx::Error) -> LogicalRunFinalizationStoreError {
     StoreError::operation(error).into()
+}
+
+fn logical_finalization_aggregation_error(
+    error: GithubCheckAggregationError,
+) -> LogicalRunFinalizationStoreError {
+    match error {
+        GithubCheckAggregationError::Operation(error) => operation_error(error),
+        GithubCheckAggregationError::CorruptData => StoreError::corrupt_data(
+            "all-direct GitHub Check aggregate contradicts its workflow outcomes",
+        )
+        .into(),
+    }
 }

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -229,6 +229,10 @@ const FROZEN_MIGRATIONS: &[(&str, &str)] = &[
         "0056_provider_processing_invocations.sql",
         "47302f91ed241062d1d9366a326d48d804bd6bbf7daba589501f6c2b92dbf6ef23707fea7999f27398bc1ef7b54203f5",
     ),
+    (
+        "0057_merge_queue_check_aggregation.sql",
+        "447aeb41ee79fe0e96431183dbb850b19769cadcaa7f43bab1efea07dd3b84290cfe034e4682b337abeb06d577d9f639",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store-postgres/src/provider_delivery.rs
+++ b/crates/automata-ci-store-postgres/src/provider_delivery.rs
@@ -24,6 +24,7 @@ use automata_ci_store::{
 
 use super::{
     PostgresStore,
+    github_check_aggregation::{GithubCheckAggregationError, reconcile_all_direct_check},
     github_checks::{github_check_conclusion_name, github_check_terminal_cause_name},
     pg_bigint,
 };
@@ -340,14 +341,15 @@ impl ProviderDeliveryRepository for PostgresStore {
             request.claim().delivery_id(),
         )
         .await?;
-        let terminal_cause = if all_direct {
-            Some(all_direct_completion_check_terminal_cause(
-                request.outcomes(),
-            ))
-        } else {
-            completion_check_terminal_cause(request.outcomes())
-        };
-        if let Some(cause) = terminal_cause {
+        if all_direct {
+            reconcile_all_direct_check(
+                &mut transaction,
+                request.claim().delivery_id().as_uuid(),
+                request.completed_at().get(),
+            )
+            .await
+            .map_err(provider_delivery_aggregation_error)?;
+        } else if let Some(cause) = completion_check_terminal_cause(request.outcomes()) {
             terminalize_pre_admission_check(
                 &mut transaction,
                 request.claim().delivery_id(),
@@ -570,28 +572,6 @@ fn completion_check_terminal_cause(
         Some(GithubCheckTerminalCause::WorkflowFailure)
     } else {
         Some(GithubCheckTerminalCause::WorkflowSkipped)
-    }
-}
-
-fn all_direct_completion_check_terminal_cause(
-    outcomes: &[ProviderDeliveryWorkflowOutcome],
-) -> GithubCheckTerminalCause {
-    if outcomes.iter().any(|outcome| {
-        matches!(
-            outcome.conclusion(),
-            ProviderDeliveryWorkflowConclusion::Failed { .. }
-        )
-    }) {
-        GithubCheckTerminalCause::WorkflowFailure
-    } else if outcomes.iter().any(|outcome| {
-        matches!(
-            outcome.conclusion(),
-            ProviderDeliveryWorkflowConclusion::Admitted { .. }
-        )
-    }) {
-        GithubCheckTerminalCause::WorkflowSuccess
-    } else {
-        GithubCheckTerminalCause::WorkflowSkipped
     }
 }
 
@@ -1475,7 +1455,10 @@ async fn insert_failed_workflow_check(
                evidence.provider_delivery_id, progress.workflow_path,
                evidence.provider_connection_id, evidence.provider_installation_id,
                evidence.github_repository_id, manifest.github_app_id,
-               evidence.github_check_head_sha, manifest.check_name, $2,
+               evidence.github_check_head_sha,
+               automata_github_workflow_check_name(
+                   manifest.check_name, progress.workflow_path
+               ), $2,
                inbox.accepted_at_ms, inbox.accepted_at_ms
         FROM provider_delivery_workflow_progress AS progress
         JOIN provider_delivery_workflow_inventories AS inventory
@@ -2119,4 +2102,13 @@ fn outcome_count_i16(
 
 fn operation_error(error: sqlx::Error) -> ProviderDeliveryStoreError {
     ProviderDeliveryStoreError::operation(error)
+}
+
+fn provider_delivery_aggregation_error(
+    error: GithubCheckAggregationError,
+) -> ProviderDeliveryStoreError {
+    match error {
+        GithubCheckAggregationError::Operation(error) => operation_error(error),
+        GithubCheckAggregationError::CorruptData => ProviderDeliveryStoreError::CorruptData,
+    }
 }

--- a/crates/automata-ci-store/src/github_checks.rs
+++ b/crates/automata-ci-store/src/github_checks.rs
@@ -1,8 +1,12 @@
-use std::num::{NonZeroU16, NonZeroU64};
+use std::{
+    fmt::Write as _,
+    num::{NonZeroU16, NonZeroU64},
+};
 
 use async_trait::async_trait;
 use automata_ci_blob::BlobDescriptor;
 use automata_ci_core::{GitObjectId, JobId, RunId, Sha256Digest, UnixMillis};
+use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -140,6 +144,40 @@ impl GithubCheckName {
         }
         let bounded = value[..end].trim_end();
         Self::new(bounded.to_owned())
+    }
+
+    /// Derives a distinct, bounded Check name for one discovered workflow.
+    ///
+    /// The configured name remains reserved for the delivery-wide aggregate.
+    /// Long paths retain a full SHA-256 suffix so separate workflows cannot
+    /// accidentally satisfy the aggregate's required status context.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty or control-bearing workflow paths.
+    pub fn from_workflow_path(
+        aggregate: &Self,
+        workflow_path: &str,
+    ) -> Result<Self, GithubCheckValueError> {
+        if workflow_path.is_empty() || workflow_path.chars().any(char::is_control) {
+            return Err(GithubCheckValueError::InvalidCheckName);
+        }
+        let projected = format!("{} / {workflow_path}", aggregate.as_str());
+        if projected.len() <= MAX_CHECK_NAME_BYTES {
+            return Self::new(projected);
+        }
+
+        let mut digest = String::with_capacity(64);
+        for byte in Sha256::digest(workflow_path.as_bytes()) {
+            write!(&mut digest, "{byte:02x}").expect("writing to a String is infallible");
+        }
+        let suffix = format!(" / workflow-{digest}");
+        let mut prefix_end = MAX_CHECK_NAME_BYTES - suffix.len();
+        while !aggregate.as_str().is_char_boundary(prefix_end) {
+            prefix_end -= 1;
+        }
+        let prefix = aggregate.as_str()[..prefix_end].trim_end();
+        Self::new(format!("{prefix}{suffix}"))
     }
 
     /// Returns the validated provider-facing name.

--- a/crates/automata-ci-store/tests/github_checks_api.rs
+++ b/crates/automata-ci-store/tests/github_checks_api.rs
@@ -95,6 +95,27 @@ fn static_and_evaluated_job_names_project_without_mutating_durable_text() {
 }
 
 #[test]
+fn discovered_workflow_check_names_cannot_collide_with_the_aggregate() {
+    let aggregate = GithubCheckName::new("Automata CI").expect("aggregate name");
+    let rust = GithubCheckName::from_workflow_path(&aggregate, ".ci/workflows/rust.yml")
+        .expect("workflow name");
+    let frontend = GithubCheckName::from_workflow_path(&aggregate, ".ci/workflows/frontend.yml")
+        .expect("workflow name");
+
+    assert_eq!(rust.as_str(), "Automata CI / .ci/workflows/rust.yml");
+    assert_ne!(rust, aggregate);
+    assert_ne!(rust, frontend);
+
+    let maximum = GithubCheckName::new("x".repeat(255)).expect("maximum aggregate name");
+    let long_path = format!(".ci/workflows/{}.yml", "workflow".repeat(128));
+    let bounded =
+        GithubCheckName::from_workflow_path(&maximum, &long_path).expect("bounded workflow name");
+    assert_eq!(bounded.as_str().len(), 255);
+    assert!(bounded.as_str().contains(" / workflow-"));
+    assert_ne!(bounded, maximum);
+}
+
+#[test]
 fn rerun_subject_identity_has_one_closed_physical_origin() {
     let rerun_run_id = RunId::from_uuid(Uuid::new_v4());
     let identity = GithubCheckSubjectIdentity::new_rerun(

--- a/docs/github-checks.md
+++ b/docs/github-checks.md
@@ -7,8 +7,11 @@ and the rerun service owns admission. Only Check Runs project results: no produc
 
 ## User-visible lifecycle
 
-- An aggregate pre-admission Check reports compilation or admission before jobs exist;
-  each concrete job attempt has a child Check, and a physical rerun gets fresh Checks.
+- The configured Check name belongs only to the delivery-wide aggregate. In
+  `all_direct` mode it remains nonterminal while any admitted workflow is
+  running and derives its terminal conclusion from every admitted workflow;
+  per-workflow Checks use distinct path-qualified names. Each concrete job
+  attempt has a child Check, and a physical rerun gets fresh Checks.
 - Delivery, schedule, and rerun origins share the same fenced projection contract.
 - Identity is immutable: tenant, repository, connection, installation, App, head SHA,
   Check name, `automata-check:<UUID>` external ID, and exact Details target.


### PR DESCRIPTION
## Outcome

The merge queue now waits for the actual workflows admitted by Automata instead of accepting a transient admission success.

The live audit found that #470 entered the merge queue at 15:52:20 UTC and merged at 15:53:12 while its Rust and PostgreSQL checks were still running. Automata had published two checks named `Automata CI`: a delivery/discovery check that concluded success as soon as the workflow was admitted, and the real workflow aggregate that remained in progress. The required status context matched the premature success.

This change reserves the configured check name for one delivery-wide aggregate, keeps that aggregate in progress until every admitted `all_direct` workflow is terminal, propagates terminal failure/cancellation/timeout state, and gives each workflow root a distinct path-qualified check name.

## Related issue

None.

## Trust and compatibility impact

This changes the GitHub Checks and merge-queue compatibility boundary. It adds a forward PostgreSQL migration for deterministic, bounded per-workflow check names and serializes aggregate reconciliation so concurrent workflow finalizers cannot publish a partial result. It does not change credentials, runner isolation, source authority, or external protocols.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p automata-ci-store -p automata-ci-store-postgres --all-targets --all-features --locked -- -D warnings`
- `cargo test -p automata-ci-store --test store_contracts --locked` — 192 passed
- `cargo test -p automata-ci-store-postgres --lib --locked` — 65 passed
- `cargo test -p automata-ci-github-delivery --all-targets --all-features --locked` — 154 passed
- `./scripts/ci/run-postgres-tests.sh` against PostgreSQL 18 — 73 passed, including the migration harness
- `./scripts/ci/lint-workflows.sh`
- `./scripts/ci/lint-ci-security.sh` — no findings

The full workspace test/doc baseline was not rerun locally; the focused owner crates, GitHub delivery boundary, and complete PostgreSQL lane were run instead.

## AI assistance

OpenAI Codex materially assisted with the live GitHub audit, implementation, tests, and pull-request preparation. I reviewed the submitted diff and verification results.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
