### PR TITLE
Add exact runtime service routes to sandbox specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/crates/automata-ci-execution/Cargo.toml
+++ b/crates/automata-ci-execution/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 automata-ci-core.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 static_assertions.workspace = true

--- a/crates/automata-ci-execution/README.md
+++ b/crates/automata-ci-execution/README.md
@@ -5,6 +5,12 @@ sandboxes, command execution, and service-container discovery. Runner and
 executor logic target `SandboxProvider` and `ExecutionEndpoint` without
 embedding a provider-specific protocol in durable control messages.
 
+`RuntimeServiceRoutes` carries a bounded, credential-free set of exact
+HTTP(S) origins into providers which advertise `RuntimeServiceProxy`. This is
+a separate side channel from general sandbox networking: a provider must
+enforce the supplied scheme, host, and port set and must not infer broader
+egress authority from it.
+
 The Podman, Kubernetes, macOS Virtualization.framework, and Windows Hyper-V
 sandbox adapters implement `SandboxProvider` directly. Providers that
 advertise service-container support return the complete healthy discovery view

--- a/crates/automata-ci-execution/src/capability.rs
+++ b/crates/automata-ci-execution/src/capability.rs
@@ -23,10 +23,15 @@ pub enum SandboxCapability {
     CopyFrom,
     /// Injects validated process-environment variables at execution time.
     EnvironmentInjection,
-    /// Enforces a sandbox with networking completely disabled.
+    /// Enforces a sandbox with general guest networking completely disabled.
+    /// A separately requested [`Self::RuntimeServiceProxy`] remains an exact,
+    /// provider-filtered side channel and does not weaken this boundary.
     NetworkDisabled,
     /// Enforces an isolated network that permits provider-controlled egress.
     PrivateEgress,
+    /// Exposes only exact job-bound HTTP(S) origins through a
+    /// provider-controlled proxy, independently of general guest networking.
+    RuntimeServiceProxy,
     /// Runs a trusted workload on the host network without network isolation.
     HostNetwork,
     /// Launches workloads with a read-only root filesystem.

--- a/crates/automata-ci-execution/src/error.rs
+++ b/crates/automata-ci-execution/src/error.rs
@@ -52,6 +52,9 @@ pub enum ValueError {
     /// A service request or discovered service view violated its invariants.
     #[error("service container request or discovery data is invalid")]
     InvalidServiceContainer,
+    /// A runtime-service route was malformed or exceeded its hard bound.
+    #[error("sandbox runtime-service route is invalid")]
+    InvalidRuntimeServiceRoute,
 }
 
 /// Whether a failed mutating provider operation is proven not to have changed

--- a/crates/automata-ci-execution/src/lib.rs
+++ b/crates/automata-ci-execution/src/lib.rs
@@ -36,6 +36,7 @@
 mod capability;
 mod endpoint;
 mod error;
+mod runtime_service;
 mod sandbox;
 mod service;
 mod value;
@@ -55,6 +56,9 @@ pub use endpoint::{
 pub use error::{
     ExecutionError, ExecutionErrorKind, ExecutionStage, OperationOutcome, ProviderError,
     ProviderErrorKind, ProviderStage, ValueError,
+};
+pub use runtime_service::{
+    MAX_RUNTIME_SERVICE_ROUTES, RuntimeServiceProtocol, RuntimeServiceRoute, RuntimeServiceRoutes,
 };
 pub use sandbox::{
     DestroyDisposition, DestroySandbox, SandboxCustody, SandboxInspection, SandboxProvider,

--- a/crates/automata-ci-execution/src/runtime_service.rs
+++ b/crates/automata-ci-execution/src/runtime_service.rs
@@ -1,0 +1,121 @@
+use std::num::NonZeroU16;
+
+use url::{Host, Url};
+
+use crate::ValueError;
+
+/// Maximum exact HTTP(S) origins exposed through a sandbox runtime-service proxy.
+pub const MAX_RUNTIME_SERVICE_ROUTES: usize = 16;
+
+/// Application protocol accepted for one exact runtime-service route.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum RuntimeServiceProtocol {
+    /// Plain HTTP, limited to deployments which separately trust that transport.
+    Http,
+    /// HTTP protected end to end by TLS.
+    Https,
+}
+
+/// One credential-free HTTP(S) origin which a sandbox may reach through a
+/// provider-controlled runtime-service proxy.
+///
+/// The route contains only the normalized scheme, host, and effective port.
+/// URL paths, credentials, headers, and bearer values never enter the sandbox
+/// provider contract.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RuntimeServiceRoute {
+    protocol: RuntimeServiceProtocol,
+    host: String,
+    port: NonZeroU16,
+}
+
+impl RuntimeServiceRoute {
+    /// Reduces a validated HTTP(S) URL to its exact network origin.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-HTTP schemes, missing hosts, URL credentials, and origins
+    /// without a non-zero effective port.
+    pub fn from_url(url: &Url) -> Result<Self, ValueError> {
+        let protocol = match url.scheme() {
+            "http" => RuntimeServiceProtocol::Http,
+            "https" => RuntimeServiceProtocol::Https,
+            _ => return Err(ValueError::InvalidRuntimeServiceRoute),
+        };
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(ValueError::InvalidRuntimeServiceRoute);
+        }
+        let host = match url.host().ok_or(ValueError::InvalidRuntimeServiceRoute)? {
+            Host::Domain(host) => host.to_owned(),
+            Host::Ipv4(address) => address.to_string(),
+            Host::Ipv6(address) => address.to_string(),
+        };
+        let port = url
+            .port_or_known_default()
+            .and_then(NonZeroU16::new)
+            .ok_or(ValueError::InvalidRuntimeServiceRoute)?;
+        Ok(Self {
+            protocol,
+            host,
+            port,
+        })
+    }
+
+    /// Returns the exact application protocol accepted by the route.
+    #[must_use]
+    pub const fn protocol(&self) -> RuntimeServiceProtocol {
+        self.protocol
+    }
+
+    /// Returns the normalized DNS name or unbracketed IP literal.
+    #[must_use]
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Returns the exact non-zero destination port.
+    #[must_use]
+    pub const fn port(&self) -> NonZeroU16 {
+        self.port
+    }
+}
+
+/// Canonical bounded set of credential-free runtime-service origins.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RuntimeServiceRoutes(Vec<RuntimeServiceRoute>);
+
+impl RuntimeServiceRoutes {
+    /// Creates a sorted, duplicate-free route set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects input containing more than [`MAX_RUNTIME_SERVICE_ROUTES`]
+    /// entries before canonicalization.
+    pub fn new(routes: impl IntoIterator<Item = RuntimeServiceRoute>) -> Result<Self, ValueError> {
+        let mut routes: Vec<_> = routes.into_iter().collect();
+        if routes.len() > MAX_RUNTIME_SERVICE_ROUTES {
+            return Err(ValueError::InvalidRuntimeServiceRoute);
+        }
+        routes.sort_unstable();
+        routes.dedup();
+        Ok(Self(routes))
+    }
+
+    /// Returns an empty route set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Returns routes in canonical order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[RuntimeServiceRoute] {
+        &self.0
+    }
+
+    /// Returns whether no runtime-service origin is requested.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}

