### PR TITLE
Make Rust coverage portable to macOS

### DIFF
--- a/crates/automata-ci/tests/internal_object_store_process.rs
+++ b/crates/automata-ci/tests/internal_object_store_process.rs
@@ -28,13 +28,13 @@ fn internal_command_initializes_the_exact_bucket_through_production_s3() {
     let task_requests = Arc::clone(&requests);
     let task = thread::spawn(move || {
         let statuses = ["404 Not Found", "200 OK", "200 OK"];
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(20);
         let mut served = 0;
         while served < statuses.len() && Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
                     stream
-                        .set_read_timeout(Some(Duration::from_secs(2)))
+                        .set_read_timeout(Some(Duration::from_secs(10)))
                         .expect("internal S3 read timeout");
                     let mut request = Vec::new();
                     let mut buffer = [0_u8; 4 * 1_024];

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,7 +162,8 @@ regression contracts.
 Coverage is a diagnostic for finding unexercised behavior; it does not replace
 the PostgreSQL, RustFS, Podman, compatibility, or security contract lanes. The
 Rust report uses the pinned toolchain's LLVM tools and a reviewed
-`cargo-llvm-cov` release:
+`cargo-llvm-cov` release. The driver supports Linux and macOS with Python 3.9
+or newer:
 
 ```console
 rustup component add llvm-tools-preview
@@ -174,9 +175,9 @@ CARGO_BUILD_JOBS=4 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 \
 The command writes `summary.json`, `coverage.lcov`, and `manifest.json`. The
 output directory must be inside the repository and ignored by Git, as the
 documented `coverage/` and `target/` locations are. The
-manifest names requested and not-requested test bundles plus each requested
-bundle's service requirements, so an ordinary report cannot be mistaken for
-service-complete workspace coverage. CI retains these files as the
+manifest names the runner platform, requested and not-requested test bundles,
+and each requested bundle's service requirements, so an ordinary report cannot
+be mistaken for service-complete workspace coverage. CI retains these files as the
 `rust-coverage-ordinary` artifact. It also binds the report to Git HEAD and a
 reproducible SHA-256 content digest of every tracked or unignored workspace
 path, and records SHA-256 hashes for both report formats. A separately named
@@ -194,27 +195,33 @@ locked, staged publication rather than being derivable from the summary JSON.
 Instrumented artifacts live under `target/llvm-cov-target`, isolated from
 ordinary Cargo fingerprints. Allow disk space for a separate all-feature
 workspace build; the runner cleans that coverage target before collection so
-stale instrumentation cannot enter a report. A nonblocking lock prevents two
-cooperating Linux/util-linux coverage runners from sharing that fixed target;
-it does not lock source files against editors. Reports are staged, the workspace
-fingerprint is checked again after collection, and the manifest is published
-last as the completion marker; a concurrent source edit leaves no final
-artifact. Checker exit status 1 is reserved for an ordinary coverage regression:
+stale instrumentation cannot enter a report. A nonblocking POSIX advisory lock
+prevents two cooperating Linux or macOS coverage runners from sharing that
+fixed target; it does not lock source files against editors. Reports are staged,
+the workspace fingerprint is checked again after collection, and the manifest
+is published last as the completion marker; a concurrent source edit leaves no
+final artifact. Checker exit status 1 is reserved for an ordinary coverage regression:
 the runner independently verifies a complete failed-guard manifest and both
 report hashes before publishing diagnostics. Checker I/O errors and partial or
 malformed manifests fail closed without a published artifact.
 
+On macOS the driver also exports a short, owner-only temporary directory under
+`target/`. This keeps instrumented Unix-domain sockets below the platform path
+limit while preserving the private-directory requirement of CLI credential
+locks; callers do not need to override `TMPDIR`.
+
 The ordinary regression guard is deliberately narrower than a raw workspace
-percentage. After the policy's renderer and generated-source exclusions, the
-reviewed report measured 64.36% of in-scope compiled production lines because
-53,999 PostgreSQL-owned adapter lines had no service profiles. The committed
-policy inventories those global exclusions and assigns the exact PostgreSQL
-paths to that service bundle; the remaining ordinary-owned source measured
-82.97%, with an 82% floor and 0.97 percentage points of headroom. The guard also
-requires at least 172,000 measured lines—more than 98% of that reviewed
-denominator—so a broad exclusion cannot make the percentage pass. S3, Podman,
-and live-client source stays in
-ordinary scope where deterministic tests cover it; their external test bundles
+percentage. The policy inventories global exclusions and assigns the exact
+PostgreSQL paths to that service bundle. Linux and macOS compile different
+conditional production paths, so each platform has a separately reviewed
+ordinary baseline while retaining the same source-ownership rules. The Linux
+baseline is 202,158 of 246,784 lines (81.92%), with an 81% floor and a 246,000
+line minimum. The macOS baseline is 191,348 of 247,854 lines (77.20%), with a
+76.25% floor and a 247,000 line minimum. The macOS ordinary command excludes
+only the explicitly Linux-only service-proxy package. Both denominator checks
+retain more than 99% of their reviewed source sets, so a broad exclusion cannot
+make the percentage pass. S3, Podman, and live-client source stays in ordinary
+scope where deterministic tests cover it; their external test bundles
 supplement that evidence.
 
 Run a service test bundle when all of that bundle's prerequisites are available:

--- a/scripts/ci/check-rust-coverage.py
+++ b/scripts/ci/check-rust-coverage.py
@@ -21,6 +21,9 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--lcov", required=True, type=Path)
     parser.add_argument("--manifest", required=True, type=Path)
     parser.add_argument("--lane", action="append", dest="lanes", required=True)
+    parser.add_argument(
+        "--runner-platform", required=True, choices=("linux", "macos")
+    )
     parser.add_argument("--source-head", required=True)
     parser.add_argument("--source-content-digest", required=True)
     parser.add_argument("--source-state-token", required=True)
@@ -405,9 +408,14 @@ def main() -> int:
 
     ordinary_files = [file for file in files if not is_external(file["source"])]
     ordinary_covered, ordinary_measured = line_counts(ordinary_files)
-    guard_policy = policy.get("ordinary_guard")
-    if not isinstance(guard_policy, dict):
-        raise ValueError("coverage policy must define the ordinary guard")
+    guard_policies = policy.get("ordinary_guards")
+    if (
+        not isinstance(guard_policies, dict)
+        or set(guard_policies) != {"linux", "macos"}
+        or any(not isinstance(value, dict) for value in guard_policies.values())
+    ):
+        raise ValueError("coverage policy must define exact Linux and macOS ordinary guards")
+    guard_policy = guard_policies[arguments.runner_platform]
     floor = guard_policy.get("line_percent_floor")
     minimum_measured = guard_policy.get("minimum_measured_lines")
     if not isinstance(floor, (int, float)) or isinstance(floor, bool) or not 0 <= floor <= 100:
@@ -449,6 +457,7 @@ def main() -> int:
     manifest = {
         "schema_version": 1,
         "cargo_llvm_cov_version": expected_tool,
+        "runner_platform": arguments.runner_platform,
         "source_snapshot": {
             "content_algorithm": "sha256-framed-git-head-and-nonignored-worktree-content-v1",
             "content_scope": "Git HEAD plus tracked and unignored working-tree paths, types, modes, and contents",

--- a/scripts/ci/fingerprint-workspace.py
+++ b/scripts/ci/fingerprint-workspace.py
@@ -57,7 +57,7 @@ def regular_file_digest(path: Path, initial: os.stat_result) -> bytes:
         for block in iter(lambda: source.read(1024 * 1024), b""):
             content.update(block)
         closed = os.fstat(source.fileno())
-    final = path.stat(follow_symlinks=False)
+    final = os.stat(path, follow_symlinks=False)
     if not stable_metadata(initial, closed) or not stable_metadata(initial, final):
         raise ValueError(f"workspace file changed while fingerprinting: {path}")
     return content.digest()
@@ -105,7 +105,7 @@ def main() -> int:
         for digest in (content_snapshot, state_token):
             framed(digest, raw_path)
         try:
-            metadata = path.stat(follow_symlinks=False)
+            metadata = os.stat(path, follow_symlinks=False)
         except FileNotFoundError:
             for digest in (content_snapshot, state_token):
                 framed(digest, b"missing")
@@ -125,7 +125,7 @@ def main() -> int:
             for digest in (content_snapshot, state_token):
                 framed(digest, b"symlink")
             target = os.fsencode(os.readlink(path))
-            final = path.stat(follow_symlinks=False)
+            final = os.stat(path, follow_symlinks=False)
             if not stable_metadata(metadata, final):
                 raise ValueError(f"workspace symlink changed while fingerprinting: {path}")
             for digest in (content_snapshot, state_token):

--- a/scripts/ci/postgres-test-environment.sh
+++ b/scripts/ci/postgres-test-environment.sh
@@ -32,7 +32,14 @@ automata_configure_postgres_test_instrumentation() {
       return 2
     fi
     local canonical_timings_dir
-    canonical_timings_dir="$(realpath -e -- "$AUTOMATA_TEST_TIMINGS_DIR")"
+    local environment_script_directory
+    environment_script_directory="$(
+      CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
+    )"
+    canonical_timings_dir="$(
+      python3 "$environment_script_directory/resolve-path.py" \
+        --existing "$AUTOMATA_TEST_TIMINGS_DIR"
+    )"
     if [[ "$canonical_timings_dir" != "$AUTOMATA_TEST_TIMINGS_DIR" ]]; then
       printf '%s\n' \
         'error: AUTOMATA_TEST_TIMINGS_DIR must already be a canonical path with no symlink components' \

--- a/scripts/ci/resolve-path.py
+++ b/scripts/ci/resolve-path.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Resolve one path with consistent Linux and macOS semantics."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--existing", action="store_true")
+    parser.add_argument("path")
+    arguments = parser.parse_args()
+
+    if "\n" in arguments.path or "\r" in arguments.path:
+        fail("path must not contain a line ending")
+    try:
+        resolved = Path(arguments.path).resolve(strict=arguments.existing)
+    except (OSError, RuntimeError) as error:
+        fail(f"could not resolve path: {error}")
+    if arguments.existing and not resolved.exists():
+        fail("path does not exist")
+    encoded = os.fsencode(resolved)
+    if b"\n" in encoded or b"\r" in encoded:
+        fail("resolved path must not contain a line ending")
+    print(os.fsdecode(encoded))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/run-rust-coverage.sh
+++ b/scripts/ci/run-rust-coverage.sh
@@ -50,7 +50,9 @@ repository_root="$(git rev-parse --show-toplevel)"
 cd "$repository_root"
 # shellcheck source=scripts/ci/postgres-test-environment.sh
 source "$repository_root/scripts/ci/postgres-test-environment.sh"
-output_directory="$(realpath -m -- "$output_directory")"
+output_directory="$(
+  python3 "$repository_root/scripts/ci/resolve-path.py" "$output_directory"
+)"
 if [[ "$output_directory" != "$repository_root/"* ]]; then
   printf 'error: coverage output must be inside the repository\n' >&2
   exit 2
@@ -61,6 +63,14 @@ if ! git check-ignore --quiet --no-index -- "$output_relative/"; then
   exit 2
 fi
 policy="$repository_root/scripts/ci/rust-coverage-policy.json"
+case "$(uname -s)" in
+  Linux) runner_platform=linux ;;
+  Darwin) runner_platform=macos ;;
+  *)
+    printf 'error: Rust coverage supports only Linux and macOS runners\n' >&2
+    exit 2
+    ;;
+esac
 
 require_environment() {
   local variable
@@ -129,9 +139,13 @@ run_ignored_command() {
 }
 
 run_ordinary() {
+  local -a excluded_packages=(--exclude automata-ci-ui-renderer)
+  if [[ "$runner_platform" == macos ]]; then
+    excluded_packages+=(--exclude automata-ci-service-proxy)
+  fi
   run_command cargo test \
     --workspace \
-    --exclude automata-ci-ui-renderer \
+    "${excluded_packages[@]}" \
     --all-targets \
     --all-features \
     --locked \
@@ -238,8 +252,10 @@ coverage_lock="$repository_root/target/llvm-cov-target.lock"
 if [[ "${AUTOMATA_COVERAGE_LOCK_HELD-}" != "$coverage_lock" ]]; then
   set +e
   AUTOMATA_COVERAGE_LOCK_HELD="$coverage_lock" \
-    flock --exclusive --nonblock --close --conflict-exit-code 73 \
-    "$coverage_lock" "$0" "$output_directory" "${lanes[@]}"
+    python3 "$repository_root/scripts/ci/run-with-file-lock.py" \
+      --conflict-exit-code 73 \
+      --lock-file "$coverage_lock" \
+      -- "$0" "$output_directory" "${lanes[@]}"
   locked_status=$?
   set -e
   if (( locked_status == 73 )); then
@@ -249,6 +265,16 @@ if [[ "${AUTOMATA_COVERAGE_LOCK_HELD-}" != "$coverage_lock" ]]; then
   exit "$locked_status"
 fi
 unset AUTOMATA_COVERAGE_LOCK_HELD
+
+if [[ "$runner_platform" == macos ]]; then
+  # Apple's per-user temporary directory is private but long enough to exceed
+  # sockaddr_un limits in instrumented process tests. Keep the short override
+  # private so it is also suitable for CLI credential-lock state.
+  coverage_tmp="$repository_root/target/llvm-cov-tmp"
+  install -d -m 0700 -- "$coverage_tmp"
+  chmod 0700 "$coverage_tmp"
+  export TMPDIR="$coverage_tmp"
+fi
 
 install -d -m 0755 -- "$output_directory"
 rm -f -- \
@@ -379,6 +405,7 @@ check_coverage_report() {
     --summary "$summary_path" \
     --lcov "$lcov_path" \
     --manifest "$manifest_path" \
+    --runner-platform "$runner_platform" \
     --source-head "$source_head" \
     --source-content-digest "$source_content_digest" \
     --source-state-token "$source_state_token" \
@@ -392,6 +419,7 @@ check_coverage_report() {
   if (( last_checker_status == 1 )); then
     if ! python3 scripts/ci/validate-rust-coverage-failure.py \
       --manifest "$manifest_path" \
+      --runner-platform "$runner_platform" \
       --summary "$summary_path" \
       --lcov "$lcov_path" \
       --source-head "$source_head" \

--- a/scripts/ci/run-with-file-lock.py
+++ b/scripts/ci/run-with-file-lock.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run one command while holding a nonblocking POSIX advisory file lock."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import stat
+import subprocess
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--conflict-exit-code", type=int, required=True)
+    parser.add_argument("--lock-file", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if not 1 <= arguments.conflict_exit_code <= 255:
+        fail("conflict exit code must be between 1 and 255")
+    if arguments.command and arguments.command[0] == "--":
+        arguments.command.pop(0)
+    if not arguments.command:
+        fail("command is required")
+
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(arguments.lock_file, flags, 0o644)
+    except OSError as error:
+        fail(f"could not open lock file: {error}")
+    with os.fdopen(descriptor, "r+") as lock_file:
+        metadata = os.fstat(lock_file.fileno())
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            fail("lock file must be a singly linked regular file")
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise SystemExit(arguments.conflict_exit_code) from None
+        completed = subprocess.run(arguments.command, check=False)
+    if completed.returncode < 0:
+        raise SystemExit(128 - completed.returncode)
+    raise SystemExit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/rust-coverage-policy.json
+++ b/scripts/ci/rust-coverage-policy.json
@@ -78,14 +78,26 @@
       "source_prefixes": []
     }
   },
-  "ordinary_guard": {
-    "line_percent_floor": 81.0,
-    "minimum_measured_lines": 246000,
-    "reviewed_baseline": {
-      "covered_lines": 202158,
-      "measured_lines": 246784,
-      "line_percent": 81.91698003112033,
-      "report_date": "2026-08-17"
+  "ordinary_guards": {
+    "linux": {
+      "line_percent_floor": 81.0,
+      "minimum_measured_lines": 246000,
+      "reviewed_baseline": {
+        "covered_lines": 202158,
+        "measured_lines": 246784,
+        "line_percent": 81.91698003112033,
+        "report_date": "2026-08-17"
+      }
+    },
+    "macos": {
+      "line_percent_floor": 76.25,
+      "minimum_measured_lines": 247000,
+      "reviewed_baseline": {
+        "covered_lines": 191348,
+        "measured_lines": 247854,
+        "line_percent": 77.20190111920728,
+        "report_date": "2026-08-18"
+      }
     }
   }
 }

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -47,14 +47,26 @@ def policy(path: Path) -> None:
                         "source_prefixes": ["crates/database/src/adapter.rs"],
                     },
                 },
-                "ordinary_guard": {
-                    "line_percent_floor": 82.0,
-                    "minimum_measured_lines": 100,
-                    "reviewed_baseline": {
-                        "covered_lines": 90,
-                        "measured_lines": 100,
-                        "line_percent": 90.0,
-                        "report_date": "2026-08-11",
+                "ordinary_guards": {
+                    "linux": {
+                        "line_percent_floor": 82.0,
+                        "minimum_measured_lines": 100,
+                        "reviewed_baseline": {
+                            "covered_lines": 90,
+                            "measured_lines": 100,
+                            "line_percent": 90.0,
+                            "report_date": "2026-08-11",
+                        },
+                    },
+                    "macos": {
+                        "line_percent_floor": 80.0,
+                        "minimum_measured_lines": 100,
+                        "reviewed_baseline": {
+                            "covered_lines": 80,
+                            "measured_lines": 100,
+                            "line_percent": 80.0,
+                            "report_date": "2026-08-18",
+                        },
                     },
                 },
             }
@@ -132,9 +144,12 @@ def synthetic_workspace_reports(
     summary_path: Path,
     lcov_path: Path,
     ordinary_covered: int,
+    runner_platform: str = "linux",
 ) -> None:
     configuration = json.loads(policy_path.read_text(encoding="utf-8"))
-    minimum_measured_lines = configuration["ordinary_guard"]["minimum_measured_lines"]
+    minimum_measured_lines = configuration["ordinary_guards"][runner_platform][
+        "minimum_measured_lines"
+    ]
     sources = [("crates/core/src/lib.rs", ordinary_covered, minimum_measured_lines)]
     for lane, lane_policy in configuration["lanes"].items():
         if lane == "ordinary":
@@ -191,6 +206,7 @@ def check(
     lcov_path: Path,
     manifest_path: Path,
     lane: str,
+    runner_platform: str = "linux",
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -206,6 +222,8 @@ def check(
             str(manifest_path),
             "--lane",
             lane,
+            "--runner-platform",
+            runner_platform,
             "--source-head",
             "0123456789abcdef0123456789abcdef01234567",
             "--source-content-digest",
@@ -253,6 +271,7 @@ def main() -> None:
         assert manifest["report"]["ordinary_owned_source"]["line_percent"] == 90
         assert manifest["report"]["ordinary_owned_source"]["files"] == 2
         assert manifest["guard"]["status"] == "passed"
+        assert manifest["runner_platform"] == "linux"
         assert manifest["test_bundles"]["not_requested"] == ["postgres"]
         assert manifest["artifacts"]["summary_json"] == {
             "bytes": summary_path.stat().st_size,
@@ -402,6 +421,19 @@ def main() -> None:
         assert failed.returncode == 1
         assert json.loads(manifest_path.read_text(encoding="utf-8"))["guard"]["status"] == "failed"
 
+        macos_passed = check(
+            policy_path,
+            summary_path,
+            lcov_path,
+            manifest_path,
+            "ordinary",
+            runner_platform="macos",
+        )
+        assert macos_passed.returncode == 0, macos_passed.stderr
+        macos_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert macos_manifest["runner_platform"] == "macos"
+        assert macos_manifest["guard"]["line_percent_floor"] == 80.0
+
         report_only = check(
             policy_path, summary_path, lcov_path, manifest_path, "postgres"
         )
@@ -412,7 +444,9 @@ def main() -> None:
         )
 
         invalid_policy = json.loads(policy_path.read_text(encoding="utf-8"))
-        invalid_policy["ordinary_guard"]["reviewed_baseline"]["line_percent"] = 91.0
+        invalid_policy["ordinary_guards"]["linux"]["reviewed_baseline"][
+            "line_percent"
+        ] = 91.0
         policy_path.write_text(json.dumps(invalid_policy), encoding="utf-8")
         invalid = check(policy_path, summary_path, lcov_path, manifest_path, "ordinary")
         assert invalid.returncode == 2
@@ -533,8 +567,10 @@ def main() -> None:
             "check-rust-coverage.py",
             "fingerprint-workspace.py",
             "postgres-test-environment.sh",
+            "resolve-path.py",
             "run-postgres-tests.sh",
             "run-rust-coverage.sh",
+            "run-with-file-lock.py",
             "rust-coverage-policy.json",
             "validate-rust-coverage-failure.py",
         ]:
@@ -562,6 +598,34 @@ def main() -> None:
         subprocess.run(
             ["git", "-C", str(runner_repository), "commit", "--quiet", "-m", "runner"],
             check=True,
+        )
+        timings_directory = runner_repository / "target" / "postgres-timings"
+        timings_directory.mkdir(parents=True)
+        timing_environment = dict(os.environ)
+        timing_environment.update(
+            {
+                "AUTOMATA_TEST_DATABASE_NAMESPACE": "coverage_contract",
+                "AUTOMATA_TEST_TIMINGS_DIR": str(timings_directory),
+                "AUTOMATA_TEST_TIMING_INVOCATION": "coverage_contract",
+                "AUTOMATA_TEST_TIMING_RUN": "0",
+            }
+        )
+        timing_configuration = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "source scripts/ci/postgres-test-environment.sh; "
+                "automata_configure_postgres_test_namespace",
+            ],
+            cwd=runner_repository,
+            env=timing_environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert timing_configuration.returncode == 0, timing_configuration.stderr
+        assert f"PostgreSQL test timings: {timings_directory}" in (
+            timing_configuration.stderr
         )
         runner_fake_bin = scratch / "runner-fake-bin"
         runner_fake_bin.mkdir()
@@ -662,10 +726,17 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
         runner_policy = json.loads(
             (runner_ci / "rust-coverage-policy.json").read_text(encoding="utf-8")
         )
-        runner_minimum_measured = runner_policy["ordinary_guard"][
+        host_runner_platform = {"Linux": "linux", "Darwin": "macos"}[
+            os.uname().sysname
+        ]
+        runner_minimum_measured = runner_policy["ordinary_guards"][
+            host_runner_platform
+        ][
             "minimum_measured_lines"
         ]
-        runner_floor = runner_policy["ordinary_guard"]["line_percent_floor"]
+        runner_floor = runner_policy["ordinary_guards"][host_runner_platform][
+            "line_percent_floor"
+        ]
         passing_covered = math.ceil(runner_minimum_measured * runner_floor / 100)
         failing_covered = passing_covered - 1
         synthetic_summary = scratch / "synthetic-summary.json"
@@ -675,6 +746,7 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
             synthetic_summary,
             synthetic_lcov,
             passing_covered,
+            runner_platform=host_runner_platform,
         )
         runner_environment = dict(os.environ)
         runner_environment["PATH"] = f"{runner_fake_bin}:{runner_environment['PATH']}"
@@ -703,6 +775,11 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
             (successful_output / "manifest.json").read_text(encoding="utf-8")
         )
         assert successful_manifest["guard"]["status"] == "passed"
+        assert successful_manifest["runner_platform"] == host_runner_platform
+        if host_runner_platform == "macos":
+            coverage_tmp = runner_repository / "target" / "llvm-cov-tmp"
+            assert coverage_tmp.is_dir()
+            assert coverage_tmp.stat().st_mode & 0o077 == 0
         for artifact_name, manifest_name in [
             ("summary.json", "summary_json"),
             ("coverage.lcov", "lcov"),
@@ -720,6 +797,7 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
             failed_summary,
             failed_lcov,
             failing_covered,
+            runner_platform=host_runner_platform,
         )
         combined_environment = dict(runner_environment)
         combined_environment["AUTOMATA_TEST_DATABASE_URL"] = (
@@ -993,6 +1071,29 @@ os.execv({real_mv!r}, [{real_mv!r}, *sys.argv[1:]])
         )
         assert reversed_plan.returncode == 2
         assert "ordinary must be the first lane" in reversed_plan.stderr
+
+        darwin_fake_bin = scratch / "darwin-fake-bin"
+        darwin_fake_bin.mkdir()
+        darwin_uname = darwin_fake_bin / "uname"
+        darwin_uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+        darwin_uname.chmod(0o755)
+        darwin_environment = dict(os.environ)
+        darwin_environment["PATH"] = f"{darwin_fake_bin}:{darwin_environment['PATH']}"
+        darwin_plan = subprocess.run(
+            [
+                str(runner_under_test),
+                "--plan",
+                str(runner_repository / "target" / "coverage-darwin-plan"),
+                "ordinary",
+            ],
+            cwd=runner_repository,
+            env=darwin_environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert darwin_plan.returncode == 0, darwin_plan.stderr
+        assert "--exclude automata-ci-service-proxy" in darwin_plan.stdout
 
         mutation_output = runner_repository / "target" / "coverage-mutation"
         mutation_path = runner_repository / "source-mutation.txt"
@@ -1374,7 +1475,8 @@ exit 99
             ("--test http_compatibility",),
             ("--test cache_http",),
         ]
-        for expected_fragments, command in zip(expected_inventory, commands, strict=True):
+        assert len(expected_inventory) == len(commands)
+        for expected_fragments, command in zip(expected_inventory, commands):
             for expected in expected_fragments:
                 assert expected in command, command
         assert all("--ignored" in command for command in commands[1:])

--- a/scripts/ci/validate-rust-coverage-failure.py
+++ b/scripts/ci/validate-rust-coverage-failure.py
@@ -19,6 +19,9 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--summary", required=True, type=Path)
     parser.add_argument("--lcov", required=True, type=Path)
     parser.add_argument("--lane", action="append", dest="lanes", required=True)
+    parser.add_argument(
+        "--runner-platform", required=True, choices=("linux", "macos")
+    )
     parser.add_argument("--source-head", required=True)
     parser.add_argument("--source-content-digest", required=True)
     parser.add_argument("--source-state-token", required=True)
@@ -112,6 +115,7 @@ def main() -> int:
     required = {
         "schema_version",
         "cargo_llvm_cov_version",
+        "runner_platform",
         "source_snapshot",
         "artifacts",
         "test_bundles",
@@ -122,6 +126,8 @@ def main() -> int:
         raise ValueError("failed-guard manifest is incomplete")
     if manifest["schema_version"] != 1 or manifest["cargo_llvm_cov_version"] != "0.8.7":
         raise ValueError("failed-guard manifest has the wrong schema or coverage tool")
+    if manifest["runner_platform"] != arguments.runner_platform:
+        raise ValueError("failed-guard manifest names the wrong runner platform")
 
     source = object_field(manifest, "source_snapshot", "manifest")
     expected_source = {


### PR DESCRIPTION
## Summary

- replace GNU `realpath` and util-linux `flock` assumptions with Python 3.9-compatible path resolution and POSIX advisory locking on Linux and macOS
- select strict, independently reviewed Linux and macOS ordinary-coverage guards and bind the runner platform into successful and failed manifests
- exclude the explicitly Linux-only service-proxy package from macOS workspace coverage while preserving the Linux source set
- provide a short owner-only macOS `TMPDIR` for instrumented Unix sockets and CLI credential locks
- make workspace fingerprinting and load-sensitive object-store process fixtures reliable under Apple Python 3.9 and full instrumentation

## Validation

Linux:

- `python3 scripts/ci/tests/rust-coverage.test.py`
- `cargo test -p automata-ci --test internal_object_store_process --all-features --locked`
- `shellcheck scripts/ci/run-rust-coverage.sh scripts/ci/postgres-test-environment.sh`
- `cargo fmt --all -- --check`
- Bash syntax, Python compilation, JSON, and diff checks

Physical Apple Silicon macOS 26.5.1 with Apple Python 3.9.6, based on current `main` (`54658b28`) with PRs #489 and #493 layered for the aggregate gate:

- full `rust-coverage.test.py` contract suite: passed
- full ordinary workspace coverage: every target passed; 191,833 / 248,714 ordinary-owned lines (77.13%) and 195,825 / 324,696 total in-scope lines (60.31%); macOS guard passed
- real PostgreSQL 18.6 coverage lane: 63 integration/application/storage tests plus 10 database-harness tests passed (73 total); PostgreSQL-owned coverage was 11,666 / 69,222 lines (16.85%); JSON, LCOV, and manifest artifacts published and the isolated database namespace was cleaned
- full current-main macOS workspace gate and physical sealed-VM runtime relay: passed

The PR changes 369 lines across 11 files, below the 10,000-line limit.
