### PR TITLE
Fix compact terminal log row layout

### DIFF
--- a/ui/src/components/TerminalOutput.stories.tsx
+++ b/ui/src/components/TerminalOutput.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 import { TerminalTranscript } from "../logs/terminal";
 import type { LogGroupView } from "../presenters/jobLogs";
 import { TerminalOutput } from "./TerminalOutput";
@@ -45,4 +46,14 @@ export const StyledUnicodeOutput: Story = {
     subscribeOutput: undefined,
   },
   render: (args) => <div className="log-viewer"><div className="log-groups"><TerminalOutput {...args} /></div></div>,
+  play: ({ canvasElement }) => {
+    const rows = [...canvasElement.querySelectorAll<HTMLElement>(".log-line")];
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      const cells = [...row.children].map((cell) => cell.getBoundingClientRect());
+      expect(cells).toHaveLength(3);
+      expect(new Set(cells.map((cell) => cell.top)).size).toBe(1);
+      expect(row.getBoundingClientRect().height).toBeLessThanOrEqual(32);
+    }
+  },
 };

--- a/ui/src/styles/pages/job-log.css
+++ b/ui/src/styles/pages/job-log.css
@@ -203,8 +203,6 @@
 
 .log-line {
   display: grid;
-  content-visibility: auto;
-  contain-intrinsic-block-size: auto 26px;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
   min-height: 26px;
@@ -238,6 +236,8 @@
 }
 
 .log-line > code {
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 26px;
   padding: 4px 16px 3px 0;
   color: inherit;
   background: transparent;


### PR DESCRIPTION
## Outcome

Restore compact terminal log rows after the terminal-aware log viewer landed. Each line number, timestamp, and styled message now shares one aligned 26px row instead of being laid out as three stacked grid rows.

The root cause was applying `content-visibility: auto` to the subgrid row itself. Layout containment makes the element ineligible for subgrid participation, so Chromium computed `grid-template-columns` as `none`. The visibility optimization now belongs to the message cell, preserving off-screen terminal-content containment without breaking the row grid.

A Chromium Storybook interaction test asserts that every terminal row has three horizontally aligned cells and remains compact.

## Related issue

None

## Trust and compatibility impact

None. This changes only terminal-log presentation CSS and its browser regression coverage; protocols, stored output, authorization, credentials, isolation, and GitHub Actions compatibility are unchanged.

## Verification

- `cd ui && npm run check` — passed: architecture check, 558 coverage tests, 8 build-verifier tests, 80 Chromium story tests, Storybook build, typecheck, client/SSR/package builds, and build/package verification.
- `cd ui && npm run benchmark:logs` — passed: append into a 5,000-line open viewer averaged 0.245 ms; replay/project 10,000 styled records averaged 26.45 ms; parse roughly 750 KiB of chunked terminal output averaged 46.90 ms.
- Manual Chromium layout inspection — each sample terminal row measured 26px, with line number, timestamp, and message sharing the same top coordinate.

## AI assistance

OpenAI Codex diagnosed the CSS containment/subgrid interaction, implemented the focused fix and Chromium regression assertion, and ran the verification commands. The submitted diff was reviewed directly.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [ ] I reviewed and understand every submitted change, including AI-assisted work.