--- a/crates/automata-ci-execution/src/sandbox.rs
+++ b/crates/automata-ci-execution/src/sandbox.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     Cancellation, EnvironmentProfile, ExecutionEndpoint, NetworkPolicy, OperationId,
     ProviderCapabilities, ProviderError, ProviderId, ResourceLimits, RootFilesystemPolicy,
-    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxPrivilegePolicy,
-    ServiceContainerBindings, ServiceContainerSpecs, TargetPath,
+    RuntimeServiceRoutes, SandboxEnvironment, SandboxGeneration, SandboxHandle,
+    SandboxPrivilegePolicy, ServiceContainerBindings, ServiceContainerSpecs, TargetPath,
 };
 
 /// Runner custody coordinates for one sandbox request.
@@ -49,6 +49,7 @@ pub struct SandboxSpec {
     resources: ResourceLimits,
     resource_allocation: Option<JobResourceAllocation>,
     services: ServiceContainerSpecs,
+    runtime_service_routes: RuntimeServiceRoutes,
 }
 
 impl SandboxSpec {
@@ -83,6 +84,7 @@ impl SandboxSpec {
             resources,
             resource_allocation: None,
             services: ServiceContainerSpecs::empty(),
+            runtime_service_routes: RuntimeServiceRoutes::empty(),
         }
     }
 
