### PR TITLE
Provider platform B4c: make control processing idempotent

### DIFF
--- a/crates/automata-ci-provider-delivery/src/control.rs
+++ b/crates/automata-ci-provider-delivery/src/control.rs
@@ -9,21 +9,27 @@ use automata_ci_provider::{
 };
 use thiserror::Error;
 
-use crate::{ProviderProcessingOutcome, ProviderProcessingProcessor};
+use crate::{ProviderProcessingLease, ProviderProcessingOutcome, ProviderProcessingProcessor};
 
-const MAX_PROVIDER_CONTROL_RESOLVERS: usize = 32;
+const MAX_PROVIDER_CONTROL_HANDLERS: usize = 32;
 
-/// Provider-specific authority that resolves native result identity to its trigger delivery.
+/// Provider-specific authority that idempotently handles one native control.
+///
+/// Implementations must reauthorize current actor and result identity, perform
+/// the requested operation idempotently, and return the originating trigger
+/// delivery when one exists. A crash may cause the same control to be handled
+/// again before its processing invocation is durably completed.
 #[async_trait]
-pub trait ProviderControlResolver: fmt::Debug + Send + Sync {
-    /// Returns the exact provider adapter type handled by this resolver.
+pub trait ProviderControlHandler: fmt::Debug + Send + Sync {
+    /// Returns the exact provider adapter type handled by this handler.
     fn provider_type(&self) -> &ProviderTypeId;
 
-    /// Reauthorizes and resolves one authenticated control to an immutable trigger.
-    async fn resolve(
+    /// Reauthorizes and idempotently executes one authenticated control.
+    async fn handle(
         &self,
         control: &VerifiedProviderControlDelivery,
-    ) -> Result<ProviderDeliveryId, ProviderControlResolutionError>;
+        lease: &ProviderProcessingLease,
+    ) -> Result<Option<ProviderDeliveryId>, ProviderControlHandlingError>;
 }
 
 /// Provider-independent workflow admission invoked only for a resolved trigger.
@@ -33,74 +39,72 @@ pub trait ProviderTriggerProcessor: fmt::Debug + Send + Sync {
     async fn process_trigger(
         &self,
         invocation: &ClaimedProviderProcessing,
+        lease: &ProviderProcessingLease,
     ) -> ProviderProcessingOutcome;
 }
 
-/// Exact duplicate-free registry of statically linked provider control resolvers.
+/// Exact duplicate-free registry of statically linked provider control handlers.
 #[derive(Clone)]
-pub struct ProviderControlResolverRegistry {
-    resolvers: BTreeMap<ProviderTypeId, Arc<dyn ProviderControlResolver>>,
+pub struct ProviderControlHandlerRegistry {
+    handlers: BTreeMap<ProviderTypeId, Arc<dyn ProviderControlHandler>>,
 }
 
-impl ProviderControlResolverRegistry {
-    /// Builds a bounded nonempty resolver registry.
+impl ProviderControlHandlerRegistry {
+    /// Builds a bounded nonempty handler registry.
     ///
     /// # Errors
     ///
-    /// Rejects an empty, excessive, duplicate, or self-inconsistent resolver set.
+    /// Rejects an empty, excessive, duplicate, or self-inconsistent handler set.
     pub fn new(
-        resolvers: impl IntoIterator<Item = Arc<dyn ProviderControlResolver>>,
-    ) -> Result<Self, ProviderControlResolverRegistryError> {
+        handlers: impl IntoIterator<Item = Arc<dyn ProviderControlHandler>>,
+    ) -> Result<Self, ProviderControlHandlerRegistryError> {
         let mut values = BTreeMap::new();
-        for resolver in resolvers {
-            let key = resolver.provider_type().clone();
-            if values.insert(key, resolver).is_some() {
-                return Err(ProviderControlResolverRegistryError::Duplicate);
+        for handler in handlers {
+            let key = handler.provider_type().clone();
+            if values.insert(key, handler).is_some() {
+                return Err(ProviderControlHandlerRegistryError::Duplicate);
             }
         }
-        if values.is_empty() || values.len() > MAX_PROVIDER_CONTROL_RESOLVERS {
-            return Err(ProviderControlResolverRegistryError::InvalidSize);
+        if values.is_empty() || values.len() > MAX_PROVIDER_CONTROL_HANDLERS {
+            return Err(ProviderControlHandlerRegistryError::InvalidSize);
         }
         if values
             .iter()
-            .any(|(key, resolver)| resolver.provider_type() != key)
+            .any(|(key, handler)| handler.provider_type() != key)
         {
-            return Err(ProviderControlResolverRegistryError::Inconsistent);
+            return Err(ProviderControlHandlerRegistryError::Inconsistent);
         }
-        Ok(Self { resolvers: values })
+        Ok(Self { handlers: values })
     }
 
-    fn resolve(&self, provider_type: &ProviderTypeId) -> Option<&dyn ProviderControlResolver> {
-        self.resolvers.get(provider_type).map(Arc::as_ref)
+    fn handler(&self, provider_type: &ProviderTypeId) -> Option<&dyn ProviderControlHandler> {
+        self.handlers.get(provider_type).map(Arc::as_ref)
     }
 }
 
-impl fmt::Debug for ProviderControlResolverRegistry {
+impl fmt::Debug for ProviderControlHandlerRegistry {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("ProviderControlResolverRegistry")
-            .field("provider_types", &self.resolvers.keys().collect::<Vec<_>>())
+            .debug_struct("ProviderControlHandlerRegistry")
+            .field("provider_types", &self.handlers.keys().collect::<Vec<_>>())
             .finish()
     }
 }
 
-/// Processing handler that resolves controls before invoking common trigger admission.
+/// Processing dispatcher for idempotent controls and ordinary trigger admission.
 pub struct ProviderProcessingDispatcher {
-    resolvers: ProviderControlResolverRegistry,
+    handlers: ProviderControlHandlerRegistry,
     triggers: Arc<dyn ProviderTriggerProcessor>,
 }
 
 impl ProviderProcessingDispatcher {
-    /// Composes exact provider control resolution with provider-independent admission.
+    /// Composes exact provider control handling with provider-independent admission.
     #[must_use]
     pub fn new(
-        resolvers: ProviderControlResolverRegistry,
+        handlers: ProviderControlHandlerRegistry,
         triggers: Arc<dyn ProviderTriggerProcessor>,
     ) -> Self {
-        Self {
-            resolvers,
-            triggers,
-        }
+        Self { handlers, triggers }
     }
 }
 
@@ -108,7 +112,7 @@ impl fmt::Debug for ProviderProcessingDispatcher {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ProviderProcessingDispatcher")
-            .field("resolvers", &self.resolvers)
+            .field("handlers", &self.handlers)
             .field("triggers", &self.triggers)
             .finish()
     }
@@ -116,35 +120,51 @@ impl fmt::Debug for ProviderProcessingDispatcher {
 
 #[async_trait]
 impl ProviderProcessingProcessor for ProviderProcessingDispatcher {
-    async fn process(&self, invocation: &ClaimedProviderProcessing) -> ProviderProcessingOutcome {
+    async fn process(
+        &self,
+        invocation: &ClaimedProviderProcessing,
+        lease: &ProviderProcessingLease,
+    ) -> ProviderProcessingOutcome {
         let ProviderProcessingInput::Control(control) = invocation.input() else {
-            return self.triggers.process_trigger(invocation).await;
+            // A control handler has already performed its idempotent operation.
+            // Binding an originating trigger is durable provenance only; it
+            // must never replay the original webhook admission side effects.
+            let Some(source_delivery_id) = invocation.receipt().source_delivery_id() else {
+                return ProviderProcessingOutcome::Fail(ProviderProcessingFailure::InvalidEvidence);
+            };
+            if invocation.receipt().cause_delivery_id() != source_delivery_id {
+                return ProviderProcessingOutcome::Complete;
+            }
+            return self.triggers.process_trigger(invocation, lease).await;
         };
-        let Some(resolver) = self.resolvers.resolve(control.evidence().provider_type()) else {
+        let Some(handler) = self.handlers.handler(control.evidence().provider_type()) else {
             return ProviderProcessingOutcome::Fail(ProviderProcessingFailure::InvalidEvidence);
         };
-        match resolver.resolve(control).await {
-            Ok(source_delivery_id) => ProviderProcessingOutcome::ResolveControl(source_delivery_id),
-            Err(ProviderControlResolutionError::Unavailable) => {
+        match handler.handle(control, lease).await {
+            Ok(Some(source_delivery_id)) => {
+                ProviderProcessingOutcome::ResolveControl(source_delivery_id)
+            }
+            Ok(None) => ProviderProcessingOutcome::Complete,
+            Err(ProviderControlHandlingError::Unavailable) => {
                 ProviderProcessingOutcome::Retry(ProviderProcessingFailure::DependencyUnavailable)
             }
             Err(
-                ProviderControlResolutionError::Unauthorized
-                | ProviderControlResolutionError::NotFound
-                | ProviderControlResolutionError::Conflict,
+                ProviderControlHandlingError::Unauthorized
+                | ProviderControlHandlingError::NotFound
+                | ProviderControlHandlingError::Conflict,
             ) => ProviderProcessingOutcome::Fail(ProviderProcessingFailure::PolicyRejected),
-            Err(ProviderControlResolutionError::InvalidEvidence) => {
+            Err(ProviderControlHandlingError::InvalidEvidence) => {
                 ProviderProcessingOutcome::Fail(ProviderProcessingFailure::InvalidEvidence)
             }
         }
     }
 }
 
-/// Sanitized provider-native control resolution failure.
+/// Sanitized provider-native control handling failure.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum ProviderControlResolutionError {
-    /// Provider or durable resolution dependencies were unavailable.
-    #[error("provider control resolution is unavailable")]
+pub enum ProviderControlHandlingError {
+    /// Provider or durable handling dependencies were unavailable.
+    #[error("provider control handling is unavailable")]
     Unavailable,
     /// The authenticated actor lacks current Automata authority.
     #[error("provider control actor is unauthorized")]
@@ -160,17 +180,17 @@ pub enum ProviderControlResolutionError {
     InvalidEvidence,
 }
 
-/// Invalid control-resolver registry construction.
+/// Invalid control-handler registry construction.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-pub enum ProviderControlResolverRegistryError {
+pub enum ProviderControlHandlerRegistryError {
     /// Registry was empty or exceeded its hard bound.
-    #[error("provider control resolver registry size is invalid")]
+    #[error("provider control handler registry size is invalid")]
     InvalidSize,
-    /// Two resolvers registered the same provider type.
-    #[error("provider control resolver type is duplicated")]
+    /// Two handlers registered the same provider type.
+    #[error("provider control handler type is duplicated")]
     Duplicate,
-    /// A resolver's declared provider type changed during construction.
-    #[error("provider control resolver identity is inconsistent")]
+    /// A handler's declared provider type changed during construction.
+    #[error("provider control handler identity is inconsistent")]
     Inconsistent,
 }
 
@@ -181,14 +201,14 @@ mod tests {
     use super::*;
 
     #[derive(Debug)]
-    struct Resolver {
+    struct Handler {
         first: ProviderTypeId,
         subsequent: ProviderTypeId,
         calls: AtomicUsize,
     }
 
     #[async_trait]
-    impl ProviderControlResolver for Resolver {
+    impl ProviderControlHandler for Handler {
         fn provider_type(&self) -> &ProviderTypeId {
             if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
                 &self.first
@@ -197,16 +217,17 @@ mod tests {
             }
         }
 
-        async fn resolve(
+        async fn handle(
             &self,
             _control: &VerifiedProviderControlDelivery,
-        ) -> Result<ProviderDeliveryId, ProviderControlResolutionError> {
+            _lease: &ProviderProcessingLease,
+        ) -> Result<Option<ProviderDeliveryId>, ProviderControlHandlingError> {
             unreachable!("registry construction never resolves controls")
         }
     }
 
-    fn resolver(first: &str, subsequent: &str) -> Arc<dyn ProviderControlResolver> {
-        Arc::new(Resolver {
+    fn handler(first: &str, subsequent: &str) -> Arc<dyn ProviderControlHandler> {
+        Arc::new(Handler {
             first: ProviderTypeId::new(first).expect("first provider type"),
             subsequent: ProviderTypeId::new(subsequent).expect("subsequent provider type"),
             calls: AtomicUsize::new(0),
@@ -216,29 +237,29 @@ mod tests {
     #[test]
     fn registry_rejects_empty_duplicate_oversized_and_changing_identities() {
         assert!(matches!(
-            ProviderControlResolverRegistry::new([]),
-            Err(ProviderControlResolverRegistryError::InvalidSize)
+            ProviderControlHandlerRegistry::new([]),
+            Err(ProviderControlHandlerRegistryError::InvalidSize)
         ));
         assert!(matches!(
-            ProviderControlResolverRegistry::new([
-                resolver("github", "github"),
-                resolver("github", "github"),
+            ProviderControlHandlerRegistry::new([
+                handler("github", "github"),
+                handler("github", "github"),
             ]),
-            Err(ProviderControlResolverRegistryError::Duplicate)
+            Err(ProviderControlHandlerRegistryError::Duplicate)
         ));
-        let oversized = (0..=MAX_PROVIDER_CONTROL_RESOLVERS)
+        let oversized = (0..=MAX_PROVIDER_CONTROL_HANDLERS)
             .map(|index| {
                 let provider_type = format!("provider-{index}");
-                resolver(&provider_type, &provider_type)
+                handler(&provider_type, &provider_type)
             })
             .collect::<Vec<_>>();
         assert!(matches!(
-            ProviderControlResolverRegistry::new(oversized),
-            Err(ProviderControlResolverRegistryError::InvalidSize)
+            ProviderControlHandlerRegistry::new(oversized),
+            Err(ProviderControlHandlerRegistryError::InvalidSize)
         ));
         assert!(matches!(
-            ProviderControlResolverRegistry::new([resolver("github", "forgejo")]),
-            Err(ProviderControlResolverRegistryError::Inconsistent)
+            ProviderControlHandlerRegistry::new([handler("github", "forgejo")]),
+            Err(ProviderControlHandlerRegistryError::Inconsistent)
         ));
     }
 }

--- a/crates/automata-ci-provider-delivery/src/lib.rs
+++ b/crates/automata-ci-provider-delivery/src/lib.rs
@@ -10,11 +10,12 @@ mod worker;
 
 pub use clock::{ProviderDeliveryClock, ProviderDeliveryClockError, SystemProviderDeliveryClock};
 pub use control::{
-    ProviderControlResolutionError, ProviderControlResolver, ProviderControlResolverRegistry,
-    ProviderControlResolverRegistryError, ProviderProcessingDispatcher, ProviderTriggerProcessor,
+    ProviderControlHandler, ProviderControlHandlerRegistry, ProviderControlHandlerRegistryError,
+    ProviderControlHandlingError, ProviderProcessingDispatcher, ProviderTriggerProcessor,
 };
 pub use ingress::{PreparedProviderWebhook, ProviderDeliveryIngress, ProviderDeliveryIngressError};
 pub use worker::{
-    ProviderProcessingOutcome, ProviderProcessingProcessor, ProviderProcessingWorker,
-    ProviderProcessingWorkerConfig, ProviderProcessingWorkerError, ProviderProcessingWorkerOutcome,
+    ProviderProcessingLease, ProviderProcessingOutcome, ProviderProcessingProcessor,
+    ProviderProcessingWorker, ProviderProcessingWorkerConfig, ProviderProcessingWorkerError,
+    ProviderProcessingWorkerOutcome,
 };

--- a/crates/automata-ci-provider-delivery/src/worker.rs
+++ b/crates/automata-ci-provider-delivery/src/worker.rs
@@ -5,12 +5,15 @@ use automata_ci_core::UnixMillis;
 use automata_ci_provider::{
     BindProviderProcessingSource, ClaimProviderProcessing, ClaimedProviderProcessing,
     CompleteProviderProcessing, FailProviderProcessing, ProviderDeliveryId,
-    ProviderProcessingFailure, ProviderProcessingInput, ProviderProcessingRepository,
-    ProviderProcessingRepositoryError, ProviderProcessingWorkerId, RenewProviderProcessing,
-    RetryProviderProcessing,
+    ProviderProcessingFailure, ProviderProcessingInput, ProviderProcessingReceipt,
+    ProviderProcessingRepository, ProviderProcessingRepositoryError, ProviderProcessingState,
+    ProviderProcessingWorkerId, RenewProviderProcessing, RetryProviderProcessing,
 };
 use thiserror::Error;
-use tokio::time::{Duration, sleep};
+use tokio::{
+    sync::watch,
+    time::{Duration, sleep},
+};
 
 use crate::ProviderDeliveryClock;
 
@@ -31,7 +34,43 @@ pub enum ProviderProcessingOutcome {
 #[async_trait]
 pub trait ProviderProcessingProcessor: fmt::Debug + Send + Sync {
     /// Performs idempotent admission for one normalized provider trigger.
-    async fn process(&self, delivery: &ClaimedProviderProcessing) -> ProviderProcessingOutcome;
+    async fn process(
+        &self,
+        delivery: &ClaimedProviderProcessing,
+        lease: &ProviderProcessingLease,
+    ) -> ProviderProcessingOutcome;
+}
+
+/// Read-only live view of the exact processing fence held by a worker.
+///
+/// The worker updates this handle after every durable renewal. Processors must
+/// take a fresh snapshot immediately before any fenced downstream mutation;
+/// retaining the fence embedded in [`ClaimedProviderProcessing`] would lose a
+/// renewal race during long-running provider or workflow operations.
+#[derive(Clone)]
+pub struct ProviderProcessingLease {
+    fence: watch::Receiver<automata_ci_provider::ProviderProcessingClaimFence>,
+}
+
+impl ProviderProcessingLease {
+    fn new(fence: watch::Receiver<automata_ci_provider::ProviderProcessingClaimFence>) -> Self {
+        Self { fence }
+    }
+
+    /// Returns the most recently committed processing fence.
+    #[must_use]
+    pub fn current(&self) -> automata_ci_provider::ProviderProcessingClaimFence {
+        *self.fence.borrow()
+    }
+}
+
+impl fmt::Debug for ProviderProcessingLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderProcessingLease")
+            .field("fence", &self.current())
+            .finish()
+    }
 }
 
 /// Bounded generic processing-worker lease and retry policy.
@@ -127,62 +166,85 @@ impl ProviderProcessingWorker {
         };
         loop {
             let disposition = self.process_with_renewal(&invocation).await?;
-            let finished_at = self.now()?;
-            match disposition.outcome {
-                ProviderProcessingOutcome::ResolveControl(source_delivery_id) => {
-                    if !matches!(invocation.input(), ProviderProcessingInput::Control(_)) {
-                        return Err(ProviderProcessingWorkerError::InvalidResolution);
-                    }
-                    let command = BindProviderProcessingSource::new(
-                        disposition.fence,
-                        source_delivery_id,
-                        finished_at,
-                    )
-                    .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
-                    invocation = self
-                        .repository
-                        .bind_processing_source(command)
-                        .await
-                        .map_err(repository_error)?;
+            match self.apply_outcome(&invocation, disposition).await? {
+                WorkerStep::Continue(bound) => invocation = bound,
+                WorkerStep::Finished(outcome) => return Ok(outcome),
+            }
+        }
+    }
+
+    async fn apply_outcome(
+        &self,
+        invocation: &ClaimedProviderProcessing,
+        disposition: ProcessedInvocation,
+    ) -> Result<WorkerStep, ProviderProcessingWorkerError> {
+        let finished_at = self.now()?;
+        match disposition.outcome {
+            ProviderProcessingOutcome::ResolveControl(source_delivery_id) => {
+                if !matches!(invocation.input(), ProviderProcessingInput::Control(_)) {
+                    return Err(ProviderProcessingWorkerError::InvalidSourceBinding);
                 }
-                ProviderProcessingOutcome::Complete => {
-                    let command = CompleteProviderProcessing::new(disposition.fence, finished_at)
+                let command = BindProviderProcessingSource::new(
+                    disposition.fence,
+                    source_delivery_id,
+                    finished_at,
+                )
+                .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                let bound = self
+                    .repository
+                    .bind_processing_source(command)
+                    .await
+                    .map_err(repository_error)?;
+                if !valid_source_binding(invocation, &bound, source_delivery_id, disposition.fence)
+                {
+                    return Err(ProviderProcessingWorkerError::Repository);
+                }
+                Ok(WorkerStep::Continue(bound))
+            }
+            ProviderProcessingOutcome::Complete => {
+                let command = CompleteProviderProcessing::new(disposition.fence, finished_at)
+                    .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
+                let receipt = self
+                    .repository
+                    .complete_processing(command)
+                    .await
+                    .map_err(repository_error)?;
+                validate_terminal(invocation, receipt, ProviderProcessingState::Completed)?;
+                Ok(WorkerStep::Finished(
+                    ProviderProcessingWorkerOutcome::Completed,
+                ))
+            }
+            ProviderProcessingOutcome::Retry(failure) => {
+                let retry_at = finished_at
+                    .get()
+                    .checked_add(self.config.retry_millis)
+                    .map(UnixMillis::new)
+                    .ok_or(ProviderProcessingWorkerError::Clock)?;
+                let command =
+                    RetryProviderProcessing::new(disposition.fence, finished_at, retry_at, failure)
                         .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
-                    self.repository
-                        .complete_processing(command)
-                        .await
-                        .map_err(repository_error)?;
-                    return Ok(ProviderProcessingWorkerOutcome::Completed);
-                }
-                ProviderProcessingOutcome::Retry(failure) => {
-                    let retry_at = finished_at
-                        .get()
-                        .checked_add(self.config.retry_millis)
-                        .map(UnixMillis::new)
-                        .ok_or(ProviderProcessingWorkerError::Clock)?;
-                    let command = RetryProviderProcessing::new(
-                        disposition.fence,
-                        finished_at,
-                        retry_at,
-                        failure,
-                    )
+                let receipt = self
+                    .repository
+                    .retry_processing(command)
+                    .await
+                    .map_err(repository_error)?;
+                validate_terminal(invocation, receipt, ProviderProcessingState::RetryPending)?;
+                Ok(WorkerStep::Finished(
+                    ProviderProcessingWorkerOutcome::Retried,
+                ))
+            }
+            ProviderProcessingOutcome::Fail(failure) => {
+                let command = FailProviderProcessing::new(disposition.fence, finished_at, failure)
                     .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
-                    self.repository
-                        .retry_processing(command)
-                        .await
-                        .map_err(repository_error)?;
-                    return Ok(ProviderProcessingWorkerOutcome::Retried);
-                }
-                ProviderProcessingOutcome::Fail(failure) => {
-                    let command =
-                        FailProviderProcessing::new(disposition.fence, finished_at, failure)
-                            .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
-                    self.repository
-                        .fail_processing(command)
-                        .await
-                        .map_err(repository_error)?;
-                    return Ok(ProviderProcessingWorkerOutcome::Failed);
-                }
+                let receipt = self
+                    .repository
+                    .fail_processing(command)
+                    .await
+                    .map_err(repository_error)?;
+                validate_terminal(invocation, receipt, ProviderProcessingState::Failed)?;
+                Ok(WorkerStep::Finished(
+                    ProviderProcessingWorkerOutcome::Failed,
+                ))
             }
         }
     }
@@ -198,7 +260,9 @@ impl ProviderProcessingWorker {
         delivery: &ClaimedProviderProcessing,
     ) -> Result<ProcessedInvocation, ProviderProcessingWorkerError> {
         let mut fence = delivery.fence();
-        let process = self.processor.process(delivery);
+        let (lease_updates, lease_view) = watch::channel(fence);
+        let lease = ProviderProcessingLease::new(lease_view);
+        let process = self.processor.process(delivery, &lease);
         tokio::pin!(process);
         let heartbeat = Duration::from_millis((self.config.lease_millis / 3).max(1));
         loop {
@@ -212,19 +276,87 @@ impl ProviderProcessingWorker {
                         self.config.lease_millis,
                     )
                     .map_err(|_| ProviderProcessingWorkerError::ClaimExpired)?;
-                    fence = self.repository
+                    let renewed = self.repository
                         .renew_processing(renewal)
                         .await
                         .map_err(repository_error)?;
+                    if !valid_renewal(fence, renewed) {
+                        return Err(ProviderProcessingWorkerError::Repository);
+                    }
+                    fence = renewed;
+                    lease_updates.send_replace(fence);
                 }
             }
         }
     }
 }
 
+fn valid_renewal(
+    prior: automata_ci_provider::ProviderProcessingClaimFence,
+    renewed: automata_ci_provider::ProviderProcessingClaimFence,
+) -> bool {
+    renewed.invocation_id() == prior.invocation_id()
+        && renewed.worker_id() == prior.worker_id()
+        && renewed.token() == prior.token()
+        && renewed.claimed_at() == prior.claimed_at()
+        && renewed.expires_at() > prior.expires_at()
+}
+
+fn valid_source_binding(
+    prior: &ClaimedProviderProcessing,
+    bound: &ClaimedProviderProcessing,
+    source_delivery_id: ProviderDeliveryId,
+    fence: automata_ci_provider::ProviderProcessingClaimFence,
+) -> bool {
+    let prior_receipt = prior.receipt();
+    let bound_receipt = bound.receipt();
+    bound.fence() == fence
+        && bound_receipt.invocation_id() == prior_receipt.invocation_id()
+        && bound_receipt.cause_delivery_id() == prior_receipt.cause_delivery_id()
+        && bound_receipt.source_delivery_id() == Some(source_delivery_id)
+        && bound_receipt.state() == ProviderProcessingState::Claimed
+        && bound_receipt.attempts() == prior_receipt.attempts()
+        && bound_receipt.created_at() == prior_receipt.created_at()
+        && matches!(
+            bound.input(),
+            ProviderProcessingInput::Trigger(source)
+                if source.evidence().delivery_id() == source_delivery_id
+        )
+}
+
+fn valid_terminal_receipt(
+    prior: ProviderProcessingReceipt,
+    terminal: ProviderProcessingReceipt,
+    state: ProviderProcessingState,
+) -> bool {
+    terminal.invocation_id() == prior.invocation_id()
+        && terminal.cause_delivery_id() == prior.cause_delivery_id()
+        && terminal.source_delivery_id() == prior.source_delivery_id()
+        && terminal.state() == state
+        && terminal.attempts() == prior.attempts()
+        && terminal.created_at() == prior.created_at()
+}
+
+fn validate_terminal(
+    invocation: &ClaimedProviderProcessing,
+    receipt: ProviderProcessingReceipt,
+    state: ProviderProcessingState,
+) -> Result<(), ProviderProcessingWorkerError> {
+    if valid_terminal_receipt(invocation.receipt(), receipt, state) {
+        Ok(())
+    } else {
+        Err(ProviderProcessingWorkerError::Repository)
+    }
+}
+
 struct ProcessedInvocation {
     outcome: ProviderProcessingOutcome,
     fence: automata_ci_provider::ProviderProcessingClaimFence,
+}
+
+enum WorkerStep {
+    Continue(ClaimedProviderProcessing),
+    Finished(ProviderProcessingWorkerOutcome),
 }
 
 impl fmt::Debug for ProviderProcessingWorker {
@@ -265,9 +397,9 @@ pub enum ProviderProcessingWorkerError {
     /// Processing outlived or lost its exact claim fence.
     #[error("provider processing worker claim expired")]
     ClaimExpired,
-    /// A handler attempted to resolve an already resolved trigger invocation.
-    #[error("provider processing control resolution is invalid")]
-    InvalidResolution,
+    /// A handler attempted to bind source evidence to a trigger invocation.
+    #[error("provider processing control source binding is invalid")]
+    InvalidSourceBinding,
     /// Durable processing storage is unavailable.
     #[error("provider processing repository is unavailable")]
     Unavailable,
@@ -296,7 +428,7 @@ const fn repository_error(
 mod tests {
     use std::sync::{
         Mutex,
-        atomic::{AtomicI64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering},
     };
 
     use automata_ci_core::{GitObjectId, Sha256Digest};
@@ -328,44 +460,97 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct SlowProcessor;
+    struct SlowProcessor {
+        initial_expiry: AtomicI64,
+        final_expiry: AtomicI64,
+    }
 
     #[async_trait]
     impl ProviderProcessingProcessor for SlowProcessor {
         async fn process(
             &self,
             _delivery: &ClaimedProviderProcessing,
+            lease: &ProviderProcessingLease,
         ) -> ProviderProcessingOutcome {
+            self.initial_expiry
+                .store(lease.current().expires_at().get(), Ordering::SeqCst);
             sleep(Duration::from_millis(25)).await;
+            self.final_expiry
+                .store(lease.current().expires_at().get(), Ordering::SeqCst);
             ProviderProcessingOutcome::Complete
         }
     }
 
     #[derive(Debug)]
-    struct ResolvingProcessor {
-        source_delivery_id: ProviderDeliveryId,
+    struct RecordingControlHandler {
+        provider_type: ProviderTypeId,
+        source_delivery_id: Option<ProviderDeliveryId>,
         calls: AtomicUsize,
     }
 
+    #[derive(Debug)]
+    struct IdempotentControlHandler {
+        provider_type: ProviderTypeId,
+        handled: AtomicBool,
+        calls: AtomicUsize,
+        effects: AtomicUsize,
+    }
+
     #[async_trait]
-    impl ProviderProcessingProcessor for ResolvingProcessor {
-        async fn process(&self, delivery: &ClaimedProviderProcessing) -> ProviderProcessingOutcome {
-            match (self.calls.fetch_add(1, Ordering::SeqCst), delivery.input()) {
-                (0, ProviderProcessingInput::Control(_)) => {
-                    ProviderProcessingOutcome::ResolveControl(self.source_delivery_id)
-                }
-                (1, ProviderProcessingInput::Trigger(source)) => {
-                    assert_eq!(source.evidence().delivery_id(), self.source_delivery_id);
-                    ProviderProcessingOutcome::Complete
-                }
-                _ => panic!("rerun processing escaped the control-to-trigger sequence"),
+    impl crate::ProviderControlHandler for IdempotentControlHandler {
+        fn provider_type(&self) -> &ProviderTypeId {
+            &self.provider_type
+        }
+
+        async fn handle(
+            &self,
+            _control: &VerifiedProviderControlDelivery,
+            _lease: &ProviderProcessingLease,
+        ) -> Result<Option<ProviderDeliveryId>, crate::ProviderControlHandlingError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if !self.handled.swap(true, Ordering::SeqCst) {
+                self.effects.fetch_add(1, Ordering::SeqCst);
             }
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl crate::ProviderControlHandler for RecordingControlHandler {
+        fn provider_type(&self) -> &ProviderTypeId {
+            &self.provider_type
+        }
+
+        async fn handle(
+            &self,
+            _control: &VerifiedProviderControlDelivery,
+            lease: &ProviderProcessingLease,
+        ) -> Result<Option<ProviderDeliveryId>, crate::ProviderControlHandlingError> {
+            assert!(lease.current().expires_at() > lease.current().claimed_at());
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.source_delivery_id)
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingTriggerProcessor(AtomicUsize);
+
+    #[async_trait]
+    impl crate::ProviderTriggerProcessor for RecordingTriggerProcessor {
+        async fn process_trigger(
+            &self,
+            _invocation: &ClaimedProviderProcessing,
+            _lease: &ProviderProcessingLease,
+        ) -> ProviderProcessingOutcome {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            ProviderProcessingOutcome::Complete
         }
     }
 
     #[derive(Debug)]
     struct RecordingRepository {
         claim: Mutex<Option<ClaimedProviderProcessing>>,
+        receipt: ProviderProcessingReceipt,
         renewals: AtomicUsize,
         completed: Mutex<Option<ProviderProcessingClaimFence>>,
     }
@@ -412,13 +597,14 @@ mod tests {
         ) -> ProviderProcessingFuture<'_, ProviderProcessingReceipt> {
             Box::pin(async move {
                 *self.completed.lock().expect("completion lock") = Some(request.fence());
+                let receipt = self.receipt;
                 ProviderProcessingReceipt::new(
-                    request.fence().invocation_id(),
-                    ProviderDeliveryId::new(),
-                    Some(ProviderDeliveryId::new()),
+                    receipt.invocation_id(),
+                    receipt.cause_delivery_id(),
+                    receipt.source_delivery_id(),
                     ProviderProcessingState::Completed,
-                    1,
-                    UnixMillis::new(1_000),
+                    receipt.attempts(),
+                    receipt.created_at(),
                 )
                 .map_err(|_| ProviderProcessingRepositoryError::Corrupt)
             })
@@ -514,15 +700,21 @@ mod tests {
     #[tokio::test]
     async fn long_processing_renews_and_completes_with_the_latest_fence() {
         let worker_id = ProviderProcessingWorkerId::new();
+        let claim = claimed(worker_id);
         let repository = Arc::new(RecordingRepository {
-            claim: Mutex::new(Some(claimed(worker_id))),
+            receipt: claim.receipt(),
+            claim: Mutex::new(Some(claim)),
             renewals: AtomicUsize::new(0),
             completed: Mutex::new(None),
+        });
+        let processor = Arc::new(SlowProcessor {
+            initial_expiry: AtomicI64::new(0),
+            final_expiry: AtomicI64::new(0),
         });
         let worker = ProviderProcessingWorker::new(
             worker_id,
             Arc::clone(&repository) as Arc<dyn ProviderProcessingRepository>,
-            Arc::new(SlowProcessor),
+            Arc::clone(&processor) as Arc<dyn ProviderProcessingProcessor>,
             Arc::new(StepClock(AtomicI64::new(1_000))),
             ProviderProcessingWorkerConfig::new(30, 30).expect("config"),
         );
@@ -532,6 +724,10 @@ mod tests {
             ProviderProcessingWorkerOutcome::Completed
         );
         assert!(repository.renewals.load(Ordering::SeqCst) >= 1);
+        assert!(
+            processor.final_expiry.load(Ordering::SeqCst)
+                > processor.initial_expiry.load(Ordering::SeqCst)
+        );
         assert!(
             repository
                 .completed
@@ -544,7 +740,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rerun_control_resolves_and_processes_a_fresh_trigger_invocation() {
+    async fn handled_control_binds_its_source_before_completion() {
         let worker_id = ProviderProcessingWorkerId::new();
         let (control, bound, source_delivery_id) = rerun_claims(worker_id);
         let repository = Arc::new(ResolvingRepository {
@@ -553,10 +749,20 @@ mod tests {
             bindings: AtomicUsize::new(0),
             completed: Mutex::new(None),
         });
-        let processor = Arc::new(ResolvingProcessor {
-            source_delivery_id,
+        let handler = Arc::new(RecordingControlHandler {
+            provider_type: ProviderTypeId::new("github").expect("provider type"),
+            source_delivery_id: Some(source_delivery_id),
             calls: AtomicUsize::new(0),
         });
+        let triggers = Arc::new(RecordingTriggerProcessor(AtomicUsize::new(0)));
+        let handlers = crate::ProviderControlHandlerRegistry::new([
+            Arc::clone(&handler) as Arc<dyn crate::ProviderControlHandler>
+        ])
+        .expect("handler registry");
+        let processor = Arc::new(crate::ProviderProcessingDispatcher::new(
+            handlers,
+            Arc::clone(&triggers) as Arc<dyn crate::ProviderTriggerProcessor>,
+        ));
         let worker = ProviderProcessingWorker::new(
             worker_id,
             Arc::clone(&repository) as Arc<dyn ProviderProcessingRepository>,
@@ -570,7 +776,8 @@ mod tests {
             ProviderProcessingWorkerOutcome::Completed
         );
         assert_eq!(repository.bindings.load(Ordering::SeqCst), 1);
-        assert_eq!(processor.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(triggers.0.load(Ordering::SeqCst), 0);
         assert_eq!(
             repository
                 .completed
@@ -579,6 +786,127 @@ mod tests {
                 .expect("completion fence"),
             repository.bound.fence()
         );
+    }
+
+    #[tokio::test]
+    async fn handled_control_without_trigger_provenance_completes_directly() {
+        let worker_id = ProviderProcessingWorkerId::new();
+        let (control, _bound, _source_delivery_id) = rerun_claims(worker_id);
+        let handler = Arc::new(RecordingControlHandler {
+            provider_type: ProviderTypeId::new("github").expect("provider type"),
+            source_delivery_id: None,
+            calls: AtomicUsize::new(0),
+        });
+        let triggers = Arc::new(RecordingTriggerProcessor(AtomicUsize::new(0)));
+        let handlers = crate::ProviderControlHandlerRegistry::new([
+            Arc::clone(&handler) as Arc<dyn crate::ProviderControlHandler>
+        ])
+        .expect("handler registry");
+        let dispatcher = crate::ProviderProcessingDispatcher::new(
+            handlers,
+            Arc::clone(&triggers) as Arc<dyn crate::ProviderTriggerProcessor>,
+        );
+        let (_updates, view) = watch::channel(control.fence());
+        let lease = ProviderProcessingLease::new(view);
+
+        assert_eq!(
+            dispatcher.process(&control, &lease).await,
+            ProviderProcessingOutcome::Complete
+        );
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(triggers.0.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn control_replay_after_completion_crash_is_idempotent() {
+        let worker_id = ProviderProcessingWorkerId::new();
+        let (control, _bound, _source_delivery_id) = rerun_claims(worker_id);
+        let handler = Arc::new(IdempotentControlHandler {
+            provider_type: ProviderTypeId::new("github").expect("provider type"),
+            handled: AtomicBool::new(false),
+            calls: AtomicUsize::new(0),
+            effects: AtomicUsize::new(0),
+        });
+        let triggers = Arc::new(RecordingTriggerProcessor(AtomicUsize::new(0)));
+        let handlers = crate::ProviderControlHandlerRegistry::new([
+            Arc::clone(&handler) as Arc<dyn crate::ProviderControlHandler>
+        ])
+        .expect("handler registry");
+        let dispatcher = crate::ProviderProcessingDispatcher::new(
+            handlers,
+            Arc::clone(&triggers) as Arc<dyn crate::ProviderTriggerProcessor>,
+        );
+        let (_updates, view) = watch::channel(control.fence());
+        let lease = ProviderProcessingLease::new(view);
+
+        // The first outcome is intentionally not persisted, modeling a crash
+        // after the native operation but before processing completion.
+        assert_eq!(
+            dispatcher.process(&control, &lease).await,
+            ProviderProcessingOutcome::Complete
+        );
+        assert_eq!(
+            dispatcher.process(&control, &lease).await,
+            ProviderProcessingOutcome::Complete
+        );
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(handler.effects.load(Ordering::SeqCst), 1);
+        assert_eq!(triggers.0.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn repository_responses_must_preserve_exact_processing_identity() {
+        let worker_id = ProviderProcessingWorkerId::new();
+        let direct = claimed(worker_id);
+        let fence = direct.fence();
+        let renewed = ProviderProcessingClaimFence::new(
+            fence.invocation_id(),
+            fence.worker_id(),
+            fence.token(),
+            fence.claimed_at(),
+            UnixMillis::new(fence.expires_at().get() + 1),
+        )
+        .expect("renewed fence");
+        assert!(valid_renewal(fence, renewed));
+        let wrong_worker = ProviderProcessingClaimFence::new(
+            fence.invocation_id(),
+            ProviderProcessingWorkerId::new(),
+            fence.token(),
+            fence.claimed_at(),
+            renewed.expires_at(),
+        )
+        .expect("wrong-worker fence");
+        assert!(!valid_renewal(fence, wrong_worker));
+
+        let receipt = direct.receipt();
+        let completed = ProviderProcessingReceipt::new(
+            receipt.invocation_id(),
+            receipt.cause_delivery_id(),
+            receipt.source_delivery_id(),
+            ProviderProcessingState::Completed,
+            receipt.attempts(),
+            receipt.created_at(),
+        )
+        .expect("completion");
+        assert!(valid_terminal_receipt(
+            receipt,
+            completed,
+            ProviderProcessingState::Completed
+        ));
+        let wrong_source = ProviderProcessingReceipt::new(
+            receipt.invocation_id(),
+            receipt.cause_delivery_id(),
+            Some(ProviderDeliveryId::new()),
+            ProviderProcessingState::Completed,
+            receipt.attempts(),
+            receipt.created_at(),
+        )
+        .expect("wrong-source completion");
+        assert!(!valid_terminal_receipt(
+            receipt,
+            wrong_source,
+            ProviderProcessingState::Completed
+        ));
     }
 
     fn rerun_claims(

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -462,6 +462,7 @@ fn verified_delivery(
 fn verified_control(
     endpoint: &ProviderWebhookEndpointManifest,
     delivery_id: ProviderDeliveryId,
+    external_delivery_id: &str,
     raw_body: &[u8],
 ) -> VerifiedProviderControlDelivery {
     let raw = provider_raw_webhook_descriptor(secret_digest(raw_body), raw_body.len() as u64)
@@ -477,7 +478,7 @@ fn verified_control(
         endpoint.connection_revision(),
         ExternalDeliveryIdentity::new(
             endpoint.instance_id(),
-            ExternalDeliveryId::new("control-100").expect("external delivery"),
+            ExternalDeliveryId::new(external_delivery_id).expect("external delivery"),
         ),
         ProviderEventName::new("check_run").expect("event type"),
         UnixMillis::new(8_000),
@@ -690,6 +691,7 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
         let control = ProviderDelivery::Control(Box::new(verified_control(
             &endpoint,
             control_id,
+            "control-100",
             b"control-body",
         )));
         let ProviderDeliveryAcceptOutcome::Inserted(control_receipt) = repository
@@ -706,6 +708,7 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
         let replay = ProviderDelivery::Control(Box::new(verified_control(
             &endpoint,
             ProviderDeliveryId::from_uuid(Uuid::from_u128(108))?,
+            "control-100",
             b"control-body",
         )));
         assert!(matches!(
@@ -762,6 +765,37 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
                 .state(),
             ProviderProcessingState::Completed
         );
+
+        let unbound_control_id = ProviderDeliveryId::from_uuid(Uuid::from_u128(109))?;
+        let unbound_control = ProviderDelivery::Control(Box::new(verified_control(
+            &endpoint,
+            unbound_control_id,
+            "control-without-trigger-source",
+            b"schedule-control-body",
+        )));
+        repository
+            .accept_delivery(AcceptProviderDelivery::new(
+                unbound_control,
+                UnixMillis::new(8_600),
+            )?)
+            .await?;
+        let unbound_claim = repository
+            .claim_processing(ClaimProviderProcessing::new(
+                worker,
+                UnixMillis::new(8_700),
+                1_000,
+            )?)
+            .await?
+            .expect("unbound control claim");
+        assert_eq!(unbound_claim.receipt().source_delivery_id(), None);
+        let unbound_completed = repository
+            .complete_processing(CompleteProviderProcessing::new(
+                unbound_claim.fence(),
+                UnixMillis::new(8_800),
+            )?)
+            .await?;
+        assert_eq!(unbound_completed.state(), ProviderProcessingState::Completed);
+        assert_eq!(unbound_completed.source_delivery_id(), None);
 
         let disabled_connection = ProviderConnectionManifest::new(
             connection.connection_id(),


### PR DESCRIPTION
## Outcome

Establish the exact processing contracts needed before the provider runtime cutover:

- expose a live read-only processing lease that advances after every durable renewal
- replace control resolution with a provider-specific idempotent control handler contract
- let controls complete without trigger provenance, including reruns of schedule-origin results
- treat an optional bound trigger delivery as audit provenance and never replay its original admission side effects
- validate renewal, source-binding, and terminal repository responses against the exact invocation identity
- fail closed on malformed trigger receipts instead of panicking

This is the bounded B4c foundation stage. Production ingress and worker composition remain unchanged until B4d can replace and delete the bespoke GitHub lifecycle atomically.

## Related issue

None

## Trust and compatibility impact

The provider-delivery public foundation API intentionally breaks the unused resolver names and signatures; no compatibility aliases remain. The new handler contract requires provider adapters to reauthorize and make native control effects idempotent across crash replay. Durable processing accepts completed controls without a source delivery, while exact claim fences and receipt identity remain enforced. There is no schema migration, credential change, or production runtime cutover in this PR.

## Verification

- cargo check --workspace --all-targets --locked --quiet
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test -j 2 --workspace --exclude automata-ci-ui-renderer --all-targets --all-features --locked --no-fail-fast -- --quiet --test-threads=2
- cargo test -p automata-ci-provider-delivery --all-targets --locked --quiet: 6 passed
- PostgreSQL 18 exact integration suite via scripts/ci/run-postgres-tests.sh: 73 passed
- cargo fmt --all -- --check
- git diff --check

Live external-provider and object-storage tests remain ignored because they require explicitly configured services; the provider PostgreSQL suite ran against a disposable local PostgreSQL 18 container.

## AI assistance

OpenAI Codex materially assisted with architecture analysis, implementation, tests, and verification. Every submitted change was reviewed in the working tree.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.
