### PR TITLE
Add allowlisted runtime service proxy for macOS VMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,11 +1087,13 @@ dependencies = [
  "automata-ci-execution",
  "automata-ci-sandbox-guest",
  "base64 0.23.1",
+ "httparse",
  "rustix",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "static_assertions",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ flate2 = { version = "1.1.9", default-features = false, features = ["rust_backen
 focaccia = "2.0.0"
 getrandom = "0.4.3"
 http = "1.3.1"
+httparse = "1.10.1"
 http-body-util = "=0.1.5"
 hyper = { version = "=1.11.0", default-features = false, features = ["client", "http2", "server"] }
 hyper-rustls = { version = "=0.27.9", default-features = false, features = ["http2", "ring"] }

--- a/crates/automata-ci-sandbox-macos/Cargo.toml
+++ b/crates/automata-ci-sandbox-macos/Cargo.toml
@@ -20,10 +20,12 @@ automata-ci-execution.workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 automata-ci-sandbox-guest.workspace = true
 base64.workspace = true
+httparse.workspace = true
 rustix.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+url.workspace = true
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 static_assertions.workspace = true

--- a/crates/automata-ci-sandbox-macos/README.md
+++ b/crates/automata-ci-sandbox-macos/README.md
@@ -24,11 +24,20 @@ macOS version/build, architecture, dedicated non-admin UID/GID, and sealed
 process ceiling. The root guest bridge admits only that exact configuration;
 the agent applies it before executing commands as the dedicated guest identity.
 
-The bridge also contains a closed, bounded guest-loopback relay for future
-runtime services. The host helper exposes its fixed Virtio socket port only
-when given an owner-only Unix socket inside the current attempt directory. The
-runner currently supplies no socket, so the relay cannot reach the host and
-does not add a network capability.
+For jobs whose validated runtime authority contains HTTP(S) origins, the
+provider starts an owner-only proxy socket inside the current attempt directory
+and opens the bridge's fixed guest-loopback relay. Every command receives
+`HTTP_PROXY` and `HTTPS_PROXY` (including their lowercase forms) pointing to
+`127.0.0.1:18081`. HTTPS remains encrypted end to end through an exact-authority
+`CONNECT` tunnel; plain HTTP is forwarded only to an exact configured origin.
+The broker rejects every other host, port, protocol, and malformed request,
+limits concurrent sessions, strips proxy credentials before plain-HTTP
+forwarding, and stops with the VM. Jobs with no runtime-service routes retain a
+closed relay. The VM still has no virtual NIC and no general network access.
+
+macOS limits Unix socket paths to 103 bytes, so provider configuration rejects
+a state root which cannot fit the fixed attempt and proxy-socket suffix. The
+documented `/Volumes/AutomataVM/state` layout is within that bound.
 
 Lifecycle mutations remain replay-safe and generation-fenced. A new journal
 namespace deliberately rejects the deleted native provider's state instead of

--- a/crates/automata-ci-sandbox-macos/src/endpoint.rs
+++ b/crates/automata-ci-sandbox-macos/src/endpoint.rs
@@ -270,7 +270,7 @@ impl MacosVirtualizationEndpoint {
                 ExecutionStage::Exec,
             ));
         }
-        let environment = request
+        let mut environment = request
             .environment()
             .values()
             .iter()
@@ -281,6 +281,13 @@ impl MacosVirtualizationEndpoint {
                 )
             })
             .collect::<BTreeMap<_, _>>();
+        if !self.entry.runtime_service_routes.is_empty() {
+            for name in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
+                environment.insert(name.to_owned(), "http://127.0.0.1:18081".to_owned());
+            }
+            environment.insert("NO_PROXY".to_owned(), String::new());
+            environment.insert("no_proxy".to_owned(), String::new());
+        }
         let timeout_millis = u64::try_from(request.timeout().as_millis())
             .map_err(|_| error(ExecutionErrorKind::BackendRejected, ExecutionStage::Exec))?;
         let guest_request = GuestRequest::Exec {
@@ -396,11 +403,12 @@ fn exchange(
     stage: ExecutionStage,
 ) -> Result<GuestResponse, ExecutionError> {
     entry
-        .vm
+        .runtime
         .lock()
         .map_err(|_| error(ExecutionErrorKind::LocalStorage, stage))?
         .as_mut()
         .ok_or_else(|| error(ExecutionErrorKind::InvalidState, stage))?
+        .vm
         .exchange(request, timeout, cancellation, stage)
 }
 

--- a/crates/automata-ci-sandbox-macos/src/lib.rs
+++ b/crates/automata-ci-sandbox-macos/src/lib.rs
@@ -18,6 +18,8 @@ mod persistence;
 #[cfg(target_os = "macos")]
 mod provider;
 #[cfg(target_os = "macos")]
+mod runtime_proxy;
+#[cfg(target_os = "macos")]
 mod template;
 #[cfg(not(target_os = "macos"))]
 mod unsupported;

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -14,9 +14,10 @@ use automata_ci_execution::{
     Cancellation, DestroyDisposition, DestroySandbox, EnvironmentProfile, ExecutionEndpoint,
     NetworkPolicy, OperationId, OperationOutcome, ProviderCapabilities, ProviderError,
     ProviderErrorKind, ProviderId, ProviderStage, ResourceLimits, RootFilesystemPolicy,
-    SandboxCapability, SandboxCustody, SandboxGeneration, SandboxHandle, SandboxInspection,
-    SandboxLaunch, SandboxPrivilegePolicy, SandboxProvider, SandboxRecord, SandboxSpec,
-    SandboxState, Sha256Digest, TargetPath, TargetPlatform,
+    RuntimeServiceProtocol, RuntimeServiceRoutes, SandboxCapability, SandboxCustody,
+    SandboxGeneration, SandboxHandle, SandboxInspection, SandboxLaunch, SandboxPrivilegePolicy,
+    SandboxProvider, SandboxRecord, SandboxSpec, SandboxState, Sha256Digest, TargetPath,
+    TargetPlatform,
 };
 use serde::de::DeserializeOwned;
 use sha2::{Digest as _, Sha256};
@@ -29,6 +30,7 @@ use crate::{
         DurableCreate, DurableDestroyRequest, DurableEntry, DurableEntryPhase, DurableEvent,
         DurableSnapshot, DurableTombstone, LifecycleJournal, recovered_generation,
     },
+    runtime_proxy::RuntimeProxy,
     template::{VerifiedTemplate, load_template, plist_to_json, verify_helper},
     vm::VmProcess,
 };
@@ -38,8 +40,10 @@ const QUIESCE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const GIBIBYTE: u64 = 1024 * 1024 * 1024;
 const MINIMUM_STORAGE_HEADROOM: u64 = 32 * GIBIBYTE;
 const MAX_DISKUTIL_PLIST_BYTES: usize = 4 * 1024 * 1024;
+const MACOS_UNIX_SOCKET_PATH_BYTES: usize = 104;
+const OPAQUE_HANDLE_PATH_SAMPLE: &str = "00000000-0000-0000-0000-000000000000";
 