@@ -213,6 +215,20 @@ impl SandboxSpec {
     #[must_use]
     pub const fn services(&self) -> &ServiceContainerSpecs {
         &self.services
+    }
+
+    /// Adds the exact credential-free HTTP(S) origins which a provider-owned
+    /// runtime-service proxy must enforce for this sandbox generation.
+    #[must_use]
+    pub fn with_runtime_service_routes(mut self, routes: RuntimeServiceRoutes) -> Self {
+        self.runtime_service_routes = routes;
+        self
+    }
+
+    /// Returns the exact origins requested through the runtime-service proxy.
+    #[must_use]
+    pub const fn runtime_service_routes(&self) -> &RuntimeServiceRoutes {
+        &self.runtime_service_routes
     }
 }
 
@@ -422,7 +438,9 @@ pub trait SandboxProvider: fmt::Debug + Send + Sync {
     ///
     /// Reusing an operation identifier with different request material must
     /// fail closed. A successful replay returns the same generation-fenced
-    /// resource rather than creating another sandbox.
+    /// resource rather than creating another sandbox. Providers which do not
+    /// advertise [`crate::SandboxCapability::RuntimeServiceProxy`] must reject
+    /// a nonempty [`SandboxSpec::runtime_service_routes`] request.
     ///
     /// # Errors
     ///

--- a/crates/automata-ci-execution/tests/validation.rs
+++ b/crates/automata-ci-execution/tests/validation.rs
@@ -6,12 +6,14 @@ use automata_ci_execution::{
     ExecutionOutput, ExecutionOutputRecord, ExecutionOutputStream, ExecutionTermination,
     ImmutableImage, MAX_EXECUTION_OUTPUT_BYTES, MAX_EXECUTION_OUTPUT_RECORD_BYTES,
     MAX_EXECUTION_OUTPUT_RECORDS, NetworkPolicy, OperationId, ProviderCapabilities, ProviderId,
-    ResourceLimits, RootFilesystemPolicy, RunnerId, SandboxCapability, SandboxCustody,
-    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxPrivilegePolicy, SandboxSpec,
-    ServiceContainerBinding, ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs,
-    ServiceHealthOverrides, ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding,
-    ServiceTransportProtocol, Sha256Digest, TargetPath, ValueError,
+    ResourceLimits, RootFilesystemPolicy, RunnerId, RuntimeServiceProtocol, RuntimeServiceRoute,
+    RuntimeServiceRoutes, SandboxCapability, SandboxCustody, SandboxEnvironment, SandboxGeneration,
+    SandboxHandle, SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBinding,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
+    ServiceHealthPolicy, ServiceNetwork, ServicePort, ServicePortBinding, ServiceTransportProtocol,
+    Sha256Digest, TargetPath, ValueError,
 };
+use url::Url;
 
 #[test]
 fn only_termination_authorizes_backend_termination_handling() {
@@ -43,6 +45,42 @@ fn custody() -> SandboxCustody {
     SandboxCustody::ProfileAdmission {
         runner_id: RunnerId::new(),
     }
+}
+
+#[test]
+fn runtime_service_routes_are_exact_credential_free_origins() {
+    let https = RuntimeServiceRoute::from_url(
+        &Url::parse("https://Results.Example.test/artifacts?version=2").expect("URL"),
+    )
+    .expect("HTTPS route");
+    assert_eq!(https.protocol(), RuntimeServiceProtocol::Https);
+    assert_eq!(https.host(), "results.example.test");
+    assert_eq!(https.port().get(), 443);
+
+    let ipv6 =
+        RuntimeServiceRoute::from_url(&Url::parse("http://[2001:db8::1]:8080/oidc").expect("URL"))
+            .expect("HTTP IPv6 route");
+    assert_eq!(ipv6.protocol(), RuntimeServiceProtocol::Http);
+    assert_eq!(ipv6.host(), "2001:db8::1");
+    assert_eq!(ipv6.port().get(), 8080);
+
+    let routes = RuntimeServiceRoutes::new([https.clone(), ipv6.clone(), https.clone()])
+        .expect("bounded route set");
+    assert_eq!(routes.as_slice(), &[ipv6, https.clone()]);
+    assert_eq!(
+        RuntimeServiceRoute::from_url(
+            &Url::parse("https://token@example.test/").expect("credential URL")
+        ),
+        Err(ValueError::InvalidRuntimeServiceRoute)
+    );
+    assert_eq!(
+        RuntimeServiceRoute::from_url(&Url::parse("ssh://example.test/").expect("SSH URL")),
+        Err(ValueError::InvalidRuntimeServiceRoute)
+    );
+    assert_eq!(
+        RuntimeServiceRoutes::new(std::iter::repeat_n(https, 17)),
+        Err(ValueError::InvalidRuntimeServiceRoute)
+    );
 }
 
 #[test]
@@ -101,6 +139,7 @@ fn image_profile_and_spec_are_exact_and_never_resolve_hosted_labels() {
         ResourceLimits::new(512 * 1024 * 1024, 2_000, 256).expect("limits"),
     );
     assert_eq!(spec.privilege(), SandboxPrivilegePolicy::Unprivileged);
+    assert!(spec.runtime_service_routes().is_empty());
     let administrative = spec
         .clone()
         .with_privilege(SandboxPrivilegePolicy::Administrator);

--- a/crates/automata-ci-job-executor-actions/README.md
+++ b/crates/automata-ci-job-executor-actions/README.md
@@ -94,6 +94,12 @@ default in the job IR. A step-local directory overrides it; otherwise the
 resolved default applies, then the workspace. Every resulting path remains
 confined to the workspace.
 
+When a provider advertises `RuntimeServiceProxy`, the executor reduces the
+already validated, job-bound runtime-authority endpoints to a canonical set of
+scheme/host/port routes on `SandboxSpec`. Credentials remain in the execution
+context and never enter the provider route contract. Providers without that
+capability receive no routes.
+
 ## Action metadata and runtime contract
 
 Repository action metadata is recursively prepared and cached after runtime

--- a/crates/automata-ci-job-executor-actions/src/container_runtime.rs
+++ b/crates/automata-ci-job-executor-actions/src/container_runtime.rs
@@ -3,10 +3,10 @@ use std::{collections::BTreeSet, time::Duration};
 use automata_ci_core::JobIrEnvelope;
 use automata_ci_execution::{
     ExecutionEnvironment, ImmutableImage, NetworkPolicy, ProviderCapabilities, ResourceLimits,
-    RootFilesystemPolicy, SandboxCapability, SandboxGeneration, SandboxLaunch,
-    SandboxPrivilegePolicy, SandboxSpec, ServiceContainerBindings, ServiceContainerSpec,
-    ServiceContainerSpecs, ServiceHealthOverrides, ServiceHealthPolicy, ServicePort,
-    ServiceTransportProtocol, TargetPath,
+    RootFilesystemPolicy, RuntimeServiceRoute, RuntimeServiceRoutes, SandboxCapability,
+    SandboxGeneration, SandboxLaunch, SandboxPrivilegePolicy, SandboxSpec,
+    ServiceContainerBindings, ServiceContainerSpec, ServiceContainerSpecs, ServiceHealthOverrides,
+    ServiceHealthPolicy, ServicePort, ServiceTransportProtocol, TargetPath,
 };
 use automata_ci_runner_runtime::{AdmissionRejection, ExecutionRequest};
 
@@ -132,6 +132,7 @@ pub(super) fn sandbox_spec(
     workspace: &TargetPath,
     scratch: &TargetPath,
     service_specs: &ServiceContainerSpecs,
+    capabilities: &ProviderCapabilities,
 ) -> Result<SandboxSpec, ExecutorAdapterError> {
     if matches!(
         request.environment().launch(),
@@ -161,6 +162,9 @@ pub(super) fn sandbox_spec(
             .resource_allocation()
             .ok_or_else(invalid_job)?,
     );
+    if capabilities.supports(SandboxCapability::RuntimeServiceProxy) {
+        spec = spec.with_runtime_service_routes(runtime_service_routes(request)?);
+    }
     if matches!(
         request.environment().launch(),
         SandboxLaunch::VirtualMachine { .. }
@@ -168,6 +172,19 @@ pub(super) fn sandbox_spec(
         spec = spec.with_scratch(scratch.clone());
     }
     Ok(spec)
+}
+
+fn runtime_service_routes(
+    request: &ExecutionRequest,
+) -> Result<RuntimeServiceRoutes, ExecutorAdapterError> {
+    let routes = request
+        .runtime_authorities()
+        .as_slice()
+        .iter()
+        .map(|authority| RuntimeServiceRoute::from_url(authority.endpoint().as_url()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| invalid_job())?;
+    RuntimeServiceRoutes::new(routes).map_err(|_| invalid_job())
 }
 
 fn valid_windows_hyperv_contract(

--- a/crates/automata-ci-job-executor-actions/src/executor.rs
+++ b/crates/automata-ci-job-executor-actions/src/executor.rs
@@ -4881,6 +4881,7 @@ impl ActionsJobExecutor {
                 workspace,
                 scratch,
                 service_specs,
+                self.ports.provider.capabilities(),
             )?;
             let record = match self.ports.provider.create(&spec, &cancellation) {
                 Ok(record) => record,

--- a/crates/automata-ci-job-executor-actions/tests/run_steps.rs
+++ b/crates/automata-ci-job-executor-actions/tests/run_steps.rs
@@ -15,8 +15,9 @@ use automata_ci_workflow_actions::{GithubConditionCompiler, GithubConditionPhase
 
 use support::{
     Fixture, PHASE_FILE_ENVIRONMENT_NAMES, PhaseResponse, SECRET, credential_free_envelope,
-    envelope_with_environment, envelope_with_working_directory, environment_map, run_step,
-    run_step_with_command_template, run_step_with_named_shell, run_step_with_working_directory,
+    envelope, envelope_with_environment, envelope_with_working_directory, environment_map,
+    run_step, run_step_with_command_template, run_step_with_named_shell,
+    run_step_with_working_directory,
 };
 
 #[tokio::test]
@@ -939,6 +940,25 @@ fn assert_sandbox_spec(fixture: &Fixture, runner_id: RunnerId, slot_ordinal: u16
             slot_ordinal: observed_slot,
         } if observed_runner == runner_id && observed_slot.get() == slot_ordinal
     ));
+}
+
+#[tokio::test]
+async fn provider_without_runtime_service_proxy_receives_no_authority_routes() {
+    let fixture =
+        Fixture::without_runtime_service_proxy(Vec::new(), vec![PhaseResponse::success()]);
+    let request = fixture.request(envelope(vec![run_step("step", "Step", "true")]));
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let result = fixture
+        .executor
+        .execute(request, events, ExecutionCancellation::new())
+        .await
+        .expect("job executes without a runtime-service proxy");
+
+    assert_eq!(result.conclusion(), JobConclusion::Success);
+    let specs = fixture.provider.specs();
+    assert_eq!(specs.len(), 1);
+    assert!(specs[0].runtime_service_routes().is_empty());
 }
 
 #[tokio::test]

--- a/crates/automata-ci-job-executor-actions/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-actions/tests/support/mod.rs
@@ -150,6 +150,24 @@ impl Fixture {
         Self::with_default_environment(actions, responses, ExecutionEnvironment::empty())
     }
 
+    pub fn without_runtime_service_proxy(
+        actions: Vec<PreparedAction>,
+        responses: Vec<PhaseResponse>,
+    ) -> Self {
+        Self::with_platform_components_and_timeout_and_node_and_runtime_service_proxy(
+            actions,
+            responses,
+            ExecutionEnvironment::empty(),
+            true,
+            Arc::new(FakeJobContent::default()),
+            Arc::new(FakeContexts::readable_secret()),
+            Duration::from_mins(5),
+            TargetPlatform::Posix,
+            true,
+            false,
+        )
+    }
+
     pub fn without_node(actions: Vec<PreparedAction>, responses: Vec<PhaseResponse>) -> Self {
         Self::with_platform_components_and_timeout_and_node(
             actions,
@@ -522,6 +540,33 @@ impl Fixture {
         platform: TargetPlatform,
         configure_node: bool,
     ) -> Self {
+        Self::with_platform_components_and_timeout_and_node_and_runtime_service_proxy(
+            actions,
+            responses,
+            default_environment,
+            service_containers,
+            content,
+            contexts,
+            timeout,
+            platform,
+            configure_node,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    fn with_platform_components_and_timeout_and_node_and_runtime_service_proxy(
+        actions: Vec<PreparedAction>,
+        responses: Vec<PhaseResponse>,
+        default_environment: ExecutionEnvironment,
+        service_containers: bool,
+        content: Arc<dyn JobContentPort>,
+        contexts: Arc<dyn GithubContextPort>,
+        timeout: Duration,
+        platform: TargetPlatform,
+        configure_node: bool,
+        runtime_service_proxy: bool,
+    ) -> Self {
         let environment = match platform {
             TargetPlatform::Posix => sandbox_environment(default_environment),
             TargetPlatform::Windows => windows_sandbox_environment(default_environment),
@@ -542,6 +587,7 @@ impl Fixture {
             environment.clone(),
             Arc::clone(&endpoint_state),
             service_containers,
+            runtime_service_proxy,
         ));
         let catalog = Arc::new(
             ImmutableSandboxEnvironmentCatalog::new([environment.clone()]).expect("valid catalog"),
@@ -1891,6 +1937,7 @@ impl FakeProvider {
         environment: SandboxEnvironment,
         endpoint_state: Arc<Mutex<EndpointState>>,
         service_containers: bool,
+        runtime_service_proxy: bool,
     ) -> Self {
         let id = ProviderId::new("fake").expect("valid provider");
         let handle = SandboxHandle::new(id.clone(), "sandbox-1").expect("valid handle");
@@ -1922,6 +1969,9 @@ impl FakeProvider {
         ];
         if administrator {
             capabilities.push(SandboxCapability::Administrator);
+        }
+        if runtime_service_proxy {
+            capabilities.push(SandboxCapability::RuntimeServiceProxy);
         }
         if service_containers && environment.workspace().platform() == TargetPlatform::Posix {
             capabilities.push(SandboxCapability::ServiceContainers);

--- a/crates/automata-ci-job-executor-actions/tests/windows_run_steps.rs
+++ b/crates/automata-ci-job-executor-actions/tests/windows_run_steps.rs
@@ -7,7 +7,9 @@ use automata_ci_core::{
     ExpressionProgram, JobConclusion, JobOutputDefinition, OutputSensitivity, ValueSource,
     ValueTemplate,
 };
-use automata_ci_execution::{NetworkPolicy, RootFilesystemPolicy, SandboxPrivilegePolicy};
+use automata_ci_execution::{
+    NetworkPolicy, RootFilesystemPolicy, RuntimeServiceProtocol, SandboxPrivilegePolicy,
+};
 use automata_ci_runner_runtime::{
     AdmissionRejection, ExecutionCancellation, ExecutionEvents, JobExecutor,
 };
@@ -175,6 +177,11 @@ async fn windows_default_shell_maps_paths_and_applies_crlf_command_files() {
     assert_eq!(specs[0].network(), NetworkPolicy::Disabled);
     assert_eq!(specs[0].root_filesystem(), RootFilesystemPolicy::Writable);
     assert_eq!(specs[0].privilege(), SandboxPrivilegePolicy::Unprivileged);
+    let routes = specs[0].runtime_service_routes().as_slice();
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].protocol(), RuntimeServiceProtocol::Https);
+    assert_eq!(routes[0].host(), "results.example.test");
+    assert_eq!(routes[0].port().get(), 443);
     assert!(
         specs[0].scratch().is_none(),
         "a Hyper-V container must not expose host scratch storage"

--- a/crates/automata-ci-local/src/local_docker/mod.rs
+++ b/crates/automata-ci-local/src/local_docker/mod.rs
@@ -2614,6 +2614,7 @@ fn validate_spec(spec: &SandboxSpec, runner_id: RunnerId) -> Result<(), Provider
         || workspace_conflicts_with_control
         || spec.scratch().is_some()
         || !spec.services().is_empty()
+        || !spec.runtime_service_routes().is_empty()
         || spec.network() != NetworkPolicy::PrivateEgress
         || spec.root_filesystem() != RootFilesystemPolicy::Writable
         || spec.privilege() != SandboxPrivilegePolicy::Administrator

--- a/crates/automata-ci-sandbox-kubernetes/src/objects.rs
+++ b/crates/automata-ci-sandbox-kubernetes/src/objects.rs
@@ -84,6 +84,7 @@ fn validated_allocation(
 ) -> Result<JobResourceAllocation, automata_ci_execution::ProviderError> {
     if spec.network() != SandboxNetworkPolicy::Disabled
         || !spec.services().is_empty()
+        || !spec.runtime_service_routes().is_empty()
         || spec.privilege() != automata_ci_execution::SandboxPrivilegePolicy::Unprivileged
         || !spec.has_coherent_resource_contract()
     {

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -922,6 +922,7 @@ fn validate_spec(
         && spec.resources().memory_bytes() >= template.minimum_memory_bytes
         && spec.resources().pids() == template.process_limit
         && spec.services().is_empty()
+        && spec.runtime_service_routes().is_empty()
         && spec.has_coherent_resource_contract()
         && !spec
             .profile()

--- a/crates/automata-ci-sandbox-podman/src/provider.rs
+++ b/crates/automata-ci-sandbox-podman/src/provider.rs
@@ -4354,6 +4354,7 @@ fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
     };
     if spec.profile().image().is_none()
         || spec.scratch().is_some()
+        || !spec.runtime_service_routes().is_empty()
         || spec.network() == NetworkPolicy::Host
         || spec.root_filesystem() == RootFilesystemPolicy::Host
         || spec.privilege() == SandboxPrivilegePolicy::Host

--- a/crates/automata-ci-sandbox-windows/src/provider.rs
+++ b/crates/automata-ci-sandbox-windows/src/provider.rs
@@ -1531,6 +1531,7 @@ fn validate_spec(spec: &SandboxSpec) -> Result<(), ProviderError> {
         || spec.root_filesystem() != RootFilesystemPolicy::Writable
         || spec.privilege() != SandboxPrivilegePolicy::Unprivileged
         || !spec.services().is_empty()
+        || !spec.runtime_service_routes().is_empty()
         || spec.scratch().is_some()
         || spec.workspace().platform() != TargetPlatform::Windows
         || !windows_descendant_or_equal(spec.workspace(), spec.profile().workspace())


### PR DESCRIPTION
## Summary
- add a bounded provider-neutral HTTP(S) runtime-service route set containing only normalized scheme, host, and port
- derive routes from validated job runtime authorities only when a provider advertises the new restricted proxy capability
- require all current non-implementing providers to reject nonempty route requests
- document the side channel as distinct from general guest networking and keep credentials outside the provider contract

## Validation
- cargo fmt --all -- --check
- cargo test --locked -j 2 --workspace --all-features --no-fail-fast (all targets passed except one transient automata-ci-local lib run; isolated rerun passed 287 tests with 5 explicit live-test ignores)
- cargo clippy --locked -j 2 --workspace --all-targets --all-features -- -D warnings
- post-rebase focused execution and Actions executor tests and clippy
- rustdoc with warnings denied for automata-ci-execution

This PR defines and wires the enforcement contract. It intentionally does not advertise RuntimeServiceProxy from the macOS provider yet; the follow-up will add the attempt-scoped CONNECT broker and physical Mac VM verification.