### PR TITLE
Strengthen the macOS workspace gate

### DIFF
--- a/crates/automata-ci-github-delivery/tests/checks_publisher.rs
+++ b/crates/automata-ci-github-delivery/tests/checks_publisher.rs
@@ -50,6 +50,7 @@ use automata_ci_store::{
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
     net::TcpListener,
+    sync::Notify,
     task::JoinHandle,
 };
 use url::Url;
@@ -104,6 +105,7 @@ struct FakeOutbox {
     annotation_begin_delay_millis: AtomicUsize,
     claim_time_offset: AtomicI64,
     claim_delay_millis: AtomicUsize,
+    claim_delay_started: Notify,
     terminal_result: Mutex<Option<BlobDescriptor>>,
     annotation_progress: Mutex<GithubCheckAnnotationProgress>,
     annotation_batch_started_at: Mutex<Option<UnixMillis>>,
@@ -129,6 +131,7 @@ impl FakeOutbox {
             annotation_begin_delay_millis: AtomicUsize::new(0),
             claim_time_offset: AtomicI64::new(0),
             claim_delay_millis: AtomicUsize::new(0),
+            claim_delay_started: Notify::new(),
             terminal_result: Mutex::new(None),
             annotation_progress: Mutex::new(GithubCheckAnnotationProgress::default()),
             annotation_batch_started_at: Mutex::new(None),
@@ -160,6 +163,7 @@ impl GithubCheckProjectionOutbox for FakeOutbox {
         self.event("store:claim");
         let claim_delay_millis = self.claim_delay_millis.load(Ordering::SeqCst);
         if claim_delay_millis > 0 {
+            self.claim_delay_started.notify_one();
             tokio::time::sleep(Duration::from_millis(
                 u64::try_from(claim_delay_millis)
                     .map_err(|_| GithubCheckStoreError::CorruptData)?,
@@ -846,6 +850,7 @@ impl ResponseSpec {
 struct FixtureServer {
     endpoint: GithubHttpEndpoint,
     requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    request_received: Arc<Notify>,
     task: JoinHandle<()>,
 }
 
@@ -861,6 +866,8 @@ impl FixtureServer {
         let address = listener.local_addr().expect("fixture address");
         let requests = Arc::new(Mutex::new(Vec::new()));
         let task_requests = Arc::clone(&requests);
+        let request_received = Arc::new(Notify::new());
+        let task_request_received = Arc::clone(&request_received);
         let task = tokio::spawn(async move {
             for response in responses {
                 let (mut stream, _) = listener.accept().await.expect("accept request");
@@ -870,6 +877,7 @@ impl FixtureServer {
                     .expect("events lock")
                     .push(format!("http:{} {}", request.method, request.target));
                 task_requests.lock().expect("requests lock").push(request);
+                task_request_received.notify_one();
                 if !response.delay.is_zero() {
                     tokio::time::sleep(response.delay).await;
                 }
@@ -892,12 +900,24 @@ impl FixtureServer {
         Self {
             endpoint,
             requests,
+            request_received,
             task,
         }
     }
 
     fn requests(&self) -> Vec<RecordedRequest> {
         self.requests.lock().expect("requests lock").clone()
+    }
+
+    async fn wait_for_request_without_advancing_time(&self) {
+        let notified = self.request_received.notified();
+        tokio::pin!(notified);
+        loop {
+            tokio::select! {
+                () = &mut notified => return,
+                () = tokio::task::yield_now() => {}
+            }
+        }
     }
 }
 
@@ -1118,8 +1138,17 @@ async fn slow_claim_response_cannot_extend_a_blocked_provider_past_the_claim_hor
         .claim_delay_millis
         .store(900, Ordering::SeqCst);
 
+    let (outcome, ()) = tokio::join!(harness.run(), async {
+        harness.outbox.claim_delay_started.notified().await;
+        tokio::time::advance(Duration::from_millis(900)).await;
+        harness
+            .server
+            .wait_for_request_without_advancing_time()
+            .await;
+    });
+
     assert!(matches!(
-        harness.run().await,
+        outcome,
         Err(GithubChecksPublisherError::ProviderDeadlineExceeded)
     ));
     assert_eq!(harness.release_calls(), 1);
@@ -1208,8 +1237,13 @@ async fn timed_out_provider_action_releases_once_after_the_future_ends() {
     )
     .await;
 
+    let (outcome, ()) = tokio::join!(
+        harness.run(),
+        harness.server.wait_for_request_without_advancing_time()
+    );
+
     assert!(matches!(
-        harness.run().await,
+        outcome,
         Err(GithubChecksPublisherError::ProviderDeadlineExceeded)
     ));
     assert_eq!(harness.release_calls(), 1);

--- a/crates/automata-ci-local/src/local_docker/engine/transport.rs
+++ b/crates/automata-ci-local/src/local_docker/engine/transport.rs
@@ -803,6 +803,27 @@ mod tests {
     };
     use super::{ERROR_BYTES, MAX_IN_FLIGHT_REQUESTS, MAX_RESPONSE_HEADERS, deadline};
 
+    #[cfg(unix)]
+    fn short_socket_path() -> std::path::PathBuf {
+        use std::os::unix::fs::DirBuilderExt as _;
+
+        let root =
+            std::path::Path::new("/tmp").join(format!("adt-{}", uuid::Uuid::new_v4().simple()));
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        builder
+            .create(&root)
+            .expect("create owner-only fake Docker socket directory");
+        root.join("s")
+    }
+
+    #[cfg(unix)]
+    fn remove_socket_fixture(socket: &std::path::Path) {
+        std::fs::remove_file(socket).expect("remove exact fake socket");
+        std::fs::remove_dir(socket.parent().expect("fake socket directory"))
+            .expect("remove fake Docker socket directory");
+    }
+
     #[test]
     fn path_components_are_encoded_without_query_or_path_injection() {
         assert_eq!(
@@ -867,10 +888,7 @@ mod tests {
     ) {
         use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let listener = tokio::net::UnixListener::bind(&socket).expect("bind fake Docker socket");
         let response = [
             format!(
@@ -909,7 +927,7 @@ mod tests {
 
     async fn finish_fake_response(socket: &std::path::Path, server: tokio::task::JoinHandle<()>) {
         server.await.expect("fake Docker server");
-        std::fs::remove_file(socket).expect("remove exact fake socket");
+        remove_socket_fixture(socket);
     }
 
     fn transport_with_raw_response(
@@ -921,10 +939,7 @@ mod tests {
     ) {
         use tokio::io::AsyncWriteExt as _;
 
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let listener = tokio::net::UnixListener::bind(&socket).expect("bind fake Docker socket");
         let server = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept fake request");
@@ -1131,10 +1146,7 @@ mod tests {
     async fn assert_stalled_response_is_cancelled(prefix: &'static [u8]) {
         use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-stall-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let listener = tokio::net::UnixListener::bind(&socket).expect("bind stalled Docker socket");
         let (stalled_tx, stalled_rx) = tokio::sync::oneshot::channel();
         let server = tokio::spawn(async move {
@@ -1223,10 +1235,7 @@ mod tests {
     async fn every_request_reconnects_to_the_exact_rebound_unix_socket() {
         use tokio::io::AsyncWriteExt as _;
 
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-rebind-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let transport = fake_transport(&socket);
         for expected in [1_u8, 2] {
             let listener = tokio::net::UnixListener::bind(&socket).expect("bind rebound socket");
@@ -1257,15 +1266,14 @@ mod tests {
             server.await.expect("rebound server");
             std::fs::remove_file(&socket).expect("remove rebound socket name");
         }
+        std::fs::remove_dir(socket.parent().expect("rebound socket directory"))
+            .expect("remove rebound socket directory");
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn failed_connection_is_not_implicitly_retried() {
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-no-retry-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let listener = tokio::net::UnixListener::bind(&socket).expect("bind no-retry socket");
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.expect("accept first request");
@@ -1296,10 +1304,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn concurrent_connection_cardinality_is_hard_bounded() {
-        let socket = std::env::temp_dir().join(format!(
-            "automata-docker-transport-cardinality-{}.sock",
-            uuid::Uuid::new_v4().simple()
-        ));
+        let socket = short_socket_path();
         let listener = tokio::net::UnixListener::bind(&socket).expect("bind cardinality socket");
         let (accepted_tx, mut accepted_rx) = tokio::sync::mpsc::channel(MAX_IN_FLIGHT_REQUESTS);
         let (checked_tx, checked_rx) = tokio::sync::oneshot::channel();

--- a/crates/automata-ci-local/src/snapshot.rs
+++ b/crates/automata-ci-local/src/snapshot.rs
@@ -3203,14 +3203,17 @@ mod tests {
             LocalSnapshotErrorCode::ResourceLimit
         );
 
-        let aliases = Fixture::new();
-        aliases.write("Directory/one", "one\n");
-        aliases.write("directory/two", "two\n");
-        aliases.commit_all("component aliases");
-        let alias_snapshot = aliases.capture().await.expect("exact alias archive");
-        let alias_files = archive_files(alias_snapshot.archive_bytes());
-        assert_eq!(alias_files.get("Directory/one").unwrap(), b"one\n");
-        assert_eq!(alias_files.get("directory/two").unwrap(), b"two\n");
+        #[cfg(target_os = "linux")]
+        {
+            let aliases = Fixture::new();
+            aliases.write("Directory/one", "one\n");
+            aliases.write("directory/two", "two\n");
+            aliases.commit_all("component aliases");
+            let alias_snapshot = aliases.capture().await.expect("exact alias archive");
+            let alias_files = archive_files(alias_snapshot.archive_bytes());
+            assert_eq!(alias_files.get("Directory/one").unwrap(), b"one\n");
+            assert_eq!(alias_files.get("directory/two").unwrap(), b"two\n");
+        }
 
         let deletion = Fixture::new();
         deletion.write("nested/deleted", "delete me\n");
@@ -3281,20 +3284,22 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn non_unicode_fifo_and_socket_entries_fail_closed() {
-        use std::{
-            ffi::OsString,
-            os::unix::{ffi::OsStringExt as _, net::UnixListener},
-        };
+        use std::os::unix::net::UnixListener;
 
-        let non_unicode = Fixture::new();
-        let invalid = OsString::from_vec(b"invalid-\xff".to_vec());
-        fs::write(non_unicode.path().join(invalid), b"bytes").expect("write non-Unicode path");
-        non_unicode.write("tracked.txt", "tracked\n");
-        non_unicode.commit_all("non-Unicode fixture");
-        assert_eq!(
-            non_unicode.capture().await.unwrap_err().code(),
-            LocalSnapshotErrorCode::NonUnicodePath
-        );
+        #[cfg(target_os = "linux")]
+        {
+            use std::{ffi::OsString, os::unix::ffi::OsStringExt as _};
+
+            let non_unicode = Fixture::new();
+            let invalid = OsString::from_vec(b"invalid-\xff".to_vec());
+            fs::write(non_unicode.path().join(invalid), b"bytes").expect("write non-Unicode path");
+            non_unicode.write("tracked.txt", "tracked\n");
+            non_unicode.commit_all("non-Unicode fixture");
+            assert_eq!(
+                non_unicode.capture().await.unwrap_err().code(),
+                LocalSnapshotErrorCode::NonUnicodePath
+            );
+        }
 
         let fifo = Fixture::new();
         fifo.write("tracked.txt", "tracked\n");
@@ -3326,8 +3331,7 @@ mod tests {
         let socket = Fixture::new();
         socket.write("tracked.txt", "tracked\n");
         socket.commit_all("socket fixture");
-        let _listener =
-            UnixListener::bind(socket.path().join("service.sock")).expect("create Unix socket");
+        let _listener = UnixListener::bind(socket.path().join("s")).expect("create Unix socket");
         assert_eq!(
             socket.capture().await.unwrap_err().code(),
             LocalSnapshotErrorCode::UnsupportedEntry
@@ -3441,10 +3445,7 @@ mod tests {
 
     impl Fixture {
         fn new() -> Self {
-            let root = std::env::temp_dir().join(format!(
-                "automata-local-snapshot-{}",
-                Uuid::new_v4().simple()
-            ));
+            let root = std::env::temp_dir().join(format!("als-{}", Uuid::new_v4().simple()));
             fs::create_dir(&root).expect("create fixture root");
             let fixture = Self { root };
             fixture.git(&["init", "--quiet"]);
@@ -3454,10 +3455,7 @@ mod tests {
         }
 
         fn clone_from(source: &Path) -> Self {
-            let root = std::env::temp_dir().join(format!(
-                "automata-local-snapshot-clone-{}",
-                Uuid::new_v4().simple()
-            ));
+            let root = std::env::temp_dir().join(format!("als-clone-{}", Uuid::new_v4().simple()));
             let output = Command::new("git")
                 .args(["clone", "--quiet"])
                 .arg(source)

--- a/crates/automata-ci/tests/cli.rs
+++ b/crates/automata-ci/tests/cli.rs
@@ -2,11 +2,26 @@
 use automata_ci::cli::InternalLocalCommand;
 use automata_ci::cli::{
     AuthCommand, Cli, Command, DatabaseTransport, EnvironmentReviewDecision, InternalCommand,
-    InternalObjectStoreCommand, LocalCommand, LocalContainerEngine, OutputFormat, RepositoryRef,
-    RerunSelection, S3TlsTrustMode, SecretCommand, SecretProviderCommand, SecretScope,
+    InternalObjectStoreArgs, InternalObjectStoreCommand, LocalCommand, LocalContainerEngine,
+    OutputFormat, RepositoryRef, RerunSelection, S3TlsTrustMode, SecretCommand,
+    SecretProviderCommand, SecretScope,
 };
 use automata_ci::server::{SecretSource, ServerConfig, ServerConfigError};
 use clap::{CommandFactory as _, Parser as _};
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn expect_internal_object_store(command: InternalCommand) -> Box<InternalObjectStoreArgs> {
+    match command {
+        InternalCommand::ObjectStore(args) => args,
+        InternalCommand::Local(_) => panic!("expected object-store command"),
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+fn expect_internal_object_store(command: InternalCommand) -> Box<InternalObjectStoreArgs> {
+    let InternalCommand::ObjectStore(args) = command;
+    args
+}
 
 #[test]
 fn server_uses_a_loopback_default() {
@@ -342,9 +357,7 @@ fn internal_object_store_bucket_initialization_is_hidden_exact_and_redacted() {
     let Command::Internal(internal) = cli.command else {
         panic!("internal command expected");
     };
-    let InternalCommand::ObjectStore(object_store) = internal.command else {
-        panic!("expected object-store command")
-    };
+    let object_store = expect_internal_object_store(internal.command);
     let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
     assert_eq!(args.s3.s3_tls_trust, S3TlsTrustMode::PrivateCa);
     let debug = format!("{args:?}");
@@ -401,9 +414,7 @@ fn internal_private_ca_raw_values_become_redacted_invalid_sources() {
     let Command::Internal(internal) = cli.command else {
         panic!("internal command expected");
     };
-    let InternalCommand::ObjectStore(object_store) = internal.command else {
-        panic!("expected object-store command")
-    };
+    let object_store = expect_internal_object_store(internal.command);
     let InternalObjectStoreCommand::EnsureBucket(args) = object_store.command;
     assert!(matches!(
         args.s3.s3_private_ca_source,

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,9 +14,10 @@ tests need rootless Podman, `podman-compose`, PostgreSQL client tools, and
 OpenSSL. Static Linux distribution builds also need musl and ELF tooling.
 
 The native Rust workspace, control plane, and PostgreSQL contract suite are
-supported on Apple Silicon macOS. The database scripts require Bash 4 or newer;
-Apple's `/bin/bash` 3.2 is too old. A headless Homebrew setup can provide the
-required shell, PostgreSQL 18 server, and client:
+supported on Apple Silicon macOS. The complete gate also requires the pinned
+Node.js 24.19.0 release used by compatibility fixtures. The database scripts
+require Bash 4 or newer; Apple's `/bin/bash` 3.2 is too old. A headless Homebrew
+setup can provide the required shell, PostgreSQL 18 server, and client:
 
 ```console
 brew install bash postgresql@18
@@ -24,6 +25,13 @@ brew services start postgresql@18
 export PATH="/opt/homebrew/bin:/opt/homebrew/opt/postgresql@18/bin:$HOME/.cargo/bin:$PATH"
 export AUTOMATA_PSQL_BINARY=/opt/homebrew/opt/postgresql@18/bin/psql
 ```
+
+Run `./scripts/ci/run-macos-checks.sh` from the repository root for the complete
+non-service macOS gate. It rejects an unpinned Node version, keeps all test
+scratch space under a short, trusted `target/` ancestry that also respects
+Darwin Unix-socket limits, formats, lints, tests, and documents every workspace
+target other than the intentionally Linux-only `automata-ci-service-proxy`, then
+builds all three release Swift executables used by the native VM provider.
 
 The secret-safe PostgreSQL launcher discovers that Apple Silicon Homebrew path
 and the Intel Homebrew prefix when no override is set. Keep the explicit

--- a/scripts/ci/lib/target-paths.sh
+++ b/scripts/ci/lib/target-paths.sh
@@ -9,13 +9,40 @@ automata_target_path_error() {
     return 1
 }
 
+automata_realpath_existing() {
+    python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve(strict=True))
+PY
+}
+
+automata_realpath_missing() {
+    python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve(strict=False))
+PY
+}
+
+automata_lexical_absolute_path() {
+    python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.abspath(os.path.normpath(sys.argv[1])))
+PY
+}
+
 automata_init_target_root() {
     local _automata_repository_root="$1"
     local _automata_nominal_target="${_automata_repository_root}/target"
     local _automata_canonical_target
 
-    command -v realpath >/dev/null 2>&1 || \
-        automata_target_path_error "realpath is required" || return 1
+    command -v python3 >/dev/null 2>&1 || \
+        automata_target_path_error "python3 is required" || return 1
     if [[ -L "${_automata_nominal_target}" ]]; then
         automata_target_path_error \
             "repository target directory must not be a symbolic link" || return 1
@@ -28,7 +55,7 @@ automata_init_target_root() {
         install -d -m 0755 -- "${_automata_nominal_target}" || return 1
     fi
     _automata_canonical_target="$(
-        realpath --canonicalize-existing -- "${_automata_nominal_target}"
+        automata_realpath_existing "${_automata_nominal_target}"
     )" || return 1
     if [[ "${_automata_canonical_target}" != "${_automata_nominal_target}" ]]; then
         automata_target_path_error \
@@ -46,7 +73,7 @@ automata_canonical_target_path() {
     [[ -n "${AUTOMATA_CANONICAL_TARGET_ROOT:-}" ]] || \
         automata_target_path_error "target root containment is not initialized" || return 1
     _automata_canonical="$(
-        realpath --canonicalize-missing -- "${_automata_candidate}"
+        automata_realpath_missing "${_automata_candidate}"
     )" || return 1
     case "${_automata_canonical}" in
         "${AUTOMATA_CANONICAL_TARGET_ROOT}")
@@ -91,7 +118,7 @@ automata_canonical_exact_target_child() {
             "${_automata_label}"
     )" || return 1
     _automata_nominal="$(
-        realpath --canonicalize-missing --no-symlinks -- "${_automata_candidate}"
+        automata_lexical_absolute_path "${_automata_candidate}"
     )" || return 1
     if [[ "${_automata_canonical}" != "${_automata_nominal}" ]]; then
         automata_target_path_error \

--- a/scripts/ci/run-macos-checks.sh
+++ b/scripts/ci/run-macos-checks.sh
@@ -6,23 +6,44 @@ if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
   exit 1
 fi
 
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd -P)
+TMPDIR="$repository_root/target/macos-tmp"
+export TMPDIR
+install -d -m 0700 -- "$TMPDIR"
+
+if [ "$(node --version)" != v24.19.0 ]; then
+  echo "macOS checks require Node.js 24.19.0" >&2
+  exit 1
+fi
+
 cargo fmt --all -- --check
 cargo clippy \
   --locked \
   --workspace \
   --exclude automata-ci-service-proxy \
-  --lib \
-  --bins \
+  --all-targets \
   --all-features \
   -- \
   -D warnings
 cargo test \
   --locked \
+  --workspace \
+  --exclude automata-ci-service-proxy \
+  --all-targets \
   --all-features \
-  --no-fail-fast \
-  -p automata-ci \
-  -p automata-ci-runner \
-  -p automata-ci-sandbox-macos
+  --no-fail-fast
+cargo test \
+  --locked \
+  --workspace \
+  --exclude automata-ci-service-proxy \
+  --doc \
+  --all-features
+RUSTDOCFLAGS='-D warnings' cargo doc \
+  --locked \
+  --workspace \
+  --exclude automata-ci-service-proxy \
+  --all-features \
+  --no-deps
 swift build \
   -c release \
   --package-path crates/automata-ci-sandbox-macos/swift


### PR DESCRIPTION
## Summary

- expand the Apple Silicon gate to lint and test every non-service workspace target, run doctests and warning-denied rustdoc, require the pinned Node 24.19.0 runtime, and build all native Swift helpers
- make target-path containment portable to BSD/macOS without weakening symlink or ancestry checks
- make paused-clock HTTP tests deterministic across Darwin networking, and keep Unix-socket/APFS fixtures representable without weakening production snapshot policy

`automata-ci-service-proxy` remains excluded because it is an intentionally Linux-only binary.

## Validation

- rebased onto current `main` (`54658b28`)
- hosted Frontend, PostgreSQL, Rust, workflow, and required checks: passed
- full `./scripts/ci/run-macos-checks.sh` on the dedicated physical Apple Silicon Mac mini, using current main with all three macOS PRs layered: passed
- Linux workspace tests after the portability split was adjusted: passed three consecutive default-parallel runs (287 passed, 5 ignored per run)
- rebased GitHub delivery suite: 47 library tests and 104 integration tests passed
- protobuf suite: 66 passed; CLI suite: 36 passed on Linux and 33 passed on macOS
- warning-denied Linux workspace Clippy: passed

The PR changes 264 lines across 7 files, below the 10,000-line limit.