-const PROVIDER_CAPABILITIES: [SandboxCapability; 11] = [
+const PROVIDER_CAPABILITIES: [SandboxCapability; 12] = [
     SandboxCapability::WholeJob,
     SandboxCapability::Attach,
     SandboxCapability::Inspect,
@@ -51,6 +55,7 @@ const PROVIDER_CAPABILITIES: [SandboxCapability; 11] = [
     SandboxCapability::WritableRootFilesystem,
     SandboxCapability::ResourceLimits,
     SandboxCapability::ProcessLimits,
+    SandboxCapability::RuntimeServiceProxy,
 ];
 
 pub(crate) const ENDPOINT_CAPABILITIES: [SandboxCapability; 4] = [
@@ -131,6 +136,7 @@ impl MacosVirtualizationProviderOptions {
             || !storage_quota_bytes.is_multiple_of(GIBIBYTE)
             || !(Duration::from_secs(30)..=Duration::from_mins(15)).contains(&boot_timeout)
             || !(Duration::from_secs(1)..=Duration::from_secs(30)).contains(&stop_timeout)
+            || !runtime_proxy_path_fits(&provider_root)
         {
             return Err(known(
                 ProviderErrorKind::InvalidConfiguration,
@@ -199,6 +205,17 @@ impl MacosVirtualizationProviderOptions {
     pub(crate) const fn provider_target(&self) -> &TargetPath {
         &self.provider_target
     }
+}
+
+fn runtime_proxy_path_fits(provider_root: &Path) -> bool {
+    provider_root
+        .join("attempts")
+        .join(OPAQUE_HANDLE_PATH_SAMPLE)
+        .join("runtime-proxy.sock")
+        .as_os_str()
+        .as_encoded_bytes()
+        .len()
+        < MACOS_UNIX_SOCKET_PATH_BYTES
 }
 
 /// macOS provider backed by one disposable Virtualization.framework VM per job.
@@ -370,9 +387,25 @@ pub(crate) struct SandboxEntry {
     pub(crate) scratch: TargetPath,
     pub(crate) operation_lock: Mutex<()>,
     pub(crate) endpoint_state: Mutex<crate::endpoint::EndpointState>,
-    pub(crate) vm: Mutex<Option<VmProcess>>,
+    pub(crate) runtime: Mutex<Option<SandboxRuntime>>,
+    pub(crate) runtime_service_routes: RuntimeServiceRoutes,
     resources: ResourceLimits,
     phase: Mutex<DurableEntryPhase>,
+}
+
+pub(crate) struct SandboxRuntime {
+    pub(crate) vm: VmProcess,
+    proxy: Option<RuntimeProxy>,
+}
+
+impl SandboxRuntime {
+    fn stop(&mut self) -> std::io::Result<()> {
+        let vm_result = self.vm.stop();
+        if let Some(proxy) = self.proxy.as_mut() {
+            proxy.stop();
+        }
+        vm_result
+    }
 }
 
 impl SandboxEntry {
@@ -498,7 +531,8 @@ impl ProviderInner {
             scratch: scratch.clone(),
             operation_lock: Mutex::new(()),
             endpoint_state: Mutex::new(crate::endpoint::EndpointState::default()),
-            vm: Mutex::new(None),
+            runtime: Mutex::new(None),
+            runtime_service_routes: spec.runtime_service_routes().clone(),
             resources,
             phase: Mutex::new(DurableEntryPhase::Intent),
         });
@@ -710,13 +744,13 @@ fn complete_destroy(
         return Err(invalid_journal());
     }
     let operation = quiesce(entry, cancellation)?;
-    if let Some(mut vm) = entry
-        .vm
+    if let Some(mut runtime) = entry
+        .runtime
         .lock()
         .map_err(|_| local(ProviderStage::DestroySandbox))?
         .take()
     {
-        vm.stop().map_err(|_| {
+        runtime.stop().map_err(|_| {
             uncertain(
                 ProviderErrorKind::AdapterUnavailable,
                 ProviderStage::DestroySandbox,
@@ -830,11 +864,11 @@ fn resume_create(
         ));
     }
     let attempt = attempt_target(&provider.options, entry.handle.opaque())?;
-    let mut vm = entry
-        .vm
+    let mut runtime = entry
+        .runtime
         .lock()
         .map_err(|_| local(ProviderStage::CreateSandbox))?;
-    if vm.is_none() {
+    if runtime.is_none() {
         provider
             .root
             .remove_owned_tree(&attempt)
@@ -846,11 +880,28 @@ fn resume_create(
                     entry.handle.clone(),
                 )
             })?;
+        let attempt_path = attempt_path(&provider.options, entry.handle.opaque());
+        let proxy = if entry.runtime_service_routes.is_empty() {
+            None
+        } else {
+            Some(
+                RuntimeProxy::start(&attempt_path, entry.runtime_service_routes.clone()).map_err(
+                    |_| {
+                        uncertain(
+                            ProviderErrorKind::AdapterUnavailable,
+                            ProviderStage::CreateSandbox,
+                            entry.handle.clone(),
+                        )
+                    },
+                )?,
+            )
+        };
         let mut launched = VmProcess::launch(
             &provider.options,
             &provider.template,
             entry.handle.opaque(),
-            &attempt_path(&provider.options, entry.handle.opaque()),
+            &attempt_path,
+            proxy.as_ref().map(RuntimeProxy::socket_path),
             entry.resources,
             cancellation,
         )
@@ -872,7 +923,10 @@ fn resume_create(
                 };
                 uncertain(kind, ProviderStage::CreateWorkspace, entry.handle.clone())
             })?;
-        *vm = Some(launched);
+        *runtime = Some(SandboxRuntime {
+            vm: launched,
+            proxy,
+        });
     }
     state
         .journal
@@ -889,7 +943,7 @@ fn resume_create(
     entry
         .set_phase(DurableEntryPhase::Running)
         .map_err(|()| local(ProviderStage::CreateSandbox))?;
-    drop(vm);
+    drop(runtime);
     entry.record()
 }
 
@@ -922,7 +976,6 @@ fn validate_spec(
         && spec.resources().memory_bytes() >= template.minimum_memory_bytes
         && spec.resources().pids() == template.process_limit
         && spec.services().is_empty()
-        && spec.runtime_service_routes().is_empty()
         && spec.has_coherent_resource_contract()
         && !spec
             .profile()
@@ -940,7 +993,7 @@ fn validate_spec(
 
 fn spec_fingerprint(spec: &SandboxSpec) -> Result<[u8; 32], ProviderError> {
     let mut digest = Sha256::new();
-    fingerprint_field(&mut digest, b"automata-macos-virtualization-spec-v2");
+    fingerprint_field(&mut digest, b"automata-macos-virtualization-spec-v3");
     fingerprint_custody(&mut digest, spec.custody());
     fingerprint_field(&mut digest, &spec.generation().get().to_le_bytes());
     fingerprint_field(
@@ -982,6 +1035,17 @@ fn spec_fingerprint(spec: &SandboxSpec) -> Result<[u8; 32], ProviderError> {
         fingerprint_field(&mut digest, variable.name().as_str().as_bytes());
         fingerprint_field(&mut digest, variable.value().expose().as_bytes());
         fingerprint_field(&mut digest, &[u8::from(variable.is_secret())]);
+    }
+    for route in spec.runtime_service_routes().as_slice() {
+        fingerprint_field(
+            &mut digest,
+            match route.protocol() {
+                RuntimeServiceProtocol::Http => b"http",
+                RuntimeServiceProtocol::Https => b"https",
+            },
+        );
+        fingerprint_field(&mut digest, route.host().as_bytes());
+        fingerprint_field(&mut digest, &route.port().get().to_be_bytes());
     }
     Ok(digest.finalize().into())
 }

--- a/crates/automata-ci-sandbox-macos/src/runtime_proxy.rs
+++ b/crates/automata-ci-sandbox-macos/src/runtime_proxy.rs
@@ -1,0 +1,909 @@
+use std::{
+    collections::HashMap,
+    fs,
+    io::{self, Read, Write},
+    net::{IpAddr, Shutdown, SocketAddr, TcpStream, ToSocketAddrs as _},
+    num::NonZeroU16,
+    os::unix::{
+        fs::{FileTypeExt as _, MetadataExt as _, PermissionsExt as _},
+        net::{UnixListener, UnixStream},
+    },
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use automata_ci_execution::{RuntimeServiceProtocol, RuntimeServiceRoute, RuntimeServiceRoutes};
+use url::Url;
+
+const SOCKET_NAME: &str = "runtime-proxy.sock";
+const MAX_HEADER_BYTES: usize = 16 * 1024;
+const MAX_HEADERS: usize = 64;
+const MAX_SESSIONS: usize = 16;
+const ACCEPT_POLL: Duration = Duration::from_millis(10);
+const HEADER_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const RELAY_IDLE_TIMEOUT: Duration = Duration::from_mins(5);
+
+#[derive(Debug)]
+pub(crate) struct RuntimeProxy {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    listener: Option<JoinHandle<()>>,
+    sessions: Arc<Mutex<HashMap<usize, SessionSockets>>>,
+}
+
+#[derive(Debug)]
+struct SessionSockets {
+    downstream: UnixStream,
+    upstream: Option<TcpStream>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestError {
+    BadRequest,
+    Forbidden,
+    MethodNotAllowed,
+}
+
+struct ForwardRequest {
+    route: RuntimeServiceRoute,
+    bytes: Vec<u8>,
+    established_response: bool,
+}
+
+impl RuntimeProxy {
+    pub(crate) fn start(
+        attempt_directory: &Path,
+        routes: RuntimeServiceRoutes,
+    ) -> io::Result<Self> {
+        if routes.is_empty() {
+            return Err(io::Error::from(io::ErrorKind::InvalidInput));
+        }
+        let socket_path = attempt_directory.join(SOCKET_NAME);
+        let listener = UnixListener::bind(&socket_path)?;
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
+        validate_socket(&socket_path)?;
+        listener.set_nonblocking(true)?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        let active = Arc::new(AtomicUsize::new(0));
+        let next_id = Arc::new(AtomicUsize::new(1));
+        let routes = Arc::new(routes);
+        let listener_shutdown = Arc::clone(&shutdown);
+        let listener_sessions = Arc::clone(&sessions);
+        let listener_active = Arc::clone(&active);
+        let listener_next_id = Arc::clone(&next_id);
+        let listener_thread = thread::Builder::new()
+            .name("automata-macos-runtime-proxy".to_owned())
+            .spawn(move || {
+                accept_loop(
+                    &listener,
+                    &routes,
+                    &listener_shutdown,
+                    &listener_sessions,
+                    &listener_active,
+                    &listener_next_id,
+                );
+            })?;
+
+        Ok(Self {
+            socket_path,
+            shutdown,
+            listener: Some(listener_thread),
+            sessions,
+        })
+    }
+
+    pub(crate) fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    pub(crate) fn stop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Ok(sessions) = self.sessions.lock() {
+            for sockets in sessions.values() {
+                let _ = sockets.downstream.shutdown(Shutdown::Both);
+                if let Some(upstream) = sockets.upstream.as_ref() {
+                    let _ = upstream.shutdown(Shutdown::Both);
+                }
+            }
+        }
+        if let Some(listener) = self.listener.take() {
+            let _ = listener.join();
+        }
+        let _ = fs::remove_file(&self.socket_path);
+    }
+}
+
+impl Drop for RuntimeProxy {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn accept_loop(
+    listener: &UnixListener,
+    routes: &Arc<RuntimeServiceRoutes>,
+    shutdown: &Arc<AtomicBool>,
+    sessions: &Arc<Mutex<HashMap<usize, SessionSockets>>>,
+    active: &Arc<AtomicUsize>,
+    next_id: &Arc<AtomicUsize>,
+) {
+    while !shutdown.load(Ordering::Acquire) {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                if active.fetch_add(1, Ordering::AcqRel) >= MAX_SESSIONS {
+                    active.fetch_sub(1, Ordering::AcqRel);
+                    let _ = write_response(&mut stream, 503, "Service Unavailable");
+                    continue;
+                }
+                let id = next_id.fetch_add(1, Ordering::Relaxed);
+                let Ok(registry_stream) = stream.try_clone() else {
+                    active.fetch_sub(1, Ordering::AcqRel);
+                    continue;
+                };
+                let Ok(mut registry) = sessions.lock() else {
+                    active.fetch_sub(1, Ordering::AcqRel);
+                    continue;
+                };
+                registry.insert(
+                    id,
+                    SessionSockets {
+                        downstream: registry_stream,
+                        upstream: None,
+                    },
+                );
+                drop(registry);
+                let routes = Arc::clone(routes);
+                let shutdown = Arc::clone(shutdown);
+                let sessions = Arc::clone(sessions);
+                let active = Arc::clone(active);
+                let _ = thread::Builder::new()
+                    .name("automata-macos-runtime-proxy-session".to_owned())
+                    .spawn(move || {
+                        let _guard = SessionGuard {
+                            id,
+                            sessions: Arc::clone(&sessions),
+                            active,
+                        };
+                        serve_session(id, &mut stream, &routes, &shutdown, &sessions);
+                    });
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(ACCEPT_POLL);
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+struct SessionGuard {
+    id: usize,
+    sessions: Arc<Mutex<HashMap<usize, SessionSockets>>>,
+    active: Arc<AtomicUsize>,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        if let Ok(mut sessions) = self.sessions.lock() {
+            sessions.remove(&self.id);
+        }
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn serve_session(
+    id: usize,
+    downstream: &mut UnixStream,
+    routes: &RuntimeServiceRoutes,
+    shutdown: &AtomicBool,
+    sessions: &Mutex<HashMap<usize, SessionSockets>>,
+) {
+    if downstream.set_read_timeout(Some(HEADER_TIMEOUT)).is_err()
+        || downstream.set_write_timeout(Some(HEADER_TIMEOUT)).is_err()
+    {
+        return;
+    }
+    let request = match read_request(downstream, routes) {
+        Ok(request) => request,
+        Err(error) => {
+            let (status, reason) = match error {
+                RequestError::BadRequest => (400, "Bad Request"),
+                RequestError::Forbidden => (403, "Forbidden"),
+                RequestError::MethodNotAllowed => (405, "Method Not Allowed"),
+            };
+            let _ = write_response(downstream, status, reason);
+            return;
+        }
+    };
+    if shutdown.load(Ordering::Acquire) {
+        return;
+    }
+    let Ok(mut upstream) = connect_route(&request.route) else {
+        let _ = write_response(downstream, 502, "Bad Gateway");
+        return;
+    };
+    let Ok(registry_upstream) = upstream.try_clone() else {
+        return;
+    };
+    let Ok(mut registry) = sessions.lock() else {
+        return;
+    };
+    let Some(session) = registry.get_mut(&id) else {
+        return;
+    };
+    session.upstream = Some(registry_upstream);
+    drop(registry);
+    if shutdown.load(Ordering::Acquire) {
+        return;
+    }
+    if request.established_response
+        && downstream
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .is_err()
+    {
+        return;
+    }
+    if !request.bytes.is_empty() && upstream.write_all(&request.bytes).is_err() {
+        return;
+    }
+    let _ = downstream.set_read_timeout(Some(RELAY_IDLE_TIMEOUT));
+    let _ = downstream.set_write_timeout(Some(RELAY_IDLE_TIMEOUT));
+    let _ = upstream.set_read_timeout(Some(RELAY_IDLE_TIMEOUT));
+    let _ = upstream.set_write_timeout(Some(RELAY_IDLE_TIMEOUT));
+    relay(downstream, &mut upstream);
+}
+
+fn read_request(
+    stream: &mut UnixStream,
+    routes: &RuntimeServiceRoutes,
+) -> Result<ForwardRequest, RequestError> {
+    let mut bytes = Vec::with_capacity(1024);
+    let header_end = loop {
+        if let Some(end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break end + 4;
+        }
+        if bytes.len() >= MAX_HEADER_BYTES {
+            return Err(RequestError::BadRequest);
+        }
+        let remaining = MAX_HEADER_BYTES - bytes.len();
+        let mut chunk = [0_u8; 4096];
+        let length = remaining.min(chunk.len());
+        let count = stream
+            .read(&mut chunk[..length])
+            .map_err(|_| RequestError::BadRequest)?;
+        if count == 0 {
+            return Err(RequestError::BadRequest);
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+    };
+
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut parsed = httparse::Request::new(&mut headers);
+    match parsed
+        .parse(&bytes[..header_end])
+        .map_err(|_| RequestError::BadRequest)?
+    {
+        httparse::Status::Complete(consumed) if consumed == header_end => {}
+        _ => return Err(RequestError::BadRequest),
+    }
+    if parsed.version != Some(1) {
+        return Err(RequestError::BadRequest);
+    }
+    let method = parsed.method.ok_or(RequestError::BadRequest)?;
+    let target = parsed.path.ok_or(RequestError::BadRequest)?;
+    if method == "CONNECT" {
+        return connect_request(target, &bytes[header_end..], routes);
+    }
+    http_request(method, target, parsed.headers, &bytes[header_end..], routes)
+}
+
+fn connect_request(
+    target: &str,
+    trailing: &[u8],
+    routes: &RuntimeServiceRoutes,
+) -> Result<ForwardRequest, RequestError> {
+    let (host, port) = explicit_authority(target).ok_or(RequestError::BadRequest)?;
+    let route = route_from_parts(RuntimeServiceProtocol::Https, &host, port)
+        .ok_or(RequestError::BadRequest)?;
+    require_route(routes, &route)?;
+    Ok(ForwardRequest {
+        route,
+        bytes: trailing.to_vec(),
+        established_response: true,
+    })
+}
+
+fn http_request(
+    method: &str,
+    target: &str,
+    headers: &[httparse::Header<'_>],
+    trailing: &[u8],
+    routes: &RuntimeServiceRoutes,
+) -> Result<ForwardRequest, RequestError> {
+    let url = Url::parse(target).map_err(|_| RequestError::BadRequest)?;
+    if url.fragment().is_some() {
+        return Err(RequestError::BadRequest);
+    }
+    let route = RuntimeServiceRoute::from_url(&url).map_err(|_| RequestError::BadRequest)?;
+    if route.protocol() != RuntimeServiceProtocol::Http {
+        return Err(RequestError::MethodNotAllowed);
+    }
+    require_route(routes, &route)?;
+    let host = single_host_header(headers).ok_or(RequestError::BadRequest)?;
+    let header_route = route_from_authority(RuntimeServiceProtocol::Http, host, 80)
+        .ok_or(RequestError::BadRequest)?;
+    if header_route != route {
+        return Err(RequestError::Forbidden);
+    }
+
+    let mut origin = if url.path().is_empty() {
+        "/".to_owned()
+    } else {
+        url.path().to_owned()
+    };
+    if let Some(query) = url.query() {
+        origin.push('?');
+        origin.push_str(query);
+    }
+    let mut rewritten = Vec::with_capacity(MAX_HEADER_BYTES + trailing.len());
+    write!(&mut rewritten, "{method} {origin} HTTP/1.1\r\n")
+        .map_err(|_| RequestError::BadRequest)?;
+    for header in headers {
+        if header.name.eq_ignore_ascii_case("proxy-connection")
+            || header.name.eq_ignore_ascii_case("proxy-authorization")
+        {
+            continue;
+        }
+        rewritten.extend_from_slice(header.name.as_bytes());
+        rewritten.extend_from_slice(b": ");
+        rewritten.extend_from_slice(header.value);
+        rewritten.extend_from_slice(b"\r\n");
+    }
+    rewritten.extend_from_slice(b"\r\n");
+    rewritten.extend_from_slice(trailing);
+    Ok(ForwardRequest {
+        route,
+        bytes: rewritten,
+        established_response: false,
+    })
+}
+
+fn single_host_header<'a>(headers: &'a [httparse::Header<'a>]) -> Option<&'a str> {
+    let mut values = headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case("host"));
+    let first = std::str::from_utf8(values.next()?.value).ok()?.trim();
+    if first.is_empty() || values.next().is_some() {
+        None
+    } else {
+        Some(first)
+    }
+}
+
+fn require_route(
+    routes: &RuntimeServiceRoutes,
+    route: &RuntimeServiceRoute,
+) -> Result<(), RequestError> {
+    routes
+        .as_slice()
+        .contains(route)
+        .then_some(())
+        .ok_or(RequestError::Forbidden)
+}
+
+fn explicit_authority(authority: &str) -> Option<(String, NonZeroU16)> {
+    if authority.contains(['@', '/', '?', '#']) {
+        return None;
+    }
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let close = rest.find(']')?;
+        let host = &rest[..close];
+        let port = rest[close + 1..].strip_prefix(':')?;
+        (host, port)
+    } else {
+        authority.rsplit_once(':')?
+    };
+    let port = port.parse::<u16>().ok().and_then(NonZeroU16::new)?;
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_owned(), port))
+}
+
+fn route_from_authority(
+    protocol: RuntimeServiceProtocol,
+    authority: &str,
+    default_port: u16,
+) -> Option<RuntimeServiceRoute> {
+    let scheme = scheme(protocol);
+    let url = Url::parse(&format!("{scheme}://{authority}/")).ok()?;
+    let route = RuntimeServiceRoute::from_url(&url).ok()?;
+    if url.port().is_none() && route.port().get() != default_port {
+        return None;
+    }
+    Some(route)
+}
+
+fn route_from_parts(
+    protocol: RuntimeServiceProtocol,
+    host: &str,
+    port: NonZeroU16,
+) -> Option<RuntimeServiceRoute> {
+    let authority = match host.parse::<IpAddr>() {
+        Ok(IpAddr::V6(_)) => format!("[{host}]:{port}"),
+        _ => format!("{host}:{port}"),
+    };
+    route_from_authority(protocol, &authority, port.get())
+}
+
+const fn scheme(protocol: RuntimeServiceProtocol) -> &'static str {
+    match protocol {
+        RuntimeServiceProtocol::Http => "http",
+        RuntimeServiceProtocol::Https => "https",
+    }
+}
+
+fn connect_route(route: &RuntimeServiceRoute) -> io::Result<TcpStream> {
+    let addresses: Vec<SocketAddr> = (route.host(), route.port().get())
+        .to_socket_addrs()?
+        .collect();
+    if addresses.is_empty() {
+        return Err(io::Error::from(io::ErrorKind::NotFound));
+    }
+    let mut last_error = None;
+    for address in addresses {
+        match TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| io::Error::from(io::ErrorKind::ConnectionRefused)))
+}
+
+fn relay(downstream: &mut UnixStream, upstream: &mut TcpStream) {
+    let Ok(mut downstream_reader) = downstream.try_clone() else {
+        return;
+    };
+    let Ok(mut upstream_writer) = upstream.try_clone() else {
+        return;
+    };
+    thread::scope(|scope| {
+        let upload = scope.spawn(move || {
+            let _ = io::copy(&mut downstream_reader, &mut upstream_writer);
+            let _ = upstream_writer.shutdown(Shutdown::Write);
+        });
+        let _ = io::copy(upstream, downstream);
+        let _ = downstream.shutdown(Shutdown::Write);
+        let _ = downstream.shutdown(Shutdown::Read);
+        let _ = upload.join();
+    });
+}
+
+fn write_response(stream: &mut UnixStream, status: u16, reason: &str) -> io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    )
+}
+
+fn validate_socket(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_socket()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.nlink() != 1
+        || metadata.permissions().mode() & 0o077 != 0
+    {
+        return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        fs,
+        io::{Read, Write},
+        net::{Shutdown, TcpListener},
+        os::unix::{fs::PermissionsExt as _, net::UnixStream},
+        path::{Path, PathBuf},
+        process::{Child, Command, ExitStatus, Stdio},
+        thread,
+    };
+
+    use automata_ci_execution::{OperationId, RuntimeServiceRoute, RuntimeServiceRoutes};
+    use automata_ci_sandbox_guest::{
+        GUEST_PROTOCOL_VERSION, GuestRequest, GuestResponse, GuestTermination, decode_frame,
+        encode_frame,
+    };
+    use serde_json::{Value, json};
+    use url::Url;
+
+    use super::RuntimeProxy;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = Path::new("/tmp").join(format!("automata-proxy-{}", OperationId::new()));
+            fs::create_dir(&path).expect("create test directory");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("secure test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn connect_relays_only_an_exact_allowed_tls_origin() {
+        let upstream = TcpListener::bind("127.0.0.1:0").expect("bind upstream");
+        let port = upstream.local_addr().expect("upstream address").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = upstream.accept().expect("accept upstream");
+            let mut request = [0_u8; 4];
+            stream.read_exact(&mut request).expect("read relayed bytes");
+            assert_eq!(&request, b"ping");
+            stream.write_all(b"pong").expect("write relayed bytes");
+        });
+        let directory = TestDirectory::new();
+        let mut proxy = RuntimeProxy::start(
+            directory.path(),
+            routes(&format!("https://127.0.0.1:{port}/")),
+        )
+        .expect("start proxy");
+        let metadata = fs::symlink_metadata(proxy.socket_path()).expect("socket metadata");
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+
+        let mut client = UnixStream::connect(proxy.socket_path()).expect("connect proxy");
+        write!(
+            client,
+            "CONNECT 127.0.0.1:{port} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\nping"
+        )
+        .expect("send CONNECT");
+        assert_eq!(
+            read_header(&mut client),
+            "HTTP/1.1 200 Connection Established\r\n\r\n"
+        );
+        let mut response = [0_u8; 4];
+        client.read_exact(&mut response).expect("read tunnel bytes");
+        assert_eq!(&response, b"pong");
+        let _ = client.shutdown(Shutdown::Both);
+        server.join().expect("join upstream");
+        proxy.stop();
+        assert!(!proxy.socket_path().exists());
+    }
+
+    #[test]
+    fn connect_rejects_an_origin_outside_the_route_set() {
+        let directory = TestDirectory::new();
+        let proxy = RuntimeProxy::start(directory.path(), routes("https://127.0.0.1:443/"))
+            .expect("start proxy");
+        let mut client = UnixStream::connect(proxy.socket_path()).expect("connect proxy");
+        client
+            .write_all(b"CONNECT 127.0.0.1:444 HTTP/1.1\r\nHost: 127.0.0.1:444\r\n\r\n")
+            .expect("send CONNECT");
+        assert!(read_header(&mut client).starts_with("HTTP/1.1 403 Forbidden\r\n"));
+    }
+
+    #[test]
+    fn plain_http_is_rewritten_to_origin_form_and_proxy_headers_are_removed() {
+        let upstream = TcpListener::bind("127.0.0.1:0").expect("bind upstream");
+        let port = upstream.local_addr().expect("upstream address").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = upstream.accept().expect("accept upstream");
+            let request = read_header(&mut stream);
+            assert!(request.starts_with("GET /path?q=1 HTTP/1.1\r\n"));
+            assert!(request.contains(&format!("Host: 127.0.0.1:{port}\r\n")));
+            assert!(!request.to_ascii_lowercase().contains("proxy-connection"));
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .expect("write response");
+        });
+        let directory = TestDirectory::new();
+        let proxy = RuntimeProxy::start(
+            directory.path(),
+            routes(&format!("http://127.0.0.1:{port}/")),
+        )
+        .expect("start proxy");
+        let mut client = UnixStream::connect(proxy.socket_path()).expect("connect proxy");
+        write!(
+            client,
+            "GET http://127.0.0.1:{port}/path?q=1 HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nProxy-Connection: keep-alive\r\n\r\n"
+        )
+        .expect("send request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("finish proxy request");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("read proxy response");
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.ends_with("\r\n\r\nok"));
+        server.join().expect("join upstream");
+    }
+
+    #[test]
+    fn plain_http_rejects_a_mismatched_host_header() {
+        let directory = TestDirectory::new();
+        let proxy = RuntimeProxy::start(directory.path(), routes("http://127.0.0.1:8080/"))
+            .expect("start proxy");
+        let mut client = UnixStream::connect(proxy.socket_path()).expect("connect proxy");
+        client
+            .write_all(b"GET http://127.0.0.1:8080/ HTTP/1.1\r\nHost: 127.0.0.1:8081\r\n\r\n")
+            .expect("send request");
+        assert!(read_header(&mut client).starts_with("HTTP/1.1 403 Forbidden\r\n"));
+    }
+
+    #[test]
+    #[ignore = "requires the dedicated physical macOS VM test host"]
+    fn physical_guest_reaches_an_allowlisted_origin_through_the_vsock_proxy() {
+        let helper = required_path("AUTOMATA_MACOS_PHYSICAL_HELPER");
+        let manifest_path = required_path("AUTOMATA_MACOS_PHYSICAL_MANIFEST");
+        let attempt_root = required_path("AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT");
+        let manifest: Value = serde_json::from_slice(
+            &fs::read(&manifest_path).expect("read physical template manifest"),
+        )
+        .expect("decode physical template manifest");
+        let attempt = attempt_root.join(format!("p-{}", OperationId::new()));
+        fs::create_dir(&attempt).expect("create physical attempt directory");
+        fs::set_permissions(&attempt, fs::Permissions::from_mode(0o700))
+            .expect("secure physical attempt directory");
+        let _attempt_cleanup = AttemptCleanup(attempt.clone());
+
+        let (port, server) = physical_upstream();
+        let mut proxy = RuntimeProxy::start(&attempt, routes(&format!("http://127.0.0.1:{port}/")))
+            .expect("start physical runtime proxy");
+
+        let launch = physical_launch_request(&manifest, &attempt, &proxy);
+        let child = Command::new(helper)
+            .args(["run", "--lock"])
+            .arg(attempt.join(".vm.lock"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("launch physical helper");
+        let mut child = PhysicalHelper(Some(child));
+        let mut input = child.child().stdin.take().expect("physical helper input");
+        let mut output = child.child().stdout.take().expect("physical helper output");
+        write_json_frame(&mut input, &launch);
+        let response = match read_json_frame(&mut output) {
+            Ok(response) => response,
+            Err(error) => {
+                drop(input);
+                let status = child.wait().expect("wait for failed physical helper");
+                panic!("physical helper closed before launch response ({status}): {error}");
+            }
+        };
+        assert_eq!(response, json!({"protocol": 2, "status": "ready"}));
+
+        let environment = BTreeMap::from([
+            ("http_proxy".to_owned(), "http://127.0.0.1:18081".to_owned()),
+            ("no_proxy".to_owned(), String::new()),
+        ]);
+        let request = GuestRequest::Exec {
+            protocol: GUEST_PROTOCOL_VERSION,
+            operation_id: OperationId::new().to_string(),
+            program: "/usr/bin/curl".to_owned(),
+            arguments: vec![
+                "--fail".to_owned(),
+                "--silent".to_owned(),
+                "--show-error".to_owned(),
+                "--max-time".to_owned(),
+                "20".to_owned(),
+                format!("http://127.0.0.1:{port}/probe"),
+            ],
+            environment,
+            working_directory: "/".to_owned(),
+            timeout_millis: 30_000,
+            output_limit: 16 * 1024,
+            process_limit: None,
+        };
+        input
+            .write_all(&encode_frame(&request).expect("encode physical guest request"))
+            .expect("send physical guest request");
+        input.flush().expect("flush physical guest request");
+        let response: GuestResponse =
+            decode_frame(&read_binary_frame(&mut output)).expect("decode physical guest response");
+        let GuestResponse::Exec {
+            termination,
+            records,
+            truncated,
+            ..
+        } = response
+        else {
+            panic!("physical guest rejected proxy request")
+        };
+        let output = records
+            .iter()
+            .filter_map(|record| record.data().ok())
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            termination,
+            GuestTermination::Exited(0),
+            "physical guest curl output: {}",
+            String::from_utf8_lossy(&output)
+        );
+        assert!(!truncated);
+        assert_eq!(output, b"macos-runtime-proxy-ok");
+        server.join().expect("join physical upstream");
+        drop(input);
+        assert!(child.wait().expect("stop physical helper").success());
+        proxy.stop();
+    }
+
+    fn routes(url: &str) -> RuntimeServiceRoutes {
+        RuntimeServiceRoutes::new([RuntimeServiceRoute::from_url(
+            &Url::parse(url).expect("route URL"),
+        )
+        .expect("runtime route")])
+        .expect("runtime routes")
+    }
+
+    fn read_header(reader: &mut impl Read) -> String {
+        let mut bytes = Vec::new();
+        while !bytes.ends_with(b"\r\n\r\n") {
+            let mut byte = [0_u8; 1];
+            reader.read_exact(&mut byte).expect("read header byte");
+            bytes.push(byte[0]);
+            assert!(bytes.len() < 16 * 1024);
+        }
+        String::from_utf8(bytes).expect("ASCII HTTP header")
+    }
+
+    struct AttemptCleanup(PathBuf);
+
+    impl Drop for AttemptCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct PhysicalHelper(Option<Child>);
+
+    impl PhysicalHelper {
+        fn child(&mut self) -> &mut Child {
+            self.0.as_mut().expect("physical helper process")
+        }
+
+        fn wait(&mut self) -> std::io::Result<ExitStatus> {
+            let mut child = self.0.take().expect("physical helper process");
+            child.wait()
+        }
+    }
+
+    impl Drop for PhysicalHelper {
+        fn drop(&mut self) {
+            if let Some(child) = self.0.as_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+
+    fn required_path(name: &str) -> PathBuf {
+        std::env::var_os(name).map_or_else(
+            || panic!("{name} must name a physical-host path"),
+            PathBuf::from,
+        )
+    }
+
+    fn physical_launch_request(manifest: &Value, attempt: &Path, proxy: &RuntimeProxy) -> Value {
+        let attempt_id = attempt
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("physical attempt name");
+        json!({
+            "protocol": 2,
+            "attempt_id": attempt_id,
+            "source_disk_image": manifest_string(manifest, "disk_image", Some("path")),
+            "source_auxiliary_storage": manifest_string(manifest, "auxiliary_storage", Some("path")),
+            "attempt_directory": attempt,
+            "hardware_model_base64": manifest_string(manifest, "hardware_model_base64", None),
+            "cpu_count": 4,
+            "memory_bytes": 8_u64 * 1024 * 1024 * 1024,
+            "process_limit": manifest_u64(manifest, "process_limit"),
+            "guest_port": manifest_u64(manifest, "guest_port"),
+            "guest_protocol": manifest_u64(manifest, "guest_protocol"),
+            "expected_profile_id": manifest_string(manifest, "profile_id", None),
+            "guest_agent_sha256": manifest_string(manifest, "guest_agent_sha256", None),
+            "expected_macos_version": manifest_string(manifest, "macos_version", None),
+            "expected_macos_build": manifest_string(manifest, "macos_build", None),
+            "expected_architecture": manifest_string(manifest, "architecture", None),
+            "expected_job_uid": manifest_u64(manifest, "job_uid"),
+            "expected_job_gid": manifest_u64(manifest, "job_gid"),
+            "expected_process_limit": manifest_u64(manifest, "process_limit"),
+            "minimum_cpu_count": manifest_u64(manifest, "minimum_cpu_count"),
+            "minimum_memory_bytes": manifest_u64(manifest, "minimum_memory_bytes"),
+            "handshake_nonce": OperationId::new().to_string(),
+            "boot_timeout_millis": 300_000,
+            "stop_timeout_millis": 10_000,
+            "runtime_proxy_socket": proxy.socket_path(),
+        })
+    }
+
+    fn physical_upstream() -> (u16, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind physical upstream");
+        let port = listener
+            .local_addr()
+            .expect("physical upstream address")
+            .port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept physical upstream");
+            let request = read_header(&mut stream);
+            assert!(request.starts_with("GET /probe HTTP/1.1\r\n"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 22\r\nConnection: close\r\n\r\nmacos-runtime-proxy-ok",
+                )
+                .expect("write physical upstream response");
+        });
+        (port, server)
+    }
+
+    fn manifest_string<'a>(manifest: &'a Value, field: &str, nested: Option<&str>) -> &'a str {
+        let value = nested.map_or(&manifest[field], |nested| &manifest[field][nested]);
+        value
+            .as_str()
+            .unwrap_or_else(|| panic!("manifest field {field} must be a string"))
+    }
+
+    fn manifest_u64(manifest: &Value, field: &str) -> u64 {
+        manifest[field]
+            .as_u64()
+            .unwrap_or_else(|| panic!("manifest field {field} must be an unsigned integer"))
+    }
+
+    fn write_json_frame(writer: &mut impl Write, value: &Value) {
+        let bytes = serde_json::to_vec(value).expect("encode physical helper request");
+        let length = u32::try_from(bytes.len()).expect("physical helper request length");
+        writer
+            .write_all(&length.to_be_bytes())
+            .and_then(|()| writer.write_all(&bytes))
+            .and_then(|()| writer.flush())
+            .expect("send physical helper request");
+    }
+
+    fn read_json_frame(reader: &mut impl Read) -> std::io::Result<Value> {
+        serde_json::from_slice(&read_binary_payload_result(reader)?).map_err(std::io::Error::other)
+    }
+
+    fn read_binary_frame(reader: &mut impl Read) -> Vec<u8> {
+        let payload = read_binary_payload(reader);
+        let length = u32::try_from(payload.len()).expect("physical response length");
+        let mut frame = length.to_be_bytes().to_vec();
+        frame.extend_from_slice(&payload);
+        frame
+    }
+
+    fn read_binary_payload(reader: &mut impl Read) -> Vec<u8> {
+        read_binary_payload_result(reader).expect("read frame")
+    }
+
+    fn read_binary_payload_result(reader: &mut impl Read) -> std::io::Result<Vec<u8>> {
+        let mut header = [0_u8; 4];
+        reader.read_exact(&mut header)?;
+        let length = usize::try_from(u32::from_be_bytes(header)).expect("frame length");
+        let mut payload = vec![0_u8; length];
+        reader.read_exact(&mut payload)?;
+        Ok(payload)
+    }
+}

--- a/crates/automata-ci-sandbox-macos/src/vm.rs
+++ b/crates/automata-ci-sandbox-macos/src/vm.rs
@@ -128,6 +128,7 @@ impl VmProcess {
         template: &VerifiedTemplate,
         attempt_id: &str,
         attempt_directory: &Path,
+        runtime_proxy_socket: Option<&Path>,
         resources: ResourceLimits,
         cancellation: &dyn Cancellation,
     ) -> io::Result<Self> {
@@ -175,9 +176,7 @@ impl VmProcess {
             handshake_nonce: &nonce,
             boot_timeout_millis: duration_millis(options.boot_timeout())?,
             stop_timeout_millis: duration_millis(options.stop_timeout())?,
-            // The transport is present in protocol 2 but remains closed until
-            // the runner supplies an attempt-scoped, route-restricted broker.
-            runtime_proxy_socket: None,
+            runtime_proxy_socket,
         };
         write_json_frame(&mut input, &request)?;
         let response = read_frame_controlled(

--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVMHelper/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSVMHelper/main.swift
@@ -721,7 +721,11 @@ private func run(lockPath: String) throws {
     stopTimeoutMillis: request.stopTimeoutMillis
   )
   defer { stopVM(machine, queue: queue, timeoutMillis: request.stopTimeoutMillis) }
-  guard let device = machine.socketDevices.first as? VZVirtioSocketDevice else {
+  guard
+    let device = queue.sync(execute: {
+      machine.socketDevices.first as? VZVirtioSocketDevice
+    })
+  else {
     throw HelperFailure(rejection: .invalidConfiguration)
   }
   var runtimeProxyListener: RuntimeProxyListener?
@@ -729,7 +733,9 @@ private func run(lockPath: String) throws {
     let delegate = RuntimeProxyListener(socketPath: socketPath)
     let listener = VZVirtioSocketListener()
     listener.delegate = delegate
-    device.setSocketListener(listener, forPort: runtimeProxyHostPort)
+    queue.sync {
+      device.setSocketListener(listener, forPort: runtimeProxyHostPort)
+    }
     runtimeProxyListener = delegate
   }
   let deadline = DispatchTime.now() + .milliseconds(Int(clamping: request.bootTimeoutMillis))

--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -80,14 +80,18 @@ fn virtualization_options_require_a_pinned_bounded_apfs_quota() {
 
 #[test]
 fn virtualization_options_require_absolute_normalized_paths_and_bounded_timeouts() {
-    let valid = options("/Users/automata-runner/Library/Application Support/Automata/vm")
-        .expect("valid VM provider options");
+    let valid = options("/Volumes/AutomataVM/state").expect("valid VM provider options");
     assert_eq!(
         valid.provider_root(),
-        std::path::Path::new("/Users/automata-runner/Library/Application Support/Automata/vm")
+        std::path::Path::new("/Volumes/AutomataVM/state")
     );
 
-    for invalid in ["relative", "/", "/Users/runner/../runner/vm"] {
+    for invalid in [
+        "relative",
+        "/",
+        "/Users/runner/../runner/vm",
+        "/Users/automata-runner/Library/Application Support/Automata/vm",
+    ] {
         assert_eq!(
             options(invalid).expect_err("invalid root must fail").kind(),
             ProviderErrorKind::InvalidConfiguration
@@ -98,8 +102,7 @@ fn virtualization_options_require_absolute_normalized_paths_and_bounded_timeouts
 #[test]
 fn provider_open_fails_closed_before_accepting_unpinned_artifacts() {
     let error = MacosVirtualizationProvider::open(
-        options("/Users/automata-runner/Library/Application Support/Automata/test-vm")
-            .expect("syntactically valid options"),
+        options("/Volumes/AutomataVM/test-state").expect("syntactically valid options"),
     )
     .expect_err("uninstalled pinned helper and template must be rejected");
     assert_eq!(error.kind(), ProviderErrorKind::InvalidConfiguration);

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -48,10 +48,14 @@ Provider startup and each job use this sequence:
 6. Challenge the guest over Virtio socket with a fresh nonce. The guest proves
    its profile, agent digest, macOS version/build, architecture, and job UID/GID.
 7. Apply the process ceiling inside the guest before accepting workflow traffic.
-8. Create the attempt's private workspace and command roots inside the fresh
+8. When the validated job runtime names HTTP(S) origins, bind an owner-only
+   attempt proxy, pass that exact socket to the helper, and inject the fixed
+   guest-loopback proxy address into commands. Otherwise leave the relay
+   closed.
+9. Create the attempt's private workspace and command roots inside the fresh
    guest, then forward bounded exec/copy frames. Closing the anonymous runner
    pipe is watched independently of blocked guest I/O and terminates the VM.
-   Destroy removes the clone under an exclusive lock.
+   Destroy stops the proxy and removes the clone under an exclusive lock.
 
 The host macOS kernel, Virtualization.framework, signed helper, Rust provider,
 and immutable template are trusted. Workflow code is not. The dedicated
@@ -60,24 +64,33 @@ workspace, runner, temp, home, and tool-cache paths. Runner TLS, object-store
 credentials, spool keys, host Keychain, and host files are never mounted or
 sent into the VM.
 
-Only `network: "disabled"` is implemented. Private egress is intentionally
-rejected until a separate authenticated host broker exists; attaching a NAT
-device would weaken the current contract.
+Only `network: "disabled"` is implemented. The VM has no NIC and cannot make
+general, private, or service-container network connections. A narrow host
+broker supports only the credential-free HTTP(S) origins derived from the
+control plane's already validated repository, Results, and OIDC authorities.
 
-The protocol-2 host helper and newly provisioned guest bridge contain the
-closed transport primitive for that broker. The guest bridge owns only
+The protocol-2 host helper and provisioned guest bridge carry this traffic. The
+guest bridge owns only
 `127.0.0.1:18081`, permits at most 16 concurrent relays, and connects to the
 host only through fixed Virtio socket port 10251. The helper registers that
 port only when its launch request names the owner-only Unix socket
 `runtime-proxy.sock` directly inside the current attempt directory. It rejects
 another path, owner, file type, link count, or group/other permission.
 
-The current runner deliberately sends `null`, so no host listener or runtime
-service route is available and no network capability is advertised. A later
-slice must supply an attempt-scoped broker that authenticates and restricts
-exact GitHub and Results routes before the runner may expose the guest
-loopback endpoint. This transport is not a generic TCP proxy and does not
-justify adding a VM network device.
+The provider advertises `RuntimeServiceProxy` and opens that transport only for
+a nonempty route set. It injects uppercase and lowercase `HTTP_PROXY` and
+`HTTPS_PROXY` variables pointing at the guest loopback endpoint. HTTPS uses
+`CONNECT` without TLS termination, keeping credentials encrypted between the
+guest and the configured origin. Plain HTTP is accepted only for authorities
+whose validated runtime URL already permits it; the proxy checks both the
+absolute request target and `Host`, rewrites to origin form, and removes proxy
+credentials. Every unmatched protocol, host, or effective port is rejected.
+The broker and bridge each cap concurrent sessions at 16 and the broker applies
+bounded headers, connection timeouts, and idle timeouts.
+
+Jobs with no runtime-service routes receive no proxy variables, the helper gets
+no socket, and the host Virtio listener remains absent. This transport is not a
+generic TCP proxy and does not justify adding a VM network device.
 
 ## Build and sign the host tools
 
@@ -151,6 +164,11 @@ sudo install -d -o root -g wheel -m 0755 \
 sudo install -d -o "$template_builder" -g "$(id -gn "$template_builder")" -m 0700 \
   /Volumes/AutomataVM/templates/macos-15-arm64-v1
 ```
+
+Keep the provider root short. Darwin Unix sockets permit at most 103 path
+bytes, and Automata appends `/attempts/<opaque-handle>/runtime-proxy.sock`.
+Provider configuration checks that worst-case suffix at startup; the path
+above is within the bound.
 
 At startup Automata independently resolves `df` and `diskutil -plist` data. It
 rejects the startup container, sibling volumes, virtual or disk-image backing
@@ -381,4 +399,20 @@ AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=107374182400 \
 cargo test --locked -p automata-ci-runner --test runner -- \
   macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_shell_job \
   --ignored --nocapture --test-threads=1
+```
+
+The runtime proxy has a separate physical contract test. It starts a temporary
+loopback HTTP origin on the host, boots the sealed NIC-less guest through the
+helper, executes guest `curl` with the fixed proxy address, and verifies that
+the request crossed the allowlisted Rust broker. The attempt root must already
+be an owner-only directory on the dedicated VM volume and short enough for its
+Unix socket suffix:
+
+```console
+AUTOMATA_MACOS_PHYSICAL_HELPER=/absolute/path/automata-macos-vm-helper \
+AUTOMATA_MACOS_PHYSICAL_MANIFEST=/Volumes/AutomataVM/templates/macos-15-arm64-v1/manifest.json \
+AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT=/Volumes/AutomataVM/proxy-tests \
+cargo test -p automata-ci-sandbox-macos --lib \
+  runtime_proxy::tests::physical_guest_reaches_an_allowlisted_origin_through_the_vsock_proxy -- \
+  --ignored --exact --nocapture
 ```


### PR DESCRIPTION
## Summary

- add an attempt-scoped, exact-allowlist HTTP/HTTPS CONNECT proxy between macOS guests and runtime service origins
- pass the private Unix listener to the Virtualization.framework helper and inject loopback proxy variables only when routes are present
- bound proxy sessions, headers, timeouts, and socket paths; close the proxy with the VM attempt lifecycle
- keep empty route sets closed and avoid adding a guest NIC, general egress, or TLS termination
- access the VZ socket device on its VM dispatch queue, fixing the physical-host trap found during testing
- document the architecture, path constraint, threat boundary, and physical validation workflow

## Validation

- rebased onto current `main` (`54658b28`)
- hosted Frontend, PostgreSQL, Rust, workflow, and required checks: passed
- full `./scripts/ci/run-macos-checks.sh` on the dedicated physical Apple Silicon Mac mini with all three macOS PRs layered: passed
- ignored physical relay test against the sealed protocol-3 macOS template: passed in 9.66 seconds; guest `curl` traversed loopback -> Virtio socket -> private Unix socket -> Rust proxy -> exact allowlisted host origin
- `cargo fmt --all -- --check`, targeted Linux tests, and warning-denied targeted Clippy: passed
- Swift helper release build, formatting, entitlement inspection, and strict signature verification: passed

PR #493 carries the workspace-wide macOS gate and portability fixes used by the aggregate validation.

Production provider E2E still requires an Apple-issued signing identity for the helper. This change does not weaken that signing policy; the disposable physical relay test uses an entitlement-bearing ad-hoc signature while the product verifier continues to reject ad-hoc production helpers.

The PR changes 1,135 lines across 12 files, below the 10,000-line limit.
